### PR TITLE
chore(flake/emacs-overlay): `977b205a` -> `28e2a597`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665603290,
-        "narHash": "sha256-xdWM+UGqjsgdRvAxf8xNX4vAZI8dpE/453RkiFyTiqA=",
+        "lastModified": 1665724727,
+        "narHash": "sha256-2lLLc2YmobzejQ6waT6F65GWqRXttjH3e+XxbRLNY3s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "977b205ab9ce857f3440dff2a114a35bf2758c05",
+        "rev": "28e2a59713f822679a174720ad3fe70554ab0457",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`28e2a597`](https://github.com/nix-community/emacs-overlay/commit/28e2a59713f822679a174720ad3fe70554ab0457) | `Updated repos/melpa`  |
| [`1a3881c4`](https://github.com/nix-community/emacs-overlay/commit/1a3881c44752cddd06ddc5b9353ef9263f3184e6) | `Updated repos/emacs`  |
| [`bb8e0002`](https://github.com/nix-community/emacs-overlay/commit/bb8e0002116c4a09092e34e743b04d65c65c30eb) | `Updated repos/elpa`   |
| [`a84e4909`](https://github.com/nix-community/emacs-overlay/commit/a84e49092938264218cf67549619084a269e9129) | `Updated repos/melpa`  |
| [`72bd545c`](https://github.com/nix-community/emacs-overlay/commit/72bd545cc40827ea7a409dd859dc07750459e54d) | `Updated repos/emacs`  |
| [`dddc3dcd`](https://github.com/nix-community/emacs-overlay/commit/dddc3dcd012a749ea7d86623d93db2ae99213aff) | `Updated repos/nongnu` |
| [`6814c3b7`](https://github.com/nix-community/emacs-overlay/commit/6814c3b76972c3c0c5535f089e3ebe6d894543b6) | `Updated repos/melpa`  |
| [`89e9a718`](https://github.com/nix-community/emacs-overlay/commit/89e9a718918fdc327c785b2c1ab05d688e93c2b3) | `Updated repos/emacs`  |
| [`388aac78`](https://github.com/nix-community/emacs-overlay/commit/388aac7847e619fc8fbe3cb69c70d23406238fa3) | `Updated repos/nongnu` |
| [`3da50fda`](https://github.com/nix-community/emacs-overlay/commit/3da50fdaa0d507be27d3483fc89aa40a8f830b9c) | `Updated repos/melpa`  |
| [`35ee7772`](https://github.com/nix-community/emacs-overlay/commit/35ee7772e536b39b1bc42127e089220daf01c992) | `Updated repos/emacs`  |
| [`fdd2f0c3`](https://github.com/nix-community/emacs-overlay/commit/fdd2f0c3e0a22e02b2d772d8266855520f072c24) | `Updated repos/elpa`   |