### PR TITLE
chore(flake/nur): `9f8503eb` -> `5298ddfd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668595071,
-        "narHash": "sha256-6pdT3riMqcSfb7TrOWNuVOb/aSctH0AA6QD97d4YA28=",
+        "lastModified": 1668603121,
+        "narHash": "sha256-hn3t4am7jTXYJegPALkllZl2o0C+1Sm22tTPYtOSwzk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9f8503eb68c02a88d6db9c8c82a32cb828558d45",
+        "rev": "5298ddfd41b01bdcf80e552d22f0baf31a4e4b13",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5298ddfd`](https://github.com/nix-community/NUR/commit/5298ddfd41b01bdcf80e552d22f0baf31a4e4b13) | `automatic update` |