### PR TITLE
chore(flake/nur): `8e8775f9` -> `56b0a7b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,11 +378,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668524723,
-        "narHash": "sha256-JIJ0MtvY23I/6aIsqi8CG67XWZ/34WtDcgFXxgSTvNU=",
+        "lastModified": 1668544268,
+        "narHash": "sha256-qOPlDEaUUiF8wUavfxzNcgakbPYm62nQlcBHeCTEZvY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8e8775f99549ba721c11643dfe70f4161d5c2f0b",
+        "rev": "56b0a7b88a5f760de8f0d9413f467f636bc4b912",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`56b0a7b8`](https://github.com/nix-community/NUR/commit/56b0a7b88a5f760de8f0d9413f467f636bc4b912) | `automatic update` |