### PR TITLE
chore(flake/nur): `d7375bd2` -> `0944908d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652045772,
-        "narHash": "sha256-1DTWgKxlBt93PzZIaMcqPOPxdoJ2VAqaUzg4r/EKYDc=",
+        "lastModified": 1652054286,
+        "narHash": "sha256-9nRiP/+O53eNFk2mqnxdlH4Nk9tbU5WM4H6XgOANO/c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d7375bd249f210e589cce1a8d68f21745e4fe70e",
+        "rev": "0944908dc00a8401aa317b290f24fca39db6ef0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0944908d`](https://github.com/nix-community/NUR/commit/0944908dc00a8401aa317b290f24fca39db6ef0c) | `automatic update` |
| [`ce522feb`](https://github.com/nix-community/NUR/commit/ce522feb5186a82657cf58bb5f3d3d071e9d57aa) | `automatic update` |