### PR TITLE
chore(flake/home-manager): `a7f0cc2d` -> `e4e639dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664573442,
-        "narHash": "sha256-AovlSIuJfMf8n9QLNUVtsCul+NVHIoen7APH2fLls3k=",
+        "lastModified": 1664783440,
+        "narHash": "sha256-KlMwR7mUf5h8MPnzV7nGFUAt6ih/euW5xgvZ5x+hwvI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a7f0cc2d7b271b4a5df9b9e351d556c172f7e903",
+        "rev": "e4e639dd4dc3e431aa5b5f95325f9a66ac7e0dd9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`e4e639dd`](https://github.com/nix-community/home-manager/commit/e4e639dd4dc3e431aa5b5f95325f9a66ac7e0dd9) | `programs/lieer: use lieer package (#3262)` |