### PR TITLE
chore(flake/nixpkgs): `d40fea9a` -> `636051e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -275,11 +275,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667231093,
-        "narHash": "sha256-RERXruzBEBuf0c7OfZeX1hxEKB+PTCUNxWeB6C1jd8Y=",
+        "lastModified": 1667426640,
+        "narHash": "sha256-zJFPcWL9i0Y1BqzqEa8RKx+SiUgupHhYqPDCaFmlBpw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d40fea9aeb8840fea0d377baa4b38e39b9582458",
+        "rev": "636051e353461f073ac55d5d42c1ed062a345046",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                           |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`636051e3`](https://github.com/NixOS/nixpkgs/commit/636051e353461f073ac55d5d42c1ed062a345046) | `linux: avoid NO_HZ_FULL on i686-linux`                                                  |
| [`a1826e78`](https://github.com/NixOS/nixpkgs/commit/a1826e78afb277ba1c5fbb54e796371eb664091e) | `josm: 18570 -> 18583`                                                                   |
| [`eb0d0de6`](https://github.com/NixOS/nixpkgs/commit/eb0d0de69f30cef555340ef99517a4f96a976543) | `terraform: 1.3.3 -> 1.3.4`                                                              |
| [`74ddb2da`](https://github.com/NixOS/nixpkgs/commit/74ddb2da471b8f3563bd71974b69456d1581817e) | `fd: 8.5.0 -> 8.5.1`                                                                     |
| [`5017d432`](https://github.com/NixOS/nixpkgs/commit/5017d4328837a80893252d3e0fbe2d26554bc7e6) | `panoply: 5.2.1 -> 5.2.2`                                                                |
| [`d869913e`](https://github.com/NixOS/nixpkgs/commit/d869913e9c3e6b596dfc7b69d7bfdab32339512c) | `pre-commit: skip tests broken with Git 2.38.1`                                          |
| [`92635588`](https://github.com/NixOS/nixpkgs/commit/92635588079534dde9c74109dee9850c89497bc4) | `zerotierone: 1.10.1 -> 1.10.2`                                                          |
| [`09685474`](https://github.com/NixOS/nixpkgs/commit/09685474e92ceb43110263f1f7fdc3be84fe46e6) | ``quictls: only set `enable-ktls` flag on Linux``                                        |
| [`31b41b4a`](https://github.com/NixOS/nixpkgs/commit/31b41b4a30dd341f9ace3e033a26fb01b80aec00) | `uhubctl: 2.4.0 -> 2.5.0`                                                                |
| [`76476ecf`](https://github.com/NixOS/nixpkgs/commit/76476ecfcb887869201ce23ecda01482077dd17f) | `electron_21: 21.0.1 -> 21.2.1`                                                          |
| [`bbae16ba`](https://github.com/NixOS/nixpkgs/commit/bbae16baa9cbb6a1bf1574bd272fc23a46c5217b) | `quictls: 3.0.5+quick_unstable-2022-07.05 -> 3.0.7+quic1`                                |
| [`7506fbd7`](https://github.com/NixOS/nixpkgs/commit/7506fbd7f438376c33eeca94010f35c85517e25b) | `nixos/cachix-watch-store: fix missing reference to the module`                          |
| [`aaef5af8`](https://github.com/NixOS/nixpkgs/commit/aaef5af8b94f27c9c94741f5a6ebe6ccc44c9bb3) | `doas: fix no-pam build with libxcrypt`                                                  |
| [`5d9a2f1c`](https://github.com/NixOS/nixpkgs/commit/5d9a2f1cdfc89af20ffda7667f51f74e645c9496) | `ventoy-bin: fix VentoyPlugson`                                                          |
| [`3afaf7d2`](https://github.com/NixOS/nixpkgs/commit/3afaf7d263025fc8c24247ec368f593af951b72f) | `verilator: enable doCheck = true`                                                       |
| [`5ceadb26`](https://github.com/NixOS/nixpkgs/commit/5ceadb26b84ff94ba4e9a150e48bf633abaa7905) | `verilator: 4.226 -> 5.002`                                                              |
| [`69df0f15`](https://github.com/NixOS/nixpkgs/commit/69df0f15ccd720f4f51e045eb924816b87c6fa37) | `Revert "Revert "pahole: 1.23 -> 1.24""`                                                 |
| [`d666b6c1`](https://github.com/NixOS/nixpkgs/commit/d666b6c19a486862ad3676fea5f9816e52b9dbe8) | `linuxKernel.kernels.linux_testing_bcachefs: 2022-09-28 -> 2022-10-31`                   |
| [`6c871c38`](https://github.com/NixOS/nixpkgs/commit/6c871c38be714c1cb4d5b7db6dd3a953cc6099e3) | `xca: build with openssl 3.0`                                                            |
| [`a0642950`](https://github.com/NixOS/nixpkgs/commit/a06429504b67debf3f50f55d1a6d6d3721031be1) | `poppler: 22.09.0 → 22.11.0`                                                             |
| [`30a7d57f`](https://github.com/NixOS/nixpkgs/commit/30a7d57f6a6a3d3a7775cba2f24a6e98d6022635) | `rnote: 0.5.4 -> 0.5.7`                                                                  |
| [`969a4732`](https://github.com/NixOS/nixpkgs/commit/969a4732ff033ea83440faef766661c64e47cb43) | `scribus: fix for Poppler 22.09`                                                         |
| [`085e1f9e`](https://github.com/NixOS/nixpkgs/commit/085e1f9e3f1c8c3ba9d6e627d2359299fd7f421c) | `inkscape: fix for Poppler 22.09`                                                        |
| [`ca9eb8ee`](https://github.com/NixOS/nixpkgs/commit/ca9eb8eee37736e4ae2d493136597e1edb3f813d) | `poppler: 22.08.0 -> 22.09.0`                                                            |
| [`c020d94f`](https://github.com/NixOS/nixpkgs/commit/c020d94ff9b568ab494e6f0438b724b8a5948a26) | `rust-analyzer-unwrapped: 2022-10-24 -> 2022-10-31`                                      |
| [`828cd4c8`](https://github.com/NixOS/nixpkgs/commit/828cd4c89520f177158c7504af3f3aa092bd8e90) | `nixos/bitcoind: fix rare startup error`                                                 |
| [`3cb7318e`](https://github.com/NixOS/nixpkgs/commit/3cb7318edf19bbe1b2b8cca5108249ecf50b32f9) | `yamlpath: 3.6.7 -> 3.6.8`                                                               |
| [`cfdce3b5`](https://github.com/NixOS/nixpkgs/commit/cfdce3b542b484ab57bd9eaf85bca51809a9e188) | `cloud-init: remove madjar from maintainers`                                             |
| [`2c039bba`](https://github.com/NixOS/nixpkgs/commit/2c039bba788e3415b0da0821c6d5ba895b7f91f3) | `rustc: removing madjar as maintainer`                                                   |
| [`2dfcc018`](https://github.com/NixOS/nixpkgs/commit/2dfcc01899e31e847c01e5e87523dcb502e9e7f6) | `cinnamon.cinnamon-control-center: Fix some localization issues`                         |
| [`c58d913b`](https://github.com/NixOS/nixpkgs/commit/c58d913bcea18c413f39b879e3f8d1798f728bdc) | `ooniprobe-cli: 3.16.4 -> 3.16.5`                                                        |
| [`309364c8`](https://github.com/NixOS/nixpkgs/commit/309364c8e03cb2d8d584a79e60761a51449b34ae) | `nordzy-icon-theme: 1.7.3 -> 1.7.6`                                                      |
| [`70ca403d`](https://github.com/NixOS/nixpkgs/commit/70ca403dc22e97fb4b73ab74af29e1c8a1f45f69) | `openssl(_3): enable KTLS only on Linux`                                                 |
| [`a4f6258b`](https://github.com/NixOS/nixpkgs/commit/a4f6258b1951172ddc27eec5e7193fffa7f12265) | `python310Packages.fastapi: 0.85.1 -> 0.85.2`                                            |
| [`428f22c3`](https://github.com/NixOS/nixpkgs/commit/428f22c3596f5bf0b3f1a0e3308816baf99a3fc8) | `gopls: 0.10.0 -> 0.10.1 (#199050)`                                                      |
| [`56cd38ad`](https://github.com/NixOS/nixpkgs/commit/56cd38ade3364b82576ddc07a22e9eb755f8bbf9) | `python310Packages.teslajsonpy: 3.0.0 -> 3.1.0`                                          |
| [`5f428e41`](https://github.com/NixOS/nixpkgs/commit/5f428e4188f699f108b33a41d32d41ee3019594b) | `python310Packages.peaqevcore: 7.0.13 -> 7.1.9`                                          |
| [`53c55a9f`](https://github.com/NixOS/nixpkgs/commit/53c55a9ff49e5256d306f83ebf293dc44afa1456) | `python310Packages.hypothesis-auto: fix validation issue`                                |
| [`b0664a02`](https://github.com/NixOS/nixpkgs/commit/b0664a021ed68d0dce45b5a6ad268896cc4244dd) | `python310Packages.cryptg: disable on older Python releases`                             |
| [`a87f7b69`](https://github.com/NixOS/nixpkgs/commit/a87f7b698b25eef18d879db22c3f21f1f344dbf9) | `obsidian: 1.0.0 -> 1.0.3`                                                               |
| [`951f81c0`](https://github.com/NixOS/nixpkgs/commit/951f81c0cc39cd0e8fa2575d708aa5eadd3e1dce) | `nixos/systemd-unit-options: document correct wantedBy default for user units (#199007)` |
| [`a23b67ad`](https://github.com/NixOS/nixpkgs/commit/a23b67add1b03a372e923985444906b8d2e01ba3) | `amarok: build with openssl 3.0`                                                         |
| [`ac8aebad`](https://github.com/NixOS/nixpkgs/commit/ac8aebad005057ee1f5f0be40368230eb5dbb390) | `sqlfluff: 1.4.0 -> 1.4.1`                                                               |
| [`36ed4b09`](https://github.com/NixOS/nixpkgs/commit/36ed4b09171547e925ce9ca05c54d2c4aba3cd28) | `terraform-providers.lxd: 1.7.2 -> 1.7.3`                                                |
| [`df775980`](https://github.com/NixOS/nixpkgs/commit/df77598045f65d71ef23100552af6ebad96f99f0) | `terraform-providers.baiducloud: 1.16.2 -> 1.16.3`                                       |
| [`b3bacada`](https://github.com/NixOS/nixpkgs/commit/b3bacada0a80a76ba538c5cd2da1b4124a685106) | `terraform-providers.ksyun: 1.3.55 → 1.3.56`                                             |
| [`e9c3f01c`](https://github.com/NixOS/nixpkgs/commit/e9c3f01cd455a34cfbbf32737d190bbc55cf451e) | `terraform-providers.cloudflare: 3.26.0 → 3.27.0`                                        |
| [`5872c135`](https://github.com/NixOS/nixpkgs/commit/5872c1356599946aa473d6e4c7a49a77fd69b3ac) | `python3Packages.cryptg: 0.3.1 -> 0.4`                                                   |
| [`7c665a85`](https://github.com/NixOS/nixpkgs/commit/7c665a85b9bbf69697442195e61096e15b79ab94) | `python310Packages.yappi: 1.3.6 -> 1.4.0`                                                |
| [`9a45d921`](https://github.com/NixOS/nixpkgs/commit/9a45d921bef2f1b3ceae83f3325c3913b4d8e904) | `ruff: 0.0.93 -> 0.0.94`                                                                 |
| [`d28249cf`](https://github.com/NixOS/nixpkgs/commit/d28249cfd262baa408d840d91ff2b46d9578ce34) | `rapidfuzz-cpp: fix build on aarch64-darwin`                                             |
| [`0fcbe58a`](https://github.com/NixOS/nixpkgs/commit/0fcbe58a19e52ffb6c060a9e2eb0ab9a1935c96f) | `cargo-zigbuild: 0.14.0 -> 0.14.1`                                                       |
| [`d38afed3`](https://github.com/NixOS/nixpkgs/commit/d38afed36a9173b259cf643d077bf200a1d8d696) | `agola: init at 0.7.0`                                                                   |
| [`f59df406`](https://github.com/NixOS/nixpkgs/commit/f59df4069f18a58d2d080a7ee66031f0c1c60109) | `cargo-audit: 0.17.2 -> 0.17.3`                                                          |
| [`d17013ea`](https://github.com/NixOS/nixpkgs/commit/d17013ea9e243628d00262e56b0f38922b278455) | `blightmud: 4.0.0 -> 5.0.0`                                                              |
| [`fdd9ddb3`](https://github.com/NixOS/nixpkgs/commit/fdd9ddb34ca3fb387a835f796443dc945d44dae6) | `jruby: 9.3.8.0 -> 9.3.9.0`                                                              |
| [`4e789b92`](https://github.com/NixOS/nixpkgs/commit/4e789b928bf6454117dba8ca1d14d744b7802718) | `netbird: 0.10.2 -> 0.10.3`                                                              |
| [`b0ae739c`](https://github.com/NixOS/nixpkgs/commit/b0ae739c9d9a206ec84396759e81328e5c169ad0) | `sourcehut.buildsrht: 0.82.8 -> 0.83.0`                                                  |
| [`608eb68f`](https://github.com/NixOS/nixpkgs/commit/608eb68fd8ab9e50186ffc3d7c7e842618037c2b) | `sourcehut.hubsrht: fix missing pyyaml dependency`                                       |
| [`e1930cf9`](https://github.com/NixOS/nixpkgs/commit/e1930cf933f306cad0611998c78671f7fe0f41ab) | `nixos/sourcehut: removing myself from maintainers`                                      |
| [`511be9e2`](https://github.com/NixOS/nixpkgs/commit/511be9e2258ceeb7ec27582c08bf7cbd3714e28b) | `sourcehut: fix pagessrht`                                                               |
| [`875723f3`](https://github.com/NixOS/nixpkgs/commit/875723f3c13b2e30ec7b9dc4edaa2ea0876c0210) | `sourcehut: clean formatting`                                                            |
| [`664edda5`](https://github.com/NixOS/nixpkgs/commit/664edda544f1ad938a3cb6444718a7e7ddfd8224) | `sourcehut: fix #198478`                                                                 |
| [`8988d3e8`](https://github.com/NixOS/nixpkgs/commit/8988d3e861531eba8c828741de76baf8b7e757dc) | `gnomeExtensions: auto-update`                                                           |
| [`744758b2`](https://github.com/NixOS/nixpkgs/commit/744758b2aa8c12e731bd1a557d03af26a9efa5c2) | `python310Packages.transformers: 4.23.1 -> 4.24.0`                                       |
| [`d3e16830`](https://github.com/NixOS/nixpkgs/commit/d3e16830b27fdae4cd469dd143f0a9ef857eb673) | `apfel: fix build on aarch64-darwin`                                                     |
| [`e88df671`](https://github.com/NixOS/nixpkgs/commit/e88df671f29df2a194b7051946db1c31730b173d) | `python310Packages.authlib: 1.0.1 -> 1.1.0`                                              |
| [`b89bcd15`](https://github.com/NixOS/nixpkgs/commit/b89bcd15f9a1108ed9dbfd4c2ef8cc6ea8107dbd) | `python310Packages.pynndescent: add input`                                               |
| [`34685273`](https://github.com/NixOS/nixpkgs/commit/34685273731b7f841fb3aa3440b24fff3bb7f6a3) | `python310Packages.sqlmap: 1.6.10 -> 1.6.11`                                             |
| [`13fdc761`](https://github.com/NixOS/nixpkgs/commit/13fdc761fb2fb8c221592a14c99aba92dd1bfd07) | `python310Packages.flipr-api: 1.4.2 -> 1.4.3`                                            |
| [`aee30a88`](https://github.com/NixOS/nixpkgs/commit/aee30a880155db2e7c84e7a4d210a02b820272f0) | `python310Packages.parsel: 1.6.0 -> 1.7.0`                                               |
| [`667df782`](https://github.com/NixOS/nixpkgs/commit/667df782dffdde1e41b0374207b31169441d02a2) | `python310Packages.twilio: 7.15.0 -> 7.15.1`                                             |
| [`d68593be`](https://github.com/NixOS/nixpkgs/commit/d68593bef66df3e7f7507e8bc1c3ab5ba7938334) | `python310Packages.angr: 9.2.24 -> 9.2.25`                                               |
| [`e54ae8ca`](https://github.com/NixOS/nixpkgs/commit/e54ae8cae8d881263bd17ffb9b27d98a2011a0a6) | `python310Packages.cle: 9.2.24 -> 9.2.25`                                                |
| [`0f48cfa9`](https://github.com/NixOS/nixpkgs/commit/0f48cfa9081af2ad0c82b2f44eefee7514977e1d) | `python310Packages.claripy: 9.2.24 -> 9.2.25`                                            |
| [`39882815`](https://github.com/NixOS/nixpkgs/commit/39882815a9ddbe2b434cc967b9f6b7218fefbe30) | `python310Packages.pyvex: 9.2.24 -> 9.2.25`                                              |
| [`8f9de886`](https://github.com/NixOS/nixpkgs/commit/8f9de886521fafc80c172f900b40b61a1405aa43) | `python310Packages.ailment: 9.2.24 -> 9.2.25`                                            |
| [`cf2685d0`](https://github.com/NixOS/nixpkgs/commit/cf2685d09c250b083ed64b31df46116808052803) | `python310Packages.archinfo: 9.2.24 -> 9.2.25`                                           |
| [`ce4f1ac8`](https://github.com/NixOS/nixpkgs/commit/ce4f1ac8b8f0e535ead429de1c98e1f3f6caff65) | `pip-audit: 2.4.4 -> 2.4.5`                                                              |
| [`48ad0adc`](https://github.com/NixOS/nixpkgs/commit/48ad0adc7e544ddcce5a48e21b021db951ea6996) | `qradiolink: 0.8.6-2 -> 0.8.7-1`                                                         |
| [`62bf5bbe`](https://github.com/NixOS/nixpkgs/commit/62bf5bbe29a7d1040209da378deb4a136f0db349) | `go_1_19: 1.19.2 -> 1.19.3`                                                              |
| [`666e33e9`](https://github.com/NixOS/nixpkgs/commit/666e33e99ce9a00d38e9ec08239a0dd3a2bc1e22) | `go_1_18: 1.18.7 -> 1.18.8`                                                              |
| [`db08a1df`](https://github.com/NixOS/nixpkgs/commit/db08a1dfae1d3e6c49f610b4e45e41415ec635cf) | `gmid: 1.8.4 -> 1.8.5`                                                                   |
| [`0be64cb3`](https://github.com/NixOS/nixpkgs/commit/0be64cb32312328a80acf59f78031e448cffae72) | `feishu: fix autopatchelf missing libgcrypt`                                             |
| [`115f084d`](https://github.com/NixOS/nixpkgs/commit/115f084d45b3b462a253a0893f13a1f1279fca20) | `argparse: fix build`                                                                    |
| [`7902df29`](https://github.com/NixOS/nixpkgs/commit/7902df29a8f2bf12450d64ed577be108fd44569c) | `iperf: 3.11 -> 3.12`                                                                    |
| [`4f4a63cb`](https://github.com/NixOS/nixpkgs/commit/4f4a63cbf8b7b6f8559c271ee7be8c8a446c00b5) | `python310Packages.asdf: allow later jsonschema releases`                                |
| [`8e7b785d`](https://github.com/NixOS/nixpkgs/commit/8e7b785d5ef0d243d1e47d2d3fd440474df4f115) | `httm: 0.15.8 -> 0.16.5`                                                                 |
| [`50fa1983`](https://github.com/NixOS/nixpkgs/commit/50fa198362ce4321d5b5101acf05924e6dc7dae4) | `hydra_unstable: 2022-09-08 -> 2022-10-22`                                               |
| [`8f6a2a16`](https://github.com/NixOS/nixpkgs/commit/8f6a2a16b0d6abd6dfced8d0002077c0122cce12) | `nsz: init at 4.1.0`                                                                     |
| [`fbc52015`](https://github.com/NixOS/nixpkgs/commit/fbc52015b6755e1f476467d7a526743c3baa6b55) | `vimPlugins: add tridactyl/vim-tridactyl`                                                |
| [`527fd33c`](https://github.com/NixOS/nixpkgs/commit/527fd33cc9a7b8dc0bfc0b68c432f3854e05d289) | `vimPlugins: update`                                                                     |
| [`8e9ec875`](https://github.com/NixOS/nixpkgs/commit/8e9ec87563ee44e2637e31f96aefc71183e35d8f) | `fd: 8.4.0 -> 8.5.0`                                                                     |
| [`6b6c5542`](https://github.com/NixOS/nixpkgs/commit/6b6c55425bda3e5ed580f465742015a1023de3c6) | `python310Packages.siobrultech-protocols: 0.6.0 -> 0.7.0`                                |
| [`009822ff`](https://github.com/NixOS/nixpkgs/commit/009822ffe81b3e6bb4cf8e5450102ef88b68a6dc) | `flyctl: 0.0.425 -> 0.0.426`                                                             |
| [`99401a0e`](https://github.com/NixOS/nixpkgs/commit/99401a0e30d8970238d2892ba0d25875485fab73) | `python310Packages.regenmaschine: 2022.10.0 -> 2022.10.1`                                |
| [`372f7f4e`](https://github.com/NixOS/nixpkgs/commit/372f7f4edd31b853e8cc69ed18f1a923ccb3f018) | `python310Packages.qcelemental: 0.25.0 -> 0.25.1`                                        |
| [`4fe3556c`](https://github.com/NixOS/nixpkgs/commit/4fe3556c48f684ed41d538058458ffb9ddbff68c) | `python310Packages.ansible-compat: remove myself from maintainers`                       |
| [`a5a7a417`](https://github.com/NixOS/nixpkgs/commit/a5a7a417e694806939d34286378c4f6041331e44) | `python3Packages.pwntools: don't wrap gdb on darwin`                                     |
| [`dc595f1a`](https://github.com/NixOS/nixpkgs/commit/dc595f1a6bb45eb695a7012e3b5eceaff833ab70) | `python3Packages.rpyc: disable checks on darwin`                                         |
| [`a6e8bd09`](https://github.com/NixOS/nixpkgs/commit/a6e8bd09f38f70074ffb81eaef56719e5f55aa9a) | `invoiceplane: 1.5.11 -> 1.6-beta-1`                                                     |
| [`409cff67`](https://github.com/NixOS/nixpkgs/commit/409cff67c356d42500bec13cc0d9c45d3ff1d364) | `flexoptix-app: 5.12.2 -> 5.13.0`                                                        |
| [`f75ed7fc`](https://github.com/NixOS/nixpkgs/commit/f75ed7fcef151ed01868472215799a551816451e) | `element: 1.0.0 -> 1.0.1`                                                                |
| [`37dc9497`](https://github.com/NixOS/nixpkgs/commit/37dc9497d7c2e55504f0dc1d0b70f9b1414c339e) | `python310Packages.python-box: 6.0.2 -> 6.1.0`                                           |
| [`b4f201f0`](https://github.com/NixOS/nixpkgs/commit/b4f201f0d4c81dd97f7e3ece058739fb8d5deaf0) | `python3Packages.dask-gateway: add setuptools as native build input`                     |
| [`b5113363`](https://github.com/NixOS/nixpkgs/commit/b5113363f4810dad88db51d5e1cfd41a811b03e9) | `dendrite: 0.10.4 -> 0.10.5`                                                             |
| [`c5837156`](https://github.com/NixOS/nixpkgs/commit/c5837156f22137e122b7e3909bc9e52378fc0419) | `dehydrated: 0.7.0 -> 0.7.1`                                                             |
| [`7f372dbb`](https://github.com/NixOS/nixpkgs/commit/7f372dbb8f0d94f95105036a47eb5e95ff56ac53) | `cloud-nuke: 0.20.0 -> 0.21.0`                                                           |
| [`f7ef7230`](https://github.com/NixOS/nixpkgs/commit/f7ef72305d7527d55996c41ffc74835c0c77063f) | `librewolf: 106.0.1-1 -> 106.0.3-1`                                                      |
| [`c79ecc1b`](https://github.com/NixOS/nixpkgs/commit/c79ecc1b3affcdbdaa527e75930b7ea09e38d01f) | `sbt: 1.7.2 -> 1.7.3 (#198879)`                                                          |
| [`4ca82611`](https://github.com/NixOS/nixpkgs/commit/4ca8261132ee5480101bb67c14eed4679c06cd4a) | `nixos/vmware-guest: depend headless option on xserver availability`                     |
| [`fc13f439`](https://github.com/NixOS/nixpkgs/commit/fc13f439c33c0e2238a7e145063ab0b3cf3eef8e) | `python310Packages.meshtastic: 1.3.44 -> 2.0.1`                                          |
| [`d7788c73`](https://github.com/NixOS/nixpkgs/commit/d7788c73037f9eeb721e9ec587f5d6987490afc6) | `miniupnpc_1: drop`                                                                      |
| [`991a5ca4`](https://github.com/NixOS/nixpkgs/commit/991a5ca464eaf59e50f3f0d102f4216f2f9d18f5) | `lnd: 0.15.2-beta -> 0.15.4-beta`                                                        |
| [`da20b081`](https://github.com/NixOS/nixpkgs/commit/da20b0814d09008d585fa17d9e1f5627d9cfb1fe) | `python310Packages.cma: limit tests`                                                     |
| [`4f2d34ad`](https://github.com/NixOS/nixpkgs/commit/4f2d34ad52874b36add23f57fafc1a0198d23cce) | `python310Packages.pymc: 4.1.3 -> 4.3.0`                                                 |
| [`4689b87f`](https://github.com/NixOS/nixpkgs/commit/4689b87f78bf70281c63c382d3bc3606b8147306) | `python310Packages.arviz: 0.12.1 -> 0.13.0`                                              |
| [`eeca5969`](https://github.com/NixOS/nixpkgs/commit/eeca5969b3f42ac943639aaec503816f053e5e53) | `openssl: 3.0.5 -> 3.0.7`                                                                |
| [`dd4481ec`](https://github.com/NixOS/nixpkgs/commit/dd4481ec9fa1a1b523426edf29e55d82f5329ddc) | `cargo-deny: 0.13.1 -> 0.13.2`                                                           |
| [`ee2353c8`](https://github.com/NixOS/nixpkgs/commit/ee2353c8bf3470b9244cd1aa8f2d79d2685c9977) | `papirus-icon-theme: 20220910 -> 20221101`                                               |
| [`8cc5d8e3`](https://github.com/NixOS/nixpkgs/commit/8cc5d8e32a64f0b93c5a5c502f498ff128565ff3) | `linuxKernel.kernels.linux_5_19: drop`                                                   |
| [`d2422216`](https://github.com/NixOS/nixpkgs/commit/d242221640a92bf85ee09d271f73eba2bec19241) | `temporalite: init at 0.2.0`                                                             |
| [`6739decb`](https://github.com/NixOS/nixpkgs/commit/6739decba3546cf6911f056fb38998da386271cd) | `cppcheck: fix broken hash`                                                              |
| [`481fe3f8`](https://github.com/NixOS/nixpkgs/commit/481fe3f8e71aad8366629cdd5c99ea02ac4b36ca) | `python310Packages.duo-client: 4.4.0 -> 4.5.0`                                           |
| [`e5ff8113`](https://github.com/NixOS/nixpkgs/commit/e5ff8113fbbd244f24841e4eeb89eef18e9bc61c) | `python310Packages.hstspreload: 2022.10.1 -> 2022.11.1`                                  |
| [`cce5b627`](https://github.com/NixOS/nixpkgs/commit/cce5b627399e5224246f54bfce4cbeeb6c907a21) | `linuxKernel.kernels.linux_testing: 6.0-rc5 -> 6.1-rc3`                                  |
| [`b4a893c2`](https://github.com/NixOS/nixpkgs/commit/b4a893c23d4b4829a8dc95aa65b90ef76e48e65d) | `alice: init at 2.003`                                                                   |
| [`06c9d4d9`](https://github.com/NixOS/nixpkgs/commit/06c9d4d95c1ef5e0fb19bf346ee297b94b32b666) | `gym: 0.21.0 -> 0.26.2`                                                                  |
| [`8a837a95`](https://github.com/NixOS/nixpkgs/commit/8a837a95ed519d667bda873eb3dfa9b5ec55858b) | `crimson-pro: init at unstable-2022-08-30`                                               |
| [`9f252b31`](https://github.com/NixOS/nixpkgs/commit/9f252b319eb5b922c8988ee020afc96f9c8f1e7a) | `musikcube: 0.98.0 -> 0.98.1`                                                            |
| [`1a2af00a`](https://github.com/NixOS/nixpkgs/commit/1a2af00ada115a400d2ab243f069628b1973f0a3) | `bisq-desktop: 1.9.5 -> 1.9.6`                                                           |
| [`739857a0`](https://github.com/NixOS/nixpkgs/commit/739857a03eec5fb43fdc7757ef00554c95c6965d) | `autotiling: 1.7 -> 1.8`                                                                 |