### PR TITLE
chore(flake/emacs-overlay): `14443210` -> `3bc69e76`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660819717,
-        "narHash": "sha256-7tgpawCX0QXUxJd47R/Ziydhja/QAPA098MqgysevsU=",
+        "lastModified": 1660882264,
+        "narHash": "sha256-nVxe7sZPpexElHJnFj3TrkOpHr6w/xfthnhMUH8kahA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "14443210f27375d5efc0cc554ad477d052e47b59",
+        "rev": "3bc69e76fc1004c85a1e337656a6d4a6eb0ca260",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`3bc69e76`](https://github.com/nix-community/emacs-overlay/commit/3bc69e76fc1004c85a1e337656a6d4a6eb0ca260) | `Updated repos/melpa` |
| [`1220e2f9`](https://github.com/nix-community/emacs-overlay/commit/1220e2f91990377c94b3baf10a9e18b448f1b817) | `Updated repos/emacs` |
| [`46f1eb47`](https://github.com/nix-community/emacs-overlay/commit/46f1eb47efc573ab8db9c025a95d48c821487369) | `Updated repos/elpa`  |