### PR TITLE
chore(flake/emacs-overlay): `4d03024a` -> `560bb95b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658833746,
-        "narHash": "sha256-bm/FXx7lH8xaM1excP4SLexVBdaTKE5tZS8PyuibnsA=",
+        "lastModified": 1658859882,
+        "narHash": "sha256-y15h05wrN+BWifRhBjTno3VpVmD0ditH3NwFW2j8UCA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4d03024af95e8338ccd4d238a46c4bbe01ecdb89",
+        "rev": "560bb95b7831ae6ad643e41f1281af1dc595c045",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`560bb95b`](https://github.com/nix-community/emacs-overlay/commit/560bb95b7831ae6ad643e41f1281af1dc595c045) | `Updated repos/melpa` |
| [`d73a1154`](https://github.com/nix-community/emacs-overlay/commit/d73a1154f68195b33d706ff90cfb49a4be42c96e) | `Updated repos/emacs` |