### PR TITLE
chore(flake/nur): `fd9aff4c` -> `c4e6331a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665080590,
-        "narHash": "sha256-zeEPZG/nVXnZbaFNaFcfNOtgfBJPtijPDf8HkXr9lH0=",
+        "lastModified": 1665096691,
+        "narHash": "sha256-2Vv9vMepmXqLrscxE52oiN154eO3yju7rfZZOUukpWU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fd9aff4c4e529fe2684acdd5ee856cc2c000c66c",
+        "rev": "c4e6331a216b7d371bb667530aaeee5b2e7e8ee0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c4e6331a`](https://github.com/nix-community/NUR/commit/c4e6331a216b7d371bb667530aaeee5b2e7e8ee0) | `automatic update` |