### PR TITLE
chore(flake/nur): `88a2b1c6` -> `13ae98a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662619181,
-        "narHash": "sha256-SB51trkmM6Z5TEnDJcRaDtlSAVLx/vl9k2Zgqvi4q6g=",
+        "lastModified": 1662621900,
+        "narHash": "sha256-Rx4ACOXYMom0EsjDNp+ZiA0wM5fYEsVkkC04yvIdTN8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "88a2b1c6da608be487139b6a32b17744c43f74a3",
+        "rev": "13ae98a46c5602929ffb4536d807f1f51d3436a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`13ae98a4`](https://github.com/nix-community/NUR/commit/13ae98a46c5602929ffb4536d807f1f51d3436a1) | `automatic update` |