### PR TITLE
chore(flake/nur): `6415192f` -> `f68c74f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1656657926,
-        "narHash": "sha256-u0GjSvC6tDnehsJMjdyl02PjD+RfFctWlzWMzJoWigg=",
+        "lastModified": 1656665154,
+        "narHash": "sha256-iP7NfgfvyWNnfhcggiIQo6ByIerxGhq/LzC0Raby3PI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6415192f56f11dd95b57e987306aba97262baa8c",
+        "rev": "f68c74f8fce42ec72fb9e8497cf3b6e5554838ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f68c74f8`](https://github.com/nix-community/NUR/commit/f68c74f8fce42ec72fb9e8497cf3b6e5554838ca) | `automatic update` |