### PR TITLE
chore(flake/emacs-overlay): `94ea63e5` -> `e1ccf03c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659843962,
-        "narHash": "sha256-Belail+OXH4kAd1apTWoTWcluSf8tuMybBbL8iQjEvE=",
+        "lastModified": 1659868437,
+        "narHash": "sha256-26V8Q3x1yJ84VtZMgvBuvTg7kJBpd6KgUIz6jWMlPFk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "94ea63e5fe0f13c61f7071eee078bcc86632d105",
+        "rev": "e1ccf03cca1f57361226b2037ead142d82ba9bd5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`e1ccf03c`](https://github.com/nix-community/emacs-overlay/commit/e1ccf03cca1f57361226b2037ead142d82ba9bd5) | `Updated repos/nongnu` |
| [`b40d0a6d`](https://github.com/nix-community/emacs-overlay/commit/b40d0a6d121a559693c969d08650f13a3b9c8727) | `Updated repos/melpa`  |
| [`9dd0844c`](https://github.com/nix-community/emacs-overlay/commit/9dd0844cfaf200facedc0e2a7a50356dd1c7ce26) | `Updated repos/emacs`  |