### PR TITLE
chore(flake/emacs-overlay): `b51bea50` -> `a2f9d8ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657840190,
-        "narHash": "sha256-eg4YXDAUm/6E3zcQW7vebDuWosx2opJ/EgknDTr8cQ4=",
+        "lastModified": 1657857882,
+        "narHash": "sha256-qYoI9xPBy7nDM9I61OC2yt5Qt1cvrhJ+cRLyOtfCTiE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b51bea50371cc7a98863fb64bf1aaa1126a68a36",
+        "rev": "a2f9d8baec7afbbb35f4f4c5e7bb4f6f24d8ea1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`a2f9d8ba`](https://github.com/nix-community/emacs-overlay/commit/a2f9d8baec7afbbb35f4f4c5e7bb4f6f24d8ea1b) | `Updated repos/melpa` |
| [`554e0a45`](https://github.com/nix-community/emacs-overlay/commit/554e0a4504f900b3e06117c6abe7a23ed974fd4f) | `Updated repos/emacs` |