### PR TITLE
chore(flake/emacs-ement): `2626e37b` -> `4ec2107e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1660583125,
-        "narHash": "sha256-bgAZFMrcriU9S1Oh9cSXAI3T3TjiidMa0pTalSHoe/I=",
+        "lastModified": 1662019099,
+        "narHash": "sha256-zKkBpaOj3qb/Oy89rt7BxmWZDZzDzMIJjjOm+1rrnnc=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "2626e37b824cb2a2e8fb008991d140ac3351a909",
+        "rev": "4ec2107e6a90ed962ddd3875d47caa523eb466b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                    |
| --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`4ec2107e`](https://github.com/alphapapa/ement.el/commit/4ec2107e6a90ed962ddd3875d47caa523eb466b9) | `Change: (ement-room-retro) More idiomatic prefix usage, message` |
| [`9d3c8258`](https://github.com/alphapapa/ement.el/commit/9d3c82582cb8e049c2b0c39eb3245686944ed821) | `Change: (ement-taxy-next-unread) Go to unread marker`            |
| [`f361abeb`](https://github.com/alphapapa/ement.el/commit/f361abebc15b77df6944463baaa9569fb7edc039) | `Add: (ement-view-room-display-buffer-action) etc.`               |
| [`c402ee49`](https://github.com/alphapapa/ement.el/commit/c402ee4931f580f37419633d96dcf71d76fdae8b) | `Add: (ement-disconnect-hook, ement-kill-buffers)`                |