### PR TITLE
chore(flake/nur): `2148d452` -> `5f58d423`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667861583,
-        "narHash": "sha256-H8grQrPEQ7YZoZkh9pu8so6HvXcWs97YxRk953/U4rw=",
+        "lastModified": 1667865591,
+        "narHash": "sha256-/3goj6gEkbIknJWMohneLvECmU1QTNyedsu4wT2nFtQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2148d452bbcba69aa5a3a7f31af26a7a9136a458",
+        "rev": "5f58d423e2b03a309b3d43ca63916dce01fe245b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5f58d423`](https://github.com/nix-community/NUR/commit/5f58d423e2b03a309b3d43ca63916dce01fe245b) | `automatic update` |