### PR TITLE
chore(flake/nur): `91bc5dcf` -> `2b6e97ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665203337,
-        "narHash": "sha256-qXrddhuI8M3gCQFLMfADbDwmxHf7tJVj434+Ncxjx/o=",
+        "lastModified": 1665209558,
+        "narHash": "sha256-9gLsfvxJP9474Xg+WGOKHYyObBKAY9JqoYnme03vI7E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "91bc5dcf2f2fedab1d3f5e975fed493e12e352db",
+        "rev": "2b6e97cef637babb574ae9cff81170d50a771a1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2b6e97ce`](https://github.com/nix-community/NUR/commit/2b6e97cef637babb574ae9cff81170d50a771a1e) | `automatic update` |