### PR TITLE
chore(flake/emacs-overlay): `4ff762be` -> `f24ebfcf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664917586,
-        "narHash": "sha256-xWGi56mAOTbaRAdhyVfI4qdxjX8fXmbOtgUV8/eE53w=",
+        "lastModified": 1664928081,
+        "narHash": "sha256-XrTESnq5STz+Ck86RSaYmF09ggKB0p6oFrvPzBZfRSs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4ff762be71c3f2c733f5e2247b3e32097b91d998",
+        "rev": "f24ebfcf553f04f1f6ed2e7b4db0c30d574c17ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`f24ebfcf`](https://github.com/nix-community/emacs-overlay/commit/f24ebfcf553f04f1f6ed2e7b4db0c30d574c17ab) | `Updated repos/melpa` |
| [`779f67ba`](https://github.com/nix-community/emacs-overlay/commit/779f67baed49c2568d51142d41aa5eff21d9c865) | `Updated repos/emacs` |
| [`8feddbc3`](https://github.com/nix-community/emacs-overlay/commit/8feddbc301c5858af111a8cf750162d4367b718f) | `Updated repos/elpa`  |