### PR TITLE
chore(flake/emacs-ement): `fd96491e` -> `157f5174`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1653081528,
-        "narHash": "sha256-iuKhCTDAisrAPWQyRDAWBFHhafbl8fJiT+tr3SJC87o=",
+        "lastModified": 1653632186,
+        "narHash": "sha256-TVwuZsHiT0FBOa/wPM2muXQSKZqmD3gpmBDb7ieW4nc=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "fd96491e82a5335058b72aaff7665f0a2c3d4495",
+        "rev": "157f5174ce574f45db9cc24f138188f60802d06c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                         |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`0541916b`](https://github.com/alphapapa/ement.el/commit/0541916b61824a07c1c8d8104bbba375a7b0af1a) | `Fix: (ement-room-list--timestamp-colors) Workaround for TTY sessions` |
| [`bf2f0862`](https://github.com/alphapapa/ement.el/commit/bf2f0862d128f9c0ec3896dd5504ec19ad4de582) | `Correcting pantalaimon connection command`                            |