### PR TITLE
chore(flake/nixos-hardware): `419dcc0e` -> `d5bacd34`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -261,11 +261,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1666873549,
-        "narHash": "sha256-a6Eu1Qv/EndjepSMja5SvcG+4vM5Rl2gzJD7xscRHss=",
+        "lastModified": 1667221253,
+        "narHash": "sha256-PGGT7D/qmi1E8D1Z32SLrzq7PJO5CajD64GfCCdslk0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "419dcc0ec767803182ed01a326f134230578bf60",
+        "rev": "d5bacd34f54328f31bef9237098fdeaad83074be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                             |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`e79d0fc1`](https://github.com/NixOS/nixos-hardware/commit/e79d0fc1849c271d8398816748ba38a892f2e488) | `framework: Add iio in order to enable brightness control` |