### PR TITLE
chore(flake/emacs-overlay): `c993a91c` -> `4d79c6e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664961264,
-        "narHash": "sha256-pXx46b8qAqgMp7w2rMGvbiz/+E0ddmjIVFnM1Go7Ogw=",
+        "lastModified": 1665000610,
+        "narHash": "sha256-2eVwFofKRFJCCkQc1wXL8jmp5yE9SrlsF01hssONYLg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c993a91cc553ab5e4a5b5268ff7077ab8bdfd7ad",
+        "rev": "4d79c6e096b671c371f75bc99d367a464474f55d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`4d79c6e0`](https://github.com/nix-community/emacs-overlay/commit/4d79c6e096b671c371f75bc99d367a464474f55d) | `Updated repos/melpa` |
| [`42f0bd08`](https://github.com/nix-community/emacs-overlay/commit/42f0bd088f22742746551d36d2ae6f7ec5194ddc) | `Updated repos/emacs` |
| [`8aa90769`](https://github.com/nix-community/emacs-overlay/commit/8aa90769af2ec3aaa481d641213864d0aa944acf) | `Updated repos/elpa`  |