### PR TITLE
chore(flake/dendrite-demo-pinecone): `bd01919f` -> `902af2cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -40,11 +40,11 @@
     "dendrite": {
       "flake": false,
       "locked": {
-        "lastModified": 1653386908,
-        "narHash": "sha256-vzlrDXAq735f8Nq2PpLBQ5xEPIEEHpYkStYvnwfZgFg=",
+        "lastModified": 1653574097,
+        "narHash": "sha256-AwLqHaGFQVneinWZJNKf2SaUFzgkV1i+30M9/BoR2GE=",
         "owner": "matrix-org",
         "repo": "dendrite",
-        "rev": "d621dd2986fa0b8cce9d164a7249456d0be47c81",
+        "rev": "b541f3043f0ad8924547c540d9235d017d1792f6",
         "type": "github"
       },
       "original": {
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1653402915,
-        "narHash": "sha256-JIvdX0N/QAi/r7yf8WHxoPNtPehqf95F8wa9XexZWbA=",
+        "lastModified": 1653593776,
+        "narHash": "sha256-wUU+zb/c/9AeZptVlXe9olDGoVBfJ+9wgxRMyiYY6GA=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "bd01919f6658f95df21bde0f1bbeb6471cab13ae",
+        "rev": "902af2cd43e2ed801b8a6f00e8256056760564b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                          | Commit Message       |
| --------------------------------------------------------------------------------------------------------------- | -------------------- |
| [`902af2cd`](https://github.com/bbigras/dendrite-demo-pinecone/commit/902af2cd43e2ed801b8a6f00e8256056760564b1) | `flake: update`      |
| [`ce287e22`](https://github.com/bbigras/dendrite-demo-pinecone/commit/ce287e22590f180c85e877e4bb4902782c0d729b) | `flake.lock: Update` |