### PR TITLE
chore(flake/home-manager): `c7283074` -> `989d4fa5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667618048,
-        "narHash": "sha256-pKgavGAXBiugdKd93Z3A8hGpUmc3wkTSHlzqXd1cTo0=",
+        "lastModified": 1667690135,
+        "narHash": "sha256-qtu8NM91d0B326KKlu/KkQ7LSwoP0rwSMUTvzaxIyyA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c728307482dacc9b2720b8036292b166c7865fa9",
+        "rev": "989d4fa536e9bcd6bc2d42b3ac8b9dc07b1f9d26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                           |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`989d4fa5`](https://github.com/nix-community/home-manager/commit/989d4fa536e9bcd6bc2d42b3ac8b9dc07b1f9d26) | `home-environment: remove no-op commands`                |
| [`ccc9164b`](https://github.com/nix-community/home-manager/commit/ccc9164b76e4167873ed819f0fb014635453ec68) | `home-environment: fix activation on new style profiles` |