### PR TITLE
chore(flake/nur): `04d9c7bd` -> `99b36707`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667496346,
-        "narHash": "sha256-n0bHzcQ/sx+E96FumgF2OeT6bbTendRDtmQHijTrQg0=",
+        "lastModified": 1667511785,
+        "narHash": "sha256-fYh7THWQjBaOlXmrcw02wBEkUYKpd8JQd0BlJebir7A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "04d9c7bd3c4a2ce32f44cc970cc3e03d5a4aa334",
+        "rev": "99b36707cc34c9702fc101e0e760df69d1f08bca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`99b36707`](https://github.com/nix-community/NUR/commit/99b36707cc34c9702fc101e0e760df69d1f08bca) | `automatic update` |
| [`371f5de8`](https://github.com/nix-community/NUR/commit/371f5de81776589795336eb3774ead350e3049d2) | `automatic update` |