### PR TITLE
chore(flake/emacs-overlay): `5d838805` -> `58d63216`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666612413,
-        "narHash": "sha256-3K3PanV+pkixNo/sPN2YLGZffiQXcVAIGo2gaNDCWHs=",
+        "lastModified": 1666641778,
+        "narHash": "sha256-C5EHT/gi7FtEiPnKDUT2GK0/v46xXMIY8FgNsOHHCS0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5d838805ff6587d0b4eafae44c9ff74fc6beeca3",
+        "rev": "58d63216b84f9399db23048c537ee7c5d1842524",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`58d63216`](https://github.com/nix-community/emacs-overlay/commit/58d63216b84f9399db23048c537ee7c5d1842524) | `Updated repos/melpa` |
| [`bba39bf9`](https://github.com/nix-community/emacs-overlay/commit/bba39bf9b2e5e616e4527a18e86f06f87608848d) | `Updated repos/emacs` |