### PR TITLE
chore(flake/nur): `6a592b28` -> `03865280`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667563824,
-        "narHash": "sha256-/KsVJuATWyxo2s21g5StQlyOryYU45tWPHhQtCcq/AU=",
+        "lastModified": 1667565798,
+        "narHash": "sha256-u8XtvQXQ9tmSHGMoSIxVIf0YyoGu1rFhDkn8AO/A0Kw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6a592b28006d3626d5b1480f1f4a6d2ba03a3e11",
+        "rev": "0386528039e72a3bb3c8cc930aa903fbbdd6d83c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`03865280`](https://github.com/nix-community/NUR/commit/0386528039e72a3bb3c8cc930aa903fbbdd6d83c) | `automatic update` |