### PR TITLE
chore(flake/emacs-overlay): `d54a1521` -> `c231c739`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669639095,
-        "narHash": "sha256-yeP89LGRqMbTuEVII4/2BCMEKgEAbEqOMcwEev2S03U=",
+        "lastModified": 1669666311,
+        "narHash": "sha256-QVxiSCDtk76Vn7/07qds6J9x7P4sAUMm9FNa/Ij0o7s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d54a1521619daa37c9aa8c9e3362abb34e676007",
+        "rev": "c231c73992cf9a024070b841fdcfdf067da1a3dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`c231c739`](https://github.com/nix-community/emacs-overlay/commit/c231c73992cf9a024070b841fdcfdf067da1a3dd) | `Updated repos/melpa` |
| [`32329085`](https://github.com/nix-community/emacs-overlay/commit/32329085c481f8ace921da5ddbcb070f19682536) | `Updated repos/emacs` |