### PR TITLE
chore(flake/nur): `03865280` -> `446feec3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667565798,
-        "narHash": "sha256-u8XtvQXQ9tmSHGMoSIxVIf0YyoGu1rFhDkn8AO/A0Kw=",
+        "lastModified": 1667574377,
+        "narHash": "sha256-bikPguZrwWubSBNS8PkpuSrUVZiiYm2ILw2AXnYHDBw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0386528039e72a3bb3c8cc930aa903fbbdd6d83c",
+        "rev": "446feec3d15aa1fa07fb9700c485fce62118be79",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`446feec3`](https://github.com/nix-community/NUR/commit/446feec3d15aa1fa07fb9700c485fce62118be79) | `automatic update` |