### PR TITLE
chore(flake/nur): `6c882119` -> `0619b6a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653223919,
-        "narHash": "sha256-SLYdVyoqnQ8rwowMtDrYg/qvg5I3+ZVHZcGSHVFWbh0=",
+        "lastModified": 1653238855,
+        "narHash": "sha256-3ERW7YK+Gpq8+OnTEUO7jjTspJopm5A3YkksUrQ1o4I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6c88211931940d3f5362749a52dc1960cf29f6f4",
+        "rev": "0619b6a0460972936b4001e45a16238a95cc78da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0619b6a0`](https://github.com/nix-community/NUR/commit/0619b6a0460972936b4001e45a16238a95cc78da) | `automatic update` |