### PR TITLE
chore(flake/nur): `f5e3ff78` -> `81a47e22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669100182,
-        "narHash": "sha256-tKyO+zy7+yKkjcq32Mf69fhOuV4oTO6MW2CPrS3Ozro=",
+        "lastModified": 1669101637,
+        "narHash": "sha256-q4s4JH8RrUnWFmwDSte8qYPXqfmUqjx+Af7CxDdqyuQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f5e3ff788f68d7718a5a9b316829049fb1d07b5a",
+        "rev": "81a47e227c43c9f6887abaa316f4597bf26813b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`81a47e22`](https://github.com/nix-community/NUR/commit/81a47e227c43c9f6887abaa316f4597bf26813b4) | `automatic update` |