### PR TITLE
chore(flake/nixpkgs): `f034b569` -> `f3d0897b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -277,11 +277,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1661328374,
-        "narHash": "sha256-GGMupfk/lGzPBQ/dRrcQEhiFZ0F5KPg0j5Q4Fb5coxc=",
+        "lastModified": 1661450036,
+        "narHash": "sha256-0/9UyJLtfWqF4uvOrjFIzk8ue1YYUHa6JIhV0mALkH0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f034b5693a26625f56068af983ed7727a60b5f8b",
+        "rev": "f3d0897be466aa09a37f6bf59e62c360c3f9a6cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                              |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`faee7f13`](https://github.com/NixOS/nixpkgs/commit/faee7f1311c5dfc2aa80c29ac2558e9f6a4ba792) | `emacs.pkgs.tree-sitter-langs: Link to each grammar's query files`          |
| [`784686d0`](https://github.com/NixOS/nixpkgs/commit/784686d06c62639c8b5ef6e78524b0d74db85433) | `tree-sitter: Package query files used for syntax highlighting`             |
| [`bec06f5b`](https://github.com/NixOS/nixpkgs/commit/bec06f5bba70771aefa58891e6e055314d2044ec) | `cc-wrapper: disable stackprotector for MicroBlaze`                         |
| [`4db467f7`](https://github.com/NixOS/nixpkgs/commit/4db467f7e921cfe26c499076ea23044bb8a60ad6) | `lib/systems: add MicroBlaze architectures`                                 |
| [`6ea77eef`](https://github.com/NixOS/nixpkgs/commit/6ea77eef79d135c3fdb2dd06c5da460432b69b04) | `obs-vkcapture: added pedrohlc to maintainers`                              |
| [`8d5c4efb`](https://github.com/NixOS/nixpkgs/commit/8d5c4efbf8754963a6b0253903fd5f240f989fe5) | `obs-vkcapture: 1.1.6 -> 1.2.0`                                             |
| [`1e0e5ad4`](https://github.com/NixOS/nixpkgs/commit/1e0e5ad4390d2548d83628a734f4ffaee37d7d93) | `mill: 0.10.6 -> 0.10.7`                                                    |
| [`27d72f5a`](https://github.com/NixOS/nixpkgs/commit/27d72f5abb99ef06a309d8e36ac042f8686ae5b5) | `nvidia_x11: mark broken`                                                   |
| [`29c68b06`](https://github.com/NixOS/nixpkgs/commit/29c68b0600fef97b80194182b765b661d19acdf2) | `nvidia_x11: expose all open variants`                                      |
| [`4d18b3a7`](https://github.com/NixOS/nixpkgs/commit/4d18b3a781ee3f1c2aeb7d142e1679e97f2c9174) | `nvidia_x11_vulkan_beta: 470.62.13 -> 515.49.14`                            |
| [`cbf9a129`](https://github.com/NixOS/nixpkgs/commit/cbf9a129d273d203a98c2fefe8bda52af42ab5e3) | `gh: 2.14.6 -> 2.14.7`                                                      |
| [`05958b22`](https://github.com/NixOS/nixpkgs/commit/05958b228b49cfe97f7faf51de4aaf3ede31894e) | `nixos/console: detect unicode properly`                                    |
| [`5e9296c3`](https://github.com/NixOS/nixpkgs/commit/5e9296c30ac0e5ec2d39104ef51a4de6e3f955b3) | `python310Packages.mne-python: 1.0.3 -> 1.1.0`                              |
| [`d4e573cd`](https://github.com/NixOS/nixpkgs/commit/d4e573cde41dd92d897c9bfaa46498aa10e460c2) | `transifex-client: Fix build`                                               |
| [`1307bb7a`](https://github.com/NixOS/nixpkgs/commit/1307bb7a2ed8bf45995a7a73a84c56a0f5044962) | `git-blame-ignore-revs: fix commit hash`                                    |
| [`e8839142`](https://github.com/NixOS/nixpkgs/commit/e88391420f76b7602de9580fe87f899aa6281ca9) | `python310Packages.pubnub: 6.5.1 -> 7.0.0`                                  |
| [`1cd8fb01`](https://github.com/NixOS/nixpkgs/commit/1cd8fb018195d5331883605c1bcba9b54231e593) | `python310Packages.weconnect-mqtt: 0.39.1 -> 0.39.2`                        |
| [`3c0eff60`](https://github.com/NixOS/nixpkgs/commit/3c0eff60c09f4f1923fbf9c394cf23d1a7ad47fa) | `python310Packages.weconnect: 0.47.0 -> 0.47.1`                             |
| [`79b926eb`](https://github.com/NixOS/nixpkgs/commit/79b926ebb609c4b0ff38845d5952ff2672e52010) | `python310Packages.twilio: 7.12.1 -> 7.13.0`                                |
| [`8df4066b`](https://github.com/NixOS/nixpkgs/commit/8df4066b7fdb127d360d0e38b3f959be1d10415c) | `n8n: 0.191.0 → 0.192.0`                                                    |
| [`3bf810a7`](https://github.com/NixOS/nixpkgs/commit/3bf810a750983d8d5fc36e7cb25df60891eb3a55) | `honggfuzz: pin to binutils-2.38 until upstream ports to 2.39`              |
| [`d2ffb555`](https://github.com/NixOS/nixpkgs/commit/d2ffb555115a3443c3c5444bcb64f875f6f2e973) | `binaryen: add patch from upstream for newer nodejs`                        |
| [`78d14c7a`](https://github.com/NixOS/nixpkgs/commit/78d14c7a0ef0009b31cda12ab4ebd10e37560a81) | `mimeo: 2021.11 -> 2022.7`                                                  |
| [`67843259`](https://github.com/NixOS/nixpkgs/commit/67843259ad477affa54a9c30e31b75f7fc2762c3) | `bpftrace: pull upstream fix for binutils-2.39`                             |
| [`28433de6`](https://github.com/NixOS/nixpkgs/commit/28433de6b20a6dcd66d2a0f263cef37a936039fc) | `kcov: pin to binutils-2.38 until upstream ports to 2.39`                   |
| [`590822ee`](https://github.com/NixOS/nixpkgs/commit/590822ee4f0af03b55bb87b1bd6f967c47aa60ec) | `ucx: pull upstream fix for binutils-2.39`                                  |
| [`7da6a2ac`](https://github.com/NixOS/nixpkgs/commit/7da6a2ac8d3973fdb35ce82ebadcd42623fdd429) | `python310Packages.slowapi: 0.1.5 -> 0.1.6`                                 |
| [`33a0ad9b`](https://github.com/NixOS/nixpkgs/commit/33a0ad9b36a0ab8c9f1e96af65d4d9bab4fe01a5) | `python310Packages.bthome-ble: 0.3.6 -> 0.3.6`                              |
| [`01cde92a`](https://github.com/NixOS/nixpkgs/commit/01cde92abb95d30c118f661f5c9494daf79d79ad) | `python310Packages.sensor-state-data: 2.3.1 -> 2.3.2`                       |
| [`855c555b`](https://github.com/NixOS/nixpkgs/commit/855c555b7b4a3f5f6c667515d30b5972d5684e70) | `python310Packages.hahomematic: 2022.8.14 -> 2022.8.15`                     |
| [`05f8c0d6`](https://github.com/NixOS/nixpkgs/commit/05f8c0d68a4ff959e29b1e7276a05e02e0ed8a60) | `python310Packages.hahomematic: 2022.8.13 -> 2022.8.14`                     |
| [`dd845813`](https://github.com/NixOS/nixpkgs/commit/dd845813dbea7850b7d295752d27542f7d58300e) | `nodejs-18_x: 18.7.0 -> 18.8.0`                                             |
| [`fe260497`](https://github.com/NixOS/nixpkgs/commit/fe26049786d1827d2deecc3dcfdedc7b52e14882) | `Revert "wxGTK31-gtk2: 3.1.5 -> 3.2.0"`                                     |
| [`a95c28a9`](https://github.com/NixOS/nixpkgs/commit/a95c28a95cc4f7970f614542d47e63901ca40cf4) | `tabnine: 4.4.98 -> 4.4.123`                                                |
| [`c33bbab8`](https://github.com/NixOS/nixpkgs/commit/c33bbab891720583126ece1f7a31dd437dafc691) | `msmtp: we always provide a path to msmtp`                                  |
| [`9e002766`](https://github.com/NixOS/nixpkgs/commit/9e0027666b63a4635a31fd40c2304b3f8ecd55de) | `open-vm-tools: 12.0.5 -> 12.1.0`                                           |
| [`36469b55`](https://github.com/NixOS/nixpkgs/commit/36469b5564dcddaef0f23359ad23ea59646a7f89) | `python310Packages.allure-pytest: 2.9.45 -> 2.10.0`                         |
| [`3f79f06b`](https://github.com/NixOS/nixpkgs/commit/3f79f06b19c885bcef468bb50d5b54ee8c56dd79) | `python310Packages.allure-behave: 2.9.45 -> 2.10.0`                         |
| [`fa325eaf`](https://github.com/NixOS/nixpkgs/commit/fa325eafe8dd351b8d2c1672bde04385690a6f43) | `elixir-ls: 0.10.0 -> 0.11.0`                                               |
| [`a4c43828`](https://github.com/NixOS/nixpkgs/commit/a4c43828e965ce6efcbe575e3f92cee276c516be) | `meilisearch: (Re-)enable nixos tests`                                      |
| [`312fd31a`](https://github.com/NixOS/nixpkgs/commit/312fd31a5827bd998771d212aa08753e77d628e2) | `nixos/meilisearch: Update tests to reflect API changes`                    |
| [`f28ab51b`](https://github.com/NixOS/nixpkgs/commit/f28ab51b54ef2518345594a6baf45b9e25378912) | `haskell.lib.makePackageSet: all-cabal-hashes can be a directory (#188203)` |
| [`e1926697`](https://github.com/NixOS/nixpkgs/commit/e19266972a84b9e94ce5ec75d250774cd32ed0bc) | `pythonPackages.whitenoise: 6.0.0 -> 6.2.0`                                 |
| [`5e053ae4`](https://github.com/NixOS/nixpkgs/commit/5e053ae4a52a394698467e84532cd3754fba943e) | `kubernetes-helm: 3.9.3 -> 3.9.4`                                           |
| [`2d61fc76`](https://github.com/NixOS/nixpkgs/commit/2d61fc7660bf294677070c327dfdbf99f8700405) | `terraform: 1.2.7 -> 1.2.8`                                                 |
| [`4e776c4c`](https://github.com/NixOS/nixpkgs/commit/4e776c4cc9c8dcb15eb79a708805461be16335b0) | `darkman: init at 1.3.1 (#181164)`                                          |
| [`4c6a2216`](https://github.com/NixOS/nixpkgs/commit/4c6a22163a95542e357afe0a1a1251d7943f625a) | `python3Packages.betterproto: init at 2.0.0b5 (#187533)`                    |
| [`a1230507`](https://github.com/NixOS/nixpkgs/commit/a12305070f7e66b872cd1b9a9eb00cb621eb1e78) | `eztrace: use binutils-2.38 until upstream is ported`                       |
| [`3fca4ba5`](https://github.com/NixOS/nixpkgs/commit/3fca4ba5ea4df268b437429e4931744d6520dd22) | `hostctl: 1.1.2 -> 1.1.3`                                                   |
| [`c7186043`](https://github.com/NixOS/nixpkgs/commit/c7186043a03336a249945fea67d41932bb648541) | `lttng-tools: 2.13.7 -> 2.13.8`                                             |
| [`986c3140`](https://github.com/NixOS/nixpkgs/commit/986c31401e06456175d09e6fd4accc84b58b8b71) | `doc/python: Properly sort pythonRelaxDepsHook in hook list`                |
| [`19f4e14d`](https://github.com/NixOS/nixpkgs/commit/19f4e14dcff3dd23885f3707838c91c36154a01a) | `python3Packages.sphinxHook: run install phase in predist`                  |
| [`caf2d010`](https://github.com/NixOS/nixpkgs/commit/caf2d010edbe5cd2193b9849798fa44858e08c00) | `python3Packages.sphinxHook: Rename loop var in source root detection`      |
| [`5a852f40`](https://github.com/NixOS/nixpkgs/commit/5a852f4085cbf4d6521a4cbb775dc9a15bd0298c) | `borgbackup: migrate to sphinxHook`                                         |
| [`8a26deba`](https://github.com/NixOS/nixpkgs/commit/8a26deba0649a05bd978804a6af3a710548fcc0b) | `doc/python: integrate sphinxHook docs`                                     |
| [`1ee5fcaf`](https://github.com/NixOS/nixpkgs/commit/1ee5fcaf0c8a298f24ada56eadec0a83c382410c) | `python3Packages.sphinxHook: Add support for multiple builders`             |
| [`9e1164a4`](https://github.com/NixOS/nixpkgs/commit/9e1164a480fdac6e1eb2bc6e0f0cbdf970e6a876) | `elmPackages.elm-review: 2.7.2 -> 2.7.4`                                    |
| [`4e7b43dd`](https://github.com/NixOS/nixpkgs/commit/4e7b43dd39b454adbe1b59c65b03cf3b1d510679) | `cargo-generate: fix darwin build`                                          |
| [`c555ac19`](https://github.com/NixOS/nixpkgs/commit/c555ac19049c0c91b4a917a0949859c194c8b9ff) | `prometheus: fix cross compile`                                             |
| [`2461a623`](https://github.com/NixOS/nixpkgs/commit/2461a6233430ce84fbd79958ab290318521de865) | `nvidia: remove deleted useGlamor option`                                   |
| [`44c79a01`](https://github.com/NixOS/nixpkgs/commit/44c79a01aeb7d3dc5a181e53028c81a0ce6cef02) | `kdepim-runtime: use XOAUTH2 SASL plugin from libkgapi (#177410)`           |
| [`f26ce2bf`](https://github.com/NixOS/nixpkgs/commit/f26ce2bf3bc159077b5c2a50e0c51f18490c5f2d) | `tidal-hifi: patch out Exec's absolute path in .desktop file`               |
| [`4a70e004`](https://github.com/NixOS/nixpkgs/commit/4a70e004c0cce9cc9802e3a0a3d4a37210c94f56) | `scala: 3.1.0 → 3.1.3`                                                      |
| [`c35b1908`](https://github.com/NixOS/nixpkgs/commit/c35b1908a21097b9ec7945e8c306d9a0cdf01a0d) | `docker-compose: 2.10.0 -> 2.10.1`                                          |
| [`87a688bb`](https://github.com/NixOS/nixpkgs/commit/87a688bb18eb68f5ae795af24887d2e0fbde9636) | `openai: 0.22.1 -> 0.23.0`                                                  |
| [`ec62674c`](https://github.com/NixOS/nixpkgs/commit/ec62674cb06b8c37b94acc56b4a7e7e847c33da5) | `python310Packages.pyisbn: remove unused input`                             |
| [`b3eb3a35`](https://github.com/NixOS/nixpkgs/commit/b3eb3a35edbbef1111d8ff4b4485db808e59936f) | `hackneyed: init at 0.8.2`                                                  |
| [`2c245c5d`](https://github.com/NixOS/nixpkgs/commit/2c245c5dd398e7841c1049ffc3455fa69c02a84f) | `aptly: add bitnomial members as maintainers`                               |
| [`d5930853`](https://github.com/NixOS/nixpkgs/commit/d593085390ac8b9720314696bc6a0efd57d94b37) | `aptly: 1.4.0 -> 1.5.0`                                                     |
| [`611a4bff`](https://github.com/NixOS/nixpkgs/commit/611a4bff158ee2dbc4dfef755cc08790aaf8cb07) | `maintainers: add bitnomial team`                                           |
| [`006765c9`](https://github.com/NixOS/nixpkgs/commit/006765c965bc1f95dbb782c617527d7b79d6d489) | `babl: drop patch that's already applied`                                   |
| [`78d94425`](https://github.com/NixOS/nixpkgs/commit/78d9442565fbf1ace3a354322c70465f41d14781) | `kompute: fix build by upstream patch`                                      |
| [`d18529e1`](https://github.com/NixOS/nixpkgs/commit/d18529e1a0c515bf661e68f5215e50e7affc455f) | `python3Packages.cymem: re-enable tests`                                    |
| [`77c00d71`](https://github.com/NixOS/nixpkgs/commit/77c00d716d406dc6ae58fdf6ca6a834c876700e9) | `python39Packages.cairo-lang: init at 0.9.1`                                |
| [`689d6788`](https://github.com/NixOS/nixpkgs/commit/689d6788f2108e93ca09f8f364a33fda3b3a16d3) | `mill: 0.10.5 -> 0.10.6`                                                    |
| [`32380286`](https://github.com/NixOS/nixpkgs/commit/32380286b4c8e62e1fb36921507454e98046efd9) | `libsForQt5.audiotube: patch missing #include`                              |
| [`da95a5e5`](https://github.com/NixOS/nixpkgs/commit/da95a5e58ef0bc8454b751fde19a021192d798a3) | `python310Packages.bthome-ble: 0.3.4 -> 0.3.5`                              |
| [`7d229369`](https://github.com/NixOS/nixpkgs/commit/7d229369554636f7bb8907a7fa9c72087a79c2d1) | `python310Packages.bthome-ble: 0.3.3 -> 0.3.4`                              |
| [`790d7cc9`](https://github.com/NixOS/nixpkgs/commit/790d7cc9bc9568c09e7147024ea18d50aa958ce8) | `python310Packages.bthome-ble: 0.3.2 -> 0.3.3`                              |
| [`568a8c87`](https://github.com/NixOS/nixpkgs/commit/568a8c875d8ccde539142c5c9500fcc1723a3c36) | `qmarkdowntextedit: unstable-2022-06-30 -> unstable-2022-08-24`             |
| [`ece2858b`](https://github.com/NixOS/nixpkgs/commit/ece2858b38acc214fe766e8edd7b895e54f4a8d8) | `cutemarked-ng: init at unstable-2021-07-29`                                |
| [`68e8f8a8`](https://github.com/NixOS/nixpkgs/commit/68e8f8a80f649dc571896f5d0a68499626e19d20) | `qmarkdowntextedit: init at unstable-2022-06-30`                            |
| [`498ba41a`](https://github.com/NixOS/nixpkgs/commit/498ba41a450a45d546204b35f7f7ca0f83a049d6) | `stratisd: init at 3.2.2`                                                   |
| [`f0127393`](https://github.com/NixOS/nixpkgs/commit/f012739348de43b8ef8c2b356165ca360839438b) | `oh-my-zsh: 2022-08-10 -> 2022-08-14 (#187446)`                             |
| [`071d09de`](https://github.com/NixOS/nixpkgs/commit/071d09de304d31d75d870892bd455668dac3f0a1) | `perlPackages: Switch to SRI hashes`                                        |
| [`2b5b3447`](https://github.com/NixOS/nixpkgs/commit/2b5b344788b5097201838277580ffc3e724cf17b) | `djvulibre: enable parallel building`                                       |
| [`75d86f0e`](https://github.com/NixOS/nixpkgs/commit/75d86f0e79ded9fcc28ee8b62a08fbc170e06469) | `djvulibre: move librsvg to nativeBuildInputs`                              |
| [`8d3fc481`](https://github.com/NixOS/nixpkgs/commit/8d3fc481a4cbd2ec474ff05996b91c76ede3132e) | `folly: expose fmt and boost libs`                                          |
| [`89ac27ff`](https://github.com/NixOS/nixpkgs/commit/89ac27ffeb151aba051ad0a41ab0e866140580e0) | `ripe-atlas-tools: init at 3.0.2`                                           |
| [`caf4a8ba`](https://github.com/NixOS/nixpkgs/commit/caf4a8ba22813fd1fc0022703f83817290175a0e) | `swayws: init at unstable-2022-03-10`                                       |
| [`c1b2e4a9`](https://github.com/NixOS/nixpkgs/commit/c1b2e4a9b17beab8d543b5f8e88c07e0e85641a3) | `perlPackages.Crypt{Blowfish,DES,IDEA}: Use correct license`                |