### PR TITLE
chore(flake/emacs-overlay): `873ca1b7` -> `d165f262`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670042556,
-        "narHash": "sha256-IMA/yx9yhm6K5H7ZqqSQz75QoqvKxb2v4X1Xw2Md3Kg=",
+        "lastModified": 1670044426,
+        "narHash": "sha256-D05ByHNdktks0oimz/n6wX8nKn11uTMiWoDLSVnQdNE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "873ca1b703a7cf9aa607634dcfcf0d71acc35c62",
+        "rev": "d165f262eb824a9e687d6cf43ea6508bc7fddab8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                 |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
| [`d165f262`](https://github.com/nix-community/emacs-overlay/commit/d165f262eb824a9e687d6cf43ea6508bc7fddab8) | `Don't mention aliased *nativeComp attributes` |