### PR TITLE
chore(flake/nur): `8b3e0f61` -> `a8e29b1a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652647187,
-        "narHash": "sha256-OxskNWXlrCeJSfhV7NCWGl9qNoiPIiANA/ZJvk4KAXM=",
+        "lastModified": 1652654100,
+        "narHash": "sha256-oX/QrH5fwm8uEpNcQb+Q+Oc5dP5pgwkvrBa2juofuAM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8b3e0f614bf2dff80967f7c7d62409d12226b166",
+        "rev": "a8e29b1a82c668e72d94be1dd6ebf5fea29b6e76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a8e29b1a`](https://github.com/nix-community/NUR/commit/a8e29b1a82c668e72d94be1dd6ebf5fea29b6e76) | `automatic update` |