### PR TITLE
chore(flake/nur): `8ab31fa5` -> `7c47f039`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1656905674,
-        "narHash": "sha256-WL7dtr0JbLUrhPIkiECE/RtmA7K0HP4CVsRBDNi+1ig=",
+        "lastModified": 1656908482,
+        "narHash": "sha256-kgUofaVRYXdQk+NbraSXQFA/DbeDG/pkpZQtHmjpD+Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8ab31fa505d51079fd2ac1ccc0ded97df07db7e9",
+        "rev": "7c47f039dff7cd2ca78cb345f23089148690c43c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7c47f039`](https://github.com/nix-community/NUR/commit/7c47f039dff7cd2ca78cb345f23089148690c43c) | `automatic update` |
| [`d2776b34`](https://github.com/nix-community/NUR/commit/d2776b34f26198cb87c5f3473d1b8e3de48bda08) | `automatic update` |