### PR TITLE
chore(flake/emacs-overlay): `e9f4792a` -> `513a50db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1652700427,
-        "narHash": "sha256-Tzuqx7w3CIN/kZRE1hjMMsB3oC+39OoCUpgbw4it3RI=",
+        "lastModified": 1652728347,
+        "narHash": "sha256-bvf6IgRsHidrFnx3tDQef3huPxYWqZEb1G0gS6bxQG4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e9f4792aa79bccedb34b3fc04d1a36f1848b7b57",
+        "rev": "513a50dbc4589f33abca1f8d1084496fbb70a08e",
         "type": "github"
       },
       "original": {
@@ -195,11 +195,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1652557277,
-        "narHash": "sha256-jSes9DaIVMdmwBB78KkFUVrlDzawmD62vrUg0GS2500=",
+        "lastModified": 1652733177,
+        "narHash": "sha256-mRpdBbVk8tbYVgEE6oTBbFT1vkVdF7EzaP7bMQ26wWA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "12806d31a381e7cd169a6bac35590e7b36dc5fe5",
+        "rev": "04b4d989fda8f14e6fcd1fee631eab9c54d15b97",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`513a50db`](https://github.com/nix-community/emacs-overlay/commit/513a50dbc4589f33abca1f8d1084496fbb70a08e) | `Updated repos/melpa` |
| [`37265b87`](https://github.com/nix-community/emacs-overlay/commit/37265b87aa5f02c589a0147346de05d25c87a3db) | `Updated repos/emacs` |