### PR TITLE
chore(flake/emacs-overlay): `0ccabd77` -> `7125a934`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659413063,
-        "narHash": "sha256-OkioKB8eT9jJ64FZApur/CcH6yomFQ3z7zBWmUjGNMU=",
+        "lastModified": 1659438534,
+        "narHash": "sha256-jDYYLlNPSixJAouUt5bC51/KDeUoWYszlbZur66ZKqE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0ccabd776050ea80faf610a9dd5b390171ee8037",
+        "rev": "7125a934f0e1cd8a22ee5bb604c9010965fb27df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`7125a934`](https://github.com/nix-community/emacs-overlay/commit/7125a934f0e1cd8a22ee5bb604c9010965fb27df) | `Updated repos/melpa` |
| [`ade68201`](https://github.com/nix-community/emacs-overlay/commit/ade682017b39fd5651b034f678a7a5ec5109075b) | `Updated repos/emacs` |