### PR TITLE
chore(flake/nur): `3623ccba` -> `6744526d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653447821,
-        "narHash": "sha256-uNVlfUGWR3yODNVz1s85DG2ixJaMb5LiEeruzxRyi84=",
+        "lastModified": 1653460497,
+        "narHash": "sha256-JRT3Z+iTJkOhLwx7mtTgRoPBsPRD2WgoEntFomfg058=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3623ccbaea4a10b3b1fb5c3b3b11e612b7943a7e",
+        "rev": "6744526df79da68164891c263b81d016934fcdfa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                 |
| -------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`6744526d`](https://github.com/nix-community/NUR/commit/6744526df79da68164891c263b81d016934fcdfa) | `automatic update`             |
| [`c7274218`](https://github.com/nix-community/NUR/commit/c727421835addac2fd5e7ab5e0822e767f03c393) | `automatic update`             |
| [`d6111e1c`](https://github.com/nix-community/NUR/commit/d6111e1cee3805f6c62d3182797f9b13a9e97139) | `add nur-pkgs repository`      |
| [`a4373ce7`](https://github.com/nix-community/NUR/commit/a4373ce7dc55610aba5daecf23cb30e014dae83c) | `add sagikazarmark repository` |