### PR TITLE
chore(flake/emacs-ement): `24c83355` -> `fc0add9c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1663628067,
-        "narHash": "sha256-gfDA3Gc+QhbolzqoQH8Br84ogkKrVM8hPq2CiusggC0=",
+        "lastModified": 1664473341,
+        "narHash": "sha256-LKLmlDsr0ytAgAB7YHs9giGTbGEYLZymluMTiNslz0Y=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "24c83355ff3ed94e3fbab6349918f446cdcb19c4",
+        "rev": "fc0add9ca1a91c297d93a8b0b5cf510936d55e91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                             |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`fc0add9c`](https://github.com/alphapapa/ement.el/commit/fc0add9ca1a91c297d93a8b0b5cf510936d55e91) | `Release: v0.3`                                                            |
| [`ef9c0e26`](https://github.com/alphapapa/ement.el/commit/ef9c0e26887ab54ba0f3f482a23bd00de384ef78) | `Comment: Add TODO`                                                        |
| [`23b44d9e`](https://github.com/alphapapa/ement.el/commit/23b44d9e117cc1a3d10240411804c918674528d1) | `Fix: (ement-room-mode) browse-url compatibility for Emacs<28`             |
| [`298a902e`](https://github.com/alphapapa/ement.el/commit/298a902e07443579db5aefc280d85361614cc832) | `Fix: Color-related compatibility with Emacs 27`                           |
| [`ebc1ff53`](https://github.com/alphapapa/ement.el/commit/ebc1ff531e2146e8a05dd458d869b541824c01d5) | `Docs: Update changelog`                                                   |
| [`0be19261`](https://github.com/alphapapa/ement.el/commit/0be192616e19dabd136f7c1efaeb59c2c7f26bd9) | `Fix: (ement-notify-dbus-p) dbus-ping with timeout`                        |
| [`640692f8`](https://github.com/alphapapa/ement.el/commit/640692f8f452a30f5a87ebccacbe479902dc7b05) | `Fix: (ement--mark-room-direct) For users with existing direct rooms`      |
| [`3dc6849c`](https://github.com/alphapapa/ement.el/commit/3dc6849c1c32ebfe31dee3b77ab94ffcce03af34) | `Add: (ement-notify-mark-frame-urgent-predicates)`                         |
| [`ef84ffcb`](https://github.com/alphapapa/ement.el/commit/ef84ffcb1e10bc5ab9ee108a85fb858233add323) | `Change/Fix: (ement-room--insert-event) Account for timestamp headers`     |
| [`cc1750de`](https://github.com/alphapapa/ement.el/commit/cc1750de113a12930e94c1f0cd0b7923e9a0299a) | `Change: (timestamp headers) Remove H:M from date-only, insert separately` |
| [`f7372fbc`](https://github.com/alphapapa/ement.el/commit/f7372fbc244fdf59b244eb96c05f5850b72965b6) | `Add/Change: (ement-room-timestamp-header-imenu-format) And use`           |
| [`ca672b5a`](https://github.com/alphapapa/ement.el/commit/ca672b5aab229b35ba9a0b750862cb2937addfe4) | `Add: (ement-directory-next) and associated changes`                       |
| [`420fdba7`](https://github.com/alphapapa/ement.el/commit/420fdba7e03a351ff6921c354bc3cd26f9160608) | `Comment: Add TODO`                                                        |
| [`f5490e4f`](https://github.com/alphapapa/ement.el/commit/f5490e4f353fb24ac7bed5f9a457a065720db77d) | `Add/Change: (ement-directory--view) INIT-FN argument`                     |
| [`7aae0f2d`](https://github.com/alphapapa/ement.el/commit/7aae0f2d03fee9a66515da9d99c280095719691c) | `Fix: (ement-directory) Revert with limit`                                 |
| [`687a27a8`](https://github.com/alphapapa/ement.el/commit/687a27a886b3bf44ae1145ec48b6fa5f95329c21) | `Tidy: (ement-directory) Docstrings`                                       |
| [`f1253e48`](https://github.com/alphapapa/ement.el/commit/f1253e48b7cfa5735eb86d59e7fa611ff47788c7) | `Add/Change: (ement-directory-etc) Buffer-local variable`                  |
| [`9344939e`](https://github.com/alphapapa/ement.el/commit/9344939e1520d2f6cd65b88d4f9a04fb9c6e0270) | `Tidy: (ement-room-leave) Move to ement-lib`                               |
| [`467f7d93`](https://github.com/alphapapa/ement.el/commit/467f7d93532a91004665642a1e46f43b553a69ff) | `Change: (ement--format-room) Quote room name`                             |
| [`1450e032`](https://github.com/alphapapa/ement.el/commit/1450e0329ad3971019c0411cbecb60b5802f8e07) | `Add: (ement-forget-room) Add FORCE-P argument to also leave room`         |
| [`96bc0f63`](https://github.com/alphapapa/ement.el/commit/96bc0f638eeaee5aef94b3101df72ec5fa795145) | `Add: (ement-room-leave) FORCE-P argument`                                 |
| [`41881685`](https://github.com/alphapapa/ement.el/commit/41881685685a00ebd63d42368c7157decc205fe3) | `Comment: Add TODO`                                                        |
| [`910ae002`](https://github.com/alphapapa/ement.el/commit/910ae0020e6e552b05f7ab395e07c862046c2762) | `Docs: Tidy`                                                               |
| [`63aab194`](https://github.com/alphapapa/ement.el/commit/63aab1943f73cb9152ac80dd7d6841c8f8406428) | `Fix: (ement-describe-room) Nil topics`                                    |
| [`8bbdcc3a`](https://github.com/alphapapa/ement.el/commit/8bbdcc3aac74a9f37423759baf304e1fbfa07739) | `Fix: (ement-directory) Interactive arguments`                             |
| [`a48e55d6`](https://github.com/alphapapa/ement.el/commit/a48e55d65541ecc6e72931e4105ed61370f773ed) | `Add: ement-directory`                                                     |
| [`489a683f`](https://github.com/alphapapa/ement.el/commit/489a683f64cd7a504a3b5fd60087859d001ec209) | `Add: (ement-message)`                                                     |
| [`f4cb5056`](https://github.com/alphapapa/ement.el/commit/f4cb5056db50b3f855106b9301e93d02a1513ff0) | `Change: (ement-complete-session) Add prompt argument`                     |
| [`96ec15cd`](https://github.com/alphapapa/ement.el/commit/96ec15cdf913813f01721d5864a8a9be5e54de7d) | `Meta: 0.3-pre`                                                            |
| [`26bb6b81`](https://github.com/alphapapa/ement.el/commit/26bb6b8172007bddc878d822791ddc03a59b0188) | `Fix/Release: v0.2.1 for Info manual filename`                             |
| [`9fa6c598`](https://github.com/alphapapa/ement.el/commit/9fa6c59836e6e284548d43aa6d7fa60d2473bf14) | `Release: v0.2`                                                            |
| [`bdc69bb2`](https://github.com/alphapapa/ement.el/commit/bdc69bb20bba9ccfb29f754f4ccfbbdf89944ff6) | `Fix: (ement-room-list--entry)`                                            |
| [`e046f66b`](https://github.com/alphapapa/ement.el/commit/e046f66ba2c1c3c6be2ce64d8955af0c42458a02) | `Fix: (ement-room-list--entry) When room avatar image fails to load`       |