### PR TITLE
chore(flake/emacs-overlay): `c3e508d7` -> `5d838805`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666593425,
-        "narHash": "sha256-hr4ItI9O5Lz4CLaZ7t/EudgJKxJIKThbHAQH75g/6M0=",
+        "lastModified": 1666612413,
+        "narHash": "sha256-3K3PanV+pkixNo/sPN2YLGZffiQXcVAIGo2gaNDCWHs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c3e508d7f6429e17283836350764d13ba564e391",
+        "rev": "5d838805ff6587d0b4eafae44c9ff74fc6beeca3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`5d838805`](https://github.com/nix-community/emacs-overlay/commit/5d838805ff6587d0b4eafae44c9ff74fc6beeca3) | `Updated repos/nongnu` |
| [`483c0162`](https://github.com/nix-community/emacs-overlay/commit/483c0162371d4a3e33c7f0dd83419c8645ed6db5) | `Updated repos/melpa`  |
| [`deef17ed`](https://github.com/nix-community/emacs-overlay/commit/deef17ed2172013214167ed6a06c67f4f30c059e) | `Updated repos/emacs`  |