### PR TITLE
chore(flake/nixos-hardware): `ea3efc80` -> `3975d515`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1659356074,
-        "narHash": "sha256-UwV6hZZEtchvtiTCCD/ODEv1226eam8kEgEyQb7xB0E=",
+        "lastModified": 1660030916,
+        "narHash": "sha256-KeVTmST6vAS85uUaSYlzv6OWhveawfIGhqX1SMq+L30=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "ea3efc80f8ab83cb73aec39f4e76fe87afb15a08",
+        "rev": "3975d5158f00accda15a11180b2c08654cfb2807",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`f217e0c0`](https://github.com/NixOS/nixos-hardware/commit/f217e0c09ae7a951e6fe5ed08c2a87a8729118cf) | `use dtmerge from nativeBuildInputs`                                                 |
| [`bfc438a2`](https://github.com/NixOS/nixos-hardware/commit/bfc438a27590e225d4eddd180a7d332ceadb67ea) | `misplaced semicolon`                                                                |
| [`f410bada`](https://github.com/NixOS/nixos-hardware/commit/f410badac50c0710c1b98ad7de23c48848b3a84f) | `added missing semicolon`                                                            |
| [`3f0991b5`](https://github.com/NixOS/nixos-hardware/commit/3f0991b531648e1a529d8eb14b483d628c29846b) | `export a single function from apply-overlays-dtmerge`                               |
| [`245d8f9f`](https://github.com/NixOS/nixos-hardware/commit/245d8f9f97d35a607822ed51bafd7c105c0e819a) | `apply review suggestions from @06kellyjac`                                          |
| [`128dad1c`](https://github.com/NixOS/nixos-hardware/commit/128dad1c8d358c4941fa7cd14cf5a2715eea94d6) | `raspberry-pi-4: add poe-plus-hat, update poe-hat, use dtmerge instead of ftoverlay` |
| [`bb846f8e`](https://github.com/NixOS/nixos-hardware/commit/bb846f8ed9cb92d5d88ca21346eb7365ec6ffa2f) | `Add Dell XPS 13 9350`                                                               |