### PR TITLE
chore(flake/nur): `98a1bae8` -> `0a4b6333`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668140343,
-        "narHash": "sha256-OJTc4gAq6ycQeJ/BNAkofALogedLVDOXoG7TdyTjyCs=",
+        "lastModified": 1668141784,
+        "narHash": "sha256-j/WpAnw/PgF1v0Y0UX3V567Ry2oEt0iwyCICVPSSuvg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "98a1bae8a5e88b713776313fc026ad3b48a92cff",
+        "rev": "0a4b633398eda8e907ffff81780ec94475354334",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0a4b6333`](https://github.com/nix-community/NUR/commit/0a4b633398eda8e907ffff81780ec94475354334) | `automatic update` |