### PR TITLE
chore(flake/nur): `1697b75c` -> `202d3023`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665113402,
-        "narHash": "sha256-2J+3PViAQYne0k6fao2s2KhuAEahy1dSUecfK62x5SY=",
+        "lastModified": 1665116919,
+        "narHash": "sha256-Wvzs0nHQ8g700x/pDdhovXi4jysEHXdbtiF7C5OgwZQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1697b75c80a49e40d7142ce011e3faaf2c6541b3",
+        "rev": "202d30233eacc207127ae3615f0e4d75f0352cc5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`202d3023`](https://github.com/nix-community/NUR/commit/202d30233eacc207127ae3615f0e4d75f0352cc5) | `automatic update` |
| [`850e7dff`](https://github.com/nix-community/NUR/commit/850e7dffbf3d5b2ff46f46185a6f205ed0fa852c) | `automatic update` |
| [`85edc5cd`](https://github.com/nix-community/NUR/commit/85edc5cd15e40756dfd30abb74e48ecbcc542fda) | `automatic update` |