### PR TITLE
chore(flake/nur): `27041d38` -> `01f680ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652433689,
-        "narHash": "sha256-iMwxqlKywkf93k4pQwEFHy0Td31KnjDu516VTdzUm4E=",
+        "lastModified": 1652434939,
+        "narHash": "sha256-LyaBhP8pu8NZs3BTOftUR9NlNoNoOYxxfuTCw8wtTTE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "27041d3839169b225fd636a09688a45a2c3641ab",
+        "rev": "01f680baba2cfd204d52b1a7f9db61a4ecf7af80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`01f680ba`](https://github.com/nix-community/NUR/commit/01f680baba2cfd204d52b1a7f9db61a4ecf7af80) | `automatic update` |