### PR TITLE
chore(flake/home-manager): `70d59298` -> `d86c1891`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658238241,
-        "narHash": "sha256-naoSta79MYYRtVnIZhzq+YWgTOBhWE1Sr1AIhG7ZA9g=",
+        "lastModified": 1658582894,
+        "narHash": "sha256-6iR8KSePwH9O2mClhu2RvDO/Gu5ISqNSB6t4YS/poaA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "70d5929885ccec8dde8585894dd3ebe606e75f41",
+        "rev": "d86c189158cb345e351190e362672a8485a52117",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`d86c1891`](https://github.com/nix-community/home-manager/commit/d86c189158cb345e351190e362672a8485a52117) | `firefox: support showing bookmarks on toolbar`             |
| [`218cb3ae`](https://github.com/nix-community/home-manager/commit/218cb3aee270aa7c073f2861864e921799bff360) | `firefox: fix empty check of bookmarks list`                |
| [`f91fb470`](https://github.com/nix-community/home-manager/commit/f91fb470bc5404b0198bbe2c427aaf8bac5857fa) | ``firefox: use `coercedTo` to convert bookmarks to a list`` |
| [`f47611fb`](https://github.com/nix-community/home-manager/commit/f47611fb171d967e0c65cfc99896913d62fa0d29) | `github: fix line wrapping`                                 |
| [`9cf40a43`](https://github.com/nix-community/home-manager/commit/9cf40a43fce5c0eab563435b4dd719b1ea610d40) | `github: ensure using the right branch of Home Manager`     |