### PR TITLE
chore(flake/emacs-overlay): `a28b388b` -> `20dc7a0a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664825376,
-        "narHash": "sha256-B69YeBaZ9fTEjwXKQ2AHfL5PxwMxuUwEbnIlcmfSzlk=",
+        "lastModified": 1664860004,
+        "narHash": "sha256-1+FKMhZH7se1Xobo8wRW6CW0Yz4isT9lkZcvYuwVfbs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a28b388b022a5fb6f8700ba04eb4d57d2e36abb6",
+        "rev": "20dc7a0a1ea9c40201c8fe1e29b91a50b5ecba9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`20dc7a0a`](https://github.com/nix-community/emacs-overlay/commit/20dc7a0a1ea9c40201c8fe1e29b91a50b5ecba9b) | `Updated repos/melpa` |
| [`469f35d4`](https://github.com/nix-community/emacs-overlay/commit/469f35d4da07e041dd1059ba26fc9a2cdaa72da3) | `Updated repos/emacs` |