### PR TITLE
chore(flake/nur): `efc883b5` -> `98a1bae8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668139719,
-        "narHash": "sha256-8/THKFJ2T5RkOLE+mEzHqk20WlXiLGIkDG6ryAGfCtY=",
+        "lastModified": 1668140343,
+        "narHash": "sha256-OJTc4gAq6ycQeJ/BNAkofALogedLVDOXoG7TdyTjyCs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "efc883b5f359a6dfa921f529a54607a0c3067930",
+        "rev": "98a1bae8a5e88b713776313fc026ad3b48a92cff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`98a1bae8`](https://github.com/nix-community/NUR/commit/98a1bae8a5e88b713776313fc026ad3b48a92cff) | `automatic update` |