### PR TITLE
chore(flake/emacs-overlay): `a864e84b` -> `b4b8a50d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667823539,
-        "narHash": "sha256-AwDCZgUT004T+skxK62ZWAlP+60yomMaHb0/+hHH448=",
+        "lastModified": 1667852773,
+        "narHash": "sha256-xklQCXCdnGRSAoi06n7QzhfRL45EgtSwjuzM8Nz/8Xs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a864e84bd842d00d686e040f552e2fa7030351a0",
+        "rev": "b4b8a50d8084f9ec21cdc1410f76cedc87c2a997",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`b4b8a50d`](https://github.com/nix-community/emacs-overlay/commit/b4b8a50d8084f9ec21cdc1410f76cedc87c2a997) | `Updated repos/melpa` |
| [`479b8d4b`](https://github.com/nix-community/emacs-overlay/commit/479b8d4b0fb624c6469d476f850952943f18b6fb) | `Updated repos/emacs` |
| [`c6b2079b`](https://github.com/nix-community/emacs-overlay/commit/c6b2079be7bc013a4167fd127ab45afb8ebf2e64) | `Updated repos/elpa`  |