### PR TITLE
chore(flake/nur): `3963ffa4` -> `744f9729`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667889117,
-        "narHash": "sha256-owI6HHXZ0gCwKqqOtkb3pX/oCP7oUnqP+L8w/YfOJdo=",
+        "lastModified": 1667890820,
+        "narHash": "sha256-pGp7GQdMM2xGR/v72v6+d3PeZ5UxnIxsZL9lXfHCJhY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3963ffa4cece9f3fd5e4cbd12606cf6d9a74f7ee",
+        "rev": "744f97297a0eb816aa5c272c4bc795eb4a4f3523",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`744f9729`](https://github.com/nix-community/NUR/commit/744f97297a0eb816aa5c272c4bc795eb4a4f3523) | `automatic update` |