### PR TITLE
chore(flake/nur): `3acc4783` -> `04d9c7bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667494722,
-        "narHash": "sha256-X1jin2vkY6BkoSEpDs2uVJB5iqUJrINsU5mZxSez48s=",
+        "lastModified": 1667496346,
+        "narHash": "sha256-n0bHzcQ/sx+E96FumgF2OeT6bbTendRDtmQHijTrQg0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3acc47836200f0fb9559dafa7e5cd9cb3d1a65eb",
+        "rev": "04d9c7bd3c4a2ce32f44cc970cc3e03d5a4aa334",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`04d9c7bd`](https://github.com/nix-community/NUR/commit/04d9c7bd3c4a2ce32f44cc970cc3e03d5a4aa334) | `automatic update` |