### PR TITLE
chore(flake/emacs-overlay): `472a238c` -> `c9b9a56b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665775650,
-        "narHash": "sha256-OTmm9PR9QUIwv0nJKOBl37mHqPXPy8odppzuho2347k=",
+        "lastModified": 1665812712,
+        "narHash": "sha256-O53W/SJECsdyXwv51UxunyEJv4q1izA7gy5+/nCx+Hg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "472a238cc3c0074bf056857c002bfa2f0eb8b0b5",
+        "rev": "c9b9a56ba697e4a0d1842f3ceaa80ecaaab66d95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                    |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
| [`05484486`](https://github.com/nix-community/emacs-overlay/commit/054844861c327a4e4f5f16022b9218ecdf1aefe1) | `Updated repos/melpa`                             |
| [`3e7e2969`](https://github.com/nix-community/emacs-overlay/commit/3e7e2969ba3934644ad40074c93758d356b43b7f) | `Updated repos/emacs`                             |
| [`86e60523`](https://github.com/nix-community/emacs-overlay/commit/86e60523105c9bb8ea70f271c87ad28f19dfbdb9) | `flake.nix: fix the hack of getting overlayAttrs` |