### PR TITLE
chore(flake/nur): `40636992` -> `4a0d26d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657259033,
-        "narHash": "sha256-wLkvkyy6lWTIM8bCeUPhK/d9Uj8kIuZTHw340exFkF8=",
+        "lastModified": 1657272425,
+        "narHash": "sha256-Y1vbPYhUi0ZKqn6XxQeE/RnyMcfHIE0YCkR1iPGoToo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "40636992d90d81efb158ba504e0231a6aa349245",
+        "rev": "4a0d26d6ccb60f24a5e771c6de4c64622fb2b4af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4a0d26d6`](https://github.com/nix-community/NUR/commit/4a0d26d6ccb60f24a5e771c6de4c64622fb2b4af) | `automatic update` |