### PR TITLE
chore(flake/nur): `49e540ef` -> `9ac87bcd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1667986374,
-        "narHash": "sha256-49W4HrAdym6uA2z+0e54wyFD+9ZE1qTQXPRovemv9dw=",
+        "lastModified": 1668002778,
+        "narHash": "sha256-36XIhA7ounf78z8ashjo4YnXVG+aVTjIUY4AIQLuNXo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "49e540ef28411fbff2f2f24023b7eb37b3603096",
+        "rev": "9ac87bcd430391ebbed8a2a906e767c04e22d969",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9ac87bcd`](https://github.com/nix-community/NUR/commit/9ac87bcd430391ebbed8a2a906e767c04e22d969) | `automatic update` |