### PR TITLE
chore(flake/nur): `05f76d53` -> `9ac6be88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1651967581,
-        "narHash": "sha256-MyoKcVkZUD/ozogDNA4N6K6wGOA0Ei+OLT9+llNTyf8=",
+        "lastModified": 1651978787,
+        "narHash": "sha256-NDoM0VivWmUcCZU2UL80MEZ2I9dj7h0DrxZa316Edq4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "05f76d53cdfe651b664af4a3ccecc102a184c6b9",
+        "rev": "9ac6be88c1f75b86545fd96feba56f7d880fe293",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9ac6be88`](https://github.com/nix-community/NUR/commit/9ac6be88c1f75b86545fd96feba56f7d880fe293) | `automatic update` |