### PR TITLE
chore(flake/nur): `3b59d61a` -> `4c59c868`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664648742,
-        "narHash": "sha256-srioqYkuLSgEbxKJ23KUEclGF3Cs8lKMXGQE7wYVN2g=",
+        "lastModified": 1664667620,
+        "narHash": "sha256-ae803FY++ea1tKK3pKvRkXsf89UkHQARMcUvnEGOne8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3b59d61a88df487f4365f907723937d8770a1e27",
+        "rev": "4c59c86802a7792f4b30ea42db40c6ea2fde1dc2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4c59c868`](https://github.com/nix-community/NUR/commit/4c59c86802a7792f4b30ea42db40c6ea2fde1dc2) | `automatic update` |