### PR TITLE
chore(flake/nur): `9689edd5` -> `247123a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669082348,
-        "narHash": "sha256-tVvOuixsbRx323zzbkSW0MJlQIv6Qg95VVFvqVLWjz4=",
+        "lastModified": 1669089361,
+        "narHash": "sha256-HK+GuvC7g9ohxZMmbnUbJGapiOEhbb/jWhF+g2n6WW0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9689edd5efe41ce8a721d8d57dea4c2c56da553f",
+        "rev": "247123a8f55e84efb1e1ae6ce9e637ad66c063eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`247123a8`](https://github.com/nix-community/NUR/commit/247123a8f55e84efb1e1ae6ce9e637ad66c063eb) | `automatic update` |