### PR TITLE
chore(flake/emacs-overlay): `b0500fca` -> `0e96e55b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670150553,
-        "narHash": "sha256-tj881q8opsRS/WnDcit6MWmgm+7K4HTfQzZy7WGpaIw=",
+        "lastModified": 1670177439,
+        "narHash": "sha256-93Ar1bNUvs98becgXjI/euYZ6nXTH/iPljsFLq6kIrE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b0500fcaf519c6def2d1d98689941cac5d921e45",
+        "rev": "0e96e55b373d71eb69bab9acd6699bf95b45db98",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`0e96e55b`](https://github.com/nix-community/emacs-overlay/commit/0e96e55b373d71eb69bab9acd6699bf95b45db98) | `Updated repos/melpa` |
| [`7b8fd092`](https://github.com/nix-community/emacs-overlay/commit/7b8fd092ec74c9026b1049b6a5f7aa1a6c40ff04) | `Updated repos/emacs` |