### PR TITLE
chore(flake/emacs-overlay): `f391425e` -> `720a9722`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660762183,
-        "narHash": "sha256-9yMWV83YPO7AFYhs0GPRwCIedue+SoyS2dwEGoNv4ik=",
+        "lastModified": 1660794348,
+        "narHash": "sha256-uamLp80Om9UmauEWRT8uYdzXYmmlRvhqvKivZC8vw5I=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f391425e518aae894dd95c9165140f1dda8283af",
+        "rev": "720a9722d3fb67ef37a0b1e8394047298b7b9b1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`720a9722`](https://github.com/nix-community/emacs-overlay/commit/720a9722d3fb67ef37a0b1e8394047298b7b9b1c) | `Updated repos/melpa` |
| [`efa045cf`](https://github.com/nix-community/emacs-overlay/commit/efa045cf3f50bf7f5abfbc57e2c5dcf302851996) | `Updated repos/emacs` |
| [`0ccaf348`](https://github.com/nix-community/emacs-overlay/commit/0ccaf3482f58fa96465566f4fd810fe01e385db3) | `Updated repos/elpa`  |