### PR TITLE
chore(flake/nur): `9ee49e01` -> `822f4ad8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668947373,
-        "narHash": "sha256-w23XqGmDtMKr7qKc2D6A6Rfo+7xYtbloPtPod+BopQk=",
+        "lastModified": 1668952056,
+        "narHash": "sha256-fMtExTRy7YPHHZRkS8UznEiFgtD9RaRIzb263JapqyY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ee49e01512c3ce211e8017f0ba592ef4695d777",
+        "rev": "822f4ad8a43a032f8f3ae8e95187eb37475b2e0d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`822f4ad8`](https://github.com/nix-community/NUR/commit/822f4ad8a43a032f8f3ae8e95187eb37475b2e0d) | `automatic update` |