### PR TITLE
chore(flake/emacs-ement): `5e66aa24` -> `0eec0073`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1657721188,
-        "narHash": "sha256-KzfzC5ecfja61Dkg7bHBYRQ/K+Sy9KNHnbM6Jgu7cIY=",
+        "lastModified": 1657724755,
+        "narHash": "sha256-dhMWXOfbY0zMCOjrK1h9BCgSFSTcgKuGMphYSqtIzg0=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "5e66aa244d1a8bff400e9338fa00c23b2191ed2b",
+        "rev": "0eec00733b905cfe37a7a64e9188bdd9b82c497c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                      |
| --------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`0eec0073`](https://github.com/alphapapa/ement.el/commit/0eec00733b905cfe37a7a64e9188bdd9b82c497c) | `Fix: (ement-room--format-message)` |