### PR TITLE
chore(flake/nur): `277feebc` -> `cc405015`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1651861511,
-        "narHash": "sha256-k6jUZ4YV9B5amS4LWPGQL15YPQjNj5LieBdL1plH34c=",
+        "lastModified": 1651879891,
+        "narHash": "sha256-EcMqOGY5gfwVa4PUX09VLIJ0FS5bVnyy395VyMGdEXE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "277feebc570634a71d706f325d94220b21de9017",
+        "rev": "cc405015943aa5846e48695afb7a3acf13f8baf5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`cc405015`](https://github.com/nix-community/NUR/commit/cc405015943aa5846e48695afb7a3acf13f8baf5) | `automatic update` |