### PR TITLE
chore(flake/nur): `af1a6c6b` -> `1c3b0c00`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665638438,
-        "narHash": "sha256-OVvMcnkay6ucs2Un68WPSfuILS2CxKaRf8rvJIo6pQ8=",
+        "lastModified": 1665641858,
+        "narHash": "sha256-P9mQkBWjbDxsLlqwpYVeuyc9TYvNmX9rIdgKP2G2uro=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "af1a6c6ba72ea3a616fa2105d5e7eecfd4c8ef4d",
+        "rev": "1c3b0c0055e006828d4eac8b45c3c9938333b115",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1c3b0c00`](https://github.com/nix-community/NUR/commit/1c3b0c0055e006828d4eac8b45c3c9938333b115) | `automatic update` |