### PR TITLE
chore(flake/emacs-overlay): `88cb5bfd` -> `9df78985`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661284014,
-        "narHash": "sha256-yc0kAEKFn+r5KuNwmDcZmHPALM3plrQBcsjpeC0vGZs=",
+        "lastModified": 1661315932,
+        "narHash": "sha256-3+CUK8wx+oEaKhrXWrK9LQVdhtkArXcy+mvihstlAXc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "88cb5bfd3f9aa6c133a2f841c94042f238c0f24a",
+        "rev": "9df7898566fe546ddebc15e665a938a9dec84d01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`9df78985`](https://github.com/nix-community/emacs-overlay/commit/9df7898566fe546ddebc15e665a938a9dec84d01) | `Updated repos/melpa` |
| [`e64d886e`](https://github.com/nix-community/emacs-overlay/commit/e64d886e1582455ecc6110aa44c7a0114b0124a5) | `Updated repos/emacs` |
| [`b7e0dc28`](https://github.com/nix-community/emacs-overlay/commit/b7e0dc28effdf226cdd5790e1f201e270971583a) | `Updated repos/elpa`  |