### PR TITLE
chore(flake/emacs-ement): `dd17b6fe` -> `459a6ce0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1651756090,
-        "narHash": "sha256-TjCTAbyej0EPMXSqi9tPLVa61wZLQpnCT8EStlpMCSs=",
+        "lastModified": 1651772396,
+        "narHash": "sha256-ryhkXk963fteSZNAqmOdbcXallD4hPJ2pbVFL9XnhnQ=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "dd17b6feec519b33a1c2caaab30cfc01a9fb7632",
+        "rev": "459a6ce0f1570eb294185494b080052921e00358",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                    |
| --------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`459a6ce0`](https://github.com/alphapapa/ement.el/commit/459a6ce0f1570eb294185494b080052921e00358) | `Add: Coalesce membership events` |
| [`469b2ae3`](https://github.com/alphapapa/ement.el/commit/469b2ae3b4cae217f0870910d765d390a6aec8c1) | `Add: (ement-room-wrap-prefix)`   |