### PR TITLE
chore(flake/nur): `852ca3d6` -> `abafb484`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657761588,
-        "narHash": "sha256-XfspTpkIqZnG8wnNRz2Q7z2D38PbgQf0k01kLmwDJTA=",
+        "lastModified": 1657762357,
+        "narHash": "sha256-BGLluF6LdiYBHGS0zjPKK5xETmAozbMW+5CpqTX40x8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "852ca3d67f7d67d276a0491b3a9bff8d86e17055",
+        "rev": "abafb484abe5424d17ed55912fbf4d43bd8e6353",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`abafb484`](https://github.com/nix-community/NUR/commit/abafb484abe5424d17ed55912fbf4d43bd8e6353) | `automatic update` |