### PR TITLE
chore(flake/nur): `5dd7d21b` -> `05d7230a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668059331,
-        "narHash": "sha256-yqW1NPS8+6CNq7NVWmN01//U2VaO9uL1w0vEzo5yak4=",
+        "lastModified": 1668062644,
+        "narHash": "sha256-RHWOXxCmBint8LUB/g7kBpZWSWhaQd4ISF45l/dYB9o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5dd7d21bccd38ca96d96b148baf53319b5ae60f2",
+        "rev": "05d7230aa5e3868ede9ed9c4e10fe3efbed97812",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`05d7230a`](https://github.com/nix-community/NUR/commit/05d7230aa5e3868ede9ed9c4e10fe3efbed97812) | `automatic update` |
| [`c186272e`](https://github.com/nix-community/NUR/commit/c186272e4803006c968ce93dc780e2417c15ba2a) | `automatic update` |