### PR TITLE
chore(flake/nur): `44284844` -> `bf84d9be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662716683,
-        "narHash": "sha256-NU+YC3jT99fp8CPhtm+mgM/c8PP6DwIRzIGkuCO3Vss=",
+        "lastModified": 1662747954,
+        "narHash": "sha256-RIX0vKuGBzbbViq3JNSa5OEVEPFFbFtUf07hd62ZAMQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "44284844e8329dfd07163965d0b9e2c3192911bc",
+        "rev": "bf84d9beccef792acbcc5189aacc8171daf8ad4e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`bf84d9be`](https://github.com/nix-community/NUR/commit/bf84d9beccef792acbcc5189aacc8171daf8ad4e) | `automatic update` |