### PR TITLE
chore(flake/emacs-ement): `212a9c9f` -> `a0d97faf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1653647676,
-        "narHash": "sha256-NfWtjvT+RMSJvXYCQ6PY0kLpKtKwc76Wn1dHLZKUM3k=",
+        "lastModified": 1653701080,
+        "narHash": "sha256-xSN0ur4e6RiaoDWY4bziY3QtHLa/zwWUOvCqH52tjWI=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "212a9c9f41fdd07c239f23dcac47521f7d94b12e",
+        "rev": "a0d97faf28fe8960f8ae6fa48fabf44424c04f9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message       |
| --------------------------------------------------------------------------------------------------- | -------------------- |
| [`a0d97faf`](https://github.com/alphapapa/ement.el/commit/a0d97faf28fe8960f8ae6fa48fabf44424c04f9f) | `Fix: (ement--sync)` |