### PR TITLE
chore(flake/nur): `45c1ba98` -> `d997f30e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1651723449,
-        "narHash": "sha256-NGWtp82nwZJmtz0REa/a5pXhUwjS3uVRAlRB25OLLOc=",
+        "lastModified": 1651737229,
+        "narHash": "sha256-bXBtGQgb139XR5iSbN/VRFAhE93j3QNqK6hITeNtyHE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "45c1ba984517d0dd08d8107740ce2457314e3429",
+        "rev": "d997f30eee0a05a198f94448e7560b75cdc23099",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                                                  |
| -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`d997f30e`](https://github.com/nix-community/NUR/commit/d997f30eee0a05a198f94448e7560b75cdc23099) | `automatic update`                                              |
| [`2793a396`](https://github.com/nix-community/NUR/commit/2793a3964016f864767907895ac93b63257968b6) | `automatic update`                                              |
| [`62eb02d5`](https://github.com/nix-community/NUR/commit/62eb02d56e638fc20e144c821fcaf2ccf63592ca) | `automatic update`                                              |
| [`530b7aa7`](https://github.com/nix-community/NUR/commit/530b7aa75d96fd0b1af1eef9b7daf6271b5c5bcb) | `automatic update`                                              |
| [`bddeaf8d`](https://github.com/nix-community/NUR/commit/bddeaf8de386e2d819a0d38d6cedeb8ed1a76c81) | `update wolfangaukang repository`                               |
| [`4d7a0669`](https://github.com/nix-community/NUR/commit/4d7a0669be7dffff00ed42181ed922a076659781) | `remove redundant branch configs that point to default branch`  |
| [`f8f0a5e3`](https://github.com/nix-community/NUR/commit/f8f0a5e36e2de78ee2f13665d4fcbcf234d66aac) | `fetch from default branch when branch isn't specified`         |
| [`cadf7264`](https://github.com/nix-community/NUR/commit/cadf72646c66e68fa5654fe43af42854f1616406) | ``refactor prefetch to get latest commit with `git ls-remote``` |
| [`1cb05e23`](https://github.com/nix-community/NUR/commit/1cb05e238b64ea513ef33dc626f10efd77934e20) | `Rename astralbijection -> astridyu`                            |
| [`90c39f69`](https://github.com/nix-community/NUR/commit/90c39f699b12d481c9d9bab1b54a751d734e6602) | `add eh5 repository`                                            |