### PR TITLE
chore(flake/emacs-overlay): `30a0861e` -> `e1c34ef6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657339794,
-        "narHash": "sha256-9AcgGeHLBK+PoRFXfYdNfvCu9cmAdYLQLSG3KLQgJhM=",
+        "lastModified": 1657362523,
+        "narHash": "sha256-hoYYqpCKsuHqYwMnK9lcUYHnuf5OaDFPqCt/RavKsRw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "30a0861e0d4b9944ee01595436de5e2d58303105",
+        "rev": "e1c34ef6f6eb7d966af5011eeeec6342017cd535",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`e1c34ef6`](https://github.com/nix-community/emacs-overlay/commit/e1c34ef6f6eb7d966af5011eeeec6342017cd535) | `Updated repos/nongnu` |
| [`eb65bc95`](https://github.com/nix-community/emacs-overlay/commit/eb65bc9557a798a4f22e9f2a4f1416fd2efa2af0) | `Updated repos/melpa`  |
| [`51b2fc64`](https://github.com/nix-community/emacs-overlay/commit/51b2fc644c1774671e0f9b3cfab5ddd58a94e001) | `Updated repos/emacs`  |