### PR TITLE
chore(flake/nur): `9a8a2140` -> `09fa71e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664950669,
-        "narHash": "sha256-N2R06cHu9rwzh7t/x4b4vD3cv/LOlnDmgNYUQ3bPeg8=",
+        "lastModified": 1664957643,
+        "narHash": "sha256-SHmJVhtkAzZRZmyiETKjxd3kM+Ft2kFZvdTGGxt2iV4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9a8a21409dbe590c93e659fff714d84e44e367c8",
+        "rev": "09fa71e7a7f3a20f2afe6c8242468318b8213a75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`09fa71e7`](https://github.com/nix-community/NUR/commit/09fa71e7a7f3a20f2afe6c8242468318b8213a75) | `automatic update` |