### PR TITLE
chore(flake/emacs-overlay): `1b9f5259` -> `4d6714a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669948527,
-        "narHash": "sha256-dfwAxGHtdL0R8oK49r3NVVjiqznAbI/FQ88p44a+3mc=",
+        "lastModified": 1669974401,
+        "narHash": "sha256-jYwjp5VbYLFwjACNjmVCpgmA9BY9W+EeYIOK2PFqJ8c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1b9f52597f61f2d8f6d40251e033410163735634",
+        "rev": "4d6714a912e2ee801c5880c147eecb387e223f30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`4d6714a9`](https://github.com/nix-community/emacs-overlay/commit/4d6714a912e2ee801c5880c147eecb387e223f30) | `Updated repos/melpa` |