### PR TITLE
chore(flake/nur): `c81b1e52` -> `ec273f3c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1669805596,
-        "narHash": "sha256-g1CPQZ+1jGhY4bsjppk+gH5jfzzqmPlqGHg0zSYS3Hw=",
+        "lastModified": 1670315391,
+        "narHash": "sha256-kUycb3KqW1OI8qSmnD3Su6Xvhx1XxJQaZjQuI1EqW/s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c81b1e527f3a220abfa9bf8096153d52784c5007",
+        "rev": "ec273f3ccefce9ad7565efe23e2bdc4bdc19dd97",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                  |
| -------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`ec273f3c`](https://github.com/nix-community/NUR/commit/ec273f3ccefce9ad7565efe23e2bdc4bdc19dd97) | `no longer use old nix version` |