### PR TITLE
chore(flake/emacs-overlay): `c5fc4c4e` -> `58e88dbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659897026,
-        "narHash": "sha256-fH25tzfpNxcgAd8ixkxTXn3WlHn5+jMWHbvixc75aIw=",
+        "lastModified": 1659930927,
+        "narHash": "sha256-unXcxPG1wH++Fa99GwIgJVYeciDLc0BQU/qkh/17bpc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c5fc4c4e83ea921f9ed826e3187b21febd5b174d",
+        "rev": "58e88dbc17d5252b51bff1266c6f10c00997e1f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`58e88dbc`](https://github.com/nix-community/emacs-overlay/commit/58e88dbc17d5252b51bff1266c6f10c00997e1f8) | `Updated repos/melpa` |
| [`6be264e5`](https://github.com/nix-community/emacs-overlay/commit/6be264e5ee71a34d15335c6dfe6d2f3d4a85924c) | `Updated repos/emacs` |
| [`db0f540f`](https://github.com/nix-community/emacs-overlay/commit/db0f540f9ce8fc55246719526e54cc65c0f3945c) | `Updated repos/elpa`  |