### PR TITLE
chore(flake/emacs-overlay): `612fc9ab` -> `4aa6dfff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670264298,
-        "narHash": "sha256-Spj2nMBXq6S/fAtagi2EotlbyXhMb0RPA0vy5JhnD9w=",
+        "lastModified": 1670294245,
+        "narHash": "sha256-OmzJP430WCd274VHjAmqgI5hme1luXWAcFA7apH3pH8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "612fc9ab31d2cdfe6ca99d606c49072d90c4e42b",
+        "rev": "4aa6dfff1ed8618cdd244e58d70569e538127f93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------- |
| [`4aa6dfff`](https://github.com/nix-community/emacs-overlay/commit/4aa6dfff1ed8618cdd244e58d70569e538127f93) | `Remove redundant hydra jobs` |