### PR TITLE
chore(flake/pre-commit-hooks): `46fb5634` -> `accaf454`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -435,11 +435,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669018323,
-        "narHash": "sha256-/2Ixw4v5JbbhH+sE6huvyG+txhBGIcx5iWIZ4kWtilU=",
+        "lastModified": 1669111527,
+        "narHash": "sha256-9riP6xeDMWJES1lcltI5dUv9Q2kSZt4YLqqP20Kwl2w=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "46fb5634676994bd333a94c8bd322eb1854ff223",
+        "rev": "accaf454bbb9adfec4549480875ca4dee96cad69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                  |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------- |
| [`59fdd498`](https://github.com/cachix/pre-commit-hooks.nix/commit/59fdd498149cb44c6aff82e7f0ebf20e084ed323) | `Always rerun hpack everywhere` |