### PR TITLE
chore(flake/emacs-overlay): `d0198a7a` -> `9fe0d44f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666122832,
-        "narHash": "sha256-nYLhVIRjD8Ag6e67e93A0samWmgDLzM2/UwqqE5/SFs=",
+        "lastModified": 1666144119,
+        "narHash": "sha256-48n4dAgAzjw/JUKxL27DjqZT76kL/YA3NO5Sy0grNlY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d0198a7a1826347de95dfdb7abd973ec5c478f67",
+        "rev": "9fe0d44ffb442a65fdf3fa7c5e16868f3545b843",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                               |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
| [`46c6c90e`](https://github.com/nix-community/emacs-overlay/commit/46c6c90eff894f4c060e97f6902eecd06994690d) | `Revert "flake.nix: fix the hack of getting overlayAttrs"`   |
| [`a03c0961`](https://github.com/nix-community/emacs-overlay/commit/a03c0961009f0028c794bd740f2e049f568247d7) | `overlays: use a better and clearer way to compose overlays` |