### PR TITLE
chore(flake/nur): `90b23462` -> `bbb8dece`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652140351,
-        "narHash": "sha256-n6j3N0vhv1Blc/1UD7lR9jc4t5GgE+aG3D6kDnZdV5g=",
+        "lastModified": 1652153597,
+        "narHash": "sha256-nyuTclPExikytINQ0FiJZ9Itx+41OeivwbxDiJKiqTQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "90b23462ddfb9113d64ba1990aeb1c728a485dda",
+        "rev": "bbb8deced1790ea361366d6a96035f2ad7caaea6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`bbb8dece`](https://github.com/nix-community/NUR/commit/bbb8deced1790ea361366d6a96035f2ad7caaea6) | `automatic update` |