### PR TITLE
chore(flake/nur): `b9d6f85b` -> `34714911`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661838244,
-        "narHash": "sha256-YJ46J9mjyRWMZRUYQuN79QoJGnXZiz/xH99WkXUmag4=",
+        "lastModified": 1661840273,
+        "narHash": "sha256-nnhHo0s3NpcNF6QSDJ2+/mZsvlDIp1bzpRw8/1TFs3w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b9d6f85b34712b1b858c345919b3397311b54550",
+        "rev": "34714911775473e5c4cb66b0b12dd513fe303c01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`34714911`](https://github.com/nix-community/NUR/commit/34714911775473e5c4cb66b0b12dd513fe303c01) | `automatic update` |