### PR TITLE
chore(flake/emacs-overlay): `cdaafbd7` -> `8c3e6c2f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666837668,
-        "narHash": "sha256-EAR96dIDxFdzukRruBLCecQe02a8v1HzWmIvLmd09eM=",
+        "lastModified": 1666874755,
+        "narHash": "sha256-+rAaB/q0OpdX4FRJNVdJZErBPx3i00eAt70k8VEq67c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cdaafbd7700b461f13869610954014f317338600",
+        "rev": "8c3e6c2f6bacda8f86e87207b8509ceaec7f5853",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`8c3e6c2f`](https://github.com/nix-community/emacs-overlay/commit/8c3e6c2f6bacda8f86e87207b8509ceaec7f5853) | `Updated repos/melpa` |
| [`0422f1e6`](https://github.com/nix-community/emacs-overlay/commit/0422f1e6cec711e75dd7a43710b86d4d6f9db992) | `Updated repos/emacs` |