### PR TITLE
chore(flake/nur): `064380ae` -> `50d6a711`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665686876,
-        "narHash": "sha256-BBcyz0FoGqpw9cmzZeN4VLPPgpsH8dW8DNyg6Zf/0nE=",
+        "lastModified": 1665695321,
+        "narHash": "sha256-djdgZGjgWp22SmikV/cu1lgyL99OnqmSMggx3xkubIM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "064380aedeff88851027cae2e1e346306c69759f",
+        "rev": "50d6a711327a33d647783ef985913b1da21aa4dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`50d6a711`](https://github.com/nix-community/NUR/commit/50d6a711327a33d647783ef985913b1da21aa4dd) | `automatic update` |
| [`4317e624`](https://github.com/nix-community/NUR/commit/4317e62493e8f83ed3493bd4a8406787a9171602) | `automatic update` |