### PR TITLE
chore(flake/utils): `12806d31` -> `04b4d989`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -497,11 +497,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1652557277,
-        "narHash": "sha256-jSes9DaIVMdmwBB78KkFUVrlDzawmD62vrUg0GS2500=",
+        "lastModified": 1652733177,
+        "narHash": "sha256-mRpdBbVk8tbYVgEE6oTBbFT1vkVdF7EzaP7bMQ26wWA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "12806d31a381e7cd169a6bac35590e7b36dc5fe5",
+        "rev": "04b4d989fda8f14e6fcd1fee631eab9c54d15b97",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                                                   |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`04b4d989`](https://github.com/numtide/flake-utils/commit/04b4d989fda8f14e6fcd1fee631eab9c54d15b97) | `Sanitize the final derivation name to ensure length limits are respected (#66)` |