### PR TITLE
chore(flake/pre-commit-hooks): `f62914b2` -> `3eb97d92`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667550824,
-        "narHash": "sha256-UlfdRiO3gVd9zkBiIrJQ/QIahMZzSmOYjfPFYByZfXM=",
+        "lastModified": 1667569243,
+        "narHash": "sha256-oJ9zVRE6EFa6Pgh0ZWPAbtDrVu1mxp9lH88LZH6MlfQ=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "f62914b2d34139349c0a2844cfc05f17b8c5a086",
+        "rev": "3eb97d920682777005930ebe01797dc54b1ccb32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                              |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------- |
| [`3eb97d92`](https://github.com/cachix/pre-commit-hooks.nix/commit/3eb97d920682777005930ebe01797dc54b1ccb32) | `fix #148: overide local pre-commit binary` |
| [`3ebf1c11`](https://github.com/cachix/pre-commit-hooks.nix/commit/3ebf1c11d2f9312a919b126d1c1c1b7605780961) | `auto-rebase pull-requests`                 |