### PR TITLE
chore(flake/nur): `c676b114` -> `a236e826`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669605742,
-        "narHash": "sha256-es5x84CuVrzPniXmPaC3lu/RtheI3EnE+rcJXGEdA7o=",
+        "lastModified": 1669608592,
+        "narHash": "sha256-owVgSfWSWTyrT4/6DIKgeWzqRu47lkBDK0t3CeTpX14=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c676b114a7607d8f836b1362f9c0ee76e115c805",
+        "rev": "a236e826c0989b4e97764ba0f9a2c81bf058f8de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a236e826`](https://github.com/nix-community/NUR/commit/a236e826c0989b4e97764ba0f9a2c81bf058f8de) | `automatic update` |