### PR TITLE
chore(flake/emacs-ement): `459a6ce0` -> `84739451`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1651772396,
-        "narHash": "sha256-ryhkXk963fteSZNAqmOdbcXallD4hPJ2pbVFL9XnhnQ=",
+        "lastModified": 1651777068,
+        "narHash": "sha256-XdegBKZfoKbFaMM/l8249VD9KKC5/4gQIK6ggPcoOaE=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "459a6ce0f1570eb294185494b080052921e00358",
+        "rev": "84739451afa8355360966dfa788d469d9dc4a8e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                      |
| --------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`84739451`](https://github.com/alphapapa/ement.el/commit/84739451afa8355360966dfa788d469d9dc4a8e3) | `Tidy: Disable expansion of debug forms by default` |
| [`28f96972`](https://github.com/alphapapa/ement.el/commit/28f96972586890e85f01ae968e504ff8929917c4) | `Add: Coalesce membership events`                   |