### PR TITLE
chore(flake/nur): `0e15486b` -> `1686158e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653599217,
-        "narHash": "sha256-00Y9dpPjzxU+TnXjtdtwDYKea3MII1R1kGc5ZJWO8PE=",
+        "lastModified": 1653600538,
+        "narHash": "sha256-7VdPyEBnjUW2R7DoB6fZDl6EEfn+MoHs6qQzfs8TNy8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0e15486b10a54fc7fb744bed812c50b2181d264b",
+        "rev": "1686158e7e23642bdb61f23071ae07f3157ba7d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1686158e`](https://github.com/nix-community/NUR/commit/1686158e7e23642bdb61f23071ae07f3157ba7d4) | `automatic update` |