### PR TITLE
chore(flake/nixpkgs): `14ddeaeb` -> `6e51c97f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670152712,
-        "narHash": "sha256-LJttwIvJqsZIj8u1LxVRv82vwUtkzVqQVi7Wb8gxPS4=",
+        "lastModified": 1670242877,
+        "narHash": "sha256-jBLh7dRHnbfvPPA9znOC6oQfKrCPJ0El8Zoe0BqnCjQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "14ddeaebcbe9a25748221d1d7ecdf98e20e2325e",
+        "rev": "6e51c97f1c849efdfd4f3b78a4870e6aa2da4198",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                    |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`543070ea`](https://github.com/NixOS/nixpkgs/commit/543070eafe8d5e86ebaa3095fd1e568db09b9b73) | `ocamlPackages.gen: 0.5 → 1.0`                                                    |
| [`31a9917a`](https://github.com/NixOS/nixpkgs/commit/31a9917ad28cb6c0d4b27057d7d03886d86d964c) | `roundcubePlugins.custom_from: init at 1.6.6`                                     |
| [`221b44a0`](https://github.com/NixOS/nixpkgs/commit/221b44a07175050f7ed4534e5ea75cd180edc6d5) | `coq: 8.16.0 → 8.16.1`                                                            |
| [`da52ce18`](https://github.com/NixOS/nixpkgs/commit/da52ce18b67bad743a45b314693b8a143b7c906a) | `coqPackages.VST: add support for Coq 8.16.1`                                     |
| [`3eb6874b`](https://github.com/NixOS/nixpkgs/commit/3eb6874bda0b517574ecfa06a7cf536fe322b42b) | `compcert: add support for Coq 8.16.1`                                            |
| [`4590da9d`](https://github.com/NixOS/nixpkgs/commit/4590da9d9c2c4d59ea10667124b0092b1e2a041a) | `terraform-providers.keycloak: 4.0.1 → 4.1.0`                                     |
| [`47a9f2f8`](https://github.com/NixOS/nixpkgs/commit/47a9f2f8f892b8c32f1736e6bac759465d949be9) | `spdx-license-list-data: 3.18 -> 3.19`                                            |
| [`02d25d3f`](https://github.com/NixOS/nixpkgs/commit/02d25d3fee5431990cc69df296dc44c53d573edf) | `esbuild: 0.15.17 -> 0.15.18`                                                     |
| [`709ab669`](https://github.com/NixOS/nixpkgs/commit/709ab669fe59aca3c984c90211bfe89d674da744) | `skaffold: 2.0.2 -> 2.0.3`                                                        |
| [`04084c17`](https://github.com/NixOS/nixpkgs/commit/04084c1775a7719e53d55bc465410ea5f8540504) | `sentry-cli: 2.9.0 -> 2.10.0`                                                     |
| [`de66678a`](https://github.com/NixOS/nixpkgs/commit/de66678a605ee3acb6ab65f9f68fceaab7ed0a5c) | `nixos/no-x-libs: add zbar`                                                       |
| [`d0ffce42`](https://github.com/NixOS/nixpkgs/commit/d0ffce42bba02f505d2038b13b88e52ade242fa7) | `nixos/no-x-libs: add imagemagick/imagemagickBig`                                 |
| [`4312ffd1`](https://github.com/NixOS/nixpkgs/commit/4312ffd16a37b560de9275440b51a3e962d1a207) | `zbar: add option to disable Xorg`                                                |
| [`e2219841`](https://github.com/NixOS/nixpkgs/commit/e22198417d98dd1a6da0d5a8fd208819dd923012) | `zbar: fix enableVideo not fully removing gtk/qt`                                 |
| [`ec2c253d`](https://github.com/NixOS/nixpkgs/commit/ec2c253ddd6b872604e10ecccbca1a626653d193) | `resvg: 0.27.0 -> 0.28.0`                                                         |
| [`58e794cd`](https://github.com/NixOS/nixpkgs/commit/58e794cdb44db6260aa415bb0ce7fe2fcfef0202) | `freenet: use jna from nixpkgs, not upstream bundled one`                         |
| [`a64dcea5`](https://github.com/NixOS/nixpkgs/commit/a64dcea595c7085ab1add8dddd5d7c1cc088d17d) | `jna: init at 4.5.2`                                                              |
| [`b43144ac`](https://github.com/NixOS/nixpkgs/commit/b43144ac4321f23090d64435582e5fd424e4237e) | `python310Packages.zodb: add changelog to meta`                                   |
| [`2e5c324f`](https://github.com/NixOS/nixpkgs/commit/2e5c324f7a78bf76802ad0c399feb1c0b5735856) | `python310Packages.line_profiler: add changelog to meta`                          |
| [`b7ec087e`](https://github.com/NixOS/nixpkgs/commit/b7ec087ea79a6d3f9ab21c36ab3fc697765d68f6) | `python310Packages.pudb: add changelog to meta`                                   |
| [`9aad74a1`](https://github.com/NixOS/nixpkgs/commit/9aad74a1620b7ef5a0ba49aab941aba9569bb4c8) | `python310Packages.pulumi-aws: add changelog`                                     |
| [`df29eeac`](https://github.com/NixOS/nixpkgs/commit/df29eeac106e92cc9d1902cf561825e047cb7b1d) | `python310Packages.pynamodb: add changelog to meta`                               |
| [`386fe38b`](https://github.com/NixOS/nixpkgs/commit/386fe38b79f5e43152855a912eca816c7c230fa5) | `python310Packages.pymupdf: add changelog to meta`                                |
| [`1eb4e747`](https://github.com/NixOS/nixpkgs/commit/1eb4e747322e8941c40329b1194f2174c2027b7f) | `pony-corral: add changelog to meta`                                              |
| [`e0e9a50e`](https://github.com/NixOS/nixpkgs/commit/e0e9a50e36be2ad34d96962eed496c9f621592bf) | `rathole: add changelog to meta`                                                  |
| [`f5a56c71`](https://github.com/NixOS/nixpkgs/commit/f5a56c71a03aa5a2bbfb0f875e187701b114cb9a) | `kermit-terminal: 3.7 -> 3.8`                                                     |
| [`8a518d43`](https://github.com/NixOS/nixpkgs/commit/8a518d43000bae6d2b3d88cdae8631335bd10337) | `aerc: substitute awk in filters`                                                 |
| [`a9635bac`](https://github.com/NixOS/nixpkgs/commit/a9635bac97d175f6b154a2db95ba0d9aad9d82ad) | `rathole: 0.4.5 -> 0.4.7`                                                         |
| [`04a55b4b`](https://github.com/NixOS/nixpkgs/commit/04a55b4bcb8b2d7a9ecc923c8fa3a31880e45341) | `librewolf: 107.0-1 -> 107.0.1-2`                                                 |
| [`285898a5`](https://github.com/NixOS/nixpkgs/commit/285898a5523e5498f1f3fe2401b075704e4ccb36) | `python310Packages.keepkey-agent: fix pythonImportsCheck`                         |
| [`49a9d9f4`](https://github.com/NixOS/nixpkgs/commit/49a9d9f42c7e92d4080329079b1bb8e9a0735be2) | `vimPlugins.vim-dotenv: init at 2022-05-15`                                       |
| [`cc7b2213`](https://github.com/NixOS/nixpkgs/commit/cc7b22137c7419162c5d3dae6fbcb20bd2c6a726) | `python310Packages.diff-cover: 7.1.1 -> 7.2.0`                                    |
| [`5b5a1e80`](https://github.com/NixOS/nixpkgs/commit/5b5a1e80565a2e06b8d6f102591f8039d33a173c) | `python310Packages.zdaemon: add changelog to meta`                                |
| [`a59bbf1a`](https://github.com/NixOS/nixpkgs/commit/a59bbf1af9d436f6f7fd071ca1b000d97a66dd0e) | `python310Packages.deezer-python: 5.8.0 -> 5.8.1`                                 |
| [`ba485938`](https://github.com/NixOS/nixpkgs/commit/ba485938581209e1c037bdadb9b1bc4f2ccf0b6e) | `python310Packages.colorful: add changelog to meta`                               |
| [`2f91ac81`](https://github.com/NixOS/nixpkgs/commit/2f91ac81a856d9cc10b22899d58707a98dae0d92) | `wasilibc: Disable bulk memory operations`                                        |
| [`a876ef33`](https://github.com/NixOS/nixpkgs/commit/a876ef3313b02a3aa1c9fcf31fda751b15a51393) | `wasilibc: build firefox in passthru.tests`                                       |
| [`218feac3`](https://github.com/NixOS/nixpkgs/commit/218feac34916d0f83f199d9305049238155bc5fe) | `wasilibc: unstable-2022-04-12 -> 16`                                             |
| [`cf3cef93`](https://github.com/NixOS/nixpkgs/commit/cf3cef938db8cf077a8cf1ecb7a41e998e517a8a) | `uxplay: 1.57 -> 1.58, fix build on darwin (#200514)`                             |
| [`d41aca6e`](https://github.com/NixOS/nixpkgs/commit/d41aca6ea929dbed629c37c315434b649e173f4d) | `sparrow: 1.7.0 -> 1.7.1 (#201321)`                                               |
| [`2d36d576`](https://github.com/NixOS/nixpkgs/commit/2d36d576f81810d72359b3f3be411ca9efe1b13d) | `rPackages.rgl: use xorg.* packages directly instead of xlibsWrapper indirection` |
| [`6f147838`](https://github.com/NixOS/nixpkgs/commit/6f147838c87847c61719e52e623a3ca5d7759ae4) | `python310Packages.crate: 0.27.2 -> 0.28.0`                                       |
| [`b7efc7cc`](https://github.com/NixOS/nixpkgs/commit/b7efc7cc2a33e67582bc0684ee8d65d3dcba934a) | `python310Packages.colorful: 0.5.4 -> 0.5.5`                                      |
| [`1d95fff3`](https://github.com/NixOS/nixpkgs/commit/1d95fff3fb2487877f9da12bf11dd120da4c9575) | `python310Packages.pyezviz: 0.2.0.9 -> 0.2.0.10`                                  |
| [`bc90272d`](https://github.com/NixOS/nixpkgs/commit/bc90272d9fe7f9be84ad89d32a436268d5e48bbc) | `python310Packages.pyezviz: add changelog to meta`                                |
| [`859567c9`](https://github.com/NixOS/nixpkgs/commit/859567c9faeaaa891c84cc347d00f65e36e417b6) | `protoc-gen-connect-go: add changelog to meta`                                    |
| [`d2f57c7a`](https://github.com/NixOS/nixpkgs/commit/d2f57c7a371101f719ac5e887b5ffee6080096f7) | `python310Packages.zdaemon: 4.3 -> 4.4`                                           |
| [`a45cdf38`](https://github.com/NixOS/nixpkgs/commit/a45cdf386b863b27ec8cbcad94f2be546d0d740b) | `protoc-gen-connect-go: 1.2.0 -> 1.3.1`                                           |
| [`58ca556f`](https://github.com/NixOS/nixpkgs/commit/58ca556f3afcaf82aaee21ce2411c7cc4b92e15d) | `odp-dpdk: 1.35.0.0_DPDK_19.11 -> 1.37.0.0_DPDK_19.11`                            |
| [`9330a280`](https://github.com/NixOS/nixpkgs/commit/9330a280be868d669f3a163cb9a1bd138135900d) | `feishu: 5.14.14 -> 5.18.11`                                                      |
| [`8d561ff2`](https://github.com/NixOS/nixpkgs/commit/8d561ff23b06efdff6dd814c91105edecaa8e2d9) | `CODEOWNERS: Add codeowners for cacert related packages`                          |
| [`d91dd6b8`](https://github.com/NixOS/nixpkgs/commit/d91dd6b8a4a89776f3dfba7a99bd93cf7fb7b66c) | `tcb: init at 1.2`                                                                |
| [`7c25415f`](https://github.com/NixOS/nixpkgs/commit/7c25415f66d326da02575dc009e4f02caee918ef) | `svtplay-dl: 4.15 -> 4.17`                                                        |
| [`bc5367de`](https://github.com/NixOS/nixpkgs/commit/bc5367def1b6a043e4e5a70ad5a5fdf755de93b2) | `cplay-ng: init at 5.1.0`                                                         |
| [`2ae17515`](https://github.com/NixOS/nixpkgs/commit/2ae17515e08dd815b8c8cfa5df38893c4ae1ff66) | `nixos/networkd: doc activation of systemd.networkd`                              |
| [`368aa875`](https://github.com/NixOS/nixpkgs/commit/368aa875310f18fc47c4c367f2da24105c86586e) | `mopidy-local: apply patch to fix tests`                                          |
| [`e05bcf68`](https://github.com/NixOS/nixpkgs/commit/e05bcf68017094d579b5d3df791e196de30525d9) | `rustic-rs: 0.4.0 -> 0.4.1`                                                       |
| [`3e5b2436`](https://github.com/NixOS/nixpkgs/commit/3e5b243639786781dbdfcf5a9faba41b1364406a) | `grafana-agent: disable ebpf`                                                     |
| [`a1aef6a7`](https://github.com/NixOS/nixpkgs/commit/a1aef6a7977c8926414910da478839885c69b849) | `pachyderm: 2.4.0 -> 2.4.1`                                                       |
| [`3bea6e3a`](https://github.com/NixOS/nixpkgs/commit/3bea6e3a93e0a8288742aed206ad55a9ff01a6a1) | `gobgpd: 3.8.0 -> 3.9.0`                                                          |
| [`da810d32`](https://github.com/NixOS/nixpkgs/commit/da810d322c7a150b0d2003b5b59df3f37f18a63a) | `gobgp: 3.8.0 -> 3.9.0`                                                           |
| [`403fcb5b`](https://github.com/NixOS/nixpkgs/commit/403fcb5b925fb6d38b7171e2b7a7edc203c996e1) | `cargo-flamegraph: update homepage link`                                          |
| [`8ec8a5c5`](https://github.com/NixOS/nixpkgs/commit/8ec8a5c5c67a1be4dc51614aba81a81acdf10d17) | `trunk-io: 1.2.2 -> 1.2.3`                                                        |
| [`53dfcae8`](https://github.com/NixOS/nixpkgs/commit/53dfcae8a12e2f81fdb788d425aa740272534e3f) | `python310Packages.yamlloader: disable on unsupported Python releases`            |
| [`0334b30d`](https://github.com/NixOS/nixpkgs/commit/0334b30dce4f71dd4dfb8f181a3c562d9feafa63) | `acme-sh: add changelog to meta`                                                  |
| [`ae5a00be`](https://github.com/NixOS/nixpkgs/commit/ae5a00be39afff763f9b752097f9eae588539fb6) | `lightningcss: add changelog to meta`                                             |
| [`16e2038b`](https://github.com/NixOS/nixpkgs/commit/16e2038be90231ad3cab0ef18ca01146576be7e4) | `python310Packages.pydrive2: add changelog to meta`                               |
| [`4542d083`](https://github.com/NixOS/nixpkgs/commit/4542d083d52a66b7d5fd346d549a1eb3d40d7a43) | `fnotifystat: add blank line to improve readability`                              |
| [`a45c3e9b`](https://github.com/NixOS/nixpkgs/commit/a45c3e9b51fa39fa29246b076fa8654adb42a4ab) | `prometheus-consul-exporter: add changelog to meta`                               |
| [`788cdf4c`](https://github.com/NixOS/nixpkgs/commit/788cdf4c905022a57b5c0e110f433ce11934c2d6) | `python310Packages.yamlloader: 1.1.0 -> 1.2.2`                                    |
| [`fa49d3a6`](https://github.com/NixOS/nixpkgs/commit/fa49d3a6850d6d6b80b5296240b52d8711db03c6) | `conftest: add changelog to meta`                                                 |
| [`a6607bae`](https://github.com/NixOS/nixpkgs/commit/a6607bae968cec8840ce5a923338a57585fae21e) | `time-decode: add changelog to meta`                                              |
| [`cc754132`](https://github.com/NixOS/nixpkgs/commit/cc75413251fe574d54d01e4f2e88a20d672173b3) | `python310Packages.aocd: add changelog to meta`                                   |
| [`925a64a3`](https://github.com/NixOS/nixpkgs/commit/925a64a3c92b4d7a1c3af7a922ec52288fd939d5) | `fastly: add changelog to meta`                                                   |
| [`73dc8f96`](https://github.com/NixOS/nixpkgs/commit/73dc8f96c529b19cc28b63cf6cfb5d71431e2e0f) | `operator-sdk: add changelog to meta`                                             |
| [`49f29b0a`](https://github.com/NixOS/nixpkgs/commit/49f29b0abcb7b9272fe01f9fc031012a69029d54) | `antimicrox: 3.3.1 -> 3.3.2`                                                      |
| [`fdfa7cff`](https://github.com/NixOS/nixpkgs/commit/fdfa7cffd824235dd1affe8ca8c9beaed8ceeb80) | `mydumper: add changelog to meta`                                                 |
| [`c4d32f96`](https://github.com/NixOS/nixpkgs/commit/c4d32f968eab628ab4134a801beae21ca429b311) | `mydumper: specify license`                                                       |
| [`d62fab81`](https://github.com/NixOS/nixpkgs/commit/d62fab813277a0da9d116ec61b9645920c66a1cb) | `praat: 6.3 -> 6.3.01`                                                            |
| [`5d80334c`](https://github.com/NixOS/nixpkgs/commit/5d80334cccd20c6325fda951205193a46d3ad3cd) | `tagger: 2022.11.1-f1 -> 2022.11.2`                                               |
| [`9aaca7a4`](https://github.com/NixOS/nixpkgs/commit/9aaca7a47e80341728a9a34f2f01db8fb3f83c89) | `operator-sdk: 1.25.2 -> 1.25.3`                                                  |
| [`f355b08c`](https://github.com/NixOS/nixpkgs/commit/f355b08c029c75f70cfb913050ee65c2e1de717b) | `lokinet: add changelog to meta`                                                  |
| [`e28c015b`](https://github.com/NixOS/nixpkgs/commit/e28c015ba2f16c5d3062ddb98de27e52866cffc4) | `open-vm-tools: add changelog to meta`                                            |
| [`0119d0ed`](https://github.com/NixOS/nixpkgs/commit/0119d0eda00e308b75cb09dc71ee152a5347210a) | `pythonPackages.opentimestamps: 0.4.2 -> 0.4.3`                                   |
| [`16b303d6`](https://github.com/NixOS/nixpkgs/commit/16b303d65b273d80094d8ce0ae7eb18bf613bb73) | `opentimestamps-client: add maintainer`                                           |
| [`f264e5e5`](https://github.com/NixOS/nixpkgs/commit/f264e5e5325909380c7cdeb0d02e62d1bed885c4) | `oapi-codegen: add changelog to meta`                                             |
| [`b9f0c28f`](https://github.com/NixOS/nixpkgs/commit/b9f0c28f6c0e0e0ddf012c447ab6e66c368b014d) | `buildMozillaMach: Cleanup obsolete version gates`                                |
| [`19759744`](https://github.com/NixOS/nixpkgs/commit/19759744324a11e04aaec13ab50a6e6eef2d5ecb) | `oh-my-posh: add changelog to meta`                                               |
| [`f10b493a`](https://github.com/NixOS/nixpkgs/commit/f10b493aa59baba06e05013e5a0cbdb7d0d9cdc1) | `open-vm-tools: 12.1.0 -> 12.1.5`                                                 |
| [`7080d3ab`](https://github.com/NixOS/nixpkgs/commit/7080d3ab55b24db73bac1931ed0176398dfda0a6) | `oh-my-posh: 12.22.0 -> 12.25.0`                                                  |
| [`e8f04fd7`](https://github.com/NixOS/nixpkgs/commit/e8f04fd71592be621ca39539e88894f612f77855) | `odo: 3.2.0 -> 3.3.0`                                                             |
| [`e02d05e9`](https://github.com/NixOS/nixpkgs/commit/e02d05e962c7e477d119ae6ca17a1cf915474e69) | `oapi-codegen: 1.12.3 -> 1.12.4`                                                  |
| [`7821c619`](https://github.com/NixOS/nixpkgs/commit/7821c619933a9d1a59ef00bbc747c2b5e694468d) | `nmap-formatter: 2.0.2 -> 2.0.4`                                                  |
| [`c2c5013a`](https://github.com/NixOS/nixpkgs/commit/c2c5013a47e8261375965cd83667b166a0616cd5) | `python310Packages.pyswitchbot: 0.20.7 -> 0.20.8`                                 |
| [`0856aceb`](https://github.com/NixOS/nixpkgs/commit/0856aceb9f44873df3d382e2dedb14efd98c6224) | `python310Packages.yalexs-ble: 1.10.3 -> 1.10.3`                                  |
| [`3a148714`](https://github.com/NixOS/nixpkgs/commit/3a148714a5a818a2f2f2605abdc7b879c9692442) | `python310Packages.aioecowitt: 2022.09.3 -> 2022.11.0`                            |
| [`bdd6f483`](https://github.com/NixOS/nixpkgs/commit/bdd6f483ae280fa0990406fd117dc21bbf407f07) | `perccli: stylistic rewrite`                                                      |
| [`adafebe3`](https://github.com/NixOS/nixpkgs/commit/adafebe352536dc4fa58d713e5f3b29085527a02) | `python310Packages.yolink-api: 0.1.0 -> 0.1.5`                                    |
| [`999b9f79`](https://github.com/NixOS/nixpkgs/commit/999b9f7978c8059022832cb2d9e1caec5006181d) | `python310Packages.yolink-api: add changelog to meta`                             |
| [`846af65f`](https://github.com/NixOS/nixpkgs/commit/846af65f2732c83b03cd656d0ab510751d54f023) | `perccli: 7.1910.00 -> 7.2110.00`                                                 |
| [`846b4de5`](https://github.com/NixOS/nixpkgs/commit/846b4de5b80b1be104fb10ee2bb2f91eaf637f99) | `storcli: add support for aarch64-linux`                                          |
| [`531b2be1`](https://github.com/NixOS/nixpkgs/commit/531b2be1af04b3a4a5fc6647274e0de15a8f17ae) | `python310Packages.async-upnp-client: 0.32.2 -> 0.32.3`                           |
| [`e3ac8c7b`](https://github.com/NixOS/nixpkgs/commit/e3ac8c7b692da04dedeb3cda9c74fe72dcf894d7) | `python310Packages.async-upnp-client: add changelog ot meta`                      |
| [`b7b1183a`](https://github.com/NixOS/nixpkgs/commit/b7b1183aed75eec4a5ae0d4dcfb4c59bc1ee048a) | `nearcore: 1.29.1 -> 1.29.2`                                                      |
| [`59074588`](https://github.com/NixOS/nixpkgs/commit/590745888b0a0e1bb0c9be67bf195815f795178b) | `python310Pacakges.emoji: add changelog to meta`                                  |
| [`0cb9f448`](https://github.com/NixOS/nixpkgs/commit/0cb9f44808f2d3d9c3b38e4dbf2c9bc0393228c6) | `python310Packages.ical: 4.1.1 -> 4.1.2`                                          |
| [`7b68789d`](https://github.com/NixOS/nixpkgs/commit/7b68789d3e6848c2e90e3af353e180793a4bddc5) | `python310Packages.aiolyric: add changelog to meta`                               |
| [`b3b74074`](https://github.com/NixOS/nixpkgs/commit/b3b74074b0bc941252374b84e78c79753782fd2f) | `python310Packages.nibe: 1.2.1 -> 1.5.0`                                          |
| [`fb7c7ce0`](https://github.com/NixOS/nixpkgs/commit/fb7c7ce096274a5427f013c75ea6d48f1abd68ae) | `python310Packages.nibe: add changelog to meta`                                   |
| [`dae6f9c7`](https://github.com/NixOS/nixpkgs/commit/dae6f9c7a828ea93cbcd8a5c29b2750e695874d2) | `python310Packages.aiolookin: 0.1.1 -> 1.0.0`                                     |