### PR TITLE
chore(flake/emacs-ement): `02015eac` -> `eae3da5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1657457142,
-        "narHash": "sha256-egZrODBJYa70a9M3ZC6Kf67X631VF/jooQlEHeiH0HY=",
+        "lastModified": 1657546543,
+        "narHash": "sha256-RNtLKjf1dmioGm4SgomrvWIgA5reqsENSvDRrc/vS1U=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "02015eacf682b53baaddf26c8a4046e6ff84d4e8",
+        "rev": "eae3da5e4547fabbecaf1dc80b19f76ae1bf28b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                         |
| --------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`eae3da5e`](https://github.com/alphapapa/ement.el/commit/eae3da5e4547fabbecaf1dc80b19f76ae1bf28b3) | `Fix: (ement--prism-color) TTY frames` |