### PR TITLE
chore(flake/nur): `098ec0aa` -> `9de74bec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666076364,
-        "narHash": "sha256-lrTeIpOtsQH2ta4vKGAA3bG3Buj8fIXpRW5NSwSONQQ=",
+        "lastModified": 1666077267,
+        "narHash": "sha256-7I2FZVhpNlGn6jq29PbKBoZgeUkI3eTxMg2Wn/GJf0w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "098ec0aa8dfa97756e97f79266990a82bcccc5d9",
+        "rev": "9de74bec479d6c2293f9c990bee8fa415d254817",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9de74bec`](https://github.com/nix-community/NUR/commit/9de74bec479d6c2293f9c990bee8fa415d254817) | `automatic update` |