### PR TITLE
chore(flake/emacs-overlay): `c9b9a56b` -> `08445dd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665812712,
-        "narHash": "sha256-O53W/SJECsdyXwv51UxunyEJv4q1izA7gy5+/nCx+Hg=",
+        "lastModified": 1665824418,
+        "narHash": "sha256-OZX8io9UKzxFAwdRvf4uOThDFpGtlbMyi13RbqIpmoY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c9b9a56ba697e4a0d1842f3ceaa80ecaaab66d95",
+        "rev": "08445dd7824253ee8580f06127460a7d14e942cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                                         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
| [`57ee1eaa`](https://github.com/nix-community/emacs-overlay/commit/57ee1eaab60a67b0ed80f787fe3caa3959eb69d5) | `README: add doc for defaultInitFile`                                  |
| [`4fd0bbbe`](https://github.com/nix-community/emacs-overlay/commit/4fd0bbbedf9f1e559870fb35fe53f358b195024a) | `elisp.nix: add a param to include user config as a default init file` |