### PR TITLE
chore(flake/nur): `4af65dab` -> `f8ea1799`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661759587,
-        "narHash": "sha256-2bqKqcAMflaQp4gsMVLOwc5t+NWkE2HlaRni86e2RFo=",
+        "lastModified": 1661763713,
+        "narHash": "sha256-2be2ghRozr5eOba9It6bG8I3vnVNIZ69BYF6xw/UR8I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4af65dab0d1099c5f0201a0a66eac5f0a8bd66c6",
+        "rev": "f8ea1799c6e931a3fc71b20a7aebecdc591879bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f8ea1799`](https://github.com/nix-community/NUR/commit/f8ea1799c6e931a3fc71b20a7aebecdc591879bd) | `automatic update` |
| [`98393b60`](https://github.com/nix-community/NUR/commit/98393b60ce5a05816c15fb364d5549075b6098ca) | `automatic update` |
| [`1e3d64bf`](https://github.com/nix-community/NUR/commit/1e3d64bf74fb70072122cb4dd3fdaeb96522cf82) | `automatic update` |
| [`9fa83172`](https://github.com/nix-community/NUR/commit/9fa831729cc9441ab2b0bf7d8a4128bb4d978c6a) | `automatic update` |
| [`ca13cabe`](https://github.com/nix-community/NUR/commit/ca13cabe83007847ddc7690f4c00f386bcd142a9) | `automatic update` |
| [`32a24056`](https://github.com/nix-community/NUR/commit/32a24056d0937a383fe52097b7c6b1a08ec40445) | `automatic update` |
| [`bf37b257`](https://github.com/nix-community/NUR/commit/bf37b25775e5e20965056922a5c4111a1d57f412) | `automatic update` |
| [`25f7d5a7`](https://github.com/nix-community/NUR/commit/25f7d5a7528393fdcbe0b36dad50ee16a772ecd2) | `automatic update` |