### PR TITLE
chore(flake/emacs-overlay): `e79f6d3c` -> `e6ec42b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1652300646,
-        "narHash": "sha256-XlzDtx7Gke3sSg+8FS9mnnbF761g7v8iZHnQNdiTHok=",
+        "lastModified": 1652332826,
+        "narHash": "sha256-rFR8zc81TlOcuHFWhm7hy1KIbRB2t6lzWVX4uS8xJPM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e79f6d3ce935898960d865faea9e9fa88ba1b26b",
+        "rev": "e6ec42b61a1a151d1f7adec951138597448007e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`e6ec42b6`](https://github.com/nix-community/emacs-overlay/commit/e6ec42b61a1a151d1f7adec951138597448007e6) | `Updated repos/melpa` |
| [`963bfcfe`](https://github.com/nix-community/emacs-overlay/commit/963bfcfecaa5deefe98d3d146f37abbad0f10d4d) | `Updated repos/emacs` |
| [`304d3e84`](https://github.com/nix-community/emacs-overlay/commit/304d3e84b36dc8c91a92b62c7de220c1b384b4fc) | `Updated repos/elpa`  |