### PR TITLE
chore(flake/nixpkgs): `f634d427` -> `ba187fbd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -277,11 +277,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665580254,
-        "narHash": "sha256-hO61XPkp1Hphl4HGNzj1VvDH5URt7LI6LaY/385Eul4=",
+        "lastModified": 1665643254,
+        "narHash": "sha256-IBVWNJxGCsshwh62eRfR6+ry3bSXmulB3VQRzLQo3hk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f634d427b0224a5f531ea5aa10c3960ba6ec5f0f",
+        "rev": "ba187fbdc5e35322c7dff556ef2c47bddfd6e8d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`d6185309`](https://github.com/NixOS/nixpkgs/commit/d618530963a0e1d112c2584e2fc1ae9743cf7b08) | `ocamlPackages.ocamlbuild: 0.14.1 → 0.14.2`                                           |
| [`ed50e176`](https://github.com/NixOS/nixpkgs/commit/ed50e17618a0b28196401a3f9d7f707df93b88b8) | `ocamlPackages.lablgtk_2_14: remove at 2.14.0 (broken)`                               |
| [`0671df7f`](https://github.com/NixOS/nixpkgs/commit/0671df7f0299648e5a08b718077ef6406a8cc70b) | `ocamlPackages.uuidm: disable for OCaml < 4.08`                                       |
| [`e1858385`](https://github.com/NixOS/nixpkgs/commit/e1858385ec9730c0120dae4bce1fade16ecdb4ca) | `python310Packages.google-cloud-firestore: 2.7.1 -> 2.7.2`                            |
| [`1f50d35a`](https://github.com/NixOS/nixpkgs/commit/1f50d35aae248ee9ff8bbdf5b499892a16d30362) | `python310Packages.google-cloud-websecurityscanner: 1.9.1 -> 1.9.2`                   |
| [`d673432b`](https://github.com/NixOS/nixpkgs/commit/d673432b224558f837382dc32b665f01690be96c) | `python310Packages.google-cloud-iam-logging: 1.0.5 -> 1.0.6`                          |
| [`ea8940ac`](https://github.com/NixOS/nixpkgs/commit/ea8940acebcebde2eae1b13fb369e8823065f370) | `python310Packages.google-cloud-error-reporting: 1.6.2 -> 1.6.3`                      |
| [`b51a278e`](https://github.com/NixOS/nixpkgs/commit/b51a278e7676bc0670534f6bcacdbad78688be07) | `python310Packages.google-cloud-dlp: 3.9.1 -> 3.9.2`                                  |
| [`a2f2949c`](https://github.com/NixOS/nixpkgs/commit/a2f2949cdb37e2cf13df4f8249078baa0085dfaf) | `python310Packages.fastapi-mail: 1.1.5 -> 1.2.0`                                      |
| [`cfea568d`](https://github.com/NixOS/nixpkgs/commit/cfea568da97a2668ef3cb3fc42eaacfb0e706807) | `terraform-providers.tencentcloud: 1.78.3 → 1.78.4`                                   |
| [`f003f0a6`](https://github.com/NixOS/nixpkgs/commit/f003f0a63bceef55afe75c51d6b5a3876bc304c0) | `terraform-providers.spotinst: 1.84.0 → 1.85.0`                                       |
| [`40dcf2f9`](https://github.com/NixOS/nixpkgs/commit/40dcf2f95b77ab4f54557d6a4e3e26d1823d16b3) | `terraform-providers.helm: 2.7.0 → 2.7.1`                                             |
| [`6dc602a4`](https://github.com/NixOS/nixpkgs/commit/6dc602a4a0d9c8b56291637fd494f2165bdf9701) | `terraform-providers.github: 5.3.0 → 5.4.0`                                           |
| [`8cd5129b`](https://github.com/NixOS/nixpkgs/commit/8cd5129b1a0a5f34dba5d40f5af627a54fb6361b) | `python310Packages.dropbox: 11.34.0 -> 11.35.0`                                       |
| [`82da2bfa`](https://github.com/NixOS/nixpkgs/commit/82da2bfa8eee921b92c30a6753c4496494f6d84c) | `prometheus-kea-exporter: 0.4.4 -> 0.5.0`                                             |
| [`e20908d8`](https://github.com/NixOS/nixpkgs/commit/e20908d82c48d20d1eb96df38ca29d57163ad5bb) | `python310Packages.desktop-notifier: 3.4.0 -> 3.4.1`                                  |
| [`13062ca2`](https://github.com/NixOS/nixpkgs/commit/13062ca2d5e11486a9226c71738a808cdf104599) | `python310Packages.hahomematic: 2022.10.4 -> 2022.10.5`                               |
| [`05c08b3f`](https://github.com/NixOS/nixpkgs/commit/05c08b3fc31798a54a1d7ed24dfa89bf19c50b8f) | `python310Packages.yalexs: 1.2.4 -> 1.2.6`                                            |
| [`eff6add8`](https://github.com/NixOS/nixpkgs/commit/eff6add801c59f67cbce6988d8dc1ce072d4200a) | `python310Packages.blebox-uniapi: disable on older Python releases`                   |
| [`2601e8bf`](https://github.com/NixOS/nixpkgs/commit/2601e8bf883a1570c39132325c53efb2b9eb2c4a) | `python310Packages.click-option-group: 0.5.3 -> 0.5.5`                                |
| [`d73c7ed6`](https://github.com/NixOS/nixpkgs/commit/d73c7ed622be830fbbb9376ae392f4c1df94497a) | `python310Packages.losant-rest: 1.16.5 -> 1.16.6`                                     |
| [`7a04eea2`](https://github.com/NixOS/nixpkgs/commit/7a04eea25017b182d65f2f8e0eca6e535355a178) | `python310Packages.blebox-uniapi: 2.1.0 -> 2.1.1`                                     |
| [`4ddefe30`](https://github.com/NixOS/nixpkgs/commit/4ddefe300357a5efe23b49d9b9cc4840f2410933) | `python310Packages.peaqevcore: 6.0.3 -> 7.0.8`                                        |
| [`b6bee1b2`](https://github.com/NixOS/nixpkgs/commit/b6bee1b2a0e9eb96072543fe1b989b6eee19d0d5) | `python310Packages.azure-storage-file-share: 12.9.0 -> 12.10.0`                       |
| [`e50c0576`](https://github.com/NixOS/nixpkgs/commit/e50c0576a0595aea7536d0197127ac9249171346) | `python310Packages.neo4j: 5.0.1 -> 5.1.0`                                             |
| [`67c319b7`](https://github.com/NixOS/nixpkgs/commit/67c319b77b90895f5e253c3179c045cf5a7426ff) | `prometheus-kea-exporter: 0.4.2 -> 0.4.4`                                             |
| [`11533d50`](https://github.com/NixOS/nixpkgs/commit/11533d5056089aecb8d0ad25187969d069b47642) | `python310Packages.angr: 9.2.21 -> 9.2.22`                                            |
| [`47a13c0e`](https://github.com/NixOS/nixpkgs/commit/47a13c0e7492c47e953b01275569c5bff0e09dcd) | `python310Packages.cle: 9.2.21 -> 9.2.22`                                             |
| [`6b295a6d`](https://github.com/NixOS/nixpkgs/commit/6b295a6dbfbc2219371d0a7669d5fb1681f63a67) | `python310Packages.claripy: 9.2.21 -> 9.2.22`                                         |
| [`370cf209`](https://github.com/NixOS/nixpkgs/commit/370cf20988bb4b388629f3a38dd74a750a66b6c6) | `python310Packages.pyvex: 9.2.21 -> 9.2.22`                                           |
| [`90133e5f`](https://github.com/NixOS/nixpkgs/commit/90133e5f7437d5a4413108ff616710a19b6f0ad2) | `python310Packages.ailment: 9.2.21 -> 9.2.22`                                         |
| [`fefc598f`](https://github.com/NixOS/nixpkgs/commit/fefc598f2cd6c1c414b77256b62ce0ab3b05644c) | `python310Packages.archinfo: 9.2.21 -> 9.2.22`                                        |
| [`9683bb1e`](https://github.com/NixOS/nixpkgs/commit/9683bb1e37c044cf24166e17cc8f8e8546c7bfd8) | `bitwarden: 2022.8.1 -> 2022.10.0`                                                    |
| [`b1dc7b33`](https://github.com/NixOS/nixpkgs/commit/b1dc7b33bc16726d63409a03d4bce2e68013daf2) | `mapcidr: 1.0.2 -> 1.0.3`                                                             |
| [`41f84310`](https://github.com/NixOS/nixpkgs/commit/41f84310f928081e9eac059b1da153b49419fb28) | `python310Packages.azure-mgmt-authorization: 2.0.0 -> 3.0.0`                          |
| [`285dc9c1`](https://github.com/NixOS/nixpkgs/commit/285dc9c1de8f8955beaa619de2d8d7536d7879f6) | `open-watcom-v2: Fix bindir name for Darwin (#191537)`                                |
| [`0f6feea4`](https://github.com/NixOS/nixpkgs/commit/0f6feea49ee7dccb8d501ffdd22edbdca20f7592) | `python310Packages.ansible-core: 2.13.4 -> 2.13.5`                                    |
| [`1101dfae`](https://github.com/NixOS/nixpkgs/commit/1101dfae20910c42290246532ca735fe454f924c) | `coq: default to version 8.16`                                                        |
| [`661ee3a2`](https://github.com/NixOS/nixpkgs/commit/661ee3a26903ff58fd57f4f4396a748950ba3570) | `coq_8_16: use OCaml 4.14`                                                            |
| [`d451ea73`](https://github.com/NixOS/nixpkgs/commit/d451ea73dc8b4ed51d2a534f9c7b6e64268c3271) | `coqPackages.coq-elpi: disable OCaml warnings`                                        |
| [`50ecf779`](https://github.com/NixOS/nixpkgs/commit/50ecf779c9804b34332f7ea5fcdc55f85fe1a9d6) | `pkgsMusl.jdk: fix build`                                                             |
| [`8886c89d`](https://github.com/NixOS/nixpkgs/commit/8886c89d0eff3a192ed9f98a13849f76e73c5073) | `{temurin,adoptopenjdk}-bin: use alpine_linux os for musl libc`                       |
| [`d968a99b`](https://github.com/NixOS/nixpkgs/commit/d968a99bc0a40279578145baeb53411afe1cbfe3) | `{temurin,adoptopenjdk}-bin: regenerate sources.json`                                 |
| [`f5ba2af2`](https://github.com/NixOS/nixpkgs/commit/f5ba2af2a218d7d490a3b8c7cd7f99e440f9ee4d) | `{temurin,adoptopenjdk}-bin: add alpine_linux os to generate-sources script`          |
| [`7f4fe58f`](https://github.com/NixOS/nixpkgs/commit/7f4fe58f00352359afa09610b9a08e7be57f8bd4) | `wofi: 1.2.4 -> 1.3 (#195595)`                                                        |
| [`58cb56ee`](https://github.com/NixOS/nixpkgs/commit/58cb56ee9cfa87cf00ecac99ccca8ca65f4a2e78) | `influxdb2: fix build with rust 1.54 (#195534)`                                       |
| [`10e5fa68`](https://github.com/NixOS/nixpkgs/commit/10e5fa68de2d259a371b450d9c362d518e9842f2) | `ungoogled-chromium: 106.0.5249.103 -> 106.0.5249.119`                                |
| [`c8d4492a`](https://github.com/NixOS/nixpkgs/commit/c8d4492a8d5e97e155f419cda0fcdc5e18f0e079) | `chromium: 106.0.5249.103 -> 106.0.5249.119`                                          |
| [`284adcab`](https://github.com/NixOS/nixpkgs/commit/284adcab1f31d3c9ddb375e1c4830297a24e234f) | `zeroad: fix build on aarch64-linux`                                                  |
| [`37053d45`](https://github.com/NixOS/nixpkgs/commit/37053d45f94e70493cbcd4808f761a797d210701) | `nvidia-texture-tools: unstable-2019-10-27 -> unstable-2020-12-21`                    |
| [`bb38470b`](https://github.com/NixOS/nixpkgs/commit/bb38470b969039859fdcfc084485b58fdb7898ad) | `ocamlPackages.ff: 0.4.0 → 0.6.2`                                                     |
| [`76f2f796`](https://github.com/NixOS/nixpkgs/commit/76f2f7968049ac6701b8f9453e96cae3776f6eb0) | `gum: 0.7.0 -> 0.8.0`                                                                 |
| [`38d712a2`](https://github.com/NixOS/nixpkgs/commit/38d712a21898424f8953ec268081a9a6ee4a7004) | `goa: 3.7.6 -> 3.10.0`                                                                |
| [`96fa2023`](https://github.com/NixOS/nixpkgs/commit/96fa2023535f2768db28622b056140ee1e8d9d58) | `wordpressPackages.plugins.worker: init at 4.9.14`                                    |
| [`81e445e5`](https://github.com/NixOS/nixpkgs/commit/81e445e508f49daabe7fc60f302207eb4555b9d8) | `rubyPackages.*: satisfy pcre* requirements in GTK stack`                             |
| [`dd34f474`](https://github.com/NixOS/nixpkgs/commit/dd34f474ed6c719c094085e24108888761ab2b67) | `nixos/restic: make it possible to use the existing backup cache for prune/check`     |
| [`c4105846`](https://github.com/NixOS/nixpkgs/commit/c41058468d91d2fce5835da673845ec5f2a96511) | `n8n: fix build on aarch64`                                                           |
| [`faacc2c5`](https://github.com/NixOS/nixpkgs/commit/faacc2c571d47ca883a75c470c363aa9e1a1f7f9) | `liferea: 1.13.9 -> 1.14-RC1`                                                         |
| [`51c9acf2`](https://github.com/NixOS/nixpkgs/commit/51c9acf26dec754b5a89c52097b30900a31ab040) | `python3Packages.astroquery: fix build`                                               |
| [`f3cdcef7`](https://github.com/NixOS/nixpkgs/commit/f3cdcef7a03c36fa02b3c7af1620353380cdbe1f) | `sockdump: unstable-2022-05-27 -> unstable-2022-10-12`                                |
| [`9673ea73`](https://github.com/NixOS/nixpkgs/commit/9673ea736af82a37bd40243eb10c9557237ea5a6) | `oh-my-zsh: 2022-10-07 → 2022-10-12 (#195666)`                                        |
| [`b468eb86`](https://github.com/NixOS/nixpkgs/commit/b468eb865524252a271cafaf59febc13765a39bb) | `jenkins: 2.361.1 -> 2.361.2 (#195565)`                                               |
| [`790c45e2`](https://github.com/NixOS/nixpkgs/commit/790c45e29ced477c88f6a37078a00b994ba77099) | `wwcd: init at unstable-2022-02-05`                                                   |
| [`fca1f750`](https://github.com/NixOS/nixpkgs/commit/fca1f7508b6d4c1077124fa3c51c67e84b1a4078) | `maintainers: add laalsaas`                                                           |
| [`61a13e2d`](https://github.com/NixOS/nixpkgs/commit/61a13e2dc7a12a6b2a75c994f0f331103da31bf2) | `selfoss: 2.18 → 2.19`                                                                |
| [`af4a69ff`](https://github.com/NixOS/nixpkgs/commit/af4a69ffffddacf8e5b58ca666b6cb9ec6786ef6) | `lxqt.lxqt-build-tools: Fix build failure of libqtxdg with GLib 2.73.1+`              |
| [`16ead09b`](https://github.com/NixOS/nixpkgs/commit/16ead09b5e3ab9b1c7a5dc43bb6ad497ccba8f4d) | `parlatype: sort dependencies and reformat`                                           |
| [`710808a8`](https://github.com/NixOS/nixpkgs/commit/710808a82b8b8c955e7d808c69f2584424350170) | `pantheon.elementary-terminal: Fix terminal freeze when closing in GLib 2.73.2+`      |
| [`ca03be95`](https://github.com/NixOS/nixpkgs/commit/ca03be9517b01f7fc2f974b3886efa24c2a9659c) | `devilspie2: update homepage in meta`                                                 |
| [`334f2a85`](https://github.com/NixOS/nixpkgs/commit/334f2a858424172756222e0270c5a3e88a787792) | `openmm: init at 7.7.0`                                                               |
| [`eafbd542`](https://github.com/NixOS/nixpkgs/commit/eafbd542ed0e721c4faae46adbe58419bbaa0f95) | `qutebrowser-qt6: fix help command`                                                   |
| [`2757fba5`](https://github.com/NixOS/nixpkgs/commit/2757fba524867a4c9de5304f6e5a508ea6ad9019) | `python310Packages.teslajsonpy: 2.4.5 -> 3.0.0`                                       |
| [`e0039724`](https://github.com/NixOS/nixpkgs/commit/e003972403574285dc4af92e0f90d21c21e46f14) | `free42: 3.0.14 -> 3.0.15`                                                            |
| [`790a7e44`](https://github.com/NixOS/nixpkgs/commit/790a7e4434e0dbd76a391d556745ba83892592d7) | `gitleaks: 8.13.0 -> 8.14.1`                                                          |
| [`85fa4ac0`](https://github.com/NixOS/nixpkgs/commit/85fa4ac03e9b26420a90512d5bf6e5c2b9a5d423) | `arduino-language-server: init at 0.7.1`                                              |
| [`a2071cad`](https://github.com/NixOS/nixpkgs/commit/a2071cad5526480efcbd06294bf81fd531843626) | `git-nomad: init at 0.6.0`                                                            |
| [`4d703382`](https://github.com/NixOS/nixpkgs/commit/4d703382f35bee9f69b573eca131362d9a9bcf3a) | `gnome.polari: 42.1 → 43.0`                                                           |
| [`336d270b`](https://github.com/NixOS/nixpkgs/commit/336d270b744ef3a4508685ad3f180dc5da1d17ff) | `vala-language-server: Fix build with GLib 2.74`                                      |
| [`375445ae`](https://github.com/NixOS/nixpkgs/commit/375445aead13312938bcb2565dc22aea452a8a01) | `entangle: Add workaround for old libselinux`                                         |
| [`72ecf256`](https://github.com/NixOS/nixpkgs/commit/72ecf256663bb90032d8388dd0e939409cdd1a58) | `greetd.gtkgreet: Fix build with GLib 2.74`                                           |
| [`bc8b66c2`](https://github.com/NixOS/nixpkgs/commit/bc8b66c2af5aa1ae4decdc9241805289e895ba87) | `pango: 1.50.10 → 1.50.11`                                                            |
| [`357536bf`](https://github.com/NixOS/nixpkgs/commit/357536bf580ca8298269d972c51ed0717eba3814) | `gnome-text-editor: 43.0 → 43.1`                                                      |
| [`6d5da1d8`](https://github.com/NixOS/nixpkgs/commit/6d5da1d8bcd8dde42ba41f7d5034bc8299a67bb2) | `gnome-builder: 43.1 → 43.2`                                                          |
| [`5e5d9256`](https://github.com/NixOS/nixpkgs/commit/5e5d9256e784d43afce44ac55894f2eff4ea869e) | `gnome.metacity: 3.44.0 → 3.46.0`                                                     |
| [`d258f6fe`](https://github.com/NixOS/nixpkgs/commit/d258f6fef875580bbd745c112e69b306e31c46ef) | `gnome.gnome-flashback: 3.45.1 → 3.46.0`                                              |
| [`64c94e66`](https://github.com/NixOS/nixpkgs/commit/64c94e66ac422828fdb6c9e95fa7c2b626eba471) | `gnome.ghex: 43.rc → 43.0`                                                            |
| [`29d57012`](https://github.com/NixOS/nixpkgs/commit/29d570122bdcac89854426fbb671d93f432838e8) | `glade: switch to webkitgtk_4_1`                                                      |
| [`919fc66e`](https://github.com/NixOS/nixpkgs/commit/919fc66e9d4d5b9698bb095fc515734941cc3d8b) | `gnome.yelp: switch to webkitgtk_4_1`                                                 |
| [`571d8e44`](https://github.com/NixOS/nixpkgs/commit/571d8e44bf78251cadbc394e65faec75eecc8460) | `tdesktop: switch to webkitgtk_4_1`                                                   |
| [`d86b3713`](https://github.com/NixOS/nixpkgs/commit/d86b3713f15f62bba9f9f31cc71b7462f8090e70) | `glib: fix gimp text editing crashes`                                                 |
| [`aa616364`](https://github.com/NixOS/nixpkgs/commit/aa616364b9375c619c002442aceaa0a2ba849c5b) | `libsoup_3: fix gnome-maps crashes`                                                   |
| [`ff5713f2`](https://github.com/NixOS/nixpkgs/commit/ff5713f2f93dfce22cff8077fdc90462f70a2f44) | `gnome.gnome-panel: 3.44.0 → 3.46.0`                                                  |
| [`dcd9db44`](https://github.com/NixOS/nixpkgs/commit/dcd9db4408ae0c2cbdd265f7f35ca718865f5fb4) | `gnome.gnome-applets: 3.44.0 → 3.46.0`                                                |
| [`e623569e`](https://github.com/NixOS/nixpkgs/commit/e623569e6a00e945069eb609f3e509b235b3de71) | `gspell: 1.11.1 → 1.12.0`                                                             |
| [`df76d94d`](https://github.com/NixOS/nixpkgs/commit/df76d94d4af0ffe46af3d307e80fbbd2d0a89d2b) | `gnome.geary: 40.0 → 43.0`                                                            |
| [`226d9e02`](https://github.com/NixOS/nixpkgs/commit/226d9e02d198d4bf4d1e5124bbc304c454eed7d3) | `blackbox-terminal: init at 0.12.0`                                                   |
| [`c737f113`](https://github.com/NixOS/nixpkgs/commit/c737f113067b5f5bd118c027d5b4a0b9db5e2068) | `gnome.mutter: fixup color-device: Don't create profiles from obvious garbage data`   |
| [`05a70bf0`](https://github.com/NixOS/nixpkgs/commit/05a70bf0a9ccbf0ccb7c65f90771f3d7628a99b1) | `gnome-builder: 43.0 → 43.1`                                                          |
| [`1a5ed6ae`](https://github.com/NixOS/nixpkgs/commit/1a5ed6aef347263bf1a0890b39b938834ebc61f0) | `gnome.gpaste: 42.1 → 43.0`                                                           |
| [`69297187`](https://github.com/NixOS/nixpkgs/commit/69297187cf3a65ccd74a273b5fdc4ae72a36aff8) | `libgweather: 4.1.0 → 4.2.0`                                                          |
| [`e88b0155`](https://github.com/NixOS/nixpkgs/commit/e88b0155b6899fa70f42124930428dacb0e2cf56) | `gnome.gnome-logs: 43.beta → 43.0`                                                    |
| [`8ce317d3`](https://github.com/NixOS/nixpkgs/commit/8ce317d389928daf0588ec011555dad4e067634c) | `gnomeExtensions.dash-to-dock: 73 → 74`                                               |
| [`134814a8`](https://github.com/NixOS/nixpkgs/commit/134814a8d47b655b1b3b7a92b776a99bdb30ba71) | `chatty: mark as broken`                                                              |
| [`31094866`](https://github.com/NixOS/nixpkgs/commit/31094866d6e637dcab24e8c0f9b530944ca2e226) | `endeavour: unstable-2022-06-12 → 42.0`                                               |
| [`c3e4064b`](https://github.com/NixOS/nixpkgs/commit/c3e4064b74813ccf07ab45824fca94e028bb31dd) | `endeavour: rename from gnome.gnome-todo`                                             |
| [`ee2cbd86`](https://github.com/NixOS/nixpkgs/commit/ee2cbd86a0d78fda4dad81863cad6de17bcede9f) | `dropbox-cli: update extension for Nautilus 43`                                       |
| [`39ae9caf`](https://github.com/NixOS/nixpkgs/commit/39ae9caf09887de6260e96f568ebac9bc2d7ee3d) | `vala-language-server: mark broken`                                                   |
| [`1702f37b`](https://github.com/NixOS/nixpkgs/commit/1702f37b39e8747389a8a80c7ad307f75130aedc) | `valum: mark as broken`                                                               |
| [`b4723898`](https://github.com/NixOS/nixpkgs/commit/b472389892cc533403ea5cc913ac03286c69cee9) | `tootle: mark broken`                                                                 |
| [`ff6ea28a`](https://github.com/NixOS/nixpkgs/commit/ff6ea28a40c0e7a041b94d79f1b87540c24000a4) | `gnomeExtensions.gsconnect: Update Nautilus extension for 43`                         |
| [`449eb2e0`](https://github.com/NixOS/nixpkgs/commit/449eb2e0b5265bfb2a9c954a88cf1cbfc0be6599) | `gnome.geary: fix libsoup2 × libsoup3 conflict`                                       |
| [`322a1bd2`](https://github.com/NixOS/nixpkgs/commit/322a1bd247ba0931ce99843d3ad54d437764d3be) | `orca: 43.beta → 43.0`                                                                |
| [`74673eb4`](https://github.com/NixOS/nixpkgs/commit/74673eb4646294cde89e7849d8c2e2c8713776bf) | `gtksourceview5: 5.6.0 → 5.6.1`                                                       |
| [`f2f9a443`](https://github.com/NixOS/nixpkgs/commit/f2f9a443d181666b904159b05ca09029847a282d) | `gnome-builder: 43.rc → 43.0`                                                         |
| [`924f1638`](https://github.com/NixOS/nixpkgs/commit/924f16384a84a7a9da48f5fca9fcc9a9efe57fb5) | `gnome.gnome-contacts: 43.rc → 43.0`                                                  |
| [`25875d75`](https://github.com/NixOS/nixpkgs/commit/25875d75bcce22fb1a615d4bb8e09e5505bc5a96) | `gnome-console: 43.rc → 42.2`                                                         |
| [`97fb1648`](https://github.com/NixOS/nixpkgs/commit/97fb1648562a3c295926a85a1a17a66a0e5e0a44) | `elementary-planner: Mark as broken`                                                  |
| [`35dffb9f`](https://github.com/NixOS/nixpkgs/commit/35dffb9f9362de07619bc6a560d0c391e3be54f1) | `pantheon.elementary-tasks: Mark as broken`                                           |
| [`c2f3c315`](https://github.com/NixOS/nixpkgs/commit/c2f3c315abd0317a4a1787157b2702fd08bc45a9) | `pantheon.wingpanel-indicator-datetime: Workaround for showing date numbers`          |
| [`bb97eab6`](https://github.com/NixOS/nixpkgs/commit/bb97eab688d2469d5d1df67f9483575ead3c06ce) | `pantheon.elementary-calendar: Fix build with evolution-data-server 3.46`             |
| [`c4c89906`](https://github.com/NixOS/nixpkgs/commit/c4c899062a4516af3c54373e674c60679a0044f8) | `pantheon.elementary-mail: Fix build with evolution-data-server 3.46`                 |
| [`0cce06c6`](https://github.com/NixOS/nixpkgs/commit/0cce06c632bcf5c10abaf93db7db31dbaedfba1e) | `pantheon.switchboard-plug-onlineaccounts: Fix build with evolution-data-server 3.46` |
| [`5364f7c7`](https://github.com/NixOS/nixpkgs/commit/5364f7c7ec04285ec95f3fa9b547c4f8b3395f29) | `libchamplain_libsoup3: init`                                                         |
| [`8499247e`](https://github.com/NixOS/nixpkgs/commit/8499247e8cef808d70b79360bf3264f9ac997173) | `libchamplain: Format with nixpkgs-fmt`                                               |
| [`58ed9b3b`](https://github.com/NixOS/nixpkgs/commit/58ed9b3b2a387f1bfcfc9c1525e0c4c76fcc33aa) | `ostree: Build with libcurl http backend instead of libsoup`                          |
| [`d80a32db`](https://github.com/NixOS/nixpkgs/commit/d80a32db1e4d3b0b5e7646e84da30cb0343777d4) | `flatpak: 1.12.7 → 1.14.0`                                                            |
| [`9121a522`](https://github.com/NixOS/nixpkgs/commit/9121a522fdc31fb108e1e98ab66688eccc74cb53) | `xdg-desktop-portal: fix icon validation`                                             |
| [`a69e7fd7`](https://github.com/NixOS/nixpkgs/commit/a69e7fd7f42b969d26889f368568eb4a869d692f) | `flatpak: clean up icon validation`                                                   |
| [`641f005b`](https://github.com/NixOS/nixpkgs/commit/641f005bc5ae1a0dedc7ee68a893be8e8b67be4c) | `gnome.ghex: 43.alpha → 43.rc`                                                        |
| [`bf4805d5`](https://github.com/NixOS/nixpkgs/commit/bf4805d52375fe4f87f0e792d56cd3e4a86d0b84) | `eiciel: 0.9.13.1 → 0.10.0-rc2`                                                       |
| [`b5a34147`](https://github.com/NixOS/nixpkgs/commit/b5a34147bf71883e154dd7df3a51f4cf05a68b97) | `libwpe-fdo: 1.12.1 → 1.14.0`                                                         |
| [`f85cf529`](https://github.com/NixOS/nixpkgs/commit/f85cf5297ad871387774f1c5df481f1c7da6aac2) | `libwpe: 1.12.3 → 1.14.0`                                                             |
| [`1598bc05`](https://github.com/NixOS/nixpkgs/commit/1598bc05161786326a997f2586e885ca5a905b93) | `python3.pkgs.pyatspi: 2.45.90 → 2.46.0`                                              |
| [`6c51009e`](https://github.com/NixOS/nixpkgs/commit/6c51009e85c3ad90306571d24329edcb93e5ed91) | `pangomm_2_48: 2.50.0 → 2.50.1`                                                       |
| [`b8534285`](https://github.com/NixOS/nixpkgs/commit/b85342857e68e706ffadb8a761a025b728bd4b44) | `pango: 1.50.8 → 1.50.10`                                                             |
| [`688e4ba7`](https://github.com/NixOS/nixpkgs/commit/688e4ba749c12bdf569fdc573af4b82ee0c982b8) | `pangomm: 2.46.2 → 2.46.3`                                                            |
| [`89226091`](https://github.com/NixOS/nixpkgs/commit/89226091055445627b7fc22b62dd9a14dbbaa681) | `gnome.simple-scan: 42.1 → 42.5`                                                      |
| [`cfcfa938`](https://github.com/NixOS/nixpkgs/commit/cfcfa9386ca98bbed2cedcdc8ea67bc2e795c772) | `gjs: 1.73.2 → 1.74.0`                                                                |
| [`09cfb4f7`](https://github.com/NixOS/nixpkgs/commit/09cfb4f7a49cf0697367a4b93f0c9abcb025abdd) | `evolution-data-server: 3.45.3 → 3.46.0`                                              |
| [`609d4f31`](https://github.com/NixOS/nixpkgs/commit/609d4f315d7276de0b290700e3b6da3164482b9f) | `gnome-tour: 43.beta → 43.0`                                                          |
| [`f68f15a9`](https://github.com/NixOS/nixpkgs/commit/f68f15a95c1864345560341c1f90d672a74cc817) | `gnome-photos: 43.beta → 43.0`                                                        |
| [`1ee62438`](https://github.com/NixOS/nixpkgs/commit/1ee6243826182ef8cf43803c5de9533a3d3f646e) | `gnome.gnome-session: 42.0 → 43.0`                                                    |
| [`0ae8b4bf`](https://github.com/NixOS/nixpkgs/commit/0ae8b4bf5ee0685168807be95edc8366873c738b) | `gnome.gnome-backgrounds: 43.rc → 43`                                                 |
| [`7ee1e7a0`](https://github.com/NixOS/nixpkgs/commit/7ee1e7a0e7dd2f23bf33ba54c7840a442d01f6ca) | `gnome.gnome-clocks: 43.beta → 43.0`                                                  |
| [`0530435a`](https://github.com/NixOS/nixpkgs/commit/0530435ac0ef6403edb0f1fdb0bf56c92bd5ed34) | `gnome.gdm: 42.0 → 43.0`                                                              |
| [`cd0c77e0`](https://github.com/NixOS/nixpkgs/commit/cd0c77e017ab09a641fa7bc46e2141b9e48f3e49) | `gnome.adwaita-icon-theme: 43.beta.1 → 43`                                            |
| [`ece83c3d`](https://github.com/NixOS/nixpkgs/commit/ece83c3dc5ee400ebd3ccd6c22e171ccc9d3d477) | `gnome.devhelp: 43.rc → 43.0`                                                         |
| [`977b5557`](https://github.com/NixOS/nixpkgs/commit/977b55577d93703d55e3dfb4be865677131a1fce) | `appstream-glib: 0.7.18 → 0.8.1`                                                      |
| [`3eff2a76`](https://github.com/NixOS/nixpkgs/commit/3eff2a7606c397d6639d633c147be8b30fcc2761) | `gnome.epiphany: remove unused libnotify dependency`                                  |
| [`10568866`](https://github.com/NixOS/nixpkgs/commit/10568866e050d1c0d517b9169349b17ee17f5327) | `malcontent: 0.10.5 → 0.11.0`                                                         |
| [`fed9f942`](https://github.com/NixOS/nixpkgs/commit/fed9f9420e6d4e99ba1365cb7553f75795179206) | `release-notes: Mention GNOME 43`                                                     |
| [`3c1965e5`](https://github.com/NixOS/nixpkgs/commit/3c1965e5b9f80b7e26b238fd4087b8f479ee7026) | `folks: Use GTK 4 variant of e-d-s`                                                   |
| [`a1baaa57`](https://github.com/NixOS/nixpkgs/commit/a1baaa57da9d0c31a6073fcf7f2c3a173d77ce27) | `almanah: Use GTK 4 variant of e-d-s`                                                 |
| [`194315fc`](https://github.com/NixOS/nixpkgs/commit/194315fc2e4e9784fc194ca9cc97f624145938f2) | `gnomeExtensions.gsconnect: Use GTK 4 variant of e-d-s`                               |
| [`6ff9e88b`](https://github.com/NixOS/nixpkgs/commit/6ff9e88b82350da2f73f9b93959d4f5a2031eba0) | `tracker-miners: Clean up dependencies`                                               |
| [`765d0f4e`](https://github.com/NixOS/nixpkgs/commit/765d0f4e5f589b7e6cbb789d8da9a3b4e6c0a3ec) | `gnome.gnome-shell: Use GTK 4 variant of e-d-s`                                       |
| [`766a245d`](https://github.com/NixOS/nixpkgs/commit/766a245dbcda372e9231d643cb5466dee6299473) | `gnome.gnome-contacts: Use GTK 4 variants of dependencies`                            |
| [`286e3329`](https://github.com/NixOS/nixpkgs/commit/286e3329fab4bac18652a5c49cb55e26f2d14c2c) | `gnome.gnome-todo: Use GTK 4 variants of dependencies`                                |
| [`1cf114b8`](https://github.com/NixOS/nixpkgs/commit/1cf114b84699e9579c54bb6e06a7083a569b70e4) | `vte: 0.69.99 → 0.70.0`                                                               |
| [`ea3d666c`](https://github.com/NixOS/nixpkgs/commit/ea3d666cc3574b14e5351c53ef15feafd8fed5ad) | `tracker-miners: 3.4.0.rc → 3.4.0`                                                    |
| [`de0d5024`](https://github.com/NixOS/nixpkgs/commit/de0d50243ca998e70f27238df3fd45385606d434) | `tracker: 3.4.0.rc → 3.4.0`                                                           |
| [`ec62268c`](https://github.com/NixOS/nixpkgs/commit/ec62268cea97f460c0544155b6b08ec9ce9a2d02) | `networkmanager-sstp: 1.3.0 → 1.3.1`                                                  |
| [`5ca8ced5`](https://github.com/NixOS/nixpkgs/commit/5ca8ced557bc77f10215a5d2db8221a505cd01a9) | `libshumate: 1.0.0.beta → 1.0.1`                                                      |
| [`828c0ec4`](https://github.com/NixOS/nixpkgs/commit/828c0ec427fa19f98e2b3687d21a28aba4b97bc6) | `gsettings-desktop-schemas: 43.rc.1 → 43.0`                                           |
| [`b695629f`](https://github.com/NixOS/nixpkgs/commit/b695629f66ff703d7c96ccfdc08fbf915f988994) | `gnome-user-docs: 42.0 → 43.0`                                                        |
| [`e143301d`](https://github.com/NixOS/nixpkgs/commit/e143301d505350ee1d2e1c4189b287683fbad81b) | `gnome-text-editor: 43.alpha1 → 43.0`                                                 |
| [`d7cc4d5c`](https://github.com/NixOS/nixpkgs/commit/d7cc4d5c8be0e71e64b9aea744ddc55e4ad3aa81) | `gnome-builder: 43.alpha1 → 43.rc`                                                    |
| [`07959355`](https://github.com/NixOS/nixpkgs/commit/0795935574025a1d83a3f468f8d97ad2d84fc539) | `d-spy: 1.2.1 → 1.4.0`                                                                |
| [`5b1ed07d`](https://github.com/NixOS/nixpkgs/commit/5b1ed07d2fcd7118dfb71b4a3751565caa669cdc) | `gnome-desktop: 43.rc → 43`                                                           |
| [`ec9acea1`](https://github.com/NixOS/nixpkgs/commit/ec9acea1e4ed2c4bd2a0af97ab0d1a41fd002d7f) | `gnome.nautilus: 43.rc → 43.0`                                                        |
| [`d2b7085a`](https://github.com/NixOS/nixpkgs/commit/d2b7085aa945dc8ef94483e897a928ed50536f35) | `gnome.gnome-weather: 43.rc → 43.0`                                                   |
| [`0188f0a5`](https://github.com/NixOS/nixpkgs/commit/0188f0a5701382dc7d2033a9150c37b2ca74810d) | `gnome.gnome-settings-daemon: 43.rc → 43.0`                                           |
| [`79c0bacd`](https://github.com/NixOS/nixpkgs/commit/79c0bacd881e319b9ea4350e64e9754cced5d788) | `gnome.gnome-font-viewer: 43.rc → 43.0`                                               |
| [`cc2e9c1c`](https://github.com/NixOS/nixpkgs/commit/cc2e9c1c3c10e642ee74c193f349f1a16896fa92) | `gnome.gnome-characters: 43.rc → 43.0`                                                |
| [`dea66f99`](https://github.com/NixOS/nixpkgs/commit/dea66f99fa54ac1d5f8b7e8ae68367ad53c359f9) | `glibmm_2_68: 2.73.2 → 2.74.0`                                                        |
| [`66efd06d`](https://github.com/NixOS/nixpkgs/commit/66efd06d7d73329198f7e658827d448f8eae1767) | `glibmm: 2.66.4 → 2.66.5`                                                             |
| [`619892ba`](https://github.com/NixOS/nixpkgs/commit/619892bab4a2f465d7d235002800bae86fe05c10) | `evince: 43.alpha → 43.0`                                                             |
| [`650985e6`](https://github.com/NixOS/nixpkgs/commit/650985e691d5008777b7609b8f6f0fbb29be9cd0) | `baobab: 43.rc → 43.0`                                                                |
| [`0985312f`](https://github.com/NixOS/nixpkgs/commit/0985312f4faa4e95c669f32d94e47a09c175e80e) | `gnome.mutter338: Fix build with separate sysprof`                                    |
| [`e6964aea`](https://github.com/NixOS/nixpkgs/commit/e6964aea3891ec2828138459cdb182b01fbf3bc3) | `sysprof: 3.45.1 → 3.46.0`                                                            |
| [`989c26c0`](https://github.com/NixOS/nixpkgs/commit/989c26c08f644f3bd619c43b9b0581667eaef6b0) | `template-glib: 3.35.0 → 3.36.0`                                                      |
| [`ee8fd4ac`](https://github.com/NixOS/nixpkgs/commit/ee8fd4ac3d3707299381fdb1be6e8cf6173c60ba) | `libpeas: 1.32.0 → 1.34.0`                                                            |
| [`7ae7e0e9`](https://github.com/NixOS/nixpkgs/commit/7ae7e0e963460f839bd6e3bbf6c6476c181a6acb) | `libgee: 0.20.5 → 0.20.6`                                                             |
| [`56e82378`](https://github.com/NixOS/nixpkgs/commit/56e823788bb85d72038ba478298374293c41457c) | `gupnp_1_6: 1.5.4 → 1.6.0`                                                            |
| [`eccead48`](https://github.com/NixOS/nixpkgs/commit/eccead48b4fdd8ba8d6d52425ab6cb896073a56b) | `gtksourceview5: 5.5.1 → 5.6.0`                                                       |
| [`e33dff6b`](https://github.com/NixOS/nixpkgs/commit/e33dff6b30f843cbb7a41761f61ebc071df5e5cc) | `gssdp_1_6: 1.5.2 → 1.6.0`                                                            |
| [`ed7392af`](https://github.com/NixOS/nixpkgs/commit/ed7392af5a55daca20084560ba3ed11d58840fae) | `gnumeric: 1.12.52 → 1.12.53`                                                         |
| [`7aa5e4bf`](https://github.com/NixOS/nixpkgs/commit/7aa5e4bf9fc1b0f41f8cb1355d87e265a7d68752) | `goffice: 0.10.52 → 0.10.53`                                                          |
| [`53f9485f`](https://github.com/NixOS/nixpkgs/commit/53f9485fcc6cf262084bac86d816052dadf862a9) | `gnome-online-accounts: 3.45.2 → 3.46.0`                                              |
| [`25aef96a`](https://github.com/NixOS/nixpkgs/commit/25aef96a105ec5cb6e4b8c417cdb7840e5c2ce80) | `gnome.yelp-xsl: 42.0 → 42.1`                                                         |
| [`9a8fe134`](https://github.com/NixOS/nixpkgs/commit/9a8fe1349c1d04f8560a3b0cc50b8ef7ce1efc8c) | `gnome.yelp: 42.1 → 42.2`                                                             |
| [`06c2b7d2`](https://github.com/NixOS/nixpkgs/commit/06c2b7d2206d504b9c90b62f125c5522d05df0d2) | `gnome.rygel: 0.41.2 → 0.42.0`                                                        |
| [`9e21c396`](https://github.com/NixOS/nixpkgs/commit/9e21c396b1a6fcda1d96bd2a4ba3e1744e5b8fcd) | `gnome.nautilus-python: 4.0.alpha → 4.0`                                              |
| [`9d6f6483`](https://github.com/NixOS/nixpkgs/commit/9d6f64834dc6f64eb8ccb76c95ea0a1afd6819c3) | `gnome.gnome-sudoku: 43.beta → 43.0`                                                  |
| [`31f1c5c6`](https://github.com/NixOS/nixpkgs/commit/31f1c5c6ae892737967383f12cd3490459ae11cb) | `gnome.gnome-shell: 43.rc → 43.0`                                                     |
| [`31df01cb`](https://github.com/NixOS/nixpkgs/commit/31df01cbaf81dcb0ddbd2bf627e7f71ce417b560) | `gnome.mutter: 43.rc → 43.0`                                                          |
| [`e39c7a46`](https://github.com/NixOS/nixpkgs/commit/e39c7a4683985a2ce927e21ca4b1b71635483deb) | `gnome.gnome-power-manager: 3.32.0 → 43.0`                                            |
| [`dd9f466e`](https://github.com/NixOS/nixpkgs/commit/dd9f466eb0ae674443eed62e78d39764aa7aa2dc) | `gnome.gnome-shell-extensions: 43.rc → 43.0`                                          |
| [`d78f7806`](https://github.com/NixOS/nixpkgs/commit/d78f7806e0f7c5f607ba37246cefa3ab245f8b98) | `gnome.gnome-remote-desktop: 43.rc → 43.0`                                            |
| [`636549aa`](https://github.com/NixOS/nixpkgs/commit/636549aa6b9e6292ed1f38e780658bab8a107fcf) | `gnome.gnome-maps: 43.rc → 43.0`                                                      |
| [`441e6856`](https://github.com/NixOS/nixpkgs/commit/441e68565ac00ff3078f7efd311c3880f56a9ec6) | `gnome.eog: 43.rc → 43.0`                                                             |
| [`841d89c6`](https://github.com/NixOS/nixpkgs/commit/841d89c6ff5473cb97d2f64788f885a4d453ec9e) | `gnome.file-roller: 43.alpha → 43.0`                                                  |