### PR TITLE
chore(flake/nur): `c2aac8da` -> `e945ad29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665944908,
-        "narHash": "sha256-wFh975seZ3MtSyzNJoaK/bLzs+YEWcNnlcVcFY/Aqro=",
+        "lastModified": 1665947847,
+        "narHash": "sha256-yNNbvo/u4hyKW37hQhzNBH2r25TmHp74lbeUlMgc43M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c2aac8da6be6966f2d3370871798d5dfc3eff76c",
+        "rev": "e945ad29f5d2449cd4d3fdace6a1222f07701b21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e945ad29`](https://github.com/nix-community/NUR/commit/e945ad29f5d2449cd4d3fdace6a1222f07701b21) | `automatic update` |