### PR TITLE
chore(flake/nixos-hardware): `2b61d650` -> `47fd7028`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -263,11 +263,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1664985631,
-        "narHash": "sha256-jUEvSieNzI0h/9ZZkeFIdx3ch7+7geRdiBZ6guxjSvA=",
+        "lastModified": 1665040200,
+        "narHash": "sha256-glqL6yj3aUm40y92inzRmowGt9aIrUrpBX7eBAMic4I=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "2b61d6502a38c00d72dc427ccac6c3df2ba28cb0",
+        "rev": "47fd70289491c1f0c0d9a1f44fb5a9e2801120c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`d5de1c72`](https://github.com/NixOS/nixos-hardware/commit/d5de1c72cfcee3dfaeacc5878f7a77ccc9270897) | `Update README & flake.nix`                                       |
| [`1c535dc0`](https://github.com/NixOS/nixos-hardware/commit/1c535dc0497f7f4f92a562f8d033abf944bfc3e2) | `gpd/pocket-3: Only workaround hidpi module bug on NixOS < 22.11` |
| [`de2ea2be`](https://github.com/NixOS/nixos-hardware/commit/de2ea2beee098e96baafd7cc3250e1e768294994) | `Add GPD Pocket 3 module to nixos-hardware`                       |