### PR TITLE
chore(flake/nur): `6d5bf7dd` -> `5f44cf91`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669669932,
-        "narHash": "sha256-qRk5hZ4FxQNT3vi+oweY+3wX2UowPDUn7oTkbKH3mCY=",
+        "lastModified": 1669672743,
+        "narHash": "sha256-0OyyFK0diGC+2FL+5okxWttmJSZbEU/Fzz5mSvf1hD4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6d5bf7dd7ad899e782c58300e3e317454306d970",
+        "rev": "5f44cf91e76f88b1621228747d58f98042074799",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5f44cf91`](https://github.com/nix-community/NUR/commit/5f44cf91e76f88b1621228747d58f98042074799) | `automatic update` |