### PR TITLE
chore(flake/nur): `b3f50660` -> `9133065f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653419556,
-        "narHash": "sha256-+kw876tPSdm9phcq9BvwBMPn6B0rYnlFknMeFJ3l88o=",
+        "lastModified": 1653420356,
+        "narHash": "sha256-iRcHBq4/kXWAJNhf6miIR3/sv9/KOTAU3D+AiqZhVrQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b3f5066002b9783fbbf6164f015eea2f5401a088",
+        "rev": "9133065fd4b8eeb9c87e73cf4701b43beb778615",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9133065f`](https://github.com/nix-community/NUR/commit/9133065fd4b8eeb9c87e73cf4701b43beb778615) | `automatic update` |