### PR TITLE
chore(flake/nur): `87e9ef48` -> `1f103f39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667918069,
-        "narHash": "sha256-kxQQam3NC5kPJuNd//IVZxETnSRXpDZoONipQcs0NEM=",
+        "lastModified": 1667919192,
+        "narHash": "sha256-KqRmPi+M9kJ298FFIeYILFA9OgeCohASuyiZrcKAIPs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "87e9ef487c304f3b2479774e34e6e5cc84b0cfbe",
+        "rev": "1f103f39f063d23468e72910027f972e282376ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1f103f39`](https://github.com/nix-community/NUR/commit/1f103f39f063d23468e72910027f972e282376ed) | `automatic update` |