### PR TITLE
chore(flake/nur): `0f3e6043` -> `b44a1d5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668344886,
-        "narHash": "sha256-JIjfkg+fZ2Fv0o2SY3RlEAR53QlU+gJaqH1S7jMvgGY=",
+        "lastModified": 1668356683,
+        "narHash": "sha256-GJCal/RROrIwXMmF++MkBy9GOjIwE8x0eSOiUA8mt3M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0f3e6043bae935e7dd60efd88a976a11995d5a6a",
+        "rev": "b44a1d5e2adb921981abb122619a0f1868088b10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b44a1d5e`](https://github.com/nix-community/NUR/commit/b44a1d5e2adb921981abb122619a0f1868088b10) | `automatic update` |