### PR TITLE
chore(flake/nur): `88866341` -> `b74ab2bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657837635,
-        "narHash": "sha256-hNwoozHwKDdMLM16p4sosN4kfjl5iLwln6b63/zqjUs=",
+        "lastModified": 1657858064,
+        "narHash": "sha256-S+MSaFTVpS6x0bRRjBlOe7aJVLQqodPnGXmzOUro0m0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "88866341491ab5de1f376cd3e499a4e6c45e806b",
+        "rev": "b74ab2bd0d47dc4b16e6dfd8cdd4d2c5a1c9c26b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b74ab2bd`](https://github.com/nix-community/NUR/commit/b74ab2bd0d47dc4b16e6dfd8cdd4d2c5a1c9c26b) | `automatic update` |
| [`22b9da76`](https://github.com/nix-community/NUR/commit/22b9da76dc8786deb8d87229592f32da21a98dfa) | `automatic update` |