### PR TITLE
chore(flake/emacs-overlay): `8001e380` -> `adf22503`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657884172,
-        "narHash": "sha256-akZ7F9zhy1XzsC03MfvT8GWI8shkm/EaMJHUzMuioak=",
+        "lastModified": 1657910668,
+        "narHash": "sha256-tIduaZblWdveLsvzaAJ8hAGe1xPVWan4OMHV6uACLZw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8001e380d2a199808e5adf69c3a6722b81fd9d01",
+        "rev": "adf225036341945726878b2fc3a761fcb38637db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`adf22503`](https://github.com/nix-community/emacs-overlay/commit/adf225036341945726878b2fc3a761fcb38637db) | `Updated repos/melpa` |
| [`616fca7a`](https://github.com/nix-community/emacs-overlay/commit/616fca7aeba7e682674e2a196eee3aa4d585843d) | `Updated repos/emacs` |