### PR TITLE
chore(flake/nixpkgs): `38e16b19` -> `324c8aaf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -277,11 +277,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1661541451,
-        "narHash": "sha256-LALyT63vpo1sftSmHAbbrj+emfCOo93Jv4xVOIcmnl0=",
+        "lastModified": 1661628722,
+        "narHash": "sha256-oR/7NhG7pPkACToUtaaT6hH+rONE2z5/4NzjoUwEZt8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "38e16b192af13ff6cffc8a35a25f390f1e96b585",
+        "rev": "324c8aaf25b2f2027af7798e5582ce3040a793b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`e607b30a`](https://github.com/NixOS/nixpkgs/commit/e607b30abe8a312676c26bb646325faa3b19c777) | `nixos/tor: convert option descriptions to MD`                           |
| [`5a20c879`](https://github.com/NixOS/nixpkgs/commit/5a20c8797072deee77020389213a546649458fcf) | `nixos/vsftpd: convert option descriptions to MD`                        |
| [`c2e133a4`](https://github.com/NixOS/nixpkgs/commit/c2e133a422f050514b0f3b267af952e5dc2ae01e) | `nixos/thanos: convert option descriptions to MD`                        |
| [`0046b457`](https://github.com/NixOS/nixpkgs/commit/0046b457d582db960b5e7163ecee56a8e29ab6bf) | `nixos/public-inbox: convert option descriptions to MD`                  |
| [`429ae9ff`](https://github.com/NixOS/nixpkgs/commit/429ae9ff3d4b91617af7a964cd53dbf3552b1828) | `nixos/thinkfan: convert descriptions to MD`                             |
| [`9217509e`](https://github.com/NixOS/nixpkgs/commit/9217509ece789e3c8c0651b58330ac131d9e0cbf) | `nixos/network-interfaces: convert option descriptions to MD`            |
| [`65fd6f07`](https://github.com/NixOS/nixpkgs/commit/65fd6f077455a9d16cf73f5c93f65816d0c66616) | `nixos/make-options-doc: eat newlines in MD admonitions`                 |
| [`51a11254`](https://github.com/NixOS/nixpkgs/commit/51a11254a7031ddfaa820e7dec55436f74881da9) | `nixos/*: literalDocBook -> literalMD`                                   |
| [`169072fb`](https://github.com/NixOS/nixpkgs/commit/169072fb6030dfe84b541db77d8705ff8a093a54) | `nixos/prometheus: convert option descriptions to MD`                    |
| [`97b6defb`](https://github.com/NixOS/nixpkgs/commit/97b6defb7b579405c39f519a608e1dfdef93dc98) | `nixos/prometheus: turn markdown in docbook`                             |
| [`7f6d0d16`](https://github.com/NixOS/nixpkgs/commit/7f6d0d1674fc3bbed16fb2b40e89549406fa80ba) | `nixos/users-groups: convert remaining descriptions to MD`               |
| [`a2ceee8f`](https://github.com/NixOS/nixpkgs/commit/a2ceee8ffef315faf9ef54b782e412b7e674b753) | `nixos/strongswan: convert to MD descriptions`                           |
| [`f7e49fae`](https://github.com/NixOS/nixpkgs/commit/f7e49fae0d5f35978314d341b6e6f2a78d157bad) | `nixos/prometheus.sachet: add module`                                    |
| [`6953eca7`](https://github.com/NixOS/nixpkgs/commit/6953eca70de848407939484ff78d1a460b503165) | `prometheus-sachet: init at 0.3.1`                                       |
| [`9701ad33`](https://github.com/NixOS/nixpkgs/commit/9701ad3399489ca30f5ada669d23c0835a7669ee) | `vscode-extensions.firefox-devtools.vscode-firefox-debug: init at 2.9.8` |
| [`35ee5a33`](https://github.com/NixOS/nixpkgs/commit/35ee5a337f056d543ced6812c07d11e9ee69c6fb) | `swaycwd: 0.0.2 -> 0.1.0`                                                |
| [`f2dabd93`](https://github.com/NixOS/nixpkgs/commit/f2dabd93e72343b498b003ff4d7d6bdc394e9028) | `lzlib: add shared objects to build`                                     |
| [`868618a4`](https://github.com/NixOS/nixpkgs/commit/868618a4c04fb84dd4bb21cb39c3a31d95ef35d2) | `mympd: 8.0.4 -> 9.5.2`                                                  |
| [`4eaef65f`](https://github.com/NixOS/nixpkgs/commit/4eaef65f796d725023934e4d08317b8ee42ba98c) | `python310Packages.pygeos: 0.12.0 -> 0.13`                               |
| [`02e4902d`](https://github.com/NixOS/nixpkgs/commit/02e4902da0d530ef40cb1338c78e5138e3bab344) | `pinegrow: 6.6 -> 6.8`                                                   |
| [`a457ddf7`](https://github.com/NixOS/nixpkgs/commit/a457ddf7f0c3542faf7991f5e3b1834f2edf1bdd) | `linuxPackages.rtl8812au: 5.9.3.2.20210427 -> 5.15.6.20210629`           |
| [`92256cc6`](https://github.com/NixOS/nixpkgs/commit/92256cc68d077970170749402c4d2d0bad868bca) | `python310Packages.py3status: 3.45 -> 3.46`                              |
| [`362cdab1`](https://github.com/NixOS/nixpkgs/commit/362cdab1e0e34c23d5a4d618662c8ec92341b612) | `everspace: don't use pango alias`                                       |
| [`a107d964`](https://github.com/NixOS/nixpkgs/commit/a107d964efb4999f60c573d5d5145d281d5aa4e2) | `stylua: 0.14.2 -> 0.14.3`                                               |
| [`c557b9d0`](https://github.com/NixOS/nixpkgs/commit/c557b9d0bdb4db8d6fb1cc89070cd58894de28d5) | `everspace: init at 1.3.5.3655`                                          |
| [`022a05ab`](https://github.com/NixOS/nixpkgs/commit/022a05ab61f968df4fe53a226947726d44496a9b) | `maintainers: add jtrees`                                                |
| [`bc755f55`](https://github.com/NixOS/nixpkgs/commit/bc755f55d70562770d9bb7675e42c68f5c7ac8de) | `firebird: add superherointj as maintainer`                              |
| [`6e96447f`](https://github.com/NixOS/nixpkgs/commit/6e96447f668732a3c621473f3a7893c2be278af7) | `firebird_3: 3.0.9 -> 3.0.10`                                            |
| [`a15c3c52`](https://github.com/NixOS/nixpkgs/commit/a15c3c52d774f67624834c3ddc1c264f89f8d730) | `firebird: 4.0.1 -> 4.0.2`                                               |
| [`0e4d8a68`](https://github.com/NixOS/nixpkgs/commit/0e4d8a687f738e2c52b2485d5aaa1661aee3a60e) | `changie: init at 1.8.0`                                                 |
| [`3d7f81f6`](https://github.com/NixOS/nixpkgs/commit/3d7f81f60980505963707ec0e09924943a286610) | `python310Packages.mockito: 1.3.5 -> 1.4.0`                              |
| [`805ca4c4`](https://github.com/NixOS/nixpkgs/commit/805ca4c49bf938289def10f197e5f4a1b7d7ea19) | `sonobuoy: Update buildinfo.GitSHA`                                      |
| [`b87d87c1`](https://github.com/NixOS/nixpkgs/commit/b87d87c161d244b66dfe682e69e7860ceafafefb) | `python310Packages.jupyterlab-lsp: 3.10.1 -> 3.10.2`                     |
| [`f9200712`](https://github.com/NixOS/nixpkgs/commit/f9200712c5999d9ebc2fac80b9b8f14acfc33eeb) | `jwx: init at 2.0.6`                                                     |
| [`b86a7899`](https://github.com/NixOS/nixpkgs/commit/b86a78992f73b4949953dd06dea348d45b2a40ae) | `devspace: 6.0.0 -> 6.0.1`                                               |
| [`ca277c8a`](https://github.com/NixOS/nixpkgs/commit/ca277c8a808b27f03f77171ed79ea688b3dc063a) | `python310Packages.teslajsonpy: 2.4.2 -> 2.4.3`                          |
| [`ae1256a5`](https://github.com/NixOS/nixpkgs/commit/ae1256a50d9022e610d939bcfd9648c8550cc54a) | `python310Packages.life360: 4.1.1 -> 5.0.0`                              |
| [`424ecf63`](https://github.com/NixOS/nixpkgs/commit/424ecf635160bc1b5d48242f78c4a5ae10d99092) | `python310Packages.pyunifiprotect: 4.1.7 -> 4.1.8`                       |
| [`20010268`](https://github.com/NixOS/nixpkgs/commit/200102683a15b661db4f277644938f6e93be9693) | `python310Packages.bluetooth-adapters: 0.2.0 -> 0.3.0`                   |
| [`f8436e29`](https://github.com/NixOS/nixpkgs/commit/f8436e29a9411afc51491179288dd426c1226bba) | `nuclei: 2.7.6 -> 2.7.7`                                                 |
| [`eee1754d`](https://github.com/NixOS/nixpkgs/commit/eee1754df0224b5702a425d4bd18a0a21326ae36) | `pulseaudio: fix evaluation with Nix 2.3`                                |
| [`b1cc8121`](https://github.com/NixOS/nixpkgs/commit/b1cc8121ddc0630c3694c3bda1f5eafa7fec852b) | `python310Packages.airthings-ble: init at 0.3.0`                         |
| [`699f951c`](https://github.com/NixOS/nixpkgs/commit/699f951c14426b023bdf77eb2e4e7438228ee16f) | `git-crecord: 20201025.0 -> 20220324.0 (#165740)`                        |
| [`5bfeb621`](https://github.com/NixOS/nixpkgs/commit/5bfeb6211a0f199165de4d395f3729e42a2622b9) | `baresip: 1.1.0 -> 2.6.0`                                                |
| [`12d7987b`](https://github.com/NixOS/nixpkgs/commit/12d7987b90e5edb01920fb1b683465ed6f240cb6) | `librem: 1.0.0 -> 2.6.0`                                                 |
| [`f6265527`](https://github.com/NixOS/nixpkgs/commit/f62655273cc23234381d70103c371b10aff4d5ac) | `libre: 2.0.1 -> 2.6.1`                                                  |
| [`0079deac`](https://github.com/NixOS/nixpkgs/commit/0079deac1fc59c38c12a052246a591bce68e91d3) | `coqPackages.stdpp: 1.7.0 → 1.8.0`                                       |
| [`98cad033`](https://github.com/NixOS/nixpkgs/commit/98cad033e1f02776f2b861a7efbbdb8d18a9e558) | `altair: 4.1.0 -> 4.6.2 #188359`                                         |
| [`be22d0a2`](https://github.com/NixOS/nixpkgs/commit/be22d0a2186df879abc049bd528b2571b7247a3e) | `nerdfonts: 2.2.0 -> 2.2.1`                                              |
| [`d5288564`](https://github.com/NixOS/nixpkgs/commit/d52885648294627a12758187fc71a18e45f76fc6) | `dura: fix build on darwin`                                              |
| [`45a63492`](https://github.com/NixOS/nixpkgs/commit/45a63492f28860dc99fccf2d57e0bf756b57643c) | `postgresqlPackages.pg_hll: 2.16 -> 2.17`                                |
| [`ae6e5d88`](https://github.com/NixOS/nixpkgs/commit/ae6e5d888b500ebe8e555a6430c6fedfe54652c4) | `wal-g: 2.0.0 -> 2.0.1`                                                  |
| [`1975d599`](https://github.com/NixOS/nixpkgs/commit/1975d5997f67d9d7d92594a43a5a2b7d30044aa6) | `postgresqlPackages.pg_topn: 2.4.0 -> 2.5.0`                             |
| [`16eca3ef`](https://github.com/NixOS/nixpkgs/commit/16eca3ef298d4c53c8f4d9ce01895ef494b1a261) | `millet: 0.3.2 -> 0.3.5`                                                 |
| [`339da548`](https://github.com/NixOS/nixpkgs/commit/339da54864c9922bb337da7e62bb747340e10d6e) | `ruby-packages: update`                                                  |
| [`a69cbfae`](https://github.com/NixOS/nixpkgs/commit/a69cbfae5829b8f17463ae95d39486aa866f293f) | `dura: 0.1.0 -> 0.2.0`                                                   |
| [`f7a56218`](https://github.com/NixOS/nixpkgs/commit/f7a56218545be53956d287551ade16904da4fa37) | `feishu: 5.9.18 -> 5.14.14`                                              |
| [`07c76c98`](https://github.com/NixOS/nixpkgs/commit/07c76c980cc8888f98b670bfce1e21e1fda765dc) | `nixos/minecraft-server: optimize world generation inside test`          |
| [`e683858f`](https://github.com/NixOS/nixpkgs/commit/e683858f463ccdab7bff0393e8f6f146388ed47d) | `roxctl: remove unnecessary override`                                    |
| [`bc745182`](https://github.com/NixOS/nixpkgs/commit/bc745182528ded091a62da523fce04546af40886) | `soulseekqt: add main program`                                           |
| [`b6b51374`](https://github.com/NixOS/nixpkgs/commit/b6b51374fc7508aa4f3d90d24653fbc01ec3d1b3) | `chromiumBeta: Fix errors due to incompatible Wayland headers`           |
| [`2b948f5f`](https://github.com/NixOS/nixpkgs/commit/2b948f5f48882509117ba77145f91dc058bf8163) | `python310Packages.mdformat: 0.7.15 -> 0.7.16`                           |
| [`a4ba3da0`](https://github.com/NixOS/nixpkgs/commit/a4ba3da0a7ad996e2ac8522b446dbca5cc75d272) | `vscode-extensions.prisma.prisma: 4.1.0 -> 4.2.0`                        |
| [`593f974c`](https://github.com/NixOS/nixpkgs/commit/593f974c75b86f19c8da7d6b0cdcebbbb395a20e) | `python310Packages.bthome-ble: 0.3.8 -> 0.4.0`                           |
| [`bb2f1ef2`](https://github.com/NixOS/nixpkgs/commit/bb2f1ef2e932e6e31938c32e5ae7bef73fcbb546) | `python310Packages.aiobiketrax: 0.2.0 -> 0.2.1`                          |
| [`f0e1cf45`](https://github.com/NixOS/nixpkgs/commit/f0e1cf45ebee1c546593240703877f8e79081efa) | `vscode-extensions.jnoortheen.nix-ide: 0.1.20 -> 0.1.23`                 |
| [`ae539d06`](https://github.com/NixOS/nixpkgs/commit/ae539d06a3294f2a836e39181e593957fe7b8792) | `vscode-extensions.ocamllabs.ocaml-platform: 1.10.4 -> 1.10.7`           |
| [`45e45a8e`](https://github.com/NixOS/nixpkgs/commit/45e45a8e4a3f3aa82c6e0fed30ad9af6773e48f2) | `python310Packages.fastcore: 1.5.18 -> 1.5.22`                           |
| [`80ebc2df`](https://github.com/NixOS/nixpkgs/commit/80ebc2df18ebc1d12bc497dc3d22cbff0a0826f5) | `vscode-extensions.jakebecker.elixir-ls: 0.9.0 -> 0.11.0`                |
| [`4ee7b35f`](https://github.com/NixOS/nixpkgs/commit/4ee7b35fb0e30e67eca29c4d2a48339c2dc0282f) | `python310Packages.adafruit-platformdetect: 3.27.1 -> 3.27.2`            |
| [`bb365ad0`](https://github.com/NixOS/nixpkgs/commit/bb365ad0bb0a477fa0e633bab3d6f39ca9df6a78) | `vscode-extensions.esbenp.prettier-vscode: 9.5.0 -> 9.8.0`               |
| [`176d3299`](https://github.com/NixOS/nixpkgs/commit/176d3299e501373551f61d239a58c14b5f93080b) | `vscode-extensions.christian-kohler.path-intellisense: 2.8.0 -> 2.8.1`   |
| [`c84fafd0`](https://github.com/NixOS/nixpkgs/commit/c84fafd005e599365d8816ee47b438338b447374) | `vscode-extensions.badochov.ocaml-formatter: 1.14.0 -> 2.0.5`            |
| [`30bc8e7c`](https://github.com/NixOS/nixpkgs/commit/30bc8e7c5e22f7588f23c2cbfd7aaf6a619def7b) | `dnscontrol: 3.19.0 -> 3.20.0`                                           |
| [`0b048f1d`](https://github.com/NixOS/nixpkgs/commit/0b048f1d8bbf4a87da00983ce58206f864595ea4) | `metasploit: 6.2.13 -> 6.2.14`                                           |
| [`bb229227`](https://github.com/NixOS/nixpkgs/commit/bb229227e354fc03ab36aa25ec347ced8eff2a40) | `linkerd: add superherointj as maintainer`                               |
| [`e98367b0`](https://github.com/NixOS/nixpkgs/commit/e98367b0ea663a73240c53ffa6327bd4b4c6429d) | `linkerd_edge: 22.6.1 -> 22.8.2`                                         |
| [`a2f0336e`](https://github.com/NixOS/nixpkgs/commit/a2f0336e5913a428ebce0ded9f1eba1be53dba2c) | `linkerd: 2.11.2 -> 2.12.0`                                              |
| [`a0d7eaf1`](https://github.com/NixOS/nixpkgs/commit/a0d7eaf10c5f94febc782e06bfb5b8d3c44c5715) | `linkerd: skip Release Candidate versions on update script`              |
| [`014f12b8`](https://github.com/NixOS/nixpkgs/commit/014f12b87e86de306fcb04f184ba933a64e4596e) | `linux: disable NTFS_FS, enable NTFS3_LZX_XPRESS and NTFS3_FS_POSIX_ACL` |
| [`2d167e8c`](https://github.com/NixOS/nixpkgs/commit/2d167e8c573df282c1955f5c79bb8ee4bf3ea32a) | `umr: unstable-2021-02-18 -> unstable-2022-08-23`                        |
| [`4afb5a24`](https://github.com/NixOS/nixpkgs/commit/4afb5a24dcc2759183d537382b9fc72967803cee) | `python310Packages.pyhumps: 3.7.2 -> 3.7.3`                              |
| [`baa64003`](https://github.com/NixOS/nixpkgs/commit/baa640036e87114bee0f86d96e52f919bf9b1a67) | `python310Packages.angr: update disabled`                                |
| [`fa28d31d`](https://github.com/NixOS/nixpkgs/commit/fa28d31d8e217491c6481b614b10c4aaa7e08432) | `python310Packages.pyvex: 9.2.14 -> 9.2.15`                              |
| [`994b8ae8`](https://github.com/NixOS/nixpkgs/commit/994b8ae83f149404949ad87dc6cb5c1ae2feb5b2) | `python310Packages.angr: 9.2.14 -> 9.2.15`                               |
| [`4399c8ad`](https://github.com/NixOS/nixpkgs/commit/4399c8addad87c2dc9bdd38601e541126597d4c7) | `python310Packages.cle: 9.2.14 -> 9.2.15`                                |
| [`006be6fb`](https://github.com/NixOS/nixpkgs/commit/006be6fbd7e035c15c0855a1db08d9a2dcd86a25) | `python310Packages.claripy: 9.2.14 -> 9.2.15`                            |
| [`efbd46c0`](https://github.com/NixOS/nixpkgs/commit/efbd46c0f19cb5b97df2ed6dd6d4cdd016a3b341) | `python310Packages.ailment: 9.2.14 -> 9.2.15`                            |
| [`0278afdf`](https://github.com/NixOS/nixpkgs/commit/0278afdf5daf6c321c7887cdd4077b8288b5d4ba) | `python310Packages.archinfo: 9.2.14 -> 9.2.15`                           |
| [`8acd2a6a`](https://github.com/NixOS/nixpkgs/commit/8acd2a6a6c5890c0897deb023e60d9847bb31c4e) | `dmlive: init at unstable-2022-08-22`                                    |
| [`a2457921`](https://github.com/NixOS/nixpkgs/commit/a24579217b75ca83d4e5f1121a1d89d4c72baa89) | `python310Packages.tailscale: 0.2.0 -> 0.3.0`                            |
| [`63b850e3`](https://github.com/NixOS/nixpkgs/commit/63b850e37428fd5ff2676880035473a8d4dbb4ab) | `python310Packages.types-setuptools: 65.1.0 -> 65.3.0`                   |
| [`511cf9be`](https://github.com/NixOS/nixpkgs/commit/511cf9becd8180c91573d67221b3fb231df4dba2) | `python310Packages.aioswitcher: 2.0.9 -> 2.0.10`                         |
| [`2d4e8018`](https://github.com/NixOS/nixpkgs/commit/2d4e801866fd10f419e2e0650045d0c4996e71d1) | `redis: fix cross compile`                                               |
| [`0cb47d3f`](https://github.com/NixOS/nixpkgs/commit/0cb47d3f23e9ff0952ed01b427b97d93eb3c1b28) | `python3Packages.monai: 0.9.0 -> 0.9.1`                                  |
| [`e298e861`](https://github.com/NixOS/nixpkgs/commit/e298e86197b8cdef415d01b9b8f5c05b3a0f7ba6) | `python310Packages.requests-cache: 0.9.5 -> 0.9.6`                       |
| [`e2dc10aa`](https://github.com/NixOS/nixpkgs/commit/e2dc10aa7420a779994357001abdb9c014b3b95f) | `wiringpi: init at 2.61-1`                                               |
| [`ffc16048`](https://github.com/NixOS/nixpkgs/commit/ffc160483fa8a35a4a3f116aa783e7428f6d445f) | `kibi: enable syntax highlighting`                                       |
| [`9d417df2`](https://github.com/NixOS/nixpkgs/commit/9d417df2e5df394ebed638a29a0919b03f0d2433) | `bambootracker: 0.5.1 -> 0.5.2`                                          |
| [`fae8a017`](https://github.com/NixOS/nixpkgs/commit/fae8a017cf6dda1326bc8513dfc55d152e5b3461) | `notify: 1.0.0 -> 1.0.2`                                                 |
| [`9ef7c44e`](https://github.com/NixOS/nixpkgs/commit/9ef7c44ec9fd27475a9ee89b79c84f16e2245177) | `glooctl: 1.12.7 -> 1.12.9`                                              |
| [`a3c4e049`](https://github.com/NixOS/nixpkgs/commit/a3c4e049b7ed2c586d8db5c118efc120fe40feac) | `chezmoi: 2.20.0 -> 2.21.0`                                              |
| [`308144cc`](https://github.com/NixOS/nixpkgs/commit/308144cc9b9d0c784fe886ddcde87be1a7228aea) | `python310Packages.python-gnupg: 0.4.9 -> 0.5.0`                         |
| [`2a355e25`](https://github.com/NixOS/nixpkgs/commit/2a355e25f021c734e519a787ed4f10aec423f55e) | `starboard: 0.15.4 -> 0.15.8`                                            |
| [`1cab5667`](https://github.com/NixOS/nixpkgs/commit/1cab5667d507751583dcc43379867b521eba5a74) | `seaweedfs: 3.15 -> 3.23`                                                |
| [`a35d1180`](https://github.com/NixOS/nixpkgs/commit/a35d1180ca79b3e2a734fd5d737b4ed19599b8e5) | `oras: 0.13.0 -> 0.14.0`                                                 |
| [`0d338477`](https://github.com/NixOS/nixpkgs/commit/0d3384772bffc5af6c0e3b0afd3d850dcc45fc09) | `imgproxy: 3.3.3 -> 3.7.2`                                               |
| [`21603c2a`](https://github.com/NixOS/nixpkgs/commit/21603c2a3e359b844434bfebf73358a45055cf6f) | `nodePackages.carto: init at 1.2.0`                                      |
| [`d755a4fc`](https://github.com/NixOS/nixpkgs/commit/d755a4fc1a69618401e2dc5d1cc0f05e2bf95ea2) | `folly: 2022.08.15.00 -> 2022.08.22.00`                                  |
| [`a895a0b3`](https://github.com/NixOS/nixpkgs/commit/a895a0b3ada453f3e7d3ecc422edc2e172efb5fe) | `postgresqlPackages.pg_ivm: init at 1.2`                                 |
| [`701380ae`](https://github.com/NixOS/nixpkgs/commit/701380ae2df363387e6e6acc114b71f12cbcef02) | `lefthook: 1.1.0 -> 1.1.1`                                               |
| [`578ce5fd`](https://github.com/NixOS/nixpkgs/commit/578ce5fd0b50f896b6f985385a41430d785784ee) | `sbctl: init at 0.9`                                                     |
| [`f40cda6e`](https://github.com/NixOS/nixpkgs/commit/f40cda6e84edd7269c17f91679fda7742c248163) | `miller: 6.3.0 -> 6.4.0`                                                 |
| [`aacdb9c6`](https://github.com/NixOS/nixpkgs/commit/aacdb9c6f1717c1be0f919e056a4ae4d8ac36a6c) | `jackett: 0.20.1473 -> 0.20.1768`                                        |
| [`3e1875cd`](https://github.com/NixOS/nixpkgs/commit/3e1875cdffb624b76181dde662f38f36c5595410) | `flintlock: 0.1.1 -> 0.3.0`                                              |
| [`89d680fa`](https://github.com/NixOS/nixpkgs/commit/89d680fa2b71b418c7578e8a60168c00e3c20395) | `bind: 9.18.5 -> 9.18.6`                                                 |
| [`af9f6cf6`](https://github.com/NixOS/nixpkgs/commit/af9f6cf68d2fd2c485075b0f9ad0817a6f2944c4) | `sonobuoy: 0.56.4 -> 0.56.10`                                            |
| [`af57fd06`](https://github.com/NixOS/nixpkgs/commit/af57fd0655880339da39cb9ec832cf6e66f3ae1c) | `scorecard: 4.3.0 -> 4.6.0`                                              |
| [`1ba19d36`](https://github.com/NixOS/nixpkgs/commit/1ba19d36ed8e298d6ee687f64a86d5f9d90484db) | `praat: 6.2.10 -> 6.2.16`                                                |
| [`98d1f4c3`](https://github.com/NixOS/nixpkgs/commit/98d1f4c35da8eb4149fc61645340f9633e84297e) | `bcftools: 1.15 -> 1.16`                                                 |
| [`ffdee611`](https://github.com/NixOS/nixpkgs/commit/ffdee611142da5ad6cd4b83a76450bf602de27f8) | `pluto: 5.7.0 -> 5.10.5`                                                 |
| [`9d19dcbf`](https://github.com/NixOS/nixpkgs/commit/9d19dcbf16a1658b01b7fd11135bbe288323e32a) | `elixir-ls: 0.10.0 -> 0.11.0`                                            |
| [`9a7b08c6`](https://github.com/NixOS/nixpkgs/commit/9a7b08c637c6d5ae279a1fd39610d1e215d1db1c) | `shipyard: 0.3.48 -> 0.4.10`                                             |
| [`5ee8b7f4`](https://github.com/NixOS/nixpkgs/commit/5ee8b7f46b89b8e50992901d0da4be5fc2a469a7) | `sysvinit: 3.01 -> 3.04`                                                 |
| [`89aad7ce`](https://github.com/NixOS/nixpkgs/commit/89aad7ce8d6f1f873a5446013c63c62df6bbabcd) | `regbot: 0.4.0 -> 0.4.2`                                                 |
| [`f97c3252`](https://github.com/NixOS/nixpkgs/commit/f97c3252e88b54375e4e459b40ce5b0d94ebb3ed) | `bundlerApp: accept nativeBuildInputs`                                   |
| [`c6568adb`](https://github.com/NixOS/nixpkgs/commit/c6568adb005175fb77ef94fee09aa4e8cc248a60) | `treewide: makeWrapper buildInputs to nativeBuildInputs`                 |
| [`2f27d033`](https://github.com/NixOS/nixpkgs/commit/2f27d033805fdb0b619bad6316d6228662947712) | `nodePackages: fix cross-eval of overrides.nix`                          |
| [`8344f3e8`](https://github.com/NixOS/nixpkgs/commit/8344f3e888ce844612578c6d19bf2d95f9547a6b) | `cdmemu: fix cross eval`                                                 |
| [`2fe86cc2`](https://github.com/NixOS/nixpkgs/commit/2fe86cc267b5637b73602b3e30a9d1eea8e5ecc9) | `cabal2nix: fix cross-eval`                                              |
| [`211fdaa0`](https://github.com/NixOS/nixpkgs/commit/211fdaa087a98b0eb3b2ba04ab22d3eca555a89b) | `treewide: bundlerApp makeWrapper buildInputs -> nativeBuildInputs`      |
| [`95898d79`](https://github.com/NixOS/nixpkgs/commit/95898d794e963265790ac427f7c1566356609b19) | `sensu-go-cli: 6.6.6 -> 6.7.5`                                           |
| [`2c77e973`](https://github.com/NixOS/nixpkgs/commit/2c77e973885f95b900d10fc5546e4511e633379b) | `sensu-go-backend: 6.6.6 -> 6.7.5`                                       |
| [`9c115694`](https://github.com/NixOS/nixpkgs/commit/9c1156941e9ac15e8d0e66468a412b967264cdc7) | `sensu-go-agent: 6.6.6 -> 6.7.5`                                         |
| [`aa97ee8b`](https://github.com/NixOS/nixpkgs/commit/aa97ee8bfaf6bf2aea56a0a1e904aa8eb909bf6e) | `sameboy: 0.14.7 -> 0.15.4`                                              |
| [`066177e5`](https://github.com/NixOS/nixpkgs/commit/066177e5a95af2dcdf26d701bc1c93f2630c61b9) | `qtstyleplugin-kvantum-qt4: 1.0.1 -> 1.0.4`                              |
| [`19e1a68f`](https://github.com/NixOS/nixpkgs/commit/19e1a68fec59f389a422ea5dedcf26c9bd1048c8) | `pspg: 5.5.4 -> 5.5.6`                                                   |
| [`39818451`](https://github.com/NixOS/nixpkgs/commit/39818451f4d491cf4693341d7c843e4ccd32ca77) | `faudio: 22.04 -> 22.08`                                                 |
| [`73b3b950`](https://github.com/NixOS/nixpkgs/commit/73b3b950bd47a4a88cccb3979d1ebc13b8f12706) | `cargo-insta: 1.15.0 -> 1.18.1`                                          |
| [`60abe56b`](https://github.com/NixOS/nixpkgs/commit/60abe56b089cba8a122148dd6555de08da170180) | `languagetool: 5.7 -> 5.8`                                               |
| [`ef3b83b8`](https://github.com/NixOS/nixpkgs/commit/ef3b83b808293519166e3e19c78e940dd3f2a02d) | `songrec: 0.3.0 -> 0.3.2`                                                |
| [`79a2bf1b`](https://github.com/NixOS/nixpkgs/commit/79a2bf1b4f68df7a185383c1c9dc17f66c1d691a) | `rinutils: 0.10.0 -> 0.10.1`                                             |
| [`0ebc8394`](https://github.com/NixOS/nixpkgs/commit/0ebc83941c89b14463a888ec31f35c18a9d29128) | `pritunl-ssh: 1.0.1674.4 -> 1.0.2435.24`                                 |
| [`22408c49`](https://github.com/NixOS/nixpkgs/commit/22408c4919a585540a2871be2d03eb3e1d47759e) | `pico-sdk: 1.3.1 -> 1.4.0`                                               |
| [`2968e9ac`](https://github.com/NixOS/nixpkgs/commit/2968e9acf16a4d62a130537d98dd58ac3bc25b5b) | `inherd-quake: 0.5.0 -> 0.5.1`                                           |
| [`180de978`](https://github.com/NixOS/nixpkgs/commit/180de978faa9c05d0b8084d6ad2f6eed5918b1b5) | `davix: 0.8.0 -> 0.8.2`                                                  |
| [`88294163`](https://github.com/NixOS/nixpkgs/commit/8829416344a88de4ab23c79b6daec69ff8c34c13) | `cups-filters: 1.28.12 -> 1.28.15`                                       |
| [`1cd84253`](https://github.com/NixOS/nixpkgs/commit/1cd842531e2159c12c64d6409a0bd23fafd82490) | `bluez-alsa: 3.1.0 -> 4.0.0`                                             |