### PR TITLE
chore(flake/nur): `838b0503` -> `769f0930`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1656390464,
-        "narHash": "sha256-Dgs+CqwLEjb2EWoGo/uOL2tNsS4McC9KInpI19CuTqY=",
+        "lastModified": 1656395221,
+        "narHash": "sha256-jyt0FA2t4yBqDNX2fJJcGESL8qXrB8slOFnZmAg+5QY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "838b0503abeca4b034e14de8584a762f4f936a88",
+        "rev": "769f0930cec23b5fa803d2b580b14cf537f01f74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`769f0930`](https://github.com/nix-community/NUR/commit/769f0930cec23b5fa803d2b580b14cf537f01f74) | `automatic update` |