### PR TITLE
chore(flake/emacs-overlay): `d35281af` -> `e3c49d6e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660975800,
-        "narHash": "sha256-FSOmC669ZauUz31FZAFclnpZ28X8Jac5CQwTm6uvfv8=",
+        "lastModified": 1660996020,
+        "narHash": "sha256-fFpf+Ash+Qcse5nQtDyiCI0Ia2cxenpRlI9vWO3+cN4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d35281af15d9daedcbb749cb24a77ba330e0d4b3",
+        "rev": "e3c49d6ea647d5727271d6858a6f414912704b79",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`e3c49d6e`](https://github.com/nix-community/emacs-overlay/commit/e3c49d6ea647d5727271d6858a6f414912704b79) | `Updated repos/nongnu` |
| [`9207a289`](https://github.com/nix-community/emacs-overlay/commit/9207a28927659d6f3fc5d603ea9cf680c9305f8b) | `Updated repos/melpa`  |
| [`1eef20d1`](https://github.com/nix-community/emacs-overlay/commit/1eef20d1c8ccc8bdf0fb193da6cc1d0c28001b39) | `Updated repos/emacs`  |