### PR TITLE
chore(flake/emacs-overlay): `89f2e82f` -> `2139a4a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669149307,
-        "narHash": "sha256-mOKsVWY9l1aC4BCQAiPsSqT4Gs8mTwfHCgwmTDLDSHs=",
+        "lastModified": 1669181845,
+        "narHash": "sha256-0AA4OCc8irRCf8eKLyf2SOIgNneGPjpkYFYFo5+CU7s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "89f2e82fec9f7c2dde0381976266a245f0072217",
+        "rev": "2139a4a0721fefe892edefaaec520e037feefd97",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`2139a4a0`](https://github.com/nix-community/emacs-overlay/commit/2139a4a0721fefe892edefaaec520e037feefd97) | `Updated repos/nongnu` |
| [`501fb94b`](https://github.com/nix-community/emacs-overlay/commit/501fb94b5e5eb4d2d7bf5da6d7d328d95c4ed03f) | `Updated repos/melpa`  |
| [`99ccc301`](https://github.com/nix-community/emacs-overlay/commit/99ccc3010d0fe24c32c85db997283761eaafb7d2) | `Updated repos/exwm`   |
| [`f5786c44`](https://github.com/nix-community/emacs-overlay/commit/f5786c44249607e5865f901f26b4716affed44d9) | `Updated repos/emacs`  |