### PR TITLE
chore(flake/emacs-overlay): `4efda86f` -> `cdaafbd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666817217,
-        "narHash": "sha256-rFuM+hQV5u6EpECYHGVPe3HU2WtKTPOy1Ozv44J2JOU=",
+        "lastModified": 1666837668,
+        "narHash": "sha256-EAR96dIDxFdzukRruBLCecQe02a8v1HzWmIvLmd09eM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4efda86fd44a8fecf9d35dd47ab262b40ff79394",
+        "rev": "cdaafbd7700b461f13869610954014f317338600",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`cdaafbd7`](https://github.com/nix-community/emacs-overlay/commit/cdaafbd7700b461f13869610954014f317338600) | `Updated repos/nongnu` |
| [`fa938ece`](https://github.com/nix-community/emacs-overlay/commit/fa938ece18408d9c938c175f6f3ea4539d7f74c9) | `Updated repos/melpa`  |
| [`dcb9b0d1`](https://github.com/nix-community/emacs-overlay/commit/dcb9b0d1d3fb45fd65a128a35fe4aa1e76c279e3) | `Updated repos/elpa`   |