### PR TITLE
chore(flake/emacs-overlay): `d5395935` -> `dd6b9bbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667160042,
-        "narHash": "sha256-Gck+WbnlVe8JZf90NTqCXc5NGPIuIu2AyJUaXghpQxw=",
+        "lastModified": 1667196736,
+        "narHash": "sha256-0IGG8SK9AHksLraRK47S/0/gEOEjn1eQWor8UPjfQ4g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d53959356bf17656f82d90ab5d7346fb3107896f",
+        "rev": "dd6b9bbc728b9eb1c53738cf64d067384dfa269a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`dd6b9bbc`](https://github.com/nix-community/emacs-overlay/commit/dd6b9bbc728b9eb1c53738cf64d067384dfa269a) | `Updated repos/melpa` |
| [`7b44a070`](https://github.com/nix-community/emacs-overlay/commit/7b44a070e4957ae59ad37ae18a7e66ef23510500) | `Updated repos/emacs` |
| [`b19a04ef`](https://github.com/nix-community/emacs-overlay/commit/b19a04efef3d883c3c70ae1467c1c44596b16519) | `Updated repos/elpa`  |