### PR TITLE
chore(flake/nur): `8ebc91de` -> `777fbf2f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653706406,
-        "narHash": "sha256-n7UMj/N5k/8A363PbzrBdc8LsqKejUFZXMC0tTW7yDs=",
+        "lastModified": 1653710603,
+        "narHash": "sha256-nmkBjFthkuSxr+W/tZ3nZDKDWZStzMEtSXnRhfFVMDY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8ebc91de450399a1da500714a13d96f3c25ae7bb",
+        "rev": "777fbf2f6f972614338bbfc54d07509360a7915f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`777fbf2f`](https://github.com/nix-community/NUR/commit/777fbf2f6f972614338bbfc54d07509360a7915f) | `automatic update` |