### PR TITLE
chore(flake/nur): `c509dbde` -> `ba7a8369`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662181571,
-        "narHash": "sha256-3t9Ky33CUcz9UgGFX0xXrYp4F9VOGx/D7ZbMRiwG+6w=",
+        "lastModified": 1662185145,
+        "narHash": "sha256-g21+7KxsvwHzwb2otYSAbJ/XLD7WQdUIjCbE44duQnM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c509dbdea41181065686c36b7829e1b8e20b06a6",
+        "rev": "ba7a836931e1d218c070c55551c9f53d71378c62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ba7a8369`](https://github.com/nix-community/NUR/commit/ba7a836931e1d218c070c55551c9f53d71378c62) | `automatic update` |