### PR TITLE
chore(flake/nur): `b4d1240b` -> `2ec1350a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665997237,
-        "narHash": "sha256-Tbtz+MxBwqJRu+ZJn+xAj7NTLM7iOt06zI4T2r326R4=",
+        "lastModified": 1665998410,
+        "narHash": "sha256-xDyZ8wSA4gCdSG5MAgcX7BIaTTLqtB3+YEAPDlt1e8U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b4d1240b6c26bf25036fb2647590a08e1c74cb24",
+        "rev": "2ec1350aefe7bd133e9b46bab06ff617433b2379",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2ec1350a`](https://github.com/nix-community/NUR/commit/2ec1350aefe7bd133e9b46bab06ff617433b2379) | `automatic update` |