### PR TITLE
chore(flake/nur): `8c4f98fa` -> `5062f4d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665030045,
-        "narHash": "sha256-tj3HyHfuFcNcZKtmIidMGejtz1QUzyl+f4ze5lX84lk=",
+        "lastModified": 1665031058,
+        "narHash": "sha256-xXlNVHuLg7SeayF+Hzc5kDZWeoWVUDV4Ce5dSm0Z5vc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8c4f98fa84bfaa6123df9cc6c4c5cf0fcc32945a",
+        "rev": "5062f4d1472adf20c5e0d5b422ad2d3a29f3bd8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5062f4d1`](https://github.com/nix-community/NUR/commit/5062f4d1472adf20c5e0d5b422ad2d3a29f3bd8d) | `automatic update` |
| [`b109c523`](https://github.com/nix-community/NUR/commit/b109c523b2bb05954dca7ce736599b14b6b09439) | `automatic update` |