### PR TITLE
chore(flake/emacs-overlay): `972925e3` -> `48b5d664`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1652613188,
-        "narHash": "sha256-vHp4U0y0w0ntf4LF8zk0FTbTkwiiJtbs78eSYQVSABw=",
+        "lastModified": 1652646435,
+        "narHash": "sha256-UUKrScutFP/Up8eMoOAolt4sj5wNumfHRVP4AdqF3Io=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "972925e3f1b6724eaf6a896f1ae9390d205fcaae",
+        "rev": "48b5d664638c851932d656c20447a632f0b58912",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`48b5d664`](https://github.com/nix-community/emacs-overlay/commit/48b5d664638c851932d656c20447a632f0b58912) | `Updated repos/melpa` |
| [`8019a5ac`](https://github.com/nix-community/emacs-overlay/commit/8019a5ac24f31e3ab3c74a49bc743e11532199fe) | `Updated repos/emacs` |