### PR TITLE
chore(flake/nur): `75f50412` -> `40636992`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657255421,
-        "narHash": "sha256-qGWXcFKZTqVRuTtc5oXGSwE4kqJFDbVaeogfuXcwqNw=",
+        "lastModified": 1657259033,
+        "narHash": "sha256-wLkvkyy6lWTIM8bCeUPhK/d9Uj8kIuZTHw340exFkF8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "75f5041259ca49de7ee1d9540f6149ff687e78cd",
+        "rev": "40636992d90d81efb158ba504e0231a6aa349245",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`40636992`](https://github.com/nix-community/NUR/commit/40636992d90d81efb158ba504e0231a6aa349245) | `automatic update` |