### PR TITLE
chore(flake/emacs-overlay): `1872c729` -> `69812253`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668256904,
-        "narHash": "sha256-woAxkqmTpzSB4JpF12cn+e2v0Lsf4fKBpkLBO2QCC2U=",
+        "lastModified": 1668290897,
+        "narHash": "sha256-UoIWSz5qJJEA3Drr7XL5HrewnO+bwtXho9GJKStrASA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1872c7297d7dfcba2d5f206baa5fcb0094575ad8",
+        "rev": "69812253cf13702aa0d6e6e0403b6282408561ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                 |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------ |
| [`69812253`](https://github.com/nix-community/emacs-overlay/commit/69812253cf13702aa0d6e6e0403b6282408561ec) | `Add more tree-sitter plugins` |
| [`c5e7dafe`](https://github.com/nix-community/emacs-overlay/commit/c5e7dafee9514e8961289f81a52dfc45c419a13f) | `Updated repos/melpa`          |
| [`79c1a5f7`](https://github.com/nix-community/emacs-overlay/commit/79c1a5f75050e2b1100b42bb99122039b3afd7fd) | `Updated repos/emacs`          |
| [`caa22ae0`](https://github.com/nix-community/emacs-overlay/commit/caa22ae0ba14709f83da4be78b535afc883be882) | `Updated repos/elpa`           |