### PR TITLE
chore(flake/nur): `c47ae3ff` -> `430db4f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665040403,
-        "narHash": "sha256-WvD8ZdGjzwKXOM39QynwxCxkX3jbe1DuVqjP2MMxm5o=",
+        "lastModified": 1665045233,
+        "narHash": "sha256-lr4j4X95N4akRfr9LTHTTsHXVxwWqUG3iU/t8oUU0Zs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c47ae3ffe9a087ac2f8392a7ee5bd95a7c075c08",
+        "rev": "430db4f013ebe5d3cea52ef4501890b31643500b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`430db4f0`](https://github.com/nix-community/NUR/commit/430db4f013ebe5d3cea52ef4501890b31643500b) | `automatic update` |