### PR TITLE
chore(flake/nur): `67b274d0` -> `509ce79e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667531872,
-        "narHash": "sha256-QRy7Nc7zvhK+2dOYN/18P9pPKX4zypL5ZQUYXAl9OTA=",
+        "lastModified": 1667533671,
+        "narHash": "sha256-4MdEQMCR2kCano9XEdH99Fy85AUtUvC3QEyUHR9lzEs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "67b274d0bfa160711a87a29abe9ccef4762ed743",
+        "rev": "509ce79e344b70f8035bf812c38cbdc752d5350d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`509ce79e`](https://github.com/nix-community/NUR/commit/509ce79e344b70f8035bf812c38cbdc752d5350d) | `automatic update` |