### PR TITLE
chore(flake/emacs-overlay): `c6869293` -> `af4ea11d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668200521,
-        "narHash": "sha256-Jh/qkrA8VCJGA5W7NRnIhiV1ErbTrG8tj/AWlxKwpZw=",
+        "lastModified": 1668232394,
+        "narHash": "sha256-scwHJBanfYDTsolRgssIuVXBGGd0vXreRmZyjv6yt/8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c6869293b585efa58e44d871611a6702fd3bdf8a",
+        "rev": "af4ea11d77395728c49e9dd006cd7a381eca2d78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`af4ea11d`](https://github.com/nix-community/emacs-overlay/commit/af4ea11d77395728c49e9dd006cd7a381eca2d78) | `Updated repos/nongnu` |
| [`3c609f07`](https://github.com/nix-community/emacs-overlay/commit/3c609f0758588d318207991c38fe3c998d305411) | `Updated repos/melpa`  |
| [`963baa4e`](https://github.com/nix-community/emacs-overlay/commit/963baa4e7b4c42d1ac776b510e96d999471c945d) | `Updated repos/emacs`  |