### PR TITLE
chore(flake/nur): `cb6883e9` -> `aa163215`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657081900,
-        "narHash": "sha256-S/VhfaLACSdLJzBuruU/h1lUQjaznJBLiGR8QyIX11E=",
+        "lastModified": 1657086771,
+        "narHash": "sha256-Z4HqRTNY4Vx4Fys5UTVSl2IerK9AcWlF84qCt5mnBv4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cb6883e9ce6b792ae5044d6967aad5c9a85f6a49",
+        "rev": "aa163215879794cec45bc371b7a2dbd353e54cc8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`aa163215`](https://github.com/nix-community/NUR/commit/aa163215879794cec45bc371b7a2dbd353e54cc8) | `automatic update` |