### PR TITLE
chore(flake/emacs-overlay): `ebb4f132` -> `551cd0a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -144,11 +144,11 @@
     },
     "emacs-overlay": {
       "locked": {
-        "lastModified": 1651921687,
-        "narHash": "sha256-NAsOvhxbgC/h1WoLI5W85I/pvzbCo0Cmng987Z2BsrU=",
+        "lastModified": 1651951124,
+        "narHash": "sha256-E/HkG7rw+LMCGiappHhibfk1qLR9gCYSRJwnbT++OeE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ebb4f13297cc67f59ed72faa1402fcd449fa8dce",
+        "rev": "551cd0a46e55d7bd0d87e6c34cc8833c5b38a468",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`551cd0a4`](https://github.com/nix-community/emacs-overlay/commit/551cd0a46e55d7bd0d87e6c34cc8833c5b38a468) | `Updated repos/melpa` |
| [`612c3ed6`](https://github.com/nix-community/emacs-overlay/commit/612c3ed67bfe5cebb1c591d4af10e74f6c976bdc) | `Updated repos/emacs` |
| [`1e70e6df`](https://github.com/nix-community/emacs-overlay/commit/1e70e6dfe07e55ba08c330d320ca8f8582b1faa1) | `Updated repos/elpa`  |