### PR TITLE
chore(flake/home-manager): `a50c0c6f` -> `04e84409`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665991070,
-        "narHash": "sha256-S1lV+3aDLjg1pbdIW9MUA03Yw1ePkBr0OGJD468na5I=",
+        "lastModified": 1667347482,
+        "narHash": "sha256-KuRYeitjusSdkJ/PeHzPfAIVwVjbtG5v+To6ffy8tiQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a50c0c6fe0e87d999022e5ce840aa3700ca58ce7",
+        "rev": "04e844090ed17298bfbe0f8249109b15770571bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`04e84409`](https://github.com/nix-community/home-manager/commit/04e844090ed17298bfbe0f8249109b15770571bc) | `oh-my-posh: add module`                                                |
| [`183a62f3`](https://github.com/nix-community/home-manager/commit/183a62f356f16d12ac60f0e4e5d54f0bd78f6ba6) | `targets/generic-linux: use the correct nix package`                    |
| [`824202b4`](https://github.com/nix-community/home-manager/commit/824202b4c4feb02e11fa1a44b140d5b0f218702c) | `readme: add inofficial option search`                                  |
| [`8957d531`](https://github.com/nix-community/home-manager/commit/8957d531997a2b1f4562a7e6313a78a450d5074b) | `awesome: fix luaModules using pkgs.lua instead of awesome.lua (#3258)` |
| [`722e8d65`](https://github.com/nix-community/home-manager/commit/722e8d65d3aba6f527100cc2d1539e4ca04d066f) | `ci: use the cachix auth token`                                         |
| [`25344cb8`](https://github.com/nix-community/home-manager/commit/25344cb808759197c0eb5a425e23732041c95062) | `ci: bump cachix/cachix-action from 11 to 12 (#3368)`                   |
| [`2464c21a`](https://github.com/nix-community/home-manager/commit/2464c21ab2b3607bed3c206a436855c487f35f55) | `sway: import XDG_SESSION_TYPE in systemd user environment (#3328)`     |
| [`fad4e7c7`](https://github.com/nix-community/home-manager/commit/fad4e7c79cb6668e9c2f90f008ee3522d9cd298f) | `flake.lock: Update`                                                    |
| [`160025ca`](https://github.com/nix-community/home-manager/commit/160025ca46e48a6a0b2bdb971801a0470f744500) | `irssi: add option for SASL external authentication`                    |
| [`42321140`](https://github.com/nix-community/home-manager/commit/423211401c245934db5052e3867cac704f658544) | `home-environment: update hm-version generation`                        |
| [`213a0629`](https://github.com/nix-community/home-manager/commit/213a06295dff96668a1d673b9fd1c03ce1de6745) | `ci: don't run tests in GitLab CI`                                      |
| [`f6764930`](https://github.com/nix-community/home-manager/commit/f67649307d4f81d8fbac68c19d1d1c564ab26dca) | `home-environment: make getVersion more robust`                         |
| [`d3f21617`](https://github.com/nix-community/home-manager/commit/d3f21617acace32097a53b0b74fb5000d333d094) | `vscode: add options to disable update checks`                          |
| [`32fe7d2e`](https://github.com/nix-community/home-manager/commit/32fe7d2ebb7e338ad95a3ea9393fc6ad681368ce) | `home-environment: add hm-version file`                                 |
| [`7dc4e4eb`](https://github.com/nix-community/home-manager/commit/7dc4e4ebd71280842b4d30975439980baaac9db8) | `k9s: add module`                                                       |
| [`186d9399`](https://github.com/nix-community/home-manager/commit/186d9399f9eb64fb06ea4385732c1cf1624ae2b6) | `borgmatic: specify where to find sleep (#3349)`                        |
| [`69d19b98`](https://github.com/nix-community/home-manager/commit/69d19b9839638fc487b370e0600a03577a559081) | `firefox: support setting search engines`                               |
| [`c485669c`](https://github.com/nix-community/home-manager/commit/c485669ca529e01c1505429fa9017c9a93f15559) | ``i3status: add `package` attribute``                                   |
| [`d1191c6d`](https://github.com/nix-community/home-manager/commit/d1191c6d05120449f3e54e1211518df7c69ee282) | `docs: bump nmd`                                                        |
| [`42f81ac1`](https://github.com/nix-community/home-manager/commit/42f81ac107c5a9a177888080107094dba57f134e) | `looking-glass-client: add module`                                      |
| [`e901c8d8`](https://github.com/nix-community/home-manager/commit/e901c8d86082be74a8be70773bbb6d401ff21e49) | `ci: bump cachix/cachix-action from 10 to 11`                           |