### PR TITLE
chore(flake/emacs-overlay): `a9c2a436` -> `89f2e82f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669120813,
-        "narHash": "sha256-00O/dvvcELCdpuFPde+bsJ9Bw974b/VunUArWlJ+lQA=",
+        "lastModified": 1669149307,
+        "narHash": "sha256-mOKsVWY9l1aC4BCQAiPsSqT4Gs8mTwfHCgwmTDLDSHs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a9c2a436757f09abc4c7bc0abc4d2529b312e42b",
+        "rev": "89f2e82fec9f7c2dde0381976266a245f0072217",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`89f2e82f`](https://github.com/nix-community/emacs-overlay/commit/89f2e82fec9f7c2dde0381976266a245f0072217) | `Updated repos/melpa` |
| [`57b38b76`](https://github.com/nix-community/emacs-overlay/commit/57b38b7671a064bcc29fc1ef0061c4a440d41bf4) | `Updated repos/emacs` |