### PR TITLE
chore(flake/pre-commit-hooks): `06f48d63` -> `ebcbfe09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -400,11 +400,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667760143,
-        "narHash": "sha256-+X5CyeNEKp41bY/I1AJgW/fn69q5cLJ1bgiaMMCKB3M=",
+        "lastModified": 1667992213,
+        "narHash": "sha256-8Ens8ozllvlaFMCZBxg6S7oUyynYx2v7yleC5M0jJsE=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "06f48d63d473516ce5b8abe70d15be96a0147fcd",
+        "rev": "ebcbfe09d2bd6d15f68de3a0ebb1e4dcb5cd324b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message |
| ------------------------------------------------------------------------------------------------------------ | -------------- |
| [`ebcbfe09`](https://github.com/cachix/pre-commit-hooks.nix/commit/ebcbfe09d2bd6d15f68de3a0ebb1e4dcb5cd324b) | `fix typo`     |