### PR TITLE
chore(flake/emacs-hass): `7820d89d` -> `0a06f486`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
     "emacs-hass": {
       "flake": false,
       "locked": {
-        "lastModified": 1643325429,
-        "narHash": "sha256-/WA2pJRHMl+hrWCXpfHtpOYUPCckHDFt5YbFg1sOrpI=",
+        "lastModified": 1648847671,
+        "narHash": "sha256-7YjVYeNVDQ6WIGNqtO4u+x7kd60Sx54WfgjjQ/aqfa4=",
         "owner": "purplg",
         "repo": "hass",
-        "rev": "7820d89dac44d355a6c8fbe950babc0bacac395e",
+        "rev": "0a06f48692bb0e48a49c7ad22391607359aaa9ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                       | Commit Message                                         |
| -------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`0a06f486`](https://github.com/purplg/hass/commit/0a06f48692bb0e48a49c7ad22391607359aaa9ae) | `Initial commentary`                                   |
| [`a0b65888`](https://github.com/purplg/hass/commit/a0b65888077b08249e65059ccc662270b8858036) | ``Use `forward-line` instead of `goto-line```          |
| [`bc31904e`](https://github.com/purplg/hass/commit/bc31904e140885472991b0b736a43d2d808aed79) | `Add new faces to customization group`                 |
| [`3aa9bca3`](https://github.com/purplg/hass/commit/3aa9bca3c19d197e6af35d0f378973635ea52039) | `Update docstrings to be less than 80 characters wide` |
| [`6ded350d`](https://github.com/purplg/hass/commit/6ded350d2f4e149d60a5059879b0e71b417f6b0f) | `Missing paren in package header`                      |
| [`41bfcb04`](https://github.com/purplg/hass/commit/41bfcb04911392281b5e2c257b4c2dfe7760f52f) | ``Made `hass-dash-refresh` autoloaded.``               |
| [`6b6a9a8f`](https://github.com/purplg/hass/commit/6b6a9a8fd448a205a6a497e80ff66a69fab298ed) | `Custom font faces`                                    |