### PR TITLE
chore(flake/emacs-overlay): `8105f0f8` -> `26386599`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658689457,
-        "narHash": "sha256-d8nUJIx3NIsRx60Un1gAxOEKziBt9waGB6gC6Lw6yFE=",
+        "lastModified": 1658723452,
+        "narHash": "sha256-TyUCByGJ3FMyTJIhzoW2kZmpY07x2TmUB7Y2pAApTAM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8105f0f88edf635dbe97dc3b40984b90b2e76029",
+        "rev": "26386599653aa6040645f99a7446c47eefee05c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`26386599`](https://github.com/nix-community/emacs-overlay/commit/26386599653aa6040645f99a7446c47eefee05c4) | `Updated repos/melpa` |
| [`5b91173f`](https://github.com/nix-community/emacs-overlay/commit/5b91173fcd7958035271eefa3527024efaebc7da) | `Updated repos/emacs` |