### PR TITLE
chore(flake/nixpkgs): `61a8a98e` -> `14ddeaeb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670064435,
-        "narHash": "sha256-+ELoY30UN+Pl3Yn7RWRPabykwebsVK/kYE9JsIsUMxQ=",
+        "lastModified": 1670152712,
+        "narHash": "sha256-LJttwIvJqsZIj8u1LxVRv82vwUtkzVqQVi7Wb8gxPS4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "61a8a98e6d557e6dd7ed0cdb54c3a3e3bbc5e25c",
+        "rev": "14ddeaebcbe9a25748221d1d7ecdf98e20e2325e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                               |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`c26ff1ed`](https://github.com/NixOS/nixpkgs/commit/c26ff1ed9badf9ec4e5c572a755985360f682010) | `pulseaudio: reference wrapped binaries in service files`                    |
| [`b8a85941`](https://github.com/NixOS/nixpkgs/commit/b8a859414f54ffc179306973c084c5bf2ce38696) | `nanomq: 0.13.6 -> 0.14.1`                                                   |
| [`7f44cba2`](https://github.com/NixOS/nixpkgs/commit/7f44cba24f8c64db973276bc79cc48ae28eca71f) | `awscli2: 2.9.1 -> 2.9.4`                                                    |
| [`f3198241`](https://github.com/NixOS/nixpkgs/commit/f31982419dd9ba4bb2defb13d9a292c762935d26) | `hyfetch: 1.4.3 -> 1.4.4`                                                    |
| [`cad01bd3`](https://github.com/NixOS/nixpkgs/commit/cad01bd3bceda723da1f422b735dd4093e0e839c) | `nextdns: 1.37.11 -> 1.38.0`                                                 |
| [`957fd5d8`](https://github.com/NixOS/nixpkgs/commit/957fd5d89f5c0ec94735e66aa1fe1d4dccaf9a49) | `mmex: 1.6.0 -> 1.6.1`                                                       |
| [`bd7d06ed`](https://github.com/NixOS/nixpkgs/commit/bd7d06ed30e83b0c8e53127f43e9d5f763b2665b) | `libzim: add changelog to meta`                                              |
| [`ad39a192`](https://github.com/NixOS/nixpkgs/commit/ad39a192bf09465724c9881feced3988fa4ad0c4) | `gopass-summon-provider: 1.14.11 -> 1.15.0`                                  |
| [`0568ed74`](https://github.com/NixOS/nixpkgs/commit/0568ed74017214b8d693f639de3be95f92f7ad66) | `gopass-jsonapi: 1.14.11 -> 1.15.0`                                          |
| [`7936dd5b`](https://github.com/NixOS/nixpkgs/commit/7936dd5b0f05b3de4cfc633ef14762319ad43a15) | `gopass-hibp: 1.14.11 -> 1.15.0`                                             |
| [`0ef57918`](https://github.com/NixOS/nixpkgs/commit/0ef57918aff1c9c8cdbf528efd6871317170de44) | `git-credential-gopass: 1.14.11 -> 1.15.0`                                   |
| [`5878e012`](https://github.com/NixOS/nixpkgs/commit/5878e0124fb1cfd9f338da333e7fc7f3cc85176a) | `gopass: 1.14.11 -> 1.15.0`                                                  |
| [`fe49c316`](https://github.com/NixOS/nixpkgs/commit/fe49c3168000bbbe59d89c273e98f1d289d06d0c) | `libzim: 8.0.1 -> 8.1.0`                                                     |
| [`0905acf0`](https://github.com/NixOS/nixpkgs/commit/0905acf06944ac5b6b38723b7b15963213e34df6) | `nixos/rog-control-center: init`                                             |
| [`8f7537e3`](https://github.com/NixOS/nixpkgs/commit/8f7537e34fdaa2d1e0dda57e36a1b93e91449757) | `nixos/asusctl: init`                                                        |
| [`ccd43485`](https://github.com/NixOS/nixpkgs/commit/ccd434854d60e568962d3cba0a2600a47f99a99b) | `asusctl: init at 4.5.2`                                                     |
| [`8f14c05c`](https://github.com/NixOS/nixpkgs/commit/8f14c05c504b2f674a274341a0203acf02bd98ca) | `nixos/supergfxctl: init`                                                    |
| [`dc3ea58a`](https://github.com/NixOS/nixpkgs/commit/dc3ea58abcb6404cdcad082f2ccd9c0d24e56925) | `supergfxctl: init at 5.0.1`                                                 |
| [`044d4812`](https://github.com/NixOS/nixpkgs/commit/044d4812c9852982da6fe768a1709d043a8e0ebe) | `libmodbus: 3.1.8 -> 3.1.9`                                                  |
| [`bac379f3`](https://github.com/NixOS/nixpkgs/commit/bac379f30a6fa1284e48b4224862e0b41ad42199) | `doc: use sri hash syntax`                                                   |
| [`58e61d48`](https://github.com/NixOS/nixpkgs/commit/58e61d48be4810bc78e25c6694939814da306df5) | `vector: 0.25.1 -> 0.25.2`                                                   |
| [`9198a8c4`](https://github.com/NixOS/nixpkgs/commit/9198a8c42081a097f95c5377e25c701420870383) | `terraform-providers: passthru.provider-source-address`                      |
| [`35763bc4`](https://github.com/NixOS/nixpkgs/commit/35763bc43b61e81c6df3ec20a7380cb8278c294a) | `cinnamon.mint-artwork: 1.7.0 -> 1.7.2`                                      |
| [`1b6468cf`](https://github.com/NixOS/nixpkgs/commit/1b6468cfb48712cad1d14deaba959ceaf22a9bb3) | `nixos/lightdm-greeters/slick: Add options for cursor themes`                |
| [`118b5e39`](https://github.com/NixOS/nixpkgs/commit/118b5e39711bc206dc16c7d2de92aba05db22e84) | `lightdm-slick-greeter: 1.5.9 -> 1.6.0`                                      |
| [`0e1cf7fc`](https://github.com/NixOS/nixpkgs/commit/0e1cf7fc3c2143335b0c26f855b88cf6952a3786) | `sticky: 1.12 -> 1.13`                                                       |
| [`28b106b5`](https://github.com/NixOS/nixpkgs/commit/28b106b5bcf849ffa3f7d91d3c4757985324d393) | `hypnotix: 3.0 -> 3.1`                                                       |
| [`8a52c0a3`](https://github.com/NixOS/nixpkgs/commit/8a52c0a3b1853b90e3bab9110dd5032ff84abbee) | `cinnamon.xapp: 2.4.1 -> 2.4.2`                                              |
| [`81b9fde6`](https://github.com/NixOS/nixpkgs/commit/81b9fde6838a7102039af4360bb232cb36b6357a) | `cinnamon.warpinator: 1.4.1 -> 1.4.2`                                        |
| [`f1df9898`](https://github.com/NixOS/nixpkgs/commit/f1df989839c28c8b6a1b948fe875fbbf5b5bbf7a) | `cinnamon.cinnamon-screensaver: 5.6.1 -> 5.6.2`                              |
| [`94379d6f`](https://github.com/NixOS/nixpkgs/commit/94379d6f90168185a15366b0bf31180b88178b08) | `cinnamon.bulky: 2.5 -> 2.6`                                                 |
| [`c0870c20`](https://github.com/NixOS/nixpkgs/commit/c0870c206a523edb2a60a1ec0648b23e3bd2e16a) | `doublecmd: 1.0.8 -> 1.0.9`                                                  |
| [`a3cb08dc`](https://github.com/NixOS/nixpkgs/commit/a3cb08dc36f752b7a0966abc2a34ef5ab6198e11) | `dnsproxy: 0.46.3 -> 0.46.4`                                                 |
| [`0236242a`](https://github.com/NixOS/nixpkgs/commit/0236242ac1f13fd4c473172ecd6ca62ab581783f) | `python310Packages.pyvicare: 2.19.0 -> 2.20.0`                               |
| [`5c4794ab`](https://github.com/NixOS/nixpkgs/commit/5c4794abda8cb8cac1afcc8cd022629627bf251a) | `python310Packages.oralb-ble: 0.14.2 -> 0.14.3`                              |
| [`53508479`](https://github.com/NixOS/nixpkgs/commit/535084792259b49f51863437265f535643b60b5c) | ` python310Packages.oralb-ble: add changelog to meta`                        |
| [`d3b52d6c`](https://github.com/NixOS/nixpkgs/commit/d3b52d6c1da27a88cf9fcb4ea945df37a28c16f5) | `libreddit: 0.24.2 -> 0.25.0`                                                |
| [`0cb72224`](https://github.com/NixOS/nixpkgs/commit/0cb72224fa93437e44824e85e3124709b9f3f03a) | `python310Packages.hahomematic: 2022.12.0 -> 2022.12.1`                      |
| [`7363bec1`](https://github.com/NixOS/nixpkgs/commit/7363bec14af03c2bab758c121bb1177cce04942e) | `fractal: fix build on darwin`                                               |
| [`c4950e53`](https://github.com/NixOS/nixpkgs/commit/c4950e533e535a5b3add343340f8c6321deb2462) | `python310Packages.levenshtein: disable LTO to fix aarch64-darwin build`     |
| [`382db54d`](https://github.com/NixOS/nixpkgs/commit/382db54de30c5599137702b3817f4bc2b9a53a80) | `dinghy: 0.15.0 -> 1.0.0`                                                    |
| [`863430a1`](https://github.com/NixOS/nixpkgs/commit/863430a1c6f9b8a5746c8ee1c7ef74fc1ccb53e4) | `linux/hardened/patches/6.0: 6.0.10-hardened1 -> 6.0.11-hardened1`           |
| [`748507d0`](https://github.com/NixOS/nixpkgs/commit/748507d0a5d00c2682616427cfb7b1958c2829fe) | `linux/hardened/patches/5.15: 5.15.80-hardened1 -> 5.15.81-hardened1`        |
| [`9865bcdf`](https://github.com/NixOS/nixpkgs/commit/9865bcdfcb493e99a08a84b2960eca96718ddeae) | `linux/hardened/patches/5.10: 5.10.156-hardened1 -> 5.10.157-hardened1`      |
| [`fc19dc62`](https://github.com/NixOS/nixpkgs/commit/fc19dc62166933b98e7cc3d069355b93b31eefb3) | `linux_latest-libre: 19001 -> 19007`                                         |
| [`66bdeac7`](https://github.com/NixOS/nixpkgs/commit/66bdeac7cba8444170de02c80818c8f113af6d04) | `chromium: 108.0.5359.71 -> 108.0.5359.94`                                   |
| [`d23b4148`](https://github.com/NixOS/nixpkgs/commit/d23b4148e703ba826320c65d70dc78504e23aa30) | `ungoogled-chromium: 108.0.5359.72 -> 108.0.5359.95`                         |
| [`65dd798a`](https://github.com/NixOS/nixpkgs/commit/65dd798ac78a7ce3fcfefd4d24446406225589b9) | `clhep: 2.4.6.0 -> 2.4.6.1 (#204263)`                                        |
| [`42a68e6a`](https://github.com/NixOS/nixpkgs/commit/42a68e6a36b8d7fd7f0cec5ef3b2f0ca6693a5e6) | ``bundlerUpdateScript: Fix evaluation with `allowAliases = false```          |
| [`a78621f9`](https://github.com/NixOS/nixpkgs/commit/a78621f9b02cb5a1a0d671b9f721349a9ad0e558) | `skim: init module`                                                          |
| [`2e1413a0`](https://github.com/NixOS/nixpkgs/commit/2e1413a0570fc01085a5a2d8b9101bff2e2813db) | `josh: move to git-and-tools`                                                |
| [`f6feed1f`](https://github.com/NixOS/nixpkgs/commit/f6feed1fd304731b3e39fec9fea4ab6327efc889) | `gitstats: move to git-and-tools`                                            |
| [`31087568`](https://github.com/NixOS/nixpkgs/commit/31087568fcac0066b5010e02a6734d5d27550ec0) | `gitsign: move to git-and-tools`                                             |
| [`690da77e`](https://github.com/NixOS/nixpkgs/commit/690da77e6523fe3e2aa3ae9597e8103524dda6bb) | `gitoxide: move to git-and-tools`                                            |
| [`b8cee524`](https://github.com/NixOS/nixpkgs/commit/b8cee524136183bc57e45ffe07abac7c6189fb58) | `gitls: move to git-and-tools`                                               |
| [`fd4fa062`](https://github.com/NixOS/nixpkgs/commit/fd4fa062b495985982e13c5369b546bbd008ff6e) | `gitlint: move to git-and-tools`                                             |
| [`7389c44b`](https://github.com/NixOS/nixpkgs/commit/7389c44bcdc3bb02088dc0460351bd3ca96526ca) | `gitless: move to git-and-tools`                                             |
| [`6d744e7d`](https://github.com/NixOS/nixpkgs/commit/6d744e7d9613a2ee1ed98f403b9846412963fe16) | `git-up: move to git-and-tools`                                              |
| [`16aa4709`](https://github.com/NixOS/nixpkgs/commit/16aa4709eb3a5463f5f1e7033e66bf0c67accb63) | `git-town: move to git-and-tools`                                            |
| [`18df6097`](https://github.com/NixOS/nixpkgs/commit/18df6097bd2f7ef59f71fd5e92f68f116ca4e9bc) | `git-sizer: move to git-and-tools`                                           |
| [`4f7ca6ba`](https://github.com/NixOS/nixpkgs/commit/4f7ca6ba792adecd397a95f38527e85b0906d043) | `git-series: move to git-and-tools`                                          |
| [`072e8e44`](https://github.com/NixOS/nixpkgs/commit/072e8e4403ed9194b24a616e1be7f64c6d4d8927) | `git-review: move to git-and-tools`                                          |
| [`83b058e9`](https://github.com/NixOS/nixpkgs/commit/83b058e95bc92c3ac32fa6c373d013c6dc571eb1) | `git-repo: move to git-and-tools`                                            |
| [`08b72ebb`](https://github.com/NixOS/nixpkgs/commit/08b72ebbb28562cb82ee2f36ca670ef329941ada) | `git-repo-updater: move to git-and-tools`                                    |
| [`c2cb7d6e`](https://github.com/NixOS/nixpkgs/commit/c2cb7d6ef64f9a7db688a397e2890bacb99099c1) | `git-quick-stats: move to git-and-tools`                                     |
| [`94250e8a`](https://github.com/NixOS/nixpkgs/commit/94250e8a63db11b3413e476d5a3c9e2e2981b3b1) | `git-privacy: move to git-and-tools`                                         |
| [`5f3cf8eb`](https://github.com/NixOS/nixpkgs/commit/5f3cf8eb59cdd3256f91bd6fdc2fd20a2496d24d) | `git-lfs: move to git-and-tools`                                             |
| [`019fac03`](https://github.com/NixOS/nixpkgs/commit/019fac031aa7431def2ece7314775b9b41d68c11) | `git-hound: move to git-and-tools`                                           |
| [`d5fdd694`](https://github.com/NixOS/nixpkgs/commit/d5fdd6944279430c3152c796983b3ef3ed19f5de) | `git-ftp: move to git-and-tools`                                             |
| [`7601b8d8`](https://github.com/NixOS/nixpkgs/commit/7601b8d8f5b8df5c2fa33c521564a697a45f88d4) | `git-fire: move to git-and-tools`                                            |
| [`f4c3e8fa`](https://github.com/NixOS/nixpkgs/commit/f4c3e8fa5a7632726632fd3242e7403360e66fc0) | `git-crecord: move to git-and-tools`                                         |
| [`5ffe5261`](https://github.com/NixOS/nixpkgs/commit/5ffe526116a7b1b6a8721ccffe266d60a0aacece) | `git-backup: move to git-and-tools`                                          |
| [`a7764c11`](https://github.com/NixOS/nixpkgs/commit/a7764c1146a6624409e0bd3e175ef27e2a42157b) | `git-aggregator: move to git-and-tools`                                      |
| [`6709a709`](https://github.com/NixOS/nixpkgs/commit/6709a70925db74d56ac0f8ddcf5fef33082f8268) | `metasploit: 6.2.28 -> 6.2.29`                                               |
| [`cbcd34b9`](https://github.com/NixOS/nixpkgs/commit/cbcd34b9926fb6ec0c95db6ec47da8348cafd8d4) | `cpuid: 20221003 -> 20221201`                                                |
| [`ba338a8d`](https://github.com/NixOS/nixpkgs/commit/ba338a8dfe5de58f3401df4f067b794e92bb71c1) | `delta: 0.14.0 -> 0.15.1`                                                    |
| [`13f3fdd8`](https://github.com/NixOS/nixpkgs/commit/13f3fdd8b3b69f93729459ba2b57d5d58570d8c7) | `element-{web,desktop}: 1.11.14 -> 1.11.15`                                  |
| [`e606938c`](https://github.com/NixOS/nixpkgs/commit/e606938c517bf9595c0af2c9fb9ef65fbb6346c5) | `CODEOWNERS: Remove piegames from matrix-appservice-irc`                     |
| [`2a7fae33`](https://github.com/NixOS/nixpkgs/commit/2a7fae33a433147cc9c78dbd33702fa9ad7c4ad0) | `skim: refactor`                                                             |
| [`470353b6`](https://github.com/NixOS/nixpkgs/commit/470353b625e24f3b3b8d86838dcd9be1dcc95298) | `aaa: init at 1.1.1`                                                         |
| [`9331816e`](https://github.com/NixOS/nixpkgs/commit/9331816ed8f9a2452d82180b1b23bae5e853780d) | `grafana: 9.2.6 -> 9.3.1`                                                    |
| [`29acb77f`](https://github.com/NixOS/nixpkgs/commit/29acb77ff244cd6885a66ef9a1ab8f376b1636a1) | `zine: 0.8.0 -> 0.8.1`                                                       |
| [`ad293fba`](https://github.com/NixOS/nixpkgs/commit/ad293fba9e7a77d1f9fd9993dd05926599f415e9) | `matrix-appservice-irc: convert to buildNpmPackage`                          |
| [`dbbccc05`](https://github.com/NixOS/nixpkgs/commit/dbbccc05c621fff953e9e54d8449035b4741795d) | `fn-cli: 0.6.20 -> 0.6.22`                                                   |
| [`d812d393`](https://github.com/NixOS/nixpkgs/commit/d812d3939bc9228eae18f32540db4f514f9759dc) | `cargo-bisect-rustc: 0.6.4 -> 0.6.5`                                         |
| [`7b7bff38`](https://github.com/NixOS/nixpkgs/commit/7b7bff387b620b3356095fc62e0e88a69adf761f) | `nixos: update release notes for unifi-poller --> unpoller.`                 |
| [`c7918fed`](https://github.com/NixOS/nixpkgs/commit/c7918fed9e51371bf7783a59492683f3533331dd) | `nixos/prometheus/unifi-poller: rename to unpoller.`                         |
| [`ffcd97b5`](https://github.com/NixOS/nixpkgs/commit/ffcd97b521a413eb53b532952be847406a9495ed) | `nixos/unifi-poller: rename to unpoller.`                                    |
| [`40ddf3e2`](https://github.com/NixOS/nixpkgs/commit/40ddf3e2c6c18122ba4d783252870adb7c5dff92) | `unifi-poller: rename to unpoller.`                                          |
| [`d6ba0135`](https://github.com/NixOS/nixpkgs/commit/d6ba013513b8a7fd47a1f58094a8b04e79d53a6c) | `fox_1_6: use xorg.* packages directly instead of xlibsWrapper indirection`  |
| [`4d06d505`](https://github.com/NixOS/nixpkgs/commit/4d06d505065d5e0c920351f44f37c7a0d5487417) | `resholve: remove aliases for old API`                                       |
| [`02b79678`](https://github.com/NixOS/nixpkgs/commit/02b796780607ad19931bf8c9ad32a00d36527559) | `resholve: selectively enable python27`                                      |
| [`13d189d6`](https://github.com/NixOS/nixpkgs/commit/13d189d68649c442602607a2d24f4ee807e795ab) | `python310Packages.rapidfuzz: 2.12.2 -> 2.12.3`                              |
| [`6b1c965f`](https://github.com/NixOS/nixpkgs/commit/6b1c965f4803c37f575411ff022a4d461ae8fd36) | `runitor: 1.1.1 -> 1.2.0`                                                    |
| [`3126eb76`](https://github.com/NixOS/nixpkgs/commit/3126eb762147bc32c23d7511992157c0ea5bb71c) | `nixos/fzf: refactor two options`                                            |
| [`1795beca`](https://github.com/NixOS/nixpkgs/commit/1795beca40c60456c0652b9c7f3529d7cc441767) | `palemoon: 31.4.0 -> 31.4.1.1`                                               |
| [`05fd5113`](https://github.com/NixOS/nixpkgs/commit/05fd51130c84b0a07b57dbf5e20082dd89655943) | `zigbee2mqtt: 1.28.0 -> 1.28.4`                                              |
| [`5d685e0e`](https://github.com/NixOS/nixpkgs/commit/5d685e0eed043faa6ee397569b58cb5162c4a7dd) | `nixos/zigbee2mqtt: Update syscall filter`                                   |
| [`feb66d6f`](https://github.com/NixOS/nixpkgs/commit/feb66d6fd867750f7d6c37dd1404ea2c74ac2bfc) | `zigbee2mqtt: convert to buildNpmPackage and adopt`                          |
| [`dad8eba0`](https://github.com/NixOS/nixpkgs/commit/dad8eba0943c56af688121543cce40cf6bd92928) | `python310Packages.aiohomekit: 2.3.4 -> 2.3.5`                               |
| [`165245c5`](https://github.com/NixOS/nixpkgs/commit/165245c5263d7232b1cfa682e7fa707c07c40310) | `python310Packages.aiohomekit: 2.3.3 -> 2.3.4`                               |
| [`947dac5f`](https://github.com/NixOS/nixpkgs/commit/947dac5f975d34912db752e1be041aab4c6415c5) | `python310Packages.dask-yarn: disable failing tests`                         |
| [`9e0ecfc5`](https://github.com/NixOS/nixpkgs/commit/9e0ecfc521ae80bfa88326810a75e44f6f4bdb26) | `iterm2: remove unused patch`                                                |
| [`20df9356`](https://github.com/NixOS/nixpkgs/commit/20df93568e8b9c3d3bc5cca29ab5e81c70a7f127) | `vector: add enrichment-tables feature to build`                             |
| [`3bf35457`](https://github.com/NixOS/nixpkgs/commit/3bf35457d8083dcf0082a822fe95a33201ce2a83) | `python310Packages.devito: disable failing tests`                            |
| [`925ba44a`](https://github.com/NixOS/nixpkgs/commit/925ba44a5f679737121998481150140a6fa1a04c) | `mosquitto: 2.0.14 -> 2.0.15`                                                |
| [`14575438`](https://github.com/NixOS/nixpkgs/commit/14575438126b6813f67f66100ac8bc79d6109a88) | `nco: add darwin support`                                                    |
| [`18df4e28`](https://github.com/NixOS/nixpkgs/commit/18df4e28c44ac5dfc36002395ccdb365e0df9bae) | `netcdfcxx4: disable tests`                                                  |
| [`7ed391ef`](https://github.com/NixOS/nixpkgs/commit/7ed391ef2cc5d9febbbf8ab061750e761d89d312) | `usbutils: 014 -> 015`                                                       |
| [`366d3c64`](https://github.com/NixOS/nixpkgs/commit/366d3c64f5541a0303519b3180554694a0ad1a08) | `antlr2: drop python2`                                                       |
| [`68c880d2`](https://github.com/NixOS/nixpkgs/commit/68c880d26dbc45015bc06763fffb5319ac80e86b) | `wxhexeditor: python2 -> python3`                                            |
| [`4ff9ef84`](https://github.com/NixOS/nixpkgs/commit/4ff9ef84c7f7e70e7ceb5446934bcdaabd772ade) | `skawarePackages: refactor`                                                  |
| [`4222bb39`](https://github.com/NixOS/nixpkgs/commit/4222bb39834e3ac5d85fca19b90d2f5dbb9f69c8) | `python310Packages.pytibber: 0.26.1 -> 0.26.3`                               |
| [`0b5a0cbc`](https://github.com/NixOS/nixpkgs/commit/0b5a0cbc69f18f2a123bf4ae0751ee718ef04e53) | `nixos/profiles/base: install vim w/nix-syntax plugin`                       |
| [`0733f1c3`](https://github.com/NixOS/nixpkgs/commit/0733f1c351afb9c81c96d844a8a8fa188da8284d) | `python310Packages.gql: disable failing tests`                               |
| [`0efb882d`](https://github.com/NixOS/nixpkgs/commit/0efb882d3f9bda5382110b6e5b59be14203fbb70) | `python310Packages.rapidfuzz: add CMake flags to fix build on x86_64-darwin` |
| [`cd53948d`](https://github.com/NixOS/nixpkgs/commit/cd53948d6d61b330aa59756b8e2e1f77a9cb0f37) | `python310Packages.rapidfuzz: disable LTO to fix aarch64-darwin build`       |
| [`927aa4b3`](https://github.com/NixOS/nixpkgs/commit/927aa4b3890fc0e6c92a7ebddf15bf7c95b7a446) | `julia: skip test expecting mbedtls 2.28.0`                                  |
| [`645b5a2f`](https://github.com/NixOS/nixpkgs/commit/645b5a2f9fcad1df56999256cb1e066ceca1c721) | `Revert "nixos/lib: add /home to pathsNeededForBoot"`                        |
| [`98de9308`](https://github.com/NixOS/nixpkgs/commit/98de93088dd48fb1b6fa6522be50c062c53c229d) | `gnomeExtensions.arcmenu: 37 -> 43`                                          |
| [`e7c1b2c3`](https://github.com/NixOS/nixpkgs/commit/e7c1b2c3ff0446eb6da83f8c71264dadaf56a181) | `python310Packages.pyswitchbot: 0.20.6 -> 0.20.7`                            |
| [`66cdfc6d`](https://github.com/NixOS/nixpkgs/commit/66cdfc6dfc02c615f830c1c0f1a07332fcd0e922) | `python310Packages.pyswitchbot: 0.20.5 -> 0.20.6`                            |
| [`ce0ae207`](https://github.com/NixOS/nixpkgs/commit/ce0ae2073a51852a1cb9253b5d634fe3cb1fb64f) | `python310Packages.lupupy: 0.1.9 -> 0.2.1`                                   |
| [`8d26811a`](https://github.com/NixOS/nixpkgs/commit/8d26811a097084984f2e06402db9b2a2ad92e4e8) | `python310Packages.elkm1-lib: 2.1.0 -> 2.2.1`                                |
| [`624ebef9`](https://github.com/NixOS/nixpkgs/commit/624ebef9015ec50ef3f2e1ab0d77db57385c3c74) | `python310Packages.elkm1-lib: add changelog to meta`                         |
| [`b0361a4a`](https://github.com/NixOS/nixpkgs/commit/b0361a4ab726726267ffa5fefe766de333a68c72) | `python310Packages.python-fullykiosk: 0.0.11 -> 0.0.12`                      |
| [`fcc70988`](https://github.com/NixOS/nixpkgs/commit/fcc7098838cdb29d162decfef28706917fe5fa88) | `python310Packages.python-fullykiosk: add changelog to meta`                 |
| [`1880b77b`](https://github.com/NixOS/nixpkgs/commit/1880b77bca6d1a4d69add0b14801a44ecc27c99c) | `python310Packages.pycomfoconnect: 0.4 -> 0.5.1`                             |
| [`c5f22dfc`](https://github.com/NixOS/nixpkgs/commit/c5f22dfc627bc87bca115347f34e917eab1fbf67) | `python310Packages.pycomfoconnect: add changelog to meta`                    |
| [`0fabdf73`](https://github.com/NixOS/nixpkgs/commit/0fabdf73bb9d2e52a31bd59f417ecd06571fb4da) | `maintainers: add DomesticMoth`                                              |
| [`da053d00`](https://github.com/NixOS/nixpkgs/commit/da053d008fb0761a572cc1270b625c4e64c99da7) | `maintainers: remove and add hmenke`                                         |
| [`15a68973`](https://github.com/NixOS/nixpkgs/commit/15a6897362a6bc21226d8c47a378fbbb4d924348) | `cargo-pgx: 0.5.6 -> 0.6.0`                                                  |
| [`87f13e01`](https://github.com/NixOS/nixpkgs/commit/87f13e014268d469503d76a77ac7da6862b232b3) | `pgamin4: 6.16 -> 6.17`                                                      |
| [`6fa55c74`](https://github.com/NixOS/nixpkgs/commit/6fa55c7487ddf449d087656ce50e8b746243f67c) | `tomlcpp: 0.pre+date=2022-05-01 -> 0.pre+date=2022-06-25`                    |
| [`87bca92e`](https://github.com/NixOS/nixpkgs/commit/87bca92e55e389eafaa0089cc8f7f534a2ae353e) | `vscode-extensions.james-yu.latex-workshop: 9.0.0 -> 9.1.0`                  |
| [`ce1e4a57`](https://github.com/NixOS/nixpkgs/commit/ce1e4a57e4c1a8f839ec145ec23f899cff87f2dd) | `python310Packages.appthreat-vulnerability-db: 4.1.5 -> 4.1.6`               |
| [`c5539bc2`](https://github.com/NixOS/nixpkgs/commit/c5539bc2127eccc327d9ef10b8ab2d031083443a) | `python310Packages.appthreat-vulnerability-db: 4.0.4 -> 4.1.5`               |
| [`617fb197`](https://github.com/NixOS/nixpkgs/commit/617fb1977816d054977b8fab56c6b945ae9e48ef) | `python310Packages.google-apitools: init at 0.5.32`                          |
| [`1dc66ce3`](https://github.com/NixOS/nixpkgs/commit/1dc66ce35479bbaf7a6e581867a9aec2cf0bba41) | `python310Packages.google-reauth: init at 0.1.1`                             |
| [`63713a81`](https://github.com/NixOS/nixpkgs/commit/63713a8130df764146444207d815a21453e4940d) | `jackett: 0.20.2297 -> 0.20.2318`                                            |