### PR TITLE
chore(flake/home-manager): `5589b28e` -> `948d1f8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668787257,
-        "narHash": "sha256-iEQaCmwEy8rm77sBMN0xMMHONMxwbq86TgE48RUs/30=",
+        "lastModified": 1668788863,
+        "narHash": "sha256-FsdUG+YkRX7JZKZm6T44J2h+0pXB1sWA9AobyiozFK0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5589b28e66ccaa13852c8aa58ecb45025e88e67e",
+        "rev": "948d1f8a5cef55a281d4f5d17f3b79df6c82fce1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`948d1f8a`](https://github.com/nix-community/home-manager/commit/948d1f8a5cef55a281d4f5d17f3b79df6c82fce1) | `programs.zsh: generate a more compact config (#3170)` |