### PR TITLE
chore(flake/nixos-hardware): `14e9f729` -> `76c96648`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1657738886,
-        "narHash": "sha256-lmAcczi6xyyNhrUcOaStekilDcS8e5tWB9ycwUFv/mQ=",
+        "lastModified": 1657781616,
+        "narHash": "sha256-M/wl8+gRNELNhEmNjWTZVf61lfZIyiUn/NkyEqQAW80=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "14e9f7298c4201566a4597560d7e141d9ff402cf",
+        "rev": "76c9664813ed7082115ac7efb8a1619a804a631f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                                         |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`6aafb996`](https://github.com/NixOS/nixos-hardware/commit/6aafb9960b426b6031b413c55f420ddd38f8e047) | `comment about silencing ACPI errors`                                                  |
| [`a3f33268`](https://github.com/NixOS/nixos-hardware/commit/a3f33268997e8cbbd11927abc60d21de0995b458) | `add comment about normalizing dpi between sync and offload mode`                      |
| [`6261a284`](https://github.com/NixOS/nixos-hardware/commit/6261a2842933491190fb2d20959513a252afb7af) | `conditionally turn on power management and modesetting when we are in sync mode`      |
| [`20530b31`](https://github.com/NixOS/nixos-hardware/commit/20530b31ef90a9a9a28089251bfaf4f16b2894a2) | `flake changes`                                                                        |
| [`47cb2be8`](https://github.com/NixOS/nixos-hardware/commit/47cb2be872750256d5749c9462baae8c69042783) | `mkDefault consistency`                                                                |
| [`bd873a98`](https://github.com/NixOS/nixos-hardware/commit/bd873a980740c1cbd9d2982ebd12067af3397b09) | `cannot replicate sleep problem without external monitor or any usb device plugged in` |
| [`22cdffc9`](https://github.com/NixOS/nixos-hardware/commit/22cdffc9253f3e37baf41468893fe604e735a8ad) | `turns out hardware.enableAllFirmware is also required for p51 wireless`               |
| [`005e19d6`](https://github.com/NixOS/nixos-hardware/commit/005e19d6f06b086f82c10a28ff6d9c2c036f4471) | `required to make wireless work`                                                       |
| [`ac75bbc4`](https://github.com/NixOS/nixos-hardware/commit/ac75bbc47637e5e46fd7b8d1b153348f0d306b99) | `transform sleep comment into optionally includable expression`                        |
| [`f90db4cb`](https://github.com/NixOS/nixos-hardware/commit/f90db4cb9e0ebc8ec767f088e324f54eef167b29) | `add p50 and p51`                                                                      |