### PR TITLE
chore(flake/home-manager): `389f2b20` -> `c1addfda`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659975201,
-        "narHash": "sha256-yHOOMq/G8jTj3QI8RhzqD9yuNqwThiZMjx6R5klZI08=",
+        "lastModified": 1659978484,
+        "narHash": "sha256-VkErPc8pXcuFQG7jkkaUOEMORe81oweRNlAYZJ2+aRI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "389f2b20371b7c0c7e52ceb817d7c8bbc63435a4",
+        "rev": "c1addfdad3825f75a66f8d73ec7d2f68c78ba6f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                     |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`c1addfda`](https://github.com/nix-community/home-manager/commit/c1addfdad3825f75a66f8d73ec7d2f68c78ba6f8) | `gammastep: wait on geoclue-agent when configured` |