### PR TITLE
chore(flake/sops-nix): `2c1dd416` -> `1c24038f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -450,11 +450,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1652478428,
-        "narHash": "sha256-fhEXU/ti79NmwgbRuCKtXFgF0d+kh2vdPf/nLSeKCus=",
+        "lastModified": 1652502358,
+        "narHash": "sha256-WBtLYn3lpeqOIBbf8kYisFKbc1rI5kz09V1fvmZhwhk=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "2c1dd416cc9483302d0f642436c1993fca0edee5",
+        "rev": "1c24038f2649973aca4d5671dda5d21993cff481",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message          |
| ----------------------------------------------------------------------------------------------- | ----------------------- |
| [`80a8ca63`](https://github.com/Mic92/sops-nix/commit/80a8ca6351e7ba23fddcac0ffc2b4b9e7ea62f20) | `update sops to v3.7.3` |