### PR TITLE
chore(flake/emacs-overlay): `3d5e5cfa` -> `8885dd26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669463559,
-        "narHash": "sha256-aemo1lyq+vi3R0+gaCJvja9LIm/OZ3nsPKvPLrjMuVw=",
+        "lastModified": 1669492747,
+        "narHash": "sha256-2H78VwT1IdFY+WjxYXQnRCc8EY0Rj156behHbYmQat8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3d5e5cfa91ed10d39e0504387242750996e8b027",
+        "rev": "8885dd262fab18c7972c037977037a35c3cbfba1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`8885dd26`](https://github.com/nix-community/emacs-overlay/commit/8885dd262fab18c7972c037977037a35c3cbfba1) | `Updated repos/melpa` |
| [`e1e62e32`](https://github.com/nix-community/emacs-overlay/commit/e1e62e32a137c846d57b240f786ea6dbc5eb0f30) | `Updated repos/emacs` |