### PR TITLE
chore(flake/nur): `781f7743` -> `488adc8f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667648785,
-        "narHash": "sha256-EeQjl6kI3Rt+qCpXRn8aacGhimS747G9w+q/VkB2Ujg=",
+        "lastModified": 1667656771,
+        "narHash": "sha256-ShwunAo4D37OVlFGNGZw1KDo0Y0YboVrzRpVA7U82Ns=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "781f77434875c7da8a9a1ea6db965379b9855d9c",
+        "rev": "488adc8fbc457c075f00bb1b7480d78127d2a8e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`488adc8f`](https://github.com/nix-community/NUR/commit/488adc8fbc457c075f00bb1b7480d78127d2a8e6) | `automatic update` |