### PR TITLE
chore(flake/nur): `3a199ebf` -> `4d426729`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669437824,
-        "narHash": "sha256-knfXDd4djsqCf4UpMqxsISF2qAMr0CK7IENoI1AluEM=",
+        "lastModified": 1669440265,
+        "narHash": "sha256-Jcy3SJEZo0pyOsq2JITA/WfsuZGS71XcawZgDryx4TQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3a199ebf635224d9f44dd23c6c468c12ee5172bf",
+        "rev": "4d42672925de2263b62c391ac3682167f558d9f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4d426729`](https://github.com/nix-community/NUR/commit/4d42672925de2263b62c391ac3682167f558d9f9) | `automatic update` |