### PR TITLE
chore(flake/nur): `b8458c69` -> `9ee11706`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653712167,
-        "narHash": "sha256-+bcMUCW1JuU/LiCmZqrVppZvVeEz472ELIYr33PacHI=",
+        "lastModified": 1653719884,
+        "narHash": "sha256-h+6nwSmn0BVZqbgpYli3Yz4o/0zzT6sZKJdRiSHj8Oc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b8458c698df20111e8a031cb2e5f69885090193c",
+        "rev": "9ee117067060bb97371a87bb969671384b60426b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9ee11706`](https://github.com/nix-community/NUR/commit/9ee117067060bb97371a87bb969671384b60426b) | `automatic update` |