### PR TITLE
chore(flake/nur): `c42a6ac4` -> `83c80bd4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665632935,
-        "narHash": "sha256-68Vggvwk+tGmcTp2z6f8VnZH1rc3/nY59iCVr/6UUNU=",
+        "lastModified": 1665634039,
+        "narHash": "sha256-KpF5WqZPeOtvgJNwLePj5m82aOVniYW40HsYceChvhM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c42a6ac4e91ed8a9a1b7af17e116da9b0426854d",
+        "rev": "83c80bd42392fe33046eb4203013d8531cdf2f61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`83c80bd4`](https://github.com/nix-community/NUR/commit/83c80bd42392fe33046eb4203013d8531cdf2f61) | `automatic update` |