### PR TITLE
chore(flake/emacs-overlay): `99f60719` -> `4bbc5d56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664650955,
-        "narHash": "sha256-YL79fBfF3M8lkvpjNoJU2HvfK34QpFYn5EIjFZ0OThM=",
+        "lastModified": 1664682350,
+        "narHash": "sha256-FX1HgFPonmj2teO1Ub7g2R6y7cR60Eu1PHyJ8MzC0SQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "99f607199684071fef8e8a411d4e5d862cd5647a",
+        "rev": "4bbc5d56111833bad701ac97279625ee17f08352",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`4bbc5d56`](https://github.com/nix-community/emacs-overlay/commit/4bbc5d56111833bad701ac97279625ee17f08352) | `Updated repos/nongnu` |
| [`81634354`](https://github.com/nix-community/emacs-overlay/commit/81634354412acf5d007d657a570fb2eeacb1a5a0) | `Updated repos/melpa`  |