### PR TITLE
chore(flake/sops-nix): `bae718a9` -> `912f9ff4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -292,11 +292,11 @@
     },
     "nixpkgs-22_05": {
       "locked": {
-        "lastModified": 1663433994,
-        "narHash": "sha256-Bpthhv1PdZRrIFct8KbHACNvOu9bsYAMEaqoH83cvqM=",
+        "lastModified": 1664201777,
+        "narHash": "sha256-cUW9DqELUNi1jNMwVSbfq4yl5YGyOfeu+UHUUImbby0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "17989edb05615c4f61803b9c427d80b84c289c6b",
+        "rev": "00f877f4927b6f7d7b75731b5a1e2ae7324eaf14",
         "type": "github"
       },
       "original": {
@@ -424,11 +424,11 @@
         "nixpkgs-22_05": "nixpkgs-22_05"
       },
       "locked": {
-        "lastModified": 1663475375,
-        "narHash": "sha256-uIhMyLFkU8Tp0uxLd7tKn++G/yHsB9r7YRvsBdoGvsk=",
+        "lastModified": 1664204020,
+        "narHash": "sha256-LAey3hr8b9EAt3n304Wt9Vm4uQFd8pSRtLX8leuYFDs=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "bae718a9d1e31ec478ddfcb75149f66e9625a825",
+        "rev": "912f9ff41fd9353dec1f783170793699789fe9aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                                            |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`48b4e099`](https://github.com/Mic92/sops-nix/commit/48b4e0997651097bb229cc0c50b32921260f8ae8) | `shell.nix: no longer use out-dated nixFlakes alias`      |
| [`3a55141d`](https://github.com/Mic92/sops-nix/commit/3a55141d7e1ad86fd7262e075cac9eefaf2bb0fa) | `update flake`                                            |
| [`9a381e3b`](https://github.com/Mic92/sops-nix/commit/9a381e3b2dae486616dda81ed8a6ebc040c9822b) | `no longer use out-dated aliases`                         |
| [`de5f517d`](https://github.com/Mic92/sops-nix/commit/de5f517dd5e385d2340990233ae7591b6718ac36) | `flake.lock: Update`                                      |
| [`fe9cb2b0`](https://github.com/Mic92/sops-nix/commit/fe9cb2b0cb29a35683fd36bcb1115aac9d8998f9) | `Bump DeterminateSystems/update-flake-lock from 12 to 14` |