### PR TITLE
chore(flake/nur): `5328552b` -> `7fdc2271`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662012752,
-        "narHash": "sha256-W6f/lga3jZo/R6sI4WtYeVGuhOF5Y+QqfdGebLy2YdM=",
+        "lastModified": 1662018754,
+        "narHash": "sha256-FCy1MfRg6ogkgTTYD+7hLr4jDfd2qayOWSbVY1fgDzc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5328552bccf15658866d76e6280447746f764f1a",
+        "rev": "7fdc2271c543d41dbde31c7a7adef5eafccf329a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7fdc2271`](https://github.com/nix-community/NUR/commit/7fdc2271c543d41dbde31c7a7adef5eafccf329a) | `automatic update` |
| [`71dc1fc4`](https://github.com/nix-community/NUR/commit/71dc1fc46e4bccc914ee16ca9e725d19e042c666) | `automatic update` |
| [`444a604e`](https://github.com/nix-community/NUR/commit/444a604e17fd7ffd52b11345aed58253f41de311) | `automatic update` |