### PR TITLE
chore(flake/nur): `a47a41aa` -> `0f4ebadd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653498660,
-        "narHash": "sha256-KP719SA0+2Ct+l+MpxdY0cEsQ61BbglLdS3L1QqLapo=",
+        "lastModified": 1653502463,
+        "narHash": "sha256-M+hnDEp9S/FMnDONuMNz72i/9JiTqsY9kExy9TclHZE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a47a41aa30287b04bd4939777faeb49e5c004e3e",
+        "rev": "0f4ebadd0f52b43e4f3dd110ad0780563fb3e13b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                  |
| -------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`0f4ebadd`](https://github.com/nix-community/NUR/commit/0f4ebadd0f52b43e4f3dd110ad0780563fb3e13b) | `automatic update`              |
| [`ac56ce83`](https://github.com/nix-community/NUR/commit/ac56ce83e65040dc1bab54bd5a61c7650b540355) | `add fliegendewurst repository` |