### PR TITLE
chore(flake/emacs-overlay): `c4eaac82` -> `873ca1b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670035469,
-        "narHash": "sha256-jEvgHQUViNdcUsAXNPiCdcbz/yoIk+jXW5D5tULTJfQ=",
+        "lastModified": 1670042556,
+        "narHash": "sha256-IMA/yx9yhm6K5H7ZqqSQz75QoqvKxb2v4X1Xw2Md3Kg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c4eaac8256718db0377d2365c9bc33252b4096c7",
+        "rev": "873ca1b703a7cf9aa607634dcfcf0d71acc35c62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                                 |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
| [`873ca1b7`](https://github.com/nix-community/emacs-overlay/commit/873ca1b703a7cf9aa607634dcfcf0d71acc35c62) | `Updated repos/melpa`                                          |
| [`7f75e987`](https://github.com/nix-community/emacs-overlay/commit/7f75e987402f3db4062e68638a3d0b520cadd750) | `Updated repos/emacs`                                          |
| [`0743ae0e`](https://github.com/nix-community/emacs-overlay/commit/0743ae0eb85b4e1087fc20fd0c9bcf8efb1fdc4f) | `Add Darwin notes for tree-sitter`                             |
| [`2b59221e`](https://github.com/nix-community/emacs-overlay/commit/2b59221ede94cce7db3aef6e2bfb707c1ddc5e70) | `Enable WebP support for emacsPgtk`                            |
| [`e9276629`](https://github.com/nix-community/emacs-overlay/commit/e92766297a7ef6b4be7a8b9ebf5fb2dc3bc7989a) | `Alias redundant attributes since in 22.11, nativeComp = true` |
| [`b816a3e7`](https://github.com/nix-community/emacs-overlay/commit/b816a3e73b48dacffc5c180854462b38bb04a51f) | `Enable tree-sitter by default when applicable`                |