### PR TITLE
chore(flake/emacs-overlay): `0c8f0386` -> `9aea9957`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658981057,
-        "narHash": "sha256-x7dlo7vrVg5ZdQA94V4lWzqHVbwqcLpVtNTvB9THKeg=",
+        "lastModified": 1659006386,
+        "narHash": "sha256-qEnu5m1AuAoA81/dsZAA1V2yIry9dUr2qRz/1ce6jRQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0c8f0386d80783f6fb04d5d0292a6937a875e335",
+        "rev": "9aea99573b75a77d6b82ef389a3fc825e52dea4e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`9aea9957`](https://github.com/nix-community/emacs-overlay/commit/9aea99573b75a77d6b82ef389a3fc825e52dea4e) | `Updated repos/melpa` |
| [`7fd6faf9`](https://github.com/nix-community/emacs-overlay/commit/7fd6faf9ddd2b91024cc05ad413ffaf2914cd570) | `Updated repos/emacs` |