### PR TITLE
chore(flake/nur): `51ec7d92` -> `8ce3617a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668973835,
-        "narHash": "sha256-ejEOqBW5Cz2Uuwh2jE8yy65wiBuR6oCMfyk7Qg0+kgM=",
+        "lastModified": 1668979765,
+        "narHash": "sha256-xVGjiIFNippgB3DJSGyI+MxWmIEiaza9UKowhx/K6mc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "51ec7d92fcfec1b4998bf2837c3031718905cae3",
+        "rev": "8ce3617aef85bd62de8163af72db3844a4299415",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8ce3617a`](https://github.com/nix-community/NUR/commit/8ce3617aef85bd62de8163af72db3844a4299415) | `automatic update` |