### PR TITLE
chore(flake/nur): `0f4ebadd` -> `9cb4cfd3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653502463,
-        "narHash": "sha256-M+hnDEp9S/FMnDONuMNz72i/9JiTqsY9kExy9TclHZE=",
+        "lastModified": 1653507861,
+        "narHash": "sha256-UO+WYkTdvnksCTY77CvEN1oow2ySArzWWSGXAgHgRQY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0f4ebadd0f52b43e4f3dd110ad0780563fb3e13b",
+        "rev": "9cb4cfd3bb34584c5f1bd7a8d9584b722f59c85e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9cb4cfd3`](https://github.com/nix-community/NUR/commit/9cb4cfd3bb34584c5f1bd7a8d9584b722f59c85e) | `automatic update` |