### PR TITLE
chore(flake/emacs-overlay): `77e195ec` -> `9f50a8d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661488398,
-        "narHash": "sha256-jV1z+3jqlsxgjut8IAo1BP2wS3Xyc+H3/bLFzeOrOrM=",
+        "lastModified": 1661511740,
+        "narHash": "sha256-+CIEu/LmxovaiKnVfzLFdW2mXc+bSm8DtH9iiXSmgEo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "77e195ec366bf53d084b735de228f3efc5800d0e",
+        "rev": "9f50a8d3be2291db155cb751448eb2e34d12b5e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`9f50a8d3`](https://github.com/nix-community/emacs-overlay/commit/9f50a8d3be2291db155cb751448eb2e34d12b5e4) | `Updated repos/emacs` |