### PR TITLE
chore(flake/emacs-overlay): `58d63216` -> `6ad04079`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666641778,
-        "narHash": "sha256-C5EHT/gi7FtEiPnKDUT2GK0/v46xXMIY8FgNsOHHCS0=",
+        "lastModified": 1666678027,
+        "narHash": "sha256-TYLiybC/wqJ30PhvzdasULBXvc54tiARF1PopP9puVM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "58d63216b84f9399db23048c537ee7c5d1842524",
+        "rev": "6ad04079d54ca9ae6770dc72b51184537c8e768b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`6ad04079`](https://github.com/nix-community/emacs-overlay/commit/6ad04079d54ca9ae6770dc72b51184537c8e768b) | `Updated repos/nongnu` |
| [`ca817b6f`](https://github.com/nix-community/emacs-overlay/commit/ca817b6f306f15ba8a8f3c1841acbf15a4375af1) | `Updated repos/melpa`  |
| [`120a9c83`](https://github.com/nix-community/emacs-overlay/commit/120a9c830d9605fc4dd4ef85120a09ce2ac07f38) | `Updated repos/emacs`  |