### PR TITLE
chore(flake/nur): `9ac6be88` -> `7f5ab4b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1651978787,
-        "narHash": "sha256-NDoM0VivWmUcCZU2UL80MEZ2I9dj7h0DrxZa316Edq4=",
+        "lastModified": 1651995977,
+        "narHash": "sha256-PfY6qYWalj9H/u5na35VZ7m7nTCrj/A9bHfk5UyEOXg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ac6be88c1f75b86545fd96feba56f7d880fe293",
+        "rev": "7f5ab4b512f9ebe775b859bf6f2874fb510a0bb1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7f5ab4b5`](https://github.com/nix-community/NUR/commit/7f5ab4b512f9ebe775b859bf6f2874fb510a0bb1) | `automatic update` |
| [`b9cf0c49`](https://github.com/nix-community/NUR/commit/b9cf0c491132934939be2d26ae498affc2ae42c9) | `automatic update` |