### PR TITLE
chore(flake/emacs-overlay): `5cf9609f` -> `a9d94944`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661371682,
-        "narHash": "sha256-TqH4RtwXpW+AWNSTEq0y98C7T/PPn9PyKaP8zxcXxqc=",
+        "lastModified": 1661404366,
+        "narHash": "sha256-MNw6Bzi3kUP+L9s7tbPErznk2JyJFJ6fnqSXpYk5tuk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5cf9609f0bb8567f2f5c951fcd31b62a2f0302f5",
+        "rev": "a9d949448fa81ed4df7ce420226c88df52f6cb28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`a9d94944`](https://github.com/nix-community/emacs-overlay/commit/a9d949448fa81ed4df7ce420226c88df52f6cb28) | `Updated repos/melpa` |
| [`506675e3`](https://github.com/nix-community/emacs-overlay/commit/506675e3dbe4c65bf3ec97dd8a829208b30ae9b3) | `Updated repos/emacs` |
| [`bb3a1a07`](https://github.com/nix-community/emacs-overlay/commit/bb3a1a079308414349c77aa91d6f880271e56d4f) | `Updated repos/elpa`  |