### PR TITLE
chore(flake/emacs-overlay): `57e74388` -> `e88e8c7f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669978292,
-        "narHash": "sha256-E/npZ+Oyzgxj2CZomCX3oHTcL1KzBY/g2HukwybJjjo=",
+        "lastModified": 1670012284,
+        "narHash": "sha256-fxKJvdeFZNgGS1UQJLzpd1NrUyBtInv6RkUQu/+xqko=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "57e743882976214a6ca0524b0de3bdba2d30cd8d",
+        "rev": "e88e8c7f0c77622bb3704ea38f146a6e353445b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`e88e8c7f`](https://github.com/nix-community/emacs-overlay/commit/e88e8c7f0c77622bb3704ea38f146a6e353445b6) | `Updated repos/nongnu` |
| [`85a88777`](https://github.com/nix-community/emacs-overlay/commit/85a88777a9d1410c79ef95487a8378802d30cc64) | `Updated repos/melpa`  |
| [`6f4aa4e8`](https://github.com/nix-community/emacs-overlay/commit/6f4aa4e86646b6e209170b9d0be17d1a90d5bb08) | `Updated repos/emacs`  |
| [`303b370c`](https://github.com/nix-community/emacs-overlay/commit/303b370c0cc20459da559bf41c4ef4419a971586) | `Updated repos/elpa`   |