### PR TITLE
chore(flake/nur): `571fbe9a` -> `7af11852`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668982282,
-        "narHash": "sha256-xHDhfjagKs6gnWtRooL7Cmm/snYBZ09jDGYoIdiqnqw=",
+        "lastModified": 1668999578,
+        "narHash": "sha256-8+U8OLC1XIx/wl3cRBG4+fs2KdhHgUgiKc2zc6GDTHc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "571fbe9a098507d1cc188662aef4f27c09ce3b30",
+        "rev": "7af1185290ce2fdac187da9f39bb0521c5525fdb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7af11852`](https://github.com/nix-community/NUR/commit/7af1185290ce2fdac187da9f39bb0521c5525fdb) | `automatic update` |
| [`978d11ba`](https://github.com/nix-community/NUR/commit/978d11baff873778b93efe6e3a349786226b0d20) | `automatic update` |
| [`3df9bf39`](https://github.com/nix-community/NUR/commit/3df9bf392d6d3f4209bb3e069cd34f6ed2ce5b58) | `automatic update` |