### PR TITLE
chore(flake/nur): `8e7b197c` -> `b6824068`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661858788,
-        "narHash": "sha256-wdNabI28yhZY+j4svkp9EsuZGRDnZ6RpJZEWUI2xXHc=",
+        "lastModified": 1661863605,
+        "narHash": "sha256-9VDNNC3u8sZjqqAOnnqZfV4XcAshs3ZdpttdA7ZkGyA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8e7b197cd862578b9a2233c1d606b1964198ac54",
+        "rev": "b6824068c418756fc3a4259c94048ea9870390e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b6824068`](https://github.com/nix-community/NUR/commit/b6824068c418756fc3a4259c94048ea9870390e4) | `automatic update` |