### PR TITLE
chore(flake/home-manager): `6427ae95` -> `599e22b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665078757,
-        "narHash": "sha256-J2zUFgChtwuHgN+qgOdfjsTH2R0NddCGMDk9qx6bDxg=",
+        "lastModified": 1665095009,
+        "narHash": "sha256-8Y6y2bgZBiakvCVCcvYLRXorlhLH2Fg80/oYRSm26/c=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6427ae95789c04534363d2b68289996f08077c0c",
+        "rev": "599e22b1c76dc56172c7bb97bc3cd04266869bd6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`599e22b1`](https://github.com/nix-community/home-manager/commit/599e22b1c76dc56172c7bb97bc3cd04266869bd6) | ``sbt: allow managing the `~/.sbt/repositories` file`` |