### PR TITLE
chore(flake/emacs-overlay): `4f1a6706` -> `0a2ab556`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660560447,
-        "narHash": "sha256-SO78pLChp8iipObuAB2RSbRKskbDBjlqy9W6bJ2J6Kg=",
+        "lastModified": 1660576670,
+        "narHash": "sha256-zlt+m7jrPebZfnuM9U94Mw/LG2GLnM5MfXUvE3RM7Q0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4f1a670645cd3dc973f6da14565d48232fa01b3a",
+        "rev": "0a2ab5565775b057487097a64b3bb115e4c82cc2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------- |
| [`65255005`](https://github.com/nix-community/emacs-overlay/commit/65255005b89ed3adb49d2f552188e34ad98d64d0) | ``Use `super.emacs` instead of `self.emacs``` |