### PR TITLE
chore(flake/nur): `ca9637d7` -> `f5db597a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662350903,
-        "narHash": "sha256-iSd2ZvH8iEy9naf0rwgLXJIvmG77MppKC9l2Ohi0Wfo=",
+        "lastModified": 1662364356,
+        "narHash": "sha256-0SeCDF3YNXTRbSrXKxF1KerIbJIldqC4SSA/S39tdj4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ca9637d7de1631f631c32a276b57ad6c7247bb85",
+        "rev": "f5db597a2a1afb82453cbbf753e4f03ac3df2d93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f5db597a`](https://github.com/nix-community/NUR/commit/f5db597a2a1afb82453cbbf753e4f03ac3df2d93) | `automatic update` |