### PR TITLE
chore(flake/nur): `3fe77891` -> `31f4399b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665657975,
-        "narHash": "sha256-w0GVntNU5j+vzJ9iGj6RszRMfpvp06JWMSpCyC+IfRQ=",
+        "lastModified": 1665665158,
+        "narHash": "sha256-QgnaHinQezc/2fzoZ4BiFgkxUivgAV31rkjGtbZft+U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3fe77891a0e0c9f52af81193ec0de303b829700f",
+        "rev": "31f4399bcbe771ef312d2e7b71a1696f799533bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`31f4399b`](https://github.com/nix-community/NUR/commit/31f4399bcbe771ef312d2e7b71a1696f799533bb) | `automatic update` |