### PR TITLE
chore(flake/sops-nix): `0c20c625` -> `9681f04f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -317,6 +317,22 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-21_11": {
+      "locked": {
+        "lastModified": 1652559422,
+        "narHash": "sha256-jPVTNImBTUIFdtur+d4IVot6eXmsvtOcBm0TzxmhWPk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8b3398bc7587ebb79f93dfeea1b8c574d3c6dba1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-21.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1651726670,
@@ -447,14 +463,15 @@
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "nixpkgs-21_11": "nixpkgs-21_11"
       },
       "locked": {
-        "lastModified": 1652502848,
-        "narHash": "sha256-rri5weQRj33EqVF9oFKuaHH7F9A55DwWsxPHVxHDtwg=",
+        "lastModified": 1652596508,
+        "narHash": "sha256-hwqENSMkOm+OwE1t459I3ZJmZmf+X7242QGskyftnaQ=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "0c20c6257ba770b1566a16b6aa93d19d15a2ac30",
+        "rev": "9681f04fa3b6af5b7eff6b086e46aee2cc2bdde2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                     |
| ----------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`c8e0dd83`](https://github.com/Mic92/sops-nix/commit/c8e0dd83f8dc72ef7497fa87c1c3c0f7a108053b) | `also build ci for 21.11`          |
| [`7e5c8249`](https://github.com/Mic92/sops-nix/commit/7e5c8249e27427235aa82e6086f9cdbd21194a48) | `shell.nix: add nixFlakes version` |
| [`a7512754`](https://github.com/Mic92/sops-nix/commit/a7512754f024c9e7e01b236c3ce5355a9179a9cc) | `fix build for 21.11`              |
| [`530098c9`](https://github.com/Mic92/sops-nix/commit/530098c90284893a2fa6148f02fbdc548ac716d3) | `drop release.nix`                 |
| [`150afcb2`](https://github.com/Mic92/sops-nix/commit/150afcb24029418f77b00b5910b0a9447fa71e24) | `move all nix expressions to pkgs` |
| [`387e1ae8`](https://github.com/Mic92/sops-nix/commit/387e1ae8367dd15fcdb91d3fd4668d549dc97650) | `flake.lock: Update`               |