### PR TITLE
chore(flake/emacs-overlay): `c24191e5` -> `4ff762be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664916500,
-        "narHash": "sha256-6fotRgeRxBa+GAzY6oOyo+2fdub6PkTwF2xZkMF6uaA=",
+        "lastModified": 1664917586,
+        "narHash": "sha256-xWGi56mAOTbaRAdhyVfI4qdxjX8fXmbOtgUV8/eE53w=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c24191e588b66cf98f0f5d24991dab91f93b8f4f",
+        "rev": "4ff762be71c3f2c733f5e2247b3e32097b91d998",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                        |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
| [`4ff762be`](https://github.com/nix-community/emacs-overlay/commit/4ff762be71c3f2c733f5e2247b3e32097b91d998) | `Revert "Use nixpkgs master for now"` |
| [`7403ebb7`](https://github.com/nix-community/emacs-overlay/commit/7403ebb77e93517a55ad1ab1e5831429fdae8806) | `Revert "Pin to Nix 2.11.0 for now"`  |