### PR TITLE
chore(flake/nur): `9d6ca7fa` -> `50e068d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664770092,
-        "narHash": "sha256-wMQFiNyQrtGNphOI5O8W0P0v5BqudgrThtqiG1yw2GQ=",
+        "lastModified": 1664771663,
+        "narHash": "sha256-docmiyEk2yG4ZOOR/+FYnhEsWi3ihNxB8hqUvTKNjLI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9d6ca7fa319d7047cd0dfe8a1d7c6c62ba8d520e",
+        "rev": "50e068d4eaa2819e10f9c7b8bbc1a0a3c0e20abe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`50e068d4`](https://github.com/nix-community/NUR/commit/50e068d4eaa2819e10f9c7b8bbc1a0a3c0e20abe) | `automatic update` |