### PR TITLE
chore(flake/dendrite-demo-pinecone): `939534d2` -> `505fa12b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -40,11 +40,11 @@
     "dendrite": {
       "flake": false,
       "locked": {
-        "lastModified": 1653046031,
-        "narHash": "sha256-BL5pKZEXQYHUNaa8M2TI+X3scX/sA3bYinHHrvDequM=",
+        "lastModified": 1653324841,
+        "narHash": "sha256-FimhJMcumqqRkDaVBwzau6aJu5Z6p3zuAaUSLVHl5tw=",
         "owner": "matrix-org",
         "repo": "dendrite",
-        "rev": "a53c9300aa501ccf31658fe832f5e4565441f8f4",
+        "rev": "447226790153afc47b62df4d81f66ec7129dca90",
         "type": "github"
       },
       "original": {
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1653285086,
-        "narHash": "sha256-bqhCXEL9EQKNtB7K2EEATyubK+N/KCcmtALPwfzwUQM=",
+        "lastModified": 1653329484,
+        "narHash": "sha256-EA/Zeyop1xyKpIoHPStcyVHdv6eK0I8EVtyL1CmAxeM=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "939534d2a9a71078338207719c36402390217caf",
+        "rev": "505fa12b1e27cabc42b7090775c2c05c5c6e0de8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                          | Commit Message       |
| --------------------------------------------------------------------------------------------------------------- | -------------------- |
| [`505fa12b`](https://github.com/bbigras/dendrite-demo-pinecone/commit/505fa12b1e27cabc42b7090775c2c05c5c6e0de8) | `flake: update`      |
| [`ff1f9d23`](https://github.com/bbigras/dendrite-demo-pinecone/commit/ff1f9d235c370615d44cdd9f0bba20b5956646aa) | `flake.lock: Update` |