### PR TITLE
chore(flake/nur): `71664bd8` -> `56a831be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662054960,
-        "narHash": "sha256-6PZ8uHv+l5xIDseb7p8d4uKeWTIm8Debl7TzdfBtlH8=",
+        "lastModified": 1662062412,
+        "narHash": "sha256-g2HuS8+wxKx3VcdXxQitxRWPQ0MA/vfztfDEDiDUB94=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "71664bd8446e5627703acb35d73fb0f82800b8d6",
+        "rev": "56a831bed43862c0d8655b055d9ee52fb3cb2645",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`56a831be`](https://github.com/nix-community/NUR/commit/56a831bed43862c0d8655b055d9ee52fb3cb2645) | `automatic update` |
| [`39a3102a`](https://github.com/nix-community/NUR/commit/39a3102aab5b179bbc2a9cffacebc5cf3068be69) | `automatic update` |