### PR TITLE
chore(flake/emacs-overlay): `28824526` -> `88b5da0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669033692,
-        "narHash": "sha256-pG2UdtY8PC9Rix8dHGYUR0+xj4In30q8TEdJhWnMYCA=",
+        "lastModified": 1669063447,
+        "narHash": "sha256-GB5ABpKMvQLaea1usgmioYbC6N9XLOItrkwYp1BJc9o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2882452693f3abf29ef583519618519e25f9fdad",
+        "rev": "88b5da0b83c722e033671728c1141c91f014a9b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`88b5da0b`](https://github.com/nix-community/emacs-overlay/commit/88b5da0b83c722e033671728c1141c91f014a9b7) | `Updated repos/melpa` |
| [`d7a3f296`](https://github.com/nix-community/emacs-overlay/commit/d7a3f296877ea991deae4c6b220836bfaa006b62) | `Updated repos/emacs` |