### PR TITLE
chore(flake/home-manager): `cb9f03d5` -> `e6869735`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -215,11 +215,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1652913097,
-        "narHash": "sha256-hOs8Z5WYzCor+qP+JgSgrCJRC+UuN9pfTUnXqyRUBvY=",
+        "lastModified": 1652996000,
+        "narHash": "sha256-xKZlvqN6a5wfGkGfznPvwlCW494evGu8PTA3JVU0vRg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cb9f03d519cf96fcd7dfb990cc0e586a62ca6e69",
+        "rev": "e6869735d25bb2d33a93ac8e5fcc9a02bbbb5351",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message              |
| ----------------------------------------------------------------------------------------------------------- | --------------------------- |
| [`e6869735`](https://github.com/nix-community/home-manager/commit/e6869735d25bb2d33a93ac8e5fcc9a02bbbb5351) | `htop: fix darwin defaults` |