### PR TITLE
chore(flake/nur): `dffc0889` -> `551654db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667958607,
-        "narHash": "sha256-eueqipanrFQ5FqOFXYZhUHdCn254MxC4JQv21nlEyO8=",
+        "lastModified": 1667961056,
+        "narHash": "sha256-EmxmLOTAIfz/SX91/0GtH4agkBB7gvKWzrIisycywAY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dffc0889c3b2f344d1f4fd76230c53cc4bc00edc",
+        "rev": "551654dbb82a3d2594ef9609bee3ceb043b58ea3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`551654db`](https://github.com/nix-community/NUR/commit/551654dbb82a3d2594ef9609bee3ceb043b58ea3) | `automatic update` |