### PR TITLE
chore(flake/nur): `d8566545` -> `b774348c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667763616,
-        "narHash": "sha256-XxsWaYbPpYmfRU+zCbNhWaVfaDjpEIckxxQxF3T6ul0=",
+        "lastModified": 1667765069,
+        "narHash": "sha256-838ZrwLseTaaaehQUD1ffOZq6IYGWfmZzc8kZr3hUxA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d8566545451e75838909b663bcbb913bfdc05fa9",
+        "rev": "b774348c6d34cf4814e12f3a42b5d6bb69f74d02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b774348c`](https://github.com/nix-community/NUR/commit/b774348c6d34cf4814e12f3a42b5d6bb69f74d02) | `automatic update` |