### PR TITLE
chore(flake/nur): `1f68e524` -> `89388f07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664783789,
-        "narHash": "sha256-buQ0uzeo9ntjhg99tOkkEm7Pyee57JtKxhVkQVcoLM4=",
+        "lastModified": 1664804515,
+        "narHash": "sha256-wfKkUmumPfF1a5M6iPnFCHcL9H5ynXf5mzYbRde7sUo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1f68e5245428cb171ac0d48e6808da3b03d1d987",
+        "rev": "89388f07bc056f8948d3ed0903eaee5f449a1502",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`89388f07`](https://github.com/nix-community/NUR/commit/89388f07bc056f8948d3ed0903eaee5f449a1502) | `automatic update` |