### PR TITLE
chore(flake/nur): `56c611aa` -> `4c41d6d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657794145,
-        "narHash": "sha256-5SnT0zcQgn4ccMnAxfocRoTo/3LZSp6a3E+XRZCd7bw=",
+        "lastModified": 1657810547,
+        "narHash": "sha256-cZQQJZT/IPeOgRAXVerlOuJl9x1yM0rWfOPqM/5z3q8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "56c611aa1d49830e2240b4c43c002ccb72d1e628",
+        "rev": "4c41d6d47f0965dd896e8b858d0f4b1cdbfe6de5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4c41d6d4`](https://github.com/nix-community/NUR/commit/4c41d6d47f0965dd896e8b858d0f4b1cdbfe6de5) | `automatic update` |