### PR TITLE
chore(flake/nur): `2a7f3cde` -> `2e28ae2c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657078506,
-        "narHash": "sha256-MU4rss4gjLVaCqgpVmFJZqCkTYUoUS8NaMR3lmxr8CE=",
+        "lastModified": 1657080269,
+        "narHash": "sha256-TPn13kjDbdR3azusjCA7QEF0ui3QtKqt+VkCVH5qpjI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2a7f3cdea2677a02d5b58f57331fac438f749d22",
+        "rev": "2e28ae2c50771b0057e8fd88151142ed647b9ca4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2e28ae2c`](https://github.com/nix-community/NUR/commit/2e28ae2c50771b0057e8fd88151142ed647b9ca4) | `automatic update` |