### PR TITLE
chore(flake/nur): `4198ac4a` -> `4d011c69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653858809,
-        "narHash": "sha256-lfkciLYro96pFCZd5C2N6cQMp3ry8zV1Om5NoMrohJ4=",
+        "lastModified": 1653883531,
+        "narHash": "sha256-zKjHf29Vqx0sE8bD6ng5Qz8Yzi3GCEnQhSE+0DLxDJ4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4198ac4a1c1590b93962b6c9c24e0cea49bf889a",
+        "rev": "4d011c6967bd90abb701ef3ce4658c823f103cb9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4d011c69`](https://github.com/nix-community/NUR/commit/4d011c6967bd90abb701ef3ce4658c823f103cb9) | `automatic update` |