### PR TITLE
chore(flake/nur): `c27698ab` -> `f8c7514c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652207195,
-        "narHash": "sha256-+7Pqoye9dBJvNzkiTFSfDZ/A6GJwYzqTW9DOS3PMx14=",
+        "lastModified": 1652215184,
+        "narHash": "sha256-PcZv0ZtlufUxAJ8Z8hGsHdvh/wQqERKzdvV+6AePBJ4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c27698ab83ab6a4a2b4cb3cdc560782e4ea597fb",
+        "rev": "f8c7514c1e3470f71a0458f1cfa7ab5a2ca05a2f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f8c7514c`](https://github.com/nix-community/NUR/commit/f8c7514c1e3470f71a0458f1cfa7ab5a2ca05a2f) | `automatic update` |