### PR TITLE
chore(flake/nur): `4714c1e7` -> `3f1d63e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652414594,
-        "narHash": "sha256-AgUMnQC+d69AVqtypU81ai1RYQHGmA2GrW2g1vs+QOw=",
+        "lastModified": 1652425060,
+        "narHash": "sha256-En0FE+nVX43mQNRs1ARvezTjtRzKlkbCG/7OfO+j90s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4714c1e7b63c3dae2b187b927ec2765ed2489b5f",
+        "rev": "3f1d63e0435b6d0ea4544308c7496ebe5dfc1097",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3f1d63e0`](https://github.com/nix-community/NUR/commit/3f1d63e0435b6d0ea4544308c7496ebe5dfc1097) | `automatic update` |