### PR TITLE
chore(flake/nur): `1fd38ac8` -> `d6f6ceb5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667448495,
-        "narHash": "sha256-xgXBnx16zYj+PcrorOZ4oDBR1yGw/o4G7WrY+GR3zhw=",
+        "lastModified": 1667449463,
+        "narHash": "sha256-NJnUitNFU+TJK9uLDx+4PxYCG6LanPBJDe7dvOGx338=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1fd38ac822bdf6103f2d0bdb8be41fa363123c85",
+        "rev": "d6f6ceb5b9ec0d06ea6e16d10c7a0e262d3c3a64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d6f6ceb5`](https://github.com/nix-community/NUR/commit/d6f6ceb5b9ec0d06ea6e16d10c7a0e262d3c3a64) | `automatic update` |