### PR TITLE
chore(flake/nur): `365c1505` -> `1001d8d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657213987,
-        "narHash": "sha256-phrU2NUM+irG3Ra7enlm8ecq3j2PwAcclf6ZEeth6rU=",
+        "lastModified": 1657240954,
+        "narHash": "sha256-Eu73Z30use64Zz1f79aBLgwubwvqtKPYt8lUh4XCbXE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "365c1505667a2bfbc03518c07580038458e894b0",
+        "rev": "1001d8d56368e4e5cbbc0776e9dec3a6161a7b3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1001d8d5`](https://github.com/nix-community/NUR/commit/1001d8d56368e4e5cbbc0776e9dec3a6161a7b3a) | `automatic update` |