### PR TITLE
chore(flake/nur): `db82381e` -> `55d10be3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657659901,
-        "narHash": "sha256-gxRrR8By5MdaoUipGaTCR3o8i7dX5Y6RIhMrHadVK7A=",
+        "lastModified": 1657665222,
+        "narHash": "sha256-LVlS5T3fotp36nInatqN/c6nQ8SoijxF5tZjexa27/A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "db82381e14a8269df7b0c9ceb5397fe774f76878",
+        "rev": "55d10be33aa2a6a368b4d0de7efbc52e9f92d638",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`55d10be3`](https://github.com/nix-community/NUR/commit/55d10be33aa2a6a368b4d0de7efbc52e9f92d638) | `automatic update` |
| [`347f2250`](https://github.com/nix-community/NUR/commit/347f2250c68d9eb5fd76d2e8c204bc0acb6872bf) | `automatic update` |