### PR TITLE
chore(flake/emacs-overlay): `0bb59bd0` -> `5046cc71`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661685287,
-        "narHash": "sha256-GfdkpJHc2LD8lamAfwn9uWmyPbStldni19bogpD38Vs=",
+        "lastModified": 1661717081,
+        "narHash": "sha256-ssz++/guNZM/52gTqFJkJuvCnqWJjMrV363xjvpzrHM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0bb59bd04ff65270b34434edde00654f43a0dec8",
+        "rev": "5046cc71d33022f237191f2a8d8df18315910d13",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`5046cc71`](https://github.com/nix-community/emacs-overlay/commit/5046cc71d33022f237191f2a8d8df18315910d13) | `Updated repos/emacs` |
| [`0bbab674`](https://github.com/nix-community/emacs-overlay/commit/0bbab6748fe821b637d6b7df517b910540e38260) | `Updated repos/elpa`  |