### PR TITLE
chore(flake/home-manager): `f5e9879e` -> `389f2b20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659878744,
-        "narHash": "sha256-81a9Mx5pDMBGN4WnVhcQVkW5mXNTZOt8DZOSI8bVKpU=",
+        "lastModified": 1659975201,
+        "narHash": "sha256-yHOOMq/G8jTj3QI8RhzqD9yuNqwThiZMjx6R5klZI08=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f5e9879e74e6202e2dbb3628fad2d20eac0d8be4",
+        "rev": "389f2b20371b7c0c7e52ceb817d7c8bbc63435a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message          |
| ----------------------------------------------------------------------------------------------------------- | ----------------------- |
| [`389f2b20`](https://github.com/nix-community/home-manager/commit/389f2b20371b7c0c7e52ceb817d7c8bbc63435a4) | `bashmount: add module` |