### PR TITLE
chore(flake/nur): `87594c04` -> `7dd0008c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661950075,
-        "narHash": "sha256-WB6cnWd7L2A9Hcv5jhazOj/VnQXQNDAm9+4+rzB/+XQ=",
+        "lastModified": 1661952120,
+        "narHash": "sha256-JwpT04L0mbLAKxTplG++RCHJgdXXHEQcGFihQqV/VF8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "87594c04be95754411246e1dff92b0afa46c072c",
+        "rev": "7dd0008c061609bc4dc5f2a0336f13082a35e00a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7dd0008c`](https://github.com/nix-community/NUR/commit/7dd0008c061609bc4dc5f2a0336f13082a35e00a) | `automatic update` |