### PR TITLE
chore(flake/nur): `4aaa2b5f` -> `f27711d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653037746,
-        "narHash": "sha256-ROHfXaa/S3gjVCC4/sdnfbLRFy6bdvE67FyPdDHzSPY=",
+        "lastModified": 1653042409,
+        "narHash": "sha256-P3h+rDxT1AScFhwc8MconD5AnhmWykoEMNDatP6IEMU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4aaa2b5f4b8d461eb2b27fb7906a0454ac8b629f",
+        "rev": "f27711d8edb9480dfb1c3c899987df4b94aa2bed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f27711d8`](https://github.com/nix-community/NUR/commit/f27711d8edb9480dfb1c3c899987df4b94aa2bed) | `automatic update` |