### PR TITLE
chore(flake/nur): `7cfa5144` -> `0e576376`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657622484,
-        "narHash": "sha256-pZFyBD7OZqmfYHvqO+5OOoN9AOwDyrTotYtHulSdq34=",
+        "lastModified": 1657625990,
+        "narHash": "sha256-o3mvJ1ihYyWZus96FC9XYuSmoR1v61MlHnRZigzSZu4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7cfa51442f4a9ec4bc0f1efdd762dc5ce28c02eb",
+        "rev": "0e576376677b821c0ab1dbd5f37eeadd424c7f25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0e576376`](https://github.com/nix-community/NUR/commit/0e576376677b821c0ab1dbd5f37eeadd424c7f25) | `automatic update` |