### PR TITLE
chore(flake/emacs-overlay): `bcd8fd24` -> `be61e563`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664767651,
-        "narHash": "sha256-fhobF1RdthAJltNXuZXTdRDbx2BPl1GA0QI2+mndMYE=",
+        "lastModified": 1664793678,
+        "narHash": "sha256-RCSaFgr3ClSNuPyYRWcnUfFVud9vJsGMf5oB+9CA0SA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bcd8fd243f70247e0c5792abb3e57204f5b30409",
+        "rev": "be61e5636f4c7478c0093ace59bc7512e320feaa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                     |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
| [`be61e563`](https://github.com/nix-community/emacs-overlay/commit/be61e5636f4c7478c0093ace59bc7512e320feaa) | `Updated repos/nongnu`                             |
| [`8ff39aa2`](https://github.com/nix-community/emacs-overlay/commit/8ff39aa20ce4d206baa22e10d807fcac77ccfe91) | `Updated repos/melpa`                              |
| [`6c1b2aae`](https://github.com/nix-community/emacs-overlay/commit/6c1b2aae7d74f1f41fe7a54579981ae742f160dd) | `Add workaround to fix failing Hydra for emacsGit` |