### PR TITLE
chore(flake/emacs-overlay): `d969a968` -> `fd5baf06`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1653162731,
-        "narHash": "sha256-CLZJgJp6wCMd388OMoe9hTxh2+b9cgm7UCdQCtAfv4c=",
+        "lastModified": 1653195452,
+        "narHash": "sha256-mELLZWAKE3CpO7eZMd4griwL1X1pdanm37qEnnkSRTE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d969a968ee668d3ed646e056710c13f2efb9073a",
+        "rev": "fd5baf065e1af4cbb9d40eba66971d31f61d6bd1",
         "type": "github"
       },
       "original": {
@@ -305,11 +305,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652840887,
-        "narHash": "sha256-gEK4NNa4GwIgTZE63kt/4WTFAWRTJVSa30+h4ZjFh9U=",
+        "lastModified": 1653117584,
+        "narHash": "sha256-5uUrHeHBIaySBTrRExcCoW8fBBYVSDjDYDU5A6iOl+k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "52dc75a4fee3fdbcb792cb6fba009876b912bfe0",
+        "rev": "f4dfed73ee886b115a99e5b85fdfbeb683290d83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`fd5baf06`](https://github.com/nix-community/emacs-overlay/commit/fd5baf065e1af4cbb9d40eba66971d31f61d6bd1) | `Updated repos/nongnu` |
| [`30010fdf`](https://github.com/nix-community/emacs-overlay/commit/30010fdfc3905e552bc8942afae06ed69b5d2211) | `Updated repos/melpa`  |
| [`7c922784`](https://github.com/nix-community/emacs-overlay/commit/7c9227843b57077ad44f4d8dd25b775e964eca14) | `Updated repos/emacs`  |
| [`af371091`](https://github.com/nix-community/emacs-overlay/commit/af371091b8aeea7946c68f6e215d4604381aac47) | `Updated repos/elpa`   |