### PR TITLE
chore(flake/nur): `566a53f2` -> `1ae22db8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652162251,
-        "narHash": "sha256-laWGFfBngnqwB8Z9/eOfc9TJ5ih9r4AKPOZEfWiVme0=",
+        "lastModified": 1652168417,
+        "narHash": "sha256-MF9ONWIhjR/LdOXA7Ld9ELj4A0geDTZvXx5s70yZpvY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "566a53f2d224bb8b1d06165db58c53a7c764d921",
+        "rev": "1ae22db823f25b21f13a4008b9b9257bbedf23db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1ae22db8`](https://github.com/nix-community/NUR/commit/1ae22db823f25b21f13a4008b9b9257bbedf23db) | `automatic update` |