### PR TITLE
chore(flake/home-manager): `267462df` -> `538343be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -196,11 +196,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1651652192,
-        "narHash": "sha256-3FUsIJ81p57rOxODRVZ+anhnVav96VWbgNA1H3Np+TY=",
+        "lastModified": 1651800560,
+        "narHash": "sha256-LUfR0/Fv8DA0uu8Uex2S1QcLiE4B5ylplbXmMs6/YoM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "267462dfb36d447421c789a3adf9d460cd09c147",
+        "rev": "538343be863cb0b9e9f1471e6dc09e0e140c7b3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`538343be`](https://github.com/nix-community/home-manager/commit/538343be863cb0b9e9f1471e6dc09e0e140c7b3d) | `Make sway onChange script use cfg.package if set (#2937)`      |
| [`4036f1a7`](https://github.com/nix-community/home-manager/commit/4036f1a751885718b324f3792819e119f98e56f2) | `home-cursor: fix x11 cursor path using invalid option (#2940)` |