### PR TITLE
chore(flake/nur): `aa163215` -> `f21f863b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657086771,
-        "narHash": "sha256-Z4HqRTNY4Vx4Fys5UTVSl2IerK9AcWlF84qCt5mnBv4=",
+        "lastModified": 1657092940,
+        "narHash": "sha256-CCadT5373eCDAKkfLVAnJrf5krX5B6Go+YlULi9MsB0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aa163215879794cec45bc371b7a2dbd353e54cc8",
+        "rev": "f21f863b74ed65b8802008aa2497e0fbd58bbe63",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f21f863b`](https://github.com/nix-community/NUR/commit/f21f863b74ed65b8802008aa2497e0fbd58bbe63) | `automatic update` |