### PR TITLE
chore(flake/home-manager): `0160a0ce` -> `8ea0e4d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661201353,
-        "narHash": "sha256-hee34c72DNz1Otj86b2NEc4s1JQ+qnIb1XyWuUD4v6o=",
+        "lastModified": 1661278301,
+        "narHash": "sha256-VNHBj7ioHWeHdAiEHKiP9mw+5JWSuAr2TLE44KMxYIM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0160a0cef076294127f8cc0750019410ab94370d",
+        "rev": "8ea0e4d6d8337b8ec4771ab57785c059a17c90c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`8ea0e4d6`](https://github.com/nix-community/home-manager/commit/8ea0e4d6d8337b8ec4771ab57785c059a17c90c7) | `udiskie: fix configuration file path typo`           |
| [`991ff352`](https://github.com/nix-community/home-manager/commit/991ff35249305ef1df8ac9151827025f9d12c4d4) | `udiskie: add tests`                                  |
| [`ee8e99ad`](https://github.com/nix-community/home-manager/commit/ee8e99add552e0cd1b861f4b4864dca1b6430723) | `udiskie: make dependency on tray.target conditional` |