### PR TITLE
chore(flake/nur): `5f58d423` -> `2d3e041e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667865591,
-        "narHash": "sha256-/3goj6gEkbIknJWMohneLvECmU1QTNyedsu4wT2nFtQ=",
+        "lastModified": 1667872116,
+        "narHash": "sha256-xsOyHO2y/AeSIqR7mEOIotLJQnc60PhlJuCU5a6SBgU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5f58d423e2b03a309b3d43ca63916dce01fe245b",
+        "rev": "2d3e041e68c3de37fcf543e65e9988e96bfeacbc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2d3e041e`](https://github.com/nix-community/NUR/commit/2d3e041e68c3de37fcf543e65e9988e96bfeacbc) | `automatic update` |