### PR TITLE
chore(flake/nur): `6faf4258` -> `ca9637d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662344746,
-        "narHash": "sha256-8SbLI+GWKm7nFxRWDY687KZQANG14ZeWQHN+yl6m6qs=",
+        "lastModified": 1662350903,
+        "narHash": "sha256-iSd2ZvH8iEy9naf0rwgLXJIvmG77MppKC9l2Ohi0Wfo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6faf4258610de258f7479ca3d27f5d27e225ca90",
+        "rev": "ca9637d7de1631f631c32a276b57ad6c7247bb85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ca9637d7`](https://github.com/nix-community/NUR/commit/ca9637d7de1631f631c32a276b57ad6c7247bb85) | `automatic update` |
| [`6820c11e`](https://github.com/nix-community/NUR/commit/6820c11e74769d7df102d201d8c6300d84595249) | `automatic update` |