### PR TITLE
chore(flake/nur): `7c195b01` -> `deabe33d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666048717,
-        "narHash": "sha256-8QHTbvM5deEKItOHtpXoqSOyb6C8eCfxjBwjuzTf+fo=",
+        "lastModified": 1666058653,
+        "narHash": "sha256-HFU6Ndxxioh4mT+M92r4CLY21bqH34bv5rzUEOfMptw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7c195b01049fac9ea47664c881d70ef1c023101a",
+        "rev": "deabe33d53cb89547af5ea7240427b9338992f13",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`deabe33d`](https://github.com/nix-community/NUR/commit/deabe33d53cb89547af5ea7240427b9338992f13) | `automatic update` |
| [`7788a14d`](https://github.com/nix-community/NUR/commit/7788a14d8b1438dc871c38301938f31b4315b761) | `automatic update` |