### PR TITLE
chore(flake/emacs-overlay): `f8e2ddd5` -> `76be734c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667390344,
-        "narHash": "sha256-SUp0LemkQHZR7hVKNi2PAwsC9PwxIsW+SKGySdIBWdA=",
+        "lastModified": 1667419897,
+        "narHash": "sha256-4+IVz2pOeUpG1EKShY1ohDndqO1PyQjGi+DksTAOE7M=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f8e2ddd5bc27b1d5be1a63f27fdde58dc5a1297f",
+        "rev": "76be734ca0a6a3c9649de4beab626e8990e10333",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`76be734c`](https://github.com/nix-community/emacs-overlay/commit/76be734ca0a6a3c9649de4beab626e8990e10333) | `Updated repos/nongnu` |
| [`89f4ae75`](https://github.com/nix-community/emacs-overlay/commit/89f4ae7539fa59eb122d9ce8198e1926f925727e) | `Updated repos/melpa`  |
| [`380e40d4`](https://github.com/nix-community/emacs-overlay/commit/380e40d49b71b43c6d18738afc631f8e80ba3e79) | `Updated repos/emacs`  |