### PR TITLE
chore(flake/nur): `40a8b474` -> `078f6ecc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669034500,
-        "narHash": "sha256-vhOtu4a7vuS2S+p0s37GGFAealNv9xZAFKHzeh/eK5Q=",
+        "lastModified": 1669039188,
+        "narHash": "sha256-FKfem8nUMBovPxrw3IWfOtEV0VIrFjmdwqKx3ohv+Kc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "40a8b474d8166079629ee83ee95c517f657dbd59",
+        "rev": "078f6ecc5d8c70b1a97c88afe7eceb08976706f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`078f6ecc`](https://github.com/nix-community/NUR/commit/078f6ecc5d8c70b1a97c88afe7eceb08976706f8) | `automatic update` |