### PR TITLE
chore(flake/nur): `3436d087` -> `4dcf7c41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669349040,
-        "narHash": "sha256-imzMro/zwrkgL3QMftPAAq6ZkIelY8o3Hn5QGHV8/H4=",
+        "lastModified": 1669354954,
+        "narHash": "sha256-bQdzUv3QKxKmFVlwl+essMu2tiIRA2zoRHoNdFp36Is=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3436d08792f3986b716239e96126cc56ea6e3401",
+        "rev": "4dcf7c4179a4e6405b369e07a98dcaf02a27a1cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4dcf7c41`](https://github.com/nix-community/NUR/commit/4dcf7c4179a4e6405b369e07a98dcaf02a27a1cf) | `automatic update` |