### PR TITLE
chore(flake/emacs-overlay): `fa293d98` -> `49d5cbd3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669290739,
-        "narHash": "sha256-0QT6o7lv4UZDR3qaneCsN51erLFpLhsTVrYJLv9JDlE=",
+        "lastModified": 1669319842,
+        "narHash": "sha256-JSfABiy5/7usgQSy/ua3XbsjJ6F9Dd3P4nJiE56gFME=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fa293d98210547e943c1e64df8d0e0aa24174eab",
+        "rev": "49d5cbd389a3fb843793cd7503ad7abdb4f40a9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`49d5cbd3`](https://github.com/nix-community/emacs-overlay/commit/49d5cbd389a3fb843793cd7503ad7abdb4f40a9d) | `Updated repos/melpa` |
| [`21ec0719`](https://github.com/nix-community/emacs-overlay/commit/21ec0719682b5ae8c02b06ce03b523731d8347e0) | `Updated repos/emacs` |