### PR TITLE
chore(flake/nix-on-droid): `4ab4767d` -> `587825a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -270,11 +270,11 @@
         "nixpkgs-for-bootstrap": "nixpkgs-for-bootstrap"
       },
       "locked": {
-        "lastModified": 1667762792,
-        "narHash": "sha256-EdqBiO3YbFYAJ3NMwoj11jqAeFQg7fr1K8kwOnHBQPU=",
+        "lastModified": 1667767431,
+        "narHash": "sha256-gEO3QQrbTIdHCEcIwvWgtGK2iqg/OKR4Uy9ua2j1sVU=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "4ab4767d5083a7ca8a05a48df09796ae00cb234e",
+        "rev": "587825a1e4f4f515de157c9dff619a2d98e9ecc2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                           |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`587825a1`](https://github.com/t184256/nix-on-droid/commit/587825a1e4f4f515de157c9dff619a2d98e9ecc2) | `tests: extend guessing $FLAKE_URL to non-github cases`  |
| [`70bc99a5`](https://github.com/t184256/nix-on-droid/commit/70bc99a562d3695fb19e17634ad5e5d980dfc653) | `tests: remove usage of undeclared runtime dependencies` |
| [`28e2fde1`](https://github.com/t184256/nix-on-droid/commit/28e2fde1331f70b4c3b881a75ae403ed01ae60a9) | `deploy: add build and deploy script as flake app`       |
| [`0a3b09df`](https://github.com/t184256/nix-on-droid/commit/0a3b09df75c78e66c69140a6bb75b8b5a81e9616) | `tests: add fakedroid as flake app`                      |
| [`1c88e73c`](https://github.com/t184256/nix-on-droid/commit/1c88e73c7810860e34cac27cecf77f3832c00750) | `flake: simplify nix-on-droid app definition`            |