### PR TITLE
chore(flake/pre-commit-hooks): `e5e7b3b5` -> `521a5247`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -372,11 +372,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1649054408,
-        "narHash": "sha256-wz8AH7orqUE4Xog29WMTqOYBs0DMj2wFM8ulrTRVgz0=",
+        "lastModified": 1652714503,
+        "narHash": "sha256-qQKVEfDe5FqvGgkZtg5Pc491foeiDPIOeycHMqnPDps=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "e5e7b3b542e7f4f96967966a943d7e1c07558042",
+        "rev": "521a524771a8e93caddaa0ac1d67d03766a8b0b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                              |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
| [`8e8095bc`](https://github.com/cachix/pre-commit-hooks.nix/commit/8e8095bc655ffcf92cc1fa1a45b1f088c620abc6) | `Add cabalDefaultExtensions option to ormolu`               |
| [`2d087219`](https://github.com/cachix/pre-commit-hooks.nix/commit/2d087219bafa8f3d626015e22416f3f70490046b) | `chore(deps): bump cachix/install-nix-action from 16 to 17` |