### PR TITLE
chore(flake/nur): `e7773ae7` -> `a15cefca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667880687,
-        "narHash": "sha256-HP6TXV16ABCgOBsZUNTKUJ40QgSfFY/pRBsaE4bco9M=",
+        "lastModified": 1667885245,
+        "narHash": "sha256-GzSPmSi5/fF88PUAK7NTf1WYOBsdw6AMZwFURgBDHoQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e7773ae7a41109e6a2bfef3a9e6de9dd3325b3cc",
+        "rev": "a15cefcae57f7ea92999f7640b9df751fc6e93ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a15cefca`](https://github.com/nix-community/NUR/commit/a15cefcae57f7ea92999f7640b9df751fc6e93ca) | `automatic update` |