### PR TITLE
chore(flake/nixpkgs): `38860c9e` -> `68c63e60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -297,11 +297,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657533762,
-        "narHash": "sha256-/cxTFSMmpAb8tBp1yVga1fj+i8LB9aAxnMjYFpRMuVs=",
+        "lastModified": 1657624652,
+        "narHash": "sha256-rFJNM0X/dxekT6EESSh80mlBGqztfN/XOF/oRL6in68=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "38860c9e91cb00f4d8cd19c7b4e36c45680c89b5",
+        "rev": "68c63e60b8413260605efbe1ac5addaa099cdfb3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                    |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`fe1cab9c`](https://github.com/NixOS/nixpkgs/commit/fe1cab9c80a14edbbcffdba51dd0bd0e7400255f) | `python310Packages.afsapi: 0.2.5 -> 0.2.6`                                        |
| [`f33ee395`](https://github.com/NixOS/nixpkgs/commit/f33ee395b2690cf7098045cdd1d9d3511be63ff6) | `python310Packages.aesara: 2.7.5 -> 2.7.6`                                        |
| [`c3fafea4`](https://github.com/NixOS/nixpkgs/commit/c3fafea4edcfed02a37f5f9dfa36c871d1b00e8d) | `nixos: remove unused "system tarball" modules`                                   |
| [`df8f5801`](https://github.com/NixOS/nixpkgs/commit/df8f580137e9120ffc60b2cc85d62fcc928c2eab) | `texlab: 4.0.0 → 4.2.0 (#181149)`                                                 |
| [`77b2ff80`](https://github.com/NixOS/nixpkgs/commit/77b2ff803d29a1d86b08333bf228fc751aad477e) | `terraform-providers: switch to go_1_18`                                          |
| [`92b7ba08`](https://github.com/NixOS/nixpkgs/commit/92b7ba081fd76b2ab87fb2d1581df24ca4fed16e) | `terraform-providers: remove outdated throw`                                      |
| [`7498aa2c`](https://github.com/NixOS/nixpkgs/commit/7498aa2c9d35e94b89443a9a87a8c4158fb555c5) | `python310Packages.hahomematic: 2022.7.3 -> 2022.7.5`                             |
| [`1120fa53`](https://github.com/NixOS/nixpkgs/commit/1120fa53d87edd1ff13d7621a40a73b0cab13d49) | `Revert "kf5/plasma-framework: backport patch to fix thumbnails in task manager"` |
| [`d2319f92`](https://github.com/NixOS/nixpkgs/commit/d2319f92aa60fb593324510c95a004c0b227ee2e) | `kde/frameworks: 5.95 -> 5.96`                                                    |
| [`edd709dc`](https://github.com/NixOS/nixpkgs/commit/edd709dcfc0e15e6b8b50c0dc320a6d16654b6f2) | `vector: 0.22.3 -> 0.23.0`                                                        |
| [`21dc8ddc`](https://github.com/NixOS/nixpkgs/commit/21dc8ddc411e60fb94c2d5deb999b9d590c6d610) | `invidious: unstable-2022-05-11 -> unstable-2022-07-10`                           |
| [`1cb6918b`](https://github.com/NixOS/nixpkgs/commit/1cb6918b9bdc25641940494682458e1f4157aa3c) | `invidious: use nix-hash in update script`                                        |
| [`0d5757c9`](https://github.com/NixOS/nixpkgs/commit/0d5757c9cb1bbf8d0a318b3ede87367240f7158e) | `python310Packages.timezonefinder: 5.2.0 -> 6.0.2`                                |
| [`4dabde8e`](https://github.com/NixOS/nixpkgs/commit/4dabde8e873684f2b4cf3805c5ca9c1ff8bdf329) | `python310Packages.python-socketio: 5.6.0 -> 5.7.0`                               |
| [`16ac6b05`](https://github.com/NixOS/nixpkgs/commit/16ac6b056767cc74a0ffeee87d379a71d7b846bb) | `python310Packages.python-engineio: 4.3.2 -> 4.3.3`                               |
| [`64421536`](https://github.com/NixOS/nixpkgs/commit/644215361ef867a1c030248415c5ed7ed6251fd6) | `step-cli: 0.20.0 -> 0.21.0`                                                      |
| [`ca52ff66`](https://github.com/NixOS/nixpkgs/commit/ca52ff66efe8666553bd0310d55e9ae2ba1dd307) | `sslscan: 2.0.14 -> 2.0.15`                                                       |
| [`28c6e6d7`](https://github.com/NixOS/nixpkgs/commit/28c6e6d71121ac34659033977c50e5ac24936412) | `gitleaks: 8.8.11 -> 8.8.12`                                                      |
| [`20390cad`](https://github.com/NixOS/nixpkgs/commit/20390cad8a470ba2fffe95524db0a308384f70c0) | `gjs: add profiler support`                                                       |
| [`31cffb8d`](https://github.com/NixOS/nixpkgs/commit/31cffb8d364f0217c41e443d253d78ea24956be4) | `wapiti: 3.1.2 -> 3.1.3`                                                          |
| [`af66b47b`](https://github.com/NixOS/nixpkgs/commit/af66b47b3aa13b24f6cc1e1db925d721d5ed6d64) | `nixos/postgresql-backup: allow setting compression level`                        |
| [`7d074643`](https://github.com/NixOS/nixpkgs/commit/7d07464337593b07f7f3f1256c83e638d318f0f5) | `python310Packages.haversine: 2.5.1 -> 2.6.0`                                     |
| [`b30074d2`](https://github.com/NixOS/nixpkgs/commit/b30074d274794462f642587a3e82e42a05f5c834) | `hexedit: 1.2.13 -> 1.6`                                                          |
| [`8f2c49ec`](https://github.com/NixOS/nixpkgs/commit/8f2c49ece6e7c589299dee84299dd46837459baa) | `nixos/home-assistant: make the reload triggers dependent upon cfg.config`        |
| [`ac42c6c9`](https://github.com/NixOS/nixpkgs/commit/ac42c6c976d84712f2423f82f0a59866997a893a) | `python310Packages.dvc-data: 0.0.18 -> 0.0.23`                                    |
| [`d5cf5f7c`](https://github.com/NixOS/nixpkgs/commit/d5cf5f7c3309c12e0c8de8ce9a16d751768f5e01) | `libime: 1.0.13 -> unstable-2022-07-11`                                           |
| [`51ae0c2a`](https://github.com/NixOS/nixpkgs/commit/51ae0c2a8cdfc729fe0ed68f630d12d5e3f6594d) | `haskell.packages.ghc923.protolude: drop obsolete patch`                          |
| [`f69e9bc2`](https://github.com/NixOS/nixpkgs/commit/f69e9bc2cca16c0c40bc3b3504c9653d383c9874) | `nixpacks: init at 0.1.7 (#179932)`                                               |
| [`c78023cb`](https://github.com/NixOS/nixpkgs/commit/c78023cbbfed055866fa6e876f19b4249ddb1c5a) | `fastjet-contrib: explicitly set 'configurePlatforms = [ ];' (#181062)`           |
| [`f617400b`](https://github.com/NixOS/nixpkgs/commit/f617400bf2a1888f4370dcc466062fe75ba813ab) | `fcitx5-configtool: add new dependencies`                                         |
| [`c60312b6`](https://github.com/NixOS/nixpkgs/commit/c60312b6d8924aa731d639da18bd0065a07af805) | `fcitx5-unikey: 5.0.10 -> 5.0.11`                                                 |
| [`6dbbc92f`](https://github.com/NixOS/nixpkgs/commit/6dbbc92f961808054665dcbba2fef5c0c845b56c) | `fcitx5-table-other: 5.0.9 -> 5.0.10`                                             |
| [`8207ef88`](https://github.com/NixOS/nixpkgs/commit/8207ef880fe9f8ed13c6980229ad77416a1d137b) | `fcitx5-table-extra: 5.0.10 -> 5.0.11`                                            |
| [`2396cf8b`](https://github.com/NixOS/nixpkgs/commit/2396cf8b80ae3abf47fc3053097be6b538067c69) | `fcitx5-rime: 5.0.13 -> 5.0.14`                                                   |
| [`63f6a1d4`](https://github.com/NixOS/nixpkgs/commit/63f6a1d44661e635896dfa4c1ed1c981f4e02310) | `libsForQt5.fcitx5-qt: 5.0.13 -> 5.0.14`                                          |
| [`54edb75b`](https://github.com/NixOS/nixpkgs/commit/54edb75b5bd6b547f930cc3c84e9288df991492c) | `fcitx5-m17n: 5.0.9 -> 5.0.10`                                                    |
| [`5282c704`](https://github.com/NixOS/nixpkgs/commit/5282c704ed098553231973c81fabb1d745cc89d7) | `fcitx5-lua: 5.0.8 -> 5.0.9`                                                      |
| [`166516b4`](https://github.com/NixOS/nixpkgs/commit/166516b41f842cda510e21419a226baf20b00e62) | `fcitx5-hangul: 5.0.9 -> 5.0.10`                                                  |
| [`9c941540`](https://github.com/NixOS/nixpkgs/commit/9c941540a7cbc5c9a29dc1a604873b123cc058b2) | `fcitx5-gtk: 5.0.15 -> 5.0.16`                                                    |
| [`88dd9e75`](https://github.com/NixOS/nixpkgs/commit/88dd9e751f6b25aaa6e873dbefb8f6309cc408c6) | `fcitx5-configtool: 5.0.13 -> 5.0.14`                                             |
| [`77da20f2`](https://github.com/NixOS/nixpkgs/commit/77da20f2452c3c96cb95d2fc843d9a7794c235a6) | `fcitx5-chinese-addons: 5.0.13 -> 5.0.14`                                         |
| [`58c7532c`](https://github.com/NixOS/nixpkgs/commit/58c7532c55de5476d2f7b46bd887dc1661e13471) | `fcitx5-chewing: 5.0.11 -> 5.0.12`                                                |
| [`f32ab0fd`](https://github.com/NixOS/nixpkgs/commit/f32ab0fd3bd67a5003181c804190358c405f61d9) | `fcitx5: 5.0.17 -> 5.0.18`                                                        |
| [`da1f2915`](https://github.com/NixOS/nixpkgs/commit/da1f29154acc04d1abd1fec6a7d53d49ee6fb33a) | `libime: 1.0.12 -> 1.0.13`                                                        |
| [`29b37f58`](https://github.com/NixOS/nixpkgs/commit/29b37f58e9f8d0321a0e5ffe1b42ddad4150df03) | `python310Packages.pyupgrade: 2.34.0 -> 2.37.1`                                   |
| [`63d72966`](https://github.com/NixOS/nixpkgs/commit/63d729665c2835be0c507ced648ccc024620afb6) | `glimpse: Drop package and plugins`                                               |
| [`fa36ef2f`](https://github.com/NixOS/nixpkgs/commit/fa36ef2f25b1357feb17d7e702c6be4397647ee2) | `bun: 0.1.1 → 0.1.2`                                                              |
| [`55d3af25`](https://github.com/NixOS/nixpkgs/commit/55d3af25beb3d159e1dd0ea329a21e7d8eb38683) | `python310Packages.bayespy: Fix tests`                                            |
| [`67258310`](https://github.com/NixOS/nixpkgs/commit/67258310baaa0d6fd42e1d6efa8e36c161ce3605) | `python310Packages.casbin: 1.16.8 -> 1.16.9`                                      |
| [`cc5a1c91`](https://github.com/NixOS/nixpkgs/commit/cc5a1c91353836de9f9ea3fca757573be2b525d6) | `python310Packages.dvc-objects: 0.0.20 -> 0.0.23`                                 |
| [`8d01b570`](https://github.com/NixOS/nixpkgs/commit/8d01b570f22ddf79d42f86bd92bc534f4a7fa28d) | `intel-gmmlib: 22.1.3 -> 22.1.5`                                                  |
| [`6d9df519`](https://github.com/NixOS/nixpkgs/commit/6d9df51984da5e8b7ed1191d416ff8a09aad80db) | `teams: add revol-xut to c3d2`                                                    |
| [`9805aedb`](https://github.com/NixOS/nixpkgs/commit/9805aedbcccadd363aeaf8e7b6be9b82688b9d8b) | `pre-commit: 2.19.0 -> 2.20.0`                                                    |
| [`24eb6920`](https://github.com/NixOS/nixpkgs/commit/24eb6920dcb43604f660b3bf8879ea1ff4ee5e8e) | `ddnet: 16.2 -> 16.2.1`                                                           |
| [`06e537ad`](https://github.com/NixOS/nixpkgs/commit/06e537ad60b199ebbf31da8537a45f6b28a7591e) | `bada-bib: add missing libadwaita and gtksourceview5 dependency`                  |
| [`9104b29c`](https://github.com/NixOS/nixpkgs/commit/9104b29c39cee2b50bf93e00374e22474a0fef9a) | `radioboat: init at 0.2.1`                                                        |
| [`19677953`](https://github.com/NixOS/nixpkgs/commit/196779537293cdd32ce5e3ca877d2750ec1df977) | `python310Packages.hahomematic: 2022.7.1 -> 2022.7.3`                             |
| [`4d9ac2f7`](https://github.com/NixOS/nixpkgs/commit/4d9ac2f79753e503ceea8ee03943fd43df5ad57f) | `cdk-go: 1.2.0 -> 1.3.0`                                                          |
| [`93f5569b`](https://github.com/NixOS/nixpkgs/commit/93f5569bd15246f3d7ae5058ef8c8ff011adefd7) | `python310Packages.teslajsonpy: 2.2.1 -> 2.3.0`                                   |
| [`ab26c636`](https://github.com/NixOS/nixpkgs/commit/ab26c6364ece4f02aa8a620ddbeebcddc16e869d) | `dmidecode: 3.2 -> 3.4`                                                           |
| [`53daacc6`](https://github.com/NixOS/nixpkgs/commit/53daacc626871885029c0f6da21a2c22b0767934) | `python310Packages.bc-python-hcl2: 0.3.44 -> 0.3.45`                              |
| [`4b4576fa`](https://github.com/NixOS/nixpkgs/commit/4b4576faf9452e394309219b38d9dc6c13c429ff) | `Revert "linux-kernel: disable BTF on 32-bit platforms on kernels 5.15+"`         |
| [`15fd4547`](https://github.com/NixOS/nixpkgs/commit/15fd45470f38fe91c997eff1a42e34a663c13c74) | `wander: init at 0.4.1`                                                           |
| [`71ee25ae`](https://github.com/NixOS/nixpkgs/commit/71ee25aecfb9535454f0aaa586db946545504aa8) | `alfis: 0.7.3 -> 0.7.4`                                                           |
| [`61c9f44a`](https://github.com/NixOS/nixpkgs/commit/61c9f44a1d1b854cb12e0173fb548094355cfe8f) | `pipewire: fix bluetooth for system-wide configuration`                           |
| [`6e87ec81`](https://github.com/NixOS/nixpkgs/commit/6e87ec81629bf514c886838259d5f438108929a6) | `librewolf: 102.0-2 -> 102.0.1-1`                                                 |
| [`e2e8e381`](https://github.com/NixOS/nixpkgs/commit/e2e8e38186060cf7af23bcb813c0506afc2ca965) | `xrootd: 5.4.2 -> 5.4.3`                                                          |
| [`f0b4a5da`](https://github.com/NixOS/nixpkgs/commit/f0b4a5da478003f11da0aaaa38be02afacd4e4d9) | `voms: default to symlink $out/etc to /etc`                                       |
| [`5a6722b0`](https://github.com/NixOS/nixpkgs/commit/5a6722b0e101c364a27bc870c1da997b665c49bf) | `voms: make meta.description more clearly`                                        |
| [`f6411523`](https://github.com/NixOS/nixpkgs/commit/f6411523e399498c5468c237b1b7d21e7fdc3c7f) | `vala-language-server: 0.48.4 -> 0.48.5`                                          |
| [`1065fb56`](https://github.com/NixOS/nixpkgs/commit/1065fb56be0a73e9bfd7732738cde4da8c37a1fa) | `confluent-platform: 7.1.0 -> 7.2.0`                                              |
| [`45ddcc04`](https://github.com/NixOS/nixpkgs/commit/45ddcc04cd9350c64fbabda5c5d32539da9e549b) | `wluma: 4.1.0 -> 4.1.2`                                                           |
| [`c7e60ccf`](https://github.com/NixOS/nixpkgs/commit/c7e60ccfd127f8f3025ffdd31de7631a16b472d0) | `kops: drop 1.21`                                                                 |
| [`28f8307a`](https://github.com/NixOS/nixpkgs/commit/28f8307a267f958cc50ea50ec36e0e9c1dfa1c38) | `kops: 1.23.2 -> 1.24.0`                                                          |
| [`cd51d7ac`](https://github.com/NixOS/nixpkgs/commit/cd51d7ac4b6a4f71a35c660920008dad865d71ce) | `cpuid: 20220224 -> 20220620`                                                     |
| [`5c8e8f74`](https://github.com/NixOS/nixpkgs/commit/5c8e8f748ffdfda0b95c468088e2fc9bc963e3ea) | `kopia: 0.11.1 -> 0.11.2`                                                         |
| [`f5f9bd03`](https://github.com/NixOS/nixpkgs/commit/f5f9bd035109e85b8b0452ed37d7b6ed439a86ee) | `voms: 2021-05-04 -> 2022-06-14`                                                  |
| [`4c4e75b3`](https://github.com/NixOS/nixpkgs/commit/4c4e75b3d6688a89ddecb0cfebdd7c5ec2270817) | `gnomeExtensions: auto-update`                                                    |
| [`4975868d`](https://github.com/NixOS/nixpkgs/commit/4975868d54636aae086d8e7cbf75c3723ce31db5) | `bada-bib: 0.6.2 -> 0.7.2`                                                        |
| [`aa602d56`](https://github.com/NixOS/nixpkgs/commit/aa602d563c30125ecf255fe8f47ed43f1ddfa5bc) | `pyinfra: 2.1 -> 2.2`                                                             |
| [`cb730cf2`](https://github.com/NixOS/nixpkgs/commit/cb730cf239b855b1dfab54e0b7598ad294a718ab) | `nixpkgs-basic-release-checks: check for case-insensitive path conflicts`         |
| [`01bbab73`](https://github.com/NixOS/nixpkgs/commit/01bbab739bbb50366d103da5c755831eda1cd9c1) | `kodi.packages.invidious: init at 0.1.0+matrix.1`                                 |
| [`cd414d01`](https://github.com/NixOS/nixpkgs/commit/cd414d016b2711f36627823f76cbef7e6ffccf85) | `python3Packages.jupyterlab_server: create temp home for tests`                   |
| [`d1b90cf5`](https://github.com/NixOS/nixpkgs/commit/d1b90cf54005e690f30bdf991df05a68ca0762d3) | `nixos/caddy: force caddy to reload config in ExecReload`                         |
| [`ef025e29`](https://github.com/NixOS/nixpkgs/commit/ef025e29984d8be59d1295829352d5653042cff6) | `i2pd: add yggdrasil settings`                                                    |
| [`0e838b31`](https://github.com/NixOS/nixpkgs/commit/0e838b311522d7d83475a0f02558d1548fd8f170) | `firefox-bin: HTTPS for homepage and updateScript`                                |
| [`f31d4de3`](https://github.com/NixOS/nixpkgs/commit/f31d4de37b81657b417f0ccea6f9d7c0b79d8fd9) | `xidel: add TLS support`                                                          |