### PR TITLE
chore(flake/nur): `cbcf4dbd` -> `e090bd50`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662009697,
-        "narHash": "sha256-OWmAXUCLVtD8fWp1kLFiojbojLh6hd0pEV/ECRLDV4g=",
+        "lastModified": 1662011886,
+        "narHash": "sha256-lJGj+VMpUX+0PevSxh/lOl5Z6hpXJonczZq6zsh1YQI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cbcf4dbd737f9e5c9d85bb6bcc7ea3fa6b897fd1",
+        "rev": "e090bd50c94b000fdffa5e162bddf13dc73932af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e090bd50`](https://github.com/nix-community/NUR/commit/e090bd50c94b000fdffa5e162bddf13dc73932af) | `automatic update` |