### PR TITLE
chore(flake/emacs-overlay): `d4443a55` -> `b0500fca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670119379,
-        "narHash": "sha256-wEOUDPMjb3bBbRObQVBs+yQH1Uwrle5U2uQmqdIQYKM=",
+        "lastModified": 1670150553,
+        "narHash": "sha256-tj881q8opsRS/WnDcit6MWmgm+7K4HTfQzZy7WGpaIw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d4443a55b8f260e4c31bf848059eb5aed5b75002",
+        "rev": "b0500fcaf519c6def2d1d98689941cac5d921e45",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`b0500fca`](https://github.com/nix-community/emacs-overlay/commit/b0500fcaf519c6def2d1d98689941cac5d921e45) | `Updated repos/melpa` |
| [`ed5e6fc5`](https://github.com/nix-community/emacs-overlay/commit/ed5e6fc55e30b437aa38e1bda2d895c7672ea48b) | `Updated repos/emacs` |