### PR TITLE
chore(flake/nur): `b101ea55` -> `cbcf4dbd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662006905,
-        "narHash": "sha256-Rll400r8C+v4sL2BRtp+gSPxtU2WiAqB+KJukzoIs3w=",
+        "lastModified": 1662009697,
+        "narHash": "sha256-OWmAXUCLVtD8fWp1kLFiojbojLh6hd0pEV/ECRLDV4g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b101ea55938343c8a92c2be44faee4925d883160",
+        "rev": "cbcf4dbd737f9e5c9d85bb6bcc7ea3fa6b897fd1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`cbcf4dbd`](https://github.com/nix-community/NUR/commit/cbcf4dbd737f9e5c9d85bb6bcc7ea3fa6b897fd1) | `automatic update` |