### PR TITLE
chore(flake/nur): `2bac6979` -> `605e9275`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662379325,
-        "narHash": "sha256-9o6LtAtw/dpIJCtESCd16jK0e2K94z9HtZn/rTpgKPY=",
+        "lastModified": 1662381288,
+        "narHash": "sha256-r1U2blOHDZh2BZeFYlFvZW1IonCbvvpUbJXIJqlhUcg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2bac697963cbe44eaf314f4df511044a859cac9a",
+        "rev": "605e9275279c13f6c8615032535d48b235a8105e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`605e9275`](https://github.com/nix-community/NUR/commit/605e9275279c13f6c8615032535d48b235a8105e) | `automatic update` |