### PR TITLE
chore(flake/nur): `dff41b1d` -> `90774854`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -333,11 +333,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1648466133,
-        "narHash": "sha256-IWNdsb4vcrP5eUAq4QOC3nNhlpMvCNhJnNcKQlMQyq0=",
+        "lastModified": 1648526859,
+        "narHash": "sha256-9TPD9rPgFP206Z0F1HfTc0TKAt3osGTlzrx9l9yd7h8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dff41b1dd6beb826a3f6c709b55590012d429bda",
+        "rev": "9077485415cbdafd82542133a309a074922d5931",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`90774854`](https://github.com/nix-community/NUR/commit/9077485415cbdafd82542133a309a074922d5931) | `automatic update` |
| [`1ae4446f`](https://github.com/nix-community/NUR/commit/1ae4446fb0017f0d74e3420b2b0d4008a764760e) | `automatic update` |
| [`efae8577`](https://github.com/nix-community/NUR/commit/efae857729653351f4743a82d7baa038b5a24fc6) | `automatic update` |