### PR TITLE
chore(flake/nur): `a0618de4` -> `5e3a767e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668470189,
-        "narHash": "sha256-uv/B3pxBM4DtCmDqO5T9I/pr7pCEIdd7wn66pF5+JBQ=",
+        "lastModified": 1668476458,
+        "narHash": "sha256-Xs1yutkI+gB6wYRhCO12K4k7aSP1i0f7ZZhRTa+TFbU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a0618de45855ae50897f9ef66536be3b1c51ac22",
+        "rev": "5e3a767e4a999b7bb3f9c52ba4307281c36cae43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5e3a767e`](https://github.com/nix-community/NUR/commit/5e3a767e4a999b7bb3f9c52ba4307281c36cae43) | `automatic update` |