### PR TITLE
chore(flake/emacs-overlay): `5b17f330` -> `2cd8b574`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661231912,
-        "narHash": "sha256-enP+/iw05O7wxDh/rfaeqCWra3lOPEaTSraY/IksLoY=",
+        "lastModified": 1661253750,
+        "narHash": "sha256-Ks9PBoR0nV5IgUwX5AX2dNAc0HEQGDU1Qpbd3RvRsEM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5b17f330ba968f090da178f4316bb193dae6e6b3",
+        "rev": "2cd8b574051e77161ea028d37fe5f43aa733e27e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`2cd8b574`](https://github.com/nix-community/emacs-overlay/commit/2cd8b574051e77161ea028d37fe5f43aa733e27e) | `Updated repos/nongnu` |
| [`f8efd708`](https://github.com/nix-community/emacs-overlay/commit/f8efd708c26e6b42879d10238020ec09c2f2f332) | `Updated repos/melpa`  |
| [`3d1a1972`](https://github.com/nix-community/emacs-overlay/commit/3d1a197255d113201c89a8fcb7097cf393090758) | `Updated repos/emacs`  |