### PR TITLE
chore(flake/nur): `7dacb892` -> `a60e2219`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657870296,
-        "narHash": "sha256-999cytgqgZPavlQrihIfasdnnVyUNXvckWKdhYwt27Y=",
+        "lastModified": 1657877414,
+        "narHash": "sha256-OgfoVfW1FJWlJZDsDLK79CjSyq5o+aItEXUydV+nAzE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7dacb89233cd396f5d6e197c085840802fe0c55e",
+        "rev": "a60e2219c8970813497058157bb178476be3b1ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a60e2219`](https://github.com/nix-community/NUR/commit/a60e2219c8970813497058157bb178476be3b1ea) | `automatic update` |