### PR TITLE
chore(flake/emacs-overlay): `a3a53c9b` -> `dd60ef06`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670205568,
-        "narHash": "sha256-E7EykNLZ2c1Zi4BTfQJoaVZwHHDKJGRwOrqFJPF3Fjo=",
+        "lastModified": 1670235510,
+        "narHash": "sha256-f+gUkF9duBRYbQdCMsaVHNFgsxN6R32ZXXOJU3cND3Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a3a53c9b51e51d4a55a9be1921daf560a9693300",
+        "rev": "dd60ef06981fec354663054e608bbfcd7f8f1cff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`dd60ef06`](https://github.com/nix-community/emacs-overlay/commit/dd60ef06981fec354663054e608bbfcd7f8f1cff) | `Updated repos/nongnu` |
| [`d12878da`](https://github.com/nix-community/emacs-overlay/commit/d12878da7e42851edf113341e5bde3192f5b1473) | `Updated repos/melpa`  |
| [`241117af`](https://github.com/nix-community/emacs-overlay/commit/241117af1c8aea2ea99419724391139a34f7014d) | `Updated repos/emacs`  |