### PR TITLE
chore(flake/nur): `ad440831` -> `d5be1730`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652111201,
-        "narHash": "sha256-s3WtZ5XEYFuM/LN4jN7b1PiIpZzLVsNdKkmX4reGZgI=",
+        "lastModified": 1652112181,
+        "narHash": "sha256-IrrY+A+xdJPUqraF3KyaaTj9M3FWjTK5+gEb71qpDrI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ad44083183d1e72dd0a8d90484f062c6dedaebfc",
+        "rev": "d5be1730b169f81a02002b4316c630d0553a5497",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d5be1730`](https://github.com/nix-community/NUR/commit/d5be1730b169f81a02002b4316c630d0553a5497) | `automatic update` |