### PR TITLE
chore(flake/nixos-hardware): `a0df6cd6` -> `3024c67a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -263,11 +263,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1663229557,
-        "narHash": "sha256-1uU4nsDLXKG0AHc/VCsNBAEPkTA/07juYhcEWRb1O1E=",
+        "lastModified": 1664628729,
+        "narHash": "sha256-A1J0ZPhBfZZiWI6ipjKJ8+RpMllzOMu/An/8Tk3t4oo=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "a0df6cd6e199df4a78c833c273781ea92fa62cfb",
+        "rev": "3024c67a2e9a35450558426c42e7419ab37efd95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                            |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`a2dab346`](https://github.com/NixOS/nixos-hardware/commit/a2dab346f9e4da7cf2298bef1c973152f76a4f42) | `CONTRIBUTING.md: mention bors`           |
| [`3a5dd128`](https://github.com/NixOS/nixos-hardware/commit/3a5dd128e410097d5b2538382b636f52c746798a) | `add bors configuration`                  |
| [`5c0995a0`](https://github.com/NixOS/nixos-hardware/commit/5c0995a0126c10838ec40406c40eb3d7558cb2d3) | `thinkpad-z: fix eval`                    |
| [`9b98a70d`](https://github.com/NixOS/nixos-hardware/commit/9b98a70d46b109bcc82bbafdd0c918330d791fed) | `Update disused function to runCommand`   |
| [`2aa0939a`](https://github.com/NixOS/nixos-hardware/commit/2aa0939a6558b0d740c2bd0eff7d8cb8e052bd36) | `Fixed utillinux package renaming`        |
| [`cc5d5020`](https://github.com/NixOS/nixos-hardware/commit/cc5d50203078bb350737b0b12c90e216c514b71e) | `onenetbook/4: stop using runCommandNoCC` |
| [`3774a528`](https://github.com/NixOS/nixos-hardware/commit/3774a528de7faf9c452e3c02fed4191593d2c585) | `kobol/helios4: init`                     |