### PR TITLE
chore(flake/emacs-ement): `a0144517` -> `0d4a3040`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1668725836,
-        "narHash": "sha256-8rEwfJ40XxnQVQ5t3xM7OSTAn9ObzNCur1BwlAk3ouI=",
+        "lastModified": 1668726637,
+        "narHash": "sha256-nHhJEW/oTq0uv6FyRHX/dujtqgByYzQAgOWw63OR5KM=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "a0144517607915ae2f93276a7dd735e18fc1441f",
+        "rev": "0d4a3040c7feca2e06b156ea30eaa2905f1ed12d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message  |
| --------------------------------------------------------------------------------------------------- | --------------- |
| [`0d4a3040`](https://github.com/alphapapa/ement.el/commit/0d4a3040c7feca2e06b156ea30eaa2905f1ed12d) | `Release: v0.5` |