### PR TITLE
chore(flake/nur): `76a09c52` -> `514746a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652584206,
-        "narHash": "sha256-3ArYXZW8fts+PijLtsii9B7DCmWNY7ehLhzkptGDzQU=",
+        "lastModified": 1652598604,
+        "narHash": "sha256-T0KazMtYjIl5PJcso0/vRYvWbFdEElzfa02Ot6rDGw8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "76a09c52fa2747dd54f7d4aa3d157612b48d9f36",
+        "rev": "514746a34841c226763a0691d1a109c718afdc03",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`514746a3`](https://github.com/nix-community/NUR/commit/514746a34841c226763a0691d1a109c718afdc03) | `automatic update` |