### PR TITLE
chore(flake/nur): `01a904c9` -> `3a199ebf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669435423,
-        "narHash": "sha256-7T1mi+PtNIXnkDLOlA9sa8B7jq8gUQNOfahvg/XpBPU=",
+        "lastModified": 1669437824,
+        "narHash": "sha256-knfXDd4djsqCf4UpMqxsISF2qAMr0CK7IENoI1AluEM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "01a904c9d5d6bec6d005a203a4e1d03d0f55737f",
+        "rev": "3a199ebf635224d9f44dd23c6c468c12ee5172bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3a199ebf`](https://github.com/nix-community/NUR/commit/3a199ebf635224d9f44dd23c6c468c12ee5172bf) | `automatic update` |