### PR TITLE
chore(flake/nix-on-droid): `dd0d1194` -> `e6c9902d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -248,11 +248,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1663051986,
-        "narHash": "sha256-PgDBQ/LkNOwNwuPGOfDHKDSyS2Y48Rp1l7CR7czPHPs=",
+        "lastModified": 1663972330,
+        "narHash": "sha256-r5l1STgGyrldeAW64Jn8nNlFkbPZLquy8ek6EaIKRCk=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "dd0d1194a8b26027e650253d3dab2c8b9f3c4736",
+        "rev": "e6c9902ddc14eaac2ee284f57fe10e7b5990080d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                           |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`e6c9902d`](https://github.com/t184256/nix-on-droid/commit/e6c9902ddc14eaac2ee284f57fe10e7b5990080d) | `CHANGELOG: Mention fake /proc/uptime workaround for ps` |
| [`49e10dbb`](https://github.com/t184256/nix-on-droid/commit/49e10dbb5248f901b28d7a40db77cc04aea0bc29) | `login: Add fake /proc/uptime workaround for ps`         |
| [`e214fdef`](https://github.com/t184256/nix-on-droid/commit/e214fdef862f6757d6a1ede3a8d0fc58d40b7ca8) | ``CHANGELOG: `terminal.font` selection``                 |
| [`9543f41d`](https://github.com/t184256/nix-on-droid/commit/9543f41de9777abeaa2d708c49fd53c0cbcf0563) | `modules/terminal: make font configurable`               |