### PR TITLE
chore(flake/emacs-overlay): `788726b7` -> `798ab8fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661027536,
-        "narHash": "sha256-P1Y1CBpYdf5vi/EONQmQV16p41KGv2hVElqqq8xx9X8=",
+        "lastModified": 1661048606,
+        "narHash": "sha256-s5kRhiNnsAe5YoQhFZQS5MS+is0z9UjWlYvuObTGjjg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "788726b74db76ddcde3130055bc6434065a7449d",
+        "rev": "798ab8fd2043e8b800a70a3eebd42388e34cf708",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`798ab8fd`](https://github.com/nix-community/emacs-overlay/commit/798ab8fd2043e8b800a70a3eebd42388e34cf708) | `Updated repos/melpa` |
| [`0189e818`](https://github.com/nix-community/emacs-overlay/commit/0189e818c5be122fd919ad28b50b779fdcdd126a) | `Updated repos/elpa`  |