### PR TITLE
chore(flake/emacs-ement): `81caaae8` -> `9bcb6fd0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1666616721,
-        "narHash": "sha256-dCuXXXfvljX0iHjLyPvmffcjimgwkFv3qqUHji/O7Bo=",
+        "lastModified": 1666890098,
+        "narHash": "sha256-33qSH9NkqS3wvhj28hcr4rVHRaehqpEwR70BVc0YJEc=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "81caaae8fd33b67759bbd7403e3e98143acb2915",
+        "rev": "9bcb6fd01493e0dade41a65900c8422bebc805ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                 |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`9bcb6fd0`](https://github.com/alphapapa/ement.el/commit/9bcb6fd01493e0dade41a65900c8422bebc805ff) | `Fix: (ement-room-mark-read) "curl process interrupted" error` |