### PR TITLE
chore(flake/nur): `f661ee11` -> `1944cd33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652625926,
-        "narHash": "sha256-C4PUO3S6WEWiPv7sk3eEIOTHyWS1TDC2OYxffBhtCsw=",
+        "lastModified": 1652639100,
+        "narHash": "sha256-IfBIwcvksquaV8c/jooskJwhQloOZpB+wlPuO9yMw8E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f661ee1189e8ed855f1bfb763e5eb3c116c27a1e",
+        "rev": "1944cd338ac341b00a288a8f8bb374b519ed4451",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1944cd33`](https://github.com/nix-community/NUR/commit/1944cd338ac341b00a288a8f8bb374b519ed4451) | `automatic update` |