### PR TITLE
chore(flake/nur): `0432735a` -> `469b6419`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653538104,
-        "narHash": "sha256-bJhXliehRtnpT9PGltEK3sLbRUmipW+Jl8RlPgH4hZk=",
+        "lastModified": 1653567301,
+        "narHash": "sha256-veNxtCoZAORH8wvo3C4NYLn8ojqp2NmPUO1DNV7Fop4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0432735abb9c7ae6211222e91f347d95cb1d1108",
+        "rev": "469b64191331109293ca4a500430f34ae9c2caf4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`469b6419`](https://github.com/nix-community/NUR/commit/469b64191331109293ca4a500430f34ae9c2caf4) | `automatic update` |
| [`c080f206`](https://github.com/nix-community/NUR/commit/c080f20692f1c407273d861fcf394b1ecdf88813) | `automatic update` |