### PR TITLE
chore(flake/nur): `24025aa0` -> `28512bb6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652610179,
-        "narHash": "sha256-gPoX6xk9Ync/6OB7eDmf2Ed8ojtIRo7rZqo2QHYnUu4=",
+        "lastModified": 1652612845,
+        "narHash": "sha256-DARupsBcouBMAGEfK+mTeE5f6ohalk+6MYyTIfsN3yQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "24025aa05f190c1f9923ccb49e45d66d3d4ee5dc",
+        "rev": "28512bb6c21feb84e10ab087d0c00ec60159dbab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`28512bb6`](https://github.com/nix-community/NUR/commit/28512bb6c21feb84e10ab087d0c00ec60159dbab) | `automatic update` |