### PR TITLE
chore(flake/nur): `9cb4cfd3` -> `a4f00d7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653507861,
-        "narHash": "sha256-UO+WYkTdvnksCTY77CvEN1oow2ySArzWWSGXAgHgRQY=",
+        "lastModified": 1653509679,
+        "narHash": "sha256-6jaji0bRfGpdxSipQ1rkstKa1OYAh349/Bv6o6SZetQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9cb4cfd3bb34584c5f1bd7a8d9584b722f59c85e",
+        "rev": "a4f00d7d3beb4e8e3f7c9b252008b93b42feaf62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a4f00d7d`](https://github.com/nix-community/NUR/commit/a4f00d7d3beb4e8e3f7c9b252008b93b42feaf62) | `automatic update` |