### PR TITLE
chore(flake/emacs-overlay): `3c34eaa0` -> `13e7244f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664909116,
-        "narHash": "sha256-uhv9W8MvOlu2X27LBNjfDpsdH6VlzScz1f3cXewDRcU=",
+        "lastModified": 1664909349,
+        "narHash": "sha256-O+QLXZ7VDJOMlwP+bwx8YxV0Nwl1LsXg2X1GAzvovmg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3c34eaa09f5c80c791a71e00b51485af52382ed0",
+        "rev": "13e7244f79bf4a75def43173386f7a693cd3a696",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                            |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
| [`13e7244f`](https://github.com/nix-community/emacs-overlay/commit/13e7244f79bf4a75def43173386f7a693cd3a696) | `Don't prepend an extra "emacs-" to the unstable tarball` |