### PR TITLE
chore(flake/home-manager): `66cc5c7e` -> `960c009c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662376540,
-        "narHash": "sha256-GcpQgMxtTj0kvzS10vtJAdJYWWG1qTnoK/BP09OM+SY=",
+        "lastModified": 1662378663,
+        "narHash": "sha256-2Dzw5OnHHkwQ6X97bOVMwDQoqfBokTLqEdKVjPIEcKY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "66cc5c7ef9cae94f41dd52860a69911be33112e6",
+        "rev": "960c009ce04305ebd52fb2b3c10122ded3146c4e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`960c009c`](https://github.com/nix-community/home-manager/commit/960c009ce04305ebd52fb2b3c10122ded3146c4e) | `git-sync: minor test cleanup` |