### PR TITLE
chore(flake/emacs-overlay): `f0fff2e0` -> `c24191e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664912345,
-        "narHash": "sha256-+2e80ecfii9KfchkgyDSGLPhR8OL9t3VzCP8QHPfeb8=",
+        "lastModified": 1664916500,
+        "narHash": "sha256-6fotRgeRxBa+GAzY6oOyo+2fdub6PkTwF2xZkMF6uaA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f0fff2e0952e97a9ad733ef96e6fa7d4f3b9fafe",
+        "rev": "c24191e588b66cf98f0f5d24991dab91f93b8f4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message              |
| ------------------------------------------------------------------------------------------------------------ | --------------------------- |
| [`c24191e5`](https://github.com/nix-community/emacs-overlay/commit/c24191e588b66cf98f0f5d24991dab91f93b8f4f) | `Pin to Nix 2.11.0 for now` |