### PR TITLE
chore(flake/emacs-overlay): `beec8777` -> `6ad17c8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657016837,
-        "narHash": "sha256-knx83nZ0xax6U1zR3rEOwIz2matk85kntbVEJRQYNuw=",
+        "lastModified": 1657045122,
+        "narHash": "sha256-YMZE+NsnhC36YqtMnsDYV2WsHUHLMffM56lNXyHxOSA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "beec877720e2b09b0b1a96450286459bcd7e6435",
+        "rev": "6ad17c8e39b64221557d1753252850f8f0b8a275",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`6ad17c8e`](https://github.com/nix-community/emacs-overlay/commit/6ad17c8e39b64221557d1753252850f8f0b8a275) | `Updated repos/melpa` |
| [`eb2d9468`](https://github.com/nix-community/emacs-overlay/commit/eb2d9468c08568193523abb29aea32b17a5a22b0) | `Updated repos/emacs` |