### PR TITLE
chore(flake/emacs-overlay): `12f87fb1` -> `82704788`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662457459,
-        "narHash": "sha256-2Ok8NSGmGP+qLCsDfIsUWyMNqLWt8U4Lcu86KbjgN9s=",
+        "lastModified": 1662496984,
+        "narHash": "sha256-SWAuZBAr3soy45+vO2gaRG0XTYO3sQVOMe7aPKqIno0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "12f87fb10e5a256c5cd361d7f0fb183c84c21cb8",
+        "rev": "82704788ffcbf4d1b417b7ce62b9f1ef7d98f442",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                                 |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
| [`9bebb050`](https://github.com/nix-community/emacs-overlay/commit/9bebb050cbdac9e9a12815fa683404788b31da88) | `Adapt to nixos-unstable default setting of nativeComp = true` |
| [`1daa8fc2`](https://github.com/nix-community/emacs-overlay/commit/1daa8fc225180a3dbc30f8cd5116d5596b2f9123) | `Update emacs-master.json`                                     |
| [`ff1e7016`](https://github.com/nix-community/emacs-overlay/commit/ff1e7016d1760ff9c5bd91b290bf18211dde34c5) | `Remove mkPgtkEmacs and use withPgtk flag instead`             |
| [`c62d7d09`](https://github.com/nix-community/emacs-overlay/commit/c62d7d09d480a083f4be5b069634fd32aafd59f2) | `Move flags for Emacs 29 bonus features to mkGitEmacs`         |