### PR TITLE
chore(flake/nur): `2631dc4f` -> `3574ef87`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1656826360,
-        "narHash": "sha256-Jm8zO7F8S0lspf5yWlzI2mx3rBSreXzbgo/lqo7YXFo=",
+        "lastModified": 1656835264,
+        "narHash": "sha256-sCHGbrrxvJ6US7JJLRhFtH7ai7gOorw8Qq1P8R+AJnU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2631dc4f5be0736d028c8816d08444584075fda9",
+        "rev": "3574ef870a60a93ee4e2aebec4039572fb36361d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3574ef87`](https://github.com/nix-community/NUR/commit/3574ef870a60a93ee4e2aebec4039572fb36361d) | `automatic update` |