### PR TITLE
chore(flake/emacs-ement): `8a354b52` -> `061c9d26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1667851575,
-        "narHash": "sha256-I4ptcR9BiI6aoDzjzO/s48/Ms5I9HITCCtoewqrnGWg=",
+        "lastModified": 1668465722,
+        "narHash": "sha256-XG6xCqTspE7hVhLZsdrpDZ85gke2Nm4C+p8zRRRo8CU=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "8a354b52d8d71f952c10c6ba355547ce9b86bd6a",
+        "rev": "061c9d26c42eb3f0951290c111cea2d33a53dd89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                         |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`061c9d26`](https://github.com/alphapapa/ement.el/commit/061c9d26c42eb3f0951290c111cea2d33a53dd89) | `Fix: (ement-room--format-canonical-alias-event) Wrap prefix and face` |
| [`85e43557`](https://github.com/alphapapa/ement.el/commit/85e43557895170d44b2bcc403d5fad6df8fcb145) | `Add: ("m.room.canonical_alias")`                                      |
| [`8128243b`](https://github.com/alphapapa/ement.el/commit/8128243b5ea7047615a20c89da33d32fbdbbb17e) | `Change: (ement--format-room) Omit empty aliases`                      |