### PR TITLE
chore(flake/nur): `530eea1e` -> `6de1069b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669329665,
-        "narHash": "sha256-OGtS3DgJlGtlk6YF1MG7uWW5Vzwx8kDg+qX3cUhRom4=",
+        "lastModified": 1669343141,
+        "narHash": "sha256-TzW2uC33BLXbu2pa/0FTxXhwgPGKkPeSRg0oMCgcWDA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "530eea1e1d563300310b6c39bd322ebffba27e5c",
+        "rev": "6de1069b5b6fbbfc42d98f772bda6e094c4a9c8e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6de1069b`](https://github.com/nix-community/NUR/commit/6de1069b5b6fbbfc42d98f772bda6e094c4a9c8e) | `automatic update` |