### PR TITLE
chore(flake/emacs-overlay): `be61e563` -> `a28b388b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664793678,
-        "narHash": "sha256-RCSaFgr3ClSNuPyYRWcnUfFVud9vJsGMf5oB+9CA0SA=",
+        "lastModified": 1664825376,
+        "narHash": "sha256-B69YeBaZ9fTEjwXKQ2AHfL5PxwMxuUwEbnIlcmfSzlk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "be61e5636f4c7478c0093ace59bc7512e320feaa",
+        "rev": "a28b388b022a5fb6f8700ba04eb4d57d2e36abb6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`a28b388b`](https://github.com/nix-community/emacs-overlay/commit/a28b388b022a5fb6f8700ba04eb4d57d2e36abb6) | `Updated repos/melpa` |
| [`15d6f9f2`](https://github.com/nix-community/emacs-overlay/commit/15d6f9f211088faedba7e8a491a724a620d211e9) | `Updated repos/emacs` |