### PR TITLE
chore(flake/nur): `c4f3a637` -> `01a904c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669434798,
-        "narHash": "sha256-Uh2Y3uQwEGBpEmGg2cnNagL+sNqxoqnJoZaVLDRD8qA=",
+        "lastModified": 1669435423,
+        "narHash": "sha256-7T1mi+PtNIXnkDLOlA9sa8B7jq8gUQNOfahvg/XpBPU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c4f3a637f26d1571bd7f0dbc4f6cd99e410597b9",
+        "rev": "01a904c9d5d6bec6d005a203a4e1d03d0f55737f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`01a904c9`](https://github.com/nix-community/NUR/commit/01a904c9d5d6bec6d005a203a4e1d03d0f55737f) | `automatic update` |