### PR TITLE
chore(flake/nur): `9bb7ec5f` -> `5e05b2e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668739092,
-        "narHash": "sha256-kIA+OhZUfo6Pdr8KrAq2SUhgSvGtpxLH5u9a0bcqTus=",
+        "lastModified": 1668742598,
+        "narHash": "sha256-QyBkwGHaiM0S3PV8SMEgAni/m2wxIl/4825WNqya1vs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9bb7ec5fc7eb43f2b00a59b6b0d8d8db014511d9",
+        "rev": "5e05b2e9f046c4ea1b92600bbd5d7f9f271aa380",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5e05b2e9`](https://github.com/nix-community/NUR/commit/5e05b2e9f046c4ea1b92600bbd5d7f9f271aa380) | `automatic update` |