### PR TITLE
chore(flake/emacs-overlay): `dcc80577` -> `d5395935`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667130250,
-        "narHash": "sha256-gciS5FqCYfC2hQUII2uan1V/vqQw1T3/7bzgK6OT7D8=",
+        "lastModified": 1667160042,
+        "narHash": "sha256-Gck+WbnlVe8JZf90NTqCXc5NGPIuIu2AyJUaXghpQxw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dcc8057790ff01b7d745123e61e037bf32c8c753",
+        "rev": "d53959356bf17656f82d90ab5d7346fb3107896f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`d5395935`](https://github.com/nix-community/emacs-overlay/commit/d53959356bf17656f82d90ab5d7346fb3107896f) | `Updated repos/melpa` |
| [`ea41c1a2`](https://github.com/nix-community/emacs-overlay/commit/ea41c1a2973d87998ef9f6308a80cb02d1be11c7) | `Updated repos/emacs` |
| [`2b63b968`](https://github.com/nix-community/emacs-overlay/commit/2b63b96857b5707d249afeccbd9ed393b4dca4b8) | `Updated repos/elpa`  |