### PR TITLE
chore(flake/nur): `b722e458` -> `1b6f408a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664853486,
-        "narHash": "sha256-PQnEEAYYWk/DSOIzNJNpLLLd+pzSECdUKLxsMa4Xmmc=",
+        "lastModified": 1664857489,
+        "narHash": "sha256-xuPU/BztU7f+EgKmmqe+6cVxRc2xobOhlTwDMZWDIkQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b722e458d56538ea51e4e4e02553f484bbcd2564",
+        "rev": "1b6f408ac18e2a2b2dbe7bec23bdb27ca49f8ba2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1b6f408a`](https://github.com/nix-community/NUR/commit/1b6f408ac18e2a2b2dbe7bec23bdb27ca49f8ba2) | `automatic update` |
| [`b81a696e`](https://github.com/nix-community/NUR/commit/b81a696e8b8146713ebc21ef583d420702adc285) | `automatic update` |