### PR TITLE
chore(flake/emacs-overlay): `49e3c66d` -> `b57c104d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670350440,
-        "narHash": "sha256-C/7MnSMXUS2oa2doCalfHd6USgh1jmys33qmvd1o91U=",
+        "lastModified": 1670375544,
+        "narHash": "sha256-B1EZDvaZKZ3Rsp/AZu2VzXzekfZL/np1wrePHCIWc9o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "49e3c66d211d5110909375fe48d85c3c43753d61",
+        "rev": "b57c104d0b4bcea51426271b32f18776d7667a72",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                                |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
| [`b57c104d`](https://github.com/nix-community/emacs-overlay/commit/b57c104d0b4bcea51426271b32f18776d7667a72) | `Revert "Revert "add tree sitter languages to rpath (#273)""` |