### PR TITLE
chore(flake/emacs-overlay): `f24ebfcf` -> `81cff349`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664928081,
-        "narHash": "sha256-XrTESnq5STz+Ck86RSaYmF09ggKB0p6oFrvPzBZfRSs=",
+        "lastModified": 1664946419,
+        "narHash": "sha256-Ey83Px/r8w58H77Mzh+id7pZ550fpWPcaxhJvpSSpvI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f24ebfcf553f04f1f6ed2e7b4db0c30d574c17ab",
+        "rev": "81cff349f6dccdbe7f0acf45846d2c3a737bc8f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`81cff349`](https://github.com/nix-community/emacs-overlay/commit/81cff349f6dccdbe7f0acf45846d2c3a737bc8f9) | `Updated repos/melpa` |
| [`15ff42e0`](https://github.com/nix-community/emacs-overlay/commit/15ff42e01d0758d16f30994b4075fec8dc8df860) | `Updated repos/emacs` |