### PR TITLE
chore(flake/nur): `d0462ae6` -> `3f453b07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665805535,
-        "narHash": "sha256-B/eW7UbT+Nk4hhiIfJdJLYEDgdiyPTFDKd9XEWEdhAA=",
+        "lastModified": 1665806969,
+        "narHash": "sha256-PcMThtGo6KN8CAICFYnsRanwpR+I2ih9pdqbjFSARyw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d0462ae66d8633dc8cd1204c92be7fccc674ea20",
+        "rev": "3f453b07e1e1184f6f9b74b6ba740f9e0c550d6a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3f453b07`](https://github.com/nix-community/NUR/commit/3f453b07e1e1184f6f9b74b6ba740f9e0c550d6a) | `automatic update` |