### PR TITLE
chore(flake/nur): `245fca98` -> `8397ce49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666012819,
-        "narHash": "sha256-nfNYLGElTf+lSBD3orLJYgpV/q0piCDctKk2brMStU4=",
+        "lastModified": 1666015907,
+        "narHash": "sha256-Fb3ZwCMVT3g7WoPZQ7IYVYx90cSaSXO7CrGHQ5/bSzE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "245fca98e334384c77bac3573ebd39531db3b3e9",
+        "rev": "8397ce4921a1a1d72895f1020a99f77cd5f84388",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8397ce49`](https://github.com/nix-community/NUR/commit/8397ce4921a1a1d72895f1020a99f77cd5f84388) | `automatic update` |