### PR TITLE
chore(flake/nur): `5692b8c2` -> `1cf195db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665982415,
-        "narHash": "sha256-/2IgRKW8VeDTKr6KwJqE8+6tqHyfvllJat1J7MrX7uo=",
+        "lastModified": 1665984439,
+        "narHash": "sha256-wpttpteAz71QMDj+I7mwT6xN9b048NQcLSTWJudksfk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5692b8c2382366d43e5b63f5267313ce80b58796",
+        "rev": "1cf195db640d7b1cf3e87fab3d7acc69ae2c25db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1cf195db`](https://github.com/nix-community/NUR/commit/1cf195db640d7b1cf3e87fab3d7acc69ae2c25db) | `automatic update` |
| [`6dd9c3d6`](https://github.com/nix-community/NUR/commit/6dd9c3d62bc81d3d459c1a8d82ea7a65f1ca5640) | `automatic update` |