### PR TITLE
chore(flake/emacs-overlay): `63e405c4` -> `977b205a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665572899,
-        "narHash": "sha256-k9q3RAv9i4R51F1CZAIUi9AePeeUwYYkJur6Q8YRX0s=",
+        "lastModified": 1665603290,
+        "narHash": "sha256-xdWM+UGqjsgdRvAxf8xNX4vAZI8dpE/453RkiFyTiqA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "63e405c4207a8ff3d3739e3a0f6f7ff7e8b37844",
+        "rev": "977b205ab9ce857f3440dff2a114a35bf2758c05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`977b205a`](https://github.com/nix-community/emacs-overlay/commit/977b205ab9ce857f3440dff2a114a35bf2758c05) | `Updated repos/melpa` |
| [`f55075f7`](https://github.com/nix-community/emacs-overlay/commit/f55075f7fb607310aa7d487099a5d001c2b221d4) | `Updated repos/emacs` |
| [`eb891529`](https://github.com/nix-community/emacs-overlay/commit/eb891529a8944d9d40928ea3d16d725c444859d1) | `Updated repos/elpa`  |