### PR TITLE
chore(flake/nur): `5d3b9410` -> `20450bc7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1651808911,
-        "narHash": "sha256-c47IJBrx3Zelh/TS8wwLk5TLvmh6A/4Y9mOLBq8+mi0=",
+        "lastModified": 1651810001,
+        "narHash": "sha256-QoEyiBq4FTi/5UrXz0sabdfOm9iaeFHU8VO/h8pmgqI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5d3b9410f820071815b6543843ff9a732e8cb9a5",
+        "rev": "20450bc75290dff88b9bd3e350d22457ed618abd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`20450bc7`](https://github.com/nix-community/NUR/commit/20450bc75290dff88b9bd3e350d22457ed618abd) | `automatic update` |