### PR TITLE
chore(flake/nur): `7d440f0c` -> `738353fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653177109,
-        "narHash": "sha256-yqRPoTqXPqWwO66nryepTDNedU9ZKR1GXVfM13UGWHY=",
+        "lastModified": 1653192230,
+        "narHash": "sha256-jqlqpshKyrRpSVKZnf4Klx+mSnflj+hjigNFoDTOuyc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7d440f0c35a42c3a37481c2f195c7ee2d7954046",
+        "rev": "738353fd4b7514f81a1f9e7251eed972a6327ac8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`738353fd`](https://github.com/nix-community/NUR/commit/738353fd4b7514f81a1f9e7251eed972a6327ac8) | `automatic update` |