### PR TITLE
chore(flake/nur): `37eabfd0` -> `de2d6340`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669444186,
-        "narHash": "sha256-3L/13NRfSK28I19gpwmmuSuy+H3CXexkg2J0hxK4lxI=",
+        "lastModified": 1669461594,
+        "narHash": "sha256-en/P5geR4tVXhl7BZaw7iftcwtR7BEZ1hb6AcLPpp6M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "37eabfd00003f01716dd62ccf593943d3454458d",
+        "rev": "de2d634003a0bd148cc914da6092ee83bedd4265",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`de2d6340`](https://github.com/nix-community/NUR/commit/de2d634003a0bd148cc914da6092ee83bedd4265) | `automatic update` |
| [`6b2dce21`](https://github.com/nix-community/NUR/commit/6b2dce21b86e63cc141bbefe03a7b7eee004a0d0) | `automatic update` |