### PR TITLE
chore(flake/emacs-ement): `ecea501f` -> `918d1d9d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1656683840,
-        "narHash": "sha256-D9xVfMVGmcSLMYIO04oufMP4TATmR6bACML74KocbXM=",
+        "lastModified": 1656779161,
+        "narHash": "sha256-3UbufmQqCDYESQxLfV/78aaoR0Re2ZPrLyoGZE1gjSY=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "ecea501f2de066397ff4b16dcda8565e5e8ece99",
+        "rev": "918d1d9d4358abadcd56086ce21028b259ea00d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                     |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`918d1d9d`](https://github.com/alphapapa/ement.el/commit/918d1d9d4358abadcd56086ce21028b259ea00d7) | `Fix: (ement-room-flush-colors) Don't refresh notification buffer` |