### PR TITLE
chore(flake/nixpkgs): `85d6b399` -> `b457130e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668505710,
-        "narHash": "sha256-DulcfsGjpSXL9Ma0iQIsb3HRbARCDcA+CNH67pPyMQ0=",
+        "lastModified": 1668596599,
+        "narHash": "sha256-rhHyZTGI31/OfgYa9xF49UTchDXTI94pEsSNa0fOkpk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "85d6b3990def7eef45f4502a82496de02a02b6e8",
+        "rev": "b457130e8a21608675ddf12c7d85227b22a27112",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                       |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`37b95c8d`](https://github.com/NixOS/nixpkgs/commit/37b95c8d49f573384a8bd7d93e37e26bee319899) | `qownnotes: 22.11.4 -> 22.11.5`                                                                      |
| [`00287cc2`](https://github.com/NixOS/nixpkgs/commit/00287cc23dc7948f3a86772c55e679f0bc983e71) | `qownnotes: update hash to upstream provided format`                                                 |
| [`82230795`](https://github.com/NixOS/nixpkgs/commit/82230795697d36356bc530db9fa0aefa76b18768) | `nsncd: unstable-2021-10-20 -> unstable-2022-11-14`                                                  |
| [`2bb77684`](https://github.com/NixOS/nixpkgs/commit/2bb776841914f78bdbc7bea7d007f2302aec0bcc) | `soft-serve: 0.4.0 -> 0.4.1`                                                                         |
| [`977a0c94`](https://github.com/NixOS/nixpkgs/commit/977a0c94601dc774f8ad148e5ce2dd9722eb6dfc) | `minikube: 1.27.1 -> 1.28.0`                                                                         |
| [`6e0c9dcd`](https://github.com/NixOS/nixpkgs/commit/6e0c9dcd87280deae219d2c5abfa1f5fd550f23a) | `mastodon: add ghuntley as maintainer`                                                               |
| [`a6151294`](https://github.com/NixOS/nixpkgs/commit/a6151294db89c8409965eb3e3d70ccced60aabed) | `yosys: 0.22 -> 0.23`                                                                                |
| [`8f1d59e2`](https://github.com/NixOS/nixpkgs/commit/8f1d59e2c5907d396cfa71110fa2115b9e3b284d) | `python310Packages.bibtexparser: clean up python 2 dependencies (#201457)`                           |
| [`8b013b65`](https://github.com/NixOS/nixpkgs/commit/8b013b65a60e2a897104cb9fc59d48dee0e2ba16) | `nixos/misc: fix grammar typo`                                                                       |
| [`5e38acae`](https://github.com/NixOS/nixpkgs/commit/5e38acae5414020b5d5c9a53ccff42ba12daf97a) | `isrcsubmit: mark as broken`                                                                         |
| [`0f86e875`](https://github.com/NixOS/nixpkgs/commit/0f86e8758dd0b010fad7b3ff8c0f722d104dd063) | `rymdport: init at 3.2.0`                                                                            |
| [`41d87c3f`](https://github.com/NixOS/nixpkgs/commit/41d87c3fb7dbd2a9755f49466a988914886b74b6) | `mopidy-ytmusic: use ytmusicapi 0.22.0`                                                              |
| [`7e180c1b`](https://github.com/NixOS/nixpkgs/commit/7e180c1b056111aacd1ba80888373374a1aca8cf) | `python310Packages.ytmusicapi: 0.22.0 -> 0.24.0`                                                     |
| [`6cb85df0`](https://github.com/NixOS/nixpkgs/commit/6cb85df0906086ee464d3f39b0c8fcca4537a78d) | `lazpaint: mark as broken`                                                                           |
| [`29dd883f`](https://github.com/NixOS/nixpkgs/commit/29dd883f5d9c91fefddc843f10bc960b97f0b9d0) | `signal-desktop: 5.63.0 -> 5.63.1`                                                                   |
| [`2f71de98`](https://github.com/NixOS/nixpkgs/commit/2f71de984e97992d223f821e63279f87cc4b4e31) | ``release-notes: mention new `services.github-runners` & breaking changes``                          |
| [`90d7b881`](https://github.com/NixOS/nixpkgs/commit/90d7b8811962d9f6f2763e5d0fc024a9a574122a) | `mautrix-facebook: unstable-2022-05-06 → 0.4.1`                                                      |
| [`647ed242`](https://github.com/NixOS/nixpkgs/commit/647ed242dcfbebd62b5f5e6880da347ac705544f) | `nixos/adguardhome: allow for empty/unmanaged configs`                                               |
| [`e322e383`](https://github.com/NixOS/nixpkgs/commit/e322e3837905a6dfed591f42056e9be8bee8ca5f) | `matrix-appservice-discord: run pre/post hooks for overridden phases`                                |
| [`895da4ca`](https://github.com/NixOS/nixpkgs/commit/895da4caae76d086db8e36a1e0993720649729fc) | `matrix-appservice-discord: 1.0.0 -> 3.1.0`                                                          |
| [`2309cbb2`](https://github.com/NixOS/nixpkgs/commit/2309cbb25eb8673a494a0e51c56000e20228714e) | `terraform-providers.baiducloud: 1.18.0 -> 1.18.2`                                                   |
| [`d16e4549`](https://github.com/NixOS/nixpkgs/commit/d16e4549e7e9d4497de65cf5159eff557b8ad4de) | `terraform-providers.tencentcloud: 1.78.10 → 1.78.11`                                                |
| [`0ec17ef8`](https://github.com/NixOS/nixpkgs/commit/0ec17ef85ecd316a2f344715edd646a4222037e3) | `terraform-providers.alicloud: 1.191.0 → 1.192.0`                                                    |
| [`a4ca36ca`](https://github.com/NixOS/nixpkgs/commit/a4ca36cab12d81ad0d1b48ea5009cb2f1f7b47ca) | `terraform-providers.newrelic: 3.7.0 → 3.7.1`                                                        |
| [`5470a0eb`](https://github.com/NixOS/nixpkgs/commit/5470a0ebf4d59829468c57719f4b7323dd3c1933) | `terraform-providers.cloudflare: 3.27.0 → 3.28.0`                                                    |
| [`8ab639a6`](https://github.com/NixOS/nixpkgs/commit/8ab639a6b718c8bee820f6c4216706158a5560b3) | `ocamlPackages.qcheck: 0.19.1 → 0.20`                                                                |
| [`ca7fcd72`](https://github.com/NixOS/nixpkgs/commit/ca7fcd72f41ce1363cf7326bf929319c976ab5ea) | `moar: init at 1.10.0`                                                                               |
| [`62b78d1e`](https://github.com/NixOS/nixpkgs/commit/62b78d1eade02c63a8df938ede8b13e3ea581e63) | `licenses: add bsd2WithViews`                                                                        |
| [`70e77a3f`](https://github.com/NixOS/nixpkgs/commit/70e77a3fa68364cb7cfa9d2258e32925e26fcd9e) | `vimPlugins.barbecue-nvim: init at 2022-11-16`                                                       |
| [`5a9d6739`](https://github.com/NixOS/nixpkgs/commit/5a9d6739de4748e809dc9b22fe39b88387c1d34a) | `vimPlugins: update`                                                                                 |
| [`eced8c3e`](https://github.com/NixOS/nixpkgs/commit/eced8c3ed46dc374075c4d4a53f73e6482e8e664) | `maintainers: add lightquantum`                                                                      |
| [`b70d4b90`](https://github.com/NixOS/nixpkgs/commit/b70d4b9009be9e274986ef7110b86860004aea00) | `gatling: mark as broken`                                                                            |
| [`ef0edbb5`](https://github.com/NixOS/nixpkgs/commit/ef0edbb5c45c8ed298306c464d45bbcb30c79c5d) | `doggo: enable darwin support`                                                                       |
| [`58419cf3`](https://github.com/NixOS/nixpkgs/commit/58419cf37c1e1d9d4313a04cd1aa70108f011327) | `copper: mark as broken`                                                                             |
| [`c6fae535`](https://github.com/NixOS/nixpkgs/commit/c6fae535ace02000fbeb76a7792fd65a133c421c) | `touchegg: 2.0.14 -> 2.0.15`                                                                         |
| [`51244a00`](https://github.com/NixOS/nixpkgs/commit/51244a007b3cd93531bd3f68099b1822c289ee3b) | `pantheon.wingpanel-applications-menu: 2.10.2 -> 2.11.0`                                             |
| [`b18da0df`](https://github.com/NixOS/nixpkgs/commit/b18da0dfe8fa0c6a36447e4cef0b1a7dd638f2c5) | `pantheon.elementary-greeter: 6.1.0 -> 6.1.1`                                                        |
| [`09473b44`](https://github.com/NixOS/nixpkgs/commit/09473b448d928af334d62909e76f245a93f7c755) | `python310Packages.miniaudio: 1.54 -> 1.55`                                                          |
| [`b37c519c`](https://github.com/NixOS/nixpkgs/commit/b37c519c1aadea7f7f91bef05137fa1996d89ab3) | `pantheon.elementary-photos: 2.7.5 -> 2.8.0`                                                         |
| [`e6dfda0f`](https://github.com/NixOS/nixpkgs/commit/e6dfda0f19dedf570dcd516e5cfd76f4d2d74184) | `Revert "unifi-poller: 2.1.3 -> 2.1.7"`                                                              |
| [`61d4e5b8`](https://github.com/NixOS/nixpkgs/commit/61d4e5b8652ad96f06313950c77ad31f48d7c631) | `pantheon.elementary-files: 6.2.0 -> 6.2.1`                                                          |
| [`c54a8f58`](https://github.com/NixOS/nixpkgs/commit/c54a8f58b45cec6a48ba2ff957a66209a124422d) | `pantheon.elementary-calendar: 6.1.1 -> 6.1.2`                                                       |
| [`639550cc`](https://github.com/NixOS/nixpkgs/commit/639550cc2ee630320b4c5029f09c028e20abe94a) | `matcha-gtk-theme: 2022-06-07 -> 2022-11-15 (#201410)`                                               |
| [`61aa1a26`](https://github.com/NixOS/nixpkgs/commit/61aa1a2664e63a87ed4d3afe6c09085bb46967d3) | `python310Packages.dill: add passthru tests`                                                         |
| [`da3200b7`](https://github.com/NixOS/nixpkgs/commit/da3200b7b67aa53f549123b279e61ece80f65ce4) | `Revert "gplates: fix failing build"`                                                                |
| [`2505b572`](https://github.com/NixOS/nixpkgs/commit/2505b57295e463db4acd473c32b4eba089954689) | `micronaut: 1.3.7 -> 3.7.2 (#197945)`                                                                |
| [`fd019e44`](https://github.com/NixOS/nixpkgs/commit/fd019e4495f09e2d7c7f334f59c1f2e85bf71856) | `python310Packages.pushover-complete: enable tests`                                                  |
| [`651cc63d`](https://github.com/NixOS/nixpkgs/commit/651cc63d4d8dbac5705d59aedba2b530904d431d) | `ruff: 0.0.120 -> 0.0.121`                                                                           |
| [`3a98554c`](https://github.com/NixOS/nixpkgs/commit/3a98554ce62a76c1dbe8aecdb5479084148dd818) | `netatalk: refactor`                                                                                 |
| [`4e4a021f`](https://github.com/NixOS/nixpkgs/commit/4e4a021fd77d4af89b7576e6187444df97379707) | `d-seams: fix failing builds`                                                                        |
| [`d145c522`](https://github.com/NixOS/nixpkgs/commit/d145c5222bdf1c1866a69a4b1c82311cf4df8c99) | `terraria-server: 1.4.4.2 -> 1.4.4.8.1`                                                              |
| [`75143fad`](https://github.com/NixOS/nixpkgs/commit/75143fad73bf3a09ba0b763d3e6bf52fb147685a) | `yq-go: 4.30.1 -> 4.30.4`                                                                            |
| [`d951688f`](https://github.com/NixOS/nixpkgs/commit/d951688f801820e628cc9001ea3012e0ddef6fa2) | `addlicense: unstable-2021-04-22 -> 1.1.0`                                                           |
| [`b97cda7d`](https://github.com/NixOS/nixpkgs/commit/b97cda7d44aa78fe915df7b0c18e3d6ed9edd157) | `mpv-unwrapped: 0.34.1 -> 0.35.0`                                                                    |
| [`9a2f7b87`](https://github.com/NixOS/nixpkgs/commit/9a2f7b878cb7ee63d6d7234bffa41e1e5c21f41a) | `librewolf: 106.0.3-1 -> 107.0-1`                                                                    |
| [`a428cc4a`](https://github.com/NixOS/nixpkgs/commit/a428cc4a2d3982f2db74c0a3526823f84b3362f5) | `cargo-raze: 0.12.0 -> 0.16.0`                                                                       |
| [`085e3f41`](https://github.com/NixOS/nixpkgs/commit/085e3f41c9a84c64bf7e6fd74521232116e1d27f) | `ruff: 0.0.119 -> 0.0.120`                                                                           |
| [`43bf542c`](https://github.com/NixOS/nixpkgs/commit/43bf542ccd8f439964a049f1586689de20bbadb1) | `tests.trivial-builders.linkFarm: init`                                                              |
| [`63825986`](https://github.com/NixOS/nixpkgs/commit/6382598677548d5b483dce4ab380067cd91af6d2) | `linkFarm: make last entry win in case of list repeats`                                              |
| [`3380742d`](https://github.com/NixOS/nixpkgs/commit/3380742d55bdb2d9c0c3584b88d73702e5bbb95d) | `python310Packages.pysvn: 1.9.12 -> 1.9.18`                                                          |
| [`eee76d2b`](https://github.com/NixOS/nixpkgs/commit/eee76d2b660cf596fd0dda1fe30bb2a119ef0c80) | `python310Packages.pikepdf: 6.2.2 -> 6.2.4`                                                          |
| [`845038dc`](https://github.com/NixOS/nixpkgs/commit/845038dc31a2f3cb6c6fef2ab7829ddf6bfc40d6) | `protonvpn-gui: add meta.mainProgram`                                                                |
| [`a93aed5b`](https://github.com/NixOS/nixpkgs/commit/a93aed5bab972d3b5201d6067ecec998d8d62eaa) | `linkFarm: allow entries to be an attrset`                                                           |
| [`b54257fb`](https://github.com/NixOS/nixpkgs/commit/b54257fb36b7d2c05778e6ff177dffad965186f4) | `linkFarm: add entries to passthru`                                                                  |
| [`946634f5`](https://github.com/NixOS/nixpkgs/commit/946634f56d19b022ee6171683f351ba15545de59) | `kubecolor: 0.0.20 -> 0.0.21`                                                                        |
| [`ad351809`](https://github.com/NixOS/nixpkgs/commit/ad35180922422d828a38e2d0e990a11d4148ccfd) | `appthreat-depscan: 2.2.1 -> 2.3.0`                                                                  |
| [`f7bed8cd`](https://github.com/NixOS/nixpkgs/commit/f7bed8cd449852a75fa46cb42fd1d18f096c7b1d) | `nixos/nginx: fix default listen port options`                                                       |
| [`c3717875`](https://github.com/NixOS/nixpkgs/commit/c371787587daf9e372eb24586aa4bb5fb6bc3c47) | `jwasm: 2.15 -> 2.16`                                                                                |
| [`3a856243`](https://github.com/NixOS/nixpkgs/commit/3a856243be8806696b14964f26bd11118a76fb4b) | `jwasm: add changelog page`                                                                          |
| [`3931b0b6`](https://github.com/NixOS/nixpkgs/commit/3931b0b6cf495b723ef0c86a0553bb6e88cb6bf9) | `asl: 142-bld211 -> 142-bld232`                                                                      |
| [`d6e3679c`](https://github.com/NixOS/nixpkgs/commit/d6e3679cc543200b0da5318190edb65f717a4d08) | `libreddit: 0.23.1 -> 0.24.0`                                                                        |
| [`3f5e89e6`](https://github.com/NixOS/nixpkgs/commit/3f5e89e6468dc56f558b3293bb8d72996ea6ac6c) | `rure: 0.2.1 -> 0.2.2`                                                                               |
| [`f478baba`](https://github.com/NixOS/nixpkgs/commit/f478baba650b3374a82f17ff3534794a7c36a78e) | `xfce.xfce4-settings: 4.16.4 -> 4.16.5`                                                              |
| [`88e0973f`](https://github.com/NixOS/nixpkgs/commit/88e0973f46ad4f000049b42f42104e11b5d01afb) | `nc4nix: unstable-2022-11-12 -> unstable-2022-11-13`                                                 |
| [`aec2518c`](https://github.com/NixOS/nixpkgs/commit/aec2518c5b144ed2a8d2b7f2a07fb3632a4e42e2) | `nextcloudPackages: init`                                                                            |
| [`1177e17c`](https://github.com/NixOS/nixpkgs/commit/1177e17c282f515bcee3255dd7ec64fb1e035fe3) | `nil: 2022-11-07 -> 2022-11-15`                                                                      |
| [`d3ccf64a`](https://github.com/NixOS/nixpkgs/commit/d3ccf64ae14abd26b44f725a1b0aed10654d0aa9) | `gh: 2.20.0 -> 2.20.2`                                                                               |
| [`6b476b87`](https://github.com/NixOS/nixpkgs/commit/6b476b87dfc19407f71eb430593c004380f7cc74) | `terraform-providers.gitlab: 3.18.0 -> 3.19.0`                                                       |
| [`78578070`](https://github.com/NixOS/nixpkgs/commit/785780706e9cedab2f32a74c8a121c679a8f7b7e) | `terraform-providers: support gitlab source`                                                         |
| [`1a24e792`](https://github.com/NixOS/nixpkgs/commit/1a24e79270dbfb4948ce66dbb442a9e3f5d22dbb) | `libsigrokdecode: unpin python dependency`                                                           |
| [`e3a720db`](https://github.com/NixOS/nixpkgs/commit/e3a720db368ed39b2f471d3431b294b6b800c9d6) | `dune_3: 3.5.0 -> 3.6.0`                                                                             |
| [`0d94bc12`](https://github.com/NixOS/nixpkgs/commit/0d94bc12c754d50f402702fcdccc47375f140455) | `python310Packages.aiopvapi: 2.0.3 -> 2.0.4`                                                         |
| [`f8d028f2`](https://github.com/NixOS/nixpkgs/commit/f8d028f2715cb8eb54945288902d118b0f7f77fb) | `python3Packages.datasets: fix build after dill bump`                                                |
| [`76085e22`](https://github.com/NixOS/nixpkgs/commit/76085e2232eb58df477274350cac10b4bdabb920) | `openshot-qt: fix Python 3.10 incompatibility`                                                       |
| [`f62a898c`](https://github.com/NixOS/nixpkgs/commit/f62a898c4fdc272008620eb01f2a377fbda3f515) | `bcompare: 4.4.2.26348 -> 4.4.4.27058`                                                               |
| [`48e236c7`](https://github.com/NixOS/nixpkgs/commit/48e236c7e0153035b6c8198fe56ebcedb44ebedb) | `ksmoothdock: patch out -Werror`                                                                     |
| [`360080de`](https://github.com/NixOS/nixpkgs/commit/360080de176a26a572384ea308e623f01eeeea3d) | `kmplayer: fix cmake configuration`                                                                  |
| [`e3cf5440`](https://github.com/NixOS/nixpkgs/commit/e3cf54408754eaf4c801ed057d8d75ebc58efe45) | `krunner-pass: fix cmake configuration`                                                              |
| [`de55c527`](https://github.com/NixOS/nixpkgs/commit/de55c52759db280803dc8f9a89e7e05d9111d525) | `icewm: 3.2.1 -> 3.2.2`                                                                              |
| [`af810aa2`](https://github.com/NixOS/nixpkgs/commit/af810aa23290ce98e34208fd1559f82197d0b562) | `vimPlugins.nvim-treesitter: move grammar generation from fetch to grammar.nix`                      |
| [`0660bc5f`](https://github.com/NixOS/nixpkgs/commit/0660bc5fb18bb387f8538bce521884c1efa309fe) | `ruff: 0.0.118 -> 0.0.119`                                                                           |
| [`065e85e8`](https://github.com/NixOS/nixpkgs/commit/065e85e8add709b5b3a3b2fe243fde9c41bea022) | `libstroke: use xorg.* packages directly instead of xlibsWrapper indirection`                        |
| [`9f52572d`](https://github.com/NixOS/nixpkgs/commit/9f52572d09a9b8ea12c7536ec203e65c5537436b) | `mautrix-telegram: fix build`                                                                        |
| [`2964d34b`](https://github.com/NixOS/nixpkgs/commit/2964d34b7cca77ca496b5c033f66e94cdfa210d0) | `rust-audit-info: 0.5.1 -> 0.5.2`                                                                    |
| [`01c9df23`](https://github.com/NixOS/nixpkgs/commit/01c9df23e87b6233d8e560436a65a7767a081a0d) | `cargo-auditable: 0.5.3 -> 0.5.4`                                                                    |
| [`f75b2066`](https://github.com/NixOS/nixpkgs/commit/f75b20666736d255199693f12048d43f3872f717) | `cargo-edit: 0.11.5 -> 0.11.6`                                                                       |
| [`ab8b9ca3`](https://github.com/NixOS/nixpkgs/commit/ab8b9ca3de11ce372f05256a43f334487cca7099) | `gnomeExtensions: auto-update`                                                                       |
| [`53b6d3d9`](https://github.com/NixOS/nixpkgs/commit/53b6d3d9f6114fbe579dc537f11f66a57644dd89) | `containerd: 1.6.9 -> 1.6.10`                                                                        |
| [`749bdf10`](https://github.com/NixOS/nixpkgs/commit/749bdf10232590a1f56f1ce45ab412a2028b1f80) | `python310Packages.tox: 3.26.0 -> 3.27.1`                                                            |
| [`5fd09198`](https://github.com/NixOS/nixpkgs/commit/5fd091987a63c00acd84e4d3a3444bd2ffd01d0c) | `karchive: add new dependency`                                                                       |
| [`37228188`](https://github.com/NixOS/nixpkgs/commit/372281881bbd3526b2e9b38b2835356b3d2bbff7) | `extra-cmake-modules: drop merged patch`                                                             |
| [`39f75847`](https://github.com/NixOS/nixpkgs/commit/39f75847d44e4dec1ff9ed126df8cb093d24158b) | `tela-circle-icon-theme: fix eval`                                                                   |
| [`11e7a67a`](https://github.com/NixOS/nixpkgs/commit/11e7a67aa6afab6af75aac7ac80fdc3c994f8e63) | `ludusavi: fix eval`                                                                                 |
| [`6164b7bb`](https://github.com/NixOS/nixpkgs/commit/6164b7bb61395b4488919ca4bbdf918d96a7d4ab) | `kde-frameworks: 5.99 -> 5.100`                                                                      |
| [`0c48d381`](https://github.com/NixOS/nixpkgs/commit/0c48d381677004bd7c1a6534461ce7fe7f8844cc) | `desmume: mark as broken on linux-aarch64`                                                           |
| [`43421bb7`](https://github.com/NixOS/nixpkgs/commit/43421bb7ea9c9c08c4a329fbb5dd0b00ce15b025) | `desmume: 0.9.11+unstable=2021-09-22 -> 0.9.13`                                                      |
| [`db320184`](https://github.com/NixOS/nixpkgs/commit/db320184662a595b8181ed9bfa684cb22a6c4418) | `dialog: 1.3-20211214 -> 1.3-20220728`                                                               |
| [`0b7f7b95`](https://github.com/NixOS/nixpkgs/commit/0b7f7b954d0b4157c515246b80de0ec868547d63) | `ares: 129 -> 130.1`                                                                                 |
| [`f35f6ff9`](https://github.com/NixOS/nixpkgs/commit/f35f6ff9f962ca65503ae5f9e2759476920ad461) | `fceux: refactor to new overlay-style overridable attributes`                                        |
| [`7cac4e55`](https://github.com/NixOS/nixpkgs/commit/7cac4e5579179149a4f7f6082f0dd05ae8b129b0) | `doublecmd: refactor to new overlay-style overridable attributes`                                    |
| [`50ab8ea4`](https://github.com/NixOS/nixpkgs/commit/50ab8ea46092e7a6fda8756f2cd5320b0279f495) | `sublime-merge: 2077 -> 2079`                                                                        |
| [`98fb7354`](https://github.com/NixOS/nixpkgs/commit/98fb73549339eba604eb59ca729042bff1dd18c4) | `sublime4: 4142 -> 4143`                                                                             |
| [`bd2baae6`](https://github.com/NixOS/nixpkgs/commit/bd2baae6d1a514aec1c5e57bfa7b6f1804c9b85a) | `grilo: add darwin support`                                                                          |
| [`0b5f3fed`](https://github.com/NixOS/nixpkgs/commit/0b5f3feddfbab46425fdbf325630f3f3dec659aa) | `dleyna-*: add darwin support`                                                                       |
| [`9e5bc1df`](https://github.com/NixOS/nixpkgs/commit/9e5bc1df9b2156faeb93537b3362491266153636) | `gupnp-*: add darwin support`                                                                        |
| [`aba8af9a`](https://github.com/NixOS/nixpkgs/commit/aba8af9a02c55241fb4bce562c08e20de4939777) | `batman-adv: 2022.1 -> 2022.3`                                                                       |
| [`e3a7c410`](https://github.com/NixOS/nixpkgs/commit/e3a7c410a77fb7ddcd24755ce1406e2994f068bc) | `jemalloc: fix aarch64-darwin build`                                                                 |
| [`c4d1b71e`](https://github.com/NixOS/nixpkgs/commit/c4d1b71ec5b3d6fb7052d3c16382a98c3a3a2e9f) | `synergy: use xorg.* packages directly instead of xlibsWrapper indirection`                          |
| [`980a853c`](https://github.com/NixOS/nixpkgs/commit/980a853c7fa42a23ce2b874cd1224a35b048497f) | `python3Packages.wandb: 0.13.4 -> 0.13.5`                                                            |
| [`adb97478`](https://github.com/NixOS/nixpkgs/commit/adb9747831855c4ead513c7d558b4d1ac40f56ac) | `flightgear: Fix missing libcurl depedency`                                                          |
| [`86ccaac0`](https://github.com/NixOS/nixpkgs/commit/86ccaac0dec8542488de0db57e3567d5a02c051a) | `python310Packages.wand: rename from Wand`                                                           |
| [`3ef8ee6b`](https://github.com/NixOS/nixpkgs/commit/3ef8ee6b24bd31ad00ce49fbd88b19be0ddd98ec) | `python310Packages.Wand: run tests`                                                                  |
| [`2eb9e002`](https://github.com/NixOS/nixpkgs/commit/2eb9e002fc119f77585d5e699dee36fb7f484525) | `python310Packages.libsass: 0.21.0 -> 0.22.0`                                                        |
| [`3ec4e3b0`](https://github.com/NixOS/nixpkgs/commit/3ec4e3b0ba0f3065efa08a16abadc3be3183427b) | `victoriametrics: 1.83.0 -> 1.83.1`                                                                  |
| [`576649e6`](https://github.com/NixOS/nixpkgs/commit/576649e65ac261e15b024435b5cb7b99950bc7d4) | `python310Packages.cypari2: 2.1.2 -> 2.1.3`                                                          |
| [`9fee934b`](https://github.com/NixOS/nixpkgs/commit/9fee934b09e36d873fd4d65f09dd4f8c501b0286) | `redis-desktop-manager: 0.9.1 -> 2022.5, rename to RESP.app`                                         |
| [`6cf7ef30`](https://github.com/NixOS/nixpkgs/commit/6cf7ef3010b061a7ea36a59335a24d3da7b83260) | `linux-zen: 6.0.7-zen1 -> 6.0.8-zen1`                                                                |
| [`f0f42c08`](https://github.com/NixOS/nixpkgs/commit/f0f42c08cea4fcf14df04e5a3b58d5acef37c836) | `linux-lqx: 6.0.7-lqx1 -> 6.0.8-lqx1`                                                                |
| [`80703c41`](https://github.com/NixOS/nixpkgs/commit/80703c4155cf59431ae1c595e203334b806278f7) | `gdal: don't depend on kea`                                                                          |
| [`3885b6dd`](https://github.com/NixOS/nixpkgs/commit/3885b6dd38d7b1a627217c0cdfe5228901136746) | `proj: don't add cURL dependency to CMake config`                                                    |
| [`82f891e2`](https://github.com/NixOS/nixpkgs/commit/82f891e22985a69e5fc8f35c9fca181137072cc2) | `python310Packages.basemap: 1.3.4 -> 1.3.6`                                                          |
| [`ac986f05`](https://github.com/NixOS/nixpkgs/commit/ac986f055a7d451a3683325b1bda94595e2c3740) | `python310Packages.pyproj: 3.3.1 -> 3.4.0`                                                           |
| [`12455a5d`](https://github.com/NixOS/nixpkgs/commit/12455a5d74a1adcada34366cd20d6d4002356d27) | `proj: 9.0.0 -> 9.1.0`                                                                               |
| [`f375a123`](https://github.com/NixOS/nixpkgs/commit/f375a1234a73689fac05e5362cd7682bf4acc941) | `openturns: 1.19 -> 1.20`                                                                            |
| [`e71f3433`](https://github.com/NixOS/nixpkgs/commit/e71f343311e08d49d40811c59191cad1cc4d28ab) | `krita: 5.1.1 -> 5.1.3`                                                                              |
| [`19b48bbc`](https://github.com/NixOS/nixpkgs/commit/19b48bbc5a94fe7100e2876943ef5636a46cd002) | `python3Packages.gpiozero: disable on darwin`                                                        |
| [`9071413f`](https://github.com/NixOS/nixpkgs/commit/9071413f400781d7d460a7d45d3686eaa6d443ce) | `onefetch: minor improvements, add figsoda as a maintainer`                                          |
| [`76ac62dc`](https://github.com/NixOS/nixpkgs/commit/76ac62dcdcb77e7e15040846753844b3f4d98206) | `nut: fix search modes not finding dynamic libs`                                                     |
| [`f938099d`](https://github.com/NixOS/nixpkgs/commit/f938099de1beafc96ddb979537d8e1288e12071c) | `nixos/modules/config/gtk/gtk-icon-cache: do not generate icon caches for files in $out/share/icons` |
| [`2a212e1d`](https://github.com/NixOS/nixpkgs/commit/2a212e1dfd8dbe8a74801c4fe8e527692bbddb39) | `ulauncher: 5.12.1 -> 5.15.0`                                                                        |
| [`98edc9b2`](https://github.com/NixOS/nixpkgs/commit/98edc9b2531827abd557d6455829b036354cb5ad) | `linuxPackages.rtl8723ds: init at unstable-2022-10-20`                                               |
| [`5d4321b7`](https://github.com/NixOS/nixpkgs/commit/5d4321b70390eba3ef64cc4154d22e51cb0daaba) | `linja-pi-pu-lukin: init at unstable-2021-10-29`                                                     |
| [`9bebad44`](https://github.com/NixOS/nixpkgs/commit/9bebad4487fb9670e557199e85016839a1d5868f) | `sitelen-seli-kiwen: init at unstable-2022-06-28`                                                    |
| [`c4f95388`](https://github.com/NixOS/nixpkgs/commit/c4f9538875af001e6173b192874e2826eab2a148) | `nixos/peertube: fix start services`                                                                 |
| [`15959cdc`](https://github.com/NixOS/nixpkgs/commit/15959cdc5f52889585b85abc16c23c17f3d2c73f) | `nixos/peertube: add quic header to nginx configuration`                                             |
| [`d4296648`](https://github.com/NixOS/nixpkgs/commit/d4296648b504b77760025eae2daf1342f1f5bdc9) | `nixos/peertube: add hsts header to nginx configuration`                                             |
| [`f237e2b8`](https://github.com/NixOS/nixpkgs/commit/f237e2b83e12a1eecc5e61c05ca3f1994469c9a9) | `onefetch: 2.12.0 -> 2.13.2`                                                                         |
| [`9a91d12b`](https://github.com/NixOS/nixpkgs/commit/9a91d12bcd83e344fef21214c377fb4e63d0de27) | `mapnik: unstable-2022-04-14 -> unstable-2022-10-18`                                                 |
| [`f75026a9`](https://github.com/NixOS/nixpkgs/commit/f75026a9372020df8bd2eadaa170f40e888c5e19) | `python3Packages.apsw: 3.39.3.0 -> 3.39.4.0`                                                         |
| [`e9384700`](https://github.com/NixOS/nixpkgs/commit/e9384700049b04cfcd79c3e890bf45111d3a917c) | `python3Packages.pipenv-poetry-migrate: 0.2.0 -> 0.2.1`                                              |
| [`7bcfaeb2`](https://github.com/NixOS/nixpkgs/commit/7bcfaeb21d57b8b926432bf017a94f030fbb2df8) | `gdal: fix build on darwin`                                                                          |
| [`434f16a7`](https://github.com/NixOS/nixpkgs/commit/434f16a76492b34b9b43271c65754d332e1fca58) | `brunsli: fix building on darwin`                                                                    |
| [`33ea1392`](https://github.com/NixOS/nixpkgs/commit/33ea1392610f5e8dba09a98cba24f09ef25795cc) | `brunsli: tidy patching`                                                                             |
| [`3d999388`](https://github.com/NixOS/nixpkgs/commit/3d9993882980bba5e7ef2cee63960179b8a174f3) | `kea: fix build on darwin`                                                                           |
| [`e0fb27cc`](https://github.com/NixOS/nixpkgs/commit/e0fb27cc3200d5a52fd9d697bc849365038b0a58) | `python3Packages.reorder-python-imports: 3.8.5 -> 3.9.0`                                             |
| [`5d916d42`](https://github.com/NixOS/nixpkgs/commit/5d916d42b0914232bc81c820e212404e0a108c2e) | `gdal: skip test failing when using PROJ < 8`                                                        |
| [`b8d78c77`](https://github.com/NixOS/nixpkgs/commit/b8d78c77609ad0a5269f76828053ceab07effce3) | `packwiz: unstable-2022-09-25 -> unstable-2022-10-29`                                                |
| [`189a229b`](https://github.com/NixOS/nixpkgs/commit/189a229b6d4055eb50d9b61ccecff2e0fef68a4a) | `python3Packages.python-mapnik: unstable-2020-02-24 -> unstable-2020-09-08`                          |
| [`d35077ae`](https://github.com/NixOS/nixpkgs/commit/d35077ae8bfeba5004438046bffd9515fef33214) | `mapnik: 3.1.0 -> unstable-2022-04-14`                                                               |
| [`7c224b3e`](https://github.com/NixOS/nixpkgs/commit/7c224b3e127ad37b27f31aaa71ae5959320bd492) | `python310Packages.fiona: fix tests with GDAL 3.5.1`                                                 |
| [`d0f3893d`](https://github.com/NixOS/nixpkgs/commit/d0f3893da05c234cd48a4c7985707b795e963c1f) | `gplates: use python39`                                                                              |
| [`dcd559e0`](https://github.com/NixOS/nixpkgs/commit/dcd559e08192c8253b7e4027f39b7fd58f655cfb) | `gdal: 3.4.2 -> 3.5.2`                                                                               |
| [`b3f94fd5`](https://github.com/NixOS/nixpkgs/commit/b3f94fd518d6004e497b717e5466da046fb5a6e1) | `lerc: init at 3.0`                                                                                  |