### PR TITLE
chore(flake/nur): `6e244dd8` -> `1f043717`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665893231,
-        "narHash": "sha256-4mIdaQVml5zmEAcw8hXMPfioFhmGNKDyMP1gtH0ezgU=",
+        "lastModified": 1665896385,
+        "narHash": "sha256-3p+3LCx+8io3quo0n3QTY3kmrehiHfHq0cB0qptfp5I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6e244dd8f52ce065dc9bfdc06a8e944f4540f48a",
+        "rev": "1f043717556049d49168d72cc474a4a3c04e4061",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1f043717`](https://github.com/nix-community/NUR/commit/1f043717556049d49168d72cc474a4a3c04e4061) | `automatic update` |