### PR TITLE
chore(flake/emacs-ement): `1e83d9f9` -> `b98843a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1652128263,
-        "narHash": "sha256-JtVF627l0KpACel8Wp5d5ktbR0nZpvcQY6hFSUNArJI=",
+        "lastModified": 1652129282,
+        "narHash": "sha256-ZqxLoru7v+PpoJBtVgkZW7MO66xbGDiYcp3AsQDfNgI=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "1e83d9f9d70b2355360c5119d79795c415aa2c55",
+        "rev": "b98843a82d9d6f5b2a0ab96fdd42d400ffd64f9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                             |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`b98843a8`](https://github.com/alphapapa/ement.el/commit/b98843a82d9d6f5b2a0ab96fdd42d400ffd64f9a) | `Change: (ement-room--format-membership-events) Format event in help-echo` |