### PR TITLE
chore(flake/emacs-overlay): `91804f38` -> `82f28256`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657966905,
-        "narHash": "sha256-hx93a72CpMs+Bdag02m9qpw0fwcekbu3Icf6v3c4rU4=",
+        "lastModified": 1657998696,
+        "narHash": "sha256-86u9aarja0Fnil1JKhynCuZIzEVlBER6kAeW6WsRUN4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "91804f38a4d3c41914d579ac1cb6a35785405c14",
+        "rev": "82f28256c57e54c37886e77a2608973acfdd356c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`82f28256`](https://github.com/nix-community/emacs-overlay/commit/82f28256c57e54c37886e77a2608973acfdd356c) | `Updated repos/melpa` |
| [`67bd8ad1`](https://github.com/nix-community/emacs-overlay/commit/67bd8ad1eba022384519d28064411802efe9fcd6) | `Updated repos/emacs` |