### PR TITLE
chore(flake/nur): `7b5af0a3` -> `7d433197`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661788105,
-        "narHash": "sha256-j9rqK3d2wBwggYZ+mrhMlM2AVQ96d99Kuh0d0FMIW8M=",
+        "lastModified": 1661797689,
+        "narHash": "sha256-Ot30t00OA2toO2d0O+VCfn+5KgSF0XLxn3nt6KnwqwY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7b5af0a33fd0e3bcae7a993f733e4635ba87ef54",
+        "rev": "7d433197fe266eca77ce9cd5359507697111d9be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7d433197`](https://github.com/nix-community/NUR/commit/7d433197fe266eca77ce9cd5359507697111d9be) | `automatic update` |