### PR TITLE
chore(flake/nixos-hardware): `3024c67a` -> `2b61d650`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -263,11 +263,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1664628729,
-        "narHash": "sha256-A1J0ZPhBfZZiWI6ipjKJ8+RpMllzOMu/An/8Tk3t4oo=",
+        "lastModified": 1664985631,
+        "narHash": "sha256-jUEvSieNzI0h/9ZZkeFIdx3ch7+7geRdiBZ6guxjSvA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3024c67a2e9a35450558426c42e7419ab37efd95",
+        "rev": "2b61d6502a38c00d72dc427ccac6c3df2ba28cb0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                    |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`32ee2e60`](https://github.com/NixOS/nixos-hardware/commit/32ee2e607094cc640c9ee6161aa25d2f20b0275c) | `framework-12th-gen-intel: workaround iGPU hangs` |
| [`1788d8f7`](https://github.com/NixOS/nixos-hardware/commit/1788d8f74ef890442f883c95cd37efeb2d61e375) | `lenovo/thinkpad/x1-extreme: remove acpi_call`    |