### PR TITLE
chore(flake/nur): `c354c1c1` -> `1ffdd1fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668314857,
-        "narHash": "sha256-5H6cnIsNWgM5ZufazCBKBAv7SreCL5XUisS/XE7+BiQ=",
+        "lastModified": 1668318826,
+        "narHash": "sha256-q5n0bcPQnHKft1NmU3l4HN562XCuKB16LTs/4HhUYLQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c354c1c19126f808f2278b9692e699bb41d8e3a1",
+        "rev": "1ffdd1fc4c8b679a610e19418d5d3a567d443faa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1ffdd1fc`](https://github.com/nix-community/NUR/commit/1ffdd1fc4c8b679a610e19418d5d3a567d443faa) | `automatic update` |