### PR TITLE
chore(flake/emacs-overlay): `f7caedcd` -> `a5ec2328`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661745860,
-        "narHash": "sha256-2efk4Xi0aBC6EJIiNyem40ElKFlDDPrDa9skCL8i/Dc=",
+        "lastModified": 1661799365,
+        "narHash": "sha256-/puVfMA5mxLbtVk4EHiur6Z980rmiME0JrEVDFv6/D8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f7caedcd0df6710e5c33b493220f729385664ae7",
+        "rev": "a5ec23280df5d9bf27ae266fdafcf375656487ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`a5ec2328`](https://github.com/nix-community/emacs-overlay/commit/a5ec23280df5d9bf27ae266fdafcf375656487ba) | `Updated repos/emacs` |
| [`56a80e1c`](https://github.com/nix-community/emacs-overlay/commit/56a80e1c2f6e63ce32dcff9f9d17643bb4ed9b8c) | `Updated repos/elpa`  |