### PR TITLE
chore(flake/home-manager): `f520832a` -> `93335810`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667410913,
-        "narHash": "sha256-5+S65dpXaIyMDeoPy823BzNH5HYY1wvZ6G+rzTnO8kY=",
+        "lastModified": 1667468181,
+        "narHash": "sha256-806/nrDW6e7bl4/oJEdAykYz/NaBuTUi7EUYArw2oic=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f520832a47dbc24d1e2c4e4b9a3dbe910777d1a2",
+        "rev": "93335810751f0404fe424e61ad58bc8e94bf8e9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`93335810`](https://github.com/nix-community/home-manager/commit/93335810751f0404fe424e61ad58bc8e94bf8e9d) | `vscode: add userTasks test`   |
| [`39c1e670`](https://github.com/nix-community/home-manager/commit/39c1e6704a58cb160d4f6b03215dffc819774f1c) | `vscode: fix invalid examples` |