### PR TITLE
chore(flake/nur): `8c95d2ee` -> `75107174`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657405814,
-        "narHash": "sha256-NOfKBtH7XDS06aDq11JG5jmVDekBlJmQSOY8vUZV/dw=",
+        "lastModified": 1657409843,
+        "narHash": "sha256-qp9HunlAE6Ux35ulaCJuu9F/YHn7+hpMNKDnet/ES5w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8c95d2ee055a209cb00425a18e8437a619fb796a",
+        "rev": "751071745f4cf265707b771c8041828bc289fb47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`75107174`](https://github.com/nix-community/NUR/commit/751071745f4cf265707b771c8041828bc289fb47) | `automatic update` |
| [`a2fbe6a7`](https://github.com/nix-community/NUR/commit/a2fbe6a70b6bd6bb509c3a3f34bedf4bdd801769) | `automatic update` |