### PR TITLE
chore(flake/nur): `bca70ea6` -> `51f45e93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668550334,
-        "narHash": "sha256-n+XMOPH9NU5tZQmE7rLKO0fQ0hdOib8dlFQafwgn1fk=",
+        "lastModified": 1668571494,
+        "narHash": "sha256-JP0etXAkppSomDfku8L4Bntu0Wol3KJleGTiGBZXi0k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bca70ea673c2426a3b654efb6862f2a3733adc91",
+        "rev": "51f45e931fef1abef44a4c47e35f48be63a62d4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`51f45e93`](https://github.com/nix-community/NUR/commit/51f45e931fef1abef44a4c47e35f48be63a62d4f) | `automatic update` |
| [`e0bb673b`](https://github.com/nix-community/NUR/commit/e0bb673b481f92b4432e37dd83af5eb13ae591b8) | `automatic update` |
| [`9461106b`](https://github.com/nix-community/NUR/commit/9461106b2aacaff70728a5587247a0131f141476) | `automatic update` |
| [`521984e0`](https://github.com/nix-community/NUR/commit/521984e03237b65a9fb6f1f748c2f1365b4e6702) | `automatic update` |
| [`768f71a3`](https://github.com/nix-community/NUR/commit/768f71a3948dc849430aa3aa1c51079b22ae83c5) | `automatic update` |