### PR TITLE
chore(flake/nur): `8a7c064e` -> `9b4b8a80`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664908096,
-        "narHash": "sha256-KcZ8IcVjjnVCzyj+7qqoIq9Kb588IJrrR8KQgDqgkF8=",
+        "lastModified": 1664910258,
+        "narHash": "sha256-dupG75CATMxNYqyTOpxcbOxHChcqyWKRuLd1oUSX07k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8a7c064eb68e087e7f8d8aa041307b2f3e253792",
+        "rev": "9b4b8a80cf98fc96a71b1b97c414d18f31c54939",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9b4b8a80`](https://github.com/nix-community/NUR/commit/9b4b8a80cf98fc96a71b1b97c414d18f31c54939) | `automatic update` |