### PR TITLE
chore(flake/nur): `1cf195db` -> `d9535419`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665984439,
-        "narHash": "sha256-wpttpteAz71QMDj+I7mwT6xN9b048NQcLSTWJudksfk=",
+        "lastModified": 1665989049,
+        "narHash": "sha256-Tfa11R+o8cVPkzE583e/FrFybjG1e933LNQr306Tsuo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1cf195db640d7b1cf3e87fab3d7acc69ae2c25db",
+        "rev": "d95354192e310acf63503cfb6024a6a27bd54802",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d9535419`](https://github.com/nix-community/NUR/commit/d95354192e310acf63503cfb6024a6a27bd54802) | `automatic update` |
| [`a3d10787`](https://github.com/nix-community/NUR/commit/a3d107877693ef0c4ec7d7781078ffb00d280f21) | `automatic update` |
| [`1fd55985`](https://github.com/nix-community/NUR/commit/1fd55985b6fabc50609ad23b8c496aa98850bb42) | `automatic update` |