### PR TITLE
chore(flake/emacs-overlay): `3ae151f2` -> `edd30ea6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657683083,
-        "narHash": "sha256-yZMhg3NqMgPGlP1ETNmcky5Lj3oTQc2Q3UQlo+1vpiQ=",
+        "lastModified": 1657707968,
+        "narHash": "sha256-qM/0yuugK31yy+ZJcTVuWNYk4ifTjY8co8iRg3my0sM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3ae151f2e68bfb663d44e27c9670b3b3171c6f84",
+        "rev": "edd30ea6e6daae76cf05a1f2b52aed19ba5b5a69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`edd30ea6`](https://github.com/nix-community/emacs-overlay/commit/edd30ea6e6daae76cf05a1f2b52aed19ba5b5a69) | `Updated repos/melpa` |
| [`7c84781e`](https://github.com/nix-community/emacs-overlay/commit/7c84781eb79f2da436850f8b24da0f7c3a13f72c) | `Updated repos/emacs` |