### PR TITLE
chore(flake/emacs-overlay): `61b4451c` -> `4daa399a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1652211304,
-        "narHash": "sha256-qQELICxOO+68ANn3z+kn8WvKYcmnPfTc6XHWEjjfFeY=",
+        "lastModified": 1652243546,
+        "narHash": "sha256-Etm7bqPCNwucjTBWSfEeqkcpNE6e1+0JrqFygTT2A9o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "61b4451c26c4759923d0794aab96e86366de0769",
+        "rev": "4daa399a9895ce76441f696be993c339d4096341",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`4daa399a`](https://github.com/nix-community/emacs-overlay/commit/4daa399a9895ce76441f696be993c339d4096341) | `Updated repos/melpa` |
| [`258a069a`](https://github.com/nix-community/emacs-overlay/commit/258a069a285100ca653d6eae9529a992c86ec1ac) | `Updated repos/emacs` |
| [`e467eb92`](https://github.com/nix-community/emacs-overlay/commit/e467eb927eda9a66638d4dabeceabf9e73767c20) | `Updated repos/elpa`  |