### PR TITLE
chore(flake/nur): `1ccc24e6` -> `6b5ed382`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666021481,
-        "narHash": "sha256-nC7hNkHlcHrF5vL5Lpyw5uvvcVgL7lv6xr+f/jOlpuE=",
+        "lastModified": 1666026067,
+        "narHash": "sha256-F5Rk+gcncz5LkKYP295UA76zuNNk9YTeFzXNHgpcoiE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1ccc24e6b99f58286af9eade6abe35f670653e12",
+        "rev": "6b5ed3824ab1fc50914fbd5d1df0139704b8ce51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6b5ed382`](https://github.com/nix-community/NUR/commit/6b5ed3824ab1fc50914fbd5d1df0139704b8ce51) | `automatic update` |