### PR TITLE
chore(flake/nix-on-droid): `587825a1` -> `27c206f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -305,11 +305,11 @@
         "nixpkgs-for-bootstrap": "nixpkgs-for-bootstrap"
       },
       "locked": {
-        "lastModified": 1667767431,
-        "narHash": "sha256-gEO3QQrbTIdHCEcIwvWgtGK2iqg/OKR4Uy9ua2j1sVU=",
+        "lastModified": 1667935792,
+        "narHash": "sha256-xdTToQCBJFhslIsIOIjBFyVSiESLht5B5UjCjk99scY=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "587825a1e4f4f515de157c9dff619a2d98e9ecc2",
+        "rev": "27c206f57ac7c6434b53032d3625fd5cb73bb325",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                 |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`27c206f5`](https://github.com/t184256/nix-on-droid/commit/27c206f57ac7c6434b53032d3625fd5cb73bb325) | `tests: ease development in fakedroid env for on-device-tests` |
| [`6a345626`](https://github.com/t184256/nix-on-droid/commit/6a345626c0be99f847e9c661f677ea4f3013436b) | `add support for default configuration in flake.nix`           |
| [`ffac515c`](https://github.com/t184256/nix-on-droid/commit/ffac515cfb12a38f60abe2aebeaa316f6b9fa339) | `environment.motd: add option`                                 |
| [`a99c1e04`](https://github.com/t184256/nix-on-droid/commit/a99c1e041639b15a4e67857bc2ebce203bd7b215) | `simplify usage of lib.nixOnDroidConfiguration`                |
| [`d68467d6`](https://github.com/t184256/nix-on-droid/commit/d68467d6796cd8bfc4c98829253ca870c948f750) | `split _module.args and specialArgs`                           |