### PR TITLE
chore(flake/nur): `1d9510e9` -> `032ac939`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652470188,
-        "narHash": "sha256-tjuPR5u32INyHHcDTlKu67rBKd6P76PPkgvblruXL84=",
+        "lastModified": 1652494987,
+        "narHash": "sha256-Jnep8YYUC1NHtVTsY0Ndbfx23FoNjvtbz+iXWJNJb+g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1d9510e9d96833c4b9a6b272ea72e09a81c5066f",
+        "rev": "032ac939dfdc02379e7a4486f67be6c20142f53c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`032ac939`](https://github.com/nix-community/NUR/commit/032ac939dfdc02379e7a4486f67be6c20142f53c) | `automatic update` |