### PR TITLE
chore(flake/emacs-ement): `6f9bd70b` -> `5d03a7dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1656605263,
-        "narHash": "sha256-Cgqgl3np52SaT+jRt4pyfm+2IH7uJNUMCvcfLUsC6JE=",
+        "lastModified": 1656606521,
+        "narHash": "sha256-q5t8XVTIHaOH2zUseEOMwOlekfQ17h0cd2XBNSgCR04=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "6f9bd70b79a5f587fc2c4e19b614ad7ca27c509b",
+        "rev": "5d03a7dd701efbef84182b99a665b9630cc2a566",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message           |
| --------------------------------------------------------------------------------------------------- | ------------------------ |
| [`5d03a7dd`](https://github.com/alphapapa/ement.el/commit/5d03a7dd701efbef84182b99a665b9630cc2a566) | `Improve: %W formatting` |