### PR TITLE
chore(flake/nur): `da216d5e` -> `577348d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652074111,
-        "narHash": "sha256-abM+5ubxIVRuP5T7ObHzyGremiO2nzSHpgwhGqz+SLE=",
+        "lastModified": 1652082379,
+        "narHash": "sha256-Bxmwvd2OJfp/9u0FGJ797Iow9vwsZwF3aEQicOLP9iM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "da216d5e95ce674d36f6ad6bb759c5afb77eb757",
+        "rev": "577348d358c3909b467db6e267ce8b16dbc1761c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`577348d3`](https://github.com/nix-community/NUR/commit/577348d358c3909b467db6e267ce8b16dbc1761c) | `automatic update` |
| [`7dd8ae74`](https://github.com/nix-community/NUR/commit/7dd8ae7417d68902a09e8b1f1aa4cb9c5e56421c) | `automatic update` |