### PR TITLE
chore(flake/nur): `2fd658b4` -> `f33db05e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653944391,
-        "narHash": "sha256-cm4mTvpK40Xi4e55YVRAGBO1Bc24NYQ+y8ClLuSjH04=",
+        "lastModified": 1653947150,
+        "narHash": "sha256-y6FfzMpgnXG1Ia3o3xYVoDrYpaboeh9x2AxQ+NkbvOc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2fd658b4c1b0de4465387cffda2f6ebe4d5f4619",
+        "rev": "f33db05e1c90f348d96810056fd5061ce4c2a169",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f33db05e`](https://github.com/nix-community/NUR/commit/f33db05e1c90f348d96810056fd5061ce4c2a169) | `automatic update` |