### PR TITLE
chore(flake/sops-nix): `edc50031` -> `da98a111`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -585,11 +585,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1670146455,
-        "narHash": "sha256-H/aKngTdxhcTw9A9RcjZ0SOaYJN6wu4szhaOXe8B8ac=",
+        "lastModified": 1670149631,
+        "narHash": "sha256-rwmtlxx45PvOeZNP51wql/cWjY3rqzIR3Oj2Y+V7jM0=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "edc5003142aba403bb8f7427ea0d5ed227c1e667",
+        "rev": "da98a111623101c64474a14983d83dad8f09f93d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message       |
| ----------------------------------------------------------------------------------------------- | -------------------- |
| [`1415fb03`](https://github.com/Mic92/sops-nix/commit/1415fb03b238e8182f6cbd8f4737c816c846eefa) | `flake.lock: Update` |