### PR TITLE
chore(flake/nur): `0a4b6333` -> `37d8c77a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668141784,
-        "narHash": "sha256-j/WpAnw/PgF1v0Y0UX3V567Ry2oEt0iwyCICVPSSuvg=",
+        "lastModified": 1668149969,
+        "narHash": "sha256-wfZwuRazRm+IJlcvPrK2xTrjBIZUc2zOlzJmj7+QHgc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0a4b633398eda8e907ffff81780ec94475354334",
+        "rev": "37d8c77ab0b1fa3f48fb94e79f272c60aad10a57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`37d8c77a`](https://github.com/nix-community/NUR/commit/37d8c77ab0b1fa3f48fb94e79f272c60aad10a57) | `automatic update` |