### PR TITLE
chore(flake/nur): `457f36dc` -> `06f41caa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668657698,
-        "narHash": "sha256-eo0bmGg3ALdZXsfj4UrGrp2ELLjFCiol35kU4dWcqbY=",
+        "lastModified": 1668658735,
+        "narHash": "sha256-t4b+99ShkeXFXFdlL9oMgAsHus2WHjV24M7VmNii7HI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "457f36dccae5859b598f8c3a17f566db25d36686",
+        "rev": "06f41caa7985fc7b85a72eac96eec37e2401684d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`06f41caa`](https://github.com/nix-community/NUR/commit/06f41caa7985fc7b85a72eac96eec37e2401684d) | `automatic update` |
| [`310ec57a`](https://github.com/nix-community/NUR/commit/310ec57af0dec477ea213d2009ec68e50f2606bc) | `automatic update` |