### PR TITLE
chore(flake/nur): `e0538145` -> `5aca1126`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668779689,
-        "narHash": "sha256-qtFph6waBED0C3uIEQ03HfWsgU3H3wWrBZ0pscfc2QU=",
+        "lastModified": 1668787852,
+        "narHash": "sha256-jjawlIfSxoCerF2QGy5NhdRiqYwoW7N4Qb8ecJP1t5w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e0538145bfb82ae6458aa5af3372e2e76dccb24a",
+        "rev": "5aca1126794703f56d8eb76cbf2926fcbe46be35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5aca1126`](https://github.com/nix-community/NUR/commit/5aca1126794703f56d8eb76cbf2926fcbe46be35) | `automatic update` |