### PR TITLE
chore(flake/nur): `5bb050ca` -> `457f36dc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668651837,
-        "narHash": "sha256-rXFMkS/7c/1wCJOSgkDi6ADE7yhn6wOosjR69uNGCY0=",
+        "lastModified": 1668657698,
+        "narHash": "sha256-eo0bmGg3ALdZXsfj4UrGrp2ELLjFCiol35kU4dWcqbY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5bb050ca96ef11cf2f83e6eece7fc26dc542e2e7",
+        "rev": "457f36dccae5859b598f8c3a17f566db25d36686",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`457f36dc`](https://github.com/nix-community/NUR/commit/457f36dccae5859b598f8c3a17f566db25d36686) | `automatic update` |