### PR TITLE
chore(flake/nur): `dd5a06c6` -> `9689edd5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669072593,
-        "narHash": "sha256-Tqp/ZiOtRfd0hZYwz3p8KRVpc/+t8Io4CuKJJShO+PM=",
+        "lastModified": 1669082348,
+        "narHash": "sha256-tVvOuixsbRx323zzbkSW0MJlQIv6Qg95VVFvqVLWjz4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd5a06c6c12865d9416e47bf950870257e2bb373",
+        "rev": "9689edd5efe41ce8a721d8d57dea4c2c56da553f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9689edd5`](https://github.com/nix-community/NUR/commit/9689edd5efe41ce8a721d8d57dea4c2c56da553f) | `automatic update` |