### PR TITLE
chore(flake/nur): `3e48120a` -> `84cd893f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669254495,
-        "narHash": "sha256-6hU8tP9Clb3fr7qFN9Qgg6HbjrUzJ572A+rcXljIUOs=",
+        "lastModified": 1669261803,
+        "narHash": "sha256-nNMrmuBgNTqYmhmKkAsyrl09BTjjW5XKaYpoK32aC7U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3e48120a23e3d524b9deaf6539225515b92fcde7",
+        "rev": "84cd893ff86a7aae1c9e9e6dca98a2cd691ecb7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`84cd893f`](https://github.com/nix-community/NUR/commit/84cd893ff86a7aae1c9e9e6dca98a2cd691ecb7f) | `automatic update` |