### PR TITLE
chore(flake/nur): `d915c748` -> `9f1f9e13`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666156129,
-        "narHash": "sha256-pbJ7rdF/0j0qXn22uvSv4CMk4jxUBQuP/W6ePGgpU78=",
+        "lastModified": 1666156577,
+        "narHash": "sha256-UJv8FzaLt5G2q0e1B5MzRPMrU7RdLgXYnh85oUD8Jvk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d915c74840a29aff277fb1d641ba49a7d2ba275f",
+        "rev": "9f1f9e13fce1d5a237623ccd0fb57a120a0544da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9f1f9e13`](https://github.com/nix-community/NUR/commit/9f1f9e13fce1d5a237623ccd0fb57a120a0544da) | `automatic update` |