### PR TITLE
chore(flake/emacs-overlay): `5046cc71` -> `f7caedcd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661717081,
-        "narHash": "sha256-ssz++/guNZM/52gTqFJkJuvCnqWJjMrV363xjvpzrHM=",
+        "lastModified": 1661745860,
+        "narHash": "sha256-2efk4Xi0aBC6EJIiNyem40ElKFlDDPrDa9skCL8i/Dc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5046cc71d33022f237191f2a8d8df18315910d13",
+        "rev": "f7caedcd0df6710e5c33b493220f729385664ae7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`f7caedcd`](https://github.com/nix-community/emacs-overlay/commit/f7caedcd0df6710e5c33b493220f729385664ae7) | `Updated repos/emacs` |