### PR TITLE
chore(flake/nur): `240b9f1e` -> `04a59a5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662484109,
-        "narHash": "sha256-+BDa9tOjGtIta+k9Y6Ddb6DANgXJo5CrTXAZ79+MJ98=",
+        "lastModified": 1662486480,
+        "narHash": "sha256-TSUy8OR2Z0y0kYKjYmzk/IJM9BLSMf8ZJSmBrULkQdg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "240b9f1e60592ae6bfd9ab7939712ca45950ac8d",
+        "rev": "04a59a5f23a2640bbdcfaa10bfb95797c8e74f36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                      |
| -------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`5cf32007`](https://github.com/nix-community/NUR/commit/5cf320077bb31d771fffde130d0b179e272a1fda) | `README: fix flake modules example` |