### PR TITLE
chore(flake/home-manager): `face4094` -> `12cfcc1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657164980,
-        "narHash": "sha256-6DlmMEN8+Lewfelx11X8nLl0EzwBHLGFeK9HfTQnFps=",
+        "lastModified": 1657176901,
+        "narHash": "sha256-aTE0EWqCqXPKYgrNCxblmPmBAx1csMhypVqxO/2P4dg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "face4094d499c84c782873464794cb976c94f079",
+        "rev": "12cfcc1b9dc9a8a7a0b4cf538841b85af5c4cd98",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`12cfcc1b`](https://github.com/nix-community/home-manager/commit/12cfcc1b9dc9a8a7a0b4cf538841b85af5c4cd98) | `fusuma: fix settings example (#3067)`                                  |
| [`ef990143`](https://github.com/nix-community/home-manager/commit/ef990143b6ae86685fc24a8d40538834a28fc994) | `nushell: fix non-nullable configFile and envFile, fixes #3050 (#3060)` |