### PR TITLE
chore(flake/nur): `7895fdcd` -> `7e2c712b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667911181,
-        "narHash": "sha256-/99FRPzEQdQu/EtmDzSTS2lZabeVKRimecyOc8Vo2no=",
+        "lastModified": 1667915918,
+        "narHash": "sha256-X4m91yV1GHKS93QqNQk++GSzNSIc6TEeSIsQ6Kqrwak=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7895fdcd64a113a6274ac17531781db1f97fb4bb",
+        "rev": "7e2c712bb26829bbdf42131db0535887e91f5541",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7e2c712b`](https://github.com/nix-community/NUR/commit/7e2c712bb26829bbdf42131db0535887e91f5541) | `automatic update` |