### PR TITLE
chore(flake/nur): `04a59a5f` -> `b0a35357`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662486480,
-        "narHash": "sha256-TSUy8OR2Z0y0kYKjYmzk/IJM9BLSMf8ZJSmBrULkQdg=",
+        "lastModified": 1662495434,
+        "narHash": "sha256-1Ofwetc8fci5tDf7uiJEaodZ9xCaHJf1PuryyUAS8Xc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "04a59a5f23a2640bbdcfaa10bfb95797c8e74f36",
+        "rev": "b0a35357871c473c5cd1de2a0a66abdcef4f52c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b0a35357`](https://github.com/nix-community/NUR/commit/b0a35357871c473c5cd1de2a0a66abdcef4f52c7) | `automatic update` |