### PR TITLE
chore(flake/nur): `cc405015` -> `50e7f21f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1651879891,
-        "narHash": "sha256-EcMqOGY5gfwVa4PUX09VLIJ0FS5bVnyy395VyMGdEXE=",
+        "lastModified": 1651881114,
+        "narHash": "sha256-QnprrDUF8jTHgx2V1maMi1Of8N24aMF85bV+pokb8LI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cc405015943aa5846e48695afb7a3acf13f8baf5",
+        "rev": "50e7f21f0313579955af583d040deb1b1a9877cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`50e7f21f`](https://github.com/nix-community/NUR/commit/50e7f21f0313579955af583d040deb1b1a9877cf) | `automatic update` |