### PR TITLE
chore(flake/emacs-ement): `1eeb0a2c` -> `fd46ea2b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1658160937,
-        "narHash": "sha256-LNj9WqbbIDMqW5OVBbubHtujusztwq8YEYdgrZgJnTU=",
+        "lastModified": 1658166740,
+        "narHash": "sha256-7TAH3n0Q5eWSpwHHXL3I1q8AKaxwH/RcGHJHw9PqjKA=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "1eeb0a2c33267561152aaf80d41edb27a97d1820",
+        "rev": "fd46ea2b8bc08dcb85a2af73b02da42ebb5844ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                           |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`fd46ea2b`](https://github.com/alphapapa/ement.el/commit/fd46ea2b8bc08dcb85a2af73b02da42ebb5844ed) | `Change/Fix: Highlight "@room" mentions` |
| [`919991ac`](https://github.com/alphapapa/ement.el/commit/919991acef1ede27cf818f29cd38098f7e3688eb) | `Tidy: Compilation warning`              |