### PR TITLE
chore(flake/nur): `b01eb1d9` -> `2e341883`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653361480,
-        "narHash": "sha256-JWf7Pv39dxbCuCQ3/+QDGr6IVdNnumgSYM9gCPeAd1Q=",
+        "lastModified": 1653365308,
+        "narHash": "sha256-G85OIjY+IaHfAhdgHIvvK0mjKUvZD92k8TG6LJ1XB38=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b01eb1d94fbf763ede75f94f0db41808e3e8c27e",
+        "rev": "2e3418831e49df27a296a8296ba7a6b15a6df063",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2e341883`](https://github.com/nix-community/NUR/commit/2e3418831e49df27a296a8296ba7a6b15a6df063) | `automatic update` |