### PR TITLE
chore(flake/nur): `473451fb` -> `db6631db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662785451,
-        "narHash": "sha256-7W3+CYYsw+PWEsLIknARvs3zQ892XodAcccZzqt96HI=",
+        "lastModified": 1662790518,
+        "narHash": "sha256-ZRS6AfxS8pwwcc8PQLFtNchx6jwSXuz3Lxs9mOn1UX0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "473451fb09ee2535cc5de3de111b16d02f89a55e",
+        "rev": "db6631db73effeb7673f6b44e89361e6c8a42056",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`db6631db`](https://github.com/nix-community/NUR/commit/db6631db73effeb7673f6b44e89361e6c8a42056) | `automatic update` |