### PR TITLE
chore(flake/nur): `95b717c7` -> `f4070d23`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653021240,
-        "narHash": "sha256-0XiW70pSgUhc2nTTojeA0XC6XCCdF1YM15mQfkEXmDs=",
+        "lastModified": 1653029348,
+        "narHash": "sha256-0YAJnBLRdU6V5xnVXJ7XDEC6otHRV500GYNW4wgYif0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "95b717c7bde13d0f73b497be6f2497cf2050f311",
+        "rev": "f4070d238f6ce4c55da6ff890dd495551cb80a52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                |
| -------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`f4070d23`](https://github.com/nix-community/NUR/commit/f4070d238f6ce4c55da6ff890dd495551cb80a52) | `automatic update`            |
| [`ec4e34a5`](https://github.com/nix-community/NUR/commit/ec4e34a5f7d47c0bb9d04e63aa08be7a6cdf21b4) | `automatic update`            |
| [`cd168d39`](https://github.com/nix-community/NUR/commit/cd168d399ee3ca205cd68159b59d88bdb88783e6) | `use --json instead of --xml` |