### PR TITLE
chore(flake/home-manager): `12cfcc1b` -> `25a99483`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657176901,
-        "narHash": "sha256-aTE0EWqCqXPKYgrNCxblmPmBAx1csMhypVqxO/2P4dg=",
+        "lastModified": 1657213438,
+        "narHash": "sha256-FKZRHORuj1BhlEqKgW7EYqRpH9WiAp+oV/tZ3x8e6Ow=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "12cfcc1b9dc9a8a7a0b4cf538841b85af5c4cd98",
+        "rev": "25a9948361cc6676e70c1b439e4d40f0610e8f76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`25a99483`](https://github.com/nix-community/home-manager/commit/25a9948361cc6676e70c1b439e4d40f0610e8f76) | `sway: import dbus env vars and explicitly specify them (#3031)` |