### PR TITLE
chore(flake/nur): `f68c2aa6` -> `93044171`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664701741,
-        "narHash": "sha256-ALbVE7EW0otvAjFCQOCZ9OO8ItKdBGPT4nFPv3rkjhk=",
+        "lastModified": 1664707264,
+        "narHash": "sha256-secIHyCftK3XqnPtI5g1Kh90yHvGN/gxKkgB/5Bb54w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f68c2aa69c95ba7e7b76cbb509532f72871f2628",
+        "rev": "93044171d44b05073b545245b1438232aff4abd9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`93044171`](https://github.com/nix-community/NUR/commit/93044171d44b05073b545245b1438232aff4abd9) | `automatic update` |