### PR TITLE
chore(flake/sops-nix): `c01f48b0` -> `c2614c4f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -433,11 +433,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1647279403,
-        "narHash": "sha256-ZsHfMah9+TElcjaENsaOIFHBNNtSbXmyLFVbiJiAECs=",
+        "lastModified": 1649756291,
+        "narHash": "sha256-KTll8bCINAzIUGaaMrbn9wb5nfhkXRLgmFrWGR/Dku0=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c01f48b055ac776f9831c9d4a0fff83e3b74dbe3",
+        "rev": "c2614c4fe61943b3d280ac1892fcebe6e8eaf8c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                                 |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`9d13b571`](https://github.com/Mic92/sops-nix/commit/9d13b571624f7af5a279eb11a0b6f34123c7bffa) | `doc: fix path towards the nobody user`        |
| [`febec2e8`](https://github.com/Mic92/sops-nix/commit/febec2e85fb9533c83eb93a65a49a9a0a34d7ba7) | `Bump cachix/install-nix-action from 16 to 17` |