### PR TITLE
chore(flake/home-manager): `e66f0ff6` -> `2c8489e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -215,11 +215,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1653340164,
-        "narHash": "sha256-t6BPApyasx6FOv2cEVyFBXvkEDrknyUe7bngMbNSBkA=",
+        "lastModified": 1653497002,
+        "narHash": "sha256-L2kb16MAU59LIEWq7ODNsz5AHw5B5Dn9DNaKJF8pG/M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e66f0ff69a6c0698b35034b842c4b68814440778",
+        "rev": "2c8489e57a04c913ba9e029cc2849a4bbac9673b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                            |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`2c8489e5`](https://github.com/nix-community/home-manager/commit/2c8489e57a04c913ba9e029cc2849a4bbac9673b) | `mpdris2: add basic test cases`           |
| [`9042c756`](https://github.com/nix-community/home-manager/commit/9042c756faaaa773107e5409ac0a9973c84cae8a) | `mpdris2: remove assertion on mpd module` |
| [`d73ba6a5`](https://github.com/nix-community/home-manager/commit/d73ba6a534a3619b64391e69e2cbcb1d9196ff78) | `mpdris2: add password option`            |