### PR TITLE
chore(flake/nur): `072fd7bc` -> `9dd63dda`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667833469,
-        "narHash": "sha256-8hqcHgkD1YsJfSyyZnmrm9kcP1O2nUE8Ej2zRWC6YfI=",
+        "lastModified": 1667842269,
+        "narHash": "sha256-OR7typzu0S/uKrVanVGI0PhiEjhF+gwmav/67zQK/Tg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "072fd7bcc7f9f4f134272d687b8744e22e8f93db",
+        "rev": "9dd63ddaabf20cfcdda6d9d7b10b5466c670f1c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9dd63dda`](https://github.com/nix-community/NUR/commit/9dd63ddaabf20cfcdda6d9d7b10b5466c670f1c4) | `automatic update` |
| [`54a1f271`](https://github.com/nix-community/NUR/commit/54a1f271e2c3a465e5fccf7e50d2637481d136fb) | `automatic update` |