### PR TITLE
chore(flake/emacs-overlay): `d2ef237d` -> `4b8f329f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661919213,
-        "narHash": "sha256-XXaX2AsnhDuQdL5X3m3sROP0H7WlIi5lB5TidEJWmkU=",
+        "lastModified": 1661971922,
+        "narHash": "sha256-s330P67qcbTvWoCjMocrZ4XrE5weP9HwDS7+ZYCkEmw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d2ef237d85c5967bc00da2d0e4e179a3118b4490",
+        "rev": "4b8f329fb51cd65be249f478672f70dbf1c0a5ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`4b8f329f`](https://github.com/nix-community/emacs-overlay/commit/4b8f329fb51cd65be249f478672f70dbf1c0a5ad) | `Updated repos/emacs` |
| [`3eebcf9f`](https://github.com/nix-community/emacs-overlay/commit/3eebcf9f1f4ae2bbfd3bb69d6d31355f4acd1362) | `Updated repos/elpa`  |