### PR TITLE
chore(flake/nur): `1bff6e16` -> `685018e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667811668,
-        "narHash": "sha256-jfdmzVWKZFk6AQ543zL5gYNir8H73IjGw4AH2rp5qXE=",
+        "lastModified": 1667827373,
+        "narHash": "sha256-dMSdfn0fwYd11JtJqls8odVeM5WCfXTj3HKJn/zZni0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1bff6e1626d7e6040f549f91954c7ae12f68f04f",
+        "rev": "685018e7a17821cf7a264b01deacefffee3651b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`685018e7`](https://github.com/nix-community/NUR/commit/685018e7a17821cf7a264b01deacefffee3651b4) | `automatic update` |