### PR TITLE
chore(flake/nixos-hardware): `7883883d` -> `9d87bc03`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -341,11 +341,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1669650994,
-        "narHash": "sha256-uwASLUfedIQ5q01TtMwZDEV2HCZr5nVPZjzVgCG+D5I=",
+        "lastModified": 1670174919,
+        "narHash": "sha256-XdQr3BUnrvVLRFunLWrZORhwYHDG0+9jUUe0Jv1pths=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "7883883d135ce5b7eae5dce4bfa12262b85c1c46",
+        "rev": "9d87bc030a0bf3f00e953dbf095a7d8e852dab6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`250d6991`](https://github.com/NixOS/nixos-hardware/commit/250d6991c9f47142350ee8a37ca07f06b49a7eee) | `surface/kernel: 5.16.11 -> 5.19.17` |