### PR TITLE
chore(flake/nur): `8aab177d` -> `1a4d0424`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667742561,
-        "narHash": "sha256-lhNo7sk3eqq9SOABZYBECXlP552B1wgsLEGSQkWMM1M=",
+        "lastModified": 1667754548,
+        "narHash": "sha256-X/EcQt5A/n0Wc+1OdlKhqUlrvy3E0gpNLdjs8AbWLhg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8aab177dc76d9b2cffe23720567ad81aaae13052",
+        "rev": "1a4d0424322e7baee1cb190b92bc9ea6397f3b1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1a4d0424`](https://github.com/nix-community/NUR/commit/1a4d0424322e7baee1cb190b92bc9ea6397f3b1a) | `automatic update` |