### PR TITLE
chore(flake/emacs-overlay): `9964dcc6` -> `39ecc84b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668685722,
-        "narHash": "sha256-/WfMEsCoJIYfgRylM7S+BFNhkLjah91jqU6ZWJVxdNw=",
+        "lastModified": 1668715867,
+        "narHash": "sha256-mw72NphT6/ZQNt5OsVEk1txgE/AKJ76eV1EUXQvbDlQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9964dcc695b86aa188e5884384b38e2d8832950d",
+        "rev": "39ecc84bfb684c442ea89f31d513f80ae383470b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                            |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
| [`39ecc84b`](https://github.com/nix-community/emacs-overlay/commit/39ecc84bfb684c442ea89f31d513f80ae383470b) | `Add tree-sitter-bash to list of plugins` |