### PR TITLE
chore(flake/nur): `69430fa0` -> `7a23107d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665897006,
-        "narHash": "sha256-yuPRqajFjuoVhVWQH/ZhE0lGuy43fDk+lr6OAiRkmxs=",
+        "lastModified": 1665900801,
+        "narHash": "sha256-m3YrhQ4Uriv4cYQ3MvJkkxUW3ryxNP8qkcF+zzTMD5s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "69430fa07087a6dff26259a60e8be541906dd679",
+        "rev": "7a23107d743a8b10a578dc6469023a4f6546c71d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7a23107d`](https://github.com/nix-community/NUR/commit/7a23107d743a8b10a578dc6469023a4f6546c71d) | `automatic update` |