### PR TITLE
chore(flake/nur): `a8e29b1a` -> `332d07bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652654100,
-        "narHash": "sha256-oX/QrH5fwm8uEpNcQb+Q+Oc5dP5pgwkvrBa2juofuAM=",
+        "lastModified": 1652673806,
+        "narHash": "sha256-meTPCEgfUbIdD2rK0do/7z4K7bKuYPS52Ecfu2nx3T8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a8e29b1a82c668e72d94be1dd6ebf5fea29b6e76",
+        "rev": "332d07bd19e96f956c2ef0378d0214ee8c4bd844",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`332d07bd`](https://github.com/nix-community/NUR/commit/332d07bd19e96f956c2ef0378d0214ee8c4bd844) | `automatic update` |