### PR TITLE
chore(flake/nur): `c099c141` -> `335b2a81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665828734,
-        "narHash": "sha256-KxlOmS04TcQwi4424GY49PT2Q5a70nkzR/0hYQfR3/M=",
+        "lastModified": 1665843281,
+        "narHash": "sha256-OvRNNVJuismkTkpFjh3/B5vKZ6g0FK5mrx3jOsyUqmA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c099c14102291374db699908c267fc3ef0f32695",
+        "rev": "335b2a8147ae0db34321842a0e2705f96091f210",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`335b2a81`](https://github.com/nix-community/NUR/commit/335b2a8147ae0db34321842a0e2705f96091f210) | `automatic update` |
| [`b659b216`](https://github.com/nix-community/NUR/commit/b659b2166ffd0bd80732cdff947fef885566eed4) | `automatic update` |