### PR TITLE
chore(flake/nur): `ed8e8ae5` -> `117eeb43`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666081840,
-        "narHash": "sha256-OXyNKbH0Fo6ZOo8/rAPmIIF37c6F/X6HhOTVJguaDik=",
+        "lastModified": 1666082537,
+        "narHash": "sha256-DHFFYPhmySbwt239oCiVaOLJe9njh+VGuNvH6E83P3E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed8e8ae5cbb1a3df04bb9532728222a64e271a1e",
+        "rev": "117eeb43bca6f66f68d2ec2365b5950683096bc4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`117eeb43`](https://github.com/nix-community/NUR/commit/117eeb43bca6f66f68d2ec2365b5950683096bc4) | `automatic update` |