### PR TITLE
chore(flake/nur): `ff12ab38` -> `4340abc0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662109208,
-        "narHash": "sha256-/+GnYpT4IdL2MEApFl8Ep/ZhXZJNf8asZ7f2XYWp1EI=",
+        "lastModified": 1662124358,
+        "narHash": "sha256-U6B9511tOEbsY1L6eNhcayVso/kST8GXaSeK4oMTAsk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ff12ab38093fcf9060a4f1036c12e97182026cb8",
+        "rev": "4340abc075d1ebd250c001bba8373dc17e7e0439",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4340abc0`](https://github.com/nix-community/NUR/commit/4340abc075d1ebd250c001bba8373dc17e7e0439) | `automatic update` |