### PR TITLE
chore(flake/nur): `b2c91c36` -> `79334a65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668014053,
-        "narHash": "sha256-GK5q9L2c9TzcbH/E8tekhrrLEEk9+/mGpJmpqB8a2tU=",
+        "lastModified": 1668033895,
+        "narHash": "sha256-aTY9dl9bpFnKz9RFMkLrseVPUJlLvChL2Kb3zOtNRyY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b2c91c3639a5f42e4f12abbe41b1d82b2aca079b",
+        "rev": "79334a654221ef684c7a9844c794b87ef5d0d07b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`79334a65`](https://github.com/nix-community/NUR/commit/79334a654221ef684c7a9844c794b87ef5d0d07b) | `automatic update` |