### PR TITLE
chore(flake/nur): `b6824068` -> `2dbfc183`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661863605,
-        "narHash": "sha256-9VDNNC3u8sZjqqAOnnqZfV4XcAshs3ZdpttdA7ZkGyA=",
+        "lastModified": 1661866737,
+        "narHash": "sha256-ZtTVYPwbBJCX+MPTKxwfG8A9PUgBCiS/m5RE05K++u0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b6824068c418756fc3a4259c94048ea9870390e4",
+        "rev": "2dbfc18381063328afc9df3a1f16bce7167d6d83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2dbfc183`](https://github.com/nix-community/NUR/commit/2dbfc18381063328afc9df3a1f16bce7167d6d83) | `automatic update` |