### PR TITLE
chore(flake/emacs-ement): `a5a8fb55` -> `d955562f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1666893882,
-        "narHash": "sha256-EDaIIqTKj3wnpPGgzUIx9jFJpV310cO88N04C4kyFEU=",
+        "lastModified": 1666902430,
+        "narHash": "sha256-R0sB7/9omvOz/W/VoBBpP78jJvfEfr8w2Fy4g6GP6QI=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "a5a8fb555f137d397accfb107b5dbda9093bd8da",
+        "rev": "d955562faaacbb720f008dfb494331d1511705e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                 |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`ebaeb41e`](https://github.com/alphapapa/ement.el/commit/ebaeb41ec680c70876d720ed28d1816f8f226562) | `Release: v0.4.1`                                              |
| [`24e82459`](https://github.com/alphapapa/ement.el/commit/24e82459e95a0af418a93bb61884b63d48c06bda) | `Fix: (ement-room-mark-read) "curl process interrupted" error` |
| [`752c8fb6`](https://github.com/alphapapa/ement.el/commit/752c8fb64ebf05980313d8ef614cdff6c915212d) | `Meta: v0.4.1-pre`                                             |