### PR TITLE
chore(flake/nur): `dd936485` -> `cbf9d821`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668054514,
-        "narHash": "sha256-k9x1Ra2/Rib4X7QqVcEfBeiD/RqaAWAg1ACV34S5Re8=",
+        "lastModified": 1668055760,
+        "narHash": "sha256-bxjYAMcWu41bn0EVSEWybaL+MI0HK5HCln/2TQTGJms=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd9364856e20b74f5e8776edce8319275181088c",
+        "rev": "cbf9d821b62e1ba2219ab35ea2d1911eb9e4972d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`cbf9d821`](https://github.com/nix-community/NUR/commit/cbf9d821b62e1ba2219ab35ea2d1911eb9e4972d) | `automatic update` |