### PR TITLE
chore(flake/nur): `836d84aa` -> `a477ad23`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657337221,
-        "narHash": "sha256-1BTbyUGO2L1Kpq1nPq1Q5BvrF8CcRK9psS50AZY0Owc=",
+        "lastModified": 1657339428,
+        "narHash": "sha256-9/EjUU8kmxq4DWkLwhtiUxR/b37ZJ6wPst/X5qGfu1k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "836d84aa9846c893851a93ead0e9f168b54e13ee",
+        "rev": "a477ad23054af444921081ec0dc22ad38fd3eebf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a477ad23`](https://github.com/nix-community/NUR/commit/a477ad23054af444921081ec0dc22ad38fd3eebf) | `automatic update` |