### PR TITLE
chore(flake/emacs-ement): `e18a6c9f` -> `12214bb0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1669060482,
-        "narHash": "sha256-ylyMi6Z32Ql+QH9nP1RT3ihsMs5l69bYw+9bdX76V58=",
+        "lastModified": 1669063138,
+        "narHash": "sha256-l/iC5IqxZl5FxjCtPNur/+6o5XajIqi9DRujTwG5nmo=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "e18a6c9ff12bd73e800012693de2e89b28d6bb1a",
+        "rev": "12214bb0ae2590a6bca515fd07ff4295d5df93de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message   |
| --------------------------------------------------------------------------------------------------- | ---------------- |
| [`12214bb0`](https://github.com/alphapapa/ement.el/commit/12214bb0ae2590a6bca515fd07ff4295d5df93de) | `Meta: v0.6-pre` |