### PR TITLE
chore(flake/emacs-overlay): `76be734c` -> `a0d5fcbe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667419897,
-        "narHash": "sha256-4+IVz2pOeUpG1EKShY1ohDndqO1PyQjGi+DksTAOE7M=",
+        "lastModified": 1667451806,
+        "narHash": "sha256-M7ksOgLh5+tIchbwBX0VI5MIKH9p4v8QVOD/UvtLCZk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "76be734ca0a6a3c9649de4beab626e8990e10333",
+        "rev": "a0d5fcbec0f9b5613c3109d434b6ff4e5b419ae8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`a0d5fcbe`](https://github.com/nix-community/emacs-overlay/commit/a0d5fcbec0f9b5613c3109d434b6ff4e5b419ae8) | `Updated repos/melpa` |
| [`e2e67e3a`](https://github.com/nix-community/emacs-overlay/commit/e2e67e3a5327bccb0eafac46cf0a72dbf9cf9bce) | `Updated repos/emacs` |
| [`c3faa1e8`](https://github.com/nix-community/emacs-overlay/commit/c3faa1e8ddf2bf4e859c3cbeba913de67f75fa27) | `Updated repos/elpa`  |