### PR TITLE
chore(flake/emacs-overlay): `87099c47` -> `90ba71c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666691950,
-        "narHash": "sha256-0+gJByTBEY/GlXXaV6b40ZgRJ0tH7YZubLGCQdVJFww=",
+        "lastModified": 1666730982,
+        "narHash": "sha256-jiHLm594HU1bc3Aw84jbd1Mj6GzR2d3MfIoEVM6ohNk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "87099c473e76a499ee78fcc4cda9f7c0a88db0ca",
+        "rev": "90ba71c4d9f760a6463023c8e9f67093f0d65ae4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`90ba71c4`](https://github.com/nix-community/emacs-overlay/commit/90ba71c4d9f760a6463023c8e9f67093f0d65ae4) | `Updated repos/melpa` |
| [`ccaceb6f`](https://github.com/nix-community/emacs-overlay/commit/ccaceb6fc03ff975843a699ced2c83dfe580bbc7) | `Updated repos/emacs` |
| [`e82a3411`](https://github.com/nix-community/emacs-overlay/commit/e82a341152b39cb1e12398abc799b1dc983047e5) | `Updated repos/elpa`  |