### PR TITLE
chore(flake/nur): `4e2c0ab1` -> `791c6278`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652994821,
-        "narHash": "sha256-GBJJD6PPOVQZO5XHax2YP0EgVPhqBFMyZoGjIOWhRmk=",
+        "lastModified": 1653000092,
+        "narHash": "sha256-SivCD3DEU5LjM4FlxWfAVmpJp7Vn/KCxKij0hNcyDDU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4e2c0ab1c9e428f964872e686953f68c2bf2bebe",
+        "rev": "791c6278ba5e064b493a4fc83afc5e3e532e5bb1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`791c6278`](https://github.com/nix-community/NUR/commit/791c6278ba5e064b493a4fc83afc5e3e532e5bb1) | `automatic update` |
| [`4ab0b3bc`](https://github.com/nix-community/NUR/commit/4ab0b3bc0bcfa401360cac1f77a4355589c465f7) | `automatic update` |