### PR TITLE
chore(flake/nur): `bb9689f8` -> `fcf01891`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653376222,
-        "narHash": "sha256-wNzttWrRtrked+7IVBI5PHqtIv8omuQSFEpdhUl/UH0=",
+        "lastModified": 1653394728,
+        "narHash": "sha256-8swJpuFRNAo+64R0NQ13DIQDt5rMFMmSXmovacaFtHw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bb9689f8de6d2ff3c364f1cb5bdbb473d2aa3801",
+        "rev": "fcf01891f0fb3f4b302328a438a0c709b350b588",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`fcf01891`](https://github.com/nix-community/NUR/commit/fcf01891f0fb3f4b302328a438a0c709b350b588) | `automatic update` |