### PR TITLE
chore(flake/emacs-overlay): `06a3e6d7` -> `94418315`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666418809,
-        "narHash": "sha256-cLLcSIQqJCERPv3VsGaeMK5PB3kesZur5xqQJ9fE84Q=",
+        "lastModified": 1666432605,
+        "narHash": "sha256-Kto6oDZSKmPfg+0e0UfGjdoqr09ecwyYl5aSQTM0lx4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "06a3e6d7d9d40eb7351f2e70fda9b5f1461c56d0",
+        "rev": "94418315592771cf69e380cf0f4eb78532410284",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`94418315`](https://github.com/nix-community/emacs-overlay/commit/94418315592771cf69e380cf0f4eb78532410284) | `Updated repos/melpa` |
| [`096fe0d5`](https://github.com/nix-community/emacs-overlay/commit/096fe0d58d13c8b600627c7445369b06f1816f4b) | `Updated repos/emacs` |