### PR TITLE
chore(flake/nur): `bd8e1572` -> `aef7d044`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652155669,
-        "narHash": "sha256-Rpmrf/+ppqubTNOfAgsKRwXkbYpw8aSWoYZireDX0sg=",
+        "lastModified": 1652159085,
+        "narHash": "sha256-Yk+ZhVeUKX8rHsetWYfiFOkmFBg1DM6JLYjyQvpW0pg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bd8e157253a50956ba00a17aad8d9f3813db925a",
+        "rev": "aef7d044a4663a1e695eb6d750d12a8d3e4f4e24",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`aef7d044`](https://github.com/nix-community/NUR/commit/aef7d044a4663a1e695eb6d750d12a8d3e4f4e24) | `automatic update` |