### PR TITLE
chore(flake/emacs-overlay): `817a3300` -> `12f87fb1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662434261,
-        "narHash": "sha256-+bf55NhDopbwEU9taYsfzYkyhTYDkaEkClL+eR55drg=",
+        "lastModified": 1662457459,
+        "narHash": "sha256-2Ok8NSGmGP+qLCsDfIsUWyMNqLWt8U4Lcu86KbjgN9s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "817a33003090677244ad5157d3148911e14372af",
+        "rev": "12f87fb10e5a256c5cd361d7f0fb183c84c21cb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`12f87fb1`](https://github.com/nix-community/emacs-overlay/commit/12f87fb10e5a256c5cd361d7f0fb183c84c21cb8) | `Updated repos/nongnu` |