### PR TITLE
chore(flake/emacs-overlay): `28e2a597` -> `c2b0e0cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665724727,
-        "narHash": "sha256-2lLLc2YmobzejQ6waT6F65GWqRXttjH3e+XxbRLNY3s=",
+        "lastModified": 1665746879,
+        "narHash": "sha256-fwYXzvO2x3nttwl+LCqIq4Hw6zeNyw8dtjOp6ze1UJo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "28e2a59713f822679a174720ad3fe70554ab0457",
+        "rev": "c2b0e0cfa4c9cdb7ed96e3fb984f5ce92eb9e4e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`c2b0e0cf`](https://github.com/nix-community/emacs-overlay/commit/c2b0e0cfa4c9cdb7ed96e3fb984f5ce92eb9e4e7) | `Updated repos/melpa` |
| [`17508435`](https://github.com/nix-community/emacs-overlay/commit/175084356587427b7ae06f8edab8219d3a9aa8b1) | `Updated repos/emacs` |