### PR TITLE
chore(flake/emacs-overlay): `0573574a` -> `b8e24cec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666269358,
-        "narHash": "sha256-SD4EoWChiHKLT1tIAQmrbw36g5JUhVDGr5DwIHuXTXc=",
+        "lastModified": 1666298449,
+        "narHash": "sha256-y1SRRRK2eTVuh/HRCxwDSInMwGv0d5cPIp4YDlbcM30=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0573574af28ce9f7113c73679fd328bb057ae759",
+        "rev": "b8e24cec99ff68f8a875b6f842a10b6b2ab398d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`b8e24cec`](https://github.com/nix-community/emacs-overlay/commit/b8e24cec99ff68f8a875b6f842a10b6b2ab398d3) | `Updated repos/melpa` |
| [`ce0c5e0d`](https://github.com/nix-community/emacs-overlay/commit/ce0c5e0de85f090a41412d8fe9c9b8126a7eb89f) | `Updated repos/emacs` |