### PR TITLE
chore(flake/nur): `56a831be` -> `d2d475f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662062412,
-        "narHash": "sha256-g2HuS8+wxKx3VcdXxQitxRWPQ0MA/vfztfDEDiDUB94=",
+        "lastModified": 1662091618,
+        "narHash": "sha256-i5wJz2yWNvZOpdKZfffyRWNbBrFb9UYv/mhWE0t/6UQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "56a831bed43862c0d8655b055d9ee52fb3cb2645",
+        "rev": "d2d475f7582003c551f58f690318a7d71fd490e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d2d475f7`](https://github.com/nix-community/NUR/commit/d2d475f7582003c551f58f690318a7d71fd490e8) | `automatic update` |