### PR TITLE
chore(flake/nur): `7278c64d` -> `955d8d3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664687384,
-        "narHash": "sha256-8+U5Qz6Kg8QTA9I+BM4omqBa0+7oYhCww2wY0ucQX30=",
+        "lastModified": 1664694427,
+        "narHash": "sha256-Bl9jUuqrImQ1GVwW0aKWEtZ2wDD6y7pjcFzvt8vbvSY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7278c64daf838e506eebef592b088b5b9c44e605",
+        "rev": "955d8d3eb40a6aef482f922b5c985415fedb0936",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`955d8d3e`](https://github.com/nix-community/NUR/commit/955d8d3eb40a6aef482f922b5c985415fedb0936) | `automatic update` |