### PR TITLE
chore(flake/nur): `d685b457` -> `d1602356`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662195553,
-        "narHash": "sha256-XSlibodNyO5N5m7AnRfJ1jQWZi56jeqBcE2STAtXOyA=",
+        "lastModified": 1662197502,
+        "narHash": "sha256-QF04Z9FlhNs315cejQZ5kqkk9HCQ/i7cW39leEVcOOw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d685b4574fc5f6422101461473a411af7ab08b44",
+        "rev": "d1602356d4a89416c783a97772ffc63116b07077",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d1602356`](https://github.com/nix-community/NUR/commit/d1602356d4a89416c783a97772ffc63116b07077) | `automatic update` |