### PR TITLE
chore(flake/nixos-hardware): `3975d515` -> `78f56d8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1660030916,
-        "narHash": "sha256-KeVTmST6vAS85uUaSYlzv6OWhveawfIGhqX1SMq+L30=",
+        "lastModified": 1660291411,
+        "narHash": "sha256-9UfJMJeCl+T/DrOJMd1vLCoV8U3V7f9Qrv/QyH0Nn28=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3975d5158f00accda15a11180b2c08654cfb2807",
+        "rev": "78f56d8ec2c67a1f80f2de649ca9aadc284f65b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`128bfab1`](https://github.com/NixOS/nixos-hardware/commit/128bfab1ffe63629e3c91bcd9363fd94e50c4ccd) | `pine64-pinebook-pro: remove unused firmware blob`                 |
| [`45f23f33`](https://github.com/NixOS/nixos-hardware/commit/45f23f335e4310764af3b5fbf5126e874e622412) | `pine64-pinebook-pro: remove inappropriate overriding of min_freq` |
| [`18575b96`](https://github.com/NixOS/nixos-hardware/commit/18575b969ceb9f89c5f4327ac6a0f5b5cf9623de) | `pine64-pinebook-pro: remove superfluous bright/sleep keys`        |