### PR TITLE
chore(flake/emacs-overlay): `e88e8c7f` -> `c4eaac82`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670012284,
-        "narHash": "sha256-fxKJvdeFZNgGS1UQJLzpd1NrUyBtInv6RkUQu/+xqko=",
+        "lastModified": 1670035469,
+        "narHash": "sha256-jEvgHQUViNdcUsAXNPiCdcbz/yoIk+jXW5D5tULTJfQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e88e8c7f0c77622bb3704ea38f146a6e353445b6",
+        "rev": "c4eaac8256718db0377d2365c9bc33252b4096c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                   |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------- |
| [`c4eaac82`](https://github.com/nix-community/emacs-overlay/commit/c4eaac8256718db0377d2365c9bc33252b4096c7) | `remove newline, remove clojure` |
| [`7f6e28bd`](https://github.com/nix-community/emacs-overlay/commit/7f6e28bdd8958d8446797f201172c3e43dada0de) | `TODO: write commit message`     |
| [`d4684817`](https://github.com/nix-community/emacs-overlay/commit/d4684817168d71cd7167f6cec7d910f1311e1cd0) | `TODO: write commit message`     |
| [`fd0da6cc`](https://github.com/nix-community/emacs-overlay/commit/fd0da6cc6c3bb214363d1c28f73d58c673e6cda6) | `TODO: write commit message`     |
| [`f2710ca9`](https://github.com/nix-community/emacs-overlay/commit/f2710ca9fa79bef0f41ee0fc80d26ee07ac98c96) | `TODO: write commit message`     |
| [`5ead1de8`](https://github.com/nix-community/emacs-overlay/commit/5ead1de8409206364a611aca63f4fbebd88ec656) | `TODO: write commit message`     |