### PR TITLE
chore(flake/sops-nix): `c2614c4f` -> `2c1dd416`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -450,11 +450,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1649756291,
-        "narHash": "sha256-KTll8bCINAzIUGaaMrbn9wb5nfhkXRLgmFrWGR/Dku0=",
+        "lastModified": 1652478428,
+        "narHash": "sha256-fhEXU/ti79NmwgbRuCKtXFgF0d+kh2vdPf/nLSeKCus=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c2614c4fe61943b3d280ac1892fcebe6e8eaf8c8",
+        "rev": "2c1dd416cc9483302d0f642436c1993fca0edee5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                           |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`0bb791e6`](https://github.com/Mic92/sops-nix/commit/0bb791e622ed7db6489ae59a9ba4a2cef5a3ead9) | `add workflow to update flakes`          |
| [`3a2686f3`](https://github.com/Mic92/sops-nix/commit/3a2686f358514095a6315bdeb21a0752352eaff3) | `move ci to garnix`                      |
| [`f04ef790`](https://github.com/Mic92/sops-nix/commit/f04ef790f6beba9b24332bda5169d6f83241fe57) | `add nixos tests to checks`              |
| [`d27137c0`](https://github.com/Mic92/sops-nix/commit/d27137c0a1daa745d45ee2c1886cafbc5afef04c) | `README: add toString to sopsPGPKeyDirs` |
| [`5ae679b5`](https://github.com/Mic92/sops-nix/commit/5ae679b566f4667e2c19e4c20cf2b3555c425257) | `Add package option to module`           |