### PR TITLE
chore(flake/emacs-overlay): `74789d57` -> `69a81fdf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668573780,
-        "narHash": "sha256-JWaKBwm3fDGqMQ5HBfrQDoc4o3RBQ3oAQYUk19u/VxA=",
+        "lastModified": 1668599879,
+        "narHash": "sha256-tbJcsUqMGqoGKyXKKK7jrTTqYjY5+eiYiiECqfkCwQ8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "74789d573f6bb8b8b4942f83fa060d76258a7e6e",
+        "rev": "69a81fdf4f4b3bfcb227a23a0926f5663b355d19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`69a81fdf`](https://github.com/nix-community/emacs-overlay/commit/69a81fdf4f4b3bfcb227a23a0926f5663b355d19) | `Updated repos/nongnu` |
| [`a870b8d8`](https://github.com/nix-community/emacs-overlay/commit/a870b8d83f171ec34572ecd4355c74181bf7af98) | `Updated repos/melpa`  |
| [`6cf71898`](https://github.com/nix-community/emacs-overlay/commit/6cf71898aa2263b83955c7d3b884ac4adc9b93d2) | `Updated repos/emacs`  |