### PR TITLE
chore(flake/nur): `13d65add` -> `5a797341`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669591713,
-        "narHash": "sha256-1z6Z+QM7FFptEzxC+RVhnSSE4qvBVIdU7j780W//QqY=",
+        "lastModified": 1669596690,
+        "narHash": "sha256-6tuU1GpHwaw8Dqj1jVMdnpwYa7Xei0Y8xYdaR4D9RA0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "13d65add74a6cfa0afde4b7361e12295a4146b9f",
+        "rev": "5a797341155486915a21bb3a727629f7ab4e4bf3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5a797341`](https://github.com/nix-community/NUR/commit/5a797341155486915a21bb3a727629f7ab4e4bf3) | `automatic update` |