### PR TITLE
chore(flake/nur): `a60e2219` -> `f78d44ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657877414,
-        "narHash": "sha256-OgfoVfW1FJWlJZDsDLK79CjSyq5o+aItEXUydV+nAzE=",
+        "lastModified": 1657887820,
+        "narHash": "sha256-EVue27rv/fS141EVEOC0eMuHPP0xufXQyXCpdVeXpgU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a60e2219c8970813497058157bb178476be3b1ea",
+        "rev": "f78d44ac2b8cd4e3969f54890c0b8b883d31d1ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f78d44ac`](https://github.com/nix-community/NUR/commit/f78d44ac2b8cd4e3969f54890c0b8b883d31d1ff) | `automatic update` |