### PR TITLE
chore(flake/nur): `ef58cc8f` -> `e5294813`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667707690,
-        "narHash": "sha256-HLjaT14bdVMkelWHmv84QsSk0uFK3YZ8nbXa6+MSvyo=",
+        "lastModified": 1667709932,
+        "narHash": "sha256-wZZe4FPM1nMvv9GpwEsDGIQpqXqsYkbtoOO1MMhhLgo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ef58cc8fe7dbb201e850a342069bafbacdb1aa0f",
+        "rev": "e5294813164d673a3de0d7eff79715534c6e992b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e5294813`](https://github.com/nix-community/NUR/commit/e5294813164d673a3de0d7eff79715534c6e992b) | `automatic update` |