### PR TITLE
chore(flake/nur): `88c55f4e` -> `71a8d4ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652534805,
-        "narHash": "sha256-bVLW1mv4S6m6VtyTnSUBU9GH6QJoXYDoooddMG1k3o0=",
+        "lastModified": 1652540486,
+        "narHash": "sha256-Y1gUhd8md0dI/3wbfM4Wi+165Trg8c31LO/FjwY3ako=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "88c55f4ee781d0cf0c023813c75eb09dfe80459a",
+        "rev": "71a8d4ee70d8e78d8d37a5c62887d006da511ac2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`71a8d4ee`](https://github.com/nix-community/NUR/commit/71a8d4ee70d8e78d8d37a5c62887d006da511ac2) | `automatic update` |