### PR TITLE
chore(flake/home-manager): `de94878b` -> `22113a3a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662472236,
-        "narHash": "sha256-epA5KzVUxw9ZV+st2aU4oFfJGyIcYleTpX28wsCQQP4=",
+        "lastModified": 1662583828,
+        "narHash": "sha256-5rlP4RhAJX+n2Jd1S6vlDksOu9Wsodzv+DeKHTI/m9o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "de94878b6b83f7f2cfda9cdff005417a6d7ac82c",
+        "rev": "22113a3ae3c8410c682324e1ac3d0b995ceaf82a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`22113a3a`](https://github.com/nix-community/home-manager/commit/22113a3ae3c8410c682324e1ac3d0b995ceaf82a) | `ci: bump DeterminateSystems/update-flake-lock from 9 to 13 (#3188)` |