### PR TITLE
chore(flake/nur): `0781de51` -> `852ca3d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657743784,
-        "narHash": "sha256-zZqvqo0m3Vs2TBTFJN9Jrw3weDIml5NiW9qa1821jw8=",
+        "lastModified": 1657761588,
+        "narHash": "sha256-XfspTpkIqZnG8wnNRz2Q7z2D38PbgQf0k01kLmwDJTA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0781de51eda86a9556aa36a8dd1d63615ecf5787",
+        "rev": "852ca3d67f7d67d276a0491b3a9bff8d86e17055",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`852ca3d6`](https://github.com/nix-community/NUR/commit/852ca3d67f7d67d276a0491b3a9bff8d86e17055) | `automatic update` |