### PR TITLE
chore(flake/nur): `1bce527d` -> `8dc375ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664683784,
-        "narHash": "sha256-vAc/YMABQnixWoj77JeqSpUmxlsRJJMl9MhLDGtNhKw=",
+        "lastModified": 1664686785,
+        "narHash": "sha256-28pUMHPI4gAk+usp1VYKdHkTASVPOuJfbb5SssiSJPo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1bce527ddff7dee9c3cf7f6dc1866bfb55ee06ee",
+        "rev": "8dc375edb5faeae35eb7e1f8d3d26b1826fb1bf5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8dc375ed`](https://github.com/nix-community/NUR/commit/8dc375edb5faeae35eb7e1f8d3d26b1826fb1bf5) | `automatic update` |