### PR TITLE
chore(flake/emacs-overlay): `97a0b4e8` -> `f7084ae4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661142448,
-        "narHash": "sha256-MKqQWdUnbQ7UVeEXhbuASvin8d42/AhmD2fanzWXkZg=",
+        "lastModified": 1661168755,
+        "narHash": "sha256-eVhR8ZykWIAPT+GQW9fTzA5sj6qgE7Y3PAqwz4tPHDw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "97a0b4e8d1bfc77f1159bad987c119394b7c2f26",
+        "rev": "f7084ae4176f6779f8de9bfa724e67002db3174c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`f7084ae4`](https://github.com/nix-community/emacs-overlay/commit/f7084ae4176f6779f8de9bfa724e67002db3174c) | `Updated repos/melpa` |
| [`b953e5c0`](https://github.com/nix-community/emacs-overlay/commit/b953e5c04196c24a1f347a5f1a4db471fd8881cd) | `Updated repos/emacs` |