### PR TITLE
chore(flake/nur): `57a4b831` -> `c90bcfbf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669170292,
-        "narHash": "sha256-x6moyz7YCXqvs1/UuqDhqZBaJ/213TccCxKgBj6uKp0=",
+        "lastModified": 1669173126,
+        "narHash": "sha256-ahiuSSuEucLw2As11hq4Yu4aXjppQpUJSmgUw+vkz4Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "57a4b831d3ccef30ce42268b436164da375fff28",
+        "rev": "c90bcfbfa1c22a37fb7f185a0eb0727a9280c55e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c90bcfbf`](https://github.com/nix-community/NUR/commit/c90bcfbfa1c22a37fb7f185a0eb0727a9280c55e) | `automatic update` |