### PR TITLE
chore(flake/nur): `b6ad2a66` -> `b2eeb22b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653744184,
-        "narHash": "sha256-YzM0ldFW0OtxDOBgCJ7PBTL+NVRLi6SHy2m9U2gDTvw=",
+        "lastModified": 1653781997,
+        "narHash": "sha256-DTOUNYEz357Ye+W317Gexz5YPxWJis/U6eh1HV/OF+M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b6ad2a66f383a92b67f760e63c6fd3c63557e5ef",
+        "rev": "b2eeb22b8af41966eba6148c52993f84971520f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b2eeb22b`](https://github.com/nix-community/NUR/commit/b2eeb22b8af41966eba6148c52993f84971520f5) | `automatic update` |