### PR TITLE
chore(flake/emacs-overlay): `2cd8b574` -> `88cb5bfd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661253750,
-        "narHash": "sha256-Ks9PBoR0nV5IgUwX5AX2dNAc0HEQGDU1Qpbd3RvRsEM=",
+        "lastModified": 1661284014,
+        "narHash": "sha256-yc0kAEKFn+r5KuNwmDcZmHPALM3plrQBcsjpeC0vGZs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2cd8b574051e77161ea028d37fe5f43aa733e27e",
+        "rev": "88cb5bfd3f9aa6c133a2f841c94042f238c0f24a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`88cb5bfd`](https://github.com/nix-community/emacs-overlay/commit/88cb5bfd3f9aa6c133a2f841c94042f238c0f24a) | `Updated repos/melpa` |
| [`877103d2`](https://github.com/nix-community/emacs-overlay/commit/877103d23f5ef614aebb1b2c3a88e3c0e4b9baae) | `Updated repos/emacs` |
| [`14b2df58`](https://github.com/nix-community/emacs-overlay/commit/14b2df58dfa803bc77b58a45f1a160a908fb1f6a) | `Updated repos/elpa`  |