### PR TITLE
chore(flake/emacs-overlay): `c071dc4e` -> `6f40609b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660472374,
-        "narHash": "sha256-Abu+KqCaEDvnR6p09YeplLZ8qDTPN7GkgP9BImSTpU4=",
+        "lastModified": 1660501107,
+        "narHash": "sha256-Os4M8XRlPv92lnL8fUQC9TXazb3M5gIcR6qIEywoUJ8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c071dc4eeaabe41e9eefdc17aaba64c2ece218a0",
+        "rev": "6f40609b4437596a4c208460c422b68495287c71",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`6f40609b`](https://github.com/nix-community/emacs-overlay/commit/6f40609b4437596a4c208460c422b68495287c71) | `Updated repos/melpa` |
| [`24b6d803`](https://github.com/nix-community/emacs-overlay/commit/24b6d803b4cebbbfd1e30605407fac85f0360a15) | `Updated repos/emacs` |
| [`82700d34`](https://github.com/nix-community/emacs-overlay/commit/82700d34e3fd1f62b1d08bf81feabd0081194286) | `Updated repos/elpa`  |