### PR TITLE
chore(flake/nur): `20dec81a` -> `098ec0aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666074377,
-        "narHash": "sha256-jK4+3PQaFdNqyodVeE04ypSSy9j1wMjezBKFeCJnOec=",
+        "lastModified": 1666076364,
+        "narHash": "sha256-lrTeIpOtsQH2ta4vKGAA3bG3Buj8fIXpRW5NSwSONQQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "20dec81a5a45b026fecf3ab7f758ef793e5e8e7b",
+        "rev": "098ec0aa8dfa97756e97f79266990a82bcccc5d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`098ec0aa`](https://github.com/nix-community/NUR/commit/098ec0aa8dfa97756e97f79266990a82bcccc5d9) | `automatic update` |
| [`e116e00d`](https://github.com/nix-community/NUR/commit/e116e00db55342e4ab4bddc155795520dff5a7f4) | `automatic update` |
| [`218d8aee`](https://github.com/nix-community/NUR/commit/218d8aeec6aaffe36cc5a94fd6085b6e03f9a93a) | `automatic update` |