### PR TITLE
chore(flake/nixpkgs): `013fcdd1` -> `85d6b399`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668417584,
-        "narHash": "sha256-yeuEyxKPwsm5fIHN49L/syn9g5coxnPp3GsVquhrv5A=",
+        "lastModified": 1668505710,
+        "narHash": "sha256-DulcfsGjpSXL9Ma0iQIsb3HRbARCDcA+CNH67pPyMQ0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "013fcdd106823416918004bb684c3c186d3c460f",
+        "rev": "85d6b3990def7eef45f4502a82496de02a02b6e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`8786f80a`](https://github.com/NixOS/nixpkgs/commit/8786f80a1c7c320f9a0637e9cf36bb8274f3602a) | `ocamlPackages.js_of_ocaml-ocamlbuild: 4.0.0 → 5.0`                        |
| [`7dd0719b`](https://github.com/NixOS/nixpkgs/commit/7dd0719b2ffe3654ab677e1fd66f235658ef7cf7) | `python310Packages.apache-beam: fix for dill 0.3.6`                        |
| [`335b2990`](https://github.com/NixOS/nixpkgs/commit/335b2990e64728fc0401b45af61a3d2cdfb0c483) | `python3Packages.pymemcache: mark broken on 32 bit`                        |
| [`2067822b`](https://github.com/NixOS/nixpkgs/commit/2067822b828cf8460ef2e72f68705c531195350f) | `got: 0.78 -> 0.79`                                                        |
| [`b6239d9b`](https://github.com/NixOS/nixpkgs/commit/b6239d9b019b76da41d5965e8d90ba18ec05adb5) | `lazygit: 0.35 -> 0.36.0`                                                  |
| [`1671115d`](https://github.com/NixOS/nixpkgs/commit/1671115dbefc87875e513cf70b77e6589ab7ff3c) | `lazydocker: 0.19.0 -> 0.20.0`                                             |
| [`8ca1aba4`](https://github.com/NixOS/nixpkgs/commit/8ca1aba4757f47204c1f11c662a5568b5a485f85) | `terraform-providers.newrelic: 3.6.1 → 3.7.0`                              |
| [`3ce72808`](https://github.com/NixOS/nixpkgs/commit/3ce72808da12ef16c7299e8d00b874cdc728ef44) | `terraform-providers.aiven: 3.8.0 → 3.8.1`                                 |
| [`3537f2cc`](https://github.com/NixOS/nixpkgs/commit/3537f2ccd52f0e54b0a90bff14279c04a1483600) | `cloudflare-dyndns: remove from python3Packages`                           |
| [`b2a6caa5`](https://github.com/NixOS/nixpkgs/commit/b2a6caa5cbbc73a6a10b7937c6cc650b865fa86f) | `flyctl: 0.0.430 -> 0.0.431`                                               |
| [`cebf764e`](https://github.com/NixOS/nixpkgs/commit/cebf764e2bf04da20b0a857df13a641fe980bfac) | `netpbm: 11.0.1 -> 11.0.2`                                                 |
| [`afd99c07`](https://github.com/NixOS/nixpkgs/commit/afd99c07525857686208f09b81fb03e78c6be2c0) | `tellico: 3.4.1 -> 3.4.4`                                                  |
| [`81cd6b06`](https://github.com/NixOS/nixpkgs/commit/81cd6b06f96c4343ad0932f117acd89237cea477) | `nixos/nginx: add default listen port options`                             |
| [`d9b1bde3`](https://github.com/NixOS/nixpkgs/commit/d9b1bde390eb133a3da66c8abd902ea2b754938c) | `nixos: Fix fsck with systemd 251.6 and later`                             |
| [`a0e343a6`](https://github.com/NixOS/nixpkgs/commit/a0e343a61b42d53cca4c9633080612d69b684d2f) | `mozillavpn: 2.10.1 → 2.11.0`                                              |
| [`af8d5c51`](https://github.com/NixOS/nixpkgs/commit/af8d5c5185eb365623360652c4321a3cc36409ed) | `mutt: 2.2.8 -> 2.2.9`                                                     |
| [`d72bcc2b`](https://github.com/NixOS/nixpkgs/commit/d72bcc2bc97723c3c9365b334553654525d8f226) | `erlang: wxmac -> wxGTK`                                                   |
| [`e695acf1`](https://github.com/NixOS/nixpkgs/commit/e695acf19250d931f4d0a7e3ab8e5ae4d86c9142) | `sbclPackages: fixed pzmq-{compat,examples,test}`                          |
| [`8e768a61`](https://github.com/NixOS/nixpkgs/commit/8e768a61d0fac08f8168482c4ef63253b784ff2d) | `sbclPackages: marked math as broken`                                      |
| [`775b15ca`](https://github.com/NixOS/nixpkgs/commit/775b15cabbd86464b93713bc03046d019dc6b202) | `python3Packages.slixmpp: 1.8.2 -> 1.8.3`                                  |
| [`ba7a40a6`](https://github.com/NixOS/nixpkgs/commit/ba7a40a602b16d121aa1dea41712b567b046d584) | `sbclPackages: fixed cl-rsvg2`                                             |
| [`118863c4`](https://github.com/NixOS/nixpkgs/commit/118863c4f2973571263656f2accb9c75a7d28b56) | `sbclPackages: fixed cl-gtk2-{gdk,glib,pango}`                             |
| [`3f50d337`](https://github.com/NixOS/nixpkgs/commit/3f50d33747883a3b4dbb31646cb32da9e86ad686) | `neko: fix build on aarch64-darwin`                                        |
| [`252ee601`](https://github.com/NixOS/nixpkgs/commit/252ee601a3f5a2e3925a912ef2fa83bf3fb148f4) | `python310Packages.mitmproxy-wireguard: 0.1.17 -> 0.1.18`                  |
| [`22b79c23`](https://github.com/NixOS/nixpkgs/commit/22b79c23a10cc8179215819f707c69629fed3308) | `sbclPackages: marked cl-random and cl-random-tests as broken`             |
| [`a4c3b8aa`](https://github.com/NixOS/nixpkgs/commit/a4c3b8aad29a581db3019b7e8f7ffa1ff4657a27) | `sbclPackages: fixed cl-pango`                                             |
| [`6ca354dd`](https://github.com/NixOS/nixpkgs/commit/6ca354dd2f0bab83aadf8b200890c1133bea0c3b) | `sbclPackages: fixed cl-cairo2-xlib`                                       |
| [`488a73f6`](https://github.com/NixOS/nixpkgs/commit/488a73f6b37df466b49fe4f26327e6d680041e98) | `spotifywm: 2016-11-28 -> 2022-10-26`                                      |
| [`bfc75b74`](https://github.com/NixOS/nixpkgs/commit/bfc75b74d6d3024a81ef0002cbbe0a89aaf2566e) | `sbclPackages: fixed cl-freetype2`                                         |
| [`aa357fcf`](https://github.com/NixOS/nixpkgs/commit/aa357fcf6e8af51b7c1c351a4d6a24f62f46ec19) | `unfs3: 0.9.22 -> 0.10.0`                                                  |
| [`06fd3af8`](https://github.com/NixOS/nixpkgs/commit/06fd3af8f33ac49f3e1598fe2decd83dd60dbab4) | `sony-headphones-client: 1.2 -> 1.3.1`                                     |
| [`2832ad57`](https://github.com/NixOS/nixpkgs/commit/2832ad5786147f96926f3dc4ab8dde7477863989) | `python310Packages.mkdocstrings-python: 0.7.1 -> 0.8.0`                    |
| [`f7161f92`](https://github.com/NixOS/nixpkgs/commit/f7161f92ec1bdf07496e5a7b4ed617b9a44cdcc8) | `ruff: 0.0.117 -> 0.0.118`                                                 |
| [`f8a32e2d`](https://github.com/NixOS/nixpkgs/commit/f8a32e2df43290fac1297ab0b846e2dcc13eefb0) | `mercurial: 6.2.3 -> 6.3.0`                                                |
| [`45aa39da`](https://github.com/NixOS/nixpkgs/commit/45aa39daec9ddba16ca46bd4c81537a5d14ad354) | `vimPlugins.legendary-nvim: downgrade to fix duplicate tags`               |
| [`29ecd6e1`](https://github.com/NixOS/nixpkgs/commit/29ecd6e1d351ba1294d5f4c3900f476eb7ea52cf) | `vimPlugins.nvim-treesitter: update grammars`                              |
| [`2f933d60`](https://github.com/NixOS/nixpkgs/commit/2f933d60fb8788a801c43d1c4c7e16fda7af372c) | `doc/vim: Clarify buildVimPlugin/buildVimPluginFrom2Nix`                   |
| [`1785135b`](https://github.com/NixOS/nixpkgs/commit/1785135be6f813707287e266935a912d54550605) | `qownnotes: 22.10.2 -> 22.11.4`                                            |
| [`2e320d1a`](https://github.com/NixOS/nixpkgs/commit/2e320d1ac0d67fbe5543ecc1ce34e4d1d0a00a6e) | `freshrss: 1.20.0 -> 1.20.1`                                               |
| [`791a23a0`](https://github.com/NixOS/nixpkgs/commit/791a23a00a8575400250ac8eaa6b844aefb23989) | `ncview: use xorg.* packages directly instead of xlibsWrapper indirection` |
| [`d180abe8`](https://github.com/NixOS/nixpkgs/commit/d180abe8840827638f446b0cc299a94bf18bac92) | `pulumi: 3.43.1 -> 3.46.1`                                                 |
| [`7c3fb577`](https://github.com/NixOS/nixpkgs/commit/7c3fb5774eac09fd3901416cbae69769ce4a66b8) | `tor: 0.4.7.10 -> 0.4.7.11`                                                |
| [`5a1852b2`](https://github.com/NixOS/nixpkgs/commit/5a1852b2d0d6534883b118cb0e5554275d986381) | `minidlna: 1.3.1 -> 1.3.2`                                                 |
| [`75a0854b`](https://github.com/NixOS/nixpkgs/commit/75a0854b211969ba834fb96ff2c8819004c8afb3) | `vimPlugins.telescope-live-grep-args-nvim: init at 2022-11-07`             |
| [`6edfa4f6`](https://github.com/NixOS/nixpkgs/commit/6edfa4f6954654cab9856880c535b1179247aacb) | `vimPlugins: update`                                                       |
| [`22dafab6`](https://github.com/NixOS/nixpkgs/commit/22dafab6506524031abbbf4c40b7610191cd314e) | `firefox-esr-102-unwrapped: 102.4.0esr -> 102.5.0esr`                      |
| [`28b268d3`](https://github.com/NixOS/nixpkgs/commit/28b268d34b55d79bb87e4b462bbc5b50a564c902) | `firefox-bin-unwrapped: 106.0.5 -> 107.0`                                  |
| [`8ec89ef1`](https://github.com/NixOS/nixpkgs/commit/8ec89ef1b50dd4602a72e6fd8842924f8e56482d) | `firefox{,-bin}, thunderbird{,-bin}: Set meta.changelog`                   |
| [`f3a8bb1e`](https://github.com/NixOS/nixpkgs/commit/f3a8bb1ec80dc68f24cfd832f032c53729c23f5f) | `firefox-unwrapped: 106.0.5 -> 107.0`                                      |
| [`259f8aaa`](https://github.com/NixOS/nixpkgs/commit/259f8aaa8b71315d9c4cdd8934c22c1dc852361c) | `sqlfluff: 1.4.1 -> 1.4.2`                                                 |
| [`376bd0eb`](https://github.com/NixOS/nixpkgs/commit/376bd0ebe0953a61b174482b258d6df10d556a88) | `python310Packages.griffe: 0.23.0 -> 0.24.0`                               |
| [`8dfd6ce8`](https://github.com/NixOS/nixpkgs/commit/8dfd6ce864367541cb250b6d4b8d9850438d3c6b) | `difftastic: 0.37.0 -> 0.38.0`                                             |
| [`ec106b98`](https://github.com/NixOS/nixpkgs/commit/ec106b98ddaf404474002d3ff32472646fdcafd2) | `inetutils: fix cross`                                                     |
| [`460e8381`](https://github.com/NixOS/nixpkgs/commit/460e838124c31eb0d6b1aca16165d3e5e1d18573) | `python310Packages.growattserver: 1.2.3 -> 1.2.4`                          |
| [`d3f5b5a6`](https://github.com/NixOS/nixpkgs/commit/d3f5b5a608c482ac9865f71b20c9c6797e054ca3) | `python310Packages.heatzypy: 2.1.1 -> 2.1.5`                               |
| [`47c355de`](https://github.com/NixOS/nixpkgs/commit/47c355de3a093565ba62c268c3309c4db3035b2b) | `python310Packages.google-nest-sdm: 2.0.0 -> 2.1.0`                        |
| [`e002041d`](https://github.com/NixOS/nixpkgs/commit/e002041da0cef3107ee25d0261cd94068ad2817e) | `python310Packages.airthings-ble: 0.5.2 -> 0.5.3`                          |
| [`bdd39e57`](https://github.com/NixOS/nixpkgs/commit/bdd39e5757d858bd6ea58ed65b4a2e52c8ed11ca) | `lollypop: 1.4.24 → 1.4.36`                                                |
| [`9aad525e`](https://github.com/NixOS/nixpkgs/commit/9aad525eac929e5c1e5285226f8cb5a6981335b9) | `vscode-extensions.timonwong.shellcheck: 0.193 -> 0.26.3`                  |
| [`cecc5530`](https://github.com/NixOS/nixpkgs/commit/cecc553095ea244e516003f7e0714669afb4af70) | `schildichat-desktop: copy sqlcipher fix from element-desktop (#201179)`   |
| [`41c56cad`](https://github.com/NixOS/nixpkgs/commit/41c56cadffe23835e60489f846675cb9e3c0a804) | `checkov: Fix exe not executable`                                          |
| [`b8ba78f1`](https://github.com/NixOS/nixpkgs/commit/b8ba78f1d614e9faa981c6d74e83aff0c9cf66cf) | `checkov: Fix build`                                                       |
| [`07e5701a`](https://github.com/NixOS/nixpkgs/commit/07e5701aca54f1b5cc5f517ac259d4bcd4208d42) | `nixos/manual: re-add mention of mdDoc marker`                             |
| [`f5ecd16c`](https://github.com/NixOS/nixpkgs/commit/f5ecd16cc8bea85e8adbb49b3ec992998662c9c4) | `syncstorage-rs: 0.12.4 -> 0.12.5`                                         |
| [`b676b764`](https://github.com/NixOS/nixpkgs/commit/b676b764e7de2ff56b48c87bee83e879154bd465) | `rustic-rs: init at 0.3.2`                                                 |
| [`88f2d44d`](https://github.com/NixOS/nixpkgs/commit/88f2d44dc112d156d1b5063f1e27ff2a3d944a01) | `nix-update: 0.7.0 -> 0.8.0`                                               |
| [`4b145674`](https://github.com/NixOS/nixpkgs/commit/4b14567454aa524f6393ba2810930f54e47e3b33) | `topicctl: 1.6.1 -> 1.7.0`                                                 |
| [`5bc1b01a`](https://github.com/NixOS/nixpkgs/commit/5bc1b01a403e071500a3b0659364fb6ee20391e1) | `boot.loader.systemd-boot: add extraInstallCommands option (#200715)`      |
| [`84da129f`](https://github.com/NixOS/nixpkgs/commit/84da129f182579be04935e88dc96e77358552ce4) | `pipenv: 2022.10.25 -> 2022.11.11`                                         |
| [`36ce4745`](https://github.com/NixOS/nixpkgs/commit/36ce474508e9de1209ca9857907a66fcbc9d27e7) | `atmos: 1.10.4 -> 1.13.1`                                                  |
| [`f955ad16`](https://github.com/NixOS/nixpkgs/commit/f955ad1647fdaf66d9a929cbd101ac93b2d6a60c) | `mutagen-compose: 0.16.0 -> 0.16.1`                                        |
| [`232a9b93`](https://github.com/NixOS/nixpkgs/commit/232a9b93b2dc6f71194be6b00bb3a9f8dfe434ee) | `velero: 1.9.2 -> 1.9.3`                                                   |
| [`e5da3f3a`](https://github.com/NixOS/nixpkgs/commit/e5da3f3aef4b692fafc270568449436ec70071b6) | `v2ray-geoip: 202211030059 -> 202211100058`                                |
| [`f23a62a5`](https://github.com/NixOS/nixpkgs/commit/f23a62a5dccf7bc7e3f8413e3a8146a2f739f75f) | `kubernetes-helm: 3.10.1 -> 3.10.2`                                        |
| [`af9a4dd3`](https://github.com/NixOS/nixpkgs/commit/af9a4dd35eb387c527cc04e6cc86c4607e532082) | `cargo-public-api: 0.21.0 -> 0.22.0`                                       |
| [`5a04b70e`](https://github.com/NixOS/nixpkgs/commit/5a04b70e1463d1ecf18ba819c1b9b6db43c56320) | `jool-cli: divert man pages`                                               |
| [`b08b69c5`](https://github.com/NixOS/nixpkgs/commit/b08b69c5a11c2f21e54c3e9878e5812cb03c7f13) | `gifski: 1.7.2 -> 1.8.0`                                                   |
| [`890d0576`](https://github.com/NixOS/nixpkgs/commit/890d0576c5f68852cd3d6ca81c5428122c620560) | `cross/mingw: make threading library configureable`                        |
| [`ec7467e2`](https://github.com/NixOS/nixpkgs/commit/ec7467e2ea318b8abd0eb913262b839f1601afb0) | `jool: 4.1.7 -> 4.1.8`                                                     |
| [`eebb43a3`](https://github.com/NixOS/nixpkgs/commit/eebb43a334806859a9444d9f99b9c52f1d432dac) | `lldpd: 1.0.15 -> 1.0.16`                                                  |
| [`2f1ca6e2`](https://github.com/NixOS/nixpkgs/commit/2f1ca6e27f0fd2a3dc250eefe53fedbff722fd80) | `whois: 5.5.13 -> 5.5.14`                                                  |
| [`0e69f6db`](https://github.com/NixOS/nixpkgs/commit/0e69f6db6498ee6f5e6c3b16c1af8d8620a6aeb4) | `ferium: 4.2.0 -> 4.2.1`                                                   |
| [`8ac4008c`](https://github.com/NixOS/nixpkgs/commit/8ac4008c0918bfcd910535203c8c9caf98da0f39) | `python3.pkgs.pytest-plt: init at 1.1.0`                                   |
| [`4d2e0a09`](https://github.com/NixOS/nixpkgs/commit/4d2e0a096b96826a6c0a6a9e8611b45a8f69edd2) | `darkman: build on linux only`                                             |
| [`3024d77c`](https://github.com/NixOS/nixpkgs/commit/3024d77c8221a8696ca53789169c279ab18ddf3b) | `deno: 1.27.2 -> 1.28.0`                                                   |
| [`e3fc19b3`](https://github.com/NixOS/nixpkgs/commit/e3fc19b301f7467df9920cdf721adcb705a783f7) | `nixos/nginx: docs: Update formatting`                                     |
| [`7f982588`](https://github.com/NixOS/nixpkgs/commit/7f9825881063fe6ac21782edbb08255883a2df8a) | `datree: 1.6.42 -> 1.7.3`                                                  |
| [`0e2c58c7`](https://github.com/NixOS/nixpkgs/commit/0e2c58c77f031d58dcdf8c64928530ad075d085e) | `emacs: add withSystemd option`                                            |
| [`0baed3d7`](https://github.com/NixOS/nixpkgs/commit/0baed3d787e16ac752e62b08ecf8e45ce4dfa1bb) | `joplin-desktop: make Icon= more bitrot resistant`                         |
| [`fd9eed5b`](https://github.com/NixOS/nixpkgs/commit/fd9eed5bf351ba90c754f2479a56455d101cb597) | `nixos/nginx: Extend acmeFallbackHost documentation`                       |
| [`ab44b889`](https://github.com/NixOS/nixpkgs/commit/ab44b8890a41845f55dab39cd96f28cfbe0108ea) | `dufs: 0.30.0 -> 0.31.0`                                                   |
| [`04be2d87`](https://github.com/NixOS/nixpkgs/commit/04be2d8747aad512fc9c907dfc6b9943d2a16412) | `zoekt: unstable-2021-03-17 -> unstable-2022-11-09`                        |
| [`5744a7b2`](https://github.com/NixOS/nixpkgs/commit/5744a7b2c670f432b5b9ab3ddd7f067d3da5303d) | `cppcheck: 2.9.1 -> 2.9.2`                                                 |
| [`000663a0`](https://github.com/NixOS/nixpkgs/commit/000663a015f2f56d392932f79365021bd5e21c16) | `survex: use xorg.* packages directly instead of xlibsWrapper indirection` |
| [`73684a65`](https://github.com/NixOS/nixpkgs/commit/73684a65aa21828d808cf38cad07fe93f4f15514) | `obs-studio-plugins.obs-source-record: init at 2022-11-10`                 |
| [`260fb8b4`](https://github.com/NixOS/nixpkgs/commit/260fb8b482a4a4a427488378f83ac2847b0f4064) | `maintainers: add robbins`                                                 |
| [`b64b1343`](https://github.com/NixOS/nixpkgs/commit/b64b13430961a4ab7842acb4853987088ce9b7f3) | `comrak: 0.14.0 -> 0.15.0`                                                 |
| [`10a4e2f5`](https://github.com/NixOS/nixpkgs/commit/10a4e2f5584c5ee42ad02b80d6fd18639cb8db80) | `cargo-auditable: 0.5.2 -> 0.5.3`                                          |
| [`5a65cc17`](https://github.com/NixOS/nixpkgs/commit/5a65cc178188ebcc98fb763861b6e378a729d977) | `python310Packages.pyswitchbot: 0.20.3 -> 0.20.4`                          |
| [`f519ea55`](https://github.com/NixOS/nixpkgs/commit/f519ea5528c1c534e76e963bdf37a31af63167c9) | `ruff: 0.0.115 -> 0.0.117`                                                 |
| [`fd8361c4`](https://github.com/NixOS/nixpkgs/commit/fd8361c44a436c852c97d9660b4aa88b3d53e8de) | `fn-cli: mark as broken on darwin`                                         |
| [`678ccdf7`](https://github.com/NixOS/nixpkgs/commit/678ccdf71645a5ed766f743e81ecdfeb56f3e868) | `element: mark as broken on darwin`                                        |
| [`0bcc9969`](https://github.com/NixOS/nixpkgs/commit/0bcc9969b25b9870868a4bc2f5af3ebab7bc28ac) | `miniflux: 2.0.39 -> 2.0.40`                                               |
| [`5376fb46`](https://github.com/NixOS/nixpkgs/commit/5376fb46762f4c823f8f7affe2b7f80197ace71e) | `_1password-gui: 8.9.4 -> 8.9.8, 8.9.6-30.BETA -> 8.9.10-1.BETA`           |
| [`354c89dc`](https://github.com/NixOS/nixpkgs/commit/354c89dc0a6fbd5819c69e3a5a5abb03b7ad8f46) | `sbclPackages: fix cl-cairo2`                                              |
| [`beb27110`](https://github.com/NixOS/nixpkgs/commit/beb27110edde03076eb77b66fe0bac37f27674b9) | `sbclPackages: fix typo`                                                   |
| [`f59352d0`](https://github.com/NixOS/nixpkgs/commit/f59352d0af7e008d93ad1cce4ada9e7e6078b0cd) | `sbclPackages: fixed pzmq`                                                 |
| [`bc8a625a`](https://github.com/NixOS/nixpkgs/commit/bc8a625adc596a2c6ee14b492666548e11279233) | `sbclPackages: bring over some fixes merged into staging-next`             |
| [`8ba634bb`](https://github.com/NixOS/nixpkgs/commit/8ba634bb13b265571eb19084cc5dd32250399ecb) | `sbclPackages: mark some failing packages as broken`                       |
| [`404a5ad0`](https://github.com/NixOS/nixpkgs/commit/404a5ad09207f5da9b452c0aa8bb0103b40bd3f3) | `python310Packages.pycocotools: 2.0.5 -> 2.0.6`                            |
| [`dfa4b898`](https://github.com/NixOS/nixpkgs/commit/dfa4b89852833d080a5b35d6ac9f9b997e198ec5) | `build: fix build on aarch64-darwin`                                       |
| [`7ba6ae63`](https://github.com/NixOS/nixpkgs/commit/7ba6ae6310e42c11d4f8ea9cb08b9632421b57d8) | `python310Packages.pyrainbird: 0.4.3 -> 0.6.2`                             |
| [`95d62439`](https://github.com/NixOS/nixpkgs/commit/95d624394e73cb0b107e0f0214307979a018a997) | `appleseed: remove`                                                        |
| [`1b00c83b`](https://github.com/NixOS/nixpkgs/commit/1b00c83b12e45e6d5a84c8f6c4458a67384a3fd4) | `python310Packages.pex: 2.1.112 -> 2.1.113`                                |
| [`ed23e9bb`](https://github.com/NixOS/nixpkgs/commit/ed23e9bb9c4aa2e1731509e2dd22b6deccb684d4) | `python310Packages.peaqevcore: 7.3.2 -> 7.3.3`                             |
| [`6a16d555`](https://github.com/NixOS/nixpkgs/commit/6a16d555f34874fdba158911ae394e0f42a86224) | `python310Packages.mypy-boto3-s3: 1.25.0 -> 1.26.0.post1`                  |
| [`113a9e98`](https://github.com/NixOS/nixpkgs/commit/113a9e987026274ccc435b895267a6fb08d9b5e2) | `ecs-agent: use buildGoModule`                                             |
| [`73dc3187`](https://github.com/NixOS/nixpkgs/commit/73dc3187f58a9a4cb9388964011e85c73c013ef4) | `python310Packages.mne-python: 1.2.1 -> 1.2.2`                             |
| [`a25c3c56`](https://github.com/NixOS/nixpkgs/commit/a25c3c56e74ff7827c9326534368bac247106ea0) | `figma-linux: init at 0.10.1`                                              |
| [`8d9763d0`](https://github.com/NixOS/nixpkgs/commit/8d9763d043a0f3cb6a2c57f1ebc6ee10f99a0174) | `mate.caja-extensions: Fix wrong schema path`                              |
| [`aa3396dc`](https://github.com/NixOS/nixpkgs/commit/aa3396dc3216d2e44e4dca26900afb494d4c59ea) | `mate.caja-extensions: Fix failed substitution`                            |
| [`f8de2411`](https://github.com/NixOS/nixpkgs/commit/f8de2411a175d09ec61e0053353bbd7b81077578) | `python310Packages.selenium: 4.5.0 -> 4.6.0`                               |
| [`65967fa6`](https://github.com/NixOS/nixpkgs/commit/65967fa684f4dce0a788779c91c982e2677fcf74) | `python310Packages.asyncio-mqtt: enable tests`                             |
| [`d7546e18`](https://github.com/NixOS/nixpkgs/commit/d7546e1813cd17e272bd6b4a712513821a462476) | `python310Packages.aiomysensors: 0.3.2 -> 0.3.3`                           |
| [`066bb437`](https://github.com/NixOS/nixpkgs/commit/066bb437c93d9323ec8e44c1b5c0618794b0a7f9) | `python310Packages.asyncio-mqtt: 0.13.0 -> 0.14.0`                         |
| [`ea58c46e`](https://github.com/NixOS/nixpkgs/commit/ea58c46e4f13c4d1bc0ecdbf7d86ce0200716d60) | `python310Packages.stevedore: 4.1.0 -> 4.1.1`                              |
| [`7b365ed5`](https://github.com/NixOS/nixpkgs/commit/7b365ed51518ba4727c3a9130d5ddb5011608062) | `python3.pkgs.misoc: init at unstable-2022-10-08`                          |
| [`3e3fe0b2`](https://github.com/NixOS/nixpkgs/commit/3e3fe0b2e21107bfcc59a958571f23b98ba5b51a) | `python3.pkgs.migen: unstable-2021-09-14 -> unstable-2022-09-02`           |
| [`b6429927`](https://github.com/NixOS/nixpkgs/commit/b6429927c04f8ae66aa3e9eed55d6ed7aa0e6d98) | `python3.pkgs.asyncserial: init at unstable-2022-06-10`                    |
| [`f97c7b38`](https://github.com/NixOS/nixpkgs/commit/f97c7b38a1c7289069282e2603ec0ec9ecf81e0a) | `python3.pkgs.myhdl: init at unstable-2022-04-26`                          |
| [`da73c860`](https://github.com/NixOS/nixpkgs/commit/da73c860aa144ba988551a96ee1cd4c70c056c37) | `python3.pkgs.pylpsd: init at 0.1.4`                                       |
| [`cdec3613`](https://github.com/NixOS/nixpkgs/commit/cdec36131ffbd447e1b239c07de014c9e22b8105) | `pulseeffects-legacy: 4.8.4 -> 4.8.7`                                      |
| [`d82962c6`](https://github.com/NixOS/nixpkgs/commit/d82962c69278ccdd926afb39a4df60e84f61c69e) | `libfixposix: 0.4.3 -> 0.5.1`                                              |
| [`bf7a3f6d`](https://github.com/NixOS/nixpkgs/commit/bf7a3f6dcf9545464da358f350df32647c92323d) | `git-cola: 4.0.2 -> 4.0.3`                                                 |
| [`b106ff14`](https://github.com/NixOS/nixpkgs/commit/b106ff14ede4034f8771025f8ac785144358f3cd) | `nixosOptionsDoc: Report in which option an error occurs`                  |
| [`429ba6c7`](https://github.com/NixOS/nixpkgs/commit/429ba6c71426418562b2047cf1433d3ed6f45533) | `nixosOptionsDoc: Add markdownByDefault parameter`                         |
| [`bfdffa62`](https://github.com/NixOS/nixpkgs/commit/bfdffa623eae307b588d585db0be2726bad51780) | `baresip: 2.8.2 -> 2.9.0`                                                  |
| [`24afcac7`](https://github.com/NixOS/nixpkgs/commit/24afcac7031066696ee2b92432f530c5c4459fd8) | `syncthingtray: Fix Nix wrapped path in autostart desktop generation`      |
| [`8dc7d564`](https://github.com/NixOS/nixpkgs/commit/8dc7d564aa91fc6efec474320840480dc92adadd) | `gammu: fix script dependencies on bash and dialog`                        |
| [`f9118a8c`](https://github.com/NixOS/nixpkgs/commit/f9118a8c9bd9b84cea11a681f099c51aaf53f268) | `codeowners: narrower responsibilities for fricklerhandwerk`               |
| [`7343a3b6`](https://github.com/NixOS/nixpkgs/commit/7343a3b642cbdbac47770fe24d65aa9f9d23e6fa) | `boehmgc: switch from versionAtLeast to == for powerpc workaround`         |
| [`8260aed1`](https://github.com/NixOS/nixpkgs/commit/8260aed123ea511cd10fb5a3385fe07cd12d349a) | `rephrase to avoid mass-rebuild`                                           |
| [`06ecc513`](https://github.com/NixOS/nixpkgs/commit/06ecc51368bb4181c313dd6fea1bc573b9b9a033) | `boehmgc: disable SOFT_VDB on powerpc64le for version 8.2.2`               |
| [`90babdcf`](https://github.com/NixOS/nixpkgs/commit/90babdcf38cd283b116fed0d79bf815e270c4638) | `maintainers: add ercao`                                                   |
| [`1e154436`](https://github.com/NixOS/nixpkgs/commit/1e154436525547c20b34811bfe32be2937e61d0a) | `bats.libraries: reduce output size`                                       |
| [`4d19f1f3`](https://github.com/NixOS/nixpkgs/commit/4d19f1f3d424e563883bccb18a6b6eeb28a6668a) | `organicmaps: 2022.09.22-3 -> 2022.11.02-2`                                |
| [`865fdea4`](https://github.com/NixOS/nixpkgs/commit/865fdea4110b7565e2be8c20b4e08a911f2482ce) | `coconut: 1.6.0 → 2.1.0`                                                   |
| [`150a54fe`](https://github.com/NixOS/nixpkgs/commit/150a54fee9d0e09bf8cd0f0d5bc081eda4a2ebb1) | `tuxpaint: 0.9.27 -> 0.9.28`                                               |
| [`392801ba`](https://github.com/NixOS/nixpkgs/commit/392801ba21400eb7b6eaabb85d22ed24d6e33baf) | `pantheon.elementary-default-settings: add files dock item`                |
| [`de8743c2`](https://github.com/NixOS/nixpkgs/commit/de8743c2734c682a750694a51b8cf024c2dd3df5) | `jetbrains.clion: patch lldb instead of replacing`                         |