### PR TITLE
chore(flake/emacs-overlay): `dcbb707a` -> `fa2f0962`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1652786163,
-        "narHash": "sha256-L75dzGAzNk+06wJBlkYCeqNTrSvwXfFZalRUlHn9tV0=",
+        "lastModified": 1652846755,
+        "narHash": "sha256-7ds14XyNmFRg0RXStbZjjxjjBPy6sW2gx1Modbool20=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dcbb707a85372909622b094eb193c4fb7a83a3a1",
+        "rev": "fa2f096282a3e8043e147faeac4323f2b0f33153",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`fa2f0962`](https://github.com/nix-community/emacs-overlay/commit/fa2f096282a3e8043e147faeac4323f2b0f33153) | `Updated repos/nongnu` |
| [`a5b353b0`](https://github.com/nix-community/emacs-overlay/commit/a5b353b0382987239f9d4b44c4cc8db3248ee0d5) | `Updated repos/melpa`  |
| [`4b055fca`](https://github.com/nix-community/emacs-overlay/commit/4b055fcaf5c599c529da13b974fce868481813e8) | `Updated repos/emacs`  |
| [`114df1a7`](https://github.com/nix-community/emacs-overlay/commit/114df1a77d5c35e0fbf87b6286b48206e15c5174) | `Updated repos/elpa`   |