### PR TITLE
chore(flake/nur): `50a76f79` -> `173bd07e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664932657,
-        "narHash": "sha256-HELqq3xHEBaozfqv0dh/R9/hzGR4UF6DIhkjNTZX2dU=",
+        "lastModified": 1664938400,
+        "narHash": "sha256-f0hfdrCvZsjhdqg6i/nl+Xvs7g2RA9f6xPGF8lAMms8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "50a76f79fffb5b5786f0a515160c9e5c14109af8",
+        "rev": "173bd07e4a930d335c1a5e6e74c423747166f469",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`173bd07e`](https://github.com/nix-community/NUR/commit/173bd07e4a930d335c1a5e6e74c423747166f469) | `automatic update` |