### PR TITLE
chore(flake/nur): `3989d8b6` -> `768c7d96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653153671,
-        "narHash": "sha256-YTm86BTIVTTxlT18odVpuScTgnC59hMaKrEas68iNSI=",
+        "lastModified": 1653157530,
+        "narHash": "sha256-9JC7EGOBwkxQ+MUuKXNvCjaQZzZxXYyG9kPlTNVziak=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3989d8b644ddf06b9ca384d02fb14a8c719b42fc",
+        "rev": "768c7d968dc9b90b6fa6f85374669de3e57d70ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`768c7d96`](https://github.com/nix-community/NUR/commit/768c7d968dc9b90b6fa6f85374669de3e57d70ca) | `automatic update` |