### PR TITLE
chore(flake/nur): `94be4b29` -> `9fa630e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653406317,
-        "narHash": "sha256-OvOGeD/75xQ1NlTrmZ96dgmdrZSQL58GnQzADQ44nBM=",
+        "lastModified": 1653409025,
+        "narHash": "sha256-BcztT7m4eBLDaMBGo/jSKoWjFC5nD52yURl/QqMNe9U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "94be4b2912fbf4128b8687d4abcf5112bfcdaea9",
+        "rev": "9fa630e25a5fb4fe71e524e63f70710802c27710",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9fa630e2`](https://github.com/nix-community/NUR/commit/9fa630e25a5fb4fe71e524e63f70710802c27710) | `automatic update` |