### PR TITLE
chore(flake/emacs-ement): `d216e049` -> `7abf04dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1652032163,
-        "narHash": "sha256-VUD/4a0UPi3NNQTKTFxyPKIU6MG1GRxlcDqL8TOuURs=",
+        "lastModified": 1652109607,
+        "narHash": "sha256-K+cfMDiSqK8Kuat7ZNNFB5Y6LmL5g6Qmu0rZNOK4oEw=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "d216e049920ccb2839b274b202254842fe762c26",
+        "rev": "7abf04dd0e755e18f5943f4b740e6fe8bd8bc56d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                      |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`7abf04dd`](https://github.com/alphapapa/ement.el/commit/7abf04dd0e755e18f5943f4b740e6fe8bd8bc56d) | `Fix: (ement-room--format-body-mentions) Regexp`                    |
| [`f233141d`](https://github.com/alphapapa/ement.el/commit/f233141d8d919e131c2fc518231da85d51e4474d) | `Fix: (ement-room-occur) Set revert-buffer-function buffer-locally` |