### PR TITLE
chore(flake/nur): `988a5977` -> `c4f3a637`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669429343,
-        "narHash": "sha256-cDEIN2WkWK/b3yN9/ZyN/MehFLLANM6GSvRg8UanHl0=",
+        "lastModified": 1669434798,
+        "narHash": "sha256-Uh2Y3uQwEGBpEmGg2cnNagL+sNqxoqnJoZaVLDRD8qA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "988a5977b3c4159faea64cf0effb696f3db13143",
+        "rev": "c4f3a637f26d1571bd7f0dbc4f6cd99e410597b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c4f3a637`](https://github.com/nix-community/NUR/commit/c4f3a637f26d1571bd7f0dbc4f6cd99e410597b9) | `automatic update` |