### PR TITLE
chore(flake/emacs-overlay): `b3f81bcb` -> `a1ffca78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666900021,
-        "narHash": "sha256-KEDx6LhRMxEdLXL1jF1LNIm+QCtOCcKcFmTJrA/iU3E=",
+        "lastModified": 1666935769,
+        "narHash": "sha256-jvf1mod8cE7XzNuLF2R1wK9cQWMdXjusipqhw7wj3nk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b3f81bcbda84bf2ef957cfff6cf89aedbdfa2be9",
+        "rev": "a1ffca78cf018cf9078a015b268cf5b22dddb017",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`a1ffca78`](https://github.com/nix-community/emacs-overlay/commit/a1ffca78cf018cf9078a015b268cf5b22dddb017) | `Updated repos/nongnu` |
| [`f63a5f5f`](https://github.com/nix-community/emacs-overlay/commit/f63a5f5f3826318d19f2fdb896d235c4c95722e7) | `Updated repos/melpa`  |
| [`4201e102`](https://github.com/nix-community/emacs-overlay/commit/4201e10223f4d8654a131f48f2db9cfd9537a3bf) | `Updated repos/emacs`  |
| [`921976d5`](https://github.com/nix-community/emacs-overlay/commit/921976d53781cf8c92b2ef26f3705c54b33f747f) | `Updated repos/elpa`   |