### PR TITLE
chore(flake/emacs-overlay): `1be5f860` -> `838bd1e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669407918,
-        "narHash": "sha256-HYgJQ6WRT6iVCYIj5tdJa2szotitB9Dt2rPX16QT+Zg=",
+        "lastModified": 1669439968,
+        "narHash": "sha256-VlQsxaHruFN29FOvRHUYecySRU9UzFqqpshfgoGxKes=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1be5f86016b1eb5bc5e12ec0d6759e3c51ec7e00",
+        "rev": "838bd1e55d9168d2df9dc0331565f884c3be3250",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`838bd1e5`](https://github.com/nix-community/emacs-overlay/commit/838bd1e55d9168d2df9dc0331565f884c3be3250) | `Updated repos/nongnu` |
| [`1e0a1afb`](https://github.com/nix-community/emacs-overlay/commit/1e0a1afb1bbcb634d0e78768a723b7749c03014d) | `Updated repos/melpa`  |
| [`4fd789cb`](https://github.com/nix-community/emacs-overlay/commit/4fd789cbe350bf816fe0375f283a71878269a435) | `Updated repos/emacs`  |