### PR TITLE
chore(flake/emacs-overlay): `672ed963` -> `b4fb024e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1652440988,
-        "narHash": "sha256-XQjFmR5O8YJqF9zxNGcapqI+tTlZhLjwPllWkBFrmGw=",
+        "lastModified": 1652471815,
+        "narHash": "sha256-a52k3l/vI2K+c598qXn+7IFBSOACJfeOUltjoR4xOr4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "672ed963c05977c629f0ec7521b4d347968cd201",
+        "rev": "b4fb024e32ceec9f65310fec4ac670d054d92477",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`b4fb024e`](https://github.com/nix-community/emacs-overlay/commit/b4fb024e32ceec9f65310fec4ac670d054d92477) | `Updated repos/melpa` |
| [`5fc2cae6`](https://github.com/nix-community/emacs-overlay/commit/5fc2cae6b4f1dca76cb006f53739e2d1a54e8199) | `Updated repos/emacs` |
| [`20c5cfea`](https://github.com/nix-community/emacs-overlay/commit/20c5cfea4b55734fe6e1b2213574c4ca56f04dc6) | `Updated repos/elpa`  |