### PR TITLE
chore(flake/emacs-overlay): `4d79c6e0` -> `1236963f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665000610,
-        "narHash": "sha256-2eVwFofKRFJCCkQc1wXL8jmp5yE9SrlsF01hssONYLg=",
+        "lastModified": 1665032392,
+        "narHash": "sha256-x4igo3tsyYr5oHueKDCsurnVT3GF22V0kHe2bDTXOiY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4d79c6e096b671c371f75bc99d367a464474f55d",
+        "rev": "1236963fffa5d7b04706009ff49668c52c91df85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`1236963f`](https://github.com/nix-community/emacs-overlay/commit/1236963fffa5d7b04706009ff49668c52c91df85) | `Updated repos/melpa` |
| [`80c01c5b`](https://github.com/nix-community/emacs-overlay/commit/80c01c5baa127816edc5e1f15684847a9f7e8a94) | `Updated repos/emacs` |
| [`63526575`](https://github.com/nix-community/emacs-overlay/commit/63526575d9c3e95f0f65b23fadf2a0e3fc248c6c) | `Updated repos/elpa`  |