### PR TITLE
chore(flake/nur): `f5db597a` -> `5226e4f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662364356,
-        "narHash": "sha256-0SeCDF3YNXTRbSrXKxF1KerIbJIldqC4SSA/S39tdj4=",
+        "lastModified": 1662364959,
+        "narHash": "sha256-DkSE0d385TUYZGO2hplWTXTrwVhqUNa6Nf+MR42EYNw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f5db597a2a1afb82453cbbf753e4f03ac3df2d93",
+        "rev": "5226e4f5eba1a30b964d65af1defecd265f4c8e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5226e4f5`](https://github.com/nix-community/NUR/commit/5226e4f5eba1a30b964d65af1defecd265f4c8e5) | `automatic update` |