### PR TITLE
chore(flake/emacs-overlay): `7570fbb3` -> `e6787f62`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658745654,
-        "narHash": "sha256-hPHX0nDNhPx8wCqodHz8d2j7SPW2rgWPmQpr4bkpYl0=",
+        "lastModified": 1658776433,
+        "narHash": "sha256-QEPVVPoJ4O9sH/Z9Ofxmbv5YVXHCC2hw9Yx54YaGHKI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7570fbb326335edc675b5d964ed0892b508562b6",
+        "rev": "e6787f627285bf1963ad582c7d635c97efea524d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`e6787f62`](https://github.com/nix-community/emacs-overlay/commit/e6787f627285bf1963ad582c7d635c97efea524d) | `Updated repos/melpa` |
| [`0b08d211`](https://github.com/nix-community/emacs-overlay/commit/0b08d211820634f49229d89c797815bd0af8f198) | `Updated repos/emacs` |
| [`3b50e7a5`](https://github.com/nix-community/emacs-overlay/commit/3b50e7a53936a3c1f732836933c224a8dd810aa5) | `Updated repos/elpa`  |