### PR TITLE
chore(flake/emacs-overlay): `798ab8fd` -> `b0d961b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661048606,
-        "narHash": "sha256-s5kRhiNnsAe5YoQhFZQS5MS+is0z9UjWlYvuObTGjjg=",
+        "lastModified": 1661080786,
+        "narHash": "sha256-MbiPU0icYLCNOzjQbdo4kjybLDl+soorRvNhPvrFopI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "798ab8fd2043e8b800a70a3eebd42388e34cf708",
+        "rev": "b0d961b43472d9c95a55fd106a1c0e43944ad10a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`b0d961b4`](https://github.com/nix-community/emacs-overlay/commit/b0d961b43472d9c95a55fd106a1c0e43944ad10a) | `Updated repos/nongnu` |
| [`c89ea9ef`](https://github.com/nix-community/emacs-overlay/commit/c89ea9ef9bed55f524afc66b4832f55d5be746cf) | `Updated repos/melpa`  |
| [`48b2f357`](https://github.com/nix-community/emacs-overlay/commit/48b2f357c5dbe265143fdb82c11735855220d493) | `Updated repos/emacs`  |