### PR TITLE
chore(flake/emacs-ement): `f2ba62c8` -> `8a354b52`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1667395988,
-        "narHash": "sha256-RWUSPT4QXw83YOozVjCHckT7hEZc9TSv4g93Wf2HQkM=",
+        "lastModified": 1667851575,
+        "narHash": "sha256-I4ptcR9BiI6aoDzjzO/s48/Ms5I9HITCCtoewqrnGWg=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "f2ba62c81387f1d54dae4873b46bcf1226503584",
+        "rev": "8a354b52d8d71f952c10c6ba355547ce9b86bd6a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                              |
| --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`8a354b52`](https://github.com/alphapapa/ement.el/commit/8a354b52d8d71f952c10c6ba355547ce9b86bd6a) | `Fix: (ement--add-reply) Use formatted_body when available` |