### PR TITLE
chore(flake/nur): `6e103ce9` -> `a8e05a2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668717409,
-        "narHash": "sha256-uSgod4fiI4K52T63nnmo23PEugOJEti1tWZT912FmLM=",
+        "lastModified": 1668733123,
+        "narHash": "sha256-iEP+//bEYA+AeyUL+QT8YSKMLUbnr4mIaMAVn8leUBw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6e103ce9e5a76afb75d93f3a936577d911299e1e",
+        "rev": "a8e05a2e54079ae69cd378641e23fb5566ef1ac6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a8e05a2e`](https://github.com/nix-community/NUR/commit/a8e05a2e54079ae69cd378641e23fb5566ef1ac6) | `automatic update` |