### PR TITLE
chore(flake/nur): `6beff0bb` -> `ccef4b4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667657747,
-        "narHash": "sha256-xPkS2smEhCEnf62VKY4g6l/QQ8dc4si8eRFIZQNTaWU=",
+        "lastModified": 1667675024,
+        "narHash": "sha256-72BLVJEujGWDdiatKsj+cxUAlmUFuzjiYqY4ixJZeMw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6beff0bb5c111ce1f26ed325ff1a5b865ba80544",
+        "rev": "ccef4b4ac1a68e97e81f762f681df4b573ba6cb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ccef4b4a`](https://github.com/nix-community/NUR/commit/ccef4b4ac1a68e97e81f762f681df4b573ba6cb8) | `automatic update` |