### PR TITLE
chore(flake/nur): `21566347` -> `9e16b967`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667973455,
-        "narHash": "sha256-POUXljwP8Q80eSfJon0fGllIRDzrthyaTNRDG/bb0jU=",
+        "lastModified": 1667982990,
+        "narHash": "sha256-ALmNvJ0asn0npQ35rr95p8sxiv0m+L6DKUPgQBjMP48=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "21566347b28e63f6e0c5ec61685364435cc723d5",
+        "rev": "9e16b967c661ef73ade9b9b252e0b59efd06ced9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9e16b967`](https://github.com/nix-community/NUR/commit/9e16b967c661ef73ade9b9b252e0b59efd06ced9) | `automatic update` |