### PR TITLE
chore(flake/emacs-overlay): `db1c01c5` -> `bb224e7e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665120353,
-        "narHash": "sha256-4wOdNQoP7F9hOshrU/APxs/L7Lma75OABRR4eMcEhsk=",
+        "lastModified": 1665141707,
+        "narHash": "sha256-yIB7Ju7yWspzjj2xNcJSNQ4zln3o2z9buKpRYkE30d8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "db1c01c5faeea34547fff2017324f8a2d2253402",
+        "rev": "bb224e7e82ac962031be7a36e1c4b01fb56ae8d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`bb224e7e`](https://github.com/nix-community/emacs-overlay/commit/bb224e7e82ac962031be7a36e1c4b01fb56ae8d9) | `Updated repos/nongnu` |
| [`69001f72`](https://github.com/nix-community/emacs-overlay/commit/69001f7209d3baae5685e657511a0d6ec9104751) | `Updated repos/melpa`  |
| [`404aa01a`](https://github.com/nix-community/emacs-overlay/commit/404aa01a3fa33e5043d88e8719476d23bd93926e) | `Updated repos/emacs`  |