### PR TITLE
chore(flake/emacs-ement): `77a2593e` -> `dd17b6fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1651500976,
-        "narHash": "sha256-JJn3pqstaURsR+39AeNnImFl5ufBUOTTxpy3Z7La0QA=",
+        "lastModified": 1651756090,
+        "narHash": "sha256-TjCTAbyej0EPMXSqi9tPLVa61wZLQpnCT8EStlpMCSs=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "77a2593e7363f9d38dc31391f0c52f6513c1e25c",
+        "rev": "dd17b6feec519b33a1c2caaab30cfc01a9fb7632",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                     |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`dd17b6fe`](https://github.com/alphapapa/ement.el/commit/dd17b6feec519b33a1c2caaab30cfc01a9fb7632) | `Fix: (ement-room-mark-read) Marking latest event` |