### PR TITLE
chore(flake/nur): `b8e93f0a` -> `954e8f47`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664806955,
-        "narHash": "sha256-LECT7sJqtb6AG/DSDEqgfeGdC0C8X7lgJyhJTz4Oo/Q=",
+        "lastModified": 1664808736,
+        "narHash": "sha256-vgAPl6xabHNDeYw8TTKe8isqnfTCKykbNTxy4Tw5PRo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b8e93f0a6cb89e6b6e0c3ebcb9e0e7bcb7bdb250",
+        "rev": "954e8f47acf514a199faaa5520265c1cb68b7ca4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`954e8f47`](https://github.com/nix-community/NUR/commit/954e8f47acf514a199faaa5520265c1cb68b7ca4) | `automatic update` |
| [`822f7e08`](https://github.com/nix-community/NUR/commit/822f7e08d84fe56517e648d456b9461573597d2b) | `automatic update` |