### PR TITLE
chore(flake/emacs-overlay): `cb0c62c7` -> `b7f32252`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660623185,
-        "narHash": "sha256-uPFH0hCm45P0moI9CFXgyul1ogZl81emtU8d9xnkj44=",
+        "lastModified": 1660646704,
+        "narHash": "sha256-jUa09GGeTNuIka6Aaq+fDMHjGO1r/iBghDLxDG/tQcE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cb0c62c7342810332453969ef453c16e51625438",
+        "rev": "b7f322524d077b01f63d413cea4059c5fffaa362",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`b7f32252`](https://github.com/nix-community/emacs-overlay/commit/b7f322524d077b01f63d413cea4059c5fffaa362) | `Updated repos/melpa` |
| [`48704146`](https://github.com/nix-community/emacs-overlay/commit/487041468db3c85f7482b1472f40bcb8dc29c867) | `Updated repos/emacs` |