### PR TITLE
chore(flake/nur): `6d1d40a3` -> `245a352b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657726503,
-        "narHash": "sha256-P1kAXenuRck+WqAN1mmGtUpMRImAsVYJgZqW4bQH6SA=",
+        "lastModified": 1657743116,
+        "narHash": "sha256-yq1524ASbaPB9rP7AKY6lbqI/Dl9T0l6AW8Y70kRw9c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6d1d40a31d2328013c4973b56e08bb98d3f9d872",
+        "rev": "245a352bf49508ff2d29bc083b95172c5c59b5fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`245a352b`](https://github.com/nix-community/NUR/commit/245a352bf49508ff2d29bc083b95172c5c59b5fb) | `automatic update` |