### PR TITLE
chore(flake/nixos-hardware): `6b4ebea9` -> `b49fe0e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -291,11 +291,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1650522846,
-        "narHash": "sha256-SxWHXRI3qJwswyXAtzsi6PKVY3KLNNnb072KaJthII8=",
+        "lastModified": 1653029861,
+        "narHash": "sha256-f9IkBMBuFZcq+lspk91OKsNaBtrrDsKn+ItHmj2fO/4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "6b4ebea9093c997c5f275c820e679108de4871ab",
+        "rev": "b49fe0e96e6b1233340eae44b257160f3c71a32d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`162fb7a9`](https://github.com/NixOS/nixos-hardware/commit/162fb7a9878f8ba190196190f3bb98b599eb2141) | `framework: acpilight should be used`                                    |
| [`34485f18`](https://github.com/NixOS/nixos-hardware/commit/34485f1807befc9b104e59e0716e7a5cd0967fcb) | `framework: Fix TRRS headphones missing a mic`                           |
| [`f3dfd301`](https://github.com/NixOS/nixos-hardware/commit/f3dfd30170425adbc377ee502c3b4af13541b3ae) | `framework: Fix headphone noise when on powersave`                       |
| [`b750b56a`](https://github.com/NixOS/nixos-hardware/commit/b750b56a20a335056c1211b91ae16a7fa057f1c2) | `feat: add acpi_call and ssd for thinkpad x270`                          |
| [`68c87ede`](https://github.com/NixOS/nixos-hardware/commit/68c87edeb979e10ccb29db2125a6bbd372092f28) | `dell-xps-15-9560-nvidia: use Nvidia Offload mode to save battery power` |