### PR TITLE
chore(flake/nixpkgs): `a2a77753` -> `3bacde62`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -275,11 +275,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667482890,
-        "narHash": "sha256-pua0jp87iwN7NBY5/ypx0s9L9CG49Ju/NI4wGwurHc4=",
+        "lastModified": 1667629849,
+        "narHash": "sha256-P+v+nDOFWicM4wziFK9S/ajF2lc0N2Rg9p6Y35uMoZI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a2a777538d971c6b01c6e54af89ddd6567c055e8",
+        "rev": "3bacde6273b09a21a8ccfba15586fb165078fb62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                              |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`429feeb3`](https://github.com/NixOS/nixpkgs/commit/429feeb354f4fbe587f857ebca60a5945df0e4cd) | `terraform-providers.tencentcloud: 1.78.7 → 1.78.8`                         |
| [`0bf54c5e`](https://github.com/NixOS/nixpkgs/commit/0bf54c5ee77086c4fb33a973ca2babb5fcde9833) | `terraform-providers.sumologic: 2.19.1 → 2.19.2`                            |
| [`9389dec4`](https://github.com/NixOS/nixpkgs/commit/9389dec4a78b4d33d97f2423c406a7867482d42a) | `terraform-providers.snowflake: 0.49.0 → 0.50.0`                            |
| [`ea85340b`](https://github.com/NixOS/nixpkgs/commit/ea85340ba702e093965b6ba9863d885e751457f2) | `terraform-providers.skytap: 0.15.0 → 0.15.1`                               |
| [`a9fb9f3b`](https://github.com/NixOS/nixpkgs/commit/a9fb9f3b062e28b5c0d98b3187bce32d925273bc) | `Revert "sysdig: pin to openssl_1_1"`                                       |
| [`f9dc9130`](https://github.com/NixOS/nixpkgs/commit/f9dc9130110d72e9c74b3d6625758796eaafee4b) | `v2ray-geoip: 202210270100 -> 202211030059`                                 |
| [`71d53b94`](https://github.com/NixOS/nixpkgs/commit/71d53b94c6b187bc99fe8e03cc7fdfc8ff6878ab) | `oh-my-posh: 12.11.0 -> 12.12.1`                                            |
| [`44770699`](https://github.com/NixOS/nixpkgs/commit/44770699eaa5f320c85a96d3dc534aba365f16c5) | `netbird: 0.10.3 -> 0.10.4`                                                 |
| [`c8abf9c3`](https://github.com/NixOS/nixpkgs/commit/c8abf9c3762dfbcd66c9e40acb857168ecd56c1a) | `debootstrap: 1.0.127 -> 1.0.128`                                           |
| [`6c731843`](https://github.com/NixOS/nixpkgs/commit/6c731843c3bb81cdfa15b65302f2c7a4e0c3af08) | `pgloader: 3.6.8 -> 3.6.9`                                                  |
| [`23909915`](https://github.com/NixOS/nixpkgs/commit/23909915446bbdf3104e6300c228486ace7548ab) | `s3cmd: 2.2.0 -> 2.3.0`                                                     |
| [`d163332f`](https://github.com/NixOS/nixpkgs/commit/d163332ff9bd18c4ae27936990bcfae8210bfb26) | `jellyfin-ffmpeg: 5.1.2-2 -> 5.1.2-4`                                       |
| [`c4937f84`](https://github.com/NixOS/nixpkgs/commit/c4937f84a54a24323376d770c80326c203c3e72f) | `cloud-init: 22.3.3 -> 22.3.4`                                              |
| [`177eaa16`](https://github.com/NixOS/nixpkgs/commit/177eaa168a88d324ab2da43eb1855beacace9372) | `terragrunt: 0.39.2 -> 0.40.0`                                              |
| [`7cd0ea9d`](https://github.com/NixOS/nixpkgs/commit/7cd0ea9d379f5b4ed164b86401bad71312099b92) | `syft: 0.60.2 -> 0.60.3`                                                    |
| [`5eaab876`](https://github.com/NixOS/nixpkgs/commit/5eaab876db34a60b79822b935a4e561bc6330eff) | `cargo-deny: 0.13.3 -> 0.13.4`                                              |
| [`fb445b51`](https://github.com/NixOS/nixpkgs/commit/fb445b517ea4b379c822723b484847e01fd5bf6c) | `nixos/fish: use a local version of runCommand for babelfishTranslate`      |
| [`665d8962`](https://github.com/NixOS/nixpkgs/commit/665d896244a1e3bc3cac7b9de1b1f1b6ce3096d8) | `logrotate: add services.logrotate.settings example`                        |
| [`01ff1dd2`](https://github.com/NixOS/nixpkgs/commit/01ff1dd23fc146dbb5a843c832af61fdefe3d6eb) | `logrotate service: cleanup deprecated options`                             |
| [`1dd8696f`](https://github.com/NixOS/nixpkgs/commit/1dd8696f96db47156e1424a49578fe7dd4ce99a4) | `vector: 0.24.1 -> 0.25.0`                                                  |
| [`2b4a5cf5`](https://github.com/NixOS/nixpkgs/commit/2b4a5cf5c13b4dca16eb7cf50423116226e4b67f) | `cargo-nextest: 0.9.42 -> 0.9.43, add figsoda as a maintainer`              |
| [`7b9bb27e`](https://github.com/NixOS/nixpkgs/commit/7b9bb27e082211b422787489384cbe31c0abf096) | `starship: reenable default features on darwin`                             |
| [`a913371b`](https://github.com/NixOS/nixpkgs/commit/a913371b15713e5f9e1f68136cd2af823ca6c644) | `python310Packages.canonicaljson: 1.6.3 -> 1.6.4`                           |
| [`ec3c0418`](https://github.com/NixOS/nixpkgs/commit/ec3c0418a513632a95df73d781f558fd9b9c3f08) | `python310Packages.google-cloud-appengine-logging: 1.1.5 -> 1.1.6`          |
| [`d8812b67`](https://github.com/NixOS/nixpkgs/commit/d8812b6746923601fedc22a427ee25f84f347030) | `python310Packages.whois: 0.9.16 -> 0.9.17`                                 |
| [`8e09c027`](https://github.com/NixOS/nixpkgs/commit/8e09c0271ca4602ef45d99b5bb2d86dcb8b58943) | `python310Packages.aiomysensors: 0.3.1 -> 0.3.2`                            |
| [`665eb10e`](https://github.com/NixOS/nixpkgs/commit/665eb10e24fda32b51445835d80eee9d16ab1235) | `python310Packages.asyncio-mqtt: 0.12.1 -> 0.13.0`                          |
| [`0411577c`](https://github.com/NixOS/nixpkgs/commit/0411577c3e4cfefdb7722e1f317d2bb5c4685873) | `python310Packages.mockupdb: switch to pytestCheckHook`                     |
| [`c72114dd`](https://github.com/NixOS/nixpkgs/commit/c72114dd062010adcc3ed1adab3c8de65fd9f659) | `python310Packages.jsonmerge: 1.8.0 -> 1.9.0`                               |
| [`8982f61d`](https://github.com/NixOS/nixpkgs/commit/8982f61dd3b58d5520705082069828d87e9fcefc) | `erigon: 2022.10.01 -> 2.29.0`                                              |
| [`f763c6f6`](https://github.com/NixOS/nixpkgs/commit/f763c6f6e41a1a195db3fda629dd29d140fe4fbf) | `python310Packages.slither-analyzer: 0.9.0 -> 0.9.1`                        |
| [`c01fdc74`](https://github.com/NixOS/nixpkgs/commit/c01fdc7455143e4fea2d36bee4c8db7ab8df1192) | `firefox-unwrapped: 106.0.4 -> 106.0.5`                                     |
| [`85a56fd3`](https://github.com/NixOS/nixpkgs/commit/85a56fd394d4d2d9155cf116c2d05d9ab8babd06) | `python310Packages.shtab: 1.5.6 -> 1.5.7`                                   |
| [`011d5fb5`](https://github.com/NixOS/nixpkgs/commit/011d5fb55c177264fd60a7a4a860c39bdb2b5f6b) | `python310Packages.pylitterbot: 2022.10.2 -> 2022.11.0`                     |
| [`797817d6`](https://github.com/NixOS/nixpkgs/commit/797817d60116115ccb1c6943f8bcee0a0e4812b7) | `rare: 1.9.2 -> 1.9.3`                                                      |
| [`f61d1afd`](https://github.com/NixOS/nixpkgs/commit/f61d1afda2626bc7d008a1d3125f6eb1c209cdfc) | `python310Packages.crownstone-uart: 2.6.0 -> 2.7.0`                         |
| [`d02835c5`](https://github.com/NixOS/nixpkgs/commit/d02835c5d2fd6bcea5d3299dbf9735aedd24f60a) | `eget: 1.2.1 -> 1.3.0`                                                      |
| [`c3995566`](https://github.com/NixOS/nixpkgs/commit/c3995566dcd7202612a7f82f7208532284d875cb) | `python310Packages.life360: 5.2.1 -> 5.3.0`                                 |
| [`e1cb783a`](https://github.com/NixOS/nixpkgs/commit/e1cb783a82aa473b8e8e8509435ace752fb36614) | `python310Packages.p1monitor: 2.1.0 -> 2.1.1`                               |
| [`d50228d3`](https://github.com/NixOS/nixpkgs/commit/d50228d355225cf96aee5ba9923274b74f627f69) | `python310Packages.peaqevcore: 7.2.1 -> 7.3.1`                              |
| [`aaf5b590`](https://github.com/NixOS/nixpkgs/commit/aaf5b590a8c8d108a57deaa2165acc0d7c567242) | `python310Packages.nomadnet: 0.2.6 -> 0.2.7`                                |
| [`60e053c7`](https://github.com/NixOS/nixpkgs/commit/60e053c7b733fde72785296475fe53b9d09c820b) | `python310Packages.lxmf: 0.2.3 -> 0.2.4`                                    |
| [`9e07b01d`](https://github.com/NixOS/nixpkgs/commit/9e07b01d2efaa9e4e1680a0297d8b6c86a7f118a) | `python310Packages.rns: 0.4.0 -> 0.4.1`                                     |
| [`2206cc18`](https://github.com/NixOS/nixpkgs/commit/2206cc181a999039ed1bb5b7c444f3c19c61842a) | `ruff: 0.0.99 -> 0.0.100`                                                   |
| [`124691a4`](https://github.com/NixOS/nixpkgs/commit/124691a4cae083b898c0d902d5121820460a2461) | `mutagen: 0.14.0 -> 0.16.0`                                                 |
| [`4ff0738f`](https://github.com/NixOS/nixpkgs/commit/4ff0738fd8f8fb833805f4083b92636c4b7fe649) | `awscli2: 2.8.8 -> 2.8.9`                                                   |
| [`61a7c250`](https://github.com/NixOS/nixpkgs/commit/61a7c250e08d7234e646b3172b01a25ee0c6c16b) | `goaccess: 1.6.4 -> 1.6.5`                                                  |
| [`18881195`](https://github.com/NixOS/nixpkgs/commit/18881195c20314aebcf54d6e5c85ae2df74da5be) | `eclipses.plugins.embed-cdt: 3.1.1 -> 6.3.1`                                |
| [`0242c271`](https://github.com/NixOS/nixpkgs/commit/0242c271aa61d1ef917e581c2d4ea9e3aaeeed75) | `tree-sitter/update: fetch orgas and directly check in python`              |
| [`8f2f2e34`](https://github.com/NixOS/nixpkgs/commit/8f2f2e34d0440b92a789ccc421c948ec65be1a85) | `tree-sitter/update: rename fetchImpl to updateImpl`                        |
| [`3b0b6d1b`](https://github.com/NixOS/nixpkgs/commit/3b0b6d1b612e85b7aebcb089e8c59b8614c21a05) | `tree-sitter/update: move atomically-write to python`                       |
| [`484bce31`](https://github.com/NixOS/nixpkgs/commit/484bce31b7cf3541e01835545453c7545d20d043) | `tree-sitter/update: move printing of the import nix file to python`        |
| [`a953387d`](https://github.com/NixOS/nixpkgs/commit/a953387d22f56bc62c67b14cbdfca846f1eef69f) | `tree-sitter/update: move checkTreeSitterRepos into python impl`            |
| [`923975a6`](https://github.com/NixOS/nixpkgs/commit/923975a604e5de29106dfe349dc5b6576b6045b6) | `tree-sitter/update: BINARIES -> ARGS.binaries`                             |
| [`aa480ba1`](https://github.com/NixOS/nixpkgs/commit/aa480ba1111f61e3774e2bd3b686c3e890955b04) | `tree-sitter/update: Move json file output to python`                       |
| [`965c698e`](https://github.com/NixOS/nixpkgs/commit/965c698e2cc1eb33ab6ae671d7d3f5abec7910ba) | `tree-sitter/update: ARGLIB_JSON -> BINARIES, factor out wrapper`           |
| [`ef9d7082`](https://github.com/NixOS/nixpkgs/commit/ef9d708262223db9b43a0ffeff43e2b129cccc29) | `tree-sitter: Update grammars`                                              |
| [`2de554d5`](https://github.com/NixOS/nixpkgs/commit/2de554d51215f318b992028ba569ea546bb57306) | `tree-sitter/update: Fetch repositories in parallel`                        |
| [`a64a9d55`](https://github.com/NixOS/nixpkgs/commit/a64a9d5552a62627ccb562c6f5ffa9c6312726e1) | `tree-sitter/update: Write files atomically`                                |
| [`26cb66b6`](https://github.com/NixOS/nixpkgs/commit/26cb66b681f5df87c431868de4459103bb7446c4) | `tree-sitter/update: Fetch the existing repos from python as well`          |
| [`805b5e97`](https://github.com/NixOS/nixpkgs/commit/805b5e978d6aff39429e9ebcbc0a6fc2df1a893a) | `tree-sitter/update: get executables from nix instead of environment`       |
| [`0d067c86`](https://github.com/NixOS/nixpkgs/commit/0d067c8603cde7118fbe11b806b718d00c78d493) | `tree-sitter/update: move pyhon impl into its own file`                     |
| [`67367631`](https://github.com/NixOS/nixpkgs/commit/673676319bfd3850ed6e4697f62d7969421ef47b) | `tree-sitter/update: factor out github url`                                 |
| [`79484399`](https://github.com/NixOS/nixpkgs/commit/7948439959252882f1b1e185a71e4c61404024da) | `tree-sitter/update: prepare moving more stuff to python`                   |
| [`d325f6f7`](https://github.com/NixOS/nixpkgs/commit/d325f6f70238f3e7b472f44918f62db947966e39) | `tree-sitter: partially rewrite update script in python`                    |
| [`1ad8079f`](https://github.com/NixOS/nixpkgs/commit/1ad8079f8bf368973659e4204f6a32b3b0fc8eee) | `ldmud: fix undefined reference to 'crypt'`                                 |
| [`bf6e7411`](https://github.com/NixOS/nixpkgs/commit/bf6e7411292ea52e26bc0d88a0a4c5846b68ddc5) | `vimPlugins.nvim-treesitter: update grammars`                               |
| [`df456957`](https://github.com/NixOS/nixpkgs/commit/df456957802bfc475b239fac5277e9b7b03c765e) | `oh-my-posh: 12.10.0 -> 12.11.0`                                            |
| [`5c5c5249`](https://github.com/NixOS/nixpkgs/commit/5c5c524933b0cb2d4967c3808f2d356adc2713b0) | `tealdeer: 1.6.0 -> 1.6.1`                                                  |
| [`56e160ee`](https://github.com/NixOS/nixpkgs/commit/56e160ee612b3f6ab9fade147742440ecaef84e5) | `nvim-treesitter: add comment on aliases`                                   |
| [`1d9b9050`](https://github.com/NixOS/nixpkgs/commit/1d9b90504041a0d8ade1e5197b11463c147eb237) | `bazarr: 1.1.1 -> 1.1.2`                                                    |
| [`8973da1d`](https://github.com/NixOS/nixpkgs/commit/8973da1d91009ecf62d18a00a26e5cab70987647) | `nixos/tests/bazarr: set timezone to fix runtime failure`                   |
| [`166c9c82`](https://github.com/NixOS/nixpkgs/commit/166c9c8269735d5bf3e49629f804bd7b995987f0) | `nixos/tests/bazarr: fix eval error`                                        |
| [`2f560270`](https://github.com/NixOS/nixpkgs/commit/2f56027040e65e1fde430ce1059c5ea7e6bd6ceb) | `cilium-cli: 0.12.5 -> 0.12.6`                                              |
| [`a3a77b48`](https://github.com/NixOS/nixpkgs/commit/a3a77b48e1bef39e00a6f3172fce512ce30e3331) | `duply: fix ftp usage`                                                      |
| [`ebb82d58`](https://github.com/NixOS/nixpkgs/commit/ebb82d58f631c16063eca5cc08d42e3b547ddca9) | `linux_xanmod: force X86_AMD_PSTATE=y`                                      |
| [`5b88d14a`](https://github.com/NixOS/nixpkgs/commit/5b88d14aac84ac6cdcfa4cf8309045a3c0d7c1dc) | `gcc-arm-embedded: remove aarch64-darwin from platforms`                    |
| [`423a5c72`](https://github.com/NixOS/nixpkgs/commit/423a5c72fd2a50c4024b163b04751450c258d2ca) | `vscode-extensions.streetsidesoftware.code-spell-checker: 2.10.1 -> 2.11.0` |
| [`ce910dae`](https://github.com/NixOS/nixpkgs/commit/ce910dae212e79ede36ae4ada54efccad5ed89a2) | `jo: 1.7 -> 1.9`                                                            |
| [`94b2d1bb`](https://github.com/NixOS/nixpkgs/commit/94b2d1bbff6cd8ce7d6eecff47d00fb19cbe7eb4) | `mimalloc: 2.0.6 -> 2.0.7 (#199488)`                                        |
| [`23d14642`](https://github.com/NixOS/nixpkgs/commit/23d146426bac06a81fc17f189250a25ba0947652) | `python3.pkgs.pylddwrap: init at 1.2.2`                                     |
| [`8af05d20`](https://github.com/NixOS/nixpkgs/commit/8af05d20835fbc861eb9b12cc0be8ed619dd94ff) | `oh-my-zsh: 2022-10-30 -> 2022-11-03`                                       |
| [`3f11b382`](https://github.com/NixOS/nixpkgs/commit/3f11b382981e852638f22e9a2b610a22544d5a20) | `howard-hinnant-date: fix CMake include path`                               |
| [`04a7bd14`](https://github.com/NixOS/nixpkgs/commit/04a7bd14b8ae910f680a8aca8549a7bc87ec5d4d) | `allure: 2.19.0 -> 2.20.0`                                                  |
| [`41af17cf`](https://github.com/NixOS/nixpkgs/commit/41af17cf5f9402d0f04910e33965a2325c8e65fc) | `yubikey-manager-qt: Depend on yubikey-manager4`                            |
| [`985b49b9`](https://github.com/NixOS/nixpkgs/commit/985b49b9425583b770ff793691d55df27026d223) | `broot: 1.16.1 -> 1.16.2`                                                   |
| [`6a88d0d8`](https://github.com/NixOS/nixpkgs/commit/6a88d0d894c72c2ff5e90669edce2a6e33feb2a9) | `calibre: 6.7.1 -> 6.8.0`                                                   |
| [`b447ffee`](https://github.com/NixOS/nixpkgs/commit/b447ffee64b3a14ce244720cf1647b436cdc7769) | `lagrange: 1.13.7 -> 1.13.8`                                                |
| [`ace92a6a`](https://github.com/NixOS/nixpkgs/commit/ace92a6aec0b1b00f082a17c6d4cbbb3736418c4) | `klipper: unstable-2022-10-25 -> unstable-2022-11-03`                       |
| [`628de9ce`](https://github.com/NixOS/nixpkgs/commit/628de9cedec35d71769eb39703f27980b4cd955b) | `bgpq4: 1.6 -> 1.7`                                                         |
| [`135d16e7`](https://github.com/NixOS/nixpkgs/commit/135d16e72f980a4c65ee2fad31eadcfa8c44cc09) | `cemu: 2.0-10 -> 2.0-13`                                                    |
| [`f622acfa`](https://github.com/NixOS/nixpkgs/commit/f622acfa26cc819f47bd2d2921970cb4b77745e5) | `htmltest: 0.16.0 -> 0.17.0`                                                |
| [`00c31fb1`](https://github.com/NixOS/nixpkgs/commit/00c31fb1cbf21b91481c620aadd081dc2d4cdc7c) | `credslayer: no longer broken`                                              |
| [`9243a44c`](https://github.com/NixOS/nixpkgs/commit/9243a44c9c46bf0a620d9fc0eb1f1d311ded7aac) | `seqkit: init at 2.3.1`                                                     |
| [`b7ea5c90`](https://github.com/NixOS/nixpkgs/commit/b7ea5c90dab1d7d5cceb4e30606d2ed093c7d787) | `python310Packages.ical: init at 4.1.0`                                     |
| [`5d4b963e`](https://github.com/NixOS/nixpkgs/commit/5d4b963e94260fe9b70017b582e9de197039bda2) | `python310Packages.pytest-golden: init at 0.2.2`                            |
| [`1ec1818c`](https://github.com/NixOS/nixpkgs/commit/1ec1818c6e8d84a6f40897d13d9bc58f8d07c447) | `python310Packages.toml-adapt: 0.2.8 -> 0.2.10`                             |
| [`e03601d3`](https://github.com/NixOS/nixpkgs/commit/e03601d3458b5d7b7a207808c4c3c13c34a6abed) | `flannel: 0.19.1 -> 0.20.1`                                                 |
| [`2b74718f`](https://github.com/NixOS/nixpkgs/commit/2b74718fdc7f0213320cc9010522b1ffbcde6238) | `lemmy-help: init at 0.9.0`                                                 |
| [`8f4eab5f`](https://github.com/NixOS/nixpkgs/commit/8f4eab5fdbf6bdb001f6d1a3b209346d94270df7) | `grype: 0.51.0 -> 0.52.0`                                                   |
| [`250ea4e9`](https://github.com/NixOS/nixpkgs/commit/250ea4e9c459f6cdda062ec5932a1caac25e1955) | `grafana-agent: 0.28.0 -> 0.28.1`                                           |
| [`ff51d7e4`](https://github.com/NixOS/nixpkgs/commit/ff51d7e4f48cc12c81419421a8beb2e7e4713710) | `firefox-devedition-bin-unwrapped: 107.0b5 -> 107.0b9`                      |
| [`eb4bcdcc`](https://github.com/NixOS/nixpkgs/commit/eb4bcdcc6960f75e54fe578dfb7981e415df55bf) | `firefox-beta-bin-unwrapped: 107.0b5 -> 107.0b9`                            |
| [`a213b3a2`](https://github.com/NixOS/nixpkgs/commit/a213b3a2e721e9faa7306e0e357417ec2be52642) | `got: 0.77 -> 0.78`                                                         |
| [`fcdfed5f`](https://github.com/NixOS/nixpkgs/commit/fcdfed5f8bfa7710031d6681e85305eb2a2770f9) | `vimPlugins: update`                                                        |
| [`4df635f6`](https://github.com/NixOS/nixpkgs/commit/4df635f6f6b396e40d762b816bcebfac27693654) | `terraform-providers.pagerduty: 2.6.3 → 2.6.4`                              |
| [`3bfa8f7d`](https://github.com/NixOS/nixpkgs/commit/3bfa8f7dc4eba30d287a92f6bfaa7ba73b886307) | `terraform-providers.aws: 4.37.0 → 4.38.0`                                  |
| [`e7b6e00b`](https://github.com/NixOS/nixpkgs/commit/e7b6e00bd9ad93c25561821784f6e2875c65f78d) | `terraform-providers.lxd: 1.7.3 → 1.8.0`                                    |
| [`411536a1`](https://github.com/NixOS/nixpkgs/commit/411536a1de1a9bcaa04beb7be609483226bfffd9) | `terraform-providers.azurerm: 3.29.1 → 3.30.0`                              |
| [`ab076b41`](https://github.com/NixOS/nixpkgs/commit/ab076b413f4df57d8f431c9779e62a48666d4829) | `deno: 1.27.0 -> 1.27.1`                                                    |
| [`3f450df5`](https://github.com/NixOS/nixpkgs/commit/3f450df5b48f627101bfba274a7679dbd2235cdc) | `kubeval: fix darwin build`                                                 |
| [`26de396a`](https://github.com/NixOS/nixpkgs/commit/26de396aa8b45cecc89f55f3b81d8d1ce474a8a1) | `grpc-gateway: 2.12.0 -> 2.13.0`                                            |
| [`bf8eaefc`](https://github.com/NixOS/nixpkgs/commit/bf8eaefc86acc2f3867864d248a14d40db3798ec) | `nodejs-19_x: 19.0.0 -> 19.0.1`                                             |
| [`57ea1f21`](https://github.com/NixOS/nixpkgs/commit/57ea1f2119a2339e42e89d0412dc8b2a45086740) | `nodejs-18_x: 18.12.0 -> 18.12.1`                                           |
| [`a3d5f09d`](https://github.com/NixOS/nixpkgs/commit/a3d5f09dfd7134153136d3153820a0642898cc9d) | `nodejs-16_x: 16.18.0 -> 16.18.1`                                           |
| [`7ce8eb28`](https://github.com/NixOS/nixpkgs/commit/7ce8eb28f05dd831be9ce88198cca45fa7652419) | `nodejs-14_x: 14.21.0 -> 14.21.1`                                           |
| [`751b6c45`](https://github.com/NixOS/nixpkgs/commit/751b6c452b873319f5a04f147fc983390b9fe6ee) | `cudatext: 1.174.0 -> 1.175.0`                                              |
| [`949e592e`](https://github.com/NixOS/nixpkgs/commit/949e592ed6ae771b2a7d0c26dc95aba096afd465) | `Revert "bazel: 5.2.0 -> 5.3.2"`                                            |
| [`6af053e2`](https://github.com/NixOS/nixpkgs/commit/6af053e21b2e3a9b87a3dab75101e18612db1e07) | `srvc: Fix darwin build`                                                    |
| [`ac603452`](https://github.com/NixOS/nixpkgs/commit/ac60345207ca0fc65599742b3ab9bdf97aab2668) | `credslayer: 0.1.2 -> 0.1.3`                                                |
| [`1d0e4d2d`](https://github.com/NixOS/nixpkgs/commit/1d0e4d2d9f5954dcf540807c2e1679fd113a02c8) | `volk: disable flaky tests`                                                 |
| [`f0fa68e1`](https://github.com/NixOS/nixpkgs/commit/f0fa68e1666b7bb67e9000e9dcf3787d2db5ea01) | `mdbook-mermaid: 0.12.0 -> 0.12.1`                                          |
| [`c57672f7`](https://github.com/NixOS/nixpkgs/commit/c57672f7af238ec0c04c2eb717b774ccbaff4c9b) | `go-ethereum: 1.10.25 -> 1.10.26`                                           |
| [`27275765`](https://github.com/NixOS/nixpkgs/commit/27275765089ba73cacfc033331337b9c09ec950a) | `mutt: add options to disable support for pop3 and smtp`                    |