### PR TITLE
chore(flake/emacs-overlay): `467fee47` -> `e9c4d10b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670409362,
-        "narHash": "sha256-kwiitU3k4FhWoosBmzgD7TyF9MVLtyGH+a3BVIxSL1w=",
+        "lastModified": 1670438727,
+        "narHash": "sha256-c8SAz45BtQTZLxX0BRoj7aGlk6jogjlTE7Tj40lQr6Q=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "467fee473347adb1f4527a3375e996f879bf817a",
+        "rev": "e9c4d10bbb4e810cbfe5e31248fe835e08efb35a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`e9c4d10b`](https://github.com/nix-community/emacs-overlay/commit/e9c4d10bbb4e810cbfe5e31248fe835e08efb35a) | `Updated repos/melpa` |
| [`52db2512`](https://github.com/nix-community/emacs-overlay/commit/52db25120dde17364e07c8a4f6fceb701f96a98c) | `Updated repos/emacs` |