### PR TITLE
chore(flake/nur): `e994fda9` -> `1f34a5ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665744735,
-        "narHash": "sha256-awbF7XXhYp4oNg4yIgLqCR0pbG61Ib11zSK7xq8QDNc=",
+        "lastModified": 1665749246,
+        "narHash": "sha256-HAJHlPWepLkhWjf9Ge++gISmfZbsvtTa2TXXyWl0zqs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e994fda93529a983ba33826604214f38fad913ea",
+        "rev": "1f34a5aba914aaedcfbdf53d891af23cd52066cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1f34a5ab`](https://github.com/nix-community/NUR/commit/1f34a5aba914aaedcfbdf53d891af23cd52066cb) | `automatic update` |