### PR TITLE
chore(flake/emacs-overlay): `49173ef2` -> `e911c43b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659349723,
-        "narHash": "sha256-1sLtL2EcAJIELwdEwakWRiitWD3hfryPBjAGhRZIpoA=",
+        "lastModified": 1659379767,
+        "narHash": "sha256-cfcutZL9YBqx2uTRfeLpic6baU/nwLlsp/hMnL/boDA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "49173ef266e5968f16b7007481f05b2e5ccbfa56",
+        "rev": "e911c43b99c7b9c94ee408c38b0c6e2c6a01132e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`e911c43b`](https://github.com/nix-community/emacs-overlay/commit/e911c43b99c7b9c94ee408c38b0c6e2c6a01132e) | `Updated repos/melpa` |
| [`520725c7`](https://github.com/nix-community/emacs-overlay/commit/520725c7bce9295af7558468a315ad7feb801985) | `Updated repos/emacs` |