### PR TITLE
chore(flake/emacs-overlay): `d0c070ee` -> `3c34eaa0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664904447,
-        "narHash": "sha256-8w4ARpE6MvYCSDwdkaDYUM6PIKx3kauyS1ov3ko4ltI=",
+        "lastModified": 1664909116,
+        "narHash": "sha256-uhv9W8MvOlu2X27LBNjfDpsdH6VlzScz1f3cXewDRcU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d0c070ee87cfabfc54dab3f4b4585ee02cb2be14",
+        "rev": "3c34eaa09f5c80c791a71e00b51485af52382ed0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                                      |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
| [`c91c353b`](https://github.com/nix-community/emacs-overlay/commit/c91c353b5dcc077c4ea60d7104ed784330109fe7) | `Split into two overlays: one for emacs and one for emacs packages` |
| [`dfa7c2a8`](https://github.com/nix-community/emacs-overlay/commit/dfa7c2a85b230ca01f259fa8a7305ece9a0c953c) | `Fix non-flake overlay usage`                                       |
| [`a6329647`](https://github.com/nix-community/emacs-overlay/commit/a6329647be7d68aa5525cdec42c3f5a0e4a11a39) | `Move default.nix into overlays dir`                                |