### PR TITLE
chore(flake/nur): `4d02b4f0` -> `3989d8b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653139206,
-        "narHash": "sha256-B3lMCTSTCnwaA8GlfgnRlnM5x5Sp1bTwkm94QM6+Z9E=",
+        "lastModified": 1653153671,
+        "narHash": "sha256-YTm86BTIVTTxlT18odVpuScTgnC59hMaKrEas68iNSI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4d02b4f0515c284934c3c8531eb68961eed2e2de",
+        "rev": "3989d8b644ddf06b9ca384d02fb14a8c719b42fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3989d8b6`](https://github.com/nix-community/NUR/commit/3989d8b644ddf06b9ca384d02fb14a8c719b42fc) | `automatic update` |