### PR TITLE
chore(flake/emacs-overlay): `f62e1223` -> `10d42a1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659464528,
-        "narHash": "sha256-eRsmsV2IoaYf61XfTWqHtTWjqFfAvqQGmc5bGiV//t4=",
+        "lastModified": 1659494711,
+        "narHash": "sha256-86qKhuVRwuqyeEGxprnxZin5hzKk9axrYpIC06xTjuk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f62e12239b7cc83a19268e86948c98a04e48342c",
+        "rev": "10d42a1d9e6032992ac047153a9bffd4444bd6ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`10d42a1d`](https://github.com/nix-community/emacs-overlay/commit/10d42a1d9e6032992ac047153a9bffd4444bd6ed) | `Updated repos/melpa` |