### PR TITLE
chore(flake/emacs-ement): `acdb429c` -> `6f2162a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1657547612,
-        "narHash": "sha256-XCrVx9yr554ftTSpSIc9+XzuJMJXeX4WygLCum6CbEM=",
+        "lastModified": 1657555617,
+        "narHash": "sha256-dktkfD2s3hQRTyKJp/H8q8yaOtWDC1Aerkub646GLI8=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "acdb429c2c81c9bc83e71290b6b7d35f7888ca90",
+        "rev": "6f2162a6f1e67bf7736aae43232ff8292be0ef6d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                   |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`6f2162a6`](https://github.com/alphapapa/ement.el/commit/6f2162a6f1e67bf7736aae43232ff8292be0ef6d) | `Change: (ement--prism-color) Use frame--current-backround-mode` |