### PR TITLE
chore(flake/emacs-overlay): `d381dcca` -> `6ebe7fe0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669251968,
-        "narHash": "sha256-RNEbDDGHEBCQR3FXnO/t9Tb24hzqwj7I9Q4U8r9hTtg=",
+        "lastModified": 1669269498,
+        "narHash": "sha256-LezPrFta8rqTYBOr0fzbZwX/IlCK8exNaYRWVXPChv0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d381dcca8193bce5c65aca58832b53b79e31d167",
+        "rev": "6ebe7fe01e32cb4ac95f456427d308fa8ce1c0fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`6ebe7fe0`](https://github.com/nix-community/emacs-overlay/commit/6ebe7fe01e32cb4ac95f456427d308fa8ce1c0fb) | `Updated repos/nongnu` |
| [`4cb6d2cc`](https://github.com/nix-community/emacs-overlay/commit/4cb6d2cc8bcadcf979fe3eda2511483af29677e3) | `Updated repos/melpa`  |
| [`a88a530b`](https://github.com/nix-community/emacs-overlay/commit/a88a530b9b9040dba3208f94fc0689fcac57075f) | `Updated repos/emacs`  |