### PR TITLE
chore(flake/nur): `8dc375ed` -> `7278c64d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664686785,
-        "narHash": "sha256-28pUMHPI4gAk+usp1VYKdHkTASVPOuJfbb5SssiSJPo=",
+        "lastModified": 1664687384,
+        "narHash": "sha256-8+U5Qz6Kg8QTA9I+BM4omqBa0+7oYhCww2wY0ucQX30=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8dc375edb5faeae35eb7e1f8d3d26b1826fb1bf5",
+        "rev": "7278c64daf838e506eebef592b088b5b9c44e605",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7278c64d`](https://github.com/nix-community/NUR/commit/7278c64daf838e506eebef592b088b5b9c44e605) | `automatic update` |