### PR TITLE
chore(flake/nixos-hardware): `1a0ccdbf` -> `6b4ebea9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -287,11 +287,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1649849514,
-        "narHash": "sha256-zQyTr2UebTKUh1KLyLtevhHsM8umPK1LfQLGUGjRjiQ=",
+        "lastModified": 1650522846,
+        "narHash": "sha256-SxWHXRI3qJwswyXAtzsi6PKVY3KLNNnb072KaJthII8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "1a0ccdbf4583ed0fce37eea7955e8ef90f840a9f",
+        "rev": "6b4ebea9093c997c5f275c820e679108de4871ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                            |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`4a0cdc97`](https://github.com/NixOS/nixos-hardware/commit/4a0cdc97c85cb941e8ff4a91226bbc92ca20cd9e) | `no longer ignore kernel config errors`   |
| [`bb8b3f19`](https://github.com/NixOS/nixos-hardware/commit/bb8b3f19e041747d9ad45a83ac6b07093720833d) | `Update flake.nix`                        |
| [`53b47058`](https://github.com/NixOS/nixos-hardware/commit/53b470587f45fc6ca0685994221da3cc0e363741) | `split CPU and GPU from common/cpu/intel` |
| [`638263b7`](https://github.com/NixOS/nixos-hardware/commit/638263b724cbddd0ed36fd3cb928c966506e9fa4) | `Add Dell XPS 17 9700`                    |