### PR TITLE
chore(flake/home-manager): `e999dfe7` -> `7ae7250d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669510155,
-        "narHash": "sha256-PS2WdRXujfxH9PuH0w8aRmrEQ+Toz3RqGlp0mXQRGio=",
+        "lastModified": 1669536800,
+        "narHash": "sha256-8E1aYwSPdc6xb/SP8LGjP4W9nkkGQM0tt1QoFLP2OUw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e999dfe7cba2e1fd59ab135e7496545bd4f82b76",
+        "rev": "7ae7250df8f38c4efc8cd6669a36272ab7a575ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                      |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`7ae7250d`](https://github.com/nix-community/home-manager/commit/7ae7250df8f38c4efc8cd6669a36272ab7a575ed) | `starship: add nushell integration support`         |
| [`4a12f304`](https://github.com/nix-community/home-manager/commit/4a12f304e0abc3f24c3c7d36423d84d7d8021364) | `nushell: add options 'extraConfig' and 'extraEnv'` |