### PR TITLE
chore(flake/emacs-overlay): `9b1df30f` -> `9b9287dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668431094,
-        "narHash": "sha256-rW2ebnScAWl/hEBDds6TX8cDpq+4XomGc6tG9SDqxoA=",
+        "lastModified": 1668449564,
+        "narHash": "sha256-ycjSx8V0Iyyk6j22FftYsLWX+jSJM09tLvdk1SDflDs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9b1df30f4c14bef457f8de6733b281441f5ba22c",
+        "rev": "9b9287dd4e0d6f81d6c92742270f18dc368b6841",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message   |
| ------------------------------------------------------------------------------------------------------------ | ---------------- |
| [`bc1041f6`](https://github.com/nix-community/emacs-overlay/commit/bc1041f640f5fbb74a31c84c6704f191e2b31a0c) | `Bump emacs-lsp` |