### PR TITLE
chore(flake/nur): `c4901dc7` -> `b3376ff2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668083168,
-        "narHash": "sha256-yDYNuoTZePsBbWaPcxEIj7rTOAKzmtT7NQnAynmi5as=",
+        "lastModified": 1668089453,
+        "narHash": "sha256-lfoOe2IGFmUQ0+AC5xHWa1u0fyWCCwAbtEMjEvlFAO8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c4901dc7660f78543d5877e7ad0c35ac1e22b1a7",
+        "rev": "b3376ff2f28d9c5e6f5c63b6cf61fa6d6a593de7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b3376ff2`](https://github.com/nix-community/NUR/commit/b3376ff2f28d9c5e6f5c63b6cf61fa6d6a593de7) | `automatic update` |