### PR TITLE
chore(flake/emacs-overlay): `bb224e7e` -> `3aa20d38`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665141707,
-        "narHash": "sha256-yIB7Ju7yWspzjj2xNcJSNQ4zln3o2z9buKpRYkE30d8=",
+        "lastModified": 1665169993,
+        "narHash": "sha256-ZcGu9zmdJ3FTT5V7klHonTsKxXcxPRa4coQ6Cg3KZ2M=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bb224e7e82ac962031be7a36e1c4b01fb56ae8d9",
+        "rev": "3aa20d38aeb38220dcccd3e53ac666d7df322053",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`3aa20d38`](https://github.com/nix-community/emacs-overlay/commit/3aa20d38aeb38220dcccd3e53ac666d7df322053) | `Updated repos/melpa` |
| [`adc46fcc`](https://github.com/nix-community/emacs-overlay/commit/adc46fcc2b963730d8b9e8c4f9a8167dbf23f842) | `Updated repos/emacs` |