### PR TITLE
chore(flake/emacs-overlay): `0ed73cdb` -> `a189248d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1656732204,
-        "narHash": "sha256-3348ZgC32uIPZ06bDMdjclSB/QKEyRCfNL1ew/U7VGE=",
+        "lastModified": 1656757008,
+        "narHash": "sha256-kqYEFrjSIUe9FSwZKaFGYu7s9/6+YiE9b418QLLnaPE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0ed73cdb0646eb9f425f1d1a24f6c3ae1207f482",
+        "rev": "a189248df5e56b652483675fd1d35727b6cc7a59",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`a189248d`](https://github.com/nix-community/emacs-overlay/commit/a189248df5e56b652483675fd1d35727b6cc7a59) | `Updated repos/melpa` |
| [`ef0618b6`](https://github.com/nix-community/emacs-overlay/commit/ef0618b6a7ba0f3c8ee6263f52baa4e9faabbde7) | `Updated repos/emacs` |