### PR TITLE
chore(flake/emacs-overlay): `faf39a31` -> `909b090c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668836187,
-        "narHash": "sha256-f38CYfIwYoSUgX2klCm+6v4ViZiVY6DdwdO/rk7GGwg=",
+        "lastModified": 1668861223,
+        "narHash": "sha256-Y7Jc7n79h7vl7WGDohiSTpc4xdUx/B2n19+zMNjj0js=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "faf39a31bc76f1cd4eb642d79eeab1d25b038e72",
+        "rev": "909b090c1181644ef3def6a37a18e9e3d08d1b07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`909b090c`](https://github.com/nix-community/emacs-overlay/commit/909b090c1181644ef3def6a37a18e9e3d08d1b07) | `Updated repos/melpa` |
| [`2fd65c60`](https://github.com/nix-community/emacs-overlay/commit/2fd65c60a3c43a45f8cdaa47f850a982d06c44b0) | `Updated repos/emacs` |