### PR TITLE
chore(flake/nur): `037aa15e` -> `a787c828`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1670486421,
-        "narHash": "sha256-uaw+db9i01dw08OipPGPiYg5RGQELJlxEHGJoGvgTjU=",
+        "lastModified": 1670518674,
+        "narHash": "sha256-mFHgBF7ZialPRoL4y7C8CvOusfZwmYiZ9iGZ5BikXyQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "037aa15e50727322f46ed49e3a4570260e4ca19f",
+        "rev": "a787c828ffd154258c04c4ac9c7cf8fd2e9e486d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message             |
| -------------------------------------------------------------------------------------------------- | -------------------------- |
| [`ef84c6a5`](https://github.com/nix-community/NUR/commit/ef84c6a596b94da344bd666e764b9f65014c4a87) | `format manifest`          |
| [`2f1995e2`](https://github.com/nix-community/NUR/commit/2f1995e2a76bc9122bb37f507f05e9207307bfa5) | `Adding vsoch NUR to list` |