### PR TITLE
chore(flake/nur): `226165de` -> `d3f7b0d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1663625813,
-        "narHash": "sha256-9uoDQ1XIjYh6YkxxhGTG8voNshyVZebt5Thj4guEv1g=",
+        "lastModified": 1664616878,
+        "narHash": "sha256-ej8qSGi6SasgPHC2FHi7XEPg4uls0bucDueRriLf+2o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "226165dee9962411b43ed287077eac3c5f526c94",
+        "rev": "d3f7b0d94792115203d69d7ce047ab00049aec64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                              |
| -------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`d3f7b0d9`](https://github.com/nix-community/NUR/commit/d3f7b0d94792115203d69d7ce047ab00049aec64) | `automatic update`                          |
| [`0e3f10c3`](https://github.com/nix-community/NUR/commit/0e3f10c31b711b2c52cf1519c78f897090e7868a) | `automatic update`                          |
| [`09932b72`](https://github.com/nix-community/NUR/commit/09932b7216b3cb0786bb0493aeeb5c381085032e) | `automatic update`                          |
| [`7b9dd1c4`](https://github.com/nix-community/NUR/commit/7b9dd1c41546be8c04eea021619b7242009e5035) | `automatic update`                          |
| [`0ce7cfc0`](https://github.com/nix-community/NUR/commit/0ce7cfc07ec92b63e6c71188f78eaa912c385eed) | `automatic update`                          |
| [`be6a2a0c`](https://github.com/nix-community/NUR/commit/be6a2a0cd39131ee6d2c19f7fd8773cb8eeaba51) | `automatic update`                          |
| [`2ced8161`](https://github.com/nix-community/NUR/commit/2ced81617a4d7e2c9f2c6046212c9f6cc8cb575c) | `automatic update`                          |
| [`0f445a1a`](https://github.com/nix-community/NUR/commit/0f445a1a765ced3874dba231303a14593d0b61bc) | `automatic update`                          |
| [`d3ee4f75`](https://github.com/nix-community/NUR/commit/d3ee4f75935acf4e29a70ebb8bf6e4eb1e66ad0a) | `add lightquantum repository`               |
| [`c2a9f8ef`](https://github.com/nix-community/NUR/commit/c2a9f8ef143d91bac0eab8d64c7db005c53e6e83) | `automatic update`                          |
| [`d111d6c3`](https://github.com/nix-community/NUR/commit/d111d6c3b57334af9a7204cffcc5b5ae4d086635) | `automatic update`                          |
| [`9caa0189`](https://github.com/nix-community/NUR/commit/9caa0189e2f667cb3d97a6d01628caa1cc4b2df8) | `automatic update`                          |
| [`09abb322`](https://github.com/nix-community/NUR/commit/09abb32275d4418c72314216a58441dcdde6c220) | `automatic update`                          |
| [`20732c22`](https://github.com/nix-community/NUR/commit/20732c22b335482c68bef253a60f611940c9ceb0) | `automatic update`                          |
| [`e3b66ebe`](https://github.com/nix-community/NUR/commit/e3b66ebe055c53b5fed2345b94465032ea9b18db) | `automatic update`                          |
| [`b1f6b64e`](https://github.com/nix-community/NUR/commit/b1f6b64ef0b26aa698087053b7e0086093564465) | `automatic update`                          |
| [`40c4ae3c`](https://github.com/nix-community/NUR/commit/40c4ae3ce7d42ea83751f3a8be8d3ca7f62a42ef) | `automatic update`                          |
| [`9a728095`](https://github.com/nix-community/NUR/commit/9a72809518ddf2e8dd6ae3179dec7705f28a39d6) | `automatic update`                          |
| [`f353c414`](https://github.com/nix-community/NUR/commit/f353c4144af1fc5195d75b5c020f83d14659f337) | `automatic update`                          |
| [`3a187fb0`](https://github.com/nix-community/NUR/commit/3a187fb0071ac92ada99838a509c9d2d9464b966) | `automatic update`                          |
| [`80519bf2`](https://github.com/nix-community/NUR/commit/80519bf2d88bd6a1390a9ae1bce6757bf887e98e) | `automatic update`                          |
| [`91d317d1`](https://github.com/nix-community/NUR/commit/91d317d1a482f43cb0c38866646395cfd37cf867) | `automatic update`                          |
| [`42ba2d21`](https://github.com/nix-community/NUR/commit/42ba2d21120a46e0d9035abee9c5b496e78aa725) | `bors: another try`                         |
| [`ec2b0bff`](https://github.com/nix-community/NUR/commit/ec2b0bff69a429bbd8c9cdcbe9c5d0693d79faf2) | `github workflows: also run on bors branch` |
| [`5a6aa74e`](https://github.com/nix-community/NUR/commit/5a6aa74ec971f35a44b06ac922f756bb121eded1) | `bors: fix status check`                    |
| [`99830540`](https://github.com/nix-community/NUR/commit/9983054095fbdf26bc897369565c313297df3877) | `bors test`                                 |
| [`8cecefba`](https://github.com/nix-community/NUR/commit/8cecefbac456d00bd40287f18780c9be07c06a8f) | `automatic update`                          |
| [`bb2f7ada`](https://github.com/nix-community/NUR/commit/bb2f7ada053f60fb6ed91f0c3e22857ffb117a46) | `add bors.toml`                             |
| [`05e2f3d0`](https://github.com/nix-community/NUR/commit/05e2f3d002a53eeb192d5e8521c6d38f24609681) | `automatic update`                          |
| [`18814d77`](https://github.com/nix-community/NUR/commit/18814d7711462c0f1452a2275a04b2d9386ce5f9) | `automatic update`                          |
| [`31dad4e8`](https://github.com/nix-community/NUR/commit/31dad4e8e897818e37aceaab06e3b26bb79104e8) | `automatic update`                          |
| [`a706d854`](https://github.com/nix-community/NUR/commit/a706d854a5bf92aec5a61c0ab4756db4e10bbc80) | `automatic update`                          |
| [`94acf67f`](https://github.com/nix-community/NUR/commit/94acf67fd18f89d6230f8185d040a7d2b04a4ef3) | `automatic update`                          |
| [`0dee0f1d`](https://github.com/nix-community/NUR/commit/0dee0f1dc8576e3c8869adc2288ffab96b2fc06d) | `automatic update`                          |
| [`7c98f66a`](https://github.com/nix-community/NUR/commit/7c98f66ae548c99b36533866d7e3227e8e2708f8) | `automatic update`                          |
| [`ff2809b0`](https://github.com/nix-community/NUR/commit/ff2809b09953ad3cc00e7dc258d7e8c86d464730) | `automatic update`                          |
| [`6cf9b5c9`](https://github.com/nix-community/NUR/commit/6cf9b5c9bc4dad0647053e275434e7cf0b06573f) | `automatic update`                          |
| [`ac6e2168`](https://github.com/nix-community/NUR/commit/ac6e2168bd88a8452bd074f4c7f4a9a913cc0d3f) | `automatic update`                          |
| [`3b1ec906`](https://github.com/nix-community/NUR/commit/3b1ec906cb6079ca163af7d9bcc19acd5522fb91) | `automatic update`                          |
| [`e378da2e`](https://github.com/nix-community/NUR/commit/e378da2e2cd205a55a0203b91162fefba04087e6) | `automatic update`                          |
| [`4b0b17e7`](https://github.com/nix-community/NUR/commit/4b0b17e70fb583970ca11972784071c607f927f3) | `automatic update`                          |
| [`8ca43145`](https://github.com/nix-community/NUR/commit/8ca43145e3b31861d807c8df3ce53f559c3b5762) | `automatic update`                          |
| [`8879c984`](https://github.com/nix-community/NUR/commit/8879c984e6fc5cd31c6266abf848d68c1953b624) | `automatic update`                          |
| [`f8a0315b`](https://github.com/nix-community/NUR/commit/f8a0315b37c267ebc839b41501dc89592b74f33f) | `automatic update`                          |
| [`9dd83311`](https://github.com/nix-community/NUR/commit/9dd8331154e6555760240be703fbf85dd3c41bab) | `automatic update`                          |
| [`9feb8f42`](https://github.com/nix-community/NUR/commit/9feb8f4282858ac34912a2fa951739c8d7b9612e) | `automatic update`                          |
| [`baba8c8c`](https://github.com/nix-community/NUR/commit/baba8c8ce399c8c55077050566b694d13bc7de0b) | `automatic update`                          |
| [`e570d301`](https://github.com/nix-community/NUR/commit/e570d3010f53367284b278ba25179334839c49bc) | `automatic update`                          |
| [`7adbbb5b`](https://github.com/nix-community/NUR/commit/7adbbb5b080a320b5ca429327ded3f9cafe458dc) | `automatic update`                          |
| [`6a3d39b1`](https://github.com/nix-community/NUR/commit/6a3d39b1510bde8013e7b5dc3a8fd47ef75736ae) | `automatic update`                          |
| [`9530ba5b`](https://github.com/nix-community/NUR/commit/9530ba5ba6961d9f63f2db308e5c036ea5d54142) | `automatic update`                          |
| [`dcc2af3d`](https://github.com/nix-community/NUR/commit/dcc2af3d2504af6726c5cf40eb5e1165d5700721) | `automatic update`                          |
| [`01694665`](https://github.com/nix-community/NUR/commit/01694665bcaf0e8f89f3dbb112a4107c3df10233) | `automatic update`                          |
| [`75db33d7`](https://github.com/nix-community/NUR/commit/75db33d7442fba2c02abe0943dbfd0fcc49a220d) | `automatic update`                          |
| [`83a95ab4`](https://github.com/nix-community/NUR/commit/83a95ab4607f23db4b13fd97e129b81840cc62a8) | `automatic update`                          |
| [`462d4f5d`](https://github.com/nix-community/NUR/commit/462d4f5d83d674979e260c1911bcc8de5d9708d3) | `automatic update`                          |
| [`e8112d47`](https://github.com/nix-community/NUR/commit/e8112d474bc222db70eb7cc34ce490f71de8cb0b) | `automatic update`                          |
| [`7e29a69d`](https://github.com/nix-community/NUR/commit/7e29a69db6154fa793ed9331f6b08c55ed8841c6) | `automatic update`                          |
| [`7775eede`](https://github.com/nix-community/NUR/commit/7775eede2fa6f993c54c7ba73bd3eb1e0a987cb1) | `automatic update`                          |
| [`e0ce9534`](https://github.com/nix-community/NUR/commit/e0ce9534e29791789dac9b60da5e39a9faab6bad) | `automatic update`                          |
| [`edd7245b`](https://github.com/nix-community/NUR/commit/edd7245be79e40e0a6246b749c32fa9cf64e28dd) | `automatic update`                          |
| [`54144d35`](https://github.com/nix-community/NUR/commit/54144d35b6904431a5cb975e1a6251bf57568ff8) | `automatic update`                          |
| [`569343bb`](https://github.com/nix-community/NUR/commit/569343bb6f883063c4e6dc319fb9f80999d285a2) | `automatic update`                          |
| [`046cab87`](https://github.com/nix-community/NUR/commit/046cab87a6ee9a7f5191585f2c340a13323771f4) | `automatic update`                          |
| [`e98db384`](https://github.com/nix-community/NUR/commit/e98db384bbb38becd5d510e366bbaa33c9ee3410) | `automatic update`                          |
| [`0cdcfefe`](https://github.com/nix-community/NUR/commit/0cdcfefee96d6843953f0279aed240c218b2b292) | `automatic update`                          |
| [`f97431dc`](https://github.com/nix-community/NUR/commit/f97431dc6120615d78a29036d9fb36bd2b6c9ead) | `automatic update`                          |
| [`5086010a`](https://github.com/nix-community/NUR/commit/5086010a76dced38bd5b56a3e89de3dffc9ac937) | `automatic update`                          |
| [`ea61575f`](https://github.com/nix-community/NUR/commit/ea61575f9f4c9fe511002e473a12a2280564d335) | `automatic update`                          |
| [`6649250b`](https://github.com/nix-community/NUR/commit/6649250b3aae2c6d8d068445a2168c1148327a32) | `automatic update`                          |
| [`09ca059a`](https://github.com/nix-community/NUR/commit/09ca059a7c70ff735e8fba999f7946e96a108927) | `automatic update`                          |
| [`e6be6d12`](https://github.com/nix-community/NUR/commit/e6be6d12caf049df8cd58fcba38e65a7f9550e73) | `automatic update`                          |
| [`1115a937`](https://github.com/nix-community/NUR/commit/1115a93774ff7333a022b4d966473f1e117c3f7b) | `automatic update`                          |
| [`3aab25c3`](https://github.com/nix-community/NUR/commit/3aab25c304dbac83a22d50a36a4412120868b38d) | `automatic update`                          |
| [`5fe4ca27`](https://github.com/nix-community/NUR/commit/5fe4ca272a07e040c5750d6ac010ce9ca2e1d4c6) | `automatic update`                          |
| [`efa68a9b`](https://github.com/nix-community/NUR/commit/efa68a9bb634fe4428bb888c4d1af928a49b342c) | `automatic update`                          |
| [`a8402e63`](https://github.com/nix-community/NUR/commit/a8402e63f7ea3dc3ca6fba0a53627bd3f509fc86) | `automatic update`                          |
| [`70271c35`](https://github.com/nix-community/NUR/commit/70271c356aec779c486d55f3ed8c779834f15f87) | `automatic update`                          |
| [`43dd5ff4`](https://github.com/nix-community/NUR/commit/43dd5ff47bdd9e4a4314a84472b45b2b67b99d38) | `automatic update`                          |
| [`129d3f7e`](https://github.com/nix-community/NUR/commit/129d3f7ee2733001dba4f315616d08ee4825dd3b) | `automatic update`                          |
| [`e3edb867`](https://github.com/nix-community/NUR/commit/e3edb867ec3d98ce48b9f31169228ec7be555994) | `automatic update`                          |
| [`443dfda0`](https://github.com/nix-community/NUR/commit/443dfda0172850616842b84ce146c0b99ca69813) | `automatic update`                          |
| [`5aa6edcd`](https://github.com/nix-community/NUR/commit/5aa6edcdf16d4348d216e3f4fefddbe104fa8a44) | `automatic update`                          |
| [`5c288f25`](https://github.com/nix-community/NUR/commit/5c288f2553a74f59cd543859f563df0a00edae1b) | `automatic update`                          |
| [`d6f9d448`](https://github.com/nix-community/NUR/commit/d6f9d448d6369d01c90a4707e4475e9dc3ba74f5) | `automatic update`                          |
| [`7d69f98d`](https://github.com/nix-community/NUR/commit/7d69f98ddcf3bb9fa952fc713d801613aadda330) | `automatic update`                          |
| [`31ca44d6`](https://github.com/nix-community/NUR/commit/31ca44d6ad2367dc019c0904abdc8e81322cbeb8) | `automatic update`                          |
| [`5cef4cfe`](https://github.com/nix-community/NUR/commit/5cef4cfe2a4512b0d0351ab60f5a279c5941396c) | `automatic update`                          |
| [`ed21a482`](https://github.com/nix-community/NUR/commit/ed21a4824c3221a36cf6ede969513b93861b0943) | `automatic update`                          |
| [`b4d05c02`](https://github.com/nix-community/NUR/commit/b4d05c022d5d56086c946d7dceb746bc57677469) | `automatic update`                          |
| [`6a01f1ed`](https://github.com/nix-community/NUR/commit/6a01f1ed1d3258aeded8764033020b12adc55ad3) | `automatic update`                          |
| [`e6c4481b`](https://github.com/nix-community/NUR/commit/e6c4481bfcf49994341432bef14e947238edc674) | `automatic update`                          |
| [`bc25b791`](https://github.com/nix-community/NUR/commit/bc25b7916941f381a0a1a3b2a8659422f2d7aab1) | `automatic update`                          |
| [`4d568111`](https://github.com/nix-community/NUR/commit/4d56811112c7a6a0976147ebcec30b14d6dc6678) | `automatic update`                          |
| [`ef78ee7a`](https://github.com/nix-community/NUR/commit/ef78ee7a8adc1ef8355c6505d1a5ec0e09773b0a) | `automatic update`                          |
| [`428c79ac`](https://github.com/nix-community/NUR/commit/428c79ac4d4a70bc2110d94479d0635c3362cefd) | `automatic update`                          |
| [`4e813680`](https://github.com/nix-community/NUR/commit/4e813680bc3b2c912015a443339f6d0e20cbebc8) | `automatic update`                          |
| [`335315f9`](https://github.com/nix-community/NUR/commit/335315f9c7a6eaa80d4e895e3cc3b0771f1ee20d) | `automatic update`                          |
| [`651c8071`](https://github.com/nix-community/NUR/commit/651c8071aa150177bf09c7f26ab25362bfa7c86e) | `automatic update`                          |
| [`b5e47924`](https://github.com/nix-community/NUR/commit/b5e47924c9aa66526a5eaa41466cb04d2e1ee7e0) | `automatic update`                          |
| [`e8f97e09`](https://github.com/nix-community/NUR/commit/e8f97e099aa265e2151df10e8d7890da505665a7) | `automatic update`                          |
| [`a643ef20`](https://github.com/nix-community/NUR/commit/a643ef20f4722ae40f8949be4c453271172be25a) | `automatic update`                          |
| [`ac54786e`](https://github.com/nix-community/NUR/commit/ac54786e25b68708330e741d5d3ea363f0dcc58a) | `add 9glenda repository`                    |
| [`bdfe254e`](https://github.com/nix-community/NUR/commit/bdfe254e6e37ccc25707846ba426ba89b4adef02) | `automatic update`                          |
| [`00f339f3`](https://github.com/nix-community/NUR/commit/00f339f3f29a12d83121de5c0e310cdbacdacd7f) | `automatic update`                          |
| [`a9faa5b8`](https://github.com/nix-community/NUR/commit/a9faa5b8fb75787ec0ecb51e85dd2626b8d6347e) | `automatic update`                          |
| [`3d9b2634`](https://github.com/nix-community/NUR/commit/3d9b2634801d088f4d208441599cae9abe8e653b) | `automatic update`                          |
| [`9d2fdb05`](https://github.com/nix-community/NUR/commit/9d2fdb05514c193529fe4d7a9ff0956ae8e879bc) | `automatic update`                          |
| [`595a8a5b`](https://github.com/nix-community/NUR/commit/595a8a5bed1aa5b859da5ff33a3b180574bca727) | `automatic update`                          |
| [`f33805ac`](https://github.com/nix-community/NUR/commit/f33805ac8734617c9e8dc8a10a8e6e1df1c3e410) | `automatic update`                          |
| [`2d2eca0b`](https://github.com/nix-community/NUR/commit/2d2eca0b1a41017e549f73b7c69988fe64b0b45a) | `automatic update`                          |
| [`06e164b0`](https://github.com/nix-community/NUR/commit/06e164b0d487dacda233d5ea849f35a8c93ed6ef) | `automatic update`                          |
| [`4c433644`](https://github.com/nix-community/NUR/commit/4c4336442f55cdb6310bed86a14924d2c98d8d03) | `add oluceps repository`                    |
| [`2548c10d`](https://github.com/nix-community/NUR/commit/2548c10d16294efdb3f61faab7dd91de25272d6a) | `automatic update`                          |
| [`0bc805f5`](https://github.com/nix-community/NUR/commit/0bc805f537a70a66ef4880320a0bd60555fb27c5) | `automatic update`                          |
| [`f166a2a5`](https://github.com/nix-community/NUR/commit/f166a2a57ff19cf60a54e148270090c866da3625) | `automatic update`                          |
| [`0732ae6e`](https://github.com/nix-community/NUR/commit/0732ae6ed0466fca9cccf565c610ffdbda03a38f) | `automatic update`                          |
| [`aadbd60d`](https://github.com/nix-community/NUR/commit/aadbd60dd9e1ad58fac42128a69edc6538c463d4) | `automatic update`                          |
| [`758b25fc`](https://github.com/nix-community/NUR/commit/758b25fcd53df53508b6d702f8d17842acbb63ca) | `automatic update`                          |
| [`8c17e044`](https://github.com/nix-community/NUR/commit/8c17e0445fe26f7d44c100f478a5855cd0385d5b) | `automatic update`                          |
| [`23dfb5e4`](https://github.com/nix-community/NUR/commit/23dfb5e4a9c61a59a5d6d2a1819a87a0643eea53) | `automatic update`                          |
| [`a22f4432`](https://github.com/nix-community/NUR/commit/a22f443201174496ce6edb237a2e9596591cd542) | `automatic update`                          |
| [`99f55240`](https://github.com/nix-community/NUR/commit/99f55240f53a75f9dc4fbf8b58240e22d4835d9a) | `automatic update`                          |
| [`6d468fd5`](https://github.com/nix-community/NUR/commit/6d468fd576d8284ef401a8d1087af17a4534b8c4) | `automatic update`                          |
| [`0209caab`](https://github.com/nix-community/NUR/commit/0209caab78db2843962be0321c95a79249be8f2d) | `automatic update`                          |
| [`20e11478`](https://github.com/nix-community/NUR/commit/20e114788fab1876f3ec4d5d8e80a9086e1c2a44) | `automatic update`                          |
| [`698b3d3d`](https://github.com/nix-community/NUR/commit/698b3d3d1c5b5e68f15bcc2f715a82e20c5e21c5) | `automatic update`                          |
| [`89c85794`](https://github.com/nix-community/NUR/commit/89c8579444b61e73a0839fc7ebbf8a813db38a01) | `automatic update`                          |
| [`a7f8e532`](https://github.com/nix-community/NUR/commit/a7f8e532678e2a98512d5bb090c4edc219dc1e1e) | `automatic update`                          |
| [`b785cada`](https://github.com/nix-community/NUR/commit/b785cada096cdb648117e1e1f708749b870a5a41) | `automatic update`                          |
| [`5766478f`](https://github.com/nix-community/NUR/commit/5766478fbe8345a490cca9382d3c57022966bc42) | `automatic update`                          |