### PR TITLE
chore(flake/nur): `078f6ecc` -> `4541a1d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669039188,
-        "narHash": "sha256-FKfem8nUMBovPxrw3IWfOtEV0VIrFjmdwqKx3ohv+Kc=",
+        "lastModified": 1669069766,
+        "narHash": "sha256-IsirdGJd22GK7uWYsJgnAR7KzE3UTnAyniF+j32lGfI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "078f6ecc5d8c70b1a97c88afe7eceb08976706f8",
+        "rev": "4541a1d885102330858c3b7913de9b451124e87a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4541a1d8`](https://github.com/nix-community/NUR/commit/4541a1d885102330858c3b7913de9b451124e87a) | `automatic update` |
| [`d6e4015a`](https://github.com/nix-community/NUR/commit/d6e4015a9d635e7ea5ef4032f4d97004959ba9f1) | `automatic update` |