### PR TITLE
chore(flake/nur): `99b36707` -> `c148356f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667511785,
-        "narHash": "sha256-fYh7THWQjBaOlXmrcw02wBEkUYKpd8JQd0BlJebir7A=",
+        "lastModified": 1667522297,
+        "narHash": "sha256-+iSD/1eJBakTlz8dIlw12Xdk9qJh6R5RwQWvC9d29vM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "99b36707cc34c9702fc101e0e760df69d1f08bca",
+        "rev": "c148356f810f76840537183b9b60ae6f9faab399",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c148356f`](https://github.com/nix-community/NUR/commit/c148356f810f76840537183b9b60ae6f9faab399) | `automatic update` |