### PR TITLE
chore(flake/emacs-ement): `049c4b67` -> `40a9833b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1664999230,
-        "narHash": "sha256-x9er3jpmHf9lqpFVz8q3MKzX7SJKnVN/3QupJWz/5Ko=",
+        "lastModified": 1665002412,
+        "narHash": "sha256-xog3ubWKkc/1b9b1eskCbctkLWcNGCIWj17A6pC1XDg=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "049c4b67c4dd693a22641221863b7d7c9fef4e4d",
+        "rev": "40a9833b905814d947d8dfd51e8244490ae0f37b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                         |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`40a9833b`](https://github.com/alphapapa/ement.el/commit/40a9833b905814d947d8dfd51e8244490ae0f37b) | `Change: (ement-room-update-read-receipt) Also mark buffer unmodified` |
| [`e6520c79`](https://github.com/alphapapa/ement.el/commit/e6520c794e6b4a85d9710750a58d664954c42651) | `Add: (ement-room-unread-only-counts-notifications)`                   |
| [`216252e2`](https://github.com/alphapapa/ement.el/commit/216252e24c0afc4d2f29000ce3c9bfa698aa73c0) | `Meta: v0.4-pre`                                                       |