### PR TITLE
chore(flake/nix-on-droid): `a9b17907` -> `c16cb917`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -326,11 +326,11 @@
         "nmd": "nmd_2"
       },
       "locked": {
-        "lastModified": 1668984854,
-        "narHash": "sha256-x5y85pV4zyAwVBJwfczBObNtN/QCd4gq1PQc/efnvJc=",
+        "lastModified": 1669300355,
+        "narHash": "sha256-YmiccJZmmAcMiGHmRz2WL8Qp6qbRvUJdYIDCswAwMdo=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "a9b1790700769269d6757d33d5442cd1dded11f3",
+        "rev": "c16cb917d7dcfe2ea20257ac5a4cb6c8fb4154a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message |
| ----------------------------------------------------------------------------------------------------- | -------------- |
| [`c16cb917`](https://github.com/t184256/nix-on-droid/commit/c16cb917d7dcfe2ea20257ac5a4cb6c8fb4154a6) | `Export pkgs`  |