### PR TITLE
chore(flake/nur): `9ac26624` -> `a223417c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657246215,
-        "narHash": "sha256-JIOkO4F4YVn0urkMPE08C+DNA5tg89OBJVHerlBo7fw=",
+        "lastModified": 1657251007,
+        "narHash": "sha256-CqFsmYegOqgnZ7DMF5+M7a0ANWS9VFvaNBdpHIhu1rs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ac26624ca65364d94acf06946a77232c012229b",
+        "rev": "a223417c3e81ecbeb3ed740d332cc05557894964",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a223417c`](https://github.com/nix-community/NUR/commit/a223417c3e81ecbeb3ed740d332cc05557894964) | `automatic update` |