### PR TITLE
chore(flake/nur): `744f9729` -> `7c908c5c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667890820,
-        "narHash": "sha256-pGp7GQdMM2xGR/v72v6+d3PeZ5UxnIxsZL9lXfHCJhY=",
+        "lastModified": 1667900857,
+        "narHash": "sha256-+J4hJpcTkx3z5+xHStw7NeaSJWKrPiv3QPAu6+biU+s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "744f97297a0eb816aa5c272c4bc795eb4a4f3523",
+        "rev": "7c908c5c6612a90721f65534e9fa5b13818c7a6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7c908c5c`](https://github.com/nix-community/NUR/commit/7c908c5c6612a90721f65534e9fa5b13818c7a6c) | `automatic update` |
| [`90672d9b`](https://github.com/nix-community/NUR/commit/90672d9b9a2d7d3f4a828641ad3649e732d3db55) | `automatic update` |
| [`f7114b33`](https://github.com/nix-community/NUR/commit/f7114b33d25c8adf209b3e408e6a485fe85bf52b) | `automatic update` |