### PR TITLE
chore(flake/emacs-overlay): `d3905234` -> `2ce014a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670063780,
-        "narHash": "sha256-fbjH0DOJmR5AigMuWDC2wgglf7i4Xf3y+2XNWT4eztw=",
+        "lastModified": 1670093871,
+        "narHash": "sha256-wMjkWTMJeQ0HiCtcpg2kdHu6bo2tWJumKNX43ZFRETc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d39052346c5fbb66c8210c263b0c8db8afd9fed2",
+        "rev": "2ce014a48bf6845b9bbeca6eabbff9ba5783c30d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                  |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`2ce014a4`](https://github.com/nix-community/emacs-overlay/commit/2ce014a48bf6845b9bbeca6eabbff9ba5783c30d) | `Revert "Remove unnecessary substituteInPlace"` |
| [`543a3b39`](https://github.com/nix-community/emacs-overlay/commit/543a3b394f6822ea5d52666ca063c85bec2d1ca0) | `Revert "Don't wipe patches"`                   |
| [`c9fb6136`](https://github.com/nix-community/emacs-overlay/commit/c9fb613635a8420cac9419ead7d0cd69126c4d26) | `Don't wipe patches`                            |
| [`336402eb`](https://github.com/nix-community/emacs-overlay/commit/336402eba8c78f6f36fa995549add0b834be994c) | `Remove unnecessary substituteInPlace`          |
| [`ae94e8c0`](https://github.com/nix-community/emacs-overlay/commit/ae94e8c0b06c2b5b8b4e2fe7766f443c96718c39) | `Updated repos/melpa`                           |
| [`fd64ab7f`](https://github.com/nix-community/emacs-overlay/commit/fd64ab7f71b2b4e555afd606d9060ee3366fe07b) | `Updated repos/emacs`                           |
| [`50d7ddad`](https://github.com/nix-community/emacs-overlay/commit/50d7ddad7e53b634c9896bf180a9a00847055457) | `Updated repos/elpa`                            |