### PR TITLE
chore(flake/nur): `1ebfa6e1` -> `932a7926`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667908590,
-        "narHash": "sha256-jRdhZwp5HYAkFvH9RhOm3vgfktyAiriKlzzjd+dnTy0=",
+        "lastModified": 1667909691,
+        "narHash": "sha256-AQzgE3PjNk0zNneJEydvWJ7cMetKcrJQJ04TulLzQPw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1ebfa6e18711c9d475d39286d2c2e13ca1da88f7",
+        "rev": "932a7926c81fb601c4e973ff9fadd69069141e09",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`932a7926`](https://github.com/nix-community/NUR/commit/932a7926c81fb601c4e973ff9fadd69069141e09) | `automatic update` |