### PR TITLE
chore(flake/nur): `982d2146` -> `d27ace2c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662447139,
-        "narHash": "sha256-Hs7QwkNgCD+ZAMBe1ZTCn2Nbt/HjzGvfsmKpSix26jU=",
+        "lastModified": 1662449380,
+        "narHash": "sha256-SsmJL2iJltEiTdZCriMUkFKgjPRMccIF1YSc3aIGBqM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "982d2146a6653898464e4d8e8ff1df5bf8894859",
+        "rev": "d27ace2cee451dde3fa0966d49a7c6d5d5dd8268",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d27ace2c`](https://github.com/nix-community/NUR/commit/d27ace2cee451dde3fa0966d49a7c6d5d5dd8268) | `automatic update` |