### PR TITLE
chore(flake/emacs-overlay): `e9fd3df6` -> `4993b3ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657425126,
-        "narHash": "sha256-ZnoUE86ilwoU8dltYSnTkapw7wTXMs5wkt4hnWW6EEo=",
+        "lastModified": 1657448983,
+        "narHash": "sha256-QnJspYg6U1Fxcc5IaXqqohR0XB8n3Zc4IWyp1jQKMjc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e9fd3df6001f2e28d6cf3da77a015bb5a5cf70ba",
+        "rev": "4993b3ca0158225301703f0e3780d5f48fd63033",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`4993b3ca`](https://github.com/nix-community/emacs-overlay/commit/4993b3ca0158225301703f0e3780d5f48fd63033) | `Updated repos/nongnu` |
| [`49911452`](https://github.com/nix-community/emacs-overlay/commit/4991145289960c4d5cdd7664c74740d232b258f4) | `Updated repos/melpa`  |
| [`7778bba2`](https://github.com/nix-community/emacs-overlay/commit/7778bba2a1768d16e47c76d8342bfe2c466e108b) | `Updated repos/emacs`  |