### PR TITLE
chore(flake/nur): `c148356f` -> `55475840`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667522297,
-        "narHash": "sha256-+iSD/1eJBakTlz8dIlw12Xdk9qJh6R5RwQWvC9d29vM=",
+        "lastModified": 1667526530,
+        "narHash": "sha256-XC8kTlxAqhI9LF1jzi2vG4//p0lTktgmNFl4uvoIpn4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c148356f810f76840537183b9b60ae6f9faab399",
+        "rev": "5547584085c6d2b25f90851611066419b03cc568",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`55475840`](https://github.com/nix-community/NUR/commit/5547584085c6d2b25f90851611066419b03cc568) | `automatic update` |