### PR TITLE
chore(flake/nur): `ab00097e` -> `5c88f1e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657600634,
-        "narHash": "sha256-/8QkPKQMjFcFHTXNSKIbxNzpjb0URlzvxZnQ76oxoRQ=",
+        "lastModified": 1657619463,
+        "narHash": "sha256-0j2alAwOoWZeOiYVuim9X1vXoksdte+82Qg55UsXkLY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ab00097eb9880bc0b3884de3725963dd9208c3af",
+        "rev": "5c88f1e0fb7797f57ef6533ca4e94a98d23f95d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5c88f1e0`](https://github.com/nix-community/NUR/commit/5c88f1e0fb7797f57ef6533ca4e94a98d23f95d5) | `automatic update` |
| [`9086c93b`](https://github.com/nix-community/NUR/commit/9086c93bacaadceb743d08de7ef93e3e13df96ad) | `automatic update` |