### PR TITLE
chore(flake/emacs-overlay): `a3ff607b` -> `a12c123f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658894784,
-        "narHash": "sha256-PH1kiQAPb5X+2skA6IFhd70TmgAqOPrHyInpcMPnam0=",
+        "lastModified": 1658918399,
+        "narHash": "sha256-77OGFLb22D81I17Ualq47BZjDhEiWFwt8VsVS4XWuG4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a3ff607bc96bc9ff051177c4b510e77c916c25ae",
+        "rev": "a12c123fd91e3206e136f5ed6f91b5390845a107",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`a12c123f`](https://github.com/nix-community/emacs-overlay/commit/a12c123fd91e3206e136f5ed6f91b5390845a107) | `Updated repos/melpa` |
| [`3ac9bcc7`](https://github.com/nix-community/emacs-overlay/commit/3ac9bcc7eada88f0ae6a63465bcde4e17c516362) | `Updated repos/emacs` |