### PR TITLE
chore(flake/templates): `af0d5d98` -> `3248d540`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -439,11 +439,11 @@
     },
     "templates": {
       "locked": {
-        "lastModified": 1664891606,
-        "narHash": "sha256-b8zpajTijlXL8GfvCnzICvMKjhX8micxfZkZp6OGE9M=",
+        "lastModified": 1665394171,
+        "narHash": "sha256-9PxRGDx3RIGnoL55/TwpTYPsNSgdoIi/TSbPQ8CRalU=",
         "owner": "NixOS",
         "repo": "templates",
-        "rev": "af0d5d98c24323e359b10628665132d2ca241a12",
+        "rev": "3248d54007cb7cb4cccdfba3e0d074f10ae013fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                                       |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`5ba78e8c`](https://github.com/NixOS/templates/commit/5ba78e8c8910633978e234df9bec51a45ba690c4) | ``Fix wrong `defaultApp` in Rust template``          |
| [`59d8dd61`](https://github.com/NixOS/templates/commit/59d8dd61df05679d0e9bf843273b564918afccf0) | ``Fix #45: PR #40 broke `nix flake show templates``` |