### PR TITLE
chore(flake/nur): `c6081f25` -> `eaabaf59`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669013910,
-        "narHash": "sha256-MGzJSp7nwWyIQkxBjI19GUMI7mQqUAr5dFKmqhnRFYw=",
+        "lastModified": 1669017032,
+        "narHash": "sha256-QMFcs+e5mQ28FgQ8QvLqVjIr0LkoxG3G/OyNnBIRVAE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c6081f25cbe13209e5d5fd600ea54cdcbf59e266",
+        "rev": "eaabaf5996b6abb6703408a53033a70eaca9834c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`eaabaf59`](https://github.com/nix-community/NUR/commit/eaabaf5996b6abb6703408a53033a70eaca9834c) | `automatic update` |
| [`74e20005`](https://github.com/nix-community/NUR/commit/74e20005a1031bc374fbb1937cb1c2ae5b9ce4de) | `automatic update` |