### PR TITLE
chore(flake/emacs-overlay): `9b9287dd` -> `297fa39a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668449564,
-        "narHash": "sha256-ycjSx8V0Iyyk6j22FftYsLWX+jSJM09tLvdk1SDflDs=",
+        "lastModified": 1668455392,
+        "narHash": "sha256-3lgqOTC+Vj/nSZGEFLjhT4CJsRaaiwnqZ0MqpQlTP0s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9b9287dd4e0d6f81d6c92742270f18dc368b6841",
+        "rev": "297fa39a6fda037a676227826d4308fd21d8d8e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`297fa39a`](https://github.com/nix-community/emacs-overlay/commit/297fa39a6fda037a676227826d4308fd21d8d8e4) | `Updated repos/melpa` |
| [`d5dc5d93`](https://github.com/nix-community/emacs-overlay/commit/d5dc5d9317d69a826fd34ff1a591df3ecf3d5e9f) | `Updated repos/emacs` |
| [`2461f7bc`](https://github.com/nix-community/emacs-overlay/commit/2461f7bc39cfa3299593f8ad9c13fe74f0c1c4c9) | `Updated repos/elpa`  |