### PR TITLE
chore(flake/nixpkgs): `f3d0897b` -> `38e16b19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -277,11 +277,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1661450036,
-        "narHash": "sha256-0/9UyJLtfWqF4uvOrjFIzk8ue1YYUHa6JIhV0mALkH0=",
+        "lastModified": 1661541451,
+        "narHash": "sha256-LALyT63vpo1sftSmHAbbrj+emfCOo93Jv4xVOIcmnl0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f3d0897be466aa09a37f6bf59e62c360c3f9a6cc",
+        "rev": "38e16b192af13ff6cffc8a35a25f390f1e96b585",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                           |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
| [`38e16b19`](https://github.com/NixOS/nixpkgs/commit/38e16b192af13ff6cffc8a35a25f390f1e96b585) | `neovim: fix plugin loading order`                                                                       |
| [`1744aec5`](https://github.com/NixOS/nixpkgs/commit/1744aec5a6a6d931e3c8a44dd63fd99a451be3e2) | `nerdfonts: 2.1.0 -> 2.2.0`                                                                              |
| [`6fc3f6e3`](https://github.com/NixOS/nixpkgs/commit/6fc3f6e38145e03b27d093fd289bce45a04bdfba) | `wpsoffice: 11.1.0.9615 -> 11.1.0.11664`                                                                 |
| [`d3c343f1`](https://github.com/NixOS/nixpkgs/commit/d3c343f104d28737cac863452c088bcb33284e2e) | `init conserver 8.2.7`                                                                                   |
| [`abd2e87d`](https://github.com/NixOS/nixpkgs/commit/abd2e87da1a2e8e13ddc43377014a558b016fb98) | `stdenv: remove deprecated adapters`                                                                     |
| [`98877ad9`](https://github.com/NixOS/nixpkgs/commit/98877ad91cc99b634aa8b9d5a619b7476a5d6f4d) | `python310Packages.werkzeug: add moto, sentry-sdk to passthru.tests`                                     |
| [`ffb24032`](https://github.com/NixOS/nixpkgs/commit/ffb2403200e3191229893a7e107059ee8f0e378f) | `python310Packages.click: add typer to passthru.tests`                                                   |
| [`57f8ec53`](https://github.com/NixOS/nixpkgs/commit/57f8ec53c8eae1dda3ec95c5be52269c76e360f8) | `cbfmt: 0.1.1 -> 0.1.4`                                                                                  |
| [`b31d80ba`](https://github.com/NixOS/nixpkgs/commit/b31d80ba92e0614b488c1db22fd57f4b5722ef88) | `yash: 2.52 -> 2.53`                                                                                     |
| [`f8f15011`](https://github.com/NixOS/nixpkgs/commit/f8f1501120eee4233a91dfd2b2ad319fec999b3b) | `ocamlPackages.pbkdf: 1.1.0 -> 1.2.0`                                                                    |
| [`c108b9f0`](https://github.com/NixOS/nixpkgs/commit/c108b9f07fe6fe8617f2e40f61364c7d69dba58b) | `nomad-driver-podman: 0.3.0 -> 0.4.0`                                                                    |
| [`ba414f5f`](https://github.com/NixOS/nixpkgs/commit/ba414f5f8478407c25bef0c7bfc33e18f7912d7f) | `eclint: init at 0.3.4`                                                                                  |
| [`f4c55b72`](https://github.com/NixOS/nixpkgs/commit/f4c55b728632e12cb195066fd5d63e761f8380ac) | `xdaliclock: 2.44 -> 2.45`                                                                               |
| [`8b74b21d`](https://github.com/NixOS/nixpkgs/commit/8b74b21d237eb4be2e769f4f5ef24e6361f8edcc) | `nixos/networkd: add missing options for DHCPServer and IPV6SendRA`                                      |
| [`cf927c27`](https://github.com/NixOS/nixpkgs/commit/cf927c27fc84886a1876af69263b1d8f241bf89a) | `python310Packages.flask: add key reverse dependencies`                                                  |
| [`6f0302c2`](https://github.com/NixOS/nixpkgs/commit/6f0302c2dde053651c6c4e5953ddc0c68bb5b1cf) | `python310Packages.aioaladdinconnect: 0.1.42 -> 0.1.43`                                                  |
| [`dae79f1d`](https://github.com/NixOS/nixpkgs/commit/dae79f1dbba498b6e1fb59fabcde96d26d773cce) | `python310Packages.accuweather: 0.3.0 -> 0.4.0`                                                          |
| [`3153b8af`](https://github.com/NixOS/nixpkgs/commit/3153b8afdf3e3a9979f7270705ec999111ab5543) | `cri-tools: 1.24.2 -> 1.25.0`                                                                            |
| [`3e0c7e72`](https://github.com/NixOS/nixpkgs/commit/3e0c7e72633a06d2fbc18aed4f57526a28266ec8) | `python310Packages.pyunifiprotect: 4.1.6 -> 4.1.7`                                                       |
| [`ed8dcee4`](https://github.com/NixOS/nixpkgs/commit/ed8dcee4b50c124a6bdd47995c20c75854aab9a5) | `python310Packages.pyunifiprotect: 4.1.5 -> 4.1.6`                                                       |
| [`d10452be`](https://github.com/NixOS/nixpkgs/commit/d10452be5558f061bcd917bd86970c5a6ab5011e) | `python310Packages.time-machine: 2.8.0 -> 2.8.1`                                                         |
| [`c9ac3fcf`](https://github.com/NixOS/nixpkgs/commit/c9ac3fcf0d1553c7a57962d1569633e136a3521c) | `python310Packages.pyunifiprotect: 4.1.4 -> 4.1.5`                                                       |
| [`17f9bfc8`](https://github.com/NixOS/nixpkgs/commit/17f9bfc8469610acae35d71ec3e64673149ce713) | `python310Packages.pymicrobot: 0.0.4 -> 0.0.5`                                                           |
| [`dc0ea522`](https://github.com/NixOS/nixpkgs/commit/dc0ea5225e31d65663481c3d0b694a96bb0528dd) | `python310Packages.peaqevcore: 5.13.0 -> 5.14.0`                                                         |
| [`cfdf164d`](https://github.com/NixOS/nixpkgs/commit/cfdf164d51b0646fa261f3bca57449fdecc6dd4e) | `python310Packages.peaqevcore: 5.12.0 -> 5.13.0`                                                         |
| [`2d3aefd8`](https://github.com/NixOS/nixpkgs/commit/2d3aefd860f9cfef753666ddee03b298006a5647) | `python310Packages.aliyun-python-sdk-iot: 8.41.0 -> 8.42.0`                                              |
| [`e70d3594`](https://github.com/NixOS/nixpkgs/commit/e70d35945aedfe2e5f8d0e283206044a7a07d896) | `python310Packages.thermopro-ble: 0.4.0 -> 0.4.1`                                                        |
| [`b1dbcccb`](https://github.com/NixOS/nixpkgs/commit/b1dbcccb23f36e1ded1d64c9afc1679fa89112a6) | `python310Packages.thermopro-ble: init at 0.4.0`                                                         |
| [`c74e976d`](https://github.com/NixOS/nixpkgs/commit/c74e976d7327a4a61cced22c61c7e8c252aa432b) | `python310Packages.thermobeacon-ble: init at 0.3.1`                                                      |
| [`f9cd86ed`](https://github.com/NixOS/nixpkgs/commit/f9cd86edd563bbef6b8f84c9e57c61b041382518) | `cosign: 1.11.0 -> 1.11.1`                                                                               |
| [`3073de22`](https://github.com/NixOS/nixpkgs/commit/3073de224d7ce13df6c02b97b222c22514199fbd) | `python310Packages.qingping-ble: 0.6.0 -> 0.6.1`                                                         |
| [`fb39efa0`](https://github.com/NixOS/nixpkgs/commit/fb39efa0e8de4680fd0e7ac8a3c947abe284c878) | `python310Packages.qingping-ble: 0.5.0 -> 0.6.0`                                                         |
| [`0441f1c7`](https://github.com/NixOS/nixpkgs/commit/0441f1c79891adaeb4ca10c46103076ee87af591) | `python310Packages.qingping-ble: 0.4.0 -> 0.5.0`                                                         |
| [`ab3460c9`](https://github.com/NixOS/nixpkgs/commit/ab3460c9c43694a5ea6cefd8a5caa24dd0617a97) | `python310Packages.qingping-ble: 0.3.0 -> 0.4.0`                                                         |
| [`52397b7c`](https://github.com/NixOS/nixpkgs/commit/52397b7c019495d28b9cf1be5c8d75969853d12f) | `python310Packages.bthome-ble: 0.3.7 -> 0.3.8`                                                           |
| [`4384daf7`](https://github.com/NixOS/nixpkgs/commit/4384daf7e2fed46d6cfbac768037d80cc6bd617d) | `python310Packages.bthome-ble: 0.3.6 -> 0.3.7`                                                           |
| [`cd3095f4`](https://github.com/NixOS/nixpkgs/commit/cd3095f49da398b51088ea5d84652e334802b077) | `Add myself to maintainers list`                                                                         |
| [`ed775257`](https://github.com/NixOS/nixpkgs/commit/ed775257a0a25041f343773d779fe43ace1cc9b2) | `vscode-extensions.azdavis.millet: init at 0.3.5`                                                        |
| [`219fd334`](https://github.com/NixOS/nixpkgs/commit/219fd334e08c4a48d78a7f3f1e787f96fd779def) | `tig: 2.5.6 -> 2.5.7`                                                                                    |
| [`3b40f3c0`](https://github.com/NixOS/nixpkgs/commit/3b40f3c0e12bdbeac7286b4b82222975ebd51fda) | `nautilus-open-any-terminal: fix build`                                                                  |
| [`63513788`](https://github.com/NixOS/nixpkgs/commit/63513788182bba1cf560a39bd48ddbdad5783c3e) | `dagger: 0.2.30 -> 0.2.31`                                                                               |
| [`346e1a42`](https://github.com/NixOS/nixpkgs/commit/346e1a426d64169d64e45549131923970fb4426b) | `kde/gear: add a few missing dependencies`                                                               |
| [`d5ea0684`](https://github.com/NixOS/nixpkgs/commit/d5ea0684a8da07bedd2a1bacaa0482cc504b9259) | `mlt-qt5: 7.0.1 -> 7.8.0`                                                                                |
| [`a550b5fd`](https://github.com/NixOS/nixpkgs/commit/a550b5fd0a74dd034d6ec4f23b3e36e33eeef4c6) | `kate: fix substitute desktop path`                                                                      |
| [`3759e4ac`](https://github.com/NixOS/nixpkgs/commit/3759e4ac86b6a6b03643d3b8522b139403f5e185) | `ksanecore: init 22.08.0`                                                                                |
| [`d4f0548f`](https://github.com/NixOS/nixpkgs/commit/d4f0548f35f3c8a3d3d7f20e70031aa1a5c7e2b9) | `kde/gear: 22.04.3 -> 22.08.0`                                                                           |
| [`ffd99e79`](https://github.com/NixOS/nixpkgs/commit/ffd99e79b3c05b4ff5a0a5d09657c87c6eb16a3b) | `tessen: init at unstable-2022-08-04`                                                                    |
| [`7e01e6a0`](https://github.com/NixOS/nixpkgs/commit/7e01e6a0727999f9334737701d5b3beec3dcb0d3) | `haruna: 0.8.0 -> 0.9.1`                                                                                 |
| [`dc153eaa`](https://github.com/NixOS/nixpkgs/commit/dc153eaa40bd4a4a0bfbdf6e48bdcc5ddddff83f) | `asus-ec-sensors: unstable-2021-12-16 -> unstable-2022-07-10`                                            |
| [`f8c5cfaf`](https://github.com/NixOS/nixpkgs/commit/f8c5cfaf3814accbeb041d5933d33bbfc3173cef) | `packwiz: unstable-2022-06-08 -> unstable-2022-08-25`                                                    |
| [`bb1d34d0`](https://github.com/NixOS/nixpkgs/commit/bb1d34d0f113b831bc891ffd596a85b0933eb30a) | `cvc3: reenable stackprotector on aarch64-darwin`                                                        |
| [`7374e664`](https://github.com/NixOS/nixpkgs/commit/7374e6644a6dd6a6ae7e73e4828544499bdfb571) | `nomad_1_2: 1.2.9 -> 1.2.11`                                                                             |
| [`5b78302c`](https://github.com/NixOS/nixpkgs/commit/5b78302c38e01d5bbd91c62b760508aa18c5d306) | `makemkv: 1.16.7 -> 1.17.1`                                                                              |
| [`3ea94290`](https://github.com/NixOS/nixpkgs/commit/3ea942905fc2c5331ddce5d8e4c778977fd43d5c) | `vcv-rack: 2.0.6 -> 2.1.2`                                                                               |
| [`42466549`](https://github.com/NixOS/nixpkgs/commit/4246654992ec971d7dc434e04994ed4ea43e8458) | `writers.makePythonWriter: fix cross compile`                                                            |
| [`63a58623`](https://github.com/NixOS/nixpkgs/commit/63a586235bc5e7061fe8fe36f0063564b133a6d8) | `home-assistant: 2022.8.6 -> 2022.8.7`                                                                   |
| [`925f53cc`](https://github.com/NixOS/nixpkgs/commit/925f53cc9881069cdf7fd980870283f3945deb31) | `k3s: 1.24.3+k3s1 -> 1.24.4+k3s1`                                                                        |
| [`fe76cced`](https://github.com/NixOS/nixpkgs/commit/fe76cced407f24b40c500d24fb3f304240da9114) | `linux_latest-libre: 18880 -> 18885`                                                                     |
| [`645ad87d`](https://github.com/NixOS/nixpkgs/commit/645ad87d82a5c253fec06b0f240e54acb0cda1d9) | `linux: 5.4.210 -> 5.4.211`                                                                              |
| [`fc04b425`](https://github.com/NixOS/nixpkgs/commit/fc04b425459a4f928576498f8fdf841777b6eb62) | `linux: 5.19.3 -> 5.19.4`                                                                                |
| [`fba0a26d`](https://github.com/NixOS/nixpkgs/commit/fba0a26dd8d37b0b519c5fc67506cdd5a5715627) | `linux: 5.15.62 -> 5.15.63`                                                                              |
| [`20009a7b`](https://github.com/NixOS/nixpkgs/commit/20009a7b1440eced7cde24fae2aff53dca808a97) | `linux: 5.10.137 -> 5.10.138`                                                                            |
| [`105b6f1b`](https://github.com/NixOS/nixpkgs/commit/105b6f1bafd807e59dd3966e4dcf0a98f59fabc9) | `linux: 4.9.325 -> 4.9.326`                                                                              |
| [`bb509335`](https://github.com/NixOS/nixpkgs/commit/bb50933572569e92429f4ffb6985dfd7d8f30c76) | `linux: 4.19.255 -> 4.19.256`                                                                            |
| [`e37f235e`](https://github.com/NixOS/nixpkgs/commit/e37f235e3a763975a96069499f03611b1a329fdf) | `linux: 4.14.290 -> 4.14.291`                                                                            |
| [`0f1a17e1`](https://github.com/NixOS/nixpkgs/commit/0f1a17e1a6f9a681383aea2bb4872a03316bc707) | `python3Packages.django-cryptography: init at 1.1`                                                       |
| [`b483c822`](https://github.com/NixOS/nixpkgs/commit/b483c822f86d0331fd097e925ec090e5a7d93175) | `nomad_1_3: 1.3.3 -> 1.3.4`                                                                              |
| [`0f5fe359`](https://github.com/NixOS/nixpkgs/commit/0f5fe359438daccee9f4d02e38f01e8fe2a9f6e2) | `rtl8189fs: patch for 5.19.2 and 6.0`                                                                    |
| [`cfe98559`](https://github.com/NixOS/nixpkgs/commit/cfe985592fc42bf6e91a9d4e706f0ec85688041c) | `runc: 1.1.3 -> 1.1.4`                                                                                   |
| [`a88df802`](https://github.com/NixOS/nixpkgs/commit/a88df802c0f163927f2fdb466144ceb67803ee68) | `python310Packages.pyxdg: 0.27 -> 0.28`                                                                  |
| [`a5cb5ba4`](https://github.com/NixOS/nixpkgs/commit/a5cb5ba44a2cb3ffc0649f7147aec7e228d68b9e) | `chromiumBeta: 105.0.5195.37 -> 105.0.5195.52`                                                           |
| [`872ca613`](https://github.com/NixOS/nixpkgs/commit/872ca61379acdd98eb46391969d46901ece9ea77) | `chromiumDev: 106.0.5231.2 -> 106.0.5245.0`                                                              |
| [`78ff80b3`](https://github.com/NixOS/nixpkgs/commit/78ff80b33a73b2ca05b0dcc6037a7c48d42d3cf8) | `python3Packages.pydeconz: 103 -> 104`                                                                   |
| [`00cf7053`](https://github.com/NixOS/nixpkgs/commit/00cf7053b41e884a6e736e21e834e71e4824a5f9) | `python3Packages.xknx: 1.0.0 -> 1.0.1`                                                                   |
| [`5e726981`](https://github.com/NixOS/nixpkgs/commit/5e7269817b2dc914d9f82c7d746db31e49d1f614) | `python3Packages.bellows: 0.32.0 -> 0.33.1`                                                              |
| [`cbf459a0`](https://github.com/NixOS/nixpkgs/commit/cbf459a0a8c9b1ff30f662bd40df29457c4b629b) | `python3Packages.zigpy-znp: 0.8.1 -> 0.8.2`                                                              |
| [`0afc0917`](https://github.com/NixOS/nixpkgs/commit/0afc09178ef8b529560cc4d39d71db41bba1219e) | `python3Packages.zigpy-zigate: 0.9.1 -> 0.9.2`                                                           |
| [`c16c6d5b`](https://github.com/NixOS/nixpkgs/commit/c16c6d5b5d9b449ea23b6ce210a5aca92dcb433b) | `python3Packages.zigpy: 0.49.1 -> 0.50.2`                                                                |
| [`2400c9dc`](https://github.com/NixOS/nixpkgs/commit/2400c9dca76c19a89c38bb6ced08931821190453) | `zen-kernels: 5.19.3 -> 5.19.4`                                                                          |
| [`901b4843`](https://github.com/NixOS/nixpkgs/commit/901b48436b644a252b391cea44eeb618da88778b) | `roccat-tools: Fix udev rules (#168463)`                                                                 |
| [`16db6bc7`](https://github.com/NixOS/nixpkgs/commit/16db6bc7e4e49ddc03b2b2c10ac1830c5be12f28) | `apr: remove no longer required darwin patch`                                                            |
| [`a92619ff`](https://github.com/NixOS/nixpkgs/commit/a92619ff25daf87f2107b327c12c00687d6675d8) | `lutris: 0.5.10.1 -> 0.5.11`                                                                             |
| [`f3228e71`](https://github.com/NixOS/nixpkgs/commit/f3228e71c86d28393e9474bb4b206e7013ea69fc) | `halide: 10.0.0 -> 14.0.0 (#180015)`                                                                     |
| [`f39c5460`](https://github.com/NixOS/nixpkgs/commit/f39c54608a8120b9479317c42278ef0d1ed6f592) | `rar: 6.11 -> 6.12`                                                                                      |
| [`5c7f600e`](https://github.com/NixOS/nixpkgs/commit/5c7f600e6728b64dc4b83d7712f1221cb556ff0f) | `restic: 0.13.1 -> 0.14.0`                                                                               |
| [`b34ed334`](https://github.com/NixOS/nixpkgs/commit/b34ed334719c6daf0725dbed492cc65e0e8a62b6) | `tracker-miners: add darwin support`                                                                     |
| [`d7bef17c`](https://github.com/NixOS/nixpkgs/commit/d7bef17c45fb3496ccd112df14b75bb74f0578b9) | `golangci-lint: 1.48.0 -> 1.49.0`                                                                        |
| [`ae1210f4`](https://github.com/NixOS/nixpkgs/commit/ae1210f4cd4678eae9ba9d1226aeaf342ae5888d) | `signalbackup-tools: 20220810 -> 20220825`                                                               |
| [`864b23a4`](https://github.com/NixOS/nixpkgs/commit/864b23a4f91513fe3af4525cdff58192b68e8f30) | `vulkan-utils: init at 0.5.7`                                                                            |
| [`75424ac7`](https://github.com/NixOS/nixpkgs/commit/75424ac7939adcdf62cf1a5296f82766a8dfe5d1) | `hw-probe: init at 1.6.4`                                                                                |
| [`59e74397`](https://github.com/NixOS/nixpkgs/commit/59e7439715d441fe4ea8313049ea23d15081443d) | `maintainers: add rehno-lindeque`                                                                        |
| [`0414c7e0`](https://github.com/NixOS/nixpkgs/commit/0414c7e0742614bbd4de6200e060dc7a7aaeaf9d) | `evolution: 3.44.3 -> 3.44.4`                                                                            |
| [`cc1ecf44`](https://github.com/NixOS/nixpkgs/commit/cc1ecf44d8c51d7a39b9ba9418fc59c5844f635e) | `evolution-ews: 3.44.3 -> 3.44.4`                                                                        |
| [`a2f98e59`](https://github.com/NixOS/nixpkgs/commit/a2f98e59145ffdb9e8703868719e76c5f6639aa3) | `gnome.evolution-data-server: 3.44.3 -> 3.44.4`                                                          |
| [`7cf3be16`](https://github.com/NixOS/nixpkgs/commit/7cf3be168eff130faa24f2a18362fd76ceef1ed9) | `ipxe: Allow to specify additional options`                                                              |
| [`37cc3ead`](https://github.com/NixOS/nixpkgs/commit/37cc3ead1b673ef44517b588c832ddd0fe9246f4) | `famistudio: 3.3.1 -> 4.0.1`                                                                             |
| [`195833f2`](https://github.com/NixOS/nixpkgs/commit/195833f20c850013446ada0cec4413f0c38d71f0) | `tesseract5: fix darwin compilation`                                                                     |
| [`0c5fbf9c`](https://github.com/NixOS/nixpkgs/commit/0c5fbf9c08bd0c91fe9820f1c04e06c0a67faf85) | `nixos/matrix-synapse: Harden systemd serivce`                                                           |
| [`153f2f6f`](https://github.com/NixOS/nixpkgs/commit/153f2f6f067dcf6b56c8c0f44591f48370603203) | `wasmtime: build c-api, bump version to 0.40.0`                                                          |
| [`38e0579e`](https://github.com/NixOS/nixpkgs/commit/38e0579ecf83219c8acaefd121b9f4395505b7ef) | `apr: fix cross compile`                                                                                 |
| [`bbe876ee`](https://github.com/NixOS/nixpkgs/commit/bbe876ee06ec27e3f9e815584c484d5321556dfe) | ``Use `substituteInPlace` instead of calling sed``                                                       |
| [`349ac490`](https://github.com/NixOS/nixpkgs/commit/349ac490d1be39ba1541aa1527eaf907cfc7299d) | `morgen: 2.5.9 -> 2.5.10`                                                                                |
| [`2a3fabed`](https://github.com/NixOS/nixpkgs/commit/2a3fabed14bbe0f45c325511227902bf34c152e9) | `monetdb: 11.43.9 -> 11.43.21`                                                                           |
| [`2c300d69`](https://github.com/NixOS/nixpkgs/commit/2c300d6918825be6954346b02bea208ccd983c2d) | `btrfs-progs: 5.18.1 -> 5.19`                                                                            |
| [`682e6b0f`](https://github.com/NixOS/nixpkgs/commit/682e6b0f9e94d158be1818ffc882faf88d561b9b) | `Fix redbug build error with Erlang/OTP ≥ 25`                                                            |
| [`d831b5e8`](https://github.com/NixOS/nixpkgs/commit/d831b5e8dc295beed8e81ae14baa88bb8ab11480) | `erlang-ls: 0.35.0 -> 0.41.2`                                                                            |
| [`0806ee7e`](https://github.com/NixOS/nixpkgs/commit/0806ee7ed5db6aa190127460ec66d6c41fac9a3c) | `github-runner: 2.295.0 -> 2.296.0`                                                                      |
| [`ec124cda`](https://github.com/NixOS/nixpkgs/commit/ec124cda59768b81555f0c13adb16aac81c81f56) | `changelogger: 0.5.2 -> 0.5.3`                                                                           |
| [`386dc413`](https://github.com/NixOS/nixpkgs/commit/386dc413601cd71dbed57926fc493b6bd2d21593) | `mariadb_109: init`                                                                                      |
| [`3291bda7`](https://github.com/NixOS/nixpkgs/commit/3291bda7b6aca51b1e2644e1adc7824c89530dc0) | `buildRustCrate: Do not compile binaries if all the requiredFeatures aren't enabled.`                    |
| [`ef48e700`](https://github.com/NixOS/nixpkgs/commit/ef48e700ff55ccf6619434e4555bbfb23c7a289c) | `python310Packages.pyunifiprotect: 4.1.3 -> 4.1.4`                                                       |
| [`a73f576b`](https://github.com/NixOS/nixpkgs/commit/a73f576bc51a194b6cf77580f84b60c610e0bbbe) | `vscode-extensions.mkhl.direnv: init at 0.6.1`                                                           |
| [`54b76185`](https://github.com/NixOS/nixpkgs/commit/54b76185d8281a4b770979d06c84decd688108b0) | `go-ethereum: add support for Auth RPC CLI flags`                                                        |
| [`eb677c22`](https://github.com/NixOS/nixpkgs/commit/eb677c22c67ca6e46b49ef4e278f84e2cc4b8acb) | `erlang-ls: 0.35.0 -> 0.41.2`                                                                            |
| [`1d143536`](https://github.com/NixOS/nixpkgs/commit/1d143536d38e33f84184ee994297fca41796d750) | `python310Packages.scikitimage: 0.18.3 -> 0.19.3`                                                        |
| [`21b24009`](https://github.com/NixOS/nixpkgs/commit/21b240095f19feab031ccf3adb9f4799fed1b937) | `picard: 2.8.1 -> 2.8.3`                                                                                 |
| [`506cb62c`](https://github.com/NixOS/nixpkgs/commit/506cb62c4e4d7c97d862665233fba55f894177e4) | `	modified:   nixos/modules/system/boot/networkd.nix`                                                    |
| [`90de9ee6`](https://github.com/NixOS/nixpkgs/commit/90de9ee6892da32b9854e0b94c828ac97fdf9c45) | ` nixos/modules/system/boot/networkd.nix: added Group= option in sectionLink of systemd.networkd config` |
| [`69347cc5`](https://github.com/NixOS/nixpkgs/commit/69347cc5fc2a1835bfa98230829184c567de1561) | ``hedgedoc: add SAML `providerName` option``                                                             |
| [`36a4a09a`](https://github.com/NixOS/nixpkgs/commit/36a4a09aabbc7c03bb4063ee5831c87de3868598) | `python3Packages.kanidm: init at 0.0.3`                                                                  |
| [`febb86fd`](https://github.com/NixOS/nixpkgs/commit/febb86fd6c304f035c3cf52e091368a2a0586143) | `python3Packages.pydantic: 1.9.1 -> 1.9.2`                                                               |
| [`35e2da1d`](https://github.com/NixOS/nixpkgs/commit/35e2da1d663590bebf4991addd941b36c31acebd) | `ddccontrol-db: 20220414 -> 20220720`                                                                    |
| [`a5fc2ede`](https://github.com/NixOS/nixpkgs/commit/a5fc2ede43716c792879dc7a320c904b7b81b825) | `cloud-sql-proxy: 1.30.0 -> 1.31.2`                                                                      |
| [`ee7dd02f`](https://github.com/NixOS/nixpkgs/commit/ee7dd02fa146015db05276240f9bf76b3ebdef02) | `aeon: 0.14.1.0 -> 0.14.2.2`                                                                             |
| [`a454a706`](https://github.com/NixOS/nixpkgs/commit/a454a706b584fa5c6583ecd8071b662caaedd9ca) | `shutdown: Protect system from make-initrd-ng`                                                           |
| [`58e7457e`](https://github.com/NixOS/nixpkgs/commit/58e7457e2afb0a0f88df0d58214d29a3f2e514c0) | `dtrx: 8.2.2 -> 8.3.1`                                                                                   |
| [`788c10d7`](https://github.com/NixOS/nixpkgs/commit/788c10d7e5716a1ba59d3829fe69ff621af8a5b6) | `libsForQt5.alkimia: 8.1.0 -> 8.1.1`                                                                     |
| [`70d8afaf`](https://github.com/NixOS/nixpkgs/commit/70d8afaf722017bf66e2e1c289a8a13bed975665) | `aspectj: 1.9.7 -> 1.9.9.1`                                                                              |
| [`a28c6dda`](https://github.com/NixOS/nixpkgs/commit/a28c6ddae0e66e2433069a840ed59e3eca73af9e) | `flatcc: 0.6.0 -> 0.6.1`                                                                                 |
| [`168cdcd9`](https://github.com/NixOS/nixpkgs/commit/168cdcd9bdaf42abfbfe317b3e6b223c0e022dbd) | `linux_lqx, linux_zen: avoid unnecessary prefetch`                                                       |
| [`9b8d6933`](https://github.com/NixOS/nixpkgs/commit/9b8d6933591f08f61a5c1c78e38199ceec0f0099) | `bobcat: 5.09.01 -> 5.10.01`                                                                             |