### PR TITLE
chore(flake/nix-on-droid): `27c206f5` -> `ae0569fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -285,14 +285,15 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "nixpkgs-for-bootstrap": "nixpkgs-for-bootstrap"
+        "nixpkgs-for-bootstrap": "nixpkgs-for-bootstrap",
+        "nmd": "nmd_2"
       },
       "locked": {
-        "lastModified": 1667935792,
-        "narHash": "sha256-xdTToQCBJFhslIsIOIjBFyVSiESLht5B5UjCjk99scY=",
+        "lastModified": 1668971731,
+        "narHash": "sha256-KZ3rlEaa9GBzv8smRtjA9ao2yTDl8Nosm3cbeZmOlqM=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "27c206f57ac7c6434b53032d3625fd5cb73bb325",
+        "rev": "ae0569fb92534e29cda4932c4508d6d58708b6a9",
         "type": "github"
       },
       "original": {
@@ -363,6 +364,22 @@
       }
     },
     "nmd": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1666190571,
+        "narHash": "sha256-Z1hc7M9X6L+H83o9vOprijpzhTfOBjd0KmUTnpHAVjA=",
+        "owner": "rycee",
+        "repo": "nmd",
+        "rev": "b75d312b4f33bd3294cd8ae5c2ca8c6da2afc169",
+        "type": "gitlab"
+      },
+      "original": {
+        "owner": "rycee",
+        "repo": "nmd",
+        "type": "gitlab"
+      }
+    },
+    "nmd_2": {
       "flake": false,
       "locked": {
         "lastModified": 1666190571,


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`ae0569fb`](https://github.com/t184256/nix-on-droid/commit/ae0569fb92534e29cda4932c4508d6d58708b6a9) | `treewide: use consitent casing of Nix-on-Droid/nix-on-droid` |
| [`b76fb095`](https://github.com/t184256/nix-on-droid/commit/b76fb0954ea679938f7972800571eb273f1f46c1) | `treewide: improve option descriptions`                       |
| [`7b039faa`](https://github.com/t184256/nix-on-droid/commit/7b039faa831b5b699b4476bad14af76f22f68d3a) | `docs: mention new docs in README and CHANGELOG`              |
| [`31bb4913`](https://github.com/t184256/nix-on-droid/commit/31bb4913c07c51065938247d209d551ac66d1c34) | `ci: add workflow to automatically deploy docs`               |
| [`f62cd709`](https://github.com/t184256/nix-on-droid/commit/f62cd709c8fad46a13233f67839b7bfd44a10f4a) | `docs: add html and man pages for options`                    |
| [`8687e3d6`](https://github.com/t184256/nix-on-droid/commit/8687e3d6dab94054e2a3775a5f6abf0a49e20ed5) | `user: add defaultText for uid and gid`                       |
| [`4ca0fc01`](https://github.com/t184256/nix-on-droid/commit/4ca0fc01e40309229c54b27997d9a26c42ed96ad) | `home-manager: exclude home-manager options docs`             |
| [`5ebbbe41`](https://github.com/t184256/nix-on-droid/commit/5ebbbe418a230f244e521c440e5a49728a7c766b) | `treewide: replace literalExample with literalExpression`     |