### PR TITLE
chore(flake/nur): `9dd63dda` -> `9395202b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667842269,
-        "narHash": "sha256-OR7typzu0S/uKrVanVGI0PhiEjhF+gwmav/67zQK/Tg=",
+        "lastModified": 1667845588,
+        "narHash": "sha256-5ifIx7bgTtM2Dh5UEsyb1Y51PvTkR1eJaHkcNrFDj/c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9dd63ddaabf20cfcdda6d9d7b10b5466c670f1c4",
+        "rev": "9395202bd590a1957dfb432693d06037390538a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9395202b`](https://github.com/nix-community/NUR/commit/9395202bd590a1957dfb432693d06037390538a3) | `automatic update` |