### PR TITLE
chore(flake/nur): `297a2d65` -> `67163301`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652357618,
-        "narHash": "sha256-7QyVEXRqkIZA8Og1ETGTSAAW+KyGfzQ6YKn0FpMAgJs=",
+        "lastModified": 1652380161,
+        "narHash": "sha256-R7niyLdDqhcKDnZa/FPCQ51kJbhVqR6ORLww319t7zo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "297a2d65cca1ccb8453a63fcd24d09ac09385ab8",
+        "rev": "671633016e1f18ea57a6d9dbd41a2c23c667bcf1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`67163301`](https://github.com/nix-community/NUR/commit/671633016e1f18ea57a6d9dbd41a2c23c667bcf1) | `automatic update` |