### PR TITLE
chore(flake/emacs-overlay): `6bf61f97` -> `f22fe28d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658515761,
-        "narHash": "sha256-2WcdSb4dJxHZAGIlj1JSLYpfU//fAedMwZFyf823deo=",
+        "lastModified": 1658548964,
+        "narHash": "sha256-qbHo8Gj5bIO1WIjUjjr5BvhUeotvxJOa3QgTA1z4+JI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6bf61f978a906be45be0aa3227942eec8a85a883",
+        "rev": "f22fe28d687085b9c969f84b8784aca67b7340f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`f22fe28d`](https://github.com/nix-community/emacs-overlay/commit/f22fe28d687085b9c969f84b8784aca67b7340f4) | `Updated repos/nongnu` |
| [`af0818a2`](https://github.com/nix-community/emacs-overlay/commit/af0818a229683f75096a9598de1026bb3484c147) | `Updated repos/melpa`  |
| [`d8ea7056`](https://github.com/nix-community/emacs-overlay/commit/d8ea70564e24919cda129431f5b7c3c3ea2ac2da) | `Updated repos/emacs`  |
| [`f4ebd37c`](https://github.com/nix-community/emacs-overlay/commit/f4ebd37cc46af7dc3588dd0e57484faf3c3bb705) | `Updated repos/elpa`   |