### PR TITLE
chore(flake/emacs-overlay): `ad374036` -> `86409cf2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -144,11 +144,11 @@
     },
     "emacs-overlay": {
       "locked": {
-        "lastModified": 1651778691,
-        "narHash": "sha256-d9TsHhy7eQ/bZUyiY2rVm3OXqlCq7+hJtdkdpFTTa40=",
+        "lastModified": 1651809404,
+        "narHash": "sha256-SWw8aXa//8/DmXSnnULvZGdJKkTuqs+mqFY4cMBUht0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ad37403611e633cbe174bb1d40fc4a1b7343c941",
+        "rev": "86409cf2583798c085f851ae27face6d2067dbb3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`86409cf2`](https://github.com/nix-community/emacs-overlay/commit/86409cf2583798c085f851ae27face6d2067dbb3) | `Updated repos/melpa` |
| [`313455c6`](https://github.com/nix-community/emacs-overlay/commit/313455c65b6fab65c228da7c4c03d52092fc298e) | `Updated repos/emacs` |
| [`499d6dd4`](https://github.com/nix-community/emacs-overlay/commit/499d6dd4a9f641a90e83486a419961c9e82237ec) | `Updated repos/elpa`  |