### PR TITLE
chore(flake/emacs-overlay): `7627a31c` -> `154e5cd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665949620,
-        "narHash": "sha256-0YRAcKQL2NDhYZvOkJAc+E+FoOgV2d8X6QIaea8UoVs=",
+        "lastModified": 1665982350,
+        "narHash": "sha256-Zy7EXpy3RD8mkUESe+XPS3KqepaxmC8OTiFhPNdj+dI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7627a31cb49b9dfafe0ecf21ac2734374730d06a",
+        "rev": "154e5cd6920f804827f3161007ea2a2541336e30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`154e5cd6`](https://github.com/nix-community/emacs-overlay/commit/154e5cd6920f804827f3161007ea2a2541336e30) | `Updated repos/nongnu` |
| [`d5848dc2`](https://github.com/nix-community/emacs-overlay/commit/d5848dc28fb89d25f5cd7ae9c573aedff6a0eefa) | `Updated repos/melpa`  |
| [`38c79c10`](https://github.com/nix-community/emacs-overlay/commit/38c79c1083f8955fc7d99ad4483f79e3423e4538) | `Updated repos/emacs`  |
| [`938cc191`](https://github.com/nix-community/emacs-overlay/commit/938cc191ca312d42ff35da5fd7705dc229ff3a2d) | `Updated repos/elpa`   |