### PR TITLE
chore(flake/pre-commit-hooks): `b8454857` -> `cc21c798`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667680128,
-        "narHash": "sha256-bnXYCDzkviKNeYwnh3YW2HpgSgUMnSGVsTtHNLXBXfE=",
+        "lastModified": 1667682049,
+        "narHash": "sha256-SJu+8wV5A9ap6otFi9ZNTSLXQJbvFiA1q2XItrt9gJ8=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "b84548575a627cad3e0b31b2c2b64eb7774c24db",
+        "rev": "cc21c7981d2ab9aa2f00e211ef8c6a0af1d31905",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                     |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------- |
| [`4089e234`](https://github.com/cachix/pre-commit-hooks.nix/commit/4089e234ca8e0eec0429ca70003e6f92b0fe9b57) | `Add settings.markdownlint.config` |