### PR TITLE
chore(flake/home-manager): `41790ba6` -> `a7f0cc2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1663629861,
-        "narHash": "sha256-CjfQUyPfG/hkE4jnMcTvVJ0ubc84u8ySruZL+emXMjw=",
+        "lastModified": 1664573442,
+        "narHash": "sha256-AovlSIuJfMf8n9QLNUVtsCul+NVHIoen7APH2fLls3k=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "41790ba656bafc023f48ccdbbe7816d30fd52d76",
+        "rev": "a7f0cc2d7b271b4a5df9b9e351d556c172f7e903",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`a7f0cc2d`](https://github.com/nix-community/home-manager/commit/a7f0cc2d7b271b4a5df9b9e351d556c172f7e903) | `lorri: add nixPackage and enableNotifications options`          |
| [`7a3384c7`](https://github.com/nix-community/home-manager/commit/7a3384c7969f50e6e3799f8d1c7817b698dd77d3) | `syncthing: add platform assertion`                              |
| [`9727190b`](https://github.com/nix-community/home-manager/commit/9727190b804f690c8590bbf191598439a35b0877) | `mangohud: fix moved link of config file`                        |
| [`5c5a5b9b`](https://github.com/nix-community/home-manager/commit/5c5a5b9b45ee92995909b7944eefc4284af93849) | `urxvt: fix package name`                                        |
| [`a053da0f`](https://github.com/nix-community/home-manager/commit/a053da0f22a05ceda845c824cf964077515c7669) | `fluxbox: use mkPackageOption instead of mkOption (#3286)`       |
| [`e7be7c46`](https://github.com/nix-community/home-manager/commit/e7be7c468842944a9877ad6ff948afd0d1cb2dbe) | `pls: add module (#3285)`                                        |
| [`864ff685`](https://github.com/nix-community/home-manager/commit/864ff685fe6443101a0a8f3950d21bcb4330e56a) | `lib: add two new gvariant types`                                |
| [`9da6c023`](https://github.com/nix-community/home-manager/commit/9da6c0232e22b7fff358db633f6bbc8f97a891e1) | `docs: explain how to enable flakes on NixOS`                    |
| [`68ea28d3`](https://github.com/nix-community/home-manager/commit/68ea28d330f2e1ef3fb2c653da42b558f14a1efd) | `kdeconnect: change package`                                     |
| [`28334988`](https://github.com/nix-community/home-manager/commit/28334988dbd613012b1b085c37d144889f8e2abc) | ``picom: use `types.numbers.between```                           |
| [`6dc8a43f`](https://github.com/nix-community/home-manager/commit/6dc8a43f397c92afbc3f771385ac803d96d5eeb5) | `flake: list deprecated args in throw`                           |
| [`1f5ef2bb`](https://github.com/nix-community/home-manager/commit/1f5ef2bb419a327fae28a83b50fab50959132c24) | `broot: fix config file location (#3273)`                        |
| [`65b65ce5`](https://github.com/nix-community/home-manager/commit/65b65ce5ef08d54bc09336fe3f35e33be487e2fe) | `broot: use upstream defaults, allow all config options (#2644)` |
| [`9e739452`](https://github.com/nix-community/home-manager/commit/9e7394523eb4f298528d457e316fc752bdf07151) | `ci: bump DeterminateSystems/update-flake-lock from 13 to 14`    |
| [`707cb75e`](https://github.com/nix-community/home-manager/commit/707cb75ed33c59b58e6e03af881a833f3538d3e3) | `tmate: add module`                                              |
| [`9b917098`](https://github.com/nix-community/home-manager/commit/9b91709899ddf20cbead93e4af622bd0a501dd0b) | `safeeyes: add module`                                           |
| [`3eaadd82`](https://github.com/nix-community/home-manager/commit/3eaadd82b8fb646a6779839c4f276b810e0354a5) | `maintainers: add Rosuavio`                                      |
| [`de3758e3`](https://github.com/nix-community/home-manager/commit/de3758e31a3a1bc79d569f5deb5dac39791bf9b6) | `neovim: fix a typo in the generated init.lua (#3252)`           |
| [`bd83eab6`](https://github.com/nix-community/home-manager/commit/bd83eab6220226085c82e637931a7ae3863d9893) | `programs.neovim: default to init.lua (#3233)`                   |
| [`f17819f4`](https://github.com/nix-community/home-manager/commit/f17819f4f198a3973be76797aa8a9370e35c7ca6) | `fluxbox: add module`                                            |
| [`f5e4614c`](https://github.com/nix-community/home-manager/commit/f5e4614c1163ffe4a30cfb3cf1b76a72f69c3fda) | ``yt-dlp: add `settings` option``                                |