### PR TITLE
chore(flake/emacs-ement): `d1e4fc20` -> `4a6b9e21`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1652535031,
-        "narHash": "sha256-oAQnepNZhdBHSpkk9Ujw+SsYkpqjmj4RnKDVSg1D6M8=",
+        "lastModified": 1653079386,
+        "narHash": "sha256-+/J2w2syFqWynScLMRBvv5k+/2zfVIPwo+7pyWpm64g=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "d1e4fc2074cebf3ee8d39e8efebab1b6e67af1b6",
+        "rev": "4a6b9e21d37a504d592b7de09e62e670505c79c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                |
| --------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`4a6b9e21`](https://github.com/alphapapa/ement.el/commit/4a6b9e21d37a504d592b7de09e62e670505c79c0) | `Change/Fix: Sender names when not in margin` |