### PR TITLE
chore(flake/emacs-ement): `e9cec7bb` -> `81caaae8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1666451502,
-        "narHash": "sha256-5OZiiksCja3Rpot1FkIK9GFmouKz3D6HMh1erNLJGBU=",
+        "lastModified": 1666616721,
+        "narHash": "sha256-dCuXXXfvljX0iHjLyPvmffcjimgwkFv3qqUHji/O7Bo=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "e9cec7bb5feae3cc8f9345b34ad395d97790a37b",
+        "rev": "81caaae8fd33b67759bbd7403e3e98143acb2915",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                    |
| --------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`81caaae8`](https://github.com/alphapapa/ement.el/commit/81caaae8fd33b67759bbd7403e3e98143acb2915) | `Fix: taxy-magit-section version` |