### PR TITLE
chore(flake/emacs-overlay): `3f21945e` -> `27246259`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1656613796,
-        "narHash": "sha256-oQn4KFUjapGOK1ncsUD/SdArRIiX9hWRJIrj4n7+23E=",
+        "lastModified": 1656648158,
+        "narHash": "sha256-e4tPuEW8Uj8PEVAYNzr3DPqxY5mGEvnCNyDih8RPP5c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3f21945eac3ef08d7f3fd329dbe3954fe52f3d10",
+        "rev": "2724625945ddeaeffd94ca56e11b75b98b8bba8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`27246259`](https://github.com/nix-community/emacs-overlay/commit/2724625945ddeaeffd94ca56e11b75b98b8bba8b) | `Updated repos/nongnu` |
| [`bdb27d40`](https://github.com/nix-community/emacs-overlay/commit/bdb27d40ec4c5b2cceb8e6b3b0d4180e10f8bbde) | `Updated repos/melpa`  |
| [`9015841e`](https://github.com/nix-community/emacs-overlay/commit/9015841ee241f98a90aed210225a677c3908afd8) | `Updated repos/emacs`  |