### PR TITLE
chore(flake/nur): `07eb5b58` -> `02bed69e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652857278,
-        "narHash": "sha256-b25odJltgIYzPFI+WVXJI6+k55GZqVemtfqeN+qSBos=",
+        "lastModified": 1652858349,
+        "narHash": "sha256-QGMHtRN5BNLa09vXUdE36w0CQwM5QaK7Lfm1kghEABw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "07eb5b58a905a460096e30e911fbaface7a848bf",
+        "rev": "02bed69ec5657ca5aad3dc6ffdf9052baad609cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`02bed69e`](https://github.com/nix-community/NUR/commit/02bed69ec5657ca5aad3dc6ffdf9052baad609cb) | `automatic update` |