### PR TITLE
chore(flake/nur): `ca4ed76d` -> `b4d1240b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665995299,
-        "narHash": "sha256-BWNxpk0kq5wB17dCMYtP2grpdkLpNsVdpRko7BbUr8A=",
+        "lastModified": 1665997237,
+        "narHash": "sha256-Tbtz+MxBwqJRu+ZJn+xAj7NTLM7iOt06zI4T2r326R4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ca4ed76d1471bcb1fe21144d3c86a173d6f53957",
+        "rev": "b4d1240b6c26bf25036fb2647590a08e1c74cb24",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b4d1240b`](https://github.com/nix-community/NUR/commit/b4d1240b6c26bf25036fb2647590a08e1c74cb24) | `automatic update` |
| [`337e3540`](https://github.com/nix-community/NUR/commit/337e3540517e44cb76091cbe0d6dc4dd3207a6c3) | `automatic update` |