### PR TITLE
chore(flake/nur): `eedf7ab8` -> `4aaa2b5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653032442,
-        "narHash": "sha256-IZPUddr5xOJSCV+UnNh8jpOpFKdcXHt6hH5QWGmoRkM=",
+        "lastModified": 1653037746,
+        "narHash": "sha256-ROHfXaa/S3gjVCC4/sdnfbLRFy6bdvE67FyPdDHzSPY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eedf7ab88beaeb8914c18d5ee62a539ad98fbddb",
+        "rev": "4aaa2b5f4b8d461eb2b27fb7906a0454ac8b629f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4aaa2b5f`](https://github.com/nix-community/NUR/commit/4aaa2b5f4b8d461eb2b27fb7906a0454ac8b629f) | `automatic update` |