### PR TITLE
chore(flake/nur): `3e3a3231` -> `90b23462`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652125341,
-        "narHash": "sha256-84/r2TMeF/Yhg/0x2vKlRAZ0HK98ZvD+KuktNvNhBZM=",
+        "lastModified": 1652140351,
+        "narHash": "sha256-n6j3N0vhv1Blc/1UD7lR9jc4t5GgE+aG3D6kDnZdV5g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3e3a32313f59e13b9a8a513801f848ce94515df7",
+        "rev": "90b23462ddfb9113d64ba1990aeb1c728a485dda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`90b23462`](https://github.com/nix-community/NUR/commit/90b23462ddfb9113d64ba1990aeb1c728a485dda) | `automatic update` |