### PR TITLE
chore(flake/nur): `5fcf9010` -> `7eae2ea4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668856705,
-        "narHash": "sha256-sJXU/vXlB8uifsS+p6hqd13Trrmg56+G41ZCY7XfeOs=",
+        "lastModified": 1668865656,
+        "narHash": "sha256-lgffTZjfsu3T9AcALeZsEYrUgHHUrp+QEtW8HBA6w/I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5fcf9010c67beec50251b857b351d80fca399a1c",
+        "rev": "7eae2ea4d29c0a906e52b5f73d77020e93fa8162",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7eae2ea4`](https://github.com/nix-community/NUR/commit/7eae2ea4d29c0a906e52b5f73d77020e93fa8162) | `automatic update` |