### PR TITLE
chore(flake/emacs-overlay): `49d5cbd3` -> `aa709808`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669319842,
-        "narHash": "sha256-JSfABiy5/7usgQSy/ua3XbsjJ6F9Dd3P4nJiE56gFME=",
+        "lastModified": 1669353837,
+        "narHash": "sha256-IaeB7ED6kxbOb7H/FzujPlSXNErbWPfyMV+tslFpBmo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "49d5cbd389a3fb843793cd7503ad7abdb4f40a9d",
+        "rev": "aa7098087716090efaa89a3966f3c3cdcfe9a9c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`aa709808`](https://github.com/nix-community/emacs-overlay/commit/aa7098087716090efaa89a3966f3c3cdcfe9a9c3) | `Updated repos/melpa` |
| [`aa1bd9d2`](https://github.com/nix-community/emacs-overlay/commit/aa1bd9d2f3b17e92f0e86b80e53e3ae61c0c7ee9) | `Updated repos/emacs` |