### PR TITLE
chore(flake/emacs-overlay): `a1ffca78` -> `c5a67519`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666935769,
-        "narHash": "sha256-jvf1mod8cE7XzNuLF2R1wK9cQWMdXjusipqhw7wj3nk=",
+        "lastModified": 1666957671,
+        "narHash": "sha256-QmFXa7AToYu1/xyo4jxo7wKpy0Ec6IYWVsQjKz4WqlM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a1ffca78cf018cf9078a015b268cf5b22dddb017",
+        "rev": "c5a67519099ded10354a96c268a9bdef8087161d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`c5a67519`](https://github.com/nix-community/emacs-overlay/commit/c5a67519099ded10354a96c268a9bdef8087161d) | `Updated repos/melpa` |
| [`93250939`](https://github.com/nix-community/emacs-overlay/commit/932509390d4005f18725a30471ad84de85c4b018) | `Updated repos/emacs` |