### PR TITLE
chore(flake/emacs-overlay): `154e5cd6` -> `bd93640e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665982350,
-        "narHash": "sha256-Zy7EXpy3RD8mkUESe+XPS3KqepaxmC8OTiFhPNdj+dI=",
+        "lastModified": 1665999197,
+        "narHash": "sha256-D2sTdEtuNv6ingyTIwT8XVx5MnolnJSuiQsZ34/88WM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "154e5cd6920f804827f3161007ea2a2541336e30",
+        "rev": "bd93640e5d5e5e0a4ea129c3e3ffd7641e552d93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                            |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
| [`c1143602`](https://github.com/nix-community/emacs-overlay/commit/c1143602cb97fa717bacdf5668ceca1bb487918d) | `address comments`                                        |
| [`a828f7f2`](https://github.com/nix-community/emacs-overlay/commit/a828f7f2ea3f79110b26ea40763326cd788e43e3) | ``Make `withTreeSitterPlugins` overridable.``             |
| [`2142ce37`](https://github.com/nix-community/emacs-overlay/commit/2142ce3789d2ac230a225eb078d3bf2f85046532) | ``Add `feature/tree-sitter` derivation to emacs overlay`` |