### PR TITLE
chore(flake/nur): `9f1f9e13` -> `15e8a12e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666156577,
-        "narHash": "sha256-UJv8FzaLt5G2q0e1B5MzRPMrU7RdLgXYnh85oUD8Jvk=",
+        "lastModified": 1666162734,
+        "narHash": "sha256-XFgV2TlQ7q2j1yjfgB/mayfORcKtmIAY2BGXTNRqNTs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9f1f9e13fce1d5a237623ccd0fb57a120a0544da",
+        "rev": "15e8a12e8793e845708c17921f1985f486400c2b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`15e8a12e`](https://github.com/nix-community/NUR/commit/15e8a12e8793e845708c17921f1985f486400c2b) | `automatic update` |