### PR TITLE
chore(flake/emacs-plz): `0bcc8a10` -> `9e43e74a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
     "emacs-plz": {
       "flake": false,
       "locked": {
-        "lastModified": 1653650653,
-        "narHash": "sha256-VuAjfqsO3FDR94umpWaMX9wCvuCVLJ5bI2JfqBsqqME=",
+        "lastModified": 1656576055,
+        "narHash": "sha256-kEKb4QKLtVJuSEPwPKpQ11XxqJQfGQ0AsAnN0g9LVzc=",
         "owner": "alphapapa",
         "repo": "plz.el",
-        "rev": "0bcc8a10514e775b19414ad7d53a7f48624583dc",
+        "rev": "9e43e74acf615b38f05258ce80adccc5aaa4c56e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                            | Commit Message             |
| ------------------------------------------------------------------------------------------------- | -------------------------- |
| [`9e43e74a`](https://github.com/alphapapa/plz.el/commit/9e43e74acf615b38f05258ce80adccc5aaa4c56e) | `Meta: Update .elpaignore` |