### PR TITLE
chore(flake/emacs-overlay): `6530a233` -> `9e53c246`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669874436,
-        "narHash": "sha256-HYvJU6SROcNwcwow5xrG2Is69UJ+GaVrFSSX7QjG/6c=",
+        "lastModified": 1669898266,
+        "narHash": "sha256-1gsmlz+ftMKg6crJOcghVOYqRiXmdmt1sAR9He4CuKI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6530a233351a806e88e83d10312d7dd9e8bc6cd3",
+        "rev": "9e53c246a9f9db278b8e881b796f099119befe79",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`9e53c246`](https://github.com/nix-community/emacs-overlay/commit/9e53c246a9f9db278b8e881b796f099119befe79) | `Updated repos/melpa` |
| [`a7500019`](https://github.com/nix-community/emacs-overlay/commit/a7500019b6c53eb07b383e309308b7a141b01afd) | `Updated repos/emacs` |