### PR TITLE
chore(flake/emacs-overlay): `eae26b7d` -> `30a0861e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657305762,
-        "narHash": "sha256-dsuJG/y2LtqyHhDEIo3d3g/+K9IqhG3qt/tf7WYheH4=",
+        "lastModified": 1657339794,
+        "narHash": "sha256-9AcgGeHLBK+PoRFXfYdNfvCu9cmAdYLQLSG3KLQgJhM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "eae26b7d5fc04699078a1687185d65077bc73c96",
+        "rev": "30a0861e0d4b9944ee01595436de5e2d58303105",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`30a0861e`](https://github.com/nix-community/emacs-overlay/commit/30a0861e0d4b9944ee01595436de5e2d58303105) | `Updated repos/nongnu` |
| [`18d17217`](https://github.com/nix-community/emacs-overlay/commit/18d1721765e9c4d8bd5c4191ac094fb3af49b444) | `Updated repos/melpa`  |
| [`71712d28`](https://github.com/nix-community/emacs-overlay/commit/71712d2809814bbb7ff76edc7a9ebac8aa391713) | `Updated repos/emacs`  |