### PR TITLE
chore(flake/nur): `6a5e6693` -> `7d0a3fef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653624501,
-        "narHash": "sha256-n9aKJmhI+LhRKWVkqNHBteVNwPzUEqIcczTOV9XeybM=",
+        "lastModified": 1653644476,
+        "narHash": "sha256-/CLFYMHQvoMtdg9QxBGgwTPGFcetqnnyDKA0agCJABs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6a5e6693a4e95030b885cd0bc3921665028d225c",
+        "rev": "7d0a3fef248bc5f6b81124e49100b55c495b27cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7d0a3fef`](https://github.com/nix-community/NUR/commit/7d0a3fef248bc5f6b81124e49100b55c495b27cf) | `automatic update` |