### PR TITLE
chore(flake/dendrite-demo-pinecone): `870e2856` -> `82db4f8c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669011925,
-        "narHash": "sha256-RtrRJeW3dOR5KsM1n5yaxS/+UbnrKptHp0NoRXmfpww=",
+        "lastModified": 1669138122,
+        "narHash": "sha256-5TSgW8fU57EufWzbcysSjchpEBBk0Arvc+4HZTfRcrk=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "870e285621e190bd31a22755f7d991ec098ffbbe",
+        "rev": "82db4f8cb5eec4ff047ead67954401a0e0cc7cdc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                          | Commit Message                  |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`82db4f8c`](https://github.com/bbigras/dendrite-demo-pinecone/commit/82db4f8cb5eec4ff047ead67954401a0e0cc7cdc) | `update-flakes: every 30 mins`  |
| [`42983c1a`](https://github.com/bbigras/dendrite-demo-pinecone/commit/42983c1abfa1f82c907f38733aeb946f28ab27c5) | `try to fix update-flakes.yaml` |