### PR TITLE
chore(flake/nixos-hardware): `e0452b33` -> `1108c1b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -304,11 +304,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1668334946,
-        "narHash": "sha256-omMbUj4r5DVBWh7KxkoO/Z/1V1shVR6Ls4jXNB4mr3U=",
+        "lastModified": 1668973873,
+        "narHash": "sha256-DnTrRduUIRgsCBruvUXsaBw2G46JNq6/DtrM5R7VrRc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e0452b33ab0ef16ffe075e980644ed92a6a200bb",
+        "rev": "1108c1b8614017c8b52005054fd27a00e4feb51b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                      |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`bf212c4e`](https://github.com/NixOS/nixos-hardware/commit/bf212c4ef57b100c97735a210a3895d3dcc69aa9) | `Add Ethernet Support on Framework` |