### PR TITLE
chore(flake/nur): `0cb3b1f6` -> `b01eb1d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653345516,
-        "narHash": "sha256-+i7O4S1L4sYYS7B+UL+YRNbrgWg5IkorempySlSsb/I=",
+        "lastModified": 1653361480,
+        "narHash": "sha256-JWf7Pv39dxbCuCQ3/+QDGr6IVdNnumgSYM9gCPeAd1Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0cb3b1f60e0681298f69a34f70c7d46efe4a8ca4",
+        "rev": "b01eb1d94fbf763ede75f94f0db41808e3e8c27e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b01eb1d9`](https://github.com/nix-community/NUR/commit/b01eb1d94fbf763ede75f94f0db41808e3e8c27e) | `automatic update` |