### PR TITLE
chore(flake/nur): `ea7e6edb` -> `0cfc41c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666185749,
-        "narHash": "sha256-H5bhfOZW/cmq54gC+sghTfB0jpwqMzfNKoDYbY55TXc=",
+        "lastModified": 1666194921,
+        "narHash": "sha256-FrcrcHo/HKYJ9UldwoeyKCrxQAqLthOhUHFIG9akcfc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ea7e6edbcd7512710d4bfda6dc2ef90595711893",
+        "rev": "0cfc41c5d31a6d7b7fb1e29fc57376a344ac51bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0cfc41c5`](https://github.com/nix-community/NUR/commit/0cfc41c5d31a6d7b7fb1e29fc57376a344ac51bb) | `automatic update` |