### PR TITLE
chore(flake/nur): `8eba199b` -> `c4ba1171`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652699429,
-        "narHash": "sha256-sWy8ftFgOb86aDFlJU8or+pE72DGeHFRNpvKxGJU0ug=",
+        "lastModified": 1652730642,
+        "narHash": "sha256-dXKmTEwi3hH/5GieOM0E9blD9OZFQFdJ80/I00FKPGU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8eba199b772313bd471b1d4ce7190f8e282ba4f2",
+        "rev": "c4ba1171cb73d1f41c3dc0800c25a83ac31de767",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c4ba1171`](https://github.com/nix-community/NUR/commit/c4ba1171cb73d1f41c3dc0800c25a83ac31de767) | `automatic update` |