### PR TITLE
chore(flake/emacs-overlay): `4cec379c` -> `bcd60c7e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665863455,
-        "narHash": "sha256-61DXjqtZ8M5a2/GZ8kp4BfmOrwkgX865ukb/LsDBSYY=",
+        "lastModified": 1665898789,
+        "narHash": "sha256-gCwzF90+l2xC6yuRBSZyRC8X6EbWr33kVCRJ4+me0AY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4cec379c853658bc1eab0344b1e525e1ab3acc73",
+        "rev": "bcd60c7ed335f46570d9c9a9f6695c6ebf13ef1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`bcd60c7e`](https://github.com/nix-community/emacs-overlay/commit/bcd60c7ed335f46570d9c9a9f6695c6ebf13ef1b) | `Updated repos/nongnu` |
| [`dc4c0a71`](https://github.com/nix-community/emacs-overlay/commit/dc4c0a71631588eaf6fe917e677f0f5a530c0b6f) | `Updated repos/melpa`  |
| [`981cb38e`](https://github.com/nix-community/emacs-overlay/commit/981cb38ebeb25e542f0c4b17adce8adfa001c19e) | `Updated repos/emacs`  |