### PR TITLE
chore(flake/nur): `b188bc4d` -> `19402e17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652916058,
-        "narHash": "sha256-wmsCN1+dKGyButDCc6DO2gdUFYYMW5b66e2/bf/0oo0=",
+        "lastModified": 1652917946,
+        "narHash": "sha256-fEe205A1ZejB62ZquKgD0jncGXJODkutCypq7KezSSU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b188bc4d079e5effbe50b72260f3282c8f414603",
+        "rev": "19402e17b9fa173045a0b77a99d8416b12d1150b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`19402e17`](https://github.com/nix-community/NUR/commit/19402e17b9fa173045a0b77a99d8416b12d1150b) | `automatic update` |