### PR TITLE
chore(flake/nur): `1493d054` -> `fd040a68`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652770818,
-        "narHash": "sha256-qnd0iqWaWUKIDj0eaxwvf2ogH6adWy1S/GUIGqXflRI=",
+        "lastModified": 1652782937,
+        "narHash": "sha256-Zina4zghyhlffMSmtgjVDI/sWr51GWlzRP5TAMwGNzA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1493d054500550b776d4f0f0b8e2dc676ac5e05d",
+        "rev": "fd040a684f367c889eb46699e645841859486f44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`fd040a68`](https://github.com/nix-community/NUR/commit/fd040a684f367c889eb46699e645841859486f44) | `automatic update` |