### PR TITLE
chore(flake/nur): `4a0d26d6` -> `a92a625e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657272425,
-        "narHash": "sha256-Y1vbPYhUi0ZKqn6XxQeE/RnyMcfHIE0YCkR1iPGoToo=",
+        "lastModified": 1657304737,
+        "narHash": "sha256-3LN0SrCMQKUdje8US9MiMNqXyBqNlZ8ZagwGBqgzBqo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4a0d26d6ccb60f24a5e771c6de4c64622fb2b4af",
+        "rev": "a92a625e00c4eebc01616478dab5af6e6f1b83b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a92a625e`](https://github.com/nix-community/NUR/commit/a92a625e00c4eebc01616478dab5af6e6f1b83b2) | `automatic update` |