### PR TITLE
chore(flake/nur): `da894c6a` -> `5845fabf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667416719,
-        "narHash": "sha256-xFYKwm6hiIz0WHQGrjVO93rIWuuTNx3ERhvJmdAoCUg=",
+        "lastModified": 1667419824,
+        "narHash": "sha256-XqPjWyY5h8RkPas7ghMQs0NSeiO8UEaRDg4QfYeaqko=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "da894c6a25c137d2944d32b893d1891dbd321967",
+        "rev": "5845fabf75ddf10067a141bd761e891738d725a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5845fabf`](https://github.com/nix-community/NUR/commit/5845fabf75ddf10067a141bd761e891738d725a1) | `automatic update` |