### PR TITLE
chore(flake/home-manager): `f9a35cac` -> `66cc5c7e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662375009,
-        "narHash": "sha256-07MocEDz6A5kJlSemjKy+3uArxBUYzP4I7mjjRywll4=",
+        "lastModified": 1662376540,
+        "narHash": "sha256-GcpQgMxtTj0kvzS10vtJAdJYWWG1qTnoK/BP09OM+SY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f9a35cacdc63678e9ace8acd8886ed798d93dc55",
+        "rev": "66cc5c7ef9cae94f41dd52860a69911be33112e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message              |
| ----------------------------------------------------------------------------------------------------------- | --------------------------- |
| [`66cc5c7e`](https://github.com/nix-community/home-manager/commit/66cc5c7ef9cae94f41dd52860a69911be33112e6) | `git-sync: add ssh to path` |