### PR TITLE
chore(flake/nur): `3ca4abf8` -> `71664bd8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662036324,
-        "narHash": "sha256-DwXECqazTrHw8syTf7724ZrMufGx7OU2fftLN6kvyUM=",
+        "lastModified": 1662054960,
+        "narHash": "sha256-6PZ8uHv+l5xIDseb7p8d4uKeWTIm8Debl7TzdfBtlH8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3ca4abf86bd5759ca3f26b8011d41dc1b6b23c61",
+        "rev": "71664bd8446e5627703acb35d73fb0f82800b8d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`71664bd8`](https://github.com/nix-community/NUR/commit/71664bd8446e5627703acb35d73fb0f82800b8d6) | `automatic update` |