### PR TITLE
chore(flake/nur): `50e068d4` -> `cf53704d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664771663,
-        "narHash": "sha256-docmiyEk2yG4ZOOR/+FYnhEsWi3ihNxB8hqUvTKNjLI=",
+        "lastModified": 1664774191,
+        "narHash": "sha256-kzC17MTN4HaXms0GB3kKWtw/W2GaUIFmU17Au0XG6D8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "50e068d4eaa2819e10f9c7b8bbc1a0a3c0e20abe",
+        "rev": "cf53704d383d1684ac2e69e6448808e700ac24e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`cf53704d`](https://github.com/nix-community/NUR/commit/cf53704d383d1684ac2e69e6448808e700ac24e2) | `automatic update` |