### PR TITLE
chore(flake/emacs-overlay): `90ba71c4` -> `67e25181`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666730982,
-        "narHash": "sha256-jiHLm594HU1bc3Aw84jbd1Mj6GzR2d3MfIoEVM6ohNk=",
+        "lastModified": 1666760262,
+        "narHash": "sha256-zSk9Eze0QPyeiU4rkWIdUDzlAqxYIAhtRbb/Lu4aEgc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "90ba71c4d9f760a6463023c8e9f67093f0d65ae4",
+        "rev": "67e2518161654552886a3eb6fbf9db35ac9df64f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`67e25181`](https://github.com/nix-community/emacs-overlay/commit/67e2518161654552886a3eb6fbf9db35ac9df64f) | `Updated repos/nongnu` |
| [`53c8b2ca`](https://github.com/nix-community/emacs-overlay/commit/53c8b2cad2ded6cac3646b47d5898a172b9b3e8e) | `Updated repos/melpa`  |
| [`0e7e0149`](https://github.com/nix-community/emacs-overlay/commit/0e7e0149d1ce872b09def88190b25d05e7fc3fdf) | `Updated repos/emacs`  |