### PR TITLE
chore(flake/emacs-overlay): `58ace00f` -> `20e53f39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658573705,
-        "narHash": "sha256-Y3ucoFYjiRGKNAt1B35xaBrTIk6XOl91mdVm73AEig8=",
+        "lastModified": 1658601459,
+        "narHash": "sha256-+exZ5xYDXxoTtYwkNE25cuVRyQ0+Uz/mUb/6RRsk5yI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "58ace00febb5ba29aba23b6c70afa58ad5da9edb",
+        "rev": "20e53f39d4144c26ab98eda94e6ba80638c5b565",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`20e53f39`](https://github.com/nix-community/emacs-overlay/commit/20e53f39d4144c26ab98eda94e6ba80638c5b565) | `Updated repos/melpa` |
| [`76978f21`](https://github.com/nix-community/emacs-overlay/commit/76978f21170db47dd945d2875b3460d4934a343f) | `Updated repos/emacs` |