### PR TITLE
chore(flake/dendrite-demo-pinecone): `8535fbd9` -> `939534d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -40,11 +40,11 @@
     "dendrite": {
       "flake": false,
       "locked": {
-        "lastModified": 1652879843,
-        "narHash": "sha256-uvifuXEsyIEP4XW5ExYf2b/OvWqNyU5fEL2MzVkJNuY=",
+        "lastModified": 1653046031,
+        "narHash": "sha256-BL5pKZEXQYHUNaa8M2TI+X3scX/sA3bYinHHrvDequM=",
         "owner": "matrix-org",
         "repo": "dendrite",
-        "rev": "f321a7d55ea75e6a5276cd88eddcbbc82ceeaaeb",
+        "rev": "a53c9300aa501ccf31658fe832f5e4565441f8f4",
         "type": "github"
       },
       "original": {
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1652897652,
-        "narHash": "sha256-N5M2sjbvDfYLKwlZmYAJ42cH8gy6UnAbLAn4oJF/mLI=",
+        "lastModified": 1653285086,
+        "narHash": "sha256-bqhCXEL9EQKNtB7K2EEATyubK+N/KCcmtALPwfzwUQM=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "8535fbd91d3773cf459f404bb7f8b4b841381c5d",
+        "rev": "939534d2a9a71078338207719c36402390217caf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                          | Commit Message       |
| --------------------------------------------------------------------------------------------------------------- | -------------------- |
| [`939534d2`](https://github.com/bbigras/dendrite-demo-pinecone/commit/939534d2a9a71078338207719c36402390217caf) | `flake.lock: Update` |