### PR TITLE
chore(flake/nur): `cdb40cd0` -> `2624234c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669599180,
-        "narHash": "sha256-JlZ0s8XL2f+juaZB+dwyCpWzLbFxQzY7uJs4J1BZzL4=",
+        "lastModified": 1669603358,
+        "narHash": "sha256-cInudUUtL/FxXwQX0W304dy9v7pNlz184sjUrwIoa3c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cdb40cd090c54d2a60f9261fd67aae0869fcc44e",
+        "rev": "2624234c4ec4785b359044271808cf1d14d63e36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2624234c`](https://github.com/nix-community/NUR/commit/2624234c4ec4785b359044271808cf1d14d63e36) | `automatic update` |
| [`e73e6eef`](https://github.com/nix-community/NUR/commit/e73e6eef8843dbb3b14073ec25193eb6da416cc6) | `automatic update` |