### PR TITLE
chore(flake/nur): `819a8b8a` -> `6b7583e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664920808,
-        "narHash": "sha256-lMcGdxxyVx+ttfgZyYU7tmlUMYZdVpv3JogfJ3f+aXM=",
+        "lastModified": 1664922090,
+        "narHash": "sha256-sdZdWTVf7ttbGtEEVllyDUBYIzPtn9pjEL/V7qx1aMc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "819a8b8a88760c2d4dd848f9b7889d8543adea6f",
+        "rev": "6b7583e42126f0ed2c2d4cb4381fbc2e55172b83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6b7583e4`](https://github.com/nix-community/NUR/commit/6b7583e42126f0ed2c2d4cb4381fbc2e55172b83) | `automatic update` |