### PR TITLE
chore(flake/emacs-ement): `82d598a2` -> `79e8cc51`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1662744420,
-        "narHash": "sha256-CnMok5iPJ+JIo1bJl/vQEGEnaZjhgTMeLxxoSaDdG9Y=",
+        "lastModified": 1662745486,
+        "narHash": "sha256-qhaYXNHzLEJrn3eU7aUHxkgVMoP/w3MoNqb6Oz0maQs=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "82d598a22a1a2605a187762f18e6b0cbdd6af7b3",
+        "rev": "79e8cc51f104b35246e73c434a024f5635ddca5f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                  |
| --------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`79e8cc51`](https://github.com/alphapapa/ement.el/commit/79e8cc51f104b35246e73c434a024f5635ddca5f) | `Fix: (ement-notify) Ensure D-Bus is available` |