### PR TITLE
chore(flake/emacs-overlay): `b8ed2226` -> `6530a233`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669837677,
-        "narHash": "sha256-N90RpOEt79SAb199foN0SxjZhwKzD6Nrdrk6pD4+GbA=",
+        "lastModified": 1669874436,
+        "narHash": "sha256-HYvJU6SROcNwcwow5xrG2Is69UJ+GaVrFSSX7QjG/6c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b8ed2226758cbd6c2d19b28f1fa9f26b9f78073c",
+        "rev": "6530a233351a806e88e83d10312d7dd9e8bc6cd3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`6530a233`](https://github.com/nix-community/emacs-overlay/commit/6530a233351a806e88e83d10312d7dd9e8bc6cd3) | `Updated repos/nongnu` |
| [`0c0e6046`](https://github.com/nix-community/emacs-overlay/commit/0c0e604638266c71d2411121db83411c3d4cbb0b) | `Updated repos/melpa`  |
| [`8a4525b4`](https://github.com/nix-community/emacs-overlay/commit/8a4525b412bd5fc5e8c943843fab9f9d27c1df9d) | `Updated repos/emacs`  |