### PR TITLE
chore(flake/nur): `b6984da0` -> `dfa1c8a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653324171,
-        "narHash": "sha256-Iw4d5ruvDGAdJpEygHUJG8oZfev/P+cNJQ+pwNisvNw=",
+        "lastModified": 1653336888,
+        "narHash": "sha256-Ap7yTJjCzSlqjKH0uOrXxhCRUDx9V/WeHY3wVjl1/8Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b6984da07f8f6eca8e2cedd488d63915fc781d43",
+        "rev": "dfa1c8a5923a4289ea094e0cd23f294c1d49ac65",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`dfa1c8a5`](https://github.com/nix-community/NUR/commit/dfa1c8a5923a4289ea094e0cd23f294c1d49ac65) | `automatic update` |
| [`0272e261`](https://github.com/nix-community/NUR/commit/0272e261b591c8f403ef6a20eaaaea0b3c4d25a3) | `automatic update` |