### PR TITLE
chore(flake/nur): `f6379a6c` -> `56ce83e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665844941,
-        "narHash": "sha256-dN/O1NyUqayFeznV06tF8pEF6Xo4P0JT8YFD7H3N11U=",
+        "lastModified": 1665847539,
+        "narHash": "sha256-AszHbWrzfm/0lOjP4dwYazXgZxXaQ/FcFVX3HE32xPA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f6379a6cf5e13f209b273991408ed792262d7054",
+        "rev": "56ce83e92e00dc5147ce96d1986e5eec880931f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`56ce83e9`](https://github.com/nix-community/NUR/commit/56ce83e92e00dc5147ce96d1986e5eec880931f6) | `automatic update` |