### PR TITLE
chore(flake/nur): `93dd2a3e` -> `2a7f3cde`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657043854,
-        "narHash": "sha256-Yj4heoWo0Laqdruz3NGpQ/SPybRo9f0y63UuVFK04Po=",
+        "lastModified": 1657078506,
+        "narHash": "sha256-MU4rss4gjLVaCqgpVmFJZqCkTYUoUS8NaMR3lmxr8CE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "93dd2a3e160fedd798342e7e91277bff8eb1c998",
+        "rev": "2a7f3cdea2677a02d5b58f57331fac438f749d22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2a7f3cde`](https://github.com/nix-community/NUR/commit/2a7f3cdea2677a02d5b58f57331fac438f749d22) | `automatic update` |