### PR TITLE
chore(flake/nur): `9fa630e2` -> `a7c59f7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653409025,
-        "narHash": "sha256-BcztT7m4eBLDaMBGo/jSKoWjFC5nD52yURl/QqMNe9U=",
+        "lastModified": 1653410291,
+        "narHash": "sha256-0Bxr0DPF5WhPe0CsR7L24ibGn6D1RFChti/ntizlGAY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9fa630e25a5fb4fe71e524e63f70710802c27710",
+        "rev": "a7c59f7a132aa9f3503704ea7e7828fdc649c034",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a7c59f7a`](https://github.com/nix-community/NUR/commit/a7c59f7a132aa9f3503704ea7e7828fdc649c034) | `automatic update` |
| [`284caf98`](https://github.com/nix-community/NUR/commit/284caf9823a2ab4e807e6e2bb7627a6e28ff99a4) | `automatic update` |