### PR TITLE
chore(flake/nixpkgs): `af50806f` -> `20fc9484`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668994630,
-        "narHash": "sha256-1lqx6HLyw6fMNX/hXrrETG1vMvZRGm2XVC9O/Jt0T6c=",
+        "lastModified": 1669052418,
+        "narHash": "sha256-M1I4BKXBQm2gey1tScemEh5TpHHE3gKptL7BpWUvL8s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "af50806f7c6ab40df3e6b239099e8f8385f6c78b",
+        "rev": "20fc948445a6c22d4e8d5178e9a6bc6e1f5417c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                          |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
| [`9c128026`](https://github.com/NixOS/nixpkgs/commit/9c128026bd193f1abbf79448782f0dc4b20f83a5) | `vulkan-caps-viewer: 3.25 -> 3.27`                                                                      |
| [`263a1252`](https://github.com/NixOS/nixpkgs/commit/263a1252f95b3517bbc36497b7b24d84a4b52a6f) | `appthreat-depscan: 3.0.2 -> 3.0.3`                                                                     |
| [`ceecc713`](https://github.com/NixOS/nixpkgs/commit/ceecc713047e3dc8aa39ea9ebeda34b9ff6c4a67) | `nano: 6.4 -> 7.0 (#201570)`                                                                            |
| [`61530287`](https://github.com/NixOS/nixpkgs/commit/61530287678617cd583a9acbff16ce4f374027f7) | `grype: 0.52.0 -> 0.53.0`                                                                               |
| [`4cdc08f9`](https://github.com/NixOS/nixpkgs/commit/4cdc08f9252c8323fdaecf047bf11cd79b835935) | `nixos/mautrix-telegram: document JSON env var config`                                                  |
| [`e14bdbb9`](https://github.com/NixOS/nixpkgs/commit/e14bdbb997707333de2114c56ab0fe764dbe9ca7) | `Revert "nixos/mautrix-telegram: substitute secrets in config file at runtime (#112966)"`               |
| [`4a8f6ceb`](https://github.com/NixOS/nixpkgs/commit/4a8f6ceb6650d818d893a86d2216beea0cd2f0d1) | `nixos/mautrix-telegram: add documentation for setting arbitrary secrets`                               |
| [`7ddf1010`](https://github.com/NixOS/nixpkgs/commit/7ddf10108be968e658dafd0b5de0d4498e056698) | `matrix-appservice-discord: 3.1.0 -> 3.1.1`                                                             |
| [`60ae5afd`](https://github.com/NixOS/nixpkgs/commit/60ae5afd44c901c83190013af1dbead86e43f268) | `xdg-desktop-portal-wlr: fix cross compilation`                                                         |
| [`73944c5c`](https://github.com/NixOS/nixpkgs/commit/73944c5c5e79d10906c224d688037c34085241a1) | `dprint: 0.32.2 -> 0.33.0`                                                                              |
| [`384ed019`](https://github.com/NixOS/nixpkgs/commit/384ed019dfb9bd9499610b0ef5dd095b01dffd97) | `eksctl: 0.119.0 -> 0.120.0`                                                                            |
| [`17933082`](https://github.com/NixOS/nixpkgs/commit/17933082cc2c62fb64131764fd38af7577b3a1a2) | `nixos/mastodon: fix emoji import`                                                                      |
| [`0a91e1a0`](https://github.com/NixOS/nixpkgs/commit/0a91e1a0e0c379e880418c3a68d278fdabcccc44) | `cargo-tarpaulin: 0.22.0 -> 0.23.1`                                                                     |
| [`4a0ceec1`](https://github.com/NixOS/nixpkgs/commit/4a0ceec14cf08c558d343194782ddf9aa04dad0a) | `elpa: explicity disable the use of SSE assembly on non x86`                                            |
| [`73eab78f`](https://github.com/NixOS/nixpkgs/commit/73eab78fd8ece416345ddfa7595cd959e0a45515) | `puddletag: fix permissions so our wrapper works`                                                       |
| [`85c5ea38`](https://github.com/NixOS/nixpkgs/commit/85c5ea3834336bacd0fad204dc9fbace0d538f2a) | `aws-c-io: 0.13.9 -> 0.13.11`                                                                           |
| [`aec0480b`](https://github.com/NixOS/nixpkgs/commit/aec0480b206405db7b55d5699d6166ca122cac04) | `guile_2_2: use correct version of guile for cross compilation`                                         |
| [`801b38a2`](https://github.com/NixOS/nixpkgs/commit/801b38a29cd6d30080b12fa8559527fc4373f19c) | `guile_3_0: use correct version of guile for cross compilation`                                         |
| [`55d8fccd`](https://github.com/NixOS/nixpkgs/commit/55d8fccd2d2dfd7b9e542255447fc586f23ed99a) | `aws-c-auth: 0.6.20 -> 0.6.21`                                                                          |
| [`46328f55`](https://github.com/NixOS/nixpkgs/commit/46328f5596bcc2743f727e3ab884dea362c627d8) | `nixosTests.systemd-initrd-luks-password: test mounting device unlocked in initrd after switching root` |
| [`51e4bd29`](https://github.com/NixOS/nixpkgs/commit/51e4bd298f8a1b449aa6784dbfdf7d575e0c2549) | `nixos/udev: enable initrd-udevadm-cleanup-db.service in systemd stage 1`                               |
| [`b2bd69ba`](https://github.com/NixOS/nixpkgs/commit/b2bd69babc51d6fe68910f6a86dadd76e0750267) | `aws-c-sdkutils: 0.1.6 -> 0.1.7`                                                                        |
| [`6ee0a023`](https://github.com/NixOS/nixpkgs/commit/6ee0a023cdd54dd5aa5fbd4b0e659f57c88e25c7) | `ocamlPackages.labltk: add version 8.06.13 for OCaml 5.0`                                               |
| [`eec37392`](https://github.com/NixOS/nixpkgs/commit/eec373924998d9f428f89d495f34fb674e81e47c) | `nix-output-monitor: 2.0.0.3 -> 2.0.0.4`                                                                |
| [`b48a3399`](https://github.com/NixOS/nixpkgs/commit/b48a339973650d10d8a24a3a31c3491eea65b145) | `maintainers: change username "mpsyco" -> "fstamour"`                                                   |
| [`71c74bf1`](https://github.com/NixOS/nixpkgs/commit/71c74bf1738d306fff289f8d48f82313e2c100f4) | `nixos: Add ext to fsPackages in stage 2 with systemd-initrd enabled`                                   |
| [`cd4c55fe`](https://github.com/NixOS/nixpkgs/commit/cd4c55fe0e57abb83d3d80919c1265c7fb6d35c0) | `python310Packages.repeated-test: add tjni as maintainer`                                               |
| [`49dcf51e`](https://github.com/NixOS/nixpkgs/commit/49dcf51e2a4b843712fbaabe6481c5cf00a94ecd) | `mullvad-vpn: 2022.4 -> 2022.5`                                                                         |
| [`77f77dc9`](https://github.com/NixOS/nixpkgs/commit/77f77dc97fd85cb7360b3607bfe363a056095880) | `mullvad: 2022.4 -> 2022.5`                                                                             |
| [`23b3add0`](https://github.com/NixOS/nixpkgs/commit/23b3add0e305ec447ba19613be723e781522e7f9) | `nixos: Fix hibernate test with systemd stage 1`                                                        |
| [`d9fb8de8`](https://github.com/NixOS/nixpkgs/commit/d9fb8de8fb379298a3dd95ea3471c11333f24d55) | `maintainers: add ataraxiasjel`                                                                         |
| [`af90e664`](https://github.com/NixOS/nixpkgs/commit/af90e66439fbb734472671ef520e2879f350ddcb) | `teensy-loader-cli: 2.1+unstable=2021-04-10 -> 2.2 (#198461)`                                           |
| [`ca87d0ca`](https://github.com/NixOS/nixpkgs/commit/ca87d0cac8e6fa6d5150d332424c37d45225efdd) | `b612: update homepage`                                                                                 |
| [`c16d0fd6`](https://github.com/NixOS/nixpkgs/commit/c16d0fd62c850c285ab5c01c598c3ead4129d31b) | `checkip: 0.43.0 -> 0.44.0`                                                                             |
| [`31df5aed`](https://github.com/NixOS/nixpkgs/commit/31df5aed9ee6abf2b00b77018640b13eb1ad31d6) | `cargo-update: 11.0.0 -> 11.1.0`                                                                        |
| [`47a45a79`](https://github.com/NixOS/nixpkgs/commit/47a45a7955fce017d974c1542c3ee9901ab7874d) | `home-assistant: 2022.11.3 -> 2022.11.4`                                                                |
| [`ecc28793`](https://github.com/NixOS/nixpkgs/commit/ecc2879314c471b118a9d0d9aee3634ec6e7b55e) | `python3Packages.xknx: 1.2.0 -> 1.2.1`                                                                  |
| [`81b13c86`](https://github.com/NixOS/nixpkgs/commit/81b13c864dc831298509aece6391a4ab55bc3167) | `python3Packages.bleak-retry-connector: 2.8.4 -> 2.8.5`                                                 |
| [`c933e987`](https://github.com/NixOS/nixpkgs/commit/c933e98715d526522818268dc06322634a41a634) | `python3Packages.ansible-runner: 2.3.0 -> 2.3.1`                                                        |
| [`a304f169`](https://github.com/NixOS/nixpkgs/commit/a304f169019d701af8d81d0396a95c91334286b9) | `python3Packages.ansible-lint: 6.8.5 -> 6.8.6`                                                          |
| [`beb97ce7`](https://github.com/NixOS/nixpkgs/commit/beb97ce75aed31a96b4f46baecb8ba8d40f35505) | `python3Packages.ansible-compat: 2.2.3 -> 2.2.5`                                                        |
| [`f3dd2a89`](https://github.com/NixOS/nixpkgs/commit/f3dd2a89c6daed303cfe94b5056dab051fd9679e) | `ansible: 2.13.5 -> 2.14.0`                                                                             |
| [`a6e32c10`](https://github.com/NixOS/nixpkgs/commit/a6e32c105cae8546aa0f03209e9049e1f948f6bd) | `python3Packages.ansible: 6.5.0 -> 6.6.0`                                                               |
| [`8cdb3094`](https://github.com/NixOS/nixpkgs/commit/8cdb30946686bf45cba20f28ca5ef57060c9ebc6) | `libva: add intel-media-driver to passthru.tests`                                                       |
| [`91137f59`](https://github.com/NixOS/nixpkgs/commit/91137f5929dad7655f3bb4e9a6122e0519cd091d) | `intel-media-driver: 22.5.3.1 -> 22.6.3`                                                                |
| [`023798d1`](https://github.com/NixOS/nixpkgs/commit/023798d172ea7a9c81b926dd56b214e2e97a79d9) | `build-pecl: fetch via https`                                                                           |
| [`8b63f7e1`](https://github.com/NixOS/nixpkgs/commit/8b63f7e1744b23ae5f6bc0e50d2cb1778fe82cb9) | `phpExtensions.yaml: update homepage`                                                                   |
| [`2953d4b9`](https://github.com/NixOS/nixpkgs/commit/2953d4b93203eb653008bb10c572c2b4761fdbba) | `phpExtensions.protobuf: format description`                                                            |
| [`c276f24e`](https://github.com/NixOS/nixpkgs/commit/c276f24e2922e2cb31230cb4bb419918ff903ed6) | `phpExtensions.pinba: replace version number`                                                           |
| [`b762a9b7`](https://github.com/NixOS/nixpkgs/commit/b762a9b71f3d91c565bb05c9d0e4e6cf05f31a97) | `ruff: 0.0.131 -> 0.0.132`                                                                              |
| [`f5253423`](https://github.com/NixOS/nixpkgs/commit/f525342399d1650a54eba42a807d86d3d9d4e083) | `waylock: init at 0.4.2`                                                                                |
| [`4bc0392e`](https://github.com/NixOS/nixpkgs/commit/4bc0392ec941e8707d0a80d9300b89b3bcc9b7a3) | `maintainers: add jordanisaacs`                                                                         |
| [`da14dfaf`](https://github.com/NixOS/nixpkgs/commit/da14dfafd9a740a01464ab2f42d04d0bd7825459) | `nixVersions.nix_2_9: add non-existing output patch`                                                    |
| [`5c45e5d3`](https://github.com/NixOS/nixpkgs/commit/5c45e5d3d9d839e43e1d947d11dee2555b3d88f6) | `nixVersions.nix_2_10: add non-existing output patch`                                                   |
| [`68981849`](https://github.com/NixOS/nixpkgs/commit/6898184997c77e735ce8c96fd0f92282387e6c7f) | `nixVersions.nix_2_11: add non-existing output patch`                                                   |
| [`48400c17`](https://github.com/NixOS/nixpkgs/commit/48400c178109a28702bffc11c3c418789ff81bbf) | `python310Packages.ocifs: 1.1.3 -> 1.1.4`                                                               |
| [`9d2ca56a`](https://github.com/NixOS/nixpkgs/commit/9d2ca56a02b2773bb9196302717147e5147ae5cb) | `python310Packages.mypy-boto3-builder: 7.11.10 -> 7.11.11`                                              |
| [`15c029ca`](https://github.com/NixOS/nixpkgs/commit/15c029caf1ebdbb354269306602e13aaf4065675) | `python310Packages.msldap: 0.4.6 -> 0.4.7`                                                              |
| [`8ad2c953`](https://github.com/NixOS/nixpkgs/commit/8ad2c9538bdaebd3c82ad4cc714ee26c2525a4d9) | `python310Packages.asyauth: 0.0.6 -> 0.0.7`                                                             |
| [`d4eb8afe`](https://github.com/NixOS/nixpkgs/commit/d4eb8afee2bc0a8f549fba282d5a33de55107e74) | `qt6.qtwebengine: remove no longer needed patch`                                                        |
| [`95f7d621`](https://github.com/NixOS/nixpkgs/commit/95f7d621b63e5ce408d39eaefce1dee403f45305) | `python310Packages.msldap: add changelog to meta`                                                       |
| [`2889b5d3`](https://github.com/NixOS/nixpkgs/commit/2889b5d347207246e1c174c9170197af724dc4af) | `python310Packages.pyotgw: 2.1.1 -> 2.1.2`                                                              |
| [`b0db91b8`](https://github.com/NixOS/nixpkgs/commit/b0db91b8e86a9b3e332f86df1f1f20a26476a930) | `python310Packages.pyotgw: add changelog to meta`                                                       |
| [`0cd2e8f5`](https://github.com/NixOS/nixpkgs/commit/0cd2e8f533fb719b6779545c90aebb4a63c0cd5e) | `qt6: 6.4.0 → 6.4.1`                                                                                    |
| [`ee147f36`](https://github.com/NixOS/nixpkgs/commit/ee147f3665004ea17762bc2a4372bfa75e4c9858) | `unifi-poller: add changelog to meta`                                                                   |
| [`22d20170`](https://github.com/NixOS/nixpkgs/commit/22d2017050fc0683bbcff8b1ecd3a2514ab77f14) | `arch-install-scripts: 27 -> 28`                                                                        |
| [`95eeff00`](https://github.com/NixOS/nixpkgs/commit/95eeff0043f01f799390b1ae86719870d6ba0aec) | `unifi-poller: 2.1.3 -> 2.1.9`                                                                          |
| [`63601d26`](https://github.com/NixOS/nixpkgs/commit/63601d26e92c423605d19623ed9bffa0a47296ff) | `prometheus-fastly-exporter: 7.2.5 -> 7.3.0`                                                            |
| [`f3455c45`](https://github.com/NixOS/nixpkgs/commit/f3455c45cc62b588c9adf50f1ae384a5f9662884) | `prometheus-bind-exporter: 0.5.0 -> 0.6.0`                                                              |
| [`f931c547`](https://github.com/NixOS/nixpkgs/commit/f931c547b05472e61515d47ad1b703ef8d5447e9) | `lxi-tools: make gui support optional`                                                                  |
| [`8fa1580c`](https://github.com/NixOS/nixpkgs/commit/8fa1580c14f8fef36f24fd190784def9fee06c9c) | `lxi-tools: 1.21 -> 2.3`                                                                                |
| [`3836d8ca`](https://github.com/NixOS/nixpkgs/commit/3836d8cac921e439e8748305f0eb0fa477d4e442) | `liblxi: 1.13 -> 1.18`                                                                                  |
| [`96f68447`](https://github.com/NixOS/nixpkgs/commit/96f6844718bf0e7177341a9eecbdd1de27f60f6f) | `python3Packages.ctfime: fix platform-dependant test failure`                                           |
| [`a133aca6`](https://github.com/NixOS/nixpkgs/commit/a133aca6cc1942aa6aec4963e76c99daa4e7c209) | `pyside2: fixup build after qt5 update`                                                                 |
| [`9b11f79c`](https://github.com/NixOS/nixpkgs/commit/9b11f79c3759529ce17b3c0c12465b47e6cc5b06) | `python3Packages.pytz-deprecation-shim: Disable tests`                                                  |
| [`ee04235b`](https://github.com/NixOS/nixpkgs/commit/ee04235b28956b572a151d5f578b5ef618a972c2) | `ceph*: fix build`                                                                                      |
| [`d10e3216`](https://github.com/NixOS/nixpkgs/commit/d10e3216b8afdc163e028462412fd3ce611afcea) | `qt*.qtwayland: fix build of versions before 5.15`                                                      |
| [`c9a56e77`](https://github.com/NixOS/nixpkgs/commit/c9a56e77a87baa3c28d570ac6ec5f5e3d9293ce8) | `python3Packages.pytz-deprecation-shim: disable flaky tests`                                            |
| [`acad0b3a`](https://github.com/NixOS/nixpkgs/commit/acad0b3a098c9a3a5c6785356b034a496094373f) | `Revert "python310Packages.h11: 0.13.0 -> 0.14.0"`                                                      |
| [`5acdf854`](https://github.com/NixOS/nixpkgs/commit/5acdf854673ffac97d3a7970d4c3026ddb411f72) | `nixos/dbus: Avoid redundant output specification`                                                      |
| [`d1dd00b6`](https://github.com/NixOS/nixpkgs/commit/d1dd00b61823e8e98fe44262090b560eee45b344) | `nixos/vaultwarden: use lib.concatMapAttrs`                                                             |
| [`f4828b40`](https://github.com/NixOS/nixpkgs/commit/f4828b40fde0b39afc5dc9b147baa60cb2a6ca47) | `vimPlugins.nvim-treesitter: use lib.concatMapAttrs`                                                    |
| [`202fff43`](https://github.com/NixOS/nixpkgs/commit/202fff431f9173a72a2f35a7e8de1adf0ab9da0c) | `qt5.15: update to latest KDE patches`                                                                  |
| [`8025f92e`](https://github.com/NixOS/nixpkgs/commit/8025f92e50c33ed6ab1fdfa6bbb4e8c5d1647256) | `pipewire: backport more upstream suggested patches`                                                    |
| [`f993f8a1`](https://github.com/NixOS/nixpkgs/commit/f993f8a18659bb15bc5697b6875caf0cba8b1825) | `lib/attrsets: add concatMapAttrs`                                                                      |
| [`43f34da0`](https://github.com/NixOS/nixpkgs/commit/43f34da0798ed4499598abc5a9bc4a87cb118cf1) | `nixos/dbus: Clean up`                                                                                  |
| [`65ddb0ef`](https://github.com/NixOS/nixpkgs/commit/65ddb0ef06abcd733bbed124ea2594b6491abd73) | `nixos/dbus: Remove socketActivated option removal warning`                                             |
| [`4536ebad`](https://github.com/NixOS/nixpkgs/commit/4536ebad69010f41df3c67c18bff3d85513faf86) | `lib/attrsets: simplify chooseDevOutputs`                                                               |
| [`a14bb81a`](https://github.com/NixOS/nixpkgs/commit/a14bb81af78688a3a455db5273400ce13fceb862) | `python3Packages.scipy: pull an upstream patch`                                                         |
| [`1f8b8cc4`](https://github.com/NixOS/nixpkgs/commit/1f8b8cc49aed8a6b55ebb42afcbaf45d0b45cf74) | `pacman: add missing dependencies of pacman-key`                                                        |
| [`b83b3f5a`](https://github.com/NixOS/nixpkgs/commit/b83b3f5a3e12336e5075050f4393a4d88408cee5) | `hatch: 1.3.1 -> 1.6.3`                                                                                 |
| [`03db455e`](https://github.com/NixOS/nixpkgs/commit/03db455ebc6242f8d55e4938895362ea60153174) | `python310Packages.hatchling: 1.9.0 -> 1.11.1`                                                          |
| [`f352d6e2`](https://github.com/NixOS/nixpkgs/commit/f352d6e27b3202bc9d773cd4763201774f7fe5fc) | `b612: fix build`                                                                                       |
| [`80809553`](https://github.com/NixOS/nixpkgs/commit/808095530a618c70e81c9f2423273860cfbed4d0) | `glib: Fix infinite loop in GNOME Keyring`                                                              |
| [`e88c8f6c`](https://github.com/NixOS/nixpkgs/commit/e88c8f6c53e8b5a96ac58baf365bf9141681cd44) | `python3.pkgs.ldap: disable failing test (#201190)`                                                     |
| [`f9e93362`](https://github.com/NixOS/nixpkgs/commit/f9e9336207b9a67b65f859783d502f096a27bf8e) | `lispPackages_new: fix for patched sources not being picked up`                                         |
| [`2f103f2b`](https://github.com/NixOS/nixpkgs/commit/2f103f2b1f4a9cd20fe00e331f1177cf31086f26) | `lispPackages_new: Fix patching without build-with-compile-into-pwd`                                    |
| [`d77b0bb6`](https://github.com/NixOS/nixpkgs/commit/d77b0bb6a5ac11afb379c981d6d484a95b385961) | `montserrat: fix build`                                                                                 |
| [`fd94629a`](https://github.com/NixOS/nixpkgs/commit/fd94629a326306fccfc0b51ecbc38f1c1fdbfc82) | `qt5/qtwayland: fix popups being placed outside the screen`                                             |
| [`b4622ed8`](https://github.com/NixOS/nixpkgs/commit/b4622ed855b2168a6526a52eb1d94f4e98bc7078) | `obfs4: add meta fields`                                                                                |
| [`bea58512`](https://github.com/NixOS/nixpkgs/commit/bea58512db5080fe6e8941c3e627ce8c64badb0b) | `rust-bindgen: 0.59.2 -> 0.61.0`                                                                        |
| [`6fa503af`](https://github.com/NixOS/nixpkgs/commit/6fa503afeff8e4eb5d239463f4dee4fefb18c8ba) | `python3Packages.orjson: 3.8.0 -> 3.8.1`                                                                |
| [`b38cf2c9`](https://github.com/NixOS/nixpkgs/commit/b38cf2c9ae0402cb00540397df78d616f371e25f) | `postgresql_15: 15.0 -> 15.1`                                                                           |
| [`9a0ebf5d`](https://github.com/NixOS/nixpkgs/commit/9a0ebf5d4772016da6528165b71e45944c3f41ef) | `postgresql_14: 14.5 -> 14.6`                                                                           |
| [`4fc31c25`](https://github.com/NixOS/nixpkgs/commit/4fc31c2539ef7abb4e761b6548e5164deb96aaeb) | `postgresql_13: 13.8 -> 13.9`                                                                           |
| [`0e7dc253`](https://github.com/NixOS/nixpkgs/commit/0e7dc2534eacdb55ee343c4b0fb7f095721f48cc) | `postgresql_12: 12.12 -> 12.13`                                                                         |
| [`06a7064e`](https://github.com/NixOS/nixpkgs/commit/06a7064ec3a7170077f40bd96cc4aa7ef6ea529d) | `postgresql_11: 11.17 -> 11.18`                                                                         |
| [`0b25ba3d`](https://github.com/NixOS/nixpkgs/commit/0b25ba3d69ab89bf987a84903e46f386ad7e50db) | `ansible-later: 2.0.22 -> 2.0.23`                                                                       |
| [`223f139e`](https://github.com/NixOS/nixpkgs/commit/223f139e1e234865951698ab705b973ba882c1d7) | `python3Packages.jsonschema: 4.16.0 -> 4.17.0`                                                          |
| [`95b73dad`](https://github.com/NixOS/nixpkgs/commit/95b73dad899bad669186fe928493cdfcbd0c58ee) | `python3Packages.orjson: Disable failing tests on 32 bit`                                               |
| [`ae9cb7be`](https://github.com/NixOS/nixpkgs/commit/ae9cb7be8c3b5a3edfd90eff8734861ae89f7df8) | `lispPackages_new: fixed a bunch of packages`                                                           |
| [`5e41dbf2`](https://github.com/NixOS/nixpkgs/commit/5e41dbf243ada801adc2754f188882c859d5d9d8) | `libnftnl: 1.2.3 -> 1.2.4`                                                                              |
| [`1215a5fb`](https://github.com/NixOS/nixpkgs/commit/1215a5fbfea687def06839cc9ceae5dd11dbee99) | `pipewire: 0.3.59 -> 0.3.60`                                                                            |
| [`878a1467`](https://github.com/NixOS/nixpkgs/commit/878a14677fcf5773401b0d084073458535377193) | `xterm: 374 -> 375`                                                                                     |
| [`952dbf0a`](https://github.com/NixOS/nixpkgs/commit/952dbf0a4aea0661bb9fc21b05a83d31c7cd77d0) | `mesa: build more Vulkan drivers on aarch64-linux`                                                      |
| [`c3f3badd`](https://github.com/NixOS/nixpkgs/commit/c3f3baddaa0405714913f77ebcb61628a871be00) | ``Revert "llvmPackages_11: Add `$rsrc/lib` to default cflags"``                                         |
| [`eeda27d0`](https://github.com/NixOS/nixpkgs/commit/eeda27d0f2e07600142ba12ddb86a9c2688c26b7) | `bpftools: fix build on ppc64le`                                                                        |
| [`5f09efa7`](https://github.com/NixOS/nixpkgs/commit/5f09efa7306838562a05d4fba883cd7f58030746) | `libwnck: fix cross`                                                                                    |
| [`62f9cc2b`](https://github.com/NixOS/nixpkgs/commit/62f9cc2bdcc274fb7a06c2b63a67e67334b9a76c) | `gtksourceview{4,5}: fix cross`                                                                         |
| [`83f01989`](https://github.com/NixOS/nixpkgs/commit/83f0198962b4016210d20713fd437eb099b06f76) | `keybinder3: fix cross`                                                                                 |
| [`34e8a6de`](https://github.com/NixOS/nixpkgs/commit/34e8a6debd044cdfc894bc18fa18efaa6bbd7ede) | `i3ipc-glib: fix cross`                                                                                 |
| [`b2f9cd34`](https://github.com/NixOS/nixpkgs/commit/b2f9cd34e75409bd7cd68a90f8754e63f92f4738) | `gobject-introspection: use wrapper.nix for the native package too`                                     |
| [`657dd4e8`](https://github.com/NixOS/nixpkgs/commit/657dd4e8bf462565272633f08e7b8705f0d80433) | `hwdata: 0.360 -> 0.363`                                                                                |