### PR TITLE
chore(flake/emacs-overlay): `bfa98bb7` -> `7ac6aef4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1656787767,
-        "narHash": "sha256-uMMSFTMfdTNOFd0VImM+9LT9V8gFygJx2XbjvuqWKrY=",
+        "lastModified": 1656820658,
+        "narHash": "sha256-nQxTUGtbXlKkeOaHVAQLOyBAy1bbIkEtV1LYHi22DCM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bfa98bb7e829b62c915e0652fff75564170e3a22",
+        "rev": "7ac6aef457d59da09089754681ec8d642a5372be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`7ac6aef4`](https://github.com/nix-community/emacs-overlay/commit/7ac6aef457d59da09089754681ec8d642a5372be) | `Updated repos/nongnu` |
| [`32c3ccfc`](https://github.com/nix-community/emacs-overlay/commit/32c3ccfc1a90b101e541c98617704210ef00ca6b) | `Updated repos/melpa`  |
| [`c0eb75e4`](https://github.com/nix-community/emacs-overlay/commit/c0eb75e456ac4dca22f765f8f4de3f7a4d75a3eb) | `Updated repos/emacs`  |