### PR TITLE
chore(flake/nur): `886e2b56` -> `ee6de31c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652692634,
-        "narHash": "sha256-1XXowfSciD00VR7/fXjBgM/Dl0L2Ol8WCOvjVW2Ryfk=",
+        "lastModified": 1652696642,
+        "narHash": "sha256-0V03EITdzFkuL5j4vGPMYCIjBXUAh81GvKPmRxCwxrQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "886e2b56da0ad08bcd4d28bb79956446bb047924",
+        "rev": "ee6de31ced94e78f01c6cf3a41d56dff130261e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ee6de31c`](https://github.com/nix-community/NUR/commit/ee6de31ced94e78f01c6cf3a41d56dff130261e7) | `automatic update` |