### PR TITLE
chore(flake/emacs-overlay): `679fceda` -> `de5c8261`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1652901942,
-        "narHash": "sha256-3HsYj0/0mHD+63oB3WM4HIfs8fxcURQKstzsQsGRbSA=",
+        "lastModified": 1652934326,
+        "narHash": "sha256-YgSgR0V/rsqJX6DWyXlPOwsaXXiOkN+9z5rfE9kn2IU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "679fcedab06892651d3173c2f504dcf40b4ef939",
+        "rev": "de5c826149bcfbaa5f0ce985bb184c9bc7f11e46",
         "type": "github"
       },
       "original": {
@@ -305,11 +305,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652739558,
-        "narHash": "sha256-znGkjGugajqF/sFS+H4+ENmGTaVPFE0uu1JjQZJLEaQ=",
+        "lastModified": 1652840887,
+        "narHash": "sha256-gEK4NNa4GwIgTZE63kt/4WTFAWRTJVSa30+h4ZjFh9U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ff691ed9ba21528c1b4e034f36a04027e4522c58",
+        "rev": "52dc75a4fee3fdbcb792cb6fba009876b912bfe0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`de5c8261`](https://github.com/nix-community/emacs-overlay/commit/de5c826149bcfbaa5f0ce985bb184c9bc7f11e46) | `Updated repos/melpa` |
| [`ee294048`](https://github.com/nix-community/emacs-overlay/commit/ee29404870b13dba20fc3b519ad4af533c2c0051) | `Updated repos/emacs` |