### PR TITLE
chore(flake/nur): `69839917` -> `9b155726`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652426201,
-        "narHash": "sha256-GZWP6yq3DLscVMbjZ8zBvnJ1+cwu1A4UdcB8nG2i6lw=",
+        "lastModified": 1652430007,
+        "narHash": "sha256-qoD5kIBsrMIG9O2e94sj77WT4akk9DCCH/aPC74JF9Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "69839917c46a7a8c5b650e557b79d7ecc2531860",
+        "rev": "9b1557265301774e289571a410ca87065d37aac1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9b155726`](https://github.com/nix-community/NUR/commit/9b1557265301774e289571a410ca87065d37aac1) | `automatic update` |