### PR TITLE
chore(flake/nur): `a27f94cf` -> `5353096a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667546787,
-        "narHash": "sha256-KXGNC5j+a93Z4WzWfvPZnOngVsHjc5dLSe8CjyM1aH8=",
+        "lastModified": 1667549886,
+        "narHash": "sha256-ZsPCOboM+ZjkoCS3KebSua8eZTOsK0gMx0qcI3G8gXo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a27f94cf525ffc8143c5e865c0c9d01a1b45616a",
+        "rev": "5353096ab815fb2ee0e5091d723e698150af660f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5353096a`](https://github.com/nix-community/NUR/commit/5353096ab815fb2ee0e5091d723e698150af660f) | `automatic update` |