### PR TITLE
chore(flake/sops-nix): `77b1233c` -> `1fc4612a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -484,11 +484,11 @@
         "nixpkgs-22_05": "nixpkgs-22_05"
       },
       "locked": {
-        "lastModified": 1653815370,
-        "narHash": "sha256-w5XcSoOtxizQ079HY+m8cJEpmeXfJ3H3h0XQOCen3UQ=",
+        "lastModified": 1653824383,
+        "narHash": "sha256-TKzj5sSIGQ7ihi30MZa+f/jj9A9rIs2UyzAxsj6wvIs=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "77b1233c66756c7ef569b4eed34c0080e27cbc05",
+        "rev": "1fc4612ae8a2dc32f68ee6a275a722bd3e702510",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message      |
| ----------------------------------------------------------------------------------------------- | ------------------- |
| [`1fc4612a`](https://github.com/Mic92/sops-nix/commit/1fc4612ae8a2dc32f68ee6a275a722bd3e702510) | `add mergify rules` |