### PR TITLE
chore(flake/emacs-overlay): `70787f42` -> `4544e7ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664705374,
-        "narHash": "sha256-ONIxfaS94t8NjoT7zMlz+e/Xa+k9d4Uhkys/IMls2A4=",
+        "lastModified": 1664735790,
+        "narHash": "sha256-yaQjvRw7tCqjcPwtb9A09Oo6cXGYkohvlAyNoCCBaHI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "70787f42dbf53b8a57c4b9181fd98da1d710ac5b",
+        "rev": "4544e7ba035b25e0abb74364192f73ef04e3e599",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`4544e7ba`](https://github.com/nix-community/emacs-overlay/commit/4544e7ba035b25e0abb74364192f73ef04e3e599) | `Updated repos/melpa` |