### PR TITLE
chore(flake/nur): `6aae5b83` -> `99fcd013`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668326838,
-        "narHash": "sha256-oWWKUFj9ZExTRmx64J2PiYG/aNj1M9VPhBMooxIcNEE=",
+        "lastModified": 1668328408,
+        "narHash": "sha256-yQiX57VCjilLLa3U4P46QpsvObrsCr0ISkZ2wqKI9Ks=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6aae5b83248381da60b3a566f369ca42cb9a7644",
+        "rev": "99fcd0139d09b9cf4fe065e70222afa45b12a2a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`99fcd013`](https://github.com/nix-community/NUR/commit/99fcd0139d09b9cf4fe065e70222afa45b12a2a2) | `automatic update` |
| [`c4f0dad2`](https://github.com/nix-community/NUR/commit/c4f0dad2a103dce1335b7747b90c4b2960ccfbf6) | `automatic update` |