### PR TITLE
chore(flake/nur): `1d0e31f1` -> `2a00893c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667757523,
-        "narHash": "sha256-iqTNs3X3u/J3PWHHrJx5P5TGXqxLo/OLcR/JlES7Hf8=",
+        "lastModified": 1667760896,
+        "narHash": "sha256-RbfDFGpXDsTUDgeq0QtyJqF8bbnZ69ZQZeWRrxZYQHs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1d0e31f101077231aa53ab1f3dc1434aa1a53461",
+        "rev": "2a00893c21db64d2691d1a4cb1210fcc23b7ef35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2a00893c`](https://github.com/nix-community/NUR/commit/2a00893c21db64d2691d1a4cb1210fcc23b7ef35) | `automatic update` |