### PR TITLE
chore(flake/emacs-overlay): `e6ec42b6` -> `4757eb63`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1652332826,
-        "narHash": "sha256-rFR8zc81TlOcuHFWhm7hy1KIbRB2t6lzWVX4uS8xJPM=",
+        "lastModified": 1652354597,
+        "narHash": "sha256-hPqFTX0Rmrj95X/nFY4plNQTNxp4cFEUearQON3lUd8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e6ec42b61a1a151d1f7adec951138597448007e6",
+        "rev": "4757eb63bcf809b5e1c014e7849cad5a49d9dc82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`4757eb63`](https://github.com/nix-community/emacs-overlay/commit/4757eb63bcf809b5e1c014e7849cad5a49d9dc82) | `Updated repos/melpa` |
| [`bb509f85`](https://github.com/nix-community/emacs-overlay/commit/bb509f857b8591fd4c02152df045111780a09d58) | `Updated repos/emacs` |