### PR TITLE
chore(flake/emacs-ement): `4da836b6` -> `7f375635`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1662649116,
-        "narHash": "sha256-fMbntXbDkZLvpaTMiguHjAL0SvQNbftyf1tJAHTZMjI=",
+        "lastModified": 1662651091,
+        "narHash": "sha256-B3FchOY5pRLuI5QWZK7A/MRaZRHIEWMMRv4QqEeszyI=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "4da836b6e88a6aa2216b1e1e22ea229a4381584c",
+        "rev": "7f3756359b22a7037c78ee6a32169a31611ccb3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                        |
| --------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`7f375635`](https://github.com/alphapapa/ement.el/commit/7f3756359b22a7037c78ee6a32169a31611ccb3f) | `Fix: (ement-room-list-avatars) Use display-images-p` |