### PR TITLE
chore(flake/emacs-overlay): `6f5b9e6e` -> `307dfb67`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667538873,
-        "narHash": "sha256-zV1OemF3Pl4t8USt0S1pu7Ye/bNX7vYjqQ531zWWQLU=",
+        "lastModified": 1667563174,
+        "narHash": "sha256-kZN8buRhKMsfkTw+3bGzmHiVlIBaRx5TGO4fvCcKIxQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6f5b9e6e9b04a750edfa9e706173635186e2c7ea",
+        "rev": "307dfb67a8080125c50d0c99f6bf6178a23395f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`307dfb67`](https://github.com/nix-community/emacs-overlay/commit/307dfb67a8080125c50d0c99f6bf6178a23395f7) | `Updated repos/nongnu` |
| [`ee6fe6ed`](https://github.com/nix-community/emacs-overlay/commit/ee6fe6ed0c5e101d1ef87d6ad843ec5b646fb993) | `Updated repos/melpa`  |
| [`35d69d22`](https://github.com/nix-community/emacs-overlay/commit/35d69d22102ab227f95358cf7aa4da0f54429727) | `Updated repos/emacs`  |