### PR TITLE
chore(flake/nur): `6744526d` -> `6f139a70`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653460497,
-        "narHash": "sha256-JRT3Z+iTJkOhLwx7mtTgRoPBsPRD2WgoEntFomfg058=",
+        "lastModified": 1653474242,
+        "narHash": "sha256-9SguS1kKoCHVqj7bxXO5EGhu9zsxz6ZHTwEqh2qmrNg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6744526df79da68164891c263b81d016934fcdfa",
+        "rev": "6f139a70bb0e68233d922f6f53ad1e8874551f07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6f139a70`](https://github.com/nix-community/NUR/commit/6f139a70bb0e68233d922f6f53ad1e8874551f07) | `automatic update` |