### PR TITLE
chore(flake/emacs-overlay): `e465278b` -> `b7dcebff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667594409,
-        "narHash": "sha256-vjsxL9GGSAffye6aDe+mWQ8Jdx+VUSLj11X5lezXFuI=",
+        "lastModified": 1667621802,
+        "narHash": "sha256-3nplOH4p9yVQslTiFNZNPAv+QjOReDFmSlu+ZNipClQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e465278b72617d97fb11ac49962c8093bace982d",
+        "rev": "b7dcebffaf478570c73595bd690ae7daf2e7d9f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`b7dcebff`](https://github.com/nix-community/emacs-overlay/commit/b7dcebffaf478570c73595bd690ae7daf2e7d9f3) | `Updated repos/melpa` |
| [`f96963ab`](https://github.com/nix-community/emacs-overlay/commit/f96963ab9d5bed499f50bcb479f539c3e4f6ec8a) | `Updated repos/exwm`  |
| [`43adfe4c`](https://github.com/nix-community/emacs-overlay/commit/43adfe4cb4c9a9018960851495de626e7f525ffe) | `Updated repos/elpa`  |