### PR TITLE
chore(flake/emacs-overlay): `cb7c1a56` -> `ab39e411`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667279950,
-        "narHash": "sha256-lwcQ7sy0GzKG/GYZM3fennTW1/wIpTikurYq+LybnZc=",
+        "lastModified": 1667306639,
+        "narHash": "sha256-KSXwI/MwkEE5oVpXSsRF19CzDzjfGgkGDPCYRSwXMFY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cb7c1a5695d398a4c11501073d67735a5f876388",
+        "rev": "ab39e4112f2f97fa5e13865fa6792e00e6344558",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ab39e411`](https://github.com/nix-community/emacs-overlay/commit/ab39e4112f2f97fa5e13865fa6792e00e6344558) | `Updated repos/melpa` |
| [`e2f22abd`](https://github.com/nix-community/emacs-overlay/commit/e2f22abd1e08a71a1c78a4a743e9d64f08a41bba) | `Updated repos/emacs` |