### PR TITLE
chore(flake/nur): `2adc08bf` -> `bc1b4de6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665028005,
-        "narHash": "sha256-xObaiGyO/uHkFD0V9fa0EdY23zWXbmGpVB0Ube/qsHc=",
+        "lastModified": 1665029090,
+        "narHash": "sha256-uVWg1Fdalvf63GhEQgr8HK/z+x9n8087Kv7Y+mxKCyg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2adc08bfa608de844ed6b7b23a24f0c9917b71ef",
+        "rev": "bc1b4de6802d2ea7db2a8043794e9b736b806359",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`bc1b4de6`](https://github.com/nix-community/NUR/commit/bc1b4de6802d2ea7db2a8043794e9b736b806359) | `automatic update` |