### PR TITLE
chore(flake/nur): `8bbefa7e` -> `d7375bd2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652034323,
-        "narHash": "sha256-gcdkE+h9Ib/CRV7PKj+GjiRBLskO+Cn61ldH4rD9/sg=",
+        "lastModified": 1652045772,
+        "narHash": "sha256-1DTWgKxlBt93PzZIaMcqPOPxdoJ2VAqaUzg4r/EKYDc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8bbefa7e35a8685ef0a7d759ea7da47d6969b991",
+        "rev": "d7375bd249f210e589cce1a8d68f21745e4fe70e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d7375bd2`](https://github.com/nix-community/NUR/commit/d7375bd249f210e589cce1a8d68f21745e4fe70e) | `automatic update` |