### PR TITLE
chore(flake/nur): `f83100c0` -> `88a2b1c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662617330,
-        "narHash": "sha256-s4PAIHbeaJx3g+AjZwPUi1sVzvFwGipcwuQMdxk0HEg=",
+        "lastModified": 1662619181,
+        "narHash": "sha256-SB51trkmM6Z5TEnDJcRaDtlSAVLx/vl9k2Zgqvi4q6g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f83100c0f1c40e3758f9d8bf8045ba9b20ca8af1",
+        "rev": "88a2b1c6da608be487139b6a32b17744c43f74a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`88a2b1c6`](https://github.com/nix-community/NUR/commit/88a2b1c6da608be487139b6a32b17744c43f74a3) | `automatic update` |
| [`a043b918`](https://github.com/nix-community/NUR/commit/a043b918d508999ad95ad2075ca5d2eb793941d5) | `automatic update` |