### PR TITLE
chore(flake/nur): `5062f4d1` -> `6488a0e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665031058,
-        "narHash": "sha256-xXlNVHuLg7SeayF+Hzc5kDZWeoWVUDV4Ce5dSm0Z5vc=",
+        "lastModified": 1665032254,
+        "narHash": "sha256-31lLlWgTwfrnS001FdwQGyWzk0l3V/TSnBI3BauKCoA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5062f4d1472adf20c5e0d5b422ad2d3a29f3bd8d",
+        "rev": "6488a0e81a4f7ffea675d742abf818eca70b2356",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6488a0e8`](https://github.com/nix-community/NUR/commit/6488a0e81a4f7ffea675d742abf818eca70b2356) | `automatic update` |