### PR TITLE
chore(flake/nur): `7eae2ea4` -> `0745a777`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668865656,
-        "narHash": "sha256-lgffTZjfsu3T9AcALeZsEYrUgHHUrp+QEtW8HBA6w/I=",
+        "lastModified": 1668876151,
+        "narHash": "sha256-12pz+OzWzjlYRIXgwu7tUBtqga6MwpG8C3tyeehkzl0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7eae2ea4d29c0a906e52b5f73d77020e93fa8162",
+        "rev": "0745a777359ca736b6852dc79cfc93f1f11835b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                     |
| -------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`0745a777`](https://github.com/nix-community/NUR/commit/0745a777359ca736b6852dc79cfc93f1f11835b7) | `automatic update`                 |
| [`76ea209c`](https://github.com/nix-community/NUR/commit/76ea209c7dacc0d4d97dcac34ee0f429cfc6e21c) | `add federicoschonborn repository` |