### PR TITLE
chore(flake/emacs-overlay): `affa8f7f` -> `0052cb41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669579034,
-        "narHash": "sha256-EjIfQ4ffSjI2jbSJ3CNHwOR3ZOed2ZssxzaDoCsX+0U=",
+        "lastModified": 1669613201,
+        "narHash": "sha256-4dHi3smsFhrRrxg4CwEahFo845RugTm9HCbfwAX9ytc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "affa8f7f6bae6d7f16df320d0b5d1683712ddf25",
+        "rev": "0052cb41ba2d278fca5ed8b48a5b3e9bff6cbed4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`0052cb41`](https://github.com/nix-community/emacs-overlay/commit/0052cb41ba2d278fca5ed8b48a5b3e9bff6cbed4) | `Updated repos/nongnu` |
| [`d6cd4615`](https://github.com/nix-community/emacs-overlay/commit/d6cd46156ea17c803f56657c87dc3d0292e89609) | `Updated repos/melpa`  |
| [`aa91ccd6`](https://github.com/nix-community/emacs-overlay/commit/aa91ccd60349c0361ab920fcfe2602bf894edf6d) | `Updated repos/emacs`  |