### PR TITLE
chore(flake/nur): `baf66ddb` -> `240b9f1e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662469431,
-        "narHash": "sha256-R10JlBNmOJdJsW8t6z0uL7arOoxZYtYoh9g1ADfnmVQ=",
+        "lastModified": 1662484109,
+        "narHash": "sha256-+BDa9tOjGtIta+k9Y6Ddb6DANgXJo5CrTXAZ79+MJ98=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "baf66ddb4e1c079ad3629e98e8e1928a2b986eb3",
+        "rev": "240b9f1e60592ae6bfd9ab7939712ca45950ac8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`240b9f1e`](https://github.com/nix-community/NUR/commit/240b9f1e60592ae6bfd9ab7939712ca45950ac8d) | `automatic update` |