### PR TITLE
chore(flake/nur): `ee547a16` -> `8dc0f200`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667433328,
-        "narHash": "sha256-MM2LL0CRB6IH+sAA/fNSHLyW4VzZwKo8NwyRtw9O8qY=",
+        "lastModified": 1667442639,
+        "narHash": "sha256-X9kaCzIGR24amVcj+rXr1AwOiIw8qEaqaBib6uqxKlg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ee547a161f275404bd2b6beeb8b0ba0e496dcb16",
+        "rev": "8dc0f200d754a48c23d0ec9425f736896a3e193e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8dc0f200`](https://github.com/nix-community/NUR/commit/8dc0f200d754a48c23d0ec9425f736896a3e193e) | `automatic update` |