### PR TITLE
chore(flake/nur): `e51616ea` -> `ed8e8ae5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666080096,
-        "narHash": "sha256-MiXpb29YGU/8k8/0YJvPNQwSCU2XPEh3wMcRw0HIIW0=",
+        "lastModified": 1666081840,
+        "narHash": "sha256-OXyNKbH0Fo6ZOo8/rAPmIIF37c6F/X6HhOTVJguaDik=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e51616ea1fb17cf2ae99a736bd5e850d74148b9b",
+        "rev": "ed8e8ae5cbb1a3df04bb9532728222a64e271a1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ed8e8ae5`](https://github.com/nix-community/NUR/commit/ed8e8ae5cbb1a3df04bb9532728222a64e271a1e) | `automatic update` |