### PR TITLE
chore(flake/nur): `2c8ceafa` -> `6351bd2c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668822541,
-        "narHash": "sha256-Vk0AfjffacNO0ged8RvqtOXEgGFVDu8zCx4EVmkOERw=",
+        "lastModified": 1668824454,
+        "narHash": "sha256-dRmTF+Q7OWWONiLA02V1hrb5LbwC5sQG1tSWqoFNNcs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2c8ceafa131632c433d88faf8ef63ccb98865ef9",
+        "rev": "6351bd2c119df23086730b5ad7ab8c200f2914e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6351bd2c`](https://github.com/nix-community/NUR/commit/6351bd2c119df23086730b5ad7ab8c200f2914e2) | `automatic update` |