### PR TITLE
chore(flake/nur): `b774348c` -> `dc8c79ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667765069,
-        "narHash": "sha256-838ZrwLseTaaaehQUD1ffOZq6IYGWfmZzc8kZr3hUxA=",
+        "lastModified": 1667767793,
+        "narHash": "sha256-nbwYEn9xWO+LDk/Dhxm/BVI9FldEFf0u272YpI1drNE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b774348c6d34cf4814e12f3a42b5d6bb69f74d02",
+        "rev": "dc8c79baddd744e5ad9b2b1b8f463915c0a5a894",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message            |
| -------------------------------------------------------------------------------------------------- | ------------------------- |
| [`dc8c79ba`](https://github.com/nix-community/NUR/commit/dc8c79baddd744e5ad9b2b1b8f463915c0a5a894) | `automatic update`        |
| [`82751f54`](https://github.com/nix-community/NUR/commit/82751f54c9f5472431d97785e505be5c687ba4d1) | `add pokon548 repository` |