### PR TITLE
chore(flake/emacs-overlay): `ab39e411` -> `ae21b52e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667306639,
-        "narHash": "sha256-KSXwI/MwkEE5oVpXSsRF19CzDzjfGgkGDPCYRSwXMFY=",
+        "lastModified": 1667332581,
+        "narHash": "sha256-GaDFhIxxUmjptlHwQMpIJT2QM6AMzeAl9Y+9Jku0LFo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ab39e4112f2f97fa5e13865fa6792e00e6344558",
+        "rev": "ae21b52edf29524933af2b25dfc49f4667676c55",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ae21b52e`](https://github.com/nix-community/emacs-overlay/commit/ae21b52edf29524933af2b25dfc49f4667676c55) | `Updated repos/melpa` |
| [`bcd8263a`](https://github.com/nix-community/emacs-overlay/commit/bcd8263acbcfc7ed9b832e06b39fb4ab419cfe40) | `Updated repos/emacs` |