### PR TITLE
chore(flake/nur): `6699dc3d` -> `cf2b108b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667790615,
-        "narHash": "sha256-HP1gbMhLru10cxGVB7kjyKEqgBcDT5RgMgcMNlIpAYE=",
+        "lastModified": 1667793015,
+        "narHash": "sha256-h+GXrOOYfYrHQweN5elAJS8uK0j5OxG73aUghH++FP4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6699dc3d26787a9cde8ceca4fe002fbfbcfd484a",
+        "rev": "cf2b108b6df595cbd8b9c654e94f4e57fcbb4f29",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`cf2b108b`](https://github.com/nix-community/NUR/commit/cf2b108b6df595cbd8b9c654e94f4e57fcbb4f29) | `automatic update` |