### PR TITLE
chore(flake/nur): `b3376ff2` -> `df449ba7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668089453,
-        "narHash": "sha256-lfoOe2IGFmUQ0+AC5xHWa1u0fyWCCwAbtEMjEvlFAO8=",
+        "lastModified": 1668099632,
+        "narHash": "sha256-0RenLyMKNh96TDCjQlyzWnYoP0gybyZSDTKNCRp/yG8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b3376ff2f28d9c5e6f5c63b6cf61fa6d6a593de7",
+        "rev": "df449ba75851790443c011ab2ddf61950e8ea352",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`df449ba7`](https://github.com/nix-community/NUR/commit/df449ba75851790443c011ab2ddf61950e8ea352) | `automatic update` |