### PR TITLE
chore(flake/nur): `0dc5d381` -> `7f76c7a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669114236,
-        "narHash": "sha256-3fm5naAfT+EoQfm47szXTZIk9wkkIIqMTsJqFSecnoQ=",
+        "lastModified": 1669125154,
+        "narHash": "sha256-/9/11IZ6vVIPEuBTY8/NWrRuLlmIdGGXYPjLd9tGqpU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0dc5d381f71beb8a3bf58e302f1d51d4f00c4177",
+        "rev": "7f76c7a7ae5e6064ecd72cf2473fa58f14318555",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7f76c7a7`](https://github.com/nix-community/NUR/commit/7f76c7a7ae5e6064ecd72cf2473fa58f14318555) | `automatic update` |