### PR TITLE
chore(flake/nur): `5d09f4fa` -> `4714c1e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652399621,
-        "narHash": "sha256-mFvQEua55GI+XDppgcCLE7nAPlMya21lYubKZJ3RqiY=",
+        "lastModified": 1652414594,
+        "narHash": "sha256-AgUMnQC+d69AVqtypU81ai1RYQHGmA2GrW2g1vs+QOw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5d09f4fa16129a35f73473948cffb4085f7417d9",
+        "rev": "4714c1e7b63c3dae2b187b927ec2765ed2489b5f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4714c1e7`](https://github.com/nix-community/NUR/commit/4714c1e7b63c3dae2b187b927ec2765ed2489b5f) | `automatic update` |