### PR TITLE
chore(flake/emacs-overlay): `4993b3ca` -> `23c09e04`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657448983,
-        "narHash": "sha256-QnJspYg6U1Fxcc5IaXqqohR0XB8n3Zc4IWyp1jQKMjc=",
+        "lastModified": 1657477325,
+        "narHash": "sha256-MeTve5Xl2947w9wZRGPo6DrGvhPW2bbeqfSXNex/EG4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4993b3ca0158225301703f0e3780d5f48fd63033",
+        "rev": "23c09e04995402b7d97b18d72ce262cb60549df1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`23c09e04`](https://github.com/nix-community/emacs-overlay/commit/23c09e04995402b7d97b18d72ce262cb60549df1) | `Updated repos/melpa` |
| [`293ccbb9`](https://github.com/nix-community/emacs-overlay/commit/293ccbb9f4d1bdaa6419bcf438c5f1f5fdb83507) | `Updated repos/emacs` |
| [`252a1a56`](https://github.com/nix-community/emacs-overlay/commit/252a1a56b768b833b8f3caeaabbef7e08d4b0864) | `Updated repos/elpa`  |