### PR TITLE
chore(flake/home-manager): `66d7007e` -> `2c94b980`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657716766,
-        "narHash": "sha256-3+fKcZvCiUSUoZGCbBmspztcSVPHsFM3b/wKcaM7PiA=",
+        "lastModified": 1657719085,
+        "narHash": "sha256-nQt3MEBwKuKlmFKSRhdoh60AGlc+YlspV5e8kO/3y8U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "66d7007e4354e7c19257e0b4fc576f61fde2e1e0",
+        "rev": "2c94b9801f1a11cde0fc97aa850687bb9137d42c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message          |
| ----------------------------------------------------------------------------------------------------------- | ----------------------- |
| [`2c94b980`](https://github.com/nix-community/home-manager/commit/2c94b9801f1a11cde0fc97aa850687bb9137d42c) | `librewolf: add module` |