### PR TITLE
chore(flake/nur): `640a03a8` -> `56b62eb9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662508464,
-        "narHash": "sha256-P6YyNLmqmQJ6RuU7YPjwV3qK/mqVlH7S6Fs9L1Joflk=",
+        "lastModified": 1662523689,
+        "narHash": "sha256-yGNNjGDJsO7ZASyXgFiGTgQ/R2TkIlt0wtk0R81gqEI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "640a03a8020923e9567ee74e0c4f0f42ed4f3d6a",
+        "rev": "56b62eb999a2ed8a2e58f1f826687dafecb5ea9c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`56b62eb9`](https://github.com/nix-community/NUR/commit/56b62eb999a2ed8a2e58f1f826687dafecb5ea9c) | `automatic update` |
| [`4f587296`](https://github.com/nix-community/NUR/commit/4f5872961d8b2f9eb02ad204336345a926b48bc0) | `automatic update` |