### PR TITLE
chore(flake/nur): `84cd893f` -> `e16b0997`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669261803,
-        "narHash": "sha256-nNMrmuBgNTqYmhmKkAsyrl09BTjjW5XKaYpoK32aC7U=",
+        "lastModified": 1669262965,
+        "narHash": "sha256-Womo1T79Fr8neM4Qb9Qk6baPch28noekAAveO7HuPmU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "84cd893ff86a7aae1c9e9e6dca98a2cd691ecb7f",
+        "rev": "e16b0997da6619baf7f050d90cf758b7f3dd2cc1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e16b0997`](https://github.com/nix-community/NUR/commit/e16b0997da6619baf7f050d90cf758b7f3dd2cc1) | `automatic update` |