### PR TITLE
chore(flake/emacs-overlay): `b4b8a50d` -> `f04cb6f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667852773,
-        "narHash": "sha256-xklQCXCdnGRSAoi06n7QzhfRL45EgtSwjuzM8Nz/8Xs=",
+        "lastModified": 1667882772,
+        "narHash": "sha256-hoVW9/xcfZTsKn++nGYwEMgBLfh+iq7i8+eEcAhOxy0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b4b8a50d8084f9ec21cdc1410f76cedc87c2a997",
+        "rev": "f04cb6f6724ba4568a7f6dae0863e507477667b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`f04cb6f6`](https://github.com/nix-community/emacs-overlay/commit/f04cb6f6724ba4568a7f6dae0863e507477667b7) | `Updated repos/nongnu` |
| [`3cdc5328`](https://github.com/nix-community/emacs-overlay/commit/3cdc5328d2cd752bd479ff098a8aac9be0c23bf1) | `Updated repos/melpa`  |
| [`68f498ae`](https://github.com/nix-community/emacs-overlay/commit/68f498ae593a711f7399bd841da982e7e9576e9f) | `Updated repos/emacs`  |