### PR TITLE
chore(flake/emacs-overlay): `4a5b9fb6` -> `43460316`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659671505,
-        "narHash": "sha256-HC8wze+/Lzc6HoVOmgJKrf9/3El6BL7ruuAy7gqzkog=",
+        "lastModified": 1659695745,
+        "narHash": "sha256-FZhS2R4thx+7ldBDeKap/YtZgWsiUUbuUbmub3d7ysE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4a5b9fb659456b31d2c15e53694e139077920592",
+        "rev": "434603164e8d33c6e7c264672cfd1aa187713a43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`43460316`](https://github.com/nix-community/emacs-overlay/commit/434603164e8d33c6e7c264672cfd1aa187713a43) | `Updated repos/nongnu` |
| [`6f88e779`](https://github.com/nix-community/emacs-overlay/commit/6f88e779ebaf6dcdb6680aca645b5b6dd5efee93) | `Updated repos/melpa`  |
| [`9019be27`](https://github.com/nix-community/emacs-overlay/commit/9019be27f46ed3a102b2e732cb679eb01217a839) | `Updated repos/emacs`  |