### PR TITLE
chore(flake/emacs-overlay): `a5732835` -> `5960fb7e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668107626,
-        "narHash": "sha256-+SqPtgD0fQ/LvYxPH+1I5lR76rAqI67GcjQ1gvwUt6U=",
+        "lastModified": 1668143487,
+        "narHash": "sha256-tMvRLP8tiHNGnUcUJ5wXgNrQu+RejWXSpPZ/+8QWQ0U=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a5732835d449b66324efa829e3b8be73be3d505e",
+        "rev": "5960fb7e82389435b6dffb909342c271589b36a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`5960fb7e`](https://github.com/nix-community/emacs-overlay/commit/5960fb7e82389435b6dffb909342c271589b36a9) | `Updated repos/nongnu` |
| [`038cd97c`](https://github.com/nix-community/emacs-overlay/commit/038cd97c32294a323d411bf78872844be82a2acb) | `Updated repos/melpa`  |
| [`7aaab890`](https://github.com/nix-community/emacs-overlay/commit/7aaab890738ccdbe06d539f12b4c43c34c8a6abf) | `Updated repos/exwm`   |
| [`8c7a6b03`](https://github.com/nix-community/emacs-overlay/commit/8c7a6b03fddd1acd38175657ed338445d6936979) | `Updated repos/emacs`  |