### PR TITLE
chore(flake/home-manager): `d8d9ff0b` -> `d9e03b7f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659484873,
-        "narHash": "sha256-6VoPiGyDdjBHOJ3IpS24lY1lrDiOHeuEefOFI0qz3WE=",
+        "lastModified": 1659863516,
+        "narHash": "sha256-gfLm3XOcSEAokqNs2sA0pXHIebdgvpA2F6lvrB/dkis=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d8d9ff0b2df77defa10375c6665b51f0251c34d6",
+        "rev": "d9e03b7f8c67890b920c92d8154dd9b60bb1242f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                           |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`d9e03b7f`](https://github.com/nix-community/home-manager/commit/d9e03b7f8c67890b920c92d8154dd9b60bb1242f) | `wezterm: add module`                                    |
| [`91f26e0b`](https://github.com/nix-community/home-manager/commit/91f26e0b0e88b6431740055c598bd586c275276a) | ``polybar: use add `.ini` suffix to configuration file`` |