### PR TITLE
chore(flake/emacs-ement): `df2110da` -> `c3a56284`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1659724373,
-        "narHash": "sha256-Bco9erqNTsq6QKJjdrx7sde+lUWgGb7FSQhx3GHRGyo=",
+        "lastModified": 1659732488,
+        "narHash": "sha256-mPwyERCvU7fQu7FkrMJFNHAd/SRrrsFlBS1fSaSkKww=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "df2110da6f392067ddf731a4ca577e08310cd8b8",
+        "rev": "c3a56284b554fe634178ce015c758ca12017aae2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                    |
| --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`c3a56284`](https://github.com/alphapapa/ement.el/commit/c3a56284b554fe634178ce015c758ca12017aae2) | `Fix: (ement-room--format-reactions) Composed Unicode variations` |