### PR TITLE
chore(flake/emacs-ement): `37f16ec1` -> `e0247f0d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1651883191,
-        "narHash": "sha256-V5twU41TRsyai8lEhfhekVuHQjvImRw4YUVCIEZaaBg=",
+        "lastModified": 1651887987,
+        "narHash": "sha256-oRaF09zR0S8Sy7iuBkbtYRjZ/dugPSEYm7NhF7HS4oQ=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "37f16ec1deec4cdc41ecb085912b3b674b94ead3",
+        "rev": "e0247f0d925c5f82964fe210fc99fbaf68fd2d57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                |
| --------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`e0247f0d`](https://github.com/alphapapa/ement.el/commit/e0247f0d925c5f82964fe210fc99fbaf68fd2d57) | `Add: (ement-room-transient)` |