### PR TITLE
chore(flake/nur): `aeea998f` -> `2e2be552`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668110071,
-        "narHash": "sha256-QgpBgyr4QPzV9o9T9Sruh3tUawWrHPDjRjq97/xDync=",
+        "lastModified": 1668112468,
+        "narHash": "sha256-iO8hhqqBaY3Ymd39xpeiLHrcBaSXyCfj5E1EYjBsSyk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aeea998f5b91de263b91e75fe6eda1b7a98a11aa",
+        "rev": "2e2be552214814f7263c68d28ac988a7f2aadc22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2e2be552`](https://github.com/nix-community/NUR/commit/2e2be552214814f7263c68d28ac988a7f2aadc22) | `automatic update` |