### PR TITLE
chore(flake/emacs-ement): `0a3869c0` -> `58c30e85`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1651787669,
-        "narHash": "sha256-F4c6/0wgY/vMv3/su/ZiTlFuoTQ7BchQr8G5s+4UcOc=",
+        "lastModified": 1651790900,
+        "narHash": "sha256-qsLGy5mSNF9CjyAYrrPw+kIxfTEARmwR57J+XbJcka4=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "0a3869c021ec0f463295c3c036746dda0cd943b8",
+        "rev": "58c30e850844c2e1365e1e0e36f73d08c3a16750",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                            |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`58c30e85`](https://github.com/alphapapa/ement.el/commit/58c30e850844c2e1365e1e0e36f73d08c3a16750) | `Change: (ement-room--format-reactions) Highlight locally sent reactions` |