### PR TITLE
chore(flake/sops-nix): `1fc4612a` -> `36b59017`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -319,11 +319,11 @@
     },
     "nixpkgs-21_11": {
       "locked": {
-        "lastModified": 1653132211,
-        "narHash": "sha256-5ugEYisGqixwarfn3BJvuWDnO6gT/AoxlsA6jnG8Fv8=",
+        "lastModified": 1653819578,
+        "narHash": "sha256-a1vaUl6VZz1NsWxMw0i5lRyHIOVUIuMZdQzV+4s+rY8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b5991e4971523a5fcc9413b9003b58e5c15aa7d8",
+        "rev": "baa82d4b626288c7439eeea073a18aabbe435991",
         "type": "github"
       },
       "original": {
@@ -335,11 +335,11 @@
     },
     "nixpkgs-22_05": {
       "locked": {
-        "lastModified": 1653460991,
-        "narHash": "sha256-8MgFe84UUKw5k5MybirNH0S+oSluN2cRQGt+ZkW+dxQ=",
+        "lastModified": 1653822412,
+        "narHash": "sha256-xZwMDQ8MdNiTwE8dcKAX1h3qCmLtuudNGxmFUX3xIes=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c3bf3a5c3ab6be29138b88900c417660a284fbd",
+        "rev": "db78278ff296cf21eca7e8c08ee99707387a54fa",
         "type": "github"
       },
       "original": {
@@ -484,11 +484,11 @@
         "nixpkgs-22_05": "nixpkgs-22_05"
       },
       "locked": {
-        "lastModified": 1653824383,
-        "narHash": "sha256-TKzj5sSIGQ7ihi30MZa+f/jj9A9rIs2UyzAxsj6wvIs=",
+        "lastModified": 1653827546,
+        "narHash": "sha256-va51HFf7UwktvriIbe9pjRPMr7p8IaxrwcDlZe7twzI=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "1fc4612ae8a2dc32f68ee6a275a722bd3e702510",
+        "rev": "36b5901782e7fbfc191cace910f67f8b8743f678",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message       |
| ----------------------------------------------------------------------------------------------- | -------------------- |
| [`9c55a37d`](https://github.com/Mic92/sops-nix/commit/9c55a37d45e0d6d3d7d867ad23cb178536547c0b) | `fix mergify rules`  |
| [`7864dddd`](https://github.com/Mic92/sops-nix/commit/7864dddd5baa155fe18b522497cf86006eb5f6b3) | `flake.lock: Update` |