### PR TITLE
chore(flake/emacs-overlay): `c04830e9` -> `ecbf3cd2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1653073925,
-        "narHash": "sha256-3CiKpKMjbKZ/FzTb/xdOxglnJtTNssfmu9DAOdT8r18=",
+        "lastModified": 1653107257,
+        "narHash": "sha256-Gn1xebxJO51WrN5UuQjQ9YuTHtvL6F7pyPylGYH4sD4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c04830e91ab27bb98f66d936f36137275804a6e3",
+        "rev": "ecbf3cd2be71e3da5427b50ef71fdb6d548a977c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ecbf3cd2`](https://github.com/nix-community/emacs-overlay/commit/ecbf3cd2be71e3da5427b50ef71fdb6d548a977c) | `Updated repos/melpa` |
| [`f02d6cdd`](https://github.com/nix-community/emacs-overlay/commit/f02d6cdd0ba5e1e2a6778886ef741cc81a2006e3) | `Updated repos/emacs` |