### PR TITLE
chore(flake/nur): `d794159c` -> `5434a3a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669273295,
-        "narHash": "sha256-CEfDHrbW1DdN8HerHH1fUUgUTC9eLELK6GOvMTj8gpQ=",
+        "lastModified": 1669287107,
+        "narHash": "sha256-X1GUpnQN4aZbtYMl2Z8JwUMCImR2WbCW1cZfmGmeLk4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d794159c1c1359338715c81b72795b699d3b642c",
+        "rev": "5434a3a4bda5b91046c16d257549120fda9ea69a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5434a3a4`](https://github.com/nix-community/NUR/commit/5434a3a4bda5b91046c16d257549120fda9ea69a) | `automatic update` |