### PR TITLE
chore(flake/nix-on-droid): `949f20f8` -> `d49fd3a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -248,11 +248,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1654667844,
-        "narHash": "sha256-0tiIwPItfniax/bFw24CXTo74C7e+aIlAfHIBVF2xEE=",
+        "lastModified": 1658777837,
+        "narHash": "sha256-12rIm639nXldGgyc1uPbF/oz2jTrpgl8zvqxrIq+Jek=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "949f20f8ba900a02dfceb5c61ccef927ce704d87",
+        "rev": "d49fd3a0c874d34a3c3f33fa73cd7a364a1332e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                  |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`d49fd3a0`](https://github.com/t184256/nix-on-droid/commit/d49fd3a0c874d34a3c3f33fa73cd7a364a1332e3) | `CHANGELOG: Release 22.05`                                      |
| [`0ad6321f`](https://github.com/t184256/nix-on-droid/commit/0ad6321f79b4501d4dc0dd626b997faa0bed9509) | `pkgs: use non-prebuilt SDK`                                    |
| [`0de95f9e`](https://github.com/t184256/nix-on-droid/commit/0de95f9e9f76dec68e311f21b0d69e1374ae2088) | `pkgs/cross-compiling/talloc-static: update, build differently` |
| [`b286ac1a`](https://github.com/t184256/nix-on-droid/commit/b286ac1aac890a1b086c6b4f8d7670fc200d6535) | `pkgs/nix-directory: update nix`                                |
| [`d1f52f2e`](https://github.com/t184256/nix-on-droid/commit/d1f52f2e1de2ae741f6cf1bd198a583acfa34c1b) | `Update 21.11 references to 22.05`                              |
| [`b4b88984`](https://github.com/t184256/nix-on-droid/commit/b4b889845c869a4ab98dd8db4ca656f513714e4e) | `pkgs/proot-termux: update`                                     |
| [`0dbf0f56`](https://github.com/t184256/nix-on-droid/commit/0dbf0f56189e7a85cbaf73b294486cd7448d7b0c) | `Update pinned nixpkgs version to 22.05`                        |
| [`2d4d5413`](https://github.com/t184256/nix-on-droid/commit/2d4d54133442e275f2db2d3d6432d03047ab5176) | `Sprinkle --extra-experimental-features nix-command`            |
| [`a7a2d569`](https://github.com/t184256/nix-on-droid/commit/a7a2d5693747c5daa39b5301b30a384af66e1170) | `.github/workflows: use 22.05`                                  |
| [`979900f9`](https://github.com/t184256/nix-on-droid/commit/979900f93b8a4257d3ffe32fbe6b44e4dc1ecd2e) | `CHANGELOG: add notes for previous changes`                     |