### PR TITLE
chore(flake/nur): `e1eeeaac` -> `fc9ae408`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669779145,
-        "narHash": "sha256-kiphpA3JQstUIEUUu4GP2RnnQm40gVTy3tJcQX5neJc=",
+        "lastModified": 1669780548,
+        "narHash": "sha256-lV2gCdZ2oPc7GJ9WqtHsdQOMZdnY1y76GLpRFwcJ08k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e1eeeaac032a122e3853c31a90c6f7d725667f94",
+        "rev": "fc9ae408b0ab06e525226a4cc273465a6098360e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`fc9ae408`](https://github.com/nix-community/NUR/commit/fc9ae408b0ab06e525226a4cc273465a6098360e) | `automatic update` |