### PR TITLE
chore(flake/nur): `173bd07e` -> `0092c612`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664938400,
-        "narHash": "sha256-f0hfdrCvZsjhdqg6i/nl+Xvs7g2RA9f6xPGF8lAMms8=",
+        "lastModified": 1664941060,
+        "narHash": "sha256-DYRmz7Tw8E0d5z8MGeRXcEWJyBZMaKcQNyt6f/oR+Qs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "173bd07e4a930d335c1a5e6e74c423747166f469",
+        "rev": "0092c612677e73dc8552d600727c7b076ca4a2da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0092c612`](https://github.com/nix-community/NUR/commit/0092c612677e73dc8552d600727c7b076ca4a2da) | `automatic update` |