### PR TITLE
chore(flake/nur): `582ea2af` -> `74be1a14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1656909686,
-        "narHash": "sha256-KdZf/5KlmE2kwKpEUoHj8uT5IZrPC1iQpEx4W0czZqg=",
+        "lastModified": 1656913427,
+        "narHash": "sha256-AJtCV69MrvvhboTZ6gR0fYzclzmzhqQWCVQkfBjcDaw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "582ea2af39bdcb2417c2cafb6b96f4f66882cab1",
+        "rev": "74be1a142c20b39bd15a4e32a865a1b0e9e2b111",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`74be1a14`](https://github.com/nix-community/NUR/commit/74be1a142c20b39bd15a4e32a865a1b0e9e2b111) | `automatic update` |