### PR TITLE
chore(flake/emacs-ement): `98745950` -> `a0144517`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1668718662,
-        "narHash": "sha256-hq0l3378TRXcx4Xl/q+cxUMhrkqmxwKksTgR8+voM7E=",
+        "lastModified": 1668725836,
+        "narHash": "sha256-8rEwfJ40XxnQVQ5t3xM7OSTAn9ObzNCur1BwlAk3ouI=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "98745950b673790c5648e67cc75b83da94b5b018",
+        "rev": "a0144517607915ae2f93276a7dd735e18fc1441f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                       |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`a0144517`](https://github.com/alphapapa/ement.el/commit/a0144517607915ae2f93276a7dd735e18fc1441f) | `Release: v0.5`                                                      |
| [`7c4a407b`](https://github.com/alphapapa/ement.el/commit/7c4a407b04ebf90cfb12b65c97cefd5fd0866abf) | `Fix: Continue replying in compose buffers`                          |
| [`955acd65`](https://github.com/alphapapa/ement.el/commit/955acd65225e063ed2ad60e439b9acf4194b9969) | `Change: (ement-room-write-reply) Rename from ement-room-send-reply` |