### PR TITLE
chore(flake/nur): `5e05b2e9` -> `f9cc225c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668742598,
-        "narHash": "sha256-QyBkwGHaiM0S3PV8SMEgAni/m2wxIl/4825WNqya1vs=",
+        "lastModified": 1668744626,
+        "narHash": "sha256-t+YhPw33jkLrsx3Its+8dlhrm3EBh3s544a0N00H6M4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5e05b2e9f046c4ea1b92600bbd5d7f9f271aa380",
+        "rev": "f9cc225c06873f023db4e6dcc1e0e43b9607d340",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f9cc225c`](https://github.com/nix-community/NUR/commit/f9cc225c06873f023db4e6dcc1e0e43b9607d340) | `automatic update` |
| [`01978215`](https://github.com/nix-community/NUR/commit/0197821554aa407a6609dc54a8e8b6c4e7c32c22) | `automatic update` |