### PR TITLE
chore(flake/nur): `dfa1c8a5` -> `ecaa00fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653336888,
-        "narHash": "sha256-Ap7yTJjCzSlqjKH0uOrXxhCRUDx9V/WeHY3wVjl1/8Q=",
+        "lastModified": 1653341652,
+        "narHash": "sha256-/+HQCL94IgBcCIm3r9VvxeKtjSS/PUOURUrXQiNuZCs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dfa1c8a5923a4289ea094e0cd23f294c1d49ac65",
+        "rev": "ecaa00fd0801b6bbf28e0fd5fbb508da12242f90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ecaa00fd`](https://github.com/nix-community/NUR/commit/ecaa00fd0801b6bbf28e0fd5fbb508da12242f90) | `automatic update` |