### PR TITLE
chore(flake/nur): `1ffdd1fc` -> `6aae5b83`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668318826,
-        "narHash": "sha256-q5n0bcPQnHKft1NmU3l4HN562XCuKB16LTs/4HhUYLQ=",
+        "lastModified": 1668326838,
+        "narHash": "sha256-oWWKUFj9ZExTRmx64J2PiYG/aNj1M9VPhBMooxIcNEE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1ffdd1fc4c8b679a610e19418d5d3a567d443faa",
+        "rev": "6aae5b83248381da60b3a566f369ca42cb9a7644",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6aae5b83`](https://github.com/nix-community/NUR/commit/6aae5b83248381da60b3a566f369ca42cb9a7644) | `automatic update` |