### PR TITLE
chore(flake/nur): `eaabaf59` -> `19a539ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669017032,
-        "narHash": "sha256-QMFcs+e5mQ28FgQ8QvLqVjIr0LkoxG3G/OyNnBIRVAE=",
+        "lastModified": 1669019519,
+        "narHash": "sha256-/zQ0gTAuhOv2dqbwJZsz1z9O0n0mXsT4nkggSaq59cI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eaabaf5996b6abb6703408a53033a70eaca9834c",
+        "rev": "19a539edf74ecbda3f02c7c345243dd2dd892f1d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`19a539ed`](https://github.com/nix-community/NUR/commit/19a539edf74ecbda3f02c7c345243dd2dd892f1d) | `automatic update` |