### PR TITLE
chore(flake/nur): `19402e17` -> `4e920d8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652917946,
-        "narHash": "sha256-fEe205A1ZejB62ZquKgD0jncGXJODkutCypq7KezSSU=",
+        "lastModified": 1652919218,
+        "narHash": "sha256-Hr0OM2VmA5Qid52GQRk4KX7ci5VUNKWtFYU2AKA+Cec=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "19402e17b9fa173045a0b77a99d8416b12d1150b",
+        "rev": "4e920d8ea51612dc1557d922d2d3204b28a46447",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4e920d8e`](https://github.com/nix-community/NUR/commit/4e920d8ea51612dc1557d922d2d3204b28a46447) | `automatic update` |