### PR TITLE
chore(flake/home-manager): `d86c1891` -> `1d3380af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658582894,
-        "narHash": "sha256-6iR8KSePwH9O2mClhu2RvDO/Gu5ISqNSB6t4YS/poaA=",
+        "lastModified": 1658666331,
+        "narHash": "sha256-zrlN3FeI3Fs8zuIWcHh9DiLKNyd++K+N+KR8slXi9wk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d86c189158cb345e351190e362672a8485a52117",
+        "rev": "1d3380afba625fdfcc131033e571140a09a993af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                           |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`1d3380af`](https://github.com/nix-community/home-manager/commit/1d3380afba625fdfcc131033e571140a09a993af) | `flake: fix self referential lib output` |