### PR TITLE
chore(flake/nur): `8397ce49` -> `00f3d031`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666015907,
-        "narHash": "sha256-Fb3ZwCMVT3g7WoPZQ7IYVYx90cSaSXO7CrGHQ5/bSzE=",
+        "lastModified": 1666019302,
+        "narHash": "sha256-TMycDjChzpx4rH/qiW5j3Jq+PgRrMgkxnXrdMu7wSKU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8397ce4921a1a1d72895f1020a99f77cd5f84388",
+        "rev": "00f3d0310cae450f96870a92149688690eb5e843",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`00f3d031`](https://github.com/nix-community/NUR/commit/00f3d0310cae450f96870a92149688690eb5e843) | `automatic update` |
| [`be1cd21c`](https://github.com/nix-community/NUR/commit/be1cd21cc67e4d33ab145bc4532b038bdc6b95e3) | `automatic update` |