### PR TITLE
chore(flake/emacs-overlay): `dd6b9bbc` -> `84217c53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667196736,
-        "narHash": "sha256-0IGG8SK9AHksLraRK47S/0/gEOEjn1eQWor8UPjfQ4g=",
+        "lastModified": 1667211759,
+        "narHash": "sha256-Vn5BKKjzY43VLQJOLXhfljVsIAlSrA9DW4vlMxIIm8w=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dd6b9bbc728b9eb1c53738cf64d067384dfa269a",
+        "rev": "84217c538479607814bfeac188ab090d66a47083",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`84217c53`](https://github.com/nix-community/emacs-overlay/commit/84217c538479607814bfeac188ab090d66a47083) | `Updated repos/nongnu` |
| [`04e3051b`](https://github.com/nix-community/emacs-overlay/commit/04e3051b28ced95ffb63d6b5ee12da25d33a5760) | `Updated repos/melpa`  |
| [`e541634b`](https://github.com/nix-community/emacs-overlay/commit/e541634ba14d3a04e52ca0af9735ccef0e10c271) | `Updated repos/emacs`  |