### PR TITLE
chore(flake/nur): `2ec1350a` -> `5cd09ebf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665998410,
-        "narHash": "sha256-xDyZ8wSA4gCdSG5MAgcX7BIaTTLqtB3+YEAPDlt1e8U=",
+        "lastModified": 1666004236,
+        "narHash": "sha256-zyJtmr/mXtjWwbYyGo+EqUVIpskuqBw4pgt7tsXiWao=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2ec1350aefe7bd133e9b46bab06ff617433b2379",
+        "rev": "5cd09ebf6e634552823b34d816fe4cd5b5f4e36b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5cd09ebf`](https://github.com/nix-community/NUR/commit/5cd09ebf6e634552823b34d816fe4cd5b5f4e36b) | `automatic update` |