### PR TITLE
chore(flake/emacs-overlay): `34074146` -> `697a2c5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659177353,
-        "narHash": "sha256-R8zCIYAJNndt/7gWOch9LN5/NuXDzFPhS7K911bGgcQ=",
+        "lastModified": 1659205090,
+        "narHash": "sha256-/cOX0Fze8nKfayE5FACX3BAUWvdbo3fSfTZjYEKWq0s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "34074146972552177d529af38f5395ef4c6eab73",
+        "rev": "697a2c5f0a4958d383be0e4067f44cffe8af9a8a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`697a2c5f`](https://github.com/nix-community/emacs-overlay/commit/697a2c5f0a4958d383be0e4067f44cffe8af9a8a) | `Updated repos/melpa` |
| [`32c95120`](https://github.com/nix-community/emacs-overlay/commit/32c9512027d98f3ce65cb8472f14210338420e2b) | `Updated repos/emacs` |
| [`2320fe4e`](https://github.com/nix-community/emacs-overlay/commit/2320fe4ee10ee33dc0b2ae8c68abb35a285afd88) | `Updated repos/elpa`  |