### PR TITLE
chore(flake/emacs-overlay): `af4ea11d` -> `1872c729`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668232394,
-        "narHash": "sha256-scwHJBanfYDTsolRgssIuVXBGGd0vXreRmZyjv6yt/8=",
+        "lastModified": 1668256904,
+        "narHash": "sha256-woAxkqmTpzSB4JpF12cn+e2v0Lsf4fKBpkLBO2QCC2U=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "af4ea11d77395728c49e9dd006cd7a381eca2d78",
+        "rev": "1872c7297d7dfcba2d5f206baa5fcb0094575ad8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`1872c729`](https://github.com/nix-community/emacs-overlay/commit/1872c7297d7dfcba2d5f206baa5fcb0094575ad8) | `Updated repos/nongnu` |
| [`7e80fed2`](https://github.com/nix-community/emacs-overlay/commit/7e80fed2300b097fede379c32e966d47c5ff50a2) | `Updated repos/melpa`  |
| [`e5759cd1`](https://github.com/nix-community/emacs-overlay/commit/e5759cd19921a0f890a14719564e1995979dc6cb) | `Updated repos/emacs`  |