### PR TITLE
chore(flake/home-manager): `7bfe3cd9` -> `2b02f8c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670156965,
-        "narHash": "sha256-TyKW3TaY3PRH+9bBLTiffZP0/Nt5yLeWtmQZKhJ4Boo=",
+        "lastModified": 1670158169,
+        "narHash": "sha256-wo/hGZ5St4VL3OUb6f9p+UfdPkmIfbWDlMcaHlFHNWs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7bfe3cd9b0c2feae04ceed52bbc0b64222ed4b7e",
+        "rev": "2b02f8c7cb71098e21f8d67674562c9977caf007",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`2b02f8c7`](https://github.com/nix-community/home-manager/commit/2b02f8c7cb71098e21f8d67674562c9977caf007) | `thunderbird: use account id for IMAP directory name` |
| [`17bbfcb8`](https://github.com/nix-community/home-manager/commit/17bbfcb82458ac2270dec71ce1f7044deb4f1ca3) | `flake.lock: Update`                                  |