### PR TITLE
chore(flake/emacs-overlay): `4d6714a9` -> `57e74388`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669974401,
-        "narHash": "sha256-jYwjp5VbYLFwjACNjmVCpgmA9BY9W+EeYIOK2PFqJ8c=",
+        "lastModified": 1669978292,
+        "narHash": "sha256-E/npZ+Oyzgxj2CZomCX3oHTcL1KzBY/g2HukwybJjjo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4d6714a912e2ee801c5880c147eecb387e223f30",
+        "rev": "57e743882976214a6ca0524b0de3bdba2d30cd8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                       |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------ |
| [`57e74388`](https://github.com/nix-community/emacs-overlay/commit/57e743882976214a6ca0524b0de3bdba2d30cd8d) | `Add tree-sitter-typescript grammar` |