### PR TITLE
chore(flake/emacs-overlay): `b7dcebff` -> `6c99919f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667621802,
-        "narHash": "sha256-3nplOH4p9yVQslTiFNZNPAv+QjOReDFmSlu+ZNipClQ=",
+        "lastModified": 1667644325,
+        "narHash": "sha256-O7mk6op7lfWaMkTt08R9YOP+98BwfbXq2+f5FNZoFaM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b7dcebffaf478570c73595bd690ae7daf2e7d9f3",
+        "rev": "6c99919ff23ccd79c5fec1753da21ff0944403b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`6c99919f`](https://github.com/nix-community/emacs-overlay/commit/6c99919ff23ccd79c5fec1753da21ff0944403b2) | `Updated repos/melpa` |