### PR TITLE
chore(flake/emacs-overlay): `2139a4a0` -> `a131c18e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669181845,
-        "narHash": "sha256-0AA4OCc8irRCf8eKLyf2SOIgNneGPjpkYFYFo5+CU7s=",
+        "lastModified": 1669203968,
+        "narHash": "sha256-l3/QgfQPtv0DjZf7KgnI1CAQJNBLPEh3cNjJXU8id4Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2139a4a0721fefe892edefaaec520e037feefd97",
+        "rev": "a131c18e862d23b83400355dae6594840f179d00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`a131c18e`](https://github.com/nix-community/emacs-overlay/commit/a131c18e862d23b83400355dae6594840f179d00) | `Updated repos/melpa` |
| [`d1490be1`](https://github.com/nix-community/emacs-overlay/commit/d1490be1e430d49604c88825004f9e1af964680d) | `Updated repos/emacs` |