### PR TITLE
chore(flake/pre-commit-hooks): `32dcd719` -> `607521be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -491,11 +491,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1670285270,
-        "narHash": "sha256-xNWM2Qcqc4NwoR1bubjOBUNh85hYkY26QouGBSfOAss=",
+        "lastModified": 1670405695,
+        "narHash": "sha256-240KGbqtLKBOfJGRgbvLjkJiIquPubpst9WMHfyHhDA=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "32dcd71912ca8f925f8f0715a554e8490d556883",
+        "rev": "607521bec0cd1e8483b8d4ead7f23433ff19c0a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message |
| ------------------------------------------------------------------------------------------------------------ | -------------- |
| [`e4411607`](https://github.com/cachix/pre-commit-hooks.nix/commit/e44116074b57ac1be2f4334313f4ef414d022fa5) | `Add flake8`   |
| [`c218cba0`](https://github.com/cachix/pre-commit-hooks.nix/commit/c218cba04b375d63c52a9ae33b3a32a238b6630b) | `Add Pylint`   |