### PR TITLE
chore(flake/nix-on-droid): `355aa408` -> `b00cb5e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -326,11 +326,11 @@
         "nmd": "nmd_2"
       },
       "locked": {
-        "lastModified": 1670169857,
-        "narHash": "sha256-WUf+tHAHtlFHuk5EOHOt2Km6hkWuPOEtnCBU30fZQ8s=",
+        "lastModified": 1670198918,
+        "narHash": "sha256-oNlUhAM0/a3pDdCMmBWA+CLrDAIYJqAAMyrDp8fNSM4=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "355aa408c25c1c97bed1e21961c2bcca5ab6a158",
+        "rev": "b00cb5e7e2a47d85a019119069b153cda4002d0a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                 |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`b00cb5e7`](https://github.com/t184256/nix-on-droid/commit/b00cb5e7e2a47d85a019119069b153cda4002d0a) | `docs: set stateVersion for manual generation` |