### PR TITLE
chore(flake/nur): `33aaad44` -> `69ea2db9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657769583,
-        "narHash": "sha256-fvURtd9HuNwYduRMfCiRW8p6t+OTnhDoF/PP3U+vMWs=",
+        "lastModified": 1657771531,
+        "narHash": "sha256-50QmTe+qWOllGQW2Q0kSa8Hvroyho/ZPmHYU0TxHmoo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "33aaad44a4fb4cbb9eb655ae7f4edad6a68b174b",
+        "rev": "69ea2db9f0233680f05cd9d77fbf90cd1fe08e53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`69ea2db9`](https://github.com/nix-community/NUR/commit/69ea2db9f0233680f05cd9d77fbf90cd1fe08e53) | `automatic update` |