### PR TITLE
chore(flake/emacs-overlay): `e911c43b` -> `0ccabd77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659379767,
-        "narHash": "sha256-cfcutZL9YBqx2uTRfeLpic6baU/nwLlsp/hMnL/boDA=",
+        "lastModified": 1659413063,
+        "narHash": "sha256-OkioKB8eT9jJ64FZApur/CcH6yomFQ3z7zBWmUjGNMU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e911c43b99c7b9c94ee408c38b0c6e2c6a01132e",
+        "rev": "0ccabd776050ea80faf610a9dd5b390171ee8037",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`0ccabd77`](https://github.com/nix-community/emacs-overlay/commit/0ccabd776050ea80faf610a9dd5b390171ee8037) | `Updated repos/melpa` |
| [`77546f92`](https://github.com/nix-community/emacs-overlay/commit/77546f927f044801c8ffd452ed4186c246350b50) | `Updated repos/emacs` |