### PR TITLE
chore(flake/nur): `cedcb622` -> `2368c24a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664942905,
-        "narHash": "sha256-0RJBe+SE0hj/cEPB7lwyMERgkAN4G8TQsFUiTas9Tuk=",
+        "lastModified": 1664944254,
+        "narHash": "sha256-1BXmITSqMqtjWu5GBiUExYbZNN2fA8Ua4jAVEepy0i8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cedcb622c88e83dd3982efb3a14eee0bf1c830ca",
+        "rev": "2368c24ad5bb62bd2dac854a7b148697f13390dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2368c24a`](https://github.com/nix-community/NUR/commit/2368c24ad5bb62bd2dac854a7b148697f13390dc) | `automatic update` |