### PR TITLE
chore(flake/pre-commit-hooks): `f436e6db` -> `61b1a82f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658611562,
-        "narHash": "sha256-jktQ3mRrFAiFzzmVxQXh+8IxZOEE4hfr7St3ncXeVy4=",
+        "lastModified": 1659628163,
+        "narHash": "sha256-3CfFGtc1FstAAF4Az9Ws67a9fxGuzsy2eKbjycGRtz0=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "f436e6dbc10bb3500775785072a40eefe057b18e",
+        "rev": "61b1a82fbe6df3570fd0691bd6e25516ddf70d3c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                 |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
| [`3d619abc`](https://github.com/cachix/pre-commit-hooks.nix/commit/3d619abc65f5eb33758f9abcc1605abbb8e16ff6) | `Add support for manual hooks.`                |
| [`bb16dc75`](https://github.com/cachix/pre-commit-hooks.nix/commit/bb16dc75e27c9ba3cb2f4acc28c99a83aa0096d1) | `Remove the individual tools from the overlay` |