### PR TITLE
chore(flake/nur): `1686158e` -> `adf5200c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653600538,
-        "narHash": "sha256-7VdPyEBnjUW2R7DoB6fZDl6EEfn+MoHs6qQzfs8TNy8=",
+        "lastModified": 1653605498,
+        "narHash": "sha256-o3uHZraG7IUik50sHu5mDBoDfuihxErolskQ6G63/Ag=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1686158e7e23642bdb61f23071ae07f3157ba7d4",
+        "rev": "adf5200c224b0b12b6831ca8b0665d1a02530f54",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`adf5200c`](https://github.com/nix-community/NUR/commit/adf5200c224b0b12b6831ca8b0665d1a02530f54) | `automatic update` |