### PR TITLE
chore(flake/emacs-overlay): `46ffe03d` -> `76b9c0cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658375000,
-        "narHash": "sha256-rnu1yFa6VXeTOYNogw758rxBnKsv1gocl6talaaQghU=",
+        "lastModified": 1658401409,
+        "narHash": "sha256-RR8/I+nZXodSFBD/3uS8m9yu7ydEa/xWSXtywSza19c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "46ffe03d0ac9f371501fd0030d7ca434c856c0c4",
+        "rev": "76b9c0cd881b1af278b955eb4d89a6a2d850de99",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`76b9c0cd`](https://github.com/nix-community/emacs-overlay/commit/76b9c0cd881b1af278b955eb4d89a6a2d850de99) | `Updated repos/melpa` |
| [`bdeb65c8`](https://github.com/nix-community/emacs-overlay/commit/bdeb65c828e9a7c5c1bb772c3d88d2b19610c1ef) | `Updated repos/emacs` |