### PR TITLE
chore(flake/nur): `4a77fee7` -> `704e1ef5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665971823,
-        "narHash": "sha256-rV0W4E/cDFoNqhCXgXMxU/ac1rL5d4iexP079yHSXMk=",
+        "lastModified": 1665979830,
+        "narHash": "sha256-0xcqP+Pr2zeX8A2BpqodcPwN5sR0TfC8twuXUjzG2g4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4a77fee7158a165a30166e2f45c10f05b977ab45",
+        "rev": "704e1ef5bdb1af57b4f7988abf2ef80c897dfc9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`704e1ef5`](https://github.com/nix-community/NUR/commit/704e1ef5bdb1af57b4f7988abf2ef80c897dfc9b) | `automatic update` |
| [`c459ae24`](https://github.com/nix-community/NUR/commit/c459ae244578254b81fdeebb5f56bb8d452697bc) | `automatic update` |
| [`9772d4e0`](https://github.com/nix-community/NUR/commit/9772d4e0d42deb220398cb82bcf08a0f99443f1a) | `automatic update` |