### PR TITLE
chore(flake/nur): `b258c967` -> `1f77a862`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665873350,
-        "narHash": "sha256-ukNur21+gaPxzoDboEQ1LORlCXz7ct/h5ts7ec1GNdk=",
+        "lastModified": 1665881041,
+        "narHash": "sha256-2zc2gjH3lMkwwj6/JQACBEvUxFhKbq522nR+KzYdSas=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b258c967ad7d2baee176d174cc15bd0f51aeee72",
+        "rev": "1f77a862389760a31a608cda430e84b7d52efe7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1f77a862`](https://github.com/nix-community/NUR/commit/1f77a862389760a31a608cda430e84b7d52efe7f) | `automatic update` |