### PR TITLE
chore(flake/nur): `d1602356` -> `bc2a5882`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662197502,
-        "narHash": "sha256-QF04Z9FlhNs315cejQZ5kqkk9HCQ/i7cW39leEVcOOw=",
+        "lastModified": 1662229521,
+        "narHash": "sha256-Dy3NAVDB6nLK0YjMOObNV9AH8+Gh+ohUwopF1KvVRCw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d1602356d4a89416c783a97772ffc63116b07077",
+        "rev": "bc2a588269deab82c5580bb9d2b9d5fb633b8dd2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`bc2a5882`](https://github.com/nix-community/NUR/commit/bc2a588269deab82c5580bb9d2b9d5fb633b8dd2) | `automatic update` |
| [`0303e830`](https://github.com/nix-community/NUR/commit/0303e830128a2e59d207bcbecc52efe71063c75a) | `automatic update` |