### PR TITLE
chore(flake/home-manager): `960c009c` -> `de079ec3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662378663,
-        "narHash": "sha256-2Dzw5OnHHkwQ6X97bOVMwDQoqfBokTLqEdKVjPIEcKY=",
+        "lastModified": 1662381277,
+        "narHash": "sha256-ytrms5bE5d/XLkge/b91yLTh5iA9YuPz3Wp7/ZqWdnw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "960c009ce04305ebd52fb2b3c10122ded3146c4e",
+        "rev": "de079ec3714e7b201c17cbe03b62be8d6dc7b3c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message     |
| ----------------------------------------------------------------------------------------------------------- | ------------------ |
| [`de079ec3`](https://github.com/nix-community/home-manager/commit/de079ec3714e7b201c17cbe03b62be8d6dc7b3c0) | `btop: add module` |