### PR TITLE
chore(flake/nixpkgs): `636051e3` -> `a2a77753`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -275,11 +275,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667426640,
-        "narHash": "sha256-zJFPcWL9i0Y1BqzqEa8RKx+SiUgupHhYqPDCaFmlBpw=",
+        "lastModified": 1667482890,
+        "narHash": "sha256-pua0jp87iwN7NBY5/ypx0s9L9CG49Ju/NI4wGwurHc4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "636051e353461f073ac55d5d42c1ed062a345046",
+        "rev": "a2a777538d971c6b01c6e54af89ddd6567c055e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                   |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`a2a77753`](https://github.com/NixOS/nixpkgs/commit/a2a777538d971c6b01c6e54af89ddd6567c055e8) | `unflac: init at 1.0`                                                            |
| [`2d549da5`](https://github.com/NixOS/nixpkgs/commit/2d549da5ea5203c5ef9e7498063fc2c479aea461) | `maintainers: add felipeqq2`                                                     |
| [`fec7683a`](https://github.com/NixOS/nixpkgs/commit/fec7683a0d3529746a811c1ca94dd1a0d5a8eed5) | `python3.pkgs.junos-eznc: 2.6.3 -> 2.6.5 (#199316)`                              |
| [`0a96a74b`](https://github.com/NixOS/nixpkgs/commit/0a96a74b3b215aadae7cba9c5a28c9b45e088bcf) | `etcd_3_4: 3.4.21 -> 3.4.22`                                                     |
| [`1b6e5ac9`](https://github.com/NixOS/nixpkgs/commit/1b6e5ac9520ebcfc283cd18c10856cdcd94c91eb) | `lib/tests/modules: Test doRename`                                               |
| [`ad10d4fd`](https://github.com/NixOS/nixpkgs/commit/ad10d4fdef46a00bbe2d95aadc96b9e062fe0539) | `lib.modules.doRename: Don't define warning, even as undefined, if not warning.` |
| [`d3f040eb`](https://github.com/NixOS/nixpkgs/commit/d3f040eb47fa99d9feded13ecd5abdd11b3fbc43) | `cpp-utilities: 5.19.0 -> 5.20.0`                                                |
| [`de432cc1`](https://github.com/NixOS/nixpkgs/commit/de432cc113091c21dd10c3f59735f10d1553cebb) | `syft: 0.59.0 -> 0.60.2`                                                         |
| [`231e389e`](https://github.com/NixOS/nixpkgs/commit/231e389e8ca6ace0b48ea6d1e6f645e4d5e771b5) | `waybar: 0.9.14 -> 0.9.15`                                                       |
| [`c66c9688`](https://github.com/NixOS/nixpkgs/commit/c66c9688840dc7a4a8b1dd46279e2fc1d26416ea) | `invidious: unstable-2022-08-13 -> unstable-2022-11-02`                          |
| [`40deff2a`](https://github.com/NixOS/nixpkgs/commit/40deff2a5bbef0f730c876fec23a10cc7c27aaad) | `python310Packages.ansible-runner: disable on older Python releases`             |
| [`1f1ed641`](https://github.com/NixOS/nixpkgs/commit/1f1ed641dee4eaa3dbabf6adec2faadd98171a7f) | `terraform-providers.tencentcloud: 1.78.6 → 1.78.7`                              |
| [`667d46ec`](https://github.com/NixOS/nixpkgs/commit/667d46ec67f16cf82f4f0ead05ca2141ab746ccd) | `terraform-providers.time: 0.9.0 → 0.9.1`                                        |
| [`fdfe6910`](https://github.com/NixOS/nixpkgs/commit/fdfe69102403250ad4c4ab265babb2a28e669fe3) | `terraform-providers.spotinst: 1.86.0 → 1.87.0`                                  |
| [`915998a5`](https://github.com/NixOS/nixpkgs/commit/915998a5c96c25aab6222c8d733f5e9516be095e) | `terraform-providers.oci: 4.96.0 → 4.98.0`                                       |
| [`ccee40c3`](https://github.com/NixOS/nixpkgs/commit/ccee40c3dedc98f8f5ee046d6417d53567732f88) | `terraform-providers.opentelekomcloud: 1.31.6 → 1.31.7`                          |
| [`3c96803b`](https://github.com/NixOS/nixpkgs/commit/3c96803bd2a1a90a5909fbdc93b51c82f94aa93e) | `terraform-providers.ibm: 1.46.0 → 1.47.0`                                       |
| [`1fd5b09e`](https://github.com/NixOS/nixpkgs/commit/1fd5b09ed47e1b56ec9705eebdfaf5c48df15240) | `terraform-providers.google-beta: 4.42.0 → 4.42.1`                               |
| [`2735c46f`](https://github.com/NixOS/nixpkgs/commit/2735c46fb7d71deec4479e5f2346d761df314359) | `terraform-providers.google: 4.42.0 → 4.42.1`                                    |
| [`78e17b0b`](https://github.com/NixOS/nixpkgs/commit/78e17b0bbb05de0ba4ae59438cfd9b86d6b0451e) | `terraform-providers.docker: 2.22.0 → 2.23.0`                                    |
| [`76c4d312`](https://github.com/NixOS/nixpkgs/commit/76c4d3126a6376c65189d57d69deb47f8007e933) | `terraform-providers.baiducloud: 1.16.3 → 1.17.0`                                |
| [`f44a61b0`](https://github.com/NixOS/nixpkgs/commit/f44a61b050326cb661170e860634a72b612ffe11) | `linode-cli: 5.24.0 -> 5.25.0`                                                   |
| [`d8f838c3`](https://github.com/NixOS/nixpkgs/commit/d8f838c3db843c1605046bcc6e3fc3e544ecee5c) | `flyway: 9.6.0 -> 9.7.0`                                                         |
| [`7c50aa43`](https://github.com/NixOS/nixpkgs/commit/7c50aa430d15bb368e8bd67d850081d642338953) | `faas-cli: 0.14.11 -> 0.15.2`                                                    |
| [`08b11dc3`](https://github.com/NixOS/nixpkgs/commit/08b11dc31e9791ed90d683f7dd6914da15ed8423) | `cargo-deps: 1.4.1 -> 1.5.0`                                                     |
| [`aabc9997`](https://github.com/NixOS/nixpkgs/commit/aabc99973a2fe2e7d91aa01d46dd2564b6bb2dbf) | `Revert "minio: 2022-10-24T18-35-07Z -> 2022-10-29T06-21-33Z"`                   |
| [`7f5b52ae`](https://github.com/NixOS/nixpkgs/commit/7f5b52aee3af33aa328909f7c1366b82173e79f9) | `cargo-nextest: 0.9.40 -> 0.9.42`                                                |
| [`4682bed7`](https://github.com/NixOS/nixpkgs/commit/4682bed77694401679b35c857ab22a6770d5d641) | `bandwidth: fix build on aarch64-darwin`                                         |
| [`f1099e95`](https://github.com/NixOS/nixpkgs/commit/f1099e95201bcf244a3935b56268aca043b9b47c) | `clj-kondo: 2022.10.14 -> 2022.11.02`                                            |
| [`96045b65`](https://github.com/NixOS/nixpkgs/commit/96045b6531e206f0badd61e5e0eb28c40bf15184) | `argo: 3.4.2 -> 3.4.3`                                                           |
| [`06709e52`](https://github.com/NixOS/nixpkgs/commit/06709e5280f0f6fcbb3c96a2064b836180d62106) | `argocd: 2.4.15 -> 2.5.1`                                                        |
| [`16ce3bc0`](https://github.com/NixOS/nixpkgs/commit/16ce3bc020b1d226f87cdf41b218989c814486cf) | `Revert "onlykey: synology-cloud-sync-decryption-tool init at 027"`              |
| [`ff698fb8`](https://github.com/NixOS/nixpkgs/commit/ff698fb8f933841f482d5066245edc27b4bbaa9a) | `python310Packages.aliyun-python-sdk-config: 2.2.0 -> 2.2.1`                     |
| [`9eb7af17`](https://github.com/NixOS/nixpkgs/commit/9eb7af17ae385e455d4bd7683062434903fb258b) | `python310Packages.scramp: 1.4.3 -> 1.4.4`                                       |
| [`63bb8fd9`](https://github.com/NixOS/nixpkgs/commit/63bb8fd9491002f9f6a1ce5be2a3c99a2295b5d9) | `gobuster: 3.2.0 -> 3.3.0`                                                       |
| [`99ec6648`](https://github.com/NixOS/nixpkgs/commit/99ec664800bc73a6c5acd8307f4927491fb4e706) | `python310Packages.weasyprint: 54.3 -> 57.0`                                     |
| [`08e401e8`](https://github.com/NixOS/nixpkgs/commit/08e401e8d2bc7980e708f97d049c352de0e87ba6) | `python310Packages.pydyf: 0.1.2 -> 0.5.0`                                        |
| [`de97a3c3`](https://github.com/NixOS/nixpkgs/commit/de97a3c324d74bd9ffec865c9b5cea1615a96140) | `python310Packages.ansible-runner: 2.2.1 -> 2.3.0`                               |
| [`e0546f44`](https://github.com/NixOS/nixpkgs/commit/e0546f44a96794592bf7aceb53a4d0e8735435bc) | `python310Packages.niaaml: init at 1.1.11 (#196752)`                             |
| [`4899641e`](https://github.com/NixOS/nixpkgs/commit/4899641ee0b2c2e9bfe7dc686c7dc190f338c462) | `gmailctl: 0.10.5 -> 0.10.6`                                                     |
| [`d17f9e8b`](https://github.com/NixOS/nixpkgs/commit/d17f9e8b0e0cff54950e892fa134ca5e662b30a6) | `python310Packages.prayer-times-calculator: 0.0.6 -> 0.0.7`                      |
| [`f5a22e99`](https://github.com/NixOS/nixpkgs/commit/f5a22e996359620fd9ca8971fef0400fc8c20ba4) | `onlykey: synology-cloud-sync-decryption-tool init at 027`                       |
| [`e1143fcf`](https://github.com/NixOS/nixpkgs/commit/e1143fcfd72252b1abd11ecbb9d66e95fde7060e) | `python310Packages.aioesphomeapi: 11.4.1 -> 11.4.2`                              |
| [`1d6b1589`](https://github.com/NixOS/nixpkgs/commit/1d6b1589f2ddc01e42ad9ea7b8ec5d11c7504574) | `python310Packages.hahomematic: 2022.10.10 -> 2022.11.0`                         |
| [`435f4524`](https://github.com/NixOS/nixpkgs/commit/435f45245e2beccf648f052b749fba52f05eabb8) | `python310Packages.flipr-api: 1.4.3 -> 1.4.4`                                    |
| [`2d06ed99`](https://github.com/NixOS/nixpkgs/commit/2d06ed99fb3f0830979d767e15e9285a33dee106) | `python310Packages.rns: 0.3.17 -> 0.3.18`                                        |
| [`50cc83b0`](https://github.com/NixOS/nixpkgs/commit/50cc83b0c55a8c3b147eefbf338ad790949740f7) | `python310Packages.pysolcast: 1.0.7 -> 1.0.11`                                   |
| [`f4290203`](https://github.com/NixOS/nixpkgs/commit/f4290203857badc8cc92e397de78f5a9f96973c4) | `python310Packages.adax-local: 0.1.4 -> 0.1.5`                                   |
| [`ee63fd2d`](https://github.com/NixOS/nixpkgs/commit/ee63fd2d7b1709b6e7c952979ca8ec2e2e43fbe6) | `nfpm: 2.20.0 -> 2.21.0`                                                         |
| [`306ab859`](https://github.com/NixOS/nixpkgs/commit/306ab8597d4817bf063273e7fb6e76b1153aae47) | `dstask: 0.23.1 -> 0.25`                                                         |
| [`f2d44cdb`](https://github.com/NixOS/nixpkgs/commit/f2d44cdb0baa4155f2e4e8a5220d0f86d4637521) | `chezmoi: 2.25.0 -> 2.26.0`                                                      |
| [`d8075266`](https://github.com/NixOS/nixpkgs/commit/d8075266e673d79c07cfbff4e9159bb5840ad8c0) | `cargo-release: 0.22.1 -> 0.22.2`                                                |
| [`dca850e3`](https://github.com/NixOS/nixpkgs/commit/dca850e3a2c8686dab126886ca0b275caf0dea50) | `adoptopenjdk 17: remove (again)`                                                |
| [`6c041cb4`](https://github.com/NixOS/nixpkgs/commit/6c041cb4970582916feacb396767893f0b47ddc5) | `github-runner: 2.298.2 -> 2.299.0`                                              |
| [`faaf43c3`](https://github.com/NixOS/nixpkgs/commit/faaf43c36adbde5a0713c9f510a7f6516d4f9b2c) | `gitlab: 15.4.2 -> 15.4.4`                                                       |
| [`050831ed`](https://github.com/NixOS/nixpkgs/commit/050831ed4954a9ed097c337bdda7067ee3feab4b) | `vimPlugins.nvim-luadev: init at 2022-01-26`                                     |
| [`ac9ce9fd`](https://github.com/NixOS/nixpkgs/commit/ac9ce9fd81a55794390f0b8f2c49f9ff1c27924a) | `vimPlugins.telescope_hoogle: init at 2022-10-27`                                |
| [`ac4d05da`](https://github.com/NixOS/nixpkgs/commit/ac4d05daa2bc89291418d5352f35dbfd3df043d1) | `vimPlugins.material-vim: init at 2022-09-14`                                    |
| [`63d966ff`](https://github.com/NixOS/nixpkgs/commit/63d966ff8b44e99ae77bb26e75b9401d73c3034e) | `vimPlugins.neotest: init at 2022-10-27`                                         |
| [`2d573e07`](https://github.com/NixOS/nixpkgs/commit/2d573e0757869da4690308f149af5525faf5d9f9) | `vis: 0.7 -> 0.8`                                                                |
| [`b8e37121`](https://github.com/NixOS/nixpkgs/commit/b8e37121d4eeb329228d6d52d63ec12fd50b6847) | `python3Packages.asyncpg: disable tests on darwin`                               |
| [`da44bf12`](https://github.com/NixOS/nixpkgs/commit/da44bf129dcfbba27c5d12742db97f7f3ec367fb) | `babashka: 1.0.164 -> 1.0.165`                                                   |
| [`b1daddcc`](https://github.com/NixOS/nixpkgs/commit/b1daddccf7b565570b1ad33e7058e67a75bbdbc4) | `grafana-agent: 0.25.1 -> 0.28.0`                                                |
| [`5e29d1a3`](https://github.com/NixOS/nixpkgs/commit/5e29d1a366e51a0f7ff6adaeeb857274c0357e3a) | `esphome: 2022.10.1 -> 2022.10.2`                                                |
| [`b57c654b`](https://github.com/NixOS/nixpkgs/commit/b57c654b9a8c85a8f6fb76940825fdadf865e3a0) | `nixpacks: 0.11.5 -> 0.11.6`                                                     |
| [`6a995fa9`](https://github.com/NixOS/nixpkgs/commit/6a995fa92c89e1e1656dfb587147957cc192bcc3) | `pkgsx86Darwin -> pkgsx86_64Darwin`                                             |
| [`93dd2e6e`](https://github.com/NixOS/nixpkgs/commit/93dd2e6e7c9bda4f5d3300d7b161770a7b978ce0) | `syncthing: 1.22.0 -> 1.22.1`                                                    |
| [`92c9b272`](https://github.com/NixOS/nixpkgs/commit/92c9b2728f1653295044f5456417404b27dca961) | `monocraft: 1.2 -> 1.4`                                                          |
| [`5e30a15b`](https://github.com/NixOS/nixpkgs/commit/5e30a15bf0f1bf71460c7b2a11c02c540e27ef26) | `rpcs3: 0.0.24-14337-5210df688 -> 0.0.25-14358-a00f9e421`                        |
| [`08e26823`](https://github.com/NixOS/nixpkgs/commit/08e26823b8bf41063063e8b01a6bb621c7974450) | `stunnel: 5.66 -> 5.67`                                                          |
| [`45bff9e8`](https://github.com/NixOS/nixpkgs/commit/45bff9e87be49f8c5b97d5d471039b9242e86251) | `libpg_query: 13-2.1.2 -> 13-2.2.0`                                              |
| [`9d23657e`](https://github.com/NixOS/nixpkgs/commit/9d23657e87a34bb1874dc8e9c1340453a7726d34) | `lefthook: 1.1.3 -> 1.1.4`                                                       |
| [`84fcda31`](https://github.com/NixOS/nixpkgs/commit/84fcda319e04961b9396f6a92d51a508c70d5f4c) | `linode-cli: 5.24.0 -> 5.25.0`                                                   |
| [`ff51fc67`](https://github.com/NixOS/nixpkgs/commit/ff51fc679bd25170a7cd871eb08dc81c5fcb6dc6) | `karlender: 0.6.2 -> 0.7.1`                                                      |
| [`ae28b4c0`](https://github.com/NixOS/nixpkgs/commit/ae28b4c0675d7741e4bf739efdc1a87db4cb0988) | `emacsPackages.evil-markdown: cleanup`                                           |
| [`09e02af5`](https://github.com/NixOS/nixpkgs/commit/09e02af555cfcfc218f9127e572ea0029d9ff096) | `logseq: 0.8.9 -> 0.8.10`                                                        |
| [`28dba7a6`](https://github.com/NixOS/nixpkgs/commit/28dba7a697653bb07aef46fd491340e56e2f54d2) | `hip: fix cmake installation directories`                                        |
| [`221c5f30`](https://github.com/NixOS/nixpkgs/commit/221c5f303714e6d40c40b092a78a3a677fe07886) | `checkstyle: 10.3.4 -> 10.4`                                                     |
| [`093c82d2`](https://github.com/NixOS/nixpkgs/commit/093c82d2cfd97ccb2446d8d070f7ae3333fda1f9) | `fan2go: init at 0.8.0`                                                          |
| [`04167b40`](https://github.com/NixOS/nixpkgs/commit/04167b4037062451e682af86ea9494cdfe627e93) | `maintainers: add mtoohey`                                                       |
| [`3e34d267`](https://github.com/NixOS/nixpkgs/commit/3e34d2674e3f7558fb57f997291b19c934f568b2) | `bazel: 5.2.0 -> 5.3.2`                                                          |
| [`fba867a9`](https://github.com/NixOS/nixpkgs/commit/fba867a930c7fb83ed87c6beb58c7eb9a2c0814f) | `python3Packages.cupy: 11.1.0 -> 11.2.0, mark as not broken`                     |
| [`2cec04c8`](https://github.com/NixOS/nixpkgs/commit/2cec04c8a278db41695f629a8f1edfa19a7e8095) | `cudaPackages.cutensor: 1.3.1.3 -> 1.5.0.3`                                      |
| [`4784cdb2`](https://github.com/NixOS/nixpkgs/commit/4784cdb28b612c0d3db2c3e7f95b54ebc80a3b96) | `cuda-library-samples.cutensor: fix`                                             |
| [`69d7939a`](https://github.com/NixOS/nixpkgs/commit/69d7939a6221bf86498488d1f641560b7d5d0a8a) | `pkgsx86Darwin: init`                                                            |
| [`621558e4`](https://github.com/NixOS/nixpkgs/commit/621558e406a7cf5cf16673b8767a87f85a446d6a) | `nss_pam_ldapd: switch to python3`                                               |