### PR TITLE
chore(flake/nur): `01f680ba` -> `44124410`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652434939,
-        "narHash": "sha256-LyaBhP8pu8NZs3BTOftUR9NlNoNoOYxxfuTCw8wtTTE=",
+        "lastModified": 1652452719,
+        "narHash": "sha256-lAd5UQ+yqxDVYynIraccFnpnuPmWTIdm9UWEXZDt9NI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "01f680baba2cfd204d52b1a7f9db61a4ecf7af80",
+        "rev": "441244102d7ee4294cdd5a89d4f0eeaee9626bfe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`44124410`](https://github.com/nix-community/NUR/commit/441244102d7ee4294cdd5a89d4f0eeaee9626bfe) | `automatic update` |