### PR TITLE
chore(flake/nur): `cc4f0187` -> `7894b4a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653612521,
-        "narHash": "sha256-Irj/UQX5OXuHg7vY2pBcfDZujLtDk0OnY0DAVIpRwwo=",
+        "lastModified": 1653619326,
+        "narHash": "sha256-NG+tjwjKTwWcQnmBv3ajznHF+Wa+vutcNimZoZrjXZk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cc4f0187d69187d5db3c4c10195e874d68266d9a",
+        "rev": "7894b4a6fa700821393bb4fb3c5b496265492bf4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7894b4a6`](https://github.com/nix-community/NUR/commit/7894b4a6fa700821393bb4fb3c5b496265492bf4) | `automatic update` |