### PR TITLE
chore(flake/nur): `5af0814a` -> `a27f94cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667540161,
-        "narHash": "sha256-2xg2LYtJzPKqO7RuyY6OfPe/4WDKR2GO48slzPCSnO4=",
+        "lastModified": 1667546787,
+        "narHash": "sha256-KXGNC5j+a93Z4WzWfvPZnOngVsHjc5dLSe8CjyM1aH8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5af0814aa6541e6905ebc008cc4be467c43f9dec",
+        "rev": "a27f94cf525ffc8143c5e865c0c9d01a1b45616a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a27f94cf`](https://github.com/nix-community/NUR/commit/a27f94cf525ffc8143c5e865c0c9d01a1b45616a) | `automatic update` |