### PR TITLE
chore(flake/emacs-overlay): `f7084ae4` -> `f274dc1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661168755,
-        "narHash": "sha256-eVhR8ZykWIAPT+GQW9fTzA5sj6qgE7Y3PAqwz4tPHDw=",
+        "lastModified": 1661195877,
+        "narHash": "sha256-yWCEloPk7ZsZ8YQ9qjDh0fXEjQbqIdDcVL/EwyB4j3o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f7084ae4176f6779f8de9bfa724e67002db3174c",
+        "rev": "f274dc1c9c898f140755c5d8061b21cff1219445",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`f274dc1c`](https://github.com/nix-community/emacs-overlay/commit/f274dc1c9c898f140755c5d8061b21cff1219445) | `Updated repos/melpa` |
| [`d0b5c74f`](https://github.com/nix-community/emacs-overlay/commit/d0b5c74f592ac6cfd03a10938f18ea9430735bbc) | `Updated repos/emacs` |