### PR TITLE
chore(flake/nur): `c13bb7bb` -> `9d6ca7fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664766624,
-        "narHash": "sha256-kpt8+KJa+y7jnteeEL6618pMvH5Uw4TEzkAvyG2STjs=",
+        "lastModified": 1664770092,
+        "narHash": "sha256-wMQFiNyQrtGNphOI5O8W0P0v5BqudgrThtqiG1yw2GQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c13bb7bb4ed055a0acf2c841cc75a0eaf32797d0",
+        "rev": "9d6ca7fa319d7047cd0dfe8a1d7c6c62ba8d520e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9d6ca7fa`](https://github.com/nix-community/NUR/commit/9d6ca7fa319d7047cd0dfe8a1d7c6c62ba8d520e) | `automatic update` |