### PR TITLE
chore(flake/home-manager): `77648a07` -> `d8d9ff0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659398318,
-        "narHash": "sha256-5wovS14I/DNXwfiMP402Ut2kxI58CO1wD943fboWMDw=",
+        "lastModified": 1659484873,
+        "narHash": "sha256-6VoPiGyDdjBHOJ3IpS24lY1lrDiOHeuEefOFI0qz3WE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "77648a07e459adff69b2c4033a77b2cababb5843",
+        "rev": "d8d9ff0b2df77defa10375c6665b51f0251c34d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                            |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`d8d9ff0b`](https://github.com/nix-community/home-manager/commit/d8d9ff0b2df77defa10375c6665b51f0251c34d6) | `tint2: correctly reference the provided package (#3125)` |