### PR TITLE
chore(flake/emacs-overlay): `c009b388` -> `5d990c40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667735920,
-        "narHash": "sha256-EfkJxfLX6vVZfNR/7gZgIgwafJ+6RxHwBKp337i09gA=",
+        "lastModified": 1667760898,
+        "narHash": "sha256-CF2P91dEU2RHIYlghsXO4oAO12adW9qcaHhUejTshBA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c009b388c8c2514b24baf6231c5612192c25745c",
+        "rev": "5d990c40dade9eb7353fbb7ca3713310c1e86cad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`5d990c40`](https://github.com/nix-community/emacs-overlay/commit/5d990c40dade9eb7353fbb7ca3713310c1e86cad) | `Updated repos/melpa` |
| [`df8c7f08`](https://github.com/nix-community/emacs-overlay/commit/df8c7f0840a2e488fcc76e6b87f4b5690d2083c5) | `Updated repos/emacs` |
| [`f572f85e`](https://github.com/nix-community/emacs-overlay/commit/f572f85e47623837f908862492684fb0469d7e11) | `Updated repos/elpa`  |