### PR TITLE
chore(flake/nur): `5b3bea7b` -> `dffc0889`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667951793,
-        "narHash": "sha256-VfhSztLlTwWefhzw8yRKLHxYgoOsZbHL2v4Rfhq/Qeg=",
+        "lastModified": 1667958607,
+        "narHash": "sha256-eueqipanrFQ5FqOFXYZhUHdCn254MxC4JQv21nlEyO8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5b3bea7b731d73f3574f7554531b79a6ae454754",
+        "rev": "dffc0889c3b2f344d1f4fd76230c53cc4bc00edc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`dffc0889`](https://github.com/nix-community/NUR/commit/dffc0889c3b2f344d1f4fd76230c53cc4bc00edc) | `automatic update` |