### PR TITLE
chore(flake/nur): `30a3b7b1` -> `d5446de0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652556777,
-        "narHash": "sha256-NFfCNCSoxF574Kpibr09PaHvIjf8c5m3A7kyPNv3dug=",
+        "lastModified": 1652570003,
+        "narHash": "sha256-F8Y+Si85W3o4Qxk2+J5rc3lRxDRJ7xkmzmG648PXJyc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "30a3b7b17f1cfd9148cebbe7f491de88bea67155",
+        "rev": "d5446de0541b90187f30b7e7e8e7818c39dc2b76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d5446de0`](https://github.com/nix-community/NUR/commit/d5446de0541b90187f30b7e7e8e7818c39dc2b76) | `automatic update` |