### PR TITLE
chore(flake/nur): `3fa1e149` -> `05f76d53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1651953898,
-        "narHash": "sha256-zczI2lYT2tC+Js5v0CWG5kX4RTWH0vMIS888ARA/fI4=",
+        "lastModified": 1651967581,
+        "narHash": "sha256-MyoKcVkZUD/ozogDNA4N6K6wGOA0Ei+OLT9+llNTyf8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3fa1e149e599698f8f6c9d3ea57ffa83cd5b5a25",
+        "rev": "05f76d53cdfe651b664af4a3ccecc102a184c6b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`05f76d53`](https://github.com/nix-community/NUR/commit/05f76d53cdfe651b664af4a3ccecc102a184c6b9) | `automatic update` |