### PR TITLE
chore(flake/emacs-overlay): `68fbdf4f` -> `8707d84e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662098936,
-        "narHash": "sha256-dAlpVqGis/LAx/mmNdwXkZ7YAzp25jRlb2wJ4eKkkAo=",
+        "lastModified": 1662144623,
+        "narHash": "sha256-LhtXgXW4Ez0fiiDTZcaTbosS8KMiEm6HKJMnTxyIbq8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "68fbdf4f08f19f95b1c64b21c4db16403b5498e3",
+        "rev": "8707d84ec67b39d5655929fc974055bcb9a160fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`8707d84e`](https://github.com/nix-community/emacs-overlay/commit/8707d84ec67b39d5655929fc974055bcb9a160fb) | `Updated repos/emacs` |
| [`eceb7cab`](https://github.com/nix-community/emacs-overlay/commit/eceb7cab0c141a216a2fccf937986ce28b71c67e) | `Updated repos/elpa`  |