### PR TITLE
chore(flake/emacs-overlay): `decf4c58` -> `d381dcca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669233286,
-        "narHash": "sha256-sQgyNUzDW7m9gyUOC1DKVo6vtIbzjV02iJFEANKCnrc=",
+        "lastModified": 1669251968,
+        "narHash": "sha256-RNEbDDGHEBCQR3FXnO/t9Tb24hzqwj7I9Q4U8r9hTtg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "decf4c588c7e1a056bc7da2f25794018590ad1bf",
+        "rev": "d381dcca8193bce5c65aca58832b53b79e31d167",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                  |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`d381dcca`](https://github.com/nix-community/emacs-overlay/commit/d381dcca8193bce5c65aca58832b53b79e31d167) | `Add C# grammar to list of tree-sitter plugins` |