### PR TITLE
chore(flake/nur): `fdfe23bb` -> `e1eeeaac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669774061,
-        "narHash": "sha256-3/B7nPg83pU1PEus8HIboAYuiq42zyYPyE8kGNkM2ic=",
+        "lastModified": 1669779145,
+        "narHash": "sha256-kiphpA3JQstUIEUUu4GP2RnnQm40gVTy3tJcQX5neJc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fdfe23bbe44250661e8c98308b921e257b5cddda",
+        "rev": "e1eeeaac032a122e3853c31a90c6f7d725667f94",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e1eeeaac`](https://github.com/nix-community/NUR/commit/e1eeeaac032a122e3853c31a90c6f7d725667f94) | `automatic update` |
| [`fbaf98fe`](https://github.com/nix-community/NUR/commit/fbaf98fe4ef25be1a72aa89f209933e8b7ab4d7f) | `automatic update` |
| [`5b9175b9`](https://github.com/nix-community/NUR/commit/5b9175b9aa8c8eae54dccdfc28f8640d0ea93483) | `automatic update` |