### PR TITLE
chore(flake/nix-on-droid): `4e58ce79` -> `9ba1fece`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -326,11 +326,11 @@
         "nmd": "nmd_2"
       },
       "locked": {
-        "lastModified": 1669422604,
-        "narHash": "sha256-3t8SFcIAhHECKIN4T6UxkSOGYfNzXXq0OUdJcHtZCmw=",
+        "lastModified": 1670155753,
+        "narHash": "sha256-UvA44Zlx8aZ/v1CsRz6nY8a7T9V+JsFrjhOBpJeU/uI=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "4e58ce79715707f00fce7d9b4a146f67720a7a3c",
+        "rev": "9ba1feced23ee4f42cfb4427bbf451978e6a70dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`9ba1fece`](https://github.com/t184256/nix-on-droid/commit/9ba1feced23ee4f42cfb4427bbf451978e6a70dd) | `deploy: allow specifying urls not ending with source.tar.gz` |
| [`5e7d6d12`](https://github.com/t184256/nix-on-droid/commit/5e7d6d1214411d010403fa78c61e5da261ab9d80) | `environment.path: fix installation with nix profile`         |