### PR TITLE
chore(flake/emacs-overlay): `76b9c0cd` -> `6c868dba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658401409,
-        "narHash": "sha256-RR8/I+nZXodSFBD/3uS8m9yu7ydEa/xWSXtywSza19c=",
+        "lastModified": 1658430126,
+        "narHash": "sha256-W5zw1NI7c47qT/FCkNAVmahA5On5UUs1pabAL6Tb2iI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "76b9c0cd881b1af278b955eb4d89a6a2d850de99",
+        "rev": "6c868dbad387da912e2a47f63a913c8a62555127",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`6c868dba`](https://github.com/nix-community/emacs-overlay/commit/6c868dbad387da912e2a47f63a913c8a62555127) | `Updated repos/melpa` |
| [`97478261`](https://github.com/nix-community/emacs-overlay/commit/97478261cf8c3a798560a46f6578d0f3d5d4e031) | `Updated repos/emacs` |