### PR TITLE
chore(flake/emacs-overlay): `ccefa5f7` -> `6f5b9e6e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667507825,
-        "narHash": "sha256-Tss8NXLO5HIqcY+v+lMy/tcdBKNwKxW5Lb4PkuS5rmY=",
+        "lastModified": 1667538873,
+        "narHash": "sha256-zV1OemF3Pl4t8USt0S1pu7Ye/bNX7vYjqQ531zWWQLU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ccefa5f7ddbb036656d8617ed2862fe057d60fb4",
+        "rev": "6f5b9e6e9b04a750edfa9e706173635186e2c7ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`6f5b9e6e`](https://github.com/nix-community/emacs-overlay/commit/6f5b9e6e9b04a750edfa9e706173635186e2c7ea) | `Updated repos/melpa` |
| [`f192bf30`](https://github.com/nix-community/emacs-overlay/commit/f192bf30615fa3f600e543293522f566a8dd40aa) | `Updated repos/emacs` |
| [`5970c1a2`](https://github.com/nix-community/emacs-overlay/commit/5970c1a2687c002167b9c0b9a941f67efc2c6787) | `Updated repos/elpa`  |