### PR TITLE
chore(flake/nur): `6ccbe180` -> `8d863ade`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669182177,
-        "narHash": "sha256-U3Bp+pZN58lEqlk1hoTyCGUckFpZfXW2b14p1NGymyY=",
+        "lastModified": 1669238506,
+        "narHash": "sha256-STqh4jWkB0R50DZksaBNjSPz5wt1GZg19QaOHj6axeM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6ccbe180fc646a7672cede9fa008fd30d744d0c8",
+        "rev": "8d863ade97012b6b0cf07cff1b6f6816433923f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8d863ade`](https://github.com/nix-community/NUR/commit/8d863ade97012b6b0cf07cff1b6f6816433923f9) | `automatic update` |