### PR TITLE
chore(flake/nur): `97c4ff6d` -> `d3d7f940`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669145901,
-        "narHash": "sha256-Yuk25xg2hkZ2Ku2CVxoBI6btp7Qj0k7wVAJey4vwa6g=",
+        "lastModified": 1669153464,
+        "narHash": "sha256-r+g42qzn/DpcNIwaS0a+/FX8zhvhby458ar4cTYYSIE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "97c4ff6d45f983309ba6e5055f8055370abfc89b",
+        "rev": "d3d7f940425225f69dcf35a59790e55077094fc7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d3d7f940`](https://github.com/nix-community/NUR/commit/d3d7f940425225f69dcf35a59790e55077094fc7) | `automatic update` |