### PR TITLE
chore(flake/emacs-overlay): `67e25181` -> `52b4a584`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666760262,
-        "narHash": "sha256-zSk9Eze0QPyeiU4rkWIdUDzlAqxYIAhtRbb/Lu4aEgc=",
+        "lastModified": 1666784648,
+        "narHash": "sha256-wVpP91AUThsQLWOh1V3Ecxo3QMjddJU0KE1Aa4u91fM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "67e2518161654552886a3eb6fbf9db35ac9df64f",
+        "rev": "52b4a58403f9103951631db70bcb740c8ca42a8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`52b4a584`](https://github.com/nix-community/emacs-overlay/commit/52b4a58403f9103951631db70bcb740c8ca42a8d) | `Updated repos/nongnu` |
| [`51fff9b2`](https://github.com/nix-community/emacs-overlay/commit/51fff9b287c92cb398839db4480b9ee19c0a98c6) | `Updated repos/melpa`  |
| [`737f27c6`](https://github.com/nix-community/emacs-overlay/commit/737f27c6571c125013888f458409a5ad465e78ca) | `Updated repos/emacs`  |