### PR TITLE
chore(flake/nixos-hardware): `47fd7028` -> `236ba4df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -263,11 +263,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1665040200,
-        "narHash": "sha256-glqL6yj3aUm40y92inzRmowGt9aIrUrpBX7eBAMic4I=",
+        "lastModified": 1665321371,
+        "narHash": "sha256-0SO6MTW0bX6lxZmz1AZW/Xmk+hnTd7/hp1vF7Tp7jg0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "47fd70289491c1f0c0d9a1f44fb5a9e2801120c9",
+        "rev": "236ba4df714131059945d7754c0aa3fbe9d2f74c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`68e08aa5`](https://github.com/NixOS/nixos-hardware/commit/68e08aa56b38fb6758ffc859b065c88634e13046) | `starfive/visionfive/v1: init`                |
| [`c156c31e`](https://github.com/NixOS/nixos-hardware/commit/c156c31e1dd86cfd7e5c5a95c4c0ce005d35881f) | `readme: add starfive visionfive v1`          |
| [`2c14c0f8`](https://github.com/NixOS/nixos-hardware/commit/2c14c0f8611278a7ca47a00e7b30e9e69a80bae0) | `flake: add starfive-visionfive-v1`           |
| [`18c0cbb6`](https://github.com/NixOS/nixos-hardware/commit/18c0cbb6b49d7b4402c9eb9fd0690e4bd3d31b63) | `raspberrypi/4: allow pi libs to detect pi 4` |