### PR TITLE
chore(flake/nur): `3f099e8c` -> `222f7c06`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669550982,
-        "narHash": "sha256-AGxfJ06Ag8Ww+L9NdT2aoGLg57//yxrV0kCpDFFs51E=",
+        "lastModified": 1669562715,
+        "narHash": "sha256-x4SOCkMcQ19g+LVD96o/01aRBW6x0hlw0wyMJ08QTZA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3f099e8c636126f988f66d41d26bb474c1887c9b",
+        "rev": "222f7c06142a675c305f863a489fb7147c5ccae1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`222f7c06`](https://github.com/nix-community/NUR/commit/222f7c06142a675c305f863a489fb7147c5ccae1) | `automatic update` |