### PR TITLE
chore(flake/nur): `89cc74f0` -> `9cf01b7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1656453384,
-        "narHash": "sha256-oxdMme4BRQlO3caX9rIarr9jIXnAwpnkSPV9cw8FDNU=",
+        "lastModified": 1656475598,
+        "narHash": "sha256-mrJZtxKySID7pey1UPa2FErbvXOYoFCt4frw5auUTYM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "89cc74f09c0dfe5d1998c4f27e35f762c6291204",
+        "rev": "9cf01b7d26b9a3a1ca6ac5e5e1fe3eaf9f3558f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9cf01b7d`](https://github.com/nix-community/NUR/commit/9cf01b7d26b9a3a1ca6ac5e5e1fe3eaf9f3558f4) | `automatic update` |
| [`e35a68a4`](https://github.com/nix-community/NUR/commit/e35a68a4c435adeaecfada17a7f2700ed2c53250) | `automatic update` |
| [`1af8be34`](https://github.com/nix-community/NUR/commit/1af8be343fcbf31a6fcc85bc00c2162d91e97440) | `automatic update` |