### PR TITLE
chore(flake/nur): `19e64a29` -> `5d3b9410`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1651801032,
-        "narHash": "sha256-HpW1c9yYaU/rMoLMj6Dk7ToVMfRrlay8xSGJrh6YOg8=",
+        "lastModified": 1651808911,
+        "narHash": "sha256-c47IJBrx3Zelh/TS8wwLk5TLvmh6A/4Y9mOLBq8+mi0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "19e64a29516e1139f4a1fb39d99381d79fb9b1ea",
+        "rev": "5d3b9410f820071815b6543843ff9a732e8cb9a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5d3b9410`](https://github.com/nix-community/NUR/commit/5d3b9410f820071815b6543843ff9a732e8cb9a5) | `automatic update` |