### PR TITLE
chore(flake/nur): `009cb541` -> `ac09047f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662539594,
-        "narHash": "sha256-g621Ta2sarVOFnquPaLAKncdWrfi2pUfDrRUPo1Zz00=",
+        "lastModified": 1662545195,
+        "narHash": "sha256-eiQO1jaEBHSHnEfWG+UP4Fpd9+YDTDhslBiRNcaUtAA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "009cb54119996702761240b2f33a4117badc860b",
+        "rev": "ac09047f0ae9b9490107966f2b2b065c843a2453",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                    |
| -------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`b518f57f`](https://github.com/nix-community/NUR/commit/b518f57f2f7ec942776e39e82364ca41f5193aeb) | `flake.nix: export hmModules.nur` |