### PR TITLE
chore(flake/nur): `ec3f8863` -> `0262e78b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664866618,
-        "narHash": "sha256-eJZNYKFVubevxkkixhm++8u5VygO11IA9e1q4PjtMuQ=",
+        "lastModified": 1664874376,
+        "narHash": "sha256-Uc2EgQ4prjRwcgLE65NwK+rNXhaHrxH0VeHxY/erlqA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ec3f8863164de94d1463a880f6e715a387d3c733",
+        "rev": "0262e78b2f7d3b43cbb873dd2de879712cd2d3be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0262e78b`](https://github.com/nix-community/NUR/commit/0262e78b2f7d3b43cbb873dd2de879712cd2d3be) | `automatic update` |