### PR TITLE
chore(flake/nur): `99305a5c` -> `c4311e64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653797235,
-        "narHash": "sha256-wcR7uRpRLN0pww9+vJBVv5/UWrwcDL4pynIPIgFbG3w=",
+        "lastModified": 1653807697,
+        "narHash": "sha256-5anB5+X33A4HLkTq46y1odX0yP59h8B/8WhF2r4bYsg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "99305a5ca98f2fde1460d481df606cde90af5893",
+        "rev": "c4311e640f72b4c80745aa365d113e232374835c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c4311e64`](https://github.com/nix-community/NUR/commit/c4311e640f72b4c80745aa365d113e232374835c) | `automatic update` |