### PR TITLE
chore(flake/nur): `6f139a70` -> `a47a41aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653474242,
-        "narHash": "sha256-9SguS1kKoCHVqj7bxXO5EGhu9zsxz6ZHTwEqh2qmrNg=",
+        "lastModified": 1653498660,
+        "narHash": "sha256-KP719SA0+2Ct+l+MpxdY0cEsQ61BbglLdS3L1QqLapo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6f139a70bb0e68233d922f6f53ad1e8874551f07",
+        "rev": "a47a41aa30287b04bd4939777faeb49e5c004e3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a47a41aa`](https://github.com/nix-community/NUR/commit/a47a41aa30287b04bd4939777faeb49e5c004e3e) | `automatic update` |