### PR TITLE
chore(flake/emacs-overlay): `4b8f329f` -> `60a3d819`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661971922,
-        "narHash": "sha256-s330P67qcbTvWoCjMocrZ4XrE5weP9HwDS7+ZYCkEmw=",
+        "lastModified": 1662003342,
+        "narHash": "sha256-1zWYm5uFYyLmvtUFIR3VvutVOUq7hNgxBklSbn5bXn4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4b8f329fb51cd65be249f478672f70dbf1c0a5ad",
+        "rev": "60a3d81954e22bec763576e8ed3f308703da3e02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`60a3d819`](https://github.com/nix-community/emacs-overlay/commit/60a3d81954e22bec763576e8ed3f308703da3e02) | `Updated repos/emacs` |
| [`798962d1`](https://github.com/nix-community/emacs-overlay/commit/798962d10c7b7b9f969493de4ca3bb750d7a74d2) | `Updated repos/elpa`  |