### PR TITLE
chore(flake/nixpkgs): `cf3ab54b` -> `0ea7a8f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -297,11 +297,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1656461576,
-        "narHash": "sha256-rlmmw6lIlkMQIiB+NsnO8wQYWTfle8TA41UREPLP5VY=",
+        "lastModified": 1656753965,
+        "narHash": "sha256-BCrB3l0qpJokOnIVc3g2lHiGhnjUi0MoXiw6t1o8H1E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cf3ab54b4afe2b7477faa1dd0b65bf74c055d70c",
+        "rev": "0ea7a8f1b939d74e5df8af9a8f7342097cdf69eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`6f9359a5`](https://github.com/NixOS/nixpkgs/commit/6f9359a504ae930346156b2428b47d48d950aea3) | `rustc: mark broken for dynamic Musl target`                                          |
| [`cd0c2b23`](https://github.com/NixOS/nixpkgs/commit/cd0c2b23749bc4084e7ff5f3643a581aa193f84a) | `thrift: fix expired certs in tests`                                                  |
| [`0ef69d1f`](https://github.com/NixOS/nixpkgs/commit/0ef69d1fab57f88ab257cd6ef22cf7271b3bfa88) | `hydra_unstable: change 5s timeout for init to 30s in tests`                          |
| [`589f060a`](https://github.com/NixOS/nixpkgs/commit/589f060ab8d98f0858d79af678b6330a27001b84) | `bookstack: fix unquoted URLs`                                                        |
| [`37e00a37`](https://github.com/NixOS/nixpkgs/commit/37e00a373eaa0b9a83d587f66e69ed4da2b47b6b) | `flyctl: 0.0.335 -> 0.0.346`                                                          |
| [`c9c93251`](https://github.com/NixOS/nixpkgs/commit/c9c932511e2e0afbf87505f6bb3a90e2a96829a8) | `babashka: 0.8.156 -> 0.8.157`                                                        |
| [`5aebd3c2`](https://github.com/NixOS/nixpkgs/commit/5aebd3c2f7fce801d36d5be0e17d8a43c6e0a6cb) | `maddy: 0.5.4 -> 0.6.2`                                                               |
| [`78abe603`](https://github.com/NixOS/nixpkgs/commit/78abe603afefa3f644000b0fe6bdc6eec11e37f8) | `openasar: add unzip; remove autoupdater; unstable-2022-06-10 -> unstable-2022-06-27` |
| [`e953e73b`](https://github.com/NixOS/nixpkgs/commit/e953e73b6f303ab97dcd0c6843e5114a8c57556d) | `go-tools: 2021.1.2 -> 2022.1.2 (#179827)`                                            |
| [`86481006`](https://github.com/NixOS/nixpkgs/commit/86481006e78633eccd6b849b88697c7f4d70f04d) | `deno: 1.23.1 -> 1.23.2`                                                              |
| [`e4ec043d`](https://github.com/NixOS/nixpkgs/commit/e4ec043d8a74940b1730d0ec98fd47667652aa4b) | `pythonPackages.klein: don't mark as broken`                                          |
| [`a8c71a47`](https://github.com/NixOS/nixpkgs/commit/a8c71a477fa3337c5cde8e5ac8b862c807c0385d) | `gitlab: 15.1.0 -> 15.1.1 (#179810)`                                                  |
| [`8b00147f`](https://github.com/NixOS/nixpkgs/commit/8b00147f1d20a3d3c4b7dc2a88cdc6c2d648abaf) | `ratman: 0.3.1 -> 0.4.0 (#179814)`                                                    |
| [`627579b7`](https://github.com/NixOS/nixpkgs/commit/627579b71a4243f833445fb96c312d283b198651) | `mattermost: Don't restrict system types`                                             |
| [`28a328a1`](https://github.com/NixOS/nixpkgs/commit/28a328a1246669a534898054cda351d37fce8ce4) | `zulu: build for aarch64-darwin`                                                      |
| [`28915606`](https://github.com/NixOS/nixpkgs/commit/28915606ba138a7016a0030c97ce95613c63c7ac) | `prometheus: add flag for dns plugin, enable by default`                              |
| [`339665a9`](https://github.com/NixOS/nixpkgs/commit/339665a9b0ce43c916c482a93a481d7377c60dbf) | `libvirt: add zfs to PATH when enabled`                                               |
| [`4e9369f6`](https://github.com/NixOS/nixpkgs/commit/4e9369f65e5babf442ded90dcf0f4ebe919df869) | `lxqt.pcmanfm-qt: add qtimageformats plugin`                                          |
| [`782b85a9`](https://github.com/NixOS/nixpkgs/commit/782b85a9c24fb137a710840954f489614599249e) | `lxqt.lximage-qt: add qtimageformats plugin`                                          |
| [`c6e76ab7`](https://github.com/NixOS/nixpkgs/commit/c6e76ab7c91d16bd627095e6a55848bc97ea31df) | `nixos/radvd: add package option`                                                     |
| [`977a9b91`](https://github.com/NixOS/nixpkgs/commit/977a9b915e15514e009e36f14e18590243635daf) | `prometheus-blackbox-exporter: 0.21.0 -> 0.21.1`                                      |
| [`12218a56`](https://github.com/NixOS/nixpkgs/commit/12218a56e0b541f1d97d5797fa771f47dd419957) | `wireless-regdb: 2022.02.18 -> 2022.06.06`                                            |
| [`3d07a3f9`](https://github.com/NixOS/nixpkgs/commit/3d07a3f961e28b340ab430ee6f68a348fcdaebd6) | `iosevka: 15.5.0 -> 15.5.2`                                                           |
| [`2833461e`](https://github.com/NixOS/nixpkgs/commit/2833461e230a75770d93bf8e63da311cce67f8cd) | `iosevka-bin: 15.3.0 -> 15.5.2`                                                       |
| [`555f9ae1`](https://github.com/NixOS/nixpkgs/commit/555f9ae132806ec686493ffd156591cb3f234f95) | `python310Packages.fastbencode: fix license`                                          |
| [`95999dfb`](https://github.com/NixOS/nixpkgs/commit/95999dfb49e78f2bfd3e170b2ef8f38b3c469144) | `python310Packages.fastbencode: 0.0.7 -> 0.0.9`                                       |
| [`b35a0fcd`](https://github.com/NixOS/nixpkgs/commit/b35a0fcd898549d675af496de30064f79fc77dc2) | `mutt: 2.2.5 -> 2.2.6`                                                                |
| [`0669fd6f`](https://github.com/NixOS/nixpkgs/commit/0669fd6f204262354c2c10f00e4829097d1b4118) | `python310Packages.wandb: 0.12.19 -> 0.12.20`                                         |
| [`84f7babb`](https://github.com/NixOS/nixpkgs/commit/84f7babbca50075ddb5ab4454e5bc7ffa684fd43) | `python310Packages.pikepdf: 5.1.5.post1 -> 5.2.0`                                     |
| [`7446edab`](https://github.com/NixOS/nixpkgs/commit/7446edab41042812a25b54c9209377d3876cba4f) | `python310Packages.lsassy: 3.1.1 -> 3.1.2`                                            |
| [`c1a59f40`](https://github.com/NixOS/nixpkgs/commit/c1a59f40e04b4703a8983510e74eeda595fb0470) | `xonotic: 0.8.2 -> 0.8.5`                                                             |
| [`a2dfde58`](https://github.com/NixOS/nixpkgs/commit/a2dfde58bc28cde00d96bc6a8e9fc5c61078e820) | `Revert "sage: link doc in jupyter kernel"`                                           |
| [`6593cea2`](https://github.com/NixOS/nixpkgs/commit/6593cea2596952bd27f1a786d86d99229346e354) | `python310Packages.boxx: 0.10.4 -> 0.10.5`                                            |
| [`62ebe417`](https://github.com/NixOS/nixpkgs/commit/62ebe4176a4f513daf2aceb9a20f2505292b01cd) | `python310Packages.stripe: 3.4.0 -> 3.5.0`                                            |
| [`268a0c5a`](https://github.com/NixOS/nixpkgs/commit/268a0c5a62045f4a2f996feec308ddbbf0366e61) | `python310Packages.env-canada: 0.5.23 -> 0.5.24`                                      |
| [`1a4ec9ef`](https://github.com/NixOS/nixpkgs/commit/1a4ec9ef7f79f84c84078abb3f6ddf04a5e8bedc) | `zoom-us: 5.10.{4,6} -> 5.11.1 (#178587)`                                             |
| [`dd3a47ef`](https://github.com/NixOS/nixpkgs/commit/dd3a47ef86bc25570c4419529eef37cf1305fc62) | `neovide: 0.8 -> 0.9`                                                                 |
| [`420f7d19`](https://github.com/NixOS/nixpkgs/commit/420f7d191ca25d7fd99c11bbede4875015c2f208) | `blueprint-compiler: 2022-05-27 -> 0.2.0`                                             |
| [`9c544193`](https://github.com/NixOS/nixpkgs/commit/9c544193df8a1e7f083a7d3261f78e71f588f3e7) | `ocrfeeder: Fix launch with patch (#179675)`                                          |
| [`f7386088`](https://github.com/NixOS/nixpkgs/commit/f73860882de91393fd29219288cbab67841c2dfa) | `lefthook: 1.0.0 -> 1.0.4`                                                            |
| [`b0997ca8`](https://github.com/NixOS/nixpkgs/commit/b0997ca8989ca2d04bba728f0040cf072273bece) | `pretendard: 1.3.0 -> 1.3.3`                                                          |
| [`1321d086`](https://github.com/NixOS/nixpkgs/commit/1321d086fa38d8cee4a458fbfb9bb9be4ecd13b9) | `revive: init at 1.2.1`                                                               |
| [`415492eb`](https://github.com/NixOS/nixpkgs/commit/415492eb719197cf436909ad01e4ac02f71f166e) | `amtk: 5.4.1 -> 5.5.1`                                                                |
| [`fc8b57d8`](https://github.com/NixOS/nixpkgs/commit/fc8b57d850b83a964a2c81c32f9f29d3c5bbf964) | `libdeltachat: 1.86.0 -> 1.87.0`                                                      |
| [`b6b5216a`](https://github.com/NixOS/nixpkgs/commit/b6b5216a70a0aab0e8f4aa9f02d088b195a52420) | `python310Packages.rapidfuzz: 2.0.15 -> 2.1.0`                                        |
| [`78958dd5`](https://github.com/NixOS/nixpkgs/commit/78958dd5fefe96687d5968d8fca8f8e758bede57) | `rapidfuzz-cpp: 1.0.3 -> 1.0.4`                                                       |
| [`638a2fbb`](https://github.com/NixOS/nixpkgs/commit/638a2fbbee9e4a6dcccd18fdfcd3469c95710dbf) | `python310Packages.jarowinkler: 1.0.4 -> 1.0.5`                                       |
| [`e03a8338`](https://github.com/NixOS/nixpkgs/commit/e03a83380d2aa2901d094c3418d92f0e15babc2e) | `ytfzf: 2.3 -> 2.4.0`                                                                 |
| [`2f37856d`](https://github.com/NixOS/nixpkgs/commit/2f37856d4afd90aebd193db888b70b5c876f5de9) | `python310Packages.ua-parser: 0.10.0 -> 0.15.0`                                       |
| [`e94f1b45`](https://github.com/NixOS/nixpkgs/commit/e94f1b45efd69a6ad89b28dd4944a2bc6e825007) | `lesspipe: 1.85 -> 2.05 (#178581)`                                                    |
| [`09ef743e`](https://github.com/NixOS/nixpkgs/commit/09ef743e10fd7923fe8a417956a1a462c74c8fc1) | `act: 0.2.28 -> 0.2.29`                                                               |
| [`a034fd52`](https://github.com/NixOS/nixpkgs/commit/a034fd5235f4cb7d61e4e2ff1e00b9f2af9a053c) | `duckdb: add patch to fix list type inference (#178886)`                              |
| [`4c357290`](https://github.com/NixOS/nixpkgs/commit/4c35729086139bae51d0575e47687e845f180eb5) | `glib-networking: 2.72.0 -> 2.72.1`                                                   |
| [`991aa3f4`](https://github.com/NixOS/nixpkgs/commit/991aa3f49ac22b71996515ba184feeb800d99ee4) | `gnome.gnome-software: 42.2 -> 42.3`                                                  |
| [`2439ddbd`](https://github.com/NixOS/nixpkgs/commit/2439ddbd9b7781e5316fa16bce66dac4f171b7d1) | `gnome.gnome-control-center: 42.2 -> 42.3`                                            |
| [`f78aac93`](https://github.com/NixOS/nixpkgs/commit/f78aac931a7bcb65bfc8d060866bf2b24c2fd5d6) | `python310Packages.cftime: 1.6.0 -> 1.6.1`                                            |
| [`987400b8`](https://github.com/NixOS/nixpkgs/commit/987400b848773e4f274c96d33630273ea7d7d02f) | `nixos/desktop-manager: Use literal newline to fix shell syntax`                      |
| [`28385978`](https://github.com/NixOS/nixpkgs/commit/28385978bc9c827d642091e5e39aa1ff1c478eb7) | `bitcoin: fix broken build on aarch64-darwin`                                         |
| [`84a29ac2`](https://github.com/NixOS/nixpkgs/commit/84a29ac208037849c25a355cc141c7d7b9b378b1) | `jprofiler: init at 13.0.2`                                                           |
| [`12ae5d95`](https://github.com/NixOS/nixpkgs/commit/12ae5d953db66bcb18bdbee0b3afee179f88680c) | `python310Packages.asana: 0.10.9 -> 1.0.0`                                            |
| [`59321863`](https://github.com/NixOS/nixpkgs/commit/5932186344b312cbb3fa9b0b0be7a90b688843ae) | `signal-desktop: fix missing tray icon`                                               |
| [`aa6d3e68`](https://github.com/NixOS/nixpkgs/commit/aa6d3e68171d35e68d6aa7f9987f8aa651bf8d66) | `top-level/linux-kernels.nix: add vendor kernels note`                                |
| [`283d9754`](https://github.com/NixOS/nixpkgs/commit/283d9754bba49eda627c146ad745d1635a08d550) | `python310Packages.tempest: 31.0.0 -> 31.1.0`                                         |
| [`d20dd119`](https://github.com/NixOS/nixpkgs/commit/d20dd119683e1b9b2f8ca557e3ca8414424bb9c3) | `pantheon.wingpanel-indicator-network: 2.3.2 -> 2.3.3`                                |
| [`a046e6c8`](https://github.com/NixOS/nixpkgs/commit/a046e6c8f31a4766d8374c5269ebb492f623072a) | `python310Packages.hcloud: enable all tests`                                          |
| [`6806e4e8`](https://github.com/NixOS/nixpkgs/commit/6806e4e8b78eae240cb9e657b168c13dd58f9a3f) | `ocamlPackages.shared-memory-ring: 3.1.0 → 3.1.1`                                     |
| [`d5423b92`](https://github.com/NixOS/nixpkgs/commit/d5423b92bc4eb0a8fa5be1f5d558f1e917412be6) | `esbuild: 0.14.47 -> 0.14.48`                                                         |
| [`bcfbf82a`](https://github.com/NixOS/nixpkgs/commit/bcfbf82aed30dd60b68827bff628ce981d6dd358) | `millet: 0.1.12 -> 0.1.14`                                                            |
| [`8d1a4469`](https://github.com/NixOS/nixpkgs/commit/8d1a4469dd9000bf9d3d445f59531ff9673271e8) | `python310Packages.netcdf4: 1.5.8 -> 1.6.0`                                           |
| [`22f96886`](https://github.com/NixOS/nixpkgs/commit/22f96886cfb31111f35f91761eadf60c22df0460) | `netcdf: 4.8.1 -> 4.9.0`                                                              |
| [`808b08df`](https://github.com/NixOS/nixpkgs/commit/808b08df16b7745809a87df423dd67b68f22b393) | `mu: 1.8.1 -> 1.8.2`                                                                  |
| [`1e698a79`](https://github.com/NixOS/nixpkgs/commit/1e698a79791b81a2da341009fd0ecc15271b2557) | `ipcalc: add geoip support`                                                           |
| [`959efb47`](https://github.com/NixOS/nixpkgs/commit/959efb4705741f193ece980bbc331b10ece725c7) | `geoip: pass through the dataDir so consumers know where to look`                     |
| [`d54b22f9`](https://github.com/NixOS/nixpkgs/commit/d54b22f9ac6271e3e2b158ed80770ad8a7f552b0) | `python310Packages.qiskit-finance: 0.3.2 -> 0.3.3`                                    |
| [`9a578a2c`](https://github.com/NixOS/nixpkgs/commit/9a578a2c083bf21a8688088c3ef787f6faae892a) | `python310Packages.splinter: 0.17.0 -> 0.18.0`                                        |
| [`3b953b5a`](https://github.com/NixOS/nixpkgs/commit/3b953b5a6973d3762b60f3f91ba7c233bfa4490c) | `ruby-packages: update`                                                               |
| [`eb92ef3a`](https://github.com/NixOS/nixpkgs/commit/eb92ef3a74d17ec23ca86affdfd90c2dafae246e) | `python310Packages.zope-testbrowser: init at 5.6.1`                                   |
| [`9fcfdda1`](https://github.com/NixOS/nixpkgs/commit/9fcfdda1accdcafa6b65ccc3637741adcc8f6cab) | `python310Packages.zope-cachedescriptors: init at 4.3.1`                              |
| [`e47f1d25`](https://github.com/NixOS/nixpkgs/commit/e47f1d2527f6109ea74940f01fcfe168a00bc5f7) | `communi: 3.5.0 -> 3.6.0`                                                             |
| [`b0feee64`](https://github.com/NixOS/nixpkgs/commit/b0feee646713c08da547723ef483f5de0ee75491) | `hypnotix: 2.7 -> 2.8`                                                                |
| [`76928386`](https://github.com/NixOS/nixpkgs/commit/76928386b0141dffc95b50a1b64df7ed25eeba5b) | `newsboat: 2.27 -> 2.28`                                                              |
| [`f84a03ad`](https://github.com/NixOS/nixpkgs/commit/f84a03ad38b5996c74a7632cbde2880c79a41583) | `warp: 0.2.0 -> 0.2.1`                                                                |
| [`14f3b5b7`](https://github.com/NixOS/nixpkgs/commit/14f3b5b7dac1d2ed8d51cdd2e893a7a0d33fbdd8) | `megapixels: 1.4.3 -> 1.5.0`                                                          |
| [`04fcf7fc`](https://github.com/NixOS/nixpkgs/commit/04fcf7fcded8cf8f261ec61c1f9065f188bad4e5) | `passExtensions.pass-import: support pykeepass 4.0.3`                                 |
| [`1bf827d0`](https://github.com/NixOS/nixpkgs/commit/1bf827d026e8f4f31de1fb483f6d3b3df90a21c6) | `python310Packages.pykeepass: 4.0.2 -> 4.0.3`                                         |
| [`40b11c14`](https://github.com/NixOS/nixpkgs/commit/40b11c149bb4f2ffd6cba9ebb4fe5f96459fad1e) | `vopono: 0.9.1 -> 0.9.2`                                                              |
| [`51b2b750`](https://github.com/NixOS/nixpkgs/commit/51b2b750524b3f99e3a9a96a6950956f5b0e98ed) | `python310Packages.pikepdf: 5.1.5 -> 5.1.5.post1`                                     |
| [`b360ddc8`](https://github.com/NixOS/nixpkgs/commit/b360ddc88c87951161cb25e4d6f1fc9aa5da61fc) | `nushell: 0.63.0 -> 0.64.0`                                                           |
| [`eb94c5c5`](https://github.com/NixOS/nixpkgs/commit/eb94c5c57e08d41856d4ad9db496cb9213c16d94) | `python310Packages.traitsui: 7.3.1 -> 7.4.0`                                          |
| [`cdcded8d`](https://github.com/NixOS/nixpkgs/commit/cdcded8d8c09cd62f32fd6890a2b93ffec2372db) | `python310Packages.textdistance: 4.2.2 -> 4.3.0`                                      |
| [`4abac2ba`](https://github.com/NixOS/nixpkgs/commit/4abac2ba6c471eda9e2f490261c0c46fdac791a8) | `python310Packages.qiskit-optimization: 0.3.2 -> 0.4.0`                               |
| [`4dc5e4c9`](https://github.com/NixOS/nixpkgs/commit/4dc5e4c97e0748a5cb00ac42d628eadc45b04aa5) | `python310Packages.venstarcolortouch: 0.16 -> 0.17`                                   |
| [`30ab1697`](https://github.com/NixOS/nixpkgs/commit/30ab1697a9c4f08cefb845f1eb2438154ac8d7d4) | `python310Packages.resampy: switch to pytestCheckHook`                                |
| [`4387a866`](https://github.com/NixOS/nixpkgs/commit/4387a86646d5414c1172e3075a51561ccc7d35ea) | `libpg_query: not just for x86_64!`                                                   |
| [`ece1a9fe`](https://github.com/NixOS/nixpkgs/commit/ece1a9fe66e849dae0a081b38d08b9111acf0cd6) | `arandr: refactor derivation`                                                         |
| [`e427ac59`](https://github.com/NixOS/nixpkgs/commit/e427ac5955f4b3abdc17636a80865b1b3fe720ae) | `ktunnel: init at 1.4.8`                                                              |
| [`a1ad66a4`](https://github.com/NixOS/nixpkgs/commit/a1ad66a4afa34b4517bd6adeb0812901271a5a58) | `vector: 0.22.2 -> 0.22.3`                                                            |
| [`08173c03`](https://github.com/NixOS/nixpkgs/commit/08173c03f052fed9c71d1b58ff7106ae19d4c6d8) | `python310Packages.resampy: 0.2.2 -> 0.3.0`                                           |
| [`e7d52cc2`](https://github.com/NixOS/nixpkgs/commit/e7d52cc26c5cbbfffa7dcedc7ab9b7ddff6bc234) | `scala-cli: 0.1.8 -> 0.1.9`                                                           |
| [`d80162d1`](https://github.com/NixOS/nixpkgs/commit/d80162d105e3665b1e2acb205a2acddad4135df1) | `solo2-cli: 0.1.1 -> 0.2.0`                                                           |
| [`8771f95f`](https://github.com/NixOS/nixpkgs/commit/8771f95f71ffb6aecd67f5743467e0961844e0a9) | `python3Packages.trezor: 0.13.0 -> 0.13.2`                                            |
| [`323b6dfb`](https://github.com/NixOS/nixpkgs/commit/323b6dfb62806caa4e02cc5fb007917ebdd49a27) | `python3Packages.simple-rlp: init at 0.1.2`                                           |
| [`588439e1`](https://github.com/NixOS/nixpkgs/commit/588439e1311c41a5779877d4d8ef603410b79cd4) | `fetchurl: Add curlOptsList test`                                                     |
| [`649c644b`](https://github.com/NixOS/nixpkgs/commit/649c644ba84193f8ef2ee12291a61296901cf457) | `banking: 0.4.0 -> 0.5.1`                                                             |
| [`3ac24f48`](https://github.com/NixOS/nixpkgs/commit/3ac24f48357076ef5c823d550bf5c9118c03b969) | `python310Packages.pysqlitecipher: init at 0.22`                                      |
| [`0ccd98ca`](https://github.com/NixOS/nixpkgs/commit/0ccd98cae581613816aacdc0bb8ea3845cf9ca61) | `python310Packages.onetimepad: init at 1.4`                                           |
| [`c856c35f`](https://github.com/NixOS/nixpkgs/commit/c856c35fe9cc736ebab69027f2c2191d7dc2720d) | `python310Packages.hcloud: 1.16.0 -> 1.17.0`                                          |
| [`6724234f`](https://github.com/NixOS/nixpkgs/commit/6724234f2821eafed028c98501edb5a4bfdb9aa3) | `ocamlPackages.mirage-vnetif: 0.5.0 → 0.6.0`                                          |
| [`fc102563`](https://github.com/NixOS/nixpkgs/commit/fc102563a6d9631c69b3a6229be3c71e7b788212) | `hydra_unstable: 2022-06-16 -> 2022-06-30`                                            |
| [`7e63d01a`](https://github.com/NixOS/nixpkgs/commit/7e63d01a23e9064ebfa5efd9b9393326bb208ad3) | `python310Packages.schwifty: 2022.6.2 -> 2022.6.3`                                    |
| [`989565d6`](https://github.com/NixOS/nixpkgs/commit/989565d67661918799c6190a43db60590600dd01) | `cachix-agent: expose verbose option`                                                 |
| [`56c5f3f3`](https://github.com/NixOS/nixpkgs/commit/56c5f3f36672a71a00dc498cfbd90f1d9ff47ad2) | `python310Packages.cron-descriptor: 1.2.24 -> 1.2.27`                                 |
| [`69e1e00e`](https://github.com/NixOS/nixpkgs/commit/69e1e00ebbdf40c1a1b2cc622f7e58aa927b4044) | `nixos/lokinet: init`                                                                 |
| [`461bdf0a`](https://github.com/NixOS/nixpkgs/commit/461bdf0a7abde1521d9a8ed5c19f57bd3d412126) | `lokinet: init at 0.9.9`                                                              |
| [`ce910fca`](https://github.com/NixOS/nixpkgs/commit/ce910fca8841061e86bfbfd15f8976132c2bfd78) | `nixos/tests: add phlactery`                                                          |
| [`f5f338c8`](https://github.com/NixOS/nixpkgs/commit/f5f338c8468a84b624980c2fd2cf2fa32d14741b) | `nixos/phylactery: init`                                                              |
| [`7727befa`](https://github.com/NixOS/nixpkgs/commit/7727befa4d5968d41cb7778d0abe0f5accdae77d) | `nrfconnect: init at 3.11.1`                                                          |
| [`78f355a1`](https://github.com/NixOS/nixpkgs/commit/78f355a11e163912ccab31079514aa3b55946599) | `davmail: 5.5.1 -> 6.0.1`                                                             |
| [`47d35130`](https://github.com/NixOS/nixpkgs/commit/47d35130e118eb160e967b505db9c3586e2be0cb) | `pngloss: init at unstable-2020-11-25`                                                |
| [`64eb5ec8`](https://github.com/NixOS/nixpkgs/commit/64eb5ec86305e6547d5a7a37efda936584fbbafc) | `maintainer: add myself`                                                              |
| [`2b9ed9cf`](https://github.com/NixOS/nixpkgs/commit/2b9ed9cf28ab5c533993029b1f374174d46609f5) | `mynewt-newt: 1.7.0 -> 1.10.0`                                                        |
| [`f6fb8628`](https://github.com/NixOS/nixpkgs/commit/f6fb8628f8ed4d0832dbbfc5fe2f7bcd90f86318) | `go-langserver: drop`                                                                 |
| [`37b1b4ec`](https://github.com/NixOS/nixpkgs/commit/37b1b4ec6a48d17807e06e054a9d70b5b5449045) | `gosca: drop`                                                                         |
| [`13165465`](https://github.com/NixOS/nixpkgs/commit/1316546506ad0b591a0e782172abdbc12af349a5) | `neovim: 0.7.0 -> 0.7.2`                                                              |
| [`9e106c15`](https://github.com/NixOS/nixpkgs/commit/9e106c15a4be9d1ddd057ddf9c34851ffd76cf52) | `wesnoth: 1.16.1 -> 1.16.3`                                                           |
| [`36634aa9`](https://github.com/NixOS/nixpkgs/commit/36634aa9d1ce6db3b351ea2c9c96f40fab76d452) | `python310Packages.motionblinds: 0.6.8 -> 0.6.10`                                     |
| [`e7f35074`](https://github.com/NixOS/nixpkgs/commit/e7f35074a20441009cc4b2301107e76a82b6c91a) | `python310Packages.hahomematic: 1.9.0 -> 1.9.1`                                       |
| [`6c8432f3`](https://github.com/NixOS/nixpkgs/commit/6c8432f34616100e7cdd60dc9eac2b86f26c6424) | `checkov: 2.1.16 -> 2.1.20`                                                           |
| [`f8b452f1`](https://github.com/NixOS/nixpkgs/commit/f8b452f1278baa0530d354facfbcd7ead5a9f773) | `linux/hardened/patches/5.4: 5.4.201-hardened1 -> 5.4.202-hardened1`                  |
| [`87f3f3ab`](https://github.com/NixOS/nixpkgs/commit/87f3f3ab17074e6e969ce0aa4425e792d076e311) | `linux/hardened/patches/5.18: 5.18.7-hardened1 -> 5.18.8-hardened1`                   |
| [`362d5a56`](https://github.com/NixOS/nixpkgs/commit/362d5a564f3c2b8cf93ea33381ab86a9126cb8fa) | `linux/hardened/patches/5.15: 5.15.50-hardened1 -> 5.15.51-hardened1`                 |
| [`02281899`](https://github.com/NixOS/nixpkgs/commit/02281899164fd848736c8ad278e25c98e76df85e) | `linux/hardened/patches/5.10: 5.10.125-hardened1 -> 5.10.127-hardened1`               |
| [`7b061f8e`](https://github.com/NixOS/nixpkgs/commit/7b061f8eb6de460c9622ad473f9ee4cc6efca8ee) | `linux: 5.4.201 -> 5.4.202`                                                           |
| [`7c4567e0`](https://github.com/NixOS/nixpkgs/commit/7c4567e0d4bb5a54c3827ca95d1222ac5b5b39df) | `linux: 5.18.7 -> 5.18.8`                                                             |
| [`5a52c819`](https://github.com/NixOS/nixpkgs/commit/5a52c81969a9c8d6b32753adb0c2fe41e1379775) | `linux: 5.15.50 -> 5.15.51`                                                           |
| [`6ed6ef2e`](https://github.com/NixOS/nixpkgs/commit/6ed6ef2ea1b60edbf2f47932494b62c3486a7973) | `linux: 5.10.126 -> 5.10.127`                                                         |
| [`783e2ef4`](https://github.com/NixOS/nixpkgs/commit/783e2ef46e9ec6639d914aa3f9ecd5cc6b812868) | `Revert "nix-prefetch-git: Fix inconsistency with fetchgit regarding deepClone"`      |
| [`41122605`](https://github.com/NixOS/nixpkgs/commit/411226059152365c13a94da80e70ef43178b7f5c) | `python310Packages.twilio: 7.9.3 -> 7.10.0`                                           |