### PR TITLE
chore(flake/nur): `aa4929a6` -> `160965fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653241022,
-        "narHash": "sha256-DSHIpi0nZpPhmPOKAw72XBUvyyoDJlM6Pd8Genr90VA=",
+        "lastModified": 1653243160,
+        "narHash": "sha256-pJecm5xlW5ayjTHuXdoeG6iygMvP7gtt5zxqdjpoI7g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aa4929a69361b0efe9597a525081eee7360b2f18",
+        "rev": "160965fe1d1011399b18a70fc635e6cb12222a75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`160965fe`](https://github.com/nix-community/NUR/commit/160965fe1d1011399b18a70fc635e6cb12222a75) | `automatic update` |