### PR TITLE
chore(flake/emacs-overlay): `84217c53` -> `eb10ed32`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667211759,
-        "narHash": "sha256-Vn5BKKjzY43VLQJOLXhfljVsIAlSrA9DW4vlMxIIm8w=",
+        "lastModified": 1667246607,
+        "narHash": "sha256-/uuXu7yu5EgpNOg2i3pqM6du7jjIHkpGiV4djmb0QVk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "84217c538479607814bfeac188ab090d66a47083",
+        "rev": "eb10ed32ed3808545382c9509ef6ee46f3716804",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`eb10ed32`](https://github.com/nix-community/emacs-overlay/commit/eb10ed32ed3808545382c9509ef6ee46f3716804) | `Updated repos/melpa` |
| [`f63f2c63`](https://github.com/nix-community/emacs-overlay/commit/f63f2c63f3a50ab45a465c8983a7e77ff453e1b2) | `Updated repos/emacs` |
| [`7d7dee93`](https://github.com/nix-community/emacs-overlay/commit/7d7dee932bf72472a7bf8eba2707cfc7ffe629ab) | `Updated repos/elpa`  |