### PR TITLE
chore(flake/emacs-overlay): `c2b890a1` -> `49b2fec8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658202424,
-        "narHash": "sha256-j+vbQSFmMJnMz/jeFwD8jpXTg+l0BoKyYVgGSSXRXhg=",
+        "lastModified": 1658227366,
+        "narHash": "sha256-kzMdsneN5uTz87BDpaAv0baJ2E2RyRC5OvD8wUEA+sk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c2b890a1886646d8c3a40bba3397d6a344fe986e",
+        "rev": "49b2fec856b3d7ad0321b74fbe453708af8906f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`49b2fec8`](https://github.com/nix-community/emacs-overlay/commit/49b2fec856b3d7ad0321b74fbe453708af8906f8) | `Updated repos/melpa` |
| [`4ec41054`](https://github.com/nix-community/emacs-overlay/commit/4ec41054a2b7b912fc5037a01cc2ebb800293419) | `Updated repos/emacs` |