### PR TITLE
chore(flake/home-manager): `04e84409` -> `916811c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667347482,
-        "narHash": "sha256-KuRYeitjusSdkJ/PeHzPfAIVwVjbtG5v+To6ffy8tiQ=",
+        "lastModified": 1667386877,
+        "narHash": "sha256-CP8CbIiykhevS9KsFO5kKP7CfrnGjORhvkHV6PMyh90=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "04e844090ed17298bfbe0f8249109b15770571bc",
+        "rev": "916811c8f9ef37beb7705150d76cc88ce79466fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message       |
| ----------------------------------------------------------------------------------------------------------- | -------------------- |
| [`916811c8`](https://github.com/nix-community/home-manager/commit/916811c8f9ef37beb7705150d76cc88ce79466fd) | `xfconf: add module` |