### PR TITLE
chore(flake/emacs-overlay): `f4d60d03` -> `26275c35`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659523043,
-        "narHash": "sha256-llcqXZrp4OsL/N/uPGRsxIKcEW+lySs82umP1H+L59E=",
+        "lastModified": 1659553056,
+        "narHash": "sha256-TfMl5JhzrN4egZTQcgiZUhQ851hDm7VqCkyRtFxNmyc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f4d60d03ea621634ab3091f2c7c036b6a4ad49c3",
+        "rev": "26275c354045b6320dcef29a0b18a244293282ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`26275c35`](https://github.com/nix-community/emacs-overlay/commit/26275c354045b6320dcef29a0b18a244293282ef) | `Updated repos/melpa` |
| [`ce91eb05`](https://github.com/nix-community/emacs-overlay/commit/ce91eb0560fd6e315cc245ee97c10baebdf2678e) | `Updated repos/emacs` |