### PR TITLE
chore(flake/nur): `a4f00d7d` -> `e6bce406`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653509679,
-        "narHash": "sha256-6jaji0bRfGpdxSipQ1rkstKa1OYAh349/Bv6o6SZetQ=",
+        "lastModified": 1653515647,
+        "narHash": "sha256-YYKjOi7kPDX2yT/bxMIsukbMs3+ZDkmlRYMA2Zj6tso=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a4f00d7d3beb4e8e3f7c9b252008b93b42feaf62",
+        "rev": "e6bce406755597c3c539598a0c3338cd5914a988",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e6bce406`](https://github.com/nix-community/NUR/commit/e6bce406755597c3c539598a0c3338cd5914a988) | `automatic update` |