### PR TITLE
chore(flake/emacs-overlay): `f8d2c22b` -> `80f4cebe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666005929,
-        "narHash": "sha256-i6L2VaYCvnAjrJKkpcHi66AYopMBKufSWq2JfiuEKeQ=",
+        "lastModified": 1666039764,
+        "narHash": "sha256-GY0Yw0hwLShjplB67338eDmGQZ+AQi4txczUsnP0M4g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f8d2c22b0714629bb7f8e90071b12fa56cd620be",
+        "rev": "80f4cebe57d8c6e7153f8837ce262bc6576a9498",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`80f4cebe`](https://github.com/nix-community/emacs-overlay/commit/80f4cebe57d8c6e7153f8837ce262bc6576a9498) | `Updated repos/melpa` |
| [`be190d94`](https://github.com/nix-community/emacs-overlay/commit/be190d94084695bec96a1a238b5f79ab9e6a55df) | `Updated repos/emacs` |