### PR TITLE
chore(flake/nur): `604b1c1a` -> `b0268e01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653921337,
-        "narHash": "sha256-RLPxioFVRFbjV9pxURW4y2A8FF9Yl825Ycb/8Uh+bj4=",
+        "lastModified": 1653942309,
+        "narHash": "sha256-qxm73Ig/313VzKTKWTp+4ItG44/5SNJPFDfGpOUwCms=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "604b1c1a24776329920ec934276e320117058563",
+        "rev": "b0268e0199af6ccf4c202540ad2932e9d6f4bbe1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b0268e01`](https://github.com/nix-community/NUR/commit/b0268e0199af6ccf4c202540ad2932e9d6f4bbe1) | `automatic update` |