### PR TITLE
chore(flake/nur): `23692721` -> `df224fc6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665033792,
-        "narHash": "sha256-S5/E3DT7rvD+Z1WroSMVbTuNFJcYwE2Fg+JNzCMvSg4=",
+        "lastModified": 1665036465,
+        "narHash": "sha256-LCd6NoM8aDIBoIlkMyMSKKZkeB8dxqItBlw52uz6MOo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2369272106f8312bf01f1fef1dfe2fe37bdda5e8",
+        "rev": "df224fc6eb72724847f38e3ea60f802f40b73e37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`df224fc6`](https://github.com/nix-community/NUR/commit/df224fc6eb72724847f38e3ea60f802f40b73e37) | `automatic update` |