### PR TITLE
chore(flake/nur): `3f453b07` -> `2ff0d134`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665806969,
-        "narHash": "sha256-PcMThtGo6KN8CAICFYnsRanwpR+I2ih9pdqbjFSARyw=",
+        "lastModified": 1665816557,
+        "narHash": "sha256-l+PbGkSE8IEQW5PFg95bf1ne8QxNdtxIOzXb/3j3Yw4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3f453b07e1e1184f6f9b74b6ba740f9e0c550d6a",
+        "rev": "2ff0d1346d6c6dadbb6435ac1d5e55c8ec9dec43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2ff0d134`](https://github.com/nix-community/NUR/commit/2ff0d1346d6c6dadbb6435ac1d5e55c8ec9dec43) | `automatic update` |