### PR TITLE
chore(flake/nur): `d687cb1d` -> `4ab3aa89`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666136750,
-        "narHash": "sha256-rYvcpi+lRyuSAL/Xqfxj8ERAEE3+o0qf11kNgq03rks=",
+        "lastModified": 1666145058,
+        "narHash": "sha256-pgwQJTXT9JUoAFFy9/hqPfDn0jwdmz6YyA4IHvXQbY4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d687cb1df7eb3e35625a94a589ab4b0ad836bbd2",
+        "rev": "4ab3aa89d4f4fd4252f785741336828066570931",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4ab3aa89`](https://github.com/nix-community/NUR/commit/4ab3aa89d4f4fd4252f785741336828066570931) | `automatic update` |