### PR TITLE
chore(flake/emacs-overlay): `5c03fb3e` -> `234b1957`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669744024,
-        "narHash": "sha256-/bDQAmpyqhR55tsGoDt/lp9pI12lvyojrCLulUUAyGc=",
+        "lastModified": 1669776659,
+        "narHash": "sha256-nrs97Xv1VTRfjwNN87fWPKKd+e+TJm5fH5eNWV/Q5sc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5c03fb3e6636b7121b8c3b126d2351e78cb54d4f",
+        "rev": "234b19572a6c0fd9af8f911bdd1ec4dde6e0a7e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`234b1957`](https://github.com/nix-community/emacs-overlay/commit/234b19572a6c0fd9af8f911bdd1ec4dde6e0a7e5) | `Updated repos/nongnu` |
| [`7eff712c`](https://github.com/nix-community/emacs-overlay/commit/7eff712ca5e587707520eb321cef49fdb48c5b7d) | `Updated repos/melpa`  |