### PR TITLE
chore(flake/nur): `b38b1f86` -> `69e333b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657393132,
-        "narHash": "sha256-evCcdZuK+IrtWYon0EcrQ+mdaIssr8/VUWiDJWy+MrQ=",
+        "lastModified": 1657397455,
+        "narHash": "sha256-ooXEEA01JwepaYpEPeLl62N57K3o8y7vYBsa/NEA7LY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b38b1f861f3c306027a609c0c83a576267a4c42f",
+        "rev": "69e333b880593d75e26d514b4403e1fe7b4eca1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`69e333b8`](https://github.com/nix-community/NUR/commit/69e333b880593d75e26d514b4403e1fe7b4eca1e) | `automatic update` |
| [`bc8fecf9`](https://github.com/nix-community/NUR/commit/bc8fecf93cae32d77462fbb770a804bd60b9293e) | `automatic update` |