### PR TITLE
chore(flake/nur): `37d8c77a` -> `fcb3fcba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668149969,
-        "narHash": "sha256-wfZwuRazRm+IJlcvPrK2xTrjBIZUc2zOlzJmj7+QHgc=",
+        "lastModified": 1668172191,
+        "narHash": "sha256-sMe8hCQQhi8OPPJkWC7JRaKIPM/rjdMSzfvRmAapJE8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "37d8c77ab0b1fa3f48fb94e79f272c60aad10a57",
+        "rev": "fcb3fcba17130a63f78a9a520d763cb148385187",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`fcb3fcba`](https://github.com/nix-community/NUR/commit/fcb3fcba17130a63f78a9a520d763cb148385187) | `automatic update` |