### PR TITLE
chore(flake/nur): `6bca59e1` -> `d772307d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668955348,
-        "narHash": "sha256-l/T3tpYLTzx9u3V4CbOe7/Ps72YlFe1ffZfzWBs3h9o=",
+        "lastModified": 1668971038,
+        "narHash": "sha256-vuovqkw+C3HTs4z5EMB/2eZ+fvRpnPKLbwtW8CHxJ+c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6bca59e15e5ce5ac408237ab7ca31674ca2664b7",
+        "rev": "d772307d9430c9d23be77fae681c2e1538559881",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d772307d`](https://github.com/nix-community/NUR/commit/d772307d9430c9d23be77fae681c2e1538559881) | `automatic update` |