### PR TITLE
chore(flake/emacs-ement): `a5c96bd6` -> `7edb0e78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1656365379,
-        "narHash": "sha256-5zzWT4R1x+c/J2Ml1rG7sqhq6zj5IQXrwOuscoUXUl8=",
+        "lastModified": 1656560651,
+        "narHash": "sha256-uGgMSzxAD85piW3sJTY7Y6jORdffL5+Vl13yqVpb5ko=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "a5c96bd682c583e728ed7bc9835a389fed94e54e",
+        "rev": "7edb0e78834eed88c9314ec8c90cdf09bef59fc1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                     |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`7edb0e78`](https://github.com/alphapapa/ement.el/commit/7edb0e78834eed88c9314ec8c90cdf09bef59fc1) | `Fix: (ement-describe-room) Rooms without avatars`                 |
| [`5878361d`](https://github.com/alphapapa/ement.el/commit/5878361df021c67fb9d0ab7255f51ba1839d66c7) | `Change: (ement-taxy) Highlight highlight count, not notification` |