### PR TITLE
chore(flake/emacs-overlay): `143aa8c3` -> `ea1129fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1656929939,
-        "narHash": "sha256-tqi1AA6uFAdCthNu91/b+MWRsYF+Iab+J3Z1T9/UyIQ=",
+        "lastModified": 1656959199,
+        "narHash": "sha256-hOR9tN06TEqp6EUF2LZLV8Up3OuJzllbLKvMflDtnoI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "143aa8c32b1921faf84e2486bf68dda5e01482e8",
+        "rev": "ea1129fe388bbeac8495e82b5b04f4a83af88bce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ea1129fe`](https://github.com/nix-community/emacs-overlay/commit/ea1129fe388bbeac8495e82b5b04f4a83af88bce) | `Updated repos/melpa` |
| [`f451bc03`](https://github.com/nix-community/emacs-overlay/commit/f451bc03ceb314c64fbc5f11a8913fde34d59b9b) | `Updated repos/emacs` |