### PR TITLE
chore(flake/nur): `fc9ae408` -> `b18ee40a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669780548,
-        "narHash": "sha256-lV2gCdZ2oPc7GJ9WqtHsdQOMZdnY1y76GLpRFwcJ08k=",
+        "lastModified": 1669781016,
+        "narHash": "sha256-JdsRXIwhojbntXANZ5fW8+bKTIW2RHgzja3T6Eo+nXw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc9ae408b0ab06e525226a4cc273465a6098360e",
+        "rev": "b18ee40a5805986036fe42792e15f23e52c5390f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b18ee40a`](https://github.com/nix-community/NUR/commit/b18ee40a5805986036fe42792e15f23e52c5390f) | `automatic update` |