### PR TITLE
chore(flake/nur): `d2d033f5` -> `6e103ce9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668704975,
-        "narHash": "sha256-4KmUwR2FqXKAX1h6AuOLC6ASZy6I9ChtUzgWxkuged4=",
+        "lastModified": 1668717409,
+        "narHash": "sha256-uSgod4fiI4K52T63nnmo23PEugOJEti1tWZT912FmLM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d2d033f5c45982795a9f73c63d4745a9570c817a",
+        "rev": "6e103ce9e5a76afb75d93f3a936577d911299e1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6e103ce9`](https://github.com/nix-community/NUR/commit/6e103ce9e5a76afb75d93f3a936577d911299e1e) | `automatic update` |