### PR TITLE
chore(flake/nur): `cf3476d0` -> `8aab177d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667733525,
-        "narHash": "sha256-NXRep2bfcNzShyUWFCP/28ySPqQRgKzwXPFM7N+0HUY=",
+        "lastModified": 1667742561,
+        "narHash": "sha256-lhNo7sk3eqq9SOABZYBECXlP552B1wgsLEGSQkWMM1M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cf3476d0c53d90865b12df7c9fabf7e570b9da8f",
+        "rev": "8aab177dc76d9b2cffe23720567ad81aaae13052",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8aab177d`](https://github.com/nix-community/NUR/commit/8aab177dc76d9b2cffe23720567ad81aaae13052) | `automatic update` |