### PR TITLE
chore(flake/emacs-ement): `578a0bab` -> `72767645`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1652378168,
-        "narHash": "sha256-623aM9ZMpUySjQG2vU/MW07Act6GvDLOIo0l6nxT/2w=",
+        "lastModified": 1652381660,
+        "narHash": "sha256-gWVYQY0+AY3cjqnjlQ8ZjPmYr/HOvnMJpmA3bAvuIcE=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "578a0babadad4ff1911ce73ce89c8206fbfdd1ab",
+        "rev": "72767645896216c723c403bdaf795c1c5fd5351a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                               |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`72767645`](https://github.com/alphapapa/ement.el/commit/72767645896216c723c403bdaf795c1c5fd5351a) | `Fix: (ement-notify--notifications-notify) Room displayname` |
| [`284d7ff4`](https://github.com/alphapapa/ement.el/commit/284d7ff4b242cc1f52ae1005d429dc840fcf880d) | `Fix: (ement-put-account-data) Variable assignment`          |