### PR TITLE
chore(flake/emacs-overlay): `dd60ef06` -> `612fc9ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670235510,
-        "narHash": "sha256-f+gUkF9duBRYbQdCMsaVHNFgsxN6R32ZXXOJU3cND3Y=",
+        "lastModified": 1670264298,
+        "narHash": "sha256-Spj2nMBXq6S/fAtagi2EotlbyXhMb0RPA0vy5JhnD9w=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dd60ef06981fec354663054e608bbfcd7f8f1cff",
+        "rev": "612fc9ab31d2cdfe6ca99d606c49072d90c4e42b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`612fc9ab`](https://github.com/nix-community/emacs-overlay/commit/612fc9ab31d2cdfe6ca99d606c49072d90c4e42b) | `Updated repos/melpa` |
| [`bca9f55d`](https://github.com/nix-community/emacs-overlay/commit/bca9f55d6c959a3845b5cf5b48a9adddec5e9f3e) | `Updated repos/emacs` |