### PR TITLE
chore(flake/nur): `6876ea53` -> `ead69315`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667584046,
-        "narHash": "sha256-M59pWZZrrlMVqei48zKj2T2tB6BdWKenOlSOkvCO0xE=",
+        "lastModified": 1667589396,
+        "narHash": "sha256-M5P+mnQ0/DtSm11sDBT0UQnVtmQoXJh48kL2+6SGC+8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6876ea53a8623667941553bdf4b470fc2d0a151f",
+        "rev": "ead693159674d2f1ac629539199b7e11e1eb5b70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ead69315`](https://github.com/nix-community/NUR/commit/ead693159674d2f1ac629539199b7e11e1eb5b70) | `automatic update` |