### PR TITLE
chore(flake/nur): `d2d475f7` -> `a62c0e74`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662091618,
-        "narHash": "sha256-i5wJz2yWNvZOpdKZfffyRWNbBrFb9UYv/mhWE0t/6UQ=",
+        "lastModified": 1662096624,
+        "narHash": "sha256-bradB8j/HpuxWfPtHZtaytqfMvjFH685kYEJ5aZmtpA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d2d475f7582003c551f58f690318a7d71fd490e8",
+        "rev": "a62c0e7487ed1a57a6fe324f6c66bce8584ec70a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a62c0e74`](https://github.com/nix-community/NUR/commit/a62c0e7487ed1a57a6fe324f6c66bce8584ec70a) | `automatic update` |
| [`4db9da78`](https://github.com/nix-community/NUR/commit/4db9da781ff445aa7290695737540663636e7180) | `automatic update` |