### PR TITLE
chore(flake/darwin): `4182ad42` -> `6349b99b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668534244,
-        "narHash": "sha256-8sgzegrEVUZMJUg4jEiC6pokeMPY02BFe49iXnVrXkk=",
+        "lastModified": 1668784520,
+        "narHash": "sha256-gGgVAMwYPPmrfnvnoRi6OkEB5KRsNTb9uYzEceLdO/g=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "4182ad42d5fb5001adb1f61bec3a04fae0eecb95",
+        "rev": "6349b99bc2b96ded34d068a88c7c5ced406b7f7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                         |
| ------------------------------------------------------------------------------------------------ | -------------------------------------- |
| [`34c4a4cf`](https://github.com/LnL7/nix-darwin/commit/34c4a4cf9057d5eea84ba7320bbb742b54f129a5) | `chore: update flake.lock`             |
| [`7d0d40ed`](https://github.com/LnL7/nix-darwin/commit/7d0d40ed26bf60173a09b14c6f1e5fd33bd4cbe9) | `docs: update flake input for example` |