### PR TITLE
chore(flake/emacs-overlay): `0a2ab556` -> `864c7d3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660576670,
-        "narHash": "sha256-zlt+m7jrPebZfnuM9U94Mw/LG2GLnM5MfXUvE3RM7Q0=",
+        "lastModified": 1660589839,
+        "narHash": "sha256-leEjC9NmyMwUr/YPrr5w2UQD0WHDqh586V3JnSLs8W4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0a2ab5565775b057487097a64b3bb115e4c82cc2",
+        "rev": "864c7d3ec1e42ac7983d832dea7f737047a9ede9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`864c7d3e`](https://github.com/nix-community/emacs-overlay/commit/864c7d3ec1e42ac7983d832dea7f737047a9ede9) | `Updated repos/melpa` |
| [`007ecd3f`](https://github.com/nix-community/emacs-overlay/commit/007ecd3f8837268923265a97ca7d1d5b919e8f06) | `Updated repos/emacs` |