### PR TITLE
chore(flake/home-manager): `140aaed3` -> `583a99f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662382359,
-        "narHash": "sha256-X8O4fns0XtXkBBzgKQ2+7TUGIdFOvg+TQpCI7wFHP74=",
+        "lastModified": 1662396970,
+        "narHash": "sha256-N1LKxBqKmWSM/YFSROAmhotZVTUt0d6yF3opFc/XcN8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "140aaed3dffbe33bb8b2e0cf333c67f36765c85e",
+        "rev": "583a99f0166e3e5df9539b972091830bb9faf6b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`583a99f0`](https://github.com/nix-community/home-manager/commit/583a99f0166e3e5df9539b972091830bb9faf6b8) | `swayidle: allow wayland targets other than sway-session.target (#3202)` |