### PR TITLE
chore(flake/nur): `de2d6340` -> `3e01b4ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669461594,
-        "narHash": "sha256-en/P5geR4tVXhl7BZaw7iftcwtR7BEZ1hb6AcLPpp6M=",
+        "lastModified": 1669462507,
+        "narHash": "sha256-aPmbfIgF5gcJqurXfBncoxaJmClnBhN8fBMFXmVisqs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "de2d634003a0bd148cc914da6092ee83bedd4265",
+        "rev": "3e01b4cae8759d2d47cac957d2c4ac9a7f7e62d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3e01b4ca`](https://github.com/nix-community/NUR/commit/3e01b4cae8759d2d47cac957d2c4ac9a7f7e62d0) | `automatic update` |