### PR TITLE
chore(flake/emacs-ement): `6f2162a6` -> `4b7d925b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1657555617,
-        "narHash": "sha256-dktkfD2s3hQRTyKJp/H8q8yaOtWDC1Aerkub646GLI8=",
+        "lastModified": 1657718146,
+        "narHash": "sha256-JZkUGdExzwdC6yMSWdSJKcDu68GOSIV/qUrCFIs09KA=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "6f2162a6f1e67bf7736aae43232ff8292be0ef6d",
+        "rev": "4b7d925bab55366548894386ccf5c05748132ff3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                         |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`4b7d925b`](https://github.com/alphapapa/ement.el/commit/4b7d925bab55366548894386ccf5c05748132ff3) | `Fix: (ement-room--format-member-event) Events with empty displayname` |
| [`b0580a96`](https://github.com/alphapapa/ement.el/commit/b0580a964d740e609900b3a30a196dc98a22fe2e) | `Tidy: (ement-room--format-member-event)`                              |