### PR TITLE
chore(flake/nur): `b74ab2bd` -> `2fb0fbdb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657858064,
-        "narHash": "sha256-S+MSaFTVpS6x0bRRjBlOe7aJVLQqodPnGXmzOUro0m0=",
+        "lastModified": 1657868325,
+        "narHash": "sha256-4iHOPir++P5aE69kYkJG/+QlvTwVO4aJv7cMngNwyEU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b74ab2bd0d47dc4b16e6dfd8cdd4d2c5a1c9c26b",
+        "rev": "2fb0fbdb0daccfc79a79ea2b67c7e9f3391a6823",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2fb0fbdb`](https://github.com/nix-community/NUR/commit/2fb0fbdb0daccfc79a79ea2b67c7e9f3391a6823) | `automatic update` |