### PR TITLE
chore(flake/nur): `0cbfd985` -> `a3f43db6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668576474,
-        "narHash": "sha256-lPzg6lTW0qUwv7gT64zSeb4sZtvd6JA6RWqC5NQMZAs=",
+        "lastModified": 1668578155,
+        "narHash": "sha256-loZ67zDXS+4xMsq8GsV+NB+8d3P2lwT0gVrSAz0cMkc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0cbfd9852bf1a864862bf6503faae623fc157dc0",
+        "rev": "a3f43db6f1c4acd0a2d37e17aace66824dab88aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a3f43db6`](https://github.com/nix-community/NUR/commit/a3f43db6f1c4acd0a2d37e17aace66824dab88aa) | `automatic update` |