### PR TITLE
chore(flake/nur): `be8deac0` -> `07e92e69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657650343,
-        "narHash": "sha256-mQZEu1kqvEtfvcGTeWsnD6PGDO47NTkB+YZsjmEh/mU=",
+        "lastModified": 1657655423,
+        "narHash": "sha256-i7VUCIl1UspOXULh/6oZ1UkzT27MyqGK1+NlLBXMZ78=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "be8deac05427027f4bf6c8a0744db288c574f5d6",
+        "rev": "07e92e699f45a488b9c4752536e70b5e5488ef19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`07e92e69`](https://github.com/nix-community/NUR/commit/07e92e699f45a488b9c4752536e70b5e5488ef19) | `automatic update` |