### PR TITLE
chore(flake/nur): `65133a5e` -> `0f3e6043`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668343806,
-        "narHash": "sha256-4BlwYl5EY8pOQ13yP6h+vW2oBi/3nXfqcgxuSlCs3tc=",
+        "lastModified": 1668344886,
+        "narHash": "sha256-JIjfkg+fZ2Fv0o2SY3RlEAR53QlU+gJaqH1S7jMvgGY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "65133a5e32c2ce7273833093f934e731859aa744",
+        "rev": "0f3e6043bae935e7dd60efd88a976a11995d5a6a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0f3e6043`](https://github.com/nix-community/NUR/commit/0f3e6043bae935e7dd60efd88a976a11995d5a6a) | `automatic update` |