### PR TITLE
chore(flake/nur): `b7a91467` -> `dda41de0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661604090,
-        "narHash": "sha256-vFDv4PPhwYopTq2wNhtv7zqMLSVMFHP0OPoTUf1glr8=",
+        "lastModified": 1661618423,
+        "narHash": "sha256-43J94pXW1GQBwHRa4gBjDsOr7DgVlVdXu5sllJJbGvg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b7a91467e843c29b44e5069b6de406f254aea668",
+        "rev": "dda41de026f7419f6ee1d4a0d5d9c10a7b56d54c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`dda41de0`](https://github.com/nix-community/NUR/commit/dda41de026f7419f6ee1d4a0d5d9c10a7b56d54c) | `automatic update` |