### PR TITLE
chore(flake/nur): `1438bfee` -> `426bb5db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652842932,
-        "narHash": "sha256-VFpdnOu9SObuPoAletbhAqIUUEmF/qCb7Lt3tQDIC+E=",
+        "lastModified": 1652843987,
+        "narHash": "sha256-z4X/Xvz13RH3yOmb9tvG6BF+iX5EN2Qp5a4yh5t783A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1438bfeef1c5c18e0fc9ace27611992ff0d1ea7a",
+        "rev": "426bb5dbeb5db67416c6084e9df50cd629ef7535",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`426bb5db`](https://github.com/nix-community/NUR/commit/426bb5dbeb5db67416c6084e9df50cd629ef7535) | `automatic update` |
| [`be9f6755`](https://github.com/nix-community/NUR/commit/be9f6755547ba12747152d2befdebbfbc7774403) | `automatic update` |