### PR TITLE
chore(flake/nur): `e945ad29` -> `c3259cad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665947847,
-        "narHash": "sha256-yNNbvo/u4hyKW37hQhzNBH2r25TmHp74lbeUlMgc43M=",
+        "lastModified": 1665967534,
+        "narHash": "sha256-PVWMDEF/M4IOl6db9VtyEavk6Iduh+KDcnP6Jv34ZHA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e945ad29f5d2449cd4d3fdace6a1222f07701b21",
+        "rev": "c3259cad9978a95f0aef29bcadd01d117ec22dc1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c3259cad`](https://github.com/nix-community/NUR/commit/c3259cad9978a95f0aef29bcadd01d117ec22dc1) | `automatic update` |