### PR TITLE
chore(flake/emacs-overlay): `79d28f83` -> `4d03024a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658808829,
-        "narHash": "sha256-A2kthh7a/MEbbrWGwkIS4dXMP1kNfdfAorxDjdtOxe4=",
+        "lastModified": 1658833746,
+        "narHash": "sha256-bm/FXx7lH8xaM1excP4SLexVBdaTKE5tZS8PyuibnsA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "79d28f8388bfe9e1933e4aa769676d2452cc6ad6",
+        "rev": "4d03024af95e8338ccd4d238a46c4bbe01ecdb89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`4d03024a`](https://github.com/nix-community/emacs-overlay/commit/4d03024af95e8338ccd4d238a46c4bbe01ecdb89) | `Updated repos/melpa` |
| [`3b253e01`](https://github.com/nix-community/emacs-overlay/commit/3b253e01ca280766a6f8d1694dca9b40ce1d6dc5) | `Updated repos/emacs` |