### PR TITLE
chore(flake/sops-nix): `1c24038f` -> `0c20c625`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -450,11 +450,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1652502358,
-        "narHash": "sha256-WBtLYn3lpeqOIBbf8kYisFKbc1rI5kz09V1fvmZhwhk=",
+        "lastModified": 1652502848,
+        "narHash": "sha256-rri5weQRj33EqVF9oFKuaHH7F9A55DwWsxPHVxHDtwg=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "1c24038f2649973aca4d5671dda5d21993cff481",
+        "rev": "0c20c6257ba770b1566a16b6aa93d19d15a2ac30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message |
| ----------------------------------------------------------------------------------------------- | -------------- |
| [`8c944d29`](https://github.com/Mic92/sops-nix/commit/8c944d29e8638e3ab3d0d1374453578751bf85ae) | `go mod tidy`  |