### PR TITLE
chore(flake/nur): `69e333b8` -> `8c95d2ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657397455,
-        "narHash": "sha256-ooXEEA01JwepaYpEPeLl62N57K3o8y7vYBsa/NEA7LY=",
+        "lastModified": 1657405814,
+        "narHash": "sha256-NOfKBtH7XDS06aDq11JG5jmVDekBlJmQSOY8vUZV/dw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "69e333b880593d75e26d514b4403e1fe7b4eca1e",
+        "rev": "8c95d2ee055a209cb00425a18e8437a619fb796a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8c95d2ee`](https://github.com/nix-community/NUR/commit/8c95d2ee055a209cb00425a18e8437a619fb796a) | `automatic update` |