### PR TITLE
chore(flake/nur): `3ad86511` -> `ee8a9dba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667452502,
-        "narHash": "sha256-AZhjoXWh/78Ww440vbZQ5pS5f1hflBtSHj2OlI1S+jA=",
+        "lastModified": 1667460978,
+        "narHash": "sha256-yP0c3Hh45Eb30LwPeT/KikkX7DvcpI4Ke2DX9+xsW7w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3ad86511b3e0a2cf2c38eafce8ffa23922ac2231",
+        "rev": "ee8a9dba687d4b79e9a5bcb9e3e1e0f2eb3060fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ee8a9dba`](https://github.com/nix-community/NUR/commit/ee8a9dba687d4b79e9a5bcb9e3e1e0f2eb3060fd) | `automatic update` |