### PR TITLE
chore(flake/pre-commit-hooks): `a7cbf54c` -> `bc84486f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667392064,
-        "narHash": "sha256-dD1uFtvjrYKkzdVjzu/x6S5GUKrCq33/AxY/DNs4ER8=",
+        "lastModified": 1667394294,
+        "narHash": "sha256-OzozPdjVrbCvotCIYYTEoAc3Hcfh2wgkelvJtqRft1Y=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "a7cbf54c1ffe46e1a1112a1f55047263c9af06b5",
+        "rev": "bc84486fe18bc71a4f5ad5f7026cb3f7f39e61ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message  |
| ------------------------------------------------------------------------------------------------------------ | --------------- |
| [`bc84486f`](https://github.com/cachix/pre-commit-hooks.nix/commit/bc84486fe18bc71a4f5ad5f7026cb3f7f39e61ac) | `no more lorri` |