### PR TITLE
chore(flake/nixpkgs): `54be84c3` -> `52b2ac8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668671332,
-        "narHash": "sha256-6QW9sTuLDcBLoR5EY+6LR7Y1k0dFVEMqcWY4jYOuiqM=",
+        "lastModified": 1668765800,
+        "narHash": "sha256-rC40+/W6Hio7b/RsY8SvQPKNx4WqNcTgfYv8cUMAvJk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "54be84c3ac0122c2b2272fc68a9015304bc0bb73",
+        "rev": "52b2ac8ae18bbad4374ff0dd5aeee0fdf1aea739",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                              |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| [`79c81777`](https://github.com/NixOS/nixpkgs/commit/79c817774c25cef4ed27af5890830afc4560c42b) | `traefik: 2.9.4 -> 2.9.5`                                                                                   |
| [`c3b773d8`](https://github.com/NixOS/nixpkgs/commit/c3b773d802f0987f2f2f670aa6bc695d47c6ae52) | `git-absorb: 0.6.7 -> 0.6.9`                                                                                |
| [`bcb2de44`](https://github.com/NixOS/nixpkgs/commit/bcb2de4443268e009b82f22570567b2b013d5523) | `renameutils: fix package on darwin (#195807)`                                                              |
| [`6e44c96a`](https://github.com/NixOS/nixpkgs/commit/6e44c96a5dcad9baf037177b5017e805f5c692f6) | `soupault: 4.3.0 → 4.3.1`                                                                                   |
| [`3ca85508`](https://github.com/NixOS/nixpkgs/commit/3ca855084a6a016c5d5e361a544025a1d860afdd) | `catch2_3: 3.1.1 -> 3.2.0`                                                                                  |
| [`6b72268e`](https://github.com/NixOS/nixpkgs/commit/6b72268ea8c7cbb525a284e205203e5f4b0b5d3c) | `terraform-providers.tencentcloud: 1.78.11 → 1.78.12`                                                       |
| [`7b90772d`](https://github.com/NixOS/nixpkgs/commit/7b90772d1328da5b3dbb70e51225bc1bdccea137) | `terraform-providers.snowflake: 0.51.0 → 0.52.0`                                                            |
| [`b70c4433`](https://github.com/NixOS/nixpkgs/commit/b70c44331bead2d1071b05058941c6b2b85924d9) | `terraform-providers.selectel: 3.8.5 → 3.9.0`                                                               |
| [`4353672e`](https://github.com/NixOS/nixpkgs/commit/4353672e75286109bc2e8db026059b4b989d6678) | `terraform-providers.opennebula: 1.0.1 → 1.0.2`                                                             |
| [`0ef22f55`](https://github.com/NixOS/nixpkgs/commit/0ef22f55eb90ae1e38bb23b52b889cd99daea027) | `terraform-providers.null: 3.2.0 → 3.2.1`                                                                   |
| [`88e8f180`](https://github.com/NixOS/nixpkgs/commit/88e8f180a474de001ef0ee5ee50f23479567c610) | `terraform-providers.mongodbatlas: 1.5.0 → 1.6.0`                                                           |
| [`81e91041`](https://github.com/NixOS/nixpkgs/commit/81e91041a10269837f172308704465196d741bd9) | `terraform-providers.aws: 4.39.0 → 4.40.0`                                                                  |
| [`2c091502`](https://github.com/NixOS/nixpkgs/commit/2c091502a80047fb28985e3a87bc315831bc2310) | `terraform-providers.minio: 1.9.0 → 1.9.1`                                                                  |
| [`d045c23a`](https://github.com/NixOS/nixpkgs/commit/d045c23ae097ab109d48fedef22fcf8e22d36a29) | `terraform-providers.exoscale: 0.41.0 → 0.41.1`                                                             |
| [`9276a552`](https://github.com/NixOS/nixpkgs/commit/9276a552387c55a96ba365cf7210913d51d7a089) | `terraform-providers.bitbucket: 2.21.4 → 2.22.0`                                                            |
| [`1d119562`](https://github.com/NixOS/nixpkgs/commit/1d1195626d4a0d82fa66002b21a6751f56d93dbe) | `terraform-providers.azurerm: 3.31.0 → 3.32.0`                                                              |
| [`b39bb37e`](https://github.com/NixOS/nixpkgs/commit/b39bb37ec2dc650b963e20d052e95402a088aae9) | `blas-reference: 3.10.0 -> 3.11.0`                                                                          |
| [`4324d95b`](https://github.com/NixOS/nixpkgs/commit/4324d95bf9a7c596a6e4667d3731a8a109874e99) | `nodejs-19_x: 19.0.1 -> 19.1.0`                                                                             |
| [`72ff99d0`](https://github.com/NixOS/nixpkgs/commit/72ff99d064c51ffcce3fd6099c213d5d2be1c532) | `python310Packages.pydata-sphinx-theme: 0.11.0 -> 0.12.0`                                                   |
| [`1525fc3a`](https://github.com/NixOS/nixpkgs/commit/1525fc3a1f359756d5e4b7d32dcaafc77c791f06) | `python310Packages.sphinxcontrib_httpdomain: 1.8.0 -> 1.8.1`                                                |
| [`5d539b62`](https://github.com/NixOS/nixpkgs/commit/5d539b62a2418a8ef823f64146588542dce23ca9) | `python310Packages.huggingface-hub: 0.10.1 -> 0.11.0`                                                       |
| [`8f8b6e37`](https://github.com/NixOS/nixpkgs/commit/8f8b6e37db334a6edfdecf2da015493416096b59) | `python310Packages.gspread: 5.6.2 -> 5.7.1`                                                                 |
| [`03e7eabb`](https://github.com/NixOS/nixpkgs/commit/03e7eabb5868b72d9230172bb487cc2f04d62ead) | `python3Packages.clip: init at unstable-2022-11-17`                                                         |
| [`ef5ded20`](https://github.com/NixOS/nixpkgs/commit/ef5ded2009ab41c9aa828f941ec42912a66fa216) | `python3Packages.termgraph: init at 0.5.3`                                                                  |
| [`e7f13761`](https://github.com/NixOS/nixpkgs/commit/e7f13761d4ffb27f0e3f95d159f75ae6d8a96e69) | `fnm: 1.31.1 -> 1.32.0`                                                                                     |
| [`89763f5d`](https://github.com/NixOS/nixpkgs/commit/89763f5da8da39d85a110124cb0570483fdf205e) | `ytt: 0.43.0 -> 0.44.0`                                                                                     |
| [`4a731bc8`](https://github.com/NixOS/nixpkgs/commit/4a731bc888a8c41ceeeb8c56cab3723d5f4432fa) | `maintainers: add maxux`                                                                                    |
| [`c3e81d96`](https://github.com/NixOS/nixpkgs/commit/c3e81d966284e61f4b327c56fb051c0ca417672b) | `sentry-cli: 2.8.1 -> 2.9.0`                                                                                |
| [`e27b8127`](https://github.com/NixOS/nixpkgs/commit/e27b8127dd1dd30b390e206883e87e41839e0678) | `ruplacer: 0.8.0 -> 0.8.1`                                                                                  |
| [`13b6f07b`](https://github.com/NixOS/nixpkgs/commit/13b6f07b87bd2b3117cd965c3372049ef2e50a01) | `esbuild: 0.15.13 -> 0.15.14`                                                                               |
| [`4be4e691`](https://github.com/NixOS/nixpkgs/commit/4be4e691e2b27a0f57313a2ec4c071ffaf0459ea) | `sccache: 0.3.0 -> 0.3.1`                                                                                   |
| [`f3465641`](https://github.com/NixOS/nixpkgs/commit/f34656418c2208c5aebc7e2e3693883f6410d5d1) | `cargo-make: 0.36.2 -> 0.36.3`                                                                              |
| [`dfa38332`](https://github.com/NixOS/nixpkgs/commit/dfa3833276f2de2b58042b79beb0398bdd0aab96) | `cargo-release: 0.23.0 -> 0.23.1`                                                                           |
| [`c3f650c3`](https://github.com/NixOS/nixpkgs/commit/c3f650c367b6a1311164e61f9fb5a355f0be63ca) | `google-fonts: add font selection parameter (#201556)`                                                      |
| [`4bd2de6e`](https://github.com/NixOS/nixpkgs/commit/4bd2de6ec4d3ee5a13e214e63393d985900a6371) | `python310Packages.hahomematic: 2022.11.1 -> 2022.11.2`                                                     |
| [`8819f633`](https://github.com/NixOS/nixpkgs/commit/8819f6338b662593674849998db2a85b13b80801) | `open-stage-control: 1.18.3 -> 1.20.0`                                                                      |
| [`b491cf37`](https://github.com/NixOS/nixpkgs/commit/b491cf37844f86e3eab570aa38948f645e1a6788) | `eksctl: 0.118.0 -> 0.119.0`                                                                                |
| [`32292827`](https://github.com/NixOS/nixpkgs/commit/322928278ac0d8ec72c2de139d9d093cf74a4791) | `deno: 1.28.0 -> 1.28.1`                                                                                    |
| [`57c6bb1b`](https://github.com/NixOS/nixpkgs/commit/57c6bb1b89c4be06e5f97d1711707e330e28d97c) | `ruff: 0.0.125 -> 0.0.126`                                                                                  |
| [`fd2e3968`](https://github.com/NixOS/nixpkgs/commit/fd2e3968aeff866f408abe37d40a29de6f274848) | `crowdin-cli: 3.9.0 -> 3.9.1`                                                                               |
| [`b94d3579`](https://github.com/NixOS/nixpkgs/commit/b94d3579aeb1669beb937271b58cbe7da4eb33b8) | `rclone: 1.60.0 -> 1.60.1`                                                                                  |
| [`4ddf92d8`](https://github.com/NixOS/nixpkgs/commit/4ddf92d84519d7a327ab2280649e42aa4eebdc1a) | `cilium-cli: 0.12.6 -> 0.12.7`                                                                              |
| [`29bafee1`](https://github.com/NixOS/nixpkgs/commit/29bafee188ca9ba4ea9a9482dd72bac7a2065f10) | `checkip: 0.42.1 -> 0.43.0`                                                                                 |
| [`48c69a13`](https://github.com/NixOS/nixpkgs/commit/48c69a13e87f96c5aeddedea23e7e34554460405) | `cariddi: 1.1.9 -> 1.2.1`                                                                                   |
| [`f423b345`](https://github.com/NixOS/nixpkgs/commit/f423b34570a098644ce0c876e27e4a7d04985c3e) | `brev-cli: 0.6.176 -> 0.6.179`                                                                              |
| [`6ee815dc`](https://github.com/NixOS/nixpkgs/commit/6ee815dcfeedcb1082bc87749d1cbfc772f4461d) | `terraform: 1.3.4 -> 1.3.5`                                                                                 |
| [`85259e37`](https://github.com/NixOS/nixpkgs/commit/85259e37d8fa8b9f1c3b3086bf125d7b79068ad3) | `hugo: 0.105.0 -> 0.106.0`                                                                                  |
| [`23f765df`](https://github.com/NixOS/nixpkgs/commit/23f765df131eb2bff9cdb89c34ad4c9282e4501d) | `elixir-ls: 0.11.0 -> 0.12.0`                                                                               |
| [`af447367`](https://github.com/NixOS/nixpkgs/commit/af447367ec02414cf16ef95054545a7854b34f00) | `nixos/mastodon: Add turion as maintainer`                                                                  |
| [`d35c9e04`](https://github.com/NixOS/nixpkgs/commit/d35c9e04e67e8c8c22f0a212cba8066b7cd79352) | `mastodon: 3.5.3 -> 4.0.2`                                                                                  |
| [`77187201`](https://github.com/NixOS/nixpkgs/commit/7718720149735af0e9ed8b770c2aaf67dfc64fc3) | `nixos/mastodon: increase RAM for NixOS test vm`                                                            |
| [`bcb09940`](https://github.com/NixOS/nixpkgs/commit/bcb099400699ed76c655c0755ba36ef2f6ed4e8c) | `librewolf: drop upstreamed patch`                                                                          |
| [`0df2046f`](https://github.com/NixOS/nixpkgs/commit/0df2046fc06aba0b54bcd54305cf5dd9fafbbbd2) | `anytype: 0.29.0 -> 0.29.1`                                                                                 |
| [`6b5448d7`](https://github.com/NixOS/nixpkgs/commit/6b5448d7e7a23e8da3ecc0952e03ba42d6c625e1) | `tabnine: 4.4.139 -> 4.4.169`                                                                               |
| [`aa9bbf6f`](https://github.com/NixOS/nixpkgs/commit/aa9bbf6fcff564f8de811286fac174e19026d042) | `pkgsStatic.procps: disable systemd support on static build`                                                |
| [`4c233af4`](https://github.com/NixOS/nixpkgs/commit/4c233af423f85f7e3ae72ea3ab14b84ff11152ac) | `lokinet: 0.9.9 -> 0.9.10`                                                                                  |
| [`6aa94133`](https://github.com/NixOS/nixpkgs/commit/6aa9413328297c0b283a856025201e3a3c65fd6f) | `liquidctl: 1.10.0 -> 1.11.1`                                                                               |
| [`1184ce89`](https://github.com/NixOS/nixpkgs/commit/1184ce89cecd0323cef0fc5708b16221a37b9217) | `vimPlugins.nvim-treesitter: update grammars`                                                               |
| [`b76f72a4`](https://github.com/NixOS/nixpkgs/commit/b76f72a467e30928a7ade5955d463f36874173f2) | `vimPlugins.nvim-dap-go: init at 2022-11-04`                                                                |
| [`935a3b86`](https://github.com/NixOS/nixpkgs/commit/935a3b86986e6aa9ecc8c0692bb796f1f7f9a1e5) | `vimPlugins: update`                                                                                        |
| [`bae8a2c9`](https://github.com/NixOS/nixpkgs/commit/bae8a2c9f20485f78c92d330dc00dd6241b8b39c) | `ruff: 0.0.122 -> 0.0.125`                                                                                  |
| [`f5148df5`](https://github.com/NixOS/nixpkgs/commit/f5148df5a65b3d7f00f196c8da7d06a0c486b65d) | `taxi: add tests and remove application/backends`                                                           |
| [`66c7c0b1`](https://github.com/NixOS/nixpkgs/commit/66c7c0b178eeb65bc68f3008d4640515780cb67d) | `onefetch: fix build on darwin`                                                                             |
| [`b0c6f4ae`](https://github.com/NixOS/nixpkgs/commit/b0c6f4ae0537804b24fdd1b9580d7eb1e7ff6a83) | `nixos/mullvad-vpn: add mullvad-exclude wrapper & systemPackage`                                            |
| [`8a4a8302`](https://github.com/NixOS/nixpkgs/commit/8a4a83024212f0e91cb2564f759b419a18040fdd) | `cargo-public-api: 0.22.0 -> 0.23.0`                                                                        |
| [`a5bd3325`](https://github.com/NixOS/nixpkgs/commit/a5bd33250a65331bf74e98fdf62c76904434a914) | `bundletool: 1.13.0 -> 1.13.1`                                                                              |
| [`9a89d0de`](https://github.com/NixOS/nixpkgs/commit/9a89d0dea0108fd9dd609e0b0bdd25fcfc2e912f) | `vulkan-utils: remove empty package`                                                                        |
| [`631baf26`](https://github.com/NixOS/nixpkgs/commit/631baf26e9b964464bde2c0c7403bb48f9ce6f1e) | `hw-probe: vulkan-utils -> vulkan-tools to fix incorrect dependency`                                        |
| [`2fcba75c`](https://github.com/NixOS/nixpkgs/commit/2fcba75c19b9bae8f99b9d9eca43243571a8bf33) | `onefetch: install shell completions`                                                                       |
| [`39185677`](https://github.com/NixOS/nixpkgs/commit/3918567776379a38cb883daf88244eb72a305743) | `gbinder-python: 1.0.0 -> 1.1.1 (#200878)`                                                                  |
| [`9edba069`](https://github.com/NixOS/nixpkgs/commit/9edba069adac709b3407221fcc28f6afe92c8317) | `vscodium: 1.73.0.22306 -> 1.73.1.22314`                                                                    |
| [`c0d9e956`](https://github.com/NixOS/nixpkgs/commit/c0d9e956e60af8c9d1387b443bd694c15f7c156c) | `ckan: 1.31.0 -> 1.31.2`                                                                                    |
| [`aea5f56b`](https://github.com/NixOS/nixpkgs/commit/aea5f56b83881a9094b21cbd61c33dd4e00fee63) | `ascii-image-converter: 1.12.0 -> 1.13.0`                                                                   |
| [`4510157b`](https://github.com/NixOS/nixpkgs/commit/4510157b4cc9b1558868b831ff2f839afe1503b0) | `tagger: 2022.10.6 -> 2022.11.1-f1`                                                                         |
| [`cbbb6463`](https://github.com/NixOS/nixpkgs/commit/cbbb646333299bd5f2f6b91f3e47b759617452ca) | `python310Packages.azure-mgmt-storage: 20.1.0 -> 21.0.0`                                                    |
| [`4fbb0244`](https://github.com/NixOS/nixpkgs/commit/4fbb0244d282a20d1903778e2162b97d3f873fa9) | `peertube: 4.3.0 -> 4.3.1`                                                                                  |
| [`c156bdf4`](https://github.com/NixOS/nixpkgs/commit/c156bdf40d2f0e64b574ade52c5611d90a0b6273) | `firefox, thunderbird, librewolf: Enable wayland support by default`                                        |
| [`a4aa5b7f`](https://github.com/NixOS/nixpkgs/commit/a4aa5b7fe7a0fd05594541e1d7813f39c74e9079) | `python310Packages.arviz: 0.13.0 -> 0.14.0`                                                                 |
| [`979532e8`](https://github.com/NixOS/nixpkgs/commit/979532e81ba0c25a89976a8d8e048ba118e4f070) | `python310Packages.aiohomekit: 2.2.19 -> 2.3.0`                                                             |
| [`c981c2a4`](https://github.com/NixOS/nixpkgs/commit/c981c2a4c1b4e977aa5f6313694b79bcf132531d) | `wabt: 1.0.30 -> 1.0.31`                                                                                    |
| [`bbbf3c45`](https://github.com/NixOS/nixpkgs/commit/bbbf3c45d5a8350f28f35e5234ebdecfa44d7ec1) | `sumneko-lua-language-server: 3.6.2 -> 3.6.3`                                                               |
| [`14f30827`](https://github.com/NixOS/nixpkgs/commit/14f30827a0b5adff297e8bfda6c42c9a25eb9b96) | `sn0int: 0.24.2 -> 0.24.3`                                                                                  |
| [`87d5df13`](https://github.com/NixOS/nixpkgs/commit/87d5df13d7380f793dcc6ca35698d7bf944bf508) | `home-assistant: 2022.11.2 -> 2022.11.3`                                                                    |
| [`29b5192b`](https://github.com/NixOS/nixpkgs/commit/29b5192b08744a6ff52484950384dd206368bc2e) | `automatic-timezoned: init at 1.0.41`                                                                       |
| [`f2b994a3`](https://github.com/NixOS/nixpkgs/commit/f2b994a384c1161a14947f36fe15e485226767e1) | `chromiumBeta: 108.0.5359.40 -> 108.0.5359.48`                                                              |
| [`efeb5c43`](https://github.com/NixOS/nixpkgs/commit/efeb5c4363b2bc497fe937a52b83521b1f161997) | `python3Packages.pyswitchbot: 0.20.4 -> 0.20.5`                                                             |
| [`3875db56`](https://github.com/NixOS/nixpkgs/commit/3875db56f6d2f03b318a74f2fd3cdea3e41a2c4e) | `python310Packages.bleak-retry-connector: 2.8.3 -> 2.8.4`                                                   |
| [`185a04dc`](https://github.com/NixOS/nixpkgs/commit/185a04dc3e5d97b1278383e610194d3a993b4b67) | `vimPlugins.nvim-treesitter: add plugins to dependencies to avoid extending vimPlugins`                     |
| [`8db07f35`](https://github.com/NixOS/nixpkgs/commit/8db07f3546873e36d70eb1d1ed2df4396620505e) | `exploitdb: 2022-10-18 -> 2022-11-12`                                                                       |
| [`8a1e1572`](https://github.com/NixOS/nixpkgs/commit/8a1e1572089b254583a9b5e5fcb80ce7f7e13bf0) | `exempi: remove gcc6Stdenv override on i686`                                                                |
| [`529ced40`](https://github.com/NixOS/nixpkgs/commit/529ced40735a80499cd12e33b8f9d3a80a95a7a4) | `odpic: 4.5.0 -> 4.6.0`                                                                                     |
| [`c0b9fec0`](https://github.com/NixOS/nixpkgs/commit/c0b9fec0d750530c30616190fd6a0648a5c126f1) | `mastodon-archive: 1.3.1 -> 1.4.2`                                                                          |
| [`6f27359f`](https://github.com/NixOS/nixpkgs/commit/6f27359f0dd6eaa0b84827c841e7d4f0225405dc) | `llama: 1.0.2 -> 1.1.0`                                                                                     |
| [`a545fb2e`](https://github.com/NixOS/nixpkgs/commit/a545fb2e32761ef94d655831897113de3dc60175) | `python310Packages.mastodon-py: 1.5.2 -> 1.6.1`                                                             |
| [`7cf198ce`](https://github.com/NixOS/nixpkgs/commit/7cf198ce2e294d316a4afdca89b9c906a0f60683) | `python310Packages.holidays: 0.16 -> 0.17`                                                                  |
| [`574faaf4`](https://github.com/NixOS/nixpkgs/commit/574faaf47d79b499dcb1bd2645ab06bac38e5b1c) | `heimdal: 7.7.0 -> 7.8.0`                                                                                   |
| [`1f19974a`](https://github.com/NixOS/nixpkgs/commit/1f19974ab690b71fa5c44ba111a7702c92d06ec5) | `python310Packages.scapy: remove coverage,tox dependency`                                                   |
| [`378ed33a`](https://github.com/NixOS/nixpkgs/commit/378ed33aa9134c140baba13aee0d871ba1bbfa84) | `pocket-casts: 0.5.0 -> 0.6.0`                                                                              |
| [`2d788512`](https://github.com/NixOS/nixpkgs/commit/2d788512960586f5d744af24021b786b2ba71c5b) | `efivar: use clickable homepage`                                                                            |
| [`c220703a`](https://github.com/NixOS/nixpkgs/commit/c220703aeea75420753ea3f8e3f0cd401ec80738) | `prismlauncher: 5.1 -> 5.2`                                                                                 |
| [`5fb4db77`](https://github.com/NixOS/nixpkgs/commit/5fb4db779e0c52b06d47df6b53c3cc1eca8d1bf3) | `Add cspell to node-packages`                                                                               |
| [`54b03e5f`](https://github.com/NixOS/nixpkgs/commit/54b03e5f4a8708f7625454563415ae36d4619d02) | `vimPlugins.coc-spell-checker: use a node package`                                                          |
| [`106e5302`](https://github.com/NixOS/nixpkgs/commit/106e5302d76f86cadcc18456624263407e99c783) | `aws-sso-cli: 1.9.4 -> 1.9.5`                                                                               |
| [`2af80901`](https://github.com/NixOS/nixpkgs/commit/2af809015a65810571e7e8d8541b4ca7ba25b8d4) | `nixos/tmux: add withUtempter option`                                                                       |
| [`56a57456`](https://github.com/NixOS/nixpkgs/commit/56a574567998855b5f46d6107edf64ed3e66fd3d) | `tmux: build with utempter`                                                                                 |
| [`1682b3d0`](https://github.com/NixOS/nixpkgs/commit/1682b3d09480122da4c69928a9122a7647ccbf69) | `libutempter: 1.1.6 -> 1.2.1`                                                                               |
| [`b7691ef2`](https://github.com/NixOS/nixpkgs/commit/b7691ef2d35e104c69f47200eeae44996fdb2ce5) | `ipmitool: 1.8.18 -> 1.8.19`                                                                                |
| [`dcb405c6`](https://github.com/NixOS/nixpkgs/commit/dcb405c652eee0918baa6edbbe8b68fd633e6d06) | `wmc-mpris: remove`                                                                                         |
| [`ffb54f78`](https://github.com/NixOS/nixpkgs/commit/ffb54f78f6163fd3c1e29d80e2b801fda72e941e) | `flycast: fix vulkan`                                                                                       |
| [`7a7ce7fa`](https://github.com/NixOS/nixpkgs/commit/7a7ce7fa949b23cf6ffa2b72fb3d6e47a9c843cc) | `omnisharp-roslyn: 1.39.1 -> 1.39.2`                                                                        |
| [`07384107`](https://github.com/NixOS/nixpkgs/commit/07384107611f80429f03e0a2e774cbf1945731f7) | `jitsi-meet-electron: 2022.3.1 -> 2022.10.1`                                                                |
| [`95567a12`](https://github.com/NixOS/nixpkgs/commit/95567a1283e61c86cd4ef3c9aaad81ba6a7a72eb) | `yarn2nix: allow running scripts`                                                                           |
| [`f9254f47`](https://github.com/NixOS/nixpkgs/commit/f9254f470cea648cfb5783f1c6ef691eda037190) | `Update pkgs/os-specific/linux/firmware/firmware-updater/default.nix`                                       |
| [`2ec4eec9`](https://github.com/NixOS/nixpkgs/commit/2ec4eec9fa46bfb5a9ce1489f49d1b3138c72fe4) | `firmware-updater: update hashes`                                                                           |
| [`cb82a002`](https://github.com/NixOS/nixpkgs/commit/cb82a002f8386aa795d9d98741dfdcfead25fe49) | `nixos: correct install summary`                                                                            |
| [`ec8f8f69`](https://github.com/NixOS/nixpkgs/commit/ec8f8f69bd57b9dfd24ed56ef8f3c53c9ee5f453) | `lib/sources: Make pathIsGitRepo not evaluate toString path`                                                |
| [`8c1b0192`](https://github.com/NixOS/nixpkgs/commit/8c1b0192c5cf48e176bd4937787ba548e050395d) | `lib/sources: remove 2 usages of toString on a path which will be read using fileContents`                  |
| [`b67ee6e8`](https://github.com/NixOS/nixpkgs/commit/b67ee6e861903abb04e9024d605dfc7b00922633) | `lib/trivial: fix 'error: cannot decode virtual path '/nix/store/virtual0000000000000000000000005-source''` |
| [`1a61c13b`](https://github.com/NixOS/nixpkgs/commit/1a61c13bfa63c731e7dd245861b4e36e33a7b969) | `java-packages.nix: detect i686 using stdenv.hostPlatform`                                                  |
| [`99e0091c`](https://github.com/NixOS/nixpkgs/commit/99e0091caea00bbf2e6b39cf15cc4186eeb5eec4) | `freetube: 0.17.1 -> 0.18.0`                                                                                |
| [`3daea5fa`](https://github.com/NixOS/nixpkgs/commit/3daea5fa9be672031f97fe3b2c360257821165e5) | `nixos-containers: Make sure same version of nixos-container is used`                                       |