### PR TITLE
chore(flake/nur): `9b155726` -> `27041d38`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652430007,
-        "narHash": "sha256-qoD5kIBsrMIG9O2e94sj77WT4akk9DCCH/aPC74JF9Y=",
+        "lastModified": 1652433689,
+        "narHash": "sha256-iMwxqlKywkf93k4pQwEFHy0Td31KnjDu516VTdzUm4E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9b1557265301774e289571a410ca87065d37aac1",
+        "rev": "27041d3839169b225fd636a09688a45a2c3641ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`27041d38`](https://github.com/nix-community/NUR/commit/27041d3839169b225fd636a09688a45a2c3641ab) | `automatic update` |