### PR TITLE
chore(flake/nur): `c4e6331a` -> `def5e68e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665096691,
-        "narHash": "sha256-2Vv9vMepmXqLrscxE52oiN154eO3yju7rfZZOUukpWU=",
+        "lastModified": 1665099320,
+        "narHash": "sha256-y4n17RZ6qWq+54Ua/m3+omszHwIf6tjnQqo6LSchANA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c4e6331a216b7d371bb667530aaeee5b2e7e8ee0",
+        "rev": "def5e68ef2aecf33e3e0a0075cc5c990c366bb26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`def5e68e`](https://github.com/nix-community/NUR/commit/def5e68ef2aecf33e3e0a0075cc5c990c366bb26) | `automatic update` |