### PR TITLE
chore(flake/nur): `685018e7` -> `072fd7bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667827373,
-        "narHash": "sha256-dMSdfn0fwYd11JtJqls8odVeM5WCfXTj3HKJn/zZni0=",
+        "lastModified": 1667833469,
+        "narHash": "sha256-8hqcHgkD1YsJfSyyZnmrm9kcP1O2nUE8Ej2zRWC6YfI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "685018e7a17821cf7a264b01deacefffee3651b4",
+        "rev": "072fd7bcc7f9f4f134272d687b8744e22e8f93db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`072fd7bc`](https://github.com/nix-community/NUR/commit/072fd7bcc7f9f4f134272d687b8744e22e8f93db) | `automatic update` |