### PR TITLE
chore(flake/emacs-overlay): `51c6e49b` -> `4e74a795`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668718165,
-        "narHash": "sha256-GLWQRgl3dJiucomkb/XCFHk+cgP2WEkpLZhSWH4l6oc=",
+        "lastModified": 1668750036,
+        "narHash": "sha256-FsHQgWte8LpSkRNEIqysFpq4WNve0pchZOJbYeVbmuI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "51c6e49b08c37ab762c1bdc8060e569197001dfe",
+        "rev": "4e74a7957f391f4e086fa4e524d140a0fde37c3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`4e74a795`](https://github.com/nix-community/emacs-overlay/commit/4e74a7957f391f4e086fa4e524d140a0fde37c3b) | `Updated repos/nongnu` |
| [`10f4d8b2`](https://github.com/nix-community/emacs-overlay/commit/10f4d8b2abb398bcf327136a39d9ae9e1d09d5c9) | `Updated repos/melpa`  |
| [`9d4d7f88`](https://github.com/nix-community/emacs-overlay/commit/9d4d7f888359a991936f496c93303f5f84a90d3f) | `Updated repos/emacs`  |