### PR TITLE
chore(flake/emacs-ement): `fb51f82e` -> `82d598a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1662742323,
-        "narHash": "sha256-2N+vPvtVTsIBp2AICdUYSTVPxLP9WFOUNh/BwwkWLs4=",
+        "lastModified": 1662744420,
+        "narHash": "sha256-CnMok5iPJ+JIo1bJl/vQEGEnaZjhgTMeLxxoSaDdG9Y=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "fb51f82eb5d79281467a62dcd317c82fd4b34a47",
+        "rev": "82d598a22a1a2605a187762f18e6b0cbdd6af7b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                  |
| --------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`068ebc12`](https://github.com/alphapapa/ement.el/commit/068ebc12097784595a9e49d40725416d614dd634) | `Docs: Add changelog entry`                     |
| [`09ad959a`](https://github.com/alphapapa/ement.el/commit/09ad959a090709a38c78ea504591edf6ba21b1ea) | `Fix: (ement-room-sync) Correct argument order` |
| [`5edc3b77`](https://github.com/alphapapa/ement.el/commit/5edc3b77a8c99d8e1ebc645c5c75121f3f32b322) | `Meta: v0.1.2-pre`                              |