### PR TITLE
chore(flake/emacs-overlay): `7b8b5a43` -> `74789d57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668545684,
-        "narHash": "sha256-bJaO0ZtwEcA67yh79Udbfai7X9cokSvVSzGxAF+tHfA=",
+        "lastModified": 1668573780,
+        "narHash": "sha256-JWaKBwm3fDGqMQ5HBfrQDoc4o3RBQ3oAQYUk19u/VxA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7b8b5a43f5e7c24b407c5c24c2030938386cd865",
+        "rev": "74789d573f6bb8b8b4942f83fa060d76258a7e6e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`74789d57`](https://github.com/nix-community/emacs-overlay/commit/74789d573f6bb8b8b4942f83fa060d76258a7e6e) | `Updated repos/melpa` |
| [`c894e234`](https://github.com/nix-community/emacs-overlay/commit/c894e234e15a123b8cc6f0ed3369b70636fbe394) | `Updated repos/emacs` |