### PR TITLE
chore(flake/emacs-overlay): `a189248d` -> `bfa98bb7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1656757008,
-        "narHash": "sha256-kqYEFrjSIUe9FSwZKaFGYu7s9/6+YiE9b418QLLnaPE=",
+        "lastModified": 1656787767,
+        "narHash": "sha256-uMMSFTMfdTNOFd0VImM+9LT9V8gFygJx2XbjvuqWKrY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a189248df5e56b652483675fd1d35727b6cc7a59",
+        "rev": "bfa98bb7e829b62c915e0652fff75564170e3a22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`bfa98bb7`](https://github.com/nix-community/emacs-overlay/commit/bfa98bb7e829b62c915e0652fff75564170e3a22) | `Updated repos/melpa` |
| [`a9e9b4b9`](https://github.com/nix-community/emacs-overlay/commit/a9e9b4b9a956fdf407cbeb6135541cffa20aa8d4) | `Updated repos/emacs` |
| [`21ccd184`](https://github.com/nix-community/emacs-overlay/commit/21ccd1846c3c9d51b1d53a0c15bc49b7099e9f1d) | `Updated repos/elpa`  |