### PR TITLE
chore(flake/nur): `ba9415d7` -> `74d6e450`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657563923,
-        "narHash": "sha256-gvouxQe93ynZzlUWBxGbk7TJRzAQ5w3wiyNRYODiFJM=",
+        "lastModified": 1657597174,
+        "narHash": "sha256-OvtrfFgjQonkwvu3pDit2eUPBRvYdNZaHZTXBPe2tws=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ba9415d7c8ad896048d4d54d770f2d0c45791d1a",
+        "rev": "74d6e4505d14b43b54b35c65e29e5ad7c6da78f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`74d6e450`](https://github.com/nix-community/NUR/commit/74d6e4505d14b43b54b35c65e29e5ad7c6da78f6) | `automatic update` |