### PR TITLE
chore(flake/home-manager): `c5fc1575` -> `d4081057`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657653991,
-        "narHash": "sha256-yHOC388wkk1x5kIqOxbC48t867oK57XBKRnx60hh7dU=",
+        "lastModified": 1657658604,
+        "narHash": "sha256-w3C5KSenBBUpqdJV/BChtOsOLNTyKJXuj1j6oE4ewu8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c5fc157554e24a75cf4fb7a8827caa43f51df708",
+        "rev": "d4081057e56dee1a720b1eda5a84eef032715f05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`d4081057`](https://github.com/nix-community/home-manager/commit/d4081057e56dee1a720b1eda5a84eef032715f05) | `codeowners: cleanup alphabetization`       |
| [`b8bb5f29`](https://github.com/nix-community/home-manager/commit/b8bb5f291a4131e94b1a49b15d2735fcff581fa3) | `xdg-desktop-entries: allow icon path type` |