### PR TITLE
chore(flake/nur): `469b6419` -> `0e15486b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653567301,
-        "narHash": "sha256-veNxtCoZAORH8wvo3C4NYLn8ojqp2NmPUO1DNV7Fop4=",
+        "lastModified": 1653599217,
+        "narHash": "sha256-00Y9dpPjzxU+TnXjtdtwDYKea3MII1R1kGc5ZJWO8PE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "469b64191331109293ca4a500430f34ae9c2caf4",
+        "rev": "0e15486b10a54fc7fb744bed812c50b2181d264b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0e15486b`](https://github.com/nix-community/NUR/commit/0e15486b10a54fc7fb744bed812c50b2181d264b) | `automatic update` |