### PR TITLE
chore(flake/nur): `b0a06840` -> `017e25b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668380282,
-        "narHash": "sha256-2A+3f5NxdaZepTWeaeYx9ZEqYFh8eBKt2UAMcRd8nfo=",
+        "lastModified": 1668386253,
+        "narHash": "sha256-VuBPVrV85zVj9s26zEdKxsJl8Z1nY2cFVuTaetfi+kk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b0a06840765ad1b229ca39cb68e23b96737c9465",
+        "rev": "017e25b8f1e07d2b788deb1f7d660b3f4a420ef2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`017e25b8`](https://github.com/nix-community/NUR/commit/017e25b8f1e07d2b788deb1f7d660b3f4a420ef2) | `automatic update` |