### PR TITLE
chore(flake/nur): `7f76c7a7` -> `0ba2c247`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669125154,
-        "narHash": "sha256-/9/11IZ6vVIPEuBTY8/NWrRuLlmIdGGXYPjLd9tGqpU=",
+        "lastModified": 1669129477,
+        "narHash": "sha256-TmSZGh97y5QU/2kH9fq58fSxCBinpCjJWEctMW/VCcE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7f76c7a7ae5e6064ecd72cf2473fa58f14318555",
+        "rev": "0ba2c247535e58012c74bf07de7833afccdd0870",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0ba2c247`](https://github.com/nix-community/NUR/commit/0ba2c247535e58012c74bf07de7833afccdd0870) | `automatic update` |