### PR TITLE
chore(flake/nixpkgs): `324c8aaf` -> `a63021a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -277,11 +277,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1661628722,
-        "narHash": "sha256-oR/7NhG7pPkACToUtaaT6hH+rONE2z5/4NzjoUwEZt8=",
+        "lastModified": 1661720780,
+        "narHash": "sha256-AJNGyaB2eKZAYaPNjBZOzap87yL+F9ZLaFzzMkvega0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "324c8aaf25b2f2027af7798e5582ce3040a793b6",
+        "rev": "a63021a330d8d33d862a8e29924b42d73037dd37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                               |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`b2190a3c`](https://github.com/NixOS/nixpkgs/commit/b2190a3cce35008d2573c75b97ccb20a000637b7) | `lib/systems/doubles: add ELFvx GNU ABIs`                                                    |
| [`82ff1f5d`](https://github.com/NixOS/nixpkgs/commit/82ff1f5db12f862e226e84254e54a10879f1629b) | `pkgsStatic: handle ELFv1/2 ABIs`                                                            |
| [`345595a8`](https://github.com/NixOS/nixpkgs/commit/345595a8b8defabac41cd61392125f47af322513) | `lib/systems: add convenience isAbiElfv2 function`                                           |
| [`cdb0f02a`](https://github.com/NixOS/nixpkgs/commit/cdb0f02a36bb6474c5be13627ce735c9b326c6d0) | `lib/systems/examples: use provided ABIs in PPC64 triple`                                    |
| [`3fa4274f`](https://github.com/NixOS/nixpkgs/commit/3fa4274ff692c0cff449763b803c46f576e54f95) | `lib/systems/parse: use ELFv2 by default for PPC64 BE`                                       |
| [`da2d9a2a`](https://github.com/NixOS/nixpkgs/commit/da2d9a2aca33d628e20b8a8693fb995192d31903) | `lib/systems: add elfv1 / elfv2 ABIs`                                                        |
| [`ce357ff2`](https://github.com/NixOS/nixpkgs/commit/ce357ff2b09382700f1362865680ecbf0a4441a1) | `kyverno: 1.7.2 -> 1.7.3`                                                                    |
| [`b3d71ba9`](https://github.com/NixOS/nixpkgs/commit/b3d71ba9d0a5ebb60662cb789aa78bc713ef0b68) | `kubeseal: 0.18.1 -> 0.18.2`                                                                 |
| [`bb1f36a2`](https://github.com/NixOS/nixpkgs/commit/bb1f36a214a1106a287165aae5eb8d193506efc6) | `kubecfg: 0.26.0 -> 0.27.0`                                                                  |
| [`44420879`](https://github.com/NixOS/nixpkgs/commit/444208798aefb1787b8ef0851f5c3d49113bd014) | `qemu: add patch for CVE-2020-14394`                                                         |
| [`02ca0640`](https://github.com/NixOS/nixpkgs/commit/02ca06405e814d6967cf741a9588a4f80ae4db8d) | `qemu: add patches for CVE-2022-0216`                                                        |
| [`f73bb818`](https://github.com/NixOS/nixpkgs/commit/f73bb818a15e176ff6352fd2db77a425b7d3533a) | `karabiner-elements: init at 14.8.0 (#188129)`                                               |
| [`f03ae291`](https://github.com/NixOS/nixpkgs/commit/f03ae29142c8d99869f7d1b30a67560f4e5fb144) | `forge-mtg: init at 1.6.53 (#182053)`                                                        |
| [`cbfc31de`](https://github.com/NixOS/nixpkgs/commit/cbfc31de7b3d3bbd58d3ddeca92b6e2dacf255a9) | `asouldocs: rename from peach, asouldocs: 0.9.8 -> 1.0.0 (#188673)`                          |
| [`5ba8f7cc`](https://github.com/NixOS/nixpkgs/commit/5ba8f7cc880b26bd44e9712c22d774c03780a6df) | `imagemagick: 7.1.0-46 -> 7.1.0-47`                                                          |
| [`670aec28`](https://github.com/NixOS/nixpkgs/commit/670aec28b0e7a82ffbe8a872b393f182c2434886) | `humioctl: 0.29.2 -> 0.30.0`                                                                 |
| [`51064f5b`](https://github.com/NixOS/nixpkgs/commit/51064f5bfffb1ca5db52326ec91929f241a36b54) | `htslib: 1.15 -> 1.16`                                                                       |
| [`126f8a03`](https://github.com/NixOS/nixpkgs/commit/126f8a0394cc6737f8ce7096ccdc8af8a67c676e) | `heimer: 3.5.0 -> 3.6.0`                                                                     |
| [`5303f524`](https://github.com/NixOS/nixpkgs/commit/5303f524555f23338d479afcc338fe445ccc493e) | `gocryptfs: 2.2.1 -> 2.3`                                                                    |
| [`64a1d8da`](https://github.com/NixOS/nixpkgs/commit/64a1d8da4ab23869e56361a9fbbabf640f3d5b3a) | `go-toml: 2.0.3 -> 2.0.5`                                                                    |
| [`544a6437`](https://github.com/NixOS/nixpkgs/commit/544a643773ab5cd61f54b4e4f19c42092e172555) | `difftastic: 0.32.0 -> 0.34.0`                                                               |
| [`b10cf087`](https://github.com/NixOS/nixpkgs/commit/b10cf087c8d558d7569ab6b4323ca3440a7f653d) | `cargo-public-api: 0.14.0 -> 0.15.0`                                                         |
| [`3909e303`](https://github.com/NixOS/nixpkgs/commit/3909e303eb7aad5ce569a111bfd44bc9bc31465c) | `qownnotes: 22.8.3 -> 22.8.4`                                                                |
| [`c7cbb380`](https://github.com/NixOS/nixpkgs/commit/c7cbb380bea9f33b2e40b5eacc7a7f7006f58026) | `gitolite: fix reference to /bin`                                                            |
| [`5bd26ec4`](https://github.com/NixOS/nixpkgs/commit/5bd26ec45c88f30bdfc8b3a6a95e3718f4c555e4) | `flyway: add downloadPage`                                                                   |
| [`56002bce`](https://github.com/NixOS/nixpkgs/commit/56002bcefcda4fcec5315bffef553e2b127d0a3e) | `python310Packages.json5: 0.9.6 -> 0.9.9`                                                    |
| [`bdf2706f`](https://github.com/NixOS/nixpkgs/commit/bdf2706f0941d29322fb9adc333bec5e7e07cdd3) | `python310Packages.pyjson5: remove duplicate package`                                        |
| [`dbdd8d15`](https://github.com/NixOS/nixpkgs/commit/dbdd8d15e0ea8a6d69249ea59920090162007fbb) | `gitRepo: 2.28 -> 2.29.1`                                                                    |
| [`498695cf`](https://github.com/NixOS/nixpkgs/commit/498695cf518e41dc1bd872bd80672fd0f1da9f76) | `logseq: 0.8.1 -> 0.8.2`                                                                     |
| [`c0f40868`](https://github.com/NixOS/nixpkgs/commit/c0f4086895b6f0b01c7a5de5b3ac26ce040e3a4a) | `netplan: 0.103 -> 0.105`                                                                    |
| [`1f698f27`](https://github.com/NixOS/nixpkgs/commit/1f698f2718d507ec883b067f5f8d1a59383d922e) | `wvkbd: 0.9 -> 0.10`                                                                         |
| [`74798cfa`](https://github.com/NixOS/nixpkgs/commit/74798cfa674961829b6d69d4b8ccd7f31040a4fe) | `flexoptix-app: 5.11.1 -> 5.12.2`                                                            |
| [`bb742b2b`](https://github.com/NixOS/nixpkgs/commit/bb742b2bb9675ce527df8a6df13ff47bfedc1be9) | `texstudio: 4.3.0 -> 4.3.1`                                                                  |
| [`eb1ec411`](https://github.com/NixOS/nixpkgs/commit/eb1ec41120fad4402e70d6f9a320f27ca88a6963) | `super-productivity: 7.11.5 -> 7.11.6`                                                       |
| [`d92383b1`](https://github.com/NixOS/nixpkgs/commit/d92383b18de4ec74807e740054ff00e2a3b8bcd9) | `piper: 0.5.1 -> 0.7 (#187758)`                                                              |
| [`1425187f`](https://github.com/NixOS/nixpkgs/commit/1425187f57566ad494f8631c4f82c778169107a7) | `python310Packages.cloudscraper: 1.2.60 -> 1.2.63`                                           |
| [`26afe025`](https://github.com/NixOS/nixpkgs/commit/26afe025c78608b9671135dbdf5286e5c819a8f5) | `smartmontools: fix lib.optional -> lib.optionals`                                           |
| [`34df0045`](https://github.com/NixOS/nixpkgs/commit/34df0045a8bfd5903929a9156c03bd187de65ac7) | `python310Packages.openstacksdk: 0.100.0 -> 0.101.0`                                         |
| [`b5df06b9`](https://github.com/NixOS/nixpkgs/commit/b5df06b95c17f8c76890e4a7043b4f3c7ef1a5e9) | `xssproxy: 1.0.1 -> 1.1.0`                                                                   |
| [`3e80b8d7`](https://github.com/NixOS/nixpkgs/commit/3e80b8d7a2b40772dc88d8ef819751cc498ee1b0) | `godns: 2.8.8 -> 2.8.9`                                                                      |
| [`eb928980`](https://github.com/NixOS/nixpkgs/commit/eb92898043049aa043904bb2a2dcabacec6d131b) | `flyway: 9.1.6 -> 9.2.0`                                                                     |
| [`a79cfbba`](https://github.com/NixOS/nixpkgs/commit/a79cfbbad816c8c4b76e32ed5127d3d5677bada1) | `flow: 0.185.1 -> 0.185.2`                                                                   |
| [`b7a2c624`](https://github.com/NixOS/nixpkgs/commit/b7a2c6240e57e98d6e7acaf00e2d9bc8ee326474) | `dsq: 0.21.0 -> 0.22.0`                                                                      |
| [`dc619120`](https://github.com/NixOS/nixpkgs/commit/dc61912099b6bfe4b9b8e88ae1b56d3b79f3772e) | `flyctl: 0.0.377 -> 0.0.383`                                                                 |
| [`8e23e320`](https://github.com/NixOS/nixpkgs/commit/8e23e320281971261787f4d3ca1ca6dc06456532) | `werf: 1.2.164 -> 1.2.165`                                                                   |
| [`5642de54`](https://github.com/NixOS/nixpkgs/commit/5642de5440127f008ef273337f31bc0fbf4479c9) | `emacs/elisp-packages: Remove manual Emacs package (apheleia)`                               |
| [`96833c9e`](https://github.com/NixOS/nixpkgs/commit/96833c9e12aa6ac94d3a40426e6f63d68720945d) | `evans: 0.10.8 -> 0.10.9`                                                                    |
| [`780c40b6`](https://github.com/NixOS/nixpkgs/commit/780c40b619aab8b3e04e69c1048c2396d9a83301) | `fetchmail: 6.4.32 -> 6.4.33`                                                                |
| [`8f3e4106`](https://github.com/NixOS/nixpkgs/commit/8f3e410636e79f6cbae513a5c6c9b6cebd12eac3) | `fclones: 0.27.0 -> 0.27.1`                                                                  |
| [`bd56129f`](https://github.com/NixOS/nixpkgs/commit/bd56129fbaea85d5cdeccaea4cd28b2f4e30640e) | `vscode-extensions.svelte.svelte-vscode: 105.3.0 -> 105.21.0`                                |
| [`7e97189a`](https://github.com/NixOS/nixpkgs/commit/7e97189ac8c73cea1788700d9b6a8058ff60aef3) | `datree: 1.5.25 -> 1.6.13`                                                                   |
| [`636f3747`](https://github.com/NixOS/nixpkgs/commit/636f3747ae07a0001a73aca73ca4c08dba60746a) | `python310Packages.daemonocle: 1.0.2 -> 1.2.3`                                               |
| [`fcdef222`](https://github.com/NixOS/nixpkgs/commit/fcdef222c2bb4db35046f9ef8c15330a071bea35) | `dendrite: 0.9.4 -> 0.9.5`                                                                   |
| [`b6a96bb5`](https://github.com/NixOS/nixpkgs/commit/b6a96bb583abd342048f19e197fe965f3c3dff32) | `dasel: 1.26.0 -> 1.26.1`                                                                    |
| [`e723d27a`](https://github.com/NixOS/nixpkgs/commit/e723d27a1c8630853893bac4c722f15f606c6fcd) | `python310Packages.itemloaders: add format`                                                  |
| [`2de7aa27`](https://github.com/NixOS/nixpkgs/commit/2de7aa27e5e557cb45d971c9144990457f040dad) | `python310Packages.env-canada: 0.5.24 -> 0.5.25`                                             |
| [`130d56cf`](https://github.com/NixOS/nixpkgs/commit/130d56cffd6443bb1e3e9e0c6c618c8dd08a3763) | `docker-compose: 2.10.1 -> 2.10.2`                                                           |
| [`f8fc6c64`](https://github.com/NixOS/nixpkgs/commit/f8fc6c64f5d043c41b4cd1b604f46d6ab8b5bff1) | `clifm: 1.6 -> 1.7`                                                                          |
| [`c5692172`](https://github.com/NixOS/nixpkgs/commit/c5692172b344a37fca263d775924b771c70cffff) | `python310Packages.jellyfin-apiclient-python: adjust inputs`                                 |
| [`21c18d68`](https://github.com/NixOS/nixpkgs/commit/21c18d68ba25125260cc4215e9b7f2f8102edc3a) | `cilium-cli: 0.12.1 -> 0.12.2`                                                               |
| [`5db524ac`](https://github.com/NixOS/nixpkgs/commit/5db524ac69ce3175337cd227e2de9e688c21441f) | `python310Packages.pytest-testmon: add pythonImportsCheck`                                   |
| [`b5f88642`](https://github.com/NixOS/nixpkgs/commit/b5f886426304b48af81d1fbd14957455a6364e7f) | `cobalt: 0.17.5 -> 0.18.3`                                                                   |
| [`fb8f5aa4`](https://github.com/NixOS/nixpkgs/commit/fb8f5aa450e340ad869558702fd38d07ff0f9893) | `python310Packages.twitter: add pythonImportsCheck`                                          |
| [`39d3ae72`](https://github.com/NixOS/nixpkgs/commit/39d3ae7220673089f3b48bf27ce9eb8ad55b6431) | `arkade: 0.8.34 -> 0.8.36`                                                                   |
| [`78e9d214`](https://github.com/NixOS/nixpkgs/commit/78e9d21446d27ba54abcd8adeb15c798dc97c1ac) | `terraform-providers: update 2022-08-28`                                                     |
| [`26238902`](https://github.com/NixOS/nixpkgs/commit/262389027131d84e9a7cb280a9cd716abe39b9b8) | `ferdium: 6.0.0 -> 6.1.0`                                                                    |
| [`c5b6df91`](https://github.com/NixOS/nixpkgs/commit/c5b6df912b8eb6fca2e47707ca1562f2018cbc3e) | `nixos/fontconfig: add missing config for Xft.hintstyle`                                     |
| [`63845e0c`](https://github.com/NixOS/nixpkgs/commit/63845e0cde2d186603837eeda362f4175587cd05) | `guile_3_0: Enable parallel build when not cross-compiling`                                  |
| [`66729606`](https://github.com/NixOS/nixpkgs/commit/66729606cff270322be5520562abfb55cf3933b8) | `oha: 0.5.3 -> 0.5.4`                                                                        |
| [`01b4f08f`](https://github.com/NixOS/nixpkgs/commit/01b4f08f8506dd397c618264a5588dbb9ce40336) | `python310Packages.django-anymail: Enable more tests`                                        |
| [`c882c08f`](https://github.com/NixOS/nixpkgs/commit/c882c08f9c59d907bf860e7a3dfd5e69f1a7426e) | `pulseaudio: remove compat for 15.0`                                                         |
| [`ac540bf0`](https://github.com/NixOS/nixpkgs/commit/ac540bf0f996e51d2765c0454f35627e5717ac28) | `ghidra-bin: 10.1.4 -> 10.1.5`                                                               |
| [`8f57be61`](https://github.com/NixOS/nixpkgs/commit/8f57be61ac87fabf6ec048225556a45fc44aefed) | `tela-icon-theme: 2022-02-21 -> 2022-08-28`                                                  |
| [`00a45bc4`](https://github.com/NixOS/nixpkgs/commit/00a45bc41be88dbaa335b891eaf7710144ca4e8a) | `linux: Enable SLAB_FREELIST_HARDENED, SLAB_FREELIST_RANDOM`                                 |
| [`1104127c`](https://github.com/NixOS/nixpkgs/commit/1104127cf32b740e1ad2a4e404e52ac337318a1a) | `python3Packages.svgwrite: 1.4.1 → 1.4.3`                                                    |
| [`48ad86aa`](https://github.com/NixOS/nixpkgs/commit/48ad86aa6a954fab59b9e1bcf1c508938555d61e) | `go-ethereum: 1.10.21 -> 1.10.23`                                                            |
| [`e8f1b090`](https://github.com/NixOS/nixpkgs/commit/e8f1b09014acf9e1b248a8ddd5cc83e60cceca77) | `nixos/plex: specify PIDFile in systemd service`                                             |
| [`e548e4b3`](https://github.com/NixOS/nixpkgs/commit/e548e4b3bfabead8af89922acb9ac1ee5cebdbc8) | `python310Packages.types-redis: 4.3.15 -> 4.3.18`                                            |
| [`9aabd155`](https://github.com/NixOS/nixpkgs/commit/9aabd155bc8d7cb98a3722b26d7186e9b2630ab7) | `python310Packages.twitter: 1.19.3 -> 1.19.4`                                                |
| [`270bd248`](https://github.com/NixOS/nixpkgs/commit/270bd248965fb0fef5f7a74e09f67b76ac8ca706) | `python310Packages.swift: 2.29.1 -> 2.30.0`                                                  |
| [`18a89ece`](https://github.com/NixOS/nixpkgs/commit/18a89eced71e66aaca742f240056814622485942) | `python310Packages.python-openstackclient: 5.8.0 -> 6.0.0`                                   |
| [`3a1b4417`](https://github.com/NixOS/nixpkgs/commit/3a1b4417835ff342c950698cb302d02f45b5b309) | `python310Packages.pytest-testmon: 1.3.4 -> 1.3.5`                                           |
| [`4f66e4fd`](https://github.com/NixOS/nixpkgs/commit/4f66e4fdd806185de9a8e3decfdc29f2e63a8164) | `python310Packages.jellyfin-apiclient-python: 1.8.1 -> 1.9.1`                                |
| [`0a5cab98`](https://github.com/NixOS/nixpkgs/commit/0a5cab9848a42f546f0ea1c479e2a0bcac915d33) | `python310Packages.hvplot: 0.8.0 -> 0.8.1`                                                   |
| [`8347ef71`](https://github.com/NixOS/nixpkgs/commit/8347ef71c0c463d0fb8865633c4a4dc8ecdf93a7) | `python310Packages.flufl_i18n: 4.0 -> 4.1`                                                   |
| [`6ccadbb8`](https://github.com/NixOS/nixpkgs/commit/6ccadbb85fac191bd8e6771ea5f21e14c35ff0e2) | `python310Packages.asn1tools: 0.163.0 -> 0.164.0`                                            |
| [`54167af0`](https://github.com/NixOS/nixpkgs/commit/54167af068ffa24e617199e151eb9c3f2795494b) | `python310Packages.django-dynamic-preferences: 1.13.0 -> 1.14.0`                             |
| [`0e14c3e9`](https://github.com/NixOS/nixpkgs/commit/0e14c3e9466cb76bd03af83b99f4a59579f10c1f) | `python310Packages.debian-inspector: 30.0.0 -> 31.0.0`                                       |
| [`22ad6987`](https://github.com/NixOS/nixpkgs/commit/22ad698760763a62869a85a9e4277385ecfe1e07) | `python310Packages.paperwork-backend: Fix tests`                                             |
| [`c0442bd5`](https://github.com/NixOS/nixpkgs/commit/c0442bd5b6790b54f02a2451da2edf166457e487) | `tauon: fix broadcast web player template`                                                   |
| [`6d7dfa0d`](https://github.com/NixOS/nixpkgs/commit/6d7dfa0d1817a12dde969fc6e0f4089cab02410b) | `gallery-dl: 1.22.4 -> 1.23.0`                                                               |
| [`a7e4a2ed`](https://github.com/NixOS/nixpkgs/commit/a7e4a2ed14ff658f0f3c3b12dad54cec0a498ee5) | `python310Packages.itemloaders: 1.0.4 -> 1.0.5`                                              |
| [`55f5af97`](https://github.com/NixOS/nixpkgs/commit/55f5af9799806631cefb5cac3cb031722e3ec595) | `postgresqlPackages.postgis: 3.2.3 -> 3.3.0`                                                 |
| [`9ad0b548`](https://github.com/NixOS/nixpkgs/commit/9ad0b548840b77fbf332cc05c869b3e0730a84b1) | `fastlane: 2.209.0 -> 2.209.1`                                                               |
| [`8382e78f`](https://github.com/NixOS/nixpkgs/commit/8382e78fdb6e4314e7906ec862cb4ea9dcd2076a) | ``cudaPackages.cudnn: migrate to `hash` and SRI hashes``                                     |
| [`214bd05c`](https://github.com/NixOS/nixpkgs/commit/214bd05cb8e7b5f752afda57922865921a9f263e) | `qovery-cli: init at 0.45.0`                                                                 |
| [`ea372796`](https://github.com/NixOS/nixpkgs/commit/ea372796ac6dbd087ae5048d772e3fb67a451018) | `geth: remove lionello from maintainers`                                                     |
| [`6f92f05f`](https://github.com/NixOS/nixpkgs/commit/6f92f05f538c478fefb6abdd0c2e0390f57a4373) | `obsidian: upgrade dependency as requested by upstream`                                      |
| [`f7922cb3`](https://github.com/NixOS/nixpkgs/commit/f7922cb328d2cdaa13893ad35fac96108a9fa937) | `nixos/nix-daemon: Add missing parenthesis`                                                  |
| [`6dfe57ad`](https://github.com/NixOS/nixpkgs/commit/6dfe57adf63b0b63da2d3d61dec355e987d48704) | `libvirt: remove ? null from packages which have boolean inputs, normalize meta.description` |
| [`47bdefbd`](https://github.com/NixOS/nixpkgs/commit/47bdefbd9a455414c77b70e9bf466235dae4484e) | `python310Packages.goobook: unpin dependencies, cleanup`                                     |
| [`7961584d`](https://github.com/NixOS/nixpkgs/commit/7961584dc5743ba461abe1c13e8cbed77bab9271) | `jira-cli-go: add anthonyroussel to maintainers`                                             |
| [`0f97f4e6`](https://github.com/NixOS/nixpkgs/commit/0f97f4e6163a3c824981082326badd2222d82783) | `jira-cli-go: build manpages`                                                                |
| [`312f72ae`](https://github.com/NixOS/nixpkgs/commit/312f72ae65b6b793d7cab9d7e3e6e22b6cede078) | `python310Packages.proto-plus: 1.20.6 -> 1.22.0`                                             |
| [`68a804ad`](https://github.com/NixOS/nixpkgs/commit/68a804ad724e2bc9d30c616010f35634bcaa996d) | `python3Packages.google-cloud-websecurityscanner: 1.8.1 -> 1.8.2`                            |
| [`6947fedd`](https://github.com/NixOS/nixpkgs/commit/6947fedd3be8e1520e15be2d0971ec9ae44bc0c4) | `python3Packages.google-cloud-vision: 3.1.0 -> 3.1.1`                                        |
| [`2531a3e6`](https://github.com/NixOS/nixpkgs/commit/2531a3e6688d815b25a01d6e0ccfcc9112810207) | `python3Packages.google-cloud-videointelligence: 2.8.0 -> 2.8.1`                             |
| [`7effe1b1`](https://github.com/NixOS/nixpkgs/commit/7effe1b1a4004877a4c68a3b54fc37a86ec211c5) | `python3Packages.google-cloud-translate: 3.8.0 -> 3.8.1`                                     |
| [`77d8d439`](https://github.com/NixOS/nixpkgs/commit/77d8d439dd385432a1cb2750b3e368ac0f8e5e5c) | `python3Packages.google-cloud-trace: 1.7.0 -> 1.7.1`                                         |
| [`50243c37`](https://github.com/NixOS/nixpkgs/commit/50243c375b6a2f8881aff09c8efb2ac6b8b77748) | `python3Packages.google-cloud-texttospeech: 2.12.0 -> 2.12.1`                                |
| [`bf6a9e15`](https://github.com/NixOS/nixpkgs/commit/bf6a9e15d114f69385ed80187ecc12cd0a9caffc) | `python3Packages.google-cloud-tasks: 2.10.1 -> 2.10.2`                                       |
| [`d741b4f2`](https://github.com/NixOS/nixpkgs/commit/d741b4f2b166fd71891f1c39fa67eb0e2f38970e) | `python3Packages.google-cloud-storage: 2.4.0 -> 2.5.0`                                       |
| [`34bc8b81`](https://github.com/NixOS/nixpkgs/commit/34bc8b8199defd541540c47b3523a3f141f0b988) | `python3Packages.google-cloud-speech: 2.15.0 -> 2.15.1`                                      |
| [`dc00c86b`](https://github.com/NixOS/nixpkgs/commit/dc00c86b85e557ecdea4d9dcfac93304b76eb335) | `python3Packages.google-cloud-spanner: 3.17.0 -> 3.19.0`                                     |
| [`cf673a9e`](https://github.com/NixOS/nixpkgs/commit/cf673a9ef4ccee21db343cdf0a24b31e0269b8c2) | `python3Packages.google-cloud-securitycenter: 1.12.0 -> 1.13.0`                              |
| [`ae621335`](https://github.com/NixOS/nixpkgs/commit/ae621335802fe4ca4638cda6a2272235dd53a50c) | `python3Packages.google-cloud-secret-manager: 2.12.2 -> 2.12.3`                              |
| [`c55e9b49`](https://github.com/NixOS/nixpkgs/commit/c55e9b496d07b62ae77235e53caf96402cc99866) | `python3Packages.google-cloud-resource-manager: 1.6.0 -> 1.6.1`                              |
| [`ca933dfe`](https://github.com/NixOS/nixpkgs/commit/ca933dfed7513ff0c413d5a3d601531a35624ad0) | `python3Packages.google-cloud-redis: 2.9.0 -> 2.9.1`                                         |
| [`4376f74b`](https://github.com/NixOS/nixpkgs/commit/4376f74bb6be3eb43363d08a47a8bd34b656eab0) | `python3Packages.google-cloud-pubsub: 2.13.5 -> 2.13.6`                                      |
| [`0288b43c`](https://github.com/NixOS/nixpkgs/commit/0288b43c41bc56bde6dee2b2e774b8157cf7a1eb) | `python3Packages.google-cloud-os-config: 1.12.1 -> 1.12.2`                                   |
| [`cc3c2ae9`](https://github.com/NixOS/nixpkgs/commit/cc3c2ae9e2077c43fc3f9a41edec4ae09fe96193) | `python3Packages.google-cloud-org-policy: 1.4.0 -> 1.4.1`                                    |
| [`18ba16f5`](https://github.com/NixOS/nixpkgs/commit/18ba16f5f20256e0da1048b924a415efca6b605d) | `python3Packages.google-cloud-monitoring: 2.11.0 -> 2.11.1`                                  |
| [`6435edc0`](https://github.com/NixOS/nixpkgs/commit/6435edc0154a8f548aa1aaadeb3a94de7e04f7a6) | `python3Packages.google-cloud-logging: 3.2.1 -> 3.2.2`                                       |
| [`83c9a5fc`](https://github.com/NixOS/nixpkgs/commit/83c9a5fc1a354d8e5ffb2becc1fd84bbc369920e) | `python3Packages.google-cloud-language: 2.5.1 -> 2.5.2`                                      |
| [`0d2e7d91`](https://github.com/NixOS/nixpkgs/commit/0d2e7d914c91bcc27a2ae65cc64b524fd0fbf56c) | `python3Packages.google-cloud-kms: 2.12.0 -> 2.12.1`                                         |
| [`c18ecc26`](https://github.com/NixOS/nixpkgs/commit/c18ecc26b96e1572a5888e65ddd02adcb83e9ca6) | `python3Packages.google-cloud-iot: 2.6.1 -> 2.6.2`                                           |
| [`c7c56d6e`](https://github.com/NixOS/nixpkgs/commit/c7c56d6ec3d8ffabe25a279f96804a9ad33a468d) | `python3Packages.google-cloud-iam-logging: 1.0.3 -> 1.0.4`                                   |
| [`3fed864d`](https://github.com/NixOS/nixpkgs/commit/3fed864d8100ec174f3e8cbf61b56a6373f4c4ef) | `python3Packages.google-cloud-iam: 2.8.0 -> 2.8.2`                                           |
| [`43acc349`](https://github.com/NixOS/nixpkgs/commit/43acc3499ef8bfded1d8fafd6a5fb009662d5add) | `python3Packages.google-cloud-firestore: 2.6.0 -> 2.6.1`                                     |
| [`dcd5f463`](https://github.com/NixOS/nixpkgs/commit/dcd5f4638f1dfe42c92318f81803465219724730) | `python3Packages.google-cloud-error-reporting: 1.6.0 -> 1.6.1`                               |
| [`c4023575`](https://github.com/NixOS/nixpkgs/commit/c402357510cb4f13166824f699dfc9ba4aae7d3f) | `python3Packages.google-cloud-dlp: 3.8.0 -> 3.8.1`                                           |
| [`06679df2`](https://github.com/NixOS/nixpkgs/commit/06679df2b570fae0b8a94b7362bea7ea948a36ad) | `python3Packages.google-cloud-datastore: 2.8.0 -> 2.8.1`                                     |
| [`c0eb249e`](https://github.com/NixOS/nixpkgs/commit/c0eb249e67accd88d011aabfb117fce665cad9cd) | `python3Packages.google-cloud-dataproc: 5.0.0 -> 5.0.1`                                      |
| [`09e0e632`](https://github.com/NixOS/nixpkgs/commit/09e0e632d087a9b2cf47a69f11c2070086441df2) | `python3Packages.google-cloud-datacatalog: 3.9.0 -> 3.9.1`                                   |
| [`082b3c3c`](https://github.com/NixOS/nixpkgs/commit/082b3c3c91c8e6bf439b7b62e53d207ab0fe0d31) | `python3Packages.google-cloud-core: 2.3.1 -> 2.3.2`                                          |
| [`0da29bba`](https://github.com/NixOS/nixpkgs/commit/0da29bba97770d0aa9d9a6c69ee31e73797b1909) | `python3Packages.google-cloud-container: 2.11.1 -> 2.11.2`                                   |
| [`59ee08a5`](https://github.com/NixOS/nixpkgs/commit/59ee08a5823cc340f6d140f7c202df39503266f7) | `python3Packages.google-cloud-bigtable: 2.11.1 -> 2.11.3`                                    |