### PR TITLE
chore(flake/nur): `d8f45eb6` -> `ecc9e500`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661930973,
-        "narHash": "sha256-y1C0agUGp3eYjSVhZ5sznlSFw1YhQ3iJgStO2p7We/Y=",
+        "lastModified": 1661932366,
+        "narHash": "sha256-jK2V2TqbK7pvu6SaXfGvSALXQx/9suN4DQaBq6Lh010=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d8f45eb686d855bbbaca3b39c1215675e2a5ed7a",
+        "rev": "ecc9e5009869e6866c4b00b7d453dc151bab94ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ecc9e500`](https://github.com/nix-community/NUR/commit/ecc9e5009869e6866c4b00b7d453dc151bab94ee) | `automatic update` |