### PR TITLE
chore(flake/nur): `9cf01b7d` -> `ccc61f97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1656475598,
-        "narHash": "sha256-mrJZtxKySID7pey1UPa2FErbvXOYoFCt4frw5auUTYM=",
+        "lastModified": 1656481649,
+        "narHash": "sha256-awcvsZPnXD0E2T8eGKlZVkL4N6f9rGgt0kMtrUmlzJg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9cf01b7d26b9a3a1ca6ac5e5e1fe3eaf9f3558f4",
+        "rev": "ccc61f9707bfc0d8f6108b334bca9a0d16ea4b02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ccc61f97`](https://github.com/nix-community/NUR/commit/ccc61f9707bfc0d8f6108b334bca9a0d16ea4b02) | `automatic update` |