### PR TITLE
chore(flake/nur): `5226e4f5` -> `9d29dc08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662364959,
-        "narHash": "sha256-DkSE0d385TUYZGO2hplWTXTrwVhqUNa6Nf+MR42EYNw=",
+        "lastModified": 1662371102,
+        "narHash": "sha256-YBNnSPU/cdZD/wcfP475IwB34s7Z0WmkKfL+wIjnM4s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5226e4f5eba1a30b964d65af1defecd265f4c8e5",
+        "rev": "9d29dc081f1a681f7c138a1b15d013602a5d88f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9d29dc08`](https://github.com/nix-community/NUR/commit/9d29dc081f1a681f7c138a1b15d013602a5d88f0) | `automatic update` |