### PR TITLE
chore(flake/emacs-overlay): `838bd1e5` -> `3d5e5cfa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669439968,
-        "narHash": "sha256-VlQsxaHruFN29FOvRHUYecySRU9UzFqqpshfgoGxKes=",
+        "lastModified": 1669463559,
+        "narHash": "sha256-aemo1lyq+vi3R0+gaCJvja9LIm/OZ3nsPKvPLrjMuVw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "838bd1e55d9168d2df9dc0331565f884c3be3250",
+        "rev": "3d5e5cfa91ed10d39e0504387242750996e8b027",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`3d5e5cfa`](https://github.com/nix-community/emacs-overlay/commit/3d5e5cfa91ed10d39e0504387242750996e8b027) | `Updated repos/melpa` |
| [`e2fc95d5`](https://github.com/nix-community/emacs-overlay/commit/e2fc95d5e82dc7bdbbfb7f5e6cb70eabf0e63101) | `Updated repos/emacs` |