### PR TITLE
chore(flake/nur): `dbb1a791` -> `07eb62a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668514042,
-        "narHash": "sha256-5sr9N2QWmrZY0VHHyXVbA29RkTunrH+Ob11Zwu6xT2Y=",
+        "lastModified": 1668524409,
+        "narHash": "sha256-ooPVhADpI3GCymEqOgrCUOO3IBO/+h+ILoIPJDV42ww=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dbb1a79139be7aaf1c5f9a8ccfa57a14dfd74250",
+        "rev": "07eb62a8aaf504f8fc41e3cd22218aa05ee0f2b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`07eb62a8`](https://github.com/nix-community/NUR/commit/07eb62a8aaf504f8fc41e3cd22218aa05ee0f2b8) | `automatic update` |
| [`4335a8ee`](https://github.com/nix-community/NUR/commit/4335a8eefacd74768d4095ea212c09c598c6b9b2) | `automatic update` |
| [`39f8fccf`](https://github.com/nix-community/NUR/commit/39f8fccffe6d204335db1db1154be0440ce38819) | `automatic update` |