### PR TITLE
chore(flake/nur): `f29556a1` -> `b40c7a59`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669403804,
-        "narHash": "sha256-TFDE31NwrffJPhf40gL1FjmSgH9Ow9bFXFVNff7zKj0=",
+        "lastModified": 1669421286,
+        "narHash": "sha256-9iOuq/MooRneMzzzXAaMtXowCBW0c10dVyxq0sBCIaY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f29556a1359ef9f7ed50e1d0cf83517d1ce9c43f",
+        "rev": "b40c7a596ffae4b2cd8da4f07d0859a839b552ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b40c7a59`](https://github.com/nix-community/NUR/commit/b40c7a596ffae4b2cd8da4f07d0859a839b552ee) | `automatic update` |