### PR TITLE
chore(flake/nur): `8dc0f200` -> `7c631c0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667442639,
-        "narHash": "sha256-X9kaCzIGR24amVcj+rXr1AwOiIw8qEaqaBib6uqxKlg=",
+        "lastModified": 1667445098,
+        "narHash": "sha256-6EvdA+KBhrEBPJo4dXDt8JwEGtkukmn19CpWU6v8nu0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8dc0f200d754a48c23d0ec9425f736896a3e193e",
+        "rev": "7c631c0b6b5666f7fc6db8b9cb73034b8aea4842",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7c631c0b`](https://github.com/nix-community/NUR/commit/7c631c0b6b5666f7fc6db8b9cb73034b8aea4842) | `automatic update` |