### PR TITLE
chore(flake/emacs-ement): `30b5dfdc` -> `5b101206`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1653900193,
-        "narHash": "sha256-MG7Tj8OpIVdc9snycZIxwMOS8FJtmSg3pJEWakaIFEI=",
+        "lastModified": 1653901272,
+        "narHash": "sha256-5HKaieG0t5v8wl4Ld01AzkpRk8m0ihVEpkJDdqk0wB4=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "30b5dfdc5a0b4953fee2d8ab77f265b2b92e0c7c",
+        "rev": "5b101206cab1c27757365e014567d3cf087df5cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                          |
| --------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`5b101206`](https://github.com/alphapapa/ement.el/commit/5b101206cab1c27757365e014567d3cf087df5cb) | `Change: (ement-prism-color) Arguments` |