### PR TITLE
chore(flake/nur): `a64ea499` -> `1d081971`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669613628,
-        "narHash": "sha256-A8HTvJSfloF4B3BzZUQjqghH9L1HDmmLPGZjn87/8sc=",
+        "lastModified": 1669616578,
+        "narHash": "sha256-uwecFtN1CMoUEaIKiGxK1t6h7RZUtZn5gmcInoptSl8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a64ea499255bfee211e8e5701e243dcdfea2ea56",
+        "rev": "1d081971f9b7ae7f902628e30c7c6e58c3c4e8d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1d081971`](https://github.com/nix-community/NUR/commit/1d081971f9b7ae7f902628e30c7c6e58c3c4e8d6) | `automatic update` |