### PR TITLE
chore(flake/emacs-overlay): `86409cf2` -> `8ac752d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -144,11 +144,11 @@
     },
     "emacs-overlay": {
       "locked": {
-        "lastModified": 1651809404,
-        "narHash": "sha256-SWw8aXa//8/DmXSnnULvZGdJKkTuqs+mqFY4cMBUht0=",
+        "lastModified": 1651839099,
+        "narHash": "sha256-Dpgc0zOlfNAqtuugaif+gbPIdMINoYnat3+V+uIjod0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "86409cf2583798c085f851ae27face6d2067dbb3",
+        "rev": "8ac752d1ff06aa4a0be94ca896fd80f6cacd40d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`8ac752d1`](https://github.com/nix-community/emacs-overlay/commit/8ac752d1ff06aa4a0be94ca896fd80f6cacd40d1) | `Updated repos/melpa` |
| [`496433d3`](https://github.com/nix-community/emacs-overlay/commit/496433d3a2ab1ae9e7f7d0edbfde96692d1c7efd) | `Updated repos/emacs` |