### PR TITLE
chore(flake/emacs-overlay): `fe461abf` -> `a6e98d6e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659240600,
-        "narHash": "sha256-HdGwrXHT7N3FOYLhlqd408OYhYUZHmm4RqHNjSq7SHE=",
+        "lastModified": 1659265188,
+        "narHash": "sha256-iq46X0i7GkbH19ulP5ViNMXnpVb1KNx16zmHiRy1jyk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fe461abf7f0718e8010aa31753173bf3001b1c73",
+        "rev": "a6e98d6e2e88c5cb354eed291c3a977e7816cec5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`a6e98d6e`](https://github.com/nix-community/emacs-overlay/commit/a6e98d6e2e88c5cb354eed291c3a977e7816cec5) | `Updated repos/melpa` |
| [`a67973c4`](https://github.com/nix-community/emacs-overlay/commit/a67973c45ab7d516881baa8e4e5756ab6ddd11ae) | `Updated repos/emacs` |