### PR TITLE
chore(flake/nix-on-droid): `c16cb917` -> `4e58ce79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -326,11 +326,11 @@
         "nmd": "nmd_2"
       },
       "locked": {
-        "lastModified": 1669300355,
-        "narHash": "sha256-YmiccJZmmAcMiGHmRz2WL8Qp6qbRvUJdYIDCswAwMdo=",
+        "lastModified": 1669422604,
+        "narHash": "sha256-3t8SFcIAhHECKIN4T6UxkSOGYfNzXXq0OUdJcHtZCmw=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "c16cb917d7dcfe2ea20257ac5a4cb6c8fb4154a6",
+        "rev": "4e58ce79715707f00fce7d9b4a146f67720a7a3c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`4e58ce79`](https://github.com/t184256/nix-on-droid/commit/4e58ce79715707f00fce7d9b4a146f67720a7a3c) | `fix(terminal.nix): quote font paths` |