### PR TITLE
chore(flake/nur): `79c9768d` -> `21566347`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667968120,
-        "narHash": "sha256-O5Jlj+EG9UaO2+r0dsjMwxgBmjLK9S5p7n1c53J8fNw=",
+        "lastModified": 1667973455,
+        "narHash": "sha256-POUXljwP8Q80eSfJon0fGllIRDzrthyaTNRDG/bb0jU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "79c9768de87812b0b766aec1df99d8de67b7e3be",
+        "rev": "21566347b28e63f6e0c5ec61685364435cc723d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`21566347`](https://github.com/nix-community/NUR/commit/21566347b28e63f6e0c5ec61685364435cc723d5) | `automatic update` |
| [`a95421b4`](https://github.com/nix-community/NUR/commit/a95421b4e44ed7a229a8c8cfe7dfb09d8981a604) | `automatic update` |