### PR TITLE
chore(flake/nur): `3f1d63e0` -> `69839917`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652425060,
-        "narHash": "sha256-En0FE+nVX43mQNRs1ARvezTjtRzKlkbCG/7OfO+j90s=",
+        "lastModified": 1652426201,
+        "narHash": "sha256-GZWP6yq3DLscVMbjZ8zBvnJ1+cwu1A4UdcB8nG2i6lw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3f1d63e0435b6d0ea4544308c7496ebe5dfc1097",
+        "rev": "69839917c46a7a8c5b650e557b79d7ecc2531860",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`69839917`](https://github.com/nix-community/NUR/commit/69839917c46a7a8c5b650e557b79d7ecc2531860) | `automatic update` |