### PR TITLE
chore(flake/emacs-overlay): `87fd982e` -> `2891c0c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666989765,
-        "narHash": "sha256-bPwGXizMQnXxEsKt1n0lGGB8kiaXhmehu1pSy0VwCow=",
+        "lastModified": 1667020827,
+        "narHash": "sha256-DbAWlUJlVeFgNdKb+j7NKg+fWoTWnOzlLXbqeOPUzH8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "87fd982e510d78c7ed61df5a0e339fe57f858f87",
+        "rev": "2891c0c12ad28fb24eafbce9a273553d3ef94def",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`2891c0c1`](https://github.com/nix-community/emacs-overlay/commit/2891c0c12ad28fb24eafbce9a273553d3ef94def) | `Updated repos/melpa` |
| [`b05302d5`](https://github.com/nix-community/emacs-overlay/commit/b05302d56cdf4fe1e09bee58707e671ca8532784) | `Updated repos/emacs` |
| [`79ce2e59`](https://github.com/nix-community/emacs-overlay/commit/79ce2e59fc8da99cc9853dccbc4b446fad047676) | `Updated repos/elpa`  |