### PR TITLE
chore(flake/nur): `f8c7514c` -> `683baa7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652215184,
-        "narHash": "sha256-PcZv0ZtlufUxAJ8Z8hGsHdvh/wQqERKzdvV+6AePBJ4=",
+        "lastModified": 1652238233,
+        "narHash": "sha256-Qfg1N/O+r9S6fUXoNkuDTGz5FQ61EG/bRONAL+g+vOU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f8c7514c1e3470f71a0458f1cfa7ab5a2ca05a2f",
+        "rev": "683baa7dc8ad15fb66e3debb94992c622d1c92ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`683baa7d`](https://github.com/nix-community/NUR/commit/683baa7dc8ad15fb66e3debb94992c622d1c92ee) | `automatic update` |