### PR TITLE
chore(flake/emacs-overlay): `b9139aa9` -> `08676a68`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660102288,
-        "narHash": "sha256-KclyXcLTw6Adb8TYAWdQAFi/HH+P1OHSGb/HEuuBxCc=",
+        "lastModified": 1660128867,
+        "narHash": "sha256-pyo0HJ/dHK6I3FeRdfIEkjlyCzpnqyec5H07p4RQliU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b9139aa9a98830ceb268a611495dc47e6b503ac4",
+        "rev": "08676a685629ee6744cce8716d29ed408dceaeb3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`08676a68`](https://github.com/nix-community/emacs-overlay/commit/08676a685629ee6744cce8716d29ed408dceaeb3) | `Updated repos/melpa` |
| [`0c26a7aa`](https://github.com/nix-community/emacs-overlay/commit/0c26a7aa19bdfb601ac1b1e7276024644f997ab7) | `Updated repos/emacs` |