### PR TITLE
chore(flake/nixpkgs): `b72b8b94` -> `61a8a98e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669969257,
-        "narHash": "sha256-mOS13sK3v+kfgP+1Mh56ohiG8uVhLHAo7m/q9kqAehc=",
+        "lastModified": 1670064435,
+        "narHash": "sha256-+ELoY30UN+Pl3Yn7RWRPabykwebsVK/kYE9JsIsUMxQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b72b8b94cf0c012b0252a9100a636cad69696666",
+        "rev": "61a8a98e6d557e6dd7ed0cdb54c3a3e3bbc5e25c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                        |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
| [`61a8a98e`](https://github.com/NixOS/nixpkgs/commit/61a8a98e6d557e6dd7ed0cdb54c3a3e3bbc5e25c) | `solfege: Add gdk-pixbuf dependency.`                                                                 |
| [`4d1b9284`](https://github.com/NixOS/nixpkgs/commit/4d1b9284cf16c03752150ca009eea01df5d79d2d) | `aliyun-cli: 3.0.137 -> 3.0.139`                                                                      |
| [`c1f6d5cb`](https://github.com/NixOS/nixpkgs/commit/c1f6d5cb6f6a20cd84af26c9da15a55c85ec9655) | `subsurface: libsForQt514 -> libsForQt5`                                                              |
| [`7348354e`](https://github.com/NixOS/nixpkgs/commit/7348354e8e80fc3db55b9464bd1ff09a1bfde58e) | `nixos/doc: add release note for Qt 5.1{2,4} deprecation`                                             |
| [`06624cd9`](https://github.com/NixOS/nixpkgs/commit/06624cd934e1d9f370496f88fd3e25a173e6d1c8) | `qt5: drop 5.12, 5.14`                                                                                |
| [`7d051646`](https://github.com/NixOS/nixpkgs/commit/7d0516461c7108a5eddd910f6beffe40e3e9d87a) | `treewide: libsForQt5{12,14} -> libsForQt5`                                                           |
| [`bb187eab`](https://github.com/NixOS/nixpkgs/commit/bb187eabf1dd6c0d9bdcd81846f5818c7bfbea6c) | `git-gone: 0.4.2 -> 0.4.3`                                                                            |
| [`809f15f2`](https://github.com/NixOS/nixpkgs/commit/809f15f2e7fd66c3d3ba6aabffa946fbd67f93fc) | `apc-temp-fetch: 0.0.1 -> 0.0.2`                                                                      |
| [`cd97c7fa`](https://github.com/NixOS/nixpkgs/commit/cd97c7fab54130ce01c2d1c41f6af07d225d9ce9) | `terraform-providers.tencentcloud: 1.78.16 → 1.79.0`                                                  |
| [`173337b4`](https://github.com/NixOS/nixpkgs/commit/173337b4be0c76c64c94da12da56f92690b64461) | `terraform-providers.tailscale: 0.13.5 → 0.13.6`                                                      |
| [`843e5d57`](https://github.com/NixOS/nixpkgs/commit/843e5d573f2706f14d8e71a6cd1a3dfc2fdd4373) | `terraform-providers.mailgun: 0.7.3 → 0.7.4`                                                          |
| [`c68c8b5e`](https://github.com/NixOS/nixpkgs/commit/c68c8b5e6b11e9115191b67901951667e92e6d7e) | `terraform-providers.aws: 4.44.0 → 4.45.0`                                                            |
| [`e0ee3589`](https://github.com/NixOS/nixpkgs/commit/e0ee35898bbdd626f711ff6ade393c50bdf776da) | `terraform-providers.ksyun: 1.3.58 → 1.3.59`                                                          |
| [`9e1bc2f1`](https://github.com/NixOS/nixpkgs/commit/9e1bc2f1731b9fe089d6bce8d702c5539d52a2e9) | `terraform-providers.cloudfoundry: 0.50.1 → 0.50.2`                                                   |
| [`bd16a316`](https://github.com/NixOS/nixpkgs/commit/bd16a3165b9b736dfa21933fbea9bddde56d8d33) | `terraform-providers.baiducloud: 1.18.2 → 1.18.3`                                                     |
| [`ba3741cc`](https://github.com/NixOS/nixpkgs/commit/ba3741cca38c558c9d043b54d8f300d5f1638791) | `terraform-providers.azurerm: 3.33.0 → 3.34.0`                                                        |
| [`6ddc0b6a`](https://github.com/NixOS/nixpkgs/commit/6ddc0b6acf671545a5a3c7bee9c845ffe16a1a38) | `entt: 3.11.0 -> 3.11.1`                                                                              |
| [`eac8b515`](https://github.com/NixOS/nixpkgs/commit/eac8b5156554857a82f581d2274ea192bf773235) | `flopoco: init at 4.1.3 (#200459)`                                                                    |
| [`bbbb55d3`](https://github.com/NixOS/nixpkgs/commit/bbbb55d3ac81aff8f953c49da56fcb07dd8364ea) | `python310Packages.tabula-py: build a self-contained package and fix missing pkg_resources (#202554)` |
| [`43cc2746`](https://github.com/NixOS/nixpkgs/commit/43cc2746c6ef3e0cbe80e043bf7521eff17c7236) | `nim: fix build on aarch64-darwin`                                                                    |
| [`0d09e743`](https://github.com/NixOS/nixpkgs/commit/0d09e743ae948573b5d50218527c9f309770a2f9) | `intel-compute-runtime: build with level-zero`                                                        |
| [`b00c8519`](https://github.com/NixOS/nixpkgs/commit/b00c85192f56e31a788b635109c8472aa17f3a94) | `level-zero: init at 1.8.8`                                                                           |
| [`b662b75c`](https://github.com/NixOS/nixpkgs/commit/b662b75cb48e6e45bb1ddb9fb7c5260925b5387f) | `maintainers:add ziguana`                                                                             |
| [`9d8767be`](https://github.com/NixOS/nixpkgs/commit/9d8767be46744f49001fd767d74eeb4f47c61028) | `xcircuit: 3.10.12 -> 3.10.37, maintain`                                                              |
| [`b3b6b3d5`](https://github.com/NixOS/nixpkgs/commit/b3b6b3d564b959b7460dcdabc3a6a0f6e7c3fac6) | `pantheon.elementary-screenshot: 6.0.2 -> 6.0.3`                                                      |
| [`257a832e`](https://github.com/NixOS/nixpkgs/commit/257a832e61e9058527ad5a8990786218240f6a84) | `fzf: init module`                                                                                    |
| [`2bd3e5f2`](https://github.com/NixOS/nixpkgs/commit/2bd3e5f292a03debb82aaed768f2bb37481e9d21) | `treefmt: 0.4.1 -> 0.5.0`                                                                             |
| [`c27f6444`](https://github.com/NixOS/nixpkgs/commit/c27f6444ac472df00af01bd528b2966168f297e4) | `aacgain: 1.9.0 -> 2.0.0`                                                                             |
| [`b3600b54`](https://github.com/NixOS/nixpkgs/commit/b3600b548eee0d25ffb0d5e7e0ea7461420c4a95) | `mp4v2: 4.1.3 -> 5.0.1`                                                                               |
| [`123cdd49`](https://github.com/NixOS/nixpkgs/commit/123cdd499040fac090267246a254d424e70f68e4) | `fzf: cleanup`                                                                                        |
| [`93e83651`](https://github.com/NixOS/nixpkgs/commit/93e836518a5fc8d3d100c8efece89cc3707e4e98) | `vscode-extensions.astro-build.astro-vscode: init at 0.29.1`                                          |
| [`239b98cf`](https://github.com/NixOS/nixpkgs/commit/239b98cf4418f5e9a48bebaa13e961af93681cd8) | `vscode-extensions.svelte.svelte-vscode: 105.21.0 -> 106.3.0`                                         |
| [`c32ce029`](https://github.com/NixOS/nixpkgs/commit/c32ce0295ef0b472374f2b57b8d65fbabed1bcad) | `python310Packages.aioesphomeapi: 12.1.0 -> 13.0.0`                                                   |
| [`512aca68`](https://github.com/NixOS/nixpkgs/commit/512aca68d38703bd2a2a86eac05b26e2b26cd7f2) | `gktcord4: add nativeBuildInput wrapGappsHook`                                                        |
| [`8bc1c3e8`](https://github.com/NixOS/nixpkgs/commit/8bc1c3e8d4a2b4ebc59f29e6415f54611773eddf) | `dnsproxy: 0.46.2 -> 0.46.3`                                                                          |
| [`5229104e`](https://github.com/NixOS/nixpkgs/commit/5229104ecee58f0689dab190de01301b7915fa88) | `teamviewer: 15.29.7 -> 15.35.7 (#202323)`                                                            |
| [`71e771c7`](https://github.com/NixOS/nixpkgs/commit/71e771c78d5c24e50aeb8ac1bc358d9aa197b61c) | `maintainers: update matrix for urandom`                                                              |
| [`9ca48eb5`](https://github.com/NixOS/nixpkgs/commit/9ca48eb5bd5650c42394dffce997fef76c67e599) | `docker-compose: 2.13.0 -> 2.14.0`                                                                    |
| [`76aad1f1`](https://github.com/NixOS/nixpkgs/commit/76aad1f1e6e6ebf96d05b96e9c1f800094a26180) | `dfrs: init at 0.0.7 (#204179)`                                                                       |
| [`d8f61952`](https://github.com/NixOS/nixpkgs/commit/d8f61952f0e8f2884ad7672028eba16830aa6d35) | `miniserve: unbreak on aarch64-darwin`                                                                |
| [`9ac7f9b9`](https://github.com/NixOS/nixpkgs/commit/9ac7f9b9ef54ba0c3dc9107a412c076ad849d996) | `sioyek: unbreak on aarch64-darwin`                                                                   |
| [`b91a56cc`](https://github.com/NixOS/nixpkgs/commit/b91a56cc6111b82f43fd4269ffd9c5a968c55d34) | `qt515.qt3d: fix build on aarch64-darwin`                                                             |
| [`3e04410c`](https://github.com/NixOS/nixpkgs/commit/3e04410ced5c98a12cfcba179b0854fff99f2813) | `pkgsMusl.cdrkit: fix build`                                                                          |
| [`188b935b`](https://github.com/NixOS/nixpkgs/commit/188b935b6d75af9b58ddd63cb665ca8410de1d74) | `alt-ergo: fix version string`                                                                        |
| [`d4a769b6`](https://github.com/NixOS/nixpkgs/commit/d4a769b6dcb29854ab80329c64300cc7cef53c2a) | `zsh-git-prompt: python2 -> python3`                                                                  |
| [`bd2f039f`](https://github.com/NixOS/nixpkgs/commit/bd2f039f4559e434dee1e55b638234fe99e79e6e) | `mame: 0.249 -> 0.250`                                                                                |
| [`735f24b7`](https://github.com/NixOS/nixpkgs/commit/735f24b77518b30923f3f8bf27cdf89dd408050b) | `marwaita: 16.0 -> 16.1`                                                                              |
| [`31759fd2`](https://github.com/NixOS/nixpkgs/commit/31759fd27f67f2ef3823e2e112b2bb0f3d5d0852) | `flannel: 0.20.1 -> 0.20.2`                                                                           |
| [`b9a49910`](https://github.com/NixOS/nixpkgs/commit/b9a4991020b229e700fd8d7443f10befdc4dd9ce) | `linux: set X86_AMD_PSTATE=y instead of =m`                                                           |
| [`44f39f4a`](https://github.com/NixOS/nixpkgs/commit/44f39f4ac73f38fa4f2b7f1660d1cce49ca76179) | `python310Packages.pyphen: fix pythonImportsCheck`                                                    |
| [`5d2434ab`](https://github.com/NixOS/nixpkgs/commit/5d2434ab0cb0e71ce4f906b5895484e44b1f982d) | `checkSSLCert: 2.55.0 -> 2.56.0`                                                                      |
| [`aea291b0`](https://github.com/NixOS/nixpkgs/commit/aea291b0187b2c897f3d8a873fad8e1d984b3b4d) | `linux/hardened/patches/6.0: 6.0.8-hardened1 -> 6.0.10-hardened1`                                     |
| [`30d0f12f`](https://github.com/NixOS/nixpkgs/commit/30d0f12f7752aca51fac44f08241b297805cd7ab) | `linux/hardened/patches/5.15: 5.15.79-hardened1 -> 5.15.80-hardened1`                                 |
| [`aea7b200`](https://github.com/NixOS/nixpkgs/commit/aea7b200b21a7b39e3268bd550462b3cb6dc3d9a) | `linux_latest-libre: 18996 -> 19001`                                                                  |
| [`c355d942`](https://github.com/NixOS/nixpkgs/commit/c355d942751324e38599478a4e11abb850feb088) | `linux: 6.0.10 -> 6.0.11`                                                                             |
| [`8f5ddf07`](https://github.com/NixOS/nixpkgs/commit/8f5ddf07cb34e7d431d2c29889c2e9bfed06ce86) | `linux: 5.15.80 -> 5.15.81`                                                                           |
| [`d779e43f`](https://github.com/NixOS/nixpkgs/commit/d779e43f22c3064418d530fb5987e4ad4f2fd634) | `linux: 5.10.156 -> 5.10.157`                                                                         |
| [`eb10cd09`](https://github.com/NixOS/nixpkgs/commit/eb10cd096365571b145df446dfd9eae0e581942e) | `logseq: 0.8.11 -> 0.8.12`                                                                            |
| [`466fbe73`](https://github.com/NixOS/nixpkgs/commit/466fbe73e3c49953aeb173dff50673a12ac26fef) | `libsForQt5.qtstyleplugin-kvantum: 1.0.6 -> 1.0.7`                                                    |
| [`0114278a`](https://github.com/NixOS/nixpkgs/commit/0114278a9a3a3bb1b026c4edbe503034d7375e07) | `zsh: fix modules when cross-compiling`                                                               |
| [`d968c6ed`](https://github.com/NixOS/nixpkgs/commit/d968c6eded3efd1d5a64cad9357f92c5cbbf149b) | `pypy2, pypy3: drop unused xlibsWrapper`                                                              |
| [`bc3b07cb`](https://github.com/NixOS/nixpkgs/commit/bc3b07cb93e042901f138ebef7433c44f468e92d) | `resilio: Add jwoudenberg as extra maintainer`                                                        |
| [`c8f9d170`](https://github.com/NixOS/nixpkgs/commit/c8f9d170d460fbbc971b8885a0ada3d3d61739b3) | `nixos/resilio: support secret files`                                                                 |
| [`df1810c6`](https://github.com/NixOS/nixpkgs/commit/df1810c6e8794384edaf8a2a9ecb44faaff0d5fa) | `ViennaRNA: 2.4.18 -> 2.5.1`                                                                          |
| [`c9ee3375`](https://github.com/NixOS/nixpkgs/commit/c9ee337525b2a0ef3900d041f72927f5e8ed468e) | `gitsign: 0.3.2 -> 0.4.1`                                                                             |
| [`4fbfcfba`](https://github.com/NixOS/nixpkgs/commit/4fbfcfba88b688c2bc1cdfce3544cd3a2d56cde2) | `dnscontrol: 3.22.1 -> 3.23.0`                                                                        |
| [`7c017889`](https://github.com/NixOS/nixpkgs/commit/7c01788915c61b7d82b1816733bab736a135c30f) | `topiary: init at unstable-2022-12-02`                                                                |
| [`16e164f0`](https://github.com/NixOS/nixpkgs/commit/16e164f0ef9d2422bd441c47caae218cbd67476b) | `dmlive: unstable-2022-08-22 -> unstable-2022-11-19`                                                  |
| [`518f576b`](https://github.com/NixOS/nixpkgs/commit/518f576b9acfdf82a24937e009edab2920466dfd) | `gitleaks: 8.15.1 -> 8.15.2`                                                                          |
| [`660bebff`](https://github.com/NixOS/nixpkgs/commit/660bebff99e9d2b0df21c27dd3285de89f5aac01) | `gitleaks: add changelog to meta`                                                                     |
| [`dbdd8fad`](https://github.com/NixOS/nixpkgs/commit/dbdd8fad26f4111a3bc6bbc2f7d32f43cb77ae57) | `testers.testBuildFailure: Read last log line without final newline`                                  |
| [`3b93e042`](https://github.com/NixOS/nixpkgs/commit/3b93e042b6a5519812b813dc4cf02bd1c4783465) | `python310Packages.adafruit-platformdetect: 3.36.0 -> 3.37.0`                                         |
| [`5b2fa95c`](https://github.com/NixOS/nixpkgs/commit/5b2fa95c0b0f55e7d7ab47822e88eed55dd1f62e) | `carapace: 0.18.0 -> 0.18.1`                                                                          |
| [`31aa7cb0`](https://github.com/NixOS/nixpkgs/commit/31aa7cb06150618479ebf51e449c8ddce0dcd80f) | `python310Packages.bleak-retry-connector: 2.8.5 -> 2.8.7`                                             |
| [`ffbb0204`](https://github.com/NixOS/nixpkgs/commit/ffbb0204d81952b4e764be84200404d643c62501) | `richgo: 0.3.10 -> 0.3.11`                                                                            |
| [`11c32f4a`](https://github.com/NixOS/nixpkgs/commit/11c32f4a71fbed97ba0d55e851425d462dff96f2) | `nixos/rl-2211: make it clear NixOS isn't a set of packages`                                          |
| [`1b31a927`](https://github.com/NixOS/nixpkgs/commit/1b31a927e0c0fe8e59355b05e21a455a3b3fd96a) | `nomad-driver-podman: 0.4.0 -> 0.4.1`                                                                 |
| [`f83b30ae`](https://github.com/NixOS/nixpkgs/commit/f83b30ae39d7285296963dbf305e4c57003b6193) | `awscli2: 2.9.0 -> 2.9.1`                                                                             |
| [`ac8be8ea`](https://github.com/NixOS/nixpkgs/commit/ac8be8eadbb429f2e43dc7a2ee983ab2df7f3386) | `copilot-cli: 1.23.0 -> 1.24.0`                                                                       |
| [`4ac78ea9`](https://github.com/NixOS/nixpkgs/commit/4ac78ea992241a6a2f4462285807161f22d7779b) | `fastly: 4.3.0 -> 4.4.0`                                                                              |
| [`ec14e0fb`](https://github.com/NixOS/nixpkgs/commit/ec14e0fbefde6e6db1b01930df020a42bea94bdc) | `snac2: init at 2.12`                                                                                 |
| [`5969123b`](https://github.com/NixOS/nixpkgs/commit/5969123b9f3449228c812b6fa0eb6c34a25b084c) | `cmst: 2022.05.01 -> 2022.11.30`                                                                      |
| [`827c5e45`](https://github.com/NixOS/nixpkgs/commit/827c5e45f8cd294f00f022cf38896a7168046b93) | `lemon-graph: unbreak on all platforms`                                                               |
| [`74949d9c`](https://github.com/NixOS/nixpkgs/commit/74949d9c4054947db0ecb667914a24dd694767e4) | `ungoogled-chromium: 107.0.5304.122 -> 108.0.5359.72`                                                 |
| [`cba2dbc7`](https://github.com/NixOS/nixpkgs/commit/cba2dbc72ff7bc3b4ede74f8b26edb17110c1141) | `vsce: init at 2.15.0`                                                                                |
| [`e22898f9`](https://github.com/NixOS/nixpkgs/commit/e22898f9a536e37ad4978680d2a9c37fdedf5668) | `smartgithg: 22.1.0 -> 22.1.1`                                                                        |
| [`600e933e`](https://github.com/NixOS/nixpkgs/commit/600e933e3d9a89266ace4cdc92dbc464ee428db8) | `aocd: 1.2.1 -> 1.2.3`                                                                                |
| [`e8927c46`](https://github.com/NixOS/nixpkgs/commit/e8927c46b8693b1d0b1d6e12cd602c6647217d3a) | ``nixos/doc: document `mkOrder` and friends``                                                         |
| [`09714939`](https://github.com/NixOS/nixpkgs/commit/097149393ff12ebd1d54f954c2a3656e5ed80896) | `python{27,310}Packages.deprecation: remove unittest2, break on Python 2 (#202236)`                   |
| [`9332df94`](https://github.com/NixOS/nixpkgs/commit/9332df94e1378f3ae96c64b4504e2a6c636e4ce2) | `nvidia-vaapi-driver: 0.0.7 > unstable-2022-12-01`                                                    |
| [`4acd8f01`](https://github.com/NixOS/nixpkgs/commit/4acd8f01256f4eca3f81918ec8e07c9c302a76de) | `waynergy: 0.0.13 -> 0.0.14`                                                                          |
| [`cddaa5ea`](https://github.com/NixOS/nixpkgs/commit/cddaa5ea0eb1167bb503fa82aed63bbee1dfd5a3) | `openasar: unstable-2022-10-10 -> unstable-2022-12-01`                                                |
| [`145c4f43`](https://github.com/NixOS/nixpkgs/commit/145c4f431d7634d374a896855886d83c2f027ed0) | `bookstack: 22.06.2 -> 22.11`                                                                         |
| [`64f6033a`](https://github.com/NixOS/nixpkgs/commit/64f6033a03c05389f3f790b917973a2ead9f3329) | `jellyfin-mpv-shim: add desktop item`                                                                 |
| [`08918f71`](https://github.com/NixOS/nixpkgs/commit/08918f71d0942753e3442a9bff9c6fd487623611) | `gcsfuse: 0.41.8 -> 0.41.9`                                                                           |
| [`6110a600`](https://github.com/NixOS/nixpkgs/commit/6110a6009fc77348e9c47e0801a9b884dc76c730) | `lib/modules: Add context to the "option does not exist" error`                                       |
| [`b647182c`](https://github.com/NixOS/nixpkgs/commit/b647182c16d1f841ca8bc6e5305bf50fc45c62ab) | `gojq: 0.12.9 -> 0.12.10`                                                                             |
| [`0cccb224`](https://github.com/NixOS/nixpkgs/commit/0cccb224ee5c2d4632170836d5d183347784d38d) | `klibc: link initrd-network-ssh test`                                                                 |
| [`3627243f`](https://github.com/NixOS/nixpkgs/commit/3627243f815fdfcad3815e4a5e16aa4b59d706b1) | `nushell: 0.71.0 -> 0.72.0`                                                                           |
| [`132e60b8`](https://github.com/NixOS/nixpkgs/commit/132e60b840e1a51ec93484a175cd1cb2adaf8e30) | `calc: 2.14.1.0 -> 2.14.1.2`                                                                          |
| [`c4d3365d`](https://github.com/NixOS/nixpkgs/commit/c4d3365d2e28a830ef063ee55330bbf132b3e435) | `vimPlugins.vim-wakatime: python2 -> python3`                                                         |
| [`748088be`](https://github.com/NixOS/nixpkgs/commit/748088becddc23e70042ea9055ba83a5d92cbbe9) | `vimPlugins.ctrlp-cmatcher: python2 -> python3`                                                       |
| [`443c7078`](https://github.com/NixOS/nixpkgs/commit/443c70789b27b1cd0be94663234edc7ac548f8ce) | `emacsPackages.ebuild-mode: 1.60 -> 1.61`                                                             |
| [`4b6303bf`](https://github.com/NixOS/nixpkgs/commit/4b6303bf3d6f3ee2d2a20a8ba69678e3fc5e0f6f) | `atmos: 1.13.1 -> 1.16.0`                                                                             |
| [`6ace7015`](https://github.com/NixOS/nixpkgs/commit/6ace70150e0ded515f9bdf78c6ebe8f389739067) | `klibc: 2.0.10 -> 2.0.11`                                                                             |
| [`3f12b7e2`](https://github.com/NixOS/nixpkgs/commit/3f12b7e27287d65d2242d12e21adb861be41ad6c) | `python310Packages.django-postgresql-netfields: disable pythonImportsCheck`                           |
| [`2d811a37`](https://github.com/NixOS/nixpkgs/commit/2d811a3709aef8b3aca8a75627685099484d6d39) | `datree: 1.8.1 -> 1.8.8`                                                                              |
| [`795fc636`](https://github.com/NixOS/nixpkgs/commit/795fc6368245a7c0bc050396ab22a88af416248a) | `vlc: 3.0.17.3 -> 3.0.18`                                                                             |
| [`99269923`](https://github.com/NixOS/nixpkgs/commit/99269923c67e0cb0c29e0d0b794b481b8a7ea373) | `live555: 2022.07.14 -> 2022.12.01`                                                                   |
| [`9b0ce022`](https://github.com/NixOS/nixpkgs/commit/9b0ce02247af67139374e07de60b10658f3625ae) | `python310Packages.django-postgresql-netfields: add missing input`                                    |
| [`22108414`](https://github.com/NixOS/nixpkgs/commit/2210841466d2d45d073bf6d43ab18bdee4d74ae9) | `python310Packages.django-postgresql-netfields: add changelog to meta`                                |
| [`da461200`](https://github.com/NixOS/nixpkgs/commit/da4612004384689017f4df09f1705ae94e494a3f) | `python310Packages.pyphen: add changelog to meta`                                                     |
| [`34b9b0fb`](https://github.com/NixOS/nixpkgs/commit/34b9b0fb5d706092e9d08c8866cf87fd0442426c) | `act: 0.2.33 -> 0.2.34`                                                                               |
| [`7c619b99`](https://github.com/NixOS/nixpkgs/commit/7c619b992947b1fe45fc26e8cf6c29766cc80cff) | `cargo-auditable: 0.5.4 -> 0.5.5`                                                                     |
| [`1a047a95`](https://github.com/NixOS/nixpkgs/commit/1a047a95484a575786f1c0c741b00173064be2ba) | `iaito: 5.7.6 -> 5.7.8`                                                                               |
| [`b3f7ea4e`](https://github.com/NixOS/nixpkgs/commit/b3f7ea4e42887ff826af7a3b02a749a0f0ecf517) | `ft2-clone: 1.61 -> 1.62`                                                                             |
| [`1fe0e1ab`](https://github.com/NixOS/nixpkgs/commit/1fe0e1abc45cbffb5b18ce6cb0841d057950a4a5) | `python3Packages.torchinfo: 1.64 -> 1.7.1`                                                            |
| [`4c1de1fc`](https://github.com/NixOS/nixpkgs/commit/4c1de1fcbe8f528916340e46de6e6d04050faef1) | `python3Packages.functorch: drop`                                                                     |
| [`c0f4a5ea`](https://github.com/NixOS/nixpkgs/commit/c0f4a5ea37ec6269bf59e86b935153c114610408) | `python3Packages.torchaudio-bin: 0.12.1 -> 0.13.0`                                                    |
| [`8d2c37c4`](https://github.com/NixOS/nixpkgs/commit/8d2c37c46bdc517e05c2b1ba4f918c4bea2a3e0b) | `python3Packages.torchvision-bin: 0.13.1 -> 0.14.0`                                                   |
| [`b37ea7e5`](https://github.com/NixOS/nixpkgs/commit/b37ea7e55e16c226bc2e8996b92f7ca34579a60b) | `python3Packages.torch-bin: 1.12.1 -> 1.13.0`                                                         |
| [`05a8ff09`](https://github.com/NixOS/nixpkgs/commit/05a8ff099f34fe774fab8d49ac95b257dc4f9772) | `python3Packages.torchvision: 0.13.1 -> 0.14.0`                                                       |
| [`db152526`](https://github.com/NixOS/nixpkgs/commit/db152526571d9e12c7789b9abb774e87847ebc34) | `python3Packages.torch: 1.12.1 -> 1.13.0`                                                             |
| [`215ff79a`](https://github.com/NixOS/nixpkgs/commit/215ff79ae891c33638d0fc6996733713ec4ba5cb) | `citrix_workspace: 22.07.0 -> 22.12.0`                                                                |
| [`dbe8182e`](https://github.com/NixOS/nixpkgs/commit/dbe8182e7433374b5ae7b5454126ce46211f0f03) | `treewide: switch to port type for nixos modules`                                                     |
| [`6a26fe20`](https://github.com/NixOS/nixpkgs/commit/6a26fe20f7bd1362679b5eb6c1b3a5263c35414b) | `citrix-workspace: fix 22.7.0`                                                                        |
| [`8be903c2`](https://github.com/NixOS/nixpkgs/commit/8be903c231c3bf7b73968800be7682e0e27b6afb) | `citrix-workspace: drop support for some older versions`                                              |
| [`62bfe945`](https://github.com/NixOS/nixpkgs/commit/62bfe94552048241032a32d679063e2c9c66f199) | `felix-fm: 2.1.0 -> 2.1.1`                                                                            |
| [`e4864d29`](https://github.com/NixOS/nixpkgs/commit/e4864d2966abc2d8c4c105f0ce6c9bdb9ce3743b) | `chromiumDev: 109.0.5414.10 -> 110.0.5449.0`                                                          |
| [`33daeebd`](https://github.com/NixOS/nixpkgs/commit/33daeebd6baf52cc5640c6c223ff926d07e6e96d) | `chromiumBeta: 108.0.5359.71 -> 109.0.5414.25`                                                        |
| [`efdcde92`](https://github.com/NixOS/nixpkgs/commit/efdcde92730d3f0c7ad2a6e8151438485c446c4b) | `python310Packages.pyphen: 0.13.0 -> 0.13.2`                                                          |
| [`eb701b9e`](https://github.com/NixOS/nixpkgs/commit/eb701b9e9f50ad5d12b8ed8f8a79421660bc6f5b) | `python310Packages.pymunk: add missing input`                                                         |
| [`cad27dd1`](https://github.com/NixOS/nixpkgs/commit/cad27dd109f40ea474ea3acdda9d5fd8faedd0ea) | `python310Packages.django-postgresql-netfields: 1.2.2 -> 1.3.0`                                       |
| [`c003849b`](https://github.com/NixOS/nixpkgs/commit/c003849b5624993cabd59e79438142eca287a6c9) | `python310Packages.pymunk: add changelog to meta`                                                     |
| [`5c9e4571`](https://github.com/NixOS/nixpkgs/commit/5c9e4571573bbd72427ca01c903b1109f2897665) | `python310Packages.pymc: add changelog to meta`                                                       |
| [`a71f71b8`](https://github.com/NixOS/nixpkgs/commit/a71f71b827e973148aa172e8c8f6f8fc6345579f) | `python310Packages.pymunk: 6.3.0 -> 6.4.0`                                                            |
| [`77aafd01`](https://github.com/NixOS/nixpkgs/commit/77aafd01c2cff68ea99ec8889c7bae6ebfec79aa) | `python310Packages.pymc: 4.3.0 -> 4.4.0`                                                              |
| [`ba9d6825`](https://github.com/NixOS/nixpkgs/commit/ba9d6825bd52b62f294f8bcf47f3e498beaca58b) | `zsh-edit: init at unstable-2022-05-05`                                                               |
| [`16b75693`](https://github.com/NixOS/nixpkgs/commit/16b756939be70c6967d73a52eccbfa6fbe4ef2eb) | `springLobby: 0.270 -> 0.273`                                                                         |
| [`a9fc8ad6`](https://github.com/NixOS/nixpkgs/commit/a9fc8ad66e794988759f99e600b56f00733dbb00) | `vscode-extensions.esbenp.prettier-vscode: 9.9.0 -> 9.10.3`                                           |
| [`d4b338dd`](https://github.com/NixOS/nixpkgs/commit/d4b338dd50e4d854a29833638f5a8a6d14b90ed6) | `wiremock: init at 2.35.0`                                                                            |
| [`328a29eb`](https://github.com/NixOS/nixpkgs/commit/328a29eb8926a861aa30ad2345c20002e5cb583d) | `rxvt-unicode: pass through meta in wrapper`                                                          |
| [`7a427a54`](https://github.com/NixOS/nixpkgs/commit/7a427a54c9582cbad21f25aed4ff5ddb1defb8e3) | `pw-viz: init at 0.1.0`                                                                               |
| [`c0cdf0ad`](https://github.com/NixOS/nixpkgs/commit/c0cdf0ad4bac64d96bd7c581878d4507c53234c8) | `appimage-run: export OWD`                                                                            |
| [`79426ce4`](https://github.com/NixOS/nixpkgs/commit/79426ce44526c562b063d04c6078b75523d65cba) | `linuxPackages.nvidia_x11_production:  515.86.01 -> 525.60.11`                                        |
| [`9c3dc3cf`](https://github.com/NixOS/nixpkgs/commit/9c3dc3cfeb15d4073eacb3802e8795abce848607) | `linux: kernel: enable DRM_HYPERV`                                                                    |
| [`f5339d23`](https://github.com/NixOS/nixpkgs/commit/f5339d2339ebc728e32131c8141786b0e5e30cce) | `honk: init at 0.9.8`                                                                                 |
| [`cdb450dc`](https://github.com/NixOS/nixpkgs/commit/cdb450dcbaed137886897fc5497bade0c895b296) | `maintainers: add huyngo`                                                                             |
| [`badc84b6`](https://github.com/NixOS/nixpkgs/commit/badc84b69e4b3028466c0f8189f23ae51d92e7f6) | `hashrat: init at 1.15`                                                                               |
| [`152d3200`](https://github.com/NixOS/nixpkgs/commit/152d32009174d62527dd36f8a1d472763a087586) | `php81Extensions.blackfire: 1.78.1 -> 1.84.0`                                                         |
| [`96cc5f97`](https://github.com/NixOS/nixpkgs/commit/96cc5f97c75988c01db7732b06c5cef20bb0f429) | `roslyn: 3.10.0-1.21102.26 -> 4.2.0`                                                                  |
| [`2d1b7b85`](https://github.com/NixOS/nixpkgs/commit/2d1b7b8557831fbcb6bf42568b237ea3fa0ed9ca) | `roslyn: use buildDotnetModule`                                                                       |
| [`8e7296e9`](https://github.com/NixOS/nixpkgs/commit/8e7296e984b6a4627ff04c4337a28933a442d95a) | `buildDotnetModule: generate a NuGet.config with source`                                              |
| [`a587e528`](https://github.com/NixOS/nixpkgs/commit/a587e528c50d11b4d4e26a7dbd0b4ec6bd511bf3) | `Add prometheus-nut-exporter module`                                                                  |