### PR TITLE
chore(flake/nur): `554d4b62` -> `c49903a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657693724,
-        "narHash": "sha256-CeeY5bLESLoTxEL0B2PvBrF3TYq00NHEjg3UbXv9e7w=",
+        "lastModified": 1657719756,
+        "narHash": "sha256-ZA04w2ltuvTBWs+hZwG3fKDBnS1OV4sNjluepMdgh6o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "554d4b625f0c47ade4b9d67a5231e5b0646c803c",
+        "rev": "c49903a30b5238557f5d6e9b2d074d786c93482e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c49903a3`](https://github.com/nix-community/NUR/commit/c49903a30b5238557f5d6e9b2d074d786c93482e) | `automatic update` |
| [`c218fe39`](https://github.com/nix-community/NUR/commit/c218fe39baedf0b1478673ba355347580489467b) | `automatic update` |