### PR TITLE
chore(flake/nur): `4ad36e58` -> `2d8f65d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652933320,
-        "narHash": "sha256-EZdjzlUJuEcGn3Hsl2Kx3OwDsQR6U2c/DfJs5HapRFY=",
+        "lastModified": 1652938196,
+        "narHash": "sha256-kv6EEwTPtvtqVlaSH/sRhWx9ecONrr5bccMdxu1nhwc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ad36e584346a4d28f1db6c58f86b2a5f37780b7",
+        "rev": "2d8f65d73133859961b8714918ac8f60d98a76e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2d8f65d7`](https://github.com/nix-community/NUR/commit/2d8f65d73133859961b8714918ac8f60d98a76e5) | `automatic update` |