### PR TITLE
chore(flake/nur): `032ac939` -> `1a4d9031`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652494987,
-        "narHash": "sha256-Jnep8YYUC1NHtVTsY0Ndbfx23FoNjvtbz+iXWJNJb+g=",
+        "lastModified": 1652501248,
+        "narHash": "sha256-8rcrO7wwopfpDSo8PntbWOLZ+BQelptdwLEyyHUcMCk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "032ac939dfdc02379e7a4486f67be6c20142f53c",
+        "rev": "1a4d9031abe2c4e3e5212b081e8886ac3ddbef85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1a4d9031`](https://github.com/nix-community/NUR/commit/1a4d9031abe2c4e3e5212b081e8886ac3ddbef85) | `automatic update` |