### PR TITLE
chore(flake/emacs-overlay): `620f79f8` -> `ccefa5f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667478861,
-        "narHash": "sha256-zXBOE+4plWIs/hnzo58+LiwfEAnJM0YDnW4xVgVFMFA=",
+        "lastModified": 1667507825,
+        "narHash": "sha256-Tss8NXLO5HIqcY+v+lMy/tcdBKNwKxW5Lb4PkuS5rmY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "620f79f8ca3c3f30536a9a3cd27e74fc6e34af36",
+        "rev": "ccefa5f7ddbb036656d8617ed2862fe057d60fb4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ccefa5f7`](https://github.com/nix-community/emacs-overlay/commit/ccefa5f7ddbb036656d8617ed2862fe057d60fb4) | `Updated repos/melpa` |
| [`20d0237f`](https://github.com/nix-community/emacs-overlay/commit/20d0237f2d863a816ef6c6c1c0ec818c8bece502) | `Updated repos/emacs` |
| [`5fb7020f`](https://github.com/nix-community/emacs-overlay/commit/5fb7020f50844c8a9e4b2de8b51a42354e420dfd) | `Updated repos/elpa`  |