### PR TITLE
chore(flake/nur): `6de1069b` -> `098a5257`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669343141,
-        "narHash": "sha256-TzW2uC33BLXbu2pa/0FTxXhwgPGKkPeSRg0oMCgcWDA=",
+        "lastModified": 1669348773,
+        "narHash": "sha256-g4bDNfkfJ0ZbaFVxWNMIX/1t9u3V+/1GeZcmzcZRbdI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6de1069b5b6fbbfc42d98f772bda6e094c4a9c8e",
+        "rev": "098a52570569faa2eb50aca2507eba80ecfc4cf1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`098a5257`](https://github.com/nix-community/NUR/commit/098a52570569faa2eb50aca2507eba80ecfc4cf1) | `automatic update` |