### PR TITLE
chore(flake/emacs-overlay): `e547e668` -> `a3770a9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659954665,
-        "narHash": "sha256-0xzyuZ5r3icZ/au6T3U3d3ljY2s11xdaav0JLUj3+vo=",
+        "lastModified": 1659983351,
+        "narHash": "sha256-FsTn0f0t2B7AKAtCDOYd34ztKa+XOUtzRa4FtO8HgDw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e547e66852fd84ecdaccb6d247104c6a5c3c9dd8",
+        "rev": "a3770a9a619f508a0828df30cb10858663d4538b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`a3770a9a`](https://github.com/nix-community/emacs-overlay/commit/a3770a9a619f508a0828df30cb10858663d4538b) | `Updated repos/melpa` |
| [`91ce887a`](https://github.com/nix-community/emacs-overlay/commit/91ce887adba4e655225241f8c3e04eae13b9046c) | `Updated repos/emacs` |
| [`495ac468`](https://github.com/nix-community/emacs-overlay/commit/495ac46875635ba3f9ef5c41f6c4497c3e405a93) | `Updated repos/elpa`  |