### PR TITLE
chore(flake/nur): `6351bd2c` -> `2e34498b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668824454,
-        "narHash": "sha256-dRmTF+Q7OWWONiLA02V1hrb5LbwC5sQG1tSWqoFNNcs=",
+        "lastModified": 1668830414,
+        "narHash": "sha256-QUhpSEW8/4bXmbyQHfZcfG5omUYopekoookO7kdCjJI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6351bd2c119df23086730b5ad7ab8c200f2914e2",
+        "rev": "2e34498bd7dc39fe7df9706d9c90e2c7465096ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2e34498b`](https://github.com/nix-community/NUR/commit/2e34498bd7dc39fe7df9706d9c90e2c7465096ac) | `automatic update` |
| [`0742a7f6`](https://github.com/nix-community/NUR/commit/0742a7f6c5f9710f08280dfa11a1715a594a22b6) | `automatic update` |