### PR TITLE
chore(flake/emacs-overlay): `0646f7ce` -> `61b4451c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1652183402,
-        "narHash": "sha256-aOxl1X8jpwlIL00lKMSp6UsLSmYVBiZWzhJvt42j35A=",
+        "lastModified": 1652211304,
+        "narHash": "sha256-qQELICxOO+68ANn3z+kn8WvKYcmnPfTc6XHWEjjfFeY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0646f7ce8d90faadd752ea8037ed4d3c82b7576e",
+        "rev": "61b4451c26c4759923d0794aab96e86366de0769",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`61b4451c`](https://github.com/nix-community/emacs-overlay/commit/61b4451c26c4759923d0794aab96e86366de0769) | `Updated repos/melpa` |
| [`e90288a8`](https://github.com/nix-community/emacs-overlay/commit/e90288a89120372b34b90437f3052bcd429a2168) | `Updated repos/emacs` |