### PR TITLE
chore(flake/emacs-overlay): `d6614609` -> `4d342a55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657564474,
-        "narHash": "sha256-zDKZtQtQbM5ixoI2i4NDNOq0eMjDZt40HHLAsWeFp6g=",
+        "lastModified": 1657597199,
+        "narHash": "sha256-BCzHNKPDgiYF9gF52xFXvHi8qRzHkToL5XhtO/LJy7s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d66146093627b60ee245249adc75029abc49db13",
+        "rev": "4d342a55aa298e8ed5168be77c2262cf5fb8a0c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`4d342a55`](https://github.com/nix-community/emacs-overlay/commit/4d342a55aa298e8ed5168be77c2262cf5fb8a0c4) | `Updated repos/nongnu` |
| [`167d38fd`](https://github.com/nix-community/emacs-overlay/commit/167d38fdc98984b24a0d6893151759de16d0ddbc) | `Updated repos/melpa`  |
| [`bb6e8912`](https://github.com/nix-community/emacs-overlay/commit/bb6e8912dba0c6bda2a802b49686dae750d34ce5) | `Updated repos/emacs`  |
| [`e1373b07`](https://github.com/nix-community/emacs-overlay/commit/e1373b072bba84cefc5c182425bc6c420b80815f) | `Updated repos/elpa`   |