### PR TITLE
chore(flake/deploy-rs): `184349d8` -> `41f15759`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -96,11 +96,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1653594315,
-        "narHash": "sha256-kJ0ENmnQJ4qL2FeYKZba9kvv1KmIuB3NVpBwMeI7AJQ=",
+        "lastModified": 1659725433,
+        "narHash": "sha256-1ZxuK67TL29YLw88vQ18Y2Y6iYg8Jb7I6/HVzmNB6nM=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "184349d8149436748986d1bdba087e4149e9c160",
+        "rev": "41f15759dd8b638e7b4f299730d94d5aa46ab7eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                              |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`9e79e402`](https://github.com/serokell/deploy-rs/commit/9e79e4028a8af2479233b5968f48f7f8d06376d1) | ``Fetch system from `stdenv.hostPlatform``` |
| [`6564bee9`](https://github.com/serokell/deploy-rs/commit/6564bee9ee7390f1d4612b1ff654ac82a8b14d17) | `Replace runCommandNoCC by runCommand`      |