### PR TITLE
chore(flake/nur): `2d9bc14f` -> `9b51cdd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661907886,
-        "narHash": "sha256-tyxTSUnNBk0BtxsxQYdbnp4uRX51iXbx1XpsCUJbwn8=",
+        "lastModified": 1661919060,
+        "narHash": "sha256-O5XVbs8uSSkXBFtCa2Oc1KAtBwt/11zoDbHK3u9UzW0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2d9bc14ff2c55aa1b9418d775f8d29be302704a4",
+        "rev": "9b51cdd6a8831fe819c21a53785d08f1bc568031",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9b51cdd6`](https://github.com/nix-community/NUR/commit/9b51cdd6a8831fe819c21a53785d08f1bc568031) | `automatic update` |
| [`de3073e9`](https://github.com/nix-community/NUR/commit/de3073e9a3751fca8f6be35c3dcfc9d7ae3e7ec0) | `automatic update` |