### PR TITLE
chore(flake/nur): `202d3023` -> `8a65f2ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665116919,
-        "narHash": "sha256-Wvzs0nHQ8g700x/pDdhovXi4jysEHXdbtiF7C5OgwZQ=",
+        "lastModified": 1665117953,
+        "narHash": "sha256-MXriPf4RzgzK2YD8rPBcdPFvA590vc/blc+MyR0WScU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "202d30233eacc207127ae3615f0e4d75f0352cc5",
+        "rev": "8a65f2abdd17428b989ad04a4ad0ef8ef5822e0a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8a65f2ab`](https://github.com/nix-community/NUR/commit/8a65f2abdd17428b989ad04a4ad0ef8ef5822e0a) | `automatic update` |
| [`1dec234d`](https://github.com/nix-community/NUR/commit/1dec234d0ec7821dcf9b9bd3e5fc9967d682681e) | `automatic update` |