### PR TITLE
chore(flake/nur): `d7fe0a11` -> `8db8795f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666037846,
-        "narHash": "sha256-sVDUf7/cbpqTzEhlYXS7yc79jR28+7RLIfA1kll55Qc=",
+        "lastModified": 1666046163,
+        "narHash": "sha256-8SHTMQm6splaigjCCVywjuAeMoMR7jiIIIilzgmXNOc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d7fe0a11734dc02ecbf93e60ecc117b67ee30897",
+        "rev": "8db8795fcc0f0b559b88516e5191cd8521344158",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8db8795f`](https://github.com/nix-community/NUR/commit/8db8795fcc0f0b559b88516e5191cd8521344158) | `automatic update` |