### PR TITLE
chore(flake/emacs-overlay): `f274dc1c` -> `5b17f330`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661195877,
-        "narHash": "sha256-yWCEloPk7ZsZ8YQ9qjDh0fXEjQbqIdDcVL/EwyB4j3o=",
+        "lastModified": 1661231912,
+        "narHash": "sha256-enP+/iw05O7wxDh/rfaeqCWra3lOPEaTSraY/IksLoY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f274dc1c9c898f140755c5d8061b21cff1219445",
+        "rev": "5b17f330ba968f090da178f4316bb193dae6e6b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`5b17f330`](https://github.com/nix-community/emacs-overlay/commit/5b17f330ba968f090da178f4316bb193dae6e6b3) | `Updated repos/melpa` |
| [`69987982`](https://github.com/nix-community/emacs-overlay/commit/699879821fee3d766066c45e5d6c3ca26dbb106e) | `Updated repos/emacs` |