### PR TITLE
chore(flake/dendrite-demo-pinecone): `82db4f8c` -> `748eaad5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669138122,
-        "narHash": "sha256-5TSgW8fU57EufWzbcysSjchpEBBk0Arvc+4HZTfRcrk=",
+        "lastModified": 1669140574,
+        "narHash": "sha256-Pgy30cd8OINyKD6/7R1kMm6zs82omX1YhOtodiOPm7A=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "82db4f8cb5eec4ff047ead67954401a0e0cc7cdc",
+        "rev": "748eaad5f07376d5cbaaf58ad1be58c427ce7f04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                          | Commit Message                                |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`748eaad5`](https://github.com/bbigras/dendrite-demo-pinecone/commit/748eaad5f07376d5cbaaf58ad1be58c427ce7f04) | `use nix channel as a temp fix for update.sh` |