### PR TITLE
chore(flake/nix-on-droid): `9ba1fece` -> `355aa408`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -326,11 +326,11 @@
         "nmd": "nmd_2"
       },
       "locked": {
-        "lastModified": 1670155753,
-        "narHash": "sha256-UvA44Zlx8aZ/v1CsRz6nY8a7T9V+JsFrjhOBpJeU/uI=",
+        "lastModified": 1670169857,
+        "narHash": "sha256-WUf+tHAHtlFHuk5EOHOt2Km6hkWuPOEtnCBU30fZQ8s=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "9ba1feced23ee4f42cfb4427bbf451978e6a70dd",
+        "rev": "355aa408c25c1c97bed1e21961c2bcca5ab6a158",
         "type": "github"
       },
       "original": {
@@ -370,17 +370,17 @@
     },
     "nixpkgs-for-bootstrap": {
       "locked": {
-        "lastModified": 1656265786,
-        "narHash": "sha256-A9RkoGrxzsmMm0vily18p92Rasb+MbdDMaSnzmywXKw=",
+        "lastModified": 1669834992,
+        "narHash": "sha256-YnhZGHgb4C3Q7DSGisO/stc50jFb9F/MzHeKS4giotg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cd90e773eae83ba7733d2377b6cdf84d45558780",
+        "rev": "596a8e828c5dfa504f91918d0fa4152db3ab5502",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cd90e773eae83ba7733d2377b6cdf84d45558780",
+        "rev": "596a8e828c5dfa504f91918d0fa4152db3ab5502",
         "type": "github"
       }
     },


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                             |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`355aa408`](https://github.com/t184256/nix-on-droid/commit/355aa408c25c1c97bed1e21961c2bcca5ab6a158) | `nix-on-droid: remove fallback for default nix < 2.4`      |
| [`588ab89b`](https://github.com/t184256/nix-on-droid/commit/588ab89b1d531c2f90484329b27b47c85799062a) | `modules/terminal: remove mention of TTF font requirement` |
| [`3dfb9d44`](https://github.com/t184256/nix-on-droid/commit/3dfb9d44b545ab815ca4a4ca72d2aa14065dce33) | `bootstrap: update nixpkgs version`                        |
| [`a45761bc`](https://github.com/t184256/nix-on-droid/commit/a45761bc875d0f4182e7c9e88c2d3cd653e6430c) | `bootstrap: update nix to 2.11.1`                          |
| [`ef3ae133`](https://github.com/t184256/nix-on-droid/commit/ef3ae133e56344227b3e8fa0aa1993b93169be20) | `tests: update qemu to 7.1.0`                              |
| [`be1e192f`](https://github.com/t184256/nix-on-droid/commit/be1e192fcd48126537ac39c55067c6229efe2423) | `CHANGELOG: add structure to 22.11 changelog`              |
| [`c70a1d97`](https://github.com/t184256/nix-on-droid/commit/c70a1d97456ea5506e230f9baa13e27938555738) | `set stable version to 22.11`                              |
| [`7e8f1ad6`](https://github.com/t184256/nix-on-droid/commit/7e8f1ad6e24c718a5c52b703452f11ec1f0db247) | `modules/version: remove default stateVersion value`       |