### PR TITLE
chore(flake/emacs-overlay): `721aa34f` -> `acbbcb78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668973951,
-        "narHash": "sha256-4KHSC7les2Ex0RmeLmtnK1CpbIeu84jOkDgsZ7QdgEo=",
+        "lastModified": 1669009625,
+        "narHash": "sha256-NM6vZ8lRmvZCRuRm4OBONnAgqkhsh/VlqbGsqhItaXg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "721aa34f1468f13b664c5f42aed1e4a560c2801c",
+        "rev": "acbbcb781724648f206068e230a7a5f77fba510c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`acbbcb78`](https://github.com/nix-community/emacs-overlay/commit/acbbcb781724648f206068e230a7a5f77fba510c) | `Updated repos/nongnu` |
| [`dde00fb4`](https://github.com/nix-community/emacs-overlay/commit/dde00fb44e5d4a799da069fec92bed7ca6ebbf2d) | `Updated repos/melpa`  |
| [`6d000fba`](https://github.com/nix-community/emacs-overlay/commit/6d000fba594c4ad90e51ef7af17dc7fdd4ec7125) | `Updated repos/emacs`  |