### PR TITLE
chore(flake/nur): `ea5a90e8` -> `ddf6e8ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669792810,
-        "narHash": "sha256-rdgvzBb0fkoXFVI9e8KSYdACaswUhvMYhKv2Aftz9wA=",
+        "lastModified": 1669796619,
+        "narHash": "sha256-vMproIVxeZTe/UvGiqbjO/6YjoqT3X1Kyt336YjaFY4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ea5a90e89a2ce6f8fb0aa49b8ae7c89f2d6ad025",
+        "rev": "ddf6e8ba0781ac1d5d9e85d6d87163096570e084",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ddf6e8ba`](https://github.com/nix-community/NUR/commit/ddf6e8ba0781ac1d5d9e85d6d87163096570e084) | `automatic update` |