### PR TITLE
chore(flake/emacs-overlay): `82704788` -> `ae5528c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662496984,
-        "narHash": "sha256-SWAuZBAr3soy45+vO2gaRG0XTYO3sQVOMe7aPKqIno0=",
+        "lastModified": 1662502665,
+        "narHash": "sha256-2Ok8NSGmGP+qLCsDfIsUWyMNqLWt8U4Lcu86KbjgN9s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "82704788ffcbf4d1b417b7ce62b9f1ef7d98f442",
+        "rev": "ae5528c72a1e1afbbcb7be7e813f4b3598f919ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                                      |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
| [`7d143d61`](https://github.com/nix-community/emacs-overlay/commit/7d143d61f8eea4d81ec029a52109900d31d033a6) | ``Revert "Use `withPgtk` option to fix failing `emacsPgtk` build"`` |