### PR TITLE
chore(flake/nur): `cbd713ef` -> `61513848`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662661687,
-        "narHash": "sha256-ze1bQpIad0S7ofPBteBfl+E4e7FQ87PQFyrZT5QI2VY=",
+        "lastModified": 1662674918,
+        "narHash": "sha256-Nc0Hxp8zZkrk9qNEtyhHl4hKihHYMzGc1wgan8nKjYo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cbd713ef9bb050c5859466d97dc692c29e4e5195",
+        "rev": "615138484d10a35feef88d6ce42e04c89cc3feb7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`61513848`](https://github.com/nix-community/NUR/commit/615138484d10a35feef88d6ce42e04c89cc3feb7) | `automatic update` |