### PR TITLE
chore(flake/nur): `29e55c0d` -> `c2aac8da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665916685,
-        "narHash": "sha256-M/SNFT5FlLwbfWLBQWtjgtk8CMFAb4ZD6EWshge5QPU=",
+        "lastModified": 1665944908,
+        "narHash": "sha256-wFh975seZ3MtSyzNJoaK/bLzs+YEWcNnlcVcFY/Aqro=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "29e55c0df8ae7fa986d12a2c96e38c0788ef2093",
+        "rev": "c2aac8da6be6966f2d3370871798d5dfc3eff76c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c2aac8da`](https://github.com/nix-community/NUR/commit/c2aac8da6be6966f2d3370871798d5dfc3eff76c) | `automatic update` |