### PR TITLE
chore(flake/nur): `8a30e1e8` -> `4ad36e58`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652926825,
-        "narHash": "sha256-uI5DQWm+HU4Gj5/PrW9L19ASurKtsGw9O3Donv3bwAY=",
+        "lastModified": 1652933320,
+        "narHash": "sha256-EZdjzlUJuEcGn3Hsl2Kx3OwDsQR6U2c/DfJs5HapRFY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8a30e1e8aeca7a42be22764ae8b84a2c87a6c981",
+        "rev": "4ad36e584346a4d28f1db6c58f86b2a5f37780b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4ad36e58`](https://github.com/nix-community/NUR/commit/4ad36e584346a4d28f1db6c58f86b2a5f37780b7) | `automatic update` |