### PR TITLE
chore(flake/emacs-overlay): `54030961` -> `098c2a81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668632502,
-        "narHash": "sha256-a7WDoqNNuqbwodL8G+CdgdfObxaO3WzFu91GCAkbck4=",
+        "lastModified": 1668663206,
+        "narHash": "sha256-rxV9n36VINDJq6acFq5kuT2jYOBzaedDW0TXF2iViVE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5403096194fd02e1a5424a365d057d934c705639",
+        "rev": "098c2a810c937564bff3f57fc406be9c144283ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`098c2a81`](https://github.com/nix-community/emacs-overlay/commit/098c2a810c937564bff3f57fc406be9c144283ae) | `Updated repos/nongnu` |
| [`8894dc98`](https://github.com/nix-community/emacs-overlay/commit/8894dc985e6aa0f8a3253d8f19ede50bd8b9c93e) | `Updated repos/melpa`  |
| [`4d90f112`](https://github.com/nix-community/emacs-overlay/commit/4d90f11266b429b8484801dc36a19e5e66cfd650) | `Updated repos/emacs`  |