### PR TITLE
chore(flake/nur): `417dc569` -> `2f9685d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669508708,
-        "narHash": "sha256-Jyb+Vs6kuTOo65LHogAfcyz7WeePUu7Hi6HOWEq4ec4=",
+        "lastModified": 1669515913,
+        "narHash": "sha256-T41m0q+tZmHSxNj6daWwARQrJR6EQCjyycLIKty3KuI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "417dc569d6e85dbe0c91ef10312c7364ce7aedb0",
+        "rev": "2f9685d2af039d6f25acda819a10615c6742d268",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2f9685d2`](https://github.com/nix-community/NUR/commit/2f9685d2af039d6f25acda819a10615c6742d268) | `automatic update` |