### PR TITLE
chore(flake/nur): `5e3a767e` -> `569e86ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668476458,
-        "narHash": "sha256-Xs1yutkI+gB6wYRhCO12K4k7aSP1i0f7ZZhRTa+TFbU=",
+        "lastModified": 1668483392,
+        "narHash": "sha256-ChIg1m9ILxkrFpJg6NeeBHqaMCZpKhQtcUX3lDBAiew=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5e3a767e4a999b7bb3f9c52ba4307281c36cae43",
+        "rev": "569e86acc0a3035af85f037db32c8714bb8e5f8e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`569e86ac`](https://github.com/nix-community/NUR/commit/569e86acc0a3035af85f037db32c8714bb8e5f8e) | `automatic update` |