### PR TITLE
chore(flake/emacs-overlay): `da35c186` -> `a151f9ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659609039,
-        "narHash": "sha256-RMN9IYCUNI+7A3kFNW5L8+Elure82390tM2XXreqNcQ=",
+        "lastModified": 1659638214,
+        "narHash": "sha256-lXa01G06Ey9qgj+rYN7Nzc53FP3p2UMMnAuxpWXu9Ko=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "da35c186463ac1b7bb04f70b4291ac0572e3ce13",
+        "rev": "a151f9ff5b9fa813ac8918f3a3a67c643e7e2edc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`a151f9ff`](https://github.com/nix-community/emacs-overlay/commit/a151f9ff5b9fa813ac8918f3a3a67c643e7e2edc) | `Updated repos/melpa` |
| [`3e321b6e`](https://github.com/nix-community/emacs-overlay/commit/3e321b6e5936c9dc4e0df9c2c751cad8c9dd7e51) | `Updated repos/emacs` |