### PR TITLE
chore(flake/emacs-overlay): `bb493503` -> `7b8b5a43`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668515977,
-        "narHash": "sha256-rIsz2iqI7ccUM9WqQRQ6U2o4Wnrsp1n6PUrdXu+POA4=",
+        "lastModified": 1668545684,
+        "narHash": "sha256-bJaO0ZtwEcA67yh79Udbfai7X9cokSvVSzGxAF+tHfA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bb493503d80488bd1c8f0eced7a210a302ae1999",
+        "rev": "7b8b5a43f5e7c24b407c5c24c2030938386cd865",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`7b8b5a43`](https://github.com/nix-community/emacs-overlay/commit/7b8b5a43f5e7c24b407c5c24c2030938386cd865) | `Updated repos/melpa` |
| [`b54a1f01`](https://github.com/nix-community/emacs-overlay/commit/b54a1f01c7326d199c687e45c47b741661625f88) | `Updated repos/emacs` |