### PR TITLE
chore(flake/sops-nix): `13079f98` -> `7385b127`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -333,6 +333,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-22_05": {
+      "locked": {
+        "lastModified": 1653460991,
+        "narHash": "sha256-8MgFe84UUKw5k5MybirNH0S+oSluN2cRQGt+ZkW+dxQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0c3bf3a5c3ab6be29138b88900c417660a284fbd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1652659998,
@@ -464,14 +480,15 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "nixpkgs-21_11": "nixpkgs-21_11"
+        "nixpkgs-21_11": "nixpkgs-21_11",
+        "nixpkgs-22_05": "nixpkgs-22_05"
       },
       "locked": {
-        "lastModified": 1653237221,
-        "narHash": "sha256-zMgangC+wDXvdAz/aP5jDg/Paw7icNFhQIZsJVACMc0=",
+        "lastModified": 1653462763,
+        "narHash": "sha256-n0beO7WNvAeEtTtnetzQCaGs615tU/DfM97k8r/7bUw=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "13079f98ddfdc9e06e4b688332626ca954c14264",
+        "rev": "7385b12722ce903e477878147794bed9040227e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                                                   |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`5837d09f`](https://github.com/Mic92/sops-nix/commit/5837d09f1195ecbd20ac1fe8b4f2f48b013d91e8) | `no longer advertise support for platforms we don't test`        |
| [`5d69dafb`](https://github.com/Mic92/sops-nix/commit/5d69dafb8d6ec0395ea79b432e80bc69ddfae010) | ``no longer use deprecated `.machine` attribute in nixos tests`` |
| [`664c4d71`](https://github.com/Mic92/sops-nix/commit/664c4d7101eff5f25ca386c400f167313cc304ba) | `also build ci for 22.05`                                        |