### PR TITLE
chore(flake/nur): `b846b764` -> `7d90d0ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661739059,
-        "narHash": "sha256-6QL19bo6KiLawvxAQvEybOXFOZiZGeP9QbOy2D94+h8=",
+        "lastModified": 1661746268,
+        "narHash": "sha256-oScjSMdMU1f0qzvot0ZGPV/VcsiSg7ReKFh/s5uC6iY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b846b764bcff8975bcd54fcbfda22d3965850926",
+        "rev": "7d90d0ffd2ff8b53a37c0ef6606abef1295e27f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7d90d0ff`](https://github.com/nix-community/NUR/commit/7d90d0ffd2ff8b53a37c0ef6606abef1295e27f2) | `automatic update` |
| [`21bc1d66`](https://github.com/nix-community/NUR/commit/21bc1d66da9096bd08caee24bce9aebbb301ae22) | `automatic update` |