### PR TITLE
chore(flake/nur): `a62c0e74` -> `65fef905`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662096624,
-        "narHash": "sha256-bradB8j/HpuxWfPtHZtaytqfMvjFH685kYEJ5aZmtpA=",
+        "lastModified": 1662103084,
+        "narHash": "sha256-zE6ftit1nllgrXJ3hnt/h/Ev+JsjkJQLKAgO5M31R5s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a62c0e7487ed1a57a6fe324f6c66bce8584ec70a",
+        "rev": "65fef905eaad9a585a3841103ed3f45608a50c56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`65fef905`](https://github.com/nix-community/NUR/commit/65fef905eaad9a585a3841103ed3f45608a50c56) | `automatic update` |