### PR TITLE
chore(flake/emacs-overlay): `9e7e8453` -> `94ea63e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659809965,
-        "narHash": "sha256-EujeArMgYV3Aveyy30ek/bon2n9KaxUahBR2RKmk87k=",
+        "lastModified": 1659843962,
+        "narHash": "sha256-Belail+OXH4kAd1apTWoTWcluSf8tuMybBbL8iQjEvE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9e7e84533fa8d0d5fdbb348410bfdae731bca80d",
+        "rev": "94ea63e5fe0f13c61f7071eee078bcc86632d105",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`94ea63e5`](https://github.com/nix-community/emacs-overlay/commit/94ea63e5fe0f13c61f7071eee078bcc86632d105) | `Updated repos/nongnu` |
| [`993442e8`](https://github.com/nix-community/emacs-overlay/commit/993442e82ab3a796ca9a57d820bedae190a26f6f) | `Updated repos/melpa`  |
| [`ca1c3a6d`](https://github.com/nix-community/emacs-overlay/commit/ca1c3a6d29c5c0ce5b998c968b6ec2465298b4be) | `Updated repos/emacs`  |