### PR TITLE
chore(flake/nur): `44124410` -> `710d002b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652452719,
-        "narHash": "sha256-lAd5UQ+yqxDVYynIraccFnpnuPmWTIdm9UWEXZDt9NI=",
+        "lastModified": 1652463335,
+        "narHash": "sha256-z9513wyO8nVwTikXT1JQdPuzIs3Gn04XGYDYAiwMBIU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "441244102d7ee4294cdd5a89d4f0eeaee9626bfe",
+        "rev": "710d002b8ef0d0a8823c4718076aad6dcd969252",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`710d002b`](https://github.com/nix-community/NUR/commit/710d002b8ef0d0a8823c4718076aad6dcd969252) | `automatic update` |