### PR TITLE
chore(flake/nixos-hardware): `674d05f9` -> `0e659363`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -263,11 +263,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1665839131,
-        "narHash": "sha256-0KYo13PfwvPw5i/SC+hGy3hsgR++Co7SIzv+0e9YOnM=",
+        "lastModified": 1665987993,
+        "narHash": "sha256-MvlaIYTRiqefG4dzI5p6vVCfl+9V8A1cPniUjcn6Ngc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "674d05f9ae2249d606a0e6fc63e522d2031a27ac",
+        "rev": "0e6593630071440eb89cd97a52921497482b22c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                              |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`17eef273`](https://github.com/NixOS/nixos-hardware/commit/17eef273bd2392c52cfc02b7dac52518756ce32f) | `build(deps): bump cachix/install-nix-action from 17 to 18` |