### PR TITLE
chore(flake/home-manager): `65700a4f` -> `7bfe3cd9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670152352,
-        "narHash": "sha256-xBsTS4un53WicWso4dq+MHR16to8pIb/aoHpoWnPj5s=",
+        "lastModified": 1670156965,
+        "narHash": "sha256-TyKW3TaY3PRH+9bBLTiffZP0/Nt5yLeWtmQZKhJ4Boo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "65700a4fd10aa20ff4a65cbf0ab8b3dc0c438dcb",
+        "rev": "7bfe3cd9b0c2feae04ceed52bbc0b64222ed4b7e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                            |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`7bfe3cd9`](https://github.com/nix-community/home-manager/commit/7bfe3cd9b0c2feae04ceed52bbc0b64222ed4b7e) | `firefox: fix expected bookmarks in test` |
| [`848ae0d6`](https://github.com/nix-community/home-manager/commit/848ae0d6bbf3f0a33126887085274195c1565209) | `neovim: avoid aliased package`           |
| [`15d94f30`](https://github.com/nix-community/home-manager/commit/15d94f3058961528bff708a3a5e5eb3ff468fe01) | `pet: don't create file without snippets` |