### PR TITLE
chore(flake/nur): `fb3e2d01` -> `4179493d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657823174,
-        "narHash": "sha256-3G4Qytob1Fv8ubR0dU4+8gkKqBWpFG2Y+yGH8+BG0ds=",
+        "lastModified": 1657828005,
+        "narHash": "sha256-KpzraczJOrFw2Gpye6/LuKzMwXBK6jP2ewHm9IxQU/s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fb3e2d0144d599586a51641fa5684abf6e14a98f",
+        "rev": "4179493d02ae29a13e007ffa2f06a226cf1d4d50",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4179493d`](https://github.com/nix-community/NUR/commit/4179493d02ae29a13e007ffa2f06a226cf1d4d50) | `automatic update` |