### PR TITLE
chore(flake/emacs-ement): `9cd7b2f1` -> `34acb9df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1656675298,
-        "narHash": "sha256-l6bq2GktobIfo6KWbfcykrJwaWJxizzL51NhtW4ZwIo=",
+        "lastModified": 1656682794,
+        "narHash": "sha256-eb4dEHaArgSxUmnpoD81DWNQJVPmIab7jJS6BYOafFk=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "9cd7b2f1926134e23e271ddf3451a8d939371724",
+        "rev": "34acb9df1c17692f611bdbf35ca486d6ac1b9a69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                             |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`34acb9df`](https://github.com/alphapapa/ement.el/commit/34acb9df1c17692f611bdbf35ca486d6ac1b9a69) | `Change: (ement-taxy-room-avatar-cache) Make buffer-local` |