### PR TITLE
chore(flake/nur): `ead69315` -> `f4435845`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667589396,
-        "narHash": "sha256-M5P+mnQ0/DtSm11sDBT0UQnVtmQoXJh48kL2+6SGC+8=",
+        "lastModified": 1667606020,
+        "narHash": "sha256-uJBDSvS08a6n9UHKTpbnZrKGGvbULie0U/MuZ0jABnw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ead693159674d2f1ac629539199b7e11e1eb5b70",
+        "rev": "f443584573366ea251234e634069106a7ffdf3d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f4435845`](https://github.com/nix-community/NUR/commit/f443584573366ea251234e634069106a7ffdf3d7) | `automatic update` |