### PR TITLE
chore(flake/emacs-overlay): `8707d84e` -> `b042c46b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662144623,
-        "narHash": "sha256-LhtXgXW4Ez0fiiDTZcaTbosS8KMiEm6HKJMnTxyIbq8=",
+        "lastModified": 1662179110,
+        "narHash": "sha256-13KYsuzprRvJQK3XXzaFGNyWZS9Pucxl+OZO6gJVzE8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8707d84ec67b39d5655929fc974055bcb9a160fb",
+        "rev": "b042c46bb68bbd24b3b8f80f21889237b3b23eef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`b042c46b`](https://github.com/nix-community/emacs-overlay/commit/b042c46bb68bbd24b3b8f80f21889237b3b23eef) | `Updated repos/nongnu` |
| [`9fb9d068`](https://github.com/nix-community/emacs-overlay/commit/9fb9d0684336f7aed0a762f2536c8fa0188b653b) | `Updated repos/emacs`  |
| [`48779acc`](https://github.com/nix-community/emacs-overlay/commit/48779accfc5af3b846e10581296cb90219d6661b) | `Updated repos/elpa`   |