### PR TITLE
chore(flake/emacs-ement): `d955562f` -> `f2ba62c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1666902430,
-        "narHash": "sha256-R0sB7/9omvOz/W/VoBBpP78jJvfEfr8w2Fy4g6GP6QI=",
+        "lastModified": 1667395988,
+        "narHash": "sha256-RWUSPT4QXw83YOozVjCHckT7hEZc9TSv4g93Wf2HQkM=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "d955562faaacbb720f008dfb494331d1511705e0",
+        "rev": "f2ba62c81387f1d54dae4873b46bcf1226503584",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                      |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`f2ba62c8`](https://github.com/alphapapa/ement.el/commit/f2ba62c81387f1d54dae4873b46bcf1226503584) | `Add: (ement-room--format-membership-events) joined-and-left pairs` |