### PR TITLE
chore(flake/emacs-overlay): `6ad04079` -> `87099c47`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666678027,
-        "narHash": "sha256-TYLiybC/wqJ30PhvzdasULBXvc54tiARF1PopP9puVM=",
+        "lastModified": 1666691950,
+        "narHash": "sha256-0+gJByTBEY/GlXXaV6b40ZgRJ0tH7YZubLGCQdVJFww=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6ad04079d54ca9ae6770dc72b51184537c8e768b",
+        "rev": "87099c473e76a499ee78fcc4cda9f7c0a88db0ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`87099c47`](https://github.com/nix-community/emacs-overlay/commit/87099c473e76a499ee78fcc4cda9f7c0a88db0ca) | `Updated repos/nongnu` |
| [`d13cb8a2`](https://github.com/nix-community/emacs-overlay/commit/d13cb8a200caa5bb2d78ef083179e96c340fd2da) | `Updated repos/melpa`  |