### PR TITLE
chore(flake/nur): `cfd6fe7c` -> `50a76f79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664924162,
-        "narHash": "sha256-y92bMH93Mm5/teaj2bH7plVoj9ZS0vv4L51v+uVzVHM=",
+        "lastModified": 1664932657,
+        "narHash": "sha256-HELqq3xHEBaozfqv0dh/R9/hzGR4UF6DIhkjNTZX2dU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cfd6fe7cb30a28b2899387ae0171f3e29fa7e686",
+        "rev": "50a76f79fffb5b5786f0a515160c9e5c14109af8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`50a76f79`](https://github.com/nix-community/NUR/commit/50a76f79fffb5b5786f0a515160c9e5c14109af8) | `automatic update` |