### PR TITLE
chore(flake/nur): `5a3b12f7` -> `8ad0d601`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652736404,
-        "narHash": "sha256-zOb1P1Iq0kCLFn4rcJaAd8w+yfXRepn9temQpSYVnpQ=",
+        "lastModified": 1652745333,
+        "narHash": "sha256-jVtaIP3KwzhsY6YYMVswYsTfD4LCIj/KRmpP9nQW3CA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5a3b12f7ccdee2620be5076f37222cdbb4fde544",
+        "rev": "8ad0d601e11519af3f3c404a8508ac086ca1f841",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8ad0d601`](https://github.com/nix-community/NUR/commit/8ad0d601e11519af3f3c404a8508ac086ca1f841) | `automatic update` |