### PR TITLE
chore(flake/nur): `babe1428` -> `fa1d59a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657148541,
-        "narHash": "sha256-gX+Zhr+YYS7IRZxWJNJsbsRIO3bce8Dx3KL5M62Epxw=",
+        "lastModified": 1657159100,
+        "narHash": "sha256-4JOwr/LRurti3AehQL0Yuhj6DYr2INrX8E3/1L7WPrQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "babe142880c724f94bcc16f61f2b62d228a5e613",
+        "rev": "fa1d59a3eab20b95de429440254fdecd44c8e719",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`fa1d59a3`](https://github.com/nix-community/NUR/commit/fa1d59a3eab20b95de429440254fdecd44c8e719) | `automatic update` |