### PR TITLE
chore(flake/emacs-overlay): `80f4cebe` -> `d5dbc29a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666039764,
-        "narHash": "sha256-GY0Yw0hwLShjplB67338eDmGQZ+AQi4txczUsnP0M4g=",
+        "lastModified": 1666073572,
+        "narHash": "sha256-Qhotz0Ja9O5McENf0HVmhbyempdIwg6ULUyl/ZjN1U8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "80f4cebe57d8c6e7153f8837ce262bc6576a9498",
+        "rev": "d5dbc29af6033b0c9ea25c5382a15612c527ae96",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`d5dbc29a`](https://github.com/nix-community/emacs-overlay/commit/d5dbc29af6033b0c9ea25c5382a15612c527ae96) | `Updated repos/nongnu` |
| [`f5ef8526`](https://github.com/nix-community/emacs-overlay/commit/f5ef8526cef8d7ab6da729883f14623f55b42811) | `Updated repos/melpa`  |
| [`43e724fa`](https://github.com/nix-community/emacs-overlay/commit/43e724face73cfad63ca68220fed5f61a070fd2d) | `Updated repos/emacs`  |
| [`52d45a4f`](https://github.com/nix-community/emacs-overlay/commit/52d45a4f4a90334095409d4f0f6cd7e5ff5100f3) | `Updated repos/elpa`   |