### PR TITLE
chore(flake/flake-compat): `b4a34015` -> `00939922`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -204,11 +204,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                 | Commit Message                                      |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
| [`6f56392c`](https://github.com/edolstra/flake-compat/commit/6f56392cc453c14b05060a1e08add387b767a847) | `fix: top level functors break legacy nix commands` |