### PR TITLE
chore(flake/nur): `b44a1d5e` -> `958d9040`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668356683,
-        "narHash": "sha256-GJCal/RROrIwXMmF++MkBy9GOjIwE8x0eSOiUA8mt3M=",
+        "lastModified": 1668357980,
+        "narHash": "sha256-BCx+CxRCbQHdlm6+pEObJVq5RkqYrhQtC7MFeGoczQY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b44a1d5e2adb921981abb122619a0f1868088b10",
+        "rev": "958d90403b9a968d1e49cbb2997423a54dc14921",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`958d9040`](https://github.com/nix-community/NUR/commit/958d90403b9a968d1e49cbb2997423a54dc14921) | `automatic update` |