### PR TITLE
chore(flake/nur): `bfeafa6b` -> `b84fc49c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1656484739,
-        "narHash": "sha256-0peBi/PB7fC9d0HPOnJPBzSsCNsgtb7lY/ExKE2sjxc=",
+        "lastModified": 1656490643,
+        "narHash": "sha256-sdvb64MIZ40dWWzq+EXWRV5vGyl0GZto4H7hQp+hmec=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bfeafa6b9b6f135f00ee288e06617e5ac8c09957",
+        "rev": "b84fc49c0df9041b0453b9296d14278a5faa88cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b84fc49c`](https://github.com/nix-community/NUR/commit/b84fc49c0df9041b0453b9296d14278a5faa88cf) | `automatic update` |