### PR TITLE
chore(flake/emacs-overlay): `eb10ed32` -> `cb7c1a56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667246607,
-        "narHash": "sha256-/uuXu7yu5EgpNOg2i3pqM6du7jjIHkpGiV4djmb0QVk=",
+        "lastModified": 1667279950,
+        "narHash": "sha256-lwcQ7sy0GzKG/GYZM3fennTW1/wIpTikurYq+LybnZc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "eb10ed32ed3808545382c9509ef6ee46f3716804",
+        "rev": "cb7c1a5695d398a4c11501073d67735a5f876388",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`cb7c1a56`](https://github.com/nix-community/emacs-overlay/commit/cb7c1a5695d398a4c11501073d67735a5f876388) | `Updated repos/nongnu` |
| [`562f03ce`](https://github.com/nix-community/emacs-overlay/commit/562f03ce976b536e7d0e3ebd3d169252832a0535) | `Updated repos/melpa`  |
| [`46985e57`](https://github.com/nix-community/emacs-overlay/commit/46985e574492dca56e71b0e54c88e663dc068e6d) | `Updated repos/emacs`  |
| [`ff110333`](https://github.com/nix-community/emacs-overlay/commit/ff110333dae4e7d2999177ec21a50fd17b5c0efe) | `Updated repos/elpa`   |