### PR TITLE
chore(flake/emacs-overlay): `2fb72619` -> `ef308886`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1652114127,
-        "narHash": "sha256-9BaM5f8gxxAvDZKmnmgI0i5Wu+GVZpPZaFKo9qj4M6c=",
+        "lastModified": 1652123915,
+        "narHash": "sha256-oUB1163GgKTVu5pu/YoAMkJ281cBKFS9DDC4K5u4n5Q=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2fb72619761bb2478715f7a5f64aad619e94da99",
+        "rev": "ef3088863916b0604dbd5c3ba402b7f52c89c53d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ef308886`](https://github.com/nix-community/emacs-overlay/commit/ef3088863916b0604dbd5c3ba402b7f52c89c53d) | `Updated repos/melpa` |
| [`bf8765e0`](https://github.com/nix-community/emacs-overlay/commit/bf8765e024d6398cfa703dc0e0d26f94232768a1) | `Updated repos/emacs` |
| [`a117f916`](https://github.com/nix-community/emacs-overlay/commit/a117f9162df212752431d09b4ba26f1bf7026287) | `Updated repos/elpa`  |