### PR TITLE
chore(flake/emacs-overlay): `ea4b92bc` -> `817a3300`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662421409,
-        "narHash": "sha256-MFhE+WDvyVdeWnqFjIDNvqKuSefvY64/JSRvbFD2oS8=",
+        "lastModified": 1662434261,
+        "narHash": "sha256-+bf55NhDopbwEU9taYsfzYkyhTYDkaEkClL+eR55drg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ea4b92bc75710e09a0d439b84f7550a30000efec",
+        "rev": "817a33003090677244ad5157d3148911e14372af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`817a3300`](https://github.com/nix-community/emacs-overlay/commit/817a33003090677244ad5157d3148911e14372af) | `Updated repos/nongnu` |