### PR TITLE
chore(flake/emacs-overlay): `5960fb7e` -> `7b58afb8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668143487,
-        "narHash": "sha256-tMvRLP8tiHNGnUcUJ5wXgNrQu+RejWXSpPZ/+8QWQ0U=",
+        "lastModified": 1668167903,
+        "narHash": "sha256-5OENaesVk94meyiaDFgxtr4TTuAg52baVHXOnXL98vI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5960fb7e82389435b6dffb909342c271589b36a9",
+        "rev": "7b58afb8604c9d53fe11bfb76e2ce903cb658b66",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`7b58afb8`](https://github.com/nix-community/emacs-overlay/commit/7b58afb8604c9d53fe11bfb76e2ce903cb658b66) | `Updated repos/melpa` |
| [`e74bed66`](https://github.com/nix-community/emacs-overlay/commit/e74bed661af99f9b6cb30f62431e00899180cf52) | `Updated repos/emacs` |