### PR TITLE
chore(flake/nur): `717f95c1` -> `f87e9df8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668917171,
-        "narHash": "sha256-sUX1vs5OT/8g0ZvaWPFTJU0jiUj1tXpidFHLrQD0vSE=",
+        "lastModified": 1668922043,
+        "narHash": "sha256-QqcS20+S5gbkw5N8ncBboNkJ977XRhx9o0p9KwS8h6k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "717f95c1cfd2d6f9c0ff36a12b66eca7e33dcfb7",
+        "rev": "f87e9df811ad7057b94df51d0fc889e2e595c6c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f87e9df8`](https://github.com/nix-community/NUR/commit/f87e9df811ad7057b94df51d0fc889e2e595c6c3) | `automatic update` |