### PR TITLE
chore(flake/nur): `c2414827` -> `aa253854`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662022924,
-        "narHash": "sha256-bdGNI3W1CZENU7o3oFqHfMbICJXItnoYtaHym2Ec1pE=",
+        "lastModified": 1662028579,
+        "narHash": "sha256-QkdYa3Nsy74pyAEhA1bGJIwjCX80paOswjITwQGaQ24=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c2414827fcc8c93b69b0cf569db56626d5734bae",
+        "rev": "aa253854769996f1ac17072b75082ceb8bb62b0b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`aa253854`](https://github.com/nix-community/NUR/commit/aa253854769996f1ac17072b75082ceb8bb62b0b) | `automatic update` |