### PR TITLE
chore(flake/emacs-overlay): `4d8d63d6` -> `a864e84b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667798050,
-        "narHash": "sha256-+WFVc1tnJX8jwNEcBYu3l2VbLJh+sywv3PfWV2aSpmg=",
+        "lastModified": 1667823539,
+        "narHash": "sha256-AwDCZgUT004T+skxK62ZWAlP+60yomMaHb0/+hHH448=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4d8d63d6c02ffb4d6830812ce1358a0920d94495",
+        "rev": "a864e84bd842d00d686e040f552e2fa7030351a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`a864e84b`](https://github.com/nix-community/emacs-overlay/commit/a864e84bd842d00d686e040f552e2fa7030351a0) | `Updated repos/nongnu` |
| [`bf6140f8`](https://github.com/nix-community/emacs-overlay/commit/bf6140f871c21c7d0c4b0c37f0918400c5bedb89) | `Updated repos/melpa`  |
| [`ef160fd0`](https://github.com/nix-community/emacs-overlay/commit/ef160fd067799a9a56752793c0d785909a65630f) | `Updated repos/emacs`  |