### PR TITLE
chore(flake/nur): `e1e3c899` -> `45c1ba98`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1651586954,
-        "narHash": "sha256-UkY9P8conevVlWSc1od5PJEMub/e5sHGvdzB37N9mKo=",
+        "lastModified": 1651723449,
+        "narHash": "sha256-NGWtp82nwZJmtz0REa/a5pXhUwjS3uVRAlRB25OLLOc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e1e3c899e9a59e0fe92e3279e6a088b41c4eb7ce",
+        "rev": "45c1ba984517d0dd08d8107740ce2457314e3429",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`45c1ba98`](https://github.com/nix-community/NUR/commit/45c1ba984517d0dd08d8107740ce2457314e3429) | `automatic update` |
| [`03fb5422`](https://github.com/nix-community/NUR/commit/03fb54220edcf45404f26405822f05fb9fb6766e) | `automatic update` |
| [`5c85d58f`](https://github.com/nix-community/NUR/commit/5c85d58f69c16766cbef392aca59318831f8b66e) | `automatic update` |
| [`e344372f`](https://github.com/nix-community/NUR/commit/e344372f24c204dbd7d75427122acaa2e645ceb4) | `automatic update` |
| [`16b5016a`](https://github.com/nix-community/NUR/commit/16b5016a13b192ee62c5b504c7f5277ee7e9cd38) | `automatic update` |
| [`f60500bf`](https://github.com/nix-community/NUR/commit/f60500bf368f4daf41cff7fabb334024d8731dcf) | `automatic update` |
| [`d458afc6`](https://github.com/nix-community/NUR/commit/d458afc6e9f30054e2c783c0d86348bbcd8f59a3) | `automatic update` |
| [`0eaa6765`](https://github.com/nix-community/NUR/commit/0eaa6765561185911f4906106d0eefc159a564b5) | `automatic update` |
| [`65ee7040`](https://github.com/nix-community/NUR/commit/65ee704063a9498cfd390612a31efd7f3fa23255) | `automatic update` |
| [`116deaec`](https://github.com/nix-community/NUR/commit/116deaecbe3ba60c6a645220ce7be96e4ff4f56f) | `automatic update` |
| [`bd64673b`](https://github.com/nix-community/NUR/commit/bd64673bea0beb6987a882ab2c872693c85064f1) | `automatic update` |
| [`ecaad5de`](https://github.com/nix-community/NUR/commit/ecaad5dee8d95e1595ec2b00639558704fa47766) | `automatic update` |
| [`04bdecae`](https://github.com/nix-community/NUR/commit/04bdecaeaaabafd5343b41e4b57c7434ec571730) | `automatic update` |
| [`d551ce60`](https://github.com/nix-community/NUR/commit/d551ce6044439a5fdf644ed827044794c18cef7c) | `automatic update` |