### PR TITLE
chore(flake/nur): `c6b76606` -> `bdd9c8ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667489402,
-        "narHash": "sha256-7UNK1zkGaNjgAtFOwcIZzI/hULVBMEqK6iHN06pKg5Y=",
+        "lastModified": 1667490385,
+        "narHash": "sha256-ySEDVzdyNWPM+eMeHu8dwkCU6Xuqmd9yE0e/VHxzd/s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c6b7660635e2a919504840fdd85a261e90ae4a0f",
+        "rev": "bdd9c8ca371a9d9fb14027d66c41e71656959848",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`bdd9c8ca`](https://github.com/nix-community/NUR/commit/bdd9c8ca371a9d9fb14027d66c41e71656959848) | `automatic update` |