### PR TITLE
chore(flake/nur): `a3f43db6` -> `9f8503eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668578155,
-        "narHash": "sha256-loZ67zDXS+4xMsq8GsV+NB+8d3P2lwT0gVrSAz0cMkc=",
+        "lastModified": 1668595071,
+        "narHash": "sha256-6pdT3riMqcSfb7TrOWNuVOb/aSctH0AA6QD97d4YA28=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a3f43db6f1c4acd0a2d37e17aace66824dab88aa",
+        "rev": "9f8503eb68c02a88d6db9c8c82a32cb828558d45",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9f8503eb`](https://github.com/nix-community/NUR/commit/9f8503eb68c02a88d6db9c8c82a32cb828558d45) | `automatic update` |