### PR TITLE
chore(flake/nur): `e5294813` -> `5e449d79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667709932,
-        "narHash": "sha256-wZZe4FPM1nMvv9GpwEsDGIQpqXqsYkbtoOO1MMhhLgo=",
+        "lastModified": 1667713440,
+        "narHash": "sha256-2oduwrFPDBhn0dG46z5HGOam4ajQ+pn6CgoXARHdJVA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e5294813164d673a3de0d7eff79715534c6e992b",
+        "rev": "5e449d79b993809893d260e98fb8df1bb6b9ec98",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5e449d79`](https://github.com/nix-community/NUR/commit/5e449d79b993809893d260e98fb8df1bb6b9ec98) | `automatic update` |