### PR TITLE
chore(flake/nur): `25c0b2f7` -> `cc349088`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1670387514,
-        "narHash": "sha256-dSsoDMyoVwy60ZaGJNoCXEzYToYfdV6XYyadnliMJnE=",
+        "lastModified": 1670473911,
+        "narHash": "sha256-YzD6BoE8sOkgTUukz92JmIrJoubXRB906R5FOgQi7Js=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "25c0b2f7f43cbe50bf17f5c190c0aa6231d3754f",
+        "rev": "cc349088c02cb52dcf16038a9a80e2c938c3b5de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`cc349088`](https://github.com/nix-community/NUR/commit/cc349088c02cb52dcf16038a9a80e2c938c3b5de) | `automatic update` |