### PR TITLE
chore(flake/nur): `e8ed6031` -> `f5e3ff78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669090133,
-        "narHash": "sha256-i81e6UZuRD2jSXw6tfsiLtKPcX4UkMG+Wl7R2L9zrsI=",
+        "lastModified": 1669100182,
+        "narHash": "sha256-tKyO+zy7+yKkjcq32Mf69fhOuV4oTO6MW2CPrS3Ozro=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e8ed6031bd3d9ebf4075622e379cb7aec64c13bc",
+        "rev": "f5e3ff788f68d7718a5a9b316829049fb1d07b5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f5e3ff78`](https://github.com/nix-community/NUR/commit/f5e3ff788f68d7718a5a9b316829049fb1d07b5a) | `automatic update` |
| [`28b2e77a`](https://github.com/nix-community/NUR/commit/28b2e77a903a32ee06d56ce46df37df3e0afc360) | `automatic update` |