### PR TITLE
chore(flake/nur): `4ae57220` -> `092b4b8f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665858357,
-        "narHash": "sha256-Byf0zFjhZE+mVEsugAXgR42ui9StrwkEn4DhP53mX6c=",
+        "lastModified": 1665863943,
+        "narHash": "sha256-RGqGgKx+Iu5x2N7gFl9eIs7BEwSGQDuSsXJ3UBUG3Ss=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ae572206eea1c19b047efd09101f4c1f8cb7dff",
+        "rev": "092b4b8fb489ec33adfad2823faacd8f5640d21c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`092b4b8f`](https://github.com/nix-community/NUR/commit/092b4b8fb489ec33adfad2823faacd8f5640d21c) | `automatic update` |