### PR TITLE
chore(flake/nur): `f7dd9c0a` -> `2e64d847`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669002090,
-        "narHash": "sha256-fj57H3uAknXJuQZDJKqRZfEJkwby/itP0bSun+zez1o=",
+        "lastModified": 1669003314,
+        "narHash": "sha256-Bh+Q83KYSDuNJ/W6fLP6VYl8+EdhOXhQugfBOnEU+I4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f7dd9c0a635a7d66e9f2bd059f80995ea464e62b",
+        "rev": "2e64d84782d8a28642b307163a19ed6ab0e1f3b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2e64d847`](https://github.com/nix-community/NUR/commit/2e64d84782d8a28642b307163a19ed6ab0e1f3b5) | `automatic update` |