### PR TITLE
chore(flake/emacs-overlay): `4bbc5d56` -> `70787f42`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664682350,
-        "narHash": "sha256-FX1HgFPonmj2teO1Ub7g2R6y7cR60Eu1PHyJ8MzC0SQ=",
+        "lastModified": 1664705374,
+        "narHash": "sha256-ONIxfaS94t8NjoT7zMlz+e/Xa+k9d4Uhkys/IMls2A4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4bbc5d56111833bad701ac97279625ee17f08352",
+        "rev": "70787f42dbf53b8a57c4b9181fd98da1d710ac5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`70787f42`](https://github.com/nix-community/emacs-overlay/commit/70787f42dbf53b8a57c4b9181fd98da1d710ac5b) | `Updated repos/melpa` |