### PR TITLE
chore(flake/home-manager): `241a375f` -> `66d7007e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657715752,
-        "narHash": "sha256-eCEG1rGFeYLWcdCQg11k5ALNT5NsWBYLaja+ZMj8fCU=",
+        "lastModified": 1657716766,
+        "narHash": "sha256-3+fKcZvCiUSUoZGCbBmspztcSVPHsFM3b/wKcaM7PiA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "241a375f49737a64300dcee35d6566837d27ef93",
+        "rev": "66d7007e4354e7c19257e0b4fc576f61fde2e1e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                           |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`66d7007e`](https://github.com/nix-community/home-manager/commit/66d7007e4354e7c19257e0b4fc576f61fde2e1e0) | `mpv: prohibit string values in scripts` |