### PR TITLE
chore(flake/nur): `ecaa00fd` -> `0cb3b1f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653341652,
-        "narHash": "sha256-/+HQCL94IgBcCIm3r9VvxeKtjSS/PUOURUrXQiNuZCs=",
+        "lastModified": 1653345516,
+        "narHash": "sha256-+i7O4S1L4sYYS7B+UL+YRNbrgWg5IkorempySlSsb/I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ecaa00fd0801b6bbf28e0fd5fbb508da12242f90",
+        "rev": "0cb3b1f60e0681298f69a34f70c7d46efe4a8ca4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0cb3b1f6`](https://github.com/nix-community/NUR/commit/0cb3b1f60e0681298f69a34f70c7d46efe4a8ca4) | `automatic update` |