### PR TITLE
chore(flake/emacs-overlay): `4d342a55` -> `eb9324be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657597199,
-        "narHash": "sha256-BCzHNKPDgiYF9gF52xFXvHi8qRzHkToL5XhtO/LJy7s=",
+        "lastModified": 1657621999,
+        "narHash": "sha256-LuG2kAxk+mT1to6Yox092Ahym6+6ShZfhJoknxlUcWc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4d342a55aa298e8ed5168be77c2262cf5fb8a0c4",
+        "rev": "eb9324be909d20ef724e939340a88bd9d7948be0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`eb9324be`](https://github.com/nix-community/emacs-overlay/commit/eb9324be909d20ef724e939340a88bd9d7948be0) | `Updated repos/melpa` |
| [`e39ac49c`](https://github.com/nix-community/emacs-overlay/commit/e39ac49c212dd5c6e92c26d0815141348d9b4368) | `Updated repos/emacs` |