### PR TITLE
chore(flake/nur): `c39480b5` -> `23a93790`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666213103,
-        "narHash": "sha256-8PssbTf7/ZUYTE/2h5UyeQeoF52JuoeJel1HNNacLDA=",
+        "lastModified": 1666216478,
+        "narHash": "sha256-osGgetmIdajR7Gr1pNWLTIStZRxKQOiZNgUaMJFFCiw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c39480b59ff7e11361785c425eb0d107e2263e2b",
+        "rev": "23a93790851a14d2b671ba14a204b6fa39931877",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`23a93790`](https://github.com/nix-community/NUR/commit/23a93790851a14d2b671ba14a204b6fa39931877) | `automatic update` |