### PR TITLE
chore(flake/nur): `840416c9` -> `a3858bf3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665596786,
-        "narHash": "sha256-cCKP6xVGftmqDF79ohtNEOxvCAb/U4DuXKnogoak4Tk=",
+        "lastModified": 1665617798,
+        "narHash": "sha256-3u7bB4IndBcRkhbC9oDrBiN7X/EiR7AyPzwdncBjrcM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "840416c998aa132adb1d660065a23e5c2ff6195d",
+        "rev": "a3858bf3babba6dd6ae5d884013e5b680ea57899",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a3858bf3`](https://github.com/nix-community/NUR/commit/a3858bf3babba6dd6ae5d884013e5b680ea57899) | `automatic update` |