### PR TITLE
chore(flake/nur): `0cfc41c5` -> `20ab3d65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666194921,
-        "narHash": "sha256-FrcrcHo/HKYJ9UldwoeyKCrxQAqLthOhUHFIG9akcfc=",
+        "lastModified": 1666200479,
+        "narHash": "sha256-VgmIbYtYVFMR6pgB0PCzMNAkiw244Cp+HlcozGLwZvo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0cfc41c5d31a6d7b7fb1e29fc57376a344ac51bb",
+        "rev": "20ab3d65532d6636515d3eebb6279078944b6600",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`20ab3d65`](https://github.com/nix-community/NUR/commit/20ab3d65532d6636515d3eebb6279078944b6600) | `automatic update` |