### PR TITLE
chore(flake/nur): `b92d4c1d` -> `2adc08bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665016859,
-        "narHash": "sha256-mLHnz8PloHMX0qH1m8+OeL4m6SBbiaisIgMiyPMHZM4=",
+        "lastModified": 1665028005,
+        "narHash": "sha256-xObaiGyO/uHkFD0V9fa0EdY23zWXbmGpVB0Ube/qsHc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b92d4c1de6f497d76dbcbb370cf180e17ab3a55e",
+        "rev": "2adc08bfa608de844ed6b7b23a24f0c9917b71ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2adc08bf`](https://github.com/nix-community/NUR/commit/2adc08bfa608de844ed6b7b23a24f0c9917b71ef) | `automatic update` |
| [`819e39d2`](https://github.com/nix-community/NUR/commit/819e39d232e7927848b7ed02efe67a4262fbf5f7) | `automatic update` |