### PR TITLE
chore(flake/nur): `293a4492` -> `6415192f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1656654393,
-        "narHash": "sha256-/NsCgHeoZLoLE6HRZTy8K/S8eFm5wep/mJ0d8Wwdu7M=",
+        "lastModified": 1656657926,
+        "narHash": "sha256-u0GjSvC6tDnehsJMjdyl02PjD+RfFctWlzWMzJoWigg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "293a44926d7381d6e2fd8f962ced015a952b2032",
+        "rev": "6415192f56f11dd95b57e987306aba97262baa8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6415192f`](https://github.com/nix-community/NUR/commit/6415192f56f11dd95b57e987306aba97262baa8c) | `automatic update` |