### PR TITLE
chore(flake/emacs-overlay): `ffc00124` -> `06a3e6d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666382611,
-        "narHash": "sha256-XTT5sL+msuYcyzh3aLG3Ekip7NiRRYJkqE/PT6p38N4=",
+        "lastModified": 1666418809,
+        "narHash": "sha256-cLLcSIQqJCERPv3VsGaeMK5PB3kesZur5xqQJ9fE84Q=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ffc00124f627fd5dec1d649555aa128b66ce6bc7",
+        "rev": "06a3e6d7d9d40eb7351f2e70fda9b5f1461c56d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`06a3e6d7`](https://github.com/nix-community/emacs-overlay/commit/06a3e6d7d9d40eb7351f2e70fda9b5f1461c56d0) | `Updated repos/melpa` |
| [`1e8f0fa9`](https://github.com/nix-community/emacs-overlay/commit/1e8f0fa9ecdd024c0cba09b0eeca7d002bffddb1) | `Updated repos/emacs` |