### PR TITLE
chore(flake/nur): `f1b21073` -> `934c40ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1656973735,
-        "narHash": "sha256-Bn+sybPw/wGIqRNEwDxZtvJGeIf8LO09T1sdwz49A+s=",
+        "lastModified": 1656994083,
+        "narHash": "sha256-MXhTGKqSRoLEMWtUUXYl96wQ4JsqXBy1oHpc+bvoDAQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f1b210733ae9e85c15f84028c6539cdace20ebe0",
+        "rev": "934c40ab5ed324ce0ec4d3982f31b9e9629742da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`934c40ab`](https://github.com/nix-community/NUR/commit/934c40ab5ed324ce0ec4d3982f31b9e9629742da) | `automatic update` |