### PR TITLE
chore(flake/nur): `50a3d894` -> `0bbb30b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668390519,
-        "narHash": "sha256-8gti/fWYeirkqIwpQb4mdzWRUf/Ha9TcBJ9SFmNaiWk=",
+        "lastModified": 1668399027,
+        "narHash": "sha256-bsnfl3LO3oOInykj3Z/gWaUIFbv4yeaiJLf+ExYan0I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "50a3d8943b7568c94816f4c6a8c7fa554c2b3e92",
+        "rev": "0bbb30b30a457685dda68065bce756a509a6b344",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0bbb30b3`](https://github.com/nix-community/NUR/commit/0bbb30b30a457685dda68065bce756a509a6b344) | `automatic update` |