### PR TITLE
chore(flake/nur): `2d3e041e` -> `e7773ae7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667872116,
-        "narHash": "sha256-xsOyHO2y/AeSIqR7mEOIotLJQnc60PhlJuCU5a6SBgU=",
+        "lastModified": 1667880687,
+        "narHash": "sha256-HP6TXV16ABCgOBsZUNTKUJ40QgSfFY/pRBsaE4bco9M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2d3e041e68c3de37fcf543e65e9988e96bfeacbc",
+        "rev": "e7773ae7a41109e6a2bfef3a9e6de9dd3325b3cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e7773ae7`](https://github.com/nix-community/NUR/commit/e7773ae7a41109e6a2bfef3a9e6de9dd3325b3cc) | `automatic update` |