### PR TITLE
chore(flake/nur): `a3858bf3` -> `c42a6ac4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665617798,
-        "narHash": "sha256-3u7bB4IndBcRkhbC9oDrBiN7X/EiR7AyPzwdncBjrcM=",
+        "lastModified": 1665632935,
+        "narHash": "sha256-68Vggvwk+tGmcTp2z6f8VnZH1rc3/nY59iCVr/6UUNU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a3858bf3babba6dd6ae5d884013e5b680ea57899",
+        "rev": "c42a6ac4e91ed8a9a1b7af17e116da9b0426854d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c42a6ac4`](https://github.com/nix-community/NUR/commit/c42a6ac4e91ed8a9a1b7af17e116da9b0426854d) | `automatic update` |