### PR TITLE
chore(flake/nur): `0ae4fdf7` -> `293a4492`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1656648450,
-        "narHash": "sha256-uRFmvhJ2y7VlgIEPpQN3LW3e/m1Hg9ks1qhejwktfMQ=",
+        "lastModified": 1656654393,
+        "narHash": "sha256-/NsCgHeoZLoLE6HRZTy8K/S8eFm5wep/mJ0d8Wwdu7M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0ae4fdf7dd5b0740e46fdf495d1c4b03cae6099a",
+        "rev": "293a44926d7381d6e2fd8f962ced015a952b2032",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`293a4492`](https://github.com/nix-community/NUR/commit/293a44926d7381d6e2fd8f962ced015a952b2032) | `automatic update` |