### PR TITLE
chore(flake/nur): `7ba50779` -> `e8d75400`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668215044,
-        "narHash": "sha256-4kg0t5rmpXbYKZph0hNE7BQj/ciaisCRl17DNKkJvOk=",
+        "lastModified": 1668217712,
+        "narHash": "sha256-cQmOv/uTy5g9ig15oXhePpal/gp6G/vAR+CvcHNxC2E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7ba507793a0d0113557bdd8033ab34e815666e28",
+        "rev": "e8d754004ba207ffc1ddb1a32d5684f0d3e5e8db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e8d75400`](https://github.com/nix-community/NUR/commit/e8d754004ba207ffc1ddb1a32d5684f0d3e5e8db) | `automatic update` |