### PR TITLE
chore(flake/emacs-overlay): `4aa6dfff` -> `2f7fff8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670294245,
-        "narHash": "sha256-OmzJP430WCd274VHjAmqgI5hme1luXWAcFA7apH3pH8=",
+        "lastModified": 1670295974,
+        "narHash": "sha256-+oQzBTxrWag9XnIndTUXvilI78fuIlhRQ+iNtBrlUF8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4aa6dfff1ed8618cdd244e58d70569e538127f93",
+        "rev": "2f7fff8ee668c01803cab2f0847151fdf647134e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`2f7fff8e`](https://github.com/nix-community/emacs-overlay/commit/2f7fff8ee668c01803cab2f0847151fdf647134e) | `Updated repos/nongnu` |
| [`cfa0166b`](https://github.com/nix-community/emacs-overlay/commit/cfa0166bf39870927c55ca6dd4c871ee558af37d) | `Updated repos/melpa`  |
| [`647e33aa`](https://github.com/nix-community/emacs-overlay/commit/647e33aacdb08d59b0b593e5e9121d02cd7edfdd) | `Updated repos/emacs`  |