### PR TITLE
chore(flake/nur): `b62a0bda` -> `63b85bbd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669694002,
-        "narHash": "sha256-uGFTrIBU3E3hnC0SXuX2iwZHdGN8W4YUJdBIYpMvvcY=",
+        "lastModified": 1669694805,
+        "narHash": "sha256-cVzxaC/Be6Rl2ajhjIqxXgG3K2BUkImd8TJEQFkslNg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b62a0bda4c7310cae8d755593072844cfe05bd11",
+        "rev": "63b85bbdce6377bc1aaa3b75f38f68b00b6a25f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`63b85bbd`](https://github.com/nix-community/NUR/commit/63b85bbdce6377bc1aaa3b75f38f68b00b6a25f7) | `automatic update` |