### PR TITLE
chore(flake/home-manager): `9fcae11f` -> `5597b3a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665119273,
-        "narHash": "sha256-neL/ZRrwk47Ke1nfjk8ltlIm+NRZyA3MBcNbqEGSBeE=",
+        "lastModified": 1665520899,
+        "narHash": "sha256-N8BYMgvrAYhiXeyrcEeLgngZZaU6MVVocSa+tIfyMyg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9fcae11ff29ca5f959b05c206f3724486c28ff07",
+        "rev": "5597b3a7425a9e3f41128308cb1105d3e780f633",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                            |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`5597b3a7`](https://github.com/nix-community/home-manager/commit/5597b3a7425a9e3f41128308cb1105d3e780f633) | `dconf: reset keys that become unmanaged on switch`       |
| [`b37a9095`](https://github.com/nix-community/home-manager/commit/b37a909508edb8d7fdcd04ac90761b2cfa2a5f28) | `ci: specify files that should be tagged "mail"`          |
| [`ebe6d2c7`](https://github.com/nix-community/home-manager/commit/ebe6d2c747cc6e2223dd5962bdca258088518b3f) | `home-manager: set state version when uninstalling`       |
| [`e1f11602`](https://github.com/nix-community/home-manager/commit/e1f1160284198a68ea8c7fffbbb1436f99e46ef9) | ``redshift/gammastep: add `enableVerboseLogging` option`` |
| [`bd87a34b`](https://github.com/nix-community/home-manager/commit/bd87a34bb487a655e1282528a70d0d6b10585a37) | `sioyek: enable multiple bindings for the same command`   |
| [`3b5a8d3d`](https://github.com/nix-community/home-manager/commit/3b5a8d3dc79e05213d3c428a0b8777e21cb0c6b8) | `ci: introduce labeler workflow`                          |