### PR TITLE
chore(flake/emacs-overlay): `3f3be217` -> `393b1d44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668024141,
-        "narHash": "sha256-pAA9M3C7nDXs3Kf4Tvz0+GAmyeSTziW+XdS0BWzA4DQ=",
+        "lastModified": 1668056654,
+        "narHash": "sha256-FC7nHetvsB+cvQh72O1CtrlXzxED5Kqf8w0gmSSs94Q=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3f3be217a2342f706705b7de4a7cae6e7a5b1140",
+        "rev": "393b1d44acf6a7ae5522e459dde3d42045c765ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`393b1d44`](https://github.com/nix-community/emacs-overlay/commit/393b1d44acf6a7ae5522e459dde3d42045c765ea) | `Updated repos/nongnu` |
| [`ea25aef6`](https://github.com/nix-community/emacs-overlay/commit/ea25aef6be5d11833b6fcfbbae30f488b721079b) | `Updated repos/melpa`  |
| [`c1b780cb`](https://github.com/nix-community/emacs-overlay/commit/c1b780cbfaee634d77f2855d07870be1d8e40403) | `Updated repos/emacs`  |