### PR TITLE
chore(flake/emacs-overlay): `08445dd7` -> `4cec379c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665824418,
-        "narHash": "sha256-OZX8io9UKzxFAwdRvf4uOThDFpGtlbMyi13RbqIpmoY=",
+        "lastModified": 1665863455,
+        "narHash": "sha256-61DXjqtZ8M5a2/GZ8kp4BfmOrwkgX865ukb/LsDBSYY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "08445dd7824253ee8580f06127460a7d14e942cf",
+        "rev": "4cec379c853658bc1eab0344b1e525e1ab3acc73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`4cec379c`](https://github.com/nix-community/emacs-overlay/commit/4cec379c853658bc1eab0344b1e525e1ab3acc73) | `Updated repos/nongnu` |
| [`36f1317b`](https://github.com/nix-community/emacs-overlay/commit/36f1317b2690f89889676f3ca6cfdd78a4fe173b) | `Updated repos/melpa`  |
| [`68323cbc`](https://github.com/nix-community/emacs-overlay/commit/68323cbc9866e5309de80febda1436a487e2bd6a) | `Updated repos/emacs`  |