### PR TITLE
chore(flake/nur): `777fbf2f` -> `b8458c69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653710603,
-        "narHash": "sha256-nmkBjFthkuSxr+W/tZ3nZDKDWZStzMEtSXnRhfFVMDY=",
+        "lastModified": 1653712167,
+        "narHash": "sha256-+bcMUCW1JuU/LiCmZqrVppZvVeEz472ELIYr33PacHI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "777fbf2f6f972614338bbfc54d07509360a7915f",
+        "rev": "b8458c698df20111e8a031cb2e5f69885090193c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b8458c69`](https://github.com/nix-community/NUR/commit/b8458c698df20111e8a031cb2e5f69885090193c) | `automatic update` |