### PR TITLE
chore(flake/emacs-overlay): `e6787f62` -> `79d28f83`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658776433,
-        "narHash": "sha256-QEPVVPoJ4O9sH/Z9Ofxmbv5YVXHCC2hw9Yx54YaGHKI=",
+        "lastModified": 1658808829,
+        "narHash": "sha256-A2kthh7a/MEbbrWGwkIS4dXMP1kNfdfAorxDjdtOxe4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e6787f627285bf1963ad582c7d635c97efea524d",
+        "rev": "79d28f8388bfe9e1933e4aa769676d2452cc6ad6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`79d28f83`](https://github.com/nix-community/emacs-overlay/commit/79d28f8388bfe9e1933e4aa769676d2452cc6ad6) | `Updated repos/melpa` |
| [`c2e19aa2`](https://github.com/nix-community/emacs-overlay/commit/c2e19aa2e259dcb38a869e2469455b83842dc6d2) | `Updated repos/emacs` |
| [`6d7d3b27`](https://github.com/nix-community/emacs-overlay/commit/6d7d3b27f8fbddbaf286f383cda9b753541ceb6b) | `Updated repos/elpa`  |