### PR TITLE
chore(flake/nur): `40f6c8e6` -> `81180b0a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665645945,
-        "narHash": "sha256-CaX7Y5s/PiEWj0rNbyy1362fPa/CMsdmBvN8ZX2ix28=",
+        "lastModified": 1665655657,
+        "narHash": "sha256-dSxJIMul0ZH/Dm5HibChuGDCvNQPiw7U5YrPloi22DY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "40f6c8e660b582b190819f4be08267bb39c51f69",
+        "rev": "81180b0a8df75be354aa0aefd04e53cf4de4297a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`81180b0a`](https://github.com/nix-community/NUR/commit/81180b0a8df75be354aa0aefd04e53cf4de4297a) | `automatic update` |
| [`cfb0f966`](https://github.com/nix-community/NUR/commit/cfb0f966307df793616baee2d58ef5dfc85a0a2b) | `automatic update` |