### PR TITLE
chore(flake/emacs-overlay): `aa709808` -> `4b6569a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669353837,
-        "narHash": "sha256-IaeB7ED6kxbOb7H/FzujPlSXNErbWPfyMV+tslFpBmo=",
+        "lastModified": 1669377172,
+        "narHash": "sha256-pruSnVjnUC036jrtBooNqC0hFfJLBuDU9hp0pOUirTo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "aa7098087716090efaa89a3966f3c3cdcfe9a9c3",
+        "rev": "4b6569a054e693a9a7d6eef423fac9b506961b76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`4b6569a0`](https://github.com/nix-community/emacs-overlay/commit/4b6569a054e693a9a7d6eef423fac9b506961b76) | `Updated repos/melpa` |
| [`bd94203b`](https://github.com/nix-community/emacs-overlay/commit/bd94203b79be2a92a9e0c9a8cab5da8ffd790af3) | `Updated repos/emacs` |