### PR TITLE
chore(flake/emacs-overlay): `a385a268` -> `721aa34f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668937370,
-        "narHash": "sha256-sxGxDs0YKR3bLzo989bERWgVlkVMirchMkSlP7qrWHQ=",
+        "lastModified": 1668973951,
+        "narHash": "sha256-4KHSC7les2Ex0RmeLmtnK1CpbIeu84jOkDgsZ7QdgEo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a385a268c2bd4a411caff28adc785f6ba479d79f",
+        "rev": "721aa34f1468f13b664c5f42aed1e4a560c2801c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`721aa34f`](https://github.com/nix-community/emacs-overlay/commit/721aa34f1468f13b664c5f42aed1e4a560c2801c) | `Updated repos/nongnu` |
| [`983af3c0`](https://github.com/nix-community/emacs-overlay/commit/983af3c08a4cec7fbe1eec336fc1894f2bf2e678) | `Updated repos/melpa`  |
| [`2f074498`](https://github.com/nix-community/emacs-overlay/commit/2f074498a0a5035b3b426b21f80793bbee6e4662) | `Updated repos/emacs`  |