### PR TITLE
chore(flake/nur): `89d5a470` -> `fd9aff4c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665070751,
-        "narHash": "sha256-N8ko/mRGFvV9dVLSrr5Xc+4Mzb50fjBmI7Rfh2QTm9w=",
+        "lastModified": 1665080590,
+        "narHash": "sha256-zeEPZG/nVXnZbaFNaFcfNOtgfBJPtijPDf8HkXr9lH0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "89d5a470c8598039562126dd427a60eb811974ef",
+        "rev": "fd9aff4c4e529fe2684acdd5ee856cc2c000c66c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`fd9aff4c`](https://github.com/nix-community/NUR/commit/fd9aff4c4e529fe2684acdd5ee856cc2c000c66c) | `automatic update` |