### PR TITLE
chore(flake/emacs-overlay): `64b233cc` -> `d3905234`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670051212,
-        "narHash": "sha256-kr1c1lj9y/yzjVoEUkXfBI7qNJ371D7+Mv4qcY0vs6Q=",
+        "lastModified": 1670063780,
+        "narHash": "sha256-fbjH0DOJmR5AigMuWDC2wgglf7i4Xf3y+2XNWT4eztw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "64b233cc9cfb1239f3725d0c5953581b43148956",
+        "rev": "d39052346c5fbb66c8210c263b0c8db8afd9fed2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`d3905234`](https://github.com/nix-community/emacs-overlay/commit/d39052346c5fbb66c8210c263b0c8db8afd9fed2) | `Updated repos/melpa` |
| [`c3c3fca2`](https://github.com/nix-community/emacs-overlay/commit/c3c3fca2d83de244852b4dd062b1edd4f6eaea8b) | `Updated repos/emacs` |