### PR TITLE
chore(flake/emacs-overlay): `86fa3768` -> `a9c2a436`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669093791,
-        "narHash": "sha256-b5Sq3NDw5DjI48xfKW9+zwVJQ/vSJscZYJcMyAc9DqY=",
+        "lastModified": 1669120813,
+        "narHash": "sha256-00O/dvvcELCdpuFPde+bsJ9Bw974b/VunUArWlJ+lQA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "86fa3768f0eb427a5c773e6dde261e8151135e22",
+        "rev": "a9c2a436757f09abc4c7bc0abc4d2529b312e42b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`a9c2a436`](https://github.com/nix-community/emacs-overlay/commit/a9c2a436757f09abc4c7bc0abc4d2529b312e42b) | `Updated repos/nongnu` |
| [`1e2c5e4e`](https://github.com/nix-community/emacs-overlay/commit/1e2c5e4e0c05145ee1ac4baa458a97ac1a9b05b6) | `Updated repos/melpa`  |
| [`6e2a6d8d`](https://github.com/nix-community/emacs-overlay/commit/6e2a6d8d863751c677f9e404a3502860ea03957f) | `Updated repos/emacs`  |