### PR TITLE
chore(flake/emacs-overlay): `9e53c246` -> `7419dbeb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669898266,
-        "narHash": "sha256-1gsmlz+ftMKg6crJOcghVOYqRiXmdmt1sAR9He4CuKI=",
+        "lastModified": 1669924706,
+        "narHash": "sha256-5YdsL731ESOT8wZ6aBPG7V2AZxYglK/N8JJopp9R+Ow=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9e53c246a9f9db278b8e881b796f099119befe79",
+        "rev": "7419dbeb120e44bfb8cbbb74f1b4e77b3f8401ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`7419dbeb`](https://github.com/nix-community/emacs-overlay/commit/7419dbeb120e44bfb8cbbb74f1b4e77b3f8401ab) | `Updated repos/melpa` |
| [`ea49c574`](https://github.com/nix-community/emacs-overlay/commit/ea49c574e00df70922c2ed4d17530a76fec6831c) | `Updated repos/emacs` |
| [`5723b609`](https://github.com/nix-community/emacs-overlay/commit/5723b609030c3810e7fcf07d21b63197de0b42f5) | `Updated repos/elpa`  |