### PR TITLE
chore(flake/nur): `8af9e013` -> `ea5a90e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669788629,
-        "narHash": "sha256-PbgPcax3BfYyJ2bfhK4Q0LpFOUV6DPyp2LCIfqASO+A=",
+        "lastModified": 1669792810,
+        "narHash": "sha256-rdgvzBb0fkoXFVI9e8KSYdACaswUhvMYhKv2Aftz9wA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8af9e013b29deed46d650e728b457ffbef6ab3a2",
+        "rev": "ea5a90e89a2ce6f8fb0aa49b8ae7c89f2d6ad025",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ea5a90e8`](https://github.com/nix-community/NUR/commit/ea5a90e89a2ce6f8fb0aa49b8ae7c89f2d6ad025) | `automatic update` |