### PR TITLE
chore(flake/nur): `b18ee40a` -> `ddf1c4cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669781016,
-        "narHash": "sha256-JdsRXIwhojbntXANZ5fW8+bKTIW2RHgzja3T6Eo+nXw=",
+        "lastModified": 1669783089,
+        "narHash": "sha256-30YQaJz9IumnIaJYeifGBoCGGUTrjY9eweQpM0qzl4E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b18ee40a5805986036fe42792e15f23e52c5390f",
+        "rev": "ddf1c4cdcec64194d13489fce9d7ffad4a55a072",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ddf1c4cd`](https://github.com/nix-community/NUR/commit/ddf1c4cdcec64194d13489fce9d7ffad4a55a072) | `automatic update` |