### PR TITLE
chore(flake/nur): `adf5200c` -> `cc4f0187`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653605498,
-        "narHash": "sha256-o3uHZraG7IUik50sHu5mDBoDfuihxErolskQ6G63/Ag=",
+        "lastModified": 1653612521,
+        "narHash": "sha256-Irj/UQX5OXuHg7vY2pBcfDZujLtDk0OnY0DAVIpRwwo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "adf5200c224b0b12b6831ca8b0665d1a02530f54",
+        "rev": "cc4f0187d69187d5db3c4c10195e874d68266d9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`cc4f0187`](https://github.com/nix-community/NUR/commit/cc4f0187d69187d5db3c4c10195e874d68266d9a) | `automatic update` |