### PR TITLE
chore(flake/emacs-ement): `58c30e85` -> `37f16ec1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1651790900,
-        "narHash": "sha256-qsLGy5mSNF9CjyAYrrPw+kIxfTEARmwR57J+XbJcka4=",
+        "lastModified": 1651883191,
+        "narHash": "sha256-V5twU41TRsyai8lEhfhekVuHQjvImRw4YUVCIEZaaBg=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "58c30e850844c2e1365e1e0e36f73d08c3a16750",
+        "rev": "37f16ec1deec4cdc41ecb085912b3b674b94ead3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                 |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`37f16ec1`](https://github.com/alphapapa/ement.el/commit/37f16ec1deec4cdc41ecb085912b3b674b94ead3) | `Fix: Calls to ement-room-send-message-filter` |