### PR TITLE
chore(flake/nur): `c4ba1171` -> `5a3b12f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652730642,
-        "narHash": "sha256-dXKmTEwi3hH/5GieOM0E9blD9OZFQFdJ80/I00FKPGU=",
+        "lastModified": 1652736404,
+        "narHash": "sha256-zOb1P1Iq0kCLFn4rcJaAd8w+yfXRepn9temQpSYVnpQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c4ba1171cb73d1f41c3dc0800c25a83ac31de767",
+        "rev": "5a3b12f7ccdee2620be5076f37222cdbb4fde544",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5a3b12f7`](https://github.com/nix-community/NUR/commit/5a3b12f7ccdee2620be5076f37222cdbb4fde544) | `automatic update` |