### PR TITLE
chore(flake/nur): `87eb4acb` -> `437d04eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668433503,
-        "narHash": "sha256-jnpSgNkWhFC981czm1vtJyUcmWzsyz1DlRyh71wEsqU=",
+        "lastModified": 1668439646,
+        "narHash": "sha256-6ImukgwTQXvJWxkk3vvlsswWI16hZbdaOxx+49rlDkg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "87eb4acbe3e415631986faaee87b181ec700a9d7",
+        "rev": "437d04eb2226617399797449a5bbf847d3324240",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`437d04eb`](https://github.com/nix-community/NUR/commit/437d04eb2226617399797449a5bbf847d3324240) | `automatic update` |
| [`fc74aa49`](https://github.com/nix-community/NUR/commit/fc74aa494f1d1f44ec703d116112ec0a3535ec28) | `automatic update` |