### PR TITLE
chore(flake/emacs-overlay): `9a0afba2` -> `6b4445aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662028330,
-        "narHash": "sha256-pwYAjBPHg/uawK3BsEmwil3LhA8WQDvB8T3h/5QSTsM=",
+        "lastModified": 1662056744,
+        "narHash": "sha256-DSVel5s2LajK2F+bxKwenfbDis63GprQLJjAfpfWgfU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9a0afba2114ca5170fe959f0432bf7bd2b272114",
+        "rev": "6b4445aa659fa26b4f36d9975b34632312699a85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`6b4445aa`](https://github.com/nix-community/emacs-overlay/commit/6b4445aa659fa26b4f36d9975b34632312699a85) | `Updated repos/emacs` |
| [`e9e42c13`](https://github.com/nix-community/emacs-overlay/commit/e9e42c132521c19d886ce6ae3239e36edf76af8d) | `Updated repos/elpa`  |