### PR TITLE
chore(flake/emacs-overlay): `f22fe28d` -> `58ace00f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658548964,
-        "narHash": "sha256-qbHo8Gj5bIO1WIjUjjr5BvhUeotvxJOa3QgTA1z4+JI=",
+        "lastModified": 1658573705,
+        "narHash": "sha256-Y3ucoFYjiRGKNAt1B35xaBrTIk6XOl91mdVm73AEig8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f22fe28d687085b9c969f84b8784aca67b7340f4",
+        "rev": "58ace00febb5ba29aba23b6c70afa58ad5da9edb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`58ace00f`](https://github.com/nix-community/emacs-overlay/commit/58ace00febb5ba29aba23b6c70afa58ad5da9edb) | `Updated repos/melpa` |
| [`a4732259`](https://github.com/nix-community/emacs-overlay/commit/a4732259483b73fe9e678c3b1c38c58902e609b9) | `Updated repos/emacs` |