### PR TITLE
chore(flake/nur): `9ffe036f` -> `577908ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665721339,
-        "narHash": "sha256-9McPiHFQSe2xveNp4vvaXsJugyyXgc4UODU+f0oddDI=",
+        "lastModified": 1665724218,
+        "narHash": "sha256-ZfkMCpXygmSTFN+hF5ZO4ulQzYOnPKQ9m9S2C+rvpDE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ffe036f1c575ae9c3acdff0a05adc5922dc486d",
+        "rev": "577908ef5a384475fe508f1ed55bf2a4b0349547",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`577908ef`](https://github.com/nix-community/NUR/commit/577908ef5a384475fe508f1ed55bf2a4b0349547) | `automatic update` |