### PR TITLE
chore(flake/emacs-overlay): `4dc13be2` -> `d8891991`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661573470,
-        "narHash": "sha256-HOPmGYEyPqhKL6OYGDqjqk4u1yOKPn5ZbRq25oNO53Y=",
+        "lastModified": 1661598612,
+        "narHash": "sha256-0W31cSC+ggoP8kxN0Hn8HWd0wK37hLx4ul7IO4gKztE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4dc13be2f27e6143e702103342bc4e143f9f095c",
+        "rev": "d8891991eef88a53a979ff242663429cef82a094",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`d8891991`](https://github.com/nix-community/emacs-overlay/commit/d8891991eef88a53a979ff242663429cef82a094) | `Updated repos/emacs` |