### PR TITLE
chore(flake/nur): `e40adef5` -> `7cbbfff5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668400123,
-        "narHash": "sha256-iuPjjIq7m2ipzN1c89MxbIUgJQztmyISbQOZvF4GpPc=",
+        "lastModified": 1668405361,
+        "narHash": "sha256-peZQOtywhMRbQ/7N4OIOmW+8qEcZ+Xv57aevw6TnzRw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e40adef52f7178172d80bc5051a95bd4652e3856",
+        "rev": "7cbbfff5ad8e8e6c299b526f336f6697785a7b43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7cbbfff5`](https://github.com/nix-community/NUR/commit/7cbbfff5ad8e8e6c299b526f336f6697785a7b43) | `automatic update` |