### PR TITLE
chore(flake/emacs-overlay): `60a3d819` -> `9a0afba2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662003342,
-        "narHash": "sha256-1zWYm5uFYyLmvtUFIR3VvutVOUq7hNgxBklSbn5bXn4=",
+        "lastModified": 1662028330,
+        "narHash": "sha256-pwYAjBPHg/uawK3BsEmwil3LhA8WQDvB8T3h/5QSTsM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "60a3d81954e22bec763576e8ed3f308703da3e02",
+        "rev": "9a0afba2114ca5170fe959f0432bf7bd2b272114",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`9a0afba2`](https://github.com/nix-community/emacs-overlay/commit/9a0afba2114ca5170fe959f0432bf7bd2b272114) | `Updated repos/emacs` |