### PR TITLE
chore(flake/emacs-ement): `0b587685` -> `02015eac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1657376778,
-        "narHash": "sha256-sdOlK96ukpCCMdmTpM1y29Vthc/OoqRPkRl2fpJsfaQ=",
+        "lastModified": 1657457142,
+        "narHash": "sha256-egZrODBJYa70a9M3ZC6Kf67X631VF/jooQlEHeiH0HY=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "0b587685fb7d722422e601d47883155e2c839a4c",
+        "rev": "02015eacf682b53baaddf26c8a4046e6ff84d4e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                        |
| --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`02015eac`](https://github.com/alphapapa/ement.el/commit/02015eacf682b53baaddf26c8a4046e6ff84d4e8) | `Change: (ement-room-avatars) Default to value from display-images-p` |