### PR TITLE
chore(flake/nur): `b3c56c07` -> `d384310b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657777937,
-        "narHash": "sha256-jl3Pber+NcgQeme3DrqZOrAwEIway38TV34H8OU+kbQ=",
+        "lastModified": 1657785178,
+        "narHash": "sha256-6Cx+gbUtiR5akAaZZhabzHHMnRgdn328LFINOBHXuNM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b3c56c07b6c0256010bff0eb4e83a9c6afdb99f8",
+        "rev": "d384310b884e3eeb6de6840cc227297156864329",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d384310b`](https://github.com/nix-community/NUR/commit/d384310b884e3eeb6de6840cc227297156864329) | `automatic update` |