### PR TITLE
chore(flake/nur): `2e341883` -> `9b84a9f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653365308,
-        "narHash": "sha256-G85OIjY+IaHfAhdgHIvvK0mjKUvZD92k8TG6LJ1XB38=",
+        "lastModified": 1653373399,
+        "narHash": "sha256-DQXi7Y0SDWlWN2NVJRu7HpEZ7refVt3CsFUnKfpJENQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2e3418831e49df27a296a8296ba7a6b15a6df063",
+        "rev": "9b84a9f7713a105c7b2efa93760d0964f4f01b3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9b84a9f7`](https://github.com/nix-community/NUR/commit/9b84a9f7713a105c7b2efa93760d0964f4f01b3e) | `automatic update` |