### PR TITLE
chore(flake/emacs-ement): `4ec2107e` -> `74a8be01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1662019099,
-        "narHash": "sha256-zKkBpaOj3qb/Oy89rt7BxmWZDZzDzMIJjjOm+1rrnnc=",
+        "lastModified": 1662022661,
+        "narHash": "sha256-LY5MRVl+Plng0dewWIT9oDMEtTCLI5/dUDIVCEOoB+g=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "4ec2107e6a90ed962ddd3875d47caa523eb466b9",
+        "rev": "74a8be013db016b278d5111e0aec56a83b17a521",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                  |
| --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`74a8be01`](https://github.com/alphapapa/ement.el/commit/74a8be013db016b278d5111e0aec56a83b17a521) | `Fix: (ement-room-list-avatars) Default to (display-graphic-p)` |
| [`d36f7067`](https://github.com/alphapapa/ement.el/commit/d36f70671cd598c641e87398a1289385cd2fd111) | `Change: (ement-room-sync) Also update room list buffers`       |