### PR TITLE
chore(flake/nur): `1b6f408a` -> `b9c55ef5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664857489,
-        "narHash": "sha256-xuPU/BztU7f+EgKmmqe+6cVxRc2xobOhlTwDMZWDIkQ=",
+        "lastModified": 1664858611,
+        "narHash": "sha256-kklUk6XRZsYanEnuYb48CldDwp/FIVlaGo9U1duUxmo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1b6f408ac18e2a2b2dbe7bec23bdb27ca49f8ba2",
+        "rev": "b9c55ef5cda83ed55ffa4f2928af36d28a3a8cc7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b9c55ef5`](https://github.com/nix-community/NUR/commit/b9c55ef5cda83ed55ffa4f2928af36d28a3a8cc7) | `automatic update` |