### PR TITLE
chore(flake/nur): `abafb484` -> `33aaad44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657762357,
-        "narHash": "sha256-BGLluF6LdiYBHGS0zjPKK5xETmAozbMW+5CpqTX40x8=",
+        "lastModified": 1657769583,
+        "narHash": "sha256-fvURtd9HuNwYduRMfCiRW8p6t+OTnhDoF/PP3U+vMWs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "abafb484abe5424d17ed55912fbf4d43bd8e6353",
+        "rev": "33aaad44a4fb4cbb9eb655ae7f4edad6a68b174b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`33aaad44`](https://github.com/nix-community/NUR/commit/33aaad44a4fb4cbb9eb655ae7f4edad6a68b174b) | `automatic update` |