### PR TITLE
chore(flake/emacs-overlay): `a151f9ff` -> `4a5b9fb6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659638214,
-        "narHash": "sha256-lXa01G06Ey9qgj+rYN7Nzc53FP3p2UMMnAuxpWXu9Ko=",
+        "lastModified": 1659671505,
+        "narHash": "sha256-HC8wze+/Lzc6HoVOmgJKrf9/3El6BL7ruuAy7gqzkog=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a151f9ff5b9fa813ac8918f3a3a67c643e7e2edc",
+        "rev": "4a5b9fb659456b31d2c15e53694e139077920592",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`4a5b9fb6`](https://github.com/nix-community/emacs-overlay/commit/4a5b9fb659456b31d2c15e53694e139077920592) | `Updated repos/melpa` |
| [`d2473ff8`](https://github.com/nix-community/emacs-overlay/commit/d2473ff8a997883dce48f9f7be891d2a7449fc05) | `Updated repos/emacs` |
| [`9081b2a2`](https://github.com/nix-community/emacs-overlay/commit/9081b2a265e8acaf94392fc04ba2ae1c35c6ae6a) | `Updated repos/elpa`  |