### PR TITLE
chore(flake/nur): `f22fa114` -> `53a19670`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669132422,
-        "narHash": "sha256-vfw9i+g7TCmJwf8Fmnq2J8ejd3tdLhI5B8GgtfIfzCE=",
+        "lastModified": 1669133078,
+        "narHash": "sha256-AJJIbF9NZbDMCABjHK8dzo4N2jU09QbktgyssGH5HTQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f22fa1147c39fa0e0c4200d3a38882a3eacff957",
+        "rev": "53a196709220157ebf34497268d31432622b4b19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`53a19670`](https://github.com/nix-community/NUR/commit/53a196709220157ebf34497268d31432622b4b19) | `automatic update` |