### PR TITLE
chore(flake/home-manager): `2c94b980` -> `8385408c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657719085,
-        "narHash": "sha256-nQt3MEBwKuKlmFKSRhdoh60AGlc+YlspV5e8kO/3y8U=",
+        "lastModified": 1657719240,
+        "narHash": "sha256-cCrOFULR7wsOWr2ITrX6lztGsrde4btF/stooVbyAII=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2c94b9801f1a11cde0fc97aa850687bb9137d42c",
+        "rev": "8385408c658345bb28c5d2d30f9b494d4045e0e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                          |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`8385408c`](https://github.com/nix-community/home-manager/commit/8385408c658345bb28c5d2d30f9b494d4045e0e2) | `Add translation using Weblate (Dutch)` |
| [`3b5330c8`](https://github.com/nix-community/home-manager/commit/3b5330c80f9bb5dbca882a22b0e265d14e92888a) | `Translate using Weblate (Dutch)`       |