### PR TITLE
chore(flake/nur): `2624234c` -> `c676b114`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669603358,
-        "narHash": "sha256-cInudUUtL/FxXwQX0W304dy9v7pNlz184sjUrwIoa3c=",
+        "lastModified": 1669605742,
+        "narHash": "sha256-es5x84CuVrzPniXmPaC3lu/RtheI3EnE+rcJXGEdA7o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2624234c4ec4785b359044271808cf1d14d63e36",
+        "rev": "c676b114a7607d8f836b1362f9c0ee76e115c805",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c676b114`](https://github.com/nix-community/NUR/commit/c676b114a7607d8f836b1362f9c0ee76e115c805) | `automatic update` |