### PR TITLE
chore(flake/nur): `c8f576f1` -> `9f6695c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652242075,
-        "narHash": "sha256-SxETLAElqmyoJoGCD3vwJk3KYA4d1LdP1yCRH+Wxehs=",
+        "lastModified": 1652293843,
+        "narHash": "sha256-jzFNrfV25/a2GV+/A5tZolgPn4XwpRPxugzJIvxToSY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c8f576f19209c1e1c78f79130e67c60f63bb7343",
+        "rev": "9f6695c87987e13b6e4d007ace69898680badb82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9f6695c8`](https://github.com/nix-community/NUR/commit/9f6695c87987e13b6e4d007ace69898680badb82) | `automatic update` |