### PR TITLE
chore(flake/nur): `d3d7f940` -> `57a4b831`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669153464,
-        "narHash": "sha256-r+g42qzn/DpcNIwaS0a+/FX8zhvhby458ar4cTYYSIE=",
+        "lastModified": 1669170292,
+        "narHash": "sha256-x6moyz7YCXqvs1/UuqDhqZBaJ/213TccCxKgBj6uKp0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d3d7f940425225f69dcf35a59790e55077094fc7",
+        "rev": "57a4b831d3ccef30ce42268b436164da375fff28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`57a4b831`](https://github.com/nix-community/NUR/commit/57a4b831d3ccef30ce42268b436164da375fff28) | `automatic update` |