### PR TITLE
chore(flake/nur): `d31becc2` -> `30a3b7b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652552747,
-        "narHash": "sha256-Errcz1MHHXg0lpgEb9CIAU4eSBLNeeRHTOAZ2FP537Y=",
+        "lastModified": 1652556777,
+        "narHash": "sha256-NFfCNCSoxF574Kpibr09PaHvIjf8c5m3A7kyPNv3dug=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d31becc23a8e9f4711bcb57523f45208042b8baa",
+        "rev": "30a3b7b17f1cfd9148cebbe7f491de88bea67155",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`30a3b7b1`](https://github.com/nix-community/NUR/commit/30a3b7b17f1cfd9148cebbe7f491de88bea67155) | `automatic update` |