### PR TITLE
chore(flake/nur): `8ad0d601` -> `f8c21a86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652745333,
-        "narHash": "sha256-jVtaIP3KwzhsY6YYMVswYsTfD4LCIj/KRmpP9nQW3CA=",
+        "lastModified": 1652760310,
+        "narHash": "sha256-61rI6TiJYAZMJ8g/+nN1F6E+fheTrmHNU7bd1t8uTT4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8ad0d601e11519af3f3c404a8508ac086ca1f841",
+        "rev": "f8c21a8631907ef0b3ed88ac40b24e3c33fe850a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f8c21a86`](https://github.com/nix-community/NUR/commit/f8c21a8631907ef0b3ed88ac40b24e3c33fe850a) | `automatic update` |