### PR TITLE
chore(flake/nur): `fce39176` -> `f75bce30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661751194,
-        "narHash": "sha256-VqrSovJGD74JG32nuD33n4c94GO/6yfnKqYcXyhbIuw=",
+        "lastModified": 1661757964,
+        "narHash": "sha256-++75XD7Q8uf3FGSKPLdhHVAzUezpA49s30blmAzRCgo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fce3917607c82c9a46d01fdc90a775f196c3c185",
+        "rev": "f75bce3052f9043a46fc0f23e76f87c996461d90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f75bce30`](https://github.com/nix-community/NUR/commit/f75bce3052f9043a46fc0f23e76f87c996461d90) | `automatic update` |
| [`aaecab80`](https://github.com/nix-community/NUR/commit/aaecab8056f80475bc768c7de733ae1c76d89160) | `automatic update` |