### PR TITLE
chore(flake/emacs-overlay): `3a0704d6` -> `0646f7ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1652157318,
-        "narHash": "sha256-sgrp+9/YXkiGFoJEiu8nREXh9/qRIgX8m/WKS8EdhFQ=",
+        "lastModified": 1652183402,
+        "narHash": "sha256-aOxl1X8jpwlIL00lKMSp6UsLSmYVBiZWzhJvt42j35A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3a0704d6ae03c5db954697b6c0873ebc14e324f5",
+        "rev": "0646f7ce8d90faadd752ea8037ed4d3c82b7576e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`0646f7ce`](https://github.com/nix-community/emacs-overlay/commit/0646f7ce8d90faadd752ea8037ed4d3c82b7576e) | `Updated repos/melpa` |
| [`a803ac7b`](https://github.com/nix-community/emacs-overlay/commit/a803ac7b1feafd1d4ead5d027524ff5cb8a3242b) | `Updated repos/emacs` |