### PR TITLE
chore(flake/emacs-ement): `7f375635` -> `fb51f82e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1662651091,
-        "narHash": "sha256-B3FchOY5pRLuI5QWZK7A/MRaZRHIEWMMRv4QqEeszyI=",
+        "lastModified": 1662742323,
+        "narHash": "sha256-2N+vPvtVTsIBp2AICdUYSTVPxLP9WFOUNh/BwwkWLs4=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "7f3756359b22a7037c78ee6a32169a31611ccb3f",
+        "rev": "fb51f82eb5d79281467a62dcd317c82fd4b34a47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message        |
| --------------------------------------------------------------------------------------------------- | --------------------- |
| [`fb51f82e`](https://github.com/alphapapa/ement.el/commit/fb51f82eb5d79281467a62dcd317c82fd4b34a47) | `Release: v0.1.1`     |
| [`d13cc0c4`](https://github.com/alphapapa/ement.el/commit/d13cc0c4deb290fcab22bdbfc86d3a7322c02bb2) | `Docs: Update README` |