### PR TITLE
chore(flake/emacs-overlay): `a4962c57` -> `c6c28e96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660414860,
-        "narHash": "sha256-KOuIVjF+4KHBpIEIeBr0T5tQpC8osSRmP8480Mu4hhs=",
+        "lastModified": 1660448139,
+        "narHash": "sha256-75TtjQ+FLBLsJJ4qBLLSnQJZ4lj5M0TUrhCT++dtpiY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a4962c57f6cf03224dac91f10848e503c8e21601",
+        "rev": "c6c28e96e85c5945c76eef5fb9814371d2d8a1b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`c6c28e96`](https://github.com/nix-community/emacs-overlay/commit/c6c28e96e85c5945c76eef5fb9814371d2d8a1b5) | `Updated repos/nongnu` |
| [`1804baea`](https://github.com/nix-community/emacs-overlay/commit/1804baeaa57088c172f0c9a9d56aecedd40c20a4) | `Updated repos/melpa`  |
| [`a41eb4ba`](https://github.com/nix-community/emacs-overlay/commit/a41eb4ba747b7df847a6ceea9f807a4b98b0d5d9) | `Updated repos/emacs`  |