### PR TITLE
chore(flake/nixpkgs): `5f43d8b0` -> `38860c9e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -297,11 +297,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657447684,
-        "narHash": "sha256-FCP9AuU1q6PE3vOeM5SFf58f/UKPBAsoSGDUGamNBbo=",
+        "lastModified": 1657533762,
+        "narHash": "sha256-/cxTFSMmpAb8tBp1yVga1fj+i8LB9aAxnMjYFpRMuVs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5f43d8b088d3771274bcfb69d3c7435b1121ac88",
+        "rev": "38860c9e91cb00f4d8cd19c7b4e36c45680c89b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                                                |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
| [`836daa7b`](https://github.com/NixOS/nixpkgs/commit/836daa7b457e18618ffd63978a265120bfda6204) | `loki: 2.5.0 -> 2.6.0`                                                                                                        |
| [`6bca1a64`](https://github.com/NixOS/nixpkgs/commit/6bca1a64167f539bef4294fe98fe880e963f4be4) | `rustdesk: 1.1.8 -> 1.1.9, fix`                                                                                               |
| [`3217a8b0`](https://github.com/NixOS/nixpkgs/commit/3217a8b0c25af95da14d73085ad6bacd5683bf5d) | `materia-kde-theme: 20210814 -> 20220607`                                                                                     |
| [`6de4f6b3`](https://github.com/NixOS/nixpkgs/commit/6de4f6b39fd26751bb096acd709ea30c645eab4e) | `digikam: 7.6.0 -> 7.7.0`                                                                                                     |
| [`8b788def`](https://github.com/NixOS/nixpkgs/commit/8b788def0fcd41438b6fbc173eca310592ac0bcd) | `kde/gear: 22.04.2 -> 22.04.3`                                                                                                |
| [`735e0d7f`](https://github.com/NixOS/nixpkgs/commit/735e0d7fa802f4b0a0c940dd1ccff8bc08a3cdc4) | `konversation: Remove maintainer`                                                                                             |
| [`0f72d3c8`](https://github.com/NixOS/nixpkgs/commit/0f72d3c8cc8e2328d3aa23bddae2616a206661d1) | `konversation: Update/move to KDE Gear`                                                                                       |
| [`3b12ce3d`](https://github.com/NixOS/nixpkgs/commit/3b12ce3da644b5d0d79491eea05406e79876b579) | `kde: sort apps alphabetically`                                                                                               |
| [`292eed75`](https://github.com/NixOS/nixpkgs/commit/292eed7510bb8ecb70696a15b1299bc983d2cfa3) | `gtkterm: 1.1.1 -> 1.2.1`                                                                                                     |
| [`afd8c1ca`](https://github.com/NixOS/nixpkgs/commit/afd8c1ca500e79d77bc2edc15c77a901093f1a2d) | `linuxPackages.nvidia_x11: fix build failure due to wrong install args`                                                       |
| [`8cae924b`](https://github.com/NixOS/nixpkgs/commit/8cae924bc20ed6155d633caf73caa67c7fb32e3f) | `croc: 9.5.6 -> 9.6.0`                                                                                                        |
| [`03a10be9`](https://github.com/NixOS/nixpkgs/commit/03a10be9721cc30f5eb65f11f7aeb2e4390ba99c) | `python310Packages.google-cloud-datastore: 2.7.1 -> 2.7.2`                                                                    |
| [`509a3cb0`](https://github.com/NixOS/nixpkgs/commit/509a3cb0ad5c42bc9eb15b7bc2f8c1ccd478d916) | `libsolv: enable more compression methods`                                                                                    |
| [`9c52a623`](https://github.com/NixOS/nixpkgs/commit/9c52a623fc5a11fbe56f352b2b271da983ddc23f) | `audacious: 4.1 -> 4.2`                                                                                                       |
| [`ff9bfb09`](https://github.com/NixOS/nixpkgs/commit/ff9bfb09093c6e54af91e6913748f72fff04f3dd) | `godns: 2.8.1 -> 2.8.3`                                                                                                       |
| [`bdf1c0e9`](https://github.com/NixOS/nixpkgs/commit/bdf1c0e9b97ed802e947be4780a80c8ec05e91e4) | `home-assistant: 2022.7.2 -> 2022.7.3`                                                                                        |
| [`78f24da8`](https://github.com/NixOS/nixpkgs/commit/78f24da88629e35636289f3f803a9116e79d2bda) | `python3Packages.regenmaschine: 2022.07.0 -> 2022.07.1`                                                                       |
| [`cc2fead1`](https://github.com/NixOS/nixpkgs/commit/cc2fead11e8135894b2a328db3eebfade7c3b7a8) | `python3Packages.pysml: 0.0.7 -> 0.0.8`                                                                                       |
| [`386142c2`](https://github.com/NixOS/nixpkgs/commit/386142c24dce30d7cc94429bac4caf5f433c49a5) | `python3Packages.afsapi: 0.2.4 -> 0.2.5`                                                                                      |
| [`341b9564`](https://github.com/NixOS/nixpkgs/commit/341b9564bb7d9f69b9e804d956680c8d2ebf61b2) | `vimUtils: remove vam support`                                                                                                |
| [`98ac43a1`](https://github.com/NixOS/nixpkgs/commit/98ac43a1cf689ecabe448489b5505107ee893ce9) | `zrepl: add package option to module (#179189)`                                                                               |
| [`60d0de8a`](https://github.com/NixOS/nixpkgs/commit/60d0de8a48b3f1f45d1881079348d506039c5f10) | `ocamlPackages.erm_xmpp: 0.3+20200317 → 0.3+20220404`                                                                         |
| [`c6fa85ef`](https://github.com/NixOS/nixpkgs/commit/c6fa85eff3f68acc4bc3ae3440184216e8d422ff) | `ipfs: 0.13.0 -> 0.13.1`                                                                                                      |
| [`631a2bdd`](https://github.com/NixOS/nixpkgs/commit/631a2bddfcef74ba71ddcff9197299723fa73811) | `nixos/tests/ipfs: disable FUSE test`                                                                                         |
| [`7ff7f666`](https://github.com/NixOS/nixpkgs/commit/7ff7f6664328a8ce9f4c5f68f21d63d48247516d) | `ipfs: use passthru for repoVersion`                                                                                          |
| [`0511ecea`](https://github.com/NixOS/nixpkgs/commit/0511eceae6d9cecc8b28f72650f44aa6946650a1) | `ferium: Update description and homepage`                                                                                     |
| [`22201396`](https://github.com/NixOS/nixpkgs/commit/22201396c911e9dac287a49463d6cc824a3c0ef0) | `etcher: 1.7.3 -> 1.7.9`                                                                                                      |
| [`d921864b`](https://github.com/NixOS/nixpkgs/commit/d921864be3076cdd20c4bca546da0852b0114e60) | `python310Packages.softlayer: 5.9.9 -> 6.1.0`                                                                                 |
| [`d747f799`](https://github.com/NixOS/nixpkgs/commit/d747f7993879edf21f789778e17aa8902ed8e2b8) | `termusic: 0.6.16 -> 0.6.17`                                                                                                  |
| [`3ea8ed7d`](https://github.com/NixOS/nixpkgs/commit/3ea8ed7d7e3fcba3d8e9286175077544c6f5faf9) | `Split out CoqIDE by default when Coq >= 8.14.`                                                                               |
| [`49548cac`](https://github.com/NixOS/nixpkgs/commit/49548cace627e0ac5dbfda31c5100f669c27324d) | `ocamlformat_0_23_0: init`                                                                                                    |
| [`825e91fc`](https://github.com/NixOS/nixpkgs/commit/825e91fc33e816a4da1794f5e5c65cd01df91617) | `sqlite: make package options slightly more obvious`                                                                          |
| [`5ef90871`](https://github.com/NixOS/nixpkgs/commit/5ef908713a80136f53ceaa42d5730fdf0e294d3f) | `libhandy: fix updateScript versionPolicy`                                                                                    |
| [`1e8ca70a`](https://github.com/NixOS/nixpkgs/commit/1e8ca70a0a18bec6650356647f61dcf3b1bfbfc5) | `libhandy: 1.6.2 → 1.6.3`                                                                                                     |
| [`b0c5f3dd`](https://github.com/NixOS/nixpkgs/commit/b0c5f3dd4c186fd630336b8cf171ff06b58ed65c) | `dhall-grafana: Update dhall-grafana version`                                                                                 |
| [`429fc9aa`](https://github.com/NixOS/nixpkgs/commit/429fc9aaf74ac1bbdaaf8d561d736d536a06a5ef) | `nixos/hedgedoc: convert to settings-style configuration`                                                                     |
| [`dd899b3c`](https://github.com/NixOS/nixpkgs/commit/dd899b3c745b5d046f3ed21382638d614551edee) | `libadwaita: 1.1.2 -> 1.1.3`                                                                                                  |
| [`34aa4fe7`](https://github.com/NixOS/nixpkgs/commit/34aa4fe7a9b48c7e81c56f6f3f758726c619cf80) | `raspberrypi-bootloader: Update doc URL for config.txt options`                                                               |
| [`cd8baca3`](https://github.com/NixOS/nixpkgs/commit/cd8baca3bcbca45390d9da2e0603845c2e666243) | `python310Packages.aiomusiccast: 0.14.4 -> 0.14.5`                                                                            |
| [`5f42ffd1`](https://github.com/NixOS/nixpkgs/commit/5f42ffd1bcba535f4df44d73278c0a9e14c5c836) | `python310Packages.aioaladdinconnect: 0.1.20 -> 0.1.21`                                                                       |
| [`4af3088e`](https://github.com/NixOS/nixpkgs/commit/4af3088e43ca1bf251e6530ea1eabd45b4e732b5) | `hwatch: 0.3.6 -> 0.3.7`                                                                                                      |
| [`ef26741e`](https://github.com/NixOS/nixpkgs/commit/ef26741ec00ca7ebd8474da0e688fb2a63456a6f) | `jadx: 1.3.5 -> 1.4.2`                                                                                                        |
| [`94d47519`](https://github.com/NixOS/nixpkgs/commit/94d47519c0f5eb66ba37daea551be7ac2d9bda01) | `python310Packages.rokuecp: 0.16.0 -> 0.17.0`                                                                                 |
| [`188c6197`](https://github.com/NixOS/nixpkgs/commit/188c6197767a844a9359d7aaed06a0bf4225160e) | `python310Packages.pyialarm: 1.9.0 -> 2.0.0`                                                                                  |
| [`af480a0f`](https://github.com/NixOS/nixpkgs/commit/af480a0ff3765c2d76bd44201cec7a1498a340fc) | `home-assistant: update component-packages`                                                                                   |
| [`6089b88a`](https://github.com/NixOS/nixpkgs/commit/6089b88a23a30f43f79d3105ae47f4201c9555e3) | `python310Packages.aioaladdinconnect: init 0.1.20`                                                                            |
| [`53e959f2`](https://github.com/NixOS/nixpkgs/commit/53e959f2958e25f11dca830c735f0325a09dd93f) | `tdlib-purple: init at 0.8.1`                                                                                                 |
| [`1f18d441`](https://github.com/NixOS/nixpkgs/commit/1f18d441063208968f38bed0fe5ddbcdb8f6cf34) | `python3.pkgs.graphite_api: remove`                                                                                           |
| [`9f2c9166`](https://github.com/NixOS/nixpkgs/commit/9f2c91667dd687fef9b92b2b5b04c610e94bf907) | `python3.pkgs.influxgraph: remove`                                                                                            |
| [`99ebc20c`](https://github.com/NixOS/nixpkgs/commit/99ebc20c1ec7e7e96f85d6354a2e1162074d3def) | `telegram-purple: remove`                                                                                                     |
| [`30874a7b`](https://github.com/NixOS/nixpkgs/commit/30874a7b94041cc3bd747af38f4ea2153ea1c32e) | `elmPackages: semi-automatic update of nodejs packages`                                                                       |
| [`03265554`](https://github.com/NixOS/nixpkgs/commit/032655547ad188e054f8a7c3a4b779df0f9abf32) | `notepad-next: 0.5.2 -> 0.5.3`                                                                                                |
| [`ada1d877`](https://github.com/NixOS/nixpkgs/commit/ada1d87767b8826ea6233952279a1d6c77784bc0) | `python3.pkgs.graphite_beacon: remove`                                                                                        |
| [`accc93f1`](https://github.com/NixOS/nixpkgs/commit/accc93f1dc7a5d0863601f40fba19b5303e06042) | `home-assistant: update component-packages`                                                                                   |
| [`9ac4852b`](https://github.com/NixOS/nixpkgs/commit/9ac4852b3d281e2800d80d4e08c256b8ce2cf4a0) | `python310Packages.aio-geojson-usgs-earthquakes: init at 0.1`                                                                 |
| [`b3db8355`](https://github.com/NixOS/nixpkgs/commit/b3db8355ca23aa716da5bb0b3e1785cf0af2e0b4) | `papirus-icon-theme: 20220606 -> 20220710`                                                                                    |
| [`ce2e4707`](https://github.com/NixOS/nixpkgs/commit/ce2e4707b782657e077a0ef072cbd67756cae673) | `hardware/nvidia: add @ to constraint on busIDType`                                                                           |
| [`ed2b3201`](https://github.com/NixOS/nixpkgs/commit/ed2b3201768ff0050fb60b30b4887db05f48657b) | `boofuzz: fix build on darwin`                                                                                                |
| [`09ae560c`](https://github.com/NixOS/nixpkgs/commit/09ae560c929b4f119dfaf7fabdf94057f8721c4c) | `sigal: fix build on darwin`                                                                                                  |
| [`f170b3ae`](https://github.com/NixOS/nixpkgs/commit/f170b3aebcf2ed764e75869c98259a7bdd4bdf0d) | `coan: fix build on darwin`                                                                                                   |
| [`3239a053`](https://github.com/NixOS/nixpkgs/commit/3239a0535787625e036af8f59a45a5fe689ff4ca) | `untrunc-anthwlock: refactor build`                                                                                           |
| [`cf88ead8`](https://github.com/NixOS/nixpkgs/commit/cf88ead89d554904e2b29aef73df98d9bd336523) | `untrunc-anthwlock: mark as unbroken on darwin`                                                                               |
| [`c39770ec`](https://github.com/NixOS/nixpkgs/commit/c39770ecc5468a54aeaafb941ca0a055788fc6aa) | `libui: fix typo when installing libs on darwin`                                                                              |
| [`6375863e`](https://github.com/NixOS/nixpkgs/commit/6375863e93c634e3821b1e1781fd6e939abd0034) | `mpd-discord-rpc: fix build on darwin`                                                                                        |
| [`bc776c4d`](https://github.com/NixOS/nixpkgs/commit/bc776c4d36fb20a80b0099bd616285e345ddf6dc) | `dotenv-linter: fix build on darwin`                                                                                          |
| [`fdfd961e`](https://github.com/NixOS/nixpkgs/commit/fdfd961ee15caf176a6278f10c31ad0e0534f3d9) | `gaw: mark as Linux-only`                                                                                                     |
| [`8211c55e`](https://github.com/NixOS/nixpkgs/commit/8211c55ec20824602f43a1c8aeba9dd7d413e6c3) | `sdnotify-wrapper: mark as Linux-only`                                                                                        |
| [`3d1e82b6`](https://github.com/NixOS/nixpkgs/commit/3d1e82b6cee04d5f5298c3063910b0870783e93b) | `traitor: mark as Linux-only`                                                                                                 |
| [`27fcfa31`](https://github.com/NixOS/nixpkgs/commit/27fcfa314f921058844ec4029522f643086a7d11) | `ventoy-bin: 1.0.77 -> 1.0.78`                                                                                                |
| [`e212af64`](https://github.com/NixOS/nixpkgs/commit/e212af64e8b4966215b012b58ab42b24ae31db82) | `magic-wormhole-rs: mark as unbroken on darwin`                                                                               |
| [`9df44cc5`](https://github.com/NixOS/nixpkgs/commit/9df44cc54023fa59258fc68b17d3061b1aae516b) | `ginac: mark as unbroken on darwin`                                                                                           |
| [`84f32ec9`](https://github.com/NixOS/nixpkgs/commit/84f32ec938db1aa5427e366107116a0e21b16207) | `dieharder: mark as unbroken on darwin`                                                                                       |
| [`6978b3da`](https://github.com/NixOS/nixpkgs/commit/6978b3da7b2a4bba5d8192de244e1313d301b347) | `binwalk: mark as unbroken on darwin`                                                                                         |
| [`38dc7696`](https://github.com/NixOS/nixpkgs/commit/38dc7696b6d17b9d8e833e7439d1609c30c0e7d1) | `cod: disable tests`                                                                                                          |
| [`ad36639f`](https://github.com/NixOS/nixpkgs/commit/ad36639f4759e607cc5e51f7e03f3b279d23eaed) | `trackma: fix bug with qt option`                                                                                             |
| [`70896ec8`](https://github.com/NixOS/nixpkgs/commit/70896ec8711c3b97208118bf3d0346d07e225544) | `ungoogled-chromium: 103.0.5060.53 -> 103.0.5060.114`                                                                         |
| [`8f00857b`](https://github.com/NixOS/nixpkgs/commit/8f00857bf94b1bd4027e7de8ae213a5f5d392cc4) | `pkgsMusl.gcc12: backport build fix (PR106102)`                                                                               |
| [`c069cea5`](https://github.com/NixOS/nixpkgs/commit/c069cea5215dd56c04f1587c477f445161ac0a47) | `roon-server: 1.8-970 -> 1.8-988`                                                                                             |
| [`661c7887`](https://github.com/NixOS/nixpkgs/commit/661c78879f026922596d052e04542e7b8147b668) | `dapr-cli: 1.7.1 -> 1.8.0`                                                                                                    |
| [`78a851db`](https://github.com/NixOS/nixpkgs/commit/78a851dbf3ea920049f5a15a3d3c1e8a2eda23aa) | `hqplayerd: 4.31.0 -> 4.32.2`                                                                                                 |
| [`b3a0a45f`](https://github.com/NixOS/nixpkgs/commit/b3a0a45f9efe4ed10c426d75860ec1cc770b8118) | `fastlane: 2.206.2 -> 2.207.0`                                                                                                |
| [`0f77809f`](https://github.com/NixOS/nixpkgs/commit/0f77809f6e45efed9dd6c22bfa98e108c69cf228) | `odyssey: 1.2 -> 1.3`                                                                                                         |
| [`4fe81e17`](https://github.com/NixOS/nixpkgs/commit/4fe81e170d33b62b989693fa788386a870b29940) | `vale: 2.18.0 -> 2.20.0`                                                                                                      |
| [`4578f699`](https://github.com/NixOS/nixpkgs/commit/4578f6997d035a88bda8d515a1599f15f84601f9) | `python310Packages.unidiff: 0.7.3 -> 0.7.4`                                                                                   |
| [`47f9f047`](https://github.com/NixOS/nixpkgs/commit/47f9f047883996aa54defa9cda7ccd7e04df7901) | `linux-kernel config: disable DEBUG_INFO_REDUCED`                                                                             |
| [`478940e2`](https://github.com/NixOS/nixpkgs/commit/478940e2c7cfc1d21418e4e78c81734636b9a190) | `librewolf: add nixos test`                                                                                                   |
| [`d64ee0ff`](https://github.com/NixOS/nixpkgs/commit/d64ee0ff26da38a6f5cd8fe9f97348f45124b097) | `kotlin-native: 1.7.0 → 1.7.10`                                                                                               |
| [`7e4e497c`](https://github.com/NixOS/nixpkgs/commit/7e4e497c43b592557d9b19766493a33d499bd838) | `kotlin: 1.7.0 → 1.7.10`                                                                                                      |
| [`03dd01dd`](https://github.com/NixOS/nixpkgs/commit/03dd01dd2fbba721f9f1a4c757e55cf2c6e15345) | `nixos: add module for tempo`                                                                                                 |
| [`0996a97b`](https://github.com/NixOS/nixpkgs/commit/0996a97b916a50d584cb5dd5de9a5769b38160ec) | `androidStudioPackages.canary: 2021.3.1.9 → 2022.1.1.8`                                                                       |
| [`ad3e3536`](https://github.com/NixOS/nixpkgs/commit/ad3e35365ad2a47259e0e697811a368b3eae9fd1) | `androidStudioPackages.beta: 2021.2.1.11 → 2022.3.1.14`                                                                       |
| [`987b20bf`](https://github.com/NixOS/nixpkgs/commit/987b20bfe9c7cd6faab22976124d61431ff91a01) | `androidStudioPackages.stable: 2021.2.1.14 → 2021.2.1.15`                                                                     |
| [`a14da86f`](https://github.com/NixOS/nixpkgs/commit/a14da86f2cfe5038ed84d3db5663c5138839fa97) | `nixosTests.hardened: fix for recent Nix`                                                                                     |
| [`d440cc93`](https://github.com/NixOS/nixpkgs/commit/d440cc931eea01c3237a9a470c9dc1a695684988) | `nixosTests.hardened: disable dhcpcd privsep`                                                                                 |
| [`cb52964d`](https://github.com/NixOS/nixpkgs/commit/cb52964d77b610b6a89b383473605a2ef6baf44e) | `gef: 2022.01 -> 2022.06`                                                                                                     |
| [`4a05028c`](https://github.com/NixOS/nixpkgs/commit/4a05028cd674b710b3912bea43b43cfc584e7601) | `python310Packages.swift: install man pages`                                                                                  |
| [`e9fe7c8a`](https://github.com/NixOS/nixpkgs/commit/e9fe7c8aab9d5401104bf3664d5cfcb8c8c2cae5) | `python310Packages.python-swiftclient: fix lazy bash-completion loading when loaded through XDG_DATA_DIRS, install man pages` |
| [`c2458eb1`](https://github.com/NixOS/nixpkgs/commit/c2458eb1ae256931387ec53f3fcb6c7afbb7cb64) | `zabbix-cli: 2.2.1 -> 2.3.0`                                                                                                  |
| [`bf67d1e0`](https://github.com/NixOS/nixpkgs/commit/bf67d1e09d0192646de77f3182d86984a34a6bcb) | `git-extras: fix lazy bash-completion loading when loaded through XDG_DATA_DIRS`                                              |
| [`bc41a593`](https://github.com/NixOS/nixpkgs/commit/bc41a593a5ce8f06dca53ca17010456c1c12d50d) | `singular: 4.3.0 -> 4.3.1`                                                                                                    |
| [`8bf5c1d4`](https://github.com/NixOS/nixpkgs/commit/8bf5c1d44c4de0db533272ab5c8f5be37e6de011) | `carp: 0.5.4 -> 0.5.5`                                                                                                        |
| [`de230234`](https://github.com/NixOS/nixpkgs/commit/de230234380bcb1c9c3da8837f055dc75c9267a8) | `cargo-binutils: 0.3.3 -> 0.3.6`                                                                                              |
| [`9280eff2`](https://github.com/NixOS/nixpkgs/commit/9280eff26434a788eeb1dfffaa6eb5b937037507) | `arc-kde-theme: 20180614 -> 20220706`                                                                                         |
| [`19a442aa`](https://github.com/NixOS/nixpkgs/commit/19a442aae7cb5c3b2d59d53570f042fc3a40c6c0) | `discordchatexporter-cli: 2.34.1 -> 2.35`                                                                                     |
| [`ea7269cd`](https://github.com/NixOS/nixpkgs/commit/ea7269cd0e00ebab2fe123185c1c4706195af9d6) | `cargo-udeps: 0.1.27 -> 0.1.30`                                                                                               |
| [`b1cb8f33`](https://github.com/NixOS/nixpkgs/commit/b1cb8f33f72a43025d85ef341cab36429f4de478) | `roundcube: 1.5.2 -> 1.5.3`                                                                                                   |
| [`90761632`](https://github.com/NixOS/nixpkgs/commit/90761632aebd1f3fc0b82524fba2b846b959eaac) | `nixos/hydra: use runuser like hydra flake`                                                                                   |
| [`f76d71f9`](https://github.com/NixOS/nixpkgs/commit/f76d71f98f8b070f638a9ce8df3ec923deb7fd28) | `darwin.network_cmds:: pin to libressl 3.4`                                                                                   |
| [`957bc348`](https://github.com/NixOS/nixpkgs/commit/957bc34894420d0c22d792eb4a64f5fbfc7ed302) | `cargo-nextest: 0.9.22 -> 0.9.24`                                                                                             |
| [`c318f375`](https://github.com/NixOS/nixpkgs/commit/c318f3753961d92f1b9f8afbc5561e3b3a9d6a48) | `cargo-tally: 1.0.5 -> 1.0.8`                                                                                                 |
| [`53e73b96`](https://github.com/NixOS/nixpkgs/commit/53e73b96212f8f42cbea6bd16fbaa7e27d6c63e1) | `bfs: 2.6 -> 2.6.1`                                                                                                           |
| [`b376d600`](https://github.com/NixOS/nixpkgs/commit/b376d600e63e067c6c149572e6a3877ac58361f1) | `argocd-autopilot: 0.3.7 -> 0.3.9`                                                                                            |
| [`610e5783`](https://github.com/NixOS/nixpkgs/commit/610e5783d007784bb9c7780969b406636099a1ae) | `wasm-pack: pin to libressl 3.4`                                                                                              |
| [`2d11af56`](https://github.com/NixOS/nixpkgs/commit/2d11af56f53c0ff99b3a823407554bb612a3546e) | `ovftool: pin to libressl 3.4`                                                                                                |
| [`6f964225`](https://github.com/NixOS/nixpkgs/commit/6f96422524210531cbb5261ab931e43c641ea5bf) | `fdbPackages: pin to libressl 3.4`                                                                                            |
| [`9b62e0e7`](https://github.com/NixOS/nixpkgs/commit/9b62e0e7b187b96f07133cb72bedc3a1365f3752) | `acme-client: pin to libressl 3.4`                                                                                            |
| [`59aa7936`](https://github.com/NixOS/nixpkgs/commit/59aa793664dc5c036bbfaaa309e09f300964f11e) | `libressl: switch default to 3.5`                                                                                             |
| [`a07161dd`](https://github.com/NixOS/nixpkgs/commit/a07161dd739bf4c6d65e51bf25151e528bfedb48) | `libressl: 3.5.2 -> 3.5.3`                                                                                                    |
| [`1a28fca8`](https://github.com/NixOS/nixpkgs/commit/1a28fca817d81896f00f5064e76e8f363dbb05cb) | `difftastic: 0.29.1 -> 0.30.0`                                                                                                |
| [`4d6eacab`](https://github.com/NixOS/nixpkgs/commit/4d6eacab55e0afef2ed16a6ca05302b46b1e3caf) | `canon-cups-ufr2: fix libdir pointing to bindir, little format`                                                               |
| [`b3aee32a`](https://github.com/NixOS/nixpkgs/commit/b3aee32add2396c1521b83b5c6c92e4c53108bcc) | `hdf5_1_10: 1.10.6 -> 1.10.9`                                                                                                 |
| [`dcc323e1`](https://github.com/NixOS/nixpkgs/commit/dcc323e1f181f670904185a08b791f27991c6dea) | `python3Packages.humanize: 4.1.0 -> 4.2.3`                                                                                    |
| [`228c2d6c`](https://github.com/NixOS/nixpkgs/commit/228c2d6c1c3e7f76a630ba1c7fb69d09c3227c27) | `python3Packages.humanize: include generated translations`                                                                    |
| [`d1dcbade`](https://github.com/NixOS/nixpkgs/commit/d1dcbade3dbe4ed018c8f25d58c8e02b282d1348) | `python3Packages.humanize: add Luflosi as maintainer`                                                                         |
| [`7b5ee6d9`](https://github.com/NixOS/nixpkgs/commit/7b5ee6d9275a26fdbcdbfc169cddab4d4a1d098a) | `python3Packages.afdko: 3.8.3 -> 3.9.0`                                                                                       |
| [`160aaf5d`](https://github.com/NixOS/nixpkgs/commit/160aaf5dd3a74d708e8a1478e98835c38f7ca8cc) | `nvidia-driver: Install windows libraries needed by Proton to support DLSS`                                                   |
| [`7d32b083`](https://github.com/NixOS/nixpkgs/commit/7d32b083ff3c6411c40172750c99d8340f112ad8) | `ntfy-sh: 1.26.0 -> 1.27.2`                                                                                                   |
| [`e2610640`](https://github.com/NixOS/nixpkgs/commit/e2610640c424eb95b3a40f5a3f2908441ef19c58) | `nixos/release.nix: fixed commands in comment`                                                                                |
| [`4af5c46f`](https://github.com/NixOS/nixpkgs/commit/4af5c46faa589c0fa1142cc59b83fd97a9e5a3ba) | ``nixos/dhcpcd: use `networking.resolvconf.package```                                                                         |
| [`953a5bd3`](https://github.com/NixOS/nixpkgs/commit/953a5bd3dd3c527d6549592e0b7dbb96d5999bc2) | ``nixos/tailscale: use `networking.resolvconf.package```                                                                      |
| [`458ac47a`](https://github.com/NixOS/nixpkgs/commit/458ac47a1d5491dfb610cb8faaffcf5d5445b224) | `nixos/wg-quick: improve usage with systemd-networkd`                                                                         |
| [`fd662e5c`](https://github.com/NixOS/nixpkgs/commit/fd662e5c4657f451d1fa534fccdc61aebba841ca) | `wireguard-tools: use resolvconf from PATH if available`                                                                      |
| [`203696f0`](https://github.com/NixOS/nixpkgs/commit/203696f098d3041b0fc97a0b8358a703de6f0672) | ``nixos/resolvconf: add `package```                                                                                           |
| [`c29a4892`](https://github.com/NixOS/nixpkgs/commit/c29a4892723e6ca61c5425cbce714bb89384e0b5) | `tempo: 1.1.0 -> 1.4.1`                                                                                                       |
| [`6b9080d3`](https://github.com/NixOS/nixpkgs/commit/6b9080d336945a00344b1ec20ce8bc6e1122d28b) | `innernet: only package systemd units for linux`                                                                              |
| [`31c82b62`](https://github.com/NixOS/nixpkgs/commit/31c82b62ff71115d93e5d71279229235d8f6099f) | `innernet: package systemd units`                                                                                             |
| [`e5b24e6d`](https://github.com/NixOS/nixpkgs/commit/e5b24e6da2b638a4519ba2cda380cfe8d47c2ba2) | `nixos/prometheus-node-exporter: do not protect home`                                                                         |