### PR TITLE
chore(flake/emacs-overlay): `b9b68fa3` -> `12c96109`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658288438,
-        "narHash": "sha256-+MVHz8cPWDp3bzImUduKt+SZto1PoNwQ8E0lhxZ/6Bk=",
+        "lastModified": 1658314033,
+        "narHash": "sha256-EtbFCs1Aic5VKFovJAOrQHqJgtFXk/LPsOelIBn51/I=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b9b68fa326b821c1c63588121bfbef5ffdf5a38a",
+        "rev": "12c96109a215d8f676a573c2ccbe93fb26d5b5db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`12c96109`](https://github.com/nix-community/emacs-overlay/commit/12c96109a215d8f676a573c2ccbe93fb26d5b5db) | `Updated repos/melpa` |
| [`ede522b3`](https://github.com/nix-community/emacs-overlay/commit/ede522b3cfa53a5ca09ba9c3b2d99ec874a2bba0) | `Updated repos/emacs` |