### PR TITLE
chore(flake/home-manager): `0639aa34` -> `177f1887`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657615706,
-        "narHash": "sha256-WKa/8I6Qo5CEGyZVYHo7CXQ/dR1bs5dvvhV+kY2L3xs=",
+        "lastModified": 1657617710,
+        "narHash": "sha256-d0gEpLLUAHXdM568bRzX7R6NK0YQRReQz6gIjwQkquY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0639aa34f1c2e584598c19a38990e81ad2b86ae2",
+        "rev": "177f1887d4d4eb347c6a8328fbd8ca0f346887bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`177f1887`](https://github.com/nix-community/home-manager/commit/177f1887d4d4eb347c6a8328fbd8ca0f346887bc) | `compton: remove`                           |
| [`b908e61d`](https://github.com/nix-community/home-manager/commit/b908e61dfad269d97376c1832eb9127e444953a3) | `picom: sync module with the NixOS version` |