### PR TITLE
chore(flake/home-manager): `7bb4576f` -> `76fbb1b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661461765,
-        "narHash": "sha256-SsguXWPNbD7Oy1jtfXuQtHciHjqYuCCnbyf5iSm/IPs=",
+        "lastModified": 1661465228,
+        "narHash": "sha256-NymlETHUvMZKyOTYaVC6bZjDX5fFoLjb5AF2EKJMyBA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7bb4576f46f7f7590347e21b14d2f6a2dbc76638",
+        "rev": "76fbb1b15e83a9243efa7efe39d1d0fdd5a4d103",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`76fbb1b1`](https://github.com/nix-community/home-manager/commit/76fbb1b15e83a9243efa7efe39d1d0fdd5a4d103) | `treewide: replace <link> by <xref> where appropriate` |