### PR TITLE
chore(flake/pre-commit-hooks): `6a9402e8` -> `8cb8ea5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659629599,
-        "narHash": "sha256-c9rvaqaH3HZo/C70E7rB18YSywa4ryTtN7CZ3cuCmoA=",
+        "lastModified": 1660830093,
+        "narHash": "sha256-HUhx3a82C7bgp2REdGFeHJdhEAzMGCk3V8xIvfBqg1I=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "6a9402e8f233de16536349d1dd3f4595c23386a4",
+        "rev": "8cb8ea5f1c7bc2984f460587fddd5f2e558f6eb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                  |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`8cb8ea5f`](https://github.com/cachix/pre-commit-hooks.nix/commit/8cb8ea5f1c7bc2984f460587fddd5f2e558f6eb8) | `use statically compiled tooling when possible` |