### PR TITLE
chore(flake/nur): `9ee11706` -> `7a8313c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653719884,
-        "narHash": "sha256-h+6nwSmn0BVZqbgpYli3Yz4o/0zzT6sZKJdRiSHj8Oc=",
+        "lastModified": 1653724318,
+        "narHash": "sha256-4J2d/fc7huLrYsU7VRiquSNOcQoqQQQGNweR48zFEc4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ee117067060bb97371a87bb969671384b60426b",
+        "rev": "7a8313c6322856a5adbf9217e289733e67020652",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7a8313c6`](https://github.com/nix-community/NUR/commit/7a8313c6322856a5adbf9217e289733e67020652) | `automatic update` |
| [`47391eb7`](https://github.com/nix-community/NUR/commit/47391eb750fd6074df49c88b46f332f8bb0ac82b) | `automatic update` |