### PR TITLE
chore(flake/nur): `94d8a188` -> `125a1e0a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1651814769,
-        "narHash": "sha256-M2nSOG20VML30u8Mh+7nSrz2rdjZicDTZBx5LbojjMU=",
+        "lastModified": 1651835449,
+        "narHash": "sha256-e56o1TC+i1vulgho1quFNl8p2toC7DTiNNm9xTP9UD4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "94d8a18882f683de3ae1fe9f4209cae06baa9f69",
+        "rev": "125a1e0a38b47b233acbabe5d5f4b91f01b1a8bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                    |
| -------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`125a1e0a`](https://github.com/nix-community/NUR/commit/125a1e0a38b47b233acbabe5d5f4b91f01b1a8bd) | `automatic update`                |
| [`3adb64d1`](https://github.com/nix-community/NUR/commit/3adb64d155aab80bbe299cebc8a1c98461fc09c2) | `update wolfangaukang repository` |