### PR TITLE
chore(flake/nur): `e090bd50` -> `5328552b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662011886,
-        "narHash": "sha256-lJGj+VMpUX+0PevSxh/lOl5Z6hpXJonczZq6zsh1YQI=",
+        "lastModified": 1662012752,
+        "narHash": "sha256-W6f/lga3jZo/R6sI4WtYeVGuhOF5Y+QqfdGebLy2YdM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e090bd50c94b000fdffa5e162bddf13dc73932af",
+        "rev": "5328552bccf15658866d76e6280447746f764f1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5328552b`](https://github.com/nix-community/NUR/commit/5328552bccf15658866d76e6280447746f764f1a) | `automatic update` |