### PR TITLE
chore(flake/nur): `f8c21a86` -> `1493d054`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652760310,
-        "narHash": "sha256-61rI6TiJYAZMJ8g/+nN1F6E+fheTrmHNU7bd1t8uTT4=",
+        "lastModified": 1652770818,
+        "narHash": "sha256-qnd0iqWaWUKIDj0eaxwvf2ogH6adWy1S/GUIGqXflRI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f8c21a8631907ef0b3ed88ac40b24e3c33fe850a",
+        "rev": "1493d054500550b776d4f0f0b8e2dc676ac5e05d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1493d054`](https://github.com/nix-community/NUR/commit/1493d054500550b776d4f0f0b8e2dc676ac5e05d) | `automatic update` |