### PR TITLE
chore(flake/nur): `c40312fe` -> `e2d41225`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652332167,
-        "narHash": "sha256-vNXKw4gg4aL0UdTDAoqTdVp+NG1jw45eHx8ScAzr5kU=",
+        "lastModified": 1652333580,
+        "narHash": "sha256-Wl1ZDf++BPnUzSFWNoHg8r5ykAOleNfKKIPO96lO6D8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c40312fe774e249db36dc62c6564f5f978918a2f",
+        "rev": "e2d412257d71e7aaca36f1e066371af09afa23b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e2d41225`](https://github.com/nix-community/NUR/commit/e2d412257d71e7aaca36f1e066371af09afa23b7) | `automatic update` |