### PR TITLE
chore(flake/nur): `1bcd8f96` -> `9ffe036f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665695739,
-        "narHash": "sha256-t1TkxpL0I2G9UdVIcLUszIyKH5mI7Z2PO53yxF01W9I=",
+        "lastModified": 1665721339,
+        "narHash": "sha256-9McPiHFQSe2xveNp4vvaXsJugyyXgc4UODU+f0oddDI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1bcd8f960c3178926ca96bdcd7a81bed715ff9d1",
+        "rev": "9ffe036f1c575ae9c3acdff0a05adc5922dc486d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9ffe036f`](https://github.com/nix-community/NUR/commit/9ffe036f1c575ae9c3acdff0a05adc5922dc486d) | `automatic update` |
| [`920c95bd`](https://github.com/nix-community/NUR/commit/920c95bded721561fd217e29aac112117cba9e76) | `automatic update` |