### PR TITLE
chore(flake/emacs-overlay): `dd48b168` -> `931ac5f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667969964,
-        "narHash": "sha256-doa7lAKtXloFbBq9FVEco3Ls4aaEMZNJuyh4tRCmnps=",
+        "lastModified": 1667995174,
+        "narHash": "sha256-TzuupNsdL7Jsz8jF48+0B6VkZDkcK5/UvEz7d63Z6To=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dd48b16890264f6b033796c2c809e177f510c66d",
+        "rev": "931ac5f67eb8f273325097f2347f3e6fbe3b1a2a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`931ac5f6`](https://github.com/nix-community/emacs-overlay/commit/931ac5f67eb8f273325097f2347f3e6fbe3b1a2a) | `Updated repos/melpa` |
| [`8ad6ae26`](https://github.com/nix-community/emacs-overlay/commit/8ad6ae2619bbed75b41d07682f914d1c694ed424) | `Updated repos/emacs` |