### PR TITLE
chore(flake/emacs-overlay): `4f2132d6` -> `4ef493b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660016977,
-        "narHash": "sha256-ZMEW6Xyztskp2PbXuvesWtXUhDf5/kKMdlHeVqo8BEE=",
+        "lastModified": 1660042366,
+        "narHash": "sha256-Gx6q2iyZ+ooBiNkc3yEQYebjvmBozILny/eo5dgOHhc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4f2132d63bdd2d49c625825d2fb2129cb19a79ec",
+        "rev": "4ef493b8be95fd8c76dd660a1e4b11e6bc690e62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`4ef493b8`](https://github.com/nix-community/emacs-overlay/commit/4ef493b8be95fd8c76dd660a1e4b11e6bc690e62) | `Updated repos/nongnu` |
| [`d22a3da5`](https://github.com/nix-community/emacs-overlay/commit/d22a3da518a100e31fb0d26c16df8a221cf87914) | `Updated repos/melpa`  |
| [`359ec6f2`](https://github.com/nix-community/emacs-overlay/commit/359ec6f26899b3723aa86658a2df1650cb98eb58) | `Updated repos/emacs`  |