### PR TITLE
chore(flake/emacs-ement): `4fef240e` -> `df2110da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1659119341,
-        "narHash": "sha256-mMrmRfbcTr1gcBECwvpvF/QPThhRlyyCJr1Ekyn6R4o=",
+        "lastModified": 1659724373,
+        "narHash": "sha256-Bco9erqNTsq6QKJjdrx7sde+lUWgGb7FSQhx3GHRGyo=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "4fef240e85d948c22cf30d7f553b8e5da4f98dd3",
+        "rev": "df2110da6f392067ddf731a4ca577e08310cd8b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                             |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`df2110da`](https://github.com/alphapapa/ement.el/commit/df2110da6f392067ddf731a4ca577e08310cd8b8) | `Fix: (ement-room--buffer) Sender headers` |