### PR TITLE
chore(flake/emacs-overlay): `334ba8c6` -> `2fb72619`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -143,12 +143,16 @@
       }
     },
     "emacs-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
       "locked": {
-        "lastModified": 1652097080,
-        "narHash": "sha256-Dui5VQKK8FLcnR29ihxlnRsdMnYCO1YXsXtj629Y0Z8=",
+        "lastModified": 1652114127,
+        "narHash": "sha256-9BaM5f8gxxAvDZKmnmgI0i5Wu+GVZpPZaFKo9qj4M6c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "334ba8c610cf5e41dfe130507030e5587e3551b4",
+        "rev": "2fb72619761bb2478715f7a5f64aad619e94da99",
         "type": "github"
       },
       "original": {
@@ -186,6 +190,21 @@
       "original": {
         "owner": "edolstra",
         "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1649676176,
+        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -286,6 +305,20 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1652059086,
+        "narHash": "sha256-CjHSbr6LSFkN4YBdTB6+8ZQmSqhsbiXqAeQ9hQJ/gBI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "934e076a441e318897aa17540f6cf7caadc69028",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
         "lastModified": 1651726670,
         "narHash": "sha256-dSGdzB49SEvdOJvrQWfQYkAefewXraHIV08Vz6iDXWQ=",
         "owner": "NixOS",
@@ -376,7 +409,7 @@
         "nix-on-droid": "nix-on-droid",
         "nixgl": "nixgl",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "nur": "nur",
         "pre-commit-hooks": "pre-commit-hooks",
         "ragenix": "ragenix",


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`2fb72619`](https://github.com/nix-community/emacs-overlay/commit/2fb72619761bb2478715f7a5f64aad619e94da99) | `Add fallback case when allowAliases is not set` |
| [`e47ffb5d`](https://github.com/nix-community/emacs-overlay/commit/e47ffb5d60d8e8271d412945c685dbeac2fca7a4) | `flake.nix: Add a packages output`               |