### PR TITLE
chore(flake/nur): `d6c6a219` -> `ab00097e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657598855,
-        "narHash": "sha256-LNF6AAhuYXJhmFHoqs97nLsLRCgJj3I/8ABLc8SvMwY=",
+        "lastModified": 1657600634,
+        "narHash": "sha256-/8QkPKQMjFcFHTXNSKIbxNzpjb0URlzvxZnQ76oxoRQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d6c6a219490694b95f714a26bd5ec2465c215c6b",
+        "rev": "ab00097eb9880bc0b3884de3725963dd9208c3af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ab00097e`](https://github.com/nix-community/NUR/commit/ab00097eb9880bc0b3884de3725963dd9208c3af) | `automatic update` |