### PR TITLE
chore(flake/nur): `332d07bd` -> `886e2b56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652673806,
-        "narHash": "sha256-meTPCEgfUbIdD2rK0do/7z4K7bKuYPS52Ecfu2nx3T8=",
+        "lastModified": 1652692634,
+        "narHash": "sha256-1XXowfSciD00VR7/fXjBgM/Dl0L2Ol8WCOvjVW2Ryfk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "332d07bd19e96f956c2ef0378d0214ee8c4bd844",
+        "rev": "886e2b56da0ad08bcd4d28bb79956446bb047924",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`886e2b56`](https://github.com/nix-community/NUR/commit/886e2b56da0ad08bcd4d28bb79956446bb047924) | `automatic update` |