### PR TITLE
chore(flake/nur): `b63492eb` -> `d983f234`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662689748,
-        "narHash": "sha256-eBBJGtvnV1xjNomkX6wLJNVI6iyP3cCa0vSxrLxFscE=",
+        "lastModified": 1662696526,
+        "narHash": "sha256-D/rRBUiRlvPi8MYdDdgtnNt84pmV7cGpvqSvwL6rQKk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b63492eb12fce1ed769edc9a3a747eb5da58d979",
+        "rev": "d983f2341c8847a1050121f7955100d0bb4012e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d983f234`](https://github.com/nix-community/NUR/commit/d983f2341c8847a1050121f7955100d0bb4012e3) | `automatic update` |
| [`8d8c1b63`](https://github.com/nix-community/NUR/commit/8d8c1b633fefab87c494d259266546832dbd56e8) | `automatic update` |
| [`68f31b28`](https://github.com/nix-community/NUR/commit/68f31b2814a514ef640a2b7615fea2073f30ef8b) | `automatic update` |