### PR TITLE
chore(flake/emacs-overlay): `92c3c295` -> `68677ad3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666527089,
-        "narHash": "sha256-FDcMUWaL9XmZKGT+cLTH07sSxm14BJ4+49AYFTpITNI=",
+        "lastModified": 1666557509,
+        "narHash": "sha256-LHelqOjrrW3WCEonVX+7m4mwAiBWUJbD88TavzXPyRs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "92c3c295daea9e71578b2e4f0cbe9906013c1adc",
+        "rev": "68677ad3456455c0d50338111e46bfe248ce3561",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`68677ad3`](https://github.com/nix-community/emacs-overlay/commit/68677ad3456455c0d50338111e46bfe248ce3561) | `Updated repos/melpa` |