### PR TITLE
chore(flake/sops-nix): `00da5de7` -> `044ccfe2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -424,11 +424,11 @@
         "nixpkgs-22_05": "nixpkgs-22_05"
       },
       "locked": {
-        "lastModified": 1662265707,
-        "narHash": "sha256-nSCTmU6Ol02JMUzueAQGq1B/TC8JLrhrYivFzEmV0iQ=",
+        "lastModified": 1662390490,
+        "narHash": "sha256-HnFHRFu0eoB0tLOZRjLgVfHzK+4bQzAmAmHSzOquuyI=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "00da5de7380e0fc01e009e7ea9eb3f391d4b6e02",
+        "rev": "044ccfe24b349859cd9efc943e4465cc993ac84e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                                 |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`f0dddc14`](https://github.com/Mic92/sops-nix/commit/f0dddc14867bcfe19dc4461ad9fc116750b73349) | `Fix lookup of users/groups in dry activation` |