### PR TITLE
chore(flake/nur): `265d2c49` -> `146d0d75`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668047351,
-        "narHash": "sha256-zDpUJMyS8xW2VAsrPC4PyjH2sRfEWjPmWQxONoallE8=",
+        "lastModified": 1668053313,
+        "narHash": "sha256-gcH34jdCedL8hL9tpJ/H2G58H0EXFwLgyZgGEqJxUCI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "265d2c4986fcaf09b5e82f65765101d0884d9f2b",
+        "rev": "146d0d7564978cb037fb9bf532c8f2604cf88c6a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`146d0d75`](https://github.com/nix-community/NUR/commit/146d0d7564978cb037fb9bf532c8f2604cf88c6a) | `automatic update` |