### PR TITLE
chore(flake/emacs-overlay): `a6e98d6e` -> `b27eeeb1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659265188,
-        "narHash": "sha256-iq46X0i7GkbH19ulP5ViNMXnpVb1KNx16zmHiRy1jyk=",
+        "lastModified": 1659291801,
+        "narHash": "sha256-SykEVItSRRJYIhpiRuCAFyx5pS7RVkiMpF4PshHTXHs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a6e98d6e2e88c5cb354eed291c3a977e7816cec5",
+        "rev": "b27eeeb1a74214b0490f4faf1ff50c213e2eb33b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`b27eeeb1`](https://github.com/nix-community/emacs-overlay/commit/b27eeeb1a74214b0490f4faf1ff50c213e2eb33b) | `Updated repos/melpa` |
| [`7ace153f`](https://github.com/nix-community/emacs-overlay/commit/7ace153f21c41d98fdc76ec5dcd82e9bc920fb74) | `Updated repos/emacs` |