### PR TITLE
chore(flake/nur): `fda7747a` -> `6faf4258`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662334128,
-        "narHash": "sha256-zzRQgAgqxn9GNR2520LXuZJN5JBQKu8g7ZVKnw03vmg=",
+        "lastModified": 1662344746,
+        "narHash": "sha256-8SbLI+GWKm7nFxRWDY687KZQANG14ZeWQHN+yl6m6qs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fda7747a105f028649d98de7ff54981408d18891",
+        "rev": "6faf4258610de258f7479ca3d27f5d27e225ca90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6faf4258`](https://github.com/nix-community/NUR/commit/6faf4258610de258f7479ca3d27f5d27e225ca90) | `automatic update` |