### PR TITLE
chore(flake/nur): `023d7228` -> `c6081f25`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669008300,
-        "narHash": "sha256-T5fjmJKnIl6HXkStIyF6HWsH+v+ARMR5jOdGDY8DTHM=",
+        "lastModified": 1669013910,
+        "narHash": "sha256-MGzJSp7nwWyIQkxBjI19GUMI7mQqUAr5dFKmqhnRFYw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "023d7228edc3e95e31dc3610b4c7b6e9473c2a38",
+        "rev": "c6081f25cbe13209e5d5fd600ea54cdcbf59e266",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c6081f25`](https://github.com/nix-community/NUR/commit/c6081f25cbe13209e5d5fd600ea54cdcbf59e266) | `automatic update` |