### PR TITLE
chore(flake/nur): `f4070d23` -> `eedf7ab8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653029348,
-        "narHash": "sha256-0YAJnBLRdU6V5xnVXJ7XDEC6otHRV500GYNW4wgYif0=",
+        "lastModified": 1653032442,
+        "narHash": "sha256-IZPUddr5xOJSCV+UnNh8jpOpFKdcXHt6hH5QWGmoRkM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f4070d238f6ce4c55da6ff890dd495551cb80a52",
+        "rev": "eedf7ab88beaeb8914c18d5ee62a539ad98fbddb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message          |
| -------------------------------------------------------------------------------------------------- | ----------------------- |
| [`eedf7ab8`](https://github.com/nix-community/NUR/commit/eedf7ab88beaeb8914c18d5ee62a539ad98fbddb) | `automatic update`      |
| [`eb2e99ea`](https://github.com/nix-community/NUR/commit/eb2e99eaa5614ba27ea28322beadbd0c705147d3) | `add imsofi repository` |