### PR TITLE
chore(flake/nur): `55d10be3` -> `1aa0179f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657665222,
-        "narHash": "sha256-LVlS5T3fotp36nInatqN/c6nQ8SoijxF5tZjexa27/A=",
+        "lastModified": 1657682982,
+        "narHash": "sha256-UWDBU417lE0ppK64+spTAxotjIrw6ytRkZo4fSfGRY4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "55d10be33aa2a6a368b4d0de7efbc52e9f92d638",
+        "rev": "1aa0179fa09507a31b34d5de9c2fd4b85721e578",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1aa0179f`](https://github.com/nix-community/NUR/commit/1aa0179fa09507a31b34d5de9c2fd4b85721e578) | `automatic update` |