### PR TITLE
chore(flake/nur): `b4601c66` -> `8ebc91de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653691392,
-        "narHash": "sha256-+EWT89CZGi9LzSX22Ka1iPMWr1b7VtdD3ndTFalf6rw=",
+        "lastModified": 1653706406,
+        "narHash": "sha256-n7UMj/N5k/8A363PbzrBdc8LsqKejUFZXMC0tTW7yDs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b4601c666cde9c43b764d815ee40d50a34515cc6",
+        "rev": "8ebc91de450399a1da500714a13d96f3c25ae7bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8ebc91de`](https://github.com/nix-community/NUR/commit/8ebc91de450399a1da500714a13d96f3c25ae7bb) | `automatic update` |