### PR TITLE
chore(flake/nur): `7fdc2271` -> `c2414827`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662018754,
-        "narHash": "sha256-FCy1MfRg6ogkgTTYD+7hLr4jDfd2qayOWSbVY1fgDzc=",
+        "lastModified": 1662022924,
+        "narHash": "sha256-bdGNI3W1CZENU7o3oFqHfMbICJXItnoYtaHym2Ec1pE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7fdc2271c543d41dbde31c7a7adef5eafccf329a",
+        "rev": "c2414827fcc8c93b69b0cf569db56626d5734bae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c2414827`](https://github.com/nix-community/NUR/commit/c2414827fcc8c93b69b0cf569db56626d5734bae) | `automatic update` |