### PR TITLE
chore(flake/nur): `c9dd93fc` -> `c5a7e11a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652955915,
-        "narHash": "sha256-tBGywOqAHHkXJkjvuFS35sWuIc7T1iOeF6M/udbLnVA=",
+        "lastModified": 1652969435,
+        "narHash": "sha256-cbNoHYnKpAkhpx5wMnvXsZ9fvAsvVIPyk940nmOGog0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c9dd93fc14d9c5da72c26d3357c6e3284891d52f",
+        "rev": "c5a7e11a501bed777dcbd0c6c7ab2093199f50e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c5a7e11a`](https://github.com/nix-community/NUR/commit/c5a7e11a501bed777dcbd0c6c7ab2093199f50e3) | `automatic update` |