### PR TITLE
chore(flake/nur): `2b6e97ce` -> `dfa4cbea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665209558,
-        "narHash": "sha256-9gLsfvxJP9474Xg+WGOKHYyObBKAY9JqoYnme03vI7E=",
+        "lastModified": 1665550982,
+        "narHash": "sha256-wg+HGJrkHGbPKaVcAvBbUZHsaDPVSBFFffYqg5je3+E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2b6e97cef637babb574ae9cff81170d50a771a1e",
+        "rev": "dfa4cbeaee8223ffdfc08606888df3a039d8370f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                         |
| -------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`dfa4cbea`](https://github.com/nix-community/NUR/commit/dfa4cbeaee8223ffdfc08606888df3a039d8370f) | `automatic update`                     |
| [`cb0438a8`](https://github.com/nix-community/NUR/commit/cb0438a8af1afc31d39c01f7841864489438e9cd) | `automatic update`                     |
| [`19afadcb`](https://github.com/nix-community/NUR/commit/19afadcbdbf2f970b3fa7f63fecb4d55cfae9c44) | `automatic update`                     |
| [`9fe33843`](https://github.com/nix-community/NUR/commit/9fe33843b561c98f172abe345dbe9bf63ba0377a) | `automatic update`                     |
| [`d79db5ae`](https://github.com/nix-community/NUR/commit/d79db5aeeca445f5415f73b7e36cedf8ff3d650d) | `automatic update`                     |
| [`4db94566`](https://github.com/nix-community/NUR/commit/4db94566495ae41552551ff80bb56cde3b4612b0) | `automatic update`                     |
| [`499d277c`](https://github.com/nix-community/NUR/commit/499d277c0b822025298e7f35332545c7a0971782) | `automatic update`                     |
| [`73bf4f93`](https://github.com/nix-community/NUR/commit/73bf4f93bc58f803404aaedec1516a6a905502b8) | `automatic update`                     |
| [`49629e6e`](https://github.com/nix-community/NUR/commit/49629e6e7a5caa3b37b6c72ae59e8bdf37b1b6fa) | `automatic update`                     |
| [`2f4d9a67`](https://github.com/nix-community/NUR/commit/2f4d9a678529ee5bc272852c93176c00db603496) | `automatic update`                     |
| [`2f5802b1`](https://github.com/nix-community/NUR/commit/2f5802b12b1790573c5929bb5be2421fce926509) | `automatic update`                     |
| [`c26ad5cf`](https://github.com/nix-community/NUR/commit/c26ad5cf4d259b637584e81289f747ef073f2ddf) | `automatic update`                     |
| [`011ca62b`](https://github.com/nix-community/NUR/commit/011ca62baf4826f5907a1e40eb8c2dd3d42e4333) | `automatic update`                     |
| [`d94d26e1`](https://github.com/nix-community/NUR/commit/d94d26e19415fe36e5c75bc36d838d67b913c840) | `automatic update`                     |
| [`12888041`](https://github.com/nix-community/NUR/commit/1288804127a95c9bdf86a44848a73a1a79fd47ed) | `automatic update`                     |
| [`c17ca0b9`](https://github.com/nix-community/NUR/commit/c17ca0b99906a93e0de5978fd8ed0dfc141b79ad) | `automatic update`                     |
| [`ab44847a`](https://github.com/nix-community/NUR/commit/ab44847a6eb2dd7cf9a20ae112e20120de0d8c1b) | `automatic update`                     |
| [`0059a301`](https://github.com/nix-community/NUR/commit/0059a301b9b5866e291e142e9044c66ff972100a) | `automatic update`                     |
| [`75a751e3`](https://github.com/nix-community/NUR/commit/75a751e312cded6508aa9a945011e8cda0ed77a7) | `automatic update`                     |
| [`a2f9ca03`](https://github.com/nix-community/NUR/commit/a2f9ca03146cd9b332ef835f51696fad01b37bdb) | `automatic update`                     |
| [`d0b6a5b2`](https://github.com/nix-community/NUR/commit/d0b6a5b2cd03f67be19939eff29c4485424ee941) | `automatic update`                     |
| [`558c3039`](https://github.com/nix-community/NUR/commit/558c3039de1aaf37ef52e068933c941f94dbb04f) | `automatic update`                     |
| [`44a712d8`](https://github.com/nix-community/NUR/commit/44a712d8014e2395ca4a9d36a92ab73f8764d34f) | `Add Grafcube/nur-packages repository` |
| [`54d93329`](https://github.com/nix-community/NUR/commit/54d93329d8f487bf665be4ee14140202ad0faa04) | `automatic update`                     |
| [`ae42ce5e`](https://github.com/nix-community/NUR/commit/ae42ce5e0b920966771e33d7a8cdae59aca01655) | `automatic update`                     |
| [`64967ed2`](https://github.com/nix-community/NUR/commit/64967ed2262362b3cd9692df3cc2aacc3ae1a8ec) | `automatic update`                     |
| [`02893f9e`](https://github.com/nix-community/NUR/commit/02893f9e67470d934d69190dc543cccc3ce0a6c6) | `automatic update`                     |
| [`08ace345`](https://github.com/nix-community/NUR/commit/08ace34530b434cec9f648d221661ab9b90165bb) | `automatic update`                     |
| [`804f69c4`](https://github.com/nix-community/NUR/commit/804f69c4de41412644a1eab20b9d5f2efdb0149d) | `automatic update`                     |
| [`f08bb78f`](https://github.com/nix-community/NUR/commit/f08bb78fa01c1be2286f039eb40da763ea7e5ef9) | `automatic update`                     |
| [`5577495e`](https://github.com/nix-community/NUR/commit/5577495e43637d08ba44d929f640f998f85c86ef) | `automatic update`                     |
| [`216b4de2`](https://github.com/nix-community/NUR/commit/216b4de2d1351cd1c09f1cd6b7345053dffdc50d) | `automatic update`                     |
| [`2f2f9d20`](https://github.com/nix-community/NUR/commit/2f2f9d20d6471663afcc90d9c2c435c6d10c01ce) | `automatic update`                     |
| [`a7ec21be`](https://github.com/nix-community/NUR/commit/a7ec21be80db18a53ecd0f7525a43abdcc83121b) | `automatic update`                     |
| [`b666acb5`](https://github.com/nix-community/NUR/commit/b666acb573ebfbf70cdbe3a2979a84508463697e) | `automatic update`                     |
| [`588bcc5a`](https://github.com/nix-community/NUR/commit/588bcc5aadb5b0463c37f1702c47956ca290e579) | `automatic update`                     |
| [`64edc180`](https://github.com/nix-community/NUR/commit/64edc180ea114de51d40b9e444f1b1b2e5f024a4) | `automatic update`                     |