### PR TITLE
chore(flake/nur): `fcb3fcba` -> `5da1d2f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668172191,
-        "narHash": "sha256-sMe8hCQQhi8OPPJkWC7JRaKIPM/rjdMSzfvRmAapJE8=",
+        "lastModified": 1668174315,
+        "narHash": "sha256-oss9lJ30HbgXpVFy5Xv9doB+1mNjQehbFlFYau95odM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fcb3fcba17130a63f78a9a520d763cb148385187",
+        "rev": "5da1d2f59d29cd1bb9c0787db9c1046825ade56a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5da1d2f5`](https://github.com/nix-community/NUR/commit/5da1d2f59d29cd1bb9c0787db9c1046825ade56a) | `automatic update` |