### PR TITLE
chore(flake/emacs-ement): `c54c86b4` -> `1eeb0a2c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1657916039,
-        "narHash": "sha256-YCp/0pzAV41VWLgYxeWNBrWfBTOkpGoFac+EWheHafA=",
+        "lastModified": 1658160937,
+        "narHash": "sha256-LNj9WqbbIDMqW5OVBbubHtujusztwq8YEYdgrZgJnTU=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "c54c86b4ffe24f41592cdd06351f16adefe0eed9",
+        "rev": "1eeb0a2c33267561152aaf80d41edb27a97d1820",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message |
| --------------------------------------------------------------------------------------------------- | -------------- |
| [`1eeb0a2c`](https://github.com/alphapapa/ement.el/commit/1eeb0a2c33267561152aaf80d41edb27a97d1820) | `Comment: Add` |