### PR TITLE
chore(flake/home-manager): `e38ce0ae` -> `478610aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669805139,
-        "narHash": "sha256-ry0PkAAJg09tg5Y81sNJteiU7LsiIIgGk947Xa3hzkA=",
+        "lastModified": 1669825171,
+        "narHash": "sha256-HxlZHSiRGXnWAFbIJMeujqBe2KgACYx5XDRY0EA9P+4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e38ce0ae16b68515c913ab50177bc7624f65f569",
+        "rev": "478610aa37c8339eacabfa03f07dacf5574edd47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`478610aa`](https://github.com/nix-community/home-manager/commit/478610aa37c8339eacabfa03f07dacf5574edd47) | `neovim: Source neovimRcContent directly from store (#3444)` |