### PR TITLE
chore(flake/home-manager): `c0f9cbcf` -> `433e8de3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -225,11 +225,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668900402,
-        "narHash": "sha256-IhVlueHoQNoN0SOHZIceKU3LyEL00g2ei0aUlaNypbQ=",
+        "lastModified": 1669044918,
+        "narHash": "sha256-Lg5gOmmVlaYKhN2QM6qeZL3HOjbshms2+CJyc+ALt64=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c0f9cbcf93ca22e4f0ca66843be61a4bdf6f0a44",
+        "rev": "433e8de330fd9c157b636f9ccea45e3eeaf69ad2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                   |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`433e8de3`](https://github.com/nix-community/home-manager/commit/433e8de330fd9c157b636f9ccea45e3eeaf69ad2) | `fzf: add colors option (#3206)` |