### PR TITLE
chore(flake/nur): `fa2af0c2` -> `4198ac4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653820457,
-        "narHash": "sha256-C1ZFWguSsFfhgLZNszVRxZcQt4FQ4XWJT0u0DSEy/qo=",
+        "lastModified": 1653858809,
+        "narHash": "sha256-lfkciLYro96pFCZd5C2N6cQMp3ry8zV1Om5NoMrohJ4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fa2af0c2d1b6a3870bcae4749bb3b60813e7cb5a",
+        "rev": "4198ac4a1c1590b93962b6c9c24e0cea49bf889a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4198ac4a`](https://github.com/nix-community/NUR/commit/4198ac4a1c1590b93962b6c9c24e0cea49bf889a) | `automatic update` |