### PR TITLE
chore(flake/nur): `1aa0179f` -> `577f79b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657682982,
-        "narHash": "sha256-UWDBU417lE0ppK64+spTAxotjIrw6ytRkZo4fSfGRY4=",
+        "lastModified": 1657685249,
+        "narHash": "sha256-e+57W1KCOLli0z2SVxui0Gw46e094zW4WHS8s2JyNVo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1aa0179fa09507a31b34d5de9c2fd4b85721e578",
+        "rev": "577f79b8f7aa93b9c2097c718b1dcf5faf3f4037",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`577f79b8`](https://github.com/nix-community/NUR/commit/577f79b8f7aa93b9c2097c718b1dcf5faf3f4037) | `automatic update` |