### PR TITLE
chore(flake/emacs-overlay): `d5dbc29a` -> `286ead3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666073572,
-        "narHash": "sha256-Qhotz0Ja9O5McENf0HVmhbyempdIwg6ULUyl/ZjN1U8=",
+        "lastModified": 1666085713,
+        "narHash": "sha256-gl3dB+HoFMbL48lSfu8dUDoy8LYPyvAue1ZKOw1GJ9g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d5dbc29af6033b0c9ea25c5382a15612c527ae96",
+        "rev": "286ead3db69a26e4f2636b48b338a98e4812d36a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`286ead3d`](https://github.com/nix-community/emacs-overlay/commit/286ead3db69a26e4f2636b48b338a98e4812d36a) | `Updated repos/melpa` |