### PR TITLE
chore(flake/home-manager): `32a7da69` -> `cb9f03d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -215,11 +215,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1652452047,
-        "narHash": "sha256-O6DI0dMH/5rNM+z9CQ/nqRMNBpNsU7TtLSsafKLZTHY=",
+        "lastModified": 1652913097,
+        "narHash": "sha256-hOs8Z5WYzCor+qP+JgSgrCJRC+UuN9pfTUnXqyRUBvY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "32a7da69dc53c9eb5ad0675eb7fdc58f7fe35272",
+        "rev": "cb9f03d519cf96fcd7dfb990cc0e586a62ca6e69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message       |
| ----------------------------------------------------------------------------------------------------------- | -------------------- |
| [`cb9f03d5`](https://github.com/nix-community/home-manager/commit/cb9f03d519cf96fcd7dfb990cc0e586a62ca6e69) | `mopidy: add module` |