### PR TITLE
chore(flake/nur): `50168c47` -> `43957661`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653253862,
-        "narHash": "sha256-2D4ixbGtauG3PQPKdGGrXNY1pU1YvdCNigDnXOvSDXM=",
+        "lastModified": 1653256745,
+        "narHash": "sha256-g5Kk27VNs9sSQonCkuczKM0vvpe+qrRA8kdz7tugKCQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "50168c477351cfa4bd5578ae351b0f7b38e97de1",
+        "rev": "43957661e46485fc2829a93b9f499b48c556e306",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`43957661`](https://github.com/nix-community/NUR/commit/43957661e46485fc2829a93b9f499b48c556e306) | `automatic update` |