### PR TITLE
chore(flake/nur): `704e1ef5` -> `5692b8c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665979830,
-        "narHash": "sha256-0xcqP+Pr2zeX8A2BpqodcPwN5sR0TfC8twuXUjzG2g4=",
+        "lastModified": 1665982415,
+        "narHash": "sha256-/2IgRKW8VeDTKr6KwJqE8+6tqHyfvllJat1J7MrX7uo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "704e1ef5bdb1af57b4f7988abf2ef80c897dfc9b",
+        "rev": "5692b8c2382366d43e5b63f5267313ce80b58796",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5692b8c2`](https://github.com/nix-community/NUR/commit/5692b8c2382366d43e5b63f5267313ce80b58796) | `automatic update` |