### PR TITLE
chore(flake/nur): `b6a80772` -> `f8307b30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665991674,
-        "narHash": "sha256-ZBQmBArFHiQIRnAPZ/nU5On83h8ne2HRN9tNHLMA2EA=",
+        "lastModified": 1665994280,
+        "narHash": "sha256-6Qi0GeeRgUYvfVVEd0YLCx+ZdTobzPy2VmcsG1tVUZs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b6a80772fbe6fe35819d32dc9f8ed032b8f1fd70",
+        "rev": "f8307b30ae6b8258bd48c4ea30d6b7899bf19cd5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f8307b30`](https://github.com/nix-community/NUR/commit/f8307b30ae6b8258bd48c4ea30d6b7899bf19cd5) | `automatic update` |