### PR TITLE
chore(flake/nixpkgs): `20fc9484` -> `2788904d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669052418,
-        "narHash": "sha256-M1I4BKXBQm2gey1tScemEh5TpHHE3gKptL7BpWUvL8s=",
+        "lastModified": 1669140675,
+        "narHash": "sha256-npzfyfLECsJWgzK/M4gWhykP2DNAJTYjgY2BWkz/oEQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "20fc948445a6c22d4e8d5178e9a6bc6e1f5417c8",
+        "rev": "2788904d26dda6cfa1921c5abb7a2466ffe3cb8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                                       |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
| [`0ea13cc6`](https://github.com/NixOS/nixpkgs/commit/0ea13cc6ca439da8c18d4e09abcc3694a781ecb8) | `python310Packages.django-maintenance-mode: fix lint issue`                                                          |
| [`ee2c00a0`](https://github.com/NixOS/nixpkgs/commit/ee2c00a01de055767fffd51b8b27e46b22980e48) | `python310Packages.deezer-python: add changelog to meta`                                                             |
| [`221f5245`](https://github.com/NixOS/nixpkgs/commit/221f524563b9d3215e895fbd85c6c6300b97a734) | `python310Packages.aiomusiccast: add changelog to meta`                                                              |
| [`62f4c61a`](https://github.com/NixOS/nixpkgs/commit/62f4c61a1fbb73bd06b1dbe83f51f791ead70a93) | `python310Packages.django-maintenance-mode: add changelog to meta`                                                   |
| [`dbde15a5`](https://github.com/NixOS/nixpkgs/commit/dbde15a513603821875b40e1f848d88c6f5f92d4) | `python310Packages.broadlink: add changelog to meta`                                                                 |
| [`03c92f54`](https://github.com/NixOS/nixpkgs/commit/03c92f54a4e10feb5a13d8ff1730e00c2d04f1b8) | `python310Packages.adafruit-platformdetect: add changelog to meta`                                                   |
| [`f01bcf0b`](https://github.com/NixOS/nixpkgs/commit/f01bcf0b88cbd9ff2096cd1a141b6195cfc2000d) | `python310Packages.PyChromecast: add changelog to meta`                                                              |
| [`b23f6b12`](https://github.com/NixOS/nixpkgs/commit/b23f6b129e6db8f2fe16a65041e13660f6be204b) | `python310Packages.arcam-fmj: add changelog to meta`                                                                 |
| [`7e88b2be`](https://github.com/NixOS/nixpkgs/commit/7e88b2bef5bf969baac40b3847cdc7c0e8089d97) | `form: 4.2.1 -> 4.3.0`                                                                                               |
| [`f0e298c0`](https://github.com/NixOS/nixpkgs/commit/f0e298c00272d745fba42be2c6e782cd2aa64444) | `Revert "lib/trivial: fix 'error: cannot decode virtual path '/nix/store/virtual0000000000000000000000005-source''"` |
| [`17d22b5e`](https://github.com/NixOS/nixpkgs/commit/17d22b5ea55929ca8bdf0f1bac359fc868ea5919) | `typos: 1.11.1 -> 1.13.0`                                                                                            |
| [`61e288ec`](https://github.com/NixOS/nixpkgs/commit/61e288ecd750b7677e79d6bdb64e931be80961b7) | `python310Packages.django-maintenance-mode: 0.16.3 -> 0.17.1`                                                        |
| [`bbc89727`](https://github.com/NixOS/nixpkgs/commit/bbc897272f4fdef7f9649594b45738b91bc4bd42) | `cemu: 2.0-13 -> 2.0-17 (#201077)`                                                                                   |
| [`5c3f27d2`](https://github.com/NixOS/nixpkgs/commit/5c3f27d2d9493655df5137e1e809d699d587115e) | `python310Packages.deezer-python: 5.7.0 -> 5.8.0`                                                                    |
| [`50934990`](https://github.com/NixOS/nixpkgs/commit/509349900629c455c84d79f3dbadf7580ab3e934) | `python310Packages.debian: 0.1.48 -> 0.1.49`                                                                         |
| [`9778ba41`](https://github.com/NixOS/nixpkgs/commit/9778ba41fdcdfc3a45b8eb00aaeae5d576489a6e) | `python310Packages.cherrypy: fix url`                                                                                |
| [`29b20985`](https://github.com/NixOS/nixpkgs/commit/29b2098551a1ce45495d7be949ffd77e0e7ed667) | `samba: explicitly enable libunwind (#201875)`                                                                       |
| [`deca1167`](https://github.com/NixOS/nixpkgs/commit/deca1167154bacb009e819beb7a52960283c6036) | `python310Packages.broadlink: 0.18.2 -> 0.18.3`                                                                      |
| [`a5f162fb`](https://github.com/NixOS/nixpkgs/commit/a5f162fb93f5e0bdf7737eebc96e298da4574357) | `python310Packages.bellows: 0.34.3 -> 0.34.4`                                                                        |
| [`c6980427`](https://github.com/NixOS/nixpkgs/commit/c6980427cececbfec6754e3edb618573f9b70da2) | `zotero: 6.0.16 -> 6.0.18`                                                                                           |
| [`287131c4`](https://github.com/NixOS/nixpkgs/commit/287131c409bcb8fb53c401ed028815c3e20b6b39) | `ocamlPackages.phylogenetics: run full test suite`                                                                   |
| [`766cc473`](https://github.com/NixOS/nixpkgs/commit/766cc473f7a92163617808190da869357f89f6ce) | `ikill: 1.5.0 -> 1.6.0`                                                                                              |
| [`8e3c88f6`](https://github.com/NixOS/nixpkgs/commit/8e3c88f66e670528efd699a859ce4579f0f6a691) | `pocketbase: 0.7.10 -> 0.8.0`                                                                                        |
| [`847e77dd`](https://github.com/NixOS/nixpkgs/commit/847e77dd2bbb539454d97fbd4d267bb6f48293ea) | `ferretdb: 0.6.1 -> 0.6.2`                                                                                           |
| [`7aac181e`](https://github.com/NixOS/nixpkgs/commit/7aac181e81b904943709a609e2d6725c2b1367ad) | `cargo-lambda: 0.11.3 -> 0.12.0`                                                                                     |
| [`2d6a6457`](https://github.com/NixOS/nixpkgs/commit/2d6a645776d29db49d2b6ebfdb779dc7708e88b9) | `pgadmin4: 6.15 -> 6.16`                                                                                             |
| [`909afd71`](https://github.com/NixOS/nixpkgs/commit/909afd71f8f0893b3250e99daa2ac91e456dbe30) | `python310Packages.adafruit-platformdetect: 3.33.0 -> 3.34.0`                                                        |
| [`5d5f5a7c`](https://github.com/NixOS/nixpkgs/commit/5d5f5a7c2160e7a6ba14b54027ee25c511d08aa1) | `python310Packages.PyChromecast: 12.1.4 -> 13.0.1`                                                                   |
| [`2ea79e0f`](https://github.com/NixOS/nixpkgs/commit/2ea79e0fe445f3fe4f7ac355e12b60ca0e2bd1fa) | `mnc: init at 0.4`                                                                                                   |
| [`b380f254`](https://github.com/NixOS/nixpkgs/commit/b380f254a02f33171469762364d9d9238381dd9f) | `dwarfs: 0.6.1 -> 0.6.2`                                                                                             |
| [`b96679c3`](https://github.com/NixOS/nixpkgs/commit/b96679c3e9dd7ca72b67a7ac702f0d91814352dc) | `python310Packages.arcam-fmj: 0.12.0 -> 1.0.1`                                                                       |
| [`f8636f5d`](https://github.com/NixOS/nixpkgs/commit/f8636f5d05f8c885cfd557d574de1748735858bf) | `terraform-providers.tencentcloud: 1.78.12 → 1.78.13`                                                                |
| [`254db8a0`](https://github.com/NixOS/nixpkgs/commit/254db8a04e4ec6a2fb034deca87946dc3e863bd0) | `terraform-providers.rancher2: 1.24.2 → 1.25.0`                                                                      |
| [`2a784c5c`](https://github.com/NixOS/nixpkgs/commit/2a784c5cf87693b370ca4c530106c4d17547778c) | `terraform-providers.google-beta: 4.43.1 → 4.44.0`                                                                   |
| [`db935280`](https://github.com/NixOS/nixpkgs/commit/db935280e5f67ae1bd37527c07d3f8579a484477) | `terraform-providers.google: 4.43.1 → 4.44.0`                                                                        |
| [`cd777c91`](https://github.com/NixOS/nixpkgs/commit/cd777c91587642ac8a0c25aca9df630a92771e5b) | `cyberchef: 9.48.0 -> 9.49.0`                                                                                        |
| [`9a1b2c5e`](https://github.com/NixOS/nixpkgs/commit/9a1b2c5ec6832113470e92ef060161fec3c5319a) | `gitleaks: 8.15.0 -> 8.15.1`                                                                                         |
| [`e21db6e7`](https://github.com/NixOS/nixpkgs/commit/e21db6e7202fbfcbe16f14145de1ed7fca3b9fc8) | `git-cliff: 0.9.2 -> 0.10.0`                                                                                         |
| [`efb156bf`](https://github.com/NixOS/nixpkgs/commit/efb156bf9a63732e75f3f908ecfee95b21d264b9) | `ginkgo: 2.5.0 -> 2.5.1`                                                                                             |
| [`fef20379`](https://github.com/NixOS/nixpkgs/commit/fef20379e4c8e574c8b0eee91cbda3a486984b88) | `esbuild: 0.15.14 -> 0.15.15`                                                                                        |
| [`de6f2b0a`](https://github.com/NixOS/nixpkgs/commit/de6f2b0a0701954a35bd7de525f7baadeda1812e) | `nixos/dbus: support dbus-broker`                                                                                    |
| [`3be2a768`](https://github.com/NixOS/nixpkgs/commit/3be2a76832fa540b32cefd8bf8e9095037f97391) | `zeal: unstable-2021-12-25 → unstable-2022-10-02`                                                                    |
| [`4c5f7afb`](https://github.com/NixOS/nixpkgs/commit/4c5f7afb5f25d1404e79c87009abb5d6fffcf0cd) | `broadlink-cli: 0.18.2 -> 0.18.3`                                                                                    |
| [`408131fd`](https://github.com/NixOS/nixpkgs/commit/408131fde1a95ce6944dae686da02cf9ad10f99b) | `fnott: Drop the unnecessary wlroots dependency`                                                                     |
| [`d2596de2`](https://github.com/NixOS/nixpkgs/commit/d2596de25e49d613b5eaf3d43d64f5ba216573c4) | `wlroots_0_16: init at 0.16`                                                                                         |
| [`ead322b5`](https://github.com/NixOS/nixpkgs/commit/ead322b582033bb5cc4787908c04d0069c30e2f0) | `wlroots: deduplicate builders`                                                                                      |
| [`b7d37b2f`](https://github.com/NixOS/nixpkgs/commit/b7d37b2f12b108a1002f77a41a11227a932d36d8) | `klipper: unstable-2022-11-03 -> unstable-2022-11-21`                                                                |
| [`2ad8652e`](https://github.com/NixOS/nixpkgs/commit/2ad8652ef2b6b6e2b9f4ada245136bdc502fdbb1) | `beets: install man pages`                                                                                           |
| [`73dd9e31`](https://github.com/NixOS/nixpkgs/commit/73dd9e31d32a5ba530be62459e69f4a23c0b5244) | `jackett: 0.20.2264 -> 0.20.2271`                                                                                    |
| [`3761ba21`](https://github.com/NixOS/nixpkgs/commit/3761ba2119fde0972cf4aac48d0b4ccc87c53ab1) | `awscli2: 2.8.12 -> 2.9.0 (#201978)`                                                                                 |
| [`802115d0`](https://github.com/NixOS/nixpkgs/commit/802115d0227228b66b691f3b85b30b868976e8eb) | `dar: unbreak on Darwin`                                                                                             |
| [`29624484`](https://github.com/NixOS/nixpkgs/commit/296244844a362590f089ea4746df96979369d49d) | `clib: 2.8.1 -> 2.8.2`                                                                                               |
| [`005233ba`](https://github.com/NixOS/nixpkgs/commit/005233baa29a7da3aa2e76ce0bd36bf286aaac4f) | `nixos/tests/evcc: init`                                                                                             |
| [`36f58b68`](https://github.com/NixOS/nixpkgs/commit/36f58b687c48494e6f849f0bb816b5d4fcdc30f4) | `nixos/evcc: init`                                                                                                   |
| [`cc8681b2`](https://github.com/NixOS/nixpkgs/commit/cc8681b2c718472614196b0424cdc47761c5d5a0) | `evcc: init at 0.107.1`                                                                                              |
| [`74b39464`](https://github.com/NixOS/nixpkgs/commit/74b39464975dfaa92194e8cec27f4699a75ea1a8) | `cargo-expand: 1.0.32 -> 1.0.35`                                                                                     |
| [`45c65058`](https://github.com/NixOS/nixpkgs/commit/45c65058c03ff13f9e242be565a8222f16c70969) | `enumer: init at 1.5.7`                                                                                              |
| [`aee7510b`](https://github.com/NixOS/nixpkgs/commit/aee7510bf1c4942b3ce0f73ed69476c21b896fc4) | `xpaste: init at 1.5 (#201602)`                                                                                      |
| [`b68bd2ee`](https://github.com/NixOS/nixpkgs/commit/b68bd2ee52051aaf983a268494cb4fc6c485b646) | `23.05 is Stoat`                                                                                                     |
| [`361cab5b`](https://github.com/NixOS/nixpkgs/commit/361cab5bb53a6c7c86525b62a4e783857091ee38) | `nfs-ganesha: 4.0.12 -> 4.1`                                                                                         |
| [`814a0bc6`](https://github.com/NixOS/nixpkgs/commit/814a0bc6b71af6928134898be2958adc603f76bf) | `open-stage-control: update deps hash`                                                                               |
| [`009a234b`](https://github.com/NixOS/nixpkgs/commit/009a234bdd91d91008e95c7e8b9de16439114635) | `prefetch-npm-deps: repack hosted git deps`                                                                          |
| [`091d039b`](https://github.com/NixOS/nixpkgs/commit/091d039b12a485bd3b677d862da5b35da4b19f36) | `prefetch-npm-deps: deduplicate dependencies when parsing lockfile`                                                  |
| [`b117b359`](https://github.com/NixOS/nixpkgs/commit/b117b359db1610173c81737a3f79da1b39032551) | `prefetch-npm-deps: move tests to separate file`                                                                     |
| [`3d5f77f4`](https://github.com/NixOS/nixpkgs/commit/3d5f77f496147a4ae553154a2fb66c4a88066325) | `npmHooks.npmConfigHook: sugget specifying legacy peer deps option for all commands`                                 |
| [`93334f52`](https://github.com/NixOS/nixpkgs/commit/93334f5234211e2cb17c58bb1f9dfe4963f7fb82) | `npmHooks.npmInstallHook: pass install flags to prune`                                                               |
| [`80ecb954`](https://github.com/NixOS/nixpkgs/commit/80ecb954e988a135422677f32b341718fe271289) | `npmHooks.npmConfigHook: add diagnostic for when dependencies aren't provided`                                       |
| [`c0e7124b`](https://github.com/NixOS/nixpkgs/commit/c0e7124bcc4421d5ce9d2e5d4d0f7eec7ce798cc) | `npmHooks.npmConfigHook: add some missing quotes around variable assignments`                                        |
| [`68d5b19f`](https://github.com/NixOS/nixpkgs/commit/68d5b19fca6f18bb2df7b287eb512b1c7b2c335a) | `npmHooks.npmConfigHook: also patch shebangs after rebuilding`                                                       |
| [`8e651111`](https://github.com/NixOS/nixpkgs/commit/8e651111b77e590a933d525563daa2a3e14bb0e2) | `npmHooks.npmBuildHook: mention dontNpmBuild if script fails to run`                                                 |
| [`c6903a01`](https://github.com/NixOS/nixpkgs/commit/c6903a01e71f77ecd2000397d081ce1447fe0615) | `prefetch-npm-deps: add etherpad-lite v1.8.18 as a test`                                                             |
| [`03a7739d`](https://github.com/NixOS/nixpkgs/commit/03a7739d75285320d7ebff7626a122c6a6592878) | `prefetch-npm-deps: skip bundled dependencies in v1 lockfiles`                                                       |
| [`276982bd`](https://github.com/NixOS/nixpkgs/commit/276982bd5e389e11c6051ac47f2647b0e860494c) | `prefetch-npm-deps: add support for hosted git shorthands`                                                           |
| [`cc5756b1`](https://github.com/NixOS/nixpkgs/commit/cc5756b1712cc1341781b6dc019f9483332c863c) | `prefetch-npm-deps: add support for link dependencies in v2 lockfiles`                                               |
| [`6d709bea`](https://github.com/NixOS/nixpkgs/commit/6d709beac3c9b58d1e0236e847d1122618ca5773) | `blackbox-terminal: 0.12.1 -> 0.12.2`                                                                                |
| [`3f1058ad`](https://github.com/NixOS/nixpkgs/commit/3f1058adb1ac9df62f97a1e8fe59c31d3bfa4787) | `ocamlPackages.linenoise: 1.3.1 → 1.4.0`                                                                             |
| [`9fc764a0`](https://github.com/NixOS/nixpkgs/commit/9fc764a0bb370f58964d0735cd527fb5c2a60225) | `toot: 0.28.0 -> 0.29.0`                                                                                             |
| [`e7fd02be`](https://github.com/NixOS/nixpkgs/commit/e7fd02bec1c4678f20aad3824a310024036a01d1) | `ntirpc: 4.0 -> 4.1`                                                                                                 |
| [`36a7a78e`](https://github.com/NixOS/nixpkgs/commit/36a7a78ed5d70ed9f6db541048b7ed0ddf3810c1) | `tut: 1.0.17 -> 1.0.19`                                                                                              |
| [`4ef32c25`](https://github.com/NixOS/nixpkgs/commit/4ef32c251a5f2d478d11e3e45a56dc8927ce9b84) | `whipper: install man pages`                                                                                         |
| [`09ff14cd`](https://github.com/NixOS/nixpkgs/commit/09ff14cdbf3a08ac264da8adbf6fdfc139ddc867) | `tailscale: 1.32.2 -> 1.32.3`                                                                                        |
| [`3fda065c`](https://github.com/NixOS/nixpkgs/commit/3fda065c6a11665ed9ff27984a565dcd4219c12a) | `gobject-introspection: inherit meta in the wrapper`                                                                 |
| [`195aa535`](https://github.com/NixOS/nixpkgs/commit/195aa5350908e039cce5c01b6f3f1e2e3bd91ef3) | `nixos/redis: fix requirepass`                                                                                       |
| [`7ed6d28f`](https://github.com/NixOS/nixpkgs/commit/7ed6d28f5c069724534854e92d3c71c79af28971) | `python310Packages.niapy: add changelog to meta`                                                                     |
| [`f2918bea`](https://github.com/NixOS/nixpkgs/commit/f2918bea1181e82e72a80bf10d9a74c65220c297) | `aocd: 1.1.3 -> 1.2.1`                                                                                               |
| [`733dee4f`](https://github.com/NixOS/nixpkgs/commit/733dee4f84cc4df22cadb365262cce3f78bf8f70) | `python310Packages.aiomusiccast: 0.14.5 -> 0.14.6`                                                                   |
| [`edf1f46a`](https://github.com/NixOS/nixpkgs/commit/edf1f46af87eb6d9a19da33efe693fe649630a9a) | `libxcrypt: Fix the build on Android by allowing warnings`                                                           |
| [`2500c927`](https://github.com/NixOS/nixpkgs/commit/2500c9270b8644f2456d0821f39b25d42a8e7f22) | `vimPlugins.nvim-treesitter: remove parser directory`                                                                |
| [`9aa81986`](https://github.com/NixOS/nixpkgs/commit/9aa81986de0e0648f969e5b468fdeb25664f40a4) | `flyctl: 0.0.432 -> 0.0.433`                                                                                         |
| [`4f184818`](https://github.com/NixOS/nixpkgs/commit/4f18481878be17e7b6d65b31810c988ecb13ab5a) | `harmonist: use buildGoModule`                                                                                       |
| [`3d8ffea1`](https://github.com/NixOS/nixpkgs/commit/3d8ffea12c2932cc355971a68c7bdaf15f6d7e7a) | `spf-engine: apply review comments`                                                                                  |
| [`d316aecc`](https://github.com/NixOS/nixpkgs/commit/d316aeccdf0c1c645027354a55872391e2ae6bb8) | `libmilter: add fixDarwinDylibNames call to fix imports on darwin`                                                   |
| [`46b4a9d7`](https://github.com/NixOS/nixpkgs/commit/46b4a9d74a1b78978a8058eac07feaea613bf096) | `pimilter: fix some tests using libredirect`                                                                         |
| [`37cc873a`](https://github.com/NixOS/nixpkgs/commit/37cc873ac8275cc6b5cdbf0f8ac8eab1f01a8038) | `pypolicyd-spf 2.0.2 -> spf-engine 2.9.3`                                                                            |
| [`2fb3bfb1`](https://github.com/NixOS/nixpkgs/commit/2fb3bfb178b2f0002b47b290f2479ea04251875b) | `python3Packages.pymilter: init at 1.0.5`                                                                            |
| [`1bff5de9`](https://github.com/NixOS/nixpkgs/commit/1bff5de944494e32885961fade67e93d4a40624e) | `python310Packages.h5py: remove unittest2 and six`                                                                   |
| [`271d7abb`](https://github.com/NixOS/nixpkgs/commit/271d7abb49faa5da0e026c994e33ef42a5932fc1) | `python310Packages.unicode-slugify: remove unittest2`                                                                |
| [`f3773f34`](https://github.com/NixOS/nixpkgs/commit/f3773f3436e62f483af9344f60b90e9f6388df6b) | `python310Packages.python-datemath: remove unittest2`                                                                |
| [`8683f16c`](https://github.com/NixOS/nixpkgs/commit/8683f16c3981aac5c622e8e2788c8529b2976282) | `rekor-cli, rekor-server: 1.0.0 -> 1.0.1`                                                                            |
| [`4de63c67`](https://github.com/NixOS/nixpkgs/commit/4de63c6750f2dcba7705f3a1bbbc16f05d6781de) | `outline: 0.66.3 -> 0.67.0`                                                                                          |
| [`403a7405`](https://github.com/NixOS/nixpkgs/commit/403a7405ab5b337b6f08349be0b7e2d09cadbc13) | `dotty: use preFixup instead of fixupPhase`                                                                          |
| [`55d1f5ea`](https://github.com/NixOS/nixpkgs/commit/55d1f5ea3c446ac6d022182449ac814b96f7e1ef) | `brakeman: 5.3.1 -> 5.4.0`                                                                                           |
| [`e8ef6a4e`](https://github.com/NixOS/nixpkgs/commit/e8ef6a4eb6baecbd90f29f577c49831f94798129) | `postgresqlPackages.postgis: 3.3.1 -> 3.3.2`                                                                         |
| [`2b778dbd`](https://github.com/NixOS/nixpkgs/commit/2b778dbd81451983146e102e5d0528d4c5bde3ad) | `shadowenv: 2.0.6 -> 2.1.0`                                                                                          |
| [`66f6e765`](https://github.com/NixOS/nixpkgs/commit/66f6e7655e68fb928069efc202e00f8066bcf751) | `python310Packages.pebble: 5.0.2 -> 5.0.3`                                                                           |
| [`570a37ea`](https://github.com/NixOS/nixpkgs/commit/570a37eaed8f995331010b3f19f2a316ebc879f8) | `python310Packages.oslo-log: 5.0.1 -> 5.0.2`                                                                         |
| [`6f552748`](https://github.com/NixOS/nixpkgs/commit/6f5527487c59421a553b76e12b4d30089a48a630) | `python310Packages.robotframework-seleniumlibrary: fix build`                                                        |
| [`bcdde34a`](https://github.com/NixOS/nixpkgs/commit/bcdde34a8962fbc973a930d44817a911d6006b98) | `python310Packages.robotframework-pythonlibcore: init at 4.0.0`                                                      |
| [`b710efb0`](https://github.com/NixOS/nixpkgs/commit/b710efb0cd10576a3afd495bb943ffd8f17de391) | `bob: 0.7.0 -> 0.7.1`                                                                                                |
| [`18c8904c`](https://github.com/NixOS/nixpkgs/commit/18c8904c11e3e393ef3c1dafdde853c8043f82db) | `workflows: add 24 hour periodic merges for 22.11`                                                                   |
| [`16647a43`](https://github.com/NixOS/nixpkgs/commit/16647a437943cfb5504969e0c05cc7d2bf96b9c1) | `python310Packages.pytest-mockito: init at 0.0.4`                                                                    |
| [`4f982504`](https://github.com/NixOS/nixpkgs/commit/4f9825046889ac72688a5f30279ddae22cacd631) | `goreleaser: 1.12.3 -> 1.13.0`                                                                                       |
| [`d1f7cd28`](https://github.com/NixOS/nixpkgs/commit/d1f7cd28080732dba67eb33fca82c5af6403f6f8) | `python310Packages.niapy: 2.0.3 -> 2.0.4`                                                                            |
| [`69dd2ae6`](https://github.com/NixOS/nixpkgs/commit/69dd2ae6faba2440312cde17684b504d54337a23) | `wiki-js: 2.5.291 -> 2.5.292`                                                                                        |
| [`f7835037`](https://github.com/NixOS/nixpkgs/commit/f7835037da3c9827b1e1938556d67f0fd3821334) | `python310Packages.smbprotocol: add changelog to meta`                                                               |
| [`b9a8eae2`](https://github.com/NixOS/nixpkgs/commit/b9a8eae2a4068c05c253508e2063fd0d3d193311) | `teamviewer: remove qtwebkit`                                                                                        |
| [`a71b35d9`](https://github.com/NixOS/nixpkgs/commit/a71b35d986d4b344f5489a461e549e2f3438c13d) | `knot-dns: 3.2.2 -> 3.2.3`                                                                                           |
| [`d743b612`](https://github.com/NixOS/nixpkgs/commit/d743b6124c4758b939d05bd2df8c1f03f3093ff7) | `godu: 1.3.0 -> 1.4.1`                                                                                               |
| [`cb0fc208`](https://github.com/NixOS/nixpkgs/commit/cb0fc208b6febd743541206f7d73b1bb47806417) | `hexgui: init at unstable-2022-5-30`                                                                                 |
| [`3fd24c2e`](https://github.com/NixOS/nixpkgs/commit/3fd24c2ee8f9b2b7a78b4c41f41f2b74ebd6fe56) | `maintainers: Add ursi`                                                                                              |
| [`b8bcebad`](https://github.com/NixOS/nixpkgs/commit/b8bcebad11bf18f2c3e94b49d92ee638332885ae) | `python3Packages.heatshrink2: init at 0.11.0`                                                                        |
| [`0c5624ce`](https://github.com/NixOS/nixpkgs/commit/0c5624ceb1f39d113ccf01d2b5c397078d9059a1) | `keepmenu: init at 1.2.2`                                                                                            |
| [`b70b4d0d`](https://github.com/NixOS/nixpkgs/commit/b70b4d0d6262ddba15009a2e1c7c6ebab6a4a4fd) | `plex-mpv-shim: add gapps-wrapper for pystray`                                                                       |
| [`4814a3b3`](https://github.com/NixOS/nixpkgs/commit/4814a3b3c76c634611a0201a18efbeb678c36739) | `jellyfin-mpv-shim: add gapps-wrapper for pystray`                                                                   |
| [`aba2c391`](https://github.com/NixOS/nixpkgs/commit/aba2c391f1fb2784b77cc26756380d3733004e2a) | `pythonPackages.pystray: fix two backends`                                                                           |
| [`e6ab90e1`](https://github.com/NixOS/nixpkgs/commit/e6ab90e164f17d68b6550f7f81bfd14d3db430e1) | `python310Packages.smbprotocol: 1.10.0 -> 1.10.1`                                                                    |
| [`92f1bc47`](https://github.com/NixOS/nixpkgs/commit/92f1bc4787e7e3fde95c9688d728dfe4fd113cce) | `python310Packages.smbprotocol: 1.9.0 -> 1.10.0`                                                                     |
| [`31531c74`](https://github.com/NixOS/nixpkgs/commit/31531c747a964adb678d732035a15a5ef2eef8c2) | `linux: cleanup common-config after drop of 4.9`                                                                     |
| [`bb5827a6`](https://github.com/NixOS/nixpkgs/commit/bb5827a6926dcd576e029459ed8e7e723d963616) | `dockerTools: prefer local builds`                                                                                   |
| [`7d589b68`](https://github.com/NixOS/nixpkgs/commit/7d589b68e651aa384cff7892d032e0897f4c0e01) | `julia_18-bin: 1.8.2 -> 1.8.3`                                                                                       |
| [`9d0884c2`](https://github.com/NixOS/nixpkgs/commit/9d0884c2886773335de3740fd282815617b5b98c) | `python310Packages.cssselect: 1.1.0 -> 1.2.0`                                                                        |
| [`4236d385`](https://github.com/NixOS/nixpkgs/commit/4236d385f985aa859695f700487b63ecfac5b80e) | `zfsUnstable: 2.1.7-2022-10-27 → 2.1.7-2022-11-08`                                                                   |
| [`ed0a8c95`](https://github.com/NixOS/nixpkgs/commit/ed0a8c95530c02d862aa03d3088857c6e6261e1f) | `mautrix-whatsapp: 0.7.1 -> 0.7.2`                                                                                   |
| [`b6624e46`](https://github.com/NixOS/nixpkgs/commit/b6624e467c10767aeeca15642062734dddc58c9e) | `senpai: unstable-2022-11-04 → unstable-2022-11-15`                                                                  |
| [`9fdf63a7`](https://github.com/NixOS/nixpkgs/commit/9fdf63a7b4cbf217a3d4843eeb1e7d90b97d54ee) | `python310Packages.django_hijack: 3.2.1 -> 3.2.4`                                                                    |
| [`c95d7d5a`](https://github.com/NixOS/nixpkgs/commit/c95d7d5a8c301cf59fde5ffd9296660bc72c3080) | `treewide: make sparseCheckout a list of strings`                                                                    |
| [`f6b07f0e`](https://github.com/NixOS/nixpkgs/commit/f6b07f0e2f5834b1fd6432a0f4c2bc11096e53ed) | `fetchgit: make sparseCheckout a list of strings`                                                                    |
| [`5ccc047d`](https://github.com/NixOS/nixpkgs/commit/5ccc047d3a2238623fd8a379fcd205e47e3acd2f) | `grocy: 3.3.1 -> 3.3.2`                                                                                              |
| [`b60de3b4`](https://github.com/NixOS/nixpkgs/commit/b60de3b41641ca29bc789c8bd946145762dbbbfc) | `julia_10, julia_15: drop infavor of latest stable versions`                                                         |
| [`c754d1b6`](https://github.com/NixOS/nixpkgs/commit/c754d1b6a30f87aa6b2af08f078cbd9b06dc213e) | `julia_18: 1.8.2 -> 1.8.3`                                                                                           |
| [`ee8ae2da`](https://github.com/NixOS/nixpkgs/commit/ee8ae2da4c3fe46c5aa40a80185861db9d45ba5c) | `nixos/doc: fix installing from other distro`                                                                        |
| [`e0b64413`](https://github.com/NixOS/nixpkgs/commit/e0b64413b0531f927c88cc0d9d36b1584c4b6304) | `gns3-server,gns3-gui: clean`                                                                                        |
| [`7d5785de`](https://github.com/NixOS/nixpkgs/commit/7d5785de2bf23f9a2d1f756e8c9ce7f51c6759e3) | `gns3-server,gns3-gui: 2.2.34 -> 2.2.35.1`                                                                           |
| [`4729d5d7`](https://github.com/NixOS/nixpkgs/commit/4729d5d7f62a989c1518cac96a3a971da00a7d12) | `nixos/proxmox-image: allow building UEFI images`                                                                    |
| [`d155128b`](https://github.com/NixOS/nixpkgs/commit/d155128b531a9b3a7a5dd1fe435f426071a2a7b7) | `bottles: 2022.5.28-trento-3 -> 2022.10.14.1`                                                                        |
| [`6b802f91`](https://github.com/NixOS/nixpkgs/commit/6b802f913f6bf12ec526f5d2ab33fc88bf4abfa5) | `fvs: init at 0.3.4`                                                                                                 |
| [`7aa3e528`](https://github.com/NixOS/nixpkgs/commit/7aa3e528bfce93c52986dca931be962532d5c985) | `icoextract: init at 0.1.4`                                                                                          |
| [`d1a4e078`](https://github.com/NixOS/nixpkgs/commit/d1a4e0784baa88c326e54183a53ec0a1bae91d8d) | `bottles: don't include system wine by default`                                                                      |
| [`a381f9bc`](https://github.com/NixOS/nixpkgs/commit/a381f9bccf279f9d2601525029f847311d8d562d) | `openssl: Rosetta Stone entry for mips32`                                                                            |