### PR TITLE
chore(flake/emacs-overlay): `2891c0c1` -> `feea89fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667020827,
-        "narHash": "sha256-DbAWlUJlVeFgNdKb+j7NKg+fWoTWnOzlLXbqeOPUzH8=",
+        "lastModified": 1667047790,
+        "narHash": "sha256-hSZykZpxo8b/IwCD8hChvLXu9HlDZBiFZWRYHypgOjs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2891c0c12ad28fb24eafbce9a273553d3ef94def",
+        "rev": "feea89fbc310afc87dff52ae0a1bc4afabfcbd43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`feea89fb`](https://github.com/nix-community/emacs-overlay/commit/feea89fbc310afc87dff52ae0a1bc4afabfcbd43) | `Updated repos/melpa` |
| [`9675b4e1`](https://github.com/nix-community/emacs-overlay/commit/9675b4e1d86fe90d27f6b61b96e24a72b3f862bc) | `Updated repos/emacs` |