### PR TITLE
chore(flake/nur): `430db4f0` -> `3f0e985d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665045233,
-        "narHash": "sha256-lr4j4X95N4akRfr9LTHTTsHXVxwWqUG3iU/t8oUU0Zs=",
+        "lastModified": 1665047320,
+        "narHash": "sha256-RKbWqOO4Qy+zaNNpXxcyMjUBQ6gk0CQHGE3fxSnZZGo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "430db4f013ebe5d3cea52ef4501890b31643500b",
+        "rev": "3f0e985d5efb172a787c311a8a5b413ea7165137",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3f0e985d`](https://github.com/nix-community/NUR/commit/3f0e985d5efb172a787c311a8a5b413ea7165137) | `automatic update` |