### PR TITLE
chore(flake/nur): `e6b3d27e` -> `0745aa93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666118412,
-        "narHash": "sha256-BaTzsAXPGxt6Q26h4HieU2FvyHiigN7KFuh4vpLvgA4=",
+        "lastModified": 1666121750,
+        "narHash": "sha256-Lj3gVd4hPjzgaZ1IkvpElgiryrfHZSXdMZS+oUlLsCs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e6b3d27ecd200be200dccd2b2f9585d606b05621",
+        "rev": "0745aa93a06c84aca0e9a4796b6008bcb4eb2052",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0745aa93`](https://github.com/nix-community/NUR/commit/0745aa93a06c84aca0e9a4796b6008bcb4eb2052) | `automatic update` |