### PR TITLE
chore(flake/nur): `d997f30e` -> `3f73809d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1651737229,
-        "narHash": "sha256-bXBtGQgb139XR5iSbN/VRFAhE93j3QNqK6hITeNtyHE=",
+        "lastModified": 1651775195,
+        "narHash": "sha256-seJ564uq91VOuHhJ4h9ph5fAu7pCcWHgni3DuTttwig=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d997f30eee0a05a198f94448e7560b75cdc23099",
+        "rev": "3f73809d3dcd2b324fa8f78088ac5ed207272c11",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3f73809d`](https://github.com/nix-community/NUR/commit/3f73809d3dcd2b324fa8f78088ac5ed207272c11) | `automatic update` |