### PR TITLE
chore(flake/nur): `8df1ce63` -> `064380ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665685771,
-        "narHash": "sha256-YllTRwDTOrmgZdC7FHsfqiG3YzpQtMiAFWXppG6hc2M=",
+        "lastModified": 1665686876,
+        "narHash": "sha256-BBcyz0FoGqpw9cmzZeN4VLPPgpsH8dW8DNyg6Zf/0nE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8df1ce630ccc17545f33875073feddc42eb8278a",
+        "rev": "064380aedeff88851027cae2e1e346306c69759f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`064380ae`](https://github.com/nix-community/NUR/commit/064380aedeff88851027cae2e1e346306c69759f) | `automatic update` |