### PR TITLE
chore(flake/nur): `aa1948a9` -> `5b3bea7b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667931999,
-        "narHash": "sha256-I8/+s+c0DSaX1U2qGx7jPYM3YiQIFzQygRQnsxO35oI=",
+        "lastModified": 1667951793,
+        "narHash": "sha256-VfhSztLlTwWefhzw8yRKLHxYgoOsZbHL2v4Rfhq/Qeg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aa1948a9de4600e5c6d362cf98bc2592aa7bae53",
+        "rev": "5b3bea7b731d73f3574f7554531b79a6ae454754",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5b3bea7b`](https://github.com/nix-community/NUR/commit/5b3bea7b731d73f3574f7554531b79a6ae454754) | `automatic update` |