### PR TITLE
chore(flake/nixpkgs): `e10da1c7` -> `cbe587c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1651007983,
-        "narHash": "sha256-GNay7yDPtLcRcKCNHldug85AhAvBpTtPEJWSSDYBw8U=",
+        "lastModified": 1651558728,
+        "narHash": "sha256-8HzyRnWlgZluUrVFNOfZAOlA1fghpOSezXvxhalGMUo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e10da1c7f542515b609f8dfbcf788f3d85b14936",
+        "rev": "cbe587c735b734405f56803e267820ee1559e6c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`deb70bd2`](https://github.com/NixOS/nixpkgs/commit/deb70bd200e9dd8e483e05cd8638979c42045edd) | `ocamlPackages.uuuu: 0.2.0 → 0.3.0`                                           |
| [`67947fa1`](https://github.com/NixOS/nixpkgs/commit/67947fa100a003a8bad3313f97f6ea7e86cafdaa) | `python310Packages.scmrepo: 0.0.19 -> 0.0.20`                                 |
| [`6fcda619`](https://github.com/NixOS/nixpkgs/commit/6fcda619244f9e07b7e8dfb3231cddbc18548ee8) | `python310Packages.youtube-search-python: 1.6.4 -> 1.6.5`                     |
| [`3c79fddd`](https://github.com/NixOS/nixpkgs/commit/3c79fddd9f8ac37aca3bc096853029e509eea870) | `python310Packages.hahomematic: 1.2.1 -> 1.2.2`                               |
| [`53bc699e`](https://github.com/NixOS/nixpkgs/commit/53bc699e2c9bf49d747089f9a56260ab1c163d52) | `python310Packages.teslajsonpy: 2.1.0 -> 2.2.0`                               |
| [`dda33d2b`](https://github.com/NixOS/nixpkgs/commit/dda33d2b2b2c69a0fc04b4abc460248e5b63436b) | `nixos/doc/manual: Remove trailing white space from 22.05 release notes`      |
| [`24c33ab7`](https://github.com/NixOS/nixpkgs/commit/24c33ab7952544ad355d0677c9eea931b23f371c) | `metals: 0.11.2 -> 0.11.4 (#171127)`                                          |
| [`4558d28c`](https://github.com/NixOS/nixpkgs/commit/4558d28cfce57227fd78a7a15120f275c9cf0389) | `scalafix: 0.9.0 -> 0.10.0, completions, setup-hook instead of jdk (#171074)` |
| [`d60e768c`](https://github.com/NixOS/nixpkgs/commit/d60e768cb1560188df672c5d08ef962ba81d96be) | `redpanda: init at 21.11.15`                                                  |
| [`d770c335`](https://github.com/NixOS/nixpkgs/commit/d770c33587d1ad73b0959c88479439c4aaa1dd90) | `cvehound: 1.0.4 -> 1.0.9`                                                    |
| [`114ea5a0`](https://github.com/NixOS/nixpkgs/commit/114ea5a07eb9448ee64ddb20175befa7e778e41b) | `lisgd: 0.3.3 -> 0.3.4`                                                       |
| [`e4dfaba5`](https://github.com/NixOS/nixpkgs/commit/e4dfaba5068580ab143b0df4e1eac5517164ec35) | `solc: disable z3 strict version check`                                       |
| [`738d1454`](https://github.com/NixOS/nixpkgs/commit/738d1454fe71b7392102769a820de8809996b383) | `gdal_2: fix build (#169738)`                                                 |
| [`4427d9cd`](https://github.com/NixOS/nixpkgs/commit/4427d9cd73a3900097d651b0bc1abebc697e94dc) | `gitbatch: 2019-12-19 -> 0.6.1`                                               |
| [`6c69577b`](https://github.com/NixOS/nixpkgs/commit/6c69577b23bca5431f6849edc9768b7e0d9d4001) | `colmena: 0.2.2 -> 0.3.0`                                                     |
| [`1df86fce`](https://github.com/NixOS/nixpkgs/commit/1df86fce588d2229a8bc19ea340e09253c0ad09f) | `saleae-logic-2: 2.3.50 -> 2.3.51`                                            |
| [`494ad978`](https://github.com/NixOS/nixpkgs/commit/494ad97836e36dd6a05fa525323622984e087297) | `gof5: init at 0.1.4 (#169422)`                                               |
| [`a7ca41f1`](https://github.com/NixOS/nixpkgs/commit/a7ca41f1ff24131c1386a20d5cfa2ce2591b17a1) | `python310Packages.secretstorage: 3.3.1 -> 3.3.2`                             |
| [`d37aa7fe`](https://github.com/NixOS/nixpkgs/commit/d37aa7fe6a8c4d5743045b2533cc2055b873ff79) | `python310Packages.pytenable: 1.4.4 -> 1.4.6`                                 |
| [`eeb57890`](https://github.com/NixOS/nixpkgs/commit/eeb57890bb962ef6a9998a5eb6c780016e8d3d3a) | `python310Packages.pywinrm: 0.4.2 -> 0.4.3`                                   |
| [`f9ec68bd`](https://github.com/NixOS/nixpkgs/commit/f9ec68bd6dbb1a8b56066330d44b91d64dc850a7) | `python310Packages.ropper: 1.13.6 -> 1.13.7`                                  |
| [`1fddd740`](https://github.com/NixOS/nixpkgs/commit/1fddd7401aa6667dd19780a3d041e9a7ea673c31) | `htop: remove linux only hint from description`                              |
| [`fddfaa3b`](https://github.com/NixOS/nixpkgs/commit/fddfaa3b72bd4f13655ac7aba1500c14ba9f0456) | `firefox: remove unused option`                                               |
| [`69945502`](https://github.com/NixOS/nixpkgs/commit/699455022496a9289ae79634eb3315d4ee14eff4) | `hjson-go: 3.1.1 -> 3.2.0`                                                    |
| [`2a0b704f`](https://github.com/NixOS/nixpkgs/commit/2a0b704f16f1984e65c661345f267e72014a1d33) | `python310Packages.pims: ignore DeprecationWarning`                           |
| [`a040d8f3`](https://github.com/NixOS/nixpkgs/commit/a040d8f34a07551866e5844de7422b7358ba7e01) | `python3Packages.pyhiveapi: 0.5.1 -> 0.5.3`                                   |
| [`e9452b3b`](https://github.com/NixOS/nixpkgs/commit/e9452b3b3ed9b295e1cede48f6549bb28c1d4773) | `python3Packages.preprocess-cancellation: fix build`                          |
| [`fc003057`](https://github.com/NixOS/nixpkgs/commit/fc00305708b4806837cb2ceb646a1b488158d87f) | `pulumi-bin: 3.30.0 -> 3.31.0`                                                |
| [`12082b1f`](https://github.com/NixOS/nixpkgs/commit/12082b1f9446284b42160c823060831ab473e01a) | `python310Packages.gensim: remove whitespace`                                 |
| [`2e24a02d`](https://github.com/NixOS/nixpkgs/commit/2e24a02d0f05a92e3611f396329f9d2359a62a68) | `python310Packages.pims: enable tests`                                        |
| [`6870929a`](https://github.com/NixOS/nixpkgs/commit/6870929ad1ffa5b78cf613b66e389ce949fc3b95) | `python310Packages.gensim:disable on older Python releases`                   |
| [`3a8257c7`](https://github.com/NixOS/nixpkgs/commit/3a8257c77be30e8908328f5ce2f5c6e9e01bd381) | `sigma-cli: add meta.mainProgram`                                             |
| [`129a6899`](https://github.com/NixOS/nixpkgs/commit/129a6899a000fa3d0fe209d80ced736de85f35d1) | `pantum-driver: init at 1.1.84`                                               |
| [`1ce2275c`](https://github.com/NixOS/nixpkgs/commit/1ce2275cf000c8aad3cbd6f86b3e03dfc89dff7c) | `sigma-cli: 0.4.2 -> 0.4.3`                                                   |
| [`b521c51c`](https://github.com/NixOS/nixpkgs/commit/b521c51c8322c897c0d5cf2168a29ba1e1222d76) | `python310Packages.zigpy-deconz: disable on older Python releases`            |
| [`aff0aeb3`](https://github.com/NixOS/nixpkgs/commit/aff0aeb33dd84ef72dea2b3b1d3556cb25c9d026) | `python310Packages.zigpy-deconz: 0.15.0 -> 0.16.0`                            |
| [`6a197290`](https://github.com/NixOS/nixpkgs/commit/6a197290608d7e40d2561b9cd683e17ba47bfab8) | `wishlist: init at 0.4.0`                                                     |
| [`cccc4592`](https://github.com/NixOS/nixpkgs/commit/cccc45928a5b9f0bae550151cb9a7e73d5516ecb) | `python310Packages.commoncode: 30.1.1 -> 30.2.0`                              |
| [`9db41e2c`](https://github.com/NixOS/nixpkgs/commit/9db41e2ceab1ba7d33bab1d13ec6b98da7f6a9ae) | `python310Packages.jedi-language-server: 0.35.1 -> 0.36.0`                    |
| [`073c11c7`](https://github.com/NixOS/nixpkgs/commit/073c11c7d305960a9267cdc8442f331e5bd5db61) | `kubecfg: 0.22.0 -> 0.26.0 (#171259)`                                         |
| [`54c357ab`](https://github.com/NixOS/nixpkgs/commit/54c357ab9361b8f8008228628e9d19ecf2062f05) | `python310Packages.pytelegrambotapi: 4.4.1 -> 4.5.0`                          |
| [`01048fa3`](https://github.com/NixOS/nixpkgs/commit/01048fa37c386a749bf8315422bf9ba4baeca833) | `python310Packages.ghp-import: disable on older Python releases`              |
| [`fe2be5ee`](https://github.com/NixOS/nixpkgs/commit/fe2be5eec29e2761d18d68f60c06232c36de6736) | `bore-cli: 0.2.3 -> 0.4.0`                                                    |
| [`d515e117`](https://github.com/NixOS/nixpkgs/commit/d515e117997d8634fce0675fce363a8c6c30ccd6) | `python310Packages.ghp-import: 2.0.2 -> 2.1.0`                                |
| [`02a4cef8`](https://github.com/NixOS/nixpkgs/commit/02a4cef89caa632fde96f695a3f0be583186ff20) | `n8n: 0.174.0 → 0.175.0`                                                      |
| [`a1337c5d`](https://github.com/NixOS/nixpkgs/commit/a1337c5d1ff8f24ac6fb027294dc00a39a917d9f) | `python310Packages.gensim: 4.1.2 -> 4.2.0`                                    |
| [`50d31845`](https://github.com/NixOS/nixpkgs/commit/50d31845fcc7f03a33128ffb85550fb8de6dff66) | `python310Packages.monty: 2022.1.19 -> 2022.4.26`                             |
| [`1ca149cc`](https://github.com/NixOS/nixpkgs/commit/1ca149cced09f22beb7d25e50fa1ff23b3e2485e) | `python310Packages.murmurhash: 1.0.6 -> 1.0.7`                                |
| [`126f2960`](https://github.com/NixOS/nixpkgs/commit/126f2960444150fe43102513cdb7294127d560f5) | `tup: patch tup to find setuid fusermount`                                    |
| [`65e57dbb`](https://github.com/NixOS/nixpkgs/commit/65e57dbb528857c8e95e9893ef7d69ba63584774) | `python310Packages.isoduration: init at 20.11.0`                              |
| [`c0824782`](https://github.com/NixOS/nixpkgs/commit/c08247828f558bdc8e536257bc6e1cc8cc7cabea) | `python310Packages.pytorch-pfn-extras: 0.5.7 -> 0.5.8`                        |
| [`39ac55ea`](https://github.com/NixOS/nixpkgs/commit/39ac55ead828149cda3b1c5ccd617dad5521a7d1) | `python310Packages.gradient: 1.11.0 -> 2.0.3`                                 |
| [`88d84fa6`](https://github.com/NixOS/nixpkgs/commit/88d84fa6558c0a6e403138a349ac433fc75a307a) | `python310Packages.pytest-datafiles: enable tests`                            |
| [`d5de6ac7`](https://github.com/NixOS/nixpkgs/commit/d5de6ac75e6d19670cdfccc381faf58b66c1efb3) | `python310Packages.pytest-datafiles: 2.0 -> 2.0.1`                            |
| [`1d9929a2`](https://github.com/NixOS/nixpkgs/commit/1d9929a29e5056aa414e42b8e1630540cb34343f) | `python310Packages.django-taggit: 2.1.0 -> 3.0.0`                             |
| [`380878b5`](https://github.com/NixOS/nixpkgs/commit/380878b5d1f2272e29f404a9736d1cc1e0eb08a1) | `go-motion: 2018-04-09 -> 1.1.0`                                              |
| [`7c084fde`](https://github.com/NixOS/nixpkgs/commit/7c084fde74f85f1742139eaa366c95ac22f59f52) | `bionic: fix evaluation on some platforms`                                    |
| [`17525e5d`](https://github.com/NixOS/nixpkgs/commit/17525e5d37860f996866a8e4a8424f04325d2b43) | `python310Packages.zeroconf: 0.38.4 -> 0.38.5`                                |
| [`d9b419dd`](https://github.com/NixOS/nixpkgs/commit/d9b419dd0d5cf1b22365ae635cbd67132465a96a) | `timetagger: 22.3.1 -> 22.4.2`                                                |
| [`4b348d6a`](https://github.com/NixOS/nixpkgs/commit/4b348d6a6faac2c877dbe325088697d20e3e835b) | `github-runner: Avoid /homeless-shelter bug (#170892)`                        |
| [`75f801a8`](https://github.com/NixOS/nixpkgs/commit/75f801a8b1b1b933c754e95250e8b4392e44ddef) | `python310Packages.poetry-dynamic-versioning: update inputs`                  |
| [`902a2859`](https://github.com/NixOS/nixpkgs/commit/902a2859182b9b17a96b6c7649b8f052450fa84e) | `python310Packages.fqdn: init at 1.5.1`                                       |
| [`17d5a572`](https://github.com/NixOS/nixpkgs/commit/17d5a5723d965df7051b4feb5045651b1ab4701f) | `python310Packages.poetry-dynamic-versioning: 0.14.1 -> 0.15.0`               |
| [`a2192e10`](https://github.com/NixOS/nixpkgs/commit/a2192e10df52feb2117c656c6621afe86dcd0c59) | `ff2mpv: init at 4.0.0`                                                       |
| [`9345a203`](https://github.com/NixOS/nixpkgs/commit/9345a203f0f8ea021c9ed1dba7c3ba78a96baeb1) | `gitlab: 14.9.3 -> 14.10.0 (#171129)`                                         |
| [`c77dd2c4`](https://github.com/NixOS/nixpkgs/commit/c77dd2c4f1b498273eeb899e53cc24132dd48a35) | `nixos/tests/gitlab: Add additional test cases (#167223)`                     |
| [`5b3ed6f9`](https://github.com/NixOS/nixpkgs/commit/5b3ed6f9a59e191b2cb6ddd45bd7a05cfccb287d) | `yubico-piv-tool: add self as maintainer`                                     |
| [`a71f6bdc`](https://github.com/NixOS/nixpkgs/commit/a71f6bdc7ccfa19b43ab6f530e5be5a67cba7ba1) | `yubico-piv-tool: 2.0.0 -> 2.2.1`                                             |
| [`5d02b868`](https://github.com/NixOS/nixpkgs/commit/5d02b868881386e126a40526c5073b29f4c54a89) | `systemd-in-stage1: include firmware in initrd`                               |
| [`db312071`](https://github.com/NixOS/nixpkgs/commit/db312071f9413048769e23fc9f9117235b00eae2) | `htop: 3.1.2 -> 3.2.0`                                                        |
| [`6022fd57`](https://github.com/NixOS/nixpkgs/commit/6022fd57b2a98cc7da139c998bcf4fd84029e0b2) | `htop: add SuperSandro2000 as maintainer`                                     |
| [`c0a1035b`](https://github.com/NixOS/nixpkgs/commit/c0a1035b5e73024a4cd57af8edce07a54a2b745f) | `orchis-theme: 2022-02-18 -> 2022-05-01`                                      |
| [`cd3794a2`](https://github.com/NixOS/nixpkgs/commit/cd3794a21dfc042980a53e3f71380caa9b3dab64) | `ibus-engines.bamboo: 0.7.0 -> 0.7.7 (#167901)`                               |
| [`92a849e6`](https://github.com/NixOS/nixpkgs/commit/92a849e613e506252d45b6b5483d87377b09ebd7) | `tesseract5: init at 5.1.0`                                                   |
| [`1b38ecfc`](https://github.com/NixOS/nixpkgs/commit/1b38ecfc74e47d49f207d9092571852de834d3e1) | `tesseract4.tessdata: 4.0.0 -> 4.1.0`                                         |
| [`7d2cee00`](https://github.com/NixOS/nixpkgs/commit/7d2cee008b636b2bb754bfbe43f09d8fbc460296) | `tesseract: add wrapper test`                                                 |
| [`8fc246e8`](https://github.com/NixOS/nixpkgs/commit/8fc246e8cf6803d63526eba0baacfa3332ab0e4b) | `python310Packages.svdtools: 0.1.22 -> 0.1.23`                                |
| [`15122dfd`](https://github.com/NixOS/nixpkgs/commit/15122dfdd9d70e4889bda2820fd05a87eb090cd3) | `python310Packages.apispec: 5.2.0 -> 5.2.1`                                   |
| [`21bf58c7`](https://github.com/NixOS/nixpkgs/commit/21bf58c74a7971776b003a837444652bf755128f) | `ssh-import-id: add self to maintainers`                                      |
| [`19e3c148`](https://github.com/NixOS/nixpkgs/commit/19e3c148be8d0a6ccb5d649bf25b335c371d505e) | `ssh-import-id: add man page`                                                 |
| [`da664a14`](https://github.com/NixOS/nixpkgs/commit/da664a14400bcc97cbd7807f1d8132798b840e94) | `duckdb: concat with space separator explicitly`                              |
| [`c05e64b2`](https://github.com/NixOS/nixpkgs/commit/c05e64b281fabb2099537100a46291b14436df50) | `duckdb: add darwin library path to allow tests to run`                       |
| [`2b88803a`](https://github.com/NixOS/nixpkgs/commit/2b88803ac9d442e8de92950228e9f23c0adc51d2) | `duckdb: skip kurtosis and skewness tests on aarch64`                         |
| [`72698b35`](https://github.com/NixOS/nixpkgs/commit/72698b35cec5ef8c00dd049df7970db4b43cadd1) | `duckdb: run unit tests`                                                      |
| [`05325328`](https://github.com/NixOS/nixpkgs/commit/05325328358a960a7308ba37fd1094758059f297) | `tesseract: use multi-line build inputs format`                               |
| [`683c50d8`](https://github.com/NixOS/nixpkgs/commit/683c50d805dcb6037a5b67331cc796dc2d60707b) | `tesseract: switch to SRI hash format`                                        |
| [`42b719a3`](https://github.com/NixOS/nixpkgs/commit/42b719a3be121861df8497b4d3de44e631694216) | ``tesseract: fix `fetch-language-hashes```                                    |
| [`917be9fa`](https://github.com/NixOS/nixpkgs/commit/917be9fa320d962a5ba75749b62377f73835aa20) | `asterisk: Create symlinks for each config individually`                      |
| [`f5a3980a`](https://github.com/NixOS/nixpkgs/commit/f5a3980a5b24bbffef9b66aba48b1eba6cfa05c8) | `adreaper: init at 1.1`                                                       |
| [`e5cd0b86`](https://github.com/NixOS/nixpkgs/commit/e5cd0b86b1ff8ddb45eb4438f310c6c2624ab560) | `python310Packages.pims: 0.5 -> 0.6.0`                                        |
| [`9f0746f9`](https://github.com/NixOS/nixpkgs/commit/9f0746f997cbbadad1f69ccd97f89430f15daecb) | `htop: make changelog url better clickable`                                   |
| [`b1b3f87d`](https://github.com/NixOS/nixpkgs/commit/b1b3f87d63c9ed6f0e22f0ec0670d281a32f10a9) | `htop: remove with lib over entire file`                                      |
| [`3bf58300`](https://github.com/NixOS/nixpkgs/commit/3bf58300c2a807746a2ff8a62ef45dfbbc5f20b3) | `godns: 2.7.5 -> 2.7.6`                                                       |
| [`1cbda904`](https://github.com/NixOS/nixpkgs/commit/1cbda904961bc865c119d693e15120fedef1e8e9) | `python310Packages.netutils: init at 1.1.0`                                   |
| [`f2070efc`](https://github.com/NixOS/nixpkgs/commit/f2070efc6b05288e5fd4f0bf6abd351e6bdc6525) | `slirp4netns: 1.1.12 -> 1.2.0`                                                |
| [`becaf4ac`](https://github.com/NixOS/nixpkgs/commit/becaf4acdf8407c4d33e5f80090600f55599e93a) | `python3Packages.flask_login: 0.6.0 -> 0.6.1`                                 |
| [`2f56ba48`](https://github.com/NixOS/nixpkgs/commit/2f56ba48c3be7b8391e4e7d7e661170cd054b771) | `python310Packages.ansible-doctor: 1.2.4 -> 1.3.0`                            |
| [`b892f9dd`](https://github.com/NixOS/nixpkgs/commit/b892f9dd339eeb897c914951c8d5817c7075b728) | `yle-dl: 20220213 -> 20220425`                                                |
| [`69c09eed`](https://github.com/NixOS/nixpkgs/commit/69c09eed58bd9c734a43cf821ec7dae662af6b8c) | `mqttui: 0.16.1 -> 0.16.2`                                                    |
| [`d4801769`](https://github.com/NixOS/nixpkgs/commit/d4801769322666d7d10117dad1e61aa3b871d3a3) | `grype: 0.35.0 -> 0.36.0`                                                     |
| [`94d2e55e`](https://github.com/NixOS/nixpkgs/commit/94d2e55ee6f102d7998b65038ad2d3a6dfbdd2c2) | `wprecon: 1.6.3a -> 2.4.5`                                                    |
| [`1ce8edff`](https://github.com/NixOS/nixpkgs/commit/1ce8edff505a33e36ef20eba23369709a6e5be1a) | `teams: 1.4.00.26453 -> 1.5.00.10453`                                         |
| [`a5e15217`](https://github.com/NixOS/nixpkgs/commit/a5e152175d3f3fae591d5798464b8beaf2e55157) | `python310Packages.pydeps: init at 1.10.17`                                   |
| [`7b5be1a0`](https://github.com/NixOS/nixpkgs/commit/7b5be1a0f8e8b0298dd71d78ec01de704d151f3b) | `lib/tests: add tests for hasInfix`                                           |
| [`7c63f0ab`](https://github.com/NixOS/nixpkgs/commit/7c63f0ab8477433eef621dca468bf43e33a32ca8) | `gspeech: 0.10.1 -> 0.11.0`                                                   |
| [`4bc73f44`](https://github.com/NixOS/nixpkgs/commit/4bc73f44e6417806d6ba25a8de60b222b985eb6a) | `gitea: 1.16.6 -> 1.16.7`                                                     |
| [`df82d7c0`](https://github.com/NixOS/nixpkgs/commit/df82d7c0aa38f5bd4a410852a196a3ee7c5f6622) | `matterircd: 0.25.0 -> 0.25.1`                                                |
| [`91bbd567`](https://github.com/NixOS/nixpkgs/commit/91bbd5677d62d409eed0d7aade97761c36affe81) | `nodePackages: use latest node2nix`                                           |
| [`a065c798`](https://github.com/NixOS/nixpkgs/commit/a065c79856199033261226eee0f0a6502af8c8a2) | `terraform-providers: update 2022-05-02`                                      |
| [`1432f1d4`](https://github.com/NixOS/nixpkgs/commit/1432f1d4c998410f5c3b07d57f66e74578373cad) | `mustache-go: 1.3.0 -> 1.3.1`                                                 |
| [`74dd0e78`](https://github.com/NixOS/nixpkgs/commit/74dd0e78123e9a75cb6858526979f1639985b09f) | `python310Packages.python-smarttub: 0.0.31 -> 0.0.32`                         |
| [`ddd70f2e`](https://github.com/NixOS/nixpkgs/commit/ddd70f2eb8bc00b20aa5a117ed179393b425b769) | `go-toml: 1.9.4 -> 2.0.0`                                                     |
| [`2f5f84a1`](https://github.com/NixOS/nixpkgs/commit/2f5f84a1112f0d010638eacb9784fbd6f4192830) | `python310Packages.twitch-python: 0.0.19 -> 0.0.20`                           |
| [`5dacb960`](https://github.com/NixOS/nixpkgs/commit/5dacb960165067ab7d04e48edb1b61c1a2ef2b52) | `python310Packages.Nikola: 8.2.1 -> 8.2.2`                                    |
| [`0fac08c0`](https://github.com/NixOS/nixpkgs/commit/0fac08c0b5abbb8ea44d8aa4c311aae3b5f75d5e) | `lao: init at 0.0.20060226`                                                   |
| [`ecfb5500`](https://github.com/NixOS/nixpkgs/commit/ecfb5500f7ed72e407b9ce5e8a6cab8483d5f47a) | `nixos/cloudflare-dyndns: init`                                               |
| [`62a0ebcc`](https://github.com/NixOS/nixpkgs/commit/62a0ebcc8d353cd3e57c312d86381230e4484fa3) | `s3-credentials: 0.10 -> 0.11`                                                |
| [`0d9517f9`](https://github.com/NixOS/nixpkgs/commit/0d9517f98b8bc78ba034ca7b8916ee0e2a670416) | `cloudflare-dyndns: init at 4.1`                                              |
| [`42830ae1`](https://github.com/NixOS/nixpkgs/commit/42830ae1be22c24c151e4882ae284319cc7bb826) | `devito: fix sha256 hash that changed`                                        |
| [`996f6afd`](https://github.com/NixOS/nixpkgs/commit/996f6afd08796bdb6f72d2f782d6c8a3a1fb05ec) | `pouf: 0.4.1 -> 0.4.3`                                                        |
| [`44d939d1`](https://github.com/NixOS/nixpkgs/commit/44d939d1c98e812edd9683dcea548d42b32fbf79) | `marktext: fix nix-env version parsing`                                       |
| [`a9850495`](https://github.com/NixOS/nixpkgs/commit/a98504952fb1fe260ee70119bbb3eb23062f9ead) | `magic-wormhole-rs: fix pname`                                                |
| [`40cb2223`](https://github.com/NixOS/nixpkgs/commit/40cb2223667542f4f8961ef8517b18de9370beca) | `python310Packages.sphinxcontrib-spelling: update inputs`                     |
| [`5561de6b`](https://github.com/NixOS/nixpkgs/commit/5561de6b331d5f2d3c57dc5ca41807fb0b1e719d) | `python310Packages.sphinxcontrib-spelling: add pythonImportsCheck`            |
| [`1b8e1232`](https://github.com/NixOS/nixpkgs/commit/1b8e123255df22c3ee8feeb3d7e6fd093ff4bbaf) | `vim/update.py: fix handling of redirects`                                    |
| [`67f45a43`](https://github.com/NixOS/nixpkgs/commit/67f45a43621047fead6bdd5c87509c51a88b9871) | `luaPackages.luaexpat: 1.3.0-1 -> 1.4.1-1`                                    |
| [`676ca56f`](https://github.com/NixOS/nixpkgs/commit/676ca56fb32b2f82dfce6a5adc523da8d08d5025) | `python3Packages.mat2: 0.12.3 -> 0.12.4`                                      |