### PR TITLE
chore(flake/emacs-overlay): `62180668` -> `0573574a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666242330,
-        "narHash": "sha256-AWtyGxkcpPespK4bLitR8qyoKsQIwvQlN03FWm3bhyg=",
+        "lastModified": 1666269358,
+        "narHash": "sha256-SD4EoWChiHKLT1tIAQmrbw36g5JUhVDGr5DwIHuXTXc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "62180668ad617d98bbafc9468048b62f6808a13c",
+        "rev": "0573574af28ce9f7113c73679fd328bb057ae759",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`0573574a`](https://github.com/nix-community/emacs-overlay/commit/0573574af28ce9f7113c73679fd328bb057ae759) | `Updated repos/melpa` |
| [`afc9e622`](https://github.com/nix-community/emacs-overlay/commit/afc9e622611f8d53293184bec0397fe69431fb78) | `Updated repos/emacs` |