### PR TITLE
chore(flake/nur): `e2d45207` -> `d8f45eb6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661922878,
-        "narHash": "sha256-XIWEoCWwNDVi9J+qRueQ8XlEmYOGiLd1XWsF9YR4n7k=",
+        "lastModified": 1661930973,
+        "narHash": "sha256-y1C0agUGp3eYjSVhZ5sznlSFw1YhQ3iJgStO2p7We/Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e2d45207cc9a0e56dc304fa55e81f3bbcc578b89",
+        "rev": "d8f45eb686d855bbbaca3b39c1215675e2a5ed7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d8f45eb6`](https://github.com/nix-community/NUR/commit/d8f45eb686d855bbbaca3b39c1215675e2a5ed7a) | `automatic update` |