### PR TITLE
chore(flake/emacs-overlay): `13e7244f` -> `f0fff2e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664909349,
-        "narHash": "sha256-O+QLXZ7VDJOMlwP+bwx8YxV0Nwl1LsXg2X1GAzvovmg=",
+        "lastModified": 1664912345,
+        "narHash": "sha256-+2e80ecfii9KfchkgyDSGLPhR8OL9t3VzCP8QHPfeb8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "13e7244f79bf4a75def43173386f7a693cd3a696",
+        "rev": "f0fff2e0952e97a9ad733ef96e6fa7d4f3b9fafe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`f0fff2e0`](https://github.com/nix-community/emacs-overlay/commit/f0fff2e0952e97a9ad733ef96e6fa7d4f3b9fafe) | `Updated repos/melpa` |