### PR TITLE
chore(flake/home-manager): `e6869735` -> `02b15de8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -215,11 +215,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1652996000,
-        "narHash": "sha256-xKZlvqN6a5wfGkGfznPvwlCW494evGu8PTA3JVU0vRg=",
+        "lastModified": 1652996682,
+        "narHash": "sha256-7ZWyd5W2tM/uxXGn16AJUXenlGPUt/r6zitEcorz5j0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e6869735d25bb2d33a93ac8e5fcc9a02bbbb5351",
+        "rev": "02b15de8ad714409358cffdc6ed518ade03402c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                   |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`02b15de8`](https://github.com/nix-community/home-manager/commit/02b15de8ad714409358cffdc6ed518ade03402c4) | `Translate using Weblate (French)`               |
| [`97fac4f2`](https://github.com/nix-community/home-manager/commit/97fac4f2820212a00ed134f9c7e5409d3ecbbf77) | `Translate using Weblate (Chinese (Simplified))` |