### PR TITLE
chore(flake/emacs-overlay): `a18eb3f2` -> `679fceda`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1652872944,
-        "narHash": "sha256-PQrbNRPck3L/D3xqRg00GeMQPgAmrVS0V56eeH7FOic=",
+        "lastModified": 1652901942,
+        "narHash": "sha256-3HsYj0/0mHD+63oB3WM4HIfs8fxcURQKstzsQsGRbSA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a18eb3f2dd7f21b70f2d1afd1c0486d8dbcce1b3",
+        "rev": "679fcedab06892651d3173c2f504dcf40b4ef939",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`679fceda`](https://github.com/nix-community/emacs-overlay/commit/679fcedab06892651d3173c2f504dcf40b4ef939) | `Updated repos/melpa` |
| [`c3b4f0e4`](https://github.com/nix-community/emacs-overlay/commit/c3b4f0e49ba0f0d9ccd1249215727c0e566f719c) | `Updated repos/emacs` |
| [`5a11a565`](https://github.com/nix-community/emacs-overlay/commit/5a11a565eeda78e787a200f3bc423e3a199829f6) | `Updated repos/elpa`  |