### PR TITLE
chore(flake/emacs-overlay): `8c3e6c2f` -> `b3f81bcb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666874755,
-        "narHash": "sha256-+rAaB/q0OpdX4FRJNVdJZErBPx3i00eAt70k8VEq67c=",
+        "lastModified": 1666900021,
+        "narHash": "sha256-KEDx6LhRMxEdLXL1jF1LNIm+QCtOCcKcFmTJrA/iU3E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8c3e6c2f6bacda8f86e87207b8509ceaec7f5853",
+        "rev": "b3f81bcbda84bf2ef957cfff6cf89aedbdfa2be9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`b3f81bcb`](https://github.com/nix-community/emacs-overlay/commit/b3f81bcbda84bf2ef957cfff6cf89aedbdfa2be9) | `Updated repos/melpa` |
| [`8a7061d6`](https://github.com/nix-community/emacs-overlay/commit/8a7061d6d072c7d42ebad78fe7fb8c61bdaa286f) | `Updated repos/emacs` |