### PR TITLE
chore(flake/nur): `ecc9e500` -> `87594c04`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661932366,
-        "narHash": "sha256-jK2V2TqbK7pvu6SaXfGvSALXQx/9suN4DQaBq6Lh010=",
+        "lastModified": 1661950075,
+        "narHash": "sha256-WB6cnWd7L2A9Hcv5jhazOj/VnQXQNDAm9+4+rzB/+XQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ecc9e5009869e6866c4b00b7d453dc151bab94ee",
+        "rev": "87594c04be95754411246e1dff92b0afa46c072c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`87594c04`](https://github.com/nix-community/NUR/commit/87594c04be95754411246e1dff92b0afa46c072c) | `automatic update` |