### PR TITLE
chore(flake/nur): `f8307b30` -> `ca4ed76d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665994280,
-        "narHash": "sha256-6Qi0GeeRgUYvfVVEd0YLCx+ZdTobzPy2VmcsG1tVUZs=",
+        "lastModified": 1665995299,
+        "narHash": "sha256-BWNxpk0kq5wB17dCMYtP2grpdkLpNsVdpRko7BbUr8A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f8307b30ae6b8258bd48c4ea30d6b7899bf19cd5",
+        "rev": "ca4ed76d1471bcb1fe21144d3c86a173d6f53957",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                                 |
| -------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`756bd476`](https://github.com/nix-community/NUR/commit/756bd4762364e7a209a6da6468b7553085ee5a44) | `Bump cachix/install-nix-action from 17 to 18` |