### PR TITLE
chore(flake/nur): `9c691852` -> `baf66ddb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662457401,
-        "narHash": "sha256-v/rabUYj2zi1q03rSa+MKwQJSSR2+WEApiNWmKsB5I0=",
+        "lastModified": 1662469431,
+        "narHash": "sha256-R10JlBNmOJdJsW8t6z0uL7arOoxZYtYoh9g1ADfnmVQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9c691852588f7a2eaa6c5b5aa7c624208fa26629",
+        "rev": "baf66ddb4e1c079ad3629e98e8e1928a2b986eb3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`baf66ddb`](https://github.com/nix-community/NUR/commit/baf66ddb4e1c079ad3629e98e8e1928a2b986eb3) | `automatic update` |