### PR TITLE
chore(flake/nur): `529b4b6f` -> `8a7c064e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664894790,
-        "narHash": "sha256-FAixnreJ0bXzK/m5a9KsC5XoiZFHqC4le0tseldsHZc=",
+        "lastModified": 1664908096,
+        "narHash": "sha256-KcZ8IcVjjnVCzyj+7qqoIq9Kb588IJrrR8KQgDqgkF8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "529b4b6fc32b428cd07cc2a11abf728bdc59b4e5",
+        "rev": "8a7c064eb68e087e7f8d8aa041307b2f3e253792",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8a7c064e`](https://github.com/nix-community/NUR/commit/8a7c064eb68e087e7f8d8aa041307b2f3e253792) | `automatic update` |