### PR TITLE
chore(flake/emacs-overlay): `52b4a584` -> `4efda86f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666784648,
-        "narHash": "sha256-wVpP91AUThsQLWOh1V3Ecxo3QMjddJU0KE1Aa4u91fM=",
+        "lastModified": 1666817217,
+        "narHash": "sha256-rFuM+hQV5u6EpECYHGVPe3HU2WtKTPOy1Ozv44J2JOU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "52b4a58403f9103951631db70bcb740c8ca42a8d",
+        "rev": "4efda86fd44a8fecf9d35dd47ab262b40ff79394",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`4efda86f`](https://github.com/nix-community/emacs-overlay/commit/4efda86fd44a8fecf9d35dd47ab262b40ff79394) | `Updated repos/melpa` |
| [`1a1da13a`](https://github.com/nix-community/emacs-overlay/commit/1a1da13a5694c63750650bb78ba03032815aa58d) | `Updated repos/emacs` |
| [`994ccd9f`](https://github.com/nix-community/emacs-overlay/commit/994ccd9fc07aa20f5236d6d477c1d29be0fc4677) | `Updated repos/elpa`  |