### PR TITLE
chore(flake/nixos-hardware): `0cab18a4` -> `78e7c2c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1654057797,
-        "narHash": "sha256-mXo7C4v7Jj2feBzcReu1Eu/3Rnw5b023E9kOyFsHZQw=",
+        "lastModified": 1656353817,
+        "narHash": "sha256-UJEzMQcft/0Ilu4LWV7UH51mr5UCo28GL06BGO+djv4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "0cab18a48de7914ef8cad35dca0bb36868f3e1af",
+        "rev": "78e7c2c397b0376526e83162b58de921362e3399",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                         |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`a3dfc310`](https://github.com/NixOS/nixos-hardware/commit/a3dfc3100b26fe664214e37a8eeb171af2f50b99) | `flake.nix: add macbook-pro`           |
| [`9194b8e9`](https://github.com/NixOS/nixos-hardware/commit/9194b8e949bed0be52729de9c1ed96674c0d3758) | ``nvidia: remove `-a` flag from exec`` |
| [`9ec5f52e`](https://github.com/NixOS/nixos-hardware/commit/9ec5f52ea235cdafa93f6fa69bf4183e8d8c1b23) | `Add lenovo legion 7 16ITHg6`          |
| [`26291dec`](https://github.com/NixOS/nixos-hardware/commit/26291dec5bc0ea4ed1534fddbb4debc9b08d9e90) | `flake.nix: add common-gpu-intel`      |