### PR TITLE
chore(flake/emacs-overlay): `1e4763dd` -> `d17b8b8f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670186246,
-        "narHash": "sha256-Th+rnPcHQsxt9G4eTCCE82L/t65n36TG9ixr+Tw+hNI=",
+        "lastModified": 1670194159,
+        "narHash": "sha256-ky7z2iSGSZdi9sSv9GXAgyF4cDQAT7Rn2Td0avXC9So=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1e4763dd90ad8712b459d1f5e53cbbc047b75dd0",
+        "rev": "d17b8b8fc033debb3e75cfc44aaaf8f47d5e04fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                 |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
| [`add580f7`](https://github.com/nix-community/emacs-overlay/commit/add580f7d29b08f66182b0cc4c1a9262d77ba2c0) | `chore(Hydra): Changed stable: 22.05 -> 22.11` |