### PR TITLE
chore(flake/emacs-ement): `79e8cc51` -> `aeba07b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1662745486,
-        "narHash": "sha256-qhaYXNHzLEJrn3eU7aUHxkgVMoP/w3MoNqb6Oz0maQs=",
+        "lastModified": 1662747038,
+        "narHash": "sha256-3o2gmVsmd6u8OdnNqXoLvJh3EEQg6MqH4AabOTHvTAM=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "79e8cc51f104b35246e73c434a024f5635ddca5f",
+        "rev": "aeba07b658ad8decdb908efcf9feebe8fca4f08e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                     |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`aeba07b6`](https://github.com/alphapapa/ement.el/commit/aeba07b658ad8decdb908efcf9feebe8fca4f08e) | `Docs: Mention availability in Debian, Guix, etc.` |