### PR TITLE
chore(flake/emacs-ement): `5b101206` -> `306c1ecf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1653901272,
-        "narHash": "sha256-5HKaieG0t5v8wl4Ld01AzkpRk8m0ihVEpkJDdqk0wB4=",
+        "lastModified": 1653909268,
+        "narHash": "sha256-ylxyHYlm0afsyOjHrhms1weSVcfdeIUT4W8PwKByrjQ=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "5b101206cab1c27757365e014567d3cf087df5cb",
+        "rev": "306c1ecfb07eacc399f47a1fbb4b16dcfe34c9a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                           |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`306c1ecf`](https://github.com/alphapapa/ement.el/commit/306c1ecfb07eacc399f47a1fbb4b16dcfe34c9a7) | `Tidy: Move --format-user and --prism-color into -lib`   |
| [`41318e29`](https://github.com/alphapapa/ement.el/commit/41318e2969e6d5e4141555b0f050fe1bb048a630) | `Add: (ement-room-describe)`                             |
| [`039c548f`](https://github.com/alphapapa/ement.el/commit/039c548fd3d6968244980e6522e40285851dfc41) | `Change: (ement-room--format-user) Add session argument` |