### PR TITLE
chore(flake/nur): `a477ad23` -> `8690d179`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657339428,
-        "narHash": "sha256-9/EjUU8kmxq4DWkLwhtiUxR/b37ZJ6wPst/X5qGfu1k=",
+        "lastModified": 1657344964,
+        "narHash": "sha256-xN+AEV1UuFsnwNO5JIxDkRNSBN6w4H5kO00FEXISEW4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a477ad23054af444921081ec0dc22ad38fd3eebf",
+        "rev": "8690d179732d13532578d2dfb5eeca9fcd39997e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8690d179`](https://github.com/nix-community/NUR/commit/8690d179732d13532578d2dfb5eeca9fcd39997e) | `automatic update` |