### PR TITLE
chore(flake/nur): `25802892` -> `c509dbde`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662170849,
-        "narHash": "sha256-bIY4zURNsvaUK2eVoMz02lBDZPLwXP2KzinNvEWtlsw=",
+        "lastModified": 1662181571,
+        "narHash": "sha256-3t9Ky33CUcz9UgGFX0xXrYp4F9VOGx/D7ZbMRiwG+6w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "258028926ec1a0976a6f9ec1c106e7cc1345f0c0",
+        "rev": "c509dbdea41181065686c36b7829e1b8e20b06a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c509dbde`](https://github.com/nix-community/NUR/commit/c509dbdea41181065686c36b7829e1b8e20b06a6) | `automatic update` |