### PR TITLE
chore(flake/nixos-hardware): `0015f5cc` -> `83009edc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1658227863,
-        "narHash": "sha256-QoRmU18dCYnZy8ks9cz2ZhsGW+AVo1pioLrs+s/8Tkg=",
+        "lastModified": 1658401027,
+        "narHash": "sha256-z/sDfzsFOoWNO9nZGfxDCNjHqXvSVZLDBDSgzr9qDXE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "0015f5cc098fae520aae458b8547e44a38aacf92",
+        "rev": "83009edccc2e24afe3d0165ed98b60ff7471a5f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                    |
| ----------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`b19015a0`](https://github.com/NixOS/nixos-hardware/commit/b19015a0ba6be4cbe3a87994133e8b11ef33b6ce) | `Adds support for Thinkpad T460p` |
| [`e3259b25`](https://github.com/NixOS/nixos-hardware/commit/e3259b25ebfe0afd8e1590d43950a4b9c2387de7) | `Fix legion 7 slim 15ach6`        |