### PR TITLE
chore(flake/nur): `bb2c11b4` -> `4288955b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664819643,
-        "narHash": "sha256-CqQYwm3o41dXkVNEz+xZNe22xiUnPdy56GrGb/SyFSE=",
+        "lastModified": 1664821594,
+        "narHash": "sha256-6JwYS9j/V5dg+hbc+gkJN/HQKUtiD9TaxqYU4y/Bqsk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bb2c11b4925c05f29906373bbc6675d8ccd6be8d",
+        "rev": "4288955ba490785d9275491b3f8d792c27399b43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4288955b`](https://github.com/nix-community/NUR/commit/4288955ba490785d9275491b3f8d792c27399b43) | `automatic update` |