### PR TITLE
chore(flake/nur): `4179493d` -> `88866341`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657828005,
-        "narHash": "sha256-KpzraczJOrFw2Gpye6/LuKzMwXBK6jP2ewHm9IxQU/s=",
+        "lastModified": 1657837635,
+        "narHash": "sha256-hNwoozHwKDdMLM16p4sosN4kfjl5iLwln6b63/zqjUs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4179493d02ae29a13e007ffa2f06a226cf1d4d50",
+        "rev": "88866341491ab5de1f376cd3e499a4e6c45e806b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`88866341`](https://github.com/nix-community/NUR/commit/88866341491ab5de1f376cd3e499a4e6c45e806b) | `automatic update` |