### PR TITLE
chore(flake/nur): `99fcd013` -> `804ad962`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668328408,
-        "narHash": "sha256-yQiX57VCjilLLa3U4P46QpsvObrsCr0ISkZ2wqKI9Ks=",
+        "lastModified": 1668329732,
+        "narHash": "sha256-+GzRK46DML6QifnKKCW3QxzIUbKe+wUPGDcVaaTKXGM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "99fcd0139d09b9cf4fe065e70222afa45b12a2a2",
+        "rev": "804ad962c8e625f065135b41b4ad45cf08194588",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`804ad962`](https://github.com/nix-community/NUR/commit/804ad962c8e625f065135b41b4ad45cf08194588) | `automatic update` |