### PR TITLE
chore(flake/nur): `426bb5db` -> `787089f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652843987,
-        "narHash": "sha256-z4X/Xvz13RH3yOmb9tvG6BF+iX5EN2Qp5a4yh5t783A=",
+        "lastModified": 1652845605,
+        "narHash": "sha256-Sz4xx9ReDj7K11NOlIexvGF3RnCMHb8gwX4McamItvs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "426bb5dbeb5db67416c6084e9df50cd629ef7535",
+        "rev": "787089f11357c34238ada719b0875bf681c5458c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`787089f1`](https://github.com/nix-community/NUR/commit/787089f11357c34238ada719b0875bf681c5458c) | `automatic update` |