### PR TITLE
chore(flake/nur): `60e87040` -> `6f2961b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662760109,
-        "narHash": "sha256-a3Sz81FzM2xvk35gjc7vxpTpBpl1725vt1tILlTXhRA=",
+        "lastModified": 1662783188,
+        "narHash": "sha256-bWOW3ShGEs8OV+4l0V8+AH8qTirFYGkFL8Riv3BbN9E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "60e87040af5fe9ad024697e3c4ba68a672575dbc",
+        "rev": "6f2961b34fc20686b1b1ae198db478702fd4c8c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6f2961b3`](https://github.com/nix-community/NUR/commit/6f2961b34fc20686b1b1ae198db478702fd4c8c8) | `automatic update` |
| [`0003c529`](https://github.com/nix-community/NUR/commit/0003c5294f200a4f5c9823c48924f8cf794d0b64) | `automatic update` |
| [`1970248e`](https://github.com/nix-community/NUR/commit/1970248e1cb183ec6c3a27dda4aa641c65bf42b3) | `automatic update` |