### PR TITLE
chore(flake/emacs-overlay): `3633040a` -> `ea4b92bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662352075,
-        "narHash": "sha256-xh8VqTB2TZOGqPwjx7Nb1YATvDNWm+fxppSk+1wdX7I=",
+        "lastModified": 1662421409,
+        "narHash": "sha256-MFhE+WDvyVdeWnqFjIDNvqKuSefvY64/JSRvbFD2oS8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3633040a41dc3379b5c4d53a4ec0fc0eb68b236d",
+        "rev": "ea4b92bc75710e09a0d439b84f7550a30000efec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                               |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
| [`57251491`](https://github.com/nix-community/emacs-overlay/commit/572514917abdfcf673c17afcca21b1597e151c99) | `Disable webp support in emacsGit-nox and emacsUnstable-nox` |