### PR TITLE
chore(flake/nur): `d3d04226` -> `c354c1c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668312945,
-        "narHash": "sha256-jhB7IVWO977+ynJ3i5kGHySRmC7B+pXZmX5trqnx81A=",
+        "lastModified": 1668314857,
+        "narHash": "sha256-5H6cnIsNWgM5ZufazCBKBAv7SreCL5XUisS/XE7+BiQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d3d042264dd9e6d4b6be978f3cf560ec2332b2a1",
+        "rev": "c354c1c19126f808f2278b9692e699bb41d8e3a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c354c1c1`](https://github.com/nix-community/NUR/commit/c354c1c19126f808f2278b9692e699bb41d8e3a1) | `automatic update` |
| [`2b6ef289`](https://github.com/nix-community/NUR/commit/2b6ef2891cc200ffffb09362a63df1a7d80911cb) | `automatic update` |
| [`a9112570`](https://github.com/nix-community/NUR/commit/a9112570c382b9ed9971e4e7ac6cad6ab4325ca1) | `automatic update` |