### PR TITLE
chore(flake/emacs-overlay): `a12c123f` -> `ccaa74f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658918399,
-        "narHash": "sha256-77OGFLb22D81I17Ualq47BZjDhEiWFwt8VsVS4XWuG4=",
+        "lastModified": 1658946476,
+        "narHash": "sha256-6yhZPvjfLDbWLpWuyQbAFimJb7rmyZhxVkieeZQCWVE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a12c123fd91e3206e136f5ed6f91b5390845a107",
+        "rev": "ccaa74f90962196b00a6acaa2c2fb206cf0983a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ccaa74f9`](https://github.com/nix-community/emacs-overlay/commit/ccaa74f90962196b00a6acaa2c2fb206cf0983a5) | `Updated repos/melpa` |
| [`97e085df`](https://github.com/nix-community/emacs-overlay/commit/97e085dfd85e2cfd6fd28d237878bff1cafd3f1a) | `Updated repos/emacs` |