### PR TITLE
chore(flake/emacs-ement): `fcbf1a55` -> `25d7d433`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1662122657,
-        "narHash": "sha256-CCQNkKyrx1pzP9EvqiOcug5yodg6BBnf1ttfnqP8POE=",
+        "lastModified": 1662371468,
+        "narHash": "sha256-lOgve25UDdTPsNfTS96HcCZNKlk18yhmyX0VIynPrHc=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "fcbf1a55e81942b9347392a3567e5fbbf8da6c8a",
+        "rev": "25d7d43336d3942469962776e31d5e079e63e070",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message               |
| --------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`25d7d433`](https://github.com/alphapapa/ement.el/commit/25d7d43336d3942469962776e31d5e079e63e070) | `Docs: Fix ELPA build error` |