### PR TITLE
chore(flake/nur): `71a8d4ee` -> `18cccff2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652540486,
-        "narHash": "sha256-Y1gUhd8md0dI/3wbfM4Wi+165Trg8c31LO/FjwY3ako=",
+        "lastModified": 1652543499,
+        "narHash": "sha256-3h6DsFPaHBTw1XM9E4Dh2+qFJnRzB6x0KL6Uik93wYc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "71a8d4ee70d8e78d8d37a5c62887d006da511ac2",
+        "rev": "18cccff25f958e3931ba00a6760b7dd66488cf4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                      |
| -------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`b178d9ed`](https://github.com/nix-community/NUR/commit/b178d9ed70c7b7ba0f66deaea85116276b6106f4) | `nix-env: allow non-linux packages` |