### PR TITLE
chore(flake/emacs-overlay): `6cee62d9` -> `9b1df30f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668392064,
-        "narHash": "sha256-9uK2WsZNBJgEEY3xkRPYUrVaQf5izYDd742pAT/LuFc=",
+        "lastModified": 1668431094,
+        "narHash": "sha256-rW2ebnScAWl/hEBDds6TX8cDpq+4XomGc6tG9SDqxoA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6cee62d984b76a01998ec7961277f650574aef61",
+        "rev": "9b1df30f4c14bef457f8de6733b281441f5ba22c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`9b1df30f`](https://github.com/nix-community/emacs-overlay/commit/9b1df30f4c14bef457f8de6733b281441f5ba22c) | `Updated repos/melpa` |
| [`1a701b70`](https://github.com/nix-community/emacs-overlay/commit/1a701b706e51b69d7874847b209a48c03b11ffc1) | `Updated repos/emacs` |