### PR TITLE
chore(flake/nur): `4ba94501` -> `5e115ebc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667630056,
-        "narHash": "sha256-md67qzJBWtDhRY0PQeo6oJ3LUXeWzrE+1TALCBghjs8=",
+        "lastModified": 1667636839,
+        "narHash": "sha256-htkPEsgLlSbyhLcsB6cNFwwCYMkBWvQm/qTUpXmPwMI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ba94501ae89dab8b72c8f75a68fe47fa99abd1a",
+        "rev": "5e115ebc710240978a10e5963e5e6f5114ad8ab1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5e115ebc`](https://github.com/nix-community/NUR/commit/5e115ebc710240978a10e5963e5e6f5114ad8ab1) | `automatic update` |