### PR TITLE
chore(flake/emacs-ement): `9bcb6fd0` -> `a5a8fb55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1666890098,
-        "narHash": "sha256-33qSH9NkqS3wvhj28hcr4rVHRaehqpEwR70BVc0YJEc=",
+        "lastModified": 1666893882,
+        "narHash": "sha256-EDaIIqTKj3wnpPGgzUIx9jFJpV310cO88N04C4kyFEU=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "9bcb6fd01493e0dade41a65900c8422bebc805ff",
+        "rev": "a5a8fb555f137d397accfb107b5dbda9093bd8da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                  |
| --------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`a5a8fb55`](https://github.com/alphapapa/ement.el/commit/a5a8fb555f137d397accfb107b5dbda9093bd8da) | `Tidy: Compilation warnings`    |
| [`cc97d0ec`](https://github.com/alphapapa/ement.el/commit/cc97d0eca7e9023631f37c0ae61de1fe628ac87b) | `Change/Fix: Room list avatars` |