### PR TITLE
chore(flake/emacs-ement): `157f5174` -> `212a9c9f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1653632186,
-        "narHash": "sha256-TVwuZsHiT0FBOa/wPM2muXQSKZqmD3gpmBDb7ieW4nc=",
+        "lastModified": 1653647676,
+        "narHash": "sha256-NfWtjvT+RMSJvXYCQ6PY0kLpKtKwc76Wn1dHLZKUM3k=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "157f5174ce574f45db9cc24f138188f60802d06c",
+        "rev": "212a9c9f41fdd07c239f23dcac47521f7d94b12e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                               |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`212a9c9f`](https://github.com/alphapapa/ement.el/commit/212a9c9f41fdd07c239f23dcac47521f7d94b12e) | `Change: (ement--sync) Retry for 502 errors` |