### PR TITLE
chore(flake/nur): `c90bcfbf` -> `332d7390`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669173126,
-        "narHash": "sha256-ahiuSSuEucLw2As11hq4Yu4aXjppQpUJSmgUw+vkz4Y=",
+        "lastModified": 1669175830,
+        "narHash": "sha256-3ZBT5zbYN5O+ShnG9pkKeycwOMnvyU0BCKqK/WfkBPs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c90bcfbfa1c22a37fb7f185a0eb0727a9280c55e",
+        "rev": "332d73907ac1c1df1d43fd94cded26ecf50ddab0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`332d7390`](https://github.com/nix-community/NUR/commit/332d73907ac1c1df1d43fd94cded26ecf50ddab0) | `automatic update` |