### PR TITLE
chore(flake/nur): `d27ace2c` -> `e4d8031b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662449380,
-        "narHash": "sha256-SsmJL2iJltEiTdZCriMUkFKgjPRMccIF1YSc3aIGBqM=",
+        "lastModified": 1662452004,
+        "narHash": "sha256-kNiP87/Yt4/APhhm+GUkgh6/nALBJOtFCjecGIkO6G0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d27ace2cee451dde3fa0966d49a7c6d5d5dd8268",
+        "rev": "e4d8031b20f1ae349d1937d7ae494b9e8fecd3b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e4d8031b`](https://github.com/nix-community/NUR/commit/e4d8031b20f1ae349d1937d7ae494b9e8fecd3b9) | `automatic update` |
| [`5d068bd9`](https://github.com/nix-community/NUR/commit/5d068bd9c6badfdcc94c4609cc61e88b2035d6d0) | `automatic update` |