### PR TITLE
chore(flake/nur): `1ae22db8` -> `c27698ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652168417,
-        "narHash": "sha256-MF9ONWIhjR/LdOXA7Ld9ELj4A0geDTZvXx5s70yZpvY=",
+        "lastModified": 1652207195,
+        "narHash": "sha256-+7Pqoye9dBJvNzkiTFSfDZ/A6GJwYzqTW9DOS3PMx14=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1ae22db823f25b21f13a4008b9b9257bbedf23db",
+        "rev": "c27698ab83ab6a4a2b4cb3cdc560782e4ea597fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c27698ab`](https://github.com/nix-community/NUR/commit/c27698ab83ab6a4a2b4cb3cdc560782e4ea597fb) | `automatic update` |