### PR TITLE
chore(flake/nur): `c35bfee6` -> `aee72bb1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665198591,
-        "narHash": "sha256-N8mAiivVuJLrcuz03pP8KTMyEGMc5MosKZSg9yrFuxc=",
+        "lastModified": 1665202371,
+        "narHash": "sha256-slVcLsN8o7XtejvWUEk4JJEUoZXpnXoSAnftJq26ngY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c35bfee6112c8ac8be7440688fd529cfbd3857be",
+        "rev": "aee72bb15051e4de6df1a40a0b83d51a0923b249",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`aee72bb1`](https://github.com/nix-community/NUR/commit/aee72bb15051e4de6df1a40a0b83d51a0923b249) | `automatic update` |