### PR TITLE
chore(flake/dendrite-demo-pinecone): `0e27974e` -> `367eac7b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -60,11 +60,11 @@
     "dendrite": {
       "flake": false,
       "locked": {
-        "lastModified": 1661504201,
-        "narHash": "sha256-XCNJirTS8O6O2vlnYhu8icbw07iZit4ias9T2jLIDXs=",
+        "lastModified": 1668800233,
+        "narHash": "sha256-vguZKsU+e/5uKrvzLcbKyo+ZCocvi2lld3CzCkwgXwk=",
         "owner": "matrix-org",
         "repo": "dendrite",
-        "rev": "38bed30b411d8e438d430eae2670482eb2778628",
+        "rev": "7ad87eace3b88b3aaa88dc8a0acec9b64ffcc52c",
         "type": "github"
       },
       "original": {
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661610624,
-        "narHash": "sha256-mHqCons+Ey3hH6GqKAcMAmsO/MjVPj6nf93K0QfruEg=",
+        "lastModified": 1668983522,
+        "narHash": "sha256-4KeV63IJYNMqXzRl0T2SHyfqdiTuxP6WHnZjC4fywYQ=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "0e27974e37531eefb4c98cdb4504bb673f59e291",
+        "rev": "367eac7bda9b69460cfa0f5dda92c2be75a814e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                          | Commit Message                                         |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`367eac7b`](https://github.com/bbigras/dendrite-demo-pinecone/commit/367eac7bda9b69460cfa0f5dda92c2be75a814e2) | `update vendorSha256`                                  |
| [`bb9e6f44`](https://github.com/bbigras/dendrite-demo-pinecone/commit/bb9e6f44fca5e2c0a8df5606ca8a1aae7ca3ec1b) | `flake.lock: Update`                                   |
| [`e4f478da`](https://github.com/bbigras/dendrite-demo-pinecone/commit/e4f478da7315e504644568a9511c9978c57021a2) | `flake: update`                                        |
| [`722d4210`](https://github.com/bbigras/dendrite-demo-pinecone/commit/722d421079c92a1257b9afcf5c1d493091951e5c) | `flake.lock: Update`                                   |
| [`c2ac8984`](https://github.com/bbigras/dendrite-demo-pinecone/commit/c2ac8984daf1ec670e6ba9faf4d84d406f59ed7d) | `chore(deps): bump cachix/cachix-action from 10 to 12` |