### PR TITLE
chore(flake/nix-on-droid): `ae0569fb` -> `a9b17907`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -289,11 +289,11 @@
         "nmd": "nmd_2"
       },
       "locked": {
-        "lastModified": 1668971731,
-        "narHash": "sha256-KZ3rlEaa9GBzv8smRtjA9ao2yTDl8Nosm3cbeZmOlqM=",
+        "lastModified": 1668984854,
+        "narHash": "sha256-x5y85pV4zyAwVBJwfczBObNtN/QCd4gq1PQc/efnvJc=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "ae0569fb92534e29cda4932c4508d6d58708b6a9",
+        "rev": "a9b1790700769269d6757d33d5442cd1dded11f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`a9b17907`](https://github.com/t184256/nix-on-droid/commit/a9b1790700769269d6757d33d5442cd1dded11f3) | `ci: fix incorrect path to docs directory` |