### PR TITLE
chore(flake/home-manager): `433e8de3` -> `f7641a3f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -225,11 +225,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669044918,
-        "narHash": "sha256-Lg5gOmmVlaYKhN2QM6qeZL3HOjbshms2+CJyc+ALt64=",
+        "lastModified": 1669071065,
+        "narHash": "sha256-KBpgj3JkvlPsJ3duOZqFJe6tgr+wc75t8sFmgRbBSbw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "433e8de330fd9c157b636f9ccea45e3eeaf69ad2",
+        "rev": "f7641a3ff398ccce952e19a199d775934e518c1d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`f7641a3f`](https://github.com/nix-community/home-manager/commit/f7641a3ff398ccce952e19a199d775934e518c1d) | `scmpuff: add fish integration flag` |
| [`3ce1c478`](https://github.com/nix-community/home-manager/commit/3ce1c4787a48f9882267e93f62af0c7f7711076d) | `Translate using Weblate (Dutch)`    |
| [`c3690701`](https://github.com/nix-community/home-manager/commit/c3690701d1a9ecb01ac322954caec548f96355b1) | `Translate using Weblate (Polish)`   |