### PR TITLE
chore(flake/nur): `804ad962` -> `8c53c50a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668329732,
-        "narHash": "sha256-+GzRK46DML6QifnKKCW3QxzIUbKe+wUPGDcVaaTKXGM=",
+        "lastModified": 1668331488,
+        "narHash": "sha256-hhCEzgwxl9WN3h5/LYrdBwprNQ3GuaM7xONSByz698Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "804ad962c8e625f065135b41b4ad45cf08194588",
+        "rev": "8c53c50ac3953d48ffa8280ddb8794e246c5d0b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8c53c50a`](https://github.com/nix-community/NUR/commit/8c53c50ac3953d48ffa8280ddb8794e246c5d0b4) | `automatic update` |
| [`fd8f73cb`](https://github.com/nix-community/NUR/commit/fd8f73cba4e4603e5c445911b9b3eeabcb9363d4) | `automatic update` |
| [`39572fae`](https://github.com/nix-community/NUR/commit/39572fae2a24786749a1659fef6f662714f9beaa) | `automatic update` |