### PR TITLE
chore(flake/nixpkgs): `71a4f0dc` -> `a5c867d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -297,11 +297,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657020478,
-        "narHash": "sha256-sU5hXEGcOcvz2xoPAuNLBQJLXjwvPpTkoddyXE8gw20=",
+        "lastModified": 1657114324,
+        "narHash": "sha256-fWuaUNXrHcz/ciHRHlcSO92dvV3EVS0GJQUSBO5JIB4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "71a4f0dc3d80ba76f437c888c1c3d59f1df98163",
+        "rev": "a5c867d9fe9e4380452628e8f171c26b69fa9d3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
| [`a5c867d9`](https://github.com/NixOS/nixpkgs/commit/a5c867d9fe9e4380452628e8f171c26b69fa9d3d) | `libschrift: 0.10.1 -> 0.10.2`                                                                      |
| [`0c0cb9db`](https://github.com/NixOS/nixpkgs/commit/0c0cb9dbe5466dc44de97d7821320f70a8360e38) | `musescore: 2.1 -> 3.6.2.548020600 on darwin`                                                       |
| [`1d5a0c0f`](https://github.com/NixOS/nixpkgs/commit/1d5a0c0f4a0b7db109adf484b953fd9921ea0877) | `mu: 1.8.3 -> 1.8.5`                                                                                |
| [`452c0ddf`](https://github.com/NixOS/nixpkgs/commit/452c0ddf8ac095fcc950a6326878c3ec1570fd77) | `cardinal: 22.04 -> 22.06`                                                                          |
| [`72e26a9f`](https://github.com/NixOS/nixpkgs/commit/72e26a9f5b2bebec3ca84036ac532e9ccd73ffab) | `hcloud: 1.29.5 -> 1.30.0`                                                                          |
| [`8ef7523c`](https://github.com/NixOS/nixpkgs/commit/8ef7523c8e11da7fd23e6b87371e7aa1eab718bb) | `pineapple-pictures: init at 0.6.1 (#178583)`                                                       |
| [`ec9ce3c9`](https://github.com/NixOS/nixpkgs/commit/ec9ce3c94bb763973bde1b860d217c1d16e3d5e8) | `python310Packages.levenshtein: 0.18.1 -> 0.18.2`                                                   |
| [`07f1d6ba`](https://github.com/NixOS/nixpkgs/commit/07f1d6bab7586bbdf0e1e94ebdfe031b32946724) | `python310Packages.rapidfuzz: 2.1.0 -> 2.1.2`                                                       |
| [`ed40dba1`](https://github.com/NixOS/nixpkgs/commit/ed40dba171076f270b4958ca7c9e0b0570882fda) | `python310Packages.jarowinkler: 1.0.5 -> 1.1.0`                                                     |
| [`934a622f`](https://github.com/NixOS/nixpkgs/commit/934a622f7ecf9bc18940e799bdc5f2b7c0c213a5) | `qemu-utils: ensure we cut off qemu dependency`                                                     |
| [`fef6723f`](https://github.com/NixOS/nixpkgs/commit/fef6723f9bea16c6530beefd20349e0e10a8d1ff) | `qemu-utils: remove qemu dependency`                                                                |
| [`3b1cbcc9`](https://github.com/NixOS/nixpkgs/commit/3b1cbcc92bbd97b890dde90805e5cae347846f9c) | `ocamlPackages.yaml: 3.0.0 -> 3.1.0 (#180139)`                                                      |
| [`25c4a062`](https://github.com/NixOS/nixpkgs/commit/25c4a062c63fb7bf4448e040bd79593353008a8d) | `puddletag: 2.1.1 -> 2.2.0`                                                                         |
| [`f4b885df`](https://github.com/NixOS/nixpkgs/commit/f4b885df97aafe36fd08637cb2d770463f1997aa) | `xosview2: remove spurious doCheck = false`                                                         |
| [`c2c8e8fd`](https://github.com/NixOS/nixpkgs/commit/c2c8e8fdd2e30937fc746c54a7b76c6ee87417b1) | `xosview: init at 1.23`                                                                             |
| [`4066f82a`](https://github.com/NixOS/nixpkgs/commit/4066f82a4de90e25b41451486bdcbf2c45805a48) | `all-packages.nix: cosmetic formatting of some comments`                                            |
| [`bf35d801`](https://github.com/NixOS/nixpkgs/commit/bf35d8018738ad3b4bf871dfd64f1ae7e83c5997) | `python310Packages.skodaconnect: 1.1.20 -> 1.1.21`                                                  |
| [`17c42e33`](https://github.com/NixOS/nixpkgs/commit/17c42e33b087b652218a69defa60f692de445ace) | `crlfsuite: 2.0 -> 2.1.1`                                                                           |
| [`069be5d4`](https://github.com/NixOS/nixpkgs/commit/069be5d42791b21d02e0c3da980cefab46271de6) | `python310Packages.ics: 0.7 -> 0.7.1`                                                               |
| [`41e0ebb9`](https://github.com/NixOS/nixpkgs/commit/41e0ebb94d075e287e11a9fd1089c92ef3d003a2) | `python310Packages.pytest-test-utils: 0.0.6 -> 0.0.7`                                               |
| [`14a84624`](https://github.com/NixOS/nixpkgs/commit/14a846241865ad63780e0be63379ff8584eeffcc) | `python310Packages.islpy: 2022.1.2 -> 2022.2`                                                       |
| [`33cda578`](https://github.com/NixOS/nixpkgs/commit/33cda5786fe4dcba66603e2feb93d254f3890182) | `libvirt: 8.4.0 -> 8.5.0`                                                                           |
| [`2f12a8d2`](https://github.com/NixOS/nixpkgs/commit/2f12a8d2b8247f3cf62e024132314dc352cb6597) | `python310Packages.pygmt: 0.6.1 -> 0.7.0`                                                           |
| [`42db1e66`](https://github.com/NixOS/nixpkgs/commit/42db1e66f3cf7026cdfdc341d13f8ba12e9fad4d) | `python310Packages.yq: 2.14.0 -> 3.0.2`                                                             |
| [`597db2e3`](https://github.com/NixOS/nixpkgs/commit/597db2e3b443f417ca71f5158d1031f08e83bd7d) | `python310Packages.spacy-transformers: 1.1.6 -> 1.1.7`                                              |
| [`00b2db64`](https://github.com/NixOS/nixpkgs/commit/00b2db645cea9941d8c2bafc7fdd509dbf5a908c) | `python310Packages.vispy: 0.10.0 -> 0.11.0`                                                         |
| [`8558ab08`](https://github.com/NixOS/nixpkgs/commit/8558ab08b6258d2964442d447527082d3c0cc081) | `vscode-extensions.ms-python.vscode-pylance: 2022.6.30 -> 2022.7.11`                                |
| [`14af83b8`](https://github.com/NixOS/nixpkgs/commit/14af83b82a6a1eb9aec9049a94b25b098d4c312d) | `vscode-extensions.ms-python.vscode-pylance: 2022.1.5 -> 2022.6.30`                                 |
| [`aeb97834`](https://github.com/NixOS/nixpkgs/commit/aeb97834a8052814fdaf078adf4befbfb03aed37) | `werf: 1.2.117 -> 1.2.120`                                                                          |
| [`6785b339`](https://github.com/NixOS/nixpkgs/commit/6785b339ccdab11cc44ae971077969b513b46f43) | `python3Packages.gradient_statsd: propagate chardet`                                                |
| [`336cc168`](https://github.com/NixOS/nixpkgs/commit/336cc1683a4199f25310f7a4b7a2c6b04f25cc89) | `mars: fix build on gcc-10`                                                                         |
| [`d47f646d`](https://github.com/NixOS/nixpkgs/commit/d47f646d16e5db553b6a30a218dbf0337ab23c42) | `python3Packages.progressbar2: re-enable check since the issue was solved upstream`                 |
| [`002e147b`](https://github.com/NixOS/nixpkgs/commit/002e147b103041e8ac2a0785a8232796f6451714) | `python3Packages.python-utils: 3.1.0 → 3.3.3`                                                       |
| [`2169ff54`](https://github.com/NixOS/nixpkgs/commit/2169ff54f191e4cd7a47c80207d9b58b7e50202a) | `cloc: 1.92 -> 1.94`                                                                                |
| [`9f97d67c`](https://github.com/NixOS/nixpkgs/commit/9f97d67c3a9093cbc0c2119ecacf043c766022a7) | `oil: 0.10.1 -> 0.11.0 (#179637)`                                                                   |
| [`183b236e`](https://github.com/NixOS/nixpkgs/commit/183b236eef3004945512d0ac507faf9828b53244) | `nebula: 1.5.2 -> 1.6.0`                                                                            |
| [`a2642faa`](https://github.com/NixOS/nixpkgs/commit/a2642faaead939295d279b64abb50c45f1b12b93) | `virtctl: 0.53.0 -> 0.54.0`                                                                         |
| [`a2012c49`](https://github.com/NixOS/nixpkgs/commit/a2012c49fc3e34581cf4b302513319c8cd45cbfe) | `hyprpaper: init at unstable-2022-07-04 (#180192)`                                                  |
| [`d1dd3b2a`](https://github.com/NixOS/nixpkgs/commit/d1dd3b2aad2030f76fee68928b6718320664b232) | `Add remaining extension metadata`                                                                  |
| [`1dd5fa64`](https://github.com/NixOS/nixpkgs/commit/1dd5fa64c1b8cf372523380e6719ca6ab468343b) | `Add lucperkins to list of maintainers`                                                             |
| [`2da5797c`](https://github.com/NixOS/nixpkgs/commit/2da5797ca521e3b62ab3262b38a0fb09bfa066b9) | `Add vrl-vscode extension for Visual Studio Code`                                                   |
| [`94053017`](https://github.com/NixOS/nixpkgs/commit/94053017142fdbd44579375b495e4e4035413879) | `python310Packages.rns: 0.3.8 -> 0.3.9`                                                             |
| [`23ee5ac4`](https://github.com/NixOS/nixpkgs/commit/23ee5ac46ad942208b82f3631d891cdb60bb8409) | `vscode-extensions.piousdeer.adwaita-theme: init at 1.0.7`                                          |
| [`af7323d1`](https://github.com/NixOS/nixpkgs/commit/af7323d1a8ca96d2cd623e628407223c2fad92a2) | `discord: fix override`                                                                             |
| [`838e78a8`](https://github.com/NixOS/nixpkgs/commit/838e78a8a602456d01d4590aa209b75daca6a926) | `firefox-bin-unwrapped: 102.0 -> 102.0.1`                                                           |
| [`e3e78bb4`](https://github.com/NixOS/nixpkgs/commit/e3e78bb4095ea946d507fa5ee8ec7f5a43628565) | `firefox-unwrapped: 102.0 -> 102.0.1`                                                               |
| [`83562c61`](https://github.com/NixOS/nixpkgs/commit/83562c61752b398dabe88be79ab03c914ff901af) | `k9s: 0.25.18 -> 0.25.21`                                                                           |
| [`e2a624dd`](https://github.com/NixOS/nixpkgs/commit/e2a624ddc6644c84cbff5283b25f43267d7e3775) | `circup: 1.1.0 -> 1.1.2`                                                                            |
| [`0c564ffe`](https://github.com/NixOS/nixpkgs/commit/0c564ffe7876338179c32ff9a6b63c36eb0c6a25) | `python3Packages.pyuv: backport python3.10 build fix`                                               |
| [`cbc4d517`](https://github.com/NixOS/nixpkgs/commit/cbc4d51711102e80013917eea84705cc471febdb) | `zen-kernels: 5.18.7 -> 5.18.9`                                                                     |
| [`000d72eb`](https://github.com/NixOS/nixpkgs/commit/000d72eb7fc02d116fe27fe2cf58f46b29d83b1e) | `nixos/privacyidea: pin python to 3.9`                                                              |
| [`1360dd9d`](https://github.com/NixOS/nixpkgs/commit/1360dd9d71eed35465e46318e3b4a26af466827d) | `privacyidea: 3.7.1 -> 3.7.2`                                                                       |
| [`20f5ebdd`](https://github.com/NixOS/nixpkgs/commit/20f5ebdd3cec7df91fc4e9805a7d002d0f7fc0ae) | `maintainers/mdize-module: Add known limitations`                                                   |
| [`eded0d65`](https://github.com/NixOS/nixpkgs/commit/eded0d654ceffd5d29113c396af268bcbfea0b8d) | `octomap: 1.9.7 -> 1.9.8`                                                                           |
| [`d10999d7`](https://github.com/NixOS/nixpkgs/commit/d10999d7335191ec644cf89ba81624a73300f893) | `Add knownVulnerabilities to libdwarf`                                                              |
| [`89100132`](https://github.com/NixOS/nixpkgs/commit/89100132771105e851d4f9e43207ef8f59dcb9b9) | `dendrite: 0.8.8 -> 0.8.9`                                                                          |
| [`2a478c94`](https://github.com/NixOS/nixpkgs/commit/2a478c942a672d588e33daef7c5ae4d9a7b83265) | `broot: 1.13.3 -> 1.14.0`                                                                           |
| [`68cc57cc`](https://github.com/NixOS/nixpkgs/commit/68cc57cce147e52f382802c8b257c8f319aac173) | `nixos/qt5ct: remove enable option and suggests qt5.platformTheme`                                  |
| [`097b70ec`](https://github.com/NixOS/nixpkgs/commit/097b70ec5c3aede047a2c3322933bf3c2fb075f5) | ``wtf: Set `meta.mainProgram` to "wtfutil"``                                                        |
| [`2f19bff1`](https://github.com/NixOS/nixpkgs/commit/2f19bff1b14cf94472c871a164b10123c1d5115e) | `kopia: 0.11.0 -> 0.11.1`                                                                           |
| [`47ba8cdc`](https://github.com/NixOS/nixpkgs/commit/47ba8cdcc7096242bd98f9d9631fa9dd4974cf53) | `nixos/qt5: add maintainer`                                                                         |
| [`04d6b89b`](https://github.com/NixOS/nixpkgs/commit/04d6b89bcc7b21f06259b040659b60d918a5df70) | `_1password-gui-beta: 8.8.0-119.BETA -> 8.8.0-165.BETA`                                             |
| [`11c38f0a`](https://github.com/NixOS/nixpkgs/commit/11c38f0a6bdc5baebadd903049f43b76c7b3b953) | `_1password-gui: 8.7.1 -> 8.7.3`                                                                    |
| [`b28aebf8`](https://github.com/NixOS/nixpkgs/commit/b28aebf8bbdbc5ea135683c17d064488565bf58b) | `python310Packages.splinter: 0.18.0 -> 0.18.1`                                                      |
| [`4b3793e0`](https://github.com/NixOS/nixpkgs/commit/4b3793e092a0cb181b71c619d2968097e8077446) | `python310Packages.rflink: 0.0.62 -> 0.0.63`                                                        |
| [`a7111548`](https://github.com/NixOS/nixpkgs/commit/a71115488920ce212479a012ba241200826faaeb) | `blueman: 2.2.5 -> 2.3`                                                                             |
| [`a264a86d`](https://github.com/NixOS/nixpkgs/commit/a264a86d935fae69558f363881d65a19a4f4d735) | `nixos/qt5: add qt5ct as a possible platform theme`                                                 |
| [`8c5079ef`](https://github.com/NixOS/nixpkgs/commit/8c5079ef3e3d77692d0f127b3ae8b8a120ed71d0) | `matrix-synapse: 1.61.1 -> 1.62.0`                                                                  |
| [`5139952b`](https://github.com/NixOS/nixpkgs/commit/5139952befe5f8f90b88e69f8dd3fe4592d758ac) | `matrix-common: 1.1.0 -> 1.2.1`                                                                     |
| [`df23b42a`](https://github.com/NixOS/nixpkgs/commit/df23b42a9aca5ef4abbd50b53cdfd5a301f9a489) | `udocker: fix build failure`                                                                        |
| [`75ec318b`](https://github.com/NixOS/nixpkgs/commit/75ec318b8000e5adfe27015607afffab346d72b5) | `wireplumber: 0.4.10 -> 0.4.11`                                                                     |
| [`70dc91a4`](https://github.com/NixOS/nixpkgs/commit/70dc91a415ab21cdaacb431abbfdfe313300f211) | `libsForQt5.bismuth: 3.1.1 -> 3.1.2`                                                                |
| [`568d2e77`](https://github.com/NixOS/nixpkgs/commit/568d2e77f43efd26b387ae43ddc4c3352920ab10) | `nixos.redis: Fix disabling of RDB persistence.`                                                    |
| [`9dc9efef`](https://github.com/NixOS/nixpkgs/commit/9dc9efefc458309fceab286c5a2fae8dd0f65372) | `jsonnet-language-server: init at 0.7.2`                                                            |
| [`01660583`](https://github.com/NixOS/nixpkgs/commit/01660583c015a330a77e0dde4f5609db60af8cb7) | `topgrade: fix build on darwin`                                                                     |
| [`c30f978f`](https://github.com/NixOS/nixpkgs/commit/c30f978f233f7adace4e8fffff12745486008751) | `trace-cmd: 3.0.3->3.1.1`                                                                           |
| [`6a5b1bc0`](https://github.com/NixOS/nixpkgs/commit/6a5b1bc0a376b4bb3e9199ed396c7f73b567cd14) | ``nixos/mailman: strip trailing `\n` when reading the secret``                                      |
| [`6c7fbcd2`](https://github.com/NixOS/nixpkgs/commit/6c7fbcd21e7e137f4fde9a5c4acaec1d2b594b94) | ``mailman: make `mailmanPackages.extend` actually work in overlays``                                |
| [`dd4b6b81`](https://github.com/NixOS/nixpkgs/commit/dd4b6b81fa95dbd71d9f2db5dee968dd8bcb5e29) | `nixos/mailman: implement LDAP support for postorius`                                               |
| [`35152923`](https://github.com/NixOS/nixpkgs/commit/351529231b162f61c00c59a4e913bedb765929a0) | `python3Packages.privacyidea-ldap-proxy: add patch to support LDAPCompareRequest`                   |
| [`df304cc7`](https://github.com/NixOS/nixpkgs/commit/df304cc7737dd27cb44861c853b74ad8f0c447d4) | `vxl: 1.17.0-nix1 -> 3.3.2`                                                                         |
| [`576a97a0`](https://github.com/NixOS/nixpkgs/commit/576a97a0d0574af262e89ff2f3332a8493977d09) | `xcftools: patch CVE-2019-5086 and CVE-2019-5087`                                                   |
| [`4ed794f1`](https://github.com/NixOS/nixpkgs/commit/4ed794f1bc5183df62f436be0230e8b4b1eb7767) | `got: 0.70 -> 0.73`                                                                                 |
| [`e45d0464`](https://github.com/NixOS/nixpkgs/commit/e45d0464d5016f2795e567738652b6bf07443ee7) | `qt6: 6.3.0 -> 6.3.1`                                                                               |
| [`a5ce71d4`](https://github.com/NixOS/nixpkgs/commit/a5ce71d4e8cbe1d3311aeddc86a8d847989d6099) | `xmr-stak: drop gcc6 requrement (and cuda support)`                                                 |
| [`de0d0a2f`](https://github.com/NixOS/nixpkgs/commit/de0d0a2fb0dd87320ce633378a5183dfb1a56b35) | `frece: init at 1.0.6`                                                                              |
| [`432bd70f`](https://github.com/NixOS/nixpkgs/commit/432bd70f7db8558b44cf52d713eb1de8bba6fac8) | `jdt-language-server: 1.8.0 -> 1.13.0`                                                              |
| [`f452ce73`](https://github.com/NixOS/nixpkgs/commit/f452ce73961cd7217208b07d6de5477630b239d8) | `cudatext: 1.166.2 -> 1.166.5`                                                                      |
| [`09528e6d`](https://github.com/NixOS/nixpkgs/commit/09528e6db80e34dbc764550c8cb1f6383f26168f) | `rPackages: CRAN and BioC update`                                                                   |
| [`cb9a3349`](https://github.com/NixOS/nixpkgs/commit/cb9a33497fb96262973c4c64ca767cb09e568dbc) | `generic-updater: fix nix edit command line`                                                        |
| [`3ed1328b`](https://github.com/NixOS/nixpkgs/commit/3ed1328b9bdc61bb220d516fbbcdbf7befa74b41) | `hplip: 3.21.12 -> 3.22.6`                                                                          |
| [`af15cfb5`](https://github.com/NixOS/nixpkgs/commit/af15cfb5b371f2bf9844f41405b6ee4f81bfea04) | `mypy: 0.941 → 0.961`                                                                               |
| [`1badcfab`](https://github.com/NixOS/nixpkgs/commit/1badcfab27a4345617035f6c269e252afa355539) | `mate.mate-tweak: 22.04.4 -> 22.04.8`                                                               |
| [`c1fc59a7`](https://github.com/NixOS/nixpkgs/commit/c1fc59a7956543a0ab93be816595987981faae30) | `libdwarf_0_4: 0.4.0 -> 0.4.1`                                                                      |
| [`aebe4d27`](https://github.com/NixOS/nixpkgs/commit/aebe4d27c7bbd18753cd0138f169a5ac47969093) | `nvidia_x11: 515.48.07 → 515.57`                                                                    |
| [`8e3c7a1f`](https://github.com/NixOS/nixpkgs/commit/8e3c7a1fd54577b49d56f40a58d6927e6027ce6a) | `maintainers: add a helper script for the options doc conversion`                                   |
| [`88223bcc`](https://github.com/NixOS/nixpkgs/commit/88223bcc015834ed93bf9ca3dcc8e51cd1f684ee) | `libsForQt5.phonon-backend-gstreamer: backport fix for https://bugs.kde.org/show_bug.cgi?id=445196` |
| [`eaf4ec26`](https://github.com/NixOS/nixpkgs/commit/eaf4ec26347eb6fa4e55a933810967ab94cd8c03) | `plasma5Package.baloo: Unbreak kde-baloo.service startup`                                           |
| [`8f1e861f`](https://github.com/NixOS/nixpkgs/commit/8f1e861f4b76b1d283cc70d5d09842aa2c4bcd51) | `R: 4.2.0 -> 4.2.1`                                                                                 |
| [`9786d883`](https://github.com/NixOS/nixpkgs/commit/9786d883ac44fe0877c934e88e9f491fa49f9cc3) | `libtraceevent: 1.5.3->1.6.1`                                                                       |
| [`60c8c66d`](https://github.com/NixOS/nixpkgs/commit/60c8c66d00b1b0b588b7ad79d12d13cb0949eb19) | `libtracefs: 1.3.1->1.4.1`                                                                          |
| [`3a9bdc3f`](https://github.com/NixOS/nixpkgs/commit/3a9bdc3f3e474627fa9e898887d0d543679431fe) | `trace-cmd: 2.9.7 -> 3.0.3`                                                                         |
| [`8d9773fe`](https://github.com/NixOS/nixpkgs/commit/8d9773fec413cb7641306fa30a48f0988c45a734) | `libtraceevent: 1.5.1 -> 1.5.3`                                                                     |
| [`f6302025`](https://github.com/NixOS/nixpkgs/commit/f63020259750bb2433ce9333009516ff20fb67fa) | `libtracefs: 1.3.0 -> 1.3.1`                                                                        |
| [`1cd8006f`](https://github.com/NixOS/nixpkgs/commit/1cd8006fdd9c67fb3717d491bd0796c34fe2f4cf) | `networkmanager_dmenu: 1.6.0 -> 2.1.0`                                                              |