### PR TITLE
chore(flake/emacs-overlay): `c6c28e96` -> `c071dc4e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660448139,
-        "narHash": "sha256-75TtjQ+FLBLsJJ4qBLLSnQJZ4lj5M0TUrhCT++dtpiY=",
+        "lastModified": 1660472374,
+        "narHash": "sha256-Abu+KqCaEDvnR6p09YeplLZ8qDTPN7GkgP9BImSTpU4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c6c28e96e85c5945c76eef5fb9814371d2d8a1b5",
+        "rev": "c071dc4eeaabe41e9eefdc17aaba64c2ece218a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`c071dc4e`](https://github.com/nix-community/emacs-overlay/commit/c071dc4eeaabe41e9eefdc17aaba64c2ece218a0) | `Updated repos/melpa` |
| [`8008b653`](https://github.com/nix-community/emacs-overlay/commit/8008b653d1bb49eeb5a792a46c5da484704a1f98) | `Updated repos/emacs` |