### PR TITLE
chore(flake/nur): `50d6a711` -> `1bcd8f96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665695321,
-        "narHash": "sha256-djdgZGjgWp22SmikV/cu1lgyL99OnqmSMggx3xkubIM=",
+        "lastModified": 1665695739,
+        "narHash": "sha256-t1TkxpL0I2G9UdVIcLUszIyKH5mI7Z2PO53yxF01W9I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "50d6a711327a33d647783ef985913b1da21aa4dd",
+        "rev": "1bcd8f960c3178926ca96bdcd7a81bed715ff9d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1bcd8f96`](https://github.com/nix-community/NUR/commit/1bcd8f960c3178926ca96bdcd7a81bed715ff9d1) | `automatic update` |