### PR TITLE
chore(flake/emacs-overlay): `30a3d95b` -> `fa0de2ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659086644,
-        "narHash": "sha256-VGK2BgT8JHK6m8cJZeNrApZkfEg6ArQVvnHdY8d6CJ0=",
+        "lastModified": 1659120193,
+        "narHash": "sha256-dpbkJuP/zSIlg7zDs0xtyYt61zk6RKk6jCgqkhMW53Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "30a3d95bb4d9812e26822260b6ac45efde0d7700",
+        "rev": "fa0de2aeb1115285c65238e07ea0aecd52765667",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`fa0de2ae`](https://github.com/nix-community/emacs-overlay/commit/fa0de2aeb1115285c65238e07ea0aecd52765667) | `Updated repos/melpa` |
| [`5440e1b1`](https://github.com/nix-community/emacs-overlay/commit/5440e1b14de5f124f4cc86649901b702d91b1707) | `Updated repos/emacs` |