### PR TITLE
chore(flake/nur): `e4d8031b` -> `9c691852`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662452004,
-        "narHash": "sha256-kNiP87/Yt4/APhhm+GUkgh6/nALBJOtFCjecGIkO6G0=",
+        "lastModified": 1662457401,
+        "narHash": "sha256-v/rabUYj2zi1q03rSa+MKwQJSSR2+WEApiNWmKsB5I0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e4d8031b20f1ae349d1937d7ae494b9e8fecd3b9",
+        "rev": "9c691852588f7a2eaa6c5b5aa7c624208fa26629",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9c691852`](https://github.com/nix-community/NUR/commit/9c691852588f7a2eaa6c5b5aa7c624208fa26629) | `automatic update` |