### PR TITLE
chore(flake/nur): `7157a2cc` -> `da216d5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652069314,
-        "narHash": "sha256-/sUW0h0kBsqXLdBujzNCBclQvDlHXIR9J6WPO0b0vXk=",
+        "lastModified": 1652074111,
+        "narHash": "sha256-abM+5ubxIVRuP5T7ObHzyGremiO2nzSHpgwhGqz+SLE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7157a2cc7d4795f7ed1369265821febfd05da512",
+        "rev": "da216d5e95ce674d36f6ad6bb759c5afb77eb757",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`da216d5e`](https://github.com/nix-community/NUR/commit/da216d5e95ce674d36f6ad6bb759c5afb77eb757) | `automatic update` |