### PR TITLE
chore(flake/emacs-overlay): `de8f6b86` -> `b152560f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669699693,
-        "narHash": "sha256-h2gEUmP3Ik6lDeUosh/CKwUXcJbLE+/X+5sWgKeXvUI=",
+        "lastModified": 1669714945,
+        "narHash": "sha256-ShZuuVOlFno/YWJXlIvXkxjXRnL2JvHHuG7DasCgPEQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "de8f6b86ab55753fa40b7f1b815d2126d203dddc",
+        "rev": "b152560f00867f85c441a2b2981f7ab4b787194e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`b152560f`](https://github.com/nix-community/emacs-overlay/commit/b152560f00867f85c441a2b2981f7ab4b787194e) | `Updated repos/melpa` |