### PR TITLE
chore(flake/emacs-overlay): `22448c09` -> `eae26b7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657275959,
-        "narHash": "sha256-pg8FB1DRImBpqXHCp/0Y7bIphpVqGmkWgWOcFDMwdTg=",
+        "lastModified": 1657305762,
+        "narHash": "sha256-dsuJG/y2LtqyHhDEIo3d3g/+K9IqhG3qt/tf7WYheH4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "22448c09bae21969ca14d1558a120dafe9853c73",
+        "rev": "eae26b7d5fc04699078a1687185d65077bc73c96",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`eae26b7d`](https://github.com/nix-community/emacs-overlay/commit/eae26b7d5fc04699078a1687185d65077bc73c96) | `Updated repos/melpa` |
| [`1a00c6b7`](https://github.com/nix-community/emacs-overlay/commit/1a00c6b75e05b151f60fca17cca65226477e9c7f) | `Updated repos/emacs` |
| [`16fefbfd`](https://github.com/nix-community/emacs-overlay/commit/16fefbfd5f50bd0263605506b70c15615bc93031) | `Updated repos/elpa`  |