### PR TITLE
chore(flake/nur): `04af34e8` -> `c35bfee6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665151116,
-        "narHash": "sha256-JTrA3EpOe94e/k/8A5JKkI0pmVqEDiM+zQcJq4neDJk=",
+        "lastModified": 1665198591,
+        "narHash": "sha256-N8mAiivVuJLrcuz03pP8KTMyEGMc5MosKZSg9yrFuxc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "04af34e85a9b2cf753d3c59d111f8f7d2f212dfe",
+        "rev": "c35bfee6112c8ac8be7440688fd529cfbd3857be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c35bfee6`](https://github.com/nix-community/NUR/commit/c35bfee6112c8ac8be7440688fd529cfbd3857be) | `automatic update` |