### PR TITLE
chore(flake/nur): `0092c612` -> `cedcb622`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664941060,
-        "narHash": "sha256-DYRmz7Tw8E0d5z8MGeRXcEWJyBZMaKcQNyt6f/oR+Qs=",
+        "lastModified": 1664942905,
+        "narHash": "sha256-0RJBe+SE0hj/cEPB7lwyMERgkAN4G8TQsFUiTas9Tuk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0092c612677e73dc8552d600727c7b076ca4a2da",
+        "rev": "cedcb622c88e83dd3982efb3a14eee0bf1c830ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`cedcb622`](https://github.com/nix-community/NUR/commit/cedcb622c88e83dd3982efb3a14eee0bf1c830ca) | `automatic update` |