### PR TITLE
chore(flake/nur): `0ab623a4` -> `982d2146`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662443012,
-        "narHash": "sha256-cZc+SqJM4nlLmU0E/W8zWTz0W29sL5QzMfimDdv3PeM=",
+        "lastModified": 1662447139,
+        "narHash": "sha256-Hs7QwkNgCD+ZAMBe1ZTCn2Nbt/HjzGvfsmKpSix26jU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0ab623a4f9865676dcec8a55d16a822ad88d0be6",
+        "rev": "982d2146a6653898464e4d8e8ff1df5bf8894859",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`982d2146`](https://github.com/nix-community/NUR/commit/982d2146a6653898464e4d8e8ff1df5bf8894859) | `automatic update` |