### PR TITLE
chore(flake/dendrite-demo-pinecone): `748eaad5` -> `2f263d0e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669140574,
-        "narHash": "sha256-Pgy30cd8OINyKD6/7R1kMm6zs82omX1YhOtodiOPm7A=",
+        "lastModified": 1669142843,
+        "narHash": "sha256-TQLkeqtvE4hpcKfqytG1BYP9IHG/QiQ5YS6twSaxm8A=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "748eaad5f07376d5cbaaf58ad1be58c427ce7f04",
+        "rev": "2f263d0e823678a5d9a6d93932f79a7b64db2c7e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                          | Commit Message       |
| --------------------------------------------------------------------------------------------------------------- | -------------------- |
| [`2f263d0e`](https://github.com/bbigras/dendrite-demo-pinecone/commit/2f263d0e823678a5d9a6d93932f79a7b64db2c7e) | `flake.lock: Update` |