### PR TITLE
chore(flake/nur): `dc8c79ba` -> `3e740e46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667767793,
-        "narHash": "sha256-nbwYEn9xWO+LDk/Dhxm/BVI9FldEFf0u272YpI1drNE=",
+        "lastModified": 1667773572,
+        "narHash": "sha256-we4+cPv+KX8D85nrT3rV4/DjrMpa4YEsdh8/fsfk6v0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dc8c79baddd744e5ad9b2b1b8f463915c0a5a894",
+        "rev": "3e740e46b8c68bf9a56738874030740fd6f4a177",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message          |
| -------------------------------------------------------------------------------------------------- | ----------------------- |
| [`3e740e46`](https://github.com/nix-community/NUR/commit/3e740e46b8c68bf9a56738874030740fd6f4a177) | `automatic update`      |
| [`a78cb57f`](https://github.com/nix-community/NUR/commit/a78cb57fad58fd0b32f3fbf55a267d221718a386) | `add rseops repository` |