### PR TITLE
chore(flake/nur): `4ab3aa89` -> `dd60327e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666145058,
-        "narHash": "sha256-pgwQJTXT9JUoAFFy9/hqPfDn0jwdmz6YyA4IHvXQbY4=",
+        "lastModified": 1666152502,
+        "narHash": "sha256-ZhOR16pcHkOH7rkk4Q4TXZNCHSnxFoCg3LUQt6uZZGU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ab3aa89d4f4fd4252f785741336828066570931",
+        "rev": "dd60327e0d0011337ca1baaf86780eaef7b15f72",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`dd60327e`](https://github.com/nix-community/NUR/commit/dd60327e0d0011337ca1baaf86780eaef7b15f72) | `automatic update` |
| [`227198b6`](https://github.com/nix-community/NUR/commit/227198b6458337860c62308164bca912ced3f8ac) | `automatic update` |