### PR TITLE
chore(flake/emacs-overlay): `b8e24cec` -> `4deb8259`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666298449,
-        "narHash": "sha256-y1SRRRK2eTVuh/HRCxwDSInMwGv0d5cPIp4YDlbcM30=",
+        "lastModified": 1666328071,
+        "narHash": "sha256-Ik2QvUmjqsV2/IAsGwCs/14Wr1thF6gRnIV9kuAozWE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b8e24cec99ff68f8a875b6f842a10b6b2ab398d3",
+        "rev": "4deb8259b99eeabe4a4343c3ecb90c40d51d5d8a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`4deb8259`](https://github.com/nix-community/emacs-overlay/commit/4deb8259b99eeabe4a4343c3ecb90c40d51d5d8a) | `Updated repos/nongnu` |
| [`d4f2658a`](https://github.com/nix-community/emacs-overlay/commit/d4f2658a2778a53be080a89a981059088e44889b) | `Updated repos/melpa`  |
| [`608a3146`](https://github.com/nix-community/emacs-overlay/commit/608a3146b2e170cd9b2272cf634d6e91f6ab1747) | `Updated repos/emacs`  |
| [`301c54b9`](https://github.com/nix-community/emacs-overlay/commit/301c54b9c1b080cb818656a5ce3592ee5e347f05) | `Updated repos/elpa`   |