### PR TITLE
chore(flake/nur): `5da1d2f5` -> `10c3d5ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668174315,
-        "narHash": "sha256-oss9lJ30HbgXpVFy5Xv9doB+1mNjQehbFlFYau95odM=",
+        "lastModified": 1668210794,
+        "narHash": "sha256-1J9UpEAHPUHwzvQYVLjXApBdrg9A9TeJlFLS1P0hjIk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5da1d2f59d29cd1bb9c0787db9c1046825ade56a",
+        "rev": "10c3d5ae7358e4a4372d82f084a85de720f5c542",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`10c3d5ae`](https://github.com/nix-community/NUR/commit/10c3d5ae7358e4a4372d82f084a85de720f5c542) | `automatic update` |