### PR TITLE
chore(flake/nur): `d384310b` -> `5a75e49b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657785178,
-        "narHash": "sha256-6Cx+gbUtiR5akAaZZhabzHHMnRgdn328LFINOBHXuNM=",
+        "lastModified": 1657791036,
+        "narHash": "sha256-xs7r80pWd9x1g/lXd3T+KB2Y0TNMwrHheq97wNvihgg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d384310b884e3eeb6de6840cc227297156864329",
+        "rev": "5a75e49b43e726c2f0ccf55dd0b61de6640ca1cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5a75e49b`](https://github.com/nix-community/NUR/commit/5a75e49b43e726c2f0ccf55dd0b61de6640ca1cc) | `automatic update` |
| [`05e0f53e`](https://github.com/nix-community/NUR/commit/05e0f53ed049ca9f7ceff9f2a868e409c683f74c) | `automatic update` |