### PR TITLE
chore(flake/emacs-overlay): `2882396c` -> `30a3d95b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659070300,
-        "narHash": "sha256-qFI9MDh6QjbtMtxdmN1lFodJKLG8OxLUB3TlzdBGZag=",
+        "lastModified": 1659086644,
+        "narHash": "sha256-VGK2BgT8JHK6m8cJZeNrApZkfEg6ArQVvnHdY8d6CJ0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2882396c157712b2a58c7f04320e262df5adada8",
+        "rev": "30a3d95bb4d9812e26822260b6ac45efde0d7700",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`30a3d95b`](https://github.com/nix-community/emacs-overlay/commit/30a3d95bb4d9812e26822260b6ac45efde0d7700) | `Updated repos/melpa` |