### PR TITLE
chore(flake/nur): `b563d04c` -> `fda7747a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662331284,
-        "narHash": "sha256-+XazJMtNdfovH3hc6Mq6fQzddgBvIrBXB7LtueU9PA0=",
+        "lastModified": 1662334128,
+        "narHash": "sha256-zzRQgAgqxn9GNR2520LXuZJN5JBQKu8g7ZVKnw03vmg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b563d04c2a7eb4d72ede356bb1ce11254f5ceb74",
+        "rev": "fda7747a105f028649d98de7ff54981408d18891",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`fda7747a`](https://github.com/nix-community/NUR/commit/fda7747a105f028649d98de7ff54981408d18891) | `automatic update` |