### PR TITLE
chore(flake/emacs-overlay): `4b6569a0` -> `1be5f860`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669377172,
-        "narHash": "sha256-pruSnVjnUC036jrtBooNqC0hFfJLBuDU9hp0pOUirTo=",
+        "lastModified": 1669407918,
+        "narHash": "sha256-HYgJQ6WRT6iVCYIj5tdJa2szotitB9Dt2rPX16QT+Zg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4b6569a054e693a9a7d6eef423fac9b506961b76",
+        "rev": "1be5f86016b1eb5bc5e12ec0d6759e3c51ec7e00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`1be5f860`](https://github.com/nix-community/emacs-overlay/commit/1be5f86016b1eb5bc5e12ec0d6759e3c51ec7e00) | `Updated repos/melpa` |
| [`0e90f23b`](https://github.com/nix-community/emacs-overlay/commit/0e90f23b9374966d042ae6625e9511ab6c9a70ed) | `Updated repos/emacs` |