### PR TITLE
chore(flake/emacs-overlay): `c507c227` -> `b726259d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661832453,
-        "narHash": "sha256-dBXlnUPa9RT3gXsUboJ5bznvOXQwWmAQZ/oP3idrpMM=",
+        "lastModified": 1661856816,
+        "narHash": "sha256-pb/Xu1p5q3xtk5nxBj25eoeM02SFSQ53FjSBqT+FNhE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c507c22745155a848b5928a5051c9aad28994d78",
+        "rev": "b726259df1d6defe5af8c5be45ff6457885f2a5f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`b726259d`](https://github.com/nix-community/emacs-overlay/commit/b726259df1d6defe5af8c5be45ff6457885f2a5f) | `Updated repos/nongnu` |
| [`2c3024c1`](https://github.com/nix-community/emacs-overlay/commit/2c3024c10d7a8916bb1680c39638c7e248321d60) | `Updated repos/emacs`  |