### PR TITLE
chore(flake/nixpkgs): `b39924fc` -> `87e7965b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -297,11 +297,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657265485,
-        "narHash": "sha256-PUQ9C7mfi0/BnaAUX2R/PIkoNCb/Jtx9EpnhMBNrO/o=",
+        "lastModified": 1657356697,
+        "narHash": "sha256-sT38tcx7m0Quz+Uj6jzx+yRa2+EVW2C3cE0FkROXUzQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b39924fc7764c08ae3b51beef9a3518c414cdb7d",
+        "rev": "87e7965bbcdbac3d103e3ed14ff04f719a4f7a58",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                          |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`1476f368`](https://github.com/NixOS/nixpkgs/commit/1476f3689b057ab2d9b0a4e127a055e3ea7d9979) | `python310Packages.vertica-python: 1.1.0 -> 1.1.1`                      |
| [`7abecbac`](https://github.com/NixOS/nixpkgs/commit/7abecbac0c5a345721be26d1bb4ed970290c34d3) | `epiphany: 42.2 -> 42.3`                                                |
| [`8b051477`](https://github.com/NixOS/nixpkgs/commit/8b051477e86e1676e36e5a941d2675541ac28a69) | `python310Packages.rns: 0.3.9 -> 0.3.10`                                |
| [`f9bc4952`](https://github.com/NixOS/nixpkgs/commit/f9bc4952ea208c14e4f8f425ba1471cbcc8d5692) | `python310Packages.google-cloud-pubsub: 2.13.0 -> 2.13.1`               |
| [`ea64a045`](https://github.com/NixOS/nixpkgs/commit/ea64a0450b4066dc56cbcc7a30383099ad7fb238) | `python310Packages.google-cloud-os-config: 1.11.2 -> 1.12.0`            |
| [`717d22a4`](https://github.com/NixOS/nixpkgs/commit/717d22a40fe777157d1518937042d91f6a988d8d) | `python310Packages.elastic-apm: 6.9.1 -> 6.10.1`                        |
| [`9870c00d`](https://github.com/NixOS/nixpkgs/commit/9870c00d2b349de876aad4ece48c68a84fd5588c) | `python310Packages.google-cloud-bigquery-storage: 2.13.2 -> 2.14.0`     |
| [`41f92265`](https://github.com/NixOS/nixpkgs/commit/41f92265611e635847ef3c84412ff407297e708e) | `python310Packages.google-cloud-monitoring: 2.9.2 -> 2.10.0`            |
| [`7bb2af4f`](https://github.com/NixOS/nixpkgs/commit/7bb2af4f3268ad79b1cc7c733a06e050df50854e) | `python310Packages.google-cloud-iam-logging: 1.0.2 -> 1.0.3`            |
| [`21eb9aca`](https://github.com/NixOS/nixpkgs/commit/21eb9aca592511a5f95b891b4e2f6cc8ac035bdf) | `home-assistant: 2022.7.1 -> 2022.7.2`                                  |
| [`2fe8ae2a`](https://github.com/NixOS/nixpkgs/commit/2fe8ae2a1a9186136ef68ee9870ffbce83f4699a) | `python3Packages.regenmaschine: 2022.06.1 -> 2022.07.0`                 |
| [`623d908c`](https://github.com/NixOS/nixpkgs/commit/623d908cc4517f53cbf8498e1d9a20511e7b78ba) | `python3Packages.pydeconz: 96 -> 97`                                    |
| [`9432a9cb`](https://github.com/NixOS/nixpkgs/commit/9432a9cb99289a9e2718c239c5c7b1230c2ad4d5) | `python3Packages.hass-nabucasa: 0.54.0 -> 0.54.1`                       |
| [`44932cf7`](https://github.com/NixOS/nixpkgs/commit/44932cf74c006709fe27e380b3506af49db212e6) | `python3Packages.atomicwrites-homeassistant: init at 1.0.4`             |
| [`5baeaf5d`](https://github.com/NixOS/nixpkgs/commit/5baeaf5d6fdc10f1bf28147e12b98a74550f9b56) | `home-assistant: 2022.7.0 -> 2022.7.1`                                  |
| [`abb0b2f6`](https://github.com/NixOS/nixpkgs/commit/abb0b2f64cf59a9bada540e7ee56e4600e57408e) | `python3Packages.elkm1-lib: 2.0.0 -> 2.0.2`                             |
| [`ca82e5b1`](https://github.com/NixOS/nixpkgs/commit/ca82e5b1ec33a98755ed345704a001913afa5187) | `python3Packages.aioskybell: 22.6.1 -> 22.7.0`                          |
| [`a3ca332d`](https://github.com/NixOS/nixpkgs/commit/a3ca332d09c753d33aa6947e70989a0c9cc119f8) | `maintainers: update github for kilimnik`                               |
| [`ea1d0347`](https://github.com/NixOS/nixpkgs/commit/ea1d03479b0d6ac8e511062024f848845de26714) | `python310Packages.tldextract: 3.3.0 -> 3.3.1`                          |
| [`f3c77572`](https://github.com/NixOS/nixpkgs/commit/f3c77572f005485afa87c2879cb251102ed0ddc7) | `python310Packages.types-setuptools: 57.4.18 -> 62.6.0`                 |
| [`51bd3393`](https://github.com/NixOS/nixpkgs/commit/51bd339361b92860e998f1a3bb037b368ee9002a) | `python310Packages.pyezviz: 0.2.0.8 -> 0.2.0.9`                         |
| [`45697c5a`](https://github.com/NixOS/nixpkgs/commit/45697c5a78bba609960896400459576d2e02f234) | `python310Packages.pyxiaomigateway: 0.13.4 -> 0.14.1`                   |
| [`2a6fe5c1`](https://github.com/NixOS/nixpkgs/commit/2a6fe5c1dd8c8cf9245e66029eb98cacaf6758c0) | `kubescape: 2.0.160 -> 2.0.161`                                         |
| [`c31e05fb`](https://github.com/NixOS/nixpkgs/commit/c31e05fb633149ed30a4fa5f88e251ca061ab590) | `kubeaudit: 0.18.0 -> 0.19.0`                                           |
| [`4b6837d9`](https://github.com/NixOS/nixpkgs/commit/4b6837d9c36e589df86dbdb3802745d8f0d85130) | `python310Packages.pycec: 0.5.1 -> 0.5.2`                               |
| [`9cd306c9`](https://github.com/NixOS/nixpkgs/commit/9cd306c9eb5b47a44c3a76971eca0938ecfead15) | `gitlab: 15.1.1 -> 15.1.2 (#180258)`                                    |
| [`1e12b929`](https://github.com/NixOS/nixpkgs/commit/1e12b9292c63207eb169ebcbaaee5b99a918d115) | `nixosTests.mjolnir: fix eval`                                          |
| [`1087880e`](https://github.com/NixOS/nixpkgs/commit/1087880e0b8f022cabbc9a8129ca7a2aa8f16bc6) | `ocs-url: init at 3.1.0`                                                |
| [`23b48c63`](https://github.com/NixOS/nixpkgs/commit/23b48c638c3362b7a4fbaddd42296cd78878849c) | `gnome.gnome-boxes: 42.2 -> 42.3`                                       |
| [`44fbd03e`](https://github.com/NixOS/nixpkgs/commit/44fbd03e79d43023381c1c583c24cccc6f9862fe) | `maintainers: Add SohamG`                                               |
| [`2c71278a`](https://github.com/NixOS/nixpkgs/commit/2c71278a2395d6d8c4e06d1ebe4de1ffdae727c7) | `ci: Add GitHub token permissions for workflows`                        |
| [`bb4d58bc`](https://github.com/NixOS/nixpkgs/commit/bb4d58bcda60e1428313138411aaab9c73c566f0) | `python310Packages.dvc-render: 0.0.6 -> 0.0.7`                          |
| [`6f9aa3fa`](https://github.com/NixOS/nixpkgs/commit/6f9aa3fa2a68e87448e3b98bccf9f500d815ef7b) | `gfold: 4.0.0 -> 4.0.1`                                                 |
| [`50dd61a9`](https://github.com/NixOS/nixpkgs/commit/50dd61a9ba21cd7c0394942b4e9dbac9b498e41a) | `nixos/polaris: init`                                                   |
| [`50ba995a`](https://github.com/NixOS/nixpkgs/commit/50ba995a1c1a1a6403d3bd45f99d09d02492ff56) | `polaris: init at 0.13.5`                                               |
| [`97039777`](https://github.com/NixOS/nixpkgs/commit/97039777aa04b646510e3351a6b72e12e3215115) | `maintainers: add pbsds`                                                |
| [`e416f880`](https://github.com/NixOS/nixpkgs/commit/e416f8806d273338effcef70acc3a43b7529fd10) | `php81: 8.1.7 -> 8.1.8`                                                 |
| [`b429bc25`](https://github.com/NixOS/nixpkgs/commit/b429bc25083c82510e4505cea74c6c26c2cbd43c) | `php80: 8.0.20 -> 8.0.21`                                               |
| [`3020f001`](https://github.com/NixOS/nixpkgs/commit/3020f0014c0604e9ab9619c96e57fdf9d28839a3) | `php: sha256 -> hash`                                                   |
| [`0a5a747b`](https://github.com/NixOS/nixpkgs/commit/0a5a747b65d58a99fd1024e40260781936ceec43) | `python3Packages.poetry: 1.1.12 -> 1.1.14`                              |
| [`d61e6280`](https://github.com/NixOS/nixpkgs/commit/d61e62804a5aba5ebda9a3a173fb68f23591172e) | `pdnsd: fix build`                                                      |
| [`28ce4709`](https://github.com/NixOS/nixpkgs/commit/28ce47092ad45b283c0ae6c0a3d2e34e9c54b302) | `gnome.gnome-bluetooth: 42.1 -> 42.2`                                   |
| [`1f23fbcc`](https://github.com/NixOS/nixpkgs/commit/1f23fbccb7fdc176bcc43981f3e2361f8fbafd40) | `orca: 42.2 -> 42.3`                                                    |
| [`45015616`](https://github.com/NixOS/nixpkgs/commit/450156162e81b6c17f540ae6576522a6b26f6197) | `buildkite-agent: 3.36.1 -> 3.37.0 (#180625)`                           |
| [`0c22b280`](https://github.com/NixOS/nixpkgs/commit/0c22b2804c9ea544e89d45b74fc61c7d32d7fca5) | `s6-networking-man-pages: 2.5.1.0.1 -> 2.5.1.1.1`                       |
| [`86ca4f59`](https://github.com/NixOS/nixpkgs/commit/86ca4f599c0979112fe6e56944450bd98d35972c) | `s6-linux-utils: 2.5.1.7 -> 2.6.0.0`                                    |
| [`d246edf6`](https://github.com/NixOS/nixpkgs/commit/d246edf60edbdd76e0d86639363a4c41eccaff78) | `execline-man-pages: 2.8.3.0.2 -> 2.9.0.0.1`                            |
| [`2ee6f663`](https://github.com/NixOS/nixpkgs/commit/2ee6f6632b2a97f090f3476b1377e1b1d41332b2) | `s6-man-pages: 2.11.0.1.1 -> 2.11.1.1.1`                                |
| [`89fe43fd`](https://github.com/NixOS/nixpkgs/commit/89fe43fd9550ea344264df412fdcb503ea1c42b2) | `s6-portable-utils-man-pages: init at 2.2.5.0.1`                        |
| [`042b6153`](https://github.com/NixOS/nixpkgs/commit/042b6153441a8e79ebe88a6fe55019a5c97ce654) | `s6-rc: 0.5.3.1 -> 0.5.3.2`                                             |
| [`058866f0`](https://github.com/NixOS/nixpkgs/commit/058866f0f87e22eab37a3764c40a6ba3a240b233) | `s6-networking: 2.5.1.0 -> 2.5.1.1`                                     |
| [`f655451d`](https://github.com/NixOS/nixpkgs/commit/f655451d81774521387565977275818315467c80) | `s6-dns: 2.3.5.3 -> 2.3.5.4`                                            |
| [`c2a48172`](https://github.com/NixOS/nixpkgs/commit/c2a481725d6efa475a4ebd484e1f2e199efdc0fe) | `s6-portable-utils: 2.2.4.0 -> 2.2.5.0`                                 |
| [`a5a04fb7`](https://github.com/NixOS/nixpkgs/commit/a5a04fb73b8d7d1a591bb6bcf442cb94dcc801b8) | `s6-linux-init: 1.0.7.3 -> 1.0.8.0`                                     |
| [`4d53e2b7`](https://github.com/NixOS/nixpkgs/commit/4d53e2b76bfb00fe2f645761197d7db4d8909032) | `mdevd: 0.1.5.1 -> 0.1.5.2`                                             |
| [`0fa78fc2`](https://github.com/NixOS/nixpkgs/commit/0fa78fc25d50f45f3518adf757800cd3056bf452) | `s6: 2.11.1.0 -> 2.11.1.2`                                              |
| [`ca01914e`](https://github.com/NixOS/nixpkgs/commit/ca01914ee2fb1d77027af19e5af1a96b40fc1060) | `skalibs: 2.11.2.0 -> 2.12.0.1`                                         |
| [`a28a389a`](https://github.com/NixOS/nixpkgs/commit/a28a389ab2d133811d6f0fad0a4861552509586b) | `execline: 2.8.3.0 -> 2.9.0.1`                                          |
| [`f0f127a3`](https://github.com/NixOS/nixpkgs/commit/f0f127a3b739b2dbd805514ed12e82abc01d256e) | `python310Packages.azure-storage-file-share: 12.8.0 -> 12.9.0`          |
| [`48a1741b`](https://github.com/NixOS/nixpkgs/commit/48a1741b5a4fc21ff2cb2700ebe11d57ad436d91) | `cloud-hypervisor: 24.0 -> 25.0`                                        |
| [`f2311c50`](https://github.com/NixOS/nixpkgs/commit/f2311c50f7b2fde7e9b82cab04829b90f6209b1d) | `fioctl: 0.25 -> 0.26`                                                  |
| [`0c2e3a94`](https://github.com/NixOS/nixpkgs/commit/0c2e3a9407aebffd2464074b97a2e77713ad54f3) | `python310Packages.azure-storage-blob: 12.12.0 -> 12.13.0`              |
| [`cb7bea13`](https://github.com/NixOS/nixpkgs/commit/cb7bea131274177c1d050072a7da2bdee954ed89) | `Update grammar in vim section`                                         |
| [`1014f00c`](https://github.com/NixOS/nixpkgs/commit/1014f00cff4d2ce2057f4103b1433e9441460446) | `Prepare Coq derivation for Coq 8.17 build infrastructure.`             |
| [`ac4398b9`](https://github.com/NixOS/nixpkgs/commit/ac4398b9d66bef0c2e7bcc49c97eb6548695f30c) | `lndhub-go: 0.8.0 -> 0.9.0`                                             |
| [`0898779c`](https://github.com/NixOS/nixpkgs/commit/0898779c3944d6ca9d90abb9641d4030796fdaa2) | `Do not rely on coq-version when coq.version works just fine.`          |
| [`c6815758`](https://github.com/NixOS/nixpkgs/commit/c6815758ac2a281c130f2e157d898091007e72d2) | `Do not rely on legacy ocaml passthru value.`                           |
| [`84419044`](https://github.com/NixOS/nixpkgs/commit/8441904435fe4f317e41fef13721f530b0bb962a) | `fswatch: 1.17.0 -> 1.17.1`                                             |
| [`6ac0bf80`](https://github.com/NixOS/nixpkgs/commit/6ac0bf80d50745434a0c2c670357c715acf77807) | `python310Packages.aioesphomeapi: 10.10.0 -> 10.11.0`                   |
| [`cdcc2b1c`](https://github.com/NixOS/nixpkgs/commit/cdcc2b1c614127bf2e7a6ab243f6e8eb94bccf2b) | `mpd: 0.23.6 -> 0.23.7`                                                 |
| [`115b16a2`](https://github.com/NixOS/nixpkgs/commit/115b16a2d179c951dde778ab2a5c1d2e5708644b) | `folly: 2022.06.13.00 -> 2022.07.04.00`                                 |
| [`e2a57c2c`](https://github.com/NixOS/nixpkgs/commit/e2a57c2c9bc83e0581ddd12c12aa4a58ade28049) | `flyctl: 0.0.348 -> 0.0.350`                                            |
| [`94348d68`](https://github.com/NixOS/nixpkgs/commit/94348d6854cd7bafcb22c1d5fd4d875b53c6c07f) | `exoscale-cli: remove myself from maintainers`                          |
| [`527425c2`](https://github.com/NixOS/nixpkgs/commit/527425c2d83338dd520015542e4ac3c57f134c5a) | `exoscale-cli: 1.57.0 -> 1.58.0`                                        |
| [`01ba1fba`](https://github.com/NixOS/nixpkgs/commit/01ba1fba641097cb2e318b89640c9a5f25db3b58) | `libtool_1_5: remove used-in-fetchurl warning`                          |
| [`bfac516b`](https://github.com/NixOS/nixpkgs/commit/bfac516ba70b35ecf681b0f07457247ffe3630bc) | `ec2-metadata-mock: 1.10.1 -> 1.11.1`                                   |
| [`42100e31`](https://github.com/NixOS/nixpkgs/commit/42100e31bfa5ad169e7bc7356ad83fe9f817e34e) | `dosbox: use SDL_compat for Wayland support`                            |
| [`e464e032`](https://github.com/NixOS/nixpkgs/commit/e464e032d88fe7716cdd6ccf491206c06ab43b31) | `elixir-ls: 0.9.0 -> 0.10.0`                                            |
| [`c23ba198`](https://github.com/NixOS/nixpkgs/commit/c23ba198feacff9df7743f535b4609ff05450b2f) | `nodejs-18_x: 18.4.0 -> 18.5.0`                                         |
| [`a7f7997a`](https://github.com/NixOS/nixpkgs/commit/a7f7997ae667f847d7cf6ca80243d77f9abaf1fc) | `dnsproxy: 0.43.0 -> 0.43.1`                                            |
| [`e2454114`](https://github.com/NixOS/nixpkgs/commit/e245411416c633cf7f4df8200c963686907e3c79) | `dismap: 0.3 -> 0.4`                                                    |
| [`699a374e`](https://github.com/NixOS/nixpkgs/commit/699a374e8a24edbd3296240f6da5d454e7fb3c21) | `starlark: Patch tests to unbreak on aarch64`                           |
| [`7afeac6b`](https://github.com/NixOS/nixpkgs/commit/7afeac6b5b5f725a977fa887ff49f04c7c54cf25) | `cloudlist: 1.0.0 -> 1.0.1`                                             |
| [`bb630787`](https://github.com/NixOS/nixpkgs/commit/bb6307872c4eeeb2c081576b25bbc5ade5b4687f) | `cloud-nuke: 0.11.8 -> 0.12.2`                                          |
| [`7b29bfd3`](https://github.com/NixOS/nixpkgs/commit/7b29bfd3af67a34085d65c1ed039b016812939d8) | `k3s: 1.24.2+k3s1 -> 1.24.2+k3s2`                                       |
| [`a6ae0af0`](https://github.com/NixOS/nixpkgs/commit/a6ae0af01ed2e266bf65950871f81ca22d2fd1b9) | `checkip: 0.38.0 -> 0.38.5`                                             |
| [`71c1d90b`](https://github.com/NixOS/nixpkgs/commit/71c1d90be4d40396c0a1e41a96de2d0a8ace137f) | `linux: include zstd in module dependencies`                            |
| [`22c2fef3`](https://github.com/NixOS/nixpkgs/commit/22c2fef365d5a1a918bfd73b7aa58defd3d1b011) | `nvc: init at 1.6.2`                                                    |
| [`a379d2bb`](https://github.com/NixOS/nixpkgs/commit/a379d2bbc0d73b92ea8d3c2a23878f8469328695) | `cdk-go: 1.0.6 -> 1.2.0`                                                |
| [`4a706341`](https://github.com/NixOS/nixpkgs/commit/4a706341b1697868373f4ca717d2974f8541f84b) | `bazel-remote: 2.3.7 -> 2.3.8`                                          |
| [`f62dd754`](https://github.com/NixOS/nixpkgs/commit/f62dd754333d0a113e0f51cdf7267427278023e2) | `elmPackages.nodejs: 14.19.3 -> 14.20.0`                                |
| [`0fd868d0`](https://github.com/NixOS/nixpkgs/commit/0fd868d030c2820b453ac48e3682ba580d222e6c) | `signal-desktop: 5.48.0 -> 5.49.0`                                      |
| [`45a07427`](https://github.com/NixOS/nixpkgs/commit/45a07427e174c6b18c028ea83362db37a25c81f7) | `python310Packages.fastcore: 1.4.5 -> 1.5.0`                            |
| [`5ffeb50e`](https://github.com/NixOS/nixpkgs/commit/5ffeb50e9043855633429c1daf6a6f9bfec07b4c) | `famistudio: 3.3.0 -> 3.3.1`                                            |
| [`6feda4d8`](https://github.com/NixOS/nixpkgs/commit/6feda4d87507aef1c43c09c03b2513566366e8c2) | `python310Packages.nats-py: 2.1.3 -> 2.1.4`                             |
| [`bfd9b6eb`](https://github.com/NixOS/nixpkgs/commit/bfd9b6ebd43893a9872098f9e6a14e7246faff0c) | `python310Packages.omnilogic: 0.4.6 -> 0.5.0`                           |
| [`9db358bd`](https://github.com/NixOS/nixpkgs/commit/9db358bd2764f2a032597d42ecd8575985241ba7) | `python310Packages.cirq-core: 0.14.1 -> 0.15.0`                         |
| [`bd517b86`](https://github.com/NixOS/nixpkgs/commit/bd517b86a198325da9055d2d8542f56225574e1c) | `python3Packages.duet: 0.2.1 -> 0.2.7`                                  |
| [`97221674`](https://github.com/NixOS/nixpkgs/commit/97221674bfdfacd14823756b7aa6da474740d5b5) | `checkSSLCert: 2.33.0 -> 2.34.0`                                        |
| [`38720fc8`](https://github.com/NixOS/nixpkgs/commit/38720fc8e1daea4d03f31ebf11f719ef72884363) | `tfsec: 1.26.2 -> 1.26.3`                                               |
| [`e42e76c9`](https://github.com/NixOS/nixpkgs/commit/e42e76c90e076b0d2fbe5ea1564a00f7c25a07dd) | `python310Packages.pontos: 22.7.0 -> 22.7.2`                            |
| [`bf55a19c`](https://github.com/NixOS/nixpkgs/commit/bf55a19ca9dbcca86185674ef84bce93a4b9283a) | `python310Packages.neo4j: 4.4.4 -> 4.4.5`                               |
| [`2568857b`](https://github.com/NixOS/nixpkgs/commit/2568857b7555b5d00ca28a1c6f2cda59e32413af) | `python310Packages.pyinsteon: 1.1.1 -> 1.1.2`                           |
| [`36187bc8`](https://github.com/NixOS/nixpkgs/commit/36187bc8644fe296ed393117201f935b6a3b7bb2) | `python310Packages.peaqevcore: 3.0.7 -> 3.1.3`                          |
| [`fc6a7454`](https://github.com/NixOS/nixpkgs/commit/fc6a7454afc6e11748cd76cb5691ee8ec2a40970) | `cargo-modules: 0.5.6 -> 0.5.9`                                         |
| [`78b7af04`](https://github.com/NixOS/nixpkgs/commit/78b7af04af74c92226c63bdcf1e47216c9090c48) | `python310Packages.pyvicare: 2.16.2 -> 2.16.4`                          |
| [`54cf6429`](https://github.com/NixOS/nixpkgs/commit/54cf6429842565ab6653a96e38dc497166873c4f) | `gmnitohtml: 0.1.1 -> 0.1.2`                                            |
| [`cc7d3f92`](https://github.com/NixOS/nixpkgs/commit/cc7d3f92284261c2abfa6266de88e9ac428d583f) | `linux/hardened/patches/5.4: 5.4.202-hardened1 -> 5.4.203-hardened1`    |
| [`287f104a`](https://github.com/NixOS/nixpkgs/commit/287f104a1573755416703e4105440e39c0be42b1) | `linux/hardened/patches/5.15: 5.15.51-hardened1 -> 5.15.52-hardened1`   |
| [`b01bc117`](https://github.com/NixOS/nixpkgs/commit/b01bc117d41bfe093e31e5f24c66eadc3051db4d) | `linux/hardened/patches/5.10: 5.10.127-hardened1 -> 5.10.128-hardened1` |
| [`b4fb4a07`](https://github.com/NixOS/nixpkgs/commit/b4fb4a07cf88c6be94dee8cc108df8ab4426c716) | `linux/hardened/patches/4.19: 4.19.249-hardened1 -> 4.19.250-hardened1` |
| [`50815fdf`](https://github.com/NixOS/nixpkgs/commit/50815fdf17214741a58d8e0e8152c1aaee82693a) | `linux/hardened/patches/4.14: 4.14.285-hardened1 -> 4.14.286-hardened1` |
| [`4a5a4a0f`](https://github.com/NixOS/nixpkgs/commit/4a5a4a0ff278761965b92faa94cda30d6bc5339c) | `linux: 5.4.203 -> 5.4.204`                                             |
| [`525e5cd3`](https://github.com/NixOS/nixpkgs/commit/525e5cd3b39a66459fb48dfe28b0bda6dd4f747d) | `linux: 5.18.9 -> 5.18.10`                                              |
| [`73610806`](https://github.com/NixOS/nixpkgs/commit/736108063578e2b350486d8f079c05843d390acf) | `linux: 5.15.52 -> 5.15.53`                                             |
| [`8e9ad03c`](https://github.com/NixOS/nixpkgs/commit/8e9ad03cbf82b40a90040591577edeb2246250e6) | `linux: 5.10.128 -> 5.10.129`                                           |
| [`eb59a193`](https://github.com/NixOS/nixpkgs/commit/eb59a193b9a42ee53bed78517c8bd857a7be3c44) | `linux: 4.9.321 -> 4.9.322`                                             |
| [`83b4ead7`](https://github.com/NixOS/nixpkgs/commit/83b4ead7e10597afc12a60d8bc42299e9016028c) | `linux: 4.19.250 -> 4.19.251`                                           |
| [`f0238d60`](https://github.com/NixOS/nixpkgs/commit/f0238d60982b865fef8097908e8d62b59f744bb8) | `linux: 4.14.286 -> 4.14.287`                                           |
| [`a6a7eb74`](https://github.com/NixOS/nixpkgs/commit/a6a7eb74a6df7f0daf8bc5bd3bc6c004a2c8d755) | `papirus-icon-theme: add color option`                                  |
| [`5194de18`](https://github.com/NixOS/nixpkgs/commit/5194de18eed275df9cec6635cf2435ffe0940b37) | `libstrangle: support 32bit via implicit layer`                         |
| [`c56c9449`](https://github.com/NixOS/nixpkgs/commit/c56c9449ee9e7d9016944de010c81dcd4e92f9d6) | `argocd: 2.4.2 -> 2.4.4`                                                |
| [`1a37a30a`](https://github.com/NixOS/nixpkgs/commit/1a37a30af7f7141df8a52972cb80557342fe9bc5) | `libstrangle: use direct nix store path in layer json`                  |
| [`539aeb16`](https://github.com/NixOS/nixpkgs/commit/539aeb1668a76c1f2f6eb469b8458b1025ca076e) | `go-ethereum: 1.10.18 -> 1.10.20`                                       |
| [`ea78ceef`](https://github.com/NixOS/nixpkgs/commit/ea78ceef64ef76bbe99922c9de429dc6604cfcc7) | `extremetuxracer: 0.8.1 -> 0.8.2`                                       |
| [`59128a34`](https://github.com/NixOS/nixpkgs/commit/59128a34c3a133ecb0563f2fb177abc83d20fe02) | `nixos/i18n: always generate C locale`                                  |
| [`253157f1`](https://github.com/NixOS/nixpkgs/commit/253157f1f43ba0d7d56d7aa040bde840b7932a69) | `jira-cli-go: 0.3.0 -> 1.0.0`                                           |
| [`25ccd71f`](https://github.com/NixOS/nixpkgs/commit/25ccd71ff83a1b6e961588ee65c9f18a7c8f0a92) | `doc: update Darwin platform doc regarding the 11.0 SDK`                |
| [`9659c7ab`](https://github.com/NixOS/nixpkgs/commit/9659c7abcebb9fd36d0a8184681574268d8b9296) | ``apple_sdk_11_0: provide SDK-specific `callPackage```                  |
| [`8344ddaf`](https://github.com/NixOS/nixpkgs/commit/8344ddaf455818e2acfb5a9bf6114f8508c38fab) | `bibletime: 3.0.2 -> 3.0.3`                                             |
| [`b68ae079`](https://github.com/NixOS/nixpkgs/commit/b68ae0793935735cd963f4f044e3e5999f018992) | `thunderbird: 102.0 -> 102.0.1`                                         |
| [`9288908d`](https://github.com/NixOS/nixpkgs/commit/9288908d8c38cc2e47925db3ce0f037255b499b3) | `thunderbird-bin: 102.0 -> 102.0.1`                                     |
| [`4741402d`](https://github.com/NixOS/nixpkgs/commit/4741402d547773cc7d7f53814e65a3b81f23666c) | `apple_sdk_11_0: expose 11.0 sdk stdenv as an attribute`                |
| [`d8f71776`](https://github.com/NixOS/nixpkgs/commit/d8f71776fffc7c98d82a58771b199a761d40cde1) | `apple_sdk_11_0: fix build on x86_64-darwin and expose as attribute`    |
| [`08626ff9`](https://github.com/NixOS/nixpkgs/commit/08626ff9d165cc0d884d924d45bce8f18294c204) | `python310Packages.numpyro: 0.9.2 -> 0.10.0`                            |
| [`234be397`](https://github.com/NixOS/nixpkgs/commit/234be397d65393c16d562fda3f397c6de6fd2510) | `xprompt: init at 2.5.0`                                                |
| [`a5f11a69`](https://github.com/NixOS/nixpkgs/commit/a5f11a6938a0cc475391e81c998f4439092a5d7b) | `nixos/tests/plasma5: also test excludePackages works as expected`      |
| [`6350d8d9`](https://github.com/NixOS/nixpkgs/commit/6350d8d9b366fd6553dfe2160c4b43c28af97ac4) | `nixos/plasma5: add excludePackages option`                             |
| [`9f75123e`](https://github.com/NixOS/nixpkgs/commit/9f75123e00657d28e617d41c17280740bf08877a) | `libbpf: 0.7.0 -> 0.8.0`                                                |
| [`d8b840a6`](https://github.com/NixOS/nixpkgs/commit/d8b840a60f70d07de496572fa706ace44f90ef78) | `bpftrace: 0.14.1 -> 0.15.0`                                            |