### PR TITLE
chore(flake/emacs-overlay): `a5ec2328` -> `c507c227`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661799365,
-        "narHash": "sha256-/puVfMA5mxLbtVk4EHiur6Z980rmiME0JrEVDFv6/D8=",
+        "lastModified": 1661832453,
+        "narHash": "sha256-dBXlnUPa9RT3gXsUboJ5bznvOXQwWmAQZ/oP3idrpMM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a5ec23280df5d9bf27ae266fdafcf375656487ba",
+        "rev": "c507c22745155a848b5928a5051c9aad28994d78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`c507c227`](https://github.com/nix-community/emacs-overlay/commit/c507c22745155a848b5928a5051c9aad28994d78) | `Updated repos/nongnu` |
| [`f1f72f64`](https://github.com/nix-community/emacs-overlay/commit/f1f72f642ebb77e6fd9fd7bc01aee69639c791df) | `Updated repos/emacs`  |
| [`22ce4e9f`](https://github.com/nix-community/emacs-overlay/commit/22ce4e9f643973754396a7133649f361bb0f2760) | `Updated repos/elpa`   |