### PR TITLE
chore(flake/nur): `49fc4ea1` -> `1697b75c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665103813,
-        "narHash": "sha256-V/ThoGH5tGMFkROrmrBThCx8nBbJT598Hav5pah7dDg=",
+        "lastModified": 1665113402,
+        "narHash": "sha256-2J+3PViAQYne0k6fao2s2KhuAEahy1dSUecfK62x5SY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "49fc4ea179abac9e09ad251864e679ef0e2aa8b9",
+        "rev": "1697b75c80a49e40d7142ce011e3faaf2c6541b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1697b75c`](https://github.com/nix-community/NUR/commit/1697b75c80a49e40d7142ce011e3faaf2c6541b3) | `automatic update` |