### PR TITLE
chore(flake/emacs-overlay): `b4fb024e` -> `20f9d4b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1652471815,
-        "narHash": "sha256-a52k3l/vI2K+c598qXn+7IFBSOACJfeOUltjoR4xOr4=",
+        "lastModified": 1652503541,
+        "narHash": "sha256-OqshdD1WR37q4PGcTY2stzNWdautl528lewUfHkd14A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b4fb024e32ceec9f65310fec4ac670d054d92477",
+        "rev": "20f9d4b117c972756c4b1fcd6e11af02a45ec493",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`20f9d4b1`](https://github.com/nix-community/emacs-overlay/commit/20f9d4b117c972756c4b1fcd6e11af02a45ec493) | `Updated repos/melpa` |
| [`b051d91d`](https://github.com/nix-community/emacs-overlay/commit/b051d91d33fdb486c38006f1a1c31b9b8d58cb18) | `Updated repos/emacs` |
| [`f5978012`](https://github.com/nix-community/emacs-overlay/commit/f5978012b29fc163beb6d4ee6f6038f96bbde9f3) | `Updated repos/elpa`  |