### PR TITLE
chore(flake/emacs-ement): `74a8be01` -> `a6ec9adc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1662022661,
-        "narHash": "sha256-LY5MRVl+Plng0dewWIT9oDMEtTCLI5/dUDIVCEOoB+g=",
+        "lastModified": 1662096965,
+        "narHash": "sha256-L2y9aMIvXTBCfLbcXfwMYkHsgmYpfplszLPJfbR7VZ8=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "74a8be013db016b278d5111e0aec56a83b17a521",
+        "rev": "a6ec9adcc1de40b47913bb95bd035588c1a020b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message              |
| --------------------------------------------------------------------------------------------------- | --------------------------- |
| [`a6ec9adc`](https://github.com/alphapapa/ement.el/commit/a6ec9adcc1de40b47913bb95bd035588c1a020b0) | `Release: 0.1`              |
| [`4ad7b405`](https://github.com/alphapapa/ement.el/commit/4ad7b4055923e5dc208f0f3f018a17db3572c11c) | `Meta: Add .elpaignore`     |
| [`d1fceb14`](https://github.com/alphapapa/ement.el/commit/d1fceb149eb555e11e57f175b8226a5482d2a080) | `Tidy: Docstrings, comment` |