### PR TITLE
chore(flake/nur): `dfaf8b1d` -> `5ee111ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664828497,
-        "narHash": "sha256-k8msq/sdqCXIdQTFdmTcHQjjPwjGk+DlroxuEKezg+8=",
+        "lastModified": 1664830042,
+        "narHash": "sha256-t3n3LFT3FdKk81v8ZUtV0kysj2o2Rmg36rdPUD6sivI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dfaf8b1dc6e217ea2e62eff2d2565b199fd2c663",
+        "rev": "5ee111ca8d4811a5ae5b6f1692d04feacac43044",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5ee111ca`](https://github.com/nix-community/NUR/commit/5ee111ca8d4811a5ae5b6f1692d04feacac43044) | `automatic update` |