### PR TITLE
chore(flake/nur): `4a521710` -> `2c8ceafa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668799045,
-        "narHash": "sha256-hXl9V71v+5riggYepioMRlI1I42Oagb7AtTbm0u+FSQ=",
+        "lastModified": 1668822541,
+        "narHash": "sha256-Vk0AfjffacNO0ged8RvqtOXEgGFVDu8zCx4EVmkOERw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4a521710572ebf433db2005719941e8dfe9dfbb8",
+        "rev": "2c8ceafa131632c433d88faf8ef63ccb98865ef9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2c8ceafa`](https://github.com/nix-community/NUR/commit/2c8ceafa131632c433d88faf8ef63ccb98865ef9) | `automatic update` |