### PR TITLE
chore(flake/emacs-ement): `4b94c46c` -> `c7928d39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1651934656,
-        "narHash": "sha256-APyGqPfXHwLJMLxI1VX+0D5N8O2BSIoGgnJ3bweMmIM=",
+        "lastModified": 1652018967,
+        "narHash": "sha256-x4vbfsGdcTfBN3m/rPs1I7oWlOjVo8jd7pQuoJg96ng=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "4b94c46c5ce6b38fa3d17f09d6adcbfc67939cc5",
+        "rev": "c7928d399f56492537eb4ce0077048760008203e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                   |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`c7928d39`](https://github.com/alphapapa/ement.el/commit/c7928d399f56492537eb4ce0077048760008203e) | `Fix: (ement-room--format-body-mentions) Regexp` |