### PR TITLE
chore(flake/nixpkgs): `34c5293a` -> `285e77ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -277,11 +277,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665349835,
-        "narHash": "sha256-UK4urM3iN80UXQ7EaOappDzcisYIuEURFRoGQ/yPkug=",
+        "lastModified": 1665449268,
+        "narHash": "sha256-cw4xrQIAZUyJGj58Dp5VLICI0rscd+uap83afiFzlcA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "34c5293a71ffdb2fe054eb5288adc1882c1eb0b1",
+        "rev": "285e77efe87df64105ec14b204de6636fb0a7a27",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                   |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`2b29a137`](https://github.com/NixOS/nixpkgs/commit/2b29a137e78915c3c30bcd0311e061c63f9df01f) | `python310Packages.ansible-lint: 6.8.0 -> 6.8.1`                 |
| [`c9481548`](https://github.com/NixOS/nixpkgs/commit/c948154885264dfb33f091ee1f09fa52bb69fa4e) | `rpcs3: 0.0.24-14141-d686b48f6 -> 0.0.24-14241-92b08a4fa`        |
| [`920b85b4`](https://github.com/NixOS/nixpkgs/commit/920b85b49924bf7a65b9d5d53078f09c8992c93e) | `python3Packages.pyjwt: remove unused types-cryptography input`  |
| [`d165f7a5`](https://github.com/NixOS/nixpkgs/commit/d165f7a5136f48745d8e113838c9fac4d4d1b9c0) | `nixos/installer: fix eval with missing config arg`              |
| [`02616a20`](https://github.com/NixOS/nixpkgs/commit/02616a20a68ed33f91b8594637d235e89cf5d2d7) | `home-assistant: 2022.10.2 -> 2022.10.3`                         |
| [`94854739`](https://github.com/NixOS/nixpkgs/commit/948547392b39c530c6ee3807616191a64beb88f0) | `python3Packages.zigpy-zigate: 0.10.1 -> 0.10.2`                 |
| [`a5bb097c`](https://github.com/NixOS/nixpkgs/commit/a5bb097c8e5fa4437fc8f02974ae1760732faff0) | `python3Packages.zigpy-xbee: 0.16.1 -> 0.16.2`                   |
| [`eb97f94b`](https://github.com/NixOS/nixpkgs/commit/eb97f94b9453b28d95cc10b4f54abb2c3c6423c1) | `python3Packages.bluetooth-auto-recovery: 0.3.3 -> 0.3.4`        |
| [`c05de1e4`](https://github.com/NixOS/nixpkgs/commit/c05de1e4402b4a5e8af2065139263e617245bc18) | `python3Packages.aiounifi: 38 -> 39`                             |
| [`205e805d`](https://github.com/NixOS/nixpkgs/commit/205e805d51eecde255764e03d329839ea9baacae) | `steam: Add extraArgs to prepend arguments to Steam`             |
| [`4cdda329`](https://github.com/NixOS/nixpkgs/commit/4cdda329f06f21f61b8bee4df9d5cf9f8efdcb77) | `nixos/modules/profiles/base.nix: omit zfs if unavailable`       |
| [`eeaa4935`](https://github.com/NixOS/nixpkgs/commit/eeaa4935084613012335c3e6fa7f27a6dfd961cf) | `prometheus-openldap-exporter: pin to go 1.18`                   |
| [`15971fd5`](https://github.com/NixOS/nixpkgs/commit/15971fd54a842a639f3ee90d1b9147cbac53c7e5) | `tracee: pin to go 1.18`                                         |
| [`b011bb05`](https://github.com/NixOS/nixpkgs/commit/b011bb05615cc34db8ab76fe01429db7ae7fcc6e) | `stripe-cli: pin to go 1.18`                                     |
| [`157a2144`](https://github.com/NixOS/nixpkgs/commit/157a2144d06dd64f80c4f1087ebfc0677f76d420) | `routedns: pin to go 1.18`                                       |
| [`5c438706`](https://github.com/NixOS/nixpkgs/commit/5c43870684a38969243af016189d766dda77af98) | `kube3d: pin to go 1.18`                                         |
| [`c8412d00`](https://github.com/NixOS/nixpkgs/commit/c8412d00f175ca87e4eeb8d54dcbc43bc5fc50b2) | `zrepl: pin to go 1.18`                                          |
| [`5a8dcde9`](https://github.com/NixOS/nixpkgs/commit/5a8dcde91a7298220615e3cf69606bc75ccc1a16) | `norouter: pin to go 1.18`                                       |
| [`eb307f80`](https://github.com/NixOS/nixpkgs/commit/eb307f8075032a78d0d6b3f0a0cb255e089209c1) | `grafana-agent: pin to go 1.18`                                  |
| [`d53de6f8`](https://github.com/NixOS/nixpkgs/commit/d53de6f8d541dc4fa316780bdabfbf73cb4ba339) | `ivy: pin to go 1.18`                                            |
| [`18e70667`](https://github.com/NixOS/nixpkgs/commit/18e70667703536f060ab2e48f0ea5bb45ec22b77) | `podman: pin to go 1.18`                                         |
| [`c38edb84`](https://github.com/NixOS/nixpkgs/commit/c38edb843b1a42d6b5889f06330ead9f76f3f15f) | `ipget: pin to go 1.18`                                          |
| [`aa8e4b78`](https://github.com/NixOS/nixpkgs/commit/aa8e4b78d3fb2b16f9cc0c905de016d9e6e1f70a) | `doggo: pin to go 1.18`                                          |
| [`35263612`](https://github.com/NixOS/nixpkgs/commit/352636126b005430314d9486be574d36b2863102) | `cue: pin to go 1.18`                                            |
| [`38ad005d`](https://github.com/NixOS/nixpkgs/commit/38ad005da6e6a1aec5072a045222ccab828f2b34) | `brev-cli: pin to go 1.18`                                       |
| [`b96de6c2`](https://github.com/NixOS/nixpkgs/commit/b96de6c275ede7bcc74ea1101ca6ba6ecf8deddf) | `infracost: mark broken on x86_64`                               |
| [`3fe097dc`](https://github.com/NixOS/nixpkgs/commit/3fe097dced49de2273e5e2a5cd37d6d43cdec905) | `flyctl: 0.0.406 -> 0.0.407`                                     |
| [`5314192d`](https://github.com/NixOS/nixpkgs/commit/5314192d1bece042e758d45e32eb79bb686b85f2) | `toxic: 0.11.1 -> 0.11.3`                                        |
| [`4fd6adc3`](https://github.com/NixOS/nixpkgs/commit/4fd6adc34b13def2d4a80aa25e53b8fc28f686c7) | `libtoxcore: 0.2.17 -> 0.2.18`                                   |
| [`93ea7dd8`](https://github.com/NixOS/nixpkgs/commit/93ea7dd8f9752f68d8bf34b0cf0ecf1f447200e1) | `libtoxcore_0_1: remove`                                         |
| [`1a62113d`](https://github.com/NixOS/nixpkgs/commit/1a62113dd9b25fd278e473f3de0a6cd2c2f8de6c) | `toxprpl: mark broken, unmantained and doesn't build`            |
| [`0ffd51df`](https://github.com/NixOS/nixpkgs/commit/0ffd51df20117c9fb85d8709f04b706bf153feb5) | `smart-wallpaper: Add missing 'redshift' dependency`             |
| [`2af32dd4`](https://github.com/NixOS/nixpkgs/commit/2af32dd4820ae062104d47c0c745b455ac8317dc) | `clusterctl: 1.2.2 -> 1.2.3`                                     |
| [`01faaeb4`](https://github.com/NixOS/nixpkgs/commit/01faaeb4bdb9e7952093f3699f2f4b1b36a811cd) | `nixos/gitolite: add 'description' module option`                |
| [`0495b021`](https://github.com/NixOS/nixpkgs/commit/0495b0217b539a41f343c61f78511d133424d872) | `writers.writeFish: avoid loading user config files`             |
| [`bb49ddeb`](https://github.com/NixOS/nixpkgs/commit/bb49ddebc9d706d122a63fb16b5f6867feb11570) | `pkgsMusl.vte: fix build (#193930)`                              |
| [`4886f37b`](https://github.com/NixOS/nixpkgs/commit/4886f37b9710c77cb9c988799f7eddbde5afb25e) | `guestfs-tools: add optional dependency openssl`                 |
| [`960cc8f3`](https://github.com/NixOS/nixpkgs/commit/960cc8f3f1b4a71ca67d8a8d55ba6f0c9058ab8c) | `guestfs-tools: install bash-completion scripts`                 |
| [`fd7f6be0`](https://github.com/NixOS/nixpkgs/commit/fd7f6be003960f6c0b624cd553d6802a0df716da) | `guestfs-tools: patch less shebangs`                             |
| [`c365b0d4`](https://github.com/NixOS/nixpkgs/commit/c365b0d47b530827ba829ca140d8ecc36f0ff78a) | `guestfs-tools: use libguestfs-with-appliance`                   |
| [`2ce78bd5`](https://github.com/NixOS/nixpkgs/commit/2ce78bd571a7985f40024af2d4ac2aa407c3e383) | `gatk: add java and python to PATH`                              |
| [`a5b2107a`](https://github.com/NixOS/nixpkgs/commit/a5b2107a233b9888372d33602fc5e7bfcfc87e0a) | `talosctl: 1.2.3 -> 1.2.4`                                       |
| [`fd41bc31`](https://github.com/NixOS/nixpkgs/commit/fd41bc31b8cf83f14e015ef490a89ade5e91d405) | `parsec-bin: init at 150_28`                                     |
| [`7cc67d5e`](https://github.com/NixOS/nixpkgs/commit/7cc67d5e6b6c860f2e6b33ab5063f92cafe6a063) | `spatialite_gui: Fix build by adding xz`                         |
| [`6b7c0d59`](https://github.com/NixOS/nixpkgs/commit/6b7c0d59c0ee1a8d617e24b993142d0d705afd12) | `alerta-server: propagate cryptography`                          |
| [`14adbf88`](https://github.com/NixOS/nixpkgs/commit/14adbf88f9137e19ade8ddb196420108b2f38922) | `vimPlugins.hydra-nvim: init at 2022-10-02`                      |
| [`94ec74b3`](https://github.com/NixOS/nixpkgs/commit/94ec74b398068c3a85ffede422e52c838f074ad8) | `vimPlugins: update`                                             |
| [`ba3ead48`](https://github.com/NixOS/nixpkgs/commit/ba3ead48e0a83bff0a6aba213f9ece8fc6d50cb4) | `gf: unstable-2022-08-01 -> unstable-2022-09-26`                 |
| [`a145fcca`](https://github.com/NixOS/nixpkgs/commit/a145fccac4d004e8398e01dcb35b509a6876a1cf) | `ruff: 0.0.65 -> 0.0.67`                                         |
| [`732633fd`](https://github.com/NixOS/nixpkgs/commit/732633fdff202425e644559bd4b70a76bfd451e9) | `python310Packages.transmission-rpc: enable tests`               |
| [`fea031c3`](https://github.com/NixOS/nixpkgs/commit/fea031c3e8c1c3f9e2b2dc057f4d1949a9f7ae05) | `python310Packages.pysnmplib: 5.0.18 -> 5.0.19`                  |
| [`d5264e6c`](https://github.com/NixOS/nixpkgs/commit/d5264e6c8dc40be11b1031e38a804ce330fd7bac) | `python310Packages.meshtastic: 1.3.37 -> 1.3.39`                 |
| [`d8648e49`](https://github.com/NixOS/nixpkgs/commit/d8648e4924017891c3a01906a4c6db4f618ad103) | `swaywsr: 1.1.0 -> 1.1.1`                                        |
| [`67246fbf`](https://github.com/NixOS/nixpkgs/commit/67246fbffa8eef29eec444ad73e3963fde6e0f12) | `nixos/ssh: pass WAYLAND_DISPLAY to ssh-askpass`                 |
| [`ab305c56`](https://github.com/NixOS/nixpkgs/commit/ab305c56e2e3f51c8abd221e0b8adda42665aa60) | `eclipses: 2022-06 -> 2022-09`                                   |
| [`cd6bdcb4`](https://github.com/NixOS/nixpkgs/commit/cd6bdcb4cae9b0d846eeec3d5fda8154851cc972) | `bloop: 1.5.3 -> 1.5.4 (#195349)`                                |
| [`6e4a14b5`](https://github.com/NixOS/nixpkgs/commit/6e4a14b54f3f62e078f999bf746ebfa2020890f8) | `writers: add writeFish and writeFishBin`                        |
| [`165b20ea`](https://github.com/NixOS/nixpkgs/commit/165b20eafab7f8170fdfb9456ac7b4959a566683) | `genact: 1.2.0 -> 1.2.2`                                         |
| [`b0b4b047`](https://github.com/NixOS/nixpkgs/commit/b0b4b047ae6eb03f907ca705db02559953c467b7) | `python310Packages.wallbox: 0.4.9 -> 0.4.10`                     |
| [`2182ed70`](https://github.com/NixOS/nixpkgs/commit/2182ed7064699d395f07177295ba835eb672750f) | `rust-analyzer-unwrapped: 2022-10-03 -> 2022-10-10`              |
| [`852bf558`](https://github.com/NixOS/nixpkgs/commit/852bf558eb909143aacb7d40262746468be4a3d7) | `fend: install man page`                                         |
| [`f0f5aa60`](https://github.com/NixOS/nixpkgs/commit/f0f5aa601e99c9415c57ce67ca5e3351d0e38d3c) | `tanka: Update ldflags`                                          |
| [`8f2f7c10`](https://github.com/NixOS/nixpkgs/commit/8f2f7c1097258ee2ed91a85c33a40ad4963ae6c8) | `tilt: 0.30.8 -> 0.30.9`                                         |
| [`f859f274`](https://github.com/NixOS/nixpkgs/commit/f859f274b18f4434050efcf043a9e5c009105790) | `python310Packages.typed-settings: 1.1.0 -> 1.1.1`               |
| [`282ac912`](https://github.com/NixOS/nixpkgs/commit/282ac9121fbd772ff461d16bc57ccdb8e8db8d84) | `python310Packages.transmission-rpc: 3.3.2 -> 3.4.0`             |
| [`151b6a4d`](https://github.com/NixOS/nixpkgs/commit/151b6a4daf39e2ffe7784face07b6919de2d733a) | `mill: 0.10.7 -> 0.10.8`                                         |
| [`d2ac2cda`](https://github.com/NixOS/nixpkgs/commit/d2ac2cda661bc2d66f4434448ba2710c3118ace2) | `pipenv: 2022.9.8 -> 2022.10.9`                                  |
| [`9bccf6da`](https://github.com/NixOS/nixpkgs/commit/9bccf6da14884e6d511d578cc9bf77d1d046bd95) | `swapspace: 1.17 -> 1.18`                                        |
| [`e0d476da`](https://github.com/NixOS/nixpkgs/commit/e0d476da339bf13eec41bdd468587a3964f3342a) | `symfony-cli: 5.4.14 -> 5.4.15`                                  |
| [`1c5a8bfa`](https://github.com/NixOS/nixpkgs/commit/1c5a8bfa7d383791ddfe7b26e0b62e5b791023a8) | `python310Packages.sphinxcontrib-spelling: 7.6.0 -> 7.6.1`       |
| [`f3ef5751`](https://github.com/NixOS/nixpkgs/commit/f3ef575175292b774369fce964ff09801eca34b6) | `lorri: 1.5.0 -> 1.6.0`                                          |
| [`eac905ea`](https://github.com/NixOS/nixpkgs/commit/eac905ea816316be2a3e418ee2667aef16f26e88) | `dbeaver: 22.2.0 -> 22.2.2`                                      |
| [`d74b3668`](https://github.com/NixOS/nixpkgs/commit/d74b3668e7bf0eb2e765fdfcb6665b6d4b751edf) | `lnd: 0.15.1-beta -> 0.15.2-beta`                                |
| [`b01d7c80`](https://github.com/NixOS/nixpkgs/commit/b01d7c80a0f3639d87801dd5619b512222717a08) | `matrix-conduit: don't use pkgs directly`                        |
| [`e622de22`](https://github.com/NixOS/nixpkgs/commit/e622de224ea183380c4b13636b0182ab289074bd) | `eclair: 0.6.2 -> 0.7.0-patch-disconnect`                        |
| [`b2f0054d`](https://github.com/NixOS/nixpkgs/commit/b2f0054dd0a8644956b5cf27e132eb06d696237a) | `plib: patch for CVE-2021-38714`                                 |
| [`91d1eb9f`](https://github.com/NixOS/nixpkgs/commit/91d1eb9f2a9c4e3c9d68a59f6c0cada8c63d5340) | `jasmin-compiler: 2022.04.0 → 2022.09.0`                         |
| [`4329682c`](https://github.com/NixOS/nixpkgs/commit/4329682cb697ea0ce5d0df6e520dcdb0cfd07786) | `ocamlPackages.x509: 0.16.0 → 0.16.2`                            |
| [`e77f9f2f`](https://github.com/NixOS/nixpkgs/commit/e77f9f2f9b32c61a9493ef04154518394c8191b1) | `minio: 2022-10-05T14-58-27Z -> 2022-10-08T20-11-00Z`            |
| [`2230d0f4`](https://github.com/NixOS/nixpkgs/commit/2230d0f441af812b0e890964d4e57f7456cc0fc6) | `minio-client: 2022-10-06T01-20-06Z -> 2022-10-09T21-10-59Z`     |
| [`32f16786`](https://github.com/NixOS/nixpkgs/commit/32f1678683e05e82b454ab3234c10bd01bf0ce6e) | `libmicrohttpd_0_9_70: drop`                                     |
| [`4902637c`](https://github.com/NixOS/nixpkgs/commit/4902637cc2c816e5746f09b01b62305302584be8) | `libmicrohttpd_0_9_70: mark as insecure`                         |
| [`a9cd1354`](https://github.com/NixOS/nixpkgs/commit/a9cd13546b0bfea319ce71f359a12710946b84a1) | `proxysql: switch libmicrohttpd from 0.9.70 to 0.9.69`           |
| [`fe2d699e`](https://github.com/NixOS/nixpkgs/commit/fe2d699e41317beadb4b075f8d1bb40309fe1a0d) | `libmicrohttpd_0_9_69: init at 0.9.69`                           |
| [`342e2816`](https://github.com/NixOS/nixpkgs/commit/342e2816248ac4a96093d123dd3582373c8b1508) | `xmr-stak: switch libmicrohttpd to 0.9.71`                       |
| [`4beb9675`](https://github.com/NixOS/nixpkgs/commit/4beb9675e32cde5ee323335c6404e4025ce70084) | `osmscout-server: move libmicrohttpd to 0.9.71`                  |
| [`e907371b`](https://github.com/NixOS/nixpkgs/commit/e907371b6199c5ef77364aea81a57989d0e1edd0) | `elfutils: move libmicrohttpd to 0.9.71`                         |
| [`00a62633`](https://github.com/NixOS/nixpkgs/commit/00a62633db0819ebc0397a934d69bf57eb1a26c1) | `ungoogled-chromium: 106.0.5249.91 -> 106.0.5249.103`            |
| [`bbbda58c`](https://github.com/NixOS/nixpkgs/commit/bbbda58c4e99601935728cc568874897d98221c1) | `nixos/fwupd: Fix configuration file merging`                    |
| [`0621cbf4`](https://github.com/NixOS/nixpkgs/commit/0621cbf4798b345531bd02a22a3fe73c30db632d) | `poetry2nix: 1.33.0 -> 1.34.1`                                   |
| [`83453bb2`](https://github.com/NixOS/nixpkgs/commit/83453bb2b4c5b2689ed1b51a685b22c804182348) | `python310Packages.pyswitchbot: 0.19.14 -> 0.19.15`              |
| [`ff111964`](https://github.com/NixOS/nixpkgs/commit/ff1119646e0de51824958c4882753acd2a93fc41) | `terraform-providers.acme: 2.10.0 -> 2.11.1`                     |
| [`a54bf008`](https://github.com/NixOS/nixpkgs/commit/a54bf00865f2f297b3b0157d8cbd1509e56c8d3d) | `terraform-providers.libvirt: 0.6.14 → 0.7.0`                    |
| [`3c22ee3f`](https://github.com/NixOS/nixpkgs/commit/3c22ee3fd0ad7e39544af76e6c34f6effb421244) | `terraform-providers.ksyun: 1.3.54 → 1.3.55`                     |
| [`7f4114fd`](https://github.com/NixOS/nixpkgs/commit/7f4114fd2edd6710d175db33a408dea6af3aea95) | `terraform-providers.fortios: 1.15.0 → 1.16.0`                   |
| [`ec610610`](https://github.com/NixOS/nixpkgs/commit/ec6106104896e037ce213c40c479306e18290075) | `gh-dash: 3.4.1 -> 3.4.2`                                        |
| [`f8c5fbfb`](https://github.com/NixOS/nixpkgs/commit/f8c5fbfb54d59a86ec2b9b401ba50834b4ca1d24) | `flexget: 3.3.32 -> 3.3.33`                                      |
| [`c9c28d62`](https://github.com/NixOS/nixpkgs/commit/c9c28d62bf23d616f27014f776282c70f5ec6b7a) | `python310Packages.pypdf2: 2.11.0 -> 2.11.1`                     |
| [`252d8c43`](https://github.com/NixOS/nixpkgs/commit/252d8c43cedba2e8f4846bee68d4c56b74d3f1d8) | `python310Packages.pylsp-mypy: 0.6.2 -> 0.6.3`                   |
| [`1d8fe07a`](https://github.com/NixOS/nixpkgs/commit/1d8fe07ab9a46998429782a18d8c5fba0aa55184) | `nixopsUnstable: remove hacky override of pythonOutputDistPhase` |
| [`8ab37281`](https://github.com/NixOS/nixpkgs/commit/8ab372812329670a886a775e1879708c0f55db75) | `ruff: 0.0.63 -> 0.0.65`                                         |
| [`beba358f`](https://github.com/NixOS/nixpkgs/commit/beba358f942049dde9f41db2c5ced065cf81b280) | `cudatext: 1.172.0 -> 1.172.5`                                   |
| [`c7110cf0`](https://github.com/NixOS/nixpkgs/commit/c7110cf07dcd80ee5d335836e3b4b574686b7b0b) | `cargo-tarpaulin: 0.21.0 -> 0.22.0`                              |
| [`6886c7f2`](https://github.com/NixOS/nixpkgs/commit/6886c7f218ba1c5812c3905057426ce71704ada4) | `bemenu: 0.6.11 -> 0.6.12`                                       |
| [`20be4b1c`](https://github.com/NixOS/nixpkgs/commit/20be4b1cef054f00220e1652ef88274c3b85e6fd) | `actionlint: 1.6.20 -> 1.6.21`                                   |
| [`142bbce9`](https://github.com/NixOS/nixpkgs/commit/142bbce98241acd1ce979a9becac19ef8acf7a54) | `python310Packages.pebble: 5.0.1 -> 5.0.2`                       |
| [`615accaf`](https://github.com/NixOS/nixpkgs/commit/615accaffe6b334342a38c5fb14d5106098eebac) | `python310Packages.patsy: 0.5.2 -> 0.5.3`                        |
| [`51b9e285`](https://github.com/NixOS/nixpkgs/commit/51b9e2857f057308ce9c95b8d3440b59ab7d617d) | `nixos/sssd: fix race condition in test`                         |
| [`8b370b3d`](https://github.com/NixOS/nixpkgs/commit/8b370b3d62f0fbf79f2c8037b4b193eee1f34336) | `wtf: 0.41.0 -> 0.42.0`                                          |
| [`67620e2f`](https://github.com/NixOS/nixpkgs/commit/67620e2fce855fa6ec812caf0f738b4fcd869952) | `star-history: init at 1.0.4`                                    |
| [`006d6768`](https://github.com/NixOS/nixpkgs/commit/006d6768ec0a5b6cc271e625e1d4397242205780) | `theme-obsidian2: 2.20 -> 2.21`                                  |
| [`a4dfb6cb`](https://github.com/NixOS/nixpkgs/commit/a4dfb6cb0b5943c36592b3aa6fb5872a118ba7f6) | `python310Packages.nbclassic: 0.4.3 -> 0.4.5`                    |
| [`cea0c626`](https://github.com/NixOS/nixpkgs/commit/cea0c62688fba15ecbe4b94541e30c0773320e9b) | `weechat: add PHP support`                                       |
| [`a2688acf`](https://github.com/NixOS/nixpkgs/commit/a2688acfd5b993e252f293d8d72918d39c68f422) | `Revert "seahub: fix build"`                                     |
| [`6ceaf4b1`](https://github.com/NixOS/nixpkgs/commit/6ceaf4b1152f2f9e46a2bf5743c73e83ee4d85ac) | `portfolio: 0.59.1 -> 0.59.2`                                    |
| [`b3a4414d`](https://github.com/NixOS/nixpkgs/commit/b3a4414dd40e00768db5a093cd4a0e52ca6006d6) | `b4: 0.8.0 -> 0.10.1; adopt`                                     |
| [`bd9cdb02`](https://github.com/NixOS/nixpkgs/commit/bd9cdb02de6a4a409ada1bd40e5a09e7482bb7d0) | `patatt: 0.5.0 -> 0.6.2; adopt`                                  |
| [`e8a7cb9c`](https://github.com/NixOS/nixpkgs/commit/e8a7cb9cd2e94e7f9f2218364480e91122bf7591) | `genact: remove patch`                                           |
| [`b60d756a`](https://github.com/NixOS/nixpkgs/commit/b60d756a713d80673b2a6f4716e94d040bb59870) | `yamlpath: 3.6.3 -> 3.6.7`                                       |
| [`012d718b`](https://github.com/NixOS/nixpkgs/commit/012d718bc18ef0f89225bad0238577ded0aa38ba) | `timedoctor: remove broken uninstallable package`                |