### PR TITLE
chore(flake/emacs-ement): `5e4fe25b` -> `6af03fb4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1652299763,
-        "narHash": "sha256-eKN1oRtM/M5Wd2P1zSAXbkqoUlodfwJw1JvyJVcdRNM=",
+        "lastModified": 1652369628,
+        "narHash": "sha256-6Sm5X3d0zpMdXucZtGIEPLtVLFDj2J38fwJMHnDYf+M=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "5e4fe25b717019092c4726e9a4ac361e464aebfa",
+        "rev": "6af03fb43315722622f5833921ef5e86d979a3a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                     |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`6af03fb4`](https://github.com/alphapapa/ement.el/commit/6af03fb43315722622f5833921ef5e86d979a3a0) | `Fix: Notifications for rooms that have no buffer` |