### PR TITLE
chore(flake/home-manager): `8e4220e6` -> `d89bdff4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661567836,
-        "narHash": "sha256-Q4Y/WMDGg88UVczciBVe7PKt4u97sYYRfmFmJqVyCcQ=",
+        "lastModified": 1661573386,
+        "narHash": "sha256-pBEg8iY00Af/SAtU2dlmOAv+2x7kScaGlFRDjNoVJO8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8e4220e6c6e937099384740b36343d1704571870",
+        "rev": "d89bdff445eadff03fe414e9c30486bc8166b72b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`d89bdff4`](https://github.com/nix-community/home-manager/commit/d89bdff445eadff03fe414e9c30486bc8166b72b) | `sway, bspwm: add extraConfigEarly (#2847)` |