### PR TITLE
chore(flake/nur): `94d707a5` -> `200993d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652513336,
-        "narHash": "sha256-tK4FefJUNO6jwdym1UCSkdnwoaalP16SdsVXGuSbTM0=",
+        "lastModified": 1652529960,
+        "narHash": "sha256-EKAd/4v666t4HauUvErPL6NoMdQJkMRoRz8FGL0y60s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "94d707a50609a73496a57d22e5973bd6ee9f7b52",
+        "rev": "200993d3e9091e835ee6815006f2343bcc202195",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                        |
| -------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`200993d3`](https://github.com/nix-community/NUR/commit/200993d3e9091e835ee6815006f2343bcc202195) | `automatic update`                    |
| [`70cd40a6`](https://github.com/nix-community/NUR/commit/70cd40a6aa4e728e81e025c730be5f5238d906bd) | `add section: Local evaluation check` |