### PR TITLE
chore(flake/nixos-hardware): `236ba4df` -> `d92ed98c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -263,11 +263,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1665321371,
-        "narHash": "sha256-0SO6MTW0bX6lxZmz1AZW/Xmk+hnTd7/hp1vF7Tp7jg0=",
+        "lastModified": 1665649208,
+        "narHash": "sha256-MDkPVG4W8gigJ8OxWDp9L6aKaEwLRV3As1RvKkMq0rc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "236ba4df714131059945d7754c0aa3fbe9d2f74c",
+        "rev": "d92ed98c099ae731664fc526c348d609c4cffe04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                   |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`7ab8eab2`](https://github.com/NixOS/nixos-hardware/commit/7ab8eab291fad85fd49959812dfcdf2ecaf44804) | `starfive/visionfive/v1: Fix README indentation` |