### PR TITLE
chore(flake/nur): `8a65f2ab` -> `a2fc233f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665117953,
-        "narHash": "sha256-MXriPf4RzgzK2YD8rPBcdPFvA590vc/blc+MyR0WScU=",
+        "lastModified": 1665127222,
+        "narHash": "sha256-RaebBxfZkOURp30Z1zH8xLiW9RrCV8TeT0141UwZY5A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8a65f2abdd17428b989ad04a4ad0ef8ef5822e0a",
+        "rev": "a2fc233f53a0cfd261af0d68c681cc98b082b605",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a2fc233f`](https://github.com/nix-community/NUR/commit/a2fc233f53a0cfd261af0d68c681cc98b082b605) | `automatic update` |
| [`e80f26e1`](https://github.com/nix-community/NUR/commit/e80f26e14feb83f740b1ab34f5b3327570a90bd2) | `automatic update` |