### PR TITLE
chore(flake/nur): `8de0a878` -> `b3f50660`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653416119,
-        "narHash": "sha256-7+PHEWJOsH8Ra9bK0dCr4/t9X0pZ9A1VvN8N6fIs+R8=",
+        "lastModified": 1653419556,
+        "narHash": "sha256-+kw876tPSdm9phcq9BvwBMPn6B0rYnlFknMeFJ3l88o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8de0a8787b5eaa82803bb3bd4e70b1a83412de46",
+        "rev": "b3f5066002b9783fbbf6164f015eea2f5401a088",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b3f50660`](https://github.com/nix-community/NUR/commit/b3f5066002b9783fbbf6164f015eea2f5401a088) | `automatic update` |