### PR TITLE
chore(flake/emacs-ement): `1aa05307` -> `d216e049`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1652025446,
-        "narHash": "sha256-nwjL1oRHoJooJtKhufsQsxPGu/S9plk4Trg9Qt+tkDk=",
+        "lastModified": 1652032163,
+        "narHash": "sha256-VUD/4a0UPi3NNQTKTFxyPKIU6MG1GRxlcDqL8TOuURs=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "1aa0530739044531d23bd1eea68e23a81dbfd241",
+        "rev": "d216e049920ccb2839b274b202254842fe762c26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                      |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`d216e049`](https://github.com/alphapapa/ement.el/commit/d216e049920ccb2839b274b202254842fe762c26) | `Tidy: Indentation`                                                 |
| [`63269197`](https://github.com/alphapapa/ement.el/commit/63269197ee4c7e91e60111119a1cbdc974ee4d02) | `Change: (ement-room-transient) Show favourite/low-priority status` |
| [`45045300`](https://github.com/alphapapa/ement.el/commit/45045300426ae938fa724eaa2103a2ae9988bb8c) | `Fix: (ement-room-occur) Timestamp headers`                         |