### PR TITLE
chore(flake/emacs-overlay): `4e0481c7` -> `ad374036`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -144,11 +144,11 @@
     },
     "emacs-overlay": {
       "locked": {
-        "lastModified": 1651750171,
-        "narHash": "sha256-IltysR3/0qLKrhbnUwdLbwFPv26Q9gvxuzqx1h/G/jQ=",
+        "lastModified": 1651778691,
+        "narHash": "sha256-d9TsHhy7eQ/bZUyiY2rVm3OXqlCq7+hJtdkdpFTTa40=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4e0481c777deab3f01cb5a6bdddffd49321ea1a3",
+        "rev": "ad37403611e633cbe174bb1d40fc4a1b7343c941",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ad374036`](https://github.com/nix-community/emacs-overlay/commit/ad37403611e633cbe174bb1d40fc4a1b7343c941) | `Updated repos/melpa` |
| [`463a98ea`](https://github.com/nix-community/emacs-overlay/commit/463a98ea6a1c137e36a05df81629a3838d2fc1dc) | `Updated repos/emacs` |