### PR TITLE
chore(flake/impermanence): `2f39baeb` -> `e7c6fbbe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -222,11 +222,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1646131459,
-        "narHash": "sha256-GPmgxvUFvQ1GmsGfWHy9+rcxWrczeDhS9XnAIPHi9XQ=",
+        "lastModified": 1661155543,
+        "narHash": "sha256-6PJ4wqDuFMIw34gM/LxQ9qZPw8vPls4xC7UCeweSvKs=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "2f39baeb7d039fda5fc8225111bb79474138e6f4",
+        "rev": "e7c6fbbe9076109263175ef992ca6edc1050973c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`723c1a75`](https://github.com/nix-community/impermanence/commit/723c1a7535b7cd194c3a2a693a2566ba1e047a89) | `nixos: Fix bind mounts in VM build` |