### PR TITLE
chore(flake/nur): `e422ae23` -> `46f5a2cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1656919473,
-        "narHash": "sha256-Pcdg5813RgfJ2xFTU+5GDmRJ5fz47xGpIFj+GiEim5A=",
+        "lastModified": 1656920981,
+        "narHash": "sha256-PgujI04XN1nUolsGzVqEAEUUfohpJTo9ul/vw2sV/lo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e422ae23b341fa4cd9da3cc4b6972407e4ed9192",
+        "rev": "46f5a2cc4af5171e4342aa62b9a6688fc5edd02a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`46f5a2cc`](https://github.com/nix-community/NUR/commit/46f5a2cc4af5171e4342aa62b9a6688fc5edd02a) | `automatic update` |
| [`ef859951`](https://github.com/nix-community/NUR/commit/ef859951b6084b6f495c746c4e3dcd6eb71c4f39) | `automatic update` |