### PR TITLE
chore(flake/nur): `7dd0008c` -> `4ea03574`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661952120,
-        "narHash": "sha256-JwpT04L0mbLAKxTplG++RCHJgdXXHEQcGFihQqV/VF8=",
+        "lastModified": 1661954440,
+        "narHash": "sha256-fdqsZWiYU4343IzK43nLaT7RnOqDNoIpbz+182LVETY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7dd0008c061609bc4dc5f2a0336f13082a35e00a",
+        "rev": "4ea035747d927489ebc542ff272f12a0f4ff74a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4ea03574`](https://github.com/nix-community/NUR/commit/4ea035747d927489ebc542ff272f12a0f4ff74a8) | `automatic update` |