### PR TITLE
chore(flake/emacs-overlay): `ec5c4c91` -> `faf39a31`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668800908,
-        "narHash": "sha256-oOaiIa+deOpIJlpOjhjr/Sz9UOtxj7AHbEl0q+5rFT0=",
+        "lastModified": 1668836187,
+        "narHash": "sha256-f38CYfIwYoSUgX2klCm+6v4ViZiVY6DdwdO/rk7GGwg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ec5c4c91b687adf1b705504379b4c2dea6e46a12",
+        "rev": "faf39a31bc76f1cd4eb642d79eeab1d25b038e72",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`faf39a31`](https://github.com/nix-community/emacs-overlay/commit/faf39a31bc76f1cd4eb642d79eeab1d25b038e72) | `Updated repos/nongnu` |
| [`145a6e70`](https://github.com/nix-community/emacs-overlay/commit/145a6e7030dee3e99f23e0721979ce6de65a21cd) | `Updated repos/melpa`  |
| [`7974efb8`](https://github.com/nix-community/emacs-overlay/commit/7974efb896723c113f59414172649f18b04d8e21) | `Updated repos/emacs`  |