### PR TITLE
chore(flake/emacs-overlay): `a131c18e` -> `decf4c58`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669203968,
-        "narHash": "sha256-l3/QgfQPtv0DjZf7KgnI1CAQJNBLPEh3cNjJXU8id4Y=",
+        "lastModified": 1669233286,
+        "narHash": "sha256-sQgyNUzDW7m9gyUOC1DKVo6vtIbzjV02iJFEANKCnrc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a131c18e862d23b83400355dae6594840f179d00",
+        "rev": "decf4c588c7e1a056bc7da2f25794018590ad1bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`decf4c58`](https://github.com/nix-community/emacs-overlay/commit/decf4c588c7e1a056bc7da2f25794018590ad1bf) | `Updated repos/melpa` |
| [`eb4061df`](https://github.com/nix-community/emacs-overlay/commit/eb4061df471adea29378843a5ead22035af8ba8b) | `Updated repos/emacs` |