### PR TITLE
chore(flake/emacs-overlay): `49b2fec8` -> `fe7e6cf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658227366,
-        "narHash": "sha256-kzMdsneN5uTz87BDpaAv0baJ2E2RyRC5OvD8wUEA+sk=",
+        "lastModified": 1658257055,
+        "narHash": "sha256-fEPloUpbx7/SieZ0MYODjcpM6viluRDVto3IqP9xfV8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "49b2fec856b3d7ad0321b74fbe453708af8906f8",
+        "rev": "fe7e6cf5de691688e49cbfc007e78f9af4c730af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`fe7e6cf5`](https://github.com/nix-community/emacs-overlay/commit/fe7e6cf5de691688e49cbfc007e78f9af4c730af) | `Updated repos/melpa` |
| [`cb4f80e4`](https://github.com/nix-community/emacs-overlay/commit/cb4f80e4817ef21d1a2d240b15ccc6653fa20b01) | `Updated repos/emacs` |
| [`793e65c4`](https://github.com/nix-community/emacs-overlay/commit/793e65c4283453d3be26815a5f877c507f52ad19) | `Updated repos/elpa`  |