### PR TITLE
chore(flake/emacs-overlay): `d165f262` -> `64b233cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670044426,
-        "narHash": "sha256-D05ByHNdktks0oimz/n6wX8nKn11uTMiWoDLSVnQdNE=",
+        "lastModified": 1670051212,
+        "narHash": "sha256-kr1c1lj9y/yzjVoEUkXfBI7qNJ371D7+Mv4qcY0vs6Q=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d165f262eb824a9e687d6cf43ea6508bc7fddab8",
+        "rev": "64b233cc9cfb1239f3725d0c5953581b43148956",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                              |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------- |
| [`64b233cc`](https://github.com/nix-community/emacs-overlay/commit/64b233cc9cfb1239f3725d0c5953581b43148956) | `add tree sitter languages to rpath (#273)` |