### PR TITLE
chore(flake/nur): `5c7dddfc` -> `95b717c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653019874,
-        "narHash": "sha256-Gi6g/R2cmpBnTJpdr7CrGjc5q3vbZeG6olWhOFJ098k=",
+        "lastModified": 1653021240,
+        "narHash": "sha256-0XiW70pSgUhc2nTTojeA0XC6XCCdF1YM15mQfkEXmDs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5c7dddfc0afb23f7459f695eb096c2c46334200d",
+        "rev": "95b717c7bde13d0f73b497be6f2497cf2050f311",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`95b717c7`](https://github.com/nix-community/NUR/commit/95b717c7bde13d0f73b497be6f2497cf2050f311) | `automatic update` |