### PR TITLE
chore(flake/sops-nix): `aff5d854` -> `d26947f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -462,11 +462,11 @@
         "nixpkgs-22_05": "nixpkgs-22_05"
       },
       "locked": {
-        "lastModified": 1656215886,
-        "narHash": "sha256-67fkBb4GUbuMZTHs08mNycg0hBzboy+5boMD76wLpj4=",
+        "lastModified": 1656399028,
+        "narHash": "sha256-re66+rVHGR3y+0QsaDAwoAHCfoi3BlGV24t2EqRZsAE=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "aff5d8542c9eb566a000302b22fcc10715bc2feb",
+        "rev": "d26947f2d6252e2aae5ffddfe9b38b7c4b94e8f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                                           |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`0f21a64c`](https://github.com/Mic92/sops-nix/commit/0f21a64c35f72d2e21d3d4d3dc53e79f22834418) | `Bump DeterminateSystems/update-flake-lock from 9 to 10` |
| [`1616f520`](https://github.com/Mic92/sops-nix/commit/1616f520317270e93f6bbb813eb24b883c7cce81) | `README: remove mention of decrypting SSH private key`   |