### PR TITLE
chore(flake/nur): `ddf1c4cd` -> `8af9e013`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669783089,
-        "narHash": "sha256-30YQaJz9IumnIaJYeifGBoCGGUTrjY9eweQpM0qzl4E=",
+        "lastModified": 1669788629,
+        "narHash": "sha256-PbgPcax3BfYyJ2bfhK4Q0LpFOUV6DPyp2LCIfqASO+A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ddf1c4cdcec64194d13489fce9d7ffad4a55a072",
+        "rev": "8af9e013b29deed46d650e728b457ffbef6ab3a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8af9e013`](https://github.com/nix-community/NUR/commit/8af9e013b29deed46d650e728b457ffbef6ab3a2) | `automatic update` |