### PR TITLE
chore(flake/nur): `514746a3` -> `24025aa0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652598604,
-        "narHash": "sha256-T0KazMtYjIl5PJcso0/vRYvWbFdEElzfa02Ot6rDGw8=",
+        "lastModified": 1652610179,
+        "narHash": "sha256-gPoX6xk9Ync/6OB7eDmf2Ed8ojtIRo7rZqo2QHYnUu4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "514746a34841c226763a0691d1a109c718afdc03",
+        "rev": "24025aa05f190c1f9923ccb49e45d66d3d4ee5dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`24025aa0`](https://github.com/nix-community/NUR/commit/24025aa05f190c1f9923ccb49e45d66d3d4ee5dc) | `automatic update` |