### PR TITLE
chore(flake/nur): `955d8d3e` -> `f68c2aa6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664694427,
-        "narHash": "sha256-Bl9jUuqrImQ1GVwW0aKWEtZ2wDD6y7pjcFzvt8vbvSY=",
+        "lastModified": 1664701741,
+        "narHash": "sha256-ALbVE7EW0otvAjFCQOCZ9OO8ItKdBGPT4nFPv3rkjhk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "955d8d3eb40a6aef482f922b5c985415fedb0936",
+        "rev": "f68c2aa69c95ba7e7b76cbb509532f72871f2628",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f68c2aa6`](https://github.com/nix-community/NUR/commit/f68c2aa69c95ba7e7b76cbb509532f72871f2628) | `automatic update` |
| [`b70d5950`](https://github.com/nix-community/NUR/commit/b70d595007dd8f961d784225bdbba0acc289d7f3) | `automatic update` |