### PR TITLE
chore(flake/nur): `dabac730` -> `6c882119`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653222288,
-        "narHash": "sha256-krjOrbgI2jC7s1lyKgpaI7J87YRTAGJXhEjqCJWrIPg=",
+        "lastModified": 1653223919,
+        "narHash": "sha256-SLYdVyoqnQ8rwowMtDrYg/qvg5I3+ZVHZcGSHVFWbh0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dabac730fc3282c6c35c0ca0540f19991863ae92",
+        "rev": "6c88211931940d3f5362749a52dc1960cf29f6f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6c882119`](https://github.com/nix-community/NUR/commit/6c88211931940d3f5362749a52dc1960cf29f6f4) | `automatic update` |