### PR TITLE
chore(flake/emacs-overlay): `b726259d` -> `8c04b52f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661856816,
-        "narHash": "sha256-pb/Xu1p5q3xtk5nxBj25eoeM02SFSQ53FjSBqT+FNhE=",
+        "lastModified": 1661884368,
+        "narHash": "sha256-ZPC68tE1g9f4q3LdOYI5jMgmbZmLOJC/Ci5KMnPoW+I=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b726259df1d6defe5af8c5be45ff6457885f2a5f",
+        "rev": "8c04b52f615b7906cc7929f2bc87e8dd3a3c2c5c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`8c04b52f`](https://github.com/nix-community/emacs-overlay/commit/8c04b52f615b7906cc7929f2bc87e8dd3a3c2c5c) | `Updated repos/emacs` |
| [`abe8b13a`](https://github.com/nix-community/emacs-overlay/commit/abe8b13adf351ca1d578b8ce073e33b70d73e7a6) | `Updated repos/elpa`  |