### PR TITLE
chore(flake/emacs-overlay): `08676a68` -> `ead1b9e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660128867,
-        "narHash": "sha256-pyo0HJ/dHK6I3FeRdfIEkjlyCzpnqyec5H07p4RQliU=",
+        "lastModified": 1660156141,
+        "narHash": "sha256-LRUddGWx6GIEEIoF/SbRotFeX4n7J2CYkUnjepES3OA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "08676a685629ee6744cce8716d29ed408dceaeb3",
+        "rev": "ead1b9e47f9e2397da8f42da887ed416fc5762b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ead1b9e4`](https://github.com/nix-community/emacs-overlay/commit/ead1b9e47f9e2397da8f42da887ed416fc5762b5) | `Updated repos/melpa` |
| [`bb05af9a`](https://github.com/nix-community/emacs-overlay/commit/bb05af9a18d6bb12bbe240e5c6361983ab970360) | `Updated repos/emacs` |