### PR TITLE
chore(flake/nur): `bf4be990` -> `2148d452`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667860722,
-        "narHash": "sha256-40cAO5H7sSy1CJca3ExoXZVlILEj7cOPZKOhFqp6Yc4=",
+        "lastModified": 1667861583,
+        "narHash": "sha256-H8grQrPEQ7YZoZkh9pu8so6HvXcWs97YxRk953/U4rw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bf4be9905ed2a54a7763227ce158b640d43236e0",
+        "rev": "2148d452bbcba69aa5a3a7f31af26a7a9136a458",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2148d452`](https://github.com/nix-community/NUR/commit/2148d452bbcba69aa5a3a7f31af26a7a9136a458) | `automatic update` |