### PR TITLE
chore(flake/emacs-overlay): `7b58afb8` -> `c6869293`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668167903,
-        "narHash": "sha256-5OENaesVk94meyiaDFgxtr4TTuAg52baVHXOnXL98vI=",
+        "lastModified": 1668200521,
+        "narHash": "sha256-Jh/qkrA8VCJGA5W7NRnIhiV1ErbTrG8tj/AWlxKwpZw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7b58afb8604c9d53fe11bfb76e2ce903cb658b66",
+        "rev": "c6869293b585efa58e44d871611a6702fd3bdf8a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`c6869293`](https://github.com/nix-community/emacs-overlay/commit/c6869293b585efa58e44d871611a6702fd3bdf8a) | `Updated repos/melpa` |
| [`26c41596`](https://github.com/nix-community/emacs-overlay/commit/26c41596596cceffc38865815fc8de960b80d059) | `Updated repos/emacs` |
| [`4e064f7f`](https://github.com/nix-community/emacs-overlay/commit/4e064f7fde6738760c354ae73b8fdd05d30feaa9) | `Updated repos/elpa`  |