### PR TITLE
chore(flake/emacs-overlay): `3d062518` -> `4f1a6706`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660536682,
-        "narHash": "sha256-CGbMejdZReOEVZxuv+mGudFE+YR/XAJWgfFihyqEEyM=",
+        "lastModified": 1660560447,
+        "narHash": "sha256-SO78pLChp8iipObuAB2RSbRKskbDBjlqy9W6bJ2J6Kg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3d062518dc99ec4841b08c1a3c4f64ef2df330ca",
+        "rev": "4f1a670645cd3dc973f6da14565d48232fa01b3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`4f1a6706`](https://github.com/nix-community/emacs-overlay/commit/4f1a670645cd3dc973f6da14565d48232fa01b3a) | `Updated repos/melpa` |
| [`35189089`](https://github.com/nix-community/emacs-overlay/commit/35189089c55a3f4a0122a55b7f917d583c268acc) | `Updated repos/emacs` |