### PR TITLE
chore(flake/emacs-overlay): `5c014cdf` -> `5d793f13`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657794283,
-        "narHash": "sha256-iTYuW4p69Q8YG9Oh6mozNl8F7L2Orn3NbnqMgvc2BO8=",
+        "lastModified": 1657824755,
+        "narHash": "sha256-ktj7nl1jfBAcXnDC7yp4t3Riaek+VEB74/orXq9sdBI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5c014cdf9a52b37d9d27754b8be07d3bc07ecce5",
+        "rev": "5d793f134d5b3ff60e890a2e0cce2483e6e745b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`5d793f13`](https://github.com/nix-community/emacs-overlay/commit/5d793f134d5b3ff60e890a2e0cce2483e6e745b7) | `Updated repos/melpa` |
| [`5ef44167`](https://github.com/nix-community/emacs-overlay/commit/5ef44167cd9c8b3fbb6310bc148a270c61cb07d3) | `Updated repos/emacs` |