### PR TITLE
chore(flake/nur): `3e740e46` -> `aae59533`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667773572,
-        "narHash": "sha256-we4+cPv+KX8D85nrT3rV4/DjrMpa4YEsdh8/fsfk6v0=",
+        "lastModified": 1667780912,
+        "narHash": "sha256-t3gj7lkMXUas89LejKd58kQ6EP7TONEiIR4ZqMlmyN0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3e740e46b8c68bf9a56738874030740fd6f4a177",
+        "rev": "aae59533dc0cec58180670bb1bea60eacfcd58a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`aae59533`](https://github.com/nix-community/NUR/commit/aae59533dc0cec58180670bb1bea60eacfcd58a7) | `automatic update` |