### PR TITLE
chore(flake/sops-nix): `8295b813` -> `da1f173f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -585,11 +585,11 @@
         "nixpkgs-22_05": "nixpkgs-22_05"
       },
       "locked": {
-        "lastModified": 1669714206,
-        "narHash": "sha256-9aiMbzRL8REsyi9U0eZ+lT4s7HaILA1gh9n2apKzLxU=",
+        "lastModified": 1670145051,
+        "narHash": "sha256-K9Cm0UQ79lIOflwlaXuVlHNCYjXMTG4fSkBnBx4NWnU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "8295b8139ef7baadeb90c5cad7a40c4c9297ebf7",
+        "rev": "da1f173f47f7eaeba6e498f3d9250dd4ec814dbd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message               |
| ----------------------------------------------------------------------------------------------- | ---------------------------- |
| [`9cbf5804`](https://github.com/Mic92/sops-nix/commit/9cbf5804d8fd60da94b6bae60a5d2e2319deda4c) | `Update README.md`           |
| [`e4c76116`](https://github.com/Mic92/sops-nix/commit/e4c761169e9431e63a6bb5785e5ed3ac8b84165a) | `Update README.md`           |
| [`39bf96e0`](https://github.com/Mic92/sops-nix/commit/39bf96e000548549072df8ee4eb89c280b7bf8af) | `README: commercial support` |