### PR TITLE
chore(flake/nixpkgs): `59d2991d` -> `fd54651f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -277,11 +277,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664687381,
-        "narHash": "sha256-9czSuDzS+OGGwq2kC4KXBLXWfYaup+oLB+AA1Md25U4=",
+        "lastModified": 1664780719,
+        "narHash": "sha256-Oxe6la5dSqRfJogjtY4sRzJjDDqvroJIVkcGEOT87MA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "59d2991d4256cdca1c0cda45d876c80a0fe45c31",
+        "rev": "fd54651f5ffb4a36e8463e0c327a78442b26cbe7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`897b8fa5`](https://github.com/NixOS/nixpkgs/commit/897b8fa5fbabe0f6cf341ae4899d037826239d56) | `python310Packages.pynobo: disable on older Python relleases`                       |
| [`28fd333c`](https://github.com/NixOS/nixpkgs/commit/28fd333c1dcbcc9893c25702f13f2b867723183e) | `uwimap: fix build on darwin`                                                       |
| [`97889527`](https://github.com/NixOS/nixpkgs/commit/978895272f8366f1a8545b26365ec0039b42ab5d) | `safe: unpin go1.17`                                                                |
| [`fca54275`](https://github.com/NixOS/nixpkgs/commit/fca54275947cd6b7698bbc3d7cd25920174666a5) | `gophernotes: unpin go1.17`                                                         |
| [`009650d1`](https://github.com/NixOS/nixpkgs/commit/009650d1ea1f496103a8ef96ead4d39b4c1f3a01) | `python310Packages.pyswitchbot: 0.19.8 -> 0.19.13`                                  |
| [`fdea7ee0`](https://github.com/NixOS/nixpkgs/commit/fdea7ee093d24adcc96666e4238d08ca656b213e) | `python310Packages.pyoctoprintapi: 0.1.8 -> 0.1.9`                                  |
| [`91290ad7`](https://github.com/NixOS/nixpkgs/commit/91290ad711cc18e63d42a2e41ea29d9c97952f4c) | `python310Packages.pynobo: 1.4.0 -> 1.5.0`                                          |
| [`f80241ac`](https://github.com/NixOS/nixpkgs/commit/f80241ac54d9a17d0f5719f5b62d5d80afac3c84) | `julia_18-bin: 1.8.1 -> 1.8.2`                                                      |
| [`c2524134`](https://github.com/NixOS/nixpkgs/commit/c2524134627a12c61f44195ac61418f219eadee5) | `python310Packages.pydmd: 0.4.0.post2209 -> 0.4.0.post2210`                         |
| [`a9d24bd6`](https://github.com/NixOS/nixpkgs/commit/a9d24bd6573bb7d57079eb7701b8588cfb563ebd) | `julia_18: 1.8.1 -> 1.8.2`                                                          |
| [`9d841939`](https://github.com/NixOS/nixpkgs/commit/9d84193910eea557ec836613c4c9b18eeff36c42) | `ruff: 0.0.49 -> 0.0.50`                                                            |
| [`156ce9ef`](https://github.com/NixOS/nixpkgs/commit/156ce9efebc55e6e36c2a3984a33d8353495e38d) | `python310Packages.pex: 2.1.106 -> 2.1.107`                                         |
| [`9ace6689`](https://github.com/NixOS/nixpkgs/commit/9ace66898fc8aedd673013e1de949edcec6e9940) | `octosql: 0.10.0 -> 0.11.0`                                                         |
| [`e1fdf86f`](https://github.com/NixOS/nixpkgs/commit/e1fdf86f7808cafdd2844d21a815a7e13f851a85) | `cargo-tally: 1.0.15 -> 1.0.16`                                                     |
| [`182018b8`](https://github.com/NixOS/nixpkgs/commit/182018b835ce4d1c586e8f240affe98a00bb6340) | `python310Packages.myst-nb: add changelog to meta`                                  |
| [`594b8a23`](https://github.com/NixOS/nixpkgs/commit/594b8a231cd2f9d869bfcac77c7073de87a0807d) | `python310Packages.myst-nb: 0.17.0 -> 0.17.1`                                       |
| [`aecd4d83`](https://github.com/NixOS/nixpkgs/commit/aecd4d8349b94f9bd5718c74a5b789f233f67326) | `element-desktop.keytar: pass yarnOfflineCache as environment variable`             |
| [`50730bed`](https://github.com/NixOS/nixpkgs/commit/50730bedf5d39e0ddc6995efc65812c46c502a4b) | `element-desktop.seshat: pass yarnOfflineCache as environment variable`             |
| [`835e1109`](https://github.com/NixOS/nixpkgs/commit/835e1109154c41ea4356014fbaf849250192124b) | `gitlab.assets: pass yarnOfflineCache as environment variable`                      |
| [`30b725dd`](https://github.com/NixOS/nixpkgs/commit/30b725dd9b7c3af9e78fd4fb2f16fee75d506b9c) | `peertube: pass yarn caches as environment variables`                               |
| [`499b26b7`](https://github.com/NixOS/nixpkgs/commit/499b26b7b8464238af0b0893c1319ed94425a7f0) | `discourse.assets: pass yarnOfflineCache as environment variable`                   |
| [`f949de4f`](https://github.com/NixOS/nixpkgs/commit/f949de4fbb5c5adb7f3ec085206f48a2efdd1d9a) | `mastodon: pass yarnOfflineCache as environment variable`                           |
| [`aa3dc644`](https://github.com/NixOS/nixpkgs/commit/aa3dc6440efbf5ad99b77ccb170f74c3784c17fd) | `fetchYarnDeps: support passing src attribute (#193047)`                            |
| [`943e48e0`](https://github.com/NixOS/nixpkgs/commit/943e48e0a2b207a8583a43566dc1b70052f3d8aa) | `python310Packages.huawei-lte-api: 1.6.1 -> 1.6.2`                                  |
| [`780986c1`](https://github.com/NixOS/nixpkgs/commit/780986c1e97fc5f9ccf04e4c682673510444483c) | `github-runner: exclude sdk packages from deps`                                     |
| [`9e0a1e7b`](https://github.com/NixOS/nixpkgs/commit/9e0a1e7b8e6441f6ad14510f76d3c1410873c3b3) | `dotnet: update lock files of packages using nuget-to-nix`                          |
| [`b60c9fd2`](https://github.com/NixOS/nixpkgs/commit/b60c9fd2fe52118f460df4ff917caaa513f4f38f) | `nuget-to-nix: find sources deterministically`                                      |
| [`f8763b87`](https://github.com/NixOS/nixpkgs/commit/f8763b87e0629828733ab6288230bb6105484992) | `nuget-to-nix: exclude by package source, not list`                                 |
| [`b22074a4`](https://github.com/NixOS/nixpkgs/commit/b22074a46eaf7909778f39712733f92ffa7f1ac7) | `omnisharp-roslyn: fix build on dotnet 6.0.9`                                       |
| [`0eb68747`](https://github.com/NixOS/nixpkgs/commit/0eb6874732bb5eb5eb1525a3034fdf4809855074) | `build-dotnet-module: fix fetch-deps usage message`                                 |
| [`f716d092`](https://github.com/NixOS/nixpkgs/commit/f716d092e257cdbc3811c1b3afa9cade01f6aa5d) | `build-dotnet-module: limit package platforms by sdk support`                       |
| [`b9f52889`](https://github.com/NixOS/nixpkgs/commit/b9f528897f930fd28d93a75bde512d172a876f2b) | `baget: fix package restore errors`                                                 |
| [`9a94932f`](https://github.com/NixOS/nixpkgs/commit/9a94932f3851d6f3e79561641f12de7a7872ee1f) | `python-language-server: restore for current platform only`                         |
| [`965a2ad4`](https://github.com/NixOS/nixpkgs/commit/965a2ad49bab106e675b8078d4753125113a8074) | `ryujinx: restore for current platform only`                                        |
| [`4b40579b`](https://github.com/NixOS/nixpkgs/commit/4b40579b2d3758e5940cf33602001bfe1d44f230) | `build-dotnet-module: clean up tmp file handling`                                   |
| [`b1bc5705`](https://github.com/NixOS/nixpkgs/commit/b1bc570518808a2d9d15c71487f9f2a541fe26b2) | `python310Packages.azure-mgmt-kusto: 2.2.0 -> 3.0.0`                                |
| [`da73e197`](https://github.com/NixOS/nixpkgs/commit/da73e197b08f47620a74a27f4778998284e9fd7a) | `python310Packages.azure-mgmt-netapp: 8.1.0 -> 9.0.0`                               |
| [`7f2cc702`](https://github.com/NixOS/nixpkgs/commit/7f2cc702abb55f94b87c076b23f049c7a7f6037f) | `python310Packages.azure-mgmt-reservations: 2.0.0 -> 2.1.0`                         |
| [`3df202df`](https://github.com/NixOS/nixpkgs/commit/3df202df293e26a201f8f4d60c1f9a9e0d1270df) | `python310Packages.azure-mgmt-security: 1.0.0 -> 2.0.0`                             |
| [`1b28795f`](https://github.com/NixOS/nixpkgs/commit/1b28795f872ddb13c9639b037d2443a9082479df) | `python310Packages.fastapi-mail: 1.1.4 -> 1.1.5`                                    |
| [`a64652f2`](https://github.com/NixOS/nixpkgs/commit/a64652f25e53cd973e50369753d2d63060de55ef) | `kmon: 1.6.0 -> 1.6.2`                                                              |
| [`69ff9c41`](https://github.com/NixOS/nixpkgs/commit/69ff9c417f962e82e88db724e7f42af1d915e7ee) | `windows-nvim: init at 2022-09-18`                                                  |
| [`16b9b0e1`](https://github.com/NixOS/nixpkgs/commit/16b9b0e181f715494b5b0dc8283fce12f207f50b) | `python3.pkgs.tensorboardx: fix build`                                              |
| [`f7262e00`](https://github.com/NixOS/nixpkgs/commit/f7262e00543be771654cfbb6525f10bc5f3e1c4d) | `xorg: remove xlibsWrapper attribute, use top-level one instead`                    |
| [`7af50793`](https://github.com/NixOS/nixpkgs/commit/7af50793539a1864b8b0c4ee40b16ec87b9def6a) | `xine-ui: use xlibsWrapper instead of xorg.xlibsWrapper`                            |
| [`132ef650`](https://github.com/NixOS/nixpkgs/commit/132ef65058e0c30300c190ff4f19583dd580634f) | `vlc: use xlibsWrapper instead of xorg.xlibsWrapper`                                |
| [`b0c751b8`](https://github.com/NixOS/nixpkgs/commit/b0c751b8003fb61b9408c3e38da0c8d69f845a1c) | `ted: use xlibsWrapper instead of xorg.xlibsWrapper`                                |
| [`0bed7c05`](https://github.com/NixOS/nixpkgs/commit/0bed7c059fa6a36c391a7a8633a7dfd2ce348300) | `pulseaudio: use xlibsWrapper instead of xorg.xlibsWrapper`                         |
| [`a6635711`](https://github.com/NixOS/nixpkgs/commit/a6635711da93e9e7681277a9bfddc0b467776543) | `gnome2.libgnomeui: use xlibsWrapper instead of xorg.xlibsWrapper`                  |
| [`2c11f47e`](https://github.com/NixOS/nixpkgs/commit/2c11f47eddd4bd269bd2305b98cb78cb4ef1eb6d) | `cargo-public-api: 0.19.0 -> 0.20.0`                                                |
| [`4c2dca62`](https://github.com/NixOS/nixpkgs/commit/4c2dca627e140292bbbc3dcf15b1d95d769e67a2) | `fulcio: 0.5.3 -> 0.6.0`                                                            |
| [`e63a3267`](https://github.com/NixOS/nixpkgs/commit/e63a3267ca635b085d61ba130400f10bc4cd8aa5) | `python310Packages.kegtron-ble: init at 0.4.0`                                      |
| [`5ebce6ac`](https://github.com/NixOS/nixpkgs/commit/5ebce6acee365f5c1b855432a2448cf7ae743484) | `python310Packages.azure-mgmt-monitor: 4.0.1 -> 5.0.1`                              |
| [`4e62f981`](https://github.com/NixOS/nixpkgs/commit/4e62f9810aab1e90229390af3238a3cc5b1f67e4) | `python310Packages.ibeacon-ble: init at 0.7.3`                                      |
| [`7cb6b325`](https://github.com/NixOS/nixpkgs/commit/7cb6b3251f51704a82a29a40de17db91ecd875c5) | `etesync-dav: add thyol to maintainers`                                             |
| [`d13fec95`](https://github.com/NixOS/nixpkgs/commit/d13fec959153c6a09e06f1df4ee74a8953bc5382) | `python310Packages.azure-mgmt-containerservice: 20.3.0 -> 20.4.0`                   |
| [`d9ff1386`](https://github.com/NixOS/nixpkgs/commit/d9ff13868730f7ebbd6dec059c28b9e1ef8d948b) | `dale: 20181024 -> 20220411`                                                        |
| [`2dc3552a`](https://github.com/NixOS/nixpkgs/commit/2dc3552aa1435ed556b7b9f92779a2310e7fcb31) | `coqPackages.mkCoqDerivation: upgrade to Dune 3`                                    |
| [`1600cba8`](https://github.com/NixOS/nixpkgs/commit/1600cba863b8c047f78b3864a0aa09d1d9941d16) | `Disable checkMeta by default again.`                                               |
| [`5485f678`](https://github.com/NixOS/nixpkgs/commit/5485f678b97ffc1ffb8cc6090e8eb4eb4bfa6218) | `hadoop: 3.3.3 -> 3.3.4, remove outdated protobuf (#193665)`                        |
| [`cff2b7fb`](https://github.com/NixOS/nixpkgs/commit/cff2b7fbb7b0152e8e46117b7a1baddff6fd002f) | `yutto: 2.0.0b13 -> 2.0.0b15`                                                       |
| [`3fdeefc6`](https://github.com/NixOS/nixpkgs/commit/3fdeefc67f431b0a245b047443c707d9432b80f3) | `mediawiki: 1.38.2 -> 1.38.4`                                                       |
| [`605a588e`](https://github.com/NixOS/nixpkgs/commit/605a588ea6d952227fe6554011add1650bfe8eb7) | `nixos/fail2ban: improve module documentation`                                      |
| [`8379e848`](https://github.com/NixOS/nixpkgs/commit/8379e84818d9594b93b37168d07463775084d860) | `pythonPackages.mypy: 0.971 -> 0.981`                                               |
| [`a49bd805`](https://github.com/NixOS/nixpkgs/commit/a49bd8055ea5c640dcebf09a91cfec88615ecfcd) | `devpi-server: 6.2.0 -> 6.7.0`                                                      |
| [`573ee6b5`](https://github.com/NixOS/nixpkgs/commit/573ee6b58c0e0c6cccff175b2ae6d7286f367c34) | `darkhttpd: 1.13 -> 1.14`                                                           |
| [`91766f2a`](https://github.com/NixOS/nixpkgs/commit/91766f2ab6bec64f2aad895c69b72760ee61180f) | `python310Packages.djangorestframework-simplejwt: disable on older Python releases` |
| [`6f72c4aa`](https://github.com/NixOS/nixpkgs/commit/6f72c4aa7676b14b615e64a03c2853f9caf45295) | `python310Packages.google-cloud-logging: update disabled`                           |
| [`cbc685e7`](https://github.com/NixOS/nixpkgs/commit/cbc685e754c84a4a209ec88833aa9750e2d1fa9f) | `apacheHttpdPackages.mod_perl: 2.0.11 -> 2.0.12`                                    |
| [`b1faf42f`](https://github.com/NixOS/nixpkgs/commit/b1faf42f3c078eab125e8dc60909fd717a160047) | `indi-3rdparty: 1.9.3 -> 1.9.8`                                                     |
| [`28356e38`](https://github.com/NixOS/nixpkgs/commit/28356e38016997d3e5a72bfc2193825b6920bc7f) | `indilib: 1.9.6 -> 1.9.8`                                                           |
| [`310701f3`](https://github.com/NixOS/nixpkgs/commit/310701f379beba79ca2d3077b6b50f39657aaf52) | `librem: 2.7.0 -> 2.8.0`                                                            |
| [`ef82bcf9`](https://github.com/NixOS/nixpkgs/commit/ef82bcf93a4ffaca42780d96686061ebec819523) | `baresip: 2.7.0 -> 2.8.1`                                                           |
| [`4c327816`](https://github.com/NixOS/nixpkgs/commit/4c327816735b861c8a707eb2d85bfca69abe6712) | `cozy: 1.2.0 -> 1.2.1`                                                              |
| [`9bec12c2`](https://github.com/NixOS/nixpkgs/commit/9bec12c2e768f836de2b4fbcc3c87c2ba29bf317) | `iozone: 3.490 -> 3.493`                                                            |
| [`0e425bdf`](https://github.com/NixOS/nixpkgs/commit/0e425bdf807c9cb2daba669d944ca28fd6f431d6) | `portfolio-filemanager: fix launching`                                              |
| [`d8bdc24f`](https://github.com/NixOS/nixpkgs/commit/d8bdc24f2162dc737d7a6447a4fe7184b5af1bb7) | `gamescope: 3.11.45-2 -> 3.11.47`                                                   |
| [`0ea8b076`](https://github.com/NixOS/nixpkgs/commit/0ea8b076b136b4f6e65ca9952f7cbd3742b047c7) | `wayland-utils: 1.0.0 -> 1.1.0`                                                     |
| [`198b38f5`](https://github.com/NixOS/nixpkgs/commit/198b38f54d38f3a6031ea9932f133ee06ab19203) | `weston: 10.0.1 -> 11.0.0`                                                          |
| [`41b7ca77`](https://github.com/NixOS/nixpkgs/commit/41b7ca77672af48dcbbb67d0a768bc12c520aa2c) | `weston: sort build inputs`                                                         |
| [`17b937f7`](https://github.com/NixOS/nixpkgs/commit/17b937f7ca487e81ae87b11f5509c7d079abcd3c) | `basex: 10.1 -> 10.2`                                                               |
| [`88d81fcb`](https://github.com/NixOS/nixpkgs/commit/88d81fcb211665627aef302be812a41db01a9cae) | `cargo-nextest: 0.9.36 -> 0.9.37`                                                   |
| [`55ea5b4f`](https://github.com/NixOS/nixpkgs/commit/55ea5b4f179afe20378ab18b322c12f3aab92a56) | `clash-geoip: init at 20220912`                                                     |
| [`fe592d44`](https://github.com/NixOS/nixpkgs/commit/fe592d446f8f387b015f5489d18138fa4b38730d) | `python310Packages.google-cloud-vision: 3.1.2 -> 3.1.3`                             |
| [`bcd1509d`](https://github.com/NixOS/nixpkgs/commit/bcd1509d10ee5427b4cc3d07751493a342354f8a) | `python310Packages.google-cloud-logging: 3.2.2 -> 3.2.3`                            |
| [`d50b74a2`](https://github.com/NixOS/nixpkgs/commit/d50b74a2ea7593c46baf5b0b13fe4e5cce600fe9) | `p4c: 1.2.3.1 -> 1.2.3.2`                                                           |
| [`95bf0d35`](https://github.com/NixOS/nixpkgs/commit/95bf0d35e0623ec7fad711701eece84dfdee76e4) | `python310Packages.djangorestframework-simplejwt: 5.2.0 -> 5.2.1`                   |
| [`5387371e`](https://github.com/NixOS/nixpkgs/commit/5387371e5227c2dfa80c308f1e5588b30be2ee1b) | `nixpacks: 0.8.0 -> 0.9.2`                                                          |
| [`65bc1cda`](https://github.com/NixOS/nixpkgs/commit/65bc1cda0f64b99c77b00706eb8e55279535ba30) | `monero-gui: 0.18.1.1 -> 0.18.1.2`                                                  |
| [`463e3d3b`](https://github.com/NixOS/nixpkgs/commit/463e3d3b32733a2157561569671c425957839f47) | `monero-cli: 0.18.1.1 -> 0.18.1.2`                                                  |
| [`89b1c95a`](https://github.com/NixOS/nixpkgs/commit/89b1c95a552f5eb67e4147ae9669e039aa5c68ca) | `metal-cli: 0.10.0 -> 0.10.2`                                                       |
| [`ac7e7b0d`](https://github.com/NixOS/nixpkgs/commit/ac7e7b0d68b5e75bbc8f62a4368b588ae226984d) | `media-downloader: 2.5.0 -> 2.6.0`                                                  |
| [`9b161752`](https://github.com/NixOS/nixpkgs/commit/9b161752607900c602f67916fa506129741fc143) | `kopia: 0.12.0 -> 0.12.1`                                                           |
| [`13f3b5a3`](https://github.com/NixOS/nixpkgs/commit/13f3b5a33a6b58ea7ac8ec4b01d9a6f78c1359dc) | `mangal: 3.10.0 -> 3.11.0`                                                          |
| [`4bd294d3`](https://github.com/NixOS/nixpkgs/commit/4bd294d3a9ce9095ebcc8456f4eec5533aa9f3c8) | `home-assistant-cli: 0.9.4 -> 0.9.5`                                                |
| [`ee2d4e68`](https://github.com/NixOS/nixpkgs/commit/ee2d4e689f02e64591745d4620a39d6ddefa0f54) | `pactorio: 0.5.2 -> 0.6.0`                                                          |
| [`64bd14d8`](https://github.com/NixOS/nixpkgs/commit/64bd14d866c025b0cc0c8046c41190e805c51a24) | `libre: 2.7.0 -> 2.8.0`                                                             |
| [`e648f3b5`](https://github.com/NixOS/nixpkgs/commit/e648f3b5df0935759415d00e3005813afc5d0774) | `kubemq-community: 2.2.13 -> 2.3.0`                                                 |
| [`e2c30c41`](https://github.com/NixOS/nixpkgs/commit/e2c30c415b473cff71ef3fdf8a11f3cdd99fd159) | `kdigger: 1.3.0 -> 1.4.0`                                                           |
| [`ad4f7319`](https://github.com/NixOS/nixpkgs/commit/ad4f7319630617ea8869a5416b31d50c71586c9a) | `tauon: change maintainer to jansol`                                                |
| [`6a6b44b8`](https://github.com/NixOS/nixpkgs/commit/6a6b44b8c5494de1b05c99e82132b3b05e6117cf) | `skopeo: 1.9.2 -> 1.10.0`                                                           |
| [`16e3fbb7`](https://github.com/NixOS/nixpkgs/commit/16e3fbb782445e0db06a2b5ed83e5ce82a80d52c) | `packr: mark broken on darwin`                                                      |
| [`cea9516b`](https://github.com/NixOS/nixpkgs/commit/cea9516bb82294293509efdb98d3170b6b48b379) | `go-jsonnet: fix aarch64-darwin build`                                              |
| [`fc15a963`](https://github.com/NixOS/nixpkgs/commit/fc15a9638f2e53fe6f09540ec4db64752e58ae4f) | `google-cloud-sdk: 400.0.0 -> 404.0.0`                                              |
| [`be6dfc75`](https://github.com/NixOS/nixpkgs/commit/be6dfc75cae53759be38d31c6e30727cffa2017b) | `ctlptl: 0.8.8 -> 0.8.9`                                                            |
| [`a7cb79af`](https://github.com/NixOS/nixpkgs/commit/a7cb79afe444cfa2757c048723e834026bcebd24) | `squid: enable tests`                                                               |
| [`ad0b61c8`](https://github.com/NixOS/nixpkgs/commit/ad0b61c8e34bbb648b22a60bc0c640204d3dd92c) | `benthos: 4.7.0 -> 4.8.0`                                                           |
| [`73e9cb6a`](https://github.com/NixOS/nixpkgs/commit/73e9cb6a78edb3e2d6c460688554e8afcad61d32) | `ubuntu-font-family: use mkDerivation`                                              |
| [`445f06d9`](https://github.com/NixOS/nixpkgs/commit/445f06d9b70d07e2c8b0f0275b605410d3835f55) | `p2pool: 2.3 -> 2.4`                                                                |
| [`ba9b47f3`](https://github.com/NixOS/nixpkgs/commit/ba9b47f30ff93dde35954337500f89a13d5deacb) | `felix-fm: 1.1.2 -> 1.2.0`                                                          |
| [`394710cf`](https://github.com/NixOS/nixpkgs/commit/394710cfd714e1b506ecc8dc954bd77eda99711f) | `phosh: 0.21.0 -> 0.21.1`                                                           |
| [`af041edd`](https://github.com/NixOS/nixpkgs/commit/af041edd86891c679e72c9c0dc219a07f5a0116b) | `zigbee2mqtt: 1.27.2 -> 1.28.0`                                                     |
| [`8ba36b07`](https://github.com/NixOS/nixpkgs/commit/8ba36b07a8c6e4c050d1ba504aca456ca1b6560a) | `consul-template: 0.29.2 -> 0.29.4`                                                 |
| [`54ce685f`](https://github.com/NixOS/nixpkgs/commit/54ce685fc42899790dab44cd635ee9a5862a054c) | `angelscript: 2.35.1 -> 2.36.0`                                                     |
| [`b1b8bb39`](https://github.com/NixOS/nixpkgs/commit/b1b8bb394e30bda9030dd9939ad05a80ab8638a4) | `xdaliclock: 2.45 -> 2.47`                                                          |
| [`bdbdb2c6`](https://github.com/NixOS/nixpkgs/commit/bdbdb2c625a6c347f70f8cfc1ffa4a4677ae2d5d) | `xapian: add mu to passthru tests`                                                  |
| [`c7e0d2d4`](https://github.com/NixOS/nixpkgs/commit/c7e0d2d4debb21c0cc28a87d186c99b6b59d427c) | `xapian: add changelog to meta`                                                     |
| [`2107c064`](https://github.com/NixOS/nixpkgs/commit/2107c064f9e441a9917c695377a92b681bf31d81) | `xapian: 1.4.20 -> 1.4.21`                                                          |
| [`786df4e6`](https://github.com/NixOS/nixpkgs/commit/786df4e6acbbf0c8aafe6f907f7d85245052b017) | `grafana-agent: 0.24.1 -> 0.25.1`                                                   |
| [`956efd67`](https://github.com/NixOS/nixpkgs/commit/956efd67032b183cd454c500dd7391621c9ba5f6) | `stress-ng: 0.14.03 -> 0.14.06`                                                     |
| [`beff5569`](https://github.com/NixOS/nixpkgs/commit/beff5569504439b8e813020351d8fe5dcd6504a9) | `synergy: 1.14.5.17 -> 1.14.5.22`                                                   |
| [`1fb27ba4`](https://github.com/NixOS/nixpkgs/commit/1fb27ba438efa4d98de19e73bb685fb4f0cae9a3) | `simgear: 2020.3.13 -> 2020.3.14`                                                   |
| [`5b8ed5fc`](https://github.com/NixOS/nixpkgs/commit/5b8ed5fc330402749771fdaedc3206739600d1bd) | `fblog: init at 4.1.0`                                                              |
| [`fe719e3b`](https://github.com/NixOS/nixpkgs/commit/fe719e3b1dffb60e83c9326fc85ae5857a2aeba5) | `remind: 04.00.03 -> 04.01.00`                                                      |
| [`3fb2cb29`](https://github.com/NixOS/nixpkgs/commit/3fb2cb298bf429b9d393090e2ef84ef7fd4ef45d) | `wayshot: 1.1.9 -> 1.2.2`                                                           |
| [`e3d61133`](https://github.com/NixOS/nixpkgs/commit/e3d61133e45f9a20ca145c65e7c210071ee8e524) | `lazycli: init at 0.1.15`                                                           |
| [`803bc179`](https://github.com/NixOS/nixpkgs/commit/803bc1795e52175244ed66c4e46ad4ebfe39a3a4) | `pop-icon-theme: unstable-2021-11-17 -> 3.3.0`                                      |
| [`ff9628be`](https://github.com/NixOS/nixpkgs/commit/ff9628bea65c712e30caae110365e6f75be92bae) | `felix-fm: init at 1.1.2`                                                           |
| [`341d953c`](https://github.com/NixOS/nixpkgs/commit/341d953ca83e3b48e1cc2264aa947d15fdd44f86) | `linux-zen: 5.19.11 -> 5.19.12`                                                     |
| [`de7c7747`](https://github.com/NixOS/nixpkgs/commit/de7c7747959612ee3ff5e868681ac3192c84e3c9) | `linux-lqx: 5.19.11 -> 5.19.12`                                                     |
| [`a6bc31eb`](https://github.com/NixOS/nixpkgs/commit/a6bc31eb8b22bd61c2b5278d33fada7a6a2ea500) | `xterm: 372 -> 373`                                                                 |
| [`850053eb`](https://github.com/NixOS/nixpkgs/commit/850053ebe74a8b4d19d64b0e91b08250625da222) | `nixos/nix-serve: add package option`                                               |
| [`f2c3880e`](https://github.com/NixOS/nixpkgs/commit/f2c3880ed4dbdc570b7995e01732689baa2a3c9c) | `ntfy: disable Darwin-native ntfy backend dependencies`                             |
| [`0491e306`](https://github.com/NixOS/nixpkgs/commit/0491e306700a5e1a02146c477f3435a91036ac82) | `python3Packages.slack-sdk: unmark as broken on Darwin`                             |
| [`d1d41e4f`](https://github.com/NixOS/nixpkgs/commit/d1d41e4fa5cf92e5d35d9aea685929f7cf617b07) | `ntfy: add options to turn off optional features`                                   |
| [`2f32fe9e`](https://github.com/NixOS/nixpkgs/commit/2f32fe9e6dc833fff338188621405bc32fbcda2b) | `vengi-tools: 0.0.20 -> 0.0.21`                                                     |
| [`4cf8a071`](https://github.com/NixOS/nixpkgs/commit/4cf8a071b0091c44a9cf4a850e1f57fd0c7fd922) | `quill: 0.2.7 -> 0.2.17`                                                            |