### PR TITLE
chore(flake/nur): `7c908c5c` -> `0b26c235`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667900857,
-        "narHash": "sha256-+J4hJpcTkx3z5+xHStw7NeaSJWKrPiv3QPAu6+biU+s=",
+        "lastModified": 1667904789,
+        "narHash": "sha256-rGhf0TYfNNLta7XtoE2LGulQGqaE7dbT2z1by8eHIr4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7c908c5c6612a90721f65534e9fa5b13818c7a6c",
+        "rev": "0b26c235ce3d24f2c501c70e1ec771b563c8d791",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0b26c235`](https://github.com/nix-community/NUR/commit/0b26c235ce3d24f2c501c70e1ec771b563c8d791) | `automatic update` |