### PR TITLE
chore(flake/emacs-overlay): `1d0bad62` -> `afb0f1be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658054880,
-        "narHash": "sha256-j+pBQjGi3zQlbgbgmrTIXjb1TiV2MVJltQNKjO6s5uM=",
+        "lastModified": 1658083628,
+        "narHash": "sha256-Sc3DibJDtveCYfAZPO8r/R5Fi8KvIYbHl7jlDRn5pNs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1d0bad6294cd4228070a60f936c6e74976d2b327",
+        "rev": "afb0f1be5bdcb7ba95495a536ed1ddea96653ee0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`afb0f1be`](https://github.com/nix-community/emacs-overlay/commit/afb0f1be5bdcb7ba95495a536ed1ddea96653ee0) | `Updated repos/melpa` |
| [`0e46b9d7`](https://github.com/nix-community/emacs-overlay/commit/0e46b9d7bb2a6912d614f893465bac539f0c28e7) | `Updated repos/emacs` |