### PR TITLE
chore(flake/emacs-overlay): `e007354f` -> `ebb4f132`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -144,11 +144,11 @@
     },
     "emacs-overlay": {
       "locked": {
-        "lastModified": 1651898579,
-        "narHash": "sha256-n77/YojHD+t+6Fq1sEA6OQtzm8rUBX+g6NfCxZVKmxo=",
+        "lastModified": 1651921687,
+        "narHash": "sha256-NAsOvhxbgC/h1WoLI5W85I/pvzbCo0Cmng987Z2BsrU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e007354fcc0f492878d85b85334ab3baa08a273b",
+        "rev": "ebb4f13297cc67f59ed72faa1402fcd449fa8dce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`ebb4f132`](https://github.com/nix-community/emacs-overlay/commit/ebb4f13297cc67f59ed72faa1402fcd449fa8dce) | `Updated repos/nongnu` |
| [`6903c7ef`](https://github.com/nix-community/emacs-overlay/commit/6903c7efd59e14ae3f51a4538efc6ad9fe982355) | `Updated repos/melpa`  |
| [`a8d8a64f`](https://github.com/nix-community/emacs-overlay/commit/a8d8a64f1bc367b2366437da55220507a055df8f) | `Updated repos/emacs`  |