### PR TITLE
chore(flake/nur): `aef7d044` -> `566a53f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652159085,
-        "narHash": "sha256-Yk+ZhVeUKX8rHsetWYfiFOkmFBg1DM6JLYjyQvpW0pg=",
+        "lastModified": 1652162251,
+        "narHash": "sha256-laWGFfBngnqwB8Z9/eOfc9TJ5ih9r4AKPOZEfWiVme0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aef7d044a4663a1e695eb6d750d12a8d3e4f4e24",
+        "rev": "566a53f2d224bb8b1d06165db58c53a7c764d921",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`566a53f2`](https://github.com/nix-community/NUR/commit/566a53f2d224bb8b1d06165db58c53a7c764d921) | `automatic update` |