### PR TITLE
chore(flake/emacs-overlay): `f251c3e4` -> `d969a968`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1653133477,
-        "narHash": "sha256-RAwSvb/5Q7bRQuHBLQXuUXy3bE/IPqRPivoWILxR2hg=",
+        "lastModified": 1653162731,
+        "narHash": "sha256-CLZJgJp6wCMd388OMoe9hTxh2+b9cgm7UCdQCtAfv4c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f251c3e4bcca34feb1b3d178843ae30a024da3a9",
+        "rev": "d969a968ee668d3ed646e056710c13f2efb9073a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`d969a968`](https://github.com/nix-community/emacs-overlay/commit/d969a968ee668d3ed646e056710c13f2efb9073a) | `Updated repos/melpa` |
| [`480968ad`](https://github.com/nix-community/emacs-overlay/commit/480968ad51a0bbee9c8ea3628bc475390273666d) | `Updated repos/emacs` |
| [`11ad86a8`](https://github.com/nix-community/emacs-overlay/commit/11ad86a8eb4dc3ba6b8256ad76ef6ab5acc663d1) | `Updated repos/elpa`  |