### PR TITLE
chore(flake/emacs-overlay): `fa0de2ae` -> `c2bf3dea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659120193,
-        "narHash": "sha256-dpbkJuP/zSIlg7zDs0xtyYt61zk6RKk6jCgqkhMW53Y=",
+        "lastModified": 1659152465,
+        "narHash": "sha256-OFXEnDkmWvlf/uFzg9onwtDGXWZhT5npkG2WduAFt6I=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fa0de2aeb1115285c65238e07ea0aecd52765667",
+        "rev": "c2bf3dea5dbc634eef4d3ef531a47ee707987ca5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`c2bf3dea`](https://github.com/nix-community/emacs-overlay/commit/c2bf3dea5dbc634eef4d3ef531a47ee707987ca5) | `Updated repos/melpa` |
| [`db59fa23`](https://github.com/nix-community/emacs-overlay/commit/db59fa2322d64780a972b6b387f28cf5ca45a399) | `Updated repos/emacs` |
| [`2836cf40`](https://github.com/nix-community/emacs-overlay/commit/2836cf40bb4c19b2afdc480f0d658310a0b19094) | `Updated repos/elpa`  |