### PR TITLE
chore(flake/nixpkgs): `27ccd290` -> `5dc7114b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669320964,
-        "narHash": "sha256-EBFw+ge12Pcr3qCk8If3/eMBAoQLR7ytndXZoRevUtM=",
+        "lastModified": 1669411043,
+        "narHash": "sha256-LfPd3+EY+jaIHTRIEOUtHXuanxm59YKgUacmSzaqMLc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "27ccd29078f974ddbdd7edc8e38c8c8ae003c877",
+        "rev": "5dc7114b7b256d217fe7752f1614be2514e61bb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                    |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`7ab5323c`](https://github.com/NixOS/nixpkgs/commit/7ab5323cfb6664df04acf9bf4b014e511ada20e2) | `npmHooks.npmInstallHook: pass --no-save to prune`                                |
| [`fde0382e`](https://github.com/NixOS/nixpkgs/commit/fde0382efdce3ca16f34164da7d930100e58cd93) | `buildNpmPackage: forward pre/postPatch to fetchNpmDeps`                          |
| [`84477691`](https://github.com/NixOS/nixpkgs/commit/84477691f7a53510fe6fce49746185bdcf5a30a7) | `fetchNpmDeps: allow package-json.lock symlinks, update hint`                     |
| [`90bf138e`](https://github.com/NixOS/nixpkgs/commit/90bf138e6c73c0df9583d78b81a529b8ff2c0a22) | `goda: 0.5.3 -> 0.5.4`                                                            |
| [`a2720aeb`](https://github.com/NixOS/nixpkgs/commit/a2720aebdd1acf557166d843017282892538ddd6) | `automatic-timezoned: add meta.changelog`                                         |
| [`c6147b56`](https://github.com/NixOS/nixpkgs/commit/c6147b56592afa6125164f267615248133b8aa45) | `automatic-timezoned: 1.0.41 -> 1.0.43`                                           |
| [`eb35d292`](https://github.com/NixOS/nixpkgs/commit/eb35d2924fd7a0bbc1c3648d712ad0a371e35d3a) | `py3c: only run tests on python3`                                                 |
| [`d6d06272`](https://github.com/NixOS/nixpkgs/commit/d6d06272a3a73e695bcd456f01e3952d2b0071ba) | `eclipses: use jdk17`                                                             |
| [`b3851cde`](https://github.com/NixOS/nixpkgs/commit/b3851cdeb076471199eb63eccf42f964de997361) | `aws-sdk-cpp: fix build on RISC-V hosts`                                          |
| [`182c974f`](https://github.com/NixOS/nixpkgs/commit/182c974f574f82115304ff61023493af208ed720) | `nlohmann_json: Enable JSON_FastTests, use JSON_BuildTests instead of BuildTests` |
| [`843684e4`](https://github.com/NixOS/nixpkgs/commit/843684e44e50a0ff2f8988c9f5ff9f58dcea4919) | `release-lib: add support for riscv64-linux`                                      |
| [`62b8fc77`](https://github.com/NixOS/nixpkgs/commit/62b8fc772567dfc125c78e1143f31feaef8741d2) | `erlangR24: fix build on x86_64-darwin`                                           |
| [`9fd38e55`](https://github.com/NixOS/nixpkgs/commit/9fd38e558fd1104923134e20fb3bed2fb7bb7850) | `erlang: migrate to wxGTK32`                                                      |
| [`c00ddaf1`](https://github.com/NixOS/nixpkgs/commit/c00ddaf144e85a3d1202437b19960f800fa3aeb7) | `aspino: remove patchShebangs`                                                    |
| [`fc653e9d`](https://github.com/NixOS/nixpkgs/commit/fc653e9de001fd38e6bed96405f66959ebc97a34) | `avy: fix build on aarch64-linux`                                                 |
| [`ee09ecac`](https://github.com/NixOS/nixpkgs/commit/ee09ecaca2da84b31df8bd25ac8c7f0274607354) | `glucose: fix build on aarch64-linux`                                             |
| [`017015a8`](https://github.com/NixOS/nixpkgs/commit/017015a82b6ceb8045e2ba446664b19218f77c9a) | `aspino: fix build`                                                               |
| [`8189da6a`](https://github.com/NixOS/nixpkgs/commit/8189da6ab30a4a9a10ad05604d2591280a691631) | `git-cola: 4.0.3 -> 4.0.4`                                                        |
| [`65c2e963`](https://github.com/NixOS/nixpkgs/commit/65c2e963195be88dfbedc8bbf7d8574c8190f9fa) | `appthreat-depscan: 3.0.3 -> 3.1.1`                                               |
| [`55b3f68b`](https://github.com/NixOS/nixpkgs/commit/55b3f68bda6d4f4dc6092eed0508063f154fa4fd) | `goresym: 1.5 -> 1.8`                                                             |
| [`be82636d`](https://github.com/NixOS/nixpkgs/commit/be82636dc642523617a5c70d7989755223cb66b5) | `git-fast-export: 220921 -> 221024`                                               |
| [`62a2b9de`](https://github.com/NixOS/nixpkgs/commit/62a2b9de2b4dd3c026945e55cee4e10611a1536c) | `git-codereview: 1.0.3 -> 1.2.0`                                                  |
| [`5cfb7fb7`](https://github.com/NixOS/nixpkgs/commit/5cfb7fb7165b988b391e4d721fc4db4ff17d6fbb) | `nixos/tests/mastodon: update test`                                               |
| [`e8927f26`](https://github.com/NixOS/nixpkgs/commit/e8927f2631084705318d97794334cb7ffe70aa1a) | `nixos/tests/mastodon: remove CA service`                                         |
| [`74f0c90e`](https://github.com/NixOS/nixpkgs/commit/74f0c90ed6672e52ff76f01a54146a04ce55b406) | `flyctl: 0.0.433 -> 0.0.435`                                                      |
| [`2139320a`](https://github.com/NixOS/nixpkgs/commit/2139320a9d226956e22696fbae41164e17c1b913) | `cargo-cyclonedx: init at 0.3.7`                                                  |
| [`9a1edefd`](https://github.com/NixOS/nixpkgs/commit/9a1edefd4528b32fa1a3785f6be4167ec7bb769a) | `prometheus-keylight-exporter: 0.1.1 -> 0.2.0`                                    |
| [`b574d069`](https://github.com/NixOS/nixpkgs/commit/b574d069b3cf0da6a01a103a4e7554c0193d0810) | `python310Packages.statmake: disable failing test`                                |
| [`9f7c1b94`](https://github.com/NixOS/nixpkgs/commit/9f7c1b9477c8f1e510237bcb40566648628cf776) | `python310Packages.statmake: add changelog to meta`                               |
| [`0763a648`](https://github.com/NixOS/nixpkgs/commit/0763a648371bb9084e6900a9ac324d455f4a8c05) | `esphome: 2022.10.2 -> 2022.11.3`                                                 |
| [`f8ee27fd`](https://github.com/NixOS/nixpkgs/commit/f8ee27fd8f3405c8234c9093c50c948e847b74e7) | `aliyun-cli: 3.0.136 -> 3.0.137`                                                  |
| [`89b81397`](https://github.com/NixOS/nixpkgs/commit/89b81397a18084a35ee0c2b71da064621da96b4a) | `notepad-next: 0.5.5 -> 0.5.6`                                                    |
| [`2d1a1c6c`](https://github.com/NixOS/nixpkgs/commit/2d1a1c6c260ec23726de766e5a6a7740210f0daa) | `fcitx5-gtk: 5.0.20 -> 5.0.21`                                                    |
| [`c48484a8`](https://github.com/NixOS/nixpkgs/commit/c48484a81f8c6688af78b384fbd0a9b9f412cf47) | `fcitx5: 5.0.20 -> 5.0.21`                                                        |
| [`6d9a36c0`](https://github.com/NixOS/nixpkgs/commit/6d9a36c0eb74e15a3d010264d2232f89213b850f) | `adguardhome: 0.107.18 -> 0.107.19`                                               |
| [`bf1fb37c`](https://github.com/NixOS/nixpkgs/commit/bf1fb37cdc5daae6e7253e24e9565cd9bcee4442) | `duf: install man page`                                                           |
| [`18d8cf38`](https://github.com/NixOS/nixpkgs/commit/18d8cf38d96dce3b41db7b18abd1e22abae8aee2) | `cppcheck: 2.9.2 -> 2.9.3`                                                        |
| [`3ecb803d`](https://github.com/NixOS/nixpkgs/commit/3ecb803d1c50d3baae89436a2e90b6d3bf6c8fd8) | `faraday-cli: 2.1.7 -> 2.1.8`                                                     |
| [`5eb20083`](https://github.com/NixOS/nixpkgs/commit/5eb20083cb9f1adc351ae67abf8b04379cda94da) | `faraday-cli: add changelog to meta`                                              |
| [`41189f11`](https://github.com/NixOS/nixpkgs/commit/41189f1178e4c21acc244c723b8d31df7e448eb3) | `faraday-agent-dispatcher: 2.3.0 -> 2.4.0`                                        |
| [`c11824f6`](https://github.com/NixOS/nixpkgs/commit/c11824f64494caa38e6b2d07a92375b996ae4e15) | `python310Packages.faraday-plugins: set version`                                  |
| [`61018342`](https://github.com/NixOS/nixpkgs/commit/610183429cfd276c3de45b9720735a52d5df8882) | `bitcoin: remove hardeningDisable for aarch64-darwin`                             |
| [`d3c7bb65`](https://github.com/NixOS/nixpkgs/commit/d3c7bb65d008314bd4dc60de1f049ac39866b4ea) | `deno: 1.28.1 -> 1.28.2`                                                          |
| [`97e63a2e`](https://github.com/NixOS/nixpkgs/commit/97e63a2e7355d4b66d696b492eeccbca9a1cc5c0) | `doctl: 1.87.0 -> 1.88.0`                                                         |
| [`c8fcb7ae`](https://github.com/NixOS/nixpkgs/commit/c8fcb7aeb88bbbecaca0f859457369c4014e2f67) | `direnv: 2.32.1 -> 2.32.2 (#202723)`                                              |
| [`5e159ac0`](https://github.com/NixOS/nixpkgs/commit/5e159ac0bc94a91dbbad05cf615d214a52a54e45) | `faraday-agent-dispatcher: add changelog to meta`                                 |
| [`df50f73b`](https://github.com/NixOS/nixpkgs/commit/df50f73b57faf99dee99a6647256fdf7739d9b2e) | `nixos/hedgedoc: configuration -> settings in option's description`               |
| [`318510cc`](https://github.com/NixOS/nixpkgs/commit/318510cca64a728c05879864b4d894a8eb502348) | `prometheus: 2.40.2 -> 2.40.3`                                                    |
| [`dade32b4`](https://github.com/NixOS/nixpkgs/commit/dade32b409ebb1ada3ca0f6f32b8aefd1260d42f) | `miniupnpc: use cmake for build`                                                  |
| [`005cf8a5`](https://github.com/NixOS/nixpkgs/commit/005cf8a5bde74f95c1226edd7bb97c8519bc263d) | `frama-c: add missing runtime dependency`                                         |
| [`bc152898`](https://github.com/NixOS/nixpkgs/commit/bc15289836e0c880dcd49c7debc8e39eca755403) | `chezmoi: 2.27.1 -> 2.27.2`                                                       |
| [`c5bacf1b`](https://github.com/NixOS/nixpkgs/commit/c5bacf1b8b8e0b9061cc281fa93cf28c6d9ea66d) | `calibre: 6.8.0 -> 6.9.0`                                                         |
| [`26541daa`](https://github.com/NixOS/nixpkgs/commit/26541daa23e80e6c3611a35b0cb31593689b2615) | `python310Packages.gradient-utils: relax pymongo constraint`                      |
| [`a6156800`](https://github.com/NixOS/nixpkgs/commit/a61568004fbd4d480fcb4ddee03fd12200860743) | `grype: 0.53.0 -> 0.53.1`                                                         |
| [`383ac106`](https://github.com/NixOS/nixpkgs/commit/383ac1066e9d2c2829fbfbdee3663c3ebe1bd757) | `starsector: reduce nix profile pollution`                                        |
| [`a2873799`](https://github.com/NixOS/nixpkgs/commit/a2873799a057a5865c55714c7dc593267175af87) | `cilium-cli: 0.12.8 -> 0.12.9`                                                    |
| [`0e4349d1`](https://github.com/NixOS/nixpkgs/commit/0e4349d1eb3b02a9a12c893058873aaa0e3979a7) | `buildah-unwrapped: 1.28.0 -> 1.28.1`                                             |
| [`ba26dcfc`](https://github.com/NixOS/nixpkgs/commit/ba26dcfcc7988f792a2ec21df71c6f34c4c553ca) | `python310Packages.pubnub: 7.0.1 -> 7.0.2`                                        |
| [`720980d3`](https://github.com/NixOS/nixpkgs/commit/720980d334e93889956ededa053c6c2477211b0d) | `python310Packages.pbnub: add changelog to meta`                                  |
| [`44587571`](https://github.com/NixOS/nixpkgs/commit/44587571d2410a75452c8bf32a0e14dbaa6ee438) | `collectd: use python3`                                                           |
| [`527fe355`](https://github.com/NixOS/nixpkgs/commit/527fe355d00f2d327099b5afaaed0b1a66369e7d) | `toluapp: build using cmake`                                                      |
| [`5037e986`](https://github.com/NixOS/nixpkgs/commit/5037e98639e640180aa7e192de78d9b5ffd142d7) | `python310Packages.nomadnet: 0.2.7 -> 0.2.8`                                      |
| [`9e0e98d0`](https://github.com/NixOS/nixpkgs/commit/9e0e98d087033692115a9065fa51593f4dd75e69) | `python310Packages.lxmf: 0.2.5 -> 0.2.6`                                          |
| [`9aef10cf`](https://github.com/NixOS/nixpkgs/commit/9aef10cf59e853edac47c6da9eda5e083163f4c1) | `python310Packages.rns: 0.4.1 -> 0.4.2`                                           |
| [`aedbb223`](https://github.com/NixOS/nixpkgs/commit/aedbb22378c8f0b218fd2b0598415e97d70292f4) | `python310Packages.nomadnet: add changelog to meta`                               |
| [`71f6d1f5`](https://github.com/NixOS/nixpkgs/commit/71f6d1f56b640e5bb4a68e7a87265675cc9072a5) | `python310Packages.rns: add changelog to meta`                                    |
| [`6f7d967e`](https://github.com/NixOS/nixpkgs/commit/6f7d967e289bbae8d9fbc3d9564f7235188b3186) | `gnat11: Fix by building with older gnatboot`                                     |
| [`6df0b07e`](https://github.com/NixOS/nixpkgs/commit/6df0b07e41b273416dc9dcaa7f9ea991c3db8c20) | `babashka: 1.0.165 -> 1.0.166`                                                    |
| [`8d7badd6`](https://github.com/NixOS/nixpkgs/commit/8d7badd689d814ff7b95d5c7ec751c0a6e511f9a) | `sapling: add a simple checkPhase`                                                |
| [`c1102605`](https://github.com/NixOS/nixpkgs/commit/c11026056884330e3811bbd7171cd020f54c2428) | `sapling: set LOCALE_ARCHIVE properly`                                            |
| [`cd0956bb`](https://github.com/NixOS/nixpkgs/commit/cd0956bb593db0764e75e749b8f50d4f344edbf8) | `dashing: use buildGoModule`                                                      |
| [`7b3a88ed`](https://github.com/NixOS/nixpkgs/commit/7b3a88ed2694394be889fc1ea40bef5cfaff70c9) | `linkchecker: 10.0.1 -> 10.2.0`                                                   |
| [`4c75a5ac`](https://github.com/NixOS/nixpkgs/commit/4c75a5ac25250b3123457d21a22784ecd0c1c6cf) | `terraform-providers.tencentcloud: 1.78.14 → 1.78.15`                             |
| [`ec384ce3`](https://github.com/NixOS/nixpkgs/commit/ec384ce35c614bd092489e6f58370a793eccd517) | `terraform-providers.opentelekomcloud: 1.31.8 → 1.31.9`                           |
| [`7dba7495`](https://github.com/NixOS/nixpkgs/commit/7dba74954d88114d9e54bfd67171ccc1b30bacba) | `terraform-providers.aws: 4.40.0 → 4.41.0`                                        |
| [`15aa7870`](https://github.com/NixOS/nixpkgs/commit/15aa7870977842b5561f178739cc7cd88b2615bd) | `terraform-providers.digitalocean: 2.24.0 → 2.25.2`                               |
| [`06f1952b`](https://github.com/NixOS/nixpkgs/commit/06f1952b84e7698317d15b3ad3c5b592948e3edb) | `terraform-providers.cloudfoundry: 0.50.0 → 0.50.1`                               |
| [`a1906566`](https://github.com/NixOS/nixpkgs/commit/a190656667f6e868cff3407d84584e7a119fbabe) | `terraform-providers.azurerm: 3.32.0 → 3.33.0`                                    |
| [`a21593d8`](https://github.com/NixOS/nixpkgs/commit/a21593d84d75369ff9684a3a34a921efabca224a) | `wasabiwallet: 2.0.1.3 -> 2.0.2`                                                  |
| [`1872a393`](https://github.com/NixOS/nixpkgs/commit/1872a3931d20ce0a10654b1c02a46637dacd7255) | `wasabiwallet: fixup bad dependencies causing app not to run`                     |
| [`ceb1f221`](https://github.com/NixOS/nixpkgs/commit/ceb1f221a0745a1e1de42fde1229d25d295ed261) | `python310Packages.pyturbojpeg: 1.6.7 -> 1.7.0`                                   |
| [`bb68fd92`](https://github.com/NixOS/nixpkgs/commit/bb68fd92c9ebf60128441324582d822e29082ef9) | `fq: 0.0.10 -> 0.1.0`                                                             |
| [`1a07981e`](https://github.com/NixOS/nixpkgs/commit/1a07981eb98e827ab4634a74b0a66f5a57c0ad53) | `msbuild: depend on dotnet-sdk 6.0`                                               |
| [`87ed2b76`](https://github.com/NixOS/nixpkgs/commit/87ed2b765a7d0fd8ead172496430ce82f2a89881) | `glib: fix build with musl`                                                       |
| [`abe1c9ee`](https://github.com/NixOS/nixpkgs/commit/abe1c9eedebadc22ed0a4c3c38e968c97401122f) | `h5utils: Add meta.changelog`                                                     |
| [`75a95fe3`](https://github.com/NixOS/nixpkgs/commit/75a95fe34051d32016d891921ce57796055cff38) | `obconf: Add meta.changelog`                                                      |
| [`7517e443`](https://github.com/NixOS/nixpkgs/commit/7517e443c72539cfe4dad30daf9f6cd262845c6e) | `python3Packages.xmldiff: Add meta.changelog`                                     |
| [`ab00a493`](https://github.com/NixOS/nixpkgs/commit/ab00a49322b7609c527f60629f70b8d289cb681c) | `python3Packages.wrapio: Add meta.changelog`                                      |
| [`13d38a03`](https://github.com/NixOS/nixpkgs/commit/13d38a03ab09b9921907fefe3c8ff1512bb05635) | `python3Packages.tappy: Add meta.changelog`                                       |
| [`9998e2f6`](https://github.com/NixOS/nixpkgs/commit/9998e2f63d0079503823459f9ca62d07af72c0c4) | `python3Packages.survey: Add meta.changelog`                                      |
| [`ba95fb97`](https://github.com/NixOS/nixpkgs/commit/ba95fb97e5074d640422e9861e98a21849c42a3a) | `python3Packages.pyprof2calltree: Add meta.changelog`                             |
| [`f2e53bb6`](https://github.com/NixOS/nixpkgs/commit/f2e53bb6a8560d1f44d7f650ed372e5319beb328) | `python3Packages.maestral: Add meta.changelog`                                    |
| [`f493aa04`](https://github.com/NixOS/nixpkgs/commit/f493aa04973bbf2fdf4af9f8feeecc17f9e53614) | `python3Packages.dropbox: Add meta.changelog`                                     |
| [`9920f30d`](https://github.com/NixOS/nixpkgs/commit/9920f30d5db443d0a441d13cb208e288cf6d59f5) | `python3Packages.dbus-next: Add meta.changelog`                                   |
| [`dbea32f9`](https://github.com/NixOS/nixpkgs/commit/dbea32f9812e9523dd8f087f94ef8715fb5cc81f) | `chromium: 107.0.5304.110 -> 107.0.5304.121`                                      |
| [`bee93145`](https://github.com/NixOS/nixpkgs/commit/bee931454b4a2e40505dc7fd3590466d13b57759) | `hydra_unstable: 2022-10-22 -> 2022-11-24`                                        |
| [`86d53c5a`](https://github.com/NixOS/nixpkgs/commit/86d53c5a6012b8b237cef54763afd9f421ca6af7) | `waybar: 0.9.15 -> 0.9.16`                                                        |
| [`788025a1`](https://github.com/NixOS/nixpkgs/commit/788025a11e0f5abd50b3b18c7689514661d0f27a) | `vscode-extensions.sonarsource.sonarlint-vscode: init at 3.12.0`                  |
| [`88a945a2`](https://github.com/NixOS/nixpkgs/commit/88a945a2d41169947ddf4573d190cf5f8d07b294) | `vimPlugins.nvim-treesitter: update grammars`                                     |
| [`ed360a1c`](https://github.com/NixOS/nixpkgs/commit/ed360a1c0a9f531b141175c31c7a881a0f29bc5f) | `vimPlugins.ssr-nvim: init at 2022-11-24`                                         |
| [`55870007`](https://github.com/NixOS/nixpkgs/commit/55870007c7cf2e56a9a7aa9b5c8f63521302886e) | `vimPlugins: update`                                                              |
| [`4db2e9fb`](https://github.com/NixOS/nixpkgs/commit/4db2e9fbef942d9af9b69d51491e8b1f9b82132b) | `grim: add wayland-scanner to nativeBuildInputs, fixes cross compilation`         |
| [`06884e02`](https://github.com/NixOS/nixpkgs/commit/06884e02ba8acf3b1cec9d5fe71925465d589a31) | `ocamlPackages.ocplib-json-typed: remove at 0.7.1`                                |
| [`5a23ebdf`](https://github.com/NixOS/nixpkgs/commit/5a23ebdf1da3402b4670727df6ed4e6d67be7de6) | `ocamlPackages.ocplib-json-typed-bson: remove at 0.7.1`                           |
| [`acab80c2`](https://github.com/NixOS/nixpkgs/commit/acab80c274f57c610b7f4d82e7b9a83f7572f85e) | `ocamlPackages.ocplib-json-typed-browser: remove at 0.7.1`                        |
| [`53021e33`](https://github.com/NixOS/nixpkgs/commit/53021e3340a19f1fac612085adffb941d0b9151c) | `nixos/flashrom: Add package option`                                              |
| [`ee58a9b4`](https://github.com/NixOS/nixpkgs/commit/ee58a9b468de929958fde5b08b4accc7f0ca8df1) | `python310Packages.pgpy: 0.5.4 -> 0.6.0`                                          |
| [`523a65c9`](https://github.com/NixOS/nixpkgs/commit/523a65c91e2f0d33081db80f8f8e2ba39f7aacf1) | `libsForQt5.qtwebengine: build using python3`                                     |
| [`e23dc698`](https://github.com/NixOS/nixpkgs/commit/e23dc698987b5f8b0034d5033127513d5d026452) | `vmware-workstation: 16.2.3 -> 17.0.0 and support macOS guests`                   |
| [`0f32b695`](https://github.com/NixOS/nixpkgs/commit/0f32b695ea7e267cab1f361bab3b243f3ef1504b) | `makemkv: 1.17.1 -> 1.17.2`                                                       |
| [`4ce44292`](https://github.com/NixOS/nixpkgs/commit/4ce442922a7dee63a475e1520f6811b071e3d1c4) | `python310Packages.pontos: 22.10.0 -> 22.11.0`                                    |
| [`57221810`](https://github.com/NixOS/nixpkgs/commit/57221810c3ccd978ae4a3c2d6f67d45f52ed3522) | `python310Packages.pontos: add changelog to meta`                                 |
| [`7dfe967b`](https://github.com/NixOS/nixpkgs/commit/7dfe967b9a6352a32a419273761e5c72a21be075) | `python310Packages.gcs-oauth2-boto-plugin: init at 3.0`                           |
| [`68abb937`](https://github.com/NixOS/nixpkgs/commit/68abb937978c83c1d820afbb5cdd992c6780c449) | `python310Packages.google-apitools: init at 0.5.32`                               |
| [`04576632`](https://github.com/NixOS/nixpkgs/commit/04576632978a7fa6c465b725dc1b592d4c407c4c) | `python310Packages.retry_decorator: switch to pytestCheckHook`                    |
| [`87b16468`](https://github.com/NixOS/nixpkgs/commit/87b16468993514a7870810f8fe2f24725c87c13a) | `nnn: 4.6 → 4.7`                                                                  |
| [`f31024ff`](https://github.com/NixOS/nixpkgs/commit/f31024ffc3a0cb1823780643c2832e20f014a1b2) | ` python310Packages.google-reauth: init at 0.1.1`                                 |
| [`aa343288`](https://github.com/NixOS/nixpkgs/commit/aa3432885ed107eb874b00113ed8c66697ea7eab) | `cargo-depgraph: 1.3.0 -> 1.4.0`                                                  |
| [`63288341`](https://github.com/NixOS/nixpkgs/commit/632883411f0846681d466cd998e248b7a3489df8) | `python310Packages.appthreat-vulnerability-db: 2.0.9 -> 3.0.2`                    |
| [`9bf73ced`](https://github.com/NixOS/nixpkgs/commit/9bf73cedb7831a2827ec3e84eebed40b8bea817e) | `gnome.mutter: Backport edge resistance fix`                                      |
| [`4df5f3f2`](https://github.com/NixOS/nixpkgs/commit/4df5f3f264dc5fae25c0948980ec29fa93cc4a83) | `python310Packages.cvss: init at 2.5`                                             |
| [`8e116f42`](https://github.com/NixOS/nixpkgs/commit/8e116f42e4865f5ec27ecc680836817fd2a3bc82) | `gnome.mutter: Revert clutter optimization causing issues on X11`                 |
| [`b79697e8`](https://github.com/NixOS/nixpkgs/commit/b79697e89b8aeda548ecf5865c42b5488ceb650b) | `wasmer: 2.3.0 -> 3.0.1`                                                          |
| [`6c96c033`](https://github.com/NixOS/nixpkgs/commit/6c96c033b78e9f58b204d0be1465f48e11f82f4a) | `zeronet-conservancy: 0.7.7 -> 0.7.8`                                             |
| [`2dc0434d`](https://github.com/NixOS/nixpkgs/commit/2dc0434dcc0481f3c99bc1668a10a1359ab027c5) | `threatest: init at 1.1.0`                                                        |
| [`9c363bae`](https://github.com/NixOS/nixpkgs/commit/9c363bae166f0581fb3cd6eb709baa95ee6c0c2f) | `qalculate-qt: update supported platforms`                                        |
| [`53ec84d1`](https://github.com/NixOS/nixpkgs/commit/53ec84d1160d5c8d4479ae6769b5efdb6569ee15) | `python310Packages.angr: 9.2.25 -> 9.2.26`                                        |
| [`23bca5f6`](https://github.com/NixOS/nixpkgs/commit/23bca5f6d2e9c93cc8ad6ac6005d094b6795a064) | `python310Packages.cle: 9.2.25 -> 9.2.26`                                         |
| [`d2bb5fbb`](https://github.com/NixOS/nixpkgs/commit/d2bb5fbb6e40193dfb538628bbcc9abdcbd49af7) | `python310Packages.claripy: 9.2.25 -> 9.2.26`                                     |
| [`047b2c3f`](https://github.com/NixOS/nixpkgs/commit/047b2c3f33688c9d61a109dab31db10cbbd53583) | `python310Packages.pyvex: 9.2.25 -> 9.2.26`                                       |
| [`a9419b64`](https://github.com/NixOS/nixpkgs/commit/a9419b6439117e943e817b1d236700ed13053d37) | `python310Packages.ailment: 9.2.25 -> 9.2.26`                                     |
| [`b4708bef`](https://github.com/NixOS/nixpkgs/commit/b4708beff841e565e389c7b0d98366e8538c8e3f) | `python310Packages.archinfo: 9.2.25 -> 9.2.26`                                    |
| [`e11030af`](https://github.com/NixOS/nixpkgs/commit/e11030af6e7ea135291ebe151879bd1259e2ba73) | `python310Packages.angr: remove unicorn override (fixes #120113)`                 |
| [`aef58508`](https://github.com/NixOS/nixpkgs/commit/aef58508e5e88f682b15de4aa045eab83eb474db) | `apache-airflow: 2.4.1 -> 2.4.3`                                                  |
| [`6bb3a9ba`](https://github.com/NixOS/nixpkgs/commit/6bb3a9baee74655ebbe1f3d9c5b2693e65846146) | `rocm-related: use finalAttrs`                                                    |
| [`0190a12a`](https://github.com/NixOS/nixpkgs/commit/0190a12af56afabed5c3b4f367870e04baf9da52) | `rocm-related: change maintainers to rocm team + old`                             |
| [`574727ed`](https://github.com/NixOS/nixpkgs/commit/574727ed487478d3c3a853246435f890d8314c32) | `rocm-related: change maintainers to rocm team`                                   |
| [`b3d651c7`](https://github.com/NixOS/nixpkgs/commit/b3d651c79a9cd9541de031d419e7bb22d421a636) | `composable_kernel: unstable-2022-11-02 -> unstable-2022-11-19`                   |
| [`6eefaa03`](https://github.com/NixOS/nixpkgs/commit/6eefaa031c52a54aff3e8a3b18dc4e2ebb075335) | `rocm-related: 5.3.1 → 5.3.3`                                                     |
| [`e76e9ed9`](https://github.com/NixOS/nixpkgs/commit/e76e9ed99c2fb8688443736deb345dec5fe9b1b7) | `rPackages.bigmemory: fix evaluation on darwin`                                   |
| [`b2891427`](https://github.com/NixOS/nixpkgs/commit/b2891427b201a12ae9071309817a2abc5357c7a7) | `open-stage-control: update npmDepsHash`                                          |
| [`81da5899`](https://github.com/NixOS/nixpkgs/commit/81da589991fd4475212e34e696f146d1894b857a) | `rocm-related: ignore same hash`                                                  |
| [`a80fa825`](https://github.com/NixOS/nixpkgs/commit/a80fa825e617e53dae7a00e97ea6d75caea3fa11) | `rocm-related: add update script`                                                 |
| [`b023946d`](https://github.com/NixOS/nixpkgs/commit/b023946d2bbfe19e3b7ba6249ef48cd59f386949) | `prefetch-npm-deps: fix hash stability`                                           |
| [`125bd1f0`](https://github.com/NixOS/nixpkgs/commit/125bd1f0b55d6fbf43dcaef44d523aec0710d06e) | `doc/languages-frameworks/javascript: update deps hash in example`                |
| [`c5f01dc2`](https://github.com/NixOS/nixpkgs/commit/c5f01dc25fceec2e0e9b06f7d61d84f9904f59b7) | `python310Packages.pyotgw: 2.1.2 -> 2.1.3`                                        |
| [`9fef864d`](https://github.com/NixOS/nixpkgs/commit/9fef864d5f2cb8b46bdd618c1a9478dc917add12) | `grafana: 9.2.5 -> 9.2.6`                                                         |
| [`6cb5f7bb`](https://github.com/NixOS/nixpkgs/commit/6cb5f7bb7e340da3385960b6e1dea452712862b2) | `libp11: build reverse dependencies with same openssl version`                    |
| [`76a812d1`](https://github.com/NixOS/nixpkgs/commit/76a812d168d5fdf79485fa71fd922a3a71ab307a) | `Enpass: Add dritter as maintainer`                                               |
| [`8793ae39`](https://github.com/NixOS/nixpkgs/commit/8793ae39e6bcfc0048e5a016794df58314745d2b) | `bchoppr: 1.10.10 -> 1.12.2`                                                      |
| [`4cfd3541`](https://github.com/NixOS/nixpkgs/commit/4cfd35418295ad55cbf5f833b6da6c4314d2d46d) | `linux: fix unused option warnings on 5.x kernels`                                |
| [`bf6a7fa5`](https://github.com/NixOS/nixpkgs/commit/bf6a7fa54c1d3ee5ce54471a71383e362fba6c8f) | `qpdf: 11.1.1 -> 11.2.0`                                                          |
| [`d02af660`](https://github.com/NixOS/nixpkgs/commit/d02af66091e3233af01a2d6184ca5b47f7d7e726) | `nixos/alps: fix for Hydra failure`                                               |
| [`152ed82e`](https://github.com/NixOS/nixpkgs/commit/152ed82e8f880d732565d63634d7333e48eb7a83) | `xwayland: 22.1.3 -> 22.1.5`                                                      |
| [`57abd8c1`](https://github.com/NixOS/nixpkgs/commit/57abd8c1cff97e2a05609f32700c687a29b89a8a) | `nixos/tests/acme/server: generate certs with longer validity`                    |
| [`7274df35`](https://github.com/NixOS/nixpkgs/commit/7274df353c0e98c4cfb2e72daa51c87eb2c3cda8) | `nixos/tests/acme/server: patch certificate generation for longer validity`       |
| [`384293bb`](https://github.com/NixOS/nixpkgs/commit/384293bbbb59b8af9ad24c50bb108d792c6ca38f) | `nixos/alps: fixes for service hardening`                                         |
| [`30a62610`](https://github.com/NixOS/nixpkgs/commit/30a62610d513f3186d46627f94ef86ad78f7785b) | `istioctl: 1.15.3 -> 1.16.0`                                                      |
| [`cb9fc545`](https://github.com/NixOS/nixpkgs/commit/cb9fc54533c0f45a8e2f8950399868bcc4a5e3a0) | `libsForQt5.juk: init at 22.08.3`                                                 |
| [`6917409e`](https://github.com/NixOS/nixpkgs/commit/6917409e3c4913bfd325c013b33cdb88d769085c) | `museeks: init at 0.13.1`                                                         |
| [`4a7925fc`](https://github.com/NixOS/nixpkgs/commit/4a7925fcc4bf81e70ed3d4fe0ecc7bd0300c586d) | `lkrg: init at 0.9.5`                                                             |
| [`0f8d48c3`](https://github.com/NixOS/nixpkgs/commit/0f8d48c3e9458d8534eba2817e8e826accbf2166) | `fluent-reader: init at 1.1.3`                                                    |
| [`9a0c2eec`](https://github.com/NixOS/nixpkgs/commit/9a0c2eecf358a993aae769a9b1763b992ac847ad) | `vscode-extensions.james-yu.latex-workshop: 8.29.0 -> 9.0.0`                      |
| [`6e52acee`](https://github.com/NixOS/nixpkgs/commit/6e52acee6326ab4d2cd146297a1d6c70847b4b6e) | `python310Packages.gaphas: 3.8.1 -> 3.8.4`                                        |
| [`e54401a2`](https://github.com/NixOS/nixpkgs/commit/e54401a274a45a67f3bfecfef26d09cfe214f264) | `libzbc: 5.12.0 -> 5.13.0`                                                        |
| [`57069c33`](https://github.com/NixOS/nixpkgs/commit/57069c33661703b841c3c2a279cb9fdf08c7be27) | `QtRVSim: 0.9.3 -> 0.9.4`                                                         |
| [`adb2e740`](https://github.com/NixOS/nixpkgs/commit/adb2e740cfbc5d0f91e21d5ebf91441c70ccbf96) | `gcc-arm-embedded: 10.3 -> 11.3.rel1`                                             |
| [`5bd7d45b`](https://github.com/NixOS/nixpkgs/commit/5bd7d45bc200f5701f5f2fc98eedd04a10a605ad) | `vscode-extensions.yzhang.markdown-all-in-one: 3.4.0 -> 3.4.4`                    |