### PR TITLE
chore(flake/nur): `fa1d59a3` -> `1e2c29a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657159100,
-        "narHash": "sha256-4JOwr/LRurti3AehQL0Yuhj6DYr2INrX8E3/1L7WPrQ=",
+        "lastModified": 1657162159,
+        "narHash": "sha256-NgMUSjCXdS9+zMh5sYjxw1UfpJDd8jjIEdMZqicpiX4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fa1d59a3eab20b95de429440254fdecd44c8e719",
+        "rev": "1e2c29a05eb9b3272cd8574df27a80217ea85b2d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1e2c29a0`](https://github.com/nix-community/NUR/commit/1e2c29a05eb9b3272cd8574df27a80217ea85b2d) | `automatic update` |
| [`d19621b7`](https://github.com/nix-community/NUR/commit/d19621b73332851728208539597b278f7d07dc22) | `automatic update` |