### PR TITLE
chore(flake/nixpkgs): `285e77ef` -> `f634d427`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -277,11 +277,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665449268,
-        "narHash": "sha256-cw4xrQIAZUyJGj58Dp5VLICI0rscd+uap83afiFzlcA=",
+        "lastModified": 1665580254,
+        "narHash": "sha256-hO61XPkp1Hphl4HGNzj1VvDH5URt7LI6LaY/385Eul4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "285e77efe87df64105ec14b204de6636fb0a7a27",
+        "rev": "f634d427b0224a5f531ea5aa10c3960ba6ec5f0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`fa2021c7`](https://github.com/NixOS/nixpkgs/commit/fa2021c7b69916754655c525d7ebbc0bc946c003) | `fido2luks: 0.2.20 -> 0.2.21`                                                 |
| [`9ff71f97`](https://github.com/NixOS/nixpkgs/commit/9ff71f97c885dd46c25dd5927ea24f3bcfd9e9bb) | `python-setup-hook: use buildPackages.callPackage to not change hashes`       |
| [`7fc8453a`](https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac) | `libusb1: enable udev support for dynamically linked musl platform (#195351)` |
| [`3dae05bb`](https://github.com/NixOS/nixpkgs/commit/3dae05bb9193f3910f1ac0251b1c1eb4f7f07872) | `update-python-libraries: enable nix command`                                 |
| [`6425011e`](https://github.com/NixOS/nixpkgs/commit/6425011efe079f34bb795a1bc192cc0db3590155) | `update-python-libraries: remove old Nix fallback`                            |
| [`07f03615`](https://github.com/NixOS/nixpkgs/commit/07f03615ba871e5f82390db41d2ff511ade7f631) | `dagger: 0.2.35 -> 0.2.36`                                                    |
| [`a0231e8c`](https://github.com/NixOS/nixpkgs/commit/a0231e8ccebfadfc742a9da51cc14c375eeeb682) | `pebble: mark broken on 32bit platforms`                                      |
| [`0310ac43`](https://github.com/NixOS/nixpkgs/commit/0310ac43a5b29b5aad8dd8bc0a9adfc4da8d8dd6) | `python3Packages.mypy: Disable mypy.report import on i686-linux`              |
| [`7d3e7f48`](https://github.com/NixOS/nixpkgs/commit/7d3e7f48903918cc8b1f102e3a2602114fba357e) | `python3Packages.bcrypt: Revert to 3.2.2 on i686-linux`                       |
| [`0d0c03fb`](https://github.com/NixOS/nixpkgs/commit/0d0c03fb0bb3b7407243bde95c482831ed9bfa9c) | `coding-conventions.chapter.md: update to account for #89885 (#191378)`       |
| [`80f28828`](https://github.com/NixOS/nixpkgs/commit/80f28828c73ae6a2bb3ad667a969fa5527657dc3) | `gerrit: 3.5.1 -> 3.6.2 (#195630)`                                            |
| [`e1734cb2`](https://github.com/NixOS/nixpkgs/commit/e1734cb2b4670d5e6bfeba9a6728fc76fddbb41f) | `redpanda: 22.2.5 -> 22.2.6`                                                  |
| [`98e5fcb9`](https://github.com/NixOS/nixpkgs/commit/98e5fcb9c784b91342e6f33d8aa0c362b847a995) | `werf: 1.2.177 -> 1.2.178`                                                    |
| [`b2a5c364`](https://github.com/NixOS/nixpkgs/commit/b2a5c364d7ce47254c5777ed4914281dbc1c7add) | ``heroic: don't use the `kdialog` top-level alias``                           |
| [`5c58d4f5`](https://github.com/NixOS/nixpkgs/commit/5c58d4f5ea4192cfc8817f3bab28574b503956c3) | `qutebrowser: fix build`                                                      |
| [`93a795a5`](https://github.com/NixOS/nixpkgs/commit/93a795a555000c0e191efe943736c40acdab12ae) | `terraform-providers.utils: 1.4.1 → 1.5.0`                                    |
| [`0d74b078`](https://github.com/NixOS/nixpkgs/commit/0d74b078cefdf642909f2d1600ab3f1c4dc89c34) | `terraform-providers.ucloud: 1.32.3 → 1.32.4`                                 |
| [`3bc6cb1e`](https://github.com/NixOS/nixpkgs/commit/3bc6cb1ef4ef086bb5388f4ce2333661cd515250) | `terraform-providers.time: 0.8.0 → 0.9.0`                                     |
| [`d309f7dc`](https://github.com/NixOS/nixpkgs/commit/d309f7dc3cecb9aaf796b9cc4b6c6b9dca2b95c7) | `terraform-providers.pagerduty: 2.6.2 → 2.6.3`                                |
| [`638a7e1d`](https://github.com/NixOS/nixpkgs/commit/638a7e1d5198812337648ccf0db234e47bbea559) | `terraform-providers.linode: 1.29.2 → 1.29.3`                                 |
| [`b9b60fad`](https://github.com/NixOS/nixpkgs/commit/b9b60fad403723526fcddfc45abc9ba2a8aa5768) | `terraform-providers.heroku: 5.1.4 → 5.1.5`                                   |
| [`ec70a388`](https://github.com/NixOS/nixpkgs/commit/ec70a388c55fb6e2378dff96d9a72839b77d3cc7) | `onedrive: 2.4.20 -> 2.4.21`                                                  |
| [`58ca4f90`](https://github.com/NixOS/nixpkgs/commit/58ca4f90608cd3a2a3805faed0b71ff1a1166676) | `faas-cli: 0.14.8 -> 0.14.10`                                                 |
| [`7b454732`](https://github.com/NixOS/nixpkgs/commit/7b4547322679f9e70f43d122a427b033d9b7d7df) | `humioctl: 0.30.1 -> 0.30.2`                                                  |
| [`9a8d7bbf`](https://github.com/NixOS/nixpkgs/commit/9a8d7bbfd104b3bff448ec0f4eae5b200d167a72) | `buildkit-nix: 0.0.3 -> 0.1.0`                                                |
| [`3e08c10e`](https://github.com/NixOS/nixpkgs/commit/3e08c10e68ec36b32ed5fde59e53526a8b386a01) | `elixir_1_14: 1.14.0 -> 1.14.1`                                               |
| [`10e11a1e`](https://github.com/NixOS/nixpkgs/commit/10e11a1e60aa2ab5fdd288e1108ae5f506e73d22) | `talosctl: 1.2.4 -> 1.2.5`                                                    |
| [`17c13ef8`](https://github.com/NixOS/nixpkgs/commit/17c13ef8862082e5d78ab5aa11fe391498a7fb6e) | `rustpython: unstable-2021-12-09 -> unstable-2022-10-11`                      |
| [`af4dbb9b`](https://github.com/NixOS/nixpkgs/commit/af4dbb9b205ee1047795076096b0d64443580dcc) | `python310Packages.enlighten: 1.10.2 -> 1.11.1`                               |
| [`cb61e14f`](https://github.com/NixOS/nixpkgs/commit/cb61e14ff832e571a8a89e638a68f0ee579b38e9) | `himalaya: 0.5.10 -> 0.6.0`                                                   |
| [`55edf1a0`](https://github.com/NixOS/nixpkgs/commit/55edf1a08a4db3c68a798353bbd14905d039f844) | `python3Packages.python3-application: 3.0.3 -> 3.0.4`                         |
| [`fc266cd0`](https://github.com/NixOS/nixpkgs/commit/fc266cd0072075b0ed264461df0f47837e77ed0b) | `ghorg: 1.8.7 -> 1.8.8`                                                       |
| [`83a898a4`](https://github.com/NixOS/nixpkgs/commit/83a898a461daad1ff07fa6b04dd042a768aa3637) | `ft2-clone: 1.59 -> 1.60`                                                     |
| [`6a31ff5b`](https://github.com/NixOS/nixpkgs/commit/6a31ff5b30058cbfccdb096e27c566bb6f1e49ed) | `outline: fix not using legacy provided during build`                         |
| [`c362c4c4`](https://github.com/NixOS/nixpkgs/commit/c362c4c440370fc75f2d4cdfc35c5736db80a0ca) | `flyctl: 0.0.407 -> 0.0.409`                                                  |
| [`4c698434`](https://github.com/NixOS/nixpkgs/commit/4c6984346080dca83083bc7063df8fe820a025bc) | `nixos/mullvad-vpn: change dependency for the daemon to pkg mullvad`          |
| [`5c087542`](https://github.com/NixOS/nixpkgs/commit/5c08754283e543071a38d948fda3b50d1bf29a63) | `python310Packages.pylitterbot: 2022.9.6 -> 2022.10.1`                        |
| [`7d62668d`](https://github.com/NixOS/nixpkgs/commit/7d62668da62c1af7c61e1b2a1d7b3a9f32c15bba) | `dnsproxy: 0.45.2 -> 0.45.3`                                                  |
| [`9c32b210`](https://github.com/NixOS/nixpkgs/commit/9c32b210d6eb6f2c5f90eb9355f28bbe029a17e6) | `dnstwist: 20221008 -> 20221011`                                              |
| [`7548a378`](https://github.com/NixOS/nixpkgs/commit/7548a378a9717937dc20524513dfb5f0d56652b1) | `python3Packages.imageio: 2.22.0 -> 2.22.1`                                   |
| [`85a36f91`](https://github.com/NixOS/nixpkgs/commit/85a36f91469057daaef5c2d64baa4efed1774903) | `writers.writeJS: pass arguments to script`                                   |
| [`7510a656`](https://github.com/NixOS/nixpkgs/commit/7510a656be18d164490757752fc3c6f5c418c562) | `checkip: 0.40.3 -> 0.40.4`                                                   |
| [`bea5ec6f`](https://github.com/NixOS/nixpkgs/commit/bea5ec6f7d97b03e9f412b184ec3d018fd23f651) | `chrysalis: 0.11.5 -> 0.11.8`                                                 |
| [`39f6f5e3`](https://github.com/NixOS/nixpkgs/commit/39f6f5e32e8e46833d9400b37a9fd58b8719a3c0) | `cf-terraforming: 0.8.7 -> 0.8.8 (#194363)`                                   |
| [`fe69c269`](https://github.com/NixOS/nixpkgs/commit/fe69c26926424d10e9e7283d82edec7be67ea000) | `python310Packages.plugwise: 0.24.1 -> 0.25.0`                                |
| [`f88fc14f`](https://github.com/NixOS/nixpkgs/commit/f88fc14fa8075b1a3984ce204e0bf2f0371567c9) | `ruff: 0.0.68 -> 0.0.69`                                                      |
| [`fe130b7a`](https://github.com/NixOS/nixpkgs/commit/fe130b7af4c00bbf628440588d8fb606eafc6ced) | `python310Packages.pex: 2.1.109 -> 2.1.110`                                   |
| [`12ac8bc7`](https://github.com/NixOS/nixpkgs/commit/12ac8bc7adb31d49218367440b1a07ff2cee9dfc) | `bemenu: 0.6.12 -> 0.6.13`                                                    |
| [`cd81115e`](https://github.com/NixOS/nixpkgs/commit/cd81115e20defb47a56e75974f927aef42b8e110) | `baresip: 2.8.1 -> 2.8.2`                                                     |
| [`dc210044`](https://github.com/NixOS/nixpkgs/commit/dc21004419911ba5ed92ccf960fabc653221f6f2) | `aws-nuke: 2.19.0 -> 2.20.0`                                                  |
| [`0925f41a`](https://github.com/NixOS/nixpkgs/commit/0925f41aacae455a64bf1c53540a2d7e0fb92024) | `aliyun-cli: 3.0.127 -> 3.0.128`                                              |
| [`938af386`](https://github.com/NixOS/nixpkgs/commit/938af386b02ba3a514878292ab90a73da37e2c28) | `ucc: init at 1.1.0`                                                          |
| [`4c5a2d8b`](https://github.com/NixOS/nixpkgs/commit/4c5a2d8ba0270b07f03e5b7e4aee9acbc66333dc) | `thicket: remove shards file`                                                 |
| [`242f9e69`](https://github.com/NixOS/nixpkgs/commit/242f9e69065383f9196437af4d4122c4b3af6e43) | `symfony-cli: 5.4.15 -> 5.4.16`                                               |
| [`3f525e0d`](https://github.com/NixOS/nixpkgs/commit/3f525e0de4fa7eda30e7ef22759faf3c4885a173) | `classicube: 1.3.2 -> 1.3.3`                                                  |
| [`0c5f797f`](https://github.com/NixOS/nixpkgs/commit/0c5f797ff11dae9a4b15599f7c6bcb9512e9ea86) | `devilspie2: 0.43 -> 0.44`                                                    |
| [`e32a01b9`](https://github.com/NixOS/nixpkgs/commit/e32a01b9226da663106ceee40594443fef24dfda) | `uxplay: 1.55 -> 1.57`                                                        |
| [`8b3ba47a`](https://github.com/NixOS/nixpkgs/commit/8b3ba47a11122cb3d101d10e2fafd6b093d0189a) | `proxychains{,-ng}: swap priority 4 and 5 in get_config_path`                 |
| [`52755d8a`](https://github.com/NixOS/nixpkgs/commit/52755d8ae129e5a7af39b49b04a9eb521cd32080) | `thedesk: 22.3.1 -> 23.0.1`                                                   |
| [`5db41b13`](https://github.com/NixOS/nixpkgs/commit/5db41b132d69a2dba10ef536d7ea0c6d99e9c88e) | `thicket: 0.1.5 -> 0.1.6`                                                     |
| [`1e3c95b7`](https://github.com/NixOS/nixpkgs/commit/1e3c95b7aa8801305a7f79bdcf696ce4d2723cae) | `taoup: 1.1.18 -> 1.1.19`                                                     |
| [`25f5ae09`](https://github.com/NixOS/nixpkgs/commit/25f5ae092e240a2f8352057342aad88992ec9f0e) | `syncstorage-rs: 0.12.3 -> 0.12.4`                                            |
| [`d97e915f`](https://github.com/NixOS/nixpkgs/commit/d97e915fafdeab433168b7bf1309c9634fba7dc9) | `nixos/tests/chromium: Enable on aarch64-linux`                               |
| [`08991fc8`](https://github.com/NixOS/nixpkgs/commit/08991fc87a784501c48499d238e6ed816e91df40) | `nixos/release-small: Test uefi cdrom`                                        |
| [`4b6758f8`](https://github.com/NixOS/nixpkgs/commit/4b6758f83e33f55da6c67868c820461f453565d4) | `nixos/release-combined: Enable more jobs on aarch64-linux`                   |
| [`373c1a8e`](https://github.com/NixOS/nixpkgs/commit/373c1a8e4322ef86f659c29e828b0a82e7df3777) | `installer: enable xe-guest-utilities only on x86`                            |
| [`8f366cbf`](https://github.com/NixOS/nixpkgs/commit/8f366cbfcc62871f481e035984e5932e30d8b0ed) | `installer: enable vmware guest support on x86 only`                          |
| [`9328b7ee`](https://github.com/NixOS/nixpkgs/commit/9328b7eebf6afbd345f20f5d76b6357f85037506) | `nixos/release-combined: Build graphical ISOs for aarch64-linux`              |
| [`cd5cc119`](https://github.com/NixOS/nixpkgs/commit/cd5cc11918cd56ae077ed098a8b6bbd2aa77ccdb) | `nixos/release-combined: Move aarch64-linux to supportedSystems`              |
| [`534a2fd1`](https://github.com/NixOS/nixpkgs/commit/534a2fd13ae96ab8052741f0548155aaf3818d29) | `nixos/release-small: Add aarch64-linux to supportedSystems`                  |
| [`efcbc9da`](https://github.com/NixOS/nixpkgs/commit/efcbc9daf5d58ca55272de33a510932b8f2db7da) | `python310Packages.bip_utils: 2.2.1 -> 2.7.0`                                 |
| [`ff5c7582`](https://github.com/NixOS/nixpkgs/commit/ff5c758289b233f4ced69d1553799c355cbd6a13) | `python310Packages.py-sr25519-bindings: init at 0.1.5`                        |
| [`198f5229`](https://github.com/NixOS/nixpkgs/commit/198f5229652d9d7bc84e6ee5e6ff4964a6967594) | `python310Packages.ed25519-blake2: init at 1.4`                               |
| [`86ee52f4`](https://github.com/NixOS/nixpkgs/commit/86ee52f4aaf5a1ca07a47e8d554e07e6565d8bf6) | `python310Packages.py-bip39-bindings: init at 0.1.10`                         |
| [`f6dc0eef`](https://github.com/NixOS/nixpkgs/commit/f6dc0eefb96c8db7680f36f308b67acb79e422b1) | `avrdude: migrate to cmake`                                                   |
| [`50d21e56`](https://github.com/NixOS/nixpkgs/commit/50d21e56fae89a99c84606ad0598ab8e4de90c83) | `minetest: fix build on darwin`                                               |
| [`1441c793`](https://github.com/NixOS/nixpkgs/commit/1441c7930e6bda56bb6e3337010551a3437332a6) | `guake: remove gbr, setuptools deps`                                          |
| [`1353c271`](https://github.com/NixOS/nixpkgs/commit/1353c271e6c5e5779652f8a7394b34526ac5b2a5) | `python310Packages.hahomematic: 2022.10.2 -> 2022.10.4`                       |
| [`c8aa2981`](https://github.com/NixOS/nixpkgs/commit/c8aa29813493163ffd7e878f2816fcf2df276483) | `Adding mathcomp-analysis single`                                             |
| [`5a121cee`](https://github.com/NixOS/nixpkgs/commit/5a121ceec99c8afc0c184293fcbe21b0e3e177ed) | `python310Packages.google-cloud-vision: 3.1.3 -> 3.1.4`                       |
| [`41ec0886`](https://github.com/NixOS/nixpkgs/commit/41ec0886c3cbc262312884444b707849ada9505f) | `clightning: 0.12.0 -> 0.12.1`                                                |
| [`21c8d87b`](https://github.com/NixOS/nixpkgs/commit/21c8d87b0cf3d08d6b94866f8ef7cd58a2a46e0e) | `python310Packages.google-cloud-videointelligence: 2.8.2 -> 2.8.3`            |
| [`92212835`](https://github.com/NixOS/nixpkgs/commit/92212835edb6a905c2766a411327213433fa0cc9) | `python310Packages.google-cloud-translate: 3.8.3 -> 3.8.4`                    |
| [`6235991a`](https://github.com/NixOS/nixpkgs/commit/6235991a9280e9c9772fc833475ac17fad82dd77) | `python310Packages.google-cloud-trace: 1.7.2 -> 1.7.3`                        |
| [`fdec223b`](https://github.com/NixOS/nixpkgs/commit/fdec223b11322f84b827a3abf4f541fc460897ec) | `python310Packages.google-cloud-texttospeech: 2.12.2 -> 2.12.3`               |
| [`0d843495`](https://github.com/NixOS/nixpkgs/commit/0d8434957a0325dc542a8303d4f287d8a00f2646) | `python310Packages.google-cloud-tasks: 2.10.3 -> 2.10.4`                      |
| [`6a43e2ca`](https://github.com/NixOS/nixpkgs/commit/6a43e2ca1381774f397223949a7ba32e16a6f722) | `python310Packages.google-cloud-spanner: 3.22.1 -> 3.22.2`                    |
| [`32ee79a1`](https://github.com/NixOS/nixpkgs/commit/32ee79a184b3efe92a48361993777d080b56849b) | `python310Packages.google-cloud-speech: 2.16.1 -> 2.16.2`                     |
| [`fe0b4fe3`](https://github.com/NixOS/nixpkgs/commit/fe0b4fe3f839ab297db8d2cb3ac35c37b7dbf2b0) | `python310Packages.google-cloud-securitycenter: 1.16.1 -> 1.16.2`             |
| [`b1514e19`](https://github.com/NixOS/nixpkgs/commit/b1514e19881d3b32f3859d2410147a6fd062d814) | `python310Packages.google-cloud-secret-manager: 2.12.5 -> 2.12.6`             |
| [`e8917baf`](https://github.com/NixOS/nixpkgs/commit/e8917baf92d229d78304300cab0f5feb376c4770) | `python310Packages.google-cloud-resource-manager: 1.6.2 -> 1.6.3`             |
| [`5b071329`](https://github.com/NixOS/nixpkgs/commit/5b07132931e60fa9141f7d3098f3b79345fe542e) | `python310Packages.google-cloud-redis: 2.9.2 -> 2.9.3`                        |
| [`f7498be8`](https://github.com/NixOS/nixpkgs/commit/f7498be8092e6978aedb61ffe11b568780c1b727) | `python310Packages.google-cloud-pubsub: 2.13.7 -> 2.13.9`                     |
| [`b5b5b150`](https://github.com/NixOS/nixpkgs/commit/b5b5b1509ccd61ec07db7fd32a997e3d2c13a24a) | `python310Packages.google-cloud-os-config: 1.12.3 -> 1.12.4`                  |
| [`a9a94aaf`](https://github.com/NixOS/nixpkgs/commit/a9a94aaf68f9474a4581cf5ae10f4523e400100a) | `python310Packages.google-cloud-monitoring: 2.11.2 -> 2.11.3`                 |
| [`268fec62`](https://github.com/NixOS/nixpkgs/commit/268fec6202242fcad8c1b0495fb424fe7600fc29) | `python310Packages.google-cloud-logging: 3.2.4 -> 3.2.5`                      |
| [`7b38f58d`](https://github.com/NixOS/nixpkgs/commit/7b38f58d0fbe3446b51414a1e829a4ceacae9f29) | `python310Packages.google-cloud-language: 2.6.0 -> 2.6.1`                     |
| [`8e0c844d`](https://github.com/NixOS/nixpkgs/commit/8e0c844d40a0f908b6b34022099502e02e9efeb5) | `python310Packages.google-cloud-iot: 2.6.3 -> 2.6.4`                          |
| [`097ec653`](https://github.com/NixOS/nixpkgs/commit/097ec65336c63730bad1f7f72e45619183f29ddf) | `teleport: fix for darwin`                                                    |
| [`d4243ae2`](https://github.com/NixOS/nixpkgs/commit/d4243ae264e8e5039f85ee01533c8691299a37a1) | `python310Packages.google-cloud-datastore: 2.8.2 -> 2.8.3`                    |
| [`d47f98e2`](https://github.com/NixOS/nixpkgs/commit/d47f98e2efe353fc106b43281860c17c2419c239) | `python310Packages.google-cloud-dataproc: 5.0.2 -> 5.0.3`                     |
| [`22707824`](https://github.com/NixOS/nixpkgs/commit/227078243ce91030cd9f1657613f5d07bd808088) | `python310Packages.google-cloud-datacatalog: 3.9.2 -> 3.9.3`                  |
| [`50769b83`](https://github.com/NixOS/nixpkgs/commit/50769b83dc27e35f2e9a9c124f2e7bf326e43a3d) | `python310Packages.google-cloud-container: 2.12.1 -> 2.12.2`                  |
| [`2cfb8244`](https://github.com/NixOS/nixpkgs/commit/2cfb824492bef01e12a825534d4f6c4431acfa73) | `python310Packages.google-cloud-bigquery-storage: 2.16.1 -> 2.16.2`           |
| [`10182552`](https://github.com/NixOS/nixpkgs/commit/10182552db7558c1de40cd81543bd27abfd914d1) | `python310Packages.google-cloud-bigquery-logging: 1.0.6 -> 1.0.7`             |
| [`726794f9`](https://github.com/NixOS/nixpkgs/commit/726794f9e3f333bd11488e4828a6a9d60e062179) | `python310Packages.google-cloud-bigquery-datatransfer: 3.7.2 -> 3.7.3`        |
| [`0567c486`](https://github.com/NixOS/nixpkgs/commit/0567c486b906d01f04109bfe51ce4bc626b9a2ef) | `run: 0.7.2 -> 0.9.1`                                                         |
| [`6b45d878`](https://github.com/NixOS/nixpkgs/commit/6b45d87804d8992419ba11b6cb313064c2b5c845) | `python310Packages.google-cloud-bigquery: 3.3.3 -> 3.3.5`                     |
| [`589c08c7`](https://github.com/NixOS/nixpkgs/commit/589c08c76e47b737ef088d8f4487465bd7ea3c23) | `python310Packages.google-cloud-automl: 2.8.2 -> 2.8.3`                       |
| [`ab568558`](https://github.com/NixOS/nixpkgs/commit/ab56855854d714f5e6af6a99fc4d15386791f90a) | `python310Packages.google-cloud-asset: 3.14.1 -> 3.14.2`                      |
| [`47315d87`](https://github.com/NixOS/nixpkgs/commit/47315d87bab82ceba4160ae42c3e982a47568277) | `python310Packages.git-filter-repo: 2.34.0 -> 2.38.0`                         |
| [`ef0ed284`](https://github.com/NixOS/nixpkgs/commit/ef0ed284ea6ce8d14de9575d1962e70590c29bfe) | `meilisearch: 0.29.0 -> 0.29.1`                                               |
| [`e7c5b434`](https://github.com/NixOS/nixpkgs/commit/e7c5b43452dabb841c54332b1125394a236444a1) | `far2l: 2.4.0 -> 2.4.1`                                                       |
| [`aee04b1b`](https://github.com/NixOS/nixpkgs/commit/aee04b1bed64cd205f4d24072750b878fe7d8e71) | `ocamlPackages.git: 3.5.0 -> 3.9.1 (#188389)`                                 |
| [`3284df4c`](https://github.com/NixOS/nixpkgs/commit/3284df4c3831c829bffe1f7a885106f360ccdd67) | `operator-sdk: 1.23.0 -> 1.24.0`                                              |
| [`24addef4`](https://github.com/NixOS/nixpkgs/commit/24addef4aee96fd7dad5f869bb375ff6614196b4) | `qrencode: fix build on x86_64-darwin`                                        |
| [`9b61ff34`](https://github.com/NixOS/nixpkgs/commit/9b61ff349a355e7f63cfe90d6d86551ec0d76765) | `gtk4: fix build on aarch64-darwin`                                           |
| [`25491b5d`](https://github.com/NixOS/nixpkgs/commit/25491b5dc3053ffa3e6bd88fd3d6f0e66a3f4b10) | `gnudatalanguage: fix build on aarch64-darwin`                                |
| [`7231983f`](https://github.com/NixOS/nixpkgs/commit/7231983f05db2a73307901370eee17dc1486d219) | `lnav: 0.11.0 -> 0.11.1`                                                      |
| [`49126873`](https://github.com/NixOS/nixpkgs/commit/49126873434bc675a937c4aa35a7e9a638c524bf) | `coqPackages.VST: enable for Coq 8.16`                                        |
| [`a861c34a`](https://github.com/NixOS/nixpkgs/commit/a861c34a3e4f879a330359bd764da15d1cfbcfab) | `coqPackages.compcert: enable for Coq 8.16`                                   |
| [`271578d1`](https://github.com/NixOS/nixpkgs/commit/271578d10355fec800c5bca37be2df97ef97f96e) | `oh-my-posh: 12.0.1 -> 12.1.0`                                                |
| [`55f09352`](https://github.com/NixOS/nixpkgs/commit/55f09352f5cfe00ebdce1e1573a035a2f183dccb) | `nats-server: 2.9.2 -> 2.9.3`                                                 |
| [`68c381a6`](https://github.com/NixOS/nixpkgs/commit/68c381a6b3c4e29ef20e526aafed00ea76589673) | `terraform-providers.utils: 1.3.0 → 1.4.1`                                    |
| [`2ff24b6f`](https://github.com/NixOS/nixpkgs/commit/2ff24b6f6a369f44a5aa5e3af2d128a063f0cd4d) | `terraform-providers.ucloud: 1.32.2 → 1.32.3`                                 |
| [`a4ba7b5d`](https://github.com/NixOS/nixpkgs/commit/a4ba7b5dee6e777bb68c4b37cf3644b0d88009fc) | `terraform-providers.keycloak: 3.10.0 → 4.0.0`                                |
| [`ef2c2068`](https://github.com/NixOS/nixpkgs/commit/ef2c2068f2f14a4020adb62f0dd035ca95acf11e) | `terraform-providers.google-beta: 4.39.0 → 4.40.0`                            |
| [`23c10875`](https://github.com/NixOS/nixpkgs/commit/23c10875d307054ae08e78ce37c06c39d4bd8e16) | `terraform-providers.google: 4.39.0 → 4.40.0`                                 |
| [`f77165f8`](https://github.com/NixOS/nixpkgs/commit/f77165f86ece0f0788419bdb621a5f4bbbc9de24) | `terraform-providers.digitalocean: 2.22.3 → 2.23.0`                           |
| [`d86ad358`](https://github.com/NixOS/nixpkgs/commit/d86ad358c4530b2e7ea3bb4fe4fe6f0c4c856cea) | `terraform-providers.auth0: 0.37.1 → 0.38.0`                                  |
| [`ad2bc19c`](https://github.com/NixOS/nixpkgs/commit/ad2bc19cb517230cef41efaf2bc1a54794c91838) | `poetry2nix: 1.34.1 -> 1.35.0`                                                |