### PR TITLE
chore(flake/emacs-overlay): `3d7c61b6` -> `ffc00124`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666352875,
-        "narHash": "sha256-kbzTmj9ihe4rowgjLxD4uT4nKh304lN0RJMd5yBX03w=",
+        "lastModified": 1666382611,
+        "narHash": "sha256-XTT5sL+msuYcyzh3aLG3Ekip7NiRRYJkqE/PT6p38N4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3d7c61b6dc5fc9d7c5e4a74e575c582aa567d547",
+        "rev": "ffc00124f627fd5dec1d649555aa128b66ce6bc7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ffc00124`](https://github.com/nix-community/emacs-overlay/commit/ffc00124f627fd5dec1d649555aa128b66ce6bc7) | `Updated repos/melpa` |
| [`b50e9d52`](https://github.com/nix-community/emacs-overlay/commit/b50e9d5295af0b332a0faf8af0c0dd3e1cb4cc53) | `Updated repos/emacs` |