### PR TITLE
chore(flake/nur): `4e920d8e` -> `8a30e1e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652919218,
-        "narHash": "sha256-Hr0OM2VmA5Qid52GQRk4KX7ci5VUNKWtFYU2AKA+Cec=",
+        "lastModified": 1652926825,
+        "narHash": "sha256-uI5DQWm+HU4Gj5/PrW9L19ASurKtsGw9O3Donv3bwAY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4e920d8ea51612dc1557d922d2d3204b28a46447",
+        "rev": "8a30e1e8aeca7a42be22764ae8b84a2c87a6c981",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8a30e1e8`](https://github.com/nix-community/NUR/commit/8a30e1e8aeca7a42be22764ae8b84a2c87a6c981) | `automatic update` |