### PR TITLE
chore(flake/emacs-overlay): `5d990c40` -> `4d8d63d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667760898,
-        "narHash": "sha256-CF2P91dEU2RHIYlghsXO4oAO12adW9qcaHhUejTshBA=",
+        "lastModified": 1667798050,
+        "narHash": "sha256-+WFVc1tnJX8jwNEcBYu3l2VbLJh+sywv3PfWV2aSpmg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5d990c40dade9eb7353fbb7ca3713310c1e86cad",
+        "rev": "4d8d63d6c02ffb4d6830812ce1358a0920d94495",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`4d8d63d6`](https://github.com/nix-community/emacs-overlay/commit/4d8d63d6c02ffb4d6830812ce1358a0920d94495) | `Updated repos/melpa` |
| [`c2b0f1e3`](https://github.com/nix-community/emacs-overlay/commit/c2b0f1e33097e7bc4f7cdbd307b1e28ad8777ad3) | `Updated repos/emacs` |