### PR TITLE
chore(flake/nur): `43e0d382` -> `ef58cc8f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667701016,
-        "narHash": "sha256-0SSl3zbAxKPdv5C5cQCXXVaptps0N3l4daJFdz4etlk=",
+        "lastModified": 1667707690,
+        "narHash": "sha256-HLjaT14bdVMkelWHmv84QsSk0uFK3YZ8nbXa6+MSvyo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "43e0d382b5f1286aea81ec734a1e6b1e20335c8a",
+        "rev": "ef58cc8fe7dbb201e850a342069bafbacdb1aa0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ef58cc8f`](https://github.com/nix-community/NUR/commit/ef58cc8fe7dbb201e850a342069bafbacdb1aa0f) | `automatic update` |