### PR TITLE
chore(flake/nur): `710d002b` -> `1d9510e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652463335,
-        "narHash": "sha256-z9513wyO8nVwTikXT1JQdPuzIs3Gn04XGYDYAiwMBIU=",
+        "lastModified": 1652470188,
+        "narHash": "sha256-tjuPR5u32INyHHcDTlKu67rBKd6P76PPkgvblruXL84=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "710d002b8ef0d0a8823c4718076aad6dcd969252",
+        "rev": "1d9510e9d96833c4b9a6b272ea72e09a81c5066f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1d9510e9`](https://github.com/nix-community/NUR/commit/1d9510e9d96833c4b9a6b272ea72e09a81c5066f) | `automatic update` |