### PR TITLE
chore(flake/emacs-overlay): `a686fa48` -> `b8ed2226`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669801362,
-        "narHash": "sha256-kwrejUngReIv3M926D/SRQkJVCiaBuBcj7t3RmIXc4U=",
+        "lastModified": 1669837677,
+        "narHash": "sha256-N90RpOEt79SAb199foN0SxjZhwKzD6Nrdrk6pD4+GbA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a686fa48a89b0cba053143ba155506c93718037f",
+        "rev": "b8ed2226758cbd6c2d19b28f1fa9f26b9f78073c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`b8ed2226`](https://github.com/nix-community/emacs-overlay/commit/b8ed2226758cbd6c2d19b28f1fa9f26b9f78073c) | `Updated repos/nongnu` |
| [`18ad9323`](https://github.com/nix-community/emacs-overlay/commit/18ad932352033ead8fe60c3ec399626b7bdc5bc5) | `Updated repos/melpa`  |
| [`6a456047`](https://github.com/nix-community/emacs-overlay/commit/6a45604758434ba36c3f6ee83bb5af943ab627e9) | `Updated repos/emacs`  |