### PR TITLE
chore(flake/nixgl): `047a34b2` -> `6ba34f86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -197,6 +197,21 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -263,16 +278,17 @@
     },
     "nixgl": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1656321324,
-        "narHash": "sha256-Sz0uWspqvshGFbT+XmRVVayuW514rNNLLvrre8jBLLU=",
+        "lastModified": 1660560253,
+        "narHash": "sha256-cq7z+NX3zIfXdRjMOgo1JysTlSpkyRLZqFL9L2S2qhc=",
         "owner": "guibou",
         "repo": "nixgl",
-        "rev": "047a34b2f087e2e3f93d43df8e67ada40bf70e5c",
+        "rev": "6ba34f86658ba9a30b3c2e5cd5ae0709676583f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                        | Commit Message                                                               |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`7701cc9f`](https://github.com/guibou/nixGL/commit/7701cc9f7faf94c823e6b19ceed5e83ae9a3fa22) | `feat: flake support for more than x86-64`                                   |
| [`858436b8`](https://github.com/guibou/nixGL/commit/858436b8c7504dd2feeb3c3a518036c53d17d05d) | `chore: reformat flake.nix`                                                  |
| [`d4fb83ca`](https://github.com/guibou/nixGL/commit/d4fb83ca17c88444a956f8164cc3fd6cfa8291fe) | `fix: make environment variables to be prepended instead of being overrided` |