### PR TITLE
chore(flake/nur): `55475840` -> `67b274d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667526530,
-        "narHash": "sha256-XC8kTlxAqhI9LF1jzi2vG4//p0lTktgmNFl4uvoIpn4=",
+        "lastModified": 1667531872,
+        "narHash": "sha256-QRy7Nc7zvhK+2dOYN/18P9pPKX4zypL5ZQUYXAl9OTA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5547584085c6d2b25f90851611066419b03cc568",
+        "rev": "67b274d0bfa160711a87a29abe9ccef4762ed743",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`67b274d0`](https://github.com/nix-community/NUR/commit/67b274d0bfa160711a87a29abe9ccef4762ed743) | `automatic update` |