### PR TITLE
chore(flake/nur): `23a93790` -> `b55b9f79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666216478,
-        "narHash": "sha256-osGgetmIdajR7Gr1pNWLTIStZRxKQOiZNgUaMJFFCiw=",
+        "lastModified": 1667398261,
+        "narHash": "sha256-fnTaNwUVjco9a3nxgg47JRf3Zt21bk7n2YBa/M1w7gM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "23a93790851a14d2b671ba14a204b6fa39931877",
+        "rev": "b55b9f795d31a3e4f27bb944178f9e5fedbcb8f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                  |
| -------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`b55b9f79`](https://github.com/nix-community/NUR/commit/b55b9f795d31a3e4f27bb944178f9e5fedbcb8f4) | `automatic update`              |
| [`1fce06a7`](https://github.com/nix-community/NUR/commit/1fce06a72e9b1cd602e877d3a0415453fc4bdb9a) | `automatic update`              |
| [`d3e70f13`](https://github.com/nix-community/NUR/commit/d3e70f13fe1ae7fb4dba188e58e9e20bdb5241ff) | `automatic update`              |
| [`a0fced8f`](https://github.com/nix-community/NUR/commit/a0fced8f63a7d4035410d71e1e07a9569c82f835) | `automatic update`              |
| [`e39e2f50`](https://github.com/nix-community/NUR/commit/e39e2f507c918bddb730c9f8b7ae6ed28a5cdd62) | `automatic update`              |
| [`1473da08`](https://github.com/nix-community/NUR/commit/1473da08310a5e03bfacc5a0b52cea240f0f4007) | `automatic update`              |
| [`43d4fb99`](https://github.com/nix-community/NUR/commit/43d4fb99ac047f2e9b6d244f9367ad3631b471b4) | `automatic update`              |
| [`7e5d3ba4`](https://github.com/nix-community/NUR/commit/7e5d3ba4f1937c99138a39abeedede5758c3a631) | `automatic update`              |
| [`be6557da`](https://github.com/nix-community/NUR/commit/be6557dae642f7693f0e55214524de1e264a82ee) | `automatic update`              |
| [`3db62a5f`](https://github.com/nix-community/NUR/commit/3db62a5f5646df32f884910ab116758da2f230bc) | `automatic update`              |
| [`603aa23b`](https://github.com/nix-community/NUR/commit/603aa23b61b4cc6c4078bdafb6ac699dacf80c60) | `automatic update`              |
| [`6e6aabf4`](https://github.com/nix-community/NUR/commit/6e6aabf41212eed186b9633916e4526d20e0a104) | `automatic update`              |
| [`59d0e6b5`](https://github.com/nix-community/NUR/commit/59d0e6b51b62951784465ce6c75246c3f2a1b90b) | `automatic update`              |
| [`b9b1f566`](https://github.com/nix-community/NUR/commit/b9b1f566b3a1dc43275ef5aa9897f19c91d3135b) | `automatic update`              |
| [`12c596b7`](https://github.com/nix-community/NUR/commit/12c596b75c902f1fcae80148efdc038f3f254b6d) | `automatic update`              |
| [`ce4d02af`](https://github.com/nix-community/NUR/commit/ce4d02afa7d80f49f1f72d477d8cb036723c65a0) | `automatic update`              |
| [`0915dff7`](https://github.com/nix-community/NUR/commit/0915dff7dfadb8beba54b8ee6ab5698a18998d79) | `automatic update`              |
| [`44510b76`](https://github.com/nix-community/NUR/commit/44510b76c0c599fb616237af32b3f2603407fe6f) | `automatic update`              |
| [`3756ca40`](https://github.com/nix-community/NUR/commit/3756ca400ad9befdb7a4c7e2ddc8b5c4283e4c2f) | `automatic update`              |
| [`b5e5da23`](https://github.com/nix-community/NUR/commit/b5e5da23731a772fd389f9b657d311da3b8d3938) | `automatic update`              |
| [`6f14058e`](https://github.com/nix-community/NUR/commit/6f14058ef784683c35668229a474352347204a9f) | `automatic update`              |
| [`cb412e68`](https://github.com/nix-community/NUR/commit/cb412e685f2787dd0dadd6a5ffa905792fde6372) | `automatic update`              |
| [`6d693bda`](https://github.com/nix-community/NUR/commit/6d693bdad48db8c2a561fb52162425236a38c271) | `automatic update`              |
| [`82d52306`](https://github.com/nix-community/NUR/commit/82d52306ba282d574dd110df1029eaac8fcc5bf0) | `automatic update`              |
| [`3cfa2166`](https://github.com/nix-community/NUR/commit/3cfa2166b7bca616088d3fc399f709f8abe483e5) | `automatic update`              |
| [`84903891`](https://github.com/nix-community/NUR/commit/849038914002df06c84a8dbff227d0901c47b029) | `automatic update`              |
| [`533f36ec`](https://github.com/nix-community/NUR/commit/533f36ec2ee77c3a855e321803d1de6e341f7d42) | `automatic update`              |
| [`b2be47b5`](https://github.com/nix-community/NUR/commit/b2be47b5c2a212a29f6a212c5cc96121a57a0a3e) | `automatic update`              |
| [`36cf4c2a`](https://github.com/nix-community/NUR/commit/36cf4c2a26ea85a1c27d1c207ea43ab3f7154cb5) | `automatic update`              |
| [`3c65690d`](https://github.com/nix-community/NUR/commit/3c65690d9e640a5d018f08fe3a7cda26bf63f331) | `automatic update`              |
| [`84dda967`](https://github.com/nix-community/NUR/commit/84dda967cf1b282b937c74448dccbd68b5c7e476) | `automatic update`              |
| [`70955c15`](https://github.com/nix-community/NUR/commit/70955c1528c5fadf8f9664dbae92c96bcaeebba0) | `automatic update`              |
| [`7c04e37b`](https://github.com/nix-community/NUR/commit/7c04e37b2300b4077a42be70ac7b703735edcb20) | `automatic update`              |
| [`2e2baa2a`](https://github.com/nix-community/NUR/commit/2e2baa2a70592c5b96e297e4323a900774d5ae6f) | `automatic update`              |
| [`07e2c7ba`](https://github.com/nix-community/NUR/commit/07e2c7bac0da00a97d5869b132bd9d6ecc05a70e) | `automatic update`              |
| [`79e9123b`](https://github.com/nix-community/NUR/commit/79e9123b6b9868b5a843e6b40f87d4dea274729c) | `automatic update`              |
| [`2bf57407`](https://github.com/nix-community/NUR/commit/2bf574074c5ec191a4147de020d629342c6e5a12) | `automatic update`              |
| [`fd26ab4a`](https://github.com/nix-community/NUR/commit/fd26ab4a1a965e731f59bb5af28b6cb08887a16c) | `automatic update`              |
| [`6816e9a1`](https://github.com/nix-community/NUR/commit/6816e9a1b1171f3d8a20f2b79dd732be0fc9059b) | `automatic update`              |
| [`97e96859`](https://github.com/nix-community/NUR/commit/97e9685943280a1c16fdf50609dbfc77f843d026) | `automatic update`              |
| [`9461fdde`](https://github.com/nix-community/NUR/commit/9461fddec2d50accd526b29670bdcb49dd63e6ef) | `automatic update`              |
| [`007429fd`](https://github.com/nix-community/NUR/commit/007429fd55659b5613c0c5d29956b68441f6901b) | `automatic update`              |
| [`800dd8ff`](https://github.com/nix-community/NUR/commit/800dd8ffe059b2c39dda3e5fffe2c25ccc2ea227) | `automatic update`              |
| [`6e050aea`](https://github.com/nix-community/NUR/commit/6e050aeae4697e35eb0ddbfe5e59813a58c77a25) | `automatic update`              |
| [`bf8cdb00`](https://github.com/nix-community/NUR/commit/bf8cdb00415ee5a42ba4cd01df6ae398bc0257b2) | `automatic update`              |
| [`ca071ade`](https://github.com/nix-community/NUR/commit/ca071adea2762f5d2814d5fdd9713d2d5c344591) | `automatic update`              |
| [`cc3b9335`](https://github.com/nix-community/NUR/commit/cc3b933526d2c9e72b946e39c10d870bedaaad60) | `automatic update`              |
| [`7e743091`](https://github.com/nix-community/NUR/commit/7e74309101583a927141f6c4e46cc2a79003c88e) | `automatic update`              |
| [`d47d7fe5`](https://github.com/nix-community/NUR/commit/d47d7fe56779ecc70a7b74a4566021d6407e9d82) | `automatic update`              |
| [`32aadc2b`](https://github.com/nix-community/NUR/commit/32aadc2bbb59718ce3f3ce7fd6044bf1a19e5c86) | `automatic update`              |
| [`2a36fb96`](https://github.com/nix-community/NUR/commit/2a36fb96710027c7b79e0bddff914a57965513d0) | `automatic update`              |
| [`a5fd942b`](https://github.com/nix-community/NUR/commit/a5fd942b0f83c2c1fcd21e73bc8acc67e0629801) | `automatic update`              |
| [`50c60a36`](https://github.com/nix-community/NUR/commit/50c60a363e0e1e7423d29efd11f7882bfe8f6bdd) | `automatic update`              |
| [`d6e3d8cd`](https://github.com/nix-community/NUR/commit/d6e3d8cd5b6141f66f908e35bf3e6410893d25ad) | `automatic update`              |
| [`7a6a6b3a`](https://github.com/nix-community/NUR/commit/7a6a6b3a703e50eefb1ce094a8a46d7e5a2ed543) | `automatic update`              |
| [`169c54ee`](https://github.com/nix-community/NUR/commit/169c54eedb779a51d82c9b5567470c9225660230) | `automatic update`              |
| [`4e1cbe61`](https://github.com/nix-community/NUR/commit/4e1cbe612e169c835c627517439892eb4e692103) | `automatic update`              |
| [`06a34dbe`](https://github.com/nix-community/NUR/commit/06a34dbef65a63c537955c5a3039f9a5318a515d) | `automatic update`              |
| [`e02cdf33`](https://github.com/nix-community/NUR/commit/e02cdf33530b9793692549300e080ccd1790183c) | `automatic update`              |
| [`bf39be82`](https://github.com/nix-community/NUR/commit/bf39be82cd1d907de1ad2a5d94fbf61ee3b11b5e) | `automatic update`              |
| [`e4440ee3`](https://github.com/nix-community/NUR/commit/e4440ee3861a2407554a948426c0afea393085c4) | `automatic update`              |
| [`f08d913b`](https://github.com/nix-community/NUR/commit/f08d913bb99af6f1e6b3036d72f47c8edf84b23b) | `automatic update`              |
| [`248c0ebe`](https://github.com/nix-community/NUR/commit/248c0ebe4a3c450fa1aa90b3c4a7a847a61fe574) | `automatic update`              |
| [`21dd1925`](https://github.com/nix-community/NUR/commit/21dd192519af12a01f1348bbfa86cde47f7aa392) | `automatic update`              |
| [`a66f3426`](https://github.com/nix-community/NUR/commit/a66f3426ef05a02de9ec4320310562683ce47e08) | `automatic update`              |
| [`08815915`](https://github.com/nix-community/NUR/commit/0881591582f6df3c921c5ed862881ab58079d2d4) | `automatic update`              |
| [`e53a22f8`](https://github.com/nix-community/NUR/commit/e53a22f88dda70f1d4ed0478915b07e38f322f41) | `automatic update`              |
| [`1f695cdb`](https://github.com/nix-community/NUR/commit/1f695cdbaa72170739eccc6eed840b48e25e32ec) | `automatic update`              |
| [`7e060767`](https://github.com/nix-community/NUR/commit/7e060767a6807908ac9ed47626af0ae176c8ada6) | `automatic update`              |
| [`7f4b27bf`](https://github.com/nix-community/NUR/commit/7f4b27bf9e7a8302b7662e37514d037f48fef4f4) | `automatic update`              |
| [`05a96a8e`](https://github.com/nix-community/NUR/commit/05a96a8e58c0c59dc993cb92427dc3e008d35764) | `automatic update`              |
| [`095c6c88`](https://github.com/nix-community/NUR/commit/095c6c883190936839ac814c858088a70d04a7b9) | `automatic update`              |
| [`e386faeb`](https://github.com/nix-community/NUR/commit/e386faeb61bda00e68ede661b678a68fee0d9d85) | `automatic update`              |
| [`3258b055`](https://github.com/nix-community/NUR/commit/3258b0551f4cdb5e13ecf09c285b9f1eced71be7) | `automatic update`              |
| [`95fb3340`](https://github.com/nix-community/NUR/commit/95fb33402828ef98e92f69f7d294ca9a697f444f) | `automatic update`              |
| [`6b00c796`](https://github.com/nix-community/NUR/commit/6b00c796841a5b6d471bee53983a727132e79839) | `automatic update`              |
| [`3a442cb9`](https://github.com/nix-community/NUR/commit/3a442cb9166aa9053ca01acf8c8367a1fd4b3a71) | `add geonix repository`         |
| [`87119c28`](https://github.com/nix-community/NUR/commit/87119c2819a3d255f2084651bcb482ae2e4a54ae) | `automatic update`              |
| [`cf6554a1`](https://github.com/nix-community/NUR/commit/cf6554a1efbb2e5cbce50c9170019934d7ca2605) | `automatic update`              |
| [`2a088dc3`](https://github.com/nix-community/NUR/commit/2a088dc31ef1046ca1c70fc390e0b94db7f584cb) | `automatic update`              |
| [`343c45a8`](https://github.com/nix-community/NUR/commit/343c45a89b3e5d2469d2baef36693f5efa7f6006) | `automatic update`              |
| [`0e0c7497`](https://github.com/nix-community/NUR/commit/0e0c749764233237161b51f43e9497da0214c4cd) | `automatic update`              |
| [`109d76c7`](https://github.com/nix-community/NUR/commit/109d76c719cd2a2c9c657ee1b7d0f1cbfb111ab1) | `automatic update`              |
| [`65b182f0`](https://github.com/nix-community/NUR/commit/65b182f02506959374b1e4d1c428bf3f5c3539f3) | `automatic update`              |
| [`59406063`](https://github.com/nix-community/NUR/commit/594060638c6a2de905724badaf037a3691e668ee) | `automatic update`              |
| [`67a074f6`](https://github.com/nix-community/NUR/commit/67a074f6cc657e33a2668bc18fa28cbb0c680859) | `automatic update`              |
| [`42b645e9`](https://github.com/nix-community/NUR/commit/42b645e9c35cf0232a1f9028571d452999845fda) | `automatic update`              |
| [`8f66a5c0`](https://github.com/nix-community/NUR/commit/8f66a5c08c0be70f9e3649ca92c644d4dc7a0cdd) | `automatic update`              |
| [`b0aedc12`](https://github.com/nix-community/NUR/commit/b0aedc1219f2d3e0462edb6424205886b72d6824) | `automatic update`              |
| [`68967fd1`](https://github.com/nix-community/NUR/commit/68967fd110a414b5e9a0f625ad8856405a172bbc) | `automatic update`              |
| [`ec9df65f`](https://github.com/nix-community/NUR/commit/ec9df65fe29210b148985cfc83579d5be609d3eb) | `automatic update`              |
| [`a94166b0`](https://github.com/nix-community/NUR/commit/a94166b012fd0980601e2b5d0f79db379b3df8d0) | `automatic update`              |
| [`7f51563a`](https://github.com/nix-community/NUR/commit/7f51563a283fa1f4767d7d4269687cec9d3e7a41) | `automatic update`              |
| [`0cfef2c9`](https://github.com/nix-community/NUR/commit/0cfef2c9f6cd19ed0afd06c94ecd4a66281d5df7) | `automatic update`              |
| [`c0471fb6`](https://github.com/nix-community/NUR/commit/c0471fb6257ef3dcabbb3a4d75d8297997bb5e24) | `automatic update`              |
| [`5982fb3b`](https://github.com/nix-community/NUR/commit/5982fb3bc4c0cd448cf3bc6ba16e5ac2d9673ff3) | `automatic update`              |
| [`75f7c63f`](https://github.com/nix-community/NUR/commit/75f7c63f890f81add7e4de4753f5519a5662b1bb) | `automatic update`              |
| [`92d7c4a0`](https://github.com/nix-community/NUR/commit/92d7c4a072dbf2f4de41c046fa985d2f81be1234) | `automatic update`              |
| [`9c05c63b`](https://github.com/nix-community/NUR/commit/9c05c63b30ccec8f9db8e0bc364f6e155b51bb88) | `automatic update`              |
| [`809de853`](https://github.com/nix-community/NUR/commit/809de853d3e8b6e95c9d2af676a9e036637b66c3) | `automatic update`              |
| [`b95d0193`](https://github.com/nix-community/NUR/commit/b95d01939221658c5a163b7b2f98097ee6def6b6) | `automatic update`              |
| [`44389243`](https://github.com/nix-community/NUR/commit/44389243c155859b6dcb90f3c266ca650843b433) | `automatic update`              |
| [`b498ea88`](https://github.com/nix-community/NUR/commit/b498ea88f3e9e2a652a98b392cdfa8643b37c981) | `automatic update`              |
| [`0a56fd62`](https://github.com/nix-community/NUR/commit/0a56fd62a737f67c6f8a83a340e99a726d7fda50) | `automatic update`              |
| [`f48a6e35`](https://github.com/nix-community/NUR/commit/f48a6e35cccf3f5de284b8bbc4043bdbbd8f7edb) | `automatic update`              |
| [`87361f37`](https://github.com/nix-community/NUR/commit/87361f376c51d0c6f7e5c420c6ebf3ed01d983be) | `Add nix-geht repository.`      |
| [`e6b2b671`](https://github.com/nix-community/NUR/commit/e6b2b67190c5057217de0400c2052c3554661a93) | `automatic update`              |
| [`c5877a2c`](https://github.com/nix-community/NUR/commit/c5877a2c4239630c38a43bba35971b513522e53e) | `automatic update`              |
| [`847910f2`](https://github.com/nix-community/NUR/commit/847910f20b5a3c14cf3092b510e13c481474bb69) | `automatic update`              |
| [`1d353117`](https://github.com/nix-community/NUR/commit/1d3531179ac8508fba868bc701a95b52cb00d2ab) | `automatic update`              |
| [`c3025822`](https://github.com/nix-community/NUR/commit/c3025822f80167e19cebca3aeca08368c77960e4) | `automatic update`              |
| [`d27415b4`](https://github.com/nix-community/NUR/commit/d27415b45fd82432b4e2fb5bc3bd3822e880cf9b) | `automatic update`              |
| [`3526b557`](https://github.com/nix-community/NUR/commit/3526b55783b8d1a118150441dbeac8e79224d46b) | `automatic update`              |
| [`c43ba753`](https://github.com/nix-community/NUR/commit/c43ba753bd15d894d24b77719e0bd668c7ad8e69) | `automatic update`              |
| [`af4b9211`](https://github.com/nix-community/NUR/commit/af4b9211d5111cf3dde3fbdfd93e86dd8d5c92f0) | `automatic update`              |
| [`36cd3478`](https://github.com/nix-community/NUR/commit/36cd347898e55fcc4a2bcd9902eef1fd766f0295) | `automatic update`              |
| [`0fffd93c`](https://github.com/nix-community/NUR/commit/0fffd93c62aeaed92963d72373b9e57ae12fc8ca) | `automatic update`              |
| [`b952d82b`](https://github.com/nix-community/NUR/commit/b952d82bb47422938d76c2979daaad2292e96fd3) | `automatic update`              |
| [`65f6c481`](https://github.com/nix-community/NUR/commit/65f6c4817779626fea05c2e0cc52f6ce13b93f9c) | `automatic update`              |
| [`b5752801`](https://github.com/nix-community/NUR/commit/b57528011f3fca94ab91dd58f0f5e7e6e8224e98) | `automatic update`              |
| [`fee81244`](https://github.com/nix-community/NUR/commit/fee81244b62f2d9712632c2c04b12f266958ab49) | `automatic update`              |
| [`e70daa61`](https://github.com/nix-community/NUR/commit/e70daa61415ecd5d2f1920b1fc6a5fb1a87ce03b) | `automatic update`              |
| [`23cf8aa5`](https://github.com/nix-community/NUR/commit/23cf8aa524a6540e7011e1a55f8029775432911f) | `automatic update`              |
| [`018cbd21`](https://github.com/nix-community/NUR/commit/018cbd2156b4f2ff4be4de7a687ed20301486e92) | `automatic update`              |
| [`4e3e2015`](https://github.com/nix-community/NUR/commit/4e3e201519fef4fcae0e0ec18bee4a35c86af77e) | `automatic update`              |
| [`c17dec15`](https://github.com/nix-community/NUR/commit/c17dec1509d3a31b7fc725b455d9e9f4f3fbb8cf) | `automatic update`              |
| [`b5176366`](https://github.com/nix-community/NUR/commit/b51763667722380d88dcc8d23f6b3f52a29ecfc2) | `automatic update`              |
| [`f87ab9ff`](https://github.com/nix-community/NUR/commit/f87ab9ff2ea215252532c9e7cf194c56fd8d6c38) | `automatic update`              |
| [`ff7c2cf3`](https://github.com/nix-community/NUR/commit/ff7c2cf3cd298e916a49aab3ff2737ca9c78e04f) | `automatic update`              |
| [`4c6c8172`](https://github.com/nix-community/NUR/commit/4c6c8172b4a7a49ffc2502ece105ab2ab169b494) | `automatic update`              |
| [`dbf813da`](https://github.com/nix-community/NUR/commit/dbf813daf7ce39846bac62d03cbe0e2a3ff5d202) | `automatic update`              |
| [`abd5dc97`](https://github.com/nix-community/NUR/commit/abd5dc97d11e943ab9ca386ed257f7ec9143f951) | `automatic update`              |
| [`7a8ec493`](https://github.com/nix-community/NUR/commit/7a8ec493cf417eae235ad6f784a8d591cb3df6f7) | `automatic update`              |
| [`419bc148`](https://github.com/nix-community/NUR/commit/419bc14853fdc6627c7cbb98f5f2b73899f44110) | `automatic update`              |
| [`56180163`](https://github.com/nix-community/NUR/commit/56180163d32187d312890d10733770288512891c) | `automatic update`              |
| [`7756b7d7`](https://github.com/nix-community/NUR/commit/7756b7d76c21ba9f80864a4d4f5385870f505d65) | `automatic update`              |
| [`ed38bca3`](https://github.com/nix-community/NUR/commit/ed38bca3ac3bf66d1d49cf61a4e5cf2237277cb1) | `automatic update`              |
| [`17e3882b`](https://github.com/nix-community/NUR/commit/17e3882babed0b965175b5c1f144bc3e052b8404) | `automatic update`              |
| [`8f863994`](https://github.com/nix-community/NUR/commit/8f86399488778cafbaa510812f9b1dff3cbde0bc) | `automatic update`              |
| [`4b6f5d0c`](https://github.com/nix-community/NUR/commit/4b6f5d0cc3b09f4f995daded739c45f8c2fdbef2) | `automatic update`              |
| [`bed3bd58`](https://github.com/nix-community/NUR/commit/bed3bd5892e0d09d14db1d5df0e1936fa2c80a0a) | `automatic update`              |
| [`97595b93`](https://github.com/nix-community/NUR/commit/97595b93949b03b335a3496b6819092d0e6ddf6d) | `automatic update`              |
| [`f42d15c6`](https://github.com/nix-community/NUR/commit/f42d15c6bc1692851a8b4a491e2c9818f93341d3) | `automatic update`              |
| [`88c48a6b`](https://github.com/nix-community/NUR/commit/88c48a6bf91b3616ed7e2e822eade6ef6a22ba69) | `automatic update`              |
| [`d11faae4`](https://github.com/nix-community/NUR/commit/d11faae4a8e0fecbdb077d998f76b08743644bc4) | `automatic update`              |
| [`950b90d1`](https://github.com/nix-community/NUR/commit/950b90d1247e5453d549e7921ce3ed6c4d4da5d9) | `automatic update`              |
| [`4a421a1d`](https://github.com/nix-community/NUR/commit/4a421a1d3b0048e773550dd58d26d9ec536d4c97) | `automatic update`              |
| [`2a883e1a`](https://github.com/nix-community/NUR/commit/2a883e1a91f337553fc2fbfa9c3fa50b866f3d72) | `automatic update`              |
| [`64a77190`](https://github.com/nix-community/NUR/commit/64a771902575732dd883a0443f899c60013d0aae) | `automatic update`              |
| [`b247e1ee`](https://github.com/nix-community/NUR/commit/b247e1ee224f611d9252d10272c41497fb3ec493) | `automatic update`              |
| [`3b5f8bd4`](https://github.com/nix-community/NUR/commit/3b5f8bd4664c63961f7f75bac5ffa64ea6571e37) | `automatic update`              |
| [`e52023bf`](https://github.com/nix-community/NUR/commit/e52023bf7677446ae18c01f4602a3e7c60dcd80b) | `automatic update`              |
| [`c691b1f9`](https://github.com/nix-community/NUR/commit/c691b1f9df54e1d03fec276ae2a3fe6658de6057) | `automatic update`              |
| [`6fe87c4b`](https://github.com/nix-community/NUR/commit/6fe87c4ba196596b2ba40c134652e5632260159b) | `add utybo repository`          |
| [`89f66216`](https://github.com/nix-community/NUR/commit/89f662169cb18014b3ec9f31f3a9be36522814ae) | `automatic update`              |
| [`1ee2bab6`](https://github.com/nix-community/NUR/commit/1ee2bab665e18e159edc312f6687406bcd23bfe4) | `automatic update`              |
| [`caf11d93`](https://github.com/nix-community/NUR/commit/caf11d93777caa3a268b404f0f843d4d5b613edc) | `automatic update`              |
| [`0f5061ee`](https://github.com/nix-community/NUR/commit/0f5061ee4214d46ee0093c39899e6d07efcb1ef6) | `automatic update`              |
| [`5d36ca27`](https://github.com/nix-community/NUR/commit/5d36ca2738ac2bc6ad784aeb5b14e66848a7fa3f) | `automatic update`              |
| [`f3b7c7f5`](https://github.com/nix-community/NUR/commit/f3b7c7f5bec9d4008fb9c3a8e85020cc247a5d81) | `automatic update`              |
| [`08d2b38f`](https://github.com/nix-community/NUR/commit/08d2b38f2cc413260e894ead138139cd96faa4e4) | `automatic update`              |
| [`741c813f`](https://github.com/nix-community/NUR/commit/741c813fef995e8258d0eb02d4c22242c3a46d14) | `automatic update`              |
| [`1970f883`](https://github.com/nix-community/NUR/commit/1970f883e139b06ae109ad2ca2c45b7fa987afb9) | `automatic update`              |
| [`012c66e5`](https://github.com/nix-community/NUR/commit/012c66e50f7656aff4b7255ff35e813f76ccb1be) | `automatic update`              |
| [`1e0f290f`](https://github.com/nix-community/NUR/commit/1e0f290f94fd2592f8cce6301c426d956ba037d1) | `automatic update`              |
| [`b104aa7b`](https://github.com/nix-community/NUR/commit/b104aa7bba45290685d35fa5642cd853bd9d1c5d) | `automatic update`              |
| [`9ac088a6`](https://github.com/nix-community/NUR/commit/9ac088a698c05304275199db5039a0525764724c) | `automatic update`              |
| [`8491ebed`](https://github.com/nix-community/NUR/commit/8491ebed39ad60c94e97108fe4a7fab1869b2b49) | `automatic update`              |
| [`da5186e7`](https://github.com/nix-community/NUR/commit/da5186e739a5849a9bc650e809f4f2976c54202d) | `automatic update`              |
| [`5e51346d`](https://github.com/nix-community/NUR/commit/5e51346dad4871f8cf1b69266559784786940f3a) | `automatic update`              |
| [`19143918`](https://github.com/nix-community/NUR/commit/191439188992f64f27d442f490a1d029e665da79) | `automatic update`              |
| [`78387c59`](https://github.com/nix-community/NUR/commit/78387c597fe301e6b96afdab7fa892e172e99502) | `automatic update`              |
| [`6395d08a`](https://github.com/nix-community/NUR/commit/6395d08a94336bd5e87b2aca193e23e4f4851e99) | `automatic update`              |
| [`5cf4749e`](https://github.com/nix-community/NUR/commit/5cf4749e79cc38e832d6ffbb3f5e8e3387e04bc0) | `automatic update`              |
| [`e57f0d92`](https://github.com/nix-community/NUR/commit/e57f0d92bd9b694339ebdf64efe293294a95693a) | `automatic update`              |
| [`520df338`](https://github.com/nix-community/NUR/commit/520df33879c5693caeefb9b3347b530e83dcc540) | `automatic update`              |
| [`2bee8e31`](https://github.com/nix-community/NUR/commit/2bee8e314e0cf218fbe374ef4c00e473c8b95f20) | `automatic update`              |
| [`5e3ac0e6`](https://github.com/nix-community/NUR/commit/5e3ac0e6da8f80945bb6385880890bf27c1535e0) | `automatic update`              |
| [`1fb7e708`](https://github.com/nix-community/NUR/commit/1fb7e7080e783fdcad15ba5ed0c6b7ce24a37f51) | `automatic update`              |
| [`c4d92630`](https://github.com/nix-community/NUR/commit/c4d92630f6d74b23c439daa7cd75ad6283d70ca1) | `automatic update`              |
| [`8d7a2916`](https://github.com/nix-community/NUR/commit/8d7a2916462d592684bc400094a669d1afbf26b5) | `automatic update`              |
| [`6c1a3c3e`](https://github.com/nix-community/NUR/commit/6c1a3c3e533118ef6466718dd389896c47cf588d) | `automatic update`              |
| [`fde31edb`](https://github.com/nix-community/NUR/commit/fde31edb08e4052b680b46a88090c5419253e144) | `automatic update`              |
| [`aa24767f`](https://github.com/nix-community/NUR/commit/aa24767fa21b3f138ace8c1919f5d0180e8651ee) | `automatic update`              |
| [`25ef4a72`](https://github.com/nix-community/NUR/commit/25ef4a725699a936721f00f35b860b8ad2f7f9ac) | `automatic update`              |
| [`3d1418d2`](https://github.com/nix-community/NUR/commit/3d1418d2e156f39c4e938f98deef003763048461) | `automatic update`              |
| [`fcda833e`](https://github.com/nix-community/NUR/commit/fcda833e9ced51d19487089718c64f6dae9e2a65) | `automatic update`              |
| [`2795d76f`](https://github.com/nix-community/NUR/commit/2795d76f99dd94a5b5089c5ee3ebec1dbd782812) | `automatic update`              |
| [`f32252be`](https://github.com/nix-community/NUR/commit/f32252be66c06b2951848ee265a190482c71065b) | `automatic update`              |
| [`0a73db20`](https://github.com/nix-community/NUR/commit/0a73db20ae25d4daee636472b6bbee2c7c7496c8) | `automatic update`              |
| [`45ef80ff`](https://github.com/nix-community/NUR/commit/45ef80ff8a455d74b3da3f599cd9953d0e3cb20d) | `automatic update`              |
| [`6a04ffbf`](https://github.com/nix-community/NUR/commit/6a04ffbf5b314e4e1564fb7578543941bbad1f68) | `add natsukium repository`      |
| [`86f9ad96`](https://github.com/nix-community/NUR/commit/86f9ad965f87891383d72b084f849e584adc298d) | `automatic update`              |
| [`9a706608`](https://github.com/nix-community/NUR/commit/9a70660866d5d2546a8016f300ea63575ff17b72) | `automatic update`              |
| [`5b5869c6`](https://github.com/nix-community/NUR/commit/5b5869c6df83d2b5409e1545692f1cbd20e18fec) | `automatic update`              |
| [`7c0ef46c`](https://github.com/nix-community/NUR/commit/7c0ef46c45b884f8334f6a3df3689b5387a387d5) | `automatic update`              |
| [`4330cb83`](https://github.com/nix-community/NUR/commit/4330cb83ca2fb2396d39bbf71371317808ba4f08) | `automatic update`              |
| [`0c09d7da`](https://github.com/nix-community/NUR/commit/0c09d7da36fc5a1dc96a22cb2654cbdb94053071) | `automatic update`              |
| [`a38fdb27`](https://github.com/nix-community/NUR/commit/a38fdb27e1b97c4f5e9adb521e4a3d073bd7c479) | `automatic update`              |
| [`8ebad343`](https://github.com/nix-community/NUR/commit/8ebad343ea4cd5f5ca28638e61f47d111b632ffc) | `automatic update`              |
| [`208b25d4`](https://github.com/nix-community/NUR/commit/208b25d47114a65b0d633b4bd3c9c6deb379e5ee) | `automatic update`              |
| [`37ac590c`](https://github.com/nix-community/NUR/commit/37ac590cf0a20220740a16f3e783bceefb852249) | `automatic update`              |
| [`e88e63a5`](https://github.com/nix-community/NUR/commit/e88e63a571d85560b363adacecc812c0b9cb35af) | `automatic update`              |
| [`4e09cae0`](https://github.com/nix-community/NUR/commit/4e09cae0bdd738d9f9816b140c0f600fd55da2f1) | `automatic update`              |
| [`b0412b6b`](https://github.com/nix-community/NUR/commit/b0412b6b7fd8ddc5e98cdba54aef368cc8007f41) | `automatic update`              |
| [`c2b636c3`](https://github.com/nix-community/NUR/commit/c2b636c31c31d4dadc18cccea805622e4fdbbe3d) | `automatic update`              |
| [`ffe97570`](https://github.com/nix-community/NUR/commit/ffe975706873e6684eb5dbffa072a43a77280f0d) | `add anthonyroussel repository` |
| [`5b7b7d60`](https://github.com/nix-community/NUR/commit/5b7b7d608d3f3782cb734fdf6e2aa99c71d57ef3) | `Add darkkirb repository`       |