### PR TITLE
chore(flake/nur): `eb7a1cf2` -> `fdfe23bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669772933,
-        "narHash": "sha256-Nqlqroean69CGGpYrlJ/8UhfLwRQ8k+kLBNVYEsO7LI=",
+        "lastModified": 1669774061,
+        "narHash": "sha256-3/B7nPg83pU1PEus8HIboAYuiq42zyYPyE8kGNkM2ic=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eb7a1cf2e25edb29c060e8b4c10d4e3351f0b775",
+        "rev": "fdfe23bbe44250661e8c98308b921e257b5cddda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`fdfe23bb`](https://github.com/nix-community/NUR/commit/fdfe23bbe44250661e8c98308b921e257b5cddda) | `automatic update` |