### PR TITLE
chore(flake/nur): `a15cefca` -> `3963ffa4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667885245,
-        "narHash": "sha256-GzSPmSi5/fF88PUAK7NTf1WYOBsdw6AMZwFURgBDHoQ=",
+        "lastModified": 1667889117,
+        "narHash": "sha256-owI6HHXZ0gCwKqqOtkb3pX/oCP7oUnqP+L8w/YfOJdo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a15cefcae57f7ea92999f7640b9df751fc6e93ca",
+        "rev": "3963ffa4cece9f3fd5e4cbd12606cf6d9a74f7ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3963ffa4`](https://github.com/nix-community/NUR/commit/3963ffa4cece9f3fd5e4cbd12606cf6d9a74f7ee) | `automatic update` |