### PR TITLE
chore(flake/nix-on-droid): `2ef9a7fa` -> `5772a879`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -237,22 +237,20 @@
     },
     "nix-on-droid": {
       "inputs": {
-        "flake-utils": [
-          "utils"
-        ],
         "home-manager": [
           "home-manager"
         ],
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "nixpkgs-for-bootstrap": "nixpkgs-for-bootstrap"
       },
       "locked": {
-        "lastModified": 1665517021,
-        "narHash": "sha256-by8E2Ne97i6Ah7dqMRsVaccZ7xO9Cc90Xx+T4ocGegk=",
+        "lastModified": 1666972347,
+        "narHash": "sha256-co1thMrkU5xYnRgLflI/Am83acDW1eB3qGQvIMOeork=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "2ef9a7faa2f59bd26eb250384096c3eb1f76d7e9",
+        "rev": "5772a879a1a7e42ae9b571d8d797234a74bb860a",
         "type": "github"
       },
       "original": {
@@ -303,6 +301,22 @@
         "owner": "NixOS",
         "ref": "release-22.05",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-for-bootstrap": {
+      "locked": {
+        "lastModified": 1656265786,
+        "narHash": "sha256-A9RkoGrxzsmMm0vily18p92Rasb+MbdDMaSnzmywXKw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cd90e773eae83ba7733d2377b6cdf84d45558780",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cd90e773eae83ba7733d2377b6cdf84d45558780",
         "type": "github"
       }
     },


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                           |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`5772a879`](https://github.com/t184256/nix-on-droid/commit/5772a879a1a7e42ae9b571d8d797234a74bb860a) | `ci: update github actions`                              |
| [`1dc1cd67`](https://github.com/t184256/nix-on-droid/commit/1dc1cd67a47890c4b209fd16c181280788b0897f) | `bootstrap: override flake inputs if needed`             |
| [`3629a122`](https://github.com/t184256/nix-on-droid/commit/3629a12231ed354435f39dbb70e77e0794856748) | `merge multiple extra-experimental-features args`        |
| [`b8ac792d`](https://github.com/t184256/nix-on-droid/commit/b8ac792d3c94c8a1ca045d80c9e1f53208ae837f) | `build.sh: update to flakified bootstrap creation`       |
| [`b01a2a8a`](https://github.com/t184256/nix-on-droid/commit/b01a2a8a57b0854be4bb6c87b3de76fc43d7b211) | `bootstrap: use env vars to set custom channel urls`     |
| [`bb8ac7fe`](https://github.com/t184256/nix-on-droid/commit/bb8ac7fe1f980da8bb0998b9fecabe9156497a84) | `flake: remove flake-utils`                              |
| [`fa250d1c`](https://github.com/t184256/nix-on-droid/commit/fa250d1c54141ba8c0bd597239648f23760c1964) | `ci: remove set up of NIX_PATH`                          |
| [`138145d3`](https://github.com/t184256/nix-on-droid/commit/138145d3b1bb263bce36acf1302f533dc4e283a2) | `flake: sort outputs alphabetically`                     |
| [`c0b87d96`](https://github.com/t184256/nix-on-droid/commit/c0b87d967f634902e8ce1478e99469a219bb92d5) | `bootstrap: add prompt to bootstrap with flakes setup`   |
| [`59004046`](https://github.com/t184256/nix-on-droid/commit/5900404627b08ad638129d56d375b27b5c623a66) | `bootstrap: inject nixOnDroidFlakeURL`                   |
| [`c4365ef0`](https://github.com/t184256/nix-on-droid/commit/c4365ef01032035c650c1ddd60096f7ebbab4b0d) | `environment.path: add support for nix profile`          |
| [`2d73773e`](https://github.com/t184256/nix-on-droid/commit/2d73773ed7f6f650747d0d1591ac215fd6058a2d) | `flake: add nix-on-droid as flake package`               |
| [`d21dce1a`](https://github.com/t184256/nix-on-droid/commit/d21dce1a414b8446eca95757aaca7d6a983daade) | `docs: update examples and default config`               |
| [`f4edb7be`](https://github.com/t184256/nix-on-droid/commit/f4edb7be868ea95ddf876a25ea5edd6f713c16a9) | `templates: add templates for some use cases`            |
| [`8b33a283`](https://github.com/t184256/nix-on-droid/commit/8b33a2837026e792ac40027534fbf9466216782f) | `CHANGELOG: document flakification of project`           |
| [`5d9e3c3d`](https://github.com/t184256/nix-on-droid/commit/5d9e3c3dd1cae009f2853381d2563844f7ba8db2) | `tests: refactor to support flake setup`                 |
| [`004faf18`](https://github.com/t184256/nix-on-droid/commit/004faf1835717dec73d7539d63052d648526fd74) | `ci: remove extra_nix_config for flakes and nix-command` |
| [`2b88cb59`](https://github.com/t184256/nix-on-droid/commit/2b88cb59572493f6b4449e42e8f00897d6a4fb1c) | `ci: replace ci.nix with build of bootstrapZip`          |
| [`7cea00a1`](https://github.com/t184256/nix-on-droid/commit/7cea00a1c709b5321fa1194379b0b58ac944471f) | `tests: increase robustness of fakedroid.sh`             |
| [`274bb4ba`](https://github.com/t184256/nix-on-droid/commit/274bb4babd866b9e582fbb316f2da56b06fa8a6f) | `bootstrap: flakify bootstrap zip ball generation`       |
| [`b10dd78e`](https://github.com/t184256/nix-on-droid/commit/b10dd78e183f76dbb15711475fa7643b55046757) | `bootstrap: refactor special args to reduce inputs`      |