### PR TITLE
chore(flake/nur): `b6f23415` -> `25802892`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662143203,
-        "narHash": "sha256-Jh8IOPFh1lXf2lw7mNOx2TFvLYYzviW4pN+hAhdadOo=",
+        "lastModified": 1662170849,
+        "narHash": "sha256-bIY4zURNsvaUK2eVoMz02lBDZPLwXP2KzinNvEWtlsw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b6f234155b9ae9134e804aad547ef70a191bad06",
+        "rev": "258028926ec1a0976a6f9ec1c106e7cc1345f0c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`25802892`](https://github.com/nix-community/NUR/commit/258028926ec1a0976a6f9ec1c106e7cc1345f0c0) | `automatic update` |
| [`e9b6253f`](https://github.com/nix-community/NUR/commit/e9b6253f4fda7d575714fb042fdb3dca2d47353b) | `automatic update` |