### PR TITLE
chore(flake/emacs-ement): `a6ec9adc` -> `fcbf1a55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1662096965,
-        "narHash": "sha256-L2y9aMIvXTBCfLbcXfwMYkHsgmYpfplszLPJfbR7VZ8=",
+        "lastModified": 1662122657,
+        "narHash": "sha256-CCQNkKyrx1pzP9EvqiOcug5yodg6BBnf1ttfnqP8POE=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "a6ec9adcc1de40b47913bb95bd035588c1a020b0",
+        "rev": "fcbf1a55e81942b9347392a3567e5fbbf8da6c8a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message          |
| --------------------------------------------------------------------------------------------------- | ----------------------- |
| [`fcbf1a55`](https://github.com/alphapapa/ement.el/commit/fcbf1a55e81942b9347392a3567e5fbbf8da6c8a) | `Release: 0.1`          |
| [`54c9b0a8`](https://github.com/alphapapa/ement.el/commit/54c9b0a89bc484363172404c13dcd9ab9ede53de) | `Meta: Add .elpaignore` |