### PR TITLE
chore(flake/nur): `18cccff2` -> `d31becc2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652543499,
-        "narHash": "sha256-3h6DsFPaHBTw1XM9E4Dh2+qFJnRzB6x0KL6Uik93wYc=",
+        "lastModified": 1652552747,
+        "narHash": "sha256-Errcz1MHHXg0lpgEb9CIAU4eSBLNeeRHTOAZ2FP537Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "18cccff25f958e3931ba00a6760b7dd66488cf4a",
+        "rev": "d31becc23a8e9f4711bcb57523f45208042b8baa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d31becc2`](https://github.com/nix-community/NUR/commit/d31becc23a8e9f4711bcb57523f45208042b8baa) | `automatic update` |