### PR TITLE
chore(flake/emacs-ement): `481f571a` -> `95dcf9d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1658417886,
-        "narHash": "sha256-4ZZB14pWluaUfH7I5zuvIec98jLPnNDQyI+61/7UdT0=",
+        "lastModified": 1659060538,
+        "narHash": "sha256-3E4yd6R8C7tTI7Z6Sc+oE+wBz5S2pB7wbqGCgqU6j7c=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "481f571a2fb62cf57acbc28848894ff48dda8a9c",
+        "rev": "95dcf9d56eb127faa032c364f80eec839121ff14",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                           |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`95dcf9d5`](https://github.com/alphapapa/ement.el/commit/95dcf9d56eb127faa032c364f80eec839121ff14) | `Fix: (ement-room--insert-sender-headers) Use ewoc-prev` |
| [`cbdba7b2`](https://github.com/alphapapa/ement.el/commit/cbdba7b2348460fb4723c091e53549ceec8c00ef) | `Fix: "kicked and banned" event coalescing`              |