### PR TITLE
chore(flake/deploy-rs): `be408237` -> `2a3c5f70`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -116,11 +116,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668453806,
-        "narHash": "sha256-rDyF0essyFdCIo336gI6nPjWhjoczGn701D1JID5wl8=",
+        "lastModified": 1668797197,
+        "narHash": "sha256-0w6iD3GSSQbIeSFVDzAAQZB+hDq670ZTms3d9XI+BtM=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "be40823735bbdc40c1f6b7725c8b74d5a85d8023",
+        "rev": "2a3c5f70eee04a465aa534d8bd4fcc9bb3c4a8ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                           |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`d0c86650`](https://github.com/serokell/deploy-rs/commit/d0c86650424ae60209767a90d5c93012c95b0fec) | `Add option to build on the remote host` |