### PR TITLE
chore(flake/emacs-overlay): `39ecc84b` -> `51c6e49b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668715867,
-        "narHash": "sha256-mw72NphT6/ZQNt5OsVEk1txgE/AKJ76eV1EUXQvbDlQ=",
+        "lastModified": 1668718165,
+        "narHash": "sha256-GLWQRgl3dJiucomkb/XCFHk+cgP2WEkpLZhSWH4l6oc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "39ecc84bfb684c442ea89f31d513f80ae383470b",
+        "rev": "51c6e49b08c37ab762c1bdc8060e569197001dfe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`51c6e49b`](https://github.com/nix-community/emacs-overlay/commit/51c6e49b08c37ab762c1bdc8060e569197001dfe) | `Updated repos/melpa` |
| [`df92c810`](https://github.com/nix-community/emacs-overlay/commit/df92c8103baa668b53189e742e989d2b4ad8d577) | `Updated repos/emacs` |