### PR TITLE
chore(flake/nur): `396d68e7` -> `4af65dab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661759099,
-        "narHash": "sha256-mZjAAFqHUDy2XZGn+d3mQo9//hVKX+wNNf3E+2pkgNo=",
+        "lastModified": 1661759587,
+        "narHash": "sha256-2bqKqcAMflaQp4gsMVLOwc5t+NWkE2HlaRni86e2RFo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "396d68e795dd3a4874561b2be0d460bc904a3ce3",
+        "rev": "4af65dab0d1099c5f0201a0a66eac5f0a8bd66c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4af65dab`](https://github.com/nix-community/NUR/commit/4af65dab0d1099c5f0201a0a66eac5f0a8bd66c6) | `automatic update` |