### PR TITLE
chore(flake/nixpkgs): `872fceee` -> `5f588eb4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -299,11 +299,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667991831,
-        "narHash": "sha256-DHgEsLZI044B9T4AjA3K6+yB9/DqLr4dyA7OIx0FG7o=",
+        "lastModified": 1668087632,
+        "narHash": "sha256-T/cUx44aYDuLMFfaiVpMdTjL4kpG7bh0VkN6JEM78/E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "872fceeed60ae6b7766cc0a4cd5bf5901b9098ec",
+        "rev": "5f588eb4a958f1a526ed8da02d6ea1bea0047b9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`d2d6d737`](https://github.com/NixOS/nixpkgs/commit/d2d6d737a844018d85052f281d932a404bc48fb4) | `alfaview: 8.54.0 -> 8.57.0`                                               |
| [`4fe6ecc1`](https://github.com/NixOS/nixpkgs/commit/4fe6ecc1fd67da719a544a4a9291ff319eadab74) | `domoticz: 2022.1 -> 2022.2`                                               |
| [`ee4de4ed`](https://github.com/NixOS/nixpkgs/commit/ee4de4edd843b58f0eeb35b9b88ff3708792b8d7) | `dstask: 0.25 -> 0.26`                                                     |
| [`bdcae807`](https://github.com/NixOS/nixpkgs/commit/bdcae8077691ca26e2a313883e528d64bf467698) | `protoc-gen-validate: 0.6.13 -> 0.9.0`                                     |
| [`4201cff0`](https://github.com/NixOS/nixpkgs/commit/4201cff07b619d3e9e79d3ec99ff20f23006caf8) | `hysteria: 1.2.2 -> 1.3.0`                                                 |
| [`2c3bd8ed`](https://github.com/NixOS/nixpkgs/commit/2c3bd8ed64d4bfaaf1805a65cc3d51438254f8aa) | `ginkgo: 2.4.0 -> 2.5.0`                                                   |
| [`aa069fc8`](https://github.com/NixOS/nixpkgs/commit/aa069fc82b8da26b7e7a60b96ddd42b0c336d97a) | `kafkactl: 3.0.0 -> 3.0.1`                                                 |
| [`ec0c1b24`](https://github.com/NixOS/nixpkgs/commit/ec0c1b2479b4125acdb6d1913b1819d68f1e9fb4) | `jc: 1.22.1 -> 1.22.2`                                                     |
| [`24658cbd`](https://github.com/NixOS/nixpkgs/commit/24658cbd461520b775e211bee2feff36469b7e16) | `coder: 0.12.4 -> 0.12.5`                                                  |
| [`0533be43`](https://github.com/NixOS/nixpkgs/commit/0533be43f1ce89c51ce9720386258ea5c19fcb1d) | `kics: 1.6.3 -> 1.6.4`                                                     |
| [`4d2a51e4`](https://github.com/NixOS/nixpkgs/commit/4d2a51e4ee698d8b5c3669e082675f62abd66f64) | `operator-sdk: 1.25.0 -> 1.25.1`                                           |
| [`94a6ba6e`](https://github.com/NixOS/nixpkgs/commit/94a6ba6e17ef251f7f9b550b10098be0612714fa) | `highfive: 2.4.1 -> 2.6.1`                                                 |
| [`950ee7c3`](https://github.com/NixOS/nixpkgs/commit/950ee7c3998b8c2f1b41aaf1ac9abb520a4b5654) | `phrase-cli: 2.5.3 -> 2.5.4`                                               |
| [`4c799a38`](https://github.com/NixOS/nixpkgs/commit/4c799a38b634439c2c5e70eb0f7f3c9d9aeee236) | `netbird: 0.10.6 -> 0.10.7`                                                |
| [`cf0c3024`](https://github.com/NixOS/nixpkgs/commit/cf0c30240e1daa7ba0703e5617ee59ba0660b12c) | `gitRepo: 2.29.5 -> 2.29.9`                                                |
| [`09b4e307`](https://github.com/NixOS/nixpkgs/commit/09b4e307bd6d0849439cbda28a044719e5165714) | `sidplayfp: 2.2.3 -> 2.4.0`                                                |
| [`6a53b035`](https://github.com/NixOS/nixpkgs/commit/6a53b035e519ea65139d21d7ca9e00e29136f975) | `protonvpn-gui: 1.11.0 -> 1.12.0`                                          |
| [`4cdc5e30`](https://github.com/NixOS/nixpkgs/commit/4cdc5e30697c12f405c686c06056160ff078bdcc) | `sssd: 2.8.0 -> 2.8.1`                                                     |
| [`2c0c029a`](https://github.com/NixOS/nixpkgs/commit/2c0c029ae388acc19219fbf0db381ee557c2ddb3) | `awscli2: 2.8.9 -> 2.8.11`                                                 |
| [`f8cd0326`](https://github.com/NixOS/nixpkgs/commit/f8cd032621c770b22f0c1970d92909e81eab69ff) | `buf: Add patch to make TestDuplicateSyntheticOneofs deterministic`        |
| [`c5668943`](https://github.com/NixOS/nixpkgs/commit/c5668943cd26e7d9406fbd634d99d253963f9221) | `mame: some improvements`                                                  |
| [`b73781c9`](https://github.com/NixOS/nixpkgs/commit/b73781c9893215ff33a7a372976a45ba8528086c) | `conmon-rs: init at 0.4.0`                                                 |
| [`054bdf8e`](https://github.com/NixOS/nixpkgs/commit/054bdf8e9be816529481e2fe8481c87987343932) | `buf: remove raboof as maintainer`                                         |
| [`89e08269`](https://github.com/NixOS/nixpkgs/commit/89e08269efaf60a56f8026040afe28b21e661cca) | `libsidplayfp: 2.3.1 -> 2.4.0`                                             |
| [`7a45af06`](https://github.com/NixOS/nixpkgs/commit/7a45af06a20c8390bf88d3ac005e49dc35a0b080) | `buf: Add patch to make TestCyclicImport deterministic`                    |
| [`d97cad58`](https://github.com/NixOS/nixpkgs/commit/d97cad58c7f83a2a8fa18c69eb128a80fb24960e) | `snappymail: 2.19.4 -> 2.20.6`                                             |
| [`0a303bce`](https://github.com/NixOS/nixpkgs/commit/0a303bce315c8588e7e0f25fc054ac74b081a073) | `nfs-ganesha: 4.0.8 -> 4.0.12`                                             |
| [`a4e879a5`](https://github.com/NixOS/nixpkgs/commit/a4e879a54919387162fb68565d7ecffda0abf9f5) | `spglib/pythonPackages.spglib: 2.0.1 -> 2.0.2`                             |
| [`b2eda582`](https://github.com/NixOS/nixpkgs/commit/b2eda58270a9b863da085f92fd2c0bc301212956) | `mpich: 4.0.2 -> 4.0.3`                                                    |
| [`891511b6`](https://github.com/NixOS/nixpkgs/commit/891511b61957757faa4c3162d173e984f9c39e34) | `nixos/doc: document mame package changes`                                 |
| [`d868053b`](https://github.com/NixOS/nixpkgs/commit/d868053b400db0fa46e2a0432fa06231a040a7cb) | `nixos/doc: formatting improvements`                                       |
| [`b89efbd9`](https://github.com/NixOS/nixpkgs/commit/b89efbd9a45aaa6563225ba2de8a93ce9663f337) | `mame-tools: init at 0.249`                                                |
| [`5ed3812a`](https://github.com/NixOS/nixpkgs/commit/5ed3812a9ff33b2ec955d36ee2444cec2e58b536) | `octave: enable JSON`                                                      |
| [`113bfd75`](https://github.com/NixOS/nixpkgs/commit/113bfd75d6d64d25981e630babe2ca36233744c8) | `gnome.gnome-maps: patch a test failure`                                   |
| [`016580f6`](https://github.com/NixOS/nixpkgs/commit/016580f6daf1836ed945840dc50db69431c31e62) | `python310Packages.azure-eventgrid: update disabled`                       |
| [`184023a1`](https://github.com/NixOS/nixpkgs/commit/184023a1f9e8ce094c2961a855e7f7ccb9eb0e79) | `cotton: fix build on darwin`                                              |
| [`f680c202`](https://github.com/NixOS/nixpkgs/commit/f680c2020f41da5d2ed5d88ad3f997b9a8d03b77) | `shards: 0.17.0 -> 0.17.1`                                                 |
| [`c3616ce8`](https://github.com/NixOS/nixpkgs/commit/c3616ce8370f4a00e6b62af80fdaace308c13b68) | `0ad: fix icon install path`                                               |
| [`ab238f2d`](https://github.com/NixOS/nixpkgs/commit/ab238f2d81857e9c77ca8d40077e50c6b8c0ffa5) | `opentelemetry-collector-contrib: 0.63.0 -> 0.64.0`                        |
| [`980b1ab0`](https://github.com/NixOS/nixpkgs/commit/980b1ab0504256b58751a7f1686c123c2863082e) | `opentelemetry-collector: 0.63.1 -> 0.64.0`                                |
| [`cbb048f8`](https://github.com/NixOS/nixpkgs/commit/cbb048f8d91149c3976f51083d3056fa17fc1622) | `terraform-providers.tencentcloud: 1.78.8 → 1.78.9`                        |
| [`d1f98aaf`](https://github.com/NixOS/nixpkgs/commit/d1f98aaf0edd18d60ec8aa363af3c13ac735fa38) | `terraform-providers.ns1: 1.12.8 → 1.13.0`                                 |
| [`9759793e`](https://github.com/NixOS/nixpkgs/commit/9759793e793e19a080d1513463b4e302c227190d) | `terraform-providers.ksyun: 1.3.57 → 1.3.58`                               |
| [`b4401413`](https://github.com/NixOS/nixpkgs/commit/b4401413f700c9507910091aa71b15d785c82d5d) | `terraform-providers.hcloud: 1.35.2 → 1.36.0`                              |
| [`ae2fd703`](https://github.com/NixOS/nixpkgs/commit/ae2fd703e1b47a27b1a967cc8eb94dff42df34b5) | `terraform-providers.external: 2.2.2 → 2.2.3`                              |
| [`d4be94cb`](https://github.com/NixOS/nixpkgs/commit/d4be94cb82a9a722000f656d868bebf3f5877d63) | `kics: add version test`                                                   |
| [`2a928587`](https://github.com/NixOS/nixpkgs/commit/2a928587658a39ac7ce17ebe4a206abe014e6ff5) | `nixpacks: 0.12.3 -> 0.13.0`                                               |
| [`9bbb7fb6`](https://github.com/NixOS/nixpkgs/commit/9bbb7fb6352c972679f3ac7d8268fd889c65233b) | `azure-functions-core-tools: remove jshcmpbll as maintainer`               |
| [`a791afd9`](https://github.com/NixOS/nixpkgs/commit/a791afd94c9902ed5c65d13f6850d337ae8f44b2) | `mmdoc: 0.12.0 -> 0.13.0`                                                  |
| [`6386d793`](https://github.com/NixOS/nixpkgs/commit/6386d793261ae917ae49bf95f587787c5b00db47) | `patchRcPath hooks: use the passthru argument`                             |
| [`a664ec27`](https://github.com/NixOS/nixpkgs/commit/a664ec27f44b4c7f29c03eff8b60ca62f90b2f16) | `root: add package test test-thisroot`                                     |
| [`7f91dec5`](https://github.com/NixOS/nixpkgs/commit/7f91dec5ddf8a75c8da23df982ad027ba333a150) | `root: wrap the executable and patch thisroot.*`                           |
| [`da31bd56`](https://github.com/NixOS/nixpkgs/commit/da31bd56732b2b954c867b0283df66539b3764c0) | `patchRcPathBash, patchRcPathCsh, patchRcPathFish, patchRcPathPosix: init` |
| [`43bd6a0e`](https://github.com/NixOS/nixpkgs/commit/43bd6a0ee63186f31876aecfc36d7b6b7ec25c1b) | `python310Packages.bellows: 0.34.2 -> 0.34.3`                              |
| [`c588a77c`](https://github.com/NixOS/nixpkgs/commit/c588a77cd54fbdbe874ddd1e63656d5fd69c6ae6) | `tela-circle-icon-theme: 2022-03-07 -> 2022-11-06 (#200377)`               |
| [`d4926fc8`](https://github.com/NixOS/nixpkgs/commit/d4926fc87fcbedf3e7485486c0e1bd58624d49d2) | `vimix-gtk-themes: 2022-04-24 -> 2022-10-30 (#198745)`                     |
| [`0a4dc86f`](https://github.com/NixOS/nixpkgs/commit/0a4dc86f057932f875c8e989e344463568c46410) | `whitesur-gtk-theme: 2022-08-26 -> 2022-10-27 (#198263)`                   |
| [`dfe6ea40`](https://github.com/NixOS/nixpkgs/commit/dfe6ea4025b2e99bcbb30528ff31e69179763372) | `tootle: add platforms.linux to meta.platforms`                            |
| [`3c603ddf`](https://github.com/NixOS/nixpkgs/commit/3c603ddf321480716ced0b084f1132e63ea7f405) | `vscode: 1.73.0 -> 1.73.1`                                                 |
| [`4f879376`](https://github.com/NixOS/nixpkgs/commit/4f87937601a15fd5bbc49d86e46b1982721876f7) | `lychee: 0.10.2 -> 0.10.3`                                                 |
| [`e280d067`](https://github.com/NixOS/nixpkgs/commit/e280d06774ab3a9adafc264f6c070d5686351474) | `python310Packages.azure-mgmt-containerservice: 20.6.0 -> 20.7.0`          |
| [`d225156c`](https://github.com/NixOS/nixpkgs/commit/d225156cde893c3061da1078f7ff2ad569e13256) | `python310Packages.aiohomekit: 2.2.18 -> 2.2.19`                           |
| [`4ae8ed46`](https://github.com/NixOS/nixpkgs/commit/4ae8ed4631c104535f8c5f3f3a3dea0b61f612e9) | `python310Packages.adafruit-platformdetect: 3.32.0 -> 3.33.0`              |
| [`255ac994`](https://github.com/NixOS/nixpkgs/commit/255ac994b8dcde49c22e5b7b9251630db53ff72c) | `nixos/firefox-syncserver: fix setup failure due to duplicate key`         |
| [`ac77d54a`](https://github.com/NixOS/nixpkgs/commit/ac77d54ab28629ccada90dc23357305f31c70ddd) | `victor-mono: Remove LICENSE.txt`                                          |
| [`e94d54dd`](https://github.com/NixOS/nixpkgs/commit/e94d54dd864062a18aaf75510600c8264353ccb8) | ``build-support/rust/lib: Add `toTargetFamily```                           |
| [`e57d0344`](https://github.com/NixOS/nixpkgs/commit/e57d034401b321839a53428b551f2eb667a9154a) | `joker: 1.0.2 -> 1.1.0`                                                    |
| [`d474e39f`](https://github.com/NixOS/nixpkgs/commit/d474e39f7d577eb509f3f39369fac575c0a04fdc) | `root: fix build on aarch64-darwin`                                        |
| [`27f703b1`](https://github.com/NixOS/nixpkgs/commit/27f703b1f863b839c3ccf6d420c01e681333114c) | `cudaPackages_11_8: fix missing manifest`                                  |
| [`293cbc46`](https://github.com/NixOS/nixpkgs/commit/293cbc467dc69cc9bfd344975d1bdc125355743b) | `matrix-synapse-tools.synadm: 0.36 -> 0.37.1`                              |
| [`ef527a4a`](https://github.com/NixOS/nixpkgs/commit/ef527a4a2bbdc1b496500a4a38b12637c8fe21d3) | `ardour: 6.9 -> 7.1 (#196290)`                                             |
| [`544af659`](https://github.com/NixOS/nixpkgs/commit/544af65981cb2d7609f8ac585258e55c19918c16) | `jackett: 0.20.2175 -> 0.20.2225`                                          |
| [`90fc7b0b`](https://github.com/NixOS/nixpkgs/commit/90fc7b0b001bc0e1a3d99cf1a6e3d834fedc2872) | `python310Packages.azure-eventgrid: 4.9.0 -> 4.9.1`                        |
| [`821d9076`](https://github.com/NixOS/nixpkgs/commit/821d9076acb51e8ba66071c8acd3d657d35f4b73) | `python310Packages.vispy: 0.11.0 -> 0.12.0`                                |
| [`444a6400`](https://github.com/NixOS/nixpkgs/commit/444a64008a10a0566c6999f88fa9cd0ed4d0d9d2) | `sublime-merge-dev: 2076 → 2078`                                           |
| [`4e96b348`](https://github.com/NixOS/nixpkgs/commit/4e96b3488e59c6c1f403b992567e753cc1349cc7) | `sublime4-dev: 4137 → 4141`                                                |
| [`41b48651`](https://github.com/NixOS/nixpkgs/commit/41b4865186d5f7bff74bf63d5ae6f0ce99eb95fb) | `home-assistant: relax aiohttp version constraint`                         |
| [`5d5c6ded`](https://github.com/NixOS/nixpkgs/commit/5d5c6ded1a57c8c8d0d74ef8d5e4d664ec4fbcd5) | `root: 6.26.06 -> 6.26.08`                                                 |
| [`6678a7ec`](https://github.com/NixOS/nixpkgs/commit/6678a7ecb7808769e19f2a0136187ef366500d29) | `nixos/geoclue2: make system service wait on network-online`               |
| [`0106a685`](https://github.com/NixOS/nixpkgs/commit/0106a6855599fbe26a7c331782d9672f829bd1e1) | `root: enable davix and ssl support (#200096)`                             |
| [`7f290a9d`](https://github.com/NixOS/nixpkgs/commit/7f290a9d35cfcce20e420987085ad535e7c6938a) | `blocky: embed version info (#200215)`                                     |
| [`76a857c7`](https://github.com/NixOS/nixpkgs/commit/76a857c71b5cc4c329645474ba1095da2a048652) | `hqplayerd: 4.32.4 -> 4.33.0`                                              |
| [`eb9835c6`](https://github.com/NixOS/nixpkgs/commit/eb9835c6766dee18ae98e2fdb7cb17198f24538e) | `python310Packages.thriftpy2: 0.4.14 -> 0.4.15`                            |
| [`f1221e56`](https://github.com/NixOS/nixpkgs/commit/f1221e56308a4ae1a2de327105524e4dcded2d98) | `universal-ctags: Fix for Darwin`                                          |
| [`cfce957d`](https://github.com/NixOS/nixpkgs/commit/cfce957d4fd026a82c1b1a096f88af351faa26cb) | `treewide: more meta changelog urls and mainPrograms (#200062)`            |
| [`16722903`](https://github.com/NixOS/nixpkgs/commit/16722903aa6f7dbe202926d61e8f54398912c9ad) | `buildNpmPackage: init`                                                    |
| [`6885cfbb`](https://github.com/NixOS/nixpkgs/commit/6885cfbb04aa0f690b4bfb469ab8fe58f98b55bc) | `tetrio-desktop: add tetrio-plus option`                                   |
| [`cc3ea178`](https://github.com/NixOS/nixpkgs/commit/cc3ea17877fb86989a83a57570ca09400ac4e584) | `tetrio-desktop: cleanup, fix GApps wrapping`                              |
| [`7ed22692`](https://github.com/NixOS/nixpkgs/commit/7ed22692b510b688b624e0495d1fa5f52c576940) | `pantheon.elementary-iconbrowser: 2.0.0 -> 2.1.1`                          |
| [`b1429a1f`](https://github.com/NixOS/nixpkgs/commit/b1429a1f70da647d1e7b8fa8487fa6b501212019) | `nitter: patch source version/rev/url into about`                          |
| [`cc9214ee`](https://github.com/NixOS/nixpkgs/commit/cc9214ee8edbe45d9c5cba10a956122e7e85e9ea) | `rustscan: 2.2.0 -> 2.2.1`                                                 |
| [`523d77cc`](https://github.com/NixOS/nixpkgs/commit/523d77cccb92a6b4edfd90aa837978692666e23a) | `cargo-generate: 0.16.0 -> 0.17.2`                                         |
| [`aef3d811`](https://github.com/NixOS/nixpkgs/commit/aef3d81135bf959b01adaf360589e4ce20c18964) | `tremor-rs: add happysalada as maintainer`                                 |
| [`6e6df58a`](https://github.com/NixOS/nixpkgs/commit/6e6df58ae33135874f25a740631663cf4f5db12b) | `tremor-rs: 0.11.0 -> 0.12.4`                                              |
| [`9a7c359a`](https://github.com/NixOS/nixpkgs/commit/9a7c359a3515116bf042364aee541ebecfb29a9c) | `ethminer: remove`                                                         |
| [`e0f3fd69`](https://github.com/NixOS/nixpkgs/commit/e0f3fd697055212016f71c938ab3cfc2125a8e83) | `python310Packages.pytenable: 1.4.8 -> 1.4.9`                              |
| [`19185500`](https://github.com/NixOS/nixpkgs/commit/19185500dddf08a6f1a228ccb878edc4ac9da231) | `dotnet-sdk_6: 6.0.402 -> 6.0.403`                                         |
| [`7eb3b456`](https://github.com/NixOS/nixpkgs/commit/7eb3b456681777dc36632387199a864797b507f4) | `dotnet-sdk_3: 3.1.424 -> 3.1.425`                                         |
| [`8e990037`](https://github.com/NixOS/nixpkgs/commit/8e990037eef6395d7fff47462fd5096353d60acf) | `allure: 2.20.0 -> 2.20.1`                                                 |
| [`f7f94426`](https://github.com/NixOS/nixpkgs/commit/f7f94426953e761dc3e33da7f5d3f6a8c350f124) | `nixos/invoiceplane: Enable clean url`                                     |
| [`2df85d0d`](https://github.com/NixOS/nixpkgs/commit/2df85d0d5fc3cabc03d1b9dd9d99823c81021145) | `qogir-icon-theme: 2022-10-08 -> 2022-11-05`                               |
| [`918c0e9f`](https://github.com/NixOS/nixpkgs/commit/918c0e9fb55e81cda9521e80bbc6ebd672a1961f) | `qogir-theme: 2022-10-16 -> 2022-11-09`                                    |
| [`659dd0ac`](https://github.com/NixOS/nixpkgs/commit/659dd0acc8230e4c10ff01100e638d6fa82fa74c) | `ffmpeg-normalize: 1.25.2 -> 1.25.3`                                       |
| [`0e6cc2bc`](https://github.com/NixOS/nixpkgs/commit/0e6cc2bc1d3eb8c4469647e437f11054c4c2ff38) | `deno: 1.27.1 -> 1.27.2`                                                   |
| [`ac520c67`](https://github.com/NixOS/nixpkgs/commit/ac520c672fed21ee4364fc37b7449900086f0cca) | `cudatext: 1.175.0 -> 1.176.0`                                             |
| [`09c1f816`](https://github.com/NixOS/nixpkgs/commit/09c1f816d1b5c63d4fac73ba98a677423430b7f2) | `plex: 1.29.1.6316-f4cdfea9c -> 1.29.2.6364-6d72b0cf6`                     |
| [`684b0f27`](https://github.com/NixOS/nixpkgs/commit/684b0f278a23f6700b56adf90c4614219a994183) | `byacc: 20220128 -> 20221106`                                              |
| [`7e12550f`](https://github.com/NixOS/nixpkgs/commit/7e12550ff9d5c9814cb4f46dc736bb2f4627d373) | `tootle: fix build`                                                        |
| [`f552429c`](https://github.com/NixOS/nixpkgs/commit/f552429c8071f9d597cb0306e9787933bc2bfc5c) | `udpreplay: init at 1.0.0`                                                 |
| [`28691b90`](https://github.com/NixOS/nixpkgs/commit/28691b90fbe1aac4b9c7d5547627620d2be3b9d0) | `wiki-js: 2.5.290 -> 2.5.291`                                              |
| [`79a49c2a`](https://github.com/NixOS/nixpkgs/commit/79a49c2a66d72308b30967a7bd602836f7d6b61d) | `grafana: 9.2.3 -> 9.2.4`                                                  |
| [`50d8cda3`](https://github.com/NixOS/nixpkgs/commit/50d8cda36000f0d68c02385ba0d02032b894e187) | `pixman: fix aarch64-darwin by disabling neon`                             |
| [`d879bde8`](https://github.com/NixOS/nixpkgs/commit/d879bde8fbbccc39eadacde853c9de52e5c68d09) | `python310Packages.aiohttp: 3.8.1 -> 3.8.3`                                |
| [`d4965f6e`](https://github.com/NixOS/nixpkgs/commit/d4965f6ef8ae3e8a4dec73eabea21ed4debfc78f) | `butler: fix darwin build`                                                 |
| [`4a42fad0`](https://github.com/NixOS/nixpkgs/commit/4a42fad0a5ae3f630dddfff417969fdc129aacf8) | `amtk: 5.5.2 → 5.6.0`                                                      |
| [`6afc2f85`](https://github.com/NixOS/nixpkgs/commit/6afc2f856d8924e97bef86c33c7882996998695e) | `gjs: 1.74.0 → 1.74.1`                                                     |
| [`e4db4901`](https://github.com/NixOS/nixpkgs/commit/e4db49011767e8e03e0590293cd7ec147b81f48a) | `yelp-tools: 42.0 → 42.1`                                                  |
| [`1bf6d3cd`](https://github.com/NixOS/nixpkgs/commit/1bf6d3cd8e907bd9cb9f887dc95cbc9e2f67db0d) | `tepl: 6.1.2 → 6.2.0`                                                      |
| [`fcccf610`](https://github.com/NixOS/nixpkgs/commit/fcccf610c59432a987dd72a10b9da32e53c7c615) | `libpanel: 1.0.1 → 1.0.2`                                                  |
| [`76a29bd3`](https://github.com/NixOS/nixpkgs/commit/76a29bd3ce78862f8b062c10dde7bd05166d1999) | `gtksourceview4: 4.8.3 → 4.8.4`                                            |
| [`5116aa1c`](https://github.com/NixOS/nixpkgs/commit/5116aa1cf2f1717f489292f827260098090a060c) | `gnome-latex: 3.41.2 → 3.42.0`                                             |
| [`d00d56fe`](https://github.com/NixOS/nixpkgs/commit/d00d56fedf027ec5d010e7d6bd453eaa28160da8) | `libftdi: fix darwin build`                                                |
| [`5b4b6b5a`](https://github.com/NixOS/nixpkgs/commit/5b4b6b5a037e2dc00ee788435fd5b8053bf40df5) | `python310Packages.mkdocs-jupyter: relax nbconvert version constraint`     |
| [`a054dab3`](https://github.com/NixOS/nixpkgs/commit/a054dab33ed58ec162c38c043d85b2ab0f1b2fce) | `log4shib: fix darwin build`                                               |
| [`341b9f80`](https://github.com/NixOS/nixpkgs/commit/341b9f80d2d94a8170139919a4eec317390460c8) | `libmysqlconnectorcpp: 8.0.30 -> 8.0.31`                                   |
| [`1eb380d4`](https://github.com/NixOS/nixpkgs/commit/1eb380d489517996794d0852cb5a389a144b4fee) | `element-{web,desktop}: 1.11.13 -> 1.11.14`                                |
| [`bc99a450`](https://github.com/NixOS/nixpkgs/commit/bc99a450c248fd95a76dd33ec26c7604fd29923a) | `go-graft: 0.2.13 -> 0.2.14`                                               |
| [`8a79bf72`](https://github.com/NixOS/nixpkgs/commit/8a79bf726d50659754c0e828a2821e2741466b56) | `nushell: 0.70.0 -> 0.71.0`                                                |
| [`560105e8`](https://github.com/NixOS/nixpkgs/commit/560105e8d1ef1d4e49c091ce07c2fcaaceb30780) | `sumneko-lua-language-server: 3.5.6 -> 3.6.1`                              |
| [`379fc293`](https://github.com/NixOS/nixpkgs/commit/379fc293524cc53eae19c9088e2481d820056534) | `pkgsi686Linux.mumble: fix build`                                          |
| [`04a590b8`](https://github.com/NixOS/nixpkgs/commit/04a590b89aafd5d7d415bc6b89808474531280c9) | `np2kai: Fix build`                                                        |
| [`7ae1b194`](https://github.com/NixOS/nixpkgs/commit/7ae1b194da97ec4a0704b4b1f54837c61e4b1522) | `microcodeIntel: 20220809 -> 20221108`                                     |
| [`da3c876c`](https://github.com/NixOS/nixpkgs/commit/da3c876cdd45dc3db05de9a1f5b0edcbea812d22) | `iterm2: 3.4.15 -> 3.4.17`                                                 |
| [`c35a9304`](https://github.com/NixOS/nixpkgs/commit/c35a930454f97d7fe134c71a7ffa75faa1d89aea) | `libvirt-glib: fixup build after glib update`                              |
| [`6ee6ee22`](https://github.com/NixOS/nixpkgs/commit/6ee6ee226baa77082b1bfdc851e34af6a2283731) | `julia: refresh patches, disable failing Zlib_jll version test`            |
| [`30395529`](https://github.com/NixOS/nixpkgs/commit/3039552944add3456ccaa03e86378b51e5e4f4b7) | `python310Packages.jupytext: fix tests`                                    |
| [`cbda4425`](https://github.com/NixOS/nixpkgs/commit/cbda4425eccd61e4ab2d2833342507a310c417c3) | `linuxPackages.nvidia_x11.open: set platforms to only x86_64-linux`        |
| [`77306d37`](https://github.com/NixOS/nixpkgs/commit/77306d371e34fb03ffe8daa356d9ea0ce31d9eba) | `python310Packages.nbformat: 5.5.0 -> 5.7.0`                               |
| [`45ab6cf9`](https://github.com/NixOS/nixpkgs/commit/45ab6cf9c84d74734200391aa872e79ad32f789d) | `python310Packages.nbconvert: 6.5.3 -> 7.2.3`                              |
| [`1df9c7e0`](https://github.com/NixOS/nixpkgs/commit/1df9c7e0ec20c679aae8a832fab5677f28dc5d77) | `mucommander: 0.9.3-3 -> 1.1.0-1`                                          |
| [`f77d334a`](https://github.com/NixOS/nixpkgs/commit/f77d334af1dc5b0bf9b15b2bcbdc5aa0f5fc7338) | `clingo: 5.6.1 -> 5.6.2`                                                   |
| [`4db7dc72`](https://github.com/NixOS/nixpkgs/commit/4db7dc72d27f94483d759beeb7d4c1914b4da1e2) | `SDL2: 2.24.1 -> 2.24.2`                                                   |
| [`89c92a92`](https://github.com/NixOS/nixpkgs/commit/89c92a92062746bc12cb066614ca4c59f13ea3bc) | `SDL2: 2.24.0 -> 2.24.1`                                                   |
| [`370c1a9a`](https://github.com/NixOS/nixpkgs/commit/370c1a9ad0388df4c3677fa82899353ae19dee40) | `python3Packages.sh: disable flaky tests`                                  |