### PR TITLE
chore(flake/nur): `2ec06c9e` -> `2d9bc14f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661883947,
-        "narHash": "sha256-qaz+6u+PJAfiW/dhSd8HWu5Mpm9jru53aH/gk3TruIM=",
+        "lastModified": 1661907886,
+        "narHash": "sha256-tyxTSUnNBk0BtxsxQYdbnp4uRX51iXbx1XpsCUJbwn8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2ec06c9e786ef01e7dd4bfab9644ffe0d9e0a71d",
+        "rev": "2d9bc14ff2c55aa1b9418d775f8d29be302704a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2d9bc14f`](https://github.com/nix-community/NUR/commit/2d9bc14ff2c55aa1b9418d775f8d29be302704a4) | `automatic update` |