### PR TITLE
chore(flake/emacs-overlay): `6ad17c8e` -> `00f0fb99`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657045122,
-        "narHash": "sha256-YMZE+NsnhC36YqtMnsDYV2WsHUHLMffM56lNXyHxOSA=",
+        "lastModified": 1657079347,
+        "narHash": "sha256-0h3ke+wmQNo64/cOZ+XW1/X3SHJdNMeWxrUno3K9buA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6ad17c8e39b64221557d1753252850f8f0b8a275",
+        "rev": "00f0fb99762db554116a116f73c3e7ecc2e6545b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`00f0fb99`](https://github.com/nix-community/emacs-overlay/commit/00f0fb99762db554116a116f73c3e7ecc2e6545b) | `Updated repos/nongnu` |
| [`0448a9be`](https://github.com/nix-community/emacs-overlay/commit/0448a9be0e842e3e80696fb5951487803dc8e018) | `Updated repos/melpa`  |
| [`2591bf8e`](https://github.com/nix-community/emacs-overlay/commit/2591bf8eeed03d9fede8ceeb0560213faee47583) | `Updated repos/emacs`  |
| [`2922cf24`](https://github.com/nix-community/emacs-overlay/commit/2922cf24903063fec62e4ccc9a19e4f3e7b1ff94) | `Updated repos/elpa`   |