### PR TITLE
chore(flake/home-manager): `518dca61` -> `ca48fced`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670110190,
-        "narHash": "sha256-abqpG1Hgd965asI7DcsBdPCnMuAhx+UhPMM7bn++c4I=",
+        "lastModified": 1670141274,
+        "narHash": "sha256-wW1nNEXo79Sw5oWaTK2LDGCc2rGwwcAPJMpQOTPT69Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "518dca61c062d66d933379c5d49908c9d3377c15",
+        "rev": "ca48fced83b37b4927ee264e54b9fdd5706c4139",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`ca48fced`](https://github.com/nix-community/home-manager/commit/ca48fced83b37b4927ee264e54b9fdd5706c4139) | `fish: format user and generated .fish files` |