### PR TITLE
chore(flake/nur): `8536a93f` -> `d41934b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666064428,
-        "narHash": "sha256-mIjfsPbC7ea8re/u32SO5n4w697RwQDBn+wODUn/N+Y=",
+        "lastModified": 1666066784,
+        "narHash": "sha256-nyFwqc2OrZQ3HNH31h2T4GYxjcU9nfGxsRRybR+XPIw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8536a93f1366d3037cb6bac538f72649b45adaf8",
+        "rev": "d41934b1dd52cd6b3b08823ef377f74cd821dc3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d41934b1`](https://github.com/nix-community/NUR/commit/d41934b1dd52cd6b3b08823ef377f74cd821dc3e) | `automatic update` |
| [`0b313889`](https://github.com/nix-community/NUR/commit/0b3138895a1f51cd90e62cc057f0466d1a4b6985) | `automatic update` |
| [`9abfea0e`](https://github.com/nix-community/NUR/commit/9abfea0ea9e29564837ef59c9fd5d144f89ef8e3) | `automatic update` |