### PR TITLE
chore(flake/nur): `9b4b8a80` -> `819a8b8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664910258,
-        "narHash": "sha256-dupG75CATMxNYqyTOpxcbOxHChcqyWKRuLd1oUSX07k=",
+        "lastModified": 1664920808,
+        "narHash": "sha256-lMcGdxxyVx+ttfgZyYU7tmlUMYZdVpv3JogfJ3f+aXM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9b4b8a80cf98fc96a71b1b97c414d18f31c54939",
+        "rev": "819a8b8a88760c2d4dd848f9b7889d8543adea6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`819a8b8a`](https://github.com/nix-community/NUR/commit/819a8b8a88760c2d4dd848f9b7889d8543adea6f) | `automatic update` |