### PR TITLE
chore(flake/nur): `b55b9f79` -> `0fac4e77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667398261,
-        "narHash": "sha256-fnTaNwUVjco9a3nxgg47JRf3Zt21bk7n2YBa/M1w7gM=",
+        "lastModified": 1667412874,
+        "narHash": "sha256-pF0ILR/RY20A4zSZNrxUIFHPhBkqaUxgkEyWRHgdJPg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b55b9f795d31a3e4f27bb944178f9e5fedbcb8f4",
+        "rev": "0fac4e77468dc96c63c4cb9e23d975fcec5dc738",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0fac4e77`](https://github.com/nix-community/NUR/commit/0fac4e77468dc96c63c4cb9e23d975fcec5dc738) | `automatic update` |