### PR TITLE
chore(flake/nur): `9395202b` -> `bf4be990`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667845588,
-        "narHash": "sha256-5ifIx7bgTtM2Dh5UEsyb1Y51PvTkR1eJaHkcNrFDj/c=",
+        "lastModified": 1667860722,
+        "narHash": "sha256-40cAO5H7sSy1CJca3ExoXZVlILEj7cOPZKOhFqp6Yc4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9395202bd590a1957dfb432693d06037390538a3",
+        "rev": "bf4be9905ed2a54a7763227ce158b640d43236e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`bf4be990`](https://github.com/nix-community/NUR/commit/bf4be9905ed2a54a7763227ce158b640d43236e0) | `automatic update` |