### PR TITLE
chore(flake/emacs-overlay): `286ead3d` -> `d0198a7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666085713,
-        "narHash": "sha256-gl3dB+HoFMbL48lSfu8dUDoy8LYPyvAue1ZKOw1GJ9g=",
+        "lastModified": 1666122832,
+        "narHash": "sha256-nYLhVIRjD8Ag6e67e93A0samWmgDLzM2/UwqqE5/SFs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "286ead3db69a26e4f2636b48b338a98e4812d36a",
+        "rev": "d0198a7a1826347de95dfdb7abd973ec5c478f67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`d0198a7a`](https://github.com/nix-community/emacs-overlay/commit/d0198a7a1826347de95dfdb7abd973ec5c478f67) | `Updated repos/melpa` |
| [`73b967f3`](https://github.com/nix-community/emacs-overlay/commit/73b967f3b7d97bfc33feac0190288692f7fcffe4) | `Updated repos/emacs` |