### PR TITLE
chore(flake/emacs-overlay): `6c99919f` -> `38fc8434`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667644325,
-        "narHash": "sha256-O7mk6op7lfWaMkTt08R9YOP+98BwfbXq2+f5FNZoFaM=",
+        "lastModified": 1667677416,
+        "narHash": "sha256-FGsxDQZEqPO0e1ITLzc5q0axFjzlsnLk0MEOGCk/GWY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6c99919ff23ccd79c5fec1753da21ff0944403b2",
+        "rev": "38fc843411aa7cd8406dfc4a2e457a7081bf2a91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`38fc8434`](https://github.com/nix-community/emacs-overlay/commit/38fc843411aa7cd8406dfc4a2e457a7081bf2a91) | `Updated repos/melpa` |
| [`b41d21c5`](https://github.com/nix-community/emacs-overlay/commit/b41d21c59570026872ca7791290a7f4a5ef72213) | `Updated repos/emacs` |