### PR TITLE
chore(flake/utils): `7e2a3b3d` -> `c0e246b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -492,11 +492,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                                     |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`c0e246b9`](https://github.com/numtide/flake-utils/commit/c0e246b9b83f637f4681389ecabcb2681b4f3af0) | `Update each-system template to use new flake output system (#76)` |