### PR TITLE
chore(flake/nixpkgs): `ba187fbd` -> `4428e233`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -277,11 +277,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665643254,
-        "narHash": "sha256-IBVWNJxGCsshwh62eRfR6+ry3bSXmulB3VQRzLQo3hk=",
+        "lastModified": 1665732960,
+        "narHash": "sha256-WBZ+uSHKFyjvd0w4inbm0cNExYTn8lpYFcHEes8tmec=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ba187fbdc5e35322c7dff556ef2c47bddfd6e8d7",
+        "rev": "4428e23312933a196724da2df7ab78eb5e67a88e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`13f4d69b`](https://github.com/NixOS/nixpkgs/commit/13f4d69b09f514d2237844fc840fa9a5c6642ed7) | `nushell: 0.68.1 -> 0.69.1 (#195652)`                                    |
| [`9c119316`](https://github.com/NixOS/nixpkgs/commit/9c1193166130ce6cf0e6076e1b5a7931739f8afc) | `arp-scan: 1.9.7 -> 1.9.8`                                               |
| [`6740eb3e`](https://github.com/NixOS/nixpkgs/commit/6740eb3eb0290c9aa70ef6b4469bd7a142359c89) | `boost-sml: init at 24d762d (#194815)`                                   |
| [`31d56784`](https://github.com/NixOS/nixpkgs/commit/31d567846255e122846548255101980162bbf641) | `v2ray-geoip: 202210060105 -> 202210130107`                              |
| [`9db161d0`](https://github.com/NixOS/nixpkgs/commit/9db161d0b0f2b3f7f31c393b2386c20532402cd0) | `terraform-providers.azurerm: 3.26.0 → 3.27.0`                           |
| [`5db8744a`](https://github.com/NixOS/nixpkgs/commit/5db8744af5c4f95930b756d662f1229b0372103b) | `terraform-providers.keycloak: 4.0.0 → 4.0.1`                            |
| [`d0d55104`](https://github.com/NixOS/nixpkgs/commit/d0d55104945380b64b8b60a9579c0cc2370f05d6) | `terraform-providers.github: 5.4.0 → 5.5.0`                              |
| [`8cdd78d9`](https://github.com/NixOS/nixpkgs/commit/8cdd78d937ce56b71afb61be016a8be592534879) | `terraform-providers.fastly: 2.3.3 → 2.4.0`                              |
| [`cb2bc52b`](https://github.com/NixOS/nixpkgs/commit/cb2bc52be55d12221979570750fd820dff470dc9) | `noti: 3.5.0 -> 3.6.0`                                                   |
| [`1c0da240`](https://github.com/NixOS/nixpkgs/commit/1c0da2400d0260586c3801b12a56c41e9f4fbf84) | `git-gone: 0.4.1 -> 0.4.2`                                               |
| [`c7894e1e`](https://github.com/NixOS/nixpkgs/commit/c7894e1e7395004e2eaf9456fa52f08bb48646ec) | `postgresql15Packages.pgjwt: 2017-04-24 -> 2021-11-13`                   |
| [`fbc179b0`](https://github.com/NixOS/nixpkgs/commit/fbc179b0d5ae1538df50a9778dba97dc719fe96e) | `millet: 0.3.14 -> 0.4.1`                                                |
| [`b0ea9c6d`](https://github.com/NixOS/nixpkgs/commit/b0ea9c6db85f30bcc6a9f3cd4b14e501807a4c64) | `postgresql15Packages.pg_partman: 4.7.0 -> 4.7.1`                        |
| [`19a7affe`](https://github.com/NixOS/nixpkgs/commit/19a7affebe7e31957fa1d20301de1d3ef37bebc3) | `postgresql15Packages.tsearch_extras: remove unneeded parameter`         |
| [`d45bce3f`](https://github.com/NixOS/nixpkgs/commit/d45bce3fe61248c130f6294df649a17db5cfd5bc) | `postgresql15Packages.wal2json: 2.4 -> 2.5`                              |
| [`97845bb2`](https://github.com/NixOS/nixpkgs/commit/97845bb25279046b60430de8784a2e9d75aeb721) | `postgresql15Packages.plpgsql_check: 2.2.1 -> 2.2.2`                     |
| [`9851053b`](https://github.com/NixOS/nixpkgs/commit/9851053baaaf51acbfd092c42333f8792401ac7c) | `postgresql15Packages.pg_repack: 1.4.7 -> 1.4.8`                         |
| [`f0456a97`](https://github.com/NixOS/nixpkgs/commit/f0456a97b42e2d4e1f14c0b6f94107112941de98) | `postgresql15Packages.periods: 1.2 -> 1.2.1`                             |
| [`972f78b6`](https://github.com/NixOS/nixpkgs/commit/972f78b6fbf75a17e192d19c20440fca24c8b01c) | `postgresql15Packages.pgvector: fix build for PostgreSQL 15`             |
| [`e7c0773e`](https://github.com/NixOS/nixpkgs/commit/e7c0773ef46b3ee40ace6b3cbcb60cb6193c6beb) | `terraform-ls: 0.29.2 -> 0.29.3`                                         |
| [`04e48fc9`](https://github.com/NixOS/nixpkgs/commit/04e48fc946c273ecd544278aec8e417b02451f8f) | `python310Packages.Pyro5: 5.13.1 -> 5.14`                                |
| [`c115f792`](https://github.com/NixOS/nixpkgs/commit/c115f79223650f25db75bd70a136740c622d23ad) | `python310Packages.azure-mgmt-network: 21.0.1 -> 22.0.0`                 |
| [`47348f48`](https://github.com/NixOS/nixpkgs/commit/47348f48a9f8797a199f05219e1498d51ed6d10f) | `haruna: 0.9.1 -> 0.9.3`                                                 |
| [`8dd7dfca`](https://github.com/NixOS/nixpkgs/commit/8dd7dfca93c3f7dd9bfe7543674bfa0aa7a243cf) | `git-interactive-rebase-tool: 2.2.0 -> 2.2.1`                            |
| [`ae24d583`](https://github.com/NixOS/nixpkgs/commit/ae24d583aefba3220fe20f92adcf7b39bdacb5bb) | `vscodium: 1.71.2.22258 -> 1.72.1.22284`                                 |
| [`9b71b34f`](https://github.com/NixOS/nixpkgs/commit/9b71b34f53ebc95845cf2144a18a20d624952db2) | `salt: 3005 -> 3005.1`                                                   |
| [`c4b5c257`](https://github.com/NixOS/nixpkgs/commit/c4b5c2574b6877d84a7bf5c2e57c85fc6cdd41bb) | `lua: test the interpreter`                                              |
| [`e48e332c`](https://github.com/NixOS/nixpkgs/commit/e48e332c3aec70727068bb13b444c370791de8ab) | `caddy: 2.6.1 -> 2.6.2`                                                  |
| [`11fc4b70`](https://github.com/NixOS/nixpkgs/commit/11fc4b7005b843e6a10d32060c919f96ec1ba86f) | `python310Packages.ansible: 6.3.0 -> 6.5.0`                              |
| [`648fa5e8`](https://github.com/NixOS/nixpkgs/commit/648fa5e8f79fb8832529a1f57d46579d918ff9db) | `nodejs-16_x-openssl_1_1: Use openssl 1.1`                               |
| [`9711a52b`](https://github.com/NixOS/nixpkgs/commit/9711a52b3d1b41ddf11282fa5cd4ba15a5352d05) | `python310Packages.ansible-lint: 6.8.1 -> 6.8.2`                         |
| [`0e7bc616`](https://github.com/NixOS/nixpkgs/commit/0e7bc616d1735016fb90fed03336dca1220dc624) | `python310Packages.ansible-later: 2.0.21 -> 2.0.22`                      |
| [`8676d396`](https://github.com/NixOS/nixpkgs/commit/8676d396c283f5f5840974561cd74eabfae614d3) | `rocksdb: 7.7.2 -> 7.7.3`                                                |
| [`e31262c3`](https://github.com/NixOS/nixpkgs/commit/e31262c3eef88eee80d950f0fd604f4ecaa634bb) | `at-spi2-core: make introspection unconditional`                         |
| [`3187ac92`](https://github.com/NixOS/nixpkgs/commit/3187ac92bbb85b72c7529b3d99e593706cb11d9e) | `opentelemetry-collector-contrib: 0.61.0 -> 0.62.0`                      |
| [`19f91b13`](https://github.com/NixOS/nixpkgs/commit/19f91b13e52b47ccf5c9c53c62d0dd9fb7e2b98c) | `opentelemetry-collector: 0.61.0 -> 0.62.0`                              |
| [`5b8ac1bb`](https://github.com/NixOS/nixpkgs/commit/5b8ac1bbdc94f2b3909e27f4bd1e20465e436f25) | `coqPackages.relation-algebra: init at 1.7.8 for Coq 8.16`               |
| [`272da6f6`](https://github.com/NixOS/nixpkgs/commit/272da6f68adb194362e2715ccd055f6b89a05b92) | `oh-my-posh: 12.1.0 -> 12.2.0`                                           |
| [`c1311d12`](https://github.com/NixOS/nixpkgs/commit/c1311d12237247e01b092e020563f34cfac8aa86) | `doc/stdenv: Move Other hooks after all hooks`                           |
| [`53088569`](https://github.com/NixOS/nixpkgs/commit/53088569de3a7b06b06f6ef2bd40cf0daa8272d2) | `doc/stdenv: Clarify that the wrappers come with hooks`                  |
| [`f4c62862`](https://github.com/NixOS/nixpkgs/commit/f4c6286284caed47d8d18bdf3102674a14120070) | `doc/stdenv: Improve language a bit`                                     |
| [`5353c753`](https://github.com/NixOS/nixpkgs/commit/5353c753884c20cc007f62eb477e567621fd32ba) | `qemu: add vmnet support`                                                |
| [`b0171888`](https://github.com/NixOS/nixpkgs/commit/b0171888fbf267342b59f79e03659ae315311f76) | `perlPackages.perlldap: 0.66 -> 0.68`                                    |
| [`ae83ba7b`](https://github.com/NixOS/nixpkgs/commit/ae83ba7b41afb0b193926d6795981c91602d114a) | `qutebrowser: enable support for widevine-cdm`                           |
| [`7d44e664`](https://github.com/NixOS/nixpkgs/commit/7d44e664ca57801509881a165e8b7ac2ce0c2c23) | `widevine-cdm: init at 4.10.2449.0`                                      |
| [`1383ef43`](https://github.com/NixOS/nixpkgs/commit/1383ef43760e29c2f84f4d69c3916dbe1bd4e717) | `linuxkit: 0.8 -> 1.0.0`                                                 |
| [`989e8d85`](https://github.com/NixOS/nixpkgs/commit/989e8d85685e3a1d3d3aee1b74f3651c130bbd56) | `nss: 3.83 -> 3.84`                                                      |
| [`7b307882`](https://github.com/NixOS/nixpkgs/commit/7b30788245205f5e53543d6bfb315ea22b80b68e) | `qemu: add patch improving 9p performance`                               |
| [`eb0fda66`](https://github.com/NixOS/nixpkgs/commit/eb0fda661d3965ded241ce9616b57cfd35a19903) | `offpunk: 1.5 -> 1.6`                                                    |
| [`fbe39952`](https://github.com/NixOS/nixpkgs/commit/fbe399529890eb555dc547d0f38e4c9ffed22d23) | `postgresql_15: init at 15.0`                                            |
| [`da0d5b7f`](https://github.com/NixOS/nixpkgs/commit/da0d5b7f558d57a53861434cecb36a4f5beb89d0) | `srvc: init at 0.6.0`                                                    |
| [`da2258f9`](https://github.com/NixOS/nixpkgs/commit/da2258f9127392462f49ebd4f950c36124a63607) | `vscode: 1.71.2 -> 1.72.1`                                               |
| [`fe83bff8`](https://github.com/NixOS/nixpkgs/commit/fe83bff80e7a397b68aeab7344acd2ebd363d936) | `lazydocker: 0.18.1 -> 0.19.0`                                           |
| [`2f5fcda3`](https://github.com/NixOS/nixpkgs/commit/2f5fcda329757f9a3d58dca4842e075c7f14ee2d) | `build-support: Fix error when building images with many layers`         |
| [`87a16031`](https://github.com/NixOS/nixpkgs/commit/87a16031f3925290825bf08121ef5a5521653666) | `mopidy-mpd: 3.2.0 -> 3.3.0 (#191907)`                                   |
| [`34a49719`](https://github.com/NixOS/nixpkgs/commit/34a497196e1bf16f97b72ef736ce6565787cc0e7) | `go-2fa: use buildGoModule (#193459)`                                    |
| [`2db8de92`](https://github.com/NixOS/nixpkgs/commit/2db8de920eebf9ef488c4725d579a2c3862d9a04) | `doc: Move non-stdenv hooks out of stdenv chapter`                       |
| [`c4cd43a2`](https://github.com/NixOS/nixpkgs/commit/c4cd43a20956675e88596216a7568ad650a60b29) | `edid-generator: actually generate binaries`                             |
| [`5b055190`](https://github.com/NixOS/nixpkgs/commit/5b055190e37d220b787b304e400391299bba022c) | `doc/stdenv: Clarify status of the hooks`                                |
| [`475ef797`](https://github.com/NixOS/nixpkgs/commit/475ef7975e2194c38b75899fa40cc0c2ddf2ccaa) | `python310Packages.mne-python: 1.1.1 -> 1.2.0`                           |
| [`bb4926ca`](https://github.com/NixOS/nixpkgs/commit/bb4926cac85130a1306c07fbeefdf9d118f3688f) | `broot: 1.16.0 -> 1.16.1`                                                |
| [`fa90ccd7`](https://github.com/NixOS/nixpkgs/commit/fa90ccd7de3c44f4f44dc66245b785a453411b43) | `freerdpUnstable: 2.8.0 -> 2.8.1`                                        |
| [`3485c3d0`](https://github.com/NixOS/nixpkgs/commit/3485c3d03fe84c75525d0e11fb21e039ba3c107b) | `flow: 0.188.2 -> 0.189.0`                                               |
| [`275f5047`](https://github.com/NixOS/nixpkgs/commit/275f5047a069285c6b4c4c2fb71f6ce0839d9b3b) | `flyctl: 0.0.409 -> 0.0.413`                                             |
| [`1859b8e8`](https://github.com/NixOS/nixpkgs/commit/1859b8e843e2c88cd62e89ded9c431c2f23cda74) | `ginkgo: 2.2.0 -> 2.3.1`                                                 |
| [`dfe919cd`](https://github.com/NixOS/nixpkgs/commit/dfe919cd8e902a0c1002e7ab0328254fba9c2da6) | `ko: 0.11.2 -> 0.12.0`                                                   |
| [`5e166272`](https://github.com/NixOS/nixpkgs/commit/5e166272ab4695dc08dd889ad3ade37b725f4eca) | `kubernetes-helm: 3.10.0 -> 3.10.1`                                      |
| [`fbcc270b`](https://github.com/NixOS/nixpkgs/commit/fbcc270b981b3caad3359c807f6c7d5b5773fd9c) | `vault-bin: 1.11.4 -> 1.12.0`                                            |
| [`a04a0f1b`](https://github.com/NixOS/nixpkgs/commit/a04a0f1bf4c25b0579b05ed473dc439018675815) | `vault: 1.11.4 -> 1.12.0`                                                |
| [`631a0782`](https://github.com/NixOS/nixpkgs/commit/631a07824d868288b96c470f3fe61810ad9e1eed) | `tailscale: 1.30.2 -> 1.32.0`                                            |
| [`872526f9`](https://github.com/NixOS/nixpkgs/commit/872526f999ad70a9d09206921699da5ff87eb944) | `pantheon.wingpanel-indicator-datetime: switch to merged patch`          |
| [`cf1e358e`](https://github.com/NixOS/nixpkgs/commit/cf1e358e04ebda06625f9efcd238e5301838cab5) | `pantheon.elementary-calendar: switch to merged patch`                   |
| [`915e21c1`](https://github.com/NixOS/nixpkgs/commit/915e21c171827c5376ea8e35d89637719a7d31ac) | `credhub-cli: 2.9.4 -> 2.9.5`                                            |
| [`0c500925`](https://github.com/NixOS/nixpkgs/commit/0c5009255db04194ef1b472f0fbb415864bf93f3) | `atmos: 1.8.2 -> 1.10.2`                                                 |
| [`d4877de9`](https://github.com/NixOS/nixpkgs/commit/d4877de9c9d6f5ae25f5f318057df0507e80d936) | `kea: add prometheus-exporter to passthru tests`                         |
| [`d2d5d5b2`](https://github.com/NixOS/nixpkgs/commit/d2d5d5b22efe38b2d8b9595dcb95479863979305) | `kea: build documentation and manpages`                                  |
| [`707f2016`](https://github.com/NixOS/nixpkgs/commit/707f2016aad8cd52a0814a57ba3e3d28bf06d62b) | `kea: build with openssl instead of botan2`                              |
| [`a580f2ed`](https://github.com/NixOS/nixpkgs/commit/a580f2ed2151c74a6b46921a2db61d569338fab9) | `ruff: 0.0.69 -> 0.0.72`                                                 |
| [`218dfe8e`](https://github.com/NixOS/nixpkgs/commit/218dfe8eae410c250967fc0fd8671d5f2b111583) | `sickgear: 0.25.44 -> 0.25.46`                                           |
| [`03229edc`](https://github.com/NixOS/nixpkgs/commit/03229edc43b025b91647b5aa33ea2170a36a143a) | `alacritty: 0.11.0-rc2 -> 0.11.0`                                        |
| [`d2e6195f`](https://github.com/NixOS/nixpkgs/commit/d2e6195f5b83e84e176bf9dc16ee93ea209037d9) | `build(deps): bump cachix/install-nix-action from 17 to 18`              |
| [`ff3f76ad`](https://github.com/NixOS/nixpkgs/commit/ff3f76ad3945fa2afa43f3a8d63aa34898ae53eb) | `build(deps): bump cachix/cachix-action from 10 to 11`                   |
| [`6302d8f8`](https://github.com/NixOS/nixpkgs/commit/6302d8f8068a04c2886faa6bed95e3ffb98d45ff) | `element-{web,desktop}: 1.11.8 -> 1.11.10`                               |
| [`2b387a08`](https://github.com/NixOS/nixpkgs/commit/2b387a08ccd110210d9594f142bb30c3ef45bda2) | `jetbrains: set JDK for JetBrains Client`                                |
| [`ca7c9834`](https://github.com/NixOS/nixpkgs/commit/ca7c98346268ffa16bf0df8f603587a04f978f52) | `jetbrains.gateway: init at 223.6646.21`                                 |
| [`e1d6e67f`](https://github.com/NixOS/nixpkgs/commit/e1d6e67f8e914adb7e3160983121e7bec46f164e) | `maintainers: add kouyk`                                                 |
| [`37a64594`](https://github.com/NixOS/nixpkgs/commit/37a64594bde38d4b3dda3298f826642b6131bfd9) | `nixos/plasma-bigscreen: enable uinput correctly`                        |
| [`5430715f`](https://github.com/NixOS/nixpkgs/commit/5430715f9ecbe6cb61ee69cbdaf0c4a62d50e3da) | `perceptualdiff: unbreak on aarch64-darwin`                              |
| [`fd0989d6`](https://github.com/NixOS/nixpkgs/commit/fd0989d64cd779d287ec6c753a3f22ebfd617090) | `freeimage: fix build on aarch64-darwin`                                 |
| [`eb7e4115`](https://github.com/NixOS/nixpkgs/commit/eb7e4115061f70b1e96c3174239985df5f3f6808) | `kwin: Fix building on aarch64-linux`                                    |
| [`961575f5`](https://github.com/NixOS/nixpkgs/commit/961575f53cd9b3d49afcaf5a8d74c7c17b7b5f5d) | `all-packages: don't recurse into libsForQt5_openssl_1_1`                |
| [`6c2e5077`](https://github.com/NixOS/nixpkgs/commit/6c2e5077f20580baab7d7dd374670b7faf5b42d8) | `kidletime: add new Wayland deps`                                        |
| [`1a805a71`](https://github.com/NixOS/nixpkgs/commit/1a805a718df2360663c686de12a8727de57a90bf) | `kde/frameworks: 5.98 -> 5.99`                                           |
| [`13961bf2`](https://github.com/NixOS/nixpkgs/commit/13961bf28e4e33bde5c7a365ec62bc5f182e9bf9) | `pkgs/desktops/plasma-5: nixpkgs-fmt the whole thing`                    |
| [`5e62c78f`](https://github.com/NixOS/nixpkgs/commit/5e62c78f4b565f98b798046c9285f5c0d663695f) | `nixos/plasma5: add very basic plasma-bigscreen module`                  |
| [`7e99c2ed`](https://github.com/NixOS/nixpkgs/commit/7e99c2ed5bf1bbb5752a6ebabeed65bd05e7cb71) | `plasma5Packages: 5.25.5 -> 5.26.0`                                      |
| [`57dd8624`](https://github.com/NixOS/nixpkgs/commit/57dd8624991d73de0473513a282333b565db4501) | `copilot-cli: 1.22.0 -> 1.22.1`                                          |
| [`73e93f45`](https://github.com/NixOS/nixpkgs/commit/73e93f456c9ec5c7e15d0bf33462ce6b0a4bae03) | `kubedog: init at 0.9.6`                                                 |
| [`16085338`](https://github.com/NixOS/nixpkgs/commit/16085338c099f5882101c4ed8160c6a4ab97f001) | `bingo: 0.6.0 -> 0.7.0`                                                  |
| [`31fa7802`](https://github.com/NixOS/nixpkgs/commit/31fa7802506dbb3fe23f43742767acafe016d647) | `python310Packages.trimesh: 3.15.3 -> 3.15.4`                            |
| [`d560440c`](https://github.com/NixOS/nixpkgs/commit/d560440cfbdde99f7df60a07d1b122e21bcfda3d) | `python310Packages.tgcrypto: 1.2.3 -> 1.2.4`                             |
| [`290707f8`](https://github.com/NixOS/nixpkgs/commit/290707f8410f7c64322f22485a18074840208b9c) | `treesheets: unstable-2022-09-26 -> unstable-2022-10-11`                 |
| [`65684678`](https://github.com/NixOS/nixpkgs/commit/656846781c5c8969b06d62cc0870123310e50169) | `pridefetch: 1.0.0 -> 1.1.0`                                             |
| [`3fe9fb88`](https://github.com/NixOS/nixpkgs/commit/3fe9fb887772bf84c4167a6e07046c1eb06ae622) | `freeradius: 3.2.0 -> 3.2.1`                                             |
| [`4a22f4be`](https://github.com/NixOS/nixpkgs/commit/4a22f4be4ed2619b905701b02539528805741b91) | `bfcal: init at 1.0`                                                     |
| [`756169bd`](https://github.com/NixOS/nixpkgs/commit/756169bde74edbeafc086ab4b588af6584b3b36b) | `maintainers: add laalsaas`                                              |
| [`186294a9`](https://github.com/NixOS/nixpkgs/commit/186294a934cfc0ab266c48b98a6c18b4c184850b) | `hercules-ci-agent: Fix cross eval`                                      |
| [`2cd55b31`](https://github.com/NixOS/nixpkgs/commit/2cd55b31f5d4eca64d8c24128ca643e4c0b2a71b) | `hci: Fix cross eval`                                                    |
| [`538299fe`](https://github.com/NixOS/nixpkgs/commit/538299fed412117d502c18bba09a7a3940e11df3) | `cargo-clone: init at 1.1.0`                                             |
| [`45f2a5ee`](https://github.com/NixOS/nixpkgs/commit/45f2a5eea089ffdf8cc96fd10a81de81387f3317) | `toml2nix: switch to rustPlatform.buildRustPackage`                      |
| [`1329ea0d`](https://github.com/NixOS/nixpkgs/commit/1329ea0d578b890a69e9af652336c52e60992ee5) | `multus-cni: 3.9.1 -> 3.9.2`                                             |
| [`b2ccc249`](https://github.com/NixOS/nixpkgs/commit/b2ccc249397ae87545d24154d44f1fe22bac1d80) | `python310Packages.azure-mgmt-resource: 21.1.0 -> 21.2.0`                |
| [`17659a0c`](https://github.com/NixOS/nixpkgs/commit/17659a0cf647916ff748695c1599254042b4dc9c) | `python310Packages.pysimplegui: 4.60.3 -> 4.60.4`                        |
| [`990575a3`](https://github.com/NixOS/nixpkgs/commit/990575a3bb04d7b593b1ea92cda8262209d4dc4f) | `kubemq-community: 2.3.0 -> 2.3.1`                                       |
| [`846cd1fb`](https://github.com/NixOS/nixpkgs/commit/846cd1fbe17532af7275eb20315fc64af9c9112b) | `flexget: 3.3.33 -> 3.3.34`                                              |
| [`bfed6304`](https://github.com/NixOS/nixpkgs/commit/bfed63047d0ec304c61a3f44197494aad23cb6c2) | ``release-notes: mention breaking changes w/r/t `systemd-networkd` 250`` |
| [`01819dae`](https://github.com/NixOS/nixpkgs/commit/01819daec129639a040e86804af87842bdf734ca) | `hip: 5.2.3 → 5.3.0`                                                     |
| [`72aaaa78`](https://github.com/NixOS/nixpkgs/commit/72aaaa782ab3e1950b4c9e80afb7c0f9e9f19b73) | `llvmPackages_rocm.llvm: 5.2.3 → 5.3.0`                                  |
| [`4ee2665a`](https://github.com/NixOS/nixpkgs/commit/4ee2665a6d9d7a04004054562abdfe4604aa8d17) | `rocminfo: 5.1.1 → 5.3.0`                                                |
| [`692bc4c5`](https://github.com/NixOS/nixpkgs/commit/692bc4c5496219bf96ec275d5fb71f731661f213) | `rocclr: 5.2.3 → 5.3.0`                                                  |
| [`6bd35937`](https://github.com/NixOS/nixpkgs/commit/6bd359374957bae5df7ba8c4da83995b1fcfa3d4) | `rocm-comgr: 5.2.0 → 5.3.0`                                              |
| [`1d6f9948`](https://github.com/NixOS/nixpkgs/commit/1d6f9948cb24ee92fdc43798179be21454179874) | `rocm-device-libs: 5.2.0 → 5.3.0`                                        |
| [`8ec49a85`](https://github.com/NixOS/nixpkgs/commit/8ec49a85c560892f324da9265b7459da0636f772) | `rocm-opencl-runtime: 5.2.1 → 5.3.0`                                     |
| [`79ef038e`](https://github.com/NixOS/nixpkgs/commit/79ef038e49d4dfe806bd3f20395cbe42dc48ccba) | `rocm-runtime: 5.2.0 → 5.3.0`                                            |
| [`421b8086`](https://github.com/NixOS/nixpkgs/commit/421b8086f0cc09778fb11d5d873eb17b5aedd240) | `rocm-thunk: 5.2.1 → 5.3.0`                                              |
| [`3bdbc120`](https://github.com/NixOS/nixpkgs/commit/3bdbc120f80f25bdf5b808efc9c13c02eac0c97a) | `rocm-cmake: 5.2.0 → 5.3.0`                                              |
| [`dee4fee1`](https://github.com/NixOS/nixpkgs/commit/dee4fee1c7beeeaea4a27a3c88bf5cf0eed761ff) | `rocm-smi: 5.2.3 → 5.3.0`                                                |
| [`3f2a81f1`](https://github.com/NixOS/nixpkgs/commit/3f2a81f1ba8fc6f6ea2a864528493bade28438d0) | `fheroes2: 0.9.19 -> 0.9.20`                                             |
| [`b5ef8c03`](https://github.com/NixOS/nixpkgs/commit/b5ef8c035e72d0d1676c1a177028b180b33b74ec) | `python310Packages.radish-bdd: add pythonImportsCheck`                   |
| [`1a6c1c95`](https://github.com/NixOS/nixpkgs/commit/1a6c1c951ddda480f390eb20734cdc54e035c3c0) | `python310Packages.radish-bdd: 0.13.4 -> 0.14.0`                         |
| [`fb9e7d16`](https://github.com/NixOS/nixpkgs/commit/fb9e7d16e2942414c35ccd4d4222997b56bef098) | `atlantis: 0.19.8 -> 0.20.1`                                             |
| [`4f442dde`](https://github.com/NixOS/nixpkgs/commit/4f442dde0ec8412d7eeb024dcb568620787901b3) | `nixos/networkd: add new options`                                        |
| [`4367b782`](https://github.com/NixOS/nixpkgs/commit/4367b782bc0371702ec398256d68a9e43b95decc) | ``nixos/networkd: deprecate `IPv6Token=```                               |
| [`036489ff`](https://github.com/NixOS/nixpkgs/commit/036489ffaa477774a0cfad0377598aaf3120aa58) | ``nixos/networkd: adapt `dhcpV6Config```                                 |
| [`bc8d6d8f`](https://github.com/NixOS/nixpkgs/commit/bc8d6d8f968fcc37b6495526b805e0de18f9f849) | ``nixos/networkd: `DHCPv6PrefixDelegation` -> `DHCPPrefixDelegation```   |
| [`f3e5a863`](https://github.com/NixOS/nixpkgs/commit/f3e5a863919f146badbea3a090e51e8efe1c0023) | `postgresqlPackages.pgroonga: 2.3.9 -> 2.4.0`                            |
| [`a1e9f1e0`](https://github.com/NixOS/nixpkgs/commit/a1e9f1e0365626ad61936244c570a3dff1ea5904) | `nixos/firewall: move rpfilter from raw to mangle`                       |
| [`c800d3fc`](https://github.com/NixOS/nixpkgs/commit/c800d3fc4002c4034558699079cf9608e3c7c981) | `python3Packages.sphinx-basic-ng: 0.0.1.a12 -> 1.0.0.beta1`              |
| [`9984d87f`](https://github.com/NixOS/nixpkgs/commit/9984d87f051c90ebb7af035813a4f88bc1394cc1) | `gsasl: 2.0.1 -> 2.2.0`                                                  |
| [`43efa490`](https://github.com/NixOS/nixpkgs/commit/43efa4900ccc8726528ed35a3f866b4c19721591) | `lib.types.unspecified: Make name match attribute name again`            |
| [`3a1054bf`](https://github.com/NixOS/nixpkgs/commit/3a1054bfd9c472c94587e88bc53985e8a198bbcd) | `ulauncher: fix gobject-introspection`                                   |
| [`09abb91d`](https://github.com/NixOS/nixpkgs/commit/09abb91d144afc26689d557afa0933e319b6eda6) | `buildMaven: Update buildMaven to pure Nix`                              |