### PR TITLE
chore(flake/nur): `882d303d` -> `89d5a470`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665064002,
-        "narHash": "sha256-J20uemxMwy5dGOEgK5vFs7w1+RkKDRJiT3dklW5hu3Y=",
+        "lastModified": 1665070751,
+        "narHash": "sha256-N8ko/mRGFvV9dVLSrr5Xc+4Mzb50fjBmI7Rfh2QTm9w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "882d303ddb6e21b92b7777e19c8b4a44d6c2a33a",
+        "rev": "89d5a470c8598039562126dd427a60eb811974ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`89d5a470`](https://github.com/nix-community/NUR/commit/89d5a470c8598039562126dd427a60eb811974ef) | `automatic update` |