### PR TITLE
chore(flake/nixpkgs): `020c7401` -> `cf3ab54b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -297,11 +297,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1656372800,
-        "narHash": "sha256-1u9SDLXvKix/QejNb2sY2J2QZXnbe/14MnLtn+ln9j0=",
+        "lastModified": 1656461576,
+        "narHash": "sha256-rlmmw6lIlkMQIiB+NsnO8wQYWTfle8TA41UREPLP5VY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "020c74014b9e2fa905bb4059c979965816cd9118",
+        "rev": "cf3ab54b4afe2b7477faa1dd0b65bf74c055d70c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`336e11b0`](https://github.com/NixOS/nixpkgs/commit/336e11b0ca9a23cb91b86de9fe61b2f668b6ea3e) | `python3Packages.mkdocs-macros: use python-dateutil directly`            |
| [`4d269d11`](https://github.com/NixOS/nixpkgs/commit/4d269d11e351fb52d8c172c4bfa34341d8fccf2a) | `nixos/doc: Fix typo in activation-script.md`                            |
| [`09143afa`](https://github.com/NixOS/nixpkgs/commit/09143afa61a477cb77be43ad3e98284adec39cc0) | `linuxPackages.evdi: enable parallel building`                           |
| [`d5872d27`](https://github.com/NixOS/nixpkgs/commit/d5872d277c4c6b9e9e51dd525830ff3d88983a55) | `linuxPackages.evdi: 1.10.1 -> 1.11.0`                                   |
| [`2ca99692`](https://github.com/NixOS/nixpkgs/commit/2ca9969237b654b3f147b471ab349de3d27ce9c1) | `thunderbird-bin: 91.10.0 -> 91.11.0`                                    |
| [`caeb4637`](https://github.com/NixOS/nixpkgs/commit/caeb46375d725c0f286e65a797f709f7b64df0eb) | `thunderbird: 91.10.0 -> 91.11.0`                                        |
| [`65958f1b`](https://github.com/NixOS/nixpkgs/commit/65958f1b046b0f8374994025d508f286f9516c08) | `hyprland: init at 0.6.0beta (#169960)`                                  |
| [`b9ac37a7`](https://github.com/NixOS/nixpkgs/commit/b9ac37a7f970985c2b8c151ab7e688303f78e366) | `python310Packages.google-i18n-address: 2.5.1 -> 2.5.2`                  |
| [`0c9bf54b`](https://github.com/NixOS/nixpkgs/commit/0c9bf54b0ca57d6fc59dc17e34e7eadcbe878483) | `python310Packages.pyisy: 3.0.6 -> 3.0.7`                                |
| [`58f73da6`](https://github.com/NixOS/nixpkgs/commit/58f73da66884c867f411a2cb3a52b6e241755fe6) | `hashlink: init at 1.12`                                                 |
| [`51aeb964`](https://github.com/NixOS/nixpkgs/commit/51aeb96449599234ffca5314a3ab2eecc19c4d38) | `roon-server: 1.8-943 -> 1.8-970`                                        |
| [`387c727f`](https://github.com/NixOS/nixpkgs/commit/387c727f8d78dca84f7c550452bc4678e8bf2cf2) | `klippy: 2022-03-14 -> 2022-06-18; drop python2`                         |
| [`89d1b48e`](https://github.com/NixOS/nixpkgs/commit/89d1b48eb5821c05b81f94ba6768001424fe9788) | `matrix-synapse: 1.61.0 -> 1.61.1`                                       |
| [`afff3ab3`](https://github.com/NixOS/nixpkgs/commit/afff3ab34cf5e68f2bfa6a5825451e2c32b77ccf) | `python310Packages.python-gitlab: 3.5.0 -> 3.6.0`                        |
| [`0a2337c4`](https://github.com/NixOS/nixpkgs/commit/0a2337c4da1464b8601b8d997fa1c2ac48613b49) | `nixos/ids: fix typo in comment`                                         |
| [`d1ffd40b`](https://github.com/NixOS/nixpkgs/commit/d1ffd40bd7f6481c835dac005ce792a252b78d25) | `openiscsi: fix systemd service location`                                |
| [`b5c2b76c`](https://github.com/NixOS/nixpkgs/commit/b5c2b76cf4e1888b231bd011c4e699ec937b23ac) | `androidndkPkgs.binaries: correct passthru parameters`                   |
| [`6f4fa5cb`](https://github.com/NixOS/nixpkgs/commit/6f4fa5cb4800f37d85c8fe9ea380f7b3977679ec) | `python310Packages.plaid-python: 9.6.0 -> 9.7.0`                         |
| [`c6024732`](https://github.com/NixOS/nixpkgs/commit/c6024732b64c6fba95430895c46592db61192859) | `numix-icon-theme-square: 22.03.01 -> 22.06.14`                          |
| [`8a329232`](https://github.com/NixOS/nixpkgs/commit/8a3292328fe63e2e48b1fef380c4ef46c1d1781a) | `numix-icon-theme-circle: 22.03.01 -> 22.06.14`                          |
| [`2c730de1`](https://github.com/NixOS/nixpkgs/commit/2c730de1411beed1b0f96f224be8d8ae6528ab64) | `kora-icon-theme: 1.5.1 -> 1.5.2`                                        |
| [`34826506`](https://github.com/NixOS/nixpkgs/commit/34826506ec2268bbddc9b0c859fb7e1fcc9be1ee) | `nordzy-icon-theme: unstable-2022-01-23 -> 1.5`                          |
| [`969ef1f5`](https://github.com/NixOS/nixpkgs/commit/969ef1f583d599fc4c604a4cbdddc9a7dd0396c0) | `mu: no relation to mesa so set platforms directly`                      |
| [`280920d0`](https://github.com/NixOS/nixpkgs/commit/280920d0c04c18c22038064c01b8462a001198f0) | `tts: 0.6.2 -> 0.7.1`                                                    |
| [`b3e7e9a7`](https://github.com/NixOS/nixpkgs/commit/b3e7e9a732a7ff98b5e8833305886c600f5abb52) | `tensorflow: 2.9.0 -> 2.9.1`                                             |
| [`a4b4d2d2`](https://github.com/NixOS/nixpkgs/commit/a4b4d2d2fd37502e556023a68e6d4d369e24d3f6) | `tensorflow-bin: 2.9.0 -> 2.9.1`                                         |
| [`6e819e82`](https://github.com/NixOS/nixpkgs/commit/6e819e825158ba6206cd4438dd5e373046adf5ca) | `python310Packages.dremel3dpy: removal of pinning is no longer needed`   |
| [`b90fa994`](https://github.com/NixOS/nixpkgs/commit/b90fa9940b6adb82d4fe07b025cca21daf6b58d1) | `dgraph: add module`                                                     |
| [`67970711`](https://github.com/NixOS/nixpkgs/commit/679707115e8596857fda6686cee795872b6b8868) | `python3.pkgs.python-crfsuite: enable for python 3.10`                   |
| [`31c7cd72`](https://github.com/NixOS/nixpkgs/commit/31c7cd728f7a2f601d490a0140e094f6afb909d6) | `python3.pkgs.coqui-trainer: 0.0.11 -> 0.0.12`                           |
| [`bbdee550`](https://github.com/NixOS/nixpkgs/commit/bbdee55013a38b1a135f0675f7816ebe1b74a5db) | `python310Packages.dremel3dpy: 1.1.1 -> 2.0.1`                           |
| [`e3b17ac5`](https://github.com/NixOS/nixpkgs/commit/e3b17ac5c33726c79d98de308e48a11742471201) | `krusader: move to file-managers`                                        |
| [`3cefeee6`](https://github.com/NixOS/nixpkgs/commit/3cefeee6a40c6b430d9abbf00759d82a631128d7) | `all-packages: reorder file-managers`                                    |
| [`34a6690d`](https://github.com/NixOS/nixpkgs/commit/34a6690deddead6bfb4b57758a481876ab8f0ad6) | `doublecmd: init at 1.0.6`                                               |
| [`2f5e9730`](https://github.com/NixOS/nixpkgs/commit/2f5e9730c0d4838208a609469f17f0481dd47500) | `all-packages: reorder file-managers`                                    |
| [`9123ed5f`](https://github.com/NixOS/nixpkgs/commit/9123ed5f368ba8415cd4e5963a134c7506e6c34d) | `openwebrx: 1.1.0 -> 1.2.0`                                              |
| [`a2e509c1`](https://github.com/NixOS/nixpkgs/commit/a2e509c1db221e8d93a2e811cc864bee97d95826) | `bindfs: 1.16.0 -> 1.16.1`                                               |
| [`346ed48f`](https://github.com/NixOS/nixpkgs/commit/346ed48f9e8dd38f791f6acfc7560385d7b6b3ea) | `filezilla: 3.58.0 -> 3.60.1`                                            |
| [`0199880d`](https://github.com/NixOS/nixpkgs/commit/0199880d19ceb214258ad46e5ae93f0d83719433) | `python310Packages.wktutils: 1.1.4 -> 1.1.5`                             |
| [`ca47950b`](https://github.com/NixOS/nixpkgs/commit/ca47950b9c19ba737568208749693aef62afdcb1) | `python310Packages.types-pytz: 2022.1.0 -> 2022.1.1`                     |
| [`35adcaab`](https://github.com/NixOS/nixpkgs/commit/35adcaabcef5523826e3b8b5b4e7f4cb10e283a9) | `libfilezilla: 0.36.0 -> 0.37.2`                                         |
| [`2c783080`](https://github.com/NixOS/nixpkgs/commit/2c7830806174a433e166796c1a89a87fb4d9acf2) | `nrf-command-line-tools: init at 10.16.0`                                |
| [`c8db82b8`](https://github.com/NixOS/nixpkgs/commit/c8db82b89cdfcd58baec571717b60c58e49bba6a) | `segger-jlink: init at 7.66`                                             |
| [`db615de4`](https://github.com/NixOS/nixpkgs/commit/db615de4de2ff5327ffa7cf129e7ff9909e2ce65) | `python3.pkgs.coqui-trainer: build on python3.10`                        |
| [`89d24b58`](https://github.com/NixOS/nixpkgs/commit/89d24b58b25cc5778eeeccfb82cb024fa08edbac) | `iosevka-comfy: init at 0.1.0`                                           |
| [`db03cac5`](https://github.com/NixOS/nixpkgs/commit/db03cac5710ed43b72b6aa32f78c66aeb6d2590e) | `checkov: 2.1.9 -> 2.1.10`                                               |
| [`6e4140da`](https://github.com/NixOS/nixpkgs/commit/6e4140dac9c56094325a22324c390801672215cb) | `lcm: init at 1.4.0`                                                     |
| [`667eea76`](https://github.com/NixOS/nixpkgs/commit/667eea766a43c9402223146a42e4532f7db56017) | `python310Packages.fastavro: 1.5.1 -> 1.5.2`                             |
| [`3e4672ef`](https://github.com/NixOS/nixpkgs/commit/3e4672efd52eb211649f498c59b928ddc7d204c7) | `spr: 1.3.2 -> 1.3.3`                                                    |
| [`de907865`](https://github.com/NixOS/nixpkgs/commit/de90786542ac717bcb65dc2b40e8d52867fc5d9f) | `python3Packages.pywlroots: 0.15.17 -> 0.15.18`                          |
| [`304f58d0`](https://github.com/NixOS/nixpkgs/commit/304f58d0926d302b543be92d37108a1e50d14b9f) | `yamlpath: init at 3.6.3`                                                |
| [`192c0e2e`](https://github.com/NixOS/nixpkgs/commit/192c0e2e1c540c195c596486075108001e4568b2) | `gnucash: 4.10 -> 4.11`                                                  |
| [`86992008`](https://github.com/NixOS/nixpkgs/commit/8699200898db42053fbf9f8312bccd35bd3ea021) | `python310Packages.tesla-powerwall: 0.3.17 -> 0.3.18`                    |
| [`652a6b6b`](https://github.com/NixOS/nixpkgs/commit/652a6b6b629ff910c5096d34e4c8430e487406cb) | `amass: 3.19.2 -> 3.19.3`                                                |
| [`6910e464`](https://github.com/NixOS/nixpkgs/commit/6910e46427c7719f0f47cdae2b0ed414f1b57e2a) | `spaceFM: move to applications/file-managers`                            |
| [`99a4c03e`](https://github.com/NixOS/nixpkgs/commit/99a4c03e774afb7beadca9e399e49afa48233afb) | `ytree: move to applications/file-managers`                              |
| [`20acab1b`](https://github.com/NixOS/nixpkgs/commit/20acab1b9b83bd534b5a311fbb1136b7f737fc47) | `xfe: move to applications/file-managers`                                |
| [`81f53206`](https://github.com/NixOS/nixpkgs/commit/81f5320646b8f5a1d16649a835886281e29165e7) | `worker: move to applications/file-managers`                             |
| [`25bc8d2b`](https://github.com/NixOS/nixpkgs/commit/25bc8d2b18f960921ea3b5eabb6eb89510c1742e) | `vifm: move to applications/file-managers`                               |
| [`d2c526c2`](https://github.com/NixOS/nixpkgs/commit/d2c526c2e6a866f62245f54e9522893d62ed9966) | `shfm: move to applications/file-managers`                               |
| [`77f472a4`](https://github.com/NixOS/nixpkgs/commit/77f472a4cf6edee31175f6afe110a10b69a5b9d6) | `noice: move to applications/file-managers`                              |
| [`39a9ea7f`](https://github.com/NixOS/nixpkgs/commit/39a9ea7f5e9a914a2e83f5805b87671c27fb5694) | `nnn: move to applications/file-managers`                                |
| [`c5ab4a57`](https://github.com/NixOS/nixpkgs/commit/c5ab4a57cbe080aa5efac1f882cc9b1a22fdd804) | `sfm: move to applications/file-managers`                                |
| [`b9432b63`](https://github.com/NixOS/nixpkgs/commit/b9432b63ab3696a2db194eed84975d4335ed897e) | `ranger: move to applications/file-managers`                             |
| [`032bbe84`](https://github.com/NixOS/nixpkgs/commit/032bbe845dd73c8031ae50241b9a171526755651) | `portfolio-filemanager: move to applications/file-managers`              |
| [`e284d732`](https://github.com/NixOS/nixpkgs/commit/e284d732bb834c598dc039981504e163b4e11dfb) | `pcmanfm: move to applications/file-managers`                            |
| [`2e6338d6`](https://github.com/NixOS/nixpkgs/commit/2e6338d62e8bdeeb7cf0001b1ecd704505a3fc8a) | `nimmm: move to applications/file-managers`                              |
| [`fbe60ee3`](https://github.com/NixOS/nixpkgs/commit/fbe60ee310367e279c97d568eb958a3ca4544fc1) | `mucommander: move to applications/file-managers`                        |
| [`13d788ff`](https://github.com/NixOS/nixpkgs/commit/13d788ff956628ecb481787470d8bf10a95221b4) | `mc: move to applications/file-managers`                                 |
| [`aa174274`](https://github.com/NixOS/nixpkgs/commit/aa1742748425e3988717ce0e562232139881d506) | `lf: move to applications/file-managers`                                 |
| [`6c8b81b0`](https://github.com/NixOS/nixpkgs/commit/6c8b81b0f1d593fba35ee40b30aaa9d3e9d54e38) | `llama: move to applications/file-managers`                              |
| [`a0b1b66a`](https://github.com/NixOS/nixpkgs/commit/a0b1b66a067d0a7709a8bf683d1fba722d991be6) | `joshuto: move to applications/file-managers`                            |
| [`e5d16d10`](https://github.com/NixOS/nixpkgs/commit/e5d16d10911b70d39ac6268f2b86477b6d35c4d1) | `dfilemanager: move to applications/file-managers`                       |
| [`98b11298`](https://github.com/NixOS/nixpkgs/commit/98b11298c2929728ddfbbb352f738e3bb76c1a87) | `clifm: move to applications/file-managers`                              |
| [`f47027df`](https://github.com/NixOS/nixpkgs/commit/f47027dfd0cf76bae4b4c59511f0a2153b6a5e86) | `clex: move to applications/file-managers`                               |
| [`fb89bc5f`](https://github.com/NixOS/nixpkgs/commit/fb89bc5fca012787bfc9396ea5a5b6d61b3b8e1f) | `cfm: move to applications/file-managers`                                |
| [`ba92e371`](https://github.com/NixOS/nixpkgs/commit/ba92e37183b29db012768b4d151add7e7cfb01b3) | `doc/contributing/coding-conventions: add a section about file managers` |
| [`e4749a8b`](https://github.com/NixOS/nixpkgs/commit/e4749a8bd249bc8a86e39ec26beebe467f1363bb) | `libcotp: 1.2.4 -> 1.2.6`                                                |
| [`7514467d`](https://github.com/NixOS/nixpkgs/commit/7514467d42f5e872adb552590b92b50c72383094) | `libbaseencode: 1.0.12 -> 1.0.14`                                        |
| [`03dc0e69`](https://github.com/NixOS/nixpkgs/commit/03dc0e6989d54bd32a4b8819b58f5e925dd43f27) | `jellyfin-ffmpeg: 5.0.1-5 -> 5.0.1-7`                                    |
| [`d7326b63`](https://github.com/NixOS/nixpkgs/commit/d7326b6372eaf596a6823d53e0a853c4d781cfb8) | `actionlint: 1.6.13 -> 1.6.14`                                           |
| [`923e3c59`](https://github.com/NixOS/nixpkgs/commit/923e3c59045cdd432748bd174dc228546956e41a) | `python310Packages.sphinxcontrib-spelling: 7.5.1 -> 7.6.0`               |
| [`c3725e42`](https://github.com/NixOS/nixpkgs/commit/c3725e42b280deca55dd480d4f681bc4b6aecee9) | `matterbridge: 1.25.1 -> 1.25.2`                                         |
| [`588f97f9`](https://github.com/NixOS/nixpkgs/commit/588f97f9dd394d45baca8a626600f656b9324d31) | `apk-tools: 2.12.9 -> 2.12.10`                                           |
| [`91e73fa5`](https://github.com/NixOS/nixpkgs/commit/91e73fa5e985fc913d4a69fbc54399995875892c) | `jellyfin-ffmpeg: bump nv-codec-headers to v11`                          |
| [`3d506e95`](https://github.com/NixOS/nixpkgs/commit/3d506e954807df4e5891396dcc0af6043f0b616f) | `notepad-next: 0.5.1 -> 0.5.2`                                           |
| [`13ba5dda`](https://github.com/NixOS/nixpkgs/commit/13ba5dda40aa9ef0852e82ff5525e19f7a20dc5c) | `deadbeefPlugins.musical-spectrum: init at unstable-2020-07-01`          |
| [`1dfaad73`](https://github.com/NixOS/nixpkgs/commit/1dfaad73ed98254c1c0522156fe45b115e0a8eb4) | `nix-prefetch-git: Fix inconsistency with fetchgit regarding deepClone`  |
| [`664dab95`](https://github.com/NixOS/nixpkgs/commit/664dab95743b9e11402d41dbedb1c8da6af163f6) | `nixos/tests/ipfs: Simplify FUSE test`                                   |
| [`392fba11`](https://github.com/NixOS/nixpkgs/commit/392fba113292aa10ba8ea9b68710a73ca17cac0e) | `pkgs.tests.haskell.cabalSdist: Avoid IFD`                               |
| [`cf5e2d51`](https://github.com/NixOS/nixpkgs/commit/cf5e2d510316ae0e2e78486e28b79b1fa30799fa) | `haskellPackages: Add buildFromCabalSdist (faster, tested)`              |
| [`699e389f`](https://github.com/NixOS/nixpkgs/commit/699e389f8343fb14f7ca3bda09e8871c705c9dde) | `nixos/ipfs: test FUSE mount`                                            |
| [`72d6d73e`](https://github.com/NixOS/nixpkgs/commit/72d6d73e3750b6ec4dfffeb05eb0688d6358aeab) | `nixos/ipfs: Only set ReadWritePaths when hardened`                      |