### PR TITLE
chore(flake/nur): `9c99082a` -> `2f6d2826`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1656928701,
-        "narHash": "sha256-fQWedhQM0NuxgEE7ZRxjRPkXxZocYxSAsjg8xrQ4xzU=",
+        "lastModified": 1656954240,
+        "narHash": "sha256-z+oUTrlrKedGr9EVMdn0mjUREaflz3g2wotPZ8LpPow=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9c99082a18ebf177d7210aa391bff308027b9cbc",
+        "rev": "2f6d28264b388e8200842513a8e5e925dd3e3382",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2f6d2826`](https://github.com/nix-community/NUR/commit/2f6d28264b388e8200842513a8e5e925dd3e3382) | `automatic update` |