### PR TITLE
chore(flake/nur): `017e25b8` -> `50a3d894`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668386253,
-        "narHash": "sha256-VuBPVrV85zVj9s26zEdKxsJl8Z1nY2cFVuTaetfi+kk=",
+        "lastModified": 1668390519,
+        "narHash": "sha256-8gti/fWYeirkqIwpQb4mdzWRUf/Ha9TcBJ9SFmNaiWk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "017e25b8f1e07d2b788deb1f7d660b3f4a420ef2",
+        "rev": "50a3d8943b7568c94816f4c6a8c7fa554c2b3e92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`50a3d894`](https://github.com/nix-community/NUR/commit/50a3d8943b7568c94816f4c6a8c7fa554c2b3e92) | `automatic update` |