### PR TITLE
chore(flake/emacs-overlay): `393b1d44` -> `e58b5f1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668056654,
-        "narHash": "sha256-FC7nHetvsB+cvQh72O1CtrlXzxED5Kqf8w0gmSSs94Q=",
+        "lastModified": 1668080947,
+        "narHash": "sha256-lo67PHtNOedK7//xrRiio297/WnbdN30t+YQ5+Dse3Q=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "393b1d44acf6a7ae5522e459dde3d42045c765ea",
+        "rev": "e58b5f1dac80f717f41121a0e4008b3050d79b9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`e58b5f1d`](https://github.com/nix-community/emacs-overlay/commit/e58b5f1dac80f717f41121a0e4008b3050d79b9d) | `Updated repos/melpa` |
| [`cf0a990a`](https://github.com/nix-community/emacs-overlay/commit/cf0a990ab58f1cd6dbe1ead35c94c3dbbf226996) | `Updated repos/emacs` |