### PR TITLE
chore(flake/emacs-overlay): `f301f0c6` -> `ec5c4c91`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668771835,
-        "narHash": "sha256-YfRdrE8qvIzAXlJsLPeIsKcPlP7KVxZOrap8J1DCkrs=",
+        "lastModified": 1668800908,
+        "narHash": "sha256-oOaiIa+deOpIJlpOjhjr/Sz9UOtxj7AHbEl0q+5rFT0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f301f0c632a7af8681a02eca35b3e1d271be2c37",
+        "rev": "ec5c4c91b687adf1b705504379b4c2dea6e46a12",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ec5c4c91`](https://github.com/nix-community/emacs-overlay/commit/ec5c4c91b687adf1b705504379b4c2dea6e46a12) | `Updated repos/melpa` |
| [`82d347e7`](https://github.com/nix-community/emacs-overlay/commit/82d347e7e26deb5072f0f71e78a8630d14cea3b9) | `Updated repos/emacs` |