### PR TITLE
chore(flake/emacs-ement): `84739451` -> `0a3869c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1651777068,
-        "narHash": "sha256-XdegBKZfoKbFaMM/l8249VD9KKC5/4gQIK6ggPcoOaE=",
+        "lastModified": 1651787669,
+        "narHash": "sha256-F4c6/0wgY/vMv3/su/ZiTlFuoTQ7BchQr8G5s+4UcOc=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "84739451afa8355360966dfa788d469d9dc4a8e3",
+        "rev": "0a3869c021ec0f463295c3c036746dda0cd943b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                        |
| --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`0a3869c0`](https://github.com/alphapapa/ement.el/commit/0a3869c021ec0f463295c3c036746dda0cd943b8) | `Change: (ement-room-defevent) Instrument with Edebug`                |
| [`f1a291a1`](https://github.com/alphapapa/ement.el/commit/f1a291a15ec13e7f1884a060c3317d415ab85e57) | `Add: (ement-room--format-reactions) Show reaction name in help-echo` |
| [`e99baffa`](https://github.com/alphapapa/ement.el/commit/e99baffacb3aca1c2d80ec157c40131cd0f4b702) | `Change/Fix: Formatting of redacted messages`                         |
| [`84b61941`](https://github.com/alphapapa/ement.el/commit/84b61941dffec7721b4a8974f95c6b0e010766d0) | `Add: (ement-room-toggle-reaction)`                                   |
| [`6f4ef971`](https://github.com/alphapapa/ement.el/commit/6f4ef9717684f0a00450e2ed3ea9d94442a8e579) | `Add: (defface ement-room-redacted)`                                  |
| [`a4dcda4d`](https://github.com/alphapapa/ement.el/commit/a4dcda4df2389db7449ea4e9a1895e43a6158e38) | `Add: (ement-room-defevent "m.room-reaction")`                        |
| [`e0004b92`](https://github.com/alphapapa/ement.el/commit/e0004b9202e76a9e31f864c2cc8c8bcc6612bd6f) | `Add: (ement-redact)`                                                 |
| [`3064b07e`](https://github.com/alphapapa/ement.el/commit/3064b07e0a659da892fde7fef1c103491ebc944f) | `Add: (ement--make-event) Record redactions`                          |