### PR TITLE
chore(flake/nur): `2b1571fc` -> `b9d6f85b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661832590,
-        "narHash": "sha256-KQsKeVgRGokl4e7cfNU6zQA+eeGGzg224njW/Vw+zNY=",
+        "lastModified": 1661838244,
+        "narHash": "sha256-YJ46J9mjyRWMZRUYQuN79QoJGnXZiz/xH99WkXUmag4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2b1571fcf9abf63e12ec04116d2438fa6f979665",
+        "rev": "b9d6f85b34712b1b858c345919b3397311b54550",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b9d6f85b`](https://github.com/nix-community/NUR/commit/b9d6f85b34712b1b858c345919b3397311b54550) | `automatic update` |
| [`fd1a122c`](https://github.com/nix-community/NUR/commit/fd1a122c959b0650877d43b54a8836bf1321b483) | `automatic update` |
| [`223ad09b`](https://github.com/nix-community/NUR/commit/223ad09ba7c9a7f4379b264085d0d661a866a739) | `automatic update` |