### PR TITLE
chore(flake/emacs-overlay): `6ebe7fe0` -> `fa293d98`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669269498,
-        "narHash": "sha256-LezPrFta8rqTYBOr0fzbZwX/IlCK8exNaYRWVXPChv0=",
+        "lastModified": 1669290739,
+        "narHash": "sha256-0QT6o7lv4UZDR3qaneCsN51erLFpLhsTVrYJLv9JDlE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6ebe7fe01e32cb4ac95f456427d308fa8ce1c0fb",
+        "rev": "fa293d98210547e943c1e64df8d0e0aa24174eab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`fa293d98`](https://github.com/nix-community/emacs-overlay/commit/fa293d98210547e943c1e64df8d0e0aa24174eab) | `Updated repos/melpa` |
| [`a7bc3dc1`](https://github.com/nix-community/emacs-overlay/commit/a7bc3dc1595f8da021a8cfddeffb02537caeabac) | `Updated repos/emacs` |