### PR TITLE
chore(flake/nur): `1f103f39` -> `aa1948a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667919192,
-        "narHash": "sha256-KqRmPi+M9kJ298FFIeYILFA9OgeCohASuyiZrcKAIPs=",
+        "lastModified": 1667931999,
+        "narHash": "sha256-I8/+s+c0DSaX1U2qGx7jPYM3YiQIFzQygRQnsxO35oI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1f103f39f063d23468e72910027f972e282376ed",
+        "rev": "aa1948a9de4600e5c6d362cf98bc2592aa7bae53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`aa1948a9`](https://github.com/nix-community/NUR/commit/aa1948a9de4600e5c6d362cf98bc2592aa7bae53) | `automatic update` |