### PR TITLE
chore(flake/nur): `10c3d5ae` -> `7ba50779`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668210794,
-        "narHash": "sha256-1J9UpEAHPUHwzvQYVLjXApBdrg9A9TeJlFLS1P0hjIk=",
+        "lastModified": 1668215044,
+        "narHash": "sha256-4kg0t5rmpXbYKZph0hNE7BQj/ciaisCRl17DNKkJvOk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "10c3d5ae7358e4a4372d82f084a85de720f5c542",
+        "rev": "7ba507793a0d0113557bdd8033ab34e815666e28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7ba50779`](https://github.com/nix-community/NUR/commit/7ba507793a0d0113557bdd8033ab34e815666e28) | `automatic update` |