### PR TITLE
chore(flake/nur): `eba4df05` -> `25b6c336`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668225976,
-        "narHash": "sha256-/hseyysPQoqNMT7ioBHUXtwMLkL+DyLva8/vLxHwcXQ=",
+        "lastModified": 1668227748,
+        "narHash": "sha256-0sw9Eqts2aRk/CJNaha/jRtcbMS7qYL1KeQ4y/zjl8Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eba4df054cf3c58cd33a5e2ffa2705eeba175382",
+        "rev": "25b6c3360ba97df2f7f221c620d9cdef4204fb30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`25b6c336`](https://github.com/nix-community/NUR/commit/25b6c3360ba97df2f7f221c620d9cdef4204fb30) | `automatic update` |