### PR TITLE
chore(flake/nur): `ed90392a` -> `6fabc919`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666103323,
-        "narHash": "sha256-NxRGd3P+qPrGfdW435Iy7LG9BgaRnSfEHzDkI+HYXH8=",
+        "lastModified": 1666105421,
+        "narHash": "sha256-FCsqGHAZ6pc9N40C+fuif8BoAF+vkYL53GeP/AW/sTc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed90392a3f721300b7b0182557fba45ef5ec6539",
+        "rev": "6fabc919a84c92e7e6d6570371f1632bb36fda9c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6fabc919`](https://github.com/nix-community/NUR/commit/6fabc919a84c92e7e6d6570371f1632bb36fda9c) | `automatic update` |