### PR TITLE
chore(flake/nur): `0b26c235` -> `1ebfa6e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667904789,
-        "narHash": "sha256-rGhf0TYfNNLta7XtoE2LGulQGqaE7dbT2z1by8eHIr4=",
+        "lastModified": 1667908590,
+        "narHash": "sha256-jRdhZwp5HYAkFvH9RhOm3vgfktyAiriKlzzjd+dnTy0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0b26c235ce3d24f2c501c70e1ec771b563c8d791",
+        "rev": "1ebfa6e18711c9d475d39286d2c2e13ca1da88f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1ebfa6e1`](https://github.com/nix-community/NUR/commit/1ebfa6e18711c9d475d39286d2c2e13ca1da88f7) | `automatic update` |
| [`3565e90f`](https://github.com/nix-community/NUR/commit/3565e90fbe665f5ce5bce98d498ae04d1a0d0876) | `automatic update` |