### PR TITLE
chore(flake/emacs-overlay): `a3770a9a` -> `4f2132d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659983351,
-        "narHash": "sha256-FsTn0f0t2B7AKAtCDOYd34ztKa+XOUtzRa4FtO8HgDw=",
+        "lastModified": 1660016977,
+        "narHash": "sha256-ZMEW6Xyztskp2PbXuvesWtXUhDf5/kKMdlHeVqo8BEE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a3770a9a619f508a0828df30cb10858663d4538b",
+        "rev": "4f2132d63bdd2d49c625825d2fb2129cb19a79ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`4f2132d6`](https://github.com/nix-community/emacs-overlay/commit/4f2132d63bdd2d49c625825d2fb2129cb19a79ec) | `Updated repos/melpa` |
| [`1203e67c`](https://github.com/nix-community/emacs-overlay/commit/1203e67cb582c4bce565702e947876b01127607a) | `Updated repos/emacs` |