### PR TITLE
chore(flake/nur): `bce042f7` -> `8e7b197c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661854630,
-        "narHash": "sha256-FxXIrpDYhDXw4GNHnVA0asPlVrS3ZKf+pgkqLbxiM2E=",
+        "lastModified": 1661858788,
+        "narHash": "sha256-wdNabI28yhZY+j4svkp9EsuZGRDnZ6RpJZEWUI2xXHc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bce042f739f4dcd7612319765f7da1075d795a7d",
+        "rev": "8e7b197cd862578b9a2233c1d606b1964198ac54",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8e7b197c`](https://github.com/nix-community/NUR/commit/8e7b197cd862578b9a2233c1d606b1964198ac54) | `automatic update` |