### PR TITLE
chore(flake/nur): `7a23107d` -> `29e55c0d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665900801,
-        "narHash": "sha256-m3YrhQ4Uriv4cYQ3MvJkkxUW3ryxNP8qkcF+zzTMD5s=",
+        "lastModified": 1665916685,
+        "narHash": "sha256-M/SNFT5FlLwbfWLBQWtjgtk8CMFAb4ZD6EWshge5QPU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7a23107d743a8b10a578dc6469023a4f6546c71d",
+        "rev": "29e55c0df8ae7fa986d12a2c96e38c0788ef2093",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`29e55c0d`](https://github.com/nix-community/NUR/commit/29e55c0df8ae7fa986d12a2c96e38c0788ef2093) | `automatic update` |