### PR TITLE
chore(flake/nur): `488adc8f` -> `6beff0bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667656771,
-        "narHash": "sha256-ShwunAo4D37OVlFGNGZw1KDo0Y0YboVrzRpVA7U82Ns=",
+        "lastModified": 1667657747,
+        "narHash": "sha256-xPkS2smEhCEnf62VKY4g6l/QQ8dc4si8eRFIZQNTaWU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "488adc8fbc457c075f00bb1b7480d78127d2a8e6",
+        "rev": "6beff0bb5c111ce1f26ed325ff1a5b865ba80544",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6beff0bb`](https://github.com/nix-community/NUR/commit/6beff0bb5c111ce1f26ed325ff1a5b865ba80544) | `automatic update` |