### PR TITLE
chore(flake/nur): `dd8e8716` -> `f661ee11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652619465,
-        "narHash": "sha256-cn6kCA4KZccmIkw3zIchoJ7TGXzL2lRi8Q1lyLznUCs=",
+        "lastModified": 1652625926,
+        "narHash": "sha256-C4PUO3S6WEWiPv7sk3eEIOTHyWS1TDC2OYxffBhtCsw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd8e87160a094d5415111abdd6ca8fc3314604bf",
+        "rev": "f661ee1189e8ed855f1bfb763e5eb3c116c27a1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f661ee11`](https://github.com/nix-community/NUR/commit/f661ee1189e8ed855f1bfb763e5eb3c116c27a1e) | `automatic update` |