### PR TITLE
chore(flake/nur): `e2d41225` -> `f69cfc11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652333580,
-        "narHash": "sha256-Wl1ZDf++BPnUzSFWNoHg8r5ykAOleNfKKIPO96lO6D8=",
+        "lastModified": 1652344611,
+        "narHash": "sha256-XmcZb6Dl69szvs6PZ7P/qnpNQxOc9oXGZAwq9Jbl6sE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e2d412257d71e7aaca36f1e066371af09afa23b7",
+        "rev": "f69cfc11e9b2312a294b8a6291de721d0d207819",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f69cfc11`](https://github.com/nix-community/NUR/commit/f69cfc11e9b2312a294b8a6291de721d0d207819) | `automatic update` |