### PR TITLE
chore(flake/nur): `a92a625e` -> `fae381cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657304737,
-        "narHash": "sha256-3LN0SrCMQKUdje8US9MiMNqXyBqNlZ8ZagwGBqgzBqo=",
+        "lastModified": 1657315594,
+        "narHash": "sha256-lkAqmREtGhWwHK3wdVSfqt+Q+xUhZmQ0UZyubeMJLR4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a92a625e00c4eebc01616478dab5af6e6f1b83b2",
+        "rev": "fae381cd12525fdfb5163ce0ac78c2705d5917c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`fae381cd`](https://github.com/nix-community/NUR/commit/fae381cd12525fdfb5163ce0ac78c2705d5917c4) | `automatic update` |