### PR TITLE
chore(flake/nur): `8f55ff96` -> `c4901dc7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668082439,
-        "narHash": "sha256-UIl9ABLTQT4UNjpmB/faszP+q2CSOcMw/D82BGMm4Fs=",
+        "lastModified": 1668083168,
+        "narHash": "sha256-yDYNuoTZePsBbWaPcxEIj7rTOAKzmtT7NQnAynmi5as=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8f55ff968242defe6c4e91eba7038fdd8dd69bb2",
+        "rev": "c4901dc7660f78543d5877e7ad0c35ac1e22b1a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c4901dc7`](https://github.com/nix-community/NUR/commit/c4901dc7660f78543d5877e7ad0c35ac1e22b1a7) | `automatic update` |