### PR TITLE
chore(flake/emacs-ement): `25d7d433` -> `4da836b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1662371468,
-        "narHash": "sha256-lOgve25UDdTPsNfTS96HcCZNKlk18yhmyX0VIynPrHc=",
+        "lastModified": 1662649116,
+        "narHash": "sha256-fMbntXbDkZLvpaTMiguHjAL0SvQNbftyf1tJAHTZMjI=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "25d7d43336d3942469962776e31d5e079e63e070",
+        "rev": "4da836b6e88a6aa2216b1e1e22ea229a4381584c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                     |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`4da836b6`](https://github.com/alphapapa/ement.el/commit/4da836b6e88a6aa2216b1e1e22ea229a4381584c) | `Tidy: Docstring`                                                  |
| [`43ab8f2e`](https://github.com/alphapapa/ement.el/commit/43ab8f2e091cecfd897df857ab2714a42f75e02b) | `Fix: (ement-room-scroll-up-mark-read) Select correct room window` |
| [`96f3c22c`](https://github.com/alphapapa/ement.el/commit/96f3c22cca6124656f4b8727e1c516c21816cd13) | `Meta: 0.1.1-pre`                                                  |