### PR TITLE
chore(flake/nixos-hardware): `062c3cca` -> `e0452b33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -285,11 +285,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1668157555,
-        "narHash": "sha256-s5rt2FSmV4PWt89rjt4cvBGOhPizStsinkIB0BXnKrk=",
+        "lastModified": 1668334946,
+        "narHash": "sha256-omMbUj4r5DVBWh7KxkoO/Z/1V1shVR6Ls4jXNB4mr3U=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "062c3cca468a4b404ddd964fb444b665e4da982e",
+        "rev": "e0452b33ab0ef16ffe075e980644ed92a6a200bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`435a9c65`](https://github.com/NixOS/nixos-hardware/commit/435a9c652666bf3533df9f592e54c588e649b7f4) | `Add support for ssd to Lenovo ThinkPad T480` |