### PR TITLE
chore(flake/nur): `9b84a9f7` -> `bb9689f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653373399,
-        "narHash": "sha256-DQXi7Y0SDWlWN2NVJRu7HpEZ7refVt3CsFUnKfpJENQ=",
+        "lastModified": 1653376222,
+        "narHash": "sha256-wNzttWrRtrked+7IVBI5PHqtIv8omuQSFEpdhUl/UH0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9b84a9f7713a105c7b2efa93760d0964f4f01b3e",
+        "rev": "bb9689f8de6d2ff3c364f1cb5bdbb473d2aa3801",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`bb9689f8`](https://github.com/nix-community/NUR/commit/bb9689f8de6d2ff3c364f1cb5bdbb473d2aa3801) | `automatic update` |