### PR TITLE
chore(flake/emacs-overlay): `0e96e55b` -> `1e4763dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670177439,
-        "narHash": "sha256-93Ar1bNUvs98becgXjI/euYZ6nXTH/iPljsFLq6kIrE=",
+        "lastModified": 1670186246,
+        "narHash": "sha256-Th+rnPcHQsxt9G4eTCCE82L/t65n36TG9ixr+Tw+hNI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0e96e55b373d71eb69bab9acd6699bf95b45db98",
+        "rev": "1e4763dd90ad8712b459d1f5e53cbbc047b75dd0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                       |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`1e4763dd`](https://github.com/nix-community/emacs-overlay/commit/1e4763dd90ad8712b459d1f5e53cbbc047b75dd0) | `Revert "add tree sitter languages to rpath (#273)"` |