### PR TITLE
chore(flake/nur): `d1a12e09` -> `b188bc4d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652877807,
-        "narHash": "sha256-SjBDrxFW++M/G8+tAbEtAK7jrzjQe1fnNr5A7q7NSZw=",
+        "lastModified": 1652916058,
+        "narHash": "sha256-wmsCN1+dKGyButDCc6DO2gdUFYYMW5b66e2/bf/0oo0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d1a12e09f8e0342e9bca13991ae70c9f32a08ce9",
+        "rev": "b188bc4d079e5effbe50b72260f3282c8f414603",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b188bc4d`](https://github.com/nix-community/NUR/commit/b188bc4d079e5effbe50b72260f3282c8f414603) | `automatic update` |