### PR TITLE
chore(flake/nur): `9d29dc08` -> `2bac6979`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662371102,
-        "narHash": "sha256-YBNnSPU/cdZD/wcfP475IwB34s7Z0WmkKfL+wIjnM4s=",
+        "lastModified": 1662379325,
+        "narHash": "sha256-9o6LtAtw/dpIJCtESCd16jK0e2K94z9HtZn/rTpgKPY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9d29dc081f1a681f7c138a1b15d013602a5d88f0",
+        "rev": "2bac697963cbe44eaf314f4df511044a859cac9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2bac6979`](https://github.com/nix-community/NUR/commit/2bac697963cbe44eaf314f4df511044a859cac9a) | `automatic update` |