### PR TITLE
chore(flake/emacs-overlay): `1deb4d66` -> `4e0481c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -144,11 +144,11 @@
     },
     "emacs-overlay": {
       "locked": {
-        "lastModified": 1651724664,
-        "narHash": "sha256-/Z0AkB2DAxMdOaFYBSkTPjHrMH2e3kReuLEtpLQZfk4=",
+        "lastModified": 1651750171,
+        "narHash": "sha256-IltysR3/0qLKrhbnUwdLbwFPv26Q9gvxuzqx1h/G/jQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1deb4d66be3117dd0d9dbf31fd458035e0f3c4de",
+        "rev": "4e0481c777deab3f01cb5a6bdddffd49321ea1a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`4e0481c7`](https://github.com/nix-community/emacs-overlay/commit/4e0481c777deab3f01cb5a6bdddffd49321ea1a3) | `Updated repos/melpa` |
| [`ed26738e`](https://github.com/nix-community/emacs-overlay/commit/ed26738e40ec90822e66a0b3e073b17913509482) | `Updated repos/emacs` |