### PR TITLE
chore(flake/nur): `1e3f6ae5` -> `4fd5d2c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667620306,
-        "narHash": "sha256-fU+79DhI7g4nACBfAInxMGAj0EgDGlaprPAQtPndCbA=",
+        "lastModified": 1667621290,
+        "narHash": "sha256-6454VbSsWaQ8V2ChMuT3FxPQIc/uyT3rkweq83embY4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1e3f6ae5efe8270cf280eb2789c0a461a9fa4bc2",
+        "rev": "4fd5d2c14764836ffa8e5c2a5103560528935670",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4fd5d2c1`](https://github.com/nix-community/NUR/commit/4fd5d2c14764836ffa8e5c2a5103560528935670) | `automatic update` |