### PR TITLE
chore(flake/home-manager): `8385408c` -> `4c5106ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657719240,
-        "narHash": "sha256-cCrOFULR7wsOWr2ITrX6lztGsrde4btF/stooVbyAII=",
+        "lastModified": 1657887110,
+        "narHash": "sha256-8VV0/kZed2z8fGtEc2zr+WLxTow+JTIlMjnSisyv0GQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8385408c658345bb28c5d2d30f9b494d4045e0e2",
+        "rev": "4c5106ed0f3168ff2df21b646aef67e86cbfc11c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`4c5106ed`](https://github.com/nix-community/home-manager/commit/4c5106ed0f3168ff2df21b646aef67e86cbfc11c) | ``firefox: reuse `escapeXML` from Nixpkgs`` |