### PR TITLE
chore(flake/emacs-overlay): `edd30ea6` -> `6608997a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657707968,
-        "narHash": "sha256-qM/0yuugK31yy+ZJcTVuWNYk4ifTjY8co8iRg3my0sM=",
+        "lastModified": 1657739074,
+        "narHash": "sha256-s7qlR7HyMrbDywk5RAJQ/YEXaMqcePSq9oOdYlUpCSA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "edd30ea6e6daae76cf05a1f2b52aed19ba5b5a69",
+        "rev": "6608997ad0224f59cae68b0c9db0eeb8c4c32e8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`6608997a`](https://github.com/nix-community/emacs-overlay/commit/6608997ad0224f59cae68b0c9db0eeb8c4c32e8f) | `Updated repos/melpa` |
| [`41a6914c`](https://github.com/nix-community/emacs-overlay/commit/41a6914c819a0d44f1e86c75b0ffe92429a5f2f2) | `Updated repos/emacs` |
| [`38ae9f74`](https://github.com/nix-community/emacs-overlay/commit/38ae9f744b4c3fbb61e506f04c6d4dd7f0b04579) | `Updated repos/elpa`  |