### PR TITLE
chore(flake/emacs-ement): `0eec0073` -> `5c02bc08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1657724755,
-        "narHash": "sha256-dhMWXOfbY0zMCOjrK1h9BCgSFSTcgKuGMphYSqtIzg0=",
+        "lastModified": 1657910286,
+        "narHash": "sha256-pMQXdN7IL3hS+RTfMUsOc1DgD/hgMgoc/cKKpAxEAg4=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "0eec00733b905cfe37a7a64e9188bdd9b82c497c",
+        "rev": "5c02bc0876d0641a311575ebd87c5594917ec651",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                         |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`5c02bc08`](https://github.com/alphapapa/ement.el/commit/5c02bc0876d0641a311575ebd87c5594917ec651) | `Fix: (ement-room--buffer) Header for encrypted rooms` |