### PR TITLE
chore(flake/nur): `7189f1e4` -> `c3696be6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669519540,
-        "narHash": "sha256-8ZhWwwtAf8NnBbherhE2A7XFbRpWjPVuV2qZ9rUcYWI=",
+        "lastModified": 1669521555,
+        "narHash": "sha256-8leEjMH0PAo9tPPtY2PHIKLPbu2g504+ZWcdyE79A8A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7189f1e4546f0bc43c82479625ec624f7b7d3b3c",
+        "rev": "c3696be698df489faab970a78be8976e98eb7ac0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c3696be6`](https://github.com/nix-community/NUR/commit/c3696be698df489faab970a78be8976e98eb7ac0) | `automatic update` |