### PR TITLE
chore(flake/nur): `a8e05a2e` -> `9bb7ec5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668733123,
-        "narHash": "sha256-iEP+//bEYA+AeyUL+QT8YSKMLUbnr4mIaMAVn8leUBw=",
+        "lastModified": 1668739092,
+        "narHash": "sha256-kIA+OhZUfo6Pdr8KrAq2SUhgSvGtpxLH5u9a0bcqTus=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a8e05a2e54079ae69cd378641e23fb5566ef1ac6",
+        "rev": "9bb7ec5fc7eb43f2b00a59b6b0d8d8db014511d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9bb7ec5f`](https://github.com/nix-community/NUR/commit/9bb7ec5fc7eb43f2b00a59b6b0d8d8db014511d9) | `automatic update` |