### PR TITLE
chore(flake/nixos-hardware): `0e659363` -> `e0edd212`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -263,11 +263,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1665987993,
-        "narHash": "sha256-MvlaIYTRiqefG4dzI5p6vVCfl+9V8A1cPniUjcn6Ngc=",
+        "lastModified": 1666850618,
+        "narHash": "sha256-aPBzSpuM3P0FNcIviELYFiPN8TxdSlvZhXGy5kwmhtc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "0e6593630071440eb89cd97a52921497482b22c6",
+        "rev": "e0edd2122f6c853bb96ebb4e1f64e01d48c64225",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                     |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`d6945f0c`](https://github.com/NixOS/nixos-hardware/commit/d6945f0ca1c2819a444b324d05b5fe27baeee89d) | `macbook-14-1: also add to README`                 |
| [`ba122332`](https://github.com/NixOS/nixos-hardware/commit/ba122332574dcd08291bb8c81140cfe2d04bf038) | `apple/macbook-pro/14-1: fix service script paths` |
| [`99ed0bc6`](https://github.com/NixOS/nixos-hardware/commit/99ed0bc663445cbb4d7501f120f5628e9e77c836) | `apple/macbook-pro: add support for 14,1`          |