### PR TITLE
chore(flake/nur): `7894b4a6` -> `6a5e6693`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653619326,
-        "narHash": "sha256-NG+tjwjKTwWcQnmBv3ajznHF+Wa+vutcNimZoZrjXZk=",
+        "lastModified": 1653624501,
+        "narHash": "sha256-n9aKJmhI+LhRKWVkqNHBteVNwPzUEqIcczTOV9XeybM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7894b4a6fa700821393bb4fb3c5b496265492bf4",
+        "rev": "6a5e6693a4e95030b885cd0bc3921665028d225c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6a5e6693`](https://github.com/nix-community/NUR/commit/6a5e6693a4e95030b885cd0bc3921665028d225c) | `automatic update` |