### PR TITLE
chore(flake/emacs-overlay): `962851d3` -> `2882396c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659035460,
-        "narHash": "sha256-zU8fxINFH9EHSMuIrSjkD8Oy6Rr9vp2ek1py97fe0tk=",
+        "lastModified": 1659070300,
+        "narHash": "sha256-qFI9MDh6QjbtMtxdmN1lFodJKLG8OxLUB3TlzdBGZag=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "962851d3e66ce26c65693ab9e2eadd87c24b5c7c",
+        "rev": "2882396c157712b2a58c7f04320e262df5adada8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`2882396c`](https://github.com/nix-community/emacs-overlay/commit/2882396c157712b2a58c7f04320e262df5adada8) | `Updated repos/melpa` |
| [`022cb714`](https://github.com/nix-community/emacs-overlay/commit/022cb7140607ea739c3a8c7807d64ff3f8aa4046) | `Updated repos/emacs` |
| [`ab903538`](https://github.com/nix-community/emacs-overlay/commit/ab903538da378145133c788cdb7153a182776a28) | `Updated repos/elpa`  |