### PR TITLE
chore(flake/emacs-overlay): `ead1b9e4` -> `d464c71c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660156141,
-        "narHash": "sha256-LRUddGWx6GIEEIoF/SbRotFeX4n7J2CYkUnjepES3OA=",
+        "lastModified": 1660183574,
+        "narHash": "sha256-BnSTg3OFLxDXs2WjPDwmtAd0U3CQp+S7n27K/dGxgFw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ead1b9e47f9e2397da8f42da887ed416fc5762b5",
+        "rev": "d464c71cfad009cf1b8f61054ea61154665b5236",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`d464c71c`](https://github.com/nix-community/emacs-overlay/commit/d464c71cfad009cf1b8f61054ea61154665b5236) | `Updated repos/melpa` |
| [`fae6603b`](https://github.com/nix-community/emacs-overlay/commit/fae6603bb1aca6f25334d8308363c380abbe201d) | `Updated repos/elpa`  |