### PR TITLE
chore(flake/emacs-overlay): `b27eeeb1` -> `e0f99212`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659291801,
-        "narHash": "sha256-SykEVItSRRJYIhpiRuCAFyx5pS7RVkiMpF4PshHTXHs=",
+        "lastModified": 1659325996,
+        "narHash": "sha256-phFMvj4cK+3acm/5avVRqzRtsRHUTYqkJJXuZ6NwzCw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b27eeeb1a74214b0490f4faf1ff50c213e2eb33b",
+        "rev": "e0f99212b780c7f55af5d5b9d6ed20528d9fbee2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`e0f99212`](https://github.com/nix-community/emacs-overlay/commit/e0f99212b780c7f55af5d5b9d6ed20528d9fbee2) | `Updated repos/melpa` |
| [`90ac16e7`](https://github.com/nix-community/emacs-overlay/commit/90ac16e769db86cf919d6c6d9577ee07d35acafb) | `Updated repos/emacs` |