### PR TITLE
chore(flake/emacs-ement): `529cca4d` -> `6fd0d563`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1653839259,
-        "narHash": "sha256-elm2aH8mEcTl1raDhJJ7YlB4A4s+fSRu6ZYW0zJvMIk=",
+        "lastModified": 1653841111,
+        "narHash": "sha256-Gje9WW1xirS7P1DmxVWjDU+34swQZTDKf8ZQVxSxzm8=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "529cca4d6152d26dc35dcd2c2443a84b9c2cc21b",
+        "rev": "6fd0d563c2924c34de2d2275059a94d59adf3190",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                      |
| --------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`6fd0d563`](https://github.com/alphapapa/ement.el/commit/6fd0d563c2924c34de2d2275059a94d59adf3190) | `Add: (ement-taxy-side-window)`                     |
| [`de1e4b8e`](https://github.com/alphapapa/ement.el/commit/de1e4b8e43706ba94fd94f36634c5a7d70d2bb1c) | `Fix: (ement-taxy-room-list) display-buffer-action` |