### PR TITLE
chore(flake/nur): `0fac4e77` -> `c6bf6776`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667412874,
-        "narHash": "sha256-pF0ILR/RY20A4zSZNrxUIFHPhBkqaUxgkEyWRHgdJPg=",
+        "lastModified": 1667415416,
+        "narHash": "sha256-7nnNjaN9h7dniAhDhXPSZ8WYKhLYEnHE50kcYf2GpUU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0fac4e77468dc96c63c4cb9e23d975fcec5dc738",
+        "rev": "c6bf677651d706b69aceba01ddb3c032244bb063",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c6bf6776`](https://github.com/nix-community/NUR/commit/c6bf677651d706b69aceba01ddb3c032244bb063) | `automatic update` |