### PR TITLE
chore(flake/nur): `5353096a` -> `35b89728`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667549886,
-        "narHash": "sha256-ZsPCOboM+ZjkoCS3KebSua8eZTOsK0gMx0qcI3G8gXo=",
+        "lastModified": 1667552450,
+        "narHash": "sha256-WLERHfNCR+I89E1cTXPWuKR4Vfp3cds+28lCyHtBFCo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5353096ab815fb2ee0e5091d723e698150af660f",
+        "rev": "35b89728bec493252794977ab46c186993e01c16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`35b89728`](https://github.com/nix-community/NUR/commit/35b89728bec493252794977ab46c186993e01c16) | `automatic update` |