### PR TITLE
chore(flake/pre-commit-hooks): `521a5247` -> `db3bd555`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -428,11 +428,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1652714503,
-        "narHash": "sha256-qQKVEfDe5FqvGgkZtg5Pc491foeiDPIOeycHMqnPDps=",
+        "lastModified": 1656169028,
+        "narHash": "sha256-y9DRauokIeVHM7d29lwT8A+0YoGUBXV3H0VErxQeA8s=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "521a524771a8e93caddaa0ac1d67d03766a8b0b3",
+        "rev": "db3bd555d3a3ceab208bed48f983ccaa6a71a25e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                     |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------- |
| [`0bc0f69a`](https://github.com/cachix/pre-commit-hooks.nix/commit/0bc0f69ad509721917c3efb07f470aeae871e5f6) | `Add support for markdownlint`     |
| [`011e950a`](https://github.com/cachix/pre-commit-hooks.nix/commit/011e950a645652366676826481c26252a795b2f5) | `Lint README with markdownlint`    |
| [`edb017af`](https://github.com/cachix/pre-commit-hooks.nix/commit/edb017afe33d1ed9be77403d5bab3d628bc921ee) | `fix build`                        |
| [`6a0c0b7a`](https://github.com/cachix/pre-commit-hooks.nix/commit/6a0c0b7a53ea03cc5fec0104b7fd2a0da372604e) | `Fix shfmt types`                  |
| [`b6f394d3`](https://github.com/cachix/pre-commit-hooks.nix/commit/b6f394d3f72ec4f8a6bf87508d9e1a4b29607a4c) | `Preserve executable bit in files` |
| [`b888e5b8`](https://github.com/cachix/pre-commit-hooks.nix/commit/b888e5b85b0c91583c2885770639b286f21a7e17) | `Add support for eslint`           |
| [`ee8ef09f`](https://github.com/cachix/pre-commit-hooks.nix/commit/ee8ef09fea0bc72f54fa7681ba507a5ab0fbba89) | `Add shfmt`                        |
| [`bf34b510`](https://github.com/cachix/pre-commit-hooks.nix/commit/bf34b51059f54ab13a274e7a8c62530725964313) | `fix: remove broken flag`          |
| [`30717bfd`](https://github.com/cachix/pre-commit-hooks.nix/commit/30717bfdb49209c4c761b919564131857525fb08) | `feat: adds hadolint`              |
| [`d2360dc5`](https://github.com/cachix/pre-commit-hooks.nix/commit/d2360dc57d4abe2ce4ef06e9e3a71a67bfa51f05) | ``feat: Add `stylua```             |