### PR TITLE
chore(flake/nur): `d1ce3858` -> `d3d04226`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668308850,
-        "narHash": "sha256-5dGYV48ivsXSUl3NUBJKjLOe8v58H41QUBsrRW4EBVQ=",
+        "lastModified": 1668312945,
+        "narHash": "sha256-jhB7IVWO977+ynJ3i5kGHySRmC7B+pXZmX5trqnx81A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d1ce3858687d8d07b75de337664ae88750e94703",
+        "rev": "d3d042264dd9e6d4b6be978f3cf560ec2332b2a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d3d04226`](https://github.com/nix-community/NUR/commit/d3d042264dd9e6d4b6be978f3cf560ec2332b2a1) | `automatic update` |
| [`7ed3b856`](https://github.com/nix-community/NUR/commit/7ed3b856d34de1e5862cc89a3259d1e2ee809f00) | `automatic update` |