### PR TITLE
chore(flake/emacs-overlay): `1b8b2da8` -> `0ed73cdb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1656701552,
-        "narHash": "sha256-SyO2YDRPt3CFuIBbCPT4mV13i//QDbJD5dineYr3rsM=",
+        "lastModified": 1656732204,
+        "narHash": "sha256-3348ZgC32uIPZ06bDMdjclSB/QKEyRCfNL1ew/U7VGE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1b8b2da85c0143b65a7738e04a57bf9b41872a05",
+        "rev": "0ed73cdb0646eb9f425f1d1a24f6c3ae1207f482",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`0ed73cdb`](https://github.com/nix-community/emacs-overlay/commit/0ed73cdb0646eb9f425f1d1a24f6c3ae1207f482) | `Updated repos/melpa` |
| [`042fec6b`](https://github.com/nix-community/emacs-overlay/commit/042fec6b0b2b81b451e72dfae13224614ce06ee8) | `Updated repos/emacs` |