### PR TITLE
chore(flake/nixpkgs): `2788904d` -> `42337aad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669140675,
-        "narHash": "sha256-npzfyfLECsJWgzK/M4gWhykP2DNAJTYjgY2BWkz/oEQ=",
+        "lastModified": 1669230746,
+        "narHash": "sha256-+rU3DixJnygpJsGhhp6OvViruJux4TaiCz4IO+DdtZU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2788904d26dda6cfa1921c5abb7a2466ffe3cb8c",
+        "rev": "42337aad353c5efff4382d7bf99deda491459845",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`f9cdaba4`](https://github.com/NixOS/nixpkgs/commit/f9cdaba46e67f71663fe03c4174cab9f7b03520b) | `part ways with leaveDotGit`                                                          |
| [`4415badd`](https://github.com/NixOS/nixpkgs/commit/4415baddd8ead057344cf87898a6029b0ef27012) | `zlint: apply review's comment`                                                       |
| [`1462c3cc`](https://github.com/NixOS/nixpkgs/commit/1462c3cc487e282988fa0a2747b021fb934f6cf6) | `zlint: init at 3.4.0`                                                                |
| [`3efbc1f9`](https://github.com/NixOS/nixpkgs/commit/3efbc1f9e58b7ca4d8f1f258eb91f9fe84cdf429) | `rofimoji: install man page`                                                          |
| [`90e22fde`](https://github.com/NixOS/nixpkgs/commit/90e22fde4b2e718b44d03b0041d72264e98e7708) | `rofimoji: 5.6.0 -> 6.0.0`                                                            |
| [`579ec5c8`](https://github.com/NixOS/nixpkgs/commit/579ec5c894f99c85aa24c825b9b9c2c308c3682d) | `python310Packages.griffe: 0.24.0 -> 0.24.1`                                          |
| [`d37848e5`](https://github.com/NixOS/nixpkgs/commit/d37848e5c01f4f1b51991ca90d6b7aefdf03f237) | `python310Packages.griffe: add changelog to meta`                                     |
| [`58930f0b`](https://github.com/NixOS/nixpkgs/commit/58930f0b7f3171d398fbc7b297ff0a8eb18de537) | `ocamlPackages.mtime: 1.2.0 → 1.4.0`                                                  |
| [`e57f897d`](https://github.com/NixOS/nixpkgs/commit/e57f897d25bd432d422709c1f944193ded0447f6) | `python310Packages.aiohomekit: 2.3.0 -> 2.3.1`                                        |
| [`4edf9eda`](https://github.com/NixOS/nixpkgs/commit/4edf9edaf461f1f206383dfce1bd4fdc48437324) | `python310Packages.aiocoap: 0.4.4 -> 0.4.5`                                           |
| [`14791e09`](https://github.com/NixOS/nixpkgs/commit/14791e09aa377424a6f0ccf87100654762bbff97) | `python310Packages.aiocoap: add changelog to meta`                                    |
| [`63808344`](https://github.com/NixOS/nixpkgs/commit/6380834436e2d6c4555d3797a148161ff4db3864) | `python310Packages.aiohomekit: add changelog to meta`                                 |
| [`36ca2b49`](https://github.com/NixOS/nixpkgs/commit/36ca2b495fc58d303d60af87f5e2568c5ed2f967) | `nixos/ec2: use only curl in metadata fetcher, log to console`                        |
| [`6fb582e0`](https://github.com/NixOS/nixpkgs/commit/6fb582e0301da53d6d5a32d02b8ecbaf0f91c188) | `ec2-metadata-fetcher: ignore failure when fetching metadata parts`                   |
| [`eddfcf86`](https://github.com/NixOS/nixpkgs/commit/eddfcf8622f547676d36c42619b68de766a78a6d) | `amazon-image: fetch metadata only in stage-2`                                        |
| [`24e33a4d`](https://github.com/NixOS/nixpkgs/commit/24e33a4d2e41fc1201034e0cd1a6bd5a642d94c5) | `nixos/ec2: remove paravirtualization-specific code`                                  |
| [`f97b4920`](https://github.com/NixOS/nixpkgs/commit/f97b4920b9f5bf0864bc71f63b8b4f614e59ee79) | ` python310Packages.lxmf: add chagnelog to meta`                                      |
| [`e977728a`](https://github.com/NixOS/nixpkgs/commit/e977728a5b627a461ce71d3b4b9ff9ca385c1ffc) | `python310Packages.pytenable: 1.4.9 -> 1.4.10`                                        |
| [`d0732c94`](https://github.com/NixOS/nixpkgs/commit/d0732c9470dbadec5812d97746423409728dbbae) | `python310Packages.pytenable: add changelog to meta`                                  |
| [`d6693545`](https://github.com/NixOS/nixpkgs/commit/d669354552227bf9567ff0d40bff8129bfe18063) | `python310Packages.sensor-state-data: 2.12.0 -> 2.12.1`                               |
| [`0781b244`](https://github.com/NixOS/nixpkgs/commit/0781b2448963c8c37c15e0024b7da16c4dcb342a) | `python310Packages.sensor-state-data: add changelog to meta`                          |
| [`31a73a22`](https://github.com/NixOS/nixpkgs/commit/31a73a22063eea13e09335414531e84d4987e579) | `aliyun-cli: 3.0.135 -> 3.0.136`                                                      |
| [`c0d004af`](https://github.com/NixOS/nixpkgs/commit/c0d004afa0e9110f147a49d351ad2e3298cceb86) | `pkgsStatic.rcshist: fix static build`                                                |
| [`62ff8337`](https://github.com/NixOS/nixpkgs/commit/62ff8337e1c1305b91c0d401e515c0c3ecaad7ac) | `vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.11.0 -> 0.12.0`                     |
| [`7393a554`](https://github.com/NixOS/nixpkgs/commit/7393a554e85f10480d111e4ee2e95c82952ff3e0) | `heroku: 7.60.2 -> 7.66.4`                                                            |
| [`20515701`](https://github.com/NixOS/nixpkgs/commit/2051570194656f89884acb924cbbbde82ebbda95) | `advancecomp: 2.3 -> 2.4`                                                             |
| [`49454c3e`](https://github.com/NixOS/nixpkgs/commit/49454c3e224d7bdbdd751cee4418c91ea1662d33) | `vscode-extensions.streetsidesoftware.code-spell-checker: 2.11.0 -> 2.11.1`           |
| [`5a8af240`](https://github.com/NixOS/nixpkgs/commit/5a8af2401c15c69ba1e72fc96686007ae44c1097) | `gnome-secrets: 6.5 -> 7.0`                                                           |
| [`2440674e`](https://github.com/NixOS/nixpkgs/commit/2440674e5f43ab1aac121b7f5f1d0bca379d55a5) | `yad: 12.0 -> 12.1`                                                                   |
| [`62d46c43`](https://github.com/NixOS/nixpkgs/commit/62d46c43cb0dc902725f0a37b9ab5c216ed95b8b) | `swappy: 1.4.0 -> 1.5.1`                                                              |
| [`1f5c55be`](https://github.com/NixOS/nixpkgs/commit/1f5c55be64894d2a258cee001c85bdb91e59dc99) | `datree: 1.8.0 -> 1.8.1`                                                              |
| [`2ab2d1ea`](https://github.com/NixOS/nixpkgs/commit/2ab2d1ea8cce120d2cb712cb1815039e3425876f) | `kyverno: 1.8.1 -> 1.8.2`                                                             |
| [`6fa4fa65`](https://github.com/NixOS/nixpkgs/commit/6fa4fa650890811ab4728e4f045e5824c3297550) | `portfolio: 0.59.3 -> 0.59.4`                                                         |
| [`f5f27446`](https://github.com/NixOS/nixpkgs/commit/f5f27446bf90d7bd34686feabab5ac86530abf33) | `heisenbridge: Fix double-hash caused by #202060`                                     |
| [`c7ae87cf`](https://github.com/NixOS/nixpkgs/commit/c7ae87cfbf43a88c8a36e43b838af5c923eabd55) | `jekyll: update dependencies`                                                         |
| [`625e691a`](https://github.com/NixOS/nixpkgs/commit/625e691a67c3c699afefb497772e7669e67fd1e1) | `sayonara: build against latest Qt5`                                                  |
| [`689f5904`](https://github.com/NixOS/nixpkgs/commit/689f5904888c41e28c78ff1d19d30484f450863c) | `subsurface: 5.0.2 -> 5.0.10 (#202145)`                                               |
| [`d0ebe6b8`](https://github.com/NixOS/nixpkgs/commit/d0ebe6b8763154152e7729e8f4fccb7c9fd064f9) | `jekyll: force ruby platform when updating dependencies`                              |
| [`d79ab83b`](https://github.com/NixOS/nixpkgs/commit/d79ab83bbca433c9c160de4e71d805f06e459a5c) | `fcitx5-unikey: 5.0.11 -> 5.0.12`                                                     |
| [`e2af29d9`](https://github.com/NixOS/nixpkgs/commit/e2af29d997dd547ba732246e1d686d5ac0f49174) | `fcitx5-table-extra: 5.0.11 -> 5.0.12`                                                |
| [`599fd132`](https://github.com/NixOS/nixpkgs/commit/599fd132818687e4b88701d2e6f3ee05a97f3bbb) | `fcitx5-rime: 5.0.14 -> 5.0.15`                                                       |
| [`e7f071f6`](https://github.com/NixOS/nixpkgs/commit/e7f071f699b62394e5d21e5e5c0b0ba5c75099c2) | `libsForQt5.fcitx5-qt: 5.0.15 -> 5.0.16`                                              |
| [`80df6e86`](https://github.com/NixOS/nixpkgs/commit/80df6e8613ca2e56e691e3e999e928f7dae80ac6) | `fcitx5-m17n: 5.0.10 -> 5.0.11`                                                       |
| [`48005968`](https://github.com/NixOS/nixpkgs/commit/48005968c770e6d12c451762d4594487ace94c91) | `fcitx5-gtk: 5.0.19 -> 5.0.20`                                                        |
| [`1c1d6523`](https://github.com/NixOS/nixpkgs/commit/1c1d65231ec4b4ff1eaad8cc6977cb2ad66780c3) | `fcitx5-configtool: 5.0.15 -> 5.0.16`                                                 |
| [`a5dcd0fe`](https://github.com/NixOS/nixpkgs/commit/a5dcd0fe353188f41e94003822c8d6f1444fad70) | `fcitx5-chinese-addons: 5.0.15 -> 5.0.16`                                             |
| [`6b274039`](https://github.com/NixOS/nixpkgs/commit/6b2740393ea8247f0d3cf4a4634af5262b7f67d3) | `fcitx5-chewing: 5.0.12 -> 5.0.13`                                                    |
| [`d7ab7262`](https://github.com/NixOS/nixpkgs/commit/d7ab72620d45cfff6b744fea7ab48305a1e67f22) | `fcitx5: 5.0.19 -> 5.0.20`                                                            |
| [`de50b1dc`](https://github.com/NixOS/nixpkgs/commit/de50b1dc24cacd22db180f37b164e8e08e2f01af) | `wasmtime: 2.0.2 -> 3.0.0`                                                            |
| [`c33ec106`](https://github.com/NixOS/nixpkgs/commit/c33ec106999b959c692a788c232f9f4bb12cf073) | `qownnotes: 22.11.5 -> 22.11.7`                                                       |
| [`cb3339b8`](https://github.com/NixOS/nixpkgs/commit/cb3339b84287079adb8bb6f56d62f452c86d001f) | `python310Packages.autopep8: 1.7.1 -> 2.0.0`                                          |
| [`20c50761`](https://github.com/NixOS/nixpkgs/commit/20c5076170eb9e885fa8b656dcc2168f73783890) | `twitterBootstrap: 5.2.2 -> 5.2.3`                                                    |
| [`1e99c150`](https://github.com/NixOS/nixpkgs/commit/1e99c15089f6563dc0d36cff0181fb2e24de0698) | `vale: 2.21.0 -> 2.21.1`                                                              |
| [`6c534a48`](https://github.com/NixOS/nixpkgs/commit/6c534a48f46b6a6768cbc8547cf0d4989bdc3dbc) | `antimony: 2020-03-28 -> 2022-11-23`                                                  |
| [`1297203f`](https://github.com/NixOS/nixpkgs/commit/1297203f6f91e74885c3ef47af6ddd6d5a458c27) | `exploitdb: 2022-11-12 -> 2022-11-22`                                                 |
| [`8040c468`](https://github.com/NixOS/nixpkgs/commit/8040c468ed9188c33fb851921327d9d9d6850f2c) | `nixosTests/prosody[-mysql]: fix tests TLS setup`                                     |
| [`501d684d`](https://github.com/NixOS/nixpkgs/commit/501d684de8fb70cac2e72eaaff0dcc94aa2af459) | `nixosTests/prosody: add timeout`                                                     |
| [`2d8cbb5a`](https://github.com/NixOS/nixpkgs/commit/2d8cbb5a215d2b854280be74e2d18f669751668c) | `unifi7: 7.2.92 -> 7.2.95`                                                            |
| [`5ab18b18`](https://github.com/NixOS/nixpkgs/commit/5ab18b18ed158e2daf924b2a40fc91224804abd2) | `ocamlPackages.reactivedata: 0.2.2 → 0.3`                                             |
| [`67a1a34e`](https://github.com/NixOS/nixpkgs/commit/67a1a34ed67bcf082c46bd03524c601b2f580330) | `python3Packages.python-lsp-server: Add undeclared but necessary optional dependency` |
| [`798c76ea`](https://github.com/NixOS/nixpkgs/commit/798c76ea130ba0b348bcf9db6f6bb7c25d0d2f7f) | `python3Packages.autopep8: replace toml with tomli`                                   |
| [`c94a435e`](https://github.com/NixOS/nixpkgs/commit/c94a435e943054ac740fef0c42cb863fb1c9d4d6) | `taskwarrior-tui: install completions and manpage`                                    |
| [`ee7bc620`](https://github.com/NixOS/nixpkgs/commit/ee7bc6209d85445ae790c3ce7948338fc8b94e6d) | `taskwarrior-tui: 0.23.6 -> 0.23.7`                                                   |
| [`639d8523`](https://github.com/NixOS/nixpkgs/commit/639d8523a99d451feb114188da83a2072901e3e4) | `plantuml: 1.2022.12 -> 1.2022.13`                                                    |
| [`7c81f8bc`](https://github.com/NixOS/nixpkgs/commit/7c81f8bc2acb4e4a8edfe211aef56582decaad49) | `syft: 0.62.0 -> 0.62.1`                                                              |
| [`3d0df173`](https://github.com/NixOS/nixpkgs/commit/3d0df173b98031f0f50d75d2766cb388f015b80d) | `cargo-public-api: 0.23.0 -> 0.24.0`                                                  |
| [`6d48f87e`](https://github.com/NixOS/nixpkgs/commit/6d48f87ec36e77c92d4fd514e120f4ff423882c7) | `python310Packages.lxmf: 0.2.4 -> 0.2.5`                                              |
| [`f0261636`](https://github.com/NixOS/nixpkgs/commit/f02616368a84ae17448f4d0e14253ab562cfaabe) | `spicetify-cli: 2.14.1 -> 2.14.2`                                                     |
| [`6a7cc8d5`](https://github.com/NixOS/nixpkgs/commit/6a7cc8d58779ebcfac2f1c4a4418b07725c06d05) | `snappymail: 2.21.3 -> 2.21.4`                                                        |
| [`c3ef258b`](https://github.com/NixOS/nixpkgs/commit/c3ef258b6ff7ce731625330f7815f8218e6c26d2) | `ocamlPackages.core: 0.15.0 → 0.15.1`                                                 |
| [`a428c94a`](https://github.com/NixOS/nixpkgs/commit/a428c94ab6b78e8f500408c482cfff5c2ca6d41a) | `ocamlPackages.ppx_expect: 0.15.0 → 0.15.1`                                           |
| [`c4c53595`](https://github.com/NixOS/nixpkgs/commit/c4c53595c4cebd22cb64d00fdf188e652f94bbfb) | `ocamlPackages.sexplib: 0.15.0 → 0.15.1`                                              |
| [`727fcd40`](https://github.com/NixOS/nixpkgs/commit/727fcd407ed27025c4abd41fc2e264f7c68e9e83) | `postgresqlPackages.plpgsql_check: 2.2.3 -> 2.2.4`                                    |
| [`eed26dd1`](https://github.com/NixOS/nixpkgs/commit/eed26dd1059b778dd463388f794413897d34b9e8) | `zuo: 2022-11-12 -> 2022-11-15`                                                       |
| [`4607cb53`](https://github.com/NixOS/nixpkgs/commit/4607cb53b4bd796441020baab133e81c9a1b221e) | `zsv: 2022-11-12 -> 0.3.3-alpha`                                                      |
| [`c69d1a21`](https://github.com/NixOS/nixpkgs/commit/c69d1a21c6b24c0953c2886821f67c88a50256dd) | `git-annex-remote-rclone: update meta`                                                |
| [`ed537115`](https://github.com/NixOS/nixpkgs/commit/ed53711511d8e59da1f142338724243caafce79a) | `git-annex-remote-rclone: use stdenvNoCC`                                             |
| [`7dd87915`](https://github.com/NixOS/nixpkgs/commit/7dd87915b4b9ddbd7e85108dff8d1afdff19fdc2) | `terraform-providers.scaleway: 2.6.0 → 2.7.1`                                         |
| [`9e38073c`](https://github.com/NixOS/nixpkgs/commit/9e38073c85907616641456d8b82d34e5bc051eab) | `terraform-providers.ovh: 0.22.0 → 0.23.0`                                            |
| [`8aa683bf`](https://github.com/NixOS/nixpkgs/commit/8aa683bfafb1932ca1693897af84c669d8a79d2c) | `terraform-providers.okta: 3.38.0 → 3.39.0`                                           |
| [`97114c7a`](https://github.com/NixOS/nixpkgs/commit/97114c7ae07a77ededf2c64f2adbcd8f982ff6ad) | `terraform-providers.grafana: 1.30.0 → 1.31.1`                                        |
| [`bebf9d49`](https://github.com/NixOS/nixpkgs/commit/bebf9d494c82ac1cc7aaf28b70c02602d2f4131b) | `terraform-providers.google-beta: 4.44.0 → 4.44.1`                                    |
| [`17ce3fff`](https://github.com/NixOS/nixpkgs/commit/17ce3fff32f5349739a5ec6d4cf95c45d1bc0211) | `terraform-providers.google: 4.44.0 → 4.44.1`                                         |
| [`de92ad30`](https://github.com/NixOS/nixpkgs/commit/de92ad302d95f4a64a4feb023d5c8c435bae990b) | `terraform-providers.github: 5.9.0 → 5.9.1`                                           |
| [`3f7e939d`](https://github.com/NixOS/nixpkgs/commit/3f7e939dd95a711f79634d26caddeb27c7745cd4) | `terraform-providers.fastly: 3.0.0 → 3.0.1`                                           |
| [`326447b6`](https://github.com/NixOS/nixpkgs/commit/326447b6106a7e21183a10bac823b9f89589bc13) | `terraform-providers.cloudfoundry: 0.15.5 → 0.50.0`                                   |
| [`d07d74ef`](https://github.com/NixOS/nixpkgs/commit/d07d74efee42b3ff4db429080a33fe764bd5758c) | `terraform-providers.dnsimple: 0.14.1 → 0.15.0`                                       |
| [`443f5eb9`](https://github.com/NixOS/nixpkgs/commit/443f5eb97f63017b37cf19916240c5f42ba5971b) | `python3Packages.monero: 1.0.1 -> 1.1.1`                                              |
| [`5b8c42f9`](https://github.com/NixOS/nixpkgs/commit/5b8c42f98c59e748201a882ead093fe48efd6a75) | `nixos/lighthouse: add dataDirs to unit ReadWritePaths`                               |
| [`dc7783ec`](https://github.com/NixOS/nixpkgs/commit/dc7783ece2224cc38b725551e903af65633fa6b3) | `qt6Packages.qttools: fix tool path`                                                  |
| [`091e6d7c`](https://github.com/NixOS/nixpkgs/commit/091e6d7c69f3101501b91cecd35b0d200d9bd9f6) | `gpxsee: 11.6 -> 11.9`                                                                |
| [`d2b9c669`](https://github.com/NixOS/nixpkgs/commit/d2b9c6691ec4ec20774bc1bda66e3503d9fc181c) | `qtpbfimageplugin: build with qt6 too`                                                |
| [`a9b8f8f2`](https://github.com/NixOS/nixpkgs/commit/a9b8f8f209a394238f218cd9b071a531ad12fdab) | `telegraf: 1.24.2 -> 1.24.3`                                                          |
| [`aeacc063`](https://github.com/NixOS/nixpkgs/commit/aeacc063c76049f8263885943566bb9aee228327) | `vimPlugins.nvim-treesitter: update grammars`                                         |
| [`2273459f`](https://github.com/NixOS/nixpkgs/commit/2273459f982a1a24e85ba035ee8c66a20787bc48) | `vimPlugins.neoconf-nvim: init at 2022-11-22`                                         |
| [`a1ff1691`](https://github.com/NixOS/nixpkgs/commit/a1ff1691faf2dea10e288f566c308eece400744f) | `vimPlugins: update`                                                                  |
| [`87823cc8`](https://github.com/NixOS/nixpkgs/commit/87823cc82806658cf8babb8698d343886652a586) | `resvg: 0.25.0 -> 0.26.1`                                                             |
| [`b72a75e7`](https://github.com/NixOS/nixpkgs/commit/b72a75e7d7e68cfaf6a802d633797052920ab3cf) | `nomad: 1.3 -> 1.4`                                                                   |
| [`40c825f8`](https://github.com/NixOS/nixpkgs/commit/40c825f840531d0e601f27b61313f6e0f7ea9567) | `nomad_1_4: 1.4.2 -> 1.4.3`                                                           |
| [`cfd38d7a`](https://github.com/NixOS/nixpkgs/commit/cfd38d7a561a849a1c88f514c658dcfe8c947bb9) | `nomad_1_3: 1.3.7 -> 1.3.8`                                                           |
| [`3c95f2c9`](https://github.com/NixOS/nixpkgs/commit/3c95f2c96802eca4f32c685ac06d1e2c7a771a32) | `nomad_1_2: 1.2.14 -> 1.2.15`                                                         |
| [`25b2efe9`](https://github.com/NixOS/nixpkgs/commit/25b2efe9dfc622db95d07ed11497abea2c42b737) | `cargo-llvm-lines: 0.4.21 -> 0.4.22`                                                  |
| [`7ef66a73`](https://github.com/NixOS/nixpkgs/commit/7ef66a7340d8ea62d93a054641ff4255b9b402fe) | `pods: 1.0.0-beta.7 -> 1.0.0-beta.8`                                                  |
| [`c2ab8369`](https://github.com/NixOS/nixpkgs/commit/c2ab8369fac82977f808878fcc9a3789b19f3d87) | `python310Packages.googlemaps: add changelog to meta`                                 |
| [`1f2f987b`](https://github.com/NixOS/nixpkgs/commit/1f2f987b51f1c7f8818b2f1782063a8b7b02f79d) | `python310Packages.httpx-socks: add changelog to meta`                                |
| [`9161d4a8`](https://github.com/NixOS/nixpkgs/commit/9161d4a8fcc7588a06695d186d9558a1f92426bb) | `crackmapexec: 5.3.0 -> 5.4.0`                                                        |
| [`58ae822d`](https://github.com/NixOS/nixpkgs/commit/58ae822d2471bc8836030f61d5d76687b217b9a2) | `python310Packages.junitparser: 1.4.1 -> 2.8.0 (#200443)`                             |
| [`9746690d`](https://github.com/NixOS/nixpkgs/commit/9746690d4a37ac926f3a1679d93eca5ad3c0daea) | `python310Packages.masky: init at 0.1.1`                                              |
| [`e599c2ae`](https://github.com/NixOS/nixpkgs/commit/e599c2ae330b2779a8c1700809383f950575ea77) | `python310Packages.httpx-socks: 0.7.4 -> 0.7.5`                                       |
| [`9d9bb3b9`](https://github.com/NixOS/nixpkgs/commit/9d9bb3b9ae1ca2d62dd7583287edbc7f4246eab9) | `python310Packages.ntlm-auth: disable failing tests`                                  |
| [`b6320d0c`](https://github.com/NixOS/nixpkgs/commit/b6320d0c45b8ecdc4fc206975dff08b1f28cdabf) | `python310Packages.pymbolic: 2022.1 -> 2022.2`                                        |
| [`365c1a5a`](https://github.com/NixOS/nixpkgs/commit/365c1a5abbbbf49dd4bbf382d7c382e64ee29e40) | `maintainer-list.nix: sort`                                                           |
| [`29384778`](https://github.com/NixOS/nixpkgs/commit/29384778fef15dc727f0a17e9ad3ba81723760c9) | `clusterctl: 1.2.5 -> 1.2.6`                                                          |
| [`e00bdab4`](https://github.com/NixOS/nixpkgs/commit/e00bdab42cdd4425cef1bdeb88bb952ab4481222) | `python310Packages.pick: 2.1.0 -> 2.2.0`                                              |
| [`b5570921`](https://github.com/NixOS/nixpkgs/commit/b557092159d3d37293aa6756dc8d44b569db93ba) | `python310Packages.pick: add changelog to meta`                                       |
| [`ece6f129`](https://github.com/NixOS/nixpkgs/commit/ece6f129b26dcd60546a235033772e53b94a24c8) | `python310Packages.googlemaps: 4.7.0 -> 4.7.3`                                        |
| [`a7d485a2`](https://github.com/NixOS/nixpkgs/commit/a7d485a21d650dd6ae94b521769374723d9ee19a) | `talosctl: 1.2.6 -> 1.2.7`                                                            |
| [`eb8e4765`](https://github.com/NixOS/nixpkgs/commit/eb8e476531a722a378d296c96048184a64257744) | `python310Packages.slack-sdk: 3.19.3 -> 3.19.4`                                       |
| [`00d4e145`](https://github.com/NixOS/nixpkgs/commit/00d4e1453322d22e382a84b4918456789f178cb8) | `python310Packages.slack-sdk: add changelog to meta`                                  |
| [`1e91f3fe`](https://github.com/NixOS/nixpkgs/commit/1e91f3feee908f94f04555feee3dbe91820820d4) | `nvme-cli: fix cross compiling`                                                       |
| [`76d23c8a`](https://github.com/NixOS/nixpkgs/commit/76d23c8a5f6edfe673532a72d4b69dc495a4540e) | `python310Packages.xknx: add changelog to meta`                                       |
| [`1b08e4e3`](https://github.com/NixOS/nixpkgs/commit/1b08e4e353d4386fde04d232ed4c2adc25ba0684) | `erosmb: add changelog to meta`                                                       |
| [`ee53f65f`](https://github.com/NixOS/nixpkgs/commit/ee53f65f0598a7e721c71ff2e34da591241a3629) | `nmap-formatter: add changelog to meta`                                               |
| [`791238f1`](https://github.com/NixOS/nixpkgs/commit/791238f17fa4b1c0f0ebb76127ae75792012e97a) | `python310Packages.pysnmplib: 5.0.19 -> 5.0.20`                                       |
| [`bc4b3e28`](https://github.com/NixOS/nixpkgs/commit/bc4b3e28515da502b073426398176d0a1c22ebbf) | `python310Packages.pysnmplib: add changelog to meta`                                  |
| [`471d8bb0`](https://github.com/NixOS/nixpkgs/commit/471d8bb07a167e502ca8fa60b5027742e2adb63c) | `opensmt: 2.4.2 -> 2.4.3`                                                             |
| [`541aa8dc`](https://github.com/NixOS/nixpkgs/commit/541aa8dcd24c1fdce5aea628c2e215696b991ebc) | `kubelogin: 0.0.23 -> 0.0.24`                                                         |
| [`694cd662`](https://github.com/NixOS/nixpkgs/commit/694cd66276770dd067d3160b4147ef78d3647f27) | `honeycomb-refinery: init at 1.19.0 (#200424)`                                        |
| [`e98c6622`](https://github.com/NixOS/nixpkgs/commit/e98c66220b35f566de51815f4d83bf808f61426e) | `yggdrasil: 0.4.6 -> 0.4.7`                                                           |
| [`35b95aab`](https://github.com/NixOS/nixpkgs/commit/35b95aab695de9a221339e72b3c5847ed617f716) | `oh-my-posh: 12.16.0 -> 12.17.2`                                                      |
| [`82fe76d1`](https://github.com/NixOS/nixpkgs/commit/82fe76d1cd0ff6607c4c6383fb9620f6615a84a0) | `carnix,cratesIO: remove`                                                             |
| [`d9441f4c`](https://github.com/NixOS/nixpkgs/commit/d9441f4cd556c15bff123ed4c1df59bd381f24c4) | `nmap-formatter: 2.0.1 -> 2.0.2`                                                      |
| [`2a65c2a4`](https://github.com/NixOS/nixpkgs/commit/2a65c2a491126cf714779d8e3cf0ee47f457f013) | `nix-direnv: 2.1.2 -> 2.2.0`                                                          |
| [`1ca3d39a`](https://github.com/NixOS/nixpkgs/commit/1ca3d39a10a8ac55d303f66c9e45cf1727ec311a) | `nanomq: 0.13.0 -> 0.13.1`                                                            |
| [`da31e2c1`](https://github.com/NixOS/nixpkgs/commit/da31e2c1b725de78d5fcf4125962e595ce4e3b16) | `typeshare: init at 1.0.0`                                                            |
| [`85681df5`](https://github.com/NixOS/nixpkgs/commit/85681df5522c04ef6d1d4d50d0f07b2d4fe30adf) | `cinnamon.warpinator: 1.2.14 -> 1.2.15`                                               |
| [`1c416b8c`](https://github.com/NixOS/nixpkgs/commit/1c416b8ce3d01786b88eba0399eb0d2dcd536d9f) | `python310Packages.teslajsonpy: 3.2.0 -> 3.2.2`                                       |
| [`f7857b2a`](https://github.com/NixOS/nixpkgs/commit/f7857b2acca7416992b5e5eeb91d9c9de5cfc26c) | `python310Packages.fastapi-mail: 1.2.0 -> 1.2.1`                                      |
| [`20ba511c`](https://github.com/NixOS/nixpkgs/commit/20ba511c986b17c9641bff5843c7bf639d704409) | `python310Packages.fastapi-mail: add changelog to meta`                               |
| [`7478ccb1`](https://github.com/NixOS/nixpkgs/commit/7478ccb19310121a97245c7c1ba5b95a5351b6c5) | `pip-audit: 2.4.5 -> 2.4.6`                                                           |
| [`5fcd9011`](https://github.com/NixOS/nixpkgs/commit/5fcd9011b95bc52bc4689af05f62370bf9cbf3f8) | `pip-audit: add changelog to meta`                                                    |
| [`eb11b252`](https://github.com/NixOS/nixpkgs/commit/eb11b252089789ba01013954ff75fda3f5726e22) | `ghostunnel: add changelog to meta`                                                   |
| [`3ac01325`](https://github.com/NixOS/nixpkgs/commit/3ac01325a6f46fcf81ea71321e8b70795b12665b) | `amdvlk: add nixos test`                                                              |
| [`fded5825`](https://github.com/NixOS/nixpkgs/commit/fded5825fde7f0454fe2ec192c147307795c5c27) | `rocm-opencl-icd: add nixos test`                                                     |
| [`76a4adc1`](https://github.com/NixOS/nixpkgs/commit/76a4adc19c3febde1ca3aa6ec031446cba925d16) | `makeImpureTest: init function for hardware tests`                                    |
| [`f6b4b52a`](https://github.com/NixOS/nixpkgs/commit/f6b4b52a17e47707e9ab6b252c50b663781f34c1) | `autojump: fixup python shebang after cross fix`                                      |
| [`6ac16c26`](https://github.com/NixOS/nixpkgs/commit/6ac16c2697031fab70705c0bab3a2bed67014fa0) | `matrix-synapse: 1.71.0 -> 1.72.0`                                                    |
| [`9735765d`](https://github.com/NixOS/nixpkgs/commit/9735765d9dadce98ce64c6185b03cad10e0f56e9) | `limesctl: 3.0.3 -> 3.1.1`                                                            |
| [`de6c1202`](https://github.com/NixOS/nixpkgs/commit/de6c1202d079b110412b5194997d15395ddf52f9) | `rocksdb: use SSE 4.2 only when supported`                                            |
| [`200d629a`](https://github.com/NixOS/nixpkgs/commit/200d629ac694d5a4db5d3800e0291ee639a3cbc0) | `kubelogin-oidc: 1.25.3 -> 1.25.4`                                                    |
| [`57f2bb49`](https://github.com/NixOS/nixpkgs/commit/57f2bb494d81f4d43441cbadc78fc8747225478d) | `i2pd: 2.43.0 -> 2.44.0`                                                              |
| [`e28ee8bb`](https://github.com/NixOS/nixpkgs/commit/e28ee8bb32b2407053d63cefc495ce7d1bab81bc) | `xpaste: 1.5 -> 1.6`                                                                  |
| [`03f2f6b9`](https://github.com/NixOS/nixpkgs/commit/03f2f6b9c458431ee114ba8b8b1b0f3b3439cb9d) | `wezterm: 20220905-102802-7d4b8249 -> 20221119-145034-49b9839f`                       |
| [`1e6a2cfa`](https://github.com/NixOS/nixpkgs/commit/1e6a2cfaa041216fa29accece7ab30b9d62c59ee) | `ghostunnel: 1.7.0 -> 1.7.1`                                                          |
| [`4eb8ee1f`](https://github.com/NixOS/nixpkgs/commit/4eb8ee1f9ee4a8140b97e89982baadce51829484) | `erosmb: 0.1.2 -> 0.1.4`                                                              |
| [`00519772`](https://github.com/NixOS/nixpkgs/commit/005197727bd4987e6cd1fd3f27e20bb693fb7074) | `cargo-llvm-lines: 0.4.20 -> 0.4.21`                                                  |
| [`cbe0fcda`](https://github.com/NixOS/nixpkgs/commit/cbe0fcda8db9032524f8f4b5763ba66471464489) | `python310Packages.robotsuite: remove unittest2`                                      |
| [`a793a1aa`](https://github.com/NixOS/nixpkgs/commit/a793a1aa45ad42d4fac3bbb798362b6ef9523161) | `todoist-electron: 1.0.3 -> 1.0.9`                                                    |
| [`f8eea402`](https://github.com/NixOS/nixpkgs/commit/f8eea402836c5f7f538b2b380c977503873b306a) | `cfitsio: 4.1.0 -> 4.2.0`                                                             |
| [`f072ce13`](https://github.com/NixOS/nixpkgs/commit/f072ce1373104ba695baeab1aa8f91f5219991eb) | `_3270font: 2.3.1 -> 3.0.1`                                                           |
| [`28e61b50`](https://github.com/NixOS/nixpkgs/commit/28e61b5057b86cb3731254a0d99349b40dda46d1) | `python310Packages.grpcio-tools: 1.50.0 -> 1.51.0`                                    |
| [`70c8641f`](https://github.com/NixOS/nixpkgs/commit/70c8641f6a59bc3aa62f5b68c6da5fd0fcf4bd9e) | `python310Packages.grpcio-status: 1.50.0 -> 1.51.0`                                   |
| [`74bd116d`](https://github.com/NixOS/nixpkgs/commit/74bd116d60568988a8b5084c9a37aafa4db783c2) | `grpc: 1.50.0 -> 1.51.0`                                                              |
| [`54aa1856`](https://github.com/NixOS/nixpkgs/commit/54aa1856e224d0d603a58a7f8897d62cd921ffdc) | `python310Packages.peaqevcore: 7.4.0 -> 8.0.2`                                        |
| [`3cb8af38`](https://github.com/NixOS/nixpkgs/commit/3cb8af381c45b7cf36d7c081bb2ffe9a6c6ce39c) | `nodePackages.pnpm: 7.14.2 -> 7.17.0`                                                 |
| [`f160eff8`](https://github.com/NixOS/nixpkgs/commit/f160eff8e7761c69e0e3a5fac77f81a5d463869c) | `libnvme: fix cross compiling`                                                        |
| [`ce20988c`](https://github.com/NixOS/nixpkgs/commit/ce20988c647fcd6d1dd49eb06b075849e932474b) | `xcb-imdkit: 1.0.3 -> 1.0.4`                                                          |
| [`949caf33`](https://github.com/NixOS/nixpkgs/commit/949caf335a7f65c862c6becf49580aba0b2bad95) | `libime: 1.0.14 -> 1.0.15`                                                            |
| [`36a566b7`](https://github.com/NixOS/nixpkgs/commit/36a566b78fe4904913c1c8d16e75da1a7aa6eadb) | `lib/systems/parse.nix: mkSkeletonFromList: improve readability`                      |