### PR TITLE
chore(flake/nur): `b0268e01` -> `2fd658b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653942309,
-        "narHash": "sha256-qxm73Ig/313VzKTKWTp+4ItG44/5SNJPFDfGpOUwCms=",
+        "lastModified": 1653944391,
+        "narHash": "sha256-cm4mTvpK40Xi4e55YVRAGBO1Bc24NYQ+y8ClLuSjH04=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b0268e0199af6ccf4c202540ad2932e9d6f4bbe1",
+        "rev": "2fd658b4c1b0de4465387cffda2f6ebe4d5f4619",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2fd658b4`](https://github.com/nix-community/NUR/commit/2fd658b4c1b0de4465387cffda2f6ebe4d5f4619) | `automatic update` |