### PR TITLE
chore(flake/emacs-overlay): `f04cb6f6` -> `88749da2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667882772,
-        "narHash": "sha256-hoVW9/xcfZTsKn++nGYwEMgBLfh+iq7i8+eEcAhOxy0=",
+        "lastModified": 1667901730,
+        "narHash": "sha256-uqeF9nZzGX6Zj+7OtApQ2xmHSHNi6BS7SFlkqlnSBDs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f04cb6f6724ba4568a7f6dae0863e507477667b7",
+        "rev": "88749da29c07c2ae565c9906565dbc895d736282",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`88749da2`](https://github.com/nix-community/emacs-overlay/commit/88749da29c07c2ae565c9906565dbc895d736282) | `Updated repos/melpa` |