### PR TITLE
chore(flake/emacs-overlay): `7cb7c8c5` -> `ff6f93f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -144,11 +144,11 @@
     },
     "emacs-overlay": {
       "locked": {
-        "lastModified": 1652038791,
-        "narHash": "sha256-dTQdPbsq+WCEo9B72+MLT+rqtVjD+ryfc6DJbR/iMHQ=",
+        "lastModified": 1652072170,
+        "narHash": "sha256-7aWTXT+tM6yNYwq6HYzNmnFvkosygMMFy0QPiLgBt6M=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7cb7c8c550ae9e746cbc65bfea7bd005409bf0a4",
+        "rev": "ff6f93f4d156d7e9b48bb9cc986d119775e7df1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ff6f93f4`](https://github.com/nix-community/emacs-overlay/commit/ff6f93f4d156d7e9b48bb9cc986d119775e7df1f) | `Updated repos/melpa` |
| [`2d0a7cd2`](https://github.com/nix-community/emacs-overlay/commit/2d0a7cd2e3d103d56537602f9b0c0157f2d411f7) | `Updated repos/emacs` |