### PR TITLE
chore(flake/dendrite-demo-pinecone): `367eac7b` -> `870e2856`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668983522,
-        "narHash": "sha256-4KeV63IJYNMqXzRl0T2SHyfqdiTuxP6WHnZjC4fywYQ=",
+        "lastModified": 1669011925,
+        "narHash": "sha256-RtrRJeW3dOR5KsM1n5yaxS/+UbnrKptHp0NoRXmfpww=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "367eac7bda9b69460cfa0f5dda92c2be75a814e2",
+        "rev": "870e285621e190bd31a22755f7d991ec098ffbbe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                          | Commit Message                                              |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`870e2856`](https://github.com/bbigras/dendrite-demo-pinecone/commit/870e285621e190bd31a22755f7d991ec098ffbbe) | `chore(deps): bump cachix/install-nix-action from 17 to 18` |