### PR TITLE
chore(flake/nur): `79334a65` -> `71dadb24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668033895,
-        "narHash": "sha256-aTY9dl9bpFnKz9RFMkLrseVPUJlLvChL2Kb3zOtNRyY=",
+        "lastModified": 1668038359,
+        "narHash": "sha256-xsEG4/ZoUpG7VWymXgRD2MAN0nkKneeD84f4RUpsNic=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "79334a654221ef684c7a9844c794b87ef5d0d07b",
+        "rev": "71dadb246555d9acab72a953cdb051dcbd926464",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`71dadb24`](https://github.com/nix-community/NUR/commit/71dadb246555d9acab72a953cdb051dcbd926464) | `automatic update` |