### PR TITLE
chore(flake/emacs-overlay): `8925d05d` -> `8a8ab565`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660709019,
-        "narHash": "sha256-Wh21bk48CIIDCTtjkP+zvh+SPW9g4kKdFOksFKhlwNI=",
+        "lastModified": 1660732240,
+        "narHash": "sha256-u3/pq8k7t9FHFEtArNinHs8ovY4hkFFuwB+zFX7FfIQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8925d05d615773f5407669a2e9ec00212eb0edab",
+        "rev": "8a8ab5655af3e7a741b8230a2c36453622ea330d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`8a8ab565`](https://github.com/nix-community/emacs-overlay/commit/8a8ab5655af3e7a741b8230a2c36453622ea330d) | `Updated repos/melpa` |
| [`a673e18d`](https://github.com/nix-community/emacs-overlay/commit/a673e18d00feb05ac486ef9e641bc63265d4dc7c) | `Updated repos/emacs` |