### PR TITLE
chore(flake/emacs-overlay): `35a111ea` -> `86fa3768`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669078562,
-        "narHash": "sha256-09zGMVUQHszDNlqXnXYixb3StGzqzjNp7POL8wcg/QE=",
+        "lastModified": 1669093791,
+        "narHash": "sha256-b5Sq3NDw5DjI48xfKW9+zwVJQ/vSJscZYJcMyAc9DqY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "35a111eafb2489b044fb0e6edbefd9e5d3ca3365",
+        "rev": "86fa3768f0eb427a5c773e6dde261e8151135e22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`86fa3768`](https://github.com/nix-community/emacs-overlay/commit/86fa3768f0eb427a5c773e6dde261e8151135e22) | `Updated repos/nongnu` |
| [`75c8accd`](https://github.com/nix-community/emacs-overlay/commit/75c8accdc205d59c65f4f5b17e9130f155e61646) | `Updated repos/melpa`  |