### PR TITLE
chore(flake/nur): `6b5ed382` -> `5b866cfe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666026067,
-        "narHash": "sha256-F5Rk+gcncz5LkKYP295UA76zuNNk9YTeFzXNHgpcoiE=",
+        "lastModified": 1666027005,
+        "narHash": "sha256-9aAqlezYw9M7n+5wubffRJAnjRT8wDzgY0AsdYCfLZo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6b5ed3824ab1fc50914fbd5d1df0139704b8ce51",
+        "rev": "5b866cfe1ffcb2dc004c862d7da2ff5c6dc66e51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5b866cfe`](https://github.com/nix-community/NUR/commit/5b866cfe1ffcb2dc004c862d7da2ff5c6dc66e51) | `automatic update` |