### PR TITLE
chore(flake/nur): `6f2961b3` -> `473451fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662783188,
-        "narHash": "sha256-bWOW3ShGEs8OV+4l0V8+AH8qTirFYGkFL8Riv3BbN9E=",
+        "lastModified": 1662785451,
+        "narHash": "sha256-7W3+CYYsw+PWEsLIknARvs3zQ892XodAcccZzqt96HI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6f2961b34fc20686b1b1ae198db478702fd4c8c8",
+        "rev": "473451fb09ee2535cc5de3de111b16d02f89a55e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`473451fb`](https://github.com/nix-community/NUR/commit/473451fb09ee2535cc5de3de111b16d02f89a55e) | `automatic update` |