### PR TITLE
chore(flake/nur): `125a1e0a` -> `630711c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1651835449,
-        "narHash": "sha256-e56o1TC+i1vulgho1quFNl8p2toC7DTiNNm9xTP9UD4=",
+        "lastModified": 1651840291,
+        "narHash": "sha256-DuVjBtiTlZEmpOclnfyGuS8u7U8+VCoO089VSKuq+s8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "125a1e0a38b47b233acbabe5d5f4b91f01b1a8bd",
+        "rev": "630711c22f9d282bfe04afe014afefe4fd26459c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`630711c2`](https://github.com/nix-community/NUR/commit/630711c22f9d282bfe04afe014afefe4fd26459c) | `automatic update` |