### PR TITLE
chore(flake/emacs-overlay): `00f0fb99` -> `88bfbe0c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657079347,
-        "narHash": "sha256-0h3ke+wmQNo64/cOZ+XW1/X3SHJdNMeWxrUno3K9buA=",
+        "lastModified": 1657103562,
+        "narHash": "sha256-lSMA2B40tJxdRdAPftDxI9h+vBaS6mjlROz5nv3Ep3s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "00f0fb99762db554116a116f73c3e7ecc2e6545b",
+        "rev": "88bfbe0c218e095f0d9e9aaa2ba18dc0df410244",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`88bfbe0c`](https://github.com/nix-community/emacs-overlay/commit/88bfbe0c218e095f0d9e9aaa2ba18dc0df410244) | `Updated repos/nongnu` |
| [`816b1671`](https://github.com/nix-community/emacs-overlay/commit/816b1671de57269ed12c44722571b553cbf093b2) | `Updated repos/melpa`  |
| [`f793d988`](https://github.com/nix-community/emacs-overlay/commit/f793d988f092c6238b5d5b06a7c67f4e45cfd7e7) | `Updated repos/emacs`  |