### PR TITLE
chore(flake/emacs-overlay): `098c2a81` -> `9964dcc6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668663206,
-        "narHash": "sha256-rxV9n36VINDJq6acFq5kuT2jYOBzaedDW0TXF2iViVE=",
+        "lastModified": 1668685722,
+        "narHash": "sha256-/WfMEsCoJIYfgRylM7S+BFNhkLjah91jqU6ZWJVxdNw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "098c2a810c937564bff3f57fc406be9c144283ae",
+        "rev": "9964dcc695b86aa188e5884384b38e2d8832950d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`9964dcc6`](https://github.com/nix-community/emacs-overlay/commit/9964dcc695b86aa188e5884384b38e2d8832950d) | `Updated repos/nongnu` |
| [`c9a123e3`](https://github.com/nix-community/emacs-overlay/commit/c9a123e3d03cdd3a89b448123237618d4fcfae30) | `Updated repos/melpa`  |
| [`5d321bc0`](https://github.com/nix-community/emacs-overlay/commit/5d321bc0b453ef6da1224d126cda443f6e9613a3) | `Updated repos/emacs`  |