### PR TITLE
chore(flake/emacs-overlay): `2ce014a4` -> `d4443a55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670093871,
-        "narHash": "sha256-wMjkWTMJeQ0HiCtcpg2kdHu6bo2tWJumKNX43ZFRETc=",
+        "lastModified": 1670119379,
+        "narHash": "sha256-wEOUDPMjb3bBbRObQVBs+yQH1Uwrle5U2uQmqdIQYKM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2ce014a48bf6845b9bbeca6eabbff9ba5783c30d",
+        "rev": "d4443a55b8f260e4c31bf848059eb5aed5b75002",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`d4443a55`](https://github.com/nix-community/emacs-overlay/commit/d4443a55b8f260e4c31bf848059eb5aed5b75002) | `Updated repos/nongnu` |
| [`a5d8c362`](https://github.com/nix-community/emacs-overlay/commit/a5d8c362c535b1c180caf08d7a8bf183cc2d2f92) | `Updated repos/melpa`  |
| [`ae96a429`](https://github.com/nix-community/emacs-overlay/commit/ae96a42959585ec167a80b7e706151469dd47057) | `Updated repos/elpa`   |