### PR TITLE
chore(flake/nur): `85a83e7c` -> `4345075e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666123616,
-        "narHash": "sha256-BPO3KJjop8fKObQ2AzhY41g7we2/Pcqk0bY1f0NyHOU=",
+        "lastModified": 1666130501,
+        "narHash": "sha256-wFhIf1cn1Ap/UkG/trwn5/EW1colZEPIEnd5X5K2PLM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "85a83e7cac3a00519e06163306999b6acb04192d",
+        "rev": "4345075e809fadcd7549cbf4faf8a10b6ed867d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4345075e`](https://github.com/nix-community/NUR/commit/4345075e809fadcd7549cbf4faf8a10b6ed867d5) | `automatic update` |