### PR TITLE
chore(flake/nur): `50cfb60e` -> `e7780169`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662383706,
-        "narHash": "sha256-IV/gpfYowYDTT8P7ubuF4/tIM5JSK0SM0/yFqykVojA=",
+        "lastModified": 1662437281,
+        "narHash": "sha256-2OiUGv6m1lnwHFSbw/ebzLilSGykTtDaquBvZWHr+2Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "50cfb60eed47a76d98ba5720f54fbbdbb35fd407",
+        "rev": "e77801698156c004515b61f3000190dd40348ab8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e7780169`](https://github.com/nix-community/NUR/commit/e77801698156c004515b61f3000190dd40348ab8) | `automatic update` |
| [`e9911a8e`](https://github.com/nix-community/NUR/commit/e9911a8e42454ec1c1c74c72afd429e30663666c) | `automatic update` |