### PR TITLE
chore(flake/emacs-overlay): `9f50a8d3` -> `cde6b0fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661511740,
-        "narHash": "sha256-+CIEu/LmxovaiKnVfzLFdW2mXc+bSm8DtH9iiXSmgEo=",
+        "lastModified": 1661539548,
+        "narHash": "sha256-9v6hp4lFLub463UTnN66vGPQ3GvZtwRmCPYS84Yq7xs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9f50a8d3be2291db155cb751448eb2e34d12b5e4",
+        "rev": "cde6b0fd7cad645fc069fe4bf54d2944ee0d8d95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`cde6b0fd`](https://github.com/nix-community/emacs-overlay/commit/cde6b0fd7cad645fc069fe4bf54d2944ee0d8d95) | `Updated repos/emacs` |