### PR TITLE
chore(flake/emacs-overlay): `0dd2d05b` -> `6c95fb87`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661629701,
-        "narHash": "sha256-ljRd914+HaWK++WQLY6evWbzPBWe3X+HK3iR4SCZ/wU=",
+        "lastModified": 1661664047,
+        "narHash": "sha256-O/affWh3Val9xtAXR6Z6rA2mhMPHjuHgDWbBmbElV6c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0dd2d05b103931f7192ab62c9e7a4b5950155c17",
+        "rev": "6c95fb87c40fc976f5de5f00ba5cca92b7537e88",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`6c95fb87`](https://github.com/nix-community/emacs-overlay/commit/6c95fb87c40fc976f5de5f00ba5cca92b7537e88) | `Updated repos/emacs` |
| [`f1a2b2e4`](https://github.com/nix-community/emacs-overlay/commit/f1a2b2e4dde0e5064e0641b426c52e9825700d5d) | `Updated repos/elpa`  |