### PR TITLE
chore(flake/nur): `8d863ade` -> `7396d005`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669238506,
-        "narHash": "sha256-STqh4jWkB0R50DZksaBNjSPz5wt1GZg19QaOHj6axeM=",
+        "lastModified": 1669245155,
+        "narHash": "sha256-+5yQreehHG4SPF/4kvoFl50FtsrmZ5bqU/lxc6yV8bk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8d863ade97012b6b0cf07cff1b6f6816433923f9",
+        "rev": "7396d005fcc104390655f2371ae39cc3c6327f71",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7396d005`](https://github.com/nix-community/NUR/commit/7396d005fcc104390655f2371ae39cc3c6327f71) | `automatic update` |