### PR TITLE
chore(flake/nur): `ec273f3c` -> `af814db1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1670315391,
-        "narHash": "sha256-kUycb3KqW1OI8qSmnD3Su6Xvhx1XxJQaZjQuI1EqW/s=",
+        "lastModified": 1670315682,
+        "narHash": "sha256-/v0RgZZIjvsFuJbJLUlzRbzSlYFXq3olgJTuJBNtcoY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ec273f3ccefce9ad7565efe23e2bdc4bdc19dd97",
+        "rev": "af814db16c89385c65e758608296440555f61ccc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`af814db1`](https://github.com/nix-community/NUR/commit/af814db16c89385c65e758608296440555f61ccc) | `automatic update` |