### PR TITLE
chore(flake/emacs-overlay): `ae5528c7` -> `62c2d63c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662502665,
-        "narHash": "sha256-2Ok8NSGmGP+qLCsDfIsUWyMNqLWt8U4Lcu86KbjgN9s=",
+        "lastModified": 1662601885,
+        "narHash": "sha256-6LM+czZ0kE8PBlWngYiwUp4D4s3j5AAphq//f8jDvvE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ae5528c72a1e1afbbcb7be7e813f4b3598f919ed",
+        "rev": "62c2d63c4fcb29719d2d4f722010c671d4497814",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message       |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`62c2d63c`](https://github.com/nix-community/emacs-overlay/commit/62c2d63c4fcb29719d2d4f722010c671d4497814) | `Updated repos/elpa` |