### PR TITLE
chore(flake/sops-nix): `486b4455` -> `44073537`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         "nixpkgs-22_05": "nixpkgs-22_05"
       },
       "locked": {
-        "lastModified": 1667427533,
-        "narHash": "sha256-MsgTnQEi1g7f8anlW5klHW2pJgam4CLbJaYyBw2ed58=",
+        "lastModified": 1667767301,
+        "narHash": "sha256-+UDtEkw6pZ+sqkC0Um5ocJ9kjvuu0qffSCbl+jAA8K8=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "486b4455da16272c1ed31bc82adcdbe7af829465",
+        "rev": "4407353739ad74a3d9744cf2988ab10f3b83e288",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                                        |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`e1c5cb7e`](https://github.com/Mic92/sops-nix/commit/e1c5cb7e35d454ef1fc12970370cdbdb06ffa150) | ``As per RFC2606 use `example.com` in documentation`` |