### PR TITLE
chore(flake/emacs-overlay): `f45b1882` -> `467fee47`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670382699,
-        "narHash": "sha256-N/o1fM4+Fw+JpnPxSoGyRVPlOdoDY+biVY1u0uQduWc=",
+        "lastModified": 1670409362,
+        "narHash": "sha256-kwiitU3k4FhWoosBmzgD7TyF9MVLtyGH+a3BVIxSL1w=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f45b18820505d7b3549c6cf886a90cdd39ca33b4",
+        "rev": "467fee473347adb1f4527a3375e996f879bf817a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`467fee47`](https://github.com/nix-community/emacs-overlay/commit/467fee473347adb1f4527a3375e996f879bf817a) | `Updated repos/melpa` |
| [`e2355f56`](https://github.com/nix-community/emacs-overlay/commit/e2355f5689f49ba43477a1a05a80df4b1d5b51d0) | `Updated repos/emacs` |