### PR TITLE
chore(flake/nur): `69ea2db9` -> `b3c56c07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657771531,
-        "narHash": "sha256-50QmTe+qWOllGQW2Q0kSa8Hvroyho/ZPmHYU0TxHmoo=",
+        "lastModified": 1657777937,
+        "narHash": "sha256-jl3Pber+NcgQeme3DrqZOrAwEIway38TV34H8OU+kbQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "69ea2db9f0233680f05cd9d77fbf90cd1fe08e53",
+        "rev": "b3c56c07b6c0256010bff0eb4e83a9c6afdb99f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b3c56c07`](https://github.com/nix-community/NUR/commit/b3c56c07b6c0256010bff0eb4e83a9c6afdb99f8) | `automatic update` |