### PR TITLE
chore(flake/emacs-ement): `4114e0e3` -> `eb73bf27`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1665106450,
-        "narHash": "sha256-lKnslTx9XpeitlhJdtBRCJG22W+0+7fy6BDac3fWnNc=",
+        "lastModified": 1665177736,
+        "narHash": "sha256-N8/aOdcNR/7LH/PI3l88+LINQyJR1z/bhEOa1XJp7XQ=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "4114e0e317b12b82bf9485ec36ad83510a6177fe",
+        "rev": "eb73bf27750e14d0ce0f9d7c6c4875955c7d9874",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                               |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`eb73bf27`](https://github.com/alphapapa/ement.el/commit/eb73bf27750e14d0ce0f9d7c6c4875955c7d9874) | `Fix: (ement--event-mentions-room-p) Regexp` |