### PR TITLE
chore(flake/nur): `2a00893c` -> `d8566545`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667760896,
-        "narHash": "sha256-RbfDFGpXDsTUDgeq0QtyJqF8bbnZ69ZQZeWRrxZYQHs=",
+        "lastModified": 1667763616,
+        "narHash": "sha256-XxsWaYbPpYmfRU+zCbNhWaVfaDjpEIckxxQxF3T6ul0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2a00893c21db64d2691d1a4cb1210fcc23b7ef35",
+        "rev": "d8566545451e75838909b663bcbb913bfdc05fa9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d8566545`](https://github.com/nix-community/NUR/commit/d8566545451e75838909b663bcbb913bfdc05fa9) | `automatic update` |