### PR TITLE
chore(flake/nixos-hardware): `727a099e` -> `ea3efc80`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1659256765,
-        "narHash": "sha256-RE4l6J+ApJ1vd4QFDhbEasv0M/deTxSK5IsIBYXuHmE=",
+        "lastModified": 1659356074,
+        "narHash": "sha256-UwV6hZZEtchvtiTCCD/ODEv1226eam8kEgEyQb7xB0E=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "727a099e871ff10ae09a1ebd056a5ba4b9dbe50f",
+        "rev": "ea3efc80f8ab83cb73aec39f4e76fe87afb15a08",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`a01a1095`](https://github.com/NixOS/nixos-hardware/commit/a01a1095e4226dcb3ba68937831c7cc90a8eedea) | `amd pstate: small typo`             |
| [`68a27c2b`](https://github.com/NixOS/nixos-hardware/commit/68a27c2b00fd6e4ed23b7093c226ef604fdf4f0f) | `Clarify kernel version condition`   |
| [`8732fa9e`](https://github.com/NixOS/nixos-hardware/commit/8732fa9eb5f4d98ed0986e8cf7214057beec0cb0) | `clarify amd pstate`                 |
| [`b183aac0`](https://github.com/NixOS/nixos-hardware/commit/b183aac0ac4115a4aae4592e761e4e79ac287324) | `g733qs: addded amd pstate handling` |
| [`5e9934fa`](https://github.com/NixOS/nixos-hardware/commit/5e9934fa077fb326001972bc4754bf45b33180eb) | `pstate:init`                        |