### PR TITLE
chore(flake/nur): `cca8d536` -> `6db5e6bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668124423,
-        "narHash": "sha256-InDPT2aAHoJl3c05acQcEiF6MaTkoUHilaMpVSYblPg=",
+        "lastModified": 1668136336,
+        "narHash": "sha256-WIVSt2KOKHN0IUgvbdpyEPcZOgQ+w0G0XkUfUZLiEjs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cca8d53616e188662884c400aae27765a2a56be3",
+        "rev": "6db5e6bc2f33677eb488e5ccb79674dbd88e19ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6db5e6bc`](https://github.com/nix-community/NUR/commit/6db5e6bc2f33677eb488e5ccb79674dbd88e19ac) | `automatic update` |