### PR TITLE
chore(flake/home-manager): `989d4fa5` -> `c5adf295`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667690135,
-        "narHash": "sha256-qtu8NM91d0B326KKlu/KkQ7LSwoP0rwSMUTvzaxIyyA=",
+        "lastModified": 1667691670,
+        "narHash": "sha256-9MgKg5LbTRuZ6oonP49go4jcUzkTOhVD3ZnQsi9aWM0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "989d4fa536e9bcd6bc2d42b3ac8b9dc07b1f9d26",
+        "rev": "c5adf29545b553089ccf9c28b68973ce6f812c1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                     |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`c5adf295`](https://github.com/nix-community/home-manager/commit/c5adf29545b553089ccf9c28b68973ce6f812c1c) | `i3: fix reloading when there are several sockets` |