### PR TITLE
chore(flake/emacs-ement): `c7928d39` -> `8d713ce4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1652018967,
-        "narHash": "sha256-x4vbfsGdcTfBN3m/rPs1I7oWlOjVo8jd7pQuoJg96ng=",
+        "lastModified": 1652023919,
+        "narHash": "sha256-o8Ldvo4S6yIpqlkNChfnprFV7OZSfWEafbmW3wAPU24=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "c7928d399f56492537eb4ce0077048760008203e",
+        "rev": "8d713ce4c1261541c18c9315f4aae4e46970e81e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                           |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`8d713ce4`](https://github.com/alphapapa/ement.el/commit/8d713ce4c1261541c18c9315f4aae4e46970e81e) | `Add: Format m.room.power_levels events` |