### PR TITLE
chore(flake/nur): `9b51cdd6` -> `e2d45207`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661919060,
-        "narHash": "sha256-O5XVbs8uSSkXBFtCa2Oc1KAtBwt/11zoDbHK3u9UzW0=",
+        "lastModified": 1661922878,
+        "narHash": "sha256-XIWEoCWwNDVi9J+qRueQ8XlEmYOGiLd1XWsF9YR4n7k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9b51cdd6a8831fe819c21a53785d08f1bc568031",
+        "rev": "e2d45207cc9a0e56dc304fa55e81f3bbcc578b89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e2d45207`](https://github.com/nix-community/NUR/commit/e2d45207cc9a0e56dc304fa55e81f3bbcc578b89) | `automatic update` |