### PR TITLE
chore(flake/nur): `f2f8cff1` -> `b563d04c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662328654,
-        "narHash": "sha256-KWEXKujFO3+s6CHlZ4eI6Cm3SJtWnPxbY3ua9/AZfTw=",
+        "lastModified": 1662331284,
+        "narHash": "sha256-+XazJMtNdfovH3hc6Mq6fQzddgBvIrBXB7LtueU9PA0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f2f8cff11708a1e9717045fb95a1cb1554b648e3",
+        "rev": "b563d04c2a7eb4d72ede356bb1ce11254f5ceb74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b563d04c`](https://github.com/nix-community/NUR/commit/b563d04c2a7eb4d72ede356bb1ce11254f5ceb74) | `automatic update` |