### PR TITLE
chore(flake/emacs-overlay): `26275c35` -> `30e49314`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659553056,
-        "narHash": "sha256-TfMl5JhzrN4egZTQcgiZUhQ851hDm7VqCkyRtFxNmyc=",
+        "lastModified": 1659584948,
+        "narHash": "sha256-o7TAbeyy4AQkHSA0nZVdgrPv2Krr8jL7d0T4AgJj6ws=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "26275c354045b6320dcef29a0b18a244293282ef",
+        "rev": "30e49314ab028a8accab3d9944a0b719556b3153",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`30e49314`](https://github.com/nix-community/emacs-overlay/commit/30e49314ab028a8accab3d9944a0b719556b3153) | `Updated repos/nongnu` |
| [`6a112319`](https://github.com/nix-community/emacs-overlay/commit/6a11231909c53573b3d0c90a22156cf5d5b2416f) | `Updated repos/melpa`  |
| [`7f58ceea`](https://github.com/nix-community/emacs-overlay/commit/7f58ceea290ebb546c43c0b2ec435fdbcbdea7df) | `Updated repos/emacs`  |
| [`6601196d`](https://github.com/nix-community/emacs-overlay/commit/6601196d5d9fdaf13161aa297218bdcdf915c865) | `Updated repos/elpa`   |