### PR TITLE
chore(flake/emacs-overlay): `b0d961b4` -> `3a6945c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661080786,
-        "narHash": "sha256-MbiPU0icYLCNOzjQbdo4kjybLDl+soorRvNhPvrFopI=",
+        "lastModified": 1661109243,
+        "narHash": "sha256-/RYJn8nCI7Pt7zkJUqGed+ze2b5rbqo0fteI3D7rEi0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b0d961b43472d9c95a55fd106a1c0e43944ad10a",
+        "rev": "3a6945c269fcbdc433b8c81afd3b36c7ac4926a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`3a6945c2`](https://github.com/nix-community/emacs-overlay/commit/3a6945c269fcbdc433b8c81afd3b36c7ac4926a1) | `Updated repos/melpa` |
| [`fd4347dc`](https://github.com/nix-community/emacs-overlay/commit/fd4347dceb0d0b7ea60963c823019478e93a77c3) | `Updated repos/emacs` |
| [`f12465df`](https://github.com/nix-community/emacs-overlay/commit/f12465df1c07593abe5c48d328f932e6f51755de) | `Updated repos/elpa`  |