### PR TITLE
chore(flake/nur): `e86ce90d` -> `d0f62e11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1656516558,
-        "narHash": "sha256-xMfUEwRG1ty4YysAl0BNlHbdLPxbi8cCFmCOTt4JLFA=",
+        "lastModified": 1656562074,
+        "narHash": "sha256-Bg2wkQeq7vHDTI8e5sA7769+a26YqqNXJ02kAd8Y/K4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e86ce90db1b2ee55ba412845161c063dff3301db",
+        "rev": "d0f62e11308c0abc442f7e6ea8c7bbc657bceb22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d0f62e11`](https://github.com/nix-community/NUR/commit/d0f62e11308c0abc442f7e6ea8c7bbc657bceb22) | `automatic update` |
| [`07f57d33`](https://github.com/nix-community/NUR/commit/07f57d3355368447ae08dee2d5f01123b155851f) | `automatic update` |