### PR TITLE
chore(flake/nur): `d5be1730` -> `405e40de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652112181,
-        "narHash": "sha256-IrrY+A+xdJPUqraF3KyaaTj9M3FWjTK5+gEb71qpDrI=",
+        "lastModified": 1652113343,
+        "narHash": "sha256-/oWymhWXVJvctnaplziyZP9DlNIdn6K6TX/PjosO1ZE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d5be1730b169f81a02002b4316c630d0553a5497",
+        "rev": "405e40de38a8f2c6929fec436c01450b373912fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`405e40de`](https://github.com/nix-community/NUR/commit/405e40de38a8f2c6929fec436c01450b373912fe) | `automatic update` |