### PR TITLE
chore(flake/emacs-overlay): `9aea9957` -> `962851d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659006386,
-        "narHash": "sha256-qEnu5m1AuAoA81/dsZAA1V2yIry9dUr2qRz/1ce6jRQ=",
+        "lastModified": 1659035460,
+        "narHash": "sha256-zU8fxINFH9EHSMuIrSjkD8Oy6Rr9vp2ek1py97fe0tk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9aea99573b75a77d6b82ef389a3fc825e52dea4e",
+        "rev": "962851d3e66ce26c65693ab9e2eadd87c24b5c7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`962851d3`](https://github.com/nix-community/emacs-overlay/commit/962851d3e66ce26c65693ab9e2eadd87c24b5c7c) | `Updated repos/melpa` |
| [`ff1758af`](https://github.com/nix-community/emacs-overlay/commit/ff1758aff712994c2a9366be837a2e716c8170d2) | `Updated repos/emacs` |
| [`e11ff59e`](https://github.com/nix-community/emacs-overlay/commit/e11ff59e05e56042073aacc33f36567efe4fd1e2) | `Updated repos/elpa`  |