### PR TITLE
chore(flake/nur): `098a5257` -> `3436d087`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669348773,
-        "narHash": "sha256-g4bDNfkfJ0ZbaFVxWNMIX/1t9u3V+/1GeZcmzcZRbdI=",
+        "lastModified": 1669349040,
+        "narHash": "sha256-imzMro/zwrkgL3QMftPAAq6ZkIelY8o3Hn5QGHV8/H4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "098a52570569faa2eb50aca2507eba80ecfc4cf1",
+        "rev": "3436d08792f3986b716239e96126cc56ea6e3401",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3436d087`](https://github.com/nix-community/NUR/commit/3436d08792f3986b716239e96126cc56ea6e3401) | `automatic update` |