### PR TITLE
chore(flake/emacs-overlay): `5c16b451` -> `affa8f7f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669552255,
-        "narHash": "sha256-zBk4OsvLgJjXyNIpldoLXsXHO/y5QynQC7d0VzWzPEI=",
+        "lastModified": 1669579034,
+        "narHash": "sha256-EjIfQ4ffSjI2jbSJ3CNHwOR3ZOed2ZssxzaDoCsX+0U=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5c16b4515d956c2db9334ac7f1a7982baca0ba4e",
+        "rev": "affa8f7f6bae6d7f16df320d0b5d1683712ddf25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`affa8f7f`](https://github.com/nix-community/emacs-overlay/commit/affa8f7f6bae6d7f16df320d0b5d1683712ddf25) | `Updated repos/melpa` |
| [`19ccc6da`](https://github.com/nix-community/emacs-overlay/commit/19ccc6da2799902d2eaef5368a13797dfc9bfe16) | `Updated repos/emacs` |