### PR TITLE
chore(flake/nur): `1e2c29a0` -> `ca08ede6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657162159,
-        "narHash": "sha256-NgMUSjCXdS9+zMh5sYjxw1UfpJDd8jjIEdMZqicpiX4=",
+        "lastModified": 1657166844,
+        "narHash": "sha256-9GB/r4DeQncHVaPinnyJxFxEPMgRovBDJcCcuBqgagw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1e2c29a05eb9b3272cd8574df27a80217ea85b2d",
+        "rev": "ca08ede600f048570a5a69bc6dd8143b033b8003",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ca08ede6`](https://github.com/nix-community/NUR/commit/ca08ede600f048570a5a69bc6dd8143b033b8003) | `automatic update` |
| [`41373de4`](https://github.com/nix-community/NUR/commit/41373de4564759899634d2be81e0ba3491144a91) | `automatic update` |