### PR TITLE
chore(flake/nixos-hardware): `c5308381` -> `3bf48d35`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1656702262,
-        "narHash": "sha256-BdVdx6LoGgAeIYrHnzk+AgbtkaVlV3JNcC6+vltLuh0=",
+        "lastModified": 1656933710,
+        "narHash": "sha256-SVG8EqY1OTJWBRY4hpct2ZR2Rk0L8hCFkug3m0ABoZE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "c5308381432cdbf14d5b1128747a2845f5c6871e",
+        "rev": "3bf48d3587d3f34f745a19ebc968b002ef5b5c5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`0efe78c5`](https://github.com/NixOS/nixos-hardware/commit/0efe78c51adc601905e683af68052cac828abd22) | `AMD: Add lib.mkDefault to AMD_VULKAN_ICD` |