### PR TITLE
chore(flake/emacs-overlay): `79d813d9` -> `8772891c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1656387960,
-        "narHash": "sha256-Rcnt6i4i9qScIJamwlXey78q9W3BiKxoN9T74yMoNPk=",
+        "lastModified": 1656413262,
+        "narHash": "sha256-I8X1LaW/qoSWeBLK0N8GPOshIuXG9zyNyZUtKZYa0h4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "79d813d9d4ebbd8ab34c1f755439cab4aedb2ddb",
+        "rev": "8772891c73e2809df5e5469d14535ea77e123d3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`8772891c`](https://github.com/nix-community/emacs-overlay/commit/8772891c73e2809df5e5469d14535ea77e123d3e) | `Updated repos/melpa` |
| [`1ba82898`](https://github.com/nix-community/emacs-overlay/commit/1ba82898e7764b61daa978b45e9f2bbe5cbe3c8d) | `Updated repos/emacs` |