### PR TITLE
chore(flake/nur): `4288955b` -> `c1a2ab70`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664821594,
-        "narHash": "sha256-6JwYS9j/V5dg+hbc+gkJN/HQKUtiD9TaxqYU4y/Bqsk=",
+        "lastModified": 1664823991,
+        "narHash": "sha256-5003SEJPepb2jDITFMua1sBoMDSE8sQotQicRBvWiLg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4288955ba490785d9275491b3f8d792c27399b43",
+        "rev": "c1a2ab70582831a66f95d9a682b94c3e2974926c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c1a2ab70`](https://github.com/nix-community/NUR/commit/c1a2ab70582831a66f95d9a682b94c3e2974926c) | `automatic update` |
| [`52bf8e72`](https://github.com/nix-community/NUR/commit/52bf8e7266da79b1777a7a2df4f68b0b2523b8ac) | `automatic update` |