### PR TITLE
chore(flake/nixpkgs): `f677051b` -> `854fdc68`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -277,11 +277,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1663494472,
-        "narHash": "sha256-fSowlaoXXWcAM8m9wA6u+eTJJtvruYHMA+Lb/tFi/qM=",
+        "lastModified": 1664370076,
+        "narHash": "sha256-NDnIo0nxJozLwEw0VPM+RApMA90uTfbvaNNtC5eB7Os=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f677051b8dc0b5e2a9348941c99eea8c4b0ff28f",
+        "rev": "854fdc68881791812eddd33b2fed94b954979a8e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                            |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
| [`e2cc8bdf`](https://github.com/NixOS/nixpkgs/commit/e2cc8bdf3020dea444d677e24b87c172817e0434) | `ipfs-cluster: 1.0.2 -> 1.0.4 (#191671)`                                                                  |
| [`a89b2794`](https://github.com/NixOS/nixpkgs/commit/a89b27942c225980fce2977d4ffd8ea832215252) | `electrum: 4.3.1 -> 4.3.2`                                                                                |
| [`8f98a6d3`](https://github.com/NixOS/nixpkgs/commit/8f98a6d39bc9bfd4bde8d9cd692ca7ef92111809) | `check-meta: Add isHydraChannel`                                                                          |
| [`b6fe86fd`](https://github.com/NixOS/nixpkgs/commit/b6fe86fd453702d76a8a14d0c1f94ecee28d9cbb) | `rabbitmq-server: Remove unused builder variable`                                                         |
| [`6200d85e`](https://github.com/NixOS/nixpkgs/commit/6200d85eb4cd357253d6d2b7f4be7c8860039c23) | `rabbitmq-server: Use openssl_1_1 to fix config decryption`                                               |
| [`9480b59b`](https://github.com/NixOS/nixpkgs/commit/9480b59b457af0143f6b02ccc3271380d780c8dc) | `nixosTests.rabbitmq: Test config decryption (fails)`                                                     |
| [`12c22bab`](https://github.com/NixOS/nixpkgs/commit/12c22babecb92d08e3ce5f8aa98ec21a029893fa) | `haskellPackages.servant-polysemy: mark as broken`                                                        |
| [`dec0fefd`](https://github.com/NixOS/nixpkgs/commit/dec0fefd52d56dcec9350b39b29afe211527e13a) | `haskellPackages.disco: run offline tests only`                                                           |
| [`46e83984`](https://github.com/NixOS/nixpkgs/commit/46e8398474ac3b1b7bb198bf9097fc213bbf59b1) | `python310Packages.google-cloud-spanner: 3.21.0 -> 3.22.0 (#193252)`                                      |
| [`d5f27c97`](https://github.com/NixOS/nixpkgs/commit/d5f27c97b835571dc1ab48e1a006f46d01fea7f6) | `python3Packages.skl2onnx: init at 1.13`                                                                  |
| [`18f7d4c9`](https://github.com/NixOS/nixpkgs/commit/18f7d4c992a49b30d76e459a8639b90521581ca3) | `python3Packages.onnxconverter-common: init at 1.12.2`                                                    |
| [`d2356bf4`](https://github.com/NixOS/nixpkgs/commit/d2356bf415cce09b2c716489e419128285c4cacf) | `onnxruntime: add Python support`                                                                         |
| [`6bb249e6`](https://github.com/NixOS/nixpkgs/commit/6bb249e65a857e05378161097790cc8460cb495b) | `python310Packages.hmmlearn: disable on older Python releases`                                            |
| [`f40a2a70`](https://github.com/NixOS/nixpkgs/commit/f40a2a70cd818fe91c85186bf989fc177e486dea) | `checkSSLCert: 2.48.0 -> 2.49.0`                                                                          |
| [`7ebc5c2d`](https://github.com/NixOS/nixpkgs/commit/7ebc5c2ddfc7830c535353b4a4a429b4e185ab07) | `python310Packages.yalexs: 1.2.1 -> 1.2.3`                                                                |
| [`be9579d6`](https://github.com/NixOS/nixpkgs/commit/be9579d6834b676f182d590718a3d6b8addee151) | `python310Packages.aiopyarr: 22.7.0 -> 22.9.0`                                                            |
| [`87ea5229`](https://github.com/NixOS/nixpkgs/commit/87ea5229dca5f8996d6eb6c40c18f30aa74d52dc) | `python310Packages.dbus-fast: 1.15.1 -> 1.17.0`                                                           |
| [`7d226b5d`](https://github.com/NixOS/nixpkgs/commit/7d226b5d12965b214d299d553fff6a3db7e4202a) | `python310Packages.skein: 0.8.1 -> 0.8.2`                                                                 |
| [`3905b8f8`](https://github.com/NixOS/nixpkgs/commit/3905b8f8e1e0e0d04535e8c869c6e715bddc6ac5) | `python310Packages.jupyter_server: 1.18.1 -> 1.19.1`                                                      |
| [`b43a371f`](https://github.com/NixOS/nixpkgs/commit/b43a371f2a368d5ab1446630463cdf2e5fb2602f) | `python310Packages.dnslib: add pythonImportsCheck`                                                        |
| [`d050bc18`](https://github.com/NixOS/nixpkgs/commit/d050bc18737ea3ad80f573b369d91861dafed69b) | `python310Packages.dnslib: 0.9.21 -> 0.9.22`                                                              |
| [`fcd37ca7`](https://github.com/NixOS/nixpkgs/commit/fcd37ca748b89745754d775c3ec1f6a3890e03d6) | `python310Packages.angr: 9.2.19 -> 9.2.20`                                                                |
| [`4a3f6232`](https://github.com/NixOS/nixpkgs/commit/4a3f62329ea8ba32fafb0dc1d194077e087e5e27) | `python310Packages.cle: 9.2.19 -> 9.2.20`                                                                 |
| [`4404c287`](https://github.com/NixOS/nixpkgs/commit/4404c287304b952aa9e6a63407de4cc274de9de7) | `python310Packages.claripy: 9.2.19 -> 9.2.20`                                                             |
| [`873b1e97`](https://github.com/NixOS/nixpkgs/commit/873b1e97a8749eb790502ec762a83deddbbc7ced) | `python310Packages.pyvex: 9.2.19 -> 9.2.20`                                                               |
| [`5d4a3298`](https://github.com/NixOS/nixpkgs/commit/5d4a329889777a00488601fcf333655e2b1ceb0c) | `python310Packages.ailment: 9.2.19 -> 9.2.20`                                                             |
| [`0cef916f`](https://github.com/NixOS/nixpkgs/commit/0cef916f2cb6418eebf67949a4d682c3fce8a9d4) | `python310Packages.archinfo: 9.2.19 -> 9.2.20`                                                            |
| [`5a3df78d`](https://github.com/NixOS/nixpkgs/commit/5a3df78d7894258b5f34a419f082d455985f3cac) | `python310Packages.oci: 2.83.0 -> 2.84.0`                                                                 |
| [`b1b6551b`](https://github.com/NixOS/nixpkgs/commit/b1b6551b95d4bde3ba8186286ba4de07486022a3) | `python310Packages.jarowinkler: 1.2.2 -> 1.2.3`                                                           |
| [`aaac522d`](https://github.com/NixOS/nixpkgs/commit/aaac522df6842594690cd090359c889f52ff1506) | `python310Packages.limnoria: 2022.8.7 -> 2022.9.20`                                                       |
| [`98f590d6`](https://github.com/NixOS/nixpkgs/commit/98f590d6771663718a33c605a960e59ded49ac2e) | `python310Packages.jc: 1.21.2 -> 1.22.0`                                                                  |
| [`57740274`](https://github.com/NixOS/nixpkgs/commit/5774027416784eaa0d2419dfdab4bf0f4f8ef345) | `python310Packages.python-gvm: 22.7.0 -> 22.9.1`                                                          |
| [`932ca1db`](https://github.com/NixOS/nixpkgs/commit/932ca1db3da602646f2721d31628e8c617b91d3f) | `python310Packages.pyfuse3: 3.2.1 -> 3.2.2`                                                               |
| [`4fafb2c0`](https://github.com/NixOS/nixpkgs/commit/4fafb2c018034cac64e1244406c7b6ae3ff6fb25) | `python310Packages.python-gitlab: 3.9.0 -> 3.10.0`                                                        |
| [`18621744`](https://github.com/NixOS/nixpkgs/commit/18621744d6e9b3e79b6e8235f093501761e70231) | `python310Packages.pyvo: 1.3 -> 1.4`                                                                      |
| [`7f91be12`](https://github.com/NixOS/nixpkgs/commit/7f91be123709ee30d218bfc5b0ce4ebb4dd0f3af) | `python310Packages.psd-tools: 1.9.22 -> 1.9.23`                                                           |
| [`4cdac93a`](https://github.com/NixOS/nixpkgs/commit/4cdac93a5d1b0726aaeb2a1306c04031b244e80d) | `python310Packages.pytest-testmon: 1.3.6 -> 1.3.7`                                                        |
| [`868658f9`](https://github.com/NixOS/nixpkgs/commit/868658f9268c2c8f19c815efd39cae08fc89db59) | `python310Packages.pulumi-aws: 5.14.0 -> 5.16.0`                                                          |
| [`a3a20468`](https://github.com/NixOS/nixpkgs/commit/a3a20468a64ab98c51611826550acf084c6acde1) | `python310Packages.pontos: 22.9.1 -> 22.9.3`                                                              |
| [`0244d678`](https://github.com/NixOS/nixpkgs/commit/0244d67891c1e3d19227aa56e80012e1d3ac8e7f) | `octosql: 0.9.3 -> 0.10.0`                                                                                |
| [`da879a3e`](https://github.com/NixOS/nixpkgs/commit/da879a3e4cb46a5df4f3f334857cc5789056c95f) | `qpwgraph: 0.3.5 -> 0.3.6`                                                                                |
| [`2f3ac56b`](https://github.com/NixOS/nixpkgs/commit/2f3ac56b362522de118533f1eaf0ef9fdcefb249) | `alfaview: 8.52.0 -> 8.53.1`                                                                              |
| [`aae4790e`](https://github.com/NixOS/nixpkgs/commit/aae4790ef952fec69813c3caa9d669160488ac6c) | `bitwig-studio: 4.3.4 -> 4.3.8`                                                                           |
| [`90fa265b`](https://github.com/NixOS/nixpkgs/commit/90fa265b6f672e6a911006cfa1096617fba5f200) | `appgate-sdp: 6.0.1 -> 6.0.2`                                                                             |
| [`5c44d5e4`](https://github.com/NixOS/nixpkgs/commit/5c44d5e4f08ffa762bc00f523d5b0f9de48a08a5) | `roxctl: 3.71.0 -> 3.72.0`                                                                                |
| [`c7306168`](https://github.com/NixOS/nixpkgs/commit/c73061682ceb426189afb84b5db2f29b89135ef8) | `iaito: 5.7.2 -> 5.7.4`                                                                                   |
| [`f56fbbc0`](https://github.com/NixOS/nixpkgs/commit/f56fbbc085eb860b7e7311a8a723648583649212) | `gcsfuse: 0.41.6 -> 0.41.7`                                                                               |
| [`d2b86be4`](https://github.com/NixOS/nixpkgs/commit/d2b86be46b372aa75559fe89c6061ecca0a31994) | `werf: 1.2.174 -> 1.2.175`                                                                                |
| [`27c9a9bb`](https://github.com/NixOS/nixpkgs/commit/27c9a9bb845db1acdad879301558018c197c4f10) | `pocketbase: 0.7.5 -> 0.7.6`                                                                              |
| [`d2b9d9c1`](https://github.com/NixOS/nixpkgs/commit/d2b9d9c1658e543971520bf3ff2e84cc8b974c61) | `velero: 1.9.1 -> 1.9.2`                                                                                  |
| [`f6b1f7c6`](https://github.com/NixOS/nixpkgs/commit/f6b1f7c61584fdad86642aa59597c06a8c54e8e4) | `dwm-status: 1.7.3 -> 1.8.0`                                                                              |
| [`bae1cc02`](https://github.com/NixOS/nixpkgs/commit/bae1cc020796bf318cb03f8f6628d49033087af0) | `boulder: 2022-09-19 -> 2022-09-26`                                                                       |
| [`97116b9f`](https://github.com/NixOS/nixpkgs/commit/97116b9f7cf954e2a1556471530d3d571a7f3528) | `pyradio: 0.8.9.27 -> 0.8.9.28`                                                                           |
| [`bacda55e`](https://github.com/NixOS/nixpkgs/commit/bacda55ef60bcd8888cfe704c96209683edb8aa9) | `minigalaxy: 1.2.1 -> 1.2.2`                                                                              |
| [`0e4ae15b`](https://github.com/NixOS/nixpkgs/commit/0e4ae15b65ba24be412021f6bab1b77a71e3fe97) | `kyverno: 1.7.3 -> 1.7.4`                                                                                 |
| [`2616f6b7`](https://github.com/NixOS/nixpkgs/commit/2616f6b7c60a3536cdb03c5e4cb8717aceda536f) | `mold: 1.4.2 -> 1.5.0`                                                                                    |
| [`46e368bf`](https://github.com/NixOS/nixpkgs/commit/46e368bf54238b88c95e2ffa84074f816037da9f) | `bloat: unstable-2022-05-10 -> unstable-2022-09-23`                                                       |
| [`0ede411e`](https://github.com/NixOS/nixpkgs/commit/0ede411efe3e195580aa199e045d7c7d4e790e8d) | `cubiomes-viewer: 2.3.3 -> 2.4.1`                                                                         |
| [`8407d056`](https://github.com/NixOS/nixpkgs/commit/8407d056ca5a5e5ea651a39d06bc053c44795505) | `netbird: 0.9.4 -> 0.9.6`                                                                                 |
| [`29671d2d`](https://github.com/NixOS/nixpkgs/commit/29671d2d116f183a624355575aec8dc85eb07324) | `kanshi: 1.2.0 -> 1.3.0`                                                                                  |
| [`11c921f5`](https://github.com/NixOS/nixpkgs/commit/11c921f51aedd95ccbc3412e37d3ac6ea9d90e4a) | `python310Packages.iminuit: 2.16.0 -> 2.17.0`                                                             |
| [`d6a24e57`](https://github.com/NixOS/nixpkgs/commit/d6a24e574c74d8b57fc1cb267f1650c60e993493) | `cpuid: 20220812 -> 20220927`                                                                             |
| [`8538bb95`](https://github.com/NixOS/nixpkgs/commit/8538bb954a0420031dbdfe86d35c56cbc3a55006) | `python310Packages.xxh: 0.8.10 -> 0.8.11`                                                                 |
| [`b3ce1549`](https://github.com/NixOS/nixpkgs/commit/b3ce1549c9cb665fc40669cd5b8b4c0c5a843d38) | `python310Packages.emcee: disable on older Python releases`                                               |
| [`f28b6e54`](https://github.com/NixOS/nixpkgs/commit/f28b6e5468f8bd60f3fb20901a64a986bde52b05) | `snakemake: 7.14.1 -> 7.14.2`                                                                             |
| [`aed60db6`](https://github.com/NixOS/nixpkgs/commit/aed60db6ad7504de0278ee4f41b1d3d327e78544) | `sqlfluff: 1.3.1 -> 1.3.2`                                                                                |
| [`f483ef90`](https://github.com/NixOS/nixpkgs/commit/f483ef90d5eb1bbd52f00b29d75eb96295ea2264) | `gdu: 5.18.1 -> 5.19.0`                                                                                   |
| [`0a49bd5b`](https://github.com/NixOS/nixpkgs/commit/0a49bd5b430d76bf388b445737e3d11833cbb55f) | `python310Packages.fakeredis: 1.9.1 -> 1.9.3`                                                             |
| [`89a429ba`](https://github.com/NixOS/nixpkgs/commit/89a429baa6acc519c2189f4a2f2902687109248e) | `python310Packages.emcee: 3.1.2 -> 3.1.3`                                                                 |
| [`33bc0765`](https://github.com/NixOS/nixpkgs/commit/33bc0765a5e6d66e2ef3d3ee9dedfe02ff31a95c) | `stage.nix: revert deletion of gcc.abi="elfv2" from 82ff1f5`                                              |
| [`c8b98cec`](https://github.com/NixOS/nixpkgs/commit/c8b98cecd7a2885729ba6d52058f194a57a3c3b5) | `zerotierone: Use pre-vendored cargo dependencies (#193093)`                                              |
| [`39ed1df4`](https://github.com/NixOS/nixpkgs/commit/39ed1df4d69f3db30456551c76fa45494e8df6ec) | `nodePackages.prisma: 4.2.1 -> 4.4.0`                                                                     |
| [`fe0266a1`](https://github.com/NixOS/nixpkgs/commit/fe0266a102fb5fe01c5fac6a446d78d9536bdc44) | `prisma-engines: 4.2.1 -> 4.4.0`                                                                          |
| [`cc89e76d`](https://github.com/NixOS/nixpkgs/commit/cc89e76d76e3fdcdc2378af3306b85a7b443acff) | `arrow-cpp: Fix building x86_64-darwin on aarch_64-darwin (#193207)`                                      |
| [`3c0d465d`](https://github.com/NixOS/nixpkgs/commit/3c0d465d9a7aabae38f992bdeb712fd70b6076a9) | `nixos/doc/rl-22.11: Add mention of openrgb option being added`                                           |
| [`a2bcf856`](https://github.com/NixOS/nixpkgs/commit/a2bcf8564d4367c4210e060dd8b3b75acb4c96ed) | `nixos/openrgb: init module`                                                                              |
| [`f57b8bd6`](https://github.com/NixOS/nixpkgs/commit/f57b8bd640d676598c0eb0b6ea35b7c26e15e10e) | `cloudfox: init at 1.7.1`                                                                                 |
| [`69b1fcd4`](https://github.com/NixOS/nixpkgs/commit/69b1fcd4e0abec4d896d911f18a1857986e23786) | `oh-my-posh: 11.0.1 -> 11.1.1`                                                                            |
| [`aded19fb`](https://github.com/NixOS/nixpkgs/commit/aded19fb3bb2b8fd84c4c837de08bf1926397486) | `error: 'mysql' has been renamed to/replaced by 'mariadb'`                                                |
| [`ab31d8e6`](https://github.com/NixOS/nixpkgs/commit/ab31d8e6560854e4a77b007b0500c08012a87151) | `nebula: 1.6.0 -> 1.6.1`                                                                                  |
| [`17e962f5`](https://github.com/NixOS/nixpkgs/commit/17e962f507c43a3343ea8eb47cc04e5f37f9bc06) | `Revert "swiProlog: 8.3.29 -> 8.5.17"`                                                                    |
| [`326b8f7d`](https://github.com/NixOS/nixpkgs/commit/326b8f7d8f0619cf48b5a5db18270e10b91b623c) | `matrix-synapse: 1.67.0 -> 1.68.0`                                                                        |
| [`36eff319`](https://github.com/NixOS/nixpkgs/commit/36eff3190b7eeb81aee9ba2017dbe52f4bb1d4e2) | `bob: 0.5.3 -> 0.6.2 https://github.com/benchkram/bob/releases/tag/0.6.2`                                 |
| [`88943ee3`](https://github.com/NixOS/nixpkgs/commit/88943ee302df9d7be54b0c98c748058249cfb3ee) | `macchina: 6.1.5 -> 6.1.6`                                                                                |
| [`dcf7d06e`](https://github.com/NixOS/nixpkgs/commit/dcf7d06e393e35591a38d67bb71db3c6be443328) | `haskellPackages.nix-serve-ng: fix build`                                                                 |
| [`fe7a1311`](https://github.com/NixOS/nixpkgs/commit/fe7a1311cb2c83aec6689220352b665c6e941824) | `vscode-extensions.vscodevim.vim: 1.23.2 -> 1.24.1`                                                       |
| [`ceccd800`](https://github.com/NixOS/nixpkgs/commit/ceccd800a54171ff52b45ec7943ca8a4252b4143) | `lethe: 0.8.0 -> 0.8.2`                                                                                   |
| [`21667ec8`](https://github.com/NixOS/nixpkgs/commit/21667ec81c19382f8f5f2a13144ee65228dae284) | `xfce.xfce4-cpugraph-plugin: use mkXfceDerivation`                                                        |
| [`51d61cee`](https://github.com/NixOS/nixpkgs/commit/51d61ceee4203bded7269c1c8a1bbee6e00e18ff) | `k9s: 0.26.5 -> 0.26.6`                                                                                   |
| [`febe17fd`](https://github.com/NixOS/nixpkgs/commit/febe17fd070266973d1d541af0fb31e268454e38) | `haskellPackages.hs-mesos: remove stale override`                                                         |
| [`2bfcff67`](https://github.com/NixOS/nixpkgs/commit/2bfcff671172276635545ccaa8ed137151dec3d1) | `haskellPackages: mark builds failing on hydra as broken`                                                 |
| [`c5c77e18`](https://github.com/NixOS/nixpkgs/commit/c5c77e181b9c70423e77c3b8aeed0219b88db82d) | `instaloader: 4.9.4 -> 4.9.5`                                                                             |
| [`ee64f05f`](https://github.com/NixOS/nixpkgs/commit/ee64f05fd429b644cba7f6597c6de307f95e4bb4) | `hjson-go: 4.1.0 -> 4.2.0`                                                                                |
| [`a782a51e`](https://github.com/NixOS/nixpkgs/commit/a782a51e4721992c29ca94a3730ee15f965e7111) | `hugo: 0.104.0 -> 0.104.1`                                                                                |
| [`e2a6c71a`](https://github.com/NixOS/nixpkgs/commit/e2a6c71a6297568bbbb60d0a7c9dcb58949022bb) | `vscode-extensions.github.codespaces: init at 1.10.6`                                                     |
| [`dd1871dd`](https://github.com/NixOS/nixpkgs/commit/dd1871dd267e88e9350ed01eef0c93f716cd6238) | `gyb: 1.70 -> 1.71`                                                                                       |
| [`aee520d5`](https://github.com/NixOS/nixpkgs/commit/aee520d5414e5097a7b285c80d779696b7c4d6e7) | `ghr: 0.15.0 -> 0.16.0`                                                                                   |
| [`13943e2b`](https://github.com/NixOS/nixpkgs/commit/13943e2b68027819051996dfef46619a671aaae7) | `geoipupdate: 4.9.0 -> 4.10.0`                                                                            |
| [`f1abf12a`](https://github.com/NixOS/nixpkgs/commit/f1abf12a042bfb0ded32ccebbe2b3634014311da) | `pg_activity: 3.0.0 -> 3.0.1`                                                                             |
| [`7f41db6c`](https://github.com/NixOS/nixpkgs/commit/7f41db6c6f3f288954a2a9647e08ce7a31784ec7) | `python3Packages.databricks-sql-connector: fix eval`                                                      |
| [`73e71f2e`](https://github.com/NixOS/nixpkgs/commit/73e71f2ef9ba1cd1ccf4d0cea2009818d41dab89) | `gnomeExtensions: Update for GNOME 43`                                                                    |
| [`ddf9f180`](https://github.com/NixOS/nixpkgs/commit/ddf9f1800a8f6ed321646026ee9c795c90a8b993) | `delly: 1.1.3 -> 1.1.5`                                                                                   |
| [`7fa106db`](https://github.com/NixOS/nixpkgs/commit/7fa106db9c46a3a79cd0d3ae77530a2aa2c63858) | `dalfox: 2.8.1 -> 2.8.2`                                                                                  |
| [`690c606f`](https://github.com/NixOS/nixpkgs/commit/690c606fccd3e15e0df24062400a6d1aa880ab4d) | `linux-lqx: 5.19.11-lqx1 -> 5.19.11-lqx2`                                                                 |
| [`0d873b37`](https://github.com/NixOS/nixpkgs/commit/0d873b37168a124e44b0a94c915ad0607345f407) | `onnxruntime: fix paths in pkg-config file`                                                               |
| [`8c6f0187`](https://github.com/NixOS/nixpkgs/commit/8c6f0187661ca49579f46d4642b8f3a82ef575fa) | `minetest: update outdated broken expression`                                                             |
| [`754c0bcf`](https://github.com/NixOS/nixpkgs/commit/754c0bcfa8d808cb56911e48efe974b6c05410f7) | `gitsign: 0.3.0 -> 0.3.1`                                                                                 |
| [`fb3c4861`](https://github.com/NixOS/nixpkgs/commit/fb3c48614fe70a547f2a87ac797657768c56ff9c) | `Add metacoq 1.1 release`                                                                                 |
| [`f7de39c6`](https://github.com/NixOS/nixpkgs/commit/f7de39c6aead868dd8dfb85eb74064053c296762) | `fcitx5-gtk: 5.0.18 -> 5.0.19`                                                                            |
| [`e79ac562`](https://github.com/NixOS/nixpkgs/commit/e79ac5627518c17a194e44f0a9452de4fbecce56) | `paperless-ngx: 1.8.0 -> 1.9.1`                                                                           |
| [`83df2f2a`](https://github.com/NixOS/nixpkgs/commit/83df2f2a9f52732581a5a0e840c5fea17e54fb7f) | `pdfmixtool: 1.0.2 -> 1.1`                                                                                |
| [`0a14c082`](https://github.com/NixOS/nixpkgs/commit/0a14c08223c4bd430517756d89d8750b89945e9e) | `python3Packages.pikepdf: 5.4.2 -> 6.0.2`                                                                 |
| [`0132cbf5`](https://github.com/NixOS/nixpkgs/commit/0132cbf58d51aaf5b076315e318c4aa08bf2d41e) | `qpdf: 10.6.3 -> 11.1.0`                                                                                  |
| [`48dd2ed6`](https://github.com/NixOS/nixpkgs/commit/48dd2ed61adbffd1ade4a1af83e4e6e67192b13c) | `python310Packages.sentry-sdk: 1.9.8 -> 1.9.9`                                                            |
| [`52d6d2fd`](https://github.com/NixOS/nixpkgs/commit/52d6d2fdf7c63b23b79d3fe9e0867d4ec0bedaab) | `vimPlugins: update`                                                                                      |
| [`6dc5f10d`](https://github.com/NixOS/nixpkgs/commit/6dc5f10d8085caa13c992dcc9e5e2296ea5fcf3b) | `snowflake: 2.3.0 -> 2.3.1`                                                                               |
| [`2819931e`](https://github.com/NixOS/nixpkgs/commit/2819931e413b241fce9ef43647cc30a7a12f813e) | `minetest: add fgaz to maintainers`                                                                       |
| [`aee300a6`](https://github.com/NixOS/nixpkgs/commit/aee300a6b58daca255efda95ec40989cbf9a0d44) | `minetest: 5.6.0 -> 5.6.1`                                                                                |
| [`7a84b04c`](https://github.com/NixOS/nixpkgs/commit/7a84b04cedd9bb072f544aac3f9445b174f560e1) | `irrlichtmt: 1.9.0mt7 -> 1.9.0mt8`                                                                        |
| [`99f1216f`](https://github.com/NixOS/nixpkgs/commit/99f1216f7e6caeec0f3f9fce9600970685a45cc8) | `apkid: 2.1.3 -> 2.1.4`                                                                                   |
| [`9c04913c`](https://github.com/NixOS/nixpkgs/commit/9c04913c44940fafc798df5f9e6736c3e4a7daf7) | `ldapnomnom: 1.0.6 -> 1.0.7`                                                                              |
| [`f27822dc`](https://github.com/NixOS/nixpkgs/commit/f27822dc425f13cb6390dce652763d39a0cbce21) | `famistudio: 4.0.1 -> 4.0.4`                                                                              |
| [`99b0e4bb`](https://github.com/NixOS/nixpkgs/commit/99b0e4bb64c7d37bba3111f736330907ad52701c) | `dasel: 1.26.1 -> 1.27.0`                                                                                 |
| [`2f96a8da`](https://github.com/NixOS/nixpkgs/commit/2f96a8dabfb8b9b28bd00282210c47cb8af73e93) | `colima: 0.4.4 -> 0.4.5`                                                                                  |
| [`e2420ef9`](https://github.com/NixOS/nixpkgs/commit/e2420ef939f2a5b83db62f837ca299ece557f60c) | `ocamlPackages.uunf: 14.0.0 → 15.0.0`                                                                     |
| [`1c66e614`](https://github.com/NixOS/nixpkgs/commit/1c66e614500d53185711f283ca43fb8fc2afae0f) | `pantheon.gala: Fix multitasking view allocation assertions`                                              |
| [`48a3044d`](https://github.com/NixOS/nixpkgs/commit/48a3044d8dc5eeda5fcfad1be58e48d025f9fef0) | `rtabmap: unstable-2022-02-07 -> unstable-2022-09-24`                                                     |
| [`91b10238`](https://github.com/NixOS/nixpkgs/commit/91b102380531935472629ec0e1cc4892cda3fcb7) | `wasmtime: 1.0.0 -> 1.0.1`                                                                                |
| [`fe2504c6`](https://github.com/NixOS/nixpkgs/commit/fe2504c61b1098c263891e775cc57543e039e0ce) | `snakemake: 7.14.0 -> 7.14.1`                                                                             |
| [`4b9e76a8`](https://github.com/NixOS/nixpkgs/commit/4b9e76a84cdab975b0e43926fcb79cbea1e44e52) | `prometheus-node-exporter: 1.3.1 -> 1.4.0`                                                                |
| [`5de59d21`](https://github.com/NixOS/nixpkgs/commit/5de59d21c90a5454eccf9eea75208049d8314246) | `onetun: fix build on darwin`                                                                             |
| [`1f239257`](https://github.com/NixOS/nixpkgs/commit/1f239257c536b461bbed049e6bc90ac5fa096ac8) | `maintainers/scripts/update.nix: make package name, pname and old version available to the update script` |
| [`50a3d218`](https://github.com/NixOS/nixpkgs/commit/50a3d218183bc2aecfd5aaee95d5b835a41f70db) | `gns3-{server-gui}: Fix build`                                                                            |
| [`f2c5fec8`](https://github.com/NixOS/nixpkgs/commit/f2c5fec8d3cc2ed9a1509e8d7e9a2ceb09a0e7f5) | `powerdns-admin: Pin jsonschema to jsonschema_3`                                                          |
| [`b84f4e94`](https://github.com/NixOS/nixpkgs/commit/b84f4e94d12ead9277c3374e4a3f5d26f1e56e35) | `pythonPackages.jsonschema_3: init at 3.2.0`                                                              |
| [`d0191994`](https://github.com/NixOS/nixpkgs/commit/d019199454513e78700afb50e1f9312d4aca4706) | `python310Packages.jellyfin-apiclient-python: 1.9.1 -> 1.9.2`                                             |