### PR TITLE
chore(flake/home-manager): `64c745fe` -> `4a724cb8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658148954,
-        "narHash": "sha256-6IM+1QXAdRPED8zLCYHIHUt8gTFFrs7otRG1gO/jpPU=",
+        "lastModified": 1658151168,
+        "narHash": "sha256-0uHoOHr20pJTOGzgS4kNgOP4wfrch0fc+9vZ/6LgD44=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "64c745fe1c019b724e241a4f3cfbe3c661f54712",
+        "rev": "4a724cb84cc3aa464af1713d11bf0cfbbdb56c00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                      |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`4a724cb8`](https://github.com/nix-community/home-manager/commit/4a724cb84cc3aa464af1713d11bf0cfbbdb56c00) | `lib: improve DAG library`          |
| [`30dda628`](https://github.com/nix-community/home-manager/commit/30dda628bcd0814f65393359a4763f1afaee25a0) | `home-manager: add ncurses to PATH` |