### PR TITLE
chore(flake/home-manager): `76fbb1b1` -> `4c8c1c99`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661465228,
-        "narHash": "sha256-NymlETHUvMZKyOTYaVC6bZjDX5fFoLjb5AF2EKJMyBA=",
+        "lastModified": 1661465825,
+        "narHash": "sha256-bMrD8ZR4TSqGLjMWnmg4+ZIlSOoYXTSK9++HK0dPtmA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "76fbb1b15e83a9243efa7efe39d1d0fdd5a4d103",
+        "rev": "4c8c1c99770494027599d73c30423d8257a224ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                     |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`4c8c1c99`](https://github.com/nix-community/home-manager/commit/4c8c1c99770494027599d73c30423d8257a224ef) | `kitty: produce fewer empty lines` |