### PR TITLE
chore(flake/emacs-overlay): `7419dbeb` -> `1b9f5259`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669924706,
-        "narHash": "sha256-5YdsL731ESOT8wZ6aBPG7V2AZxYglK/N8JJopp9R+Ow=",
+        "lastModified": 1669948527,
+        "narHash": "sha256-dfwAxGHtdL0R8oK49r3NVVjiqznAbI/FQ88p44a+3mc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7419dbeb120e44bfb8cbbb74f1b4e77b3f8401ab",
+        "rev": "1b9f52597f61f2d8f6d40251e033410163735634",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`1b9f5259`](https://github.com/nix-community/emacs-overlay/commit/1b9f52597f61f2d8f6d40251e033410163735634) | `Updated repos/melpa` |
| [`0e3679f4`](https://github.com/nix-community/emacs-overlay/commit/0e3679f4cfe7d53f02ffd42eac757647687ea539) | `Updated repos/elpa`  |