### PR TITLE
chore(flake/nur): `cf2b108b` -> `fff1aa46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667793015,
-        "narHash": "sha256-h+GXrOOYfYrHQweN5elAJS8uK0j5OxG73aUghH++FP4=",
+        "lastModified": 1667794180,
+        "narHash": "sha256-KceQXTiXoE1CxWK2LAya5ztwzpbb+IqXZR+uUSfV1iw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cf2b108b6df595cbd8b9c654e94f4e57fcbb4f29",
+        "rev": "fff1aa46970f790ab9e3aeda38b2707f045a3275",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`fff1aa46`](https://github.com/nix-community/NUR/commit/fff1aa46970f790ab9e3aeda38b2707f045a3275) | `automatic update` |