### PR TITLE
chore(flake/emacs-overlay): `ef308886` -> `3a0704d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1652123915,
-        "narHash": "sha256-oUB1163GgKTVu5pu/YoAMkJ281cBKFS9DDC4K5u4n5Q=",
+        "lastModified": 1652157318,
+        "narHash": "sha256-sgrp+9/YXkiGFoJEiu8nREXh9/qRIgX8m/WKS8EdhFQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ef3088863916b0604dbd5c3ba402b7f52c89c53d",
+        "rev": "3a0704d6ae03c5db954697b6c0873ebc14e324f5",
         "type": "github"
       },
       "original": {
@@ -305,11 +305,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652059086,
-        "narHash": "sha256-CjHSbr6LSFkN4YBdTB6+8ZQmSqhsbiXqAeQ9hQJ/gBI=",
+        "lastModified": 1652133925,
+        "narHash": "sha256-kfATGChLe9/fQVZkXN9G71JAVMlhePv1qDbaRKklkQs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "934e076a441e318897aa17540f6cf7caadc69028",
+        "rev": "51d859cdab1ef58755bd342d45352fc607f5e59b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`3a0704d6`](https://github.com/nix-community/emacs-overlay/commit/3a0704d6ae03c5db954697b6c0873ebc14e324f5) | `Updated repos/melpa` |
| [`9beebb6c`](https://github.com/nix-community/emacs-overlay/commit/9beebb6ca0b557de24b3f31d07fbcd0f97994bdd) | `Updated repos/emacs` |
| [`b7cb2919`](https://github.com/nix-community/emacs-overlay/commit/b7cb291928af9a1c69447b56d76e08a7d1271f13) | `Updated repos/elpa`  |