### PR TITLE
chore(flake/emacs-overlay): `da0320fc` -> `ab5e238d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660216115,
-        "narHash": "sha256-I15k4CgbVnlfG21p1wOTKR1AK+XVlnTkQ5U63rICN2s=",
+        "lastModified": 1660242581,
+        "narHash": "sha256-koLVNZS7qfk/eDcIRC221YqHnfI0YzochmA3IqZrbmE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "da0320fc0afff7870d20a478d2a031ca1cd0c3ca",
+        "rev": "ab5e238d6bc15e112beb82d898efab22426001bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ab5e238d`](https://github.com/nix-community/emacs-overlay/commit/ab5e238d6bc15e112beb82d898efab22426001bf) | `Updated repos/melpa` |
| [`46d5cfbd`](https://github.com/nix-community/emacs-overlay/commit/46d5cfbd1f5645fdc2501299dca2cdc131f8ba97) | `Updated repos/emacs` |