### PR TITLE
chore(flake/nur): `35b89728` -> `6a592b28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667552450,
-        "narHash": "sha256-WLERHfNCR+I89E1cTXPWuKR4Vfp3cds+28lCyHtBFCo=",
+        "lastModified": 1667563824,
+        "narHash": "sha256-/KsVJuATWyxo2s21g5StQlyOryYU45tWPHhQtCcq/AU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "35b89728bec493252794977ab46c186993e01c16",
+        "rev": "6a592b28006d3626d5b1480f1f4a6d2ba03a3e11",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6a592b28`](https://github.com/nix-community/NUR/commit/6a592b28006d3626d5b1480f1f4a6d2ba03a3e11) | `automatic update` |