### PR TITLE
chore(flake/nix-on-droid): `e7e7d134` -> `949f20f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -258,11 +258,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1650613939,
-        "narHash": "sha256-x+OlhRDWXpqFZKmeEOE+vXbmt9kiCe35rKVBcJo3gxQ=",
+        "lastModified": 1654667844,
+        "narHash": "sha256-0tiIwPItfniax/bFw24CXTo74C7e+aIlAfHIBVF2xEE=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "e7e7d1347ffa88f8f67852a58a94d339c7d58fa0",
+        "rev": "949f20f8ba900a02dfceb5c61ccef927ce704d87",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`949f20f8`](https://github.com/t184256/nix-on-droid/commit/949f20f8ba900a02dfceb5c61ccef927ce704d87) | `fix: don't force the use of nix_2_4 for flakes when nix is new enough` |