### PR TITLE
chore(flake/nur): `d7f057ac` -> `4bce3038`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662698718,
-        "narHash": "sha256-d6aNBk6BweAasM2Zqy3mxvYPSVb+ISy44cCZovryevw=",
+        "lastModified": 1662704608,
+        "narHash": "sha256-qRMQKcxkjk/EX/Q8mqlVXq1SRic3hrENqI16HFCOmrg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d7f057ac57ae1e46004bb04526ff7007959b54ae",
+        "rev": "4bce3038e4e167490c59256d73edf2d3bdb35569",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4bce3038`](https://github.com/nix-community/NUR/commit/4bce3038e4e167490c59256d73edf2d3bdb35569) | `automatic update` |