### PR TITLE
chore(flake/sops-nix): `aff5d854` -> `6068774a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -310,29 +310,13 @@
         "type": "indirect"
       }
     },
-    "nixpkgs-21_11": {
-      "locked": {
-        "lastModified": 1656198488,
-        "narHash": "sha256-xe81o3Kin6a0jXA3mTxcR+jeA1jLKw3TCar5LUo/B5c=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "46af3303651699dc58cfc251d9b18c0f59d857da",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "release-21.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-22_05": {
       "locked": {
-        "lastModified": 1656199498,
-        "narHash": "sha256-/BCpM7j7y1G4het6Z3idlnv9A87/s0O1glVmH7fnWvk=",
+        "lastModified": 1661009065,
+        "narHash": "sha256-i+Q2ttGp4uOL3j0wEYP3MXLcu/4L/WbChxGQogiNSZo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "72a1f167077060a1a7b6e0104863245d0483fa7f",
+        "rev": "9a91318fffec81ad009b73fd3b640d2541d87909",
         "type": "github"
       },
       "original": {
@@ -458,15 +442,14 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "nixpkgs-21_11": "nixpkgs-21_11",
         "nixpkgs-22_05": "nixpkgs-22_05"
       },
       "locked": {
-        "lastModified": 1656215886,
-        "narHash": "sha256-67fkBb4GUbuMZTHs08mNycg0hBzboy+5boMD76wLpj4=",
+        "lastModified": 1661054796,
+        "narHash": "sha256-SWiWmENiim8liUNOZ1oxjc5yKb/fNpcyfSRo41bsEy0=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "aff5d8542c9eb566a000302b22fcc10715bc2feb",
+        "rev": "6068774a8e85fea4b0177efcc90afb3c3b74430b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                                            |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`8a399e19`](https://github.com/Mic92/sops-nix/commit/8a399e195776d3a1cc42817ca50e062f01bd7f27) | `flake.lock: Update`                                      |
| [`abba06d6`](https://github.com/Mic92/sops-nix/commit/abba06d6e24b65a0e5645c605189db90da559430) | `flake.lock: Update`                                      |
| [`fadc91bf`](https://github.com/Mic92/sops-nix/commit/fadc91bfd7dcf5827c47971d0b70012b48b90620) | `Bump DeterminateSystems/update-flake-lock from 10 to 12` |
| [`1d13af80`](https://github.com/Mic92/sops-nix/commit/1d13af80f509cb9b461112d9400a829cbe95d52e) | `flake.lock: Update`                                      |
| [`19b567f1`](https://github.com/Mic92/sops-nix/commit/19b567f131b90c88e693ca3abac71526d87ace55) | `flake.lock: Update`                                      |
| [`de37ae4b`](https://github.com/Mic92/sops-nix/commit/de37ae4b4a31788dae4df75c0ba36b2a5a121912) | `module: add defaultText to validationPackage`            |
| [`f3f51f7d`](https://github.com/Mic92/sops-nix/commit/f3f51f7dbc34b317d8a9a510cea003848557c594) | `flake.lock: Update`                                      |
| [`fc2b603a`](https://github.com/Mic92/sops-nix/commit/fc2b603a9b03a1c5c440345e684b8d2a2943b722) | `Add validationPackage option for cross-compilation`      |
| [`8cdf51e1`](https://github.com/Mic92/sops-nix/commit/8cdf51e19832a41c31a7da0fcad73038b6527214) | `flake.lock: Update`                                      |
| [`c3e5c221`](https://github.com/Mic92/sops-nix/commit/c3e5c221f076be11a9f240a871e5e5e145a7b999) | `Drop 21.11 mergify rules`                                |
| [`8f8e4e7c`](https://github.com/Mic92/sops-nix/commit/8f8e4e7cdd4f28f960df25421780c261b3bd78f2) | `Fix test indentation once and for all`                   |
| [`cb4c7963`](https://github.com/Mic92/sops-nix/commit/cb4c79633dcf767977d61b6dc3d62baa396a4258) | `Also print imported age keys`                            |
| [`33041373`](https://github.com/Mic92/sops-nix/commit/33041373c9a705502fabad6854dc19bcf4eecd5d) | `Update go.mod, go.sum and go`                            |
| [`a94c4a7d`](https://github.com/Mic92/sops-nix/commit/a94c4a7d401f88341fdfefcb2582161e02a6e1bc) | `Remove the 21.11 version`                                |
| [`a83c8ff3`](https://github.com/Mic92/sops-nix/commit/a83c8ff3b08f560544a659b0454880edadc052ed) | `flake.lock: Update`                                      |
| [`0f21a64c`](https://github.com/Mic92/sops-nix/commit/0f21a64c35f72d2e21d3d4d3dc53e79f22834418) | `Bump DeterminateSystems/update-flake-lock from 9 to 10`  |
| [`1616f520`](https://github.com/Mic92/sops-nix/commit/1616f520317270e93f6bbb813eb24b883c7cce81) | `README: remove mention of decrypting SSH private key`    |