### PR TITLE
chore(flake/emacs-ement): `fc0add9c` -> `049c4b67`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1664473341,
-        "narHash": "sha256-LKLmlDsr0ytAgAB7YHs9giGTbGEYLZymluMTiNslz0Y=",
+        "lastModified": 1664999230,
+        "narHash": "sha256-x9er3jpmHf9lqpFVz8q3MKzX7SJKnVN/3QupJWz/5Ko=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "fc0add9ca1a91c297d93a8b0b5cf510936d55e91",
+        "rev": "049c4b67c4dd693a22641221863b7d7c9fef4e4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                |
| --------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`049c4b67`](https://github.com/alphapapa/ement.el/commit/049c4b67c4dd693a22641221863b7d7c9fef4e4d) | `Release: v0.3.1`             |
| [`38dcb906`](https://github.com/alphapapa/ement.el/commit/38dcb906d6cc623a6eb7b66fe33470743c735c51) | `Fix: (ement--room-unread-p)` |
| [`8892291f`](https://github.com/alphapapa/ement.el/commit/8892291f042e24ef02215fc1ce68b20f5974ea43) | `Meta: 0.3.1-pre`             |