### PR TITLE
chore(flake/nur): `b3cd58eb` -> `1e29117a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668491059,
-        "narHash": "sha256-Z35fJwM03flVPQcR3ikYrIapJzQoHsBzVIHTKy2Tods=",
+        "lastModified": 1668498133,
+        "narHash": "sha256-LCgZzGNYCU+i6hwUSojV1y06zDYzugoGaaOTwJzgU+Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b3cd58ebaf2c1113b21a84ea035b2976d9871308",
+        "rev": "1e29117ab98a42b0f9f1dab4378dab448cd585a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1e29117a`](https://github.com/nix-community/NUR/commit/1e29117ab98a42b0f9f1dab4378dab448cd585a9) | `automatic update` |