### PR TITLE
chore(flake/nur): `9b6d17ac` -> `8f16e7d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669686500,
-        "narHash": "sha256-m5QOGy221kz30TAs1iiiDvBjWP1/H+fAhNwiRGuEviY=",
+        "lastModified": 1669691950,
+        "narHash": "sha256-cHpXbhDlprnpuxH5jbI1c5uqXIqAPf1ZA+z/+2ZvSxI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9b6d17ac962447e86764efd767d5bafbf7fea449",
+        "rev": "8f16e7d1a6a327e718c704664602a23946f6ae1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8f16e7d1`](https://github.com/nix-community/NUR/commit/8f16e7d1a6a327e718c704664602a23946f6ae1e) | `automatic update` |