### PR TITLE
chore(flake/nur): `e6432bf5` -> `b7a91467`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661201175,
-        "narHash": "sha256-IshRSIE4aOYNjLua6vwVUto1NVat/eMJUIsYWYhyUYU=",
+        "lastModified": 1661604090,
+        "narHash": "sha256-vFDv4PPhwYopTq2wNhtv7zqMLSVMFHP0OPoTUf1glr8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e6432bf55ebbc109219d79f19572c5d0a75319f5",
+        "rev": "b7a91467e843c29b44e5069b6de406f254aea668",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                            |
| -------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`b7a91467`](https://github.com/nix-community/NUR/commit/b7a91467e843c29b44e5069b6de406f254aea668) | `automatic update`                        |
| [`97e379f7`](https://github.com/nix-community/NUR/commit/97e379f7286d90cd5086827d1250ad7ca7a3878b) | `automatic update`                        |
| [`1f91085f`](https://github.com/nix-community/NUR/commit/1f91085feca911d694413d2491c9ac125661178a) | `automatic update`                        |
| [`82fb242e`](https://github.com/nix-community/NUR/commit/82fb242e6d238169846b97422f6673a366093cd2) | `automatic update`                        |
| [`4db69ed8`](https://github.com/nix-community/NUR/commit/4db69ed85756b1e8c4486d32c3bdbc889948beaf) | `automatic update`                        |
| [`7ec954ab`](https://github.com/nix-community/NUR/commit/7ec954abaff857b2836260ce97828711600540c8) | `add aaqaishtyaq/nur-packages repository` |
| [`41f04470`](https://github.com/nix-community/NUR/commit/41f04470b3f4bb805051bd3d6f6d363debb004a1) | `automatic update`                        |
| [`37b9bb99`](https://github.com/nix-community/NUR/commit/37b9bb99e40b769a5bc469b2582ce2fb9d9343be) | `automatic update`                        |
| [`7df270a9`](https://github.com/nix-community/NUR/commit/7df270a9c4e019210f145a002a11cd1cd807c0b0) | `automatic update`                        |
| [`5cef0b58`](https://github.com/nix-community/NUR/commit/5cef0b582ca047d6d2bd07277bce6e05f61662f3) | `automatic update`                        |
| [`c3836a37`](https://github.com/nix-community/NUR/commit/c3836a37186a240e5792891811ff2219d8c3f7ae) | `automatic update`                        |
| [`44faceaa`](https://github.com/nix-community/NUR/commit/44faceaabc0c9a4dc09fb468577e9a5d6a7e4c9a) | `automatic update`                        |
| [`eaa68234`](https://github.com/nix-community/NUR/commit/eaa682341c0775fa95e80e6e6cea5a0f945ea209) | `automatic update`                        |
| [`80efa306`](https://github.com/nix-community/NUR/commit/80efa3063c90950ab8ff0327f8c5309d4b10f2f2) | `automatic update`                        |
| [`86a329da`](https://github.com/nix-community/NUR/commit/86a329da84199b1bdf3092fe55301f0a8e74505c) | `automatic update`                        |
| [`a0d15bc0`](https://github.com/nix-community/NUR/commit/a0d15bc02bb667de6d649546b18990794e7ffd10) | `automatic update`                        |
| [`3e402de5`](https://github.com/nix-community/NUR/commit/3e402de55c555612ba9012b8b655f5903f6c476d) | `automatic update`                        |
| [`6625084e`](https://github.com/nix-community/NUR/commit/6625084e9a168fe64ef25e2484f391123fa9e841) | `automatic update`                        |
| [`9e8c3a5d`](https://github.com/nix-community/NUR/commit/9e8c3a5df165d90558e5da4274b46dde743f5ce3) | `automatic update`                        |
| [`fa287831`](https://github.com/nix-community/NUR/commit/fa287831388396ff7200a60e16e338c0402672a2) | `automatic update`                        |
| [`68f5f1a4`](https://github.com/nix-community/NUR/commit/68f5f1a4a60d1b885fa8e899541ca55e83639329) | `automatic update`                        |
| [`e3e72eaf`](https://github.com/nix-community/NUR/commit/e3e72eafcf25cccb26c57d12ccfa9b71bfb7cc9b) | `add ocfox repository`                    |
| [`41a1e5e0`](https://github.com/nix-community/NUR/commit/41a1e5e010bbf43dfeda78c8ef4faac183b7de28) | `automatic update`                        |
| [`5fc00a83`](https://github.com/nix-community/NUR/commit/5fc00a83e755fbbb9820d7463ede69b4b8e98058) | `automatic update`                        |
| [`1edccb29`](https://github.com/nix-community/NUR/commit/1edccb2986de9dd7132d52b89e9872b57280655f) | `automatic update`                        |
| [`b7dd7d75`](https://github.com/nix-community/NUR/commit/b7dd7d75ef51d51c21c123e52abaf673974eb2f7) | `automatic update`                        |
| [`99687e8c`](https://github.com/nix-community/NUR/commit/99687e8cc87c5afb8e748d6ef60f62b3eca1a583) | `automatic update`                        |
| [`d47ff88c`](https://github.com/nix-community/NUR/commit/d47ff88cde3cefdea617ee5f5d4a3f43e889603e) | `automatic update`                        |
| [`74753e04`](https://github.com/nix-community/NUR/commit/74753e04193613bf2962a1c3b33b15476a1a05c3) | `automatic update`                        |
| [`24fd4829`](https://github.com/nix-community/NUR/commit/24fd482909bc01157f588a2152f72820503bae70) | `automatic update`                        |
| [`60ac7a93`](https://github.com/nix-community/NUR/commit/60ac7a933c1dfcbb5b8fab8ee508fea8437ffeac) | `automatic update`                        |
| [`c82d9134`](https://github.com/nix-community/NUR/commit/c82d9134a79752ccb71f39cceb6c0a2cc88a71a0) | `automatic update`                        |
| [`82dd3c5d`](https://github.com/nix-community/NUR/commit/82dd3c5d400c350d68af9042bbd1655f93bf75e8) | `automatic update`                        |
| [`63164015`](https://github.com/nix-community/NUR/commit/63164015a1ae4f097ed353571c2436092640cea6) | `automatic update`                        |
| [`57845dff`](https://github.com/nix-community/NUR/commit/57845dff30b921e0d3d122ad5b7209ff1d8682b0) | `automatic update`                        |
| [`40adb27c`](https://github.com/nix-community/NUR/commit/40adb27c9ad4fe82e12470521c4dc03ddc2a9d95) | `automatic update`                        |
| [`1e64575b`](https://github.com/nix-community/NUR/commit/1e64575bd36cd79a5191b2dd1f04368258ec16f3) | `automatic update`                        |
| [`5f8e4344`](https://github.com/nix-community/NUR/commit/5f8e4344cd7ec4c5a379c3024e2cf6fb03f0faec) | `automatic update`                        |
| [`e6c59771`](https://github.com/nix-community/NUR/commit/e6c597713e80ef207031c8060667a601c39d6db7) | `automatic update`                        |
| [`842deafb`](https://github.com/nix-community/NUR/commit/842deafbde84aaac2d37ec9ccb24c35c7bcd36e9) | `added baduhai repo`                      |
| [`c968fb83`](https://github.com/nix-community/NUR/commit/c968fb832af73dbc2d5bc4fd3161177e4688ba77) | `automatic update`                        |
| [`6920297c`](https://github.com/nix-community/NUR/commit/6920297cefc510f80312e5be9f6fd381c20708c8) | `automatic update`                        |
| [`3612e191`](https://github.com/nix-community/NUR/commit/3612e191a2b25bf5b5b5c762ba1d27639e03eef9) | `automatic update`                        |
| [`5e8f0a05`](https://github.com/nix-community/NUR/commit/5e8f0a05e3005a78081dadcf4c766e683034db64) | `automatic update`                        |
| [`dc161d82`](https://github.com/nix-community/NUR/commit/dc161d82324b7f8c2c711ac52e94bb9b715b3ebb) | `automatic update`                        |
| [`f0808d13`](https://github.com/nix-community/NUR/commit/f0808d13b2e2275ebc8d9ecd40881a43fb86f5ea) | `automatic update`                        |
| [`69a3c010`](https://github.com/nix-community/NUR/commit/69a3c01055a304cfa5c2768a8d4b156fd3c0d477) | `automatic update`                        |
| [`2ff04cfe`](https://github.com/nix-community/NUR/commit/2ff04cfe51ed1039e2ddba649e081922e54d0541) | `automatic update`                        |
| [`0f20f9d8`](https://github.com/nix-community/NUR/commit/0f20f9d85c5c5a334be033f366687f4b9d6b4950) | `automatic update`                        |
| [`a59c360e`](https://github.com/nix-community/NUR/commit/a59c360ec53fd1023ec00c52369994505b484ae6) | `automatic update`                        |
| [`67fc6290`](https://github.com/nix-community/NUR/commit/67fc62908c93529adb71baadc9d120e5a0106711) | `automatic update`                        |
| [`81cd3f14`](https://github.com/nix-community/NUR/commit/81cd3f140f555003ae1178abde54417ec6c722df) | `automatic update`                        |
| [`e6eee4bd`](https://github.com/nix-community/NUR/commit/e6eee4bd8ac9df954e4bd289a75126815f445a0c) | `automatic update`                        |
| [`56421063`](https://github.com/nix-community/NUR/commit/564210630716bbd6002d90cea7228c68ccd90387) | `automatic update`                        |
| [`3066e93e`](https://github.com/nix-community/NUR/commit/3066e93ed4c5a8636d648778a68e376c28407db9) | `automatic update`                        |
| [`8a39b770`](https://github.com/nix-community/NUR/commit/8a39b770e7b930fe251cb8cd968499a88c5ffbca) | `automatic update`                        |
| [`8a8c9ac4`](https://github.com/nix-community/NUR/commit/8a8c9ac43b0c6caab8380bef3a7757349e9f6b6b) | `automatic update`                        |
| [`ad1adc14`](https://github.com/nix-community/NUR/commit/ad1adc14fa01a3cd268c14642c88650c067ac418) | `automatic update`                        |
| [`4dbaa0e3`](https://github.com/nix-community/NUR/commit/4dbaa0e39810bfde67171432bdb7d9bcedb0dd1b) | `automatic update`                        |
| [`8b40322d`](https://github.com/nix-community/NUR/commit/8b40322d917b468674761ca62ab15c3cb08316c8) | `automatic update`                        |
| [`77c5cb84`](https://github.com/nix-community/NUR/commit/77c5cb84a7641803b7525be174253ca8a0863eb5) | `automatic update`                        |
| [`7bc81914`](https://github.com/nix-community/NUR/commit/7bc81914650bc77426c6c39876b288f8ca2e314b) | `automatic update`                        |
| [`b63e0469`](https://github.com/nix-community/NUR/commit/b63e0469d769c1af45b6136e122824e91868b53c) | `automatic update`                        |
| [`a07e2fd3`](https://github.com/nix-community/NUR/commit/a07e2fd36d613786590befd40e036b12be73107a) | `automatic update`                        |
| [`cf11bb8b`](https://github.com/nix-community/NUR/commit/cf11bb8b78e52a4c773e8b6862de7d1b1a3ed613) | `remove icecafecup repository`            |