### PR TITLE
chore(flake/nixpkgs): `854fdc68` -> `59d2991d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -277,11 +277,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664370076,
-        "narHash": "sha256-NDnIo0nxJozLwEw0VPM+RApMA90uTfbvaNNtC5eB7Os=",
+        "lastModified": 1664687381,
+        "narHash": "sha256-9czSuDzS+OGGwq2kC4KXBLXWfYaup+oLB+AA1Md25U4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "854fdc68881791812eddd33b2fed94b954979a8e",
+        "rev": "59d2991d4256cdca1c0cda45d876c80a0fe45c31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`c5209172`](https://github.com/NixOS/nixpkgs/commit/c5209172f405daa7e329ac051d4a6bd035dac53a) | `tealdeer: 1.5.0 -> 1.6.0`                                                    |
| [`d9f5a82c`](https://github.com/NixOS/nixpkgs/commit/d9f5a82c8c957de94cb2c66b989bfeccbfc841b1) | `neovim: 0.7.2 -> 0.8.0`                                                      |
| [`62615de6`](https://github.com/NixOS/nixpkgs/commit/62615de614376985be37d37682f64992ccbc96ac) | `libvterm-neovim: 0.1.3 -> 0.3`                                               |
| [`5e2ce525`](https://github.com/NixOS/nixpkgs/commit/5e2ce525446f84dfc8b117bc814e6a86ed5bfc53) | `terraform-providers: update 2022-09-25`                                      |
| [`298d13c6`](https://github.com/NixOS/nixpkgs/commit/298d13c67d298d4efd0e481313e7a9795516fca6) | `libmaxminddb: 1.7.0 -> 1.7.1`                                                |
| [`423e9cc4`](https://github.com/NixOS/nixpkgs/commit/423e9cc42c5b9560a8e1240abc09bca98c2a36bc) | `hashlink: add x86_64-darwin compatibility (#193580)`                         |
| [`5550d568`](https://github.com/NixOS/nixpkgs/commit/5550d56819bad351461cfb3b3ecd4f311a7a2467) | `python310Packages.hstspreload: 2022.8.1 -> 2022.10.1`                        |
| [`0ba5a52d`](https://github.com/NixOS/nixpkgs/commit/0ba5a52d190b2b3ebd24b70516368bdecdf81e9a) | `gh-dash: 3.4.0 -> 3.4.1`                                                     |
| [`b2c770b9`](https://github.com/NixOS/nixpkgs/commit/b2c770b9934842892392f805300c785af517ea95) | `tidal-hifi: generate hicolor icon set and use it in .desktop file (#193186)` |
| [`5a14d519`](https://github.com/NixOS/nixpkgs/commit/5a14d5190b6a6bd4c0b606f479071054e0234535) | `flyctl: 0.0.383 -> 0.0.402`                                                  |
| [`1e1a63f6`](https://github.com/NixOS/nixpkgs/commit/1e1a63f6d2ded41d534a8887a238aa7b84d46e04) | `flow: 0.188.0 -> 0.188.1`                                                    |
| [`aaef97d1`](https://github.com/NixOS/nixpkgs/commit/aaef97d1e745302d734e7ca576a3730750b38458) | `python310Packages.boxx: 0.10.6 -> 0.10.7`                                    |
| [`af752650`](https://github.com/NixOS/nixpkgs/commit/af752650eb4c36fb8080b74424f914e3ff6f547e) | `python310Packages.dwdwfsapi: disable on older  Python releases`              |
| [`2cf30038`](https://github.com/NixOS/nixpkgs/commit/2cf300385873504337a1af0502d9d10f8f4613df) | `pgadmin4: 6.13 -> 6.14`                                                      |
| [`5652fe29`](https://github.com/NixOS/nixpkgs/commit/5652fe2948ab0cc7b988ef3334f413870ffd5556) | `python310Packages.weconnect-mqtt: 0.39.2 -> 0.40.1`                          |
| [`7921ab6a`](https://github.com/NixOS/nixpkgs/commit/7921ab6a2c85b908e5926cb0db34a567868bf8ad) | `python310Packages.weconnect: handle extra dependencies`                      |
| [`708ec5b4`](https://github.com/NixOS/nixpkgs/commit/708ec5b43a6bf0d2d107f1bd37a8ff8d02a973b3) | `fclones: 0.29.0 -> 0.29.1`                                                   |
| [`0e4b9cd0`](https://github.com/NixOS/nixpkgs/commit/0e4b9cd06d07d60b557d36473707c5c96745f1ad) | `python310Packages.dwdwfsapi: 1.0.5 -> 1.0.6`                                 |
| [`f88dfed4`](https://github.com/NixOS/nixpkgs/commit/f88dfed48e9f95536214070dfce6981c6a1b7ed2) | `steampipe: 0.15.3 -> 0.16.4`                                                 |
| [`b912f348`](https://github.com/NixOS/nixpkgs/commit/b912f34820c153456348b55e51e00a4c9774a6dc) | `doctl: 1.82.0 -> 1.82.2`                                                     |
| [`637e53f4`](https://github.com/NixOS/nixpkgs/commit/637e53f4cc8090bccc9d600e1a9fc6583188d3fb) | `dnsproxy: 0.45.1 -> 0.45.2`                                                  |
| [`7b75f98d`](https://github.com/NixOS/nixpkgs/commit/7b75f98df50df3e0b7a80e0bedcf65a22e75357a) | `python310Packages.aioswitcher: 3.0.2 -> 3.0.3`                               |
| [`96349ba9`](https://github.com/NixOS/nixpkgs/commit/96349ba99b14386d0098fb32a15e691b5353bcea) | `python310Packages.aiowebostv: 0.2.0 -> 0.2.1`                                |
| [`67a07358`](https://github.com/NixOS/nixpkgs/commit/67a07358810d4ee3f45604954e14035f32ac23e7) | `plex: 1.28.2.6151-914ddd2b3 -> 1.29.0.6244-819d3678c`                        |
| [`3df3bbdc`](https://github.com/NixOS/nixpkgs/commit/3df3bbdc50111caac67251801b13b312fa011b5c) | `nixos/nixos-build-vms: fix eval`                                             |
| [`5b82a055`](https://github.com/NixOS/nixpkgs/commit/5b82a0559d98ba697717e50faffdc01988d25af0) | `python310Packages.aiohomekit: 1.5.12 -> 2.0.1`                               |
| [`e7fc6763`](https://github.com/NixOS/nixpkgs/commit/e7fc67638a3fd97b14442419fc2b7a12c12d2f60) | `brev-cli: 0.6.114 -> 0.6.116`                                                |
| [`85106f37`](https://github.com/NixOS/nixpkgs/commit/85106f3741545a818b16e9dd04232115f946948c) | `jot: init at 0.1.1 (#193732)`                                                |
| [`5d07e0f0`](https://github.com/NixOS/nixpkgs/commit/5d07e0f0886f0893903e8392f5d2798de38fec57) | `python310Packages.awesomeversion: 22.8.0 -> 22.9.0`                          |
| [`1000b93b`](https://github.com/NixOS/nixpkgs/commit/1000b93ba6f46bb839fcf6fc643ed499c895b2d1) | `python310Packages.peaqevcore: 6.0.0 -> 6.0.3`                                |
| [`cb81a9ca`](https://github.com/NixOS/nixpkgs/commit/cb81a9ca94e7631bc67788d858e214d56571983a) | `ocamlPackages.mldoc: 1.4.8 -> 1.4.9`                                         |
| [`4f744eed`](https://github.com/NixOS/nixpkgs/commit/4f744eed582d6cb12f596a5e6c279622c65694f4) | `ocamlPackages.otoml: 1.0.1 -> 1.0.2`                                         |
| [`749fb432`](https://github.com/NixOS/nixpkgs/commit/749fb432008e97c21f927efdf20093b6a2bbec76) | `pdsh: Fix building on aarch64-darwin`                                        |
| [`1ca01b26`](https://github.com/NixOS/nixpkgs/commit/1ca01b264b57d6574f606d793bf7b074df4a6f86) | `python3Packages.msrest: 0.6.21 -> 0.7.1`                                     |
| [`06566fc8`](https://github.com/NixOS/nixpkgs/commit/06566fc86c7b7d48ff2158aa12298d3c0411f77f) | `python3Packages.vsts: relax msrest dependency`                               |
| [`6350f1b1`](https://github.com/NixOS/nixpkgs/commit/6350f1b106e441761a12bb23acf3350dda3446de) | `php: enable sysvsem by default`                                              |
| [`cc731c92`](https://github.com/NixOS/nixpkgs/commit/cc731c92773c218ea2fa22b40237acbb2e3090c4) | `iaito: 5.7.4 -> 5.7.6`                                                       |
| [`534e5629`](https://github.com/NixOS/nixpkgs/commit/534e5629af1235c0f44959761916ffbe85b4a4ec) | `nixos/tests/make-test-python.nix: Restore stand-alone invocation`            |
| [`59005001`](https://github.com/NixOS/nixpkgs/commit/590050018d14a915c6ca5e1526627b089f2fd957) | `godns: 2.8.9 -> 2.9.0`                                                       |
| [`ff8794f1`](https://github.com/NixOS/nixpkgs/commit/ff8794f1b56cc756ecd17787bebc4ba2bf03a168) | `pkgsMusl.libxcrypt: fix build`                                               |
| [`82517bf1`](https://github.com/NixOS/nixpkgs/commit/82517bf14e7ddd069a78568fee3ced2e0dbdf470) | `mysql-client: fix fallout from removing this alias`                          |
| [`2982e21d`](https://github.com/NixOS/nixpkgs/commit/2982e21d32e6f3e2c5be53eb845a89415c0d1b98) | `python3Packages.casa-format-io: 0.2 -> 0.2.1`                                |
| [`11b5e0c5`](https://github.com/NixOS/nixpkgs/commit/11b5e0c5b740dbcbff14db0eba1d29053aa3fc1e) | `snapcast: Add macos support`                                                 |
| [`1330ca31`](https://github.com/NixOS/nixpkgs/commit/1330ca311c0f1737e06f0bcbaab68c3fa07b65e4) | `ocamlPackages.ocp-index: 1.3.3 -> 1.3.4`                                     |
| [`4f647e91`](https://github.com/NixOS/nixpkgs/commit/4f647e91a86ceb863a0e3135ca0c74d7476f9815) | `zrepl: fix build with go 1.18`                                               |
| [`92ea9b65`](https://github.com/NixOS/nixpkgs/commit/92ea9b65d820f398cb572797bdfea284309ee61c) | `pantalaimon: 0.10.4 -> 0.10.5`                                               |
| [`45215f47`](https://github.com/NixOS/nixpkgs/commit/45215f4701e4de4da3c2d49f62ffa5ce3456d74b) | `python310Packages.aioswitcher: 3.0.0 -> 3.0.2`                               |
| [`b0b4034d`](https://github.com/NixOS/nixpkgs/commit/b0b4034d01822dc875439a294a7e8767251ba499) | `flyway: 9.3.1 -> 9.4.0`                                                      |
| [`f3cf5a09`](https://github.com/NixOS/nixpkgs/commit/f3cf5a091205708247ebf1c4b84bc8ade508664a) | `python3Packages.matrix-nio: 0.19.0 -> 0.20.0`                                |
| [`693a215b`](https://github.com/NixOS/nixpkgs/commit/693a215bb87b440a999592190444b959cce1c087) | `python3Packages.azure-core: remove msrest as dependency`                     |
| [`2d66f08d`](https://github.com/NixOS/nixpkgs/commit/2d66f08d28439ef9c1ca3970557b36cf416da90a) | `plantuml-c4: Add sprites library`                                            |
| [`cec24ab1`](https://github.com/NixOS/nixpkgs/commit/cec24ab1c8b51b3ae975ea4ed40fab35e2de072b) | `plantuml-c4: init at unstable-2022-08-21`                                    |
| [`89b29c62`](https://github.com/NixOS/nixpkgs/commit/89b29c6217be020a5717f32246260e41926a5b66) | `eksctl: 0.112.0 -> 0.113.0`                                                  |
| [`ed1577d1`](https://github.com/NixOS/nixpkgs/commit/ed1577d17dd639c1a315b343740295ff6224499c) | `haskellPackages: mark builds failing on hydra as broken`                     |
| [`05a85c42`](https://github.com/NixOS/nixpkgs/commit/05a85c42b56cccdd5977414b9c944e30995e1429) | `diffoscope: 222 -> 223`                                                      |
| [`7cd0de9b`](https://github.com/NixOS/nixpkgs/commit/7cd0de9b17d00965770d9fc2825a34a7f13fd310) | `fzf: build with go 1.19`                                                     |
| [`b27ca41f`](https://github.com/NixOS/nixpkgs/commit/b27ca41f15d52fe7285dd3bca35dd0e056d0721e) | `python310Packages.yalexs: 1.2.3 -> 1.2.4`                                    |
| [`7f4b5f68`](https://github.com/NixOS/nixpkgs/commit/7f4b5f686a94003d8135648b9ade965673f75d4a) | `python310Packages.weconnect: 0.47.1 -> 0.48.1`                               |
| [`81aeccf5`](https://github.com/NixOS/nixpkgs/commit/81aeccf50f595b8a4d50f519cf6faefa9af491f2) | `act: 0.2.31 -> 0.2.32`                                                       |
| [`2b41f1c7`](https://github.com/NixOS/nixpkgs/commit/2b41f1c73a915af1adeb596b27d8d8bc8735dbda) | `python310Packages.sensor-state-data: 2.8.0 -> 2.9.0`                         |
| [`0c52d583`](https://github.com/NixOS/nixpkgs/commit/0c52d58322279ca549523ba35e218efa20295b08) | `python310Packages.aiopvapi: 2.0.1 -> 2.0.2`                                  |
| [`54724e7f`](https://github.com/NixOS/nixpkgs/commit/54724e7f329c345b9047135886e674b1825e61da) | `python310Packages.pylutron-caseta: 0.15.2 -> 0.16.0`                         |
| [`146aa898`](https://github.com/NixOS/nixpkgs/commit/146aa898d0e28098ba436010a42dc4f888771b55) | `python310Packages.plugwise: 0.22.1 -> 0.23.0`                                |
| [`4c8c97e7`](https://github.com/NixOS/nixpkgs/commit/4c8c97e78960a0c97eae10b879a682f170a656e3) | `python310Packages.nomadnet: 0.2.1 -> 0.2.2`                                  |
| [`bfa9c717`](https://github.com/NixOS/nixpkgs/commit/bfa9c717c3f471f8d8383d65cee48fbfa42f63de) | `python310Packages.lxmf: 0.1.7 -> 0.1.8`                                      |
| [`31100e2e`](https://github.com/NixOS/nixpkgs/commit/31100e2ee7f90f7f11cd52835f28f02680c746d2) | `python310Packages.rns: 0.3.11 -> 0.3.12`                                     |
| [`b520c27d`](https://github.com/NixOS/nixpkgs/commit/b520c27d3d4b0924a63e8b205b9bdc603378c7a2) | `python310Packages.govee-ble: 0.19.0 -> 0.19.1`                               |
| [`af96f22f`](https://github.com/NixOS/nixpkgs/commit/af96f22fd80a1ffe7e680866afdbc415ac37ec3d) | `python310Packages.fjaraskupan: 2.0.1 -> 2.1.0`                               |
| [`4375fc66`](https://github.com/NixOS/nixpkgs/commit/4375fc660eb01a0d0650ed4575e3003678d66dda) | `actionlint: 1.6.19 -> 1.6.20`                                                |
| [`eee41789`](https://github.com/NixOS/nixpkgs/commit/eee417892ebbfd1fd19cb3067be8dda1730eb154) | `ookla-speedtest: 1.1.1 -> 1.2.0`                                             |
| [`d4572a24`](https://github.com/NixOS/nixpkgs/commit/d4572a24bc215d445ab05e83014ae23c82266b1c) | `kconf: use default buildGoModule`                                            |
| [`e5700377`](https://github.com/NixOS/nixpkgs/commit/e57003773608a1fecb7b4b7dd5dbf3739cd0f867) | `batsignal: 1.6.0 -> 1.6.2`                                                   |
| [`af1b30a4`](https://github.com/NixOS/nixpkgs/commit/af1b30a46345e4c738a17aaa12b18019b717a007) | `yoshimi: 2.2.1 -> 2.2.2.1`                                                   |
| [`2f06a5fb`](https://github.com/NixOS/nixpkgs/commit/2f06a5fb8eec97b4bd0aaaeb952ae5b6b62c292e) | `wimlib: 1.13.5 -> 1.13.6`                                                    |
| [`0a3e6b07`](https://github.com/NixOS/nixpkgs/commit/0a3e6b071bb17f6ed920446d8a15b034f972eaf5) | `vttest: 20220215 -> 20220827`                                                |
| [`4e47d686`](https://github.com/NixOS/nixpkgs/commit/4e47d686bdf9af07b4b0c1b29028c2539df80a8d) | `wxSVG: 1.5.23 -> 1.5.24`                                                     |
| [`ef6baeef`](https://github.com/NixOS/nixpkgs/commit/ef6baeef5835d12f29425df03ea740b1a29afc5c) | `gallery-dl: 1.23.1 -> 1.23.2`                                                |
| [`4a758b5d`](https://github.com/NixOS/nixpkgs/commit/4a758b5da3e987dd0e4107d5ce3382c0ae5478b1) | `tdesktop: 4.2.0 -> 4.2.4`                                                    |
| [`5e618226`](https://github.com/NixOS/nixpkgs/commit/5e618226cc18e7b8d13d041e26fd3090ea1c4471) | `uacme: 1.7.2 -> 1.7.3`                                                       |
| [`c1ec1f33`](https://github.com/NixOS/nixpkgs/commit/c1ec1f33b61a6e7647bd5b84cfdc007a2f8105c7) | `squid: enable parallel building`                                             |
| [`5427faad`](https://github.com/NixOS/nixpkgs/commit/5427faad32ee35fe04dc4be2a53f46328386a11e) | `squid: 5.6 -> 5.7`                                                           |
| [`7c547060`](https://github.com/NixOS/nixpkgs/commit/7c5470600aafb1764f33b9624ba9dd0e17184fd1) | `worker: 4.10.1 -> 4.11.0`                                                    |
| [`23d73af5`](https://github.com/NixOS/nixpkgs/commit/23d73af59914a5a768276bd07e00cc1286a073be) | `qcad: 3.27.6.7 -> 3.27.6.11`                                                 |
| [`e46cc5e1`](https://github.com/NixOS/nixpkgs/commit/e46cc5e1ec0d3c970fbcae7925cfb62bb4dd4e6a) | `protoc-gen-validate: 0.6.8 -> 0.6.12`                                        |
| [`4d8fa668`](https://github.com/NixOS/nixpkgs/commit/4d8fa668e70d8a0c2e6765a9e785024a8b210cf5) | `system76-firmware: 1.0.42 -> 1.0.43`                                         |
| [`a29c38fe`](https://github.com/NixOS/nixpkgs/commit/a29c38fe52a889570a2b1f796626f2fabd273876) | `tree: 2.0.2 -> 2.0.4`                                                        |
| [`f9736adf`](https://github.com/NixOS/nixpkgs/commit/f9736adfb1cfce39474550a4c330c636cfad8c1f) | `kuttl: 0.11.1 -> 0.13.0`                                                     |
| [`db969c0a`](https://github.com/NixOS/nixpkgs/commit/db969c0adcd5c1be4ea37e6ea6a1cbc9978898d1) | `thermald: 2.5 -> 2.5.1`                                                      |
| [`86d941c4`](https://github.com/NixOS/nixpkgs/commit/86d941c4f44ce2e1b3d938fd8a6b0e908ab36ce4) | `terraria-server: 1.4.3.6 -> 1.4.4.2`                                         |
| [`bb29a9b4`](https://github.com/NixOS/nixpkgs/commit/bb29a9b4f94da24d5489e0cd2c36a7acbf69c729) | `gowitness: 2.4.0 -> 2.4.2`                                                   |
| [`38ab351f`](https://github.com/NixOS/nixpkgs/commit/38ab351f44e1354daf1f311a8568eed050c46129) | `toxiproxy: unpin go1.17`                                                     |
| [`f4a40812`](https://github.com/NixOS/nixpkgs/commit/f4a408122e9def0120cd9709edf5dad9ff1356f4) | `shotgun: 2.2.1 -> 2.3.1`                                                     |
| [`ddd27c44`](https://github.com/NixOS/nixpkgs/commit/ddd27c442687e9b669f60ec5b14ebbc6bbb57d73) | `shellharden: 4.2.0 -> 4.3.0`                                                 |
| [`ebf2df23`](https://github.com/NixOS/nixpkgs/commit/ebf2df23127d2c3d104622484e530498aa8deef1) | `rq: fix version output, add figsoda as a maintainer`                         |
| [`18a40dcc`](https://github.com/NixOS/nixpkgs/commit/18a40dcc195562e130d1e4d07ca483ccb260bae9) | `snapper: 0.10.2 -> 0.10.3`                                                   |
| [`a6213329`](https://github.com/NixOS/nixpkgs/commit/a621332926b9218d7609941ba1092b84fad25147) | `frostwire: mark broken`                                                      |