### PR TITLE
chore(flake/nur): `a236e826` -> `a64ea499`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669608592,
-        "narHash": "sha256-owVgSfWSWTyrT4/6DIKgeWzqRu47lkBDK0t3CeTpX14=",
+        "lastModified": 1669613628,
+        "narHash": "sha256-A8HTvJSfloF4B3BzZUQjqghH9L1HDmmLPGZjn87/8sc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a236e826c0989b4e97764ba0f9a2c81bf058f8de",
+        "rev": "a64ea499255bfee211e8e5701e243dcdfea2ea56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a64ea499`](https://github.com/nix-community/NUR/commit/a64ea499255bfee211e8e5701e243dcdfea2ea56) | `automatic update` |