### PR TITLE
chore(flake/home-manager): `25a99483` -> `8160b3b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657213438,
-        "narHash": "sha256-FKZRHORuj1BhlEqKgW7EYqRpH9WiAp+oV/tZ3x8e6Ow=",
+        "lastModified": 1657241847,
+        "narHash": "sha256-/aN3p2LaRNVXf7w92GWgXq9H5f23YRQPOvsm3BrBqzU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "25a9948361cc6676e70c1b439e4d40f0610e8f76",
+        "rev": "8160b3b45b8457d58d2b3af2aeb2eb6f47042e0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`8160b3b4`](https://github.com/nix-community/home-manager/commit/8160b3b45b8457d58d2b3af2aeb2eb6f47042e0f) | `zsh: source zsh-syntax-highlighting at the end of .zshrc (#3068)` |