### PR TITLE
chore(flake/pre-commit-hooks): `db3bd555` -> `f436e6db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1656169028,
-        "narHash": "sha256-y9DRauokIeVHM7d29lwT8A+0YoGUBXV3H0VErxQeA8s=",
+        "lastModified": 1658611562,
+        "narHash": "sha256-jktQ3mRrFAiFzzmVxQXh+8IxZOEE4hfr7St3ncXeVy4=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "db3bd555d3a3ceab208bed48f983ccaa6a71a25e",
+        "rev": "f436e6dbc10bb3500775785072a40eefe057b18e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                 |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------ |
| [`75a58e98`](https://github.com/cachix/pre-commit-hooks.nix/commit/75a58e9829ef83ff441a1de3d013165ef0fa2c06) | `Fix rustfmt and Clippy hooks` |