### PR TITLE
chore(flake/nixgl): `1cce2dd7` -> `047a34b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -298,11 +298,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1654775507,
-        "narHash": "sha256-NPkQiaz6Oo5EuWj5hRXMKebAhAfiVtnklii0imR85dE=",
+        "lastModified": 1656321324,
+        "narHash": "sha256-Sz0uWspqvshGFbT+XmRVVayuW514rNNLLvrre8jBLLU=",
         "owner": "guibou",
         "repo": "nixgl",
-        "rev": "1cce2dd704829504d057dacc71daf1c00951460d",
+        "rev": "047a34b2f087e2e3f93d43df8e67ada40bf70e5c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                        | Commit Message               |
| --------------------------------------------------------------------------------------------- | ---------------------------- |
| [`35e2e24c`](https://github.com/guibou/nixGL/commit/35e2e24c873b766d1f56e00da26d5db8255951b6) | `add "exec" to bash scripts` |