### PR TITLE
chore(flake/nur): `f488ecd8` -> `22ae8427`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667807912,
-        "narHash": "sha256-I3je0MdhIssxAz7rWK9QsSDgoNv7rQirwLxihN09VlQ=",
+        "lastModified": 1667809462,
+        "narHash": "sha256-1ZJdPgwU94rqLVbeeNyW8t1WC001ctgQ287R5roYVww=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f488ecd8bb4d62e6b535b87a1fa5a299c5da197d",
+        "rev": "22ae842712005fb7e70c2f5d77c2722797c2d151",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`22ae8427`](https://github.com/nix-community/NUR/commit/22ae842712005fb7e70c2f5d77c2722797c2d151) | `automatic update` |
| [`209c5028`](https://github.com/nix-community/NUR/commit/209c5028f016733f691b756e351191544e79e540) | `automatic update` |