### PR TITLE
chore(flake/emacs-overlay): `ea1129fe` -> `7783abca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1656959199,
-        "narHash": "sha256-hOR9tN06TEqp6EUF2LZLV8Up3OuJzllbLKvMflDtnoI=",
+        "lastModified": 1656991399,
+        "narHash": "sha256-/yriocQgmxPMwijVfkt8aEaFv65xcgnQXAtqL4vH9CU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ea1129fe388bbeac8495e82b5b04f4a83af88bce",
+        "rev": "7783abca6324f2dfdf8ca7d3632c376df416bf88",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`7783abca`](https://github.com/nix-community/emacs-overlay/commit/7783abca6324f2dfdf8ca7d3632c376df416bf88) | `Updated repos/melpa` |
| [`06553892`](https://github.com/nix-community/emacs-overlay/commit/0655389204c83a014e584121e7a7f47543af4571) | `Updated repos/emacs` |
| [`d28d973d`](https://github.com/nix-community/emacs-overlay/commit/d28d973de1f26d5b750df0be156a23e0ca6d360c) | `Updated repos/elpa`  |