### PR TITLE
chore(flake/nur): `c5a7e11a` -> `4e2c0ab1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652969435,
-        "narHash": "sha256-cbNoHYnKpAkhpx5wMnvXsZ9fvAsvVIPyk940nmOGog0=",
+        "lastModified": 1652994821,
+        "narHash": "sha256-GBJJD6PPOVQZO5XHax2YP0EgVPhqBFMyZoGjIOWhRmk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c5a7e11a501bed777dcbd0c6c7ab2093199f50e3",
+        "rev": "4e2c0ab1c9e428f964872e686953f68c2bf2bebe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4e2c0ab1`](https://github.com/nix-community/NUR/commit/4e2c0ab1c9e428f964872e686953f68c2bf2bebe) | `automatic update` |