### PR TITLE
chore(flake/nur): `a7dfe44e` -> `be40fb54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665772052,
-        "narHash": "sha256-wTPmOp/zEIpcDe8OjSkP4o99IeUH3ZbcBbW9H4KsJ1Q=",
+        "lastModified": 1665788726,
+        "narHash": "sha256-6kRYefjO1xnV5pktALYKdH+J3F1c6Es8P3Tdy7BXf8s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a7dfe44e7472e0d61d869f5fb82076f4408813e4",
+        "rev": "be40fb543c7445a8827da43d59cdd1dedf783f56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`be40fb54`](https://github.com/nix-community/NUR/commit/be40fb543c7445a8827da43d59cdd1dedf783f56) | `automatic update` |