### PR TITLE
chore(flake/pre-commit-hooks): `cc21c798` -> `06f48d63`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667682049,
-        "narHash": "sha256-SJu+8wV5A9ap6otFi9ZNTSLXQJbvFiA1q2XItrt9gJ8=",
+        "lastModified": 1667760143,
+        "narHash": "sha256-+X5CyeNEKp41bY/I1AJgW/fn69q5cLJ1bgiaMMCKB3M=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "cc21c7981d2ab9aa2f00e211ef8c6a0af1d31905",
+        "rev": "06f48d63d473516ce5b8abe70d15be96a0147fcd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                               |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------- |
| [`19a284d6`](https://github.com/cachix/pre-commit-hooks.nix/commit/19a284d6b457482acfcafd448dfa5f1982f074b8) | `Add setting to configure nixfmt line width` |