### PR TITLE
chore(flake/nur): `20450bc7` -> `94d8a188`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1651810001,
-        "narHash": "sha256-QoEyiBq4FTi/5UrXz0sabdfOm9iaeFHU8VO/h8pmgqI=",
+        "lastModified": 1651814769,
+        "narHash": "sha256-M2nSOG20VML30u8Mh+7nSrz2rdjZicDTZBx5LbojjMU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "20450bc75290dff88b9bd3e350d22457ed618abd",
+        "rev": "94d8a18882f683de3ae1fe9f4209cae06baa9f69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`94d8a188`](https://github.com/nix-community/NUR/commit/94d8a18882f683de3ae1fe9f4209cae06baa9f69) | `automatic update` |