### PR TITLE
chore(flake/emacs-overlay): `4daa399a` -> `681b5512`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1652243546,
-        "narHash": "sha256-Etm7bqPCNwucjTBWSfEeqkcpNE6e1+0JrqFygTT2A9o=",
+        "lastModified": 1652270865,
+        "narHash": "sha256-xgOPavQUsZF1hND48JYYyyMEzlVGi22+GrigSvd9f7k=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4daa399a9895ce76441f696be993c339d4096341",
+        "rev": "681b5512f5bc6ae454cf3a8c224c72d368981d12",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`681b5512`](https://github.com/nix-community/emacs-overlay/commit/681b5512f5bc6ae454cf3a8c224c72d368981d12) | `Updated repos/melpa` |
| [`e2c944b2`](https://github.com/nix-community/emacs-overlay/commit/e2c944b28b964730ed98dc83a28d9c07dcde3063) | `Updated repos/emacs` |