### PR TITLE
chore(flake/nur): `392b2628` -> `c13bb7bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664718272,
-        "narHash": "sha256-BNnUks1BKzBr8HzoKBFQ8a7/avQhDkKCu0DSgW1ulcY=",
+        "lastModified": 1664766624,
+        "narHash": "sha256-kpt8+KJa+y7jnteeEL6618pMvH5Uw4TEzkAvyG2STjs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "392b26288ad1cdebd03eac17adb70491f9f392d3",
+        "rev": "c13bb7bb4ed055a0acf2c841cc75a0eaf32797d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c13bb7bb`](https://github.com/nix-community/NUR/commit/c13bb7bb4ed055a0acf2c841cc75a0eaf32797d0) | `automatic update` |