### PR TITLE
chore(flake/nur): `a354feb1` -> `b41b1b84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665724982,
-        "narHash": "sha256-d/vigGTUepQZvm8CbchC69/JNJH7pc4HvegL49qEJww=",
+        "lastModified": 1665733078,
+        "narHash": "sha256-m63UbFNkDUfnEfPIR9f5SaFjBALGkI8EsV3t6f2Psds=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a354feb1ff90ebe6fcab5dcdfc175d3a6b58d0d1",
+        "rev": "b41b1b84be7bb777edefae52742ae89fb2aa524f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b41b1b84`](https://github.com/nix-community/NUR/commit/b41b1b84be7bb777edefae52742ae89fb2aa524f) | `automatic update` |