### PR TITLE
chore(flake/nixpkgs): `3bacde62` -> `adc7d07c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -299,11 +299,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667629849,
-        "narHash": "sha256-P+v+nDOFWicM4wziFK9S/ajF2lc0N2Rg9p6Y35uMoZI=",
+        "lastModified": 1667702334,
+        "narHash": "sha256-2oihoCZvQvg+oUrMz8OGc1z4J9HflqEjkk666VKm9jw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3bacde6273b09a21a8ccfba15586fb165078fb62",
+        "rev": "adc7d07c0c8162ecb9fe0b075386d549680ef914",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                          |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`adc7d07c`](https://github.com/NixOS/nixpkgs/commit/adc7d07c0c8162ecb9fe0b075386d549680ef914) | `oil: 0.12.6 -> 0.12.7`                                                 |
| [`4b59590a`](https://github.com/NixOS/nixpkgs/commit/4b59590ac5326b82581e96f4eb1ff7417c932387) | `Revert "lib,doc: remove obvious usages of toString on paths"`          |
| [`77de45c8`](https://github.com/NixOS/nixpkgs/commit/77de45c852cc6e2e2830588e73303c5fa98af783) | `gcsfuse: 0.41.7 -> 0.41.8`                                             |
| [`79efdd54`](https://github.com/NixOS/nixpkgs/commit/79efdd54d699827d0e3d80c160e450bca6785a01) | `trezord: 2.0.31 -> 2.0.32`                                             |
| [`836f31e1`](https://github.com/NixOS/nixpkgs/commit/836f31e1040dedd6d895570b6030d12f53e6e58a) | `trezor-suite: 22.8.2 -> 22.10.3`                                       |
| [`407b1ce0`](https://github.com/NixOS/nixpkgs/commit/407b1ce09d0b0d169a3392299eb0e4031096f100) | `weka: use openjdk11`                                                   |
| [`6abb510b`](https://github.com/NixOS/nixpkgs/commit/6abb510b481b9530001186674ffa3f3736dd906d) | `just: 1.7.0 -> 1.8.0`                                                  |
| [`5d4e386d`](https://github.com/NixOS/nixpkgs/commit/5d4e386d55ea66e573e4f4d93f1b2e4323c5e993) | `ripdrag: 0.2.0 -> 0.2.1`                                               |
| [`c0c7fb71`](https://github.com/NixOS/nixpkgs/commit/c0c7fb71354e5cef862961b387dc6906302b91ee) | `ruff: 0.0.100 -> 0.0.102`                                              |
| [`66cf79f2`](https://github.com/NixOS/nixpkgs/commit/66cf79f28218d47f076826001198b849366504de) | `lib,doc: remove obvious usages of toString on paths`                   |
| [`90aff4b3`](https://github.com/NixOS/nixpkgs/commit/90aff4b3e624bf2f0c90a6ba4fb317161abddf9e) | `conmon: 2.1.4 -> 2.1.5`                                                |
| [`830a385b`](https://github.com/NixOS/nixpkgs/commit/830a385b5f3f9a03c4f44f08071c655f9d85c2b3) | `ocamlPackages.stdint: 0.7.0 → 0.7.2`                                   |
| [`8a88bac9`](https://github.com/NixOS/nixpkgs/commit/8a88bac92b164558d330b40a34b86d9324ff5713) | `ocamlPackages.ounit2: 2.2.4 → 2.2.6`                                   |
| [`ae179a48`](https://github.com/NixOS/nixpkgs/commit/ae179a485e1ef1d6b6e393600c6c46450daf46b2) | `ocamlPackages.ocaml_gettext: disable tests`                            |
| [`ee94fbdf`](https://github.com/NixOS/nixpkgs/commit/ee94fbdfe2faa1f1c7628b054856feb927668123) | `numix-icon-theme-square: 22.10.31 -> 22.11.05`                         |
| [`bfc4a9d9`](https://github.com/NixOS/nixpkgs/commit/bfc4a9d9d33d44f7d183553be8e1712917f1213b) | `dino: 0.3.0 -> 0.3.1`                                                  |
| [`07fae505`](https://github.com/NixOS/nixpkgs/commit/07fae5053b2fffff1c17f9e81e370d8f18bba463) | `obs-studio-plugins.obs-vkcapture: 1.2.0 -> 1.2.1`                      |
| [`472f3dfa`](https://github.com/NixOS/nixpkgs/commit/472f3dfaa246e0c08e23afae1bc83b0c95ef96d7) | `apksigner: enable on unix platforms`                                   |
| [`d2d68fb1`](https://github.com/NixOS/nixpkgs/commit/d2d68fb1f9d835ba583373f6562da101d5cdb59a) | `grafana: 9.2.2 -> 9.2.3`                                               |
| [`11b9b7bf`](https://github.com/NixOS/nixpkgs/commit/11b9b7bf86781e12342eab9ac15d3ac95a7c4c21) | `flent: 2.0.1 -> 2.1.1; fixes`                                          |
| [`bbb86222`](https://github.com/NixOS/nixpkgs/commit/bbb862227565df77cfbdda9dcf66e39682e97bc4) | `timg: apply patch for CVE-2022-43151`                                  |
| [`7f29a574`](https://github.com/NixOS/nixpkgs/commit/7f29a5746a521fc6b736a2995454534eca9be9ce) | `tomcat: 9.0.53 -> 9.0.68, 10.0.11 -> 10.0.27`                          |
| [`8896a575`](https://github.com/NixOS/nixpkgs/commit/8896a5757950f32bdaaa4bfbf38488d94d7e4b6f) | `linux-lqx: 6.0.6-lqx1 -> 6.0.7-lqx1`                                   |
| [`ab9739da`](https://github.com/NixOS/nixpkgs/commit/ab9739da39014efef0d25112faa32cba6a212528) | `duplicacy: add devusb to maintainers`                                  |
| [`7a0eed97`](https://github.com/NixOS/nixpkgs/commit/7a0eed9731f3ee926d70b80fbbf38a22ea7bb105) | `duplicacy: 2.7.2 -> 3.0.1`                                             |
| [`3c9272a5`](https://github.com/NixOS/nixpkgs/commit/3c9272a5cf30dcda2fc5c7c53963b539fb5183ef) | `linux-zen: 6.0.6-zen1 -> 6.0.7-zen1`                                   |
| [`2b43dcf6`](https://github.com/NixOS/nixpkgs/commit/2b43dcf62053734082da71104f96a4212882bb50) | `google-guest-agent: 20221025.00 -> 20221104.00`                        |
| [`fd1711f4`](https://github.com/NixOS/nixpkgs/commit/fd1711f46266380f4b3366c41b9412f1e40359ad) | `globalarrays: 5.8.1 -> 5.8.2`                                          |
| [`e01db33b`](https://github.com/NixOS/nixpkgs/commit/e01db33b9a68d78938bf5eddafa9d194ba2cd790) | `ghostunnel: 1.6.1 -> 1.7.0`                                            |
| [`f23ddc55`](https://github.com/NixOS/nixpkgs/commit/f23ddc55a6c695277b56a5cba37dfc322e5d1820) | `nixos/sane: mention sane-airscan in the extraBackends option`          |
| [`c9dbda41`](https://github.com/NixOS/nixpkgs/commit/c9dbda414edb755886a1a4de104548747fae203b) | `i3: 4.21 -> 4.21.1`                                                    |
| [`adb52996`](https://github.com/NixOS/nixpkgs/commit/adb52996cbd47fbbf6d61ae4562a62772fc396ec) | `flow: 0.191.0 -> 0.192.0`                                              |
| [`64686c25`](https://github.com/NixOS/nixpkgs/commit/64686c25b749c0de8f3f2fcc09d083b97a5f6510) | `ocamlPackages.lablgtk: 2.18.12 → 2.18.13`                              |
| [`49caaf34`](https://github.com/NixOS/nixpkgs/commit/49caaf34d70a628de4b984ac464fa6047d55a239) | `flyctl: 0.0.427 -> 0.0.429`                                            |
| [`3b7410ff`](https://github.com/NixOS/nixpkgs/commit/3b7410ff82190b17ae289fad4b4736f8760803a4) | `python310Packages.plugwise: 0.25.4 -> 0.25.6`                          |
| [`a18ecf7b`](https://github.com/NixOS/nixpkgs/commit/a18ecf7b73476e9e8f2f484d476b44ca790f676e) | `tio: remove unused cmake from nativeBuildInputs`                       |
| [`751f0f83`](https://github.com/NixOS/nixpkgs/commit/751f0f831672e12fa86c19c547d1752d1a48ca1f) | `python3Packages.mpi4py: cleanup inputs and meta data`                  |
| [`12c069cd`](https://github.com/NixOS/nixpkgs/commit/12c069cd35b7aeec713207be0c1190cb8a68190c) | `webkitgtk: 2.38.1 -> 2.38.2`                                           |
| [`88a8282e`](https://github.com/NixOS/nixpkgs/commit/88a8282e7c3d42c47b5051bcb612fc855115c83a) | `faust2: darwin support`                                                |
| [`7bbc6e29`](https://github.com/NixOS/nixpkgs/commit/7bbc6e29b134f277ed40fd81948ddb367cbdb64f) | `nixos/home-assistant: update bluetooth components`                     |
| [`521dc77a`](https://github.com/NixOS/nixpkgs/commit/521dc77a2a9a8c640e98c66692f1dd5a478670ab) | `home-assistant: 2022.10.5 -> 2022.11.1`                                |
| [`69cf4149`](https://github.com/NixOS/nixpkgs/commit/69cf4149ab2fb9ed26f6f81d354a2e2c7b3d45b7) | `python3Packages.aiolifx-themes: init at v0.2.0`                        |
| [`35b0503f`](https://github.com/NixOS/nixpkgs/commit/35b0503fecb7b3daac0eecf6e940126c865d70b1) | `python3Packages.ibeacon-ble: 0.7.4 -> 1.0.1`                           |
| [`a975823d`](https://github.com/NixOS/nixpkgs/commit/a975823d5b148f58547bdbb4b0a444a609ae6712) | `python3Packages.mac-vendor-lookup: init at 0.1.12`                     |
| [`171e8e0c`](https://github.com/NixOS/nixpkgs/commit/171e8e0c8994ee2ba6ea919d847333b8cc1779d2) | `python3Packages.av: 9.2.0 -> 10.0.0`                                   |
| [`de0d6bd5`](https://github.com/NixOS/nixpkgs/commit/de0d6bd58d4fd29559f41cc4b035795ce6cce93b) | `python3Packages.pyrmvtransport: 0.3.2 -> 0.3.3`                        |
| [`35619a92`](https://github.com/NixOS/nixpkgs/commit/35619a928d4e415541e75ef7f69377a7f0b95c90) | `home-assistant: fix requirements parser version detection`             |
| [`7be740d9`](https://github.com/NixOS/nixpkgs/commit/7be740d950202af2ad2a60074d8c35cd8205a1fa) | `python310Packages.zigpy-zigate: 0.10.2 -> 0.10.3`                      |
| [`c38beec6`](https://github.com/NixOS/nixpkgs/commit/c38beec6b2849ffb4e285c0fdf38d197bab15d08) | `python310Packages.zigpy: 0.51.3 -> 0.51.5`                             |
| [`3d3e6b8a`](https://github.com/NixOS/nixpkgs/commit/3d3e6b8ac13c5a50ae3854f96a6a9320b67fc3c1) | `python310Packages.zha-quirks: 0.0.83 -> 0.0.84`                        |
| [`0e7b91dd`](https://github.com/NixOS/nixpkgs/commit/0e7b91dd13908cedb47187a284e3b5770f22d9cb) | `python3Packages.xknx: 1.1.0 -> 1.2.0`                                  |
| [`6406b938`](https://github.com/NixOS/nixpkgs/commit/6406b938358c2b38a284d7a4bac34ad1600e0a15) | `python310Packages.subarulink: 0.5.0 -> 0.6.1 (#193462)`                |
| [`b563b609`](https://github.com/NixOS/nixpkgs/commit/b563b609e0f4206d95696cae2774d15d4cf247c8) | `python310Packages.pysma: 0.6.12 -> 0.7.2 (#196816)`                    |
| [`8fd76214`](https://github.com/NixOS/nixpkgs/commit/8fd76214e51916f96ab74cc15c9cbf083f7f32a6) | `python3Packages.pylutron-caseta: 0.17.0 -> 0.17.1`                     |
| [`5e9e8a21`](https://github.com/NixOS/nixpkgs/commit/5e9e8a21d99550c8f2533fbe150b497d1f3aae16) | `python310Packages.pydeconz: 104 -> 105`                                |
| [`852d12c5`](https://github.com/NixOS/nixpkgs/commit/852d12c567be8583d9e276b84d604637b3ff6569) | `python310Packages.pydaikin: 2.7.2 -> 2.8.0`                            |
| [`31dcf328`](https://github.com/NixOS/nixpkgs/commit/31dcf3282fc2ef463001e567f7744f1bf55e042d) | `python310Packages.pyatmo: 7.2.0 -> 7.3.0`                              |
| [`b342a3d2`](https://github.com/NixOS/nixpkgs/commit/b342a3d291eea516ccb8b5dec8034011f50ddfec) | `python310Packages.gcal-sync: 2.1.0 -> 3.0.0`                           |
| [`71663ee8`](https://github.com/NixOS/nixpkgs/commit/71663ee8565be81be5345ba21701da66eb12a7d5) | `python310Packages.freebox-api: 1.0.0 -> 1.0.1`                         |
| [`80f87533`](https://github.com/NixOS/nixpkgs/commit/80f87533206b54d4b8c7c864cd0b9927ba0982ff) | `python310Packages.aiounifi: 40 -> 41`                                  |
| [`a3109223`](https://github.com/NixOS/nixpkgs/commit/a3109223f306dd7c9b876913209bbba8b5ee25ce) | `python310Packages.aioshelly: 3.0.0 -> 4.1.2`                           |
| [`4153fd34`](https://github.com/NixOS/nixpkgs/commit/4153fd3444089f9837f9345956080c595b49c3ad) | `python310Packages.aiopyarr: 22.9.0 -> 22.10.0`                         |
| [`619ffc8c`](https://github.com/NixOS/nixpkgs/commit/619ffc8cb0ae1c46d324c914f23ae7d46312efd2) | `python310Packages.yalexs-ble: 1.9.2 -> 1.9.5`                          |
| [`d4cc3aba`](https://github.com/NixOS/nixpkgs/commit/d4cc3aba2edb2479afe81db8f2402ee13c1a6a1d) | `python310Packages.sensor-state-data: 2.9.1 -> 2.10.1`                  |
| [`3c7db594`](https://github.com/NixOS/nixpkgs/commit/3c7db59478e0ec575e4bd1c4ecaeab1ad7be2a1e) | `python310Packages.pyswitchbot: 0.19.15 -> 0.20.2`                      |
| [`0917dd48`](https://github.com/NixOS/nixpkgs/commit/0917dd484eb2d93ecdb10da60cdebaf1e9579120) | `python310Packages.oralb-ble: init at 0.10.1`                           |
| [`c2687f97`](https://github.com/NixOS/nixpkgs/commit/c2687f97958d07e9dfb655b33d180e74c5bc34f3) | `python310Packages.led-ble: 0.10.1 -> 1.0.0`                            |
| [`be8ee7e2`](https://github.com/NixOS/nixpkgs/commit/be8ee7e2275b6e991a2f74a45cb325b66604bfd3) | `python310Packages.home-assistant-bluetooth: 1.5.1 -> 1.6.0`            |
| [`e1cbc3f8`](https://github.com/NixOS/nixpkgs/commit/e1cbc3f8a2e00d43ae8823238e78d89adb8f7ad7) | `python310Packages.fjaraskupan: 2.1.0 -> 2.2.0`                         |
| [`cec0949d`](https://github.com/NixOS/nixpkgs/commit/cec0949d405e143e0dfb5a38076d81420c2e0371) | `python310Packages.dbus-fast: 1.29.1 -> 1.64.0`                         |
| [`3c783987`](https://github.com/NixOS/nixpkgs/commit/3c783987b8b8b578b0fcf76fc9598ca9f0ebca17) | `python310Packages.bluetooth-data-tools: 0.1.2 -> 0.2.0`                |
| [`85bd60c7`](https://github.com/NixOS/nixpkgs/commit/85bd60c7cb1226ea0b07cc0fd408421095b187d5) | `python310Packages.bthome-ble: 1.2.2 -> 2.1.0`                          |
| [`677f3cde`](https://github.com/NixOS/nixpkgs/commit/677f3cdeabcb79a4c3887f5daa9cf8f0afed4cc8) | `python310Packages.bleak-retry-connector: 2.1.3 -> 2.8.2`               |
| [`8d7cec09`](https://github.com/NixOS/nixpkgs/commit/8d7cec09c3166ac5be69baa398123794a3846f7f) | `python310Packages.bleak: 0.18.1 -> 0.19.1`                             |
| [`482ea02e`](https://github.com/NixOS/nixpkgs/commit/482ea02ea0c356254f121c48f9349c4c59e3fc96) | `python310Packages.aiohomekit: 2.0.2 -> 2.2.14`                         |
| [`2d4340c2`](https://github.com/NixOS/nixpkgs/commit/2d4340c2b7ff626878f19657b605921af5162768) | `python3Packages.bsblan: remove in favor of python-bsblan`              |
| [`a0b7b603`](https://github.com/NixOS/nixpkgs/commit/a0b7b60364db219d127fcb7151487d569563567f) | `ctlptl: 0.8.11 -> 0.8.12`                                              |
| [`1bd99d92`](https://github.com/NixOS/nixpkgs/commit/1bd99d9268a3497997e5d3e7c608890ec874a536) | `tree-sitter-grammars: add eex`                                         |
| [`3628ad0a`](https://github.com/NixOS/nixpkgs/commit/3628ad0a9e7caf6b1c5a0f5cbadfa4b71936afd1) | `nixos/security/wrappers: add test`                                     |
| [`4eb6de16`](https://github.com/NixOS/nixpkgs/commit/4eb6de16edcd5000cb044a70b1f4d9609ac09169) | `clair: 4.4.4 -> 4.5.0`                                                 |
| [`b4fef779`](https://github.com/NixOS/nixpkgs/commit/b4fef779596b9f04135038f9ff5b21bd5009650e) | `cargo-release: 0.22.2 -> 0.23.0`                                       |
| [`3d6b83c9`](https://github.com/NixOS/nixpkgs/commit/3d6b83c97359cf8888b16a75a802cafef0c55012) | `bazelisk: 1.14.0 -> 1.15.0`                                            |
| [`9c85db3a`](https://github.com/NixOS/nixpkgs/commit/9c85db3a3701135877142cbb64e8a0596131efa9) | `handbrake: build against ffmpeg with custom patches`                   |
| [`9c341e1b`](https://github.com/NixOS/nixpkgs/commit/9c341e1ba305508553b9a277b66723081d256ef7) | `erigon: init module`                                                   |
| [`69d5c864`](https://github.com/NixOS/nixpkgs/commit/69d5c86471fa5bef6da054e6556bc2c7423bef06) | `firefox-bin-unwrapped: 106.0.3 -> 106.0.5`                             |
| [`c60cb848`](https://github.com/NixOS/nixpkgs/commit/c60cb848d995b418bc20a1beb7399e97ebe81df7) | `python310Packages.PyGithub: add format attribute`                      |
| [`bc127cc3`](https://github.com/NixOS/nixpkgs/commit/bc127cc35ce431594bf2d5a6cb315becde61cf83) | `python310Packages.PyGithub: 1.56 -> 1.57`                              |
| [`b34f18ae`](https://github.com/NixOS/nixpkgs/commit/b34f18aed9bbc984ec78efe45e7daf84bf380c41) | `cargo-generate: fix by skipping failing test`                          |
| [`d2ef363c`](https://github.com/NixOS/nixpkgs/commit/d2ef363cc1e1816e1c9a92440d40367cf60a2414) | `eksctl: 0.115.0 -> 0.117.0`                                            |
| [`afae4d8f`](https://github.com/NixOS/nixpkgs/commit/afae4d8f2880845cebc0b63560b1bf5537246f62) | `python310Packages.asyncclick: 8.0.1.3 -> 8.1.3.2`                      |
| [`17be899f`](https://github.com/NixOS/nixpkgs/commit/17be899fcd06415af6a03c2cab48760eee5e656c) | `python310Packages.pyxiaomigateway: 0.14.1 -> 0.14.3`                   |
| [`f6edde42`](https://github.com/NixOS/nixpkgs/commit/f6edde4214c9572b723ad1847a32d030c64374a9) | `natscli: 0.0.34 -> 0.0.35`                                             |
| [`5c1a9de6`](https://github.com/NixOS/nixpkgs/commit/5c1a9de616925910a66481e8a4cbedab527a1dba) | `grandorgue: 3.8.0-1 -> 3.9.0-1`                                        |
| [`e4230d0c`](https://github.com/NixOS/nixpkgs/commit/e4230d0c89098cca44db1456959e825c6bbabe26) | `pipenv: 2022.10.12 -> 2022.10.25`                                      |
| [`29943858`](https://github.com/NixOS/nixpkgs/commit/29943858a96707e2a885e249664ad6d574f49c4c) | `linuxquota: 4.06 -> 4.09`                                              |
| [`514072bd`](https://github.com/NixOS/nixpkgs/commit/514072bd0784ad27c009aeaa8ace459db48ad93a) | `oh-my-zsh: 2022-11-03 -> 2022-11-04`                                   |
| [`98f64d34`](https://github.com/NixOS/nixpkgs/commit/98f64d342525c5e8ffb46edcf8eb929cdaac5795) | `apt: 2.5.2 -> 2.5.4`                                                   |
| [`a4582297`](https://github.com/NixOS/nixpkgs/commit/a45822979bf27f4498421a4157ce45895b53f069) | `kubemq-community: 2.3.3 -> 2.3.4`                                      |
| [`76c4748d`](https://github.com/NixOS/nixpkgs/commit/76c4748d4db17c521a0d2ff1fcef0a7ca2309345) | `clojure-lsp: 2022.10.05-16.39.51 -> 2022.11.03-00.14.57`               |
| [`a7284bf3`](https://github.com/NixOS/nixpkgs/commit/a7284bf3dcf6063e37df4479aca52a798210969a) | `alfis: 0.8.2 -> 0.8.3`                                                 |
| [`3ddb7c1a`](https://github.com/NixOS/nixpkgs/commit/3ddb7c1a19f6aff296785ca6924e0b596b1f6254) | `micropad: 4.1.0 -> 4.2.0`                                              |
| [`3c18086d`](https://github.com/NixOS/nixpkgs/commit/3c18086d7e954fb5c7fcd69a67fa37e668cce729) | `bitwig-studio: 4.4.1 -> 4.4.2`                                         |
| [`3bf7a943`](https://github.com/NixOS/nixpkgs/commit/3bf7a9438919346b47ad7205c076b36d1517e26a) | `wasmedge: 0.11.1 -> 0.11.2`                                            |
| [`5e6f8757`](https://github.com/NixOS/nixpkgs/commit/5e6f87576bd21c70b364ec78a03850962b0b3924) | `linux_xanmod_latest: 6.0.6 -> 6.0.7`                                   |
| [`ee33796d`](https://github.com/NixOS/nixpkgs/commit/ee33796d9af212f2b4b8049ccb451d4d2296fec4) | `vscodium: 1.72.2.22289 -> 1.73.0.22306`                                |
| [`2660e014`](https://github.com/NixOS/nixpkgs/commit/2660e014748ed5e8aa98b468ce0f623d58afe1de) | `laminar: pass version to the build system`                             |
| [`44757a1a`](https://github.com/NixOS/nixpkgs/commit/44757a1a48bcb22b76409d4f9397661b515d991e) | `sudo: 1.9.12 -> 1.9.12p1`                                              |
| [`4ab518fd`](https://github.com/NixOS/nixpkgs/commit/4ab518fd62ee276dbbd636d65b82ab7f09c1aa83) | `python310Packages.mpi4py: 3.1.3 -> 3.1.4`                              |
| [`321be963`](https://github.com/NixOS/nixpkgs/commit/321be9630bc59cfc274a4ec648093e31f7ad0543) | `waypoint: 0.10.2 -> 0.10.3`                                            |
| [`d59b9ca5`](https://github.com/NixOS/nixpkgs/commit/d59b9ca501d0cf436391c1470dfd8788a0491bc8) | `python310Packages.pdfminer: 20220524 -> 20221105`                      |
| [`8e97d700`](https://github.com/NixOS/nixpkgs/commit/8e97d7003e8e9b102be12cb760f9538eab2b58f9) | `nixpacks: 0.12.1 -> 0.12.2`                                            |
| [`9f07f3bc`](https://github.com/NixOS/nixpkgs/commit/9f07f3bc7e382eda7dcc1366c0aa88a08e44b976) | `texlab: format with nixpkgs-fmt`                                       |
| [`0912afd6`](https://github.com/NixOS/nixpkgs/commit/0912afd6efd0f7acc0855dbefe94b0eac3c016f9) | `texlab: 4.3.0 → 4.3.1`                                                 |
| [`cdd3dda6`](https://github.com/NixOS/nixpkgs/commit/cdd3dda63b198675a4c5ed186a15b8fbd35d19a9) | `cni: 0.8.1 -> 1.1.2`                                                   |
| [`b090a8c2`](https://github.com/NixOS/nixpkgs/commit/b090a8c2517c7ee479f2e2a821bae6ec26f0f812) | `wallutils: 5.11.1 -> 5.12.4`                                           |
| [`01341179`](https://github.com/NixOS/nixpkgs/commit/0134117916a433f9f3cb1daf14f84836b3138765) | `python3Packages.pygls: 0.12.1 → 0.12.3`                                |
| [`ad5d00e6`](https://github.com/NixOS/nixpkgs/commit/ad5d00e65c38ba036a74f2b8a758dbfb4eec2348) | `pantheon.elementary-files: 6.1.4 -> 6.2.0`                             |
| [`0b894f55`](https://github.com/NixOS/nixpkgs/commit/0b894f5564ab21bcff4454d2358fc04eda7e1492) | `kicad: migrate to wxGTK32`                                             |
| [`98cb415b`](https://github.com/NixOS/nixpkgs/commit/98cb415b958c0ee747035a758bcb3bc2fa833e30) | `shiv: 1.0.2 -> 1.0.3`                                                  |
| [`d0850781`](https://github.com/NixOS/nixpkgs/commit/d0850781b3f71ad1a3b63eace9b2cd9635f87737) | `rtsp-simple-server: 0.20.1 -> 0.20.2`                                  |
| [`cd7b1e6e`](https://github.com/NixOS/nixpkgs/commit/cd7b1e6e3a733d65e8279eb06a13695ec83e0ff1) | `python310Packages.python-stdnum: don't run doctests`                   |
| [`f0c1d179`](https://github.com/NixOS/nixpkgs/commit/f0c1d179544ffdee036923380352b8fc7118f44f) | `libpulsar: 2.10.1 -> 2.10.2`                                           |
| [`fe2fe7c5`](https://github.com/NixOS/nixpkgs/commit/fe2fe7c588e88da98488db7c7b777076a27215da) | `chromiumDev: 109.0.5384.0 -> 109.0.5396.2`                             |
| [`f432eecb`](https://github.com/NixOS/nixpkgs/commit/f432eecba77bd1df377efb4ce5ef13bb37213a41) | `chromiumBeta: 108.0.5359.22 -> 108.0.5359.30`                          |
| [`ed9bd02e`](https://github.com/NixOS/nixpkgs/commit/ed9bd02e77a8d0b2d8657b3d3c8acb8383ecabca) | `httping: 2.5 -> 2.9`                                                   |
| [`02dd2667`](https://github.com/NixOS/nixpkgs/commit/02dd2667d67eda0512640517244bdc975c0a4a75) | `btrfs-progs: 6.0 -> 6.0.1`                                             |
| [`b9efaafc`](https://github.com/NixOS/nixpkgs/commit/b9efaafce142169ae72210deb48534d4ed2af294) | `xmlcopyeditor: 1.2.1.3 -> 1.3.1.0`                                     |
| [`98550c8d`](https://github.com/NixOS/nixpkgs/commit/98550c8dfadfd12f263f80d8c924cd57d9c783b3) | `wine-wayland: 7.0-rc2 -> 7.20`                                         |
| [`a3f5f537`](https://github.com/NixOS/nixpkgs/commit/a3f5f537022b8bf4198fb1332ba1d6209c6f21dd) | `nixpacks: 0.11.6 -> 0.12.1`                                            |
| [`6a20958e`](https://github.com/NixOS/nixpkgs/commit/6a20958e75b1364dffa88082da94ba401d44d1a4) | `fastly: 3.2.4 -> 4.3.0`                                                |
| [`dab266f3`](https://github.com/NixOS/nixpkgs/commit/dab266f371936fc46c27b74c837820269be32108) | `linux/hardened/patches/6.0: 6.0.6-hardened1 -> 6.0.7-hardened1`        |
| [`451e251e`](https://github.com/NixOS/nixpkgs/commit/451e251ea46776e4e48d240c582944fed6e27438) | `linux/hardened/patches/5.4: 5.4.221-hardened1 -> 5.4.223-hardened1`    |
| [`525ee051`](https://github.com/NixOS/nixpkgs/commit/525ee05190d8ac080d9ba779a994f9dbc8e4df36) | `linux/hardened/patches/5.15: 5.15.76-hardened1 -> 5.15.77-hardened1`   |
| [`7791bbd5`](https://github.com/NixOS/nixpkgs/commit/7791bbd54b119c30c56528d9da55b6d3a8703fc2) | `linux/hardened/patches/5.10: 5.10.152-hardened1 -> 5.10.153-hardened1` |
| [`a2ddd1ac`](https://github.com/NixOS/nixpkgs/commit/a2ddd1ac1ab04030971239b75d78c7ebd6a00f36) | `linux/hardened/patches/4.19: 4.19.262-hardened1 -> 4.19.264-hardened1` |
| [`b674b426`](https://github.com/NixOS/nixpkgs/commit/b674b426d4801fed86f16868330427e92df3438c) | `linux/hardened/patches/4.14: 4.14.296-hardened1 -> 4.14.298-hardened1` |
| [`b43ea993`](https://github.com/NixOS/nixpkgs/commit/b43ea993265d5f05c665f96e823b32bf2aca75c3) | `linux_latest-libre: 18950 -> 18978`                                    |
| [`8bb69951`](https://github.com/NixOS/nixpkgs/commit/8bb699516f9b1f51070133e139423b74404e832d) | `linux: 6.0.6 -> 6.0.7`                                                 |
| [`b44d44e9`](https://github.com/NixOS/nixpkgs/commit/b44d44e951b122dbaee28d67232847daf1b51290) | `linux: 5.4.221 -> 5.4.223`                                             |
| [`b0c196f1`](https://github.com/NixOS/nixpkgs/commit/b0c196f1489f00564621c6a7b73115281da072dc) | `linux: 5.15.76 -> 5.15.77`                                             |
| [`ff99944b`](https://github.com/NixOS/nixpkgs/commit/ff99944b11d05376891e71c69ae2d9e661fd3e7a) | `linux: 5.10.152 -> 5.10.153`                                           |
| [`e3286850`](https://github.com/NixOS/nixpkgs/commit/e3286850985325791b3afc682558f5cb580bb0c6) | `linux: 4.9.331 -> 4.9.332`                                             |
| [`267d467e`](https://github.com/NixOS/nixpkgs/commit/267d467ecd5182a5e35d4a146217a15fb8b06f49) | `linux: 4.19.262 -> 4.19.264`                                           |
| [`282901a0`](https://github.com/NixOS/nixpkgs/commit/282901a0505ad496055ff715f4cfb77e5b43a27d) | `linux: 4.14.296 -> 4.14.298`                                           |
| [`088cd569`](https://github.com/NixOS/nixpkgs/commit/088cd569cbc983f6e855583a823c5ef9089cf4b6) | `sabnzbd: 3.6.1 -> 3.7.0`                                               |