### PR TITLE
chore(flake/emacs-ement): `918d1d9d` -> `2b4ee52e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1656779161,
-        "narHash": "sha256-3UbufmQqCDYESQxLfV/78aaoR0Re2ZPrLyoGZE1gjSY=",
+        "lastModified": 1657122783,
+        "narHash": "sha256-zyXJ0wc7CbgNPo7BlhI3aXlErkQgPM6EADcN0yRjL1c=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "918d1d9d4358abadcd56086ce21028b259ea00d7",
+        "rev": "2b4ee52e6796747399a194127f0c8fc7e1f3fdfc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                            |
| --------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`2b4ee52e`](https://github.com/alphapapa/ement.el/commit/2b4ee52e6796747399a194127f0c8fc7e1f3fdfc) | `Change: Make membership event type bold` |