### PR TITLE
chore(flake/nixpkgs): `adc7d07c` -> `667e5581`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -299,11 +299,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667702334,
-        "narHash": "sha256-2oihoCZvQvg+oUrMz8OGc1z4J9HflqEjkk666VKm9jw=",
+        "lastModified": 1667811565,
+        "narHash": "sha256-HYml7RdQPQ7X13VNe2CoDMqmifsXbt4ACTKxHRKQE3Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "adc7d07c0c8162ecb9fe0b075386d549680ef914",
+        "rev": "667e5581d16745bcda791300ae7e2d73f49fff25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
| [`667e5581`](https://github.com/NixOS/nixpkgs/commit/667e5581d16745bcda791300ae7e2d73f49fff25) | `bazarr: update expr`                                                                                        |
| [`4488784f`](https://github.com/NixOS/nixpkgs/commit/4488784f4924c8d696c9bc1d6b04646be0c1db3f) | `maintainers: fix name for obfusk`                                                                           |
| [`9b7725ff`](https://github.com/NixOS/nixpkgs/commit/9b7725ff8a1169c4c55602a078acd079ff47c5c5) | `sshs: 3.3.0 -> 3.4.0`                                                                                       |
| [`9998ec71`](https://github.com/NixOS/nixpkgs/commit/9998ec71ccea8f6f794c9484412b90010fd9959d) | `pkgsStatic.cmark: fix build`                                                                                |
| [`8c60992e`](https://github.com/NixOS/nixpkgs/commit/8c60992ea9ce55bd280200cbaa2a95f7cd6d34bf) | `webkitgtk: unset separateDebugInfo for 32 bit platforms`                                                    |
| [`34c43658`](https://github.com/NixOS/nixpkgs/commit/34c4365854efb3bd47e4be041e2b5b235990524e) | `kronometer: 2.2.3 -> 2.3.0`                                                                                 |
| [`4f150a78`](https://github.com/NixOS/nixpkgs/commit/4f150a789fd17e11edd3760b62737f5289eb0e54) | `oil: 0.12.7 -> 0.12.8`                                                                                      |
| [`256b8388`](https://github.com/NixOS/nixpkgs/commit/256b838850db66a9278d4bfe1b23ea262a37d80a) | `oapi-codegen: 1.11.0 -> 1.12.2`                                                                             |
| [`0c8bb927`](https://github.com/NixOS/nixpkgs/commit/0c8bb9272f3ebf2d9452bb9bac887c380c7c772f) | `nats-server: 2.9.4 -> 2.9.6`                                                                                |
| [`c8a8b641`](https://github.com/NixOS/nixpkgs/commit/c8a8b641b32e2434b99bb4d7a489956b47ee708d) | `terraform-providers.avi: 22.1.1 -> 22.1.2`                                                                  |
| [`6fbb4b1e`](https://github.com/NixOS/nixpkgs/commit/6fbb4b1eec44f89e7240c60a796edd73dfd076bd) | `odo: 3.1.0 -> 3.2.0`                                                                                        |
| [`58a59738`](https://github.com/NixOS/nixpkgs/commit/58a59738d5420fbf5b320a0ece48e58664b1a309) | `nixos/tests/podman: fix rootless systemd`                                                                   |
| [`bbfdc6ce`](https://github.com/NixOS/nixpkgs/commit/bbfdc6ce4d312b56aa57b38f23c88d339430b38c) | `nixos/tests/podman: move docker tests to separate node`                                                     |
| [`7a3b6039`](https://github.com/NixOS/nixpkgs/commit/7a3b60394b20637bff664e94a07f2f37f29e36a0) | `gyb: 1.71 -> 1.72`                                                                                          |
| [`83255472`](https://github.com/NixOS/nixpkgs/commit/83255472687e2e4eb68c82c435b35a93cb8b39ac) | `cargo-lambda: 0.11.2 -> 0.11.3`                                                                             |
| [`659fc3d8`](https://github.com/NixOS/nixpkgs/commit/659fc3d8f47c311d86ca680a4c705d210602b6b8) | `maintainers: add calavera`                                                                                  |
| [`c94492f3`](https://github.com/NixOS/nixpkgs/commit/c94492f30a952e3a72dbef3c7a1621e296b19044) | `linuxPackages.rtw88: 2022-06-03 to 2022-11-05`                                                              |
| [`bb3d289e`](https://github.com/NixOS/nixpkgs/commit/bb3d289ee6d5ae358a9a8ff7c8fe241400ca48cf) | `sbctl: supported platforms are unix derivatives at the moment`                                              |
| [`6698fca1`](https://github.com/NixOS/nixpkgs/commit/6698fca169904f39e8adecef7878ff40f278d84e) | `osu-lazer: 2022.723.0 -> 2022.1101.0`                                                                       |
| [`eccb0a9b`](https://github.com/NixOS/nixpkgs/commit/eccb0a9b8037bf3941729cddfda96a4817bf1ff8) | `zsnes: pin to c++14 to fix build with gcc-11`                                                               |
| [`4a3fc076`](https://github.com/NixOS/nixpkgs/commit/4a3fc076e4f5a4169f67e8b4208245a3c190c45a) | `clingcon: 5.0.0 -> 5.2.0 and fix build`                                                                     |
| [`6d70ae99`](https://github.com/NixOS/nixpkgs/commit/6d70ae996c0d1020b69d429dc333c28e33de4a67) | `npush: fix build`                                                                                           |
| [`bc7e9b1b`](https://github.com/NixOS/nixpkgs/commit/bc7e9b1b43b6a429f2a9b17c11834087a9a01061) | `cheat: 4.3.3 -> 4.4.0`                                                                                      |
| [`9b2cb8b1`](https://github.com/NixOS/nixpkgs/commit/9b2cb8b1cbd65b52ac5abaa5b693d347ee0106a3) | `bindle: fix build failure`                                                                                  |
| [`521b33da`](https://github.com/NixOS/nixpkgs/commit/521b33dae27779a03937274a7c0a1a3fc4675cf1) | `carapace: 0.17.1 -> 0.18.0`                                                                                 |
| [`c02cb0fd`](https://github.com/NixOS/nixpkgs/commit/c02cb0fd58c74b97b3477cd59246e2f344623f80) | `raspberrypi-firmware: 1.20220331 -> 1.20221028`                                                             |
| [`c069200f`](https://github.com/NixOS/nixpkgs/commit/c069200f256a62aa71c9b36f0ca7a9cddbcd7485) | `python310Packages.aioesphomeapi: 11.4.2 -> 11.4.3`                                                          |
| [`afe72b6b`](https://github.com/NixOS/nixpkgs/commit/afe72b6bdfdf65db278398d889940e0ca4bc6d76) | `linux_rpi{1,2,3,4}: 1.20220331 -> 1.20221028`                                                               |
| [`604779ea`](https://github.com/NixOS/nixpkgs/commit/604779ea89e6ec7483b68a5688208809e36a4bfc) | `python310Packages.BTrees: 4.10.1 -> 4.11.0`                                                                 |
| [`59bd411d`](https://github.com/NixOS/nixpkgs/commit/59bd411df92d35958b00bd85fb70ddfa9dbb6370) | `alps: fix default smtp port`                                                                                |
| [`6068b854`](https://github.com/NixOS/nixpkgs/commit/6068b8549d791d43b7880bb0571048dc115d1604) | `oh-my-zsh: 2022-11-04 -> 2022-11-06`                                                                        |
| [`55773459`](https://github.com/NixOS/nixpkgs/commit/55773459bbc9531a51add4abfe1e994c1831847a) | `numix-icon-theme-circle: 22.10.31 -> 22.11.05`                                                              |
| [`910ab0bd`](https://github.com/NixOS/nixpkgs/commit/910ab0bda82b41458ed9e6a4d617b71aa43e006a) | `mutt: 2.2.7 -> 2.2.8`                                                                                       |
| [`b3ee591a`](https://github.com/NixOS/nixpkgs/commit/b3ee591aa85ce6ce247387bb14ba656a31d5fecf) | `squeekboard: add tomfitzhenry as co-maintainer`                                                             |
| [`1d0d17f7`](https://github.com/NixOS/nixpkgs/commit/1d0d17f73dc09d31fd24a6c536c441ef6937342d) | `python310Packages.pywebview: 3.6.3 -> 3.7`                                                                  |
| [`58244a71`](https://github.com/NixOS/nixpkgs/commit/58244a7189e3ecb1a0a3238ecce738587ea2b969) | `nftables: Set meta.mainProgram to "nft"`                                                                    |
| [`87f4f101`](https://github.com/NixOS/nixpkgs/commit/87f4f101d773a53c8639d7127ab2f9ee6371ef98) | `cross/mingw: fix emulator for mingw32`                                                                      |
| [`63136264`](https://github.com/NixOS/nixpkgs/commit/63136264aa4198ee15ffa1fe63601624f0fa59f6) | `Add wrapGAppsHook to lifeograph to fix issue with being unable to decrypt diaries when launched from dmenu` |
| [`7e07e345`](https://github.com/NixOS/nixpkgs/commit/7e07e34547097d06836a4336d3910c9a770152f8) | `python310Packages.spyder: 5.3.3 -> 5.4.0`                                                                   |
| [`70619cbf`](https://github.com/NixOS/nixpkgs/commit/70619cbff75debaa3189fcca3278e952b4a9959a) | `python310Packages.qtconsole: 5.3.2 -> 5.4.0`                                                                |
| [`e6fa5b83`](https://github.com/NixOS/nixpkgs/commit/e6fa5b83dca44e892ded6f6467f707c11db7e436) | `python310Packages.qstylizer: 0.2.1 -> 0.2.2`                                                                |
| [`106a616e`](https://github.com/NixOS/nixpkgs/commit/106a616eaefe8561ccfedddc435e4cc946be7756) | `photoprism: init at 221102-905925b4d`                                                                       |
| [`37046863`](https://github.com/NixOS/nixpkgs/commit/370468638ecc4b3fd15bb81db3a9afcfdc04496d) | `maintainers: add benesim`                                                                                   |
| [`ad8c5054`](https://github.com/NixOS/nixpkgs/commit/ad8c505447ad365aa0824c1800ca444d598b9988) | `python310Packages.qtawesome: 1.1.1 -> 1.2.1`                                                                |
| [`2a9615d0`](https://github.com/NixOS/nixpkgs/commit/2a9615d0d071a3c9d4f8336c20032c5621785a5c) | `python310Packages.spyder-kernels: 2.3.3 -> 2.4.0`                                                           |
| [`0d36fdc6`](https://github.com/NixOS/nixpkgs/commit/0d36fdc66bb40f9471e63d41c4f2246da1e8e5ea) | `samsung-unified-linux-driver (cups driver): call {pre,post}Install`                                         |
| [`2c28e0dc`](https://github.com/NixOS/nixpkgs/commit/2c28e0dc18110736437e2a0b760aa933dd475ee0) | `cups-kyocera (cups driver): call {pre,post}Install`                                                         |
| [`075d1121`](https://github.com/NixOS/nixpkgs/commit/075d11213142f0f8b96b3213a6714df6ae7395be) | `foomatic-db-ppds (cups ppd files): init`                                                                    |
| [`156cc612`](https://github.com/NixOS/nixpkgs/commit/156cc612ff9588cbcdfb858c0086ee250b42c781) | `foomatic-db-nonfree (cups ppd files): init at unstable/2015-06-05`                                          |
| [`90a8a78e`](https://github.com/NixOS/nixpkgs/commit/90a8a78e7c703ec6d9a4e9d5251f09823498bc12) | `foomatic-db (cups ppd files): init at unstable/2022-10-03`                                                  |
| [`cd4c8d63`](https://github.com/NixOS/nixpkgs/commit/cd4c8d63f5698d86960086c3d0e3c94c08efd285) | `foomatic-db-engine: init at unstable-2022-05-03`                                                            |
| [`f14cafb9`](https://github.com/NixOS/nixpkgs/commit/f14cafb94463f4ba0dc4f14dc9666e288cb8d59b) | `python310Packages.pylint-venv: init at 2.3.0`                                                               |
| [`f22af061`](https://github.com/NixOS/nixpkgs/commit/f22af0612d569f7d49912fc5d73618ea00b58e82) | `mariadb: fix nixos tests`                                                                                   |
| [`7d532994`](https://github.com/NixOS/nixpkgs/commit/7d532994cde4383838ac039af6a557769bb85dc0) | `python310Packages.gcal-sync: 3.0.0 -> 4.0.0`                                                                |
| [`7994d962`](https://github.com/NixOS/nixpkgs/commit/7994d962261786c03408beae15b1cc926d168eaf) | `python310Packages.ical: 4.1.0 -> 4.1.1`                                                                     |
| [`3ec4d80d`](https://github.com/NixOS/nixpkgs/commit/3ec4d80d0f997c7295f9ad4a046d5aaa10b048f2) | `python310Packages.pyatmo: 7.3.0 -> 7.4.0`                                                                   |
| [`1a664a8d`](https://github.com/NixOS/nixpkgs/commit/1a664a8d9673e61fbc12f363205c44f2c8e92588) | `python310Packages.aiohomekit: 2.2.16 -> 2.2.17`                                                             |
| [`79653a44`](https://github.com/NixOS/nixpkgs/commit/79653a44c7cb3ed4af77faec6747a837c91aca72) | `python310Packages.oralb-ble: 0.10.1 -> 0.14.0`                                                              |
| [`c5385d87`](https://github.com/NixOS/nixpkgs/commit/c5385d8717adca5a4fac6b62341dcbb807750119) | `universal-ctags: 5.9.20220814.0 -> 5.9.20221106.0`                                                          |
| [`d2552d4b`](https://github.com/NixOS/nixpkgs/commit/d2552d4b8f272af9ecc5a7b3663c229211b127b4) | `python310Packages.plugwise: 0.25.7 -> 0.26.0`                                                               |
| [`f3b9ad92`](https://github.com/NixOS/nixpkgs/commit/f3b9ad927b1acfe24ff5eb9d4ce111f2ad3c068a) | `python310Packages.spidev: 3.5 -> 3.6`                                                                       |
| [`8fa4d005`](https://github.com/NixOS/nixpkgs/commit/8fa4d00505a2d3eedcb20397df9017ddca5584ac) | `svd2rust: 0.27.1 -> 0.27.2`                                                                                 |
| [`3cbd455a`](https://github.com/NixOS/nixpkgs/commit/3cbd455a2d53d78b44930060a1219591d6fccf06) | `android-tools: 31.0.3p1 -> 33.0.3`                                                                          |
| [`76796543`](https://github.com/NixOS/nixpkgs/commit/76796543e4f9c9318a22126042b804cd86a34d93) | `ocamlPackages.eqaf: 0.8 → 0.9`                                                                              |
| [`0cd89bba`](https://github.com/NixOS/nixpkgs/commit/0cd89bba2bf7ad48d186ca6e81867d3c03a38057) | `python3Packages.dask-glm: disable failing tests`                                                            |
| [`bafefd7a`](https://github.com/NixOS/nixpkgs/commit/bafefd7ae237ce6f82300a3093574c1c697bb8ce) | `samsung-unified-linux-driver (cups driver): patch all filters`                                              |
| [`bfe3271f`](https://github.com/NixOS/nixpkgs/commit/bfe3271fc0cc6d0a471f8ef4ebe466cd8cf4c949) | `samsung-unified-linux-driver (cups driver): use patchPpdFilesHook`                                          |
| [`bf30b538`](https://github.com/NixOS/nixpkgs/commit/bf30b53817652cc0bdaca8fbf8891165e273e332) | `cups-kyocera (cups driver): use patchPpdFilesHook`                                                          |
| [`ef8566f3`](https://github.com/NixOS/nixpkgs/commit/ef8566f38b422f92759cdbaa5510c06fdb49106e) | `cups-drv-rastertosag-gdi (cups driver): patch ppd bin paths`                                                |
| [`335a9083`](https://github.com/NixOS/nixpkgs/commit/335a9083b02d2a7034dd98c8641f019e85e50426) | `patchPpdFilesHook: new setup hook for absolute executable paths`                                            |
| [`6f622e91`](https://github.com/NixOS/nixpkgs/commit/6f622e91c5daefe73b4c988d375a854a37bf92a7) | `cups-drv-rastertosag-gdi (cups driver): gzip ppd files`                                                     |
| [`52223639`](https://github.com/NixOS/nixpkgs/commit/5222363936e343150ed74df660a90d30714fe931) | `cups-drv-rastertosag-gdi (cups driver): fix simple comment typo`                                            |
| [`654375b6`](https://github.com/NixOS/nixpkgs/commit/654375b618dc408622f92845404211420d903b20) | `python3Packages.distributed: 2022.9.1 -> 2022.10.2`                                                         |
| [`e28e2a76`](https://github.com/NixOS/nixpkgs/commit/e28e2a76b704e7dc0b0c6ae003de2333827bd851) | `python3Packages.threadpoolctl: disable failing tests`                                                       |
| [`51e1e1ea`](https://github.com/NixOS/nixpkgs/commit/51e1e1ea473c78b10d873672aeb580d24c5d6b80) | `ocamlPackages.base: 0.15.0 → 0.15.1`                                                                        |
| [`462b6c28`](https://github.com/NixOS/nixpkgs/commit/462b6c2826424c1db71af17f3a6160d629cb5480) | `python3Packages.dask: 2022.9.1 -> 2022.10.2`                                                                |
| [`4ad56cad`](https://github.com/NixOS/nixpkgs/commit/4ad56cadeda1ae184bbaf0388410fd2ef5be43fa) | `cjdns: fix package and update`                                                                              |
| [`6a36558f`](https://github.com/NixOS/nixpkgs/commit/6a36558f5227f728d4fa433ab8ec1b80bebe4f50) | `lighthouse: 3.1.2 -> 3.2.1`                                                                                 |
| [`bc38a21a`](https://github.com/NixOS/nixpkgs/commit/bc38a21a2e6933b57be3ae6be01bea2df88b3d27) | `python310Packages.stestr: 4.0.0 -> 4.0.1`                                                                   |
| [`523030c5`](https://github.com/NixOS/nixpkgs/commit/523030c5bc7336f077ba20045aec5b2e1e00f541) | ``python3Packages.duckdb: build using `$NIX_BUILD_CORES```                                                   |
| [`f16bbb58`](https://github.com/NixOS/nixpkgs/commit/f16bbb58e17f35640e2d2622288d014ffba3af41) | `auto-multiple-choice: fix build on darwin`                                                                  |
| [`98617d37`](https://github.com/NixOS/nixpkgs/commit/98617d37efe3a19681d55bbdfdb210056de72c33) | `termusic: 0.7.3 -> 0.7.5`                                                                                   |
| [`5e8c2439`](https://github.com/NixOS/nixpkgs/commit/5e8c2439cd3f7721772aab63bd2f62845673e7bc) | `python310Packages.plugwise: 0.25.6 -> 0.25.7`                                                               |
| [`b3df5fbe`](https://github.com/NixOS/nixpkgs/commit/b3df5fbee59454ba337e76a07b33793573c8f4d5) | `python310Packages.cometblue-lite: 0.5.2 -> 0.5.3`                                                           |
| [`392d155d`](https://github.com/NixOS/nixpkgs/commit/392d155d7991078f9019b952eb8aace88995dbef) | `python310Packages.peaqevcore: 7.3.1 -> 7.3.2`                                                               |
| [`0c1324d0`](https://github.com/NixOS/nixpkgs/commit/0c1324d049a3507cd8192ea0ab921a0928769c0f) | `python310Packages.pyoverkiz: 1.5.6 -> 1.6.0`                                                                |
| [`fd70c595`](https://github.com/NixOS/nixpkgs/commit/fd70c59577924b00bf1337402909e02275e8603d) | `plantuml-server: 1.2022.7 -> 1.2022.12`                                                                     |
| [`fbf5d54f`](https://github.com/NixOS/nixpkgs/commit/fbf5d54f181c46e045bde3fbe8efe1b07b2cd095) | `doctl: 1.84.1 -> 1.85.0`                                                                                    |
| [`26232043`](https://github.com/NixOS/nixpkgs/commit/26232043e26292dd8173179c63582b3aa256ab46) | `karate: 1.2.0 -> 1.3.0`                                                                                     |
| [`0efbf0bb`](https://github.com/NixOS/nixpkgs/commit/0efbf0bba7e64502ca1b7caa93438d3624dbe9f5) | `python310Packages.dbus-fast: 1.71.0 -> 1.72.0`                                                              |
| [`40158472`](https://github.com/NixOS/nixpkgs/commit/401584723253f49c8027c03dd83f89985c33e170) | `python310Packages.dbus-fast: 1.70.0 -> 1.71.0`                                                              |
| [`8d2e0a98`](https://github.com/NixOS/nixpkgs/commit/8d2e0a9823fe65c1b4f224eb46bec77deba4f2c4) | `python310Packages.dbus-fast: 1.64.0 -> 1.70.0`                                                              |
| [`95a2527f`](https://github.com/NixOS/nixpkgs/commit/95a2527f863b91558aae832115e201958ca377e7) | `python310Packages.bluetooth-adapters: 0.6.0 -> 0.7.0`                                                       |
| [`a2764883`](https://github.com/NixOS/nixpkgs/commit/a27648835a52e400a0b4947b4a57d063484f32ec) | `python310Packages.zamg: 0.1.1 -> 0.1.2`                                                                     |
| [`5b2a9280`](https://github.com/NixOS/nixpkgs/commit/5b2a928051a8461ead24a313db55f0e6ac5629a7) | `python310Packages.bthome-ble: 2.1.0 -> 2.2.0`                                                               |
| [`696449de`](https://github.com/NixOS/nixpkgs/commit/696449dedb246f42dc2c24ca42f95492e83b608a) | `spotify: consolidate wrapper`                                                                               |
| [`8de97392`](https://github.com/NixOS/nixpkgs/commit/8de97392b76f1fd54b14c47aabbecbf6a537df46) | `s2n-tls: 1.3.26 -> 1.3.27`                                                                                  |
| [`e23da836`](https://github.com/NixOS/nixpkgs/commit/e23da83661695dcbbdb9d3217ae947e132d8677b) | `json-schema-for-humans: 0.41.8 -> 0.42.1`                                                                   |
| [`fdce3577`](https://github.com/NixOS/nixpkgs/commit/fdce357748f9d947bdd8d1b97e484c82391a7962) | `sile: 0.14.3 → 0.14.4`                                                                                      |
| [`3f60403f`](https://github.com/NixOS/nixpkgs/commit/3f60403fe13f79421cdba4998394184194921fd9) | `classicube: 1.3.3 -> 1.3.4`                                                                                 |
| [`5e504877`](https://github.com/NixOS/nixpkgs/commit/5e50487731a164712a0bc1524ca13764e195216c) | `ocamlPackages.sexplib0: 0.15.0 → 0.15.1`                                                                    |
| [`8102e154`](https://github.com/NixOS/nixpkgs/commit/8102e1547d1511df14875f987f3158f9f074e161) | `foxotron: 2022-08-06 -> 2022-11-02`                                                                         |
| [`7b4d4010`](https://github.com/NixOS/nixpkgs/commit/7b4d4010c1a98d86d3095ae9fecbd6d430818b2a) | `vgmtools: unstable-2022-08-03 -> unstable-2022-10-31`                                                       |
| [`163a3544`](https://github.com/NixOS/nixpkgs/commit/163a3544a85894795befeca22531456635966dd0) | `ocamlPackages.lablgtk3: 3.1.2 → 3.1.3`                                                                      |
| [`ce616942`](https://github.com/NixOS/nixpkgs/commit/ce616942474745fe21825b3da76855ce84a38ace) | `kanata: override kanata to generate kanata-with-cmd`                                                        |
| [`877282ff`](https://github.com/NixOS/nixpkgs/commit/877282ff49dd8867cc24ee91ec87230afc641fbb) | `kanata: 1.0.7 -> 1.0.8`                                                                                     |
| [`fcbfbdb5`](https://github.com/NixOS/nixpkgs/commit/fcbfbdb5f7bd03c43b11cb5c18e8be51f3670f9a) | `pspg: 5.5.8 -> 5.5.9`                                                                                       |
| [`d6f077a5`](https://github.com/NixOS/nixpkgs/commit/d6f077a56708682dcfc8c9141c0de01edab53354) | `squeekboard: 1.17.0 -> 1.20.0`                                                                              |
| [`b44a7cb8`](https://github.com/NixOS/nixpkgs/commit/b44a7cb8b30cf00ff121f6594d3ba05b3fe07616) | `fluent-icon-theme: 2022-09-20 -> 2022-11-05`                                                                |
| [`b523abff`](https://github.com/NixOS/nixpkgs/commit/b523abff50c8a8a9546863b0cad5b304cef0b380) | `tdesktop: 4.2.4 -> 4.3.0`                                                                                   |
| [`50386476`](https://github.com/NixOS/nixpkgs/commit/503864768b60de4b0c932b856ecd38072cea0dde) | `or-tools: 9.1 → 9.4`                                                                                        |
| [`dba57a03`](https://github.com/NixOS/nixpkgs/commit/dba57a03626c9d33ad423de73afddadfcb742549) | `pkgs/tools/misc/bat-extras: fix tests`                                                                      |
| [`76df7b5d`](https://github.com/NixOS/nixpkgs/commit/76df7b5d94ed67710389953d92e1fa7ddeccff43) | `bat-extras: add batpipe`                                                                                    |
| [`455ea2e5`](https://github.com/NixOS/nixpkgs/commit/455ea2e5e53714352022c951e4a3aeb2d7f2883a) | `iwifi: init at 1.0.3`                                                                                       |
| [`de4601c3`](https://github.com/NixOS/nixpkgs/commit/de4601c37ef5005ca9ff3553eb9c0804f058ad0e) | `nixos/influxdb2: set timezone data environment variable`                                                    |
| [`1ff699ed`](https://github.com/NixOS/nixpkgs/commit/1ff699ed67e776db595c30e216d451fc5bfea527) | `python310Packages.poetry: relax xattr version constraint`                                                   |
| [`89a8b7be`](https://github.com/NixOS/nixpkgs/commit/89a8b7beb45e31de1977b0a81ab48b00b2cdefae) | `python310Packages.aiohomekit: 2.2.14 -> 2.2.16`                                                             |
| [`e1903020`](https://github.com/NixOS/nixpkgs/commit/e1903020180882ec85eceeda37a8f20d26a45d94) | `nixos options markdown: fix html escaping`                                                                  |
| [`d858f8d5`](https://github.com/NixOS/nixpkgs/commit/d858f8d546c122456d393a684880ae868fe96132) | `python310Packages.hg-git: 1.0.0 -> 1.0.1`                                                                   |
| [`9ab02e1e`](https://github.com/NixOS/nixpkgs/commit/9ab02e1ec6e7a9a44a087a8b131e65f77e924c0d) | `nginxModules.njs: init at 0.7.8`                                                                            |
| [`01b794ca`](https://github.com/NixOS/nixpkgs/commit/01b794ca75db6a964201c92659f2c04d159cf4a7) | `junction: 1.5.0 -> 1.6`                                                                                     |
| [`dce91a73`](https://github.com/NixOS/nixpkgs/commit/dce91a7345ca8b6d9344ed4db95a0b4250939ac3) | `element-{web,desktop}: 1.11.12 -> 1.11.13`                                                                  |
| [`b42282ab`](https://github.com/NixOS/nixpkgs/commit/b42282abdf05c4afedf1e6576cf84f2f2d3fae3d) | `octave: 7.1.0 -> 7.3.0`                                                                                     |
| [`125e22ba`](https://github.com/NixOS/nixpkgs/commit/125e22ba13d70a10645ce30f49eb890328f811ff) | `python310Packages.sensor-state-data: 2.10.1 -> 2.11.0`                                                      |
| [`be7eb483`](https://github.com/NixOS/nixpkgs/commit/be7eb483b87999600dd606462d99d9ab99420482) | `discord: add aarch64-darwin to platforms`                                                                   |
| [`5c8a5cfb`](https://github.com/NixOS/nixpkgs/commit/5c8a5cfba18c5c71117ed739d4f3fcb8120c16b0) | `dnsmonster: 0.9.5 -> 0.9.6`                                                                                 |
| [`90275986`](https://github.com/NixOS/nixpkgs/commit/9027598655757c3eefb8ebe1757797712821fff1) | `python310Packages.pulp: disable on older Python releases`                                                   |
| [`9402ab5a`](https://github.com/NixOS/nixpkgs/commit/9402ab5a6530cf0c7063700402925074217e798c) | `python310Packages.python-lsp-server: 1.5.0 -> 1.6.0`                                                        |
| [`2435d48a`](https://github.com/NixOS/nixpkgs/commit/2435d48ae76113245325853a83bd70e849847a4a) | `python310Packages.pulp: 2.6.0 -> 2.7.0`                                                                     |
| [`b45cf446`](https://github.com/NixOS/nixpkgs/commit/b45cf446ea501649bdccef866fb01e5b1042143c) | `linuxHeaders: fix cross-compilation from darwin to mips`                                                    |
| [`b6c1fb29`](https://github.com/NixOS/nixpkgs/commit/b6c1fb293e8b3a0914ac74d9fd0f6df7dcafbbad) | `mpvScripts.thumbnail: 0.4.9 -> 0.5.1`                                                                       |
| [`78399b66`](https://github.com/NixOS/nixpkgs/commit/78399b66f1979eb3bc078adc69994ab335ae66fc) | `picard: add patch to fix failing test`                                                                      |
| [`f968b3da`](https://github.com/NixOS/nixpkgs/commit/f968b3da7386593e2ccb1ef6d8ff4e20a6408ffa) | `snipe-it: 6.0.12 -> 6.0.13`                                                                                 |
| [`efa86fc3`](https://github.com/NixOS/nixpkgs/commit/efa86fc3b0daa9782d7bd1a2e25d52206be94100) | `mold: Unbreak on aarch64-linux`                                                                             |
| [`ec690a4c`](https://github.com/NixOS/nixpkgs/commit/ec690a4cf4a61e7de746970e8dee44d0c4cedfdc) | `rocthrust: init at 2.16.0-5.3.1`                                                                            |
| [`edbebe1d`](https://github.com/NixOS/nixpkgs/commit/edbebe1dbbc8753b2c6e1dcff1f22374f95bfc64) | `clang-ocl: init at 5.3.1`                                                                                   |
| [`d147c1d5`](https://github.com/NixOS/nixpkgs/commit/d147c1d5dd7c2173b0b0de196e6c25f09cbeef5f) | `composable_kernel: init at unstable-2022-11-02`                                                             |
| [`6cdf1908`](https://github.com/NixOS/nixpkgs/commit/6cdf19083fb545f5584b11a1f1a5fc8cdcda2ea9) | `miopengemm: init at 5.3.1`                                                                                  |
| [`6aa9de9f`](https://github.com/NixOS/nixpkgs/commit/6aa9de9f719cf404b95468b823319e976c82c11f) | `rocblas: init at 2.45.0-5.3.1`                                                                              |