### PR TITLE
chore(flake/nur): `577f79b8` -> `554d4b62`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657685249,
-        "narHash": "sha256-e+57W1KCOLli0z2SVxui0Gw46e094zW4WHS8s2JyNVo=",
+        "lastModified": 1657693724,
+        "narHash": "sha256-CeeY5bLESLoTxEL0B2PvBrF3TYq00NHEjg3UbXv9e7w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "577f79b8f7aa93b9c2097c718b1dcf5faf3f4037",
+        "rev": "554d4b625f0c47ade4b9d67a5231e5b0646c803c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`554d4b62`](https://github.com/nix-community/NUR/commit/554d4b625f0c47ade4b9d67a5231e5b0646c803c) | `automatic update` |