### PR TITLE
chore(flake/nixpkgs): `87e7965b` -> `5f43d8b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -297,11 +297,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657356697,
-        "narHash": "sha256-sT38tcx7m0Quz+Uj6jzx+yRa2+EVW2C3cE0FkROXUzQ=",
+        "lastModified": 1657447684,
+        "narHash": "sha256-FCP9AuU1q6PE3vOeM5SFf58f/UKPBAsoSGDUGamNBbo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "87e7965bbcdbac3d103e3ed14ff04f719a4f7a58",
+        "rev": "5f43d8b088d3771274bcfb69d3c7435b1121ac88",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                              |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`cbfd288f`](https://github.com/NixOS/nixpkgs/commit/cbfd288fd1494dca775019fe4973d190e920fdd0) | `libhugetlbfs: fix build with recent Glibc`                                 |
| [`90514b78`](https://github.com/NixOS/nixpkgs/commit/90514b78654ae4706355884ef0f5782cb1943d69) | `python310Packages.panflute: remove whitespace`                             |
| [`259acf44`](https://github.com/NixOS/nixpkgs/commit/259acf447a247502bbf4cf00a858b0d3807c3540) | `python310Packages.panflute: add pythonImportsCheck`                        |
| [`c4e35baa`](https://github.com/NixOS/nixpkgs/commit/c4e35baa74345a9aebc65f0675d7575b948f1117) | `python310Packages.pymazda: 0.3.4 -> 0.3.6`                                 |
| [`33be3deb`](https://github.com/NixOS/nixpkgs/commit/33be3debd5f2121d0815ca3ba1bb556c615b4bb3) | `terraform-providers: update 2022-07-10`                                    |
| [`0b35c85b`](https://github.com/NixOS/nixpkgs/commit/0b35c85b3ff888955f2637d3f1c754be00ad6034) | `python310Packages.levenshtein: 0.18.2 -> 0.19.1`                           |
| [`e259d968`](https://github.com/NixOS/nixpkgs/commit/e259d968555be7a93b524b50f75314e453e5d8e1) | `python310Packages.sunpy: 4.0.2 -> 4.0.3`                                   |
| [`8adfc296`](https://github.com/NixOS/nixpkgs/commit/8adfc29685055843d3d8171d78417b53eb2198ce) | `myst-docutils: init at 0.17.2 (#171710)`                                   |
| [`69cb6138`](https://github.com/NixOS/nixpkgs/commit/69cb613852db5ec56250d664ee1a98a0dbd8af18) | `python310Packages.panflute: 2.1.3 -> 2.1.5`                                |
| [`86138531`](https://github.com/NixOS/nixpkgs/commit/86138531bc5040d35d9c5822066b0a973a56a3e3) | `python310Packages.tweepy: add missing input`                               |
| [`b7609e10`](https://github.com/NixOS/nixpkgs/commit/b7609e106f0692506f58e401de5b6cd2431d64e2) | `python310Packages.shodan: 1.27.0 -> 1.28.0`                                |
| [`87ac6eda`](https://github.com/NixOS/nixpkgs/commit/87ac6eda56acfe22bf6853736b05f83ce257ee02) | `wails: v2.0.0-beta.37 -> v2.0.0-beta.38 (#179429)`                         |
| [`db01a669`](https://github.com/NixOS/nixpkgs/commit/db01a66901e48cf5210a1ac679cb54592bcb2457) | `python310Packages.ormar: update stale substituteInPlace`                   |
| [`64a4bd8e`](https://github.com/NixOS/nixpkgs/commit/64a4bd8e05a00cc6ea8e7fa3bfb2e8ae9196144a) | `python310Packages.pex: 2.1.94 -> 2.1.95`                                   |
| [`5039fc4e`](https://github.com/NixOS/nixpkgs/commit/5039fc4ec0307b931e5e95d2a6c749a94d5fd715) | `chromium: 103.0.5060.53 -> 103.0.5060.114`                                 |
| [`d9a4e827`](https://github.com/NixOS/nixpkgs/commit/d9a4e827c4d66e69d945a01bf89835a69b962a24) | `python310Packages.peaqevcore: 3.1.3 -> 3.1.6`                              |
| [`3dfd0a00`](https://github.com/NixOS/nixpkgs/commit/3dfd0a00c280d6e51d1e4c3434863bfa0d8a0eac) | `python310Packages.peewee: 3.14.10 -> 3.15.0`                               |
| [`9ce8939b`](https://github.com/NixOS/nixpkgs/commit/9ce8939ba596fa8c9ea835f33c84dafc64adcfeb) | `python3Packages.ics: Remove myself as maintainer`                          |
| [`34685a86`](https://github.com/NixOS/nixpkgs/commit/34685a86b0ce6c3990af4dd23451306371985e15) | `python3Packages.cmd2: don't require vim for tests`                         |
| [`30377e34`](https://github.com/NixOS/nixpkgs/commit/30377e344cae9ea1140a13ad11eb48d6c9252640) | `python310Packages.geopandas: 0.10.2 -> 0.11.0`                             |
| [`4db76b63`](https://github.com/NixOS/nixpkgs/commit/4db76b63c36346666b0b3a5a344f9d15c3f81419) | `python310Packages.fs: 2.4.15 -> 2.4.16`                                    |
| [`11a003ae`](https://github.com/NixOS/nixpkgs/commit/11a003ae4567a2c4334c4c058e9b3befd3c39250) | `python310Packages.sagemaker: 2.98.0 -> 2.99.0`                             |
| [`20534135`](https://github.com/NixOS/nixpkgs/commit/205341353556b628920c9141e60ca4ec1c327b19) | `python310Packages.qcengine: add pythonImportsCheck`                        |
| [`155a5240`](https://github.com/NixOS/nixpkgs/commit/155a5240c48db90da93f3fc82693853534f3e5a1) | `python310Packages.qcelemental: add pythonImportsCheck`                     |
| [`2f11f9d1`](https://github.com/NixOS/nixpkgs/commit/2f11f9d10c09afa9effc6a9d6bef2f394a8d9739) | `python310Packages.aioairzone: 0.4.5 -> 0.4.6`                              |
| [`e7f4b94c`](https://github.com/NixOS/nixpkgs/commit/e7f4b94cdc050423785c2785b6c6cadfc5cbc0d3) | `python310Packages.nomadnet: 0.2.0 -> 0.2.1`                                |
| [`21a7d74f`](https://github.com/NixOS/nixpkgs/commit/21a7d74fd98ca1c6d881806791c680ef2cdf3a69) | `python310Packages.rns: 0.3.10 -> 0.3.11`                                   |
| [`b3c7e23d`](https://github.com/NixOS/nixpkgs/commit/b3c7e23d3d43c64cb51e2bac9b38969757e6f3be) | `python310Packages.pydeconz: 97 -> 98`                                      |
| [`f9de76b5`](https://github.com/NixOS/nixpkgs/commit/f9de76b5e2f85e7400509ff936ba259f848074d8) | `datree: 0.15.22 -> 1.5.25`                                                 |
| [`63a859c8`](https://github.com/NixOS/nixpkgs/commit/63a859c835148abcad17ff54af1fe84e61f417cb) | `bun: init at 0.1.1`                                                        |
| [`78137411`](https://github.com/NixOS/nixpkgs/commit/78137411f2d257bae45dc6fb1d70af69a10ae2e9) | `tts: relax cython constraint`                                              |
| [`26329f9a`](https://github.com/NixOS/nixpkgs/commit/26329f9ae8f59b072a15752a9b0d77bef35b64d3) | `xnotify: init at unstable-2022-02-18`                                      |
| [`fcbb5ecd`](https://github.com/NixOS/nixpkgs/commit/fcbb5ecd6f7451d84807a32884b9e2569e29aab4) | `python310Packages.qcengine: 0.23.0 -> 0.24.0`                              |
| [`42b8ddcf`](https://github.com/NixOS/nixpkgs/commit/42b8ddcfd2e23e3dba8ed8674a94811c9912b24e) | `ledger-live-desktop: 2.43.1 -> 2.44.0`                                     |
| [`757334cb`](https://github.com/NixOS/nixpkgs/commit/757334cba258e7e67f582014338994002136ca87) | `python310Packages.ics: 0.7.1 -> 0.7.2`                                     |
| [`cbad871a`](https://github.com/NixOS/nixpkgs/commit/cbad871ace2056384f08648bcb81adbc9be94e82) | `python310Packages.holoviews: 1.14.9 -> 1.15.0`                             |
| [`a88f7d2f`](https://github.com/NixOS/nixpkgs/commit/a88f7d2f4fe66a093aed598f0595a2570e2ba914) | ``offpunk: remove unused argument `testVersion```                           |
| [`7d69cd59`](https://github.com/NixOS/nixpkgs/commit/7d69cd5908e92862e449b53509e0d3b9bd07b3b8) | `feh: 3.8 -> 3.9`                                                           |
| [`efa78245`](https://github.com/NixOS/nixpkgs/commit/efa78245a3dbb7b06872fdc6d80902fde70342ca) | `libmd: enable on darwin`                                                   |
| [`1d64ca4f`](https://github.com/NixOS/nixpkgs/commit/1d64ca4f34bbb2101ae0e87c2b0f00047c598453) | `python310Packages.resampy: 0.3.0 -> 0.3.1`                                 |
| [`18ea5451`](https://github.com/NixOS/nixpkgs/commit/18ea5451e9b3366d74f13ec2c9ba9510ae95e100) | `josm: 18463 -> 18513`                                                      |
| [`dbb7bd6a`](https://github.com/NixOS/nixpkgs/commit/dbb7bd6a07fe2d398d0d52c5ced08ae29a6c4d2f) | `ledger-live-desktop: add WeebSorceress as a maintainer`                    |
| [`cb6a80ce`](https://github.com/NixOS/nixpkgs/commit/cb6a80cee040684c96aaf30384642b32eb0aa199) | `gnubg: Fix build`                                                          |
| [`920d60c5`](https://github.com/NixOS/nixpkgs/commit/920d60c5611d039227a95160afa0a9c1605e52ef) | `python310Packages.browser-cookie3: 0.16.0 -> 0.16.1`                       |
| [`9e544fd8`](https://github.com/NixOS/nixpkgs/commit/9e544fd8759c0a3adae825f6f50742a1aada9cff) | `python310Packages.dvc-objects: 0.0.19 -> 0.0.20`                           |
| [`d4cb9de8`](https://github.com/NixOS/nixpkgs/commit/d4cb9de838b79c6022ae24ba9473fda9b2ce5f7c) | `ocamlPackages.nocrypto: remove at 0.5.4`                                   |
| [`f8529770`](https://github.com/NixOS/nixpkgs/commit/f85297709073424bbc485e25abaa13fad1c8d865) | `ocamlPackages.noise: remove at 0.2.0`                                      |
| [`a59fc55a`](https://github.com/NixOS/nixpkgs/commit/a59fc55a6e69c1a87bdc9dbe4a99ab72dce5c641) | `python310Packages.schwifty: 2022.6.3 -> 2022.7.0`                          |
| [`076be105`](https://github.com/NixOS/nixpkgs/commit/076be1052437bb625f4cd9284017c087ad137472) | `poetry2nix: 1.30.0 -> 1.31.0`                                              |
| [`9864278e`](https://github.com/NixOS/nixpkgs/commit/9864278e985f10963efa5be89b058242f3b662c1) | `python310Packages.pysigma: 0.6.4 -> 0.6.5`                                 |
| [`b413a2f3`](https://github.com/NixOS/nixpkgs/commit/b413a2f3e5d023c796350c1c4b7d91ca3a355343) | `python310Packages.aioqsw: 0.1.0 -> 0.1.1`                                  |
| [`3f8c5470`](https://github.com/NixOS/nixpkgs/commit/3f8c5470692c0ad4ae4f8ad9bfac8603a0de3b0d) | `python310Packages.extractcode: disable failing test`                       |
| [`d56221e1`](https://github.com/NixOS/nixpkgs/commit/d56221e143ab92187738ffa613d4a0b65d9db7b2) | `python310Packages.h5netcdf: add pythonImportsCheck`                        |
| [`e8101310`](https://github.com/NixOS/nixpkgs/commit/e810131094ce836cd29c09dadf577b52fcf3fd95) | `eksctl: 0.104.0 -> 0.105.0`                                                |
| [`80e1334f`](https://github.com/NixOS/nixpkgs/commit/80e1334f334027f22475ae6a58c4ba58f20af160) | `python310Packages.mongomock: disable on older Python releases`             |
| [`b55d83f1`](https://github.com/NixOS/nixpkgs/commit/b55d83f112ac82a05e8edcc7d5502da73c59e173) | `decoder: pull patch pending upstream inclusion for -fno-common toolchains` |
| [`823653c4`](https://github.com/NixOS/nixpkgs/commit/823653c46f738ea853b2fab22ebf1803a171fe58) | `python310Packages.moku: 2.3 -> 2.4`                                        |
| [`cbee67a9`](https://github.com/NixOS/nixpkgs/commit/cbee67a9bac75d0f3c0a591ad2ae9de038a833d1) | `v2ray-domain-list-community: 20220624025859 -> 20220708161253`             |
| [`b85fe98d`](https://github.com/NixOS/nixpkgs/commit/b85fe98d49c7a12b925e7ac6a1192a0b03e873fb) | `v2ray-geoip: 202206230045 -> 202207070057`                                 |
| [`9f566485`](https://github.com/NixOS/nixpkgs/commit/9f5664857b2a42b86cef541b4d1b8dcfc0e4ff32) | `crowdin-cli: 3.7.8 -> 3.7.9`                                               |
| [`dcb5e9ba`](https://github.com/NixOS/nixpkgs/commit/dcb5e9baa0d662b4387d5c9162b52ff5acdb67f0) | `kbs2: 0.5.1 -> 0.6.0`                                                      |
| [`7ca3b1a2`](https://github.com/NixOS/nixpkgs/commit/7ca3b1a2fce2547367c7487836016a79ae51324a) | `smlpkg: add platforms`                                                     |
| [`adb5a1f3`](https://github.com/NixOS/nixpkgs/commit/adb5a1f37dda1684b789cfff232bd272cbdadfec) | `libpg_query: 13-2.1.1 -> 13-2.1.2`                                         |
| [`627a544d`](https://github.com/NixOS/nixpkgs/commit/627a544d8723f86c94795cb5a0f461acfb7157c1) | `ytarchive: 2022-03-11 -> 2022-05-28`                                       |
| [`1ba6a578`](https://github.com/NixOS/nixpkgs/commit/1ba6a578875c12578b3a30980c3e678eeae0b7c1) | `mlkit: 4.5.9 -> 4.6.1`                                                     |
| [`06a02ba5`](https://github.com/NixOS/nixpkgs/commit/06a02ba5224975cdd13d382f637519e4095ceafa) | `diffoscope: 217 -> 218`                                                    |
| [`21a43e94`](https://github.com/NixOS/nixpkgs/commit/21a43e94ac0535f8d9bc36d2953cba59c7afff59) | `python310Packages.mongomock: 4.0.0 -> 4.1.2`                               |
| [`fd701a9c`](https://github.com/NixOS/nixpkgs/commit/fd701a9cd17b6064557bb866b7d7bc42d15f7b4a) | `logrotate: fix config check without sandbox`                               |
| [`1d0ed376`](https://github.com/NixOS/nixpkgs/commit/1d0ed37658cee3d974e750eb7f386af9d60e8bb7) | `atlantis: 0.19.4 -> 0.19.6`                                                |
| [`2f784861`](https://github.com/NixOS/nixpkgs/commit/2f784861e1c4311836f4699326d31b97a06074f4) | `steampipe: 0.13.4 -> 0.15.0`                                               |
| [`016e4b74`](https://github.com/NixOS/nixpkgs/commit/016e4b74f9bda284bf015267fb657a5f6da15b61) | `python310Packages.aiopyarr: 22.6.0 -> 22.7.0`                              |
| [`eb480037`](https://github.com/NixOS/nixpkgs/commit/eb480037ead352117441133d9ac7748f67a2a432) | `python310Packages.rstcheck: 5.0.0 -> 6.0.0.post1`                          |
| [`ae421141`](https://github.com/NixOS/nixpkgs/commit/ae42114134a2b8c3b4c53a7c6ec01711fe3ca058) | `python310Packages.rstcheck-core: init at 1.0.2`                            |
| [`924540c6`](https://github.com/NixOS/nixpkgs/commit/924540c6c7478092e4b9933a4b0f09454fcbb4d8) | `chromiumDev: 104.0.5112.20 -> 105.0.5148.2`                                |
| [`510f1462`](https://github.com/NixOS/nixpkgs/commit/510f1462a27568248cdb55312e19dec275f4ea73) | `python310Packages.types-docutils: 0.18.3 -> 0.19.0`                        |
| [`fcc3bd05`](https://github.com/NixOS/nixpkgs/commit/fcc3bd053c85b2db6e49d79cd2934ace4687a31e) | `slack: 4.26.1 -> 4.27.154 (darwin), 4.27.156 (linux)`                      |
| [`541dc618`](https://github.com/NixOS/nixpkgs/commit/541dc6185823eba8208a4b2c2640cbb04e500f03) | `zen-kernels: linux_lqx, linux_zen: 5.18.9 -> 5.18.10`                      |
| [`aefbb8eb`](https://github.com/NixOS/nixpkgs/commit/aefbb8eb17ad01058a15d1bd0c8506d1073baa1f) | `python310Packages.hahomematic: 1.9.4 -> 2022.7.1`                          |
| [`a5aa0860`](https://github.com/NixOS/nixpkgs/commit/a5aa0860b9c599eee3280fa4899ec0237a1eb260) | `python310Packages.elkm1-lib: 2.0.0 -> 2.0.2`                               |
| [`3d947c1d`](https://github.com/NixOS/nixpkgs/commit/3d947c1d277a8fef15c58705c5fee46f210543db) | `pip-audit: 2.4.0 -> 2.4.1`                                                 |
| [`d9da51c6`](https://github.com/NixOS/nixpkgs/commit/d9da51c6ba366cba6e84ad6f5c33482bbd040b42) | `librespeed-cli: 1.0.9 -> 1.0.10`                                           |
| [`8e7f3ac8`](https://github.com/NixOS/nixpkgs/commit/8e7f3ac8f6f1032f38b53ec7730eea13c919efec) | `python3Packages.fonttools: fix for aarch64-darwin`                         |
| [`09b73d74`](https://github.com/NixOS/nixpkgs/commit/09b73d741c56782609d6d7cbfd98b070fc36aaa4) | `dpkg: 1.20.9ubuntu2 -> 1.21.1ubuntu2.1`                                    |
| [`f3b7105c`](https://github.com/NixOS/nixpkgs/commit/f3b7105c7762b08e5f79dc876612cd5063090b81) | `python310Packages.azure-servicebus: 7.7.0 -> 7.8.0`                        |
| [`871b935d`](https://github.com/NixOS/nixpkgs/commit/871b935d7db63c827b29f71e2908c01aff91fcf6) | `goreleaser: 1.10.1 -> 1.10.2`                                              |
| [`ff914ab7`](https://github.com/NixOS/nixpkgs/commit/ff914ab7907a3538567edde8f8720595d838c2cd) | `python310Packages.asf-search: 4.0.1 -> 4.0.3`                              |
| [`6c85a9ea`](https://github.com/NixOS/nixpkgs/commit/6c85a9eafbf3e7c46af9da4c95a0f7f40391a614) | `gdcm: 3.0.12 -> 3.0.14`                                                    |
| [`231e9367`](https://github.com/NixOS/nixpkgs/commit/231e9367d7081dcc7e96f659cd6918ecf3d37539) | `fundoc: 0.4.1 -> 0.4.2`                                                    |
| [`3b60f88f`](https://github.com/NixOS/nixpkgs/commit/3b60f88f6e748a0e63c46e129f783919653ef0f0) | `python310Packages.aioskybell: 22.6.1 -> 22.7.0`                            |
| [`dc856a0c`](https://github.com/NixOS/nixpkgs/commit/dc856a0cccba595a500e8a5a7d8b9f97cce307a0) | `faustPhysicalModeling: 2.40.0 -> 2.41.1`                                   |
| [`9ec702a4`](https://github.com/NixOS/nixpkgs/commit/9ec702a44c2ab8906d4a31d07f6f90967ae01772) | `erigon: 2022.07.01 -> 2022.07.02`                                          |
| [`ab77b420`](https://github.com/NixOS/nixpkgs/commit/ab77b42008c31c21eec66b7d6ff079a1ed7d12d4) | `python310Packages.h5netcdf: 0.8.1 -> 1.0.1`                                |
| [`6e4203aa`](https://github.com/NixOS/nixpkgs/commit/6e4203aa50c79ea68f10556d9a30a00845650b66) | `python310Packages.typecode: Fix tests`                                     |
| [`d3918653`](https://github.com/NixOS/nixpkgs/commit/d39186531eeee59520af328b9bdda67bc95f13da) | `clickhouse-backup: 1.4.0 -> 1.4.7`                                         |
| [`d65897fd`](https://github.com/NixOS/nixpkgs/commit/d65897fdcb6586f3b0558cc7f7ef391571fdd782) | `bschaffl: 1.4.8 -> 1.4.10`                                                 |
| [`bce9c41a`](https://github.com/NixOS/nixpkgs/commit/bce9c41aa6dd9e6b7a732ba14048e7c6d3811aa4) | `bazel-gazelle: 0.25.0 -> 0.26.0`                                           |
| [`5460a68a`](https://github.com/NixOS/nixpkgs/commit/5460a68aa4e6778234785a66893ca48baf51ef7f) | `difftastic: 0.29.1 -> 0.30.0`                                              |
| [`034e77ee`](https://github.com/NixOS/nixpkgs/commit/034e77eea24e84bc4d575432e9c7cf82308a0778) | `ceph: 16.2.7 -> 16.2.9`                                                    |
| [`e4499991`](https://github.com/NixOS/nixpkgs/commit/e4499991ec2009ee43ed8f8f307ff0c240268131) | `capnproto: 0.10.1 -> 0.10.2`                                               |
| [`41dbc0bd`](https://github.com/NixOS/nixpkgs/commit/41dbc0bdf257c820a5fbfc4b1faa1bc11da8f6df) | `nixos/qt5: add kde platform theme`                                         |
| [`92ee92f7`](https://github.com/NixOS/nixpkgs/commit/92ee92f7832bc151995790ae11a79f9b06677d62) | `rdkafka: 1.8.2 -> 1.9.1`                                                   |
| [`3c0659d6`](https://github.com/NixOS/nixpkgs/commit/3c0659d6a93a4ea4b2391bc53a8b8e76bfe1450b) | `fastly: 3.1.0 -> 3.1.1`                                                    |
| [`aa2c8f20`](https://github.com/NixOS/nixpkgs/commit/aa2c8f202652ec02db8477b7bc1db9ca01abdc67) | `faustlive: 2.5.10 -> 2.5.11`                                               |
| [`1271b83b`](https://github.com/NixOS/nixpkgs/commit/1271b83b6364cfcb9761e4b1a581094eee5aa487) | `faust: 2.40.0 -> 2.41.1`                                                   |
| [`4439918c`](https://github.com/NixOS/nixpkgs/commit/4439918c3aa22593d3b34ceddedb532462766969) | `python310Packages.dogpile-cache: 1.1.6 -> 1.1.7`                           |
| [`abbdfc25`](https://github.com/NixOS/nixpkgs/commit/abbdfc25d174a46dfa4a96f055ce4cb7172b4367) | `powerdns-admin: 0.2.4 -> 0.3.0`                                            |
| [`ae2d1ed9`](https://github.com/NixOS/nixpkgs/commit/ae2d1ed93257d75124daa578459eca692f88d5ad) | `sumneko-lua-language-server: 3.2.3 -> 3.4.1`                               |
| [`08af7583`](https://github.com/NixOS/nixpkgs/commit/08af758396433af628747879dc4430176c48992a) | `gf: init at unstable-2022-06-22`                                           |
| [`f167634b`](https://github.com/NixOS/nixpkgs/commit/f167634b357bb205e3001797be83720dc6abaaa4) | `maintainers: add 0xd61`                                                    |