### PR TITLE
chore(flake/ragenix): `e453cac2` -> `88b7de1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1663491704,
-        "narHash": "sha256-9SzHcVjZtFki8H0LybMDv2lCvRnWJRk9/KbkjZJ2zWc=",
+        "lastModified": 1664205677,
+        "narHash": "sha256-XEQ3zskr1LZrSJbTb3TKb4eln9k5ZGjoztqFj4foidg=",
         "owner": "yaxitech",
         "repo": "ragenix",
-        "rev": "e453cac2e0884b5f5ebbc0991d27f7f385c4037b",
+        "rev": "88b7de1ca98b2bd96838ba9554cf24b8401541ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                            | Commit Message                       |
| ------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`88b7de1c`](https://github.com/yaxitech/ragenix/commit/88b7de1ca98b2bd96838ba9554cf24b8401541ce) | `refactor: new flake outputs (#111)` |