### PR TITLE
chore(flake/nur): `6ccdf92d` -> `fe1f9944`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657431484,
-        "narHash": "sha256-N/i3xc4HBUHl0pOKsw/pkzXdN9Wd6m/yERfwvVCSoqE=",
+        "lastModified": 1657458605,
+        "narHash": "sha256-WAoPHlCNTV/yXLF72D7vj+gk1yjfNBM3PmZ61sCT4co=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6ccdf92dd780210f4c2822e348bb044affec804c",
+        "rev": "fe1f99449c93be772b31de520eebaee6feb8717e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`fe1f9944`](https://github.com/nix-community/NUR/commit/fe1f99449c93be772b31de520eebaee6feb8717e) | `automatic update` |