### PR TITLE
chore(flake/emacs-ement): `f4e1eb9b` -> `b06c78d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1665535982,
-        "narHash": "sha256-/MwxLy+PPWKQRpltcM3lyY0dF7rYYTnABCKpv3fUkaE=",
+        "lastModified": 1666449437,
+        "narHash": "sha256-j30qJY3sFVZtIlMBBjaA8izcNDqjyfHvl5wKvFj9ml0=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "f4e1eb9b392a93920542080a06dcc90b37f61712",
+        "rev": "b06c78d1ba700857330520bc796c5a29018b7ec5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message  |
| --------------------------------------------------------------------------------------------------- | --------------- |
| [`b06c78d1`](https://github.com/alphapapa/ement.el/commit/b06c78d1ba700857330520bc796c5a29018b7ec5) | `Release: v0.4` |