### PR TITLE
chore(flake/nur): `1c3b0c00` -> `40f6c8e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665641858,
-        "narHash": "sha256-P9mQkBWjbDxsLlqwpYVeuyc9TYvNmX9rIdgKP2G2uro=",
+        "lastModified": 1665645945,
+        "narHash": "sha256-CaX7Y5s/PiEWj0rNbyy1362fPa/CMsdmBvN8ZX2ix28=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1c3b0c0055e006828d4eac8b45c3c9938333b115",
+        "rev": "40f6c8e660b582b190819f4be08267bb39c51f69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`40f6c8e6`](https://github.com/nix-community/NUR/commit/40f6c8e660b582b190819f4be08267bb39c51f69) | `automatic update` |