### PR TITLE
chore(flake/home-manager): `f9f4c8e1` -> `b92826d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662717397,
-        "narHash": "sha256-syEbuNepU1RJMVBxPzv52MpqE0CRHm4rEj7J1g55ON8=",
+        "lastModified": 1662736595,
+        "narHash": "sha256-43viuA7wymW9shuGxFE5U3XGauucm7sQc83P8cvNLLo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f9f4c8e1e77c7447db5f7edd6b8d343b4c864550",
+        "rev": "b92826d0c4a6a7c50fece3caaeaa0cb08536a3f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`b92826d0`](https://github.com/nix-community/home-manager/commit/b92826d0c4a6a7c50fece3caaeaa0cb08536a3f3) | `codeowners: fix typo (#3215)` |