### PR TITLE
chore(flake/emacs-overlay): `90530888` -> `6cee62d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668359576,
-        "narHash": "sha256-BV/Q2WXkzt50HoC5T0btoo5iCSsKU5/8Fa1u7BifOls=",
+        "lastModified": 1668392064,
+        "narHash": "sha256-9uK2WsZNBJgEEY3xkRPYUrVaQf5izYDd742pAT/LuFc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "90530888811ea4e15b221a051f54cc3a50e62f1f",
+        "rev": "6cee62d984b76a01998ec7961277f650574aef61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`6cee62d9`](https://github.com/nix-community/emacs-overlay/commit/6cee62d984b76a01998ec7961277f650574aef61) | `Updated repos/melpa` |
| [`f714e4e1`](https://github.com/nix-community/emacs-overlay/commit/f714e4e11fdf87dffcf822b185a387943a248c9b) | `Updated repos/elpa`  |