### PR TITLE
chore(flake/nur): `5b77a018` -> `af1a6c6b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665638044,
-        "narHash": "sha256-2XTveW+wXzXblbjN1o1AKRhyg4XKCS59TQG6GTqQFRQ=",
+        "lastModified": 1665638438,
+        "narHash": "sha256-OVvMcnkay6ucs2Un68WPSfuILS2CxKaRf8rvJIo6pQ8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5b77a018c6411c7f8acb6dc524145dca93b7bfcf",
+        "rev": "af1a6c6ba72ea3a616fa2105d5e7eecfd4c8ef4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`af1a6c6b`](https://github.com/nix-community/NUR/commit/af1a6c6ba72ea3a616fa2105d5e7eecfd4c8ef4d) | `automatic update` |