### PR TITLE
chore(flake/nur): `146d0d75` -> `dd936485`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668053313,
-        "narHash": "sha256-gcH34jdCedL8hL9tpJ/H2G58H0EXFwLgyZgGEqJxUCI=",
+        "lastModified": 1668054514,
+        "narHash": "sha256-k9x1Ra2/Rib4X7QqVcEfBeiD/RqaAWAg1ACV34S5Re8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "146d0d7564978cb037fb9bf532c8f2604cf88c6a",
+        "rev": "dd9364856e20b74f5e8776edce8319275181088c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`dd936485`](https://github.com/nix-community/NUR/commit/dd9364856e20b74f5e8776edce8319275181088c) | `automatic update` |