### PR TITLE
chore(flake/nur): `f4435845` -> `802f1e22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667606020,
-        "narHash": "sha256-uJBDSvS08a6n9UHKTpbnZrKGGvbULie0U/MuZ0jABnw=",
+        "lastModified": 1667613022,
+        "narHash": "sha256-6mduXuqke6GYW7arJ0kV6UtUrUMlD0I/3X6DFjc1FbY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f443584573366ea251234e634069106a7ffdf3d7",
+        "rev": "802f1e2294429a97fa348a2e46caeb00a0fa4b47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`802f1e22`](https://github.com/nix-community/NUR/commit/802f1e2294429a97fa348a2e46caeb00a0fa4b47) | `automatic update` |