### PR TITLE
chore(flake/nur): `791c6278` -> `dd5922d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653000092,
-        "narHash": "sha256-SivCD3DEU5LjM4FlxWfAVmpJp7Vn/KCxKij0hNcyDDU=",
+        "lastModified": 1653014896,
+        "narHash": "sha256-HIh9g3KIl18ScYjMbndYaWJ8mY0HFv1bVHRCzRPsdVg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "791c6278ba5e064b493a4fc83afc5e3e532e5bb1",
+        "rev": "dd5922d9ffc57fc925938ed9e264ba3a7a6d6ef0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`dd5922d9`](https://github.com/nix-community/NUR/commit/dd5922d9ffc57fc925938ed9e264ba3a7a6d6ef0) | `automatic update` |