### PR TITLE
chore(flake/emacs-overlay): `88b5da0b` -> `35a111ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669063447,
-        "narHash": "sha256-GB5ABpKMvQLaea1usgmioYbC6N9XLOItrkwYp1BJc9o=",
+        "lastModified": 1669078562,
+        "narHash": "sha256-09zGMVUQHszDNlqXnXYixb3StGzqzjNp7POL8wcg/QE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "88b5da0b83c722e033671728c1141c91f014a9b7",
+        "rev": "35a111eafb2489b044fb0e6edbefd9e5d3ca3365",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                         |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------- |
| [`35a111ea`](https://github.com/nix-community/emacs-overlay/commit/35a111eafb2489b044fb0e6edbefd9e5d3ca3365) | `Build emacsGitTreeSitter from master` |