### PR TITLE
chore(flake/emacs-overlay): `d73ef414` -> `a4962c57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660386324,
-        "narHash": "sha256-yyJlSsK0Rw9IBXbcaoGGzbGQYhTRzX8NEFr7fbAAaW4=",
+        "lastModified": 1660414860,
+        "narHash": "sha256-KOuIVjF+4KHBpIEIeBr0T5tQpC8osSRmP8480Mu4hhs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d73ef414f3b07c4e675e9582c4f181580853e53b",
+        "rev": "a4962c57f6cf03224dac91f10848e503c8e21601",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`a4962c57`](https://github.com/nix-community/emacs-overlay/commit/a4962c57f6cf03224dac91f10848e503c8e21601) | `Updated repos/melpa` |
| [`e61a0020`](https://github.com/nix-community/emacs-overlay/commit/e61a0020cbbeff4f9e97fe320f1e083a27dd0142) | `Updated repos/emacs` |