### PR TITLE
chore(flake/nur): `61513848` -> `b63492eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662674918,
-        "narHash": "sha256-Nc0Hxp8zZkrk9qNEtyhHl4hKihHYMzGc1wgan8nKjYo=",
+        "lastModified": 1662689748,
+        "narHash": "sha256-eBBJGtvnV1xjNomkX6wLJNVI6iyP3cCa0vSxrLxFscE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "615138484d10a35feef88d6ce42e04c89cc3feb7",
+        "rev": "b63492eb12fce1ed769edc9a3a747eb5da58d979",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b63492eb`](https://github.com/nix-community/NUR/commit/b63492eb12fce1ed769edc9a3a747eb5da58d979) | `automatic update` |