### PR TITLE
chore(flake/emacs-overlay): `9c90a10f` -> `672ed963`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1652416036,
-        "narHash": "sha256-cfNmuHmGwdhHB9/BT1dDxo5anYFAewuvZ/wVFDAgl8w=",
+        "lastModified": 1652440988,
+        "narHash": "sha256-XQjFmR5O8YJqF9zxNGcapqI+tTlZhLjwPllWkBFrmGw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9c90a10f7c5d4e99392090820460c1fa7486ae2c",
+        "rev": "672ed963c05977c629f0ec7521b4d347968cd201",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`672ed963`](https://github.com/nix-community/emacs-overlay/commit/672ed963c05977c629f0ec7521b4d347968cd201) | `Updated repos/melpa` |
| [`7456759c`](https://github.com/nix-community/emacs-overlay/commit/7456759c0fe5f1a8da6b62218055b01f8cd9b85b) | `Updated repos/emacs` |