### PR TITLE
chore(flake/nur): `802f1e22` -> `aa555e1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667613022,
-        "narHash": "sha256-6mduXuqke6GYW7arJ0kV6UtUrUMlD0I/3X6DFjc1FbY=",
+        "lastModified": 1667615881,
+        "narHash": "sha256-sfh0M8DQOAezD3UPsw7qliQ9uLAe7jwE0dh9CsVayAc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "802f1e2294429a97fa348a2e46caeb00a0fa4b47",
+        "rev": "aa555e1b057727727aea7b5df838f241401ef5ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`aa555e1b`](https://github.com/nix-community/NUR/commit/aa555e1b057727727aea7b5df838f241401ef5ae) | `automatic update` |