### PR TITLE
chore(flake/emacs-overlay): `c231c739` -> `de8f6b86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669666311,
-        "narHash": "sha256-QVxiSCDtk76Vn7/07qds6J9x7P4sAUMm9FNa/Ij0o7s=",
+        "lastModified": 1669699693,
+        "narHash": "sha256-h2gEUmP3Ik6lDeUosh/CKwUXcJbLE+/X+5sWgKeXvUI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c231c73992cf9a024070b841fdcfdf067da1a3dd",
+        "rev": "de8f6b86ab55753fa40b7f1b815d2126d203dddc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`de8f6b86`](https://github.com/nix-community/emacs-overlay/commit/de8f6b86ab55753fa40b7f1b815d2126d203dddc) | `Updated repos/nongnu` |
| [`5db1a158`](https://github.com/nix-community/emacs-overlay/commit/5db1a15886a8f7de934fdd3e8106cea7380b086c) | `Updated repos/melpa`  |
| [`ce16b980`](https://github.com/nix-community/emacs-overlay/commit/ce16b98056ddcb47221823072269df39de4cb930) | `Updated repos/emacs`  |