### PR TITLE
chore(flake/nur): `19a539ed` -> `5309a60c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669019519,
-        "narHash": "sha256-/zQ0gTAuhOv2dqbwJZsz1z9O0n0mXsT4nkggSaq59cI=",
+        "lastModified": 1669022658,
+        "narHash": "sha256-h3OB3mknuxZd+y/HNsVF88RbGERVvr9slxtZTeIe2fc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "19a539edf74ecbda3f02c7c345243dd2dd892f1d",
+        "rev": "5309a60c0e50f34fdeb61b5fb0e3b334b48bb3ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5309a60c`](https://github.com/nix-community/NUR/commit/5309a60c0e50f34fdeb61b5fb0e3b334b48bb3ed) | `automatic update` |