### PR TITLE
chore(flake/nur): `bc8d4232` -> `c6b76606`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667482622,
-        "narHash": "sha256-DtpxfpYaJRD99bS2y/SVrN5M0cFnj23nTrMLIjMq22I=",
+        "lastModified": 1667489402,
+        "narHash": "sha256-7UNK1zkGaNjgAtFOwcIZzI/hULVBMEqK6iHN06pKg5Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bc8d423249bb18e21c3950e2cf3522908f17ddb6",
+        "rev": "c6b7660635e2a919504840fdd85a261e90ae4a0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c6b76606`](https://github.com/nix-community/NUR/commit/c6b7660635e2a919504840fdd85a261e90ae4a0f) | `automatic update` |