### PR TITLE
chore(flake/dendrite-demo-pinecone): `96a6703b` -> `0fd462b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -40,11 +40,11 @@
     "dendrite": {
       "flake": false,
       "locked": {
-        "lastModified": 1651754532,
-        "narHash": "sha256-wmcA7M/s6LSknyIq1PfZTUtLSYhi5sKPCgU/eFA4Z2g=",
+        "lastModified": 1651775438,
+        "narHash": "sha256-UM/e9r3PnAqMv2FP5G0OMwpQnKeQJLPTVzFXZvaxRjE=",
         "owner": "matrix-org",
         "repo": "dendrite",
-        "rev": "42f35a57ac82e78e7035547504806733089f21a0",
+        "rev": "9957752a9d60d4519cc0b7e8b9b40a781240c27d",
         "type": "github"
       },
       "original": {
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1651765307,
-        "narHash": "sha256-IIf1A1fbVgyX7/QiUWE8bUhNrQ4yinvhoko1tVcTghg=",
+        "lastModified": 1651776201,
+        "narHash": "sha256-eEKp5ct/on4twMyZ2C56BXpe7ddmxK2glez9z1KDBLw=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "96a6703b65ac4b76fa011a8d104adfb53859e092",
+        "rev": "0fd462b386371fd902dffd645559cfc66128a24d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                          | Commit Message       |
| --------------------------------------------------------------------------------------------------------------- | -------------------- |
| [`0fd462b3`](https://github.com/bbigras/dendrite-demo-pinecone/commit/0fd462b386371fd902dffd645559cfc66128a24d) | `flake: update`      |
| [`d7aebe8e`](https://github.com/bbigras/dendrite-demo-pinecone/commit/d7aebe8ed269ffd350389b27d1cb494def67c7dc) | `flake.lock: Update` |