### PR TITLE
chore(flake/nixos-hardware): `12620020` -> `78663333`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -263,11 +263,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1660407119,
-        "narHash": "sha256-04lWO0pDbhAXFdL4v2VzzwgxrZ5IefKn+TmZPiPeKxg=",
+        "lastModified": 1662092548,
+        "narHash": "sha256-nmAbyJ5+DBXcNJ2Rcy/Gx84maqtLdr6xEe82+AXCaY8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "12620020f76b1b5d2b0e6fbbda831ed4f5fe56e1",
+        "rev": "786633331724f36967853b98d9100b5cfaa4d798",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                   |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`fb635bfb`](https://github.com/NixOS/nixos-hardware/commit/fb635bfba081e9e707571abaf462d27d81580072) | `lenovo/z: add Lenovo Thinkpad Z(13)`            |
| [`7ffa4176`](https://github.com/NixOS/nixos-hardware/commit/7ffa41766accb949920459813bdf324e3edb9286) | `added lenovo thinkpad T590`                     |
| [`adbeb1a5`](https://github.com/NixOS/nixos-hardware/commit/adbeb1a5d672df746b1009cddc7d68919f81e7e3) | ``Enable `throttled` for Thinkpad X1 gen 7 too`` |
| [`22846218`](https://github.com/NixOS/nixos-hardware/commit/2284621815598261bd444cded4053eb0d8e02f8e) | `Quirks no more needed`                          |