### PR TITLE
chore(flake/emacs-overlay): `88749da2` -> `cff0588f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667901730,
-        "narHash": "sha256-uqeF9nZzGX6Zj+7OtApQ2xmHSHNi6BS7SFlkqlnSBDs=",
+        "lastModified": 1667937848,
+        "narHash": "sha256-c8TlhsDfqM2Zk6EzRaR2V30AOMdLTH84en9+wetDj1I=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "88749da29c07c2ae565c9906565dbc895d736282",
+        "rev": "cff0588fd51f95b9f87b95540ea35640b14cd133",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`cff0588f`](https://github.com/nix-community/emacs-overlay/commit/cff0588fd51f95b9f87b95540ea35640b14cd133) | `Updated repos/melpa` |
| [`194cd5d8`](https://github.com/nix-community/emacs-overlay/commit/194cd5d85845c3c04a42c68a93131dd1f7bb72cf) | `Updated repos/emacs` |
| [`acd095ae`](https://github.com/nix-community/emacs-overlay/commit/acd095aeb5b11864824182a2766b4123c365e18c) | `Updated repos/elpa`  |