### PR TITLE
chore(flake/emacs-overlay): `e0f99212` -> `49173ef2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659325996,
-        "narHash": "sha256-phFMvj4cK+3acm/5avVRqzRtsRHUTYqkJJXuZ6NwzCw=",
+        "lastModified": 1659349723,
+        "narHash": "sha256-1sLtL2EcAJIELwdEwakWRiitWD3hfryPBjAGhRZIpoA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e0f99212b780c7f55af5d5b9d6ed20528d9fbee2",
+        "rev": "49173ef266e5968f16b7007481f05b2e5ccbfa56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`49173ef2`](https://github.com/nix-community/emacs-overlay/commit/49173ef266e5968f16b7007481f05b2e5ccbfa56) | `Updated repos/melpa` |
| [`18c1bf35`](https://github.com/nix-community/emacs-overlay/commit/18c1bf356efb2fc52cf97ca67acc251df9067176) | `Updated repos/emacs` |