### PR TITLE
chore(flake/nur): `7c631c0b` -> `1fd38ac8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667445098,
-        "narHash": "sha256-6EvdA+KBhrEBPJo4dXDt8JwEGtkukmn19CpWU6v8nu0=",
+        "lastModified": 1667448495,
+        "narHash": "sha256-xgXBnx16zYj+PcrorOZ4oDBR1yGw/o4G7WrY+GR3zhw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7c631c0b6b5666f7fc6db8b9cb73034b8aea4842",
+        "rev": "1fd38ac822bdf6103f2d0bdb8be41fa363123c85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1fd38ac8`](https://github.com/nix-community/NUR/commit/1fd38ac822bdf6103f2d0bdb8be41fa363123c85) | `automatic update` |