### PR TITLE
chore(flake/emacs-overlay): `69a81fdf` -> `54030961`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668599879,
-        "narHash": "sha256-tbJcsUqMGqoGKyXKKK7jrTTqYjY5+eiYiiECqfkCwQ8=",
+        "lastModified": 1668632502,
+        "narHash": "sha256-a7WDoqNNuqbwodL8G+CdgdfObxaO3WzFu91GCAkbck4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "69a81fdf4f4b3bfcb227a23a0926f5663b355d19",
+        "rev": "5403096194fd02e1a5424a365d057d934c705639",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`54030961`](https://github.com/nix-community/emacs-overlay/commit/5403096194fd02e1a5424a365d057d934c705639) | `Updated repos/melpa` |
| [`d71ca4cd`](https://github.com/nix-community/emacs-overlay/commit/d71ca4cd3aeca28fd49986f7f11e1c022df0ef12) | `Updated repos/emacs` |