### PR TITLE
chore(flake/emacs-overlay): `c2b0e0cf` -> `472a238c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665746879,
-        "narHash": "sha256-fwYXzvO2x3nttwl+LCqIq4Hw6zeNyw8dtjOp6ze1UJo=",
+        "lastModified": 1665775650,
+        "narHash": "sha256-OTmm9PR9QUIwv0nJKOBl37mHqPXPy8odppzuho2347k=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c2b0e0cfa4c9cdb7ed96e3fb984f5ce92eb9e4e7",
+        "rev": "472a238cc3c0074bf056857c002bfa2f0eb8b0b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`472a238c`](https://github.com/nix-community/emacs-overlay/commit/472a238cc3c0074bf056857c002bfa2f0eb8b0b5) | `Updated repos/melpa` |
| [`fd9d1779`](https://github.com/nix-community/emacs-overlay/commit/fd9d1779bb1ce35e362857987faa0f0a132ee6a6) | `Updated repos/emacs` |
| [`caf856bd`](https://github.com/nix-community/emacs-overlay/commit/caf856bd53157cdd6cc6949ff7720927e88bdc0a) | `Updated repos/elpa`  |