### PR TITLE
chore(flake/emacs-overlay): `29d3a70a` -> `f66d6692`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660905973,
-        "narHash": "sha256-ewfVcGu4jkFpR0VHsrZ1noDikrX5I6ZpfOxLLwV5tfQ=",
+        "lastModified": 1660942124,
+        "narHash": "sha256-mTR0vwQ/9H7D5bonKB5YkePEMgAkgneLyTxqzBpcjIE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "29d3a70af302db1ebb25672d68ada374ef64fad6",
+        "rev": "f66d669288605e8dff2e1596ba596a47cc599600",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`f66d6692`](https://github.com/nix-community/emacs-overlay/commit/f66d669288605e8dff2e1596ba596a47cc599600) | `Updated repos/melpa` |
| [`ac52210d`](https://github.com/nix-community/emacs-overlay/commit/ac52210de95d05f77e81015a2be2b60f1a42c4dd) | `Updated repos/emacs` |
| [`9e551fa5`](https://github.com/nix-community/emacs-overlay/commit/9e551fa5186a96a29b7f7a299306bba13ebb90ba) | `Updated repos/elpa`  |