### PR TITLE
chore(flake/emacs-overlay): `1ddaf3ee` -> `e883ec1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668887399,
-        "narHash": "sha256-NWPVZx6Px2gkRDN51bZTb2oTh9PXDTTwpjLSX+zJrCA=",
+        "lastModified": 1668920664,
+        "narHash": "sha256-fN/gbUzHuFddjdFr6T2eh1827ghVSngAHxbAuFNXfzY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1ddaf3eea07315ee3923c161e6a358b53d9fceea",
+        "rev": "e883ec1ccbecceadb3b38cb3b3c45a67e2ece6b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`e883ec1c`](https://github.com/nix-community/emacs-overlay/commit/e883ec1ccbecceadb3b38cb3b3c45a67e2ece6b1) | `Updated repos/nongnu` |
| [`e380486c`](https://github.com/nix-community/emacs-overlay/commit/e380486c5be07345c5738a2df78660c3c2c8a2f0) | `Updated repos/melpa`  |
| [`1c527416`](https://github.com/nix-community/emacs-overlay/commit/1c5274164f7a16e62b7b16f81998ca4c0a6423da) | `Updated repos/emacs`  |