### PR TITLE
chore(flake/pre-commit-hooks): `bc84486f` -> `3c3a9b48`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667394294,
-        "narHash": "sha256-OzozPdjVrbCvotCIYYTEoAc3Hcfh2wgkelvJtqRft1Y=",
+        "lastModified": 1667395358,
+        "narHash": "sha256-XZz4M000K5FefEanQTDmLZbh+/WHxwS1yxQJfBgm3co=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "bc84486fe18bc71a4f5ad5f7026cb3f7f39e61ac",
+        "rev": "3c3a9b48116547449cd51dc1b24e8afc16568492",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`3c3a9b48`](https://github.com/cachix/pre-commit-hooks.nix/commit/3c3a9b48116547449cd51dc1b24e8afc16568492) | `remove 20y old arch` |
| [`7b1e0d79`](https://github.com/cachix/pre-commit-hooks.nix/commit/7b1e0d7900639edeed905ae7709079f703fd13ad) | `bump flake.lock`     |