### PR TITLE
chore(flake/emacs-overlay): `2f7fff8e` -> `49e3c66d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670295974,
-        "narHash": "sha256-+oQzBTxrWag9XnIndTUXvilI78fuIlhRQ+iNtBrlUF8=",
+        "lastModified": 1670350440,
+        "narHash": "sha256-C/7MnSMXUS2oa2doCalfHd6USgh1jmys33qmvd1o91U=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2f7fff8ee668c01803cab2f0847151fdf647134e",
+        "rev": "49e3c66d211d5110909375fe48d85c3c43753d61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`49e3c66d`](https://github.com/nix-community/emacs-overlay/commit/49e3c66d211d5110909375fe48d85c3c43753d61) | `Updated repos/melpa` |
| [`dcebfe77`](https://github.com/nix-community/emacs-overlay/commit/dcebfe77d4e54c74bdf98863abd6a33878b94301) | `Updated repos/emacs` |
| [`a5342a40`](https://github.com/nix-community/emacs-overlay/commit/a5342a40845f3117a77a664511b77cd9735203f3) | `Updated repos/elpa`  |