### PR TITLE
chore(flake/emacs-overlay): `b7f32252` -> `8925d05d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660646704,
-        "narHash": "sha256-jUa09GGeTNuIka6Aaq+fDMHjGO1r/iBghDLxDG/tQcE=",
+        "lastModified": 1660709019,
+        "narHash": "sha256-Wh21bk48CIIDCTtjkP+zvh+SPW9g4kKdFOksFKhlwNI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b7f322524d077b01f63d413cea4059c5fffaa362",
+        "rev": "8925d05d615773f5407669a2e9ec00212eb0edab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`8925d05d`](https://github.com/nix-community/emacs-overlay/commit/8925d05d615773f5407669a2e9ec00212eb0edab) | `Updated repos/melpa` |
| [`e6fb9bdd`](https://github.com/nix-community/emacs-overlay/commit/e6fb9bddf24d303364ac2bc28c471dcf9d8c98fe) | `Updated repos/emacs` |
| [`f3a42164`](https://github.com/nix-community/emacs-overlay/commit/f3a4216461b2e568d418715ea0dd8482e45d9a38) | `Updated repos/elpa`  |
| [`50eb2134`](https://github.com/nix-community/emacs-overlay/commit/50eb213413b3e6c865e7006159f2aba3f7a71f34) | `Updated repos/melpa` |
| [`33b473f1`](https://github.com/nix-community/emacs-overlay/commit/33b473f1f037d2b5138e1660f96e2509be2f8d79) | `Updated repos/emacs` |
| [`4418438e`](https://github.com/nix-community/emacs-overlay/commit/4418438e70ff6cddbae5c28b238954dd3ed14dfc) | `Updated repos/elpa`  |