### PR TITLE
chore(flake/home-manager): `b382b59f` -> `ae474885`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661371005,
-        "narHash": "sha256-PfWRIyJQhBtVhENqmVcI+C9kisctmzos+nrH+feGX3U=",
+        "lastModified": 1661455062,
+        "narHash": "sha256-Fjemndb2Yuxklkt+H4k8Tu0csYmdRjIaGb8BE57Y8aY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b382b59faf717c5b36f4cd8e1c5d96cdabd382c9",
+        "rev": "ae474885f7b2f13f186d40786e962c97e997e131",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`ae474885`](https://github.com/nix-community/home-manager/commit/ae474885f7b2f13f186d40786e962c97e997e131) | `email: add yandex and office365 email flavors`                         |
| [`c5b4177b`](https://github.com/nix-community/home-manager/commit/c5b4177bda8b17f8f027b8145cd961210e6f4482) | `i3-sway: allow "container" and "output" in focus.mouseWarping (#3154)` |