### PR TITLE
chore(flake/nur): `222f7c06` -> `50763014`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669562715,
-        "narHash": "sha256-x4SOCkMcQ19g+LVD96o/01aRBW6x0hlw0wyMJ08QTZA=",
+        "lastModified": 1669573691,
+        "narHash": "sha256-SyvKlVh5NBAmNtLIpsGfOGiSgkvLJnx4xwPXyOiiSCY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "222f7c06142a675c305f863a489fb7147c5ccae1",
+        "rev": "50763014e7b34c05c596856628658796525e0451",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`50763014`](https://github.com/nix-community/NUR/commit/50763014e7b34c05c596856628658796525e0451) | `automatic update` |