### PR TITLE
chore(flake/nur): `05d7230a` -> `a38b9438`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668062644,
-        "narHash": "sha256-RHWOXxCmBint8LUB/g7kBpZWSWhaQd4ISF45l/dYB9o=",
+        "lastModified": 1668078747,
+        "narHash": "sha256-rMEJW0Nfph3MwbnWAlZXEvopl1T3DKwxuTwNm3Sippc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "05d7230aa5e3868ede9ed9c4e10fe3efbed97812",
+        "rev": "a38b94388e746736c2551dd65fe0ded707818a63",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a38b9438`](https://github.com/nix-community/NUR/commit/a38b94388e746736c2551dd65fe0ded707818a63) | `automatic update` |