### PR TITLE
chore(flake/emacs-overlay): `4ef493b8` -> `f54f1ef6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660042366,
-        "narHash": "sha256-Gx6q2iyZ+ooBiNkc3yEQYebjvmBozILny/eo5dgOHhc=",
+        "lastModified": 1660069420,
+        "narHash": "sha256-w08sZQd0h5uXG7IlDjn+tQJF0Gp6BboEVpN9CXPCraI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4ef493b8be95fd8c76dd660a1e4b11e6bc690e62",
+        "rev": "f54f1ef6a85f892b57c2d020d17afe52f163a651",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`f54f1ef6`](https://github.com/nix-community/emacs-overlay/commit/f54f1ef6a85f892b57c2d020d17afe52f163a651) | `Updated repos/melpa` |
| [`991a3e78`](https://github.com/nix-community/emacs-overlay/commit/991a3e78df1eb93d6c0d9ad7678d27bfc83aad9a) | `Updated repos/emacs` |
| [`b3aa957c`](https://github.com/nix-community/emacs-overlay/commit/b3aa957c4f1b6300a5aae9b251b49665ff232090) | `Updated repos/elpa`  |