### PR TITLE
chore(flake/emacs-overlay): `97727816` -> `e007354f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -144,11 +144,11 @@
     },
     "emacs-overlay": {
       "locked": {
-        "lastModified": 1651864305,
-        "narHash": "sha256-NP5lt1ZJqdQMXBT2yp9jRU9/rD8e+COBmOMtsPTbrxE=",
+        "lastModified": 1651898579,
+        "narHash": "sha256-n77/YojHD+t+6Fq1sEA6OQtzm8rUBX+g6NfCxZVKmxo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "97727816f744ecc1eb327c28169fae29ac847124",
+        "rev": "e007354fcc0f492878d85b85334ab3baa08a273b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`e007354f`](https://github.com/nix-community/emacs-overlay/commit/e007354fcc0f492878d85b85334ab3baa08a273b) | `Updated repos/melpa` |
| [`bec12ee2`](https://github.com/nix-community/emacs-overlay/commit/bec12ee24503fda518f6964bed9f71cdcc2c85a9) | `Updated repos/emacs` |
| [`9bf0039f`](https://github.com/nix-community/emacs-overlay/commit/9bf0039f2976fbc9d4f562c034a388d8b14e64f9) | `Updated repos/elpa`  |