### PR TITLE
chore(flake/nur): `aa555e1b` -> `d82c6918`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667615881,
-        "narHash": "sha256-sfh0M8DQOAezD3UPsw7qliQ9uLAe7jwE0dh9CsVayAc=",
+        "lastModified": 1667618448,
+        "narHash": "sha256-zijEua+uOekI8z6pcMwQNvCXBEINMm4T7NOX24g72Kw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aa555e1b057727727aea7b5df838f241401ef5ae",
+        "rev": "d82c691876eb24e6dec4c26d25ffe80aa5ede0f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d82c6918`](https://github.com/nix-community/NUR/commit/d82c691876eb24e6dec4c26d25ffe80aa5ede0f6) | `automatic update` |