### PR TITLE
chore(flake/emacs-overlay): `feea89fb` -> `4a44c7df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667047790,
-        "narHash": "sha256-hSZykZpxo8b/IwCD8hChvLXu9HlDZBiFZWRYHypgOjs=",
+        "lastModified": 1667109116,
+        "narHash": "sha256-LLDHrCT8DScvl9QOwwTQFbOH8X2GV5Geo1C29vmw3Q0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "feea89fbc310afc87dff52ae0a1bc4afabfcbd43",
+        "rev": "4a44c7dfdea3e794b25eae37773c9a89c4fb1526",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`4a44c7df`](https://github.com/nix-community/emacs-overlay/commit/4a44c7dfdea3e794b25eae37773c9a89c4fb1526) | `Updated repos/nongnu` |
| [`9ec3de0f`](https://github.com/nix-community/emacs-overlay/commit/9ec3de0fef1399241be32a730385d6e738d6703b) | `Updated repos/melpa`  |
| [`86928a52`](https://github.com/nix-community/emacs-overlay/commit/86928a5201089a30c0e3f59dd48c0fd29db1f53e) | `Updated repos/emacs`  |
| [`e8b9a442`](https://github.com/nix-community/emacs-overlay/commit/e8b9a442257fce8ad6282a634b82c3fc74a27775) | `Updated repos/elpa`   |
| [`d078c99b`](https://github.com/nix-community/emacs-overlay/commit/d078c99b943d96fdffe831dfb9ea1cbfca57a357) | `Updated repos/melpa`  |
| [`b52e5604`](https://github.com/nix-community/emacs-overlay/commit/b52e56040e56fec18d9da5f221b05e97429fde1c) | `Updated repos/emacs`  |
| [`19f915a7`](https://github.com/nix-community/emacs-overlay/commit/19f915a726ae8dcd99e4a1b4cd76111f91914a61) | `Updated repos/elpa`   |