### PR TITLE
chore(flake/nur): `f8e26878` -> `7157a2cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652068187,
-        "narHash": "sha256-UloY8jABiePCVDccLmXIbFTevja3nZ2zfyYKA1cPu00=",
+        "lastModified": 1652069314,
+        "narHash": "sha256-/sUW0h0kBsqXLdBujzNCBclQvDlHXIR9J6WPO0b0vXk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f8e268783e8931a11ba7346ac7e12231daab1a18",
+        "rev": "7157a2cc7d4795f7ed1369265821febfd05da512",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7157a2cc`](https://github.com/nix-community/NUR/commit/7157a2cc7d4795f7ed1369265821febfd05da512) | `automatic update` |