### PR TITLE
chore(flake/impermanence): `e7c6fbbe` -> `2237ad28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -222,11 +222,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1661155543,
-        "narHash": "sha256-6PJ4wqDuFMIw34gM/LxQ9qZPw8vPls4xC7UCeweSvKs=",
+        "lastModified": 1661590580,
+        "narHash": "sha256-XoPSucNvccnT50LWme/7BiENZDwr8tArEg36OGQFFnA=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "e7c6fbbe9076109263175ef992ca6edc1050973c",
+        "rev": "2237ad28093cb53ad2eb0fd1a9f870997287e0fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`fc9ca99e`](https://github.com/nix-community/impermanence/commit/fc9ca99ef8e633156772d25c72182700f0f82aa0) | `home-manager: adds configurable symlink/bindfs option` |