### PR TITLE
chore(flake/nur): `5e115ebc` -> `781f7743`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667636839,
-        "narHash": "sha256-htkPEsgLlSbyhLcsB6cNFwwCYMkBWvQm/qTUpXmPwMI=",
+        "lastModified": 1667648785,
+        "narHash": "sha256-EeQjl6kI3Rt+qCpXRn8aacGhimS747G9w+q/VkB2Ujg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5e115ebc710240978a10e5963e5e6f5114ad8ab1",
+        "rev": "781f77434875c7da8a9a1ea6db965379b9855d9c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`781f7743`](https://github.com/nix-community/NUR/commit/781f77434875c7da8a9a1ea6db965379b9855d9c) | `automatic update` |