### PR TITLE
chore(flake/nur): `1e29117a` -> `dbb1a791`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668498133,
-        "narHash": "sha256-LCgZzGNYCU+i6hwUSojV1y06zDYzugoGaaOTwJzgU+Y=",
+        "lastModified": 1668514042,
+        "narHash": "sha256-5sr9N2QWmrZY0VHHyXVbA29RkTunrH+Ob11Zwu6xT2Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1e29117ab98a42b0f9f1dab4378dab448cd585a9",
+        "rev": "dbb1a79139be7aaf1c5f9a8ccfa57a14dfd74250",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`dbb1a791`](https://github.com/nix-community/NUR/commit/dbb1a79139be7aaf1c5f9a8ccfa57a14dfd74250) | `automatic update` |