### PR TITLE
chore(flake/home-manager): `04f53999` -> `a50c0c6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665949912,
-        "narHash": "sha256-NAp+YHTxgnpEaIJanOmtUx9XAnhKTCzG8LlFyZIAz7M=",
+        "lastModified": 1665991070,
+        "narHash": "sha256-S1lV+3aDLjg1pbdIW9MUA03Yw1ePkBr0OGJD468na5I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "04f53999788cd47c6ce932d6cbd7cbfd3998712f",
+        "rev": "a50c0c6fe0e87d999022e5ce840aa3700ca58ce7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                     |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`a50c0c6f`](https://github.com/nix-community/home-manager/commit/a50c0c6fe0e87d999022e5ce840aa3700ca58ce7) | `dependabot: switch target from 21.11 to 22.05`    |
| [`bc7432fb`](https://github.com/nix-community/home-manager/commit/bc7432fbcc5bdd15f90109ac32fc4c7b75b968af) | `ci: bump cachix/install-nix-action from 17 to 18` |