### PR TITLE
chore(flake/dendrite-demo-pinecone): `8b77f0b0` -> `d32a1e88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -40,11 +40,11 @@
     "dendrite": {
       "flake": false,
       "locked": {
-        "lastModified": 1657022031,
-        "narHash": "sha256-yd4hAPXDFF/mnHKgl4DKQdDu0EXE4G6qeMZvWLQ7T5o=",
+        "lastModified": 1657037606,
+        "narHash": "sha256-yU5gSjEr9LP75dCEF8P7Io5XUOqbcfVEwIjW0z1+W1I=",
         "owner": "matrix-org",
         "repo": "dendrite",
-        "rev": "43147bd65415de2477826677a08f6655ece7f38c",
+        "rev": "460dccf93d5eb77db00620f0ef5a4f1a91bbe7ae",
         "type": "github"
       },
       "original": {
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657023463,
-        "narHash": "sha256-w/7SnBe3Ce9GfmpN8XL7nrQK5iPc+uTtCfKtgnjLarU=",
+        "lastModified": 1657044588,
+        "narHash": "sha256-AiD61tP/DSq4e2ExIMtMSG8uKCriXF+23pepCBRmtrA=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "8b77f0b00780e75c479e50042688f4c8c05ad58f",
+        "rev": "d32a1e88e6dc2cb77c3f4103b930a169963cae21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                          | Commit Message       |
| --------------------------------------------------------------------------------------------------------------- | -------------------- |
| [`d32a1e88`](https://github.com/bbigras/dendrite-demo-pinecone/commit/d32a1e88e6dc2cb77c3f4103b930a169963cae21) | `flake.lock: Update` |