### PR TITLE
chore(flake/deploy-rs): `83e0c782` -> `690f698b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -96,11 +96,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1648475189,
-        "narHash": "sha256-gAGAS6IagwoUr1B0ohE3iR6sZ8hP4LSqzYLC8Mq3WGU=",
+        "lastModified": 1652079807,
+        "narHash": "sha256-aCs1EwO9K2yJ1DcT4+4g7BMlJBWP7Xjs4k5i8ueR8PU=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "83e0c78291cd08cb827ba0d553ad9158ae5a95c3",
+        "rev": "690f698b18345d894784752b5fa93b9b8f3cc29f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message |
| --------------------------------------------------------------------------------------------------- | -------------- |
| [`0868184b`](https://github.com/serokell/deploy-rs/commit/0868184b0376deb761a97702e6e41845ce224422) | `Fix a typo`   |