### PR TITLE
chore(flake/nur): `9133065f` -> `3623ccba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653420356,
-        "narHash": "sha256-iRcHBq4/kXWAJNhf6miIR3/sv9/KOTAU3D+AiqZhVrQ=",
+        "lastModified": 1653447821,
+        "narHash": "sha256-uNVlfUGWR3yODNVz1s85DG2ixJaMb5LiEeruzxRyi84=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9133065fd4b8eeb9c87e73cf4701b43beb778615",
+        "rev": "3623ccbaea4a10b3b1fb5c3b3b11e612b7943a7e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3623ccba`](https://github.com/nix-community/NUR/commit/3623ccbaea4a10b3b1fb5c3b3b11e612b7943a7e) | `automatic update` |