### PR TITLE
chore(flake/nur): `aee72bb1` -> `91bc5dcf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665202371,
-        "narHash": "sha256-slVcLsN8o7XtejvWUEk4JJEUoZXpnXoSAnftJq26ngY=",
+        "lastModified": 1665203337,
+        "narHash": "sha256-qXrddhuI8M3gCQFLMfADbDwmxHf7tJVj434+Ncxjx/o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aee72bb15051e4de6df1a40a0b83d51a0923b249",
+        "rev": "91bc5dcf2f2fedab1d3f5e975fed493e12e352db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`91bc5dcf`](https://github.com/nix-community/NUR/commit/91bc5dcf2f2fedab1d3f5e975fed493e12e352db) | `automatic update` |