### PR TITLE
chore(flake/nixpkgs): `0ea7a8f1` -> `18b14a25`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -297,11 +297,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1656753965,
-        "narHash": "sha256-BCrB3l0qpJokOnIVc3g2lHiGhnjUi0MoXiw6t1o8H1E=",
+        "lastModified": 1656835607,
+        "narHash": "sha256-zONMAG6JSfGyW20AsVWGnlZwNWws6Q/7IT0oDNGc1xY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0ea7a8f1b939d74e5df8af9a8f7342097cdf69eb",
+        "rev": "18b14a254dca6b68ca0ce2ce885ce2b550065799",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`4d1e5c11`](https://github.com/NixOS/nixpkgs/commit/4d1e5c1140938c0e6f2891cd9093676c9f0715b8) | `erigon: 2022.02.04 -> 2022.07.01`                                            |
| [`b1c6e1b8`](https://github.com/NixOS/nixpkgs/commit/b1c6e1b8a21075a78bfa2b668c7ea310f90cd9f3) | `python310Packages.pylutron-caseta: 0.13.1 -> 0.14.0`                         |
| [`b752d82c`](https://github.com/NixOS/nixpkgs/commit/b752d82cdd323bb38c61d8142d682f306e6999b3) | `python310Packages.pysyncobj: 0.3.10 -> 0.3.11`                               |
| [`76dff1dd`](https://github.com/NixOS/nixpkgs/commit/76dff1dd20bf708c1a40209721403586dbb2bbf6) | `flexget: 3.3.18 -> 3.3.19`                                                   |
| [`9eba797f`](https://github.com/NixOS/nixpkgs/commit/9eba797f29c79f8ad0014f3ea6304266bdaada38) | `python310Packages.s3-credentials: 0.11 -> 0.12`                              |
| [`d5bacc3c`](https://github.com/NixOS/nixpkgs/commit/d5bacc3c95ff818defca93d88125672fcf524148) | `exploitdb: 2022-06-28 -> 2022-07-02`                                         |
| [`6a7da5b5`](https://github.com/NixOS/nixpkgs/commit/6a7da5b520eba152f200cd761e4d90e6aa404af5) | `geocode-glib: fix installed tests`                                           |
| [`7be0e091`](https://github.com/NixOS/nixpkgs/commit/7be0e091bd8fa7d3647c0821aad59fea77472c3a) | `sbcl: pull darwin fix pending upstream inclusion for -fno-common toolchains` |
| [`85ab32d7`](https://github.com/NixOS/nixpkgs/commit/85ab32d794cec27fdb4807198e48df3884372b4e) | `wasynth: 0.10.0 -> 0.11.0`                                                   |
| [`f76ac449`](https://github.com/NixOS/nixpkgs/commit/f76ac449d1bdbd9cd9b76fbf98c511d26f849abc) | `srcOnly: fix with separateDebugInfo and/or multiple outputs`                 |
| [`22a183bf`](https://github.com/NixOS/nixpkgs/commit/22a183bf789cb60a2d80d757b1b6c25786cf3829) | `ocamlPackages.hacl_x25519: remove at 0.2.2`                                  |
| [`f5ad4e79`](https://github.com/NixOS/nixpkgs/commit/f5ad4e7964c733ca0ebdfbf15b266590567a6b32) | `ocamlPackages.awa: 0.0.5 → 0.1.0`                                            |
| [`85752ae3`](https://github.com/NixOS/nixpkgs/commit/85752ae3906029642d015b8ed30a54560d1213d8) | `python310Packages.trimesh: 3.12.6 -> 3.12.7`                                 |
| [`6b820ecf`](https://github.com/NixOS/nixpkgs/commit/6b820ecfab44378d05b2f0ea5996c25876d56acb) | `nixos: systemd: add missing sliceToUnit (#179841)`                           |
| [`d7d1174c`](https://github.com/NixOS/nixpkgs/commit/d7d1174c934e2645e2ec1702992afb7b001b4073) | `bochs: new recursive style`                                                  |
| [`d9d051d6`](https://github.com/NixOS/nixpkgs/commit/d9d051d6dd089cc6f1762a8a154f6bff0b60b94a) | `python310Packages.aesara: 2.7.3 -> 2.7.4`                                    |
| [`13b9616f`](https://github.com/NixOS/nixpkgs/commit/13b9616f7e79ec92a1edcda62332c49b79c11c94) | `python310Packages.pex: 2.1.93 -> 2.1.94`                                     |
| [`b8b42d6c`](https://github.com/NixOS/nixpkgs/commit/b8b42d6c77311f16780640d684e2c90151762edf) | `python310Packages.asf-search: 3.2.2 -> 4.0.1`                                |
| [`bd6fe08c`](https://github.com/NixOS/nixpkgs/commit/bd6fe08cc047416e9b991dffa2aaf8506282ab99) | `python310Packages.peaqevcore: 2.1.1 -> 3.0.5`                                |
| [`7f74d98b`](https://github.com/NixOS/nixpkgs/commit/7f74d98bdc1588212c7144b25ba4c45904315919) | `python310Packages.pyjet: 1.8.2 -> 1.9.0`                                     |
| [`8f9d0669`](https://github.com/NixOS/nixpkgs/commit/8f9d06690909cc74f34b25e848b68471f00163f2) | `python310Packages.pywayland: 0.4.12 -> 0.4.13`                               |
| [`a2403ed3`](https://github.com/NixOS/nixpkgs/commit/a2403ed37f4e8bb2f581b7ad0bb25a9e30fb435a) | `trackma: init at 0.8.4`                                                      |
| [`269b5000`](https://github.com/NixOS/nixpkgs/commit/269b50007315c08ebb9a86d778fca2e39ed6ac21) | `freecad: fix crash when selecting color of a solid`                          |
| [`2de1b09b`](https://github.com/NixOS/nixpkgs/commit/2de1b09bf049a4a838f95e7ae0fcd99be0a3a36e) | `neovide: fixup hash`                                                         |
| [`f4b3fb07`](https://github.com/NixOS/nixpkgs/commit/f4b3fb0703974703b171f2afee744c881b35125d) | `khal: 0.10.4 -> 0.10.5`                                                      |
| [`bcd503e7`](https://github.com/NixOS/nixpkgs/commit/bcd503e7fc940501c5f679edf04d8f1e0b5b5b4a) | `u001-font: init at unstable-2016-08-01`                                      |
| [`bf0608a6`](https://github.com/NixOS/nixpkgs/commit/bf0608a64253ee1b4baec38e0297b4801c59b09d) | `lib.licenses: add Aladdin Free Public License`                               |
| [`e2d48d0e`](https://github.com/NixOS/nixpkgs/commit/e2d48d0ece7aa3033c670f2bcae727e0ed0ae0d7) | `deja-dup: 43.3 → 43.4`                                                       |
| [`fb2877c3`](https://github.com/NixOS/nixpkgs/commit/fb2877c36f3e2a6de74dce7310160d9673a4a48f) | `geocode-glib: 3.26.2 → 3.26.3`                                               |
| [`e13726c8`](https://github.com/NixOS/nixpkgs/commit/e13726c80ea86cb356293cd7d2d2ab44995ee4f9) | `pitivi: 2021.05 → 2022.06`                                                   |
| [`c6217958`](https://github.com/NixOS/nixpkgs/commit/c6217958d040ffd004c6d553a6481ca9d92d0357) | `rhythmbox: 3.4.5 → 3.4.6`                                                    |
| [`dbb3c8d6`](https://github.com/NixOS/nixpkgs/commit/dbb3c8d6a716809dfcb1bb159d2576c53bb461d6) | `orca: 42.1 → 42.2`                                                           |
| [`ac47a22a`](https://github.com/NixOS/nixpkgs/commit/ac47a22add424a0f35dda0949862e702e94e3d4a) | `gnome.sushi: 41.2 → 42.0`                                                    |
| [`679a373a`](https://github.com/NixOS/nixpkgs/commit/679a373a81d3e88bd76afe10c9d3cd6205965937) | `gnome.gnome-maps: 42.2 → 42.3`                                               |
| [`6654f950`](https://github.com/NixOS/nixpkgs/commit/6654f950105717b7401a0d140fa9c00043c235f1) | `gnome.gnome-calculator: 42.1 → 42.2`                                         |
| [`5e2d29c7`](https://github.com/NixOS/nixpkgs/commit/5e2d29c7f2cfa964153d60095c3fa08584b5a928) | `gnome.gnome-boxes: 42.1 → 42.2`                                              |
| [`bd9e9f51`](https://github.com/NixOS/nixpkgs/commit/bd9e9f512daf9b8f1bad82f7a3c8eb8fe70df17b) | `evolution: 3.44.2 → 3.44.3`                                                  |
| [`d87a011c`](https://github.com/NixOS/nixpkgs/commit/d87a011c1e38153508bf6940d6bc2a5221069220) | `evolution-data-server: 3.44.2 → 3.44.3`                                      |
| [`e88d3738`](https://github.com/NixOS/nixpkgs/commit/e88d37389cb58827dd39d7a2712ef34cc5dc190d) | `evolution-ews: 3.44.2 → 3.44.3`                                              |
| [`bf528b86`](https://github.com/NixOS/nixpkgs/commit/bf528b867adcc00b8a02883c6677f157ec56bbac) | `power-profiles-daemon: 0.11.1 → 0.12`                                        |
| [`258bf7f1`](https://github.com/NixOS/nixpkgs/commit/258bf7f10ad8746ca8010033cb15ea4d2cc63994) | `python3Packages.flake8-bugbear: 22.6.22 -> 22.7.1`                           |
| [`96876767`](https://github.com/NixOS/nixpkgs/commit/968767675404db4144dd83c7760c39ef2d99ead9) | `yara: 4.2.1 -> 4.2.2`                                                        |
| [`eb5d09dd`](https://github.com/NixOS/nixpkgs/commit/eb5d09dd0fd8ca1d9925a0d4005087cdc7c7335d) | `pip-audit: 2.3.4 -> 2.4.0`                                                   |
| [`4cb1c832`](https://github.com/NixOS/nixpkgs/commit/4cb1c832e4e8060b9c1ffa2cf80a943a92409c06) | `swaysettings: init at 0.3.0`                                                 |
| [`b5d5648d`](https://github.com/NixOS/nixpkgs/commit/b5d5648d817695555174ea8675cc5df01cb87497) | `maintainers: add aacebedo`                                                   |
| [`a584258d`](https://github.com/NixOS/nixpkgs/commit/a584258d5268524e7415fabf0a35468769881d89) | `python310Packages.jupyter-book: init at 0.13.0`                              |
| [`c8a97d3f`](https://github.com/NixOS/nixpkgs/commit/c8a97d3f54e010d0e0e387c2ec6033889a528468) | `nvchecker: 2.8 -> 2.9`                                                       |
| [`97ea6594`](https://github.com/NixOS/nixpkgs/commit/97ea65945b712db46c93b6fd91eb684f3987f076) | `python310Packages.sphinx-multitoc-numbering: init at 0.1.3`                  |
| [`2c4c660d`](https://github.com/NixOS/nixpkgs/commit/2c4c660dc6b0f0cf65113d3e7d07b99f03ba5469) | `python310Packages.sphinx-book-theme: init at 0.3.2`                          |
| [`50825202`](https://github.com/NixOS/nixpkgs/commit/50825202d73ba82541dd564754fb01d6e65e22da) | `python310Packages.pydata-sphinx-theme: init at 0.8.1`                        |
| [`eccb49d4`](https://github.com/NixOS/nixpkgs/commit/eccb49d429991ee66497309328379b312ff27cc3) | `python310Packages.sphinx-thebe: init at 0.1.2`                               |
| [`7eca257a`](https://github.com/NixOS/nixpkgs/commit/7eca257a4a37bf2ed821a6fc99a0651c5b5bbf43) | `python310Packages.sphinx-design: init at 0.2.0`                              |
| [`f5c3ceaf`](https://github.com/NixOS/nixpkgs/commit/f5c3ceaf9190148f20dfc0c73db3f4fb5be5e1ae) | `python310Packages.sphinx-jupyterbook-latex: init at 0.4.6`                   |
| [`dd9632d2`](https://github.com/NixOS/nixpkgs/commit/dd9632d2227e5d5d2bc205f208c05231d00383f1) | `python310Packages.sphinx-external-toc: init at 0.3.0`                        |
| [`018764c3`](https://github.com/NixOS/nixpkgs/commit/018764c3b3776ab2170a79d498339d18e0dd7129) | `python310Packages.sphinx-comments: init at 0.0.3`                            |
| [`543652ab`](https://github.com/NixOS/nixpkgs/commit/543652ab74c0917576cbdb3eb75d6be12d8469bb) | `python310Packages.myst-nb: init at 0.16.0`                                   |
| [`4c2ff9c6`](https://github.com/NixOS/nixpkgs/commit/4c2ff9c6f52a1844fcae173bcb2808a5c705927d) | `python310Packages.sphinx-togglebutton: init at 0.3.1`                        |
| [`dbdee604`](https://github.com/NixOS/nixpkgs/commit/dbdee6040ec38a93cb8bfd43f2fbd674fda2a659) | `python310Packages.jupyter-cache: init at 0.5.0`                              |
| [`9d144953`](https://github.com/NixOS/nixpkgs/commit/9d144953c4f77c3b83c08eaf47bc3a51067e1134) | `python310Packages.skia-pathops: fix build on darwin`                         |
| [`d5720b7b`](https://github.com/NixOS/nixpkgs/commit/d5720b7be76fb6f292e596e9a644e7b25b3710ff) | `thunderbirdPackages: make thunderbird an alias to thunderbird-102`           |
| [`bc6a464c`](https://github.com/NixOS/nixpkgs/commit/bc6a464c32f22fc1f12c136d5b29a757594e9da3) | `nginx: build with pcre`                                                      |
| [`f169a1af`](https://github.com/NixOS/nixpkgs/commit/f169a1af97b28a0835e6447873ff7e4d5f4041db) | `nixos/tests: small update nginx-http3 test`                                  |
| [`ccff32fa`](https://github.com/NixOS/nixpkgs/commit/ccff32fa91711f2c05b4f4b7ce80d2890690814a) | `nginxModules.moreheaders: v0.33 -> unstable-2022-06-21`                      |
| [`ec443943`](https://github.com/NixOS/nixpkgs/commit/ec443943f5b3e96e704b8cdc69c1f300548cea35) | `nginxQuic: 5b1011b5702b -> 8d0753760546`                                     |
| [`7a8c5414`](https://github.com/NixOS/nixpkgs/commit/7a8c541412ff6c714c06f4c8f953e0e250879a8b) | `nginxMainline: 1.22.0 -> 1.23.0`                                             |
| [`4ecde975`](https://github.com/NixOS/nixpkgs/commit/4ecde975ea8b53f38561f1e6af73291a7eece23d) | `hilbish: 1.0.4 -> 1.2.0`                                                     |
| [`a5cb4532`](https://github.com/NixOS/nixpkgs/commit/a5cb45329edea6564149f63a031d5c07156292e8) | `thunderbird*: 91.11.0 -> 102.0`                                              |
| [`bb8d6d0b`](https://github.com/NixOS/nixpkgs/commit/bb8d6d0bc6e636e1b5aff7c516455a2f976137e4) | `vim: 8.2.4975 -> 9.0.0001`                                                   |
| [`4f9fc50b`](https://github.com/NixOS/nixpkgs/commit/4f9fc50b1941b81119e28c850cf6cdb36e0aa741) | `tilt: 0.30.0 -> 0.30.4`                                                      |
| [`de611c1c`](https://github.com/NixOS/nixpkgs/commit/de611c1c8196f7e3b7b09d766679343faf3f9ffd) | `sirula: unstable-2021-10-12 -> 1.0.0`                                        |
| [`5c21665b`](https://github.com/NixOS/nixpkgs/commit/5c21665ba8c0546bf0fdabd9da368f5e9f91c344) | `jellyfin-media-player: 1.7.0 -> 1.7.1`                                       |
| [`69ca5c98`](https://github.com/NixOS/nixpkgs/commit/69ca5c9898b26c2063d0e8a4db013e4ba0548159) | `wasm-bindgen-cli: 0.2.80 -> 0.2.81`                                          |
| [`c4025efc`](https://github.com/NixOS/nixpkgs/commit/c4025efcc15a2e0940e9d98f350091e9396b92b7) | `wasynth: init at 0.10.0`                                                     |
| [`75ca3807`](https://github.com/NixOS/nixpkgs/commit/75ca3807524e1ac806d15b802f90ed2c557921ae) | `fcitx5-unikey: 5.0.9 -> 5.0.10`                                              |
| [`8eb59b31`](https://github.com/NixOS/nixpkgs/commit/8eb59b316568979febc227001257c016c32bca71) | `libsForQt5.fcitx5-qt: 5.0.12 -> 5.0.13`                                      |
| [`539920f3`](https://github.com/NixOS/nixpkgs/commit/539920f342fdeeeffc4b3513d27c55a7cd0c2ea2) | `fcitx5-gtk: 5.0.14 -> 5.0.15`                                                |
| [`0595b6c5`](https://github.com/NixOS/nixpkgs/commit/0595b6c5593572e269def36fd2346428084b970b) | `fcitx5-chinese-addons: 5.0.12 -> 5.0.13`                                     |
| [`5416c7a0`](https://github.com/NixOS/nixpkgs/commit/5416c7a0ec311ad354735e7f9d0341e5ece47023) | `fcitx5: 5.0.16 -> 5.0.17`                                                    |
| [`f410db89`](https://github.com/NixOS/nixpkgs/commit/f410db89dc5ff01bd7718291468c8d712a54dc04) | `libime: 1.0.11 -> 1.0.12`                                                    |
| [`1d00e386`](https://github.com/NixOS/nixpkgs/commit/1d00e3862c8b4fd7cac0b49d02102d40038e5804) | `featherpad: 1.2.0 -> 1.3.0`                                                  |
| [`e2633217`](https://github.com/NixOS/nixpkgs/commit/e2633217affc4f2e7a1664ccae111f96caeae4d9) | `flat-remix-icon-theme: 20220304 -> 20220525`                                 |
| [`83aaee54`](https://github.com/NixOS/nixpkgs/commit/83aaee5434a6e26327b0e6ee99ddc1a2a398adbc) | `flat-remix-gtk: 20220427 -> 20220527`                                        |
| [`285970c3`](https://github.com/NixOS/nixpkgs/commit/285970c35f383aa46f41e382042095e7a208dd08) | `flacon: 9.0.0 -> 9.1.0`                                                      |
| [`fce17bf6`](https://github.com/NixOS/nixpkgs/commit/fce17bf68bb5706a78adf6f8ed3770e245a3a6eb) | `nixops_unstable: update lock file`                                           |
| [`ea7336a0`](https://github.com/NixOS/nixpkgs/commit/ea7336a084a37d99548781ddeb4de41f394ca3f1) | `nixops_unstable: set Python interpreter to python39`                         |