### PR TITLE
chore(flake/nur): `2f9685d2` -> `7189f1e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669515913,
-        "narHash": "sha256-T41m0q+tZmHSxNj6daWwARQrJR6EQCjyycLIKty3KuI=",
+        "lastModified": 1669519540,
+        "narHash": "sha256-8ZhWwwtAf8NnBbherhE2A7XFbRpWjPVuV2qZ9rUcYWI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2f9685d2af039d6f25acda819a10615c6742d268",
+        "rev": "7189f1e4546f0bc43c82479625ec624f7b7d3b3c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7189f1e4`](https://github.com/nix-community/NUR/commit/7189f1e4546f0bc43c82479625ec624f7b7d3b3c) | `automatic update` |