### PR TITLE
chore(flake/nur): `4c41d6d4` -> `fb3e2d01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657810547,
-        "narHash": "sha256-cZQQJZT/IPeOgRAXVerlOuJl9x1yM0rWfOPqM/5z3q8=",
+        "lastModified": 1657823174,
+        "narHash": "sha256-3G4Qytob1Fv8ubR0dU4+8gkKqBWpFG2Y+yGH8+BG0ds=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4c41d6d47f0965dd896e8b858d0f4b1cdbfe6de5",
+        "rev": "fb3e2d0144d599586a51641fa5684abf6e14a98f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`fb3e2d01`](https://github.com/nix-community/NUR/commit/fb3e2d0144d599586a51641fa5684abf6e14a98f) | `automatic update` |