### PR TITLE
chore(flake/emacs-overlay): `5d793f13` -> `b51bea50`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657824755,
-        "narHash": "sha256-ktj7nl1jfBAcXnDC7yp4t3Riaek+VEB74/orXq9sdBI=",
+        "lastModified": 1657840190,
+        "narHash": "sha256-eg4YXDAUm/6E3zcQW7vebDuWosx2opJ/EgknDTr8cQ4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5d793f134d5b3ff60e890a2e0cce2483e6e745b7",
+        "rev": "b51bea50371cc7a98863fb64bf1aaa1126a68a36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                              |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------- |
| [`b51bea50`](https://github.com/nix-community/emacs-overlay/commit/b51bea50371cc7a98863fb64bf1aaa1126a68a36) | `Jobsets for cross building emacsen (#231)` |