### PR TITLE
chore(flake/nur): `738353fd` -> `0302f3bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653192230,
-        "narHash": "sha256-jqlqpshKyrRpSVKZnf4Klx+mSnflj+hjigNFoDTOuyc=",
+        "lastModified": 1653207879,
+        "narHash": "sha256-bfvSmNcgGhTz6ME0EeVl4BjyXwKmC3ZVHYNSN1Wc6Eg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "738353fd4b7514f81a1f9e7251eed972a6327ac8",
+        "rev": "0302f3bdabf55396777b580d4f2aa051445f4943",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0302f3bd`](https://github.com/nix-community/NUR/commit/0302f3bdabf55396777b580d4f2aa051445f4943) | `automatic update` |