### PR TITLE
chore(flake/nur): `fcf01891` -> `94be4b29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653394728,
-        "narHash": "sha256-8swJpuFRNAo+64R0NQ13DIQDt5rMFMmSXmovacaFtHw=",
+        "lastModified": 1653406317,
+        "narHash": "sha256-OvOGeD/75xQ1NlTrmZ96dgmdrZSQL58GnQzADQ44nBM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fcf01891f0fb3f4b302328a438a0c709b350b588",
+        "rev": "94be4b2912fbf4128b8687d4abcf5112bfcdaea9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`94be4b29`](https://github.com/nix-community/NUR/commit/94be4b2912fbf4128b8687d4abcf5112bfcdaea9) | `automatic update` |