### PR TITLE
chore(flake/emacs-overlay): `4e74a795` -> `f301f0c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668750036,
-        "narHash": "sha256-FsHQgWte8LpSkRNEIqysFpq4WNve0pchZOJbYeVbmuI=",
+        "lastModified": 1668771835,
+        "narHash": "sha256-YfRdrE8qvIzAXlJsLPeIsKcPlP7KVxZOrap8J1DCkrs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4e74a7957f391f4e086fa4e524d140a0fde37c3b",
+        "rev": "f301f0c632a7af8681a02eca35b3e1d271be2c37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`f301f0c6`](https://github.com/nix-community/emacs-overlay/commit/f301f0c632a7af8681a02eca35b3e1d271be2c37) | `Updated repos/melpa` |
| [`344e943a`](https://github.com/nix-community/emacs-overlay/commit/344e943a6590691b1bdaa3fdca3d4f5fba1ffffb) | `Updated repos/emacs` |