### PR TITLE
chore(flake/emacs-overlay): `fa2f0962` -> `a18eb3f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1652846755,
-        "narHash": "sha256-7ds14XyNmFRg0RXStbZjjxjjBPy6sW2gx1Modbool20=",
+        "lastModified": 1652872944,
+        "narHash": "sha256-PQrbNRPck3L/D3xqRg00GeMQPgAmrVS0V56eeH7FOic=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fa2f096282a3e8043e147faeac4323f2b0f33153",
+        "rev": "a18eb3f2dd7f21b70f2d1afd1c0486d8dbcce1b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`a18eb3f2`](https://github.com/nix-community/emacs-overlay/commit/a18eb3f2dd7f21b70f2d1afd1c0486d8dbcce1b3) | `Updated repos/melpa` |
| [`3133c11a`](https://github.com/nix-community/emacs-overlay/commit/3133c11a05ad2a52cf760d6b185d816194d36f9a) | `Updated repos/emacs` |