### PR TITLE
chore(flake/nur): `2e34498b` -> `78616417`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668830414,
-        "narHash": "sha256-QUhpSEW8/4bXmbyQHfZcfG5omUYopekoookO7kdCjJI=",
+        "lastModified": 1668830845,
+        "narHash": "sha256-4Fhnwm+Hq76+SgwfIhaQTPb6s3fXyhIeQMs99hjLAPM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2e34498bd7dc39fe7df9706d9c90e2c7465096ac",
+        "rev": "78616417940738382a7914bb68e63f40055335a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`78616417`](https://github.com/nix-community/NUR/commit/78616417940738382a7914bb68e63f40055335a1) | `automatic update` |