### PR TITLE
chore(flake/home-manager): `50c9bccb` -> `cd2a826f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669573161,
-        "narHash": "sha256-UAOXq+LIX+goAAY2MiC0+zCxdNPaO7NAPTvCQExpIBs=",
+        "lastModified": 1669724748,
+        "narHash": "sha256-lXt0GnHogW63B8EQGME9ERkoCPqwUQtOG/qF20clfUw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "50c9bccb6abc52811a59db620606e016fcde32bd",
+        "rev": "cd2a826f33ee96f705e8c07b01fd1346b2eccbc0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`cd2a826f`](https://github.com/nix-community/home-manager/commit/cd2a826f33ee96f705e8c07b01fd1346b2eccbc0) | `ssh: make news item conditional`    |
| [`02c05460`](https://github.com/nix-community/home-manager/commit/02c05460339e5239ef6fc83eecea047e7e879704) | `dbus: fix dbus-run-session command` |