### PR TITLE
chore(flake/nixos-hardware): `b49fe0e9` -> `be2b338c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -291,11 +291,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1653029861,
-        "narHash": "sha256-f9IkBMBuFZcq+lspk91OKsNaBtrrDsKn+ItHmj2fO/4=",
+        "lastModified": 1653065754,
+        "narHash": "sha256-qZPWVTl/JSIivgPQCbRwD0hSLLp4Y7uIUQ59ucSoRQM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b49fe0e96e6b1233340eae44b257160f3c71a32d",
+        "rev": "be2b338c6a05b9e46a811119e3c5bca98a118467",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                              |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`4a8259f0`](https://github.com/NixOS/nixos-hardware/commit/4a8259f0e255d0406728a4ff250b18aecf7eceeb) | `framework: add nvme.noacpi=1`                              |
| [`de8271f7`](https://github.com/NixOS/nixos-hardware/commit/de8271f760987a29a8a181675d7b36cb3f324f11) | `framework: make it possible to disable fprintd if desired` |