### PR TITLE
chore(flake/nur): `ee6de31c` -> `8eba199b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652696642,
-        "narHash": "sha256-0V03EITdzFkuL5j4vGPMYCIjBXUAh81GvKPmRxCwxrQ=",
+        "lastModified": 1652699429,
+        "narHash": "sha256-sWy8ftFgOb86aDFlJU8or+pE72DGeHFRNpvKxGJU0ug=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ee6de31ced94e78f01c6cf3a41d56dff130261e7",
+        "rev": "8eba199b772313bd471b1d4ce7190f8e282ba4f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8eba199b`](https://github.com/nix-community/NUR/commit/8eba199b772313bd471b1d4ce7190f8e282ba4f2) | `automatic update` |