### PR TITLE
chore(flake/emacs-overlay): `e1ccf03c` -> `0ba1cdec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659868437,
-        "narHash": "sha256-26V8Q3x1yJ84VtZMgvBuvTg7kJBpd6KgUIz6jWMlPFk=",
+        "lastModified": 1659875169,
+        "narHash": "sha256-d8Hat5zjFht2/crT58iM6N5WcBEyQ+cRrvPvEKzG8sI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e1ccf03cca1f57361226b2037ead142d82ba9bd5",
+        "rev": "0ba1cdec346f8f31f0c520ceca9795e8522252ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                           |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
| [`e46c7738`](https://github.com/nix-community/emacs-overlay/commit/e46c7738bd06c8bdbe265782ea7072e52fcb6b8b) | `Build Emacs 29 with libwebp by default` |