### PR TITLE
chore(flake/emacs-overlay): `697a2c5f` -> `fe461abf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659205090,
-        "narHash": "sha256-/cOX0Fze8nKfayE5FACX3BAUWvdbo3fSfTZjYEKWq0s=",
+        "lastModified": 1659240600,
+        "narHash": "sha256-HdGwrXHT7N3FOYLhlqd408OYhYUZHmm4RqHNjSq7SHE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "697a2c5f0a4958d383be0e4067f44cffe8af9a8a",
+        "rev": "fe461abf7f0718e8010aa31753173bf3001b1c73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`fe461abf`](https://github.com/nix-community/emacs-overlay/commit/fe461abf7f0718e8010aa31753173bf3001b1c73) | `Updated repos/melpa` |
| [`0846f792`](https://github.com/nix-community/emacs-overlay/commit/0846f7927044b3f1de5ad398b2edc1e7c65073ac) | `Updated repos/emacs` |