### PR TITLE
chore(flake/emacs-overlay): `fd5baf06` -> `99235a10`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1653195452,
-        "narHash": "sha256-mELLZWAKE3CpO7eZMd4griwL1X1pdanm37qEnnkSRTE=",
+        "lastModified": 1653219729,
+        "narHash": "sha256-1ES4JeKpJCZYxCb4h4aoeliSpeYBHEIJaozPAW4Rj44=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fd5baf065e1af4cbb9d40eba66971d31f61d6bd1",
+        "rev": "99235a10c3b3ddd0b3e5fef006c394a4ffba3c37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`99235a10`](https://github.com/nix-community/emacs-overlay/commit/99235a10c3b3ddd0b3e5fef006c394a4ffba3c37) | `Updated repos/melpa` |
| [`042cfa90`](https://github.com/nix-community/emacs-overlay/commit/042cfa90b8257e5d751a797384eb671e6852d3c1) | `Updated repos/emacs` |