### PR TITLE
chore(flake/home-manager): `599e22b1` -> `8c297e18`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665095009,
-        "narHash": "sha256-8Y6y2bgZBiakvCVCcvYLRXorlhLH2Fg80/oYRSm26/c=",
+        "lastModified": 1665097600,
+        "narHash": "sha256-Jubg2lNeFuICuI9wYgg+vcAQ7HOyBU7efktK0OX2/cY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "599e22b1c76dc56172c7bb97bc3cd04266869bd6",
+        "rev": "8c297e1816c9744da5a90d8b7aef8ff5c3a41bad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                          |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`8c297e18`](https://github.com/nix-community/home-manager/commit/8c297e1816c9744da5a90d8b7aef8ff5c3a41bad) | `ledger: add module`                    |
| [`7fee13eb`](https://github.com/nix-community/home-manager/commit/7fee13eb4c64740261c774a90e43830f7213c57c) | ``sbt: cache `passwordCommand` output`` |