### PR TITLE
chore(flake/nur): `822f4ad8` -> `6bca59e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668952056,
-        "narHash": "sha256-fMtExTRy7YPHHZRkS8UznEiFgtD9RaRIzb263JapqyY=",
+        "lastModified": 1668955348,
+        "narHash": "sha256-l/T3tpYLTzx9u3V4CbOe7/Ps72YlFe1ffZfzWBs3h9o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "822f4ad8a43a032f8f3ae8e95187eb37475b2e0d",
+        "rev": "6bca59e15e5ce5ac408237ab7ca31674ca2664b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6bca59e1`](https://github.com/nix-community/NUR/commit/6bca59e15e5ce5ac408237ab7ca31674ca2664b7) | `automatic update` |