### PR TITLE
chore(flake/emacs-ement): `4a6b9e21` -> `fd96491e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1653079386,
-        "narHash": "sha256-+/J2w2syFqWynScLMRBvv5k+/2zfVIPwo+7pyWpm64g=",
+        "lastModified": 1653081528,
+        "narHash": "sha256-iuKhCTDAisrAPWQyRDAWBFHhafbl8fJiT+tr3SJC87o=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "4a6b9e21d37a504d592b7de09e62e670505c79c0",
+        "rev": "fd96491e82a5335058b72aaff7665f0a2c3d4495",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                 |
| --------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`fd96491e`](https://github.com/alphapapa/ement.el/commit/fd96491e82a5335058b72aaff7665f0a2c3d4495) | `Fix: (ement-room-goto-event)` |