### PR TITLE
chore(flake/emacs-overlay): `ef5d67c5` -> `4bf8caf3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666471010,
-        "narHash": "sha256-Ehq7DB68ue5YHJ8sUNJXZhhW4fcT1oc2NkpQPVvrB2c=",
+        "lastModified": 1666502500,
+        "narHash": "sha256-r8xtx6BMx3hfWlMx5ddI7BoB0oB+RL1DiPfci62SqwE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ef5d67c561a8b6ce001dbc555814fdb21c7bd5dd",
+        "rev": "4bf8caf3960ec720088711cc24a541b5180dd83f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`4bf8caf3`](https://github.com/nix-community/emacs-overlay/commit/4bf8caf3960ec720088711cc24a541b5180dd83f) | `Updated repos/nongnu` |
| [`bf945807`](https://github.com/nix-community/emacs-overlay/commit/bf94580785aa4b291f30d0f23345fa13fa50531d) | `Updated repos/melpa`  |
| [`c498ad90`](https://github.com/nix-community/emacs-overlay/commit/c498ad9091a221b197c6887124fe3663c4d8820e) | `Updated repos/emacs`  |
| [`3ac83b37`](https://github.com/nix-community/emacs-overlay/commit/3ac83b37f7aa31c50b2e231322bb35ba81ed139d) | `Updated repos/elpa`   |