### PR TITLE
chore(flake/emacs-overlay): `9fd14c3a` -> `c2b890a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658168569,
-        "narHash": "sha256-ikqqoDSmutMUgSm7ID2CKMG9oD3g6rgh9k4V9VVK3Nw=",
+        "lastModified": 1658202424,
+        "narHash": "sha256-j+vbQSFmMJnMz/jeFwD8jpXTg+l0BoKyYVgGSSXRXhg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9fd14c3ad83603804e5f42d4a6095f9021b49ede",
+        "rev": "c2b890a1886646d8c3a40bba3397d6a344fe986e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`c2b890a1`](https://github.com/nix-community/emacs-overlay/commit/c2b890a1886646d8c3a40bba3397d6a344fe986e) | `Updated repos/melpa` |
| [`b9499ce3`](https://github.com/nix-community/emacs-overlay/commit/b9499ce3a6b59285cdd9f915aa57f7a19dd54c58) | `Updated repos/emacs` |