### PR TITLE
chore(flake/nur): `872b0d61` -> `19e64a29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1651794827,
-        "narHash": "sha256-dP9TrANJ+Hiqq67yKfcKvmlEEh+DxL3wmToFa0QNVcY=",
+        "lastModified": 1651801032,
+        "narHash": "sha256-HpW1c9yYaU/rMoLMj6Dk7ToVMfRrlay8xSGJrh6YOg8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "872b0d61837a49d34b02a3ff6bfb2ad01d350760",
+        "rev": "19e64a29516e1139f4a1fb39d99381d79fb9b1ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`19e64a29`](https://github.com/nix-community/NUR/commit/19e64a29516e1139f4a1fb39d99381d79fb9b1ea) | `automatic update` |
| [`8d790b4f`](https://github.com/nix-community/NUR/commit/8d790b4fe77e6eb45506cc4fffa21f4004e02991) | `automatic update` |