### PR TITLE
chore(flake/nur): `63b85bbd` -> `2b809545`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669694805,
-        "narHash": "sha256-cVzxaC/Be6Rl2ajhjIqxXgG3K2BUkImd8TJEQFkslNg=",
+        "lastModified": 1669700557,
+        "narHash": "sha256-RegdEdvysRTyvH+Da/6KCZqiDBKnH/j4Mt+Exx8mMIw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "63b85bbdce6377bc1aaa3b75f38f68b00b6a25f7",
+        "rev": "2b80954516040e9da4561d88c7e3189742a8198e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2b809545`](https://github.com/nix-community/NUR/commit/2b80954516040e9da4561d88c7e3189742a8198e) | `automatic update` |