### PR TITLE
chore(flake/nur): `f6fa0c8e` -> `c39480b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666204981,
-        "narHash": "sha256-v1nsKMx/vP6xUibFT7kdWk2MqItAZ7rRgbjPzH2AafI=",
+        "lastModified": 1666213103,
+        "narHash": "sha256-8PssbTf7/ZUYTE/2h5UyeQeoF52JuoeJel1HNNacLDA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f6fa0c8e46d15ba80a76e37235c02a29e938e6e7",
+        "rev": "c39480b59ff7e11361785c425eb0d107e2263e2b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c39480b5`](https://github.com/nix-community/NUR/commit/c39480b59ff7e11361785c425eb0d107e2263e2b) | `automatic update` |