### PR TITLE
chore(flake/nur): `a7c59f7a` -> `8de0a878`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653410291,
-        "narHash": "sha256-0Bxr0DPF5WhPe0CsR7L24ibGn6D1RFChti/ntizlGAY=",
+        "lastModified": 1653416119,
+        "narHash": "sha256-7+PHEWJOsH8Ra9bK0dCr4/t9X0pZ9A1VvN8N6fIs+R8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a7c59f7a132aa9f3503704ea7e7828fdc649c034",
+        "rev": "8de0a8787b5eaa82803bb3bd4e70b1a83412de46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8de0a878`](https://github.com/nix-community/NUR/commit/8de0a8787b5eaa82803bb3bd4e70b1a83412de46) | `automatic update` |