### PR TITLE
chore(flake/nix-on-droid): `4050f7f9` -> `4ab4767d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -235,22 +235,46 @@
         "type": "github"
       }
     },
+    "nix-formatter-pack": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-on-droid",
+          "nixpkgs"
+        ],
+        "nmd": "nmd",
+        "nmt": "nmt"
+      },
+      "locked": {
+        "lastModified": 1666720474,
+        "narHash": "sha256-iWojjDS1D19zpeZXbBdjWb9MiKmVVFQCqtJmtTXgPx8=",
+        "owner": "Gerschtli",
+        "repo": "nix-formatter-pack",
+        "rev": "14876cc8fe94a3d329964ecb073b4c988c7b61f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Gerschtli",
+        "repo": "nix-formatter-pack",
+        "type": "github"
+      }
+    },
     "nix-on-droid": {
       "inputs": {
         "home-manager": [
           "home-manager"
         ],
+        "nix-formatter-pack": "nix-formatter-pack",
         "nixpkgs": [
           "nixpkgs"
         ],
         "nixpkgs-for-bootstrap": "nixpkgs-for-bootstrap"
       },
       "locked": {
-        "lastModified": 1667040435,
-        "narHash": "sha256-8Bim2PcQqMV7m7BOxXOhIPb4Uv44F5LWlklo9llpznY=",
+        "lastModified": 1667762792,
+        "narHash": "sha256-EdqBiO3YbFYAJ3NMwoj11jqAeFQg7fr1K8kwOnHBQPU=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "4050f7f992019e6f724a0063017bda06264a12c4",
+        "rev": "4ab4767d5083a7ca8a05a48df09796ae00cb234e",
         "type": "github"
       },
       "original": {
@@ -318,6 +342,38 @@
         "repo": "nixpkgs",
         "rev": "cd90e773eae83ba7733d2377b6cdf84d45558780",
         "type": "github"
+      }
+    },
+    "nmd": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1666190571,
+        "narHash": "sha256-Z1hc7M9X6L+H83o9vOprijpzhTfOBjd0KmUTnpHAVjA=",
+        "owner": "rycee",
+        "repo": "nmd",
+        "rev": "b75d312b4f33bd3294cd8ae5c2ca8c6da2afc169",
+        "type": "gitlab"
+      },
+      "original": {
+        "owner": "rycee",
+        "repo": "nmd",
+        "type": "gitlab"
+      }
+    },
+    "nmt": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1648075362,
+        "narHash": "sha256-u36WgzoA84dMVsGXzml4wZ5ckGgfnvS0ryzo/3zn/Pc=",
+        "owner": "rycee",
+        "repo": "nmt",
+        "rev": "d83601002c99b78c89ea80e5e6ba21addcfe12ae",
+        "type": "gitlab"
+      },
+      "original": {
+        "owner": "rycee",
+        "repo": "nmt",
+        "type": "gitlab"
       }
     },
     "nur": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                    |
| ----------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`4ab4767d`](https://github.com/t184256/nix-on-droid/commit/4ab4767d5083a7ca8a05a48df09796ae00cb234e) | `treewide: format code`           |
| [`0d984e44`](https://github.com/t184256/nix-on-droid/commit/0d984e4415159387315505b327c18c7d4f7ee998) | `flake: setup nix-formatter-pack` |