### PR TITLE
chore(flake/nur): `67163301` -> `5d09f4fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652380161,
-        "narHash": "sha256-R7niyLdDqhcKDnZa/FPCQ51kJbhVqR6ORLww319t7zo=",
+        "lastModified": 1652399621,
+        "narHash": "sha256-mFvQEua55GI+XDppgcCLE7nAPlMya21lYubKZJ3RqiY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "671633016e1f18ea57a6d9dbd41a2c23c667bcf1",
+        "rev": "5d09f4fa16129a35f73473948cffb4085f7417d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5d09f4fa`](https://github.com/nix-community/NUR/commit/5d09f4fa16129a35f73473948cffb4085f7417d9) | `automatic update` |