### PR TITLE
chore(flake/nur): `e7591dec` -> `56c611aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657791967,
-        "narHash": "sha256-imIS+OJHEqWquQvQ9gxC4EIrPb/ah0vAYUAqnOpCVWw=",
+        "lastModified": 1657794145,
+        "narHash": "sha256-5SnT0zcQgn4ccMnAxfocRoTo/3LZSp6a3E+XRZCd7bw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e7591deca57a26dde6418957cb0b75f4300d6c29",
+        "rev": "56c611aa1d49830e2240b4c43c002ccb72d1e628",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`56c611aa`](https://github.com/nix-community/NUR/commit/56c611aa1d49830e2240b4c43c002ccb72d1e628) | `automatic update` |