### PR TITLE
chore(flake/emacs-ement): `fd46ea2b` -> `aaba533c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1658166740,
-        "narHash": "sha256-7TAH3n0Q5eWSpwHHXL3I1q8AKaxwH/RcGHJHw9PqjKA=",
+        "lastModified": 1658236177,
+        "narHash": "sha256-NQAB3LKdjGfNdJtgOgI3a0NEGxw+lPrQoMtLELZKRxI=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "fd46ea2b8bc08dcb85a2af73b02da42ebb5844ed",
+        "rev": "aaba533c9553bf1bc05aa523d89e5c8c7527f05d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                          |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`aaba533c`](https://github.com/alphapapa/ement.el/commit/aaba533c9553bf1bc05aa523d89e5c8c7527f05d) | `Fix: (ement-room) browse-url-handlers in Emacs < 28.1` |