### PR TITLE
chore(flake/emacs-overlay): `94418315` -> `ef5d67c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666432605,
-        "narHash": "sha256-Kto6oDZSKmPfg+0e0UfGjdoqr09ecwyYl5aSQTM0lx4=",
+        "lastModified": 1666471010,
+        "narHash": "sha256-Ehq7DB68ue5YHJ8sUNJXZhhW4fcT1oc2NkpQPVvrB2c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "94418315592771cf69e380cf0f4eb78532410284",
+        "rev": "ef5d67c561a8b6ce001dbc555814fdb21c7bd5dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ef5d67c5`](https://github.com/nix-community/emacs-overlay/commit/ef5d67c561a8b6ce001dbc555814fdb21c7bd5dd) | `Updated repos/melpa` |
| [`e0e50591`](https://github.com/nix-community/emacs-overlay/commit/e0e505919ed5f3e92a3ed7319da0d13766a12e27) | `Updated repos/emacs` |