### PR TITLE
chore(flake/nixpkgs): `4428e233` -> `d40fea9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -275,11 +275,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665732960,
-        "narHash": "sha256-WBZ+uSHKFyjvd0w4inbm0cNExYTn8lpYFcHEes8tmec=",
+        "lastModified": 1667231093,
+        "narHash": "sha256-RERXruzBEBuf0c7OfZeX1hxEKB+PTCUNxWeB6C1jd8Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4428e23312933a196724da2df7ab78eb5e67a88e",
+        "rev": "d40fea9aeb8840fea0d377baa4b38e39b9582458",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`3d5035f8`](https://github.com/NixOS/nixpkgs/commit/3d5035f8f55ffb495b5afba2e5057dd40c1710e1) | `python3Packages: use toPythonModule on packages that are modules`                   |
| [`06e2c42a`](https://github.com/NixOS/nixpkgs/commit/06e2c42ae411d57087217096cacb409ade96ac74) | `xpra: fix application icon location`                                                |
| [`19d9ac28`](https://github.com/NixOS/nixpkgs/commit/19d9ac28cc04047b2a7b9ed8a0c509f2d1d3d8d2) | `raylib-games: init at 2022-10-14`                                                   |
| [`7aa48a0d`](https://github.com/NixOS/nixpkgs/commit/7aa48a0dd39ac66c850ccc123c3608fca6bca4ee) | `raylib: propagate GL and X11 libraries`                                             |
| [`80c63fbb`](https://github.com/NixOS/nixpkgs/commit/80c63fbba6b5febba1b1b53c0434f46e73ab3585) | `ooniprobe-cli: 3.16.3 -> 3.16.4`                                                    |
| [`b28f6cc8`](https://github.com/NixOS/nixpkgs/commit/b28f6cc8a34598ba7b9528f07c2ba814aef4ec82) | `mame: general improvements`                                                         |
| [`7e5af951`](https://github.com/NixOS/nixpkgs/commit/7e5af95176894a256613b887731d5b7ca9cff84f) | `fits-cloudctl: 0.10.22 -> 0.11.1`                                                   |
| [`0426b36f`](https://github.com/NixOS/nixpkgs/commit/0426b36f9fcf18a73be034797699a0bbae7c60ac) | `doc/vim: update docs for nvim-treesitter`                                           |
| [`ca846a34`](https://github.com/NixOS/nixpkgs/commit/ca846a348f8a112498082f06372fdb966cfb60b5) | `vimPlugins.nvim-treesitter: add tree sitter grammars`                               |
| [`6c346e3f`](https://github.com/NixOS/nixpkgs/commit/6c346e3fa5e819c85449c910201d27699c2f7e3d) | `dpdk: update kernel version constraint.`                                            |
| [`1a15be69`](https://github.com/NixOS/nixpkgs/commit/1a15be699b935816762e98d8346c2769fa26708f) | `dpdk-kmods: fix build against 5.18`                                                 |
| [`9d220f50`](https://github.com/NixOS/nixpkgs/commit/9d220f506756cf405d6ceda3706ff068a479954f) | `dpdk: 22.03 -> 22.07`                                                               |
| [`a8f36d57`](https://github.com/NixOS/nixpkgs/commit/a8f36d5717d293d0680a9330109e4273d7ae6a6a) | `xprite-editor: mark as broken for all platforms`                                    |
| [`49ae64fb`](https://github.com/NixOS/nixpkgs/commit/49ae64fb607da5dbfb6df4995877be0f0445c0ca) | `terraform-providers.argocd: init at 4.1.0`                                          |
| [`d4013213`](https://github.com/NixOS/nixpkgs/commit/d40132138b215d4562a116c63ec30ab499bbbb3f) | `keepassxc: 2.7.3 -> 2.7.4`                                                          |
| [`b43605fb`](https://github.com/NixOS/nixpkgs/commit/b43605fb031248ddb615b7caf562ccfcb49f910d) | `nixos/merecat: init`                                                                |
| [`ada312b3`](https://github.com/NixOS/nixpkgs/commit/ada312b3c41a24dd8a5c78903a09281857fecb55) | `merecat: add version test`                                                          |
| [`9f50ee94`](https://github.com/NixOS/nixpkgs/commit/9f50ee94a54a6b8d08dfc397fac3f4624a640e74) | `merecat: init at 2.31`                                                              |
| [`31f8cc8e`](https://github.com/NixOS/nixpkgs/commit/31f8cc8ea159e5c7bc0ef1227244212032212815) | `python310Packages.pytile: 2022.02.0 -> 2022.10.0`                                   |
| [`ffc1db5a`](https://github.com/NixOS/nixpkgs/commit/ffc1db5a97ba476bf09cef8e98937b15138e2333) | `komga: 0.157.2 -> 0.157.3`                                                          |
| [`4c33f7db`](https://github.com/NixOS/nixpkgs/commit/4c33f7db6a6d58e5ff1825f81814488caf243b58) | `python310Packages.levenshtein: 0.20.3 -> 0.20.8`                                    |
| [`1f80e27a`](https://github.com/NixOS/nixpkgs/commit/1f80e27aa7048b2e34893edc4d50fc6a18e8ac37) | `python310Packages.rapidfuzz: 2.6.0 -> 2.13.0`                                       |
| [`84600b6b`](https://github.com/NixOS/nixpkgs/commit/84600b6b7ee8253b214e37b940623dc756da20fb) | `rapidfuzz-cpp: 1.3.0 -> 1.10.0`                                                     |
| [`041135e4`](https://github.com/NixOS/nixpkgs/commit/041135e417346082d0eef82709626109b161f7c6) | `hyfetch: 1.4.2 -> 1.4.3`                                                            |
| [`78c370ae`](https://github.com/NixOS/nixpkgs/commit/78c370aed744d6943162bfbe60e239278e337b1a) | `pythonPackages.dbus-next: Ignore tcp_connection_with_forwarding test`               |
| [`a995997c`](https://github.com/NixOS/nixpkgs/commit/a995997c68c005530bf32b72adbcfec62fb3c9d6) | `odo: 3.0.0 -> 3.1.0`                                                                |
| [`54cf191a`](https://github.com/NixOS/nixpkgs/commit/54cf191a16f67d4904dacdce8a6722dfc86fe42a) | `tengine: 2.3.3 -> 2.3.4`                                                            |
| [`41cd71f3`](https://github.com/NixOS/nixpkgs/commit/41cd71f33878879f4979d9590b09afebea2fb46d) | `xq: 0.2.39 -> 0.2.40`                                                               |
| [`83018dd5`](https://github.com/NixOS/nixpkgs/commit/83018dd5d795a7f0729c94c2d234986f2858c300) | `cava: 0.7.4 -> 0.8.2`                                                               |
| [`b5520a27`](https://github.com/NixOS/nixpkgs/commit/b5520a2726dcec8e30d649ce9a4c3feacc08cf49) | `bambootracker: 0.5.2 -> 0.5.3`                                                      |
| [`e641cfb7`](https://github.com/NixOS/nixpkgs/commit/e641cfb78e5241cdde733d79d9973246d1724fec) | `ruff: 0.0.91 -> 0.0.92`                                                             |
| [`71d12f69`](https://github.com/NixOS/nixpkgs/commit/71d12f6934142af967880dceb15684dcda5bbaab) | `firefox-bin-unwrapped: 106.0.2 -> 106.0.3`                                          |
| [`0fad4307`](https://github.com/NixOS/nixpkgs/commit/0fad4307e8040fa5c0939e51df7e96b5a9624f55) | `firefox-unwrapped: 106.0.2 -> 106.0.3`                                              |
| [`41004f4e`](https://github.com/NixOS/nixpkgs/commit/41004f4e0ea36afca9b6edd88c8d23f7e2c3ac86) | `hyfetch: 1.4.1 -> 1.4.2`                                                            |
| [`b2bb7c13`](https://github.com/NixOS/nixpkgs/commit/b2bb7c13488b78dbae93396cdf7de4624ab0ae64) | `cemu-ti: update license`                                                            |
| [`026f99d8`](https://github.com/NixOS/nixpkgs/commit/026f99d83dd3ac00ddf499c389ee2622f903b129) | `go-font: avoid .gitignore and .gitattributes in output`                             |
| [`025ba5cc`](https://github.com/NixOS/nixpkgs/commit/025ba5cc19af6ef8443ae27e684e8c60a0bbe5b1) | `bundlewrap: init at 4.15.0 (#197904)`                                               |
| [`d1e9d8fb`](https://github.com/NixOS/nixpkgs/commit/d1e9d8fb2e693242dd76e186f7683c3682fd1b13) | `python310Packages.editdistance: disable on older Python releases`                   |
| [`1a6c366b`](https://github.com/NixOS/nixpkgs/commit/1a6c366b80e41219fddf67ddac1d7b360e6e02b5) | `python310Packages.editdistance: 0.6.0 -> 0.6.1`                                     |
| [`2dea2607`](https://github.com/NixOS/nixpkgs/commit/2dea2607a96fa047859a06aed3e21e669a927c90) | `python310Packages.meshtastic: 1.3.43 -> 1.3.44`                                     |
| [`1f876826`](https://github.com/NixOS/nixpkgs/commit/1f8768261cd903eb1910d06bcbdc461f1bb0de0b) | `python310Packages.pyswitchbee: 1.6.0 -> 1.6.1`                                      |
| [`5310040d`](https://github.com/NixOS/nixpkgs/commit/5310040d3f7c9d4b59116e9df853a14e56e212f4) | `flyctl: 0.0.424 -> 0.0.425`                                                         |
| [`685b0daf`](https://github.com/NixOS/nixpkgs/commit/685b0daf363ae3f92896fcb2982af1eddf8e409f) | `python310Packages.ge25519: add setuptools`                                          |
| [`aaaad710`](https://github.com/NixOS/nixpkgs/commit/aaaad710c135c1fe432f100c95d3f2285ce3801f) | `ruff: 0.0.89 -> 0.0.91`                                                             |
| [`4dec4ce1`](https://github.com/NixOS/nixpkgs/commit/4dec4ce11eec7e1cea552778c6eacae5c40cfcab) | `python310Packages.asyncmy: add setuptools`                                          |
| [`2fd858d0`](https://github.com/NixOS/nixpkgs/commit/2fd858d0a2063da6acc9185f2815e959fb97ef74) | `python3Packages.scapy: build with libpcap`                                          |
| [`72e230af`](https://github.com/NixOS/nixpkgs/commit/72e230af141ee70109ddb64d95b70be036c54005) | `haskellPackages: mark builds failing on hydra as broken`                            |
| [`c6cbeab8`](https://github.com/NixOS/nixpkgs/commit/c6cbeab8bc163454b4c07f83be734287064429b3) | `bochs: cosmetical rewrite`                                                          |
| [`1cd7d0b2`](https://github.com/NixOS/nixpkgs/commit/1cd7d0b232d5cd2d04f4edaa58e856d27c17ab79) | `gamescope: 3.11.47 -> 3.11.48`                                                      |
| [`49728da5`](https://github.com/NixOS/nixpkgs/commit/49728da5421b2bae8c42ae611f39a83184ba73ce) | `vscode-extensions.jnoortheen.nix-ide: 0.1.23 -> 0.2.1 (#198007)`                    |
| [`97cba633`](https://github.com/NixOS/nixpkgs/commit/97cba63343af69f0c7fe422e3d5e994d6130cc2d) | `python310Packages.python-utils: disable on older Python releases`                   |
| [`26d5ac5e`](https://github.com/NixOS/nixpkgs/commit/26d5ac5eeeaa53c3bcb527b6264e360a3ff69bc1) | `python3Packages.ducc0: 0.26 -> 0.27`                                                |
| [`a2144b36`](https://github.com/NixOS/nixpkgs/commit/a2144b36c7f394f89b82b3f6a83841458c8e1076) | `python310Packages.python-gitlab: add optional-dependencies`                         |
| [`b8930547`](https://github.com/NixOS/nixpkgs/commit/b893054798674bb7fc66e00285abee66a12b8af7) | `python310Packages.python-box: update disabled`                                      |
| [`fcf81f91`](https://github.com/NixOS/nixpkgs/commit/fcf81f91a3a90c2ee009d180368d9ecdca178334) | `nixos/jenkins-job-builder: better defaults for accessUser/accessTokenFile`          |
| [`ea809481`](https://github.com/NixOS/nixpkgs/commit/ea809481a465249215d9f42857862ffebb9d3a85) | `python310Packages.robotframework-requests: add pythonImportsCheck`                  |
| [`3df7f95b`](https://github.com/NixOS/nixpkgs/commit/3df7f95b0dd350288261b1edf404d63328ef08c2) | `python310Packages.spotipy: disable on older Python releases`                        |
| [`4abe8dcd`](https://github.com/NixOS/nixpkgs/commit/4abe8dcd616ad752b20cffd29269948b1db4cf14) | `nixos/mautrix-telegram: fix link to example config`                                 |
| [`8e803f43`](https://github.com/NixOS/nixpkgs/commit/8e803f436457fffca2c8a5a721a9488105eccf4e) | `nixos/mautrix-telegram: add new required config option`                             |
| [`0590d6d0`](https://github.com/NixOS/nixpkgs/commit/0590d6d01c4b35434a1943a3eddc4c9486ee56e5) | `ungoogled-chromium: 107.0.5304.68 -> 107.0.5304.88`                                 |
| [`1cd6b2c7`](https://github.com/NixOS/nixpkgs/commit/1cd6b2c7f4cbabe9cbcf82409c4522f29341359a) | `chromium: 107.0.5304.68 -> 107.0.5304.87`                                           |
| [`4add137b`](https://github.com/NixOS/nixpkgs/commit/4add137b0d5ac88847050134fee357ba723ca91e) | `haskell.packages.ghc942.cabal-install*: drop unnecessary jailbreak`                 |
| [`5fa41df4`](https://github.com/NixOS/nixpkgs/commit/5fa41df499a53aeb56ab9bf3cb9b7578a47e1513) | `chromiumBeta: 107.0.5304.68 -> 108.0.5359.22`                                       |
| [`1e999fae`](https://github.com/NixOS/nixpkgs/commit/1e999fae15b986212d1c60b7a6f6062128d5ce1e) | `chromiumDev: 108.0.5359.19 -> 109.0.5384.0`                                         |
| [`566fb969`](https://github.com/NixOS/nixpkgs/commit/566fb969874e342598a8d81bc2b30c08344ff21a) | `frei: init at 0.1.0`                                                                |
| [`502531cb`](https://github.com/NixOS/nixpkgs/commit/502531cb2dbfba40d6f1a2912149aac6717adf51) | `haskell.packages.ghc924.purescript: allow building and test on Hydra`               |
| [`a0383f7a`](https://github.com/NixOS/nixpkgs/commit/a0383f7ad9c2c7550ce34907fe6dc62dba1b3457) | `haskellPackages.xdg-basedir-compliant: work around missing test data`               |
| [`a4340923`](https://github.com/NixOS/nixpkgs/commit/a434092372a6c12b010e475f78e24a8b1b90b31b) | `haskellPackages.xlsx: work around missing test data`                                |
| [`1761c5d0`](https://github.com/NixOS/nixpkgs/commit/1761c5d08504cd3736acc3a85cd05a8d2b824069) | `python310Packages.types-pyyaml: 6.0.12 -> 6.0.12.1`                                 |
| [`a53a14bc`](https://github.com/NixOS/nixpkgs/commit/a53a14bc2df5e9975fd8352cddb5b343d62daa72) | `haskellPackages: mark builds failing on hydra as broken`                            |
| [`41ed7ae5`](https://github.com/NixOS/nixpkgs/commit/41ed7ae5d285dfe6c4ad63eb325ab6d5152c5149) | `python310Packages.tweepy: 4.11.0 -> 4.12.0`                                         |
| [`9d697a3b`](https://github.com/NixOS/nixpkgs/commit/9d697a3be3d1a36599a3c820dbe413760637c0a1) | `haskellPackages.*: disable postgresql tests on darwin`                              |
| [`311881f5`](https://github.com/NixOS/nixpkgs/commit/311881f51c0f96e57435f179328937cfc7097d9f) | `python310Packages.trimesh: 3.15.7 -> 3.15.8`                                        |
| [`3fa15c35`](https://github.com/NixOS/nixpkgs/commit/3fa15c357033b1c7bdb88f34c1fb9f6427b4754c) | `freeglut: use xorg.* packages directly instead of xlibsWrapper indirection`         |
| [`da9574e4`](https://github.com/NixOS/nixpkgs/commit/da9574e43153ac3eb245eeaa684657a5b04458a4) | `nedit: use xorg.* packages directly instead of xlibsWrapper indirection`            |
| [`1be66b24`](https://github.com/NixOS/nixpkgs/commit/1be66b246c4a74adf458883e428e2f578a84e795) | `ccache: 4.7.1 -> 4.7.2`                                                             |
| [`4ac5076d`](https://github.com/NixOS/nixpkgs/commit/4ac5076d75da8af6f83fcf948a406fc802927ccc) | `cargo-tally: 1.0.16 -> 1.0.17`                                                      |
| [`4941d433`](https://github.com/NixOS/nixpkgs/commit/4941d433fa77557a3f7d5151d519b8e90c5d47a7) | `ngspice: add darwin to platforms`                                                   |
| [`d10131aa`](https://github.com/NixOS/nixpkgs/commit/d10131aa3b9bc7c9cc1af468430e56780e05c8b4) | `python310Packages.spotipy: 2.20.0 -> 2.21.0`                                        |
| [`b2f1884d`](https://github.com/NixOS/nixpkgs/commit/b2f1884dd85b55a63ae05fb84bea65082aece223) | `kicad: 6.0.8 -> 6.0.9`                                                              |
| [`f6ddbf25`](https://github.com/NixOS/nixpkgs/commit/f6ddbf25240c5b6f49229153b9060e87b7a66286) | `python310Packages.robotframework-requests: 0.9.3 -> 0.9.4`                          |
| [`2eb47b27`](https://github.com/NixOS/nixpkgs/commit/2eb47b274f1fab1588dbee2dc77fe41b95401764) | `python310Packages.python-utils: 3.3.3 -> 3.4.5`                                     |
| [`ffdd42b7`](https://github.com/NixOS/nixpkgs/commit/ffdd42b7af97bb7f772dd0408df24275af361b37) | `python310Packages.python-gitlab: 3.10.0 -> 3.11.0`                                  |
| [`04c151b9`](https://github.com/NixOS/nixpkgs/commit/04c151b9e35c1cd7ba6f03426d97a17aea251436) | `python310Packages.python-box: 6.0.2 -> 6.10.0`                                      |
| [`02a83732`](https://github.com/NixOS/nixpkgs/commit/02a8373229448a6df8c7318628b64816c2698318) | `python310Packages.pytest-mypy-plugins: 1.10.0 -> 1.10.1`                            |
| [`425810dc`](https://github.com/NixOS/nixpkgs/commit/425810dc193d15ae9c3625878280d153d2a3539f) | `python310Packages.pysqueezebox: 0.6.0 -> 0.6.1`                                     |
| [`593929c7`](https://github.com/NixOS/nixpkgs/commit/593929c7484e1113b6759c69bcd27993b7fa2347) | `xfe: use xorg.* packages directly instead of xlibsWrapper indirection`              |
| [`229fa2fd`](https://github.com/NixOS/nixpkgs/commit/229fa2fd6da968085fc3a4225c5ed84ab76fc02b) | `xautolock: use xorg.* packages directly instead of xlibsWrapper indirection`        |
| [`bfa19140`](https://github.com/NixOS/nixpkgs/commit/bfa191404f33bc72d6b6fa1647ea3462ebacdbe4) | `voxelands: use xorg.* packages directly instead of xlibsWrapper indirection`        |
| [`3809602f`](https://github.com/NixOS/nixpkgs/commit/3809602fd4cc838f0a35e79f94afed056db814cc) | `wordnet: drop unused xlibsWrapper`                                                  |
| [`3fd2a244`](https://github.com/NixOS/nixpkgs/commit/3fd2a24468aad7fc0faab16fcd639c2dbb36be58) | `bitcoind-knots: 22.0.knots20211108 -> 23.0.knots20220529`                           |
| [`3d5f6e4c`](https://github.com/NixOS/nixpkgs/commit/3d5f6e4c314662988aeb49680f431bfc5e23dea6) | `unclutter-xfixes: use xorg.* packages directly instead of xlibsWrapper indirection` |
| [`d9ffff59`](https://github.com/NixOS/nixpkgs/commit/d9ffff599a22c8091687d4e5f56140a838ba337a) | `unclutter: use xorg.* packages directly instead of xlibsWrapper indirection`        |
| [`e8229690`](https://github.com/NixOS/nixpkgs/commit/e8229690bb1fdc41b44fbc432a0df559bd6457cc) | `pasystray: use xorg.* packages directly instead of xlibsWrapper indirection`        |
| [`f88447d1`](https://github.com/NixOS/nixpkgs/commit/f88447d108b9da9dbf300fb7b249e703ac8a9e53) | `soxt: use xorg.* packages directly instead of xlibsWrapper indirection`             |
| [`d5b82c0a`](https://github.com/NixOS/nixpkgs/commit/d5b82c0a63c9faea8109c04f243aab7dafb2cd76) | `fox: use xorg.* packages directly instead of xlibsWrapper indirection`              |
| [`b4530d1e`](https://github.com/NixOS/nixpkgs/commit/b4530d1ed4f3dc5cbf1d2a08fb8ed4cbb5b94114) | `povray: use xorg.* packages directly instead of xlibsWrapper indirection`           |
| [`d09843bf`](https://github.com/NixOS/nixpkgs/commit/d09843bf11098b696fc2831f47287369745c6a56) | `blender: 3.3.0 -> 3.3.1`                                                            |
| [`4cef88b8`](https://github.com/NixOS/nixpkgs/commit/4cef88b8526cd9de2eb742fea179e169ed7d8a7b) | `openrw: use xorg.* packages directly instead of xlibsWrapper indirection`           |
| [`4eb6161e`](https://github.com/NixOS/nixpkgs/commit/4eb6161eeeb7c35647fe9dd230c5a2e4028614db) | `oneko: use xorg.* packages directly instead of xlibsWrapper indirection`            |
| [`c0eb1f38`](https://github.com/NixOS/nixpkgs/commit/c0eb1f38f821d75066fac0d335ba76fa3552d10e) | `netdiscover: 0.9 -> 0.10`                                                           |
| [`b3ed8ba1`](https://github.com/NixOS/nixpkgs/commit/b3ed8ba167c1f6210e58aa1b44033a5fe53e0e2f) | `python310Packages.mitmproxy-wireguard: init at 0.1.15`                              |
| [`170c46ce`](https://github.com/NixOS/nixpkgs/commit/170c46ce2b75d67d7a98cc262b52f8155e9610e2) | `python310Packages.progressbar2: use pytestCheckHook`                                |
| [`d654690b`](https://github.com/NixOS/nixpkgs/commit/d654690be5aee7d227d7426e92e167f7afe1d451) | `yq-go: 4.28.2 -> 4.29.1`                                                            |
| [`2575f0fc`](https://github.com/NixOS/nixpkgs/commit/2575f0fc36cc591e4519f4faa2cddafb49634b86) | `wiki-js: 2.5.289 -> 2.5.290`                                                        |
| [`32441349`](https://github.com/NixOS/nixpkgs/commit/32441349518013cbb2750a4d90fb36f34333ad25) | `python310Packages.django_silk: disable on older Python releases`                    |
| [`b91b2224`](https://github.com/NixOS/nixpkgs/commit/b91b22248c0479e74789ed9b94393ea84c3fe411) | `lima: 0.12.0 -> 0.13.0`                                                             |
| [`54cb67ac`](https://github.com/NixOS/nixpkgs/commit/54cb67ac972aebf45cf8bd6330d72fe6ba30fa38) | `python310Packages.motor: update disabled`                                           |
| [`ec02fca5`](https://github.com/NixOS/nixpkgs/commit/ec02fca53a70b069c5e708a7bdad6859e2c47f53) | `python310Packages.mss: disable on older Python releases`                            |
| [`d97c29dd`](https://github.com/NixOS/nixpkgs/commit/d97c29dd842cc0815b7536c8d78bd81b0b9c0dcb) | `notion: use xorg.* packages directly instead of xlibsWrapper indirection`           |
| [`e90683d7`](https://github.com/NixOS/nixpkgs/commit/e90683d79f50aa600e3e918273490497c8fce358) | `python310Packages.pulumi-aws: 5.18.0 -> 5.19.0`                                     |
| [`3c2305eb`](https://github.com/NixOS/nixpkgs/commit/3c2305ebc320840db33847db45a134118383211e) | `python310Packages.psygnal: 0.5.0 -> 0.6.0`                                          |
| [`c2e1495f`](https://github.com/NixOS/nixpkgs/commit/c2e1495fd7a0f88b84cdd83afeb0113e6d640df1) | `python310Packages.progressbar2: 4.1.1 -> 4.2.0`                                     |
| [`4fbac129`](https://github.com/NixOS/nixpkgs/commit/4fbac1297f16ed6a096ab982d99a33cd90ae3c07) | `qmmp: drop unused xlibsWrapper`                                                     |
| [`84510146`](https://github.com/NixOS/nixpkgs/commit/84510146d4420d0fb659263c89e05bf7f346d46e) | `terraform-providers.flexibleengine: 1.33.0 → 1.34.0`                                |