### PR TITLE
chore(flake/nur): `45c1ba98` -> `530b7aa7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1651723449,
-        "narHash": "sha256-NGWtp82nwZJmtz0REa/a5pXhUwjS3uVRAlRB25OLLOc=",
+        "lastModified": 1651734079,
+        "narHash": "sha256-9Ygyc7XA4FfKApyH/nvIKhNMGZBrZ/boYqeIgNQGw8A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "45c1ba984517d0dd08d8107740ce2457314e3429",
+        "rev": "530b7aa75d96fd0b1af1eef9b7daf6271b5c5bcb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`530b7aa7`](https://github.com/nix-community/NUR/commit/530b7aa75d96fd0b1af1eef9b7daf6271b5c5bcb) | `automatic update` |