### PR TITLE
chore(flake/nur): `e16b0997` -> `d794159c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669262965,
-        "narHash": "sha256-Womo1T79Fr8neM4Qb9Qk6baPch28noekAAveO7HuPmU=",
+        "lastModified": 1669273295,
+        "narHash": "sha256-CEfDHrbW1DdN8HerHH1fUUgUTC9eLELK6GOvMTj8gpQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e16b0997da6619baf7f050d90cf758b7f3dd2cc1",
+        "rev": "d794159c1c1359338715c81b72795b699d3b642c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d794159c`](https://github.com/nix-community/NUR/commit/d794159c1c1359338715c81b72795b699d3b642c) | `automatic update` |