### PR TITLE
chore(flake/nur): `144e0349` -> `5bdb92ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662584505,
-        "narHash": "sha256-aOwo5NVWV3sudmZct0sof+6/ywqBiWOPMAbrpxPATXM=",
+        "lastModified": 1662611270,
+        "narHash": "sha256-hB0eX4kG0nSJO3G5wXHZs1O6tGL8i0/79aNhbTxvINo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "144e03494fec7c6d6547949f90d63b4cde9f27c2",
+        "rev": "5bdb92ba691affdbda3a4314cd036e88dd0b7451",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5bdb92ba`](https://github.com/nix-community/NUR/commit/5bdb92ba691affdbda3a4314cd036e88dd0b7451) | `automatic update` |
| [`f7a4bfa4`](https://github.com/nix-community/NUR/commit/f7a4bfa4689bc82a2e9027b7d1a3ce6a2c7f6c07) | `automatic update` |
| [`bafda117`](https://github.com/nix-community/NUR/commit/bafda11797db6e33d90cf0d5831233c8c91a853d) | `automatic update` |