### PR TITLE
chore(flake/home-manager): `c3060ab9` -> `747e3647`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670241377,
-        "narHash": "sha256-3OHyE6/NyfYvvNUL+07hJV+uDRKZCjOFZJWm+ww2kuw=",
+        "lastModified": 1670245450,
+        "narHash": "sha256-SSHD2iuPw7dKpAHX7DMTBKCm+/drigwC5//xkf+v/AM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c3060ab93790012e3c6ba30e6e5585cd43c6c516",
+        "rev": "747e36476f341720404bd0d14d687a135a4ce5bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`747e3647`](https://github.com/nix-community/home-manager/commit/747e36476f341720404bd0d14d687a135a4ce5bf) | `ci: bump DeterminateSystems/update-flake-lock from 14 to 15` |
| [`8faa86f1`](https://github.com/nix-community/home-manager/commit/8faa86f134e8fda97a75c9d810945e4ae0c1a896) | `ci: bump 22.05 to 22.11 in dependabot setup`                 |
| [`b5c08330`](https://github.com/nix-community/home-manager/commit/b5c083300bbc679f1dcd09d007e1c71b6f34d35d) | `treewide: fix typos`                                         |