### PR TITLE
chore(flake/nixos-hardware): `1108c1b8` -> `0099253a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -338,11 +338,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1668973873,
-        "narHash": "sha256-DnTrRduUIRgsCBruvUXsaBw2G46JNq6/DtrM5R7VrRc=",
+        "lastModified": 1669146234,
+        "narHash": "sha256-HEby7EG1yaq1oT2Ze6Cvok9CFju1XHkSvVHmkptLW9U=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "1108c1b8614017c8b52005054fd27a00e4feb51b",
+        "rev": "0099253ad0b5283f06ffe31cf010af3f9ad7837d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                         |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`cdd049a3`](https://github.com/NixOS/nixos-hardware/commit/cdd049a353645cbeaba48cb9e339123b9aeae743) | `treewide: Migrate to new nvidia modules`                              |
| [`7e60458d`](https://github.com/NixOS/nixos-hardware/commit/7e60458d8646f79a5df228913f87f59cc14414da) | `common/gpu/nvidia*: Migrate to common/gpu/nvidia/* and add non-prime` |