### PR TITLE
chore(flake/emacs-overlay): `10d42a1d` -> `f4d60d03`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659494711,
-        "narHash": "sha256-86qKhuVRwuqyeEGxprnxZin5hzKk9axrYpIC06xTjuk=",
+        "lastModified": 1659523043,
+        "narHash": "sha256-llcqXZrp4OsL/N/uPGRsxIKcEW+lySs82umP1H+L59E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "10d42a1d9e6032992ac047153a9bffd4444bd6ed",
+        "rev": "f4d60d03ea621634ab3091f2c7c036b6a4ad49c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`f4d60d03`](https://github.com/nix-community/emacs-overlay/commit/f4d60d03ea621634ab3091f2c7c036b6a4ad49c3) | `Updated repos/melpa` |
| [`a79315e6`](https://github.com/nix-community/emacs-overlay/commit/a79315e600804fbad481119ec98ce055bc40af91) | `Updated repos/emacs` |