### PR TITLE
chore(flake/nur): `74d6e450` -> `d6c6a219`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657597174,
-        "narHash": "sha256-OvtrfFgjQonkwvu3pDit2eUPBRvYdNZaHZTXBPe2tws=",
+        "lastModified": 1657598855,
+        "narHash": "sha256-LNF6AAhuYXJhmFHoqs97nLsLRCgJj3I/8ABLc8SvMwY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "74d6e4505d14b43b54b35c65e29e5ad7c6da78f6",
+        "rev": "d6c6a219490694b95f714a26bd5ec2465c215c6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d6c6a219`](https://github.com/nix-community/NUR/commit/d6c6a219490694b95f714a26bd5ec2465c215c6b) | `automatic update` |