### PR TITLE
chore(flake/nix-on-droid): `f246a9e8` -> `e7e7d134`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -257,11 +257,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1650224986,
-        "narHash": "sha256-XQvNX6GtC2hSTfD1nls5PYcvnwnPXErJHlWlQOSbzLI=",
+        "lastModified": 1650613939,
+        "narHash": "sha256-x+OlhRDWXpqFZKmeEOE+vXbmt9kiCe35rKVBcJo3gxQ=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "f246a9e82d7f5d93c1447c4f3a2340d3c9f8a3b3",
+        "rev": "e7e7d1347ffa88f8f67852a58a94d339c7d58fa0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                     |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`e7e7d134`](https://github.com/t184256/nix-on-droid/commit/e7e7d1347ffa88f8f67852a58a94d339c7d58fa0) | `modules/environment/login: Fix fakeProcStat path` |