### PR TITLE
chore(flake/nur): `579c4f14` -> `0d573e7f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668911090,
-        "narHash": "sha256-vhr4Ot+ZAxwpKgm5K9BwPzgQvz17Nc78P1q//WGmUv8=",
+        "lastModified": 1668914798,
+        "narHash": "sha256-E74TuC1swO1zRa56Hg7NQZ8L2Wfheks/40EudXnfA9U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "579c4f1416c1de9cc3618552addb23c08e884269",
+        "rev": "0d573e7ff202158e0616e910a632c0eeff8b0a92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0d573e7f`](https://github.com/nix-community/NUR/commit/0d573e7ff202158e0616e910a632c0eeff8b0a92) | `automatic update` |