### PR TITLE
chore(flake/nur): `b389fc32` -> `07eb5b58`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652846926,
-        "narHash": "sha256-ccw2S5un8oFm+Z4mTRmqlJY5eWUcFmENqm2TJNJZUdY=",
+        "lastModified": 1652857278,
+        "narHash": "sha256-b25odJltgIYzPFI+WVXJI6+k55GZqVemtfqeN+qSBos=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b389fc3246a8efba543f5cefaffefbce35e07243",
+        "rev": "07eb5b58a905a460096e30e911fbaface7a848bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`07eb5b58`](https://github.com/nix-community/NUR/commit/07eb5b58a905a460096e30e911fbaface7a848bf) | `automatic update` |