### PR TITLE
chore(flake/emacs-overlay): `7783abca` -> `beec8777`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1656991399,
-        "narHash": "sha256-/yriocQgmxPMwijVfkt8aEaFv65xcgnQXAtqL4vH9CU=",
+        "lastModified": 1657016837,
+        "narHash": "sha256-knx83nZ0xax6U1zR3rEOwIz2matk85kntbVEJRQYNuw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7783abca6324f2dfdf8ca7d3632c376df416bf88",
+        "rev": "beec877720e2b09b0b1a96450286459bcd7e6435",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`beec8777`](https://github.com/nix-community/emacs-overlay/commit/beec877720e2b09b0b1a96450286459bcd7e6435) | `Updated repos/melpa` |
| [`7d898090`](https://github.com/nix-community/emacs-overlay/commit/7d8980907738b174c14b73e5d24f55481d334b3a) | `Updated repos/emacs` |