### PR TITLE
chore(flake/nixpkgs): `b7a6fde1` -> `37bd3983`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -277,11 +277,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664871473,
-        "narHash": "sha256-1LzbW6G6Uz8akWiOdlIi435GAm1ct5jF5tovw/9to0o=",
+        "lastModified": 1664989420,
+        "narHash": "sha256-Q8IxomUjjmewsoJgO3htkXLfCckQ7HkDJ/ZhdYVf/fA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b7a6fde153d9470afdb6aa1da51c4117f03b84ed",
+        "rev": "37bd39839acf99c5b738319f42478296f827f274",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`396f4f05`](https://github.com/NixOS/nixpkgs/commit/396f4f05b9c7dc15a3cf36cba246c32088e37c32) | `nixos/tmate-ssh-server: init module (#192270)`                            |
| [`9b4fc691`](https://github.com/NixOS/nixpkgs/commit/9b4fc6915437eb04ae6a568d2ab8aedb894f194b) | `roon-server: 1.8-1105 -> 2.0-1128`                                        |
| [`35955e36`](https://github.com/NixOS/nixpkgs/commit/35955e360c6851e9a53fed945a9e98cfea5d67be) | `linux_5_19: 5.19.13 -> 5.19.14`                                           |
| [`0a8eb742`](https://github.com/NixOS/nixpkgs/commit/0a8eb742885275a3112b2c2ffaa1c9f5551f8e9c) | `bash_unit: 2.0.0 -> 2.0.1`                                                |
| [`14abeff7`](https://github.com/NixOS/nixpkgs/commit/14abeff728ec0b7ac619fb6424a1c3a24d165060) | `sbt: 1.7.1 -> 1.7.2 (#194300)`                                            |
| [`7e914831`](https://github.com/NixOS/nixpkgs/commit/7e91483125beb3af4a7e6762aeb47061d70331af) | `sbt-extras: 2022-09-23 -> 2022-10-03 (#194517)`                           |
| [`0cde97cb`](https://github.com/NixOS/nixpkgs/commit/0cde97cbd902a6b610b2177cfa87ed66bc102cda) | `haskellPackages: mark builds failing on hydra as broken`                  |
| [`c0a44951`](https://github.com/NixOS/nixpkgs/commit/c0a4495169ac65e87a52be632e675965ca4203c6) | `vimPlugins.noice-nvim: init at 2022-10-04`                                |
| [`590b1f6f`](https://github.com/NixOS/nixpkgs/commit/590b1f6f1f18f6c3b1ee74c49cadc916bf771144) | `vimPlugins: update`                                                       |
| [`0addd969`](https://github.com/NixOS/nixpkgs/commit/0addd9696c52f897756ceea0c023c11747f934fb) | `rspamd: 3.2 -> 3.3`                                                       |
| [`9ae45311`](https://github.com/NixOS/nixpkgs/commit/9ae4531199d71e4e809f0ac71e25e016987710d5) | `libertine: rename name to pname&version (#193940)`                        |
| [`9a2bba46`](https://github.com/NixOS/nixpkgs/commit/9a2bba46e1975a54503e006d69f357f2d0757d39) | `proggyfonts: rename name to pname&version (#193937)`                      |
| [`a2c91786`](https://github.com/NixOS/nixpkgs/commit/a2c917865f4939150fef94f2323148e0d1e0e5bb) | `coqPackages.mathcomp-word: 1.1 → 2.0`                                     |
| [`36d0c5fa`](https://github.com/NixOS/nixpkgs/commit/36d0c5fa77b6ff3ce229aad2cbc22c138f643fb4) | `python310Packages.batchspawner: disable on older Python releases`         |
| [`65572a26`](https://github.com/NixOS/nixpkgs/commit/65572a26d075522aeb1dcdc388007dd54c054e32) | `python310Packages.browser-cookie3: 0.16.1 -> 0.16.2`                      |
| [`66663178`](https://github.com/NixOS/nixpkgs/commit/666631787e2e4c23b439903cf7eff4b40bab528f) | `python310Packages.batchspawner: 1.1.0 -> 1.2.0`                           |
| [`a44b2043`](https://github.com/NixOS/nixpkgs/commit/a44b2043ffc9f3858798b4a51f6ff63975441d00) | `python310Packages.awscrt: 0.14.6 -> 0.14.7`                               |
| [`b02e24b4`](https://github.com/NixOS/nixpkgs/commit/b02e24b4511938cd16317998e959ee1f8e9ab0e2) | `vimUtils.packDir: fix build in absence of pname`                          |
| [`67756dbb`](https://github.com/NixOS/nixpkgs/commit/67756dbbd89c4c416be5230eeea7f57caa4487fd) | `python310Packages.aiounifi: 36 -> 37`                                     |
| [`0c7a6a08`](https://github.com/NixOS/nixpkgs/commit/0c7a6a0832b9531217d724a60ddd4377e841d68d) | `go_1_19: 1.19.1 -> 1.19.2`                                                |
| [`d745231c`](https://github.com/NixOS/nixpkgs/commit/d745231c7780ec5e3a336a7b03b7b7739d197ed9) | ``weston: avoid removed alias `libseat```                                  |
| [`c736ed13`](https://github.com/NixOS/nixpkgs/commit/c736ed13b2e3b4781d96e7a2c54a3c6a01386947) | `linux: 5.19.12 -> 5.19.13`                                                |
| [`4076104a`](https://github.com/NixOS/nixpkgs/commit/4076104a385f152b16d338c8bdea0cd0efd40414) | `coqPackages.category-theory: 20211213 → 1.0.0`                            |
| [`68a8e9aa`](https://github.com/NixOS/nixpkgs/commit/68a8e9aa62b7dfac81ec5c523de9871734f1bb38) | `jmol: 14.32.75 -> 14.32.76`                                               |
| [`1c919127`](https://github.com/NixOS/nixpkgs/commit/1c919127c55d69de0731f31982f7947a8edcd83c) | `uefitool: A61 -> A62`                                                     |
| [`04b714db`](https://github.com/NixOS/nixpkgs/commit/04b714dbc03ce5b4936d2bf77f30297314087b98) | `adw-gtk3: 3.7 -> 4.0`                                                     |
| [`032490f3`](https://github.com/NixOS/nixpkgs/commit/032490f3bff9446e89f552a8c70f81c27d076525) | `libvirt: 8.7.0 -> 8.8.0`                                                  |
| [`56c56109`](https://github.com/NixOS/nixpkgs/commit/56c56109a3dc82dc9575412ab7e009962994d459) | `kubo: 0.15.0 -> 0.16.0`                                                   |
| [`3c920098`](https://github.com/NixOS/nixpkgs/commit/3c92009868109ec8a3695d2ebacf0b53e23778d1) | `nixos/tests/systemd-initrd-modprobe: init`                                |
| [`e338844d`](https://github.com/NixOS/nixpkgs/commit/e338844d9015050edadc8dde36c16128884e3ddd) | `usbimager: Fix filechooser dialog`                                        |
| [`32a43582`](https://github.com/NixOS/nixpkgs/commit/32a43582e7dc2eadc58c572b8eb83be992cd6ffa) | `redmine: 4.2.7 -> 4.2.8`                                                  |
| [`5662a307`](https://github.com/NixOS/nixpkgs/commit/5662a3075747515e6e1cb5662cb3fa67f8314f10) | `rain: build with Go 1.18 instead of 1.17`                                 |
| [`645c8426`](https://github.com/NixOS/nixpkgs/commit/645c8426f5c97e7ed7005e544f7d8c0a64d3d2ce) | `gh: 2.16.1 -> 2.17.0`                                                     |
| [`868a6714`](https://github.com/NixOS/nixpkgs/commit/868a6714da40500e22471d60247cef78bb416873) | `maintainers/team-list.nix: add lua team`                                  |
| [`3bc29710`](https://github.com/NixOS/nixpkgs/commit/3bc2971030c70a9191b3682346f98067e88d0a94) | `fix typo`                                                                 |
| [`6b4bcde2`](https://github.com/NixOS/nixpkgs/commit/6b4bcde22d1d2c5ce421111de1bef430c4d33f6b) | `dart: remove myself from maintainers`                                     |
| [`94eb56b8`](https://github.com/NixOS/nixpkgs/commit/94eb56b8da7503d7cdd8e22d0d3be19d1c165d7a) | `hover: remove myself from maintainers`                                    |
| [`2bb9abc7`](https://github.com/NixOS/nixpkgs/commit/2bb9abc7623d6feb8660c6cb8b570d274a1b0614) | `osm2pgsql: 1.7.0 → 1.7.1`                                                 |
| [`6f3d5e6d`](https://github.com/NixOS/nixpkgs/commit/6f3d5e6da2b0f29cbdba964030babaa14de8607f) | `python310Packages.weconnect: 0.48.1 -> 0.48.2`                            |
| [`eb43d1e6`](https://github.com/NixOS/nixpkgs/commit/eb43d1e6e553d318337eda4ae5f3cd20ac9dda9c) | `telegraf: 1.23.3 -> 1.24.2`                                               |
| [`2f93baec`](https://github.com/NixOS/nixpkgs/commit/2f93baecd058da202010cd4bcfc24de4dfa76a8e) | `python3Packages.django_4: 4.1.1 -> 4.1.2`                                 |
| [`2cf4152b`](https://github.com/NixOS/nixpkgs/commit/2cf4152bc2163cae042d63f813318ae90f338a9d) | `python310Packages.types-requests: 2.28.11 -> 2.28.11.1`                   |
| [`82092633`](https://github.com/NixOS/nixpkgs/commit/82092633bd44b8c17903ff3258fb06aa0715544c) | `python310Packages.types-redis: 4.3.21 -> 4.3.21.1`                        |
| [`76619655`](https://github.com/NixOS/nixpkgs/commit/766196550b1ba2a39c1f65dbaced59a9b11426d8) | `firefox-bin-unwrapped: 105.0.1 -> 105.0.2`                                |
| [`a12dd80a`](https://github.com/NixOS/nixpkgs/commit/a12dd80a496b8d2763eb29b81940e24cc4ece8e4) | `firefox-unwrapped: 105.0.1 -> 105.0.2`                                    |
| [`76b6b66d`](https://github.com/NixOS/nixpkgs/commit/76b6b66d8da1b3222f36795d33c6d1f57c445aec) | `python310Packages.trimesh: 3.15.2 -> 3.15.3`                              |
| [`654c7c76`](https://github.com/NixOS/nixpkgs/commit/654c7c76e5c84d61354c4fa778e6a24b78c8ce88) | `python310Packages.traitsui: 7.4.0 -> 7.4.1`                               |
| [`b5005d36`](https://github.com/NixOS/nixpkgs/commit/b5005d36ad81828e477112ba4efd78c57e7b33e3) | `snappymail: 2.18.3 -> 2.18.4`                                             |
| [`fbbf9ff6`](https://github.com/NixOS/nixpkgs/commit/fbbf9ff6df94e936ca59b5998de9e273068f71c2) | `libretro.puae: init at unstable-2022-04-21`                               |
| [`0b90eee7`](https://github.com/NixOS/nixpkgs/commit/0b90eee76d40751d6824cc8f00900922d6f14ac7) | `python310Packages.sphinx-jupyterbook-latex: 0.5.0 -> 0.5.1`               |
| [`f12ebd47`](https://github.com/NixOS/nixpkgs/commit/f12ebd47af76062851b0aa7dbd4bd823cc022d86) | `python310Packages.slack-sdk: 3.18.4 -> 3.18.5`                            |
| [`2e19f2fa`](https://github.com/NixOS/nixpkgs/commit/2e19f2fa5391b3b30e9eace7b4b6a60926b828ae) | `maintainers: remove superherointj`                                        |
| [`14bb4ee9`](https://github.com/NixOS/nixpkgs/commit/14bb4ee9b7e652409856feefedd8377f9b52727c) | `opcr-policy: init at 0.1.42`                                              |
| [`3646a756`](https://github.com/NixOS/nixpkgs/commit/3646a7561f064e5bcb84df6d01d13ee101f67ac5) | `maintainers: add naphta`                                                  |
| [`092bb3c6`](https://github.com/NixOS/nixpkgs/commit/092bb3c6e023d91a03a538c092b7768b63393018) | `python3Packages.libvirt: Fix build on darwin`                             |
| [`42793abe`](https://github.com/NixOS/nixpkgs/commit/42793abe52f422de44294e8aec05bfa9faeb9a91) | `pantheon.elementary-iconbrowser: init at 2.0.0`                           |
| [`b368d66d`](https://github.com/NixOS/nixpkgs/commit/b368d66d752e07f631ed01fce43d09607697b383) | `gmpc.libmpd: rename name to pname&version`                                |
| [`94b9ed29`](https://github.com/NixOS/nixpkgs/commit/94b9ed29b989186a39541667ee37f475626b44ec) | `wireplumber: 0.4.11 -> 0.4.12`                                            |
| [`9817dd37`](https://github.com/NixOS/nixpkgs/commit/9817dd375c1504fc175179583c7534dd3315c247) | `spglib: 1.16.5 -> 2.0.1`                                                  |
| [`b070c222`](https://github.com/NixOS/nixpkgs/commit/b070c222d137ac32d687df7f84997e0e67401ede) | `avogadro2: 1.95.1 -> 1.97.0`                                              |
| [`93c7d807`](https://github.com/NixOS/nixpkgs/commit/93c7d8070c30692d8974fae34f16f54bfe84fb8a) | `avogadrolibs: 1.95.1 -> 1.97.0, disable mmtf-cpp`                         |
| [`5a55c0e5`](https://github.com/NixOS/nixpkgs/commit/5a55c0e512a4242d15a5a44ad820f8423b7e1856) | `haskellPackages.satchmo: unbreak`                                         |
| [`ebd65936`](https://github.com/NixOS/nixpkgs/commit/ebd659367f431d9cd126154fe577e5f80082cbec) | `haskellPackages.sint: unbreak`                                            |
| [`f633575a`](https://github.com/NixOS/nixpkgs/commit/f633575af3ad7b4dcf77fd4cb7733184d5b65e3e) | `libvori: 210412 -> 220621`                                                |
| [`11bb01e7`](https://github.com/NixOS/nixpkgs/commit/11bb01e7fa509db5a8adce09b5edfc8554f7eee4) | `python3Packages.dlib: split name to pname&version (#194382)`              |
| [`04c496c1`](https://github.com/NixOS/nixpkgs/commit/04c496c1551125f409546ed990c817dc8d7dc1d6) | `telepathy-farstream: rename name to pname&version (#193575)`              |
| [`c75b4ee2`](https://github.com/NixOS/nixpkgs/commit/c75b4ee2f0af0b3c66c03219416254088b39da1a) | `cp2k: 9.1.0 -> 2022.2`                                                    |
| [`a2c41adf`](https://github.com/NixOS/nixpkgs/commit/a2c41adf739aaef0e0b3fd81a36b498c08db1291) | `cfdg: remove src-for-default.nix, cleanups (#192727)`                     |
| [`8d764e5a`](https://github.com/NixOS/nixpkgs/commit/8d764e5a35ddf95bafc7430a574a0e3af4ac788a) | `python310Packages.vt-py: 0.16.0 -> 0.17.1 (#194410)`                      |
| [`60c89561`](https://github.com/NixOS/nixpkgs/commit/60c89561041dc66c264c372a133060c557b69b15) | `python310Packages.velbus-aio: 2022.10.1 -> 2022.10.2 (#194409)`           |
| [`1c660d1a`](https://github.com/NixOS/nixpkgs/commit/1c660d1a00dff4f57f456db6a0167d473642ed1d) | `betterlockscreen: wrap with dbus and dunst (#176335)`                     |
| [`453efa31`](https://github.com/NixOS/nixpkgs/commit/453efa3153cc5ce9b782b45861abba60876db10f) | `python310Packages.versioningit: move patching to postPatch`               |
| [`5598afb4`](https://github.com/NixOS/nixpkgs/commit/5598afb4208fc35aa011aed90877188385f22c24) | `mdbook-linkcheck: 0.7.6 -> 0.7.7`                                         |
| [`5bae92a7`](https://github.com/NixOS/nixpkgs/commit/5bae92a7155b885619cbab9d3ddae91aa59e91cc) | `zfs: 2.1.5 → 2.1.6`                                                       |
| [`b794e83b`](https://github.com/NixOS/nixpkgs/commit/b794e83b395253fc46df958a0a12e1fc7b80d069) | `python3Packages.wxPython4_1: fix build`                                   |
| [`081db4e4`](https://github.com/NixOS/nixpkgs/commit/081db4e4b79572972e320163dd3e6f7429b9bca0) | `python3Packages.wxPython4_0: fix build`                                   |
| [`1b6bef9c`](https://github.com/NixOS/nixpkgs/commit/1b6bef9c08aad93643a3c823069f51004d80c7d7) | `pip-audit: 2.4.3 -> 2.4.4`                                                |
| [`a097585e`](https://github.com/NixOS/nixpkgs/commit/a097585ef1506f133ecb754c24b231f07cc48832) | `ft2-clone: 1.58 -> 1.59`                                                  |
| [`7994937e`](https://github.com/NixOS/nixpkgs/commit/7994937ed20a50681738e1dd91619a6672e5ac19) | `pygtk: fix build on aarch64-darwin`                                       |
| [`d8cb6419`](https://github.com/NixOS/nixpkgs/commit/d8cb641929a86d2036a4d16713240af3c5cb6dc0) | `pygobject: fix build on aarch64-darwin`                                   |
| [`4ef739ad`](https://github.com/NixOS/nixpkgs/commit/4ef739adf11585fa15e9edd943a5049bda9f63e7) | `scandir: fix build on aarch64-darwin`                                     |
| [`7527505f`](https://github.com/NixOS/nixpkgs/commit/7527505f0be45af148e864a51b0430446cda1a24) | `schema2ldif: Fix ldap-schema-manager not working`                         |
| [`d0637e1a`](https://github.com/NixOS/nixpkgs/commit/d0637e1a25b7aa04a123d98cff471420d84aa1fe) | `vouch-proxy: enable checkPhase`                                           |
| [`6ffc7353`](https://github.com/NixOS/nixpkgs/commit/6ffc735377f7248d25ab6164e992edecf3c1a74c) | `k3sup: 0.12.3 -> 0.12.7`                                                  |
| [`6520ff3a`](https://github.com/NixOS/nixpkgs/commit/6520ff3aadd400c6547b5ab8996cf50b0226aa9f) | `python310Packages.identify: 2.5.5 -> 2.5.6`                               |
| [`85827a5d`](https://github.com/NixOS/nixpkgs/commit/85827a5de806435c1a6042ac000f98362df1ea30) | `jql: 5.0.2 -> 5.1.0`                                                      |
| [`ee42f9b2`](https://github.com/NixOS/nixpkgs/commit/ee42f9b29c2a1f35026ff430d94c9afe5d6af6ec) | `python310Packages.nomadnet: 0.2.2 -> 0.2.3`                               |
| [`052cb086`](https://github.com/NixOS/nixpkgs/commit/052cb0862e1c4facc20d347ced4c3ffdd2fde645) | `python310Packages.lxmf: 0.1.8 -> 0.1.9`                                   |
| [`e9b0609a`](https://github.com/NixOS/nixpkgs/commit/e9b0609af7cd8d7b3365384584efd24408e76180) | `python310Packages.rns: 0.3.12 -> 0.3.13`                                  |
| [`3241ef22`](https://github.com/NixOS/nixpkgs/commit/3241ef22f987ed3dfee7456d0432842ba710736a) | `vscode-extensions.streetsidesoftware.code-spell-checker: 2.3.1 -> 2.10.1` |
| [`0b4cd241`](https://github.com/NixOS/nixpkgs/commit/0b4cd241e277b1395f074c064ab878586031e990) | `haskellPackages.webauthn: unbreak`                                        |
| [`75436580`](https://github.com/NixOS/nixpkgs/commit/75436580086dfdef0305830c6d3a2cf484b3524a) | `gum: 0.6.0 -> 0.7.0`                                                      |
| [`bb3010ea`](https://github.com/NixOS/nixpkgs/commit/bb3010ea13c93b591a7ad16c2650ffea33dff2a3) | `python3Packages.ducc0: 0.25.0 -> 0.26.0`                                  |
| [`4094a617`](https://github.com/NixOS/nixpkgs/commit/4094a6176ecc32d0dc551776d210d3dc03a68846) | `python310Packages.pyhiveapi: 0.5.13 -> 0.5.14`                            |
| [`5ff268a1`](https://github.com/NixOS/nixpkgs/commit/5ff268a184fa41ee6c9cf337975fbdec62f8481e) | `haskellPackages.rec-def: Unbreak`                                         |
| [`3d92e818`](https://github.com/NixOS/nixpkgs/commit/3d92e81834bc497b218e1e46f81601a98f9aa39a) | `icinga2: Add pname to .vim`                                               |
| [`0406a782`](https://github.com/NixOS/nixpkgs/commit/0406a78202ef273a956b5277b83ce7ae649c7389) | `python310Packages.pyatmo: 7.0.1 -> 7.1.0`                                 |
| [`f9af6656`](https://github.com/NixOS/nixpkgs/commit/f9af66562a3e2316eef4d021f231a9e9e77e2be2) | `neovim-remote: fix build with neovim 0.8`                                 |
| [`34d1d336`](https://github.com/NixOS/nixpkgs/commit/34d1d336adec65ecd6547924c5149709eec798de) | `onnnxruntime, python3Packages.onnxruntime: improve packaging`             |
| [`a2a6cb1a`](https://github.com/NixOS/nixpkgs/commit/a2a6cb1a6940d95e119fa69ac1b9f6a2aa6aaa80) | `python3Packages.langcodes: add missing setuptools`                        |
| [`28827908`](https://github.com/NixOS/nixpkgs/commit/28827908017f7d628e0ff4e89de91595670c5f02) | `libplctag: 2.5.1 -> 2.5.2`                                                |
| [`31852b46`](https://github.com/NixOS/nixpkgs/commit/31852b460051a58339b7a154ad51189f9291d465) | `kotlin: 1.7.10 -> 1.7.20`                                                 |
| [`e2f8348f`](https://github.com/NixOS/nixpkgs/commit/e2f8348fabaa1f5fba7e28371e9fc40e8d39e706) | `buildah: 1.27.2 -> 1.28.0 (#194360)`                                      |
| [`d8c964c2`](https://github.com/NixOS/nixpkgs/commit/d8c964c2f7a12bacb4c90b219773304b46b8a615) | `carapace: 0.16.0 -> 0.17.0`                                               |
| [`288222ff`](https://github.com/NixOS/nixpkgs/commit/288222fff98d048c47b7ba96aa79618aa3fff296) | `python310Packages.django-reversion: disable on older Python releases`     |
| [`be3f2e85`](https://github.com/NixOS/nixpkgs/commit/be3f2e855475b36d3a118f9164b69ddb05a8ecea) | `yt-dlp: 2022.9.1 -> 2022.10.4`                                            |
| [`2034a3da`](https://github.com/NixOS/nixpkgs/commit/2034a3da5a0107070fc420bcce04c3de39d74892) | `streamlink: 3.2.0 -> 5.0.1`                                               |
| [`5a65614c`](https://github.com/NixOS/nixpkgs/commit/5a65614cbdf083be2f339c645e967869e292ffb1) | `pythonPackages.versioningit: init at 2.0.1`                               |
| [`03b51707`](https://github.com/NixOS/nixpkgs/commit/03b51707ff1ac75ceb1435f7d81bbe5e80256920) | `lego: 4.8.0 -> 4.9.0`                                                     |
| [`1d9aabad`](https://github.com/NixOS/nixpkgs/commit/1d9aabadc127934a8b65739476598529b9f1c086) | `pods: 1.0.0-beta.4 -> 1.0.0-beta.5`                                       |
| [`128f745f`](https://github.com/NixOS/nixpkgs/commit/128f745ffff126f1c90937f239ef4cfed349c3d9) | `gzdoom: fix IWAD selection menu`                                          |
| [`3e117af1`](https://github.com/NixOS/nixpkgs/commit/3e117af149cde4bd6ecb5a585872d15eadf7014d) | `gzdoom: fix libfluidsynth not loading`                                    |
| [`4f65cecd`](https://github.com/NixOS/nixpkgs/commit/4f65cecd453709aae763e08ccc985ec8db432507) | `emacs: remove warning of xargs when doing AOT native-comp`                |
| [`3a2881ab`](https://github.com/NixOS/nixpkgs/commit/3a2881abb219b610c8985fc5abbb204a80485a24) | `lemmeknow: init at 0.6.0`                                                 |
| [`d7652698`](https://github.com/NixOS/nixpkgs/commit/d76526987254786d5fe08702f9bea079898cd5fe) | `traefik: 2.8.8 -> 2.9.1`                                                  |
| [`66044f7e`](https://github.com/NixOS/nixpkgs/commit/66044f7e4384e12ffd68ce7d7372fcdcb528a358) | `artem: init at 1.1.5`                                                     |
| [`a75e477c`](https://github.com/NixOS/nixpkgs/commit/a75e477c016b68f0d4a9575f02136f226eaa224e) | `cargo-lock: init at 8.0.2`                                                |
| [`f33230dc`](https://github.com/NixOS/nixpkgs/commit/f33230dc4c0a51a8ffa10cb11ae614e9c1e82145) | `firefox-devedition-bin-unwrapped: 106.0b5 -> 106.0b7`                     |
| [`fad386ba`](https://github.com/NixOS/nixpkgs/commit/fad386bad17441c8954736ffd61935c7af889677) | `firefox-beta-bin-unwrapped: 106.0b5 -> 106.0b7`                           |
| [`c04611da`](https://github.com/NixOS/nixpkgs/commit/c04611da264995cbaee32c500e2c3b17bd83d9c2) | `nvtop: 2.0.3->2.0.4`                                                      |
| [`16e2cfc5`](https://github.com/NixOS/nixpkgs/commit/16e2cfc5b1157bf3913578bdacb38662251f80fb) | `aws-sso-cli: 1.9.2 -> 1.9.4`                                              |
| [`1b015cf5`](https://github.com/NixOS/nixpkgs/commit/1b015cf57b6bc1dac2e066ca991153d022dc81b8) | `ucx: 1.13.0 -> 1.13.1`                                                    |
| [`9ef4c7f4`](https://github.com/NixOS/nixpkgs/commit/9ef4c7f4f6b23a8f0f4c59fa6de68494389411e6) | `nmap: 7.92 -> 7.93`                                                       |
| [`90b6f0d2`](https://github.com/NixOS/nixpkgs/commit/90b6f0d20a6e46de0b8a14ee52fe45326c9375ce) | `kooha: 2.0.1 -> 2.2.2`                                                    |
| [`bcca922d`](https://github.com/NixOS/nixpkgs/commit/bcca922de57099a275284616e63b975fb0e6dce8) | `prusa-slicer: Fix STEP format support`                                    |
| [`5620b7cc`](https://github.com/NixOS/nixpkgs/commit/5620b7ccad9447c8335e56587bcbe7630ab1e592) | `libretro.mame{2015,2016}: disable enableParallelBuilding again`           |
| [`650e4347`](https://github.com/NixOS/nixpkgs/commit/650e434781a3b0458a610132d0cf1a6d1152f0c1) | `libretro.flycast: fix aarch64-linux build`                                |
| [`400b95cf`](https://github.com/NixOS/nixpkgs/commit/400b95cfb94e78f68c1e48e37e19f0c724d4039a) | `libretro.blastem: mark it only available in x86`                          |
| [`f3313e87`](https://github.com/NixOS/nixpkgs/commit/f3313e870c74cb2406b1605cf0843eb58e78b5fb) | `libretro.parallel-n64: return aarch64 patch`                              |
| [`e2a22846`](https://github.com/NixOS/nixpkgs/commit/e2a22846581333e02cca7a79df758a1f2e29f631) | `electrum: make compatible with protobuf 4+`                               |
| [`30e0247a`](https://github.com/NixOS/nixpkgs/commit/30e0247a1594bd3cc0eafba7d429df525520d672) | `libretro.mame*: enableParallelBuilding = true`                            |
| [`fcab0c74`](https://github.com/NixOS/nixpkgs/commit/fcab0c7453fa3e983fcf6e874dffd5e0d6bcfae6) | `python310Packages.django-reversion: 5.0.2 -> 5.0.3`                       |
| [`2d55e4d1`](https://github.com/NixOS/nixpkgs/commit/2d55e4d1eed9c39fcadea9ebbbd46ea4f866f3f7) | `k3s: 1.25.2+k3s1 -> 1.25.2+k3s1`                                          |
| [`3d200bd9`](https://github.com/NixOS/nixpkgs/commit/3d200bd959e9b448e52212e9989e109c6dce3ab4) | `nixos/tests/k3s: fix tests`                                               |
| [`49b29907`](https://github.com/NixOS/nixpkgs/commit/49b299074d4fbd2becdc6dbc5362a3d0fc2fb2b1) | `k3s: convenience change to update script`                                 |
| [`107160d3`](https://github.com/NixOS/nixpkgs/commit/107160d3426d3448492d60436f040d3e69feca44) | `dotnet-sdk: move license files to the proper folder`                      |
| [`9d97b342`](https://github.com/NixOS/nixpkgs/commit/9d97b342de4dcbe74a7413c6497a75a42afbf58d) | `haskell.packages.ghc942: get inital support up`                           |
| [`312d7560`](https://github.com/NixOS/nixpkgs/commit/312d75605a3e1faa823e132c04cbf2731e5d0289) | `hdl-dump: unstable-2021-08-20 -> unstable-2022-09-19`                     |
| [`5320dc63`](https://github.com/NixOS/nixpkgs/commit/5320dc6325c6a214d6d4ba5df4faa7a29aa16103) | `nongnu-packages: updated 2022-10-01 (from overlay)`                       |
| [`a2cf6b9e`](https://github.com/NixOS/nixpkgs/commit/a2cf6b9e596403764f489d909da0d08666acdb8d) | `melpa-packages: updated 2022-10-01 (from overlay)`                        |
| [`cad97ab9`](https://github.com/NixOS/nixpkgs/commit/cad97ab908b1579651cc4b245b60b5d9eba69727) | `elpa-packages: updated 2022-10-01 (from overlay)`                         |
| [`8c045370`](https://github.com/NixOS/nixpkgs/commit/8c0453705721d167247bc9934492fa09d5eb18fe) | `dirstalk: init at 1.3.3`                                                  |
| [`a8218609`](https://github.com/NixOS/nixpkgs/commit/a82186094c7b1bb9dbd92a9a70dcc2724a8b3215) | `libretro.dosbox: remove gcc10Stdenv override`                             |
| [`ec66f492`](https://github.com/NixOS/nixpkgs/commit/ec66f492688d2e0019794a3e44a1ba524f7ed858) | `libretro.citra: remove gcc10Stdenv override`                              |
| [`49bc117c`](https://github.com/NixOS/nixpkgs/commit/49bc117c6c0d35812065e9895632c2bac8163d2b) | `libretro: remove unnecessary code`                                        |
| [`f486658d`](https://github.com/NixOS/nixpkgs/commit/f486658da49c6f501f5f99973b5331aa06d952ab) | `haskell.packages.ghc924.alex: remove obsolete override`                   |
| [`f1b0b727`](https://github.com/NixOS/nixpkgs/commit/f1b0b727b455a44ae45fb27fed39b195910bb671) | `all-cabal-hashes: 2022-09-28T11:00:39Z -> 2022-10-01T15:28:21Z`           |
| [`0eadc3bb`](https://github.com/NixOS/nixpkgs/commit/0eadc3bbf285bd6d66ff2071047148534668b563) | `maintainers: add libretro team, use it in retroarch/libretro`             |