### PR TITLE
chore(flake/emacs-overlay): `e3c49d6e` -> `788726b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660996020,
-        "narHash": "sha256-fFpf+Ash+Qcse5nQtDyiCI0Ia2cxenpRlI9vWO3+cN4=",
+        "lastModified": 1661027536,
+        "narHash": "sha256-P1Y1CBpYdf5vi/EONQmQV16p41KGv2hVElqqq8xx9X8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e3c49d6ea647d5727271d6858a6f414912704b79",
+        "rev": "788726b74db76ddcde3130055bc6434065a7449d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`788726b7`](https://github.com/nix-community/emacs-overlay/commit/788726b74db76ddcde3130055bc6434065a7449d) | `Updated repos/melpa` |
| [`a748f651`](https://github.com/nix-community/emacs-overlay/commit/a748f65165a0e319e848612b29e3223121a66d41) | `Updated repos/emacs` |
| [`bdca297f`](https://github.com/nix-community/emacs-overlay/commit/bdca297f3aee6179109a714f978f9e3011036ae0) | `Updated repos/elpa`  |