### PR TITLE
chore(flake/emacs-overlay): `551cd0a4` -> `d863097f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -144,11 +144,11 @@
     },
     "emacs-overlay": {
       "locked": {
-        "lastModified": 1651951124,
-        "narHash": "sha256-E/HkG7rw+LMCGiappHhibfk1qLR9gCYSRJwnbT++OeE=",
+        "lastModified": 1651983125,
+        "narHash": "sha256-sOgYyjsI8cLf5/3MrsRRyqCnln1DlAIP+pgbibnT8fM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "551cd0a46e55d7bd0d87e6c34cc8833c5b38a468",
+        "rev": "d863097fb813a4fdf856df265714614aebf28aa6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`d863097f`](https://github.com/nix-community/emacs-overlay/commit/d863097fb813a4fdf856df265714614aebf28aa6) | `Updated repos/melpa` |
| [`6f41b4aa`](https://github.com/nix-community/emacs-overlay/commit/6f41b4aaf37f166615f4edba872a66c341cfc01f) | `Updated repos/emacs` |
| [`3c01cc16`](https://github.com/nix-community/emacs-overlay/commit/3c01cc1667238149f9ff2aa241808f0ca5acfdaa) | `Updated repos/elpa`  |