### PR TITLE
chore(flake/nur): `7af11852` -> `f7dd9c0a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1668999578,
-        "narHash": "sha256-8+U8OLC1XIx/wl3cRBG4+fs2KdhHgUgiKc2zc6GDTHc=",
+        "lastModified": 1669002090,
+        "narHash": "sha256-fj57H3uAknXJuQZDJKqRZfEJkwby/itP0bSun+zez1o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7af1185290ce2fdac187da9f39bb0521c5525fdb",
+        "rev": "f7dd9c0a635a7d66e9f2bd059f80995ea464e62b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f7dd9c0a`](https://github.com/nix-community/NUR/commit/f7dd9c0a635a7d66e9f2bd059f80995ea464e62b) | `automatic update` |
| [`c541b4cc`](https://github.com/nix-community/NUR/commit/c541b4cc0f4c6d537d274d4088c27a1808cb3bf2) | `automatic update` |
| [`29f7f8d8`](https://github.com/nix-community/NUR/commit/29f7f8d80bd6d106eb044b59f928f89aa22e7ddd) | `automatic update` |