### PR TITLE
chore(flake/nur): `5f44cf91` -> `99171c9c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669672743,
-        "narHash": "sha256-0OyyFK0diGC+2FL+5okxWttmJSZbEU/Fzz5mSvf1hD4=",
+        "lastModified": 1669681934,
+        "narHash": "sha256-aA1nWXYZX6EHYlgHVyqWxG9B9ZHaOXBZv8wXU+5cbiw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5f44cf91e76f88b1621228747d58f98042074799",
+        "rev": "99171c9c412dc59cc2ca846c1792a199134ac862",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`99171c9c`](https://github.com/nix-community/NUR/commit/99171c9c412dc59cc2ca846c1792a199134ac862) | `automatic update` |