### PR TITLE
chore(flake/nur): `9d5909b4` -> `3f099e8c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669534318,
-        "narHash": "sha256-1ksAAxQzlA5lwrnjByagezyR39Mt9LNaGSyBxXAuVkM=",
+        "lastModified": 1669550982,
+        "narHash": "sha256-AGxfJ06Ag8Ww+L9NdT2aoGLg57//yxrV0kCpDFFs51E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9d5909b40465cac756c183a6bc6e88addabb9cd9",
+        "rev": "3f099e8c636126f988f66d41d26bb474c1887c9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3f099e8c`](https://github.com/nix-community/NUR/commit/3f099e8c636126f988f66d41d26bb474c1887c9b) | `automatic update` |