### PR TITLE
chore(flake/nur): `d6f6ceb5` -> `3ad86511`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667449463,
-        "narHash": "sha256-NJnUitNFU+TJK9uLDx+4PxYCG6LanPBJDe7dvOGx338=",
+        "lastModified": 1667452502,
+        "narHash": "sha256-AZhjoXWh/78Ww440vbZQ5pS5f1hflBtSHj2OlI1S+jA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d6f6ceb5b9ec0d06ea6e16d10c7a0e262d3c3a64",
+        "rev": "3ad86511b3e0a2cf2c38eafce8ffa23922ac2231",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3ad86511`](https://github.com/nix-community/NUR/commit/3ad86511b3e0a2cf2c38eafce8ffa23922ac2231) | `automatic update` |