### PR TITLE
chore(flake/nixpkgs): `cbe587c7` -> `c777cdf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1651558728,
-        "narHash": "sha256-8HzyRnWlgZluUrVFNOfZAOlA1fghpOSezXvxhalGMUo=",
+        "lastModified": 1651726670,
+        "narHash": "sha256-dSGdzB49SEvdOJvrQWfQYkAefewXraHIV08Vz6iDXWQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cbe587c735b734405f56803e267820ee1559e6c1",
+        "rev": "c777cdf5c564015d5f63b09cc93bef4178b19b01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                              |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`c777cdf5`](https://github.com/NixOS/nixpkgs/commit/c777cdf5c564015d5f63b09cc93bef4178b19b01) | `easycrypt-runtest: init at 2022.04`                                        |
| [`b20934a6`](https://github.com/NixOS/nixpkgs/commit/b20934a65c0541c2b83b688de24e3991b3db426e) | `easycrypt: init at 2022.04`                                                |
| [`0ab6bceb`](https://github.com/NixOS/nixpkgs/commit/0ab6bcebc81cec39295802a0d76780ddf237722e) | `libdeltachat: 1.78.0 -> 1.79.0`                                            |
| [`55352488`](https://github.com/NixOS/nixpkgs/commit/5535248877bbd27bea37b0a9e1b0231159125ff5) | `rust-analyzer: 2022-04-11 -> 2022-05-02`                                   |
| [`9dd25bbe`](https://github.com/NixOS/nixpkgs/commit/9dd25bbe3f416cd806d552c62a946803d4c92296) | `chezmoi: 2.15.1 -> 2.15.2`                                                 |
| [`e02a0ba3`](https://github.com/NixOS/nixpkgs/commit/e02a0ba32c1e2bb2163414a8950f183cc52815fd) | `python310Packages.nbclient: remove comment`                                |
| [`063015ee`](https://github.com/NixOS/nixpkgs/commit/063015ee9c4583bb657c564029cfc7b921d10a70) | `poetry2nix: 1.27.1 -> 1.28.0`                                              |
| [`ec0ae174`](https://github.com/NixOS/nixpkgs/commit/ec0ae174f8b273e024341d2ffbf2e9e58d30c706) | `Revert "networkmanager-applet: rename from networkmanagerapplet"`          |
| [`9146215b`](https://github.com/NixOS/nixpkgs/commit/9146215b37ce504c443e440a9be5acc15b77721d) | `python3Packages.nbclient: 0.5.13 -> 0.6.0`                                 |
| [`5f8ac4de`](https://github.com/NixOS/nixpkgs/commit/5f8ac4de773cd78bb07809054b83f0e324b3487c) | `python3Packages.nbconvert: 6.4.5 -> 6.5.0`                                 |
| [`60b4f7d8`](https://github.com/NixOS/nixpkgs/commit/60b4f7d8e86c81838c76c98a7a7b9de8aec7acd7) | `zerobin: raise version bounds for bleach to <6`                            |
| [`0c90ed17`](https://github.com/NixOS/nixpkgs/commit/0c90ed17cedcd618bdbacb45a3d5a8c5d2ee3b09) | `python3Packages.bleach: 4.1.0 -> 5.0.0`                                    |
| [`ab0bd3af`](https://github.com/NixOS/nixpkgs/commit/ab0bd3aff91e64bbeab321b5a182ca24428de937) | `python3.pkgs.nbclient: always disable tests`                               |
| [`2d5d1d4c`](https://github.com/NixOS/nixpkgs/commit/2d5d1d4c1326a7472c79cc6c23c2792d6cce32e1) | `pssh: 2.3.1 -> 2.3.4`                                                      |
| [`ffa38b77`](https://github.com/NixOS/nixpkgs/commit/ffa38b7712d0dbb3c39fd13500de66c2bbb90498) | `pixie: remove`                                                             |
| [`b4cc9cd3`](https://github.com/NixOS/nixpkgs/commit/b4cc9cd38f05f1a764e21bfb1b14e89be76068b0) | `Revert "zimg: 3.0.3 -> 3.0.4" (#171566)`                                   |
| [`8e225170`](https://github.com/NixOS/nixpkgs/commit/8e225170e2e821119c3341e102bc2ad4c9ac3046) | `prometheus-haproxy-exporter: 0.12.0 -> 0.13.0 (#171336)`                   |
| [`a60992ba`](https://github.com/NixOS/nixpkgs/commit/a60992bad95d7de32c0ed8e68f9c4107db2baed5) | `gosec: enable tests`                                                       |
| [`b377b29d`](https://github.com/NixOS/nixpkgs/commit/b377b29d9e097cca191ce28689dfbb956f7d8b67) | `dive: enable tests`                                                        |
| [`c201d1bc`](https://github.com/NixOS/nixpkgs/commit/c201d1bc1dde27d4e7514ab26dd8f6713e6785fa) | `nvchecker: 2.7 -> 2.8`                                                     |
| [`8696e36f`](https://github.com/NixOS/nixpkgs/commit/8696e36fca99fca1808feb1a953721325d0d7d7a) | `winbox: licenses.gpl3Plus -> licenses.unfree`                              |
| [`eb8ce992`](https://github.com/NixOS/nixpkgs/commit/eb8ce99204db35f505f0c029cf204963e5444bae) | `ssm-session-manager-plugin: 1.2.54.0 -> 1.2.312.0`                         |
| [`872280e3`](https://github.com/NixOS/nixpkgs/commit/872280e35aabaa29d5d442c71fdaab6b4a4d43c8) | `fluxcd: 0.29.5 -> 0.30.2`                                                  |
| [`40d5cb2e`](https://github.com/NixOS/nixpkgs/commit/40d5cb2e8355e8f4346efd0325bd920df29ee133) | `fluxcd: add superherointj as maintainer`                                   |
| [`4263a211`](https://github.com/NixOS/nixpkgs/commit/4263a2116396f8c773963078f61c57ecaeb84677) | `fluxcd: fix update script unbound variable`                                |
| [`ff4c5643`](https://github.com/NixOS/nixpkgs/commit/ff4c5643e6613ccf4e2a4c6aa854522e00dbc67b) | `pdepend: init at 2.10.3`                                                   |
| [`81b77fd3`](https://github.com/NixOS/nixpkgs/commit/81b77fd3847a2eb23618b7cbaa23049ba6139fa2) | `php74Extensions.openswoole: init at 4.11.1`                                |
| [`f27f57a1`](https://github.com/NixOS/nixpkgs/commit/f27f57a12057bee13086ca1b1ad579eb24c214bf) | `scala-cli: 0.1.4 -> 0.1.5`                                                 |
| [`c52b904e`](https://github.com/NixOS/nixpkgs/commit/c52b904e6664c7e9fd966ee456da2721fa667670) | `haskellPackages.streamly: fix darwin override`                             |
| [`ab093932`](https://github.com/NixOS/nixpkgs/commit/ab09393283f120a01b0fb52202a61cd2e742af90) | `modem-manager-gui: fix build with meson >= 0.61`                           |
| [`65d0a8d7`](https://github.com/NixOS/nixpkgs/commit/65d0a8d7a19a3fe1347df128e483435cf5ad3f98) | `python310Packages.pymyq: 3.1.4 -> 3.1.5`                                   |
| [`3ea13a6f`](https://github.com/NixOS/nixpkgs/commit/3ea13a6f55531faf8b0fb8a429c674dc277809fa) | `hare: run test suite`                                                      |
| [`141e57f5`](https://github.com/NixOS/nixpkgs/commit/141e57f59862929b77324ee2051c3330c150c8b8) | `python310Packages.sqlalchemy-mixins: 1.5.1 -> 1.5.3`                       |
| [`1d2a0b80`](https://github.com/NixOS/nixpkgs/commit/1d2a0b801a8c5aad8d7d302df661a16142eddc7d) | `nixos/tests/matrix-appservice-irc: disable registration verification`      |
| [`2c3b8035`](https://github.com/NixOS/nixpkgs/commit/2c3b80358b89467427e090484c5f7c363bcf97d8) | `python310Packages.slack-sdk: 3.15.2 -> 3.16.0`                             |
| [`19687b6c`](https://github.com/NixOS/nixpkgs/commit/19687b6c9c7acd06c0d9e6d2872f371cdae99731) | `matrix-appservice-irc: 0.33.1 -> 0.34.0`                                   |
| [`2bca68d1`](https://github.com/NixOS/nixpkgs/commit/2bca68d1be6ad681d4becdb11ac06c7b9d038cdf) | `python39Packages.wandb: 0.12.15 -> 0.12.16`                                |
| [`404e8283`](https://github.com/NixOS/nixpkgs/commit/404e8283e9dcd874cd4192aa298262c56e6d76c6) | `mastodon: 3.5.1 -> 3.5.2`                                                  |
| [`562fdfd0`](https://github.com/NixOS/nixpkgs/commit/562fdfd04ea1565bb079a3aa29abef4be9df6018) | `kdash: 0.2.4 -> 0.3.1`                                                     |
| [`c3a7edf7`](https://github.com/NixOS/nixpkgs/commit/c3a7edf7d23fe20f8ba9a4e0c4b6fe6678f8e0ea) | `purescript: drop ncurses dep`                                              |
| [`7d5e8244`](https://github.com/NixOS/nixpkgs/commit/7d5e82443b3b48415d916dff97fc8ec1c25caee4) | `just: 1.1.2 -> 1.1.3`                                                      |
| [`29037ae6`](https://github.com/NixOS/nixpkgs/commit/29037ae61657e2552c12b54551ffdace720d8920) | `ungoogled-chromium: 101.0.4951.41 -> 101.0.4951.54`                        |
| [`65be503d`](https://github.com/NixOS/nixpkgs/commit/65be503d82bb448a990d11144b7e07702ba5119d) | `xplr: 0.17.3 -> 0.17.6`                                                    |
| [`7e2559da`](https://github.com/NixOS/nixpkgs/commit/7e2559da3618d78f896317ede0e8f2d7142c9db9) | `python310Packages.superqt: 0.3.1 -> 0.3.2`                                 |
| [`af911e84`](https://github.com/NixOS/nixpkgs/commit/af911e8452bd05d40674bf603332f37480ceb03d) | `doctest: 2.4.7 -> 2.4.8 (#164599)`                                         |
| [`c62eceb9`](https://github.com/NixOS/nixpkgs/commit/c62eceb91e5b463974fca2bcedf033ae1f6c52db) | `openssl_3_0: 3.0.2 -> 3.0.3`                                               |
| [`ad38a2a6`](https://github.com/NixOS/nixpkgs/commit/ad38a2a6464394697f0672717f39c1b6188c1a89) | `nixos/ssh: remove empty host key files before generating new ones`         |
| [`cc67617d`](https://github.com/NixOS/nixpkgs/commit/cc67617dd59d6ada1e7ee71adc145a3fdaafa78d) | `udiskie: 2.4.0 -> 2.4.2`                                                   |
| [`79265fba`](https://github.com/NixOS/nixpkgs/commit/79265fba343e801dd5328ae2ca2074669517328a) | `nixos/tests/openssh: add timeouts to all ssh invocations`                  |
| [`9d984937`](https://github.com/NixOS/nixpkgs/commit/9d9849374f60dea33a9005b0adc96ec3595bb64c) | `python310Packages.xknx: 0.21.1 -> 0.21.2`                                  |
| [`ecf564b2`](https://github.com/NixOS/nixpkgs/commit/ecf564b266bc268bb868e66916fc55d3a18ed2b2) | `cargo-sync-readme: 1.0 -> 1.1`                                             |
| [`c0bb20e0`](https://github.com/NixOS/nixpkgs/commit/c0bb20e08e426f585b45cafc51b0ba73109a8434) | `nodejs-18_x: fix completion generation`                                    |
| [`7b1a7987`](https://github.com/NixOS/nixpkgs/commit/7b1a798741ceb02aa572a73896bab88c6ea981b1) | `platformsh: 3.79.1 -> 3.79.2`                                              |
| [`70f212bb`](https://github.com/NixOS/nixpkgs/commit/70f212bb5bd19642a5d419c33dd1d4e00eb3962a) | `nodejs-14_x: 14.19.1 -> 14.19.2`                                           |
| [`1c8e735d`](https://github.com/NixOS/nixpkgs/commit/1c8e735d76120fd2e6a42fb53e4268890c395f3b) | `python310Packages.stripe: 2.74.0 -> 2.75.0`                                |
| [`8e756d0c`](https://github.com/NixOS/nixpkgs/commit/8e756d0ce7bfae2457ceaca8d3e11c371a0f7ff6) | `python310Packages.mypy-boto3-s3: 1.22.0.post1 -> 1.22.6`                   |
| [`51835cfa`](https://github.com/NixOS/nixpkgs/commit/51835cfa3cc80a3cbdbb8442900044daad0840c0) | `clojure-lsp: 2022.04.18-00.59.32 -> 2022.05.03-12.35.40`                   |
| [`a656052b`](https://github.com/NixOS/nixpkgs/commit/a656052b5d7a02bd49be50aef559d8a4e23f8852) | `Vulkan: Refactor (pkgconfig -> pkg-config)`                                |
| [`f908b3e3`](https://github.com/NixOS/nixpkgs/commit/f908b3e348ecfd7651f455d3afa7ba49b027a6ab) | `pantheon.switchboard: 6.0.0 -> 6.0.1`                                      |
| [`b04e8524`](https://github.com/NixOS/nixpkgs/commit/b04e85247425c5a4a24a43a9f7f51be4f797ae4c) | `librewolf: 99.0.1-4 -> 100.0-1`                                            |
| [`596c5e7e`](https://github.com/NixOS/nixpkgs/commit/596c5e7ea26ba8c0bcd6d2f09ca7cb8202c20e70) | `Static bwa`                                                                |
| [`47588733`](https://github.com/NixOS/nixpkgs/commit/47588733783c4133de4973caa466d52d9c04992a) | `Static build for samtools`                                                 |
| [`967a5d78`](https://github.com/NixOS/nixpkgs/commit/967a5d78962b88f4e91fe5e3e4497912556ea60b) | `Static builds for HTSLIB`                                                  |
| [`0b1c28d5`](https://github.com/NixOS/nixpkgs/commit/0b1c28d5a1c46a7a10aa518863b1bd532824495e) | `Static build for megahit`                                                  |
| [`338ed797`](https://github.com/NixOS/nixpkgs/commit/338ed797fe4a2caa02f7bb4568627ac1f71e0f84) | `gfortran: fix wrapper host/target offset for cross`                        |
| [`3382215f`](https://github.com/NixOS/nixpkgs/commit/3382215fd732192dddf071ab0dc15e5cb9ff83cd) | `firefox-devedition-bin-unwrapped: 100.0b7 -> 101.0b2`                      |
| [`c15cf25d`](https://github.com/NixOS/nixpkgs/commit/c15cf25d3d8af5db8bd090d41a639bc912c39543) | `roon-server: 1.8-933 -> 1.8-935`                                           |
| [`23fbc081`](https://github.com/NixOS/nixpkgs/commit/23fbc0816c62f4a95f28e0cd9520f2bcff4d452a) | `hqplayerd: 4.30.3-87 -> 4.31.0-89`                                         |
| [`342e99a5`](https://github.com/NixOS/nixpkgs/commit/342e99a587bbcb0db2c69ae47dfb4e810d57a950) | `seafile-client: build v8.0.7 from proper commit`                           |
| [`352750b3`](https://github.com/NixOS/nixpkgs/commit/352750b3af534ae614cd4659b2eed711d3136751) | `python39Packages.sentry-sdk: 1.5.10 -> 1.5.11`                             |
| [`4df2c1fe`](https://github.com/NixOS/nixpkgs/commit/4df2c1fe35da1207b9c8c199339e01901d60bf59) | `jwt-cli: 5.0.2 -> 5.0.3`                                                   |
| [`3e93ff80`](https://github.com/NixOS/nixpkgs/commit/3e93ff80f8837aaadc5a3a7c0111e2fc6f39ffec) | `checkov: 2.0.1102 -> 2.0.1110`                                             |
| [`561d29b6`](https://github.com/NixOS/nixpkgs/commit/561d29b64d8b61d4368277c93aced88504f70773) | `cryptomator: 1.6.8 -> 1.6.10`                                              |
| [`37fec07a`](https://github.com/NixOS/nixpkgs/commit/37fec07a96a35b4e996468ac9f14794929555b5f) | `python310Packages.aiooncue: 0.3.3 -> 0.3.4`                                |
| [`ac2858f9`](https://github.com/NixOS/nixpkgs/commit/ac2858f9f59a41edd516d57d85c1a9365f8f22a3) | `python310Packages.pynetgear: 0.9.4 -> 0.10.0`                              |
| [`3e8e52bb`](https://github.com/NixOS/nixpkgs/commit/3e8e52bb91d0da2a06c24ae70975f8ba309eb214) | `nixos/vmware-host: init at 16.2.3`                                         |
| [`e1da7f4d`](https://github.com/NixOS/nixpkgs/commit/e1da7f4d4483643dcb32bfbc63af281123825056) | `vmware-workstation: init at 16.2.3`                                        |
| [`59e6af3d`](https://github.com/NixOS/nixpkgs/commit/59e6af3dc14f9dcc80eee84ff945db2734d2c547) | `linuxPackages.vmware: init at 16.2.3`                                      |
| [`6a415cd3`](https://github.com/NixOS/nixpkgs/commit/6a415cd37c166059c817dd32632716d4af11985c) | `containerd: 1.6.3 -> 1.6.4`                                                |
| [`c094f76b`](https://github.com/NixOS/nixpkgs/commit/c094f76bf94471857c43dd7406b4c807515a434d) | `python310Packages.luxtronik: 0.3.12 -> 0.3.13`                             |
| [`5912e391`](https://github.com/NixOS/nixpkgs/commit/5912e391b5af902d687c0c29f991553ced8fa229) | `chickenEggs.tcp6: init at 0.2.1`                                           |
| [`5c9f8061`](https://github.com/NixOS/nixpkgs/commit/5c9f806102ab6846db36a553e1d8d9798da3a3df) | `chickenEggs.socket: init at 0.3.3`                                         |
| [`298a451e`](https://github.com/NixOS/nixpkgs/commit/298a451eb65c006c550589861b62bbed82f28286) | `chickenEggs.foreigners: init at 1.5`                                       |
| [`e31de323`](https://github.com/NixOS/nixpkgs/commit/e31de323966763d0baf976aaf019589f10bfb82d) | `chickenEggs.feature-test: init at 0.2.0`                                   |
| [`b756fabd`](https://github.com/NixOS/nixpkgs/commit/b756fabd1a12e7454e40a151bbddcb83b888d42f) | `chickenEggs.address-info: init at 1.0.5`                                   |
| [`876def94`](https://github.com/NixOS/nixpkgs/commit/876def9433d8ee01d0675f71bb5c38623b25a37a) | `chickenEggs.sha2: init at 4.0.5`                                           |
| [`e9fa73c9`](https://github.com/NixOS/nixpkgs/commit/e9fa73c93d1fd27166af5311cdb6ca1d4a9266a2) | `chickenEggs.message-digest-primitive: init at 4.3.2`                       |
| [`e7bd776d`](https://github.com/NixOS/nixpkgs/commit/e7bd776d5b315a5d21c41851596dbd8d2c5945ab) | `chickenEggs.json: init at 1.6`                                             |
| [`01ab95c8`](https://github.com/NixOS/nixpkgs/commit/01ab95c8861a9279346e6b553b9a9fbe9790b3b3) | `chickenEggs.packrat: init at 1.5`                                          |
| [`09f4886b`](https://github.com/NixOS/nixpkgs/commit/09f4886b37cf356b6f6427571b1cf92080d31304) | `chickenEggs.utf8: init at 3.6.2`                                           |
| [`95d24cad`](https://github.com/NixOS/nixpkgs/commit/95d24cad2ad8c986f7822098848da166c01f7544) | `chickenEggs.uri-generic: init at 3.2`                                      |
| [`7e65e01f`](https://github.com/NixOS/nixpkgs/commit/7e65e01f838ad0344eb8e06f54b84cdb45de420f) | `chickenEggs.uri-common: init at 2.0`                                       |
| [`534f88d3`](https://github.com/NixOS/nixpkgs/commit/534f88d368dd745ba71c378dfc56009f87d1ffd9) | `chickenEggs.symbol-utils: init at 2.1.0`                                   |
| [`42cd5123`](https://github.com/NixOS/nixpkgs/commit/42cd512356cdcb75fb09be073ce9579e0fb8862b) | `chickenEggs.string-utils: init at 2.4.0`                                   |
| [`e91febd4`](https://github.com/NixOS/nixpkgs/commit/e91febd45456e762843f46638bc3959f85b9fdb0) | `chickenEggs.srfi-69: init at 0.4.1`                                        |
| [`236e58ec`](https://github.com/NixOS/nixpkgs/commit/236e58ec33668296406cc78b36295d6298a40a04) | `chickenEggs.srfi-18: init at 0.1.6`                                        |
| [`d74cdc67`](https://github.com/NixOS/nixpkgs/commit/d74cdc673462e539f5ca5a5b7538322934749763) | `chickenEggs.spiffy: init at 6.3`                                           |
| [`477e0610`](https://github.com/NixOS/nixpkgs/commit/477e06109e6276da7e3f2a8b27d6d02caebbcc5b) | `chickenEggs.sendfile: init at 1.8.3`                                       |
| [`8d3b68f5`](https://github.com/NixOS/nixpkgs/commit/8d3b68f5183b17445b0de1f59064e0ab6008eb8a) | `chickenEggs.regex: init at 2.0`                                            |
| [`8c7f1233`](https://github.com/NixOS/nixpkgs/commit/8c7f1233e617e49d795cf0a08c08bb2355e7822c) | `chickenEggs.miscmacros: init at 1.0`                                       |
| [`bb9bf815`](https://github.com/NixOS/nixpkgs/commit/bb9bf815fea322e55d610da704ab2997b5a87659) | `chickenEggs.memory-mapped-files: init at 0.4`                              |
| [`588e7507`](https://github.com/NixOS/nixpkgs/commit/588e750718594a97543cf6f41724c18a9b45bc7c) | `chickenEggs.set: init at 2.2`                                              |
| [`38f7ead8`](https://github.com/NixOS/nixpkgs/commit/38f7ead82d8d0059c99cb0f105dcdf6f7ca36297) | `chickenEggs.intarweb: init at 2.0.1`                                       |
| [`4c7e5a08`](https://github.com/NixOS/nixpkgs/commit/4c7e5a0812aece2351d162b6bbea2cd180e29ff9) | `chickenEggs.defstruct: init at 2.0`                                        |
| [`bdfbb00e`](https://github.com/NixOS/nixpkgs/commit/bdfbb00e0c530588704ae3eb6d5fd83a1dcd7e06) | `chickenEggs.check-errors: init at 3.2.0`                                   |
| [`6ebe5ef3`](https://github.com/NixOS/nixpkgs/commit/6ebe5ef3200e9cae7d26b2519cc995eb87084ef4) | `chickenEggs.base64: init at 1.0`                                           |
| [`91d2292a`](https://github.com/NixOS/nixpkgs/commit/91d2292a53fc07bbb744c42f4ae5ecce262b40e5) | `chickenEggs.apropos: init at 3.6.0`                                        |
| [`4fc3c441`](https://github.com/NixOS/nixpkgs/commit/4fc3c441e976e92383b90d4398556496b8f3bdf5) | `python310Packages.exceptiongroup: 1.0.0rc2 -> 1.0.0rc5`                    |
| [`006c38fa`](https://github.com/NixOS/nixpkgs/commit/006c38fa5353e0a157d1af59ca4b345f42a7ae16) | `platforms.nix: use {} on failed detection instead of silently assuming pc` |
| [`9600919e`](https://github.com/NixOS/nixpkgs/commit/9600919e140428252d812d03f53170ccc710b3ea) | `urlwatch: 2.24 -> 2.25`                                                    |
| [`0ad18569`](https://github.com/NixOS/nixpkgs/commit/0ad185694c0b70d1f779c7ac357a8af86a46a6d6) | `opencpn: unstable-2019-11-21 -> 5.6.2`                                     |
| [`4def222e`](https://github.com/NixOS/nixpkgs/commit/4def222ea40aef58ee83fb00bd412b78ee807205) | `stdenv/check-meta: add a "maintainerless" warning`                         |
| [`3a34b6c8`](https://github.com/NixOS/nixpkgs/commit/3a34b6c820b1cd62ed1b1747b6cad6275e81321d) | `stdenv/check-meta: add an eval warning option`                             |
| [`be8f036f`](https://github.com/NixOS/nixpkgs/commit/be8f036f64e9845e31c796932c2b78a9d3df4bcd) | `gopass: 1.14.0 → 1.14.1`                                                   |
| [`5e420c24`](https://github.com/NixOS/nixpkgs/commit/5e420c24556053e2a5ad3ca69993afb42fffbc54) | `stdenv/check-meta: turn validity.valid into a str`                         |
| [`11e5f517`](https://github.com/NixOS/nixpkgs/commit/11e5f517f97739a2280c32e674c1ccbadd97d746) | `python3Packages.pyrogram: 2.0.14 -> 2.0.16`                                |
| [`c5a273b3`](https://github.com/NixOS/nixpkgs/commit/c5a273b38ee97ae257a0d08ac854e6f5027f2ee7) | `kiln: 0.2.1 → 0.3.0`                                                       |
| [`f1531b1b`](https://github.com/NixOS/nixpkgs/commit/f1531b1b825101dc68395de89846e64a2bb182fe) | `unifi: 7.0.25 -> 7.1.61`                                                   |
| [`aefb74d2`](https://github.com/NixOS/nixpkgs/commit/aefb74d24caf3a9a0bb88d782480bf0cf2e4ae7a) | `python310Packages.aioslimproto: 1.0.1 -> 2.0.0`                            |