### PR TITLE
chore(flake/nur): `9de74bec` -> `e51616ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666077267,
-        "narHash": "sha256-7I2FZVhpNlGn6jq29PbKBoZgeUkI3eTxMg2Wn/GJf0w=",
+        "lastModified": 1666080096,
+        "narHash": "sha256-MiXpb29YGU/8k8/0YJvPNQwSCU2XPEh3wMcRw0HIIW0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9de74bec479d6c2293f9c990bee8fa415d254817",
+        "rev": "e51616ea1fb17cf2ae99a736bd5e850d74148b9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e51616ea`](https://github.com/nix-community/NUR/commit/e51616ea1fb17cf2ae99a736bd5e850d74148b9b) | `automatic update` |
| [`82258ac6`](https://github.com/nix-community/NUR/commit/82258ac62489e8a13f4fa7132794a56bc88912e7) | `automatic update` |