### PR TITLE
chore(flake/nur): `8f16e7d1` -> `b62a0bda`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669691950,
-        "narHash": "sha256-cHpXbhDlprnpuxH5jbI1c5uqXIqAPf1ZA+z/+2ZvSxI=",
+        "lastModified": 1669694002,
+        "narHash": "sha256-uGFTrIBU3E3hnC0SXuX2iwZHdGN8W4YUJdBIYpMvvcY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8f16e7d1a6a327e718c704664602a23946f6ae1e",
+        "rev": "b62a0bda4c7310cae8d755593072844cfe05bd11",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b62a0bda`](https://github.com/nix-community/NUR/commit/b62a0bda4c7310cae8d755593072844cfe05bd11) | `automatic update` |