### PR TITLE
chore(flake/home-manager): `dbed4c79` -> `b1394643`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658751516,
-        "narHash": "sha256-Y/3dHoTjbvYBtWd+TTBQJUIgDPO9d+Gqt05C5dyR7E4=",
+        "lastModified": 1658923832,
+        "narHash": "sha256-VOvRIcjE0nVLP7WJBwpYpLFkI4J+Rg/UrYRjJjnd0ao=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "dbed4c794d20d51027fc1107f063ec5be027dafc",
+        "rev": "b13946438f235a002c6a1c966b84b124123b26cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                     |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`b1394643`](https://github.com/nix-community/home-manager/commit/b13946438f235a002c6a1c966b84b124123b26cf) | `docs: improve contributing documentation`         |
| [`119febc4`](https://github.com/nix-community/home-manager/commit/119febc46489fc2b366fb5915667a6eb5d688059) | `vscode: avoid unnecessary IFD (again)`            |
| [`0b7fd187`](https://github.com/nix-community/home-manager/commit/0b7fd187e2dc8364cf31ed69347e4793c2d83a57) | ``xdg-mime-apps: fix regex in `mimeAssociations``` |