### PR TITLE
chore(flake/nur): `488ed96c` -> `6e0ba57d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653117001,
-        "narHash": "sha256-8YVJMqPBcW1VLIh5JthcdrVMMpe11bky9vSVQER2Fzs=",
+        "lastModified": 1653136000,
+        "narHash": "sha256-VE2PJR1EO8QmTPyC5AJJxIb8YI+a8R4J+xwHvkB/pWg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "488ed96c873f6b5f163db4712fc3d6aded3cde11",
+        "rev": "6e0ba57d9579bfc2ff652cd7c4d725423f76a8c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6e0ba57d`](https://github.com/nix-community/NUR/commit/6e0ba57d9579bfc2ff652cd7c4d725423f76a8c4) | `automatic update` |