### PR TITLE
chore(flake/nur): `cffc444c` -> `23692721`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665032917,
-        "narHash": "sha256-lZI1VPt0vq5th5Tbw92JGvKM5Lu/rlnYiaqHtwnajHk=",
+        "lastModified": 1665033792,
+        "narHash": "sha256-S5/E3DT7rvD+Z1WroSMVbTuNFJcYwE2Fg+JNzCMvSg4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cffc444cd7e09da68ca5783b6a19096ae6e6b998",
+        "rev": "2369272106f8312bf01f1fef1dfe2fe37bdda5e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`23692721`](https://github.com/nix-community/NUR/commit/2369272106f8312bf01f1fef1dfe2fe37bdda5e8) | `automatic update` |