### PR TITLE
chore(flake/home-manager): `177f1887` -> `45ef70cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657617710,
-        "narHash": "sha256-d0gEpLLUAHXdM568bRzX7R6NK0YQRReQz6gIjwQkquY=",
+        "lastModified": 1657620121,
+        "narHash": "sha256-/F1KpOMy3FISxS7lEyQuDBUQB6cBFeR4ajQwhBepHCQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "177f1887d4d4eb347c6a8328fbd8ca0f346887bc",
+        "rev": "45ef70cc73540fbf9718cce5da65e2aa6e7ab2f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`45ef70cc`](https://github.com/nix-community/home-manager/commit/45ef70cc73540fbf9718cce5da65e2aa6e7ab2f7) | `swayidle: remove unnecessary config wrapper` |
| [`43ea4c51`](https://github.com/nix-community/home-manager/commit/43ea4c5123d9d335ff4eba6341509d45f60ceeec) | `swayidle: fix systemd service`               |
| [`6311f4ad`](https://github.com/nix-community/home-manager/commit/6311f4adc39fc8ce77f7b80212024fe4286280d1) | `lib/types: make DAG entries mergeable`       |