### PR TITLE
chore(flake/emacs-ement): `aeba07b6` -> `28cb94cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1662747038,
-        "narHash": "sha256-3o2gmVsmd6u8OdnNqXoLvJh3EEQg6MqH4AabOTHvTAM=",
+        "lastModified": 1662750766,
+        "narHash": "sha256-2YqCeA5KTyMq4Cr29sKEv4ASPgnetLNma9PcmFEPF04=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "aeba07b658ad8decdb908efcf9feebe8fca4f08e",
+        "rev": "28cb94cfb5b31fdfaa344c9db42116e0179681c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message    |
| --------------------------------------------------------------------------------------------------- | ----------------- |
| [`28cb94cf`](https://github.com/alphapapa/ement.el/commit/28cb94cfb5b31fdfaa344c9db42116e0179681c6) | `Release: v0.1.2` |