### PR TITLE
chore(flake/nur): `89388f07` -> `b8e93f0a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664804515,
-        "narHash": "sha256-wfKkUmumPfF1a5M6iPnFCHcL9H5ynXf5mzYbRde7sUo=",
+        "lastModified": 1664806955,
+        "narHash": "sha256-LECT7sJqtb6AG/DSDEqgfeGdC0C8X7lgJyhJTz4Oo/Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "89388f07bc056f8948d3ed0903eaee5f449a1502",
+        "rev": "b8e93f0a6cb89e6b6e0c3ebcb9e0e7bcb7bdb250",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b8e93f0a`](https://github.com/nix-community/NUR/commit/b8e93f0a6cb89e6b6e0c3ebcb9e0e7bcb7bdb250) | `automatic update` |