### PR TITLE
chore(flake/nur): `b41b1b84` -> `eb37af46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665733078,
-        "narHash": "sha256-m63UbFNkDUfnEfPIR9f5SaFjBALGkI8EsV3t6f2Psds=",
+        "lastModified": 1665738558,
+        "narHash": "sha256-O++SySdByZLP+BhYFLeFupIHCB/KYANcRhmPuAEOTJI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b41b1b84be7bb777edefae52742ae89fb2aa524f",
+        "rev": "eb37af46052487d302bafcdc519afe4cd8d8fcba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`eb37af46`](https://github.com/nix-community/NUR/commit/eb37af46052487d302bafcdc519afe4cd8d8fcba) | `automatic update` |