### PR TITLE
chore(flake/nur): `25b6c336` -> `1e799d20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668227748,
-        "narHash": "sha256-0sw9Eqts2aRk/CJNaha/jRtcbMS7qYL1KeQ4y/zjl8Q=",
+        "lastModified": 1668231904,
+        "narHash": "sha256-bC+QdBPZ8cprHI3eiuFx3kF9+AOpV9Xp2+LR96Zkh4c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "25b6c3360ba97df2f7f221c620d9cdef4204fb30",
+        "rev": "1e799d205b365d1e6e8f84830d744b3a40493c19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1e799d20`](https://github.com/nix-community/NUR/commit/1e799d205b365d1e6e8f84830d744b3a40493c19) | `automatic update` |
| [`162b3605`](https://github.com/nix-community/NUR/commit/162b3605b087a7b7765c31085e1ca7a4468d0d8b) | `automatic update` |