### PR TITLE
chore(flake/emacs-overlay): `4deb8259` -> `3d7c61b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666328071,
-        "narHash": "sha256-Ik2QvUmjqsV2/IAsGwCs/14Wr1thF6gRnIV9kuAozWE=",
+        "lastModified": 1666352875,
+        "narHash": "sha256-kbzTmj9ihe4rowgjLxD4uT4nKh304lN0RJMd5yBX03w=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4deb8259b99eeabe4a4343c3ecb90c40d51d5d8a",
+        "rev": "3d7c61b6dc5fc9d7c5e4a74e575c582aa567d547",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`3d7c61b6`](https://github.com/nix-community/emacs-overlay/commit/3d7c61b6dc5fc9d7c5e4a74e575c582aa567d547) | `Updated repos/melpa` |
| [`9d3e3cf5`](https://github.com/nix-community/emacs-overlay/commit/9d3e3cf5330f7c280f50f1b16d9b7f117d9d7ed3) | `Updated repos/emacs` |