### PR TITLE
chore(flake/nixpkgs): `37bd3983` -> `34c5293a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -277,11 +277,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664989420,
-        "narHash": "sha256-Q8IxomUjjmewsoJgO3htkXLfCckQ7HkDJ/ZhdYVf/fA=",
+        "lastModified": 1665349835,
+        "narHash": "sha256-UK4urM3iN80UXQ7EaOappDzcisYIuEURFRoGQ/yPkug=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "37bd39839acf99c5b738319f42478296f827f274",
+        "rev": "34c5293a71ffdb2fe054eb5288adc1882c1eb0b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                         |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`1c6a1eef`](https://github.com/NixOS/nixpkgs/commit/1c6a1eefe8188723f903ef218e368e706a188d1f) | `python3Packages.pymicrobot: 0.0.6 -> 0.0.8`                           |
| [`2fcfc5d0`](https://github.com/NixOS/nixpkgs/commit/2fcfc5d061a66ad68256836c6d17e7bd95b0c03e) | `josm: 18565 -> 18570`                                                 |
| [`4ad043f5`](https://github.com/NixOS/nixpkgs/commit/4ad043f5f19d4ed913cee4980947984a01be031d) | `home-assistant: 2022.10.1 -> 2022.10.2`                               |
| [`6992b0d1`](https://github.com/NixOS/nixpkgs/commit/6992b0d15ec072518fdeb0e752b7aeea59667385) | `python3Packages.pyoverkiz: 1.5.4 -> 1.5.5`                            |
| [`06c4dbb4`](https://github.com/NixOS/nixpkgs/commit/06c4dbb4cdcbd0ed7046dde3c655d228d6fe2fa5) | `python3Packages.pyhumps: Fix regression in symbols export`            |
| [`6359a05f`](https://github.com/NixOS/nixpkgs/commit/6359a05f4d6e9116d361f775e708cbccdd479fdb) | `python310Packages.zigpy-znp: 0.9.0 -> 0.9.1`                          |
| [`a6e08695`](https://github.com/NixOS/nixpkgs/commit/a6e0869512a850e3d7e6ea296ed2a1184d63ec4c) | `python310Packages.zigpy-zigate: 0.10.0 -> 0.10.1`                     |
| [`3c86ff13`](https://github.com/NixOS/nixpkgs/commit/3c86ff131f97a7780fd7b44c1c668099c3e239e2) | `python310Packages.zigpy-xbee: 0.16.0 -> 0.16.1`                       |
| [`82f5c8d1`](https://github.com/NixOS/nixpkgs/commit/82f5c8d144c1083c88da125c1f611abab7bae240) | `python310Packages.zigpy: 0.51.2 -> 0.51.3`                            |
| [`ffee5992`](https://github.com/NixOS/nixpkgs/commit/ffee5992374d3df89775f24f378a7f38af8d79cc) | `python310Packages.pydaikin: 2.7.0 -> 2.7.2`                           |
| [`070c93d1`](https://github.com/NixOS/nixpkgs/commit/070c93d16e81302430f33e7a9a9ac5d7955d4be8) | `sickgear: 0.25.40 -> 0.25.44`                                         |
| [`9ddb8eea`](https://github.com/NixOS/nixpkgs/commit/9ddb8eead167fc3d06d0bdd1c0e380a256995179) | `python310Packages.bellows: 0.34.1 -> 0.34.2`                          |
| [`627c1199`](https://github.com/NixOS/nixpkgs/commit/627c1199b5ea7d9788582420ed330db677785ea1) | `python310Packages.aiounifi: 37 -> 38`                                 |
| [`1a615dc4`](https://github.com/NixOS/nixpkgs/commit/1a615dc4ac20953d9f98e5e7101fe00bc71e9dae) | `process-viewer: set meta.mainProgram`                                 |
| [`987d2f57`](https://github.com/NixOS/nixpkgs/commit/987d2f575aff1da36d964a6e3fd3e4ba42445a76) | `nixos/seafile: avoid sleep in tests`                                  |
| [`2189b95e`](https://github.com/NixOS/nixpkgs/commit/2189b95ebf4ddeb7b0397df7de8719f998020d47) | `seahub: fix build`                                                    |
| [`6471cff5`](https://github.com/NixOS/nixpkgs/commit/6471cff5ddc7d85ee037f5ee8f0590325141a1db) | `exiv2: drop a test on darwin, really now`                             |
| [`c0972c16`](https://github.com/NixOS/nixpkgs/commit/c0972c16dcbdce1b7505751e1ce537142071bb15) | `update-python-libraries: add missing dependency nix`                  |
| [`8f292e36`](https://github.com/NixOS/nixpkgs/commit/8f292e361367bddbdab3f6c89359041519f126e8) | `retroarch: mark as broken in macOS`                                   |
| [`fc75cc94`](https://github.com/NixOS/nixpkgs/commit/fc75cc94f4abea666d9b76a2c9dfdbef88d0c080) | `praat: 6.2.22 -> 6.2.23`                                              |
| [`92437299`](https://github.com/NixOS/nixpkgs/commit/924372998beaa8f8964a15e925666871f25852dc) | `open-watcom-v2-unwrapped: opt-out of nixpkgs-update`                  |
| [`b31c4283`](https://github.com/NixOS/nixpkgs/commit/b31c42831f1b99544f81bc27f9da183d3276e9aa) | `conntrack-tools: 1.4.6 -> 1.4.7`                                      |
| [`329f5980`](https://github.com/NixOS/nixpkgs/commit/329f59805f466db154245f2ff4b6783e6b1aaf67) | `flyctl: 0.0.404 -> 0.0.406`                                           |
| [`74fc4924`](https://github.com/NixOS/nixpkgs/commit/74fc4924fb2d678ff4fdf49b38040e635ebee5c2) | `xmonadctl: use xmonad-contrib's src`                                  |
| [`4836d085`](https://github.com/NixOS/nixpkgs/commit/4836d085e453cb460afa16d26da9057f45513852) | `audacity: deprecate wxGTK31 and gtk2`                                 |
| [`aafc60e4`](https://github.com/NixOS/nixpkgs/commit/aafc60e4c2526e56e642768c6dc62617e17f7421) | `audacity: 3.1.3 -> 3.2.1`                                             |
| [`17b9d619`](https://github.com/NixOS/nixpkgs/commit/17b9d61957bcd2bfb26d86f65121b63d955afaaf) | `mediathekview: 13.8.0 -> 13.9.1 (#194125)`                            |
| [`ef72b5f8`](https://github.com/NixOS/nixpkgs/commit/ef72b5f86e3a5cbded3694b4a4e250e2d02dba4d) | `freefilesync: update license`                                         |
| [`ec947b13`](https://github.com/NixOS/nixpkgs/commit/ec947b13cd678b4a08f0289ccda6bba71ac025a0) | `gdal_2: drop`                                                         |
| [`df229a80`](https://github.com/NixOS/nixpkgs/commit/df229a80c24788fe7b66b1d39022d78652aa937e) | `libssh2: update license`                                              |
| [`7eef7379`](https://github.com/NixOS/nixpkgs/commit/7eef7379fe3b5caae95083ebbdb81f9b3534d409) | `licenses: add libssh2 license`                                        |
| [`cc1dbce2`](https://github.com/NixOS/nixpkgs/commit/cc1dbce261847370fb8a787972a22693b233c72e) | `yaws: 2.0.6 -> 2.1.1`                                                 |
| [`daf5a09d`](https://github.com/NixOS/nixpkgs/commit/daf5a09d375c1a7b8d74742972aa45a287483c5b) | `gajim: 1.5.1 → 1.5.2`                                                 |
| [`9755cb84`](https://github.com/NixOS/nixpkgs/commit/9755cb848a9e33594d99567a1be948a15710aa9c) | `pythonPackages.nbxmpp: 3.2.2 → 3.2.4`                                 |
| [`0e211108`](https://github.com/NixOS/nixpkgs/commit/0e211108227518c4f841425145a822a76e0e05b0) | `ocamlPackages.caqti: 1.8.0 → 1.9.1`                                   |
| [`9927b2f2`](https://github.com/NixOS/nixpkgs/commit/9927b2f2c3da285077877e3d445336dc3472f72d) | `exiv2: drop a test on darwin`                                         |
| [`4fd75277`](https://github.com/NixOS/nixpkgs/commit/4fd75277dd383abfa0d8719306b1fbe18c024366) | `nixos/coturn: refactor secret injection`                              |
| [`17c43ab2`](https://github.com/NixOS/nixpkgs/commit/17c43ab2c8ab39c4de7cc65943a01a589caf0cd5) | `colima: 0.4.5 -> 0.4.6`                                               |
| [`fae653de`](https://github.com/NixOS/nixpkgs/commit/fae653deb4af085526163467e73f2d26b2220b52) | `nixos/gitlab: Configure ActionCable`                                  |
| [`9b3ff51c`](https://github.com/NixOS/nixpkgs/commit/9b3ff51c777d51f3aa0f23e3a6c956504ccd2f7e) | `nixos/gitlab: Set a more appropriate type for extraConfig`            |
| [`58158100`](https://github.com/NixOS/nixpkgs/commit/58158100f766214a9493ca32afc6e8bfc6c8b10e) | `nixos/gitlab: Make sure docker-registry starts after cert generation` |
| [`8e8253dd`](https://github.com/NixOS/nixpkgs/commit/8e8253ddb4b5b0488e476a1a1c50b340990bd516) | `nixos/gitlab: Create registry state path`                             |
| [`3dedfb3f`](https://github.com/NixOS/nixpkgs/commit/3dedfb3fa03c5a4eda64bdb1dfd9a39fa587bc8a) | `nixos/gitlab: Connect to redis through a unix socket by default`      |
| [`843082eb`](https://github.com/NixOS/nixpkgs/commit/843082eb3af6a453b3aeb6c3c6724e508aa44478) | `nixos/gitlab: Add findutils to runtime dependencies`                  |
| [`bee6e1da`](https://github.com/NixOS/nixpkgs/commit/bee6e1dafa55df37ac4a6199cd8b0c00ac73ed07) | `nixos/gitlab: Deduplicate runtime dependency listing`                 |
| [`0211edd1`](https://github.com/NixOS/nixpkgs/commit/0211edd1ff005575c5b2061f25d73fccb6271252) | `nixos/gitlab: Add workhorse.config option`                            |
| [`4df4d2a8`](https://github.com/NixOS/nixpkgs/commit/4df4d2a8eac999e47f973911857b9756281f8273) | `genJqSecretsReplacementSnippet: Allow dots in attribute names...`     |
| [`de25676c`](https://github.com/NixOS/nixpkgs/commit/de25676c9f0954c9fdbb703cdb9326af9301ad50) | `promtail: move alongside grafana-loki`                                |
| [`bd97c7ab`](https://github.com/NixOS/nixpkgs/commit/bd97c7ab87994a268a3096af14c53a16efdd8eea) | `terraform-providers.mongodbatlas: drop workaround`                    |
| [`b4d431bb`](https://github.com/NixOS/nixpkgs/commit/b4d431bbd2e9ee953a95fc0ddde8b80edcb0dc12) | `terraform-providers.baiducloud: drop workaround`                      |
| [`0e9f1a02`](https://github.com/NixOS/nixpkgs/commit/0e9f1a027c9a7d4c66ab2dbc353c0c2dd1820ceb) | `terraform-providers.alicloud: drop workaround`                        |
| [`5ba91d79`](https://github.com/NixOS/nixpkgs/commit/5ba91d79fef463f17551b9fd28e00ec43a5e2f40) | `werf: switch to go 1.19`                                              |
| [`c2db0129`](https://github.com/NixOS/nixpkgs/commit/c2db012912c80d284e0e0d2fc6a3530681e00834) | `wails: switch to go 1.19`                                             |
| [`7a4a8bae`](https://github.com/NixOS/nixpkgs/commit/7a4a8baee52a4a277b10052a6c4261a335d3ef10) | `trivy: switch to go 1.19`                                             |
| [`a03716e5`](https://github.com/NixOS/nixpkgs/commit/a03716e5476397c7dfe005c5bf143360f1a089c5) | `telegraf: switch to go 1.19`                                          |
| [`1e1e7dea`](https://github.com/NixOS/nixpkgs/commit/1e1e7dea1d006b4ac048724148dc9b44aff6d420) | `opentelemetry-collector-contrib: switch to go 1.19`                   |
| [`3f2a8cbb`](https://github.com/NixOS/nixpkgs/commit/3f2a8cbb98fd3e623a6adea62eeccf17209edf5b) | `argocd-autopilot: switch to go 1.19`                                  |
| [`ea57902e`](https://github.com/NixOS/nixpkgs/commit/ea57902e29a41bcbb6dcab1d18f9aa5df13b5d86) | `gotop: switch to go 1.19`                                             |
| [`27407ada`](https://github.com/NixOS/nixpkgs/commit/27407adae9d602581737f1848c17b647f79f4edb) | `hysteria: switch to go 1.19`                                          |
| [`9e044493`](https://github.com/NixOS/nixpkgs/commit/9e0444931cd465b9776e5edd95415a8b02896b26) | `mangal: switch to go 1.19`                                            |
| [`8b4a4570`](https://github.com/NixOS/nixpkgs/commit/8b4a4570abc8b3a64d32c33dee8220dfc3924717) | `hugo: switch to go 1.19`                                              |
| [`165e181f`](https://github.com/NixOS/nixpkgs/commit/165e181f5d83d9f506a4e49677c53bab50f048f8) | `erigon: switch to go 1.19`                                            |
| [`2f814ff7`](https://github.com/NixOS/nixpkgs/commit/2f814ff713272093bfa220aa3b5fdafc504a6809) | `terraform-providers: switch to go 1.19`                               |
| [`e1e561d0`](https://github.com/NixOS/nixpkgs/commit/e1e561d0d16a6cf15683bbd3e1326d52de48547f) | `bacon: 2.2.3 -> 2.2.5`                                                |
| [`e848fcc2`](https://github.com/NixOS/nixpkgs/commit/e848fcc292596b63a419405471d4aff0630ac039) | `cargo-zigbuild: 0.12.3 -> 0.13.0`                                     |
| [`00e90def`](https://github.com/NixOS/nixpkgs/commit/00e90defe5f98f36d7dc5110c2ac9c21d6661594) | `flexget: 3.3.31 -> 3.3.32`                                            |
| [`a5c7d3b0`](https://github.com/NixOS/nixpkgs/commit/a5c7d3b021fe2d1df9118a338577d33a525d32b1) | `genact: 1.1.1 -> 1.2.0`                                               |
| [`441788b7`](https://github.com/NixOS/nixpkgs/commit/441788b712ec18c3dfc1995543b10ded9250b570) | `vimPlugins.flit-nvim: init at 2022-09-23`                             |
| [`da7676ec`](https://github.com/NixOS/nixpkgs/commit/da7676ecd6949cce6031be5db9e43960f7c186c3) | `vimPlugins.leap-ast-nvim: init at 2022-08-02`                         |
| [`342dd0bf`](https://github.com/NixOS/nixpkgs/commit/342dd0bf48a50b8f90993934d811b8a1f4bba0a6) | `vimPlugins.leap-nvim: init at 2022-10-01`                             |
| [`804fb8e1`](https://github.com/NixOS/nixpkgs/commit/804fb8e11b221e9a16fa82aa160b6be0f7db8604) | `vimPlugins.dial-nvim: init at 2022-08-29`                             |
| [`232f8d1e`](https://github.com/NixOS/nixpkgs/commit/232f8d1ea0ca8234822de3e18e47de91d626661b) | `vimPlugins.live-command-nvim: init at 2022-10-06`                     |
| [`d1a8b129`](https://github.com/NixOS/nixpkgs/commit/d1a8b12916d4aa4d741d147198c60f026a414a03) | `vimPlugins: update`                                                   |
| [`8bf050c4`](https://github.com/NixOS/nixpkgs/commit/8bf050c4956c1ce222ae2f38e0c57d66d4334aaf) | `ruff: 0.0.61 -> 0.0.63`                                               |
| [`64fb9479`](https://github.com/NixOS/nixpkgs/commit/64fb94794f70a0e05319a05fc8931e8fdd01b934) | `dnstwist: 20220815 -> 20221008`                                       |
| [`6a62a6e8`](https://github.com/NixOS/nixpkgs/commit/6a62a6e8e4dfc027c143f2f365d2093a49c56a38) | `gvproxy: pin to go 1.18`                                              |
| [`fdbb7e87`](https://github.com/NixOS/nixpkgs/commit/fdbb7e87aee736d6474500a34e6d72237b966acc) | `gojq: remove unnecessary proxyVendor`                                 |
| [`9731c061`](https://github.com/NixOS/nixpkgs/commit/9731c06199112275ca35a9abdb592df0a382d75f) | `apprise: 1.0.0 -> 1.1.0`                                              |
| [`990828dc`](https://github.com/NixOS/nixpkgs/commit/990828dcfdbf76b36edb4c7df921a3bdf0c291e7) | `p4c: correct native/buildInputs mistake`                              |
| [`1af64ac2`](https://github.com/NixOS/nixpkgs/commit/1af64ac23eafaaa01de42b0d6772470bb5c9bdc2) | `cargo-edit: 0.11.4 -> 0.11.5`                                         |
| [`72a72547`](https://github.com/NixOS/nixpkgs/commit/72a72547566813fd019c1c6b72f2de9f6622a77f) | `snazy: install shell completions, add figsoda as a maintainer`        |
| [`61309fba`](https://github.com/NixOS/nixpkgs/commit/61309fba90d7a9e989b800878d6f254468456545) | `oxker: init at 0.1.5`                                                 |
| [`f97ac9e8`](https://github.com/NixOS/nixpkgs/commit/f97ac9e87cdb39385b17c8c27a082a120b43f914) | `ruff: 0.0.60 -> 0.0.61`                                               |
| [`23075ec2`](https://github.com/NixOS/nixpkgs/commit/23075ec21a926c2759a3dfe002551c34c9680b49) | `python310Packages.types-tabulate: 0.8.11 -> 0.9.0.0`                  |
| [`47fc6c2f`](https://github.com/NixOS/nixpkgs/commit/47fc6c2f82635fa0bff36bb7fed0e2c5ba086b1e) | `python310Packages.types-requests: 2.28.11.1 -> 2.28.11.2`             |
| [`7e959388`](https://github.com/NixOS/nixpkgs/commit/7e959388cddd24a46cbeff8e62214bb79248e76a) | `pcem: migrate to wxGTK32`                                             |
| [`968f9d2d`](https://github.com/NixOS/nixpkgs/commit/968f9d2d767713f7bc3faeceba07d982b6a7fbd7) | `hedgedoc: fix package name in update script help text`                |
| [`327a4e1c`](https://github.com/NixOS/nixpkgs/commit/327a4e1ce0d570f219e2b4cedf03f16fac099416) | `keytar: fix package name in update script help text`                  |
| [`ae28acab`](https://github.com/NixOS/nixpkgs/commit/ae28acabb0884a1f46b4b741a8f51e303b75042d) | `webengine: fix github crashes with upstream patch`                    |
| [`c6c52c52`](https://github.com/NixOS/nixpkgs/commit/c6c52c521f50457e48f3e6c0f8b0b1b65a72da51) | `qutebrowser: init qt6 variant`                                        |
| [`0875c04f`](https://github.com/NixOS/nixpkgs/commit/0875c04f15e4d197d770ce690d7ba4e26b7db8ba) | `cosmopolitan: 2.1 -> 2.1.1`                                           |
| [`801580d9`](https://github.com/NixOS/nixpkgs/commit/801580d934a427927347c027701fc074c7adff5e) | `python310Packages.sumo: 2.3.4 -> 2.3.5`                               |
| [`4a4300ea`](https://github.com/NixOS/nixpkgs/commit/4a4300eae49622868868999f773b72d3e4598d59) | `wxhexeditor: add darwin support`                                      |
| [`d00db576`](https://github.com/NixOS/nixpkgs/commit/d00db576d4c3dd2c32592a198e67af29694a989a) | `python310Packages.strictyaml: 1.6.1 -> 1.6.2`                         |
| [`b206c7d0`](https://github.com/NixOS/nixpkgs/commit/b206c7d019517276f22761b515509382d139499b) | `bitcoin-abc: 0.21.13 -> 0.26.2`                                       |
| [`e27e1885`](https://github.com/NixOS/nixpkgs/commit/e27e1885c5065088b62620648e7ba47db759af61) | `python310Packages.sqlmap: 1.6.9 -> 1.6.10`                            |
| [`7d943230`](https://github.com/NixOS/nixpkgs/commit/7d94323083a759d2fe84eb9aadd491b6a6516d84) | `aegisub: migrate to wxGTK32`                                          |
| [`3d675948`](https://github.com/NixOS/nixpkgs/commit/3d675948c56b4557885be70ec3d00e4200809759) | `treesheets: add darwin support`                                       |
| [`679cd346`](https://github.com/NixOS/nixpkgs/commit/679cd3462fab51ba0534532d5a28b96659cc8b63) | `sget: init at unstable-2022-10-04`                                    |
| [`c856e2c3`](https://github.com/NixOS/nixpkgs/commit/c856e2c30601caa5eca85d8b591af16c04191eeb) | `duckstation: unstable-2022-08-22 -> unstable-2022-07-08`              |
| [`d21043c4`](https://github.com/NixOS/nixpkgs/commit/d21043c4659a2f8e09783860471fdab35ed7f067) | `exploitdb: 2022-09-24 -> 2022-10-07`                                  |
| [`2733d9b3`](https://github.com/NixOS/nixpkgs/commit/2733d9b328f107f66c250672960bf6b577cc5b2e) | `nuclei: 2.7.7 -> 2.7.8`                                               |
| [`729189ee`](https://github.com/NixOS/nixpkgs/commit/729189eee8cd504aa4fc1f54799e8ec5dc1b93c5) | `nim_builder: enable parallel building`                                |
| [`1471e0c7`](https://github.com/NixOS/nixpkgs/commit/1471e0c73968d2062baade43ee2262044eb95e67) | `nim: unescape "\ " before splitting NIX_LDFLAGS`                      |
| [`c1184a3f`](https://github.com/NixOS/nixpkgs/commit/c1184a3f8c11162ff554dbadbe896af9c095ee0b) | `nim: 1.6.6 -> 1.6.8`                                                  |
| [`10843480`](https://github.com/NixOS/nixpkgs/commit/108434803ac0e482a7a333e2cbf4ba494bd9e038) | `maintainers: add siph`                                                |
| [`b5460566`](https://github.com/NixOS/nixpkgs/commit/b54605669c24511d48dd52681b621b0c7f707abf) | `minikube: 1.27.0 -> 1.27.1`                                           |
| [`a369a550`](https://github.com/NixOS/nixpkgs/commit/a369a5502b762908be3bfc399ffcfd4b8a2177e4) | `python310Packages.pytrafikverket: 0.2.0.1 -> 0.2.1`                   |
| [`b4bb571f`](https://github.com/NixOS/nixpkgs/commit/b4bb571fa076bdcd60033d05a943e7ea3df0aac6) | `iwd: remove myself as maintainer`                                     |
| [`dcd82ae5`](https://github.com/NixOS/nixpkgs/commit/dcd82ae5d9f55b74c7d650c15b29539e838c9a0e) | `maeparser: refresh meta`                                              |
| [`8bed3364`](https://github.com/NixOS/nixpkgs/commit/8bed3364f02d671fb76bc74227103b6921d8f5be) | `wasm-pack: Update LibreSSL to 3.5`                                    |
| [`52d9fd78`](https://github.com/NixOS/nixpkgs/commit/52d9fd78e29eb844eefa4d294a6f46b9959fd842) | `sarasa-gothic: 0.37.0 -> 0.37.4`                                      |
| [`9c9c818f`](https://github.com/NixOS/nixpkgs/commit/9c9c818f46761f539ee0fb7b9aace6483cfd4163) | `python310Packages.pysigma: 0.8.8 -> 0.8.9`                            |
| [`ffd9fc28`](https://github.com/NixOS/nixpkgs/commit/ffd9fc281188d873dac77049d271372365876b83) | `grim: disable -Werror so compiler updates can't break the build`      |
| [`c02b06d6`](https://github.com/NixOS/nixpkgs/commit/c02b06d612c164d4915675080516a4c43068f2a4) | `chromedriver: fix darwin aarch64`                                     |
| [`c1af7320`](https://github.com/NixOS/nixpkgs/commit/c1af7320e6c10ce22bbda1bf626112b59b3a48e9) | `vdpauinfo: 1.3 -> 1.5`                                                |
| [`9542fd2d`](https://github.com/NixOS/nixpkgs/commit/9542fd2dc524a55d90fbc10fe574c85a94ef0e13) | `rocketchat-desktop: 3.8.9 -> 3.8.11`                                  |
| [`a07f22f2`](https://github.com/NixOS/nixpkgs/commit/a07f22f26fcd3c0087f06a7a91b402c894b6486f) | `phrase-cli: 2.5.1 -> 2.5.2`                                           |
| [`b110b996`](https://github.com/NixOS/nixpkgs/commit/b110b99666514cc62fcc878d5af74b7c5c789447) | `qogir-icon-theme: 2022-07-20 -> 2022-10-08`                           |
| [`4e44672a`](https://github.com/NixOS/nixpkgs/commit/4e44672a0ae4df762dd76a7afa9e6082c7fbd775) | `shipyard: 0.4.10 -> 0.4.12`                                           |
| [`5ec24ce0`](https://github.com/NixOS/nixpkgs/commit/5ec24ce090a82ee341cbdca458aec72f0f0f4a5a) | `janusgraph: init at 0.6.2`                                            |
| [`2c5c2399`](https://github.com/NixOS/nixpkgs/commit/2c5c239958bc9f9e7fda9f37c3515586f793f7b9) | `apache-directory-server: init at 2.0.0.AM26`                          |
| [`9766d612`](https://github.com/NixOS/nixpkgs/commit/9766d6127ab52253174ff5989d6054745ba1b7bf) | `maintainers: add ners`                                                |
| [`043641f5`](https://github.com/NixOS/nixpkgs/commit/043641f58a167759dfb9e21f1871b9ea5b21d7b8) | `twitterBootstrap: 5.2.1 -> 5.2.2`                                     |
| [`c51e91db`](https://github.com/NixOS/nixpkgs/commit/c51e91dbbb76bfff78902b02439117ad1d3aadf3) | `python310Packages.pydata-sphinx-theme: 0.10.1 -> 0.11.0`              |
| [`9b16f08a`](https://github.com/NixOS/nixpkgs/commit/9b16f08a95589022e3ebc3e3642013d98bc5a1f0) | `yosys-ghdl: 2021.01.25 -> 2022.01.11`                                 |