### PR TITLE
chore(flake/nur): `ee8a9dba` -> `539dbd0f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667460978,
-        "narHash": "sha256-yP0c3Hh45Eb30LwPeT/KikkX7DvcpI4Ke2DX9+xsW7w=",
+        "lastModified": 1667469493,
+        "narHash": "sha256-/IZkwnY/ZawCciZY4NVIF6FioZ40Si3fTx4ica7FRcY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ee8a9dba687d4b79e9a5bcb9e3e1e0f2eb3060fd",
+        "rev": "539dbd0f420d86d9ed790693ce26599b9d041aa2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`539dbd0f`](https://github.com/nix-community/NUR/commit/539dbd0f420d86d9ed790693ce26599b9d041aa2) | `automatic update` |