### PR TITLE
chore(flake/emacs-plz): `9e43e74a` -> `9e9a3708`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
     "emacs-plz": {
       "flake": false,
       "locked": {
-        "lastModified": 1656576055,
-        "narHash": "sha256-kEKb4QKLtVJuSEPwPKpQ11XxqJQfGQ0AsAnN0g9LVzc=",
+        "lastModified": 1657914511,
+        "narHash": "sha256-YtM9d8eGWrYGGdAw4PkL+ThpcRGOvAga9D9M7iNeF5w=",
         "owner": "alphapapa",
         "repo": "plz.el",
-        "rev": "9e43e74acf615b38f05258ce80adccc5aaa4c56e",
+        "rev": "9e9a370830a879592a4c6c9e66a5e9ec9f27d698",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                            | Commit Message     |
| ------------------------------------------------------------------------------------------------- | ------------------ |
| [`9e9a3708`](https://github.com/alphapapa/plz.el/commit/9e9a370830a879592a4c6c9e66a5e9ec9f27d698) | `Release: 0.2`     |
| [`9a9c7bb9`](https://github.com/alphapapa/plz.el/commit/9a9c7bb919952b67455dbe0f3b57f2d046626bde) | `Meta: 0.2-pre`    |
| [`a6cb9bd0`](https://github.com/alphapapa/plz.el/commit/a6cb9bd0e2df667967e924937a6114ca9077e41d) | `Docs: Queueing`   |
| [`894168d4`](https://github.com/alphapapa/plz.el/commit/894168d4a29eb2f7d11beb9bacda198b5b1fff02) | `Tidy: Docstring`  |
| [`fb1c8fdf`](https://github.com/alphapapa/plz.el/commit/fb1c8fdf56bf1e685e10d6edb98d938f56dab7d2) | `WIP: Queueing II` |
| [`3469bcdb`](https://github.com/alphapapa/plz.el/commit/3469bcdbb2e2c1a772ecadcf4f50da317065a96d) | `WIP: Queueing`    |