### PR TITLE
chore(flake/emacs-overlay): `c87ea178` -> `e8ea1c44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660329097,
-        "narHash": "sha256-yE8qvJ+NhtZxS2dEhjr5ZPLgvzrjyiEO2j24IoB2pj8=",
+        "lastModified": 1660360969,
+        "narHash": "sha256-Ta1Bi+QQjVpWn3fLK6ivXxPOOQ/r26N94AZ8GrvVQR8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c87ea178146721cc5c3bdb2f0e09e5ed74602f84",
+        "rev": "e8ea1c440e46dcf900428543438c5fc5c0ea56e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`e8ea1c44`](https://github.com/nix-community/emacs-overlay/commit/e8ea1c440e46dcf900428543438c5fc5c0ea56e0) | `Updated repos/melpa` |
| [`9738e732`](https://github.com/nix-community/emacs-overlay/commit/9738e732faa5104e952b9a1336aa261ea7939fc0) | `Updated repos/emacs` |