### PR TITLE
chore(flake/nixos-hardware): `e0edd212` -> `dfd91284`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -263,11 +263,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1666850618,
-        "narHash": "sha256-aPBzSpuM3P0FNcIviELYFiPN8TxdSlvZhXGy5kwmhtc=",
+        "lastModified": 1666851028,
+        "narHash": "sha256-e6DpqCMGzlpkhZDuS2fdDX1DsauFk8NARqQ1DDF42VY=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e0edd2122f6c853bb96ebb4e1f64e01d48c64225",
+        "rev": "dfd91284332a4882c504b4807b1922e0fe386621",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`2c27afc7`](https://github.com/NixOS/nixos-hardware/commit/2c27afc7eda8f35327e9a8b7c6c45f4a9b1d602f) | `add lenovo/thinkpad/x1/yoga/7th-gen` |