### PR TITLE
chore(flake/nur): `cdad2b3d` -> `79c9768d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667966895,
-        "narHash": "sha256-mcXZU/lq2qtkiz29FEo2GP5vhSPdCoYT4ffmg88nxr0=",
+        "lastModified": 1667968120,
+        "narHash": "sha256-O5Jlj+EG9UaO2+r0dsjMwxgBmjLK9S5p7n1c53J8fNw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cdad2b3dc6278fe0cb752355550e6aa74715b9a0",
+        "rev": "79c9768de87812b0b766aec1df99d8de67b7e3be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`79c9768d`](https://github.com/nix-community/NUR/commit/79c9768de87812b0b766aec1df99d8de67b7e3be) | `automatic update` |