### PR TITLE
chore(flake/nur): `07d68146` -> `a55a1129`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661969909,
-        "narHash": "sha256-pZjXGVfRsElSPH3Ia1aIKb+rLL/AVgsRxkaNkYsBQ9o=",
+        "lastModified": 1662003245,
+        "narHash": "sha256-q2im1CGdK6HCyJxyLvNR2xBHRh9qEgGBL+UZTtPiOqk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "07d68146baa03cb73cf50f2b1119449bd244b6ed",
+        "rev": "a55a112968534ce85c4b1e2ea54f7bf25db6ac13",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a55a1129`](https://github.com/nix-community/NUR/commit/a55a112968534ce85c4b1e2ea54f7bf25db6ac13) | `automatic update` |