### PR TITLE
chore(flake/emacs-ement): `7edb0e78` -> `6f9bd70b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1656560651,
-        "narHash": "sha256-uGgMSzxAD85piW3sJTY7Y6jORdffL5+Vl13yqVpb5ko=",
+        "lastModified": 1656605263,
+        "narHash": "sha256-Cgqgl3np52SaT+jRt4pyfm+2IH7uJNUMCvcfLUsC6JE=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "7edb0e78834eed88c9314ec8c90cdf09bef59fc1",
+        "rev": "6f9bd70b79a5f587fc2c4e19b614ad7ca27c509b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                          |
| --------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`6f9bd70b`](https://github.com/alphapapa/ement.el/commit/6f9bd70b79a5f587fc2c4e19b614ad7ca27c509b) | `Add: %W wrap-prefix message formatter` |