### PR TITLE
chore(flake/nur): `fc128f90` -> `f7b4e636`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669741829,
-        "narHash": "sha256-jQQV/+ntNI5W5GfiY8KgKmdHgARzVoLbiFjNI9BXYm8=",
+        "lastModified": 1669749637,
+        "narHash": "sha256-QAJt9dov1gJTNFaWbEwaHV1IDtVrsM18E7LsLsvsHIA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc128f900b45a334c0cad397b955316fcaaad495",
+        "rev": "f7b4e636b872255bf3ea0712d93ce9dc934d4076",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f7b4e636`](https://github.com/nix-community/NUR/commit/f7b4e636b872255bf3ea0712d93ce9dc934d4076) | `automatic update` |