### PR TITLE
chore(flake/emacs-ement): `b06c78d1` -> `89e91b83`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1666449437,
-        "narHash": "sha256-j30qJY3sFVZtIlMBBjaA8izcNDqjyfHvl5wKvFj9ml0=",
+        "lastModified": 1666450058,
+        "narHash": "sha256-YhHydlE1MsJTq5e51F93ge6VVZQTlpb7TzhnLy4+SB0=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "b06c78d1ba700857330520bc796c5a29018b7ec5",
+        "rev": "89e91b836489bd6a6a729c88ad9f34fe846c3946",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                             |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`89e91b83`](https://github.com/alphapapa/ement.el/commit/89e91b836489bd6a6a729c88ad9f34fe846c3946) | `Change: Don't offer spaces when completing rooms to view` |
| [`c8cd6a44`](https://github.com/alphapapa/ement.el/commit/c8cd6a440042982ef31e064096dd0b96ceb562a0) | `Meta: v0.5-pre`                                           |