### PR TITLE
chore(flake/nixgl): `56f2fbcc` -> `3214ffea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1651078744,
-        "narHash": "sha256-+S/NEzZoTt7EoSOMEUsR/LuNTtzYhbribFaIewNxdCQ=",
+        "lastModified": 1653311504,
+        "narHash": "sha256-4/EOfhL9gRAhUlC57DEQyg74RrcXPG8TTUDF8G7l6OY=",
         "owner": "guibou",
         "repo": "nixgl",
-        "rev": "56f2fbcce7a08c60c98394a64e900d5e9227bcb2",
+        "rev": "3214ffead3934d1d8873657fdde4a4527078f9f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                        | Commit Message                              |
| --------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`4fda57f5`](https://github.com/guibou/nixGL/commit/4fda57f53c0a288d23a90712c0dd3cc644f6bb7d) | `Silence false error on non-nvidia systems` |