### PR TITLE
chore(flake/emacs-overlay): `45cc4b01` -> `269cf763`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670468462,
-        "narHash": "sha256-FnV4mR+gWBCclkHRIwT5vqly/kVBlaEWyAjLeVAkglU=",
+        "lastModified": 1670494225,
+        "narHash": "sha256-Pb4ZfjIxBznbfTsWEkYc2FVB41yyfqh20nhmLk67LuI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "45cc4b01c55c0b18944637b186d37942517901e9",
+        "rev": "269cf7633d51bd316e00ba35467e8a5f5136d28c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`269cf763`](https://github.com/nix-community/emacs-overlay/commit/269cf7633d51bd316e00ba35467e8a5f5136d28c) | `Updated repos/melpa` |
| [`97b7d6b7`](https://github.com/nix-community/emacs-overlay/commit/97b7d6b717a038f6443c88faf410c116ef97a898) | `Updated repos/emacs` |