### PR TITLE
chore(flake/nur): `d6c4b6e3` -> `1438bfee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652829536,
-        "narHash": "sha256-1SQ6CA9Uq9aot74ofDOKjjsaLRWELPbNuFxa3nK1/jA=",
+        "lastModified": 1652842932,
+        "narHash": "sha256-VFpdnOu9SObuPoAletbhAqIUUEmF/qCb7Lt3tQDIC+E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d6c4b6e35b103d45f02b4fa0ce6d8e5648dd4364",
+        "rev": "1438bfeef1c5c18e0fc9ace27611992ff0d1ea7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1438bfee`](https://github.com/nix-community/NUR/commit/1438bfeef1c5c18e0fc9ace27611992ff0d1ea7a) | `automatic update` |