### PR TITLE
chore(flake/nixos-hardware): `d92ed98c` -> `c8c54d8f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -263,11 +263,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1665649208,
-        "narHash": "sha256-MDkPVG4W8gigJ8OxWDp9L6aKaEwLRV3As1RvKkMq0rc=",
+        "lastModified": 1665734422,
+        "narHash": "sha256-v8DMfRyFdulDyCCoOXak+oue1IgVBJZdSY1eXqdMRwQ=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d92ed98c099ae731664fc526c348d609c4cffe04",
+        "rev": "c8c54d8f0af9f19ed6e929e60f0e1609b89b1240",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                      |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`d3e383e9`](https://github.com/NixOS/nixos-hardware/commit/d3e383e974fea21fde01864d67c6c231f597df5f) | `15arh05: add acpi_call`            |
| [`322dc8db`](https://github.com/NixOS/nixos-hardware/commit/322dc8db3e2a40cdb5a03ed9e094d8666029b9e9) | `15arh05: fix tlp scaling governor` |