### PR TITLE
chore(flake/emacs-overlay): `acbbcb78` -> `28824526`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669009625,
-        "narHash": "sha256-NM6vZ8lRmvZCRuRm4OBONnAgqkhsh/VlqbGsqhItaXg=",
+        "lastModified": 1669033692,
+        "narHash": "sha256-pG2UdtY8PC9Rix8dHGYUR0+xj4In30q8TEdJhWnMYCA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "acbbcb781724648f206068e230a7a5f77fba510c",
+        "rev": "2882452693f3abf29ef583519618519e25f9fdad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`28824526`](https://github.com/nix-community/emacs-overlay/commit/2882452693f3abf29ef583519618519e25f9fdad) | `Updated repos/melpa` |
| [`3f886f65`](https://github.com/nix-community/emacs-overlay/commit/3f886f65be24a57a90e4849bb83f991e3b68a31c) | `Updated repos/emacs` |