### PR TITLE
chore(flake/emacs-overlay): `8a7c1d35` -> `c87ea178`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660301723,
-        "narHash": "sha256-Mt1W+1dBmqmn2dMpqmutG0yrAo+11Ddo9YIcDscoUvE=",
+        "lastModified": 1660329097,
+        "narHash": "sha256-yE8qvJ+NhtZxS2dEhjr5ZPLgvzrjyiEO2j24IoB2pj8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8a7c1d3582856a2e34942cc4371718ef252784ac",
+        "rev": "c87ea178146721cc5c3bdb2f0e09e5ed74602f84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`c87ea178`](https://github.com/nix-community/emacs-overlay/commit/c87ea178146721cc5c3bdb2f0e09e5ed74602f84) | `Updated repos/melpa` |
| [`95e865eb`](https://github.com/nix-community/emacs-overlay/commit/95e865eb064628f73e848b8ab3d621f54e4d8e17) | `Updated repos/emacs` |