### PR TITLE
chore(flake/nur): `e384de96` -> `65133a5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668340434,
-        "narHash": "sha256-oKEwhuu7Ek//vW6fTXI9L5jM/XAhRSsxkI0nc42+n0Q=",
+        "lastModified": 1668343806,
+        "narHash": "sha256-4BlwYl5EY8pOQ13yP6h+vW2oBi/3nXfqcgxuSlCs3tc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e384de9655aef3e18994611e40baae46b83886b6",
+        "rev": "65133a5e32c2ce7273833093f934e731859aa744",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`65133a5e`](https://github.com/nix-community/NUR/commit/65133a5e32c2ce7273833093f934e731859aa744) | `automatic update` |