### PR TITLE
chore(flake/home-manager): `64831f93` -> `bda2c80b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -215,11 +215,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1653518057,
-        "narHash": "sha256-cam3Nfae5ADeEs6mRPzr0jXB7+DhyMIXz0/0Q13r/yk=",
+        "lastModified": 1653937612,
+        "narHash": "sha256-HybwffYKOM3UwlY54ZVCZgX7o5xpp2KhbZyyOnvwFMo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "64831f938bd413cefde0b0cf871febc494afaa4f",
+        "rev": "bda2c80b4c1a8d85c84c343a25ac7303fbc7999d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                       |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`bda2c80b`](https://github.com/nix-community/home-manager/commit/bda2c80b4c1a8d85c84c343a25ac7303fbc7999d) | `himalaya: fix account.folders to new config syntax` |