### PR TITLE
chore(flake/nur): `bb1f7e0b` -> `d2d033f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668693329,
-        "narHash": "sha256-Vo9bKWr9QioM52jDRynHYw/kElAcMa89iufFQ3ZJSvI=",
+        "lastModified": 1668704975,
+        "narHash": "sha256-4KmUwR2FqXKAX1h6AuOLC6ASZy6I9ChtUzgWxkuged4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bb1f7e0be1e69ddd933814533560ba76ade284b8",
+        "rev": "d2d033f5c45982795a9f73c63d4745a9570c817a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d2d033f5`](https://github.com/nix-community/NUR/commit/d2d033f5c45982795a9f73c63d4745a9570c817a) | `automatic update` |