### PR TITLE
chore(flake/nur): `1a4d0424` -> `1d0e31f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667754548,
-        "narHash": "sha256-X/EcQt5A/n0Wc+1OdlKhqUlrvy3E0gpNLdjs8AbWLhg=",
+        "lastModified": 1667757523,
+        "narHash": "sha256-iqTNs3X3u/J3PWHHrJx5P5TGXqxLo/OLcR/JlES7Hf8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1a4d0424322e7baee1cb190b92bc9ea6397f3b1a",
+        "rev": "1d0e31f101077231aa53ab1f3dc1434aa1a53461",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1d0e31f1`](https://github.com/nix-community/NUR/commit/1d0e31f101077231aa53ab1f3dc1434aa1a53461) | `automatic update` |
| [`5643c6a5`](https://github.com/nix-community/NUR/commit/5643c6a52a08e5a6c070e8351b1273aab2b20d4b) | `automatic update` |
| [`96f30063`](https://github.com/nix-community/NUR/commit/96f30063b797ad3c4a0eab7084ed35cd8b6c5b3e) | `automatic update` |