### PR TITLE
chore(flake/nur): `13ae98a4` -> `2b9b51e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662621900,
-        "narHash": "sha256-Rx4ACOXYMom0EsjDNp+ZiA0wM5fYEsVkkC04yvIdTN8=",
+        "lastModified": 1662627977,
+        "narHash": "sha256-NypoYMWM8cTwrDmU9mBaHo0tGDO/Vfr3XBHQUNPS97A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "13ae98a46c5602929ffb4536d807f1f51d3436a1",
+        "rev": "2b9b51e305cefd217c609f4dabd2cb414848b39e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2b9b51e3`](https://github.com/nix-community/NUR/commit/2b9b51e305cefd217c609f4dabd2cb414848b39e) | `automatic update` |