### PR TITLE
chore(flake/nur): `5e449d79` -> `cf3476d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667713440,
-        "narHash": "sha256-2oduwrFPDBhn0dG46z5HGOam4ajQ+pn6CgoXARHdJVA=",
+        "lastModified": 1667733525,
+        "narHash": "sha256-NXRep2bfcNzShyUWFCP/28ySPqQRgKzwXPFM7N+0HUY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5e449d79b993809893d260e98fb8df1bb6b9ec98",
+        "rev": "cf3476d0c53d90865b12df7c9fabf7e570b9da8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`cf3476d0`](https://github.com/nix-community/NUR/commit/cf3476d0c53d90865b12df7c9fabf7e570b9da8f) | `automatic update` |