### PR TITLE
chore(flake/nixpkgs): `b457130e` -> `54be84c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668596599,
-        "narHash": "sha256-rhHyZTGI31/OfgYa9xF49UTchDXTI94pEsSNa0fOkpk=",
+        "lastModified": 1668671332,
+        "narHash": "sha256-6QW9sTuLDcBLoR5EY+6LR7Y1k0dFVEMqcWY4jYOuiqM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b457130e8a21608675ddf12c7d85227b22a27112",
+        "rev": "54be84c3ac0122c2b2272fc68a9015304bc0bb73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                  |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`54be84c3`](https://github.com/NixOS/nixpkgs/commit/54be84c3ac0122c2b2272fc68a9015304bc0bb73) | `pass2csv: 0.3.2 -> 1.0.0`                                                      |
| [`0b3c49e5`](https://github.com/NixOS/nixpkgs/commit/0b3c49e57a26a9cdfa492c1ca5545373987b0ade) | `lisgd: 0.3.5 -> 0.3.6`                                                         |
| [`396ba2dd`](https://github.com/NixOS/nixpkgs/commit/396ba2dd17956d991bd0eb97f91e7f0a234401ff) | `rootlesskit: 1.0.1 -> 1.1.0`                                                   |
| [`ebf34bdb`](https://github.com/NixOS/nixpkgs/commit/ebf34bdb533f61cfd364a3082e5913a5e094204a) | `terraform-providers.vault: 3.10.0 → 3.11.0`                                    |
| [`edfd1a3a`](https://github.com/NixOS/nixpkgs/commit/edfd1a3af100ac8fd531ed6c7fb758fd6947e61a) | `terraform-providers.oci: 4.99.0 → 4.100.0`                                     |
| [`21e97bb3`](https://github.com/NixOS/nixpkgs/commit/21e97bb3dc38df96382757a4005cbcdd8ef534a7) | `terraform-providers.opentelekomcloud: 1.31.7 → 1.31.8`                         |
| [`4412d8b2`](https://github.com/NixOS/nixpkgs/commit/4412d8b2b569d8948fa8255fc9c2d109fda3e729) | `terraform-providers.google-beta: 4.43.0 → 4.43.1`                              |
| [`61c0b1fb`](https://github.com/NixOS/nixpkgs/commit/61c0b1fb68214fe83d9f815b97039d7d6ae105e2) | `terraform-providers.google: 4.43.0 → 4.43.1`                                   |
| [`0cf52fa9`](https://github.com/NixOS/nixpkgs/commit/0cf52fa9fff50be20d294ff39a2beef8fb4a4330) | `terraform-providers.fastly: 2.4.0 → 3.0.0`                                     |
| [`9f8fd12a`](https://github.com/NixOS/nixpkgs/commit/9f8fd12a1c093d8a2a0e1011e095a0362b6d6aa9) | `terraform-providers.digitalocean: 2.23.0 → 2.24.0`                             |
| [`8d3254af`](https://github.com/NixOS/nixpkgs/commit/8d3254afaf432a3d9861e90cebdbd049699270e6) | `ssh-to-age: 1.0.2 -> 1.0.3`                                                    |
| [`3a86856a`](https://github.com/NixOS/nixpkgs/commit/3a86856a13c88c8c64ea32082a851fefc79aa700) | `gh-dash: 3.4.2 -> 3.5.1`                                                       |
| [`c089e2b9`](https://github.com/NixOS/nixpkgs/commit/c089e2b91735c3ef073f0909e240289cccc1e488) | `melt: 0.4.1 -> 0.5.0`                                                          |
| [`e26059fb`](https://github.com/NixOS/nixpkgs/commit/e26059fb71886b42d92591a431e4c2afacf9ae7a) | `brev-cli: 0.6.170 -> 0.6.176`                                                  |
| [`62fcb867`](https://github.com/NixOS/nixpkgs/commit/62fcb86736ae64958a866dfe09ecbe860445ec3c) | `datree: 1.7.3 -> 1.8.0`                                                        |
| [`b9d8e648`](https://github.com/NixOS/nixpkgs/commit/b9d8e64847e41fe7c73f027d56846eaa03a03307) | `goeland: 0.11.0 -> 0.12.1`                                                     |
| [`3ac91d27`](https://github.com/NixOS/nixpkgs/commit/3ac91d2719a982c9a92d01e55b36250ba06542d2) | `libplctag: 2.5.3 -> 2.5.4`                                                     |
| [`7b70b812`](https://github.com/NixOS/nixpkgs/commit/7b70b8122483ab7f30cd0ec35c586e693bbfb30a) | `ferium: 4.2.1 -> 4.2.2`                                                        |
| [`47a678b5`](https://github.com/NixOS/nixpkgs/commit/47a678b594dff84761b08558d73d87dcfa4b52aa) | `redli: 0.6.0 -> 0.7.0`                                                         |
| [`a0cea97e`](https://github.com/NixOS/nixpkgs/commit/a0cea97ebe27ab1c8f6ee159c2fffa67cae4b0cd) | `netbird: 0.10.7 -> 0.10.8`                                                     |
| [`bd713dae`](https://github.com/NixOS/nixpkgs/commit/bd713daea62313358aa2c8cddd2f354fd98e1f82) | `oxker: 0.1.6 -> 0.1.7`                                                         |
| [`f209de7e`](https://github.com/NixOS/nixpkgs/commit/f209de7ef2e4c205eb3c2c24fafb678ac2bcc6e6) | `operator-sdk: 1.25.1 -> 1.25.2`                                                |
| [`c3571072`](https://github.com/NixOS/nixpkgs/commit/c35710721b2923689d82baa8ac1c538bc1fdfbc9) | `cava: 0.8.2 -> 0.8.3`                                                          |
| [`02210afe`](https://github.com/NixOS/nixpkgs/commit/02210afe4faa6f921a02620fe3247402c07a7aeb) | `imgui: 1.88 -> 1.89`                                                           |
| [`e216dbeb`](https://github.com/NixOS/nixpkgs/commit/e216dbebfdd8d193a402e3efd5316d19722471b5) | `radioboat: 0.2.2 -> 0.2.3`                                                     |
| [`5f4cfa67`](https://github.com/NixOS/nixpkgs/commit/5f4cfa67e6f7e92d8acddeebd8f56d1098ffa81e) | `ipcalc: add patch to disable tests failing in Darwin sandbox`                  |
| [`47709a98`](https://github.com/NixOS/nixpkgs/commit/47709a986a4630fa8580db245c33a66aa7d60eb3) | `psst: unstable-2022-05-19 -> 2022-10-13`                                       |
| [`1d6f6c0e`](https://github.com/NixOS/nixpkgs/commit/1d6f6c0ec656835191a2970b360fb3558c522f76) | `buildah: refactor wrapper`                                                     |
| [`a0c079f6`](https://github.com/NixOS/nixpkgs/commit/a0c079f6521934632ec023a9f1a72855c452ea19) | `podman: refactor wrapper`                                                      |
| [`684ffc10`](https://github.com/NixOS/nixpkgs/commit/684ffc109ebf4f611cc2b91a37a39541eff4c166) | `cri-o: refactor wrapper`                                                       |
| [`4dabd9c3`](https://github.com/NixOS/nixpkgs/commit/4dabd9c39b217ed2798ca9780ce27afd5bf738e3) | `linux: 6.0.8 -> 6.0.9`                                                         |
| [`63adc7fa`](https://github.com/NixOS/nixpkgs/commit/63adc7fafe7dfbfdc96754ebe65bdb6cf3a65ec8) | `linux: 5.15.78 -> 5.15.79`                                                     |
| [`bd9a5606`](https://github.com/NixOS/nixpkgs/commit/bd9a5606b4773948e699b6fe98622dfe69a2a7b1) | `linux: 5.10.154 -> 5.10.155`                                                   |
| [`667767d4`](https://github.com/NixOS/nixpkgs/commit/667767d439515f62bb1c45cb6abc281095c6a98f) | `samba4: 4.17.2 -> 4.17.3`                                                      |
| [`eb8b2d71`](https://github.com/NixOS/nixpkgs/commit/eb8b2d71428eb6ad5c7b9a56fe28b01ce434894c) | `nixos/docs: document picom module changes`                                     |
| [`6785dae7`](https://github.com/NixOS/nixpkgs/commit/6785dae7483bfd5ef3596ddee74726fa541cb850) | `nixos/picom: remove experimentalBackends option`                               |
| [`a29510ba`](https://github.com/NixOS/nixpkgs/commit/a29510ba1a8d4f347d6ebabe850626a61fade2ea) | `duckdb: 0.5.1 -> 0.6.0`                                                        |
| [`2fcfc5f3`](https://github.com/NixOS/nixpkgs/commit/2fcfc5f3c136467d4154399cd7af500e702b5d06) | `picom: 9.1 -> 10`                                                              |
| [`80e1bfb0`](https://github.com/NixOS/nixpkgs/commit/80e1bfb0347f04b14d8f0c28e4f1dad66d8b7e9c) | `zfp: 0.5.5 -> 1.0.0, fix issues`                                               |
| [`5df86d63`](https://github.com/NixOS/nixpkgs/commit/5df86d63053f0c95d06693dcbdbe27b64131a72a) | `vscode-extensions.bmalehorn.vscode-fish: init at 1.0.31`                       |
| [`7cef955f`](https://github.com/NixOS/nixpkgs/commit/7cef955fab4c08130d36634e7e2e89bdecddad62) | `vscode-extensions.thenuprojectcontributors.vscode-nushell-lang: init at 0.7.0` |
| [`7eac2c13`](https://github.com/NixOS/nixpkgs/commit/7eac2c13e6f1a3a9efe7606c7c90029f2cef48e8) | `python310Packages.git-annex-adapter: fix tests`                                |
| [`a8d318b5`](https://github.com/NixOS/nixpkgs/commit/a8d318b5728fbb038bc097688b9140874c3f60cd) | `vscode-extensions.matangover.mypy: init at 0.2.2`                              |
| [`7cb62293`](https://github.com/NixOS/nixpkgs/commit/7cb6229334cecda7592a6df2a23a2d19549044f1) | `python310Packages.graphviz: 0.20 -> 0.20.1`                                    |
| [`6995b471`](https://github.com/NixOS/nixpkgs/commit/6995b471b4a212028ea32e7f2bddef0e6c6b846f) | `python310Packages.huawei-lte-api: 1.6.6 -> 1.6.7`                              |
| [`646ca73d`](https://github.com/NixOS/nixpkgs/commit/646ca73d81e28b421fba64d97a7b8998906ea6d6) | `python310Packages.aprslib: 0.7.1 -> 0.7.2`                                     |
| [`216e161b`](https://github.com/NixOS/nixpkgs/commit/216e161b69cf9909b1e263dc8694ca7e20898a93) | `meilisearch: 0.29.1 -> 0.29.2`                                                 |
| [`b88a8ae8`](https://github.com/NixOS/nixpkgs/commit/b88a8ae8eaf89f264f640b230b36e99ed3dd6944) | `libdeltachat: 1.100.0 -> 1.101.0`                                              |
| [`f0a73a2a`](https://github.com/NixOS/nixpkgs/commit/f0a73a2a02a5402168f00e797222a1bb9068ba5d) | `python310Packages.keyring: 23.9.3 -> 23.11.0`                                  |
| [`b60a96d0`](https://github.com/NixOS/nixpkgs/commit/b60a96d063dcd4d229c0891b4aef99374a4952b5) | `clojure: 1.11.1.1189 -> 1.11.1.1200`                                           |
| [`432467df`](https://github.com/NixOS/nixpkgs/commit/432467df113250aa9fa77653c1607c7e527d2199) | `python310Packages.check-manifest: fix tests`                                   |
| [`dcfe88be`](https://github.com/NixOS/nixpkgs/commit/dcfe88be5c7e5552d26bb6468fe6ba8f81d98c4e) | `oh-my-posh: 12.13.0 -> 12.13.3`                                                |
| [`6c4166cc`](https://github.com/NixOS/nixpkgs/commit/6c4166ccb9a468b5423859110a9a0aa29840fcab) | `python3Packages.latexify-py: init at 0.2.0`                                    |
| [`3313844e`](https://github.com/NixOS/nixpkgs/commit/3313844e4e30b9542cee8e35ececa8bd54d946bd) | `adw-gtk3: 4.0 -> 4.1`                                                          |
| [`0e332ecb`](https://github.com/NixOS/nixpkgs/commit/0e332ecb95b7e82a1796d534fe501a3288ea28de) | `meerk40t: 0.8.0031 -> 0.8.1000`                                                |
| [`a110f08f`](https://github.com/NixOS/nixpkgs/commit/a110f08f12eb10a25e1e0c7545c13e1246d0da25) | `ocamlPackages.extlib: rename from ocaml_extlib`                                |
| [`a834cc84`](https://github.com/NixOS/nixpkgs/commit/a834cc840fddf422d8b8ba6c2b06726cdacf2eec) | `ocamlPackages.ocaml_extlib: 1.7.8 -> 1.7.9`                                    |
| [`14e0c0db`](https://github.com/NixOS/nixpkgs/commit/14e0c0dba242ec4acd2b29769d27434e896c65a4) | `gnatinspect, gnatcoll-db2ada: drop gnatcoll- prefix from pname`                |
| [`35b623b8`](https://github.com/NixOS/nixpkgs/commit/35b623b82b7ac751a76ba32d26f21a2d340da102) | `gnatcoll-{lzma,gmp,iconv,omp,python3,readline,syslog,zlib}: 22.0.0 -> 23.0.0`  |
| [`30908712`](https://github.com/NixOS/nixpkgs/commit/30908712726f2647823daaddab1262b14a13f454) | `gnatcoll-{sql*,postgres,xref,db2ada}, gnatinspect: 22.0.0 -> 23.0.0`           |
| [`a1647c38`](https://github.com/NixOS/nixpkgs/commit/a1647c38b6a1f24b872f04dfa135b435270ce343) | `gnatcoll-core: 22.0.0 -> 23.0.0`                                               |
| [`e3ef549a`](https://github.com/NixOS/nixpkgs/commit/e3ef549a597c096a30303fa19146a57e31e8a483) | `gprbuild, gprbuild-boot: 22.0.0 -> 23.0.0`                                     |
| [`9a7a5256`](https://github.com/NixOS/nixpkgs/commit/9a7a5256fdc21669bf076441ad24d6035f5f395c) | `xmlada: 22.0.0 -> 23.0.0`                                                      |
| [`4e658264`](https://github.com/NixOS/nixpkgs/commit/4e65826439f45a5a760d45c4c4d07ce2971f5b62) | `surrealdb: init at 1.0.0-beta.8`                                               |
| [`22b96bfb`](https://github.com/NixOS/nixpkgs/commit/22b96bfb353a5198845782325ed5269c8e4b7278) | ``dwarf-therapist: pass through `meta```                                        |
| [`8b713a99`](https://github.com/NixOS/nixpkgs/commit/8b713a9958634bf5263ee4d37ecc88d219f02c56) | `keeperrl: alpha28 -> alpha34`                                                  |
| [`67aacbb9`](https://github.com/NixOS/nixpkgs/commit/67aacbb937fc35710cf7101d42d1f1aa5fcbed72) | `dwarf-therapist: restrict platforms to x86`                                    |
| [`4d68c2f0`](https://github.com/NixOS/nixpkgs/commit/4d68c2f0ba402642584f17c6b5fe478d32087c3f) | ``remove dead `make-symlinks` builder``                                         |
| [`4bcb88fa`](https://github.com/NixOS/nixpkgs/commit/4bcb88fa2611f685587f8c3de5e1a81024c67b89) | `jwx: 2.0.6 -> 2.0.7`                                                           |
| [`959585a2`](https://github.com/NixOS/nixpkgs/commit/959585a2ed1bf19ed6dbb8dea2568790a944c800) | `coyim: tweak platforms`                                                        |
| [`b4b5dfd5`](https://github.com/NixOS/nixpkgs/commit/b4b5dfd542db9f71c08b457027c60c6785565b15) | `vimPlugins.nvim-treesitter: check queries in passthru.tests`                   |
| [`dc6a5f24`](https://github.com/NixOS/nixpkgs/commit/dc6a5f24fe9333578f7d93c9609e1898e5dfc469) | `ruff: 0.0.121 -> 0.0.122`                                                      |
| [`626e0a13`](https://github.com/NixOS/nixpkgs/commit/626e0a13a32644d711b9a2899a9818b976a62199) | `git-credential-keepassxc: init at 0.10.1`                                      |
| [`bbea26a3`](https://github.com/NixOS/nixpkgs/commit/bbea26a395e78f1f5bec3d781747c14c532dec94) | `python310Packages.ibm-watson: remove not required tox requirement`             |
| [`b28ecff1`](https://github.com/NixOS/nixpkgs/commit/b28ecff1e6ffc17c23314c528c77f082f2b88f4c) | `nixos: Add util-linux to systemd PATH to fix fsck with systemd 251.6`          |
| [`acecd1ec`](https://github.com/NixOS/nixpkgs/commit/acecd1ec7bc009b644e9a6dc64d164583eb23860) | `Revert "nixos: Fix fsck with systemd 251.6 and later"`                         |
| [`3b6c0372`](https://github.com/NixOS/nixpkgs/commit/3b6c0372c86bd2f7d5faca942c40e2f0934e0ac0) | `consul: 1.13.3 -> 1.14.0`                                                      |
| [`4a599be7`](https://github.com/NixOS/nixpkgs/commit/4a599be7758b743b2ba2c87e2ac2f46b3e68e620) | `lunatic: 0.10.1 -> 0.12.0`                                                     |
| [`0dd4e5e1`](https://github.com/NixOS/nixpkgs/commit/0dd4e5e12b0b76169e8bec8963c9e996779126e2) | `jenkins: 2.361.3 -> 2.361.4`                                                   |
| [`4b5d9e65`](https://github.com/NixOS/nixpkgs/commit/4b5d9e651457910ad87c0abd1433475b11183691) | `discourse: 2.9.0.beta11 -> 2.9.0.beta12`                                       |
| [`8e4f5036`](https://github.com/NixOS/nixpkgs/commit/8e4f5036eea2e694efc65d758d0b820b6b0dc18f) | `CONTRIBUTING: Reference release notes in package bumps`                        |
| [`118e531c`](https://github.com/NixOS/nixpkgs/commit/118e531c2d1b80389a69fce0a24c0258fff2e5a7) | `samba: fix cross-compilation`                                                  |
| [`d3819072`](https://github.com/NixOS/nixpkgs/commit/d3819072613a7ecbee4d75b65dc6c38693e52086) | `sympa: 6.2.68 -> 6.2.70`                                                       |
| [`a705b941`](https://github.com/NixOS/nixpkgs/commit/a705b9411cb71bc64e264662f9dad063e110c2c3) | `sic: 1.2 → 1.3`                                                                |
| [`c35b5503`](https://github.com/NixOS/nixpkgs/commit/c35b5503f4da5ceeb12ba4370703e18575229f22) | `dsview: 1.1.2 -> 1.2.1`                                                        |
| [`661ee45c`](https://github.com/NixOS/nixpkgs/commit/661ee45c0c3214a184ee11f87a82dcb2ae89b13a) | `icinga2: 2.13.5 -> 2.13.6`                                                     |
| [`5d07c39b`](https://github.com/NixOS/nixpkgs/commit/5d07c39b149797c710ff09abda3ad90da231d53e) | `nixos/power-management: fix deadlock with post-resume.{target,service}`        |
| [`233205c4`](https://github.com/NixOS/nixpkgs/commit/233205c4646e4d1e62ef4da15bf143008945060c) | `rustBuildCrate: properly handle cargo env pragmas with spaces`                 |