### PR TITLE
chore(flake/nur): `605e9275` -> `50cfb60e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662381288,
-        "narHash": "sha256-r1U2blOHDZh2BZeFYlFvZW1IonCbvvpUbJXIJqlhUcg=",
+        "lastModified": 1662383706,
+        "narHash": "sha256-IV/gpfYowYDTT8P7ubuF4/tIM5JSK0SM0/yFqykVojA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "605e9275279c13f6c8615032535d48b235a8105e",
+        "rev": "50cfb60eed47a76d98ba5720f54fbbdbb35fd407",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`50cfb60e`](https://github.com/nix-community/NUR/commit/50cfb60eed47a76d98ba5720f54fbbdbb35fd407) | `automatic update` |
| [`5d7ea4bb`](https://github.com/nix-community/NUR/commit/5d7ea4bbc53ed13261f023e97ac17ab656791077) | `automatic update` |