### PR TITLE
chore(flake/emacs-overlay): `0b01e1fd` -> `a5732835`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668101004,
-        "narHash": "sha256-6B25gyZqBWCOP23vEzGlRL2qX2yZ5XwsW6rGlxAV3QA=",
+        "lastModified": 1668107626,
+        "narHash": "sha256-+SqPtgD0fQ/LvYxPH+1I5lR76rAqI67GcjQ1gvwUt6U=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0b01e1fd7c40a8b97e3f4754d6bcdecd4b2effc7",
+        "rev": "a5732835d449b66324efa829e3b8be73be3d505e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`a22d7910`](https://github.com/nix-community/emacs-overlay/commit/a22d79104426b9442ec3540da7e27864beae564a) | `emacs: add emacsLsp` |