### PR TITLE
chore(flake/emacs-overlay): `cde6b0fd` -> `4dc13be2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661539548,
-        "narHash": "sha256-9v6hp4lFLub463UTnN66vGPQ3GvZtwRmCPYS84Yq7xs=",
+        "lastModified": 1661573470,
+        "narHash": "sha256-HOPmGYEyPqhKL6OYGDqjqk4u1yOKPn5ZbRq25oNO53Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cde6b0fd7cad645fc069fe4bf54d2944ee0d8d95",
+        "rev": "4dc13be2f27e6143e702103342bc4e143f9f095c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`4dc13be2`](https://github.com/nix-community/emacs-overlay/commit/4dc13be2f27e6143e702103342bc4e143f9f095c) | `Updated repos/emacs` |
| [`b16db084`](https://github.com/nix-community/emacs-overlay/commit/b16db08460bae5437834863d9dd5cffc30aff89d) | `Updated repos/elpa`  |