### PR TITLE
chore(flake/pre-commit-hooks): `11aff801` -> `94b0f300`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -330,11 +330,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665395272,
-        "narHash": "sha256-kkV5gfDJWMxKmYq3Y2pgvD7zH/I3WoW/0wr659Stj1Q=",
+        "lastModified": 1665584211,
+        "narHash": "sha256-Qc9zn43UjLpP823BP416hAsoaXugwWw+nKPVqsNhqdY=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "11aff801aa0ea1fb02ae43e61f7cdf610f5fe2e5",
+        "rev": "94b0f300dd9a23d4e851aa2a947a1511d3410e2d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                  |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`fb9ffa12`](https://github.com/cachix/pre-commit-hooks.nix/commit/fb9ffa12010607eb60e77e9591d286f76588e9fd) | `Make cabal2nix work in subdirectories as well` |
| [`380f0846`](https://github.com/cachix/pre-commit-hooks.nix/commit/380f08460be3f1ddd3bceb6cfb505de5d8e479e0) | `Fix name of elm-test hook`                     |