### PR TITLE
chore(flake/emacs-ement): `7ae73664` -> `961d6503`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1652426824,
-        "narHash": "sha256-kQ/XgZd4i5xmAVpqnPJq+egIFWCJbqgs6K+t/md0nWw=",
+        "lastModified": 1652483764,
+        "narHash": "sha256-4KTSPgso7UvzCRKNFI3YaPR1t4DUwggO4KtBYLm0W4Y=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "7ae7366488eea598fcbd6915f2ff310945625514",
+        "rev": "961d650377f9e7440e47c36c0386e899f5b2d86b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                     |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`961d6503`](https://github.com/alphapapa/ement.el/commit/961d650377f9e7440e47c36c0386e899f5b2d86b) | `Change: (ement-room-set-topic) Use INITIAL-INPUT for read-string` |