### PR TITLE
chore(flake/nur): `405e40de` -> `3e3a3231`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652113343,
-        "narHash": "sha256-/oWymhWXVJvctnaplziyZP9DlNIdn6K6TX/PjosO1ZE=",
+        "lastModified": 1652125341,
+        "narHash": "sha256-84/r2TMeF/Yhg/0x2vKlRAZ0HK98ZvD+KuktNvNhBZM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "405e40de38a8f2c6929fec436c01450b373912fe",
+        "rev": "3e3a32313f59e13b9a8a513801f848ce94515df7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3e3a3231`](https://github.com/nix-community/NUR/commit/3e3a32313f59e13b9a8a513801f848ce94515df7) | `automatic update` |