### PR TITLE
chore(flake/nixpkgs): `a115bb9b` -> `e76c78d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669542132,
-        "narHash": "sha256-DRlg++NJAwPh8io3ExBJdNW7Djs3plVI5jgYQ+iXAZQ=",
+        "lastModified": 1669791787,
+        "narHash": "sha256-KBfoA2fOI5+wCrm7PR+j7jHqXeTkVRPQ0m5fcKchyuU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a115bb9bd56831941be3776c8a94005867f316a7",
+        "rev": "e76c78d20685a043d23f5f9e0ccd2203997f1fb1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`1853c7df`](https://github.com/NixOS/nixpkgs/commit/1853c7df0f50be9a95eff3ac11124d624ef752b0) | `ocamlPackages.calendar: 2.5 → 3.0`                                                  |
| [`fc7eef65`](https://github.com/NixOS/nixpkgs/commit/fc7eef65a275471d2c64486b3c2e605c2e6d0930) | `dockerTools: fix nginx test`                                                        |
| [`16f1d25e`](https://github.com/NixOS/nixpkgs/commit/16f1d25e44baa62cb16f74ad9515122d293d25ea) | `plasma-workspace: 5.26.4 -> 5.26.4.1`                                               |
| [`3b9bc132`](https://github.com/NixOS/nixpkgs/commit/3b9bc1320a700336e08ea51dea92b0f915f3fbd6) | `tut: 1.0.22 -> 1.0.23`                                                              |
| [`eecf736f`](https://github.com/NixOS/nixpkgs/commit/eecf736ff4bac9687b491e0e3cd117ec7dd7f3bf) | `threatest: 1.1.0 -> 1.1.1`                                                          |
| [`87245df5`](https://github.com/NixOS/nixpkgs/commit/87245df5d3021be4de530a45b74d05c671a6fd5a) | `nixos/stubby: Support fine-grained logLevel`                                        |
| [`64f3ba47`](https://github.com/NixOS/nixpkgs/commit/64f3ba470e97aded776b6c3b100fbaa7b6e8f010) | `poetry2conda: use poetry-core`                                                      |
| [`e0ed66ab`](https://github.com/NixOS/nixpkgs/commit/e0ed66ab21cbc55326e29e0e80f3666b79084017) | `cmake-language-server: relax pygls version constraint`                              |
| [`1d96cb71`](https://github.com/NixOS/nixpkgs/commit/1d96cb7166adc385b2084328c44482f73d85638f) | `cmake-language-server: use poetry-core`                                             |
| [`24eab6ba`](https://github.com/NixOS/nixpkgs/commit/24eab6bae704efd51abf2ea90ef23e1944521886) | `python310Packages.strawberry-graphql: use poetry-core`                              |
| [`4af24f80`](https://github.com/NixOS/nixpkgs/commit/4af24f80e99de4b0616c640a2a8a7ce0c60d5925) | `python310Packages.pipenv-poetry-migrate: use poetry-core`                           |
| [`1f17c129`](https://github.com/NixOS/nixpkgs/commit/1f17c1297c5264665ca9a1ac139ff917b880d581) | `commitizen: use poetry-core`                                                        |
| [`2137dd92`](https://github.com/NixOS/nixpkgs/commit/2137dd928c5b9aeba055c29881df90f2f196ffe3) | `python310Packages.pyairnow: use poetry-core`                                        |
| [`bb53b956`](https://github.com/NixOS/nixpkgs/commit/bb53b9562436ae0d2afdec419a54ec89288d25f9) | `python310Packages.aria2p: 0.9.1 -> 0.11.2`                                          |
| [`75115a0f`](https://github.com/NixOS/nixpkgs/commit/75115a0f7237cbd48074e0677318b41965cfeaf6) | `python310Packages.expecttest: use poetry-core`                                      |
| [`1b16f384`](https://github.com/NixOS/nixpkgs/commit/1b16f38425190ea1825d6fbc5f1621c5c3223282) | `python310Packages.jedi-language-server: 0.37.0 -> 0.39.0`                           |
| [`48db7277`](https://github.com/NixOS/nixpkgs/commit/48db7277dd3667f05f11419ac731713d23c19f68) | `python310Packages.pygls: 0.12.3 -> 0.13.0`                                          |
| [`22ccf277`](https://github.com/NixOS/nixpkgs/commit/22ccf277fc8d60ef8aaec7e952ba54779072835c) | `python310Packages.pytest-golden: use poetry-core`                                   |
| [`3e99f312`](https://github.com/NixOS/nixpkgs/commit/3e99f31265c171d125df9c47735f249885379a16) | `python310Packages.aioeafm: use poetry-core`                                         |
| [`96807bab`](https://github.com/NixOS/nixpkgs/commit/96807bab30963db67158242183cf8f207785969c) | `streamdeck-ui: use poetry-core`                                                     |
| [`84ed05ea`](https://github.com/NixOS/nixpkgs/commit/84ed05ea4c4bde55c29a84999fe008ea483e4ab1) | `python310Packages.hypothesis-auto: use poetry-core`                                 |
| [`857e8c00`](https://github.com/NixOS/nixpkgs/commit/857e8c001b657bad295f183c9a36316adaf7138c) | `python310Packages.cleo: 1.0.0a5 -> 2.0.1`                                           |
| [`9f4bd9f9`](https://github.com/NixOS/nixpkgs/commit/9f4bd9f98de8b6342582366fef294f71480a5949) | `python310Packages.crashtest: 0.4.0 -> 0.4.1`                                        |
| [`ed78ff51`](https://github.com/NixOS/nixpkgs/commit/ed78ff51a627dfa7a757239cfc87201a97ac0a49) | `syft: 0.62.1 -> 0.62.2`                                                             |
| [`d3b71d53`](https://github.com/NixOS/nixpkgs/commit/d3b71d535cb65381881df40e9d71c00644ba957a) | `gimp: condition python2 behind new withPython argument`                             |
| [`ff16070c`](https://github.com/NixOS/nixpkgs/commit/ff16070ce3b9d32ae872f36855e2dd7c758e8f28) | `crun: 1.7.1 -> 1.7.2`                                                               |
| [`2735f88b`](https://github.com/NixOS/nixpkgs/commit/2735f88b2f814d9b64b210875f100bc229d9f9fd) | `mopidy-ytmusic: 0.3.7 -> 0.3.8`                                                     |
| [`49ec58bd`](https://github.com/NixOS/nixpkgs/commit/49ec58bd1caca87891e5e10ec267ff44bf5138f9) | `gatling: fix undefined reference to 'crypt'`                                        |
| [`38ffd641`](https://github.com/NixOS/nixpkgs/commit/38ffd641e0da8f37b82858ebd7cd679fa4716b66) | `bundlerUpdateScript: use Nix 2.3`                                                   |
| [`8db42896`](https://github.com/NixOS/nixpkgs/commit/8db42896f1f22639d819188d7fa8184279f8f363) | `licensee: 9.15.1 -> 9.15.3`                                                         |
| [`f4340b12`](https://github.com/NixOS/nixpkgs/commit/f4340b1247a24df86e0f13ae03500a8c536f220d) | `pokefinder: init at 4.0.1`                                                          |
| [`bb4cc151`](https://github.com/NixOS/nixpkgs/commit/bb4cc151b6dfee792e98f53a30895b66cf7b4a48) | `nixos/openrgb: fix linking in release notes`                                        |
| [`cf3813f0`](https://github.com/NixOS/nixpkgs/commit/cf3813f0a29dc5edf313687a037e9815f4766a8a) | `pip-audit: 2.4.6 -> 2.4.7`                                                          |
| [`50ddc203`](https://github.com/NixOS/nixpkgs/commit/50ddc2039ec34c996e0c50b296c9a7e0ef4b75df) | `tabnine: 4.4.169 -> 4.4.186`                                                        |
| [`7f9711a5`](https://github.com/NixOS/nixpkgs/commit/7f9711a52c7d1f05724c2eb31b3a1ccf8185dd20) | `clamav: 0.105.1 -> 1.0.0`                                                           |
| [`c95c5abe`](https://github.com/NixOS/nixpkgs/commit/c95c5abe40fa95997434dcb6c5fe54a31b583004) | `python310Packages.cyclonedx-python-lib: add changelog to meta`                      |
| [`bd463331`](https://github.com/NixOS/nixpkgs/commit/bd463331ce59971d04e90ae9917b51edc90f31ff) | `scala-cli: 0.1.16 -> 0.1.17, set argv0`                                             |
| [`19a6b85e`](https://github.com/NixOS/nixpkgs/commit/19a6b85e8f8daca80e38418e96247cc499e2640e) | `nixos: disable systemd-oomd when enableUnifiedCgroupHierarchy is false`             |
| [`5fe4c60e`](https://github.com/NixOS/nixpkgs/commit/5fe4c60e49e10afd624fd0b022f92da4511f671e) | `smartmontools: remove unneeded inetutils`                                           |
| [`43052306`](https://github.com/NixOS/nixpkgs/commit/43052306ac871786ff17a5e62d04356737a4eea5) | `smartmontools: add hostname to runtime closure`                                     |
| [`c4eac0bb`](https://github.com/NixOS/nixpkgs/commit/c4eac0bbd9f2bc202140fd445f2d385e80f1fe3c) | `safety-cli: 2.3.2 -> 2.3.3`                                                         |
| [`54dba443`](https://github.com/NixOS/nixpkgs/commit/54dba44317a34835dca271c5b265770c20284bfc) | `meshcentral: 1.0.18 -> 1.1.0`                                                       |
| [`491ccdb0`](https://github.com/NixOS/nixpkgs/commit/491ccdb05cc27e4a443e8433c7ef986236e73f09) | `open-stage-control: 1.20.0 -> 1.21.0`                                               |
| [`83807f3a`](https://github.com/NixOS/nixpkgs/commit/83807f3aaa4ea9a835709015e6b51bedb86c1f9a) | `nixos/doc/rl-2211: document nsncd option`                                           |
| [`ca609211`](https://github.com/NixOS/nixpkgs/commit/ca609211710f9d2065348efb1457f9a88816b857) | `prometheus-pushgateway: 1.4.3 -> 1.5.1`                                             |
| [`a2c6287b`](https://github.com/NixOS/nixpkgs/commit/a2c6287bfcb38d319fc6fb8872b8e4f28b3bfc30) | `refinery-cli: 0.8.6 -> 0.8.7`                                                       |
| [`7c3eeb56`](https://github.com/NixOS/nixpkgs/commit/7c3eeb5667f5f5be7aa4c9374f01a72e59f415bb) | `keepassxc: Fix GApps wrapping`                                                      |
| [`2067c9cc`](https://github.com/NixOS/nixpkgs/commit/2067c9ccaf9a0c004184eae7884230c4b27f8469) | `vimPlugins.nvim-treesitter: update grammars`                                        |
| [`b0998ceb`](https://github.com/NixOS/nixpkgs/commit/b0998ceb7144ea39bf6eb4c67ca84542924399ed) | `vimPlugins: update`                                                                 |
| [`12ac85bb`](https://github.com/NixOS/nixpkgs/commit/12ac85bbe7010dbe6d05e2f54b86aa600327f202) | `pspg: 5.5.13 -> 5.6.0`                                                              |
| [`e8b8afb2`](https://github.com/NixOS/nixpkgs/commit/e8b8afb2552b76e9ac2cf8b9245c9fe31f8ac9d2) | `Revert "libguestfs: remove unnecessary ? null from inputs"`                         |
| [`81e8d927`](https://github.com/NixOS/nixpkgs/commit/81e8d927e019d1f8bc9ed5c2fe75d7e88b9c6d59) | `polkadot: 0.9.32 -> 0.9.33`                                                         |
| [`5c3e0a28`](https://github.com/NixOS/nixpkgs/commit/5c3e0a2899b6a9bb6048bdd5b63ea8273d08297a) | `ngn-k: allow cross compilation to FreeBSD 13`                                       |
| [`f68fdcfc`](https://github.com/NixOS/nixpkgs/commit/f68fdcfc4e86335a4fa1b02d6abfb69a3545aaee) | `ngn-k: build k-libc flavor by default`                                              |
| [`5822bee6`](https://github.com/NixOS/nixpkgs/commit/5822bee639c7877e45690f7d91c3e1c31a1182e5) | `ngn-k: unstable-2021-12-17 -> 2022-11-27`                                           |
| [`58871bb9`](https://github.com/NixOS/nixpkgs/commit/58871bb9ee273732921a1285472e27426fcfa495) | `pgbackrest: 2.42 -> 2.43`                                                           |
| [`f3466a31`](https://github.com/NixOS/nixpkgs/commit/f3466a31c75653e81cd79c85ad2cf3d19c165660) | `opensc: 0.22.0 -> 0.23.0`                                                           |
| [`1c1f4b76`](https://github.com/NixOS/nixpkgs/commit/1c1f4b76350702be20074588bea6f1bf087f1efe) | `python310Packages.diff-cover: 7.1.0 -> 7.1.1`                                       |
| [`9790786a`](https://github.com/NixOS/nixpkgs/commit/9790786a00880d1b7240d519953274f141a0ceaf) | `stratisd: 3.4.0 -> 3.4.1`                                                           |
| [`8b542d1f`](https://github.com/NixOS/nixpkgs/commit/8b542d1f936ebea47560f4406066e54beb9fbb62) | `plasma: 5.26.3 -> 5.26.4`                                                           |
| [`2158497b`](https://github.com/NixOS/nixpkgs/commit/2158497bb99f747a5642f26efe7bedd20f427bbf) | `python310Packages.cyclonedx-python-lib: 3.1.0 -> 3.1.1`                             |
| [`b330de2e`](https://github.com/NixOS/nixpkgs/commit/b330de2e1aa0a22744ccfbcbe920182961a2d084) | `meilisearch: 0.29.2 -> 0.30.0`                                                      |
| [`9cf0ee43`](https://github.com/NixOS/nixpkgs/commit/9cf0ee43e72dec65365ffa2e2c2da4cb2ebc3b5d) | `doc: Use POSIX syntax to source file`                                               |
| [`22d3b5a9`](https://github.com/NixOS/nixpkgs/commit/22d3b5a9e9ce78947bcf70fc970301708df0b7e4) | `doc: Quote variable references`                                                     |
| [`852ef6e9`](https://github.com/NixOS/nixpkgs/commit/852ef6e9716b00e6400ee905ee80e62e11192e3c) | `doc: Fix grammar`                                                                   |
| [`22b02022`](https://github.com/NixOS/nixpkgs/commit/22b020228f034fbfa436033b091112b1f699c2fa) | `python310Packages.pylsp-mypy: fix test`                                             |
| [`7e5e6625`](https://github.com/NixOS/nixpkgs/commit/7e5e6625e2c9c35942e0f0a97fee18cd53991187) | `Update HoTT and drop archaic 8.6 specific install`                                  |
| [`11fbf96e`](https://github.com/NixOS/nixpkgs/commit/11fbf96e2b08d563c9166a958c3372e93a55257c) | `nixos/rosetta: add release notes`                                                   |
| [`624ebdc1`](https://github.com/NixOS/nixpkgs/commit/624ebdc10d479d0aecc63c9963b7652742abd69d) | `nixos/rosetta: init module`                                                         |
| [`26cdf77a`](https://github.com/NixOS/nixpkgs/commit/26cdf77ac6d3fb626ebce4dd2f135e3a69ab646e) | `oh-my-posh: 12.20.0 -> 12.22.0`                                                     |
| [`80013363`](https://github.com/NixOS/nixpkgs/commit/8001336320fba24158a0474e574e5ede1543a6ba) | `geant4: use xorg.* packages directly instead of xlibsWrapper indirection (#203570)` |
| [`5834fbb9`](https://github.com/NixOS/nixpkgs/commit/5834fbb994f0d8e266ab3e1a861f8c3e7d689772) | `firefox-bin-unwrapped: 107.0 -> 107.0.1`                                            |
| [`83c75c0f`](https://github.com/NixOS/nixpkgs/commit/83c75c0f43b7fb62d7902630a0068165871dcc46) | `firefox-unwrapped: 107.0 -> 107.0.1`                                                |
| [`8039ea1b`](https://github.com/NixOS/nixpkgs/commit/8039ea1b4ead2e228f40aeeae6afdfea4125e13c) | `mopidy: 3.3.0 -> 3.4.0`                                                             |
| [`affff597`](https://github.com/NixOS/nixpkgs/commit/affff597fd3564ae5457492dcd0435e30f63c941) | `weston: use xorg.* packages directly instead of xlibsWrapper indirection`           |
| [`ec992804`](https://github.com/NixOS/nixpkgs/commit/ec992804b42df6715e8704805b647bb50e1c0799) | `tightvnc: use xorg.* packages directly instead of xlibsWrapper indirection`         |
| [`4eb17f3a`](https://github.com/NixOS/nixpkgs/commit/4eb17f3a37582b8059eabdd148673f0a9442867d) | `gnome.ghex: restrict platforms`                                                     |
| [`11b4ede6`](https://github.com/NixOS/nixpkgs/commit/11b4ede68ac6c5101fa8e2e0ab9aced6ec3fa6cb) | `gnome.eog: mark as broken on darwin`                                                |
| [`da7e49ef`](https://github.com/NixOS/nixpkgs/commit/da7e49efe9be3c095cec639d4801bdf8dc006e42) | `miller: 6.4.0 -> 6.5.0`                                                             |
| [`0517db94`](https://github.com/NixOS/nixpkgs/commit/0517db94db621c370e20ad293fcaf4c1349edcab) | `btcpayserver: 1.6.12 -> 1.7.1`                                                      |
| [`ea5fcc02`](https://github.com/NixOS/nixpkgs/commit/ea5fcc0204d1ac481e65e75e8f8a67060691db76) | `maintainers/scripts: Use Bash shebang line for files with bashisms`                 |
| [`280b4b82`](https://github.com/NixOS/nixpkgs/commit/280b4b8279563836c8ff978605492eed6c782392) | `root: fix build on aarch64-linux (#203267)`                                         |
| [`2a028c4f`](https://github.com/NixOS/nixpkgs/commit/2a028c4f467610e42c62dfa79e29810e1e980193) | `build-support: Use equivalent valid exit code`                                      |
| [`0f3ad0e8`](https://github.com/NixOS/nixpkgs/commit/0f3ad0e8b20f49d381880756fc6ff4384a93e407) | `moar: 1.11.0 -> 1.11.1`                                                             |
| [`81353462`](https://github.com/NixOS/nixpkgs/commit/81353462668d7dc886a84926e6efb12c9c25a854) | `libjwt: 1.13.1 -> 1.15.2`                                                           |
| [`dba8c055`](https://github.com/NixOS/nixpkgs/commit/dba8c05520f0e706c2f6486036f0d8c048f457fa) | `python310Packages.appthreat-vulnerability-db: 4.0.0 -> 4.0.4`                       |
| [`c9fe0f83`](https://github.com/NixOS/nixpkgs/commit/c9fe0f83fa55ba55ac6a8d939a035c6e4ad85d1f) | `ocamlPackages.integers: 0.5.1 → 0.7.0`                                              |
| [`b014ff9e`](https://github.com/NixOS/nixpkgs/commit/b014ff9e0bf3cd172bef39527a60be1ac8de0172) | `python310Packages.mathlibtools: add changelog to meta`                              |
| [`b239fcd2`](https://github.com/NixOS/nixpkgs/commit/b239fcd2fac9ee5a591acf105f0edfc8ce7a30ba) | `resvg: 0.26.1 -> 0.27.0`                                                            |
| [`7ee31588`](https://github.com/NixOS/nixpkgs/commit/7ee31588735de1238c8f54288aaadee97ef134c7) | `python310Packages.sphinx-external-toc: add changelog to meta`                       |
| [`6b4f497e`](https://github.com/NixOS/nixpkgs/commit/6b4f497e1fe83f6ca092f83515d50839329f6253) | `python310Packages.pex: 2.1.116 -> 2.1.117`                                          |
| [`2904fdf8`](https://github.com/NixOS/nixpkgs/commit/2904fdf8390e0fbdd12cdee8b7e77271ae2cc74b) | `python310Packages.mathlibtools: 1.3.0 -> 1.3.1`                                     |
| [`4a1156fc`](https://github.com/NixOS/nixpkgs/commit/4a1156fcddf73f3fd3f2a640235736f99442ae9c) | `python310Packages.sphinx-external-toc: 0.3.0 -> 0.3.1`                              |
| [`18a67c1e`](https://github.com/NixOS/nixpkgs/commit/18a67c1ed3c09ab6d4d6a6798ffc9d6cda8c17cf) | `python310Packages.aioesphomeapi: 12.0.0 -> 12.1.0`                                  |
| [`89f3049f`](https://github.com/NixOS/nixpkgs/commit/89f3049f9dfd1b03f70dde44737c245f889b2d13) | `rl-23.05: Mention cinnamon 5.6 update`                                              |
| [`7891c258`](https://github.com/NixOS/nixpkgs/commit/7891c2582cb5fe649bb6781071ae280040c402a8) | `cinnamon.mint-themes: 2.0.5 -> 2.0.7`                                               |
| [`9bb2e8dc`](https://github.com/NixOS/nixpkgs/commit/9bb2e8dcada0decfd4e7bafa579e1bd3bceeacfe) | `cinnamon.mint-y-icons: 1.6.1 -> 1.6.5`                                              |
| [`131c145e`](https://github.com/NixOS/nixpkgs/commit/131c145e61bd509a5fd4b00cd97f70068b646ebe) | `timeshift: 22.06.5 -> 22.11.1`                                                      |
| [`4035cd52`](https://github.com/NixOS/nixpkgs/commit/4035cd5222bac5ee929b393f7d1d764caf96f73b) | `cinnamon.mint-themes: Switch to tags, use stdenvNoCC`                               |