### PR TITLE
chore(flake/nur): `1001d8d5` -> `1d95a5c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657240954,
-        "narHash": "sha256-Eu73Z30use64Zz1f79aBLgwubwvqtKPYt8lUh4XCbXE=",
+        "lastModified": 1657243249,
+        "narHash": "sha256-5GD96UgpT6INSWQqaxtHyO7UcOVLLnB9ffh+DxtPbjg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1001d8d56368e4e5cbbc0776e9dec3a6161a7b3a",
+        "rev": "1d95a5c12a1ca7feeb4c20c6554994142e034dda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1d95a5c1`](https://github.com/nix-community/NUR/commit/1d95a5c12a1ca7feeb4c20c6554994142e034dda) | `automatic update` |