### PR TITLE
chore(flake/emacs-overlay): `7c2397bc` -> `6bf61f97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658486466,
-        "narHash": "sha256-UijJuQfXi8iqUcJ4s6vvuNHU777xRzuVmTCv2tXEbQc=",
+        "lastModified": 1658515761,
+        "narHash": "sha256-2WcdSb4dJxHZAGIlj1JSLYpfU//fAedMwZFyf823deo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7c2397bcc1012a17cae20339456526dce978986a",
+        "rev": "6bf61f978a906be45be0aa3227942eec8a85a883",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`6bf61f97`](https://github.com/nix-community/emacs-overlay/commit/6bf61f978a906be45be0aa3227942eec8a85a883) | `Updated repos/melpa` |
| [`69c893bd`](https://github.com/nix-community/emacs-overlay/commit/69c893bd4f16139723f4e40faab79371f1491af2) | `Updated repos/emacs` |