### PR TITLE
chore(flake/nur): `683baa7d` -> `c8f576f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652238233,
-        "narHash": "sha256-Qfg1N/O+r9S6fUXoNkuDTGz5FQ61EG/bRONAL+g+vOU=",
+        "lastModified": 1652242075,
+        "narHash": "sha256-SxETLAElqmyoJoGCD3vwJk3KYA4d1LdP1yCRH+Wxehs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "683baa7dc8ad15fb66e3debb94992c622d1c92ee",
+        "rev": "c8f576f19209c1e1c78f79130e67c60f63bb7343",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c8f576f1`](https://github.com/nix-community/NUR/commit/c8f576f19209c1e1c78f79130e67c60f63bb7343) | `automatic update` |