### PR TITLE
chore(flake/nur): `fbde81b9` -> `b3cd58eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668485465,
-        "narHash": "sha256-x6nB6P2gxQ5JE2G18oHy6U26kYNNNq2GoVRIssU/1qY=",
+        "lastModified": 1668491059,
+        "narHash": "sha256-Z35fJwM03flVPQcR3ikYrIapJzQoHsBzVIHTKy2Tods=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fbde81b9b10a198a7f89e68dbae3229e9c9220df",
+        "rev": "b3cd58ebaf2c1113b21a84ea035b2976d9871308",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b3cd58eb`](https://github.com/nix-community/NUR/commit/b3cd58ebaf2c1113b21a84ea035b2976d9871308) | `automatic update` |