### PR TITLE
chore(flake/emacs-overlay): `3bc69e76` -> `29d3a70a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660882264,
-        "narHash": "sha256-nVxe7sZPpexElHJnFj3TrkOpHr6w/xfthnhMUH8kahA=",
+        "lastModified": 1660905973,
+        "narHash": "sha256-ewfVcGu4jkFpR0VHsrZ1noDikrX5I6ZpfOxLLwV5tfQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3bc69e76fc1004c85a1e337656a6d4a6eb0ca260",
+        "rev": "29d3a70af302db1ebb25672d68ada374ef64fad6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`29d3a70a`](https://github.com/nix-community/emacs-overlay/commit/29d3a70af302db1ebb25672d68ada374ef64fad6) | `Updated repos/nongnu` |
| [`7fafcb89`](https://github.com/nix-community/emacs-overlay/commit/7fafcb893b962b5d480f5682ea15effe898547aa) | `Updated repos/melpa`  |
| [`5faa2abd`](https://github.com/nix-community/emacs-overlay/commit/5faa2abde9cd8aa08cba96ac123f94751a942b95) | `Updated repos/emacs`  |