### PR TITLE
chore(flake/home-manager): `1bdbebc3` -> `fa671f17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669562132,
-        "narHash": "sha256-ooDSmyf7a8qJF/e5qowTa5FDvOBtpIS7TXCF+ER0UOQ=",
+        "lastModified": 1669571446,
+        "narHash": "sha256-jJ/OxFnwJfpY8qCAogHhHsu+gw6mV7c0Zu2QkudRg7s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1bdbebc3f83a7b6a69f84797d5cda9ece8ca3c37",
+        "rev": "fa671f1795824ea2e92629555d63e2b8196f6f99",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`fa671f17`](https://github.com/nix-community/home-manager/commit/fa671f1795824ea2e92629555d63e2b8196f6f99) | `programs.zsh: set ZPLUG_HOME before loading zplug (#2987)` |
| [`f7fed4dd`](https://github.com/nix-community/home-manager/commit/f7fed4dd3d9086ff4b7813a8600a262423cb63c1) | ``picom: add `egl` backend to options (#3441)``             |