### PR TITLE
chore(flake/nixpkgs): `a5c867d9` -> `b39924fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -297,11 +297,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657114324,
-        "narHash": "sha256-fWuaUNXrHcz/ciHRHlcSO92dvV3EVS0GJQUSBO5JIB4=",
+        "lastModified": 1657265485,
+        "narHash": "sha256-PUQ9C7mfi0/BnaAUX2R/PIkoNCb/Jtx9EpnhMBNrO/o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a5c867d9fe9e4380452628e8f171c26b69fa9d3d",
+        "rev": "b39924fc7764c08ae3b51beef9a3518c414cdb7d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                          |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`add0201f`](https://github.com/NixOS/nixpkgs/commit/add0201f354284b5447b1bcf6a065a9a50aebea8) | `python3.pkgs.gpgme: fix a test`                                        |
| [`134c7be4`](https://github.com/NixOS/nixpkgs/commit/134c7be40b4764a4f57ff546d5d594f20e3e9f3e) | `reaper: add support for pipewire-jack`                                 |
| [`17d97257`](https://github.com/NixOS/nixpkgs/commit/17d97257e54a706636cae144906785552f0fe777) | `yggdrasil: 0.4.3 -> 0.4.4`                                             |
| [`14dbf57e`](https://github.com/NixOS/nixpkgs/commit/14dbf57ee7394870d57c7a3e90a036f36f3380df) | `esphome: 2022.6.0 -> 2022.6.2`                                         |
| [`10085937`](https://github.com/NixOS/nixpkgs/commit/10085937f4d89ce4a0c9726044881cdb42cee1fb) | `bosh-cli: 6.4.17 -> 7.0.1`                                             |
| [`f5adaf2b`](https://github.com/NixOS/nixpkgs/commit/f5adaf2ba83ac6001ec6a587c380b88849c122c1) | `proj_7: drop tests that time out with newest sqlite`                   |
| [`abc00789`](https://github.com/NixOS/nixpkgs/commit/abc007896b255bb80e9cbdef00bd558f72eb168c) | `maintainers: add matrix for thiagokokada`                              |
| [`9b3ec85d`](https://github.com/NixOS/nixpkgs/commit/9b3ec85d58665024ffd4f31f9c8009a48a2f6d67) | `ocamlPackages.mirage-random: 2.0.0 -> 3.0.0`                           |
| [`3e65be69`](https://github.com/NixOS/nixpkgs/commit/3e65be6910588fd20fe20cdcae5bcc4833995805) | `bugdom: 1.3.1 -> 1.3.2`                                                |
| [`e3f26208`](https://github.com/NixOS/nixpkgs/commit/e3f26208bcee2d133c30de725b2aa7e6f63e40ae) | `anime-downloader: fix missing runtime dependencies`                    |
| [`30744e35`](https://github.com/NixOS/nixpkgs/commit/30744e35e0463ba94653d6ec3dcfdbaa08f5d4e5) | `maintainers: add kilimnik`                                             |
| [`a508339b`](https://github.com/NixOS/nixpkgs/commit/a508339bc649d64e8e0cb7f13d53785253c0d02f) | `protoc-gen-connect-go: init at 0.1.1`                                  |
| [`a8406971`](https://github.com/NixOS/nixpkgs/commit/a8406971c3ef3438cf2511c5d59a7579f601d6b9) | `ocamlPackages.dns: 5.0.1 → 6.1.4`                                      |
| [`26a6c659`](https://github.com/NixOS/nixpkgs/commit/26a6c659f0b239048f8e33a8a8a8b70c6e95e123) | `ocamlPackages.happy-eyeballs: init at 0.1.3`                           |
| [`41c19456`](https://github.com/NixOS/nixpkgs/commit/41c194565f48e26d3efc6d1fd1857a826253128b) | `wireplumber: backport a fix for no sound in VMs`                       |
| [`4eeaca86`](https://github.com/NixOS/nixpkgs/commit/4eeaca86fdc4158db8fb5677d48149675a61929e) | `nixosTests.installed-tests.flatpak-builder: fix tests`                 |
| [`d2773000`](https://github.com/NixOS/nixpkgs/commit/d277300000989a3b0645462af749c2ff30015074) | `gitlab-triage: 1.20.0 -> 1.23.1`                                       |
| [`95f9a70b`](https://github.com/NixOS/nixpkgs/commit/95f9a70b481464e3d64743ad5f4c481cc1a77e9e) | `flatpak-builder: remove libdwarf dependency`                           |
| [`4f4aa968`](https://github.com/NixOS/nixpkgs/commit/4f4aa9685a7860a140100f31bd8c2108d65526d6) | `tsm-client: 8.1.14.0 -> 8.1.15.0`                                      |
| [`1ed9ba08`](https://github.com/NixOS/nixpkgs/commit/1ed9ba08f1e83a5fdcebcffa0aff2d5b4452c9b1) | `tsm-client: fix patching rpath with autoPatchelf`                      |
| [`db356849`](https://github.com/NixOS/nixpkgs/commit/db3568499d9eb31c446245c6c7d29137fbb5009d) | `apacheHttpdPackages.mod_mbtiles: init at 2022-05-25`                   |
| [`e9177aba`](https://github.com/NixOS/nixpkgs/commit/e9177abaacdfe7ca9e65c57ce80581b1ccf06b0b) | `arb: 2.22.1 -> 2.23.0`                                                 |
| [`4950cb01`](https://github.com/NixOS/nixpkgs/commit/4950cb01e533fc7d46c5e5f17fcee9260987c891) | `bookletimposer: init at 0.3.1`                                         |
| [`abe756d6`](https://github.com/NixOS/nixpkgs/commit/abe756d691637199ef9968466c2035600e16da45) | `wcpg: init at 0.9`                                                     |
| [`9fbc67d6`](https://github.com/NixOS/nixpkgs/commit/9fbc67d63ec3730e116e6be64b8029e10c640377) | `opensoldat: rename from soldat-unstable`                               |
| [`1812c19e`](https://github.com/NixOS/nixpkgs/commit/1812c19e369727beb0f7bbc8cc5f3a13914be855) | `soldat-unstable: 2021-11-01 -> 2022-07-02`                             |
| [`e2859ee1`](https://github.com/NixOS/nixpkgs/commit/e2859ee197c3aa394a4a60d0f1370470f565bc5b) | `gamenetworkingsockets: 1.3.0 -> 1.4.1`                                 |
| [`007c4341`](https://github.com/NixOS/nixpkgs/commit/007c4341fe6a37ad70a584f78f0cc837edf8d0d1) | `blender: fix on darwin`                                                |
| [`46e67b80`](https://github.com/NixOS/nixpkgs/commit/46e67b80435730e358bf52b7b9b560d32ad0f8bf) | `maintainers: update email for leo60228, add matrix and keys`           |
| [`ddcb3f9f`](https://github.com/NixOS/nixpkgs/commit/ddcb3f9ff4fb7e0419cc665c27b351759a0300ac) | `twisted: remove pyOpenSSL dependency on aarch64-darwin`                |
| [`05c85f96`](https://github.com/NixOS/nixpkgs/commit/05c85f967dccb8f41814361bd65724c4d2927423) | `gopls: 0.8.4 -> 0.9.0 (#180530)`                                       |
| [`0874b00c`](https://github.com/NixOS/nixpkgs/commit/0874b00cd83335f760b9f6dac9b7f5c7b44a3d57) | `tgswitch: 0.5.389 -> 0.6.0 (#179718)`                                  |
| [`6e1b0ef6`](https://github.com/NixOS/nixpkgs/commit/6e1b0ef6b71e3052aaac94127a6dff1a071ef80e) | `python310Packages.ocrmypdf: 13.5.0 -> 13.6.0`                          |
| [`3aa678fd`](https://github.com/NixOS/nixpkgs/commit/3aa678fde28c93dd9c394664f07d7d72820224b1) | `python310Packages.pikepdf: 5.2.0 -> 5.3.1`                             |
| [`38c59e60`](https://github.com/NixOS/nixpkgs/commit/38c59e60bf10e84ab2f518f99853baa9e1769e77) | `flyctl: 0.0.346 -> 0.0.348`                                            |
| [`d89c89c0`](https://github.com/NixOS/nixpkgs/commit/d89c89c0638c1cf1b04e058ea056bb188415f35a) | `python310Packages.sphinx-jinja: 2.0.1 -> 2.0.2`                        |
| [`48fb865e`](https://github.com/NixOS/nixpkgs/commit/48fb865e6a382188412a5f5e079729e6ce6af601) | `python310Packages.omnilogic: 0.4.6 -> 0.4.9`                           |
| [`34d26c15`](https://github.com/NixOS/nixpkgs/commit/34d26c15f8d61538a19dfc71963dc18c3b89d702) | `python310Packages.pysensibo: 1.0.17 -> 1.0.18`                         |
| [`9a08be84`](https://github.com/NixOS/nixpkgs/commit/9a08be84267a13a15cc9be2b2724e0629859a131) | `python310Packages.gphoto2: 2.3.3 -> 2.3.4`                             |
| [`60353621`](https://github.com/NixOS/nixpkgs/commit/6035362129b85d18a98242f8a4b5b9fbc7b80a66) | `gt: 2021-09-30 -> 2022-05-08`                                          |
| [`1b1684c2`](https://github.com/NixOS/nixpkgs/commit/1b1684c21f0bb449d53cddb81b5dabb528b377da) | `open-stage-control: init at 1.17.0`                                    |
| [`a4802cfc`](https://github.com/NixOS/nixpkgs/commit/a4802cfcbf6f96b9dec4e6f64f14e7a04956e129) | `element-desktop: use nodejs 16 (default) for dependencies`             |
| [`eb3e42ea`](https://github.com/NixOS/nixpkgs/commit/eb3e42ea5f36d0932baad06a2e5358010c9ca60c) | `element-web: remove unused nodejs buildInput`                          |
| [`2dc17021`](https://github.com/NixOS/nixpkgs/commit/2dc170210f3e56e2a73a1ee426b879a8b89030bb) | `fnlfmt: remove gpanders from maintainers`                              |
| [`8f620026`](https://github.com/NixOS/nixpkgs/commit/8f62002673be953cc8175c290ac9260baca8c20f) | `archisteamfarm.ui: format, inherit maintainers from asf, too`          |
| [`ef2e27eb`](https://github.com/NixOS/nixpkgs/commit/ef2e27ebe2f60f4063018ab515bf8b3be384f739) | `python310Packages.selenium: fix dependencies`                          |
| [`7927333d`](https://github.com/NixOS/nixpkgs/commit/7927333d481829ecc1b9e55c0d0cada7aee481f5) | `python310Packages.urllib3: add optional-dependencies secure back`      |
| [`dbf41bb6`](https://github.com/NixOS/nixpkgs/commit/dbf41bb61478283a3e1adc2f2d87d54723af445f) | `openvdb: 7.0.0 -> 9.1.0 (#180144)`                                     |
| [`715b7691`](https://github.com/NixOS/nixpkgs/commit/715b7691f2c4826d9c8b709beccda8b917540bca) | `electron_19: init at 19.0.7`                                           |
| [`6802686d`](https://github.com/NixOS/nixpkgs/commit/6802686d6920023b6c15c39575ae4293175d7508) | `python3Packages.pyialarmxr-homeassistant: drop`                        |
| [`69fe24c8`](https://github.com/NixOS/nixpkgs/commit/69fe24c8581f36d070495488f909776aa2e22215) | `electron-cash: 4.2.7 -> 4.2.10`                                        |
| [`fc4b3a84`](https://github.com/NixOS/nixpkgs/commit/fc4b3a846d54254e628d05614cfa2d182c772f38) | `klee: 2.2 -> 2.3`                                                      |
| [`17caac62`](https://github.com/NixOS/nixpkgs/commit/17caac62885d12df7e920d0626662a307a29ca45) | `python3Packages.spacy_models: 3.0.0 -> 3.3.0`                          |
| [`6593595e`](https://github.com/NixOS/nixpkgs/commit/6593595ee50c029de45c205665c73d8fb088e64d) | `nixos/qt5: add lxqt platform theme`                                    |
| [`2b01fc08`](https://github.com/NixOS/nixpkgs/commit/2b01fc0862267e3fd8acc468e49dbe7cb2f0566f) | `firewalld: 1.1.1 -> 1.2.0`                                             |
| [`1c755103`](https://github.com/NixOS/nixpkgs/commit/1c755103fe8eda13ac58aa34f63ee7a331c8b9f4) | `ferium: 4.1.1 -> 4.1.5`                                                |
| [`2ad5262c`](https://github.com/NixOS/nixpkgs/commit/2ad5262cba9e737ff06c3ae80dd2c524a0c72b09) | `elementary-xfce-icon-theme: 0.16 -> 0.17`                              |
| [`72c332c0`](https://github.com/NixOS/nixpkgs/commit/72c332c0d8699ef7c0b209e05f34d40eaba43cb3) | `earthly: 0.6.16 -> 0.6.19`                                             |
| [`06189dc2`](https://github.com/NixOS/nixpkgs/commit/06189dc2f4b60927673c64e11313417c0bd7833a) | `xdg-desktop-portal-gnome: 42.1 → 42.3`                                 |
| [`d7997bee`](https://github.com/NixOS/nixpkgs/commit/d7997beea24d8ae304c51d3eec4805a29b301590) | `dsp: 1.8 -> 1.9`                                                       |
| [`0a0baa89`](https://github.com/NixOS/nixpkgs/commit/0a0baa8935a79ad07c1b14b6283d5b4ffd2b042e) | `haskellPackages.futhark: 0.21.12 -> 0.21.13`                           |
| [`3014367d`](https://github.com/NixOS/nixpkgs/commit/3014367d9eda9f1337adbbf8bac4899016638564) | `btop: 1.2.7 -> 1.2.8`                                                  |
| [`8dc427a8`](https://github.com/NixOS/nixpkgs/commit/8dc427a8c0713c0b84ffd37bf6f480b47f965ce7) | `dunst: 1.8.1 -> 1.9.0`                                                 |
| [`947314d7`](https://github.com/NixOS/nixpkgs/commit/947314d7be1bf4863aea307a4536ffc7cade3b6d) | `cpp-utilities: 5.16.0 -> 5.17.0`                                       |
| [`d4299341`](https://github.com/NixOS/nixpkgs/commit/d42993419c75e0cdbd666d257ece67e1445fb30b) | `doctl: 1.77.0 -> 1.78.0`                                               |
| [`2be2a78f`](https://github.com/NixOS/nixpkgs/commit/2be2a78f422f4eda8edef93832416828ddb71c63) | `git-annex: update sha256 for 10.20220624`                              |
| [`0ff49576`](https://github.com/NixOS/nixpkgs/commit/0ff495768ced9e8fb5e35aedccc1bf3d1a2c604c) | `delve: 1.8.3 -> 1.9.0`                                                 |
| [`632f3059`](https://github.com/NixOS/nixpkgs/commit/632f30598552878d00041eab62452c24d2802c80) | `matterhorn: provide brick 0.70.*`                                      |
| [`1fc76041`](https://github.com/NixOS/nixpkgs/commit/1fc760419dd067b0747f934957e901a40d1c4ce4) | `fixup! gpgme: fix a test after disallowing compressed signatures`      |
| [`db6b3e0a`](https://github.com/NixOS/nixpkgs/commit/db6b3e0a5ec774c7d0a46c56b7682be05697d841) | `gpgme: fix a test after disallowing compressed signatures`             |
| [`61dc821a`](https://github.com/NixOS/nixpkgs/commit/61dc821aacc149909d8135425dad54adff56cc75) | `cmctl: 1.8.1 -> 1.8.2`                                                 |
| [`1b967531`](https://github.com/NixOS/nixpkgs/commit/1b967531ecf2e1021827dbc303ccd4a3d8fabe84) | `chafa: 1.10.3 -> 1.12.3`                                               |
| [`a5172bfb`](https://github.com/NixOS/nixpkgs/commit/a5172bfbf2b345d33a0bd746cfc96ec238069524) | `cargo-whatfeatures: 0.9.6 -> 0.9.7`                                    |
| [`39401993`](https://github.com/NixOS/nixpkgs/commit/39401993df0dd92ab1b9f5a1971cec253232d5ab) | `haskellPackages: mark builds failing on hydra as broken`               |
| [`5c0ddf82`](https://github.com/NixOS/nixpkgs/commit/5c0ddf82c5b23cc5f9f4192aa54b4c8420bda63d) | `mate.caja: 1.26.0 -> 1.26.1`                                           |
| [`e7a90bc4`](https://github.com/NixOS/nixpkgs/commit/e7a90bc428be03e0abe83aef3147bbf3f067f60b) | `python310Packages.pyenvisalink: 4.5 -> 4.6`                            |
| [`465728b2`](https://github.com/NixOS/nixpkgs/commit/465728b266f1106373f5690a98b4c8e3821803f1) | `cilium-cli: 0.11.10 -> 0.11.11`                                        |
| [`0c82c6d2`](https://github.com/NixOS/nixpkgs/commit/0c82c6d29482b4e08c264288e0a4bc14d5d84e8e) | `buildah: 1.26.1 -> 1.26.2`                                             |
| [`b19cb885`](https://github.com/NixOS/nixpkgs/commit/b19cb885f364d37461668e0e921579cd21cae7c5) | `chromiumBeta: 104.0.5112.20 -> 104.0.5112.29`                          |
| [`3943a16b`](https://github.com/NixOS/nixpkgs/commit/3943a16b8b43c50acc95b9cb303302de833acb00) | `checkstyle: 10.3 -> 10.3.1`                                            |
| [`808fa2fb`](https://github.com/NixOS/nixpkgs/commit/808fa2fb1903bd13efa32cf0f24a62509a607dc3) | `python310Packages.aresponses: 2.1.5 -> 2.1.6`                          |
| [`c16deed1`](https://github.com/NixOS/nixpkgs/commit/c16deed1a6aead1c531a21b0f95a7a29e5a46e4c) | `haskellPackages: mark builds failing on hydra as broken`               |
| [`20c05528`](https://github.com/NixOS/nixpkgs/commit/20c05528c349ed89f6ce3d206ed918f117ad67e6) | `kde/plasma: 5.25.1 -> 5.25.2`                                          |
| [`d471a03a`](https://github.com/NixOS/nixpkgs/commit/d471a03a67595531a1b2a88d02ab4aba462b7fd8) | `loksh: 7.0 -> 7.1`                                                     |
| [`fa844907`](https://github.com/NixOS/nixpkgs/commit/fa844907f3452344b021077e110b34d547f18309) | `oh-my-fish: fix some egregious errors`                                 |
| [`47955687`](https://github.com/NixOS/nixpkgs/commit/47955687cc12ca98b0b1931511eb380a40afbaea) | `aws-iam-authenticator: 0.5.7 -> 0.5.9`                                 |
| [`2128994a`](https://github.com/NixOS/nixpkgs/commit/2128994aaa9b60e343ca40d36ae1e86cb0e78564) | `git-town: use buildGoModule`                                           |
| [`bed9f53c`](https://github.com/NixOS/nixpkgs/commit/bed9f53c4114d69d961986fc4785c2be762b9d26) | `aml: 0.2.1 -> 0.2.2`                                                   |
| [`9b7bd914`](https://github.com/NixOS/nixpkgs/commit/9b7bd914d246b9db0a317163e026fcfbd426784f) | `home-assistant: 2022.6.7 -> 2022.7.0`                                  |
| [`bdae2919`](https://github.com/NixOS/nixpkgs/commit/bdae2919d2759e4ce37e72a725b1dddb9bd6a5b0) | `stgit: mark as unbroken on darwin (#180393)`                           |
| [`9d51787b`](https://github.com/NixOS/nixpkgs/commit/9d51787b536d843926dfd232f806ca0f5b5f5546) | `codec2: fix build`                                                     |
| [`a49a073f`](https://github.com/NixOS/nixpkgs/commit/a49a073fc0bcc1382382d15dfed0bbd36daa5cab) | `haskellPackages.patch: back-pin patch to fix build`                    |
| [`794928ce`](https://github.com/NixOS/nixpkgs/commit/794928ce5a2f71e2b4d6ed7136a9d015f0202b3d) | `python310Packages.google-cloud-websecurityscanner: add missing inputs` |
| [`134d3cee`](https://github.com/NixOS/nixpkgs/commit/134d3cee2e57aa95872656b89b52098b62d158d3) | `gitleaks: 8.8.10 -> 8.8.11`                                            |
| [`10565fcc`](https://github.com/NixOS/nixpkgs/commit/10565fccde3cacd75e6ba0ed6ad6496265041f7b) | `m17-cxx-demod: init at 2.3, add to nixos/openwebrx`                    |
| [`2cec3ce2`](https://github.com/NixOS/nixpkgs/commit/2cec3ce26be0fe5d93f55b94d7ee4f959eece17c) | `syft: 0.49.0 -> 0.50.0`                                                |
| [`8bf3d0d2`](https://github.com/NixOS/nixpkgs/commit/8bf3d0d2dd24056d2fd708bcb35d303b83e4c881) | `grype: 0.40.11 -> 0.41.0`                                              |
| [`8508c785`](https://github.com/NixOS/nixpkgs/commit/8508c7850277b7620e99fe57d47a8dd3da175b51) | `tfsec: 1.26.0 -> 1.26.2`                                               |
| [`458ca59f`](https://github.com/NixOS/nixpkgs/commit/458ca59ffbb34665d6931535d2042b7bf253676f) | `python310Packages.nomadnet: 0.1.9 -> 0.2.0`                            |
| [`ad79941e`](https://github.com/NixOS/nixpkgs/commit/ad79941ef236538b3ee327115dc91409bf3dd835) | `stylua: 0.13.1 -> 0.14.0`                                              |
| [`f33e0432`](https://github.com/NixOS/nixpkgs/commit/f33e04326c4c8f92c5a6b08b6e0fb1df258b0c24) | `cirrus-cli: init at 0.81.1`                                            |
| [`b7eb3285`](https://github.com/NixOS/nixpkgs/commit/b7eb3285b376fa554f540bbc8b4fa923ed8b6f12) | `railcar, nixos/railcar: remove`                                        |
| [`c3f498f8`](https://github.com/NixOS/nixpkgs/commit/c3f498f8c02ff11f2328de9cfee960c7b55d0850) | `python3Packages.ldap: 3.4.0 -> 3.4.2`                                  |
| [`aee004ea`](https://github.com/NixOS/nixpkgs/commit/aee004ea14fc0f9579f06e0a0209938d9ffd02d0) | `python310Packages.pontos: 22.5.0 -> 22.7.0`                            |
| [`500e1d34`](https://github.com/NixOS/nixpkgs/commit/500e1d34d0fd205e7355cb6c1dcb1442c1bdd848) | `python310Packages.types-urllib3: 1.26.15 -> 1.26.16`                   |
| [`86d0daf8`](https://github.com/NixOS/nixpkgs/commit/86d0daf81934a219ec218226bc846bbeb34a15f3) | `terraform-providers.metal: 3.2.2 -> 3.3.0`                             |
| [`a685a91d`](https://github.com/NixOS/nixpkgs/commit/a685a91de20e3aff7f3e7df9d5adc5434bdd703d) | `terraform-providers.equinix: 1.5.0 -> 1.6.0`                           |
| [`852a7cac`](https://github.com/NixOS/nixpkgs/commit/852a7cac86554bb55a4e252ff545016eb162fa62) | `python310Packages.sagemaker: 2.97.0 -> 2.98.0`                         |
| [`fd58375f`](https://github.com/NixOS/nixpkgs/commit/fd58375f82b43f34d78e93a6ba1d335f7880c47c) | `ocm: 0.1.63 -> 0.1.64`                                                 |
| [`f3c3f1d0`](https://github.com/NixOS/nixpkgs/commit/f3c3f1d06ce62cb71f1b6c709b31569595f8a7bf) | `boundary: 0.9.0 -> 0.9.1`                                              |
| [`18a01737`](https://github.com/NixOS/nixpkgs/commit/18a01737c6a55f2a688a2c51e9b5696ded61558b) | `python310Packages.lsassy: 3.1.2 -> 3.1.3`                              |
| [`08ac808b`](https://github.com/NixOS/nixpkgs/commit/08ac808bb3c8ac66c844ab631dcc2dbd20cc8937) | `python3Packages.zwave-js-server-python: 0.37.2 -> 0.39.0`              |
| [`d550d69c`](https://github.com/NixOS/nixpkgs/commit/d550d69c5eb931dfc9821de53e26bc13554bfbb9) | `python3Packages.spotipy: 2.19.0 -> 2.20.0`                             |
| [`05cf713a`](https://github.com/NixOS/nixpkgs/commit/05cf713a5bf3fb8b8e5a1b48ea84292ddfb7d18a) | `python3Packages.pyunifiprotect: 4.0.8 -> 4.0.9`                        |
| [`5724ddfc`](https://github.com/NixOS/nixpkgs/commit/5724ddfc4a89a281aefa2e6cb3bf5495df1e8ed1) | `python310Packages.zigpy-znp: 0.7.0 -> 0.8.0`                           |
| [`c2127eae`](https://github.com/NixOS/nixpkgs/commit/c2127eaef0b7c8a40c3ae071b2c95783cebff674) | `python310Packages.zigpy-cc: disable failing test`                      |
| [`9e355454`](https://github.com/NixOS/nixpkgs/commit/9e355454e64ed0a66e81333f7c35bb74492d3677) | `python310Packages.bellows: 0.30.0 -> 0.31.0`                           |
| [`2b7af387`](https://github.com/NixOS/nixpkgs/commit/2b7af3878c0754e04d3fd04649c931e38e732aac) | `python310Packages.zigpy-zigate: 0.8.0 -> 0.9.0`                        |
| [`c75cc76c`](https://github.com/NixOS/nixpkgs/commit/c75cc76caa38869524fc3c0f993409d979805d4d) | `python310Packages.zigpy-xbee: 0.14.0 -> 0.15.0`                        |
| [`29d80716`](https://github.com/NixOS/nixpkgs/commit/29d807166298f95d94ffad11f34827716823e96c) | `python310Packages.zigpy-deconz: 0.16.0 -> 0.18.0`                      |
| [`f3466e51`](https://github.com/NixOS/nixpkgs/commit/f3466e515b319b09f5f24345857375d5c6bd2e16) | `python310Packages.zigpy: 0.46.0 -> 0.47.2`                             |
| [`dadd1fe5`](https://github.com/NixOS/nixpkgs/commit/dadd1fe5993fb9ad2397fa6373d4fda82491b45d) | `python310Packages.pyunifiprotect: 3.9.2 -> 4.0.8`                      |
| [`d431a932`](https://github.com/NixOS/nixpkgs/commit/d431a93225f632f166c25dd39919f95312b5bbb1) | `python310Packages.google-cloud-websecurityscanner: 1.7.2 -> 1.8.0`     |
| [`606022d3`](https://github.com/NixOS/nixpkgs/commit/606022d3990fcaefd736bf8d57a8b4f6e363e593) | `python310Packages.pyhiveapi: 0.5.11 -> 0.5.13`                         |
| [`6383b6c2`](https://github.com/NixOS/nixpkgs/commit/6383b6c2b44e73a30a8fca60504c4e44ae6ddd3c) | `python310Packages.gradient: 2.0.4 -> 2.0.5`                            |
| [`2406e2ea`](https://github.com/NixOS/nixpkgs/commit/2406e2ea3d98fa4956f4c73f882f635aa5e4567b) | `python3Packages.pydeconz: 92 -> 96`                                    |
| [`382f8d6a`](https://github.com/NixOS/nixpkgs/commit/382f8d6a09a827e50c40762f23b863e103d8ee1e) | `python3Packages.pyatv: 0.10.0 -> 0.10.2`                               |
| [`0b246ce0`](https://github.com/NixOS/nixpkgs/commit/0b246ce0d5181d71871f07f87b28916c50da3318) | `python3Packages.nexia: 1.0.2 -> 2.0.1`                                 |
| [`17658626`](https://github.com/NixOS/nixpkgs/commit/176586261efd4c78b9eab7c3d5499dee3d287ad1) | `python310Packages.py-canary: 0.5.2 -> 0.5.3`                           |
| [`dc1a8000`](https://github.com/NixOS/nixpkgs/commit/dc1a8000ef0866341b4bf1616fc7efe23017f162) | `python310Packages.intellifire4py: 1.0.5 -> 2.0.1 (#174986)`            |