### PR TITLE
chore(flake/emacs-overlay): `90a8239e` -> `e72f7202`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1656872948,
-        "narHash": "sha256-PpkbO+yOmeDgEss9tV3ce3hgnrkeukZY7NJBcdUZowU=",
+        "lastModified": 1656906720,
+        "narHash": "sha256-qf+akdeRf5fmOy3E0HpzmveefpZiNKqJNLVQVpaNpBs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "90a8239ebb7c12ddefca43fca4d6b74d630ac433",
+        "rev": "e72f72027366c3987a84a7a6f7d75b91bb800ea8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`e72f7202`](https://github.com/nix-community/emacs-overlay/commit/e72f72027366c3987a84a7a6f7d75b91bb800ea8) | `Updated repos/nongnu` |
| [`7f04caa6`](https://github.com/nix-community/emacs-overlay/commit/7f04caa61e12c942267736a391ec83c3588a7c65) | `Updated repos/melpa`  |
| [`9061493f`](https://github.com/nix-community/emacs-overlay/commit/9061493feae8f393fa83eb9853016127445353d5) | `Updated repos/emacs`  |