### PR TITLE
chore(flake/nixos-hardware): `18934557` -> `6b35a59c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -261,11 +261,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1667283320,
-        "narHash": "sha256-qHvB/6XBKVjjJJCUM+z6/t9HzUC7J55wdY3KJ/ZWSHo=",
+        "lastModified": 1667585378,
+        "narHash": "sha256-cvOwucrjBaAkaGk3FunG+MQiwiSBeIVTtO5n/YavpC0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "18934557eeba8fa2e575b0fd4ab95186e2e3bde3",
+        "rev": "6b35a59c19ddbbeb229fcd1d3dcd422dcc0fa927",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`ca3a7fca`](https://github.com/NixOS/nixos-hardware/commit/ca3a7fca0298f0f7f3a34cf552394eb4310514b5) | `starfive/visionfive/v1: Make README.MD formatting more readable` |
| [`6c2ae977`](https://github.com/NixOS/nixos-hardware/commit/6c2ae977a7f36b7b8bd8d87c9f2a0cf32ecf2a19) | `starfive/visionfive/v1: Make sd-image more flake-friendly`       |