### PR TITLE
chore(flake/home-manager): `88667599` -> `d20e3d07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667830176,
-        "narHash": "sha256-TNm8W88Jf9qELqKI8rGMr0sZWlTV9WKIlqN4dzvuKUA=",
+        "lastModified": 1667898954,
+        "narHash": "sha256-VqHVeoxcOl9M6yQ+LV3yTWMb0h5Rl5yixn9PCY/MJJo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "886675991b643b701a33f533443db165c70692d1",
+        "rev": "d20e3d070c78271356a2d5d73c01f1de94586087",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                         |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`d20e3d07`](https://github.com/nix-community/home-manager/commit/d20e3d070c78271356a2d5d73c01f1de94586087) | `screen-locker: minor description fix` |
| [`b0cf7245`](https://github.com/nix-community/home-manager/commit/b0cf7245c430df2ae9e511449e5840bfdfd01cc7) | `Translate using Weblate (Dutch)`      |