### PR TITLE
chore(flake/emacs-overlay): `6608997a` -> `27297eec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657739074,
-        "narHash": "sha256-s7qlR7HyMrbDywk5RAJQ/YEXaMqcePSq9oOdYlUpCSA=",
+        "lastModified": 1657769861,
+        "narHash": "sha256-id1oLAYQpaezrNHj7/2s/XPcaXftPbtiaHHIEywpCi4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6608997ad0224f59cae68b0c9db0eeb8c4c32e8f",
+        "rev": "27297eece41ecca4b26cd7dcb0af665bf1fca0e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`27297eec`](https://github.com/nix-community/emacs-overlay/commit/27297eece41ecca4b26cd7dcb0af665bf1fca0e4) | `Updated repos/nongnu` |
| [`40244bd6`](https://github.com/nix-community/emacs-overlay/commit/40244bd6b0e9474b8c5867791a8bed54bd2b1948) | `Updated repos/melpa`  |
| [`655e3e21`](https://github.com/nix-community/emacs-overlay/commit/655e3e210f810d65a4b9b9536be8944d5034ecf4) | `Updated repos/emacs`  |