### PR TITLE
chore(flake/emacs-overlay): `e1c34ef6` -> `f6ea0808`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657362523,
-        "narHash": "sha256-hoYYqpCKsuHqYwMnK9lcUYHnuf5OaDFPqCt/RavKsRw=",
+        "lastModified": 1657390826,
+        "narHash": "sha256-yZNR8u0/Bkd+snEJDww3wheFB+GaVYD6znqxMi4QDoY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e1c34ef6f6eb7d966af5011eeeec6342017cd535",
+        "rev": "f6ea0808082826283775ca329aa63a2315b6e155",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`f6ea0808`](https://github.com/nix-community/emacs-overlay/commit/f6ea0808082826283775ca329aa63a2315b6e155) | `Updated repos/melpa` |
| [`e037805d`](https://github.com/nix-community/emacs-overlay/commit/e037805da1abdc4f023ad6cdcb26e828a2731c6a) | `Updated repos/emacs` |
| [`61a75b50`](https://github.com/nix-community/emacs-overlay/commit/61a75b50e97aaff61a748f073f646cde47455a92) | `Updated repos/elpa`  |