### PR TITLE
chore(flake/emacs-overlay): `e65da89e` -> `ec244f95`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668315120,
-        "narHash": "sha256-U9QIBsK9o1OJHdQIcXpKc5kCF6zUQ5W8dnIALko96lU=",
+        "lastModified": 1668342450,
+        "narHash": "sha256-YDRX1q5GKNTHD/gvxYzKBuZ1moO24+XdeV78foEMSnE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e65da89ecdf7e728610bf93c603e9b8761607f07",
+        "rev": "ec244f95e9df58c7a51d8029b404bd45081f88a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`ec244f95`](https://github.com/nix-community/emacs-overlay/commit/ec244f95e9df58c7a51d8029b404bd45081f88a0) | `Updated repos/nongnu` |
| [`7e501eb6`](https://github.com/nix-community/emacs-overlay/commit/7e501eb660cdc127f282d88f169fabb6eca7a08c) | `Updated repos/melpa`  |
| [`ea453849`](https://github.com/nix-community/emacs-overlay/commit/ea45384949c27847fae37096858833754440d3ae) | `Updated repos/emacs`  |