### PR TITLE
chore(flake/emacs-overlay): `c5a67519` -> `87fd982e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666957671,
-        "narHash": "sha256-QmFXa7AToYu1/xyo4jxo7wKpy0Ec6IYWVsQjKz4WqlM=",
+        "lastModified": 1666989765,
+        "narHash": "sha256-bPwGXizMQnXxEsKt1n0lGGB8kiaXhmehu1pSy0VwCow=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c5a67519099ded10354a96c268a9bdef8087161d",
+        "rev": "87fd982e510d78c7ed61df5a0e339fe57f858f87",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`87fd982e`](https://github.com/nix-community/emacs-overlay/commit/87fd982e510d78c7ed61df5a0e339fe57f858f87) | `Updated repos/melpa` |
| [`74cc6c27`](https://github.com/nix-community/emacs-overlay/commit/74cc6c27d89cd5c2854432f1cfd135fc921d80f9) | `Updated repos/emacs` |
| [`206b2ac5`](https://github.com/nix-community/emacs-overlay/commit/206b2ac5119038fdeb77961444bdf6e8386be11c) | `Updated repos/elpa`  |