### PR TITLE
chore(flake/emacs-overlay): `6f40609b` -> `3d062518`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660501107,
-        "narHash": "sha256-Os4M8XRlPv92lnL8fUQC9TXazb3M5gIcR6qIEywoUJ8=",
+        "lastModified": 1660536682,
+        "narHash": "sha256-CGbMejdZReOEVZxuv+mGudFE+YR/XAJWgfFihyqEEyM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6f40609b4437596a4c208460c422b68495287c71",
+        "rev": "3d062518dc99ec4841b08c1a3c4f64ef2df330ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`3d062518`](https://github.com/nix-community/emacs-overlay/commit/3d062518dc99ec4841b08c1a3c4f64ef2df330ca) | `Updated repos/melpa` |
| [`4870db36`](https://github.com/nix-community/emacs-overlay/commit/4870db363445633efea62c393337c762eb1d7c8b) | `Updated repos/emacs` |