### PR TITLE
chore(flake/nur): `dd5922d9` -> `5c7dddfc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653014896,
-        "narHash": "sha256-HIh9g3KIl18ScYjMbndYaWJ8mY0HFv1bVHRCzRPsdVg=",
+        "lastModified": 1653019874,
+        "narHash": "sha256-Gi6g/R2cmpBnTJpdr7CrGjc5q3vbZeG6olWhOFJ098k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd5922d9ffc57fc925938ed9e264ba3a7a6d6ef0",
+        "rev": "5c7dddfc0afb23f7459f695eb096c2c46334200d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5c7dddfc`](https://github.com/nix-community/NUR/commit/5c7dddfc0afb23f7459f695eb096c2c46334200d) | `automatic update` |