### PR TITLE
chore(flake/ragenix): `6b772909` -> `36964905`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -348,11 +348,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1651044792,
-        "narHash": "sha256-9UQboE2nXQUgJTdiY+jnwqOtP14cuXd9MdgzCFxaTBM=",
+        "lastModified": 1651391319,
+        "narHash": "sha256-KmNO8/Ll8M4kKyvLxeELmr02TYX8ADLDKVQO4t9OaDk=",
         "owner": "yaxitech",
         "repo": "ragenix",
-        "rev": "6b772909c5a91c927469a683e326b14588de2c65",
+        "rev": "36964905ee503b51de804d9cf29319a5004779cd",
         "type": "github"
       },
       "original": {
@@ -397,11 +397,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1651027770,
-        "narHash": "sha256-L1tl7tezuIkDUgMkcDpg8zkfzPsysp2BMb4a7pT439s=",
+        "lastModified": 1651286718,
+        "narHash": "sha256-sPGOKDL6TNRfLnwarbdlmeD0FW4BmPfOoB/AMax91pg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "628301be224ea8822f043fe9de9299dbcb356a3c",
+        "rev": "8a687a6e5dc1f5c39715b01521a7aa0122529a05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                            | Commit Message                                      |
| ------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`36964905`](https://github.com/yaxitech/ragenix/commit/36964905ee503b51de804d9cf29319a5004779cd) | `Update flake inputs and Cargo dependencies (#104)` |