### PR TITLE
chore(flake/nixpkgs): `6e51c97f` -> `64e0bf05`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670242877,
-        "narHash": "sha256-jBLh7dRHnbfvPPA9znOC6oQfKrCPJ0El8Zoe0BqnCjQ=",
+        "lastModified": 1670751203,
+        "narHash": "sha256-XdoH1v3shKDGlrwjgrNX/EN8s3c+kQV7xY6cLCE8vcI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6e51c97f1c849efdfd4f3b78a4870e6aa2da4198",
+        "rev": "64e0bf055f9d25928c31fb12924e59ff8ce71e60",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                           |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`657e1417`](https://github.com/NixOS/nixpkgs/commit/657e1417688556d764ca2214382ad74989df5383) | `infracost: 0.10.13 -> 0.10.14`                                                          |
| [`f23126ab`](https://github.com/NixOS/nixpkgs/commit/f23126ab66cf40edd3cf52da43bb35fcfdc75569) | `kube-linter: 0.5.0 -> 0.5.1`                                                            |
| [`96c45683`](https://github.com/NixOS/nixpkgs/commit/96c456834f611d12708cedc472fb537c6fecf236) | `prometheus-artifactory-exporter: 1.9.5 -> 1.10.0`                                       |
| [`4668b4e2`](https://github.com/NixOS/nixpkgs/commit/4668b4e211d04ad419e424ff183e2ce1a36deb10) | `kics: 1.6.5 -> 1.6.6`                                                                   |
| [`fc3f7a8a`](https://github.com/NixOS/nixpkgs/commit/fc3f7a8ae70e01ff2fee0a147a02c19c902f31c6) | `altair: 5.0.5 -> 5.0.9`                                                                 |
| [`5705a4ab`](https://github.com/NixOS/nixpkgs/commit/5705a4ab95bc0d92193aab383cfb439945adadfe) | `cargo-nextest: 0.9.46 -> 0.9.47`                                                        |
| [`dc29c443`](https://github.com/NixOS/nixpkgs/commit/dc29c443277c6ccd86c912980bfbaba0c29a4af5) | `terraform-providers.bitbucket: 2.23.0 → 2.24.0`                                         |
| [`f30e1cd0`](https://github.com/NixOS/nixpkgs/commit/f30e1cd088548dbbd67ed0c9b0f5e79bb475f558) | `httplib: 0.11.1 -> 0.11.3`                                                              |
| [`8fd00153`](https://github.com/NixOS/nixpkgs/commit/8fd00153ffb8d853e500bfb11135622668fe6928) | `redpanda: 22.3.1 -> 22.3.5`                                                             |
| [`02f60f03`](https://github.com/NixOS/nixpkgs/commit/02f60f038a8c89cb90d7b133c628b148b86cc8c1) | `rust-script: 0.21.0 -> 0.22.0`                                                          |
| [`c135439e`](https://github.com/NixOS/nixpkgs/commit/c135439ed4f4a5053931096bec6c896c607f54dc) | `cargo-nextest: 0.9.45 -> 0.9.46`                                                        |
| [`70ebc593`](https://github.com/NixOS/nixpkgs/commit/70ebc593614cc7a49cee8f67462a82b0df8a1921) | `wander: 0.8.0 -> 0.8.2`                                                                 |
| [`b29ef173`](https://github.com/NixOS/nixpkgs/commit/b29ef173996d5de36ed41bec9ac0dee37ec37028) | `python310Packages.diff-cover: 7.2.0 -> 7.3.0`                                           |
| [`280f04da`](https://github.com/NixOS/nixpkgs/commit/280f04daaffc1ae40d8e50570ee55c151614fa23) | `python310Packages.toggl-cli: relax notify-py version constraint`                        |
| [`df429dc6`](https://github.com/NixOS/nixpkgs/commit/df429dc6476721559cd5d66c0a27789a4042611d) | `python310Packages.notify-py: 0.3.3 -> 0.3.38`                                           |
| [`76e96215`](https://github.com/NixOS/nixpkgs/commit/76e962151ae9dc0660f343afae782a8b6df3b102) | `nixos/tests/evcc: Fail when the unit produces fatal log messages`                       |
| [`fda65523`](https://github.com/NixOS/nixpkgs/commit/fda65523fbb8dd7ef4a2eba4d39f88ce19245713) | `nixos/evcc: Fix unit environment`                                                       |
| [`ad109982`](https://github.com/NixOS/nixpkgs/commit/ad109982a131342b7153ff62346cc3569a919a3b) | `python310Packages.databricks-cli: enable tests`                                         |
| [`23dfe1a2`](https://github.com/NixOS/nixpkgs/commit/23dfe1a2320f8327cea3bc3ee03cb2c3b5afb270) | `python310Packages.databricks-cli: add changelog to meta`                                |
| [`99dc2586`](https://github.com/NixOS/nixpkgs/commit/99dc258685849b22c3c160cf154f8e0ae1e4e380) | `python310Packages.databricks-cli: 0.17.3 -> 0.17.4`                                     |
| [`51d4147b`](https://github.com/NixOS/nixpkgs/commit/51d4147bd028b7b3bd572b993a6ca4b3c112b69f) | `geos: 3.11.0 -> 3.11.1`                                                                 |
| [`e1070d4c`](https://github.com/NixOS/nixpkgs/commit/e1070d4c5261449fe05f4aa22c880e942fb15aa3) | `process-compose: add changelog to meta`                                                 |
| [`a0cc9d8d`](https://github.com/NixOS/nixpkgs/commit/a0cc9d8d7b1ec4bde63160f7f90fc994efeee814) | `prometheus-influxdb-exporter: add changelog to meta`                                    |
| [`78a8d5bd`](https://github.com/NixOS/nixpkgs/commit/78a8d5bd0c125f40a622ebf045a9d8daeec8e94a) | `prometheus-statsd-exporter: add changelog to meta`                                      |
| [`f397db39`](https://github.com/NixOS/nixpkgs/commit/f397db3947dbe5bfaf01fd7498b8afa622299302) | `python310Packages.velbus-aio: 2022.10.4 -> 2022.12.0`                                   |
| [`55c4146f`](https://github.com/NixOS/nixpkgs/commit/55c4146f390bc4b7d0000791cfb495e4033d5ce6) | `python310Packages.velbus-aio: add changelog to meta`                                    |
| [`dcab0ebe`](https://github.com/NixOS/nixpkgs/commit/dcab0ebe6a2d790963615bd2c25fa7439380a02f) | `python310Packages.androidtv: 0.0.69 -> 0.0.70`                                          |
| [`4400bb23`](https://github.com/NixOS/nixpkgs/commit/4400bb23f367eda7bd5e8ff5be18ea05553e3325) | `python310Packages.hap-python: 4.5.0 -> 4.6.0`                                           |
| [`5c036da6`](https://github.com/NixOS/nixpkgs/commit/5c036da61115662a10adbe372612e2b21ce10cac) | `python310Packages.hap-python: add changelog to meta`                                    |
| [`d38dc84a`](https://github.com/NixOS/nixpkgs/commit/d38dc84a1caae9c1e0272684aa9aaf80f898bd6b) | `python310Packages.rapidfuzz: 2.13.3 -> 2.13.4`                                          |
| [`2309d5a5`](https://github.com/NixOS/nixpkgs/commit/2309d5a571ff017408dc2b091c8b3fca20b98b27) | `python310Packages.rapidfuzz: cleanup`                                                   |
| [`75300fb3`](https://github.com/NixOS/nixpkgs/commit/75300fb33d096f6f08b065992d883aaa7d25a79a) | `nbstripout: 0.6.0 -> 0.6.1`                                                             |
| [`32c555f1`](https://github.com/NixOS/nixpkgs/commit/32c555f1c26b1759fb8494e72eebc4563c3e9427) | `devpi-client: don't depend on pytest-flake8`                                            |
| [`e31ad37f`](https://github.com/NixOS/nixpkgs/commit/e31ad37f109b0786bb7981723aebadb136a31b38) | `devpi-server: don't depend on pytest-flake8`                                            |
| [`02d780ef`](https://github.com/NixOS/nixpkgs/commit/02d780efe51573aaf65eecdd846996a01aa96f46) | `python310Packages.devpi-common: don't depend on pytest-flake8`                          |
| [`a0b2da31`](https://github.com/NixOS/nixpkgs/commit/a0b2da31160a16d13d39873b5de82f3550b17bef) | `python310Packages.pytest-flake8: mark broken`                                           |
| [`b3590bf4`](https://github.com/NixOS/nixpkgs/commit/b3590bf49846edee66ae445a070118b277f24b96) | `python310Packages.flake8: 5.0.4 -> 6.0.0`                                               |
| [`3a2e1fcd`](https://github.com/NixOS/nixpkgs/commit/3a2e1fcdd319f5bb4dce8b69abafc1fd0635079d) | `python310Packages.pycodestyle: 2.9.1 -> 2.10.0`                                         |
| [`e2f54dec`](https://github.com/NixOS/nixpkgs/commit/e2f54dec753940bcc2de4a291db2be6497db867d) | `python310Packages.pyflakes: 2.5.0 -> 3.0.1`                                             |
| [`795aa422`](https://github.com/NixOS/nixpkgs/commit/795aa4229078ec93fa19b949ccf76e7ab2a38f7d) | `pt2-clone: 1.54 -> 1.55`                                                                |
| [`c7ad50f4`](https://github.com/NixOS/nixpkgs/commit/c7ad50f48699f8c3048dce2c84a2a990c124434d) | `prometheus-statsd-exporter: 0.22.8 -> 0.23.0`                                           |
| [`f8b73b82`](https://github.com/NixOS/nixpkgs/commit/f8b73b826a74b566776cce911390d91879d87efa) | `prometheus-influxdb-exporter: 0.10.0 -> 0.11.1`                                         |
| [`917fca39`](https://github.com/NixOS/nixpkgs/commit/917fca391353f976e8e9f54ffcd979c9e1bd60c6) | `process-compose: 0.28.0 -> 0.29.0`                                                      |
| [`e19d35a2`](https://github.com/NixOS/nixpkgs/commit/e19d35a2a51bc72f4d593c0908b4798c0946b8a5) | `plantuml: 1.2022.13 -> 1.2022.14`                                                       |
| [`477e7641`](https://github.com/NixOS/nixpkgs/commit/477e76410c46b2e34a24945bfbe9239a19eae1d0) | `miniflux: 2.0.40 → 2.0.41`                                                              |
| [`ccf0f09e`](https://github.com/NixOS/nixpkgs/commit/ccf0f09e2e6744dcd721860a44c633e8708fde2b) | `nsjail: 3.2 -> 3.3`                                                                     |
| [`44bec8f7`](https://github.com/NixOS/nixpkgs/commit/44bec8f79d5063bb78511328e2363916b231221b) | `page: 4.3.0 -> 4.4.0`                                                                   |
| [`c82e96df`](https://github.com/NixOS/nixpkgs/commit/c82e96df6f9b0f3b04bd287dcdecaf4855b173e1) | `oven-media-engine: 0.14.16 -> 0.14.17`                                                  |
| [`945182bc`](https://github.com/NixOS/nixpkgs/commit/945182bc68d3f28cb83c9458faef63c43f27e5b8) | `netbox: 3.3.5 -> 3.3.9`                                                                 |
| [`01943196`](https://github.com/NixOS/nixpkgs/commit/019431968a64a012308ed4a310fca0b9a6d38120) | `python310Packages.ttls: 1.5.1 -> 1.6.1`                                                 |
| [`e27d2edf`](https://github.com/NixOS/nixpkgs/commit/e27d2edf934bee6e0e3dd65e801161a53e98a620) | `nats-server: add changelog to meta`                                                     |
| [`0c7665d0`](https://github.com/NixOS/nixpkgs/commit/0c7665d03ebbf7859f84c40d7d31ce18deed49cc) | `python310Packages.dissect: 3.2 -> 3.3`                                                  |
| [`7b131f4b`](https://github.com/NixOS/nixpkgs/commit/7b131f4bf915ffb013fc4cb6a86fd64d7e3d42fe) | `oh-my-posh: 12.25.0 -> 12.26.1`                                                         |
| [`973dc457`](https://github.com/NixOS/nixpkgs/commit/973dc4579f231277a0c8bd5984ba1daef76bcf60) | `python310Packages.dissect-target: add new input dissect-thumbcache`                     |
| [`8b2f69ef`](https://github.com/NixOS/nixpkgs/commit/8b2f69ef6aca73321e23d840ffca3a738187aefe) | `python310Packages.dissect-thumbcache: init at 1.1`                                      |
| [`a27e2053`](https://github.com/NixOS/nixpkgs/commit/a27e205374595746eef462b350d732ed11aa9a65) | `nixpacks: 0.15.0 -> 0.16.0`                                                             |
| [`745a9856`](https://github.com/NixOS/nixpkgs/commit/745a9856c6b81669186331ff845b7464b1652bba) | `nickel: 0.2.1 -> 0.3.0`                                                                 |
| [`6103a7e5`](https://github.com/NixOS/nixpkgs/commit/6103a7e5a0f5fada923c1df6a75aeccc1de27d47) | `python310Packages.pyswitchbee: add changelog to meta`                                   |
| [`d5daa9ef`](https://github.com/NixOS/nixpkgs/commit/d5daa9ef40cb373331ea62d4b08e98b2ec2a654b) | `python310Packages.flow-record: 3.5 -> 3.7`                                              |
| [`79140821`](https://github.com/NixOS/nixpkgs/commit/791408211753543619083ed83217c9a65e44bd60) | `netbird: 0.11.4 -> 0.11.5`                                                              |
| [`ff39a158`](https://github.com/NixOS/nixpkgs/commit/ff39a1583b46159c9b522f3ded2d5077056cece4) | `python310Packages.netio: 1.0.6 -> 1.0.7`                                                |
| [`7a82b1aa`](https://github.com/NixOS/nixpkgs/commit/7a82b1aac7dbd1fe5f02eaa00da5786a0cedfdb7) | `python310Packages.netio: add changelog to meta`                                         |
| [`810c6124`](https://github.com/NixOS/nixpkgs/commit/810c61244dd799af035519eb5934651ab22ea51b) | `python310Packages.dissect-xfs: 3.1 -> 3.2`                                              |
| [`af538dbe`](https://github.com/NixOS/nixpkgs/commit/af538dbeff21ea0f9a30e46a8a3a3d54607b7c21) | `python310Packages.dissect-volume: 3.1 -> 3.2`                                           |
| [`a2507843`](https://github.com/NixOS/nixpkgs/commit/a2507843ab76fc355db8432a8887733cb9087b81) | `python310Packages.dissect-vmfs: 3.1 -> 3.2`                                             |
| [`de897eb4`](https://github.com/NixOS/nixpkgs/commit/de897eb4f1ee04ba65983bcc3c968732efacf79e) | `python310Packages.dissect-util: 3.2 -> 3.3`                                             |
| [`34de5ed9`](https://github.com/NixOS/nixpkgs/commit/34de5ed97f2339bda1bcd897ce5ac07d7a70d579) | `python310Packages.dissect-target: 3.3 -> 3.4`                                           |
| [`6e6fa9d8`](https://github.com/NixOS/nixpkgs/commit/6e6fa9d8294c68fc0667366a797982d9723b93a5) | `python310Packages.dissect-sql: 3.1 -> 3.2`                                              |
| [`ba4b4ad5`](https://github.com/NixOS/nixpkgs/commit/ba4b4ad598587a3a1fd5d63241fe7c2342be01b2) | `python310Packages.dissect-shellitem: 3.1 -> 3.2`                                        |
| [`a04a8b36`](https://github.com/NixOS/nixpkgs/commit/a04a8b36886b06e49f222c54690f4f85b68b9e8a) | `python310Packages.dissect-regf: 3.1 -> 3.2`                                             |
| [`90c0a7fe`](https://github.com/NixOS/nixpkgs/commit/90c0a7fecd84c21e265e351ca61a48ccd9cce160) | `python310Packages.dissect-ole: 3.1 -> 3.2`                                              |
| [`e2b51d68`](https://github.com/NixOS/nixpkgs/commit/e2b51d6805d9691d40b6b62a1a532e0bf38a3a59) | `python310Packages.dissect-ntfs: 3.1 -> 3.2`                                             |
| [`4d3fa06b`](https://github.com/NixOS/nixpkgs/commit/4d3fa06bfb55d8b96a17a1c7857e0c58d17e3791) | `python310Packages.dissect-hypervisor: 3.2 -> 3.3`                                       |
| [`2df77f81`](https://github.com/NixOS/nixpkgs/commit/2df77f818c5246fd49d46da8401a3c68d4300704) | `python310Packages.dissect-ffs: 3.1 -> 3.2`                                              |
| [`dd9505ef`](https://github.com/NixOS/nixpkgs/commit/dd9505ef740e6c78752a8a8d607b4c96f1cf4872) | `python310Packages.dissect-fat: 3.1 -> 3.2`                                              |
| [`1543d6d4`](https://github.com/NixOS/nixpkgs/commit/1543d6d42473cb3243e0a544c57835c7d0d40f75) | `python310Packages.dissect-extfs: 3.1 -> 3.2`                                            |
| [`0ae29582`](https://github.com/NixOS/nixpkgs/commit/0ae29582cf08a2e20a381a214a38c8f2e6c163f0) | `python310Packages.dissect-evidence: 3.1 -> 3.2`                                         |
| [`9b15e2a3`](https://github.com/NixOS/nixpkgs/commit/9b15e2a3f7aa225f426cb274c40c4bfdab514c21) | `python310Packages.dissect-eventlog: 3.1 -> 3.2`                                         |
| [`01433d04`](https://github.com/NixOS/nixpkgs/commit/01433d0493c338798f0a0d1515b15af2e76ed519) | `python310Packages.dissect-etl: 3.1 -> 3.2`                                              |
| [`af399af2`](https://github.com/NixOS/nixpkgs/commit/af399af20cb719e1f41e12eff96f90c573896bee) | `python310Packages.dissect-esedb: 3.2 -> 3.3`                                            |
| [`c72311b5`](https://github.com/NixOS/nixpkgs/commit/c72311b5f7fb4a39c77ccc94fb034c71e65e0d85) | `python310Packages.dissect-cstruct: 3.2 -> 3.3`                                          |
| [`0635be92`](https://github.com/NixOS/nixpkgs/commit/0635be9221a1efbed19d1b19a5565acade23cdec) | `python310Packages.dissect-clfs: 1.1 -> 1.2`                                             |
| [`7ae09fdc`](https://github.com/NixOS/nixpkgs/commit/7ae09fdc4b706188a726fd38a73a4ee3a95ecb21) | `python310Packages.dissect-cim: 3.2 -> 3.3`                                              |
| [`464b66a6`](https://github.com/NixOS/nixpkgs/commit/464b66a662a22975a568b1492e8dbc8adb8f2bd1) | `nats-server: 2.9.8 -> 2.9.9`                                                            |
| [`e212230b`](https://github.com/NixOS/nixpkgs/commit/e212230b2ddac52b4fab0f4e758ed1edfc437f94) | `meilisearch: add changelog to meta`                                                     |
| [`14fd1bf6`](https://github.com/NixOS/nixpkgs/commit/14fd1bf61c7dc6cec472db9a88f58a892f98cc1e) | `meilisearch: 0.30.0 -> 0.30.2`                                                          |
| [`582c8068`](https://github.com/NixOS/nixpkgs/commit/582c80689da8fcb9d1f18994b04661fafe7978b5) | `python310Packages.acquire: 3.2 -> 3.3`                                                  |
| [`41f9d0cf`](https://github.com/NixOS/nixpkgs/commit/41f9d0cf89abfc1dbb503ca87b40eb93df4d3282) | `python310Packages.aiobiketrax: 0.4.0 -> 0.5.0`                                          |
| [`1f65b6a5`](https://github.com/NixOS/nixpkgs/commit/1f65b6a51132650e161ef241dc71f03af1b326ff) | `python310Packages.aiobiketrax: add changelog to meta`                                   |
| [`36b73ca2`](https://github.com/NixOS/nixpkgs/commit/36b73ca21a2c15c021864f2eebce117a5db489ec) | `python310Packages.mailchecker: 5.0.4 -> 5.0.5`                                          |
| [`14f2ef9f`](https://github.com/NixOS/nixpkgs/commit/14f2ef9fb9f9a42c41a5fd77b2c71550b3d64b25) | `python310Packages.mailchecker: add changelog to meta`                                   |
| [`bdf8a69e`](https://github.com/NixOS/nixpkgs/commit/bdf8a69ecc82eaf81b2cc2b876b147faf48440b1) | `surrealdb: module: add secret management`                                               |
| [`f6c0dcfb`](https://github.com/NixOS/nixpkgs/commit/f6c0dcfb9eb730437d0089ae27f031d91e0789bd) | `rustdesk: fix for rust 1.65`                                                            |
| [`2627d90b`](https://github.com/NixOS/nixpkgs/commit/2627d90bd4baeb204beedd023e932972bbc7bf67) | `python310Packages.meilisearch: 0.19.1 -> 0.23.0`                                        |
| [`b9f6e210`](https://github.com/NixOS/nixpkgs/commit/b9f6e210fa8cab0f4fecdac75ba8a9252e76b1b1) | `python310Packages.camel-converter: init at 3.0.0`                                       |
| [`75e0609a`](https://github.com/NixOS/nixpkgs/commit/75e0609a001e6c12ca7ecfa72c4d290eb4ebc73c) | `nixos/borgbackup: fix newline escaping with optional arguments`                        |
| [`90b7e76b`](https://github.com/NixOS/nixpkgs/commit/90b7e76b07a9b422568f08bf23c5e3c46d6ac2e8) | `python310Packages.meilisearch: add changelog to meta`                                   |
| [`c0660ba1`](https://github.com/NixOS/nixpkgs/commit/c0660ba1953bd0cfe924807bbb0e3bd3c171f393) | `memray: 1.4.1 -> 1.5.0`                                                                 |
| [`69b6d5a5`](https://github.com/NixOS/nixpkgs/commit/69b6d5a5f283219f6734f79cc739d9b3622d3173) | `libmodbus: 3.1.9 -> 3.1.10`                                                             |
| [`15c39787`](https://github.com/NixOS/nixpkgs/commit/15c39787d83adb20b4f7a4619aa044f4e517fdbb) | `monotoneViz: use xorg.* packages directly instead of xlibsWrapper indirection`          |
| [`a5717f4f`](https://github.com/NixOS/nixpkgs/commit/a5717f4f9a4d0b95b8eb51e7ae2d94c75308dde9) | `adriconf: 2.5.0 -> 2.5.1`                                                               |
| [`f82f0ec1`](https://github.com/NixOS/nixpkgs/commit/f82f0ec1b70b2879c3f3d9a1015a05c73a90a17c) | `brev-cli: 0.6.185 -> 0.6.186`                                                           |
| [`8493ebc8`](https://github.com/NixOS/nixpkgs/commit/8493ebc89ce5ef1de16929f7c43a494892e12e8c) | `poetry2nix: 1.38.0 -> 1.39.1`                                                           |
| [`49c8d8d9`](https://github.com/NixOS/nixpkgs/commit/49c8d8d9717791fbc51d25cd80dbb1fc26997c5f) | `liquidsoap: 2.1.2 -> 2.1.3`                                                             |
| [`a8e4768a`](https://github.com/NixOS/nixpkgs/commit/a8e4768ae2bca3b19aec091835a19cec4eba4065) | `python310Packages.dbus-fast: 1.81.0 -> 1.82.0`                                          |
| [`3b22a2f6`](https://github.com/NixOS/nixpkgs/commit/3b22a2f65232ca32d771dc8bf60336c8d25dc16d) | `python310Packages.dbus-fast: 1.80.0 -> 1.81.0`                                          |
| [`6631a459`](https://github.com/NixOS/nixpkgs/commit/6631a459c2b8348bf62414e23e5dc79f1e41fc06) | `libspng: 0.7.2 -> 0.7.3`                                                                |
| [`f9db53a5`](https://github.com/NixOS/nixpkgs/commit/f9db53a542b9d6c282056b48eb79392c346eb97f) | `clhep: 2.4.6.1 -> 2.4.6.2`                                                              |
| [`62e863e9`](https://github.com/NixOS/nixpkgs/commit/62e863e98c8f5c22c0dd4ee3845613a858262b4c) | ``lib.strings: fix negative number handling for `toInt` and `toIntBase10```              |
| [`80909c90`](https://github.com/NixOS/nixpkgs/commit/80909c90916fa2468da7a5edeaeecd010bb2b196) | `pantheon.elementary-code: Backport upstream fix for DnD`                                |
| [`445119ad`](https://github.com/NixOS/nixpkgs/commit/445119adbc6ac0d102b717b85e3de3453468f444) | `pantheon.elementary-capnet-assist: 2.4.2 -> 2.4.3`                                      |
| [`ada93a66`](https://github.com/NixOS/nixpkgs/commit/ada93a66647b3363adae69f022c3af37faee5655) | `pantheon.elementary-videos: 2.8.4 -> 2.9.0`                                             |
| [`c75297dc`](https://github.com/NixOS/nixpkgs/commit/c75297dc01c499c33e8e5909866bc5b24e226930) | `jujutsu: 0.6.0 -> 0.6.1`                                                                |
| [`990f3360`](https://github.com/NixOS/nixpkgs/commit/990f3360997076bffe1cccfa3faa44a520c09cfc) | `python310Packages.types-setuptools: 65.6.0.0 -> 65.6.0.2`                               |
| [`d9f9ead5`](https://github.com/NixOS/nixpkgs/commit/d9f9ead58a390545e9b508cbfb71e56cd5824199) | `Update doc/contributing/coding-conventions.chapter.md`                                  |
| [`1d07be8b`](https://github.com/NixOS/nixpkgs/commit/1d07be8be7eaba247b6786198f7819a34b8955aa) | `python310Packages.python-fsutil: 0.7.0 -> 0.8.0`                                        |
| [`bc389275`](https://github.com/NixOS/nixpkgs/commit/bc3892758b92949394e26f2cd96fa3dd41eb044a) | `python310Packages.python-fsutil: add changelog to meta`                                 |
| [`8344efbb`](https://github.com/NixOS/nixpkgs/commit/8344efbbf86fbdb0c0d119b2d422fa1ee87cd692) | `python310Packages.authlib: add changelog to meta`                                       |
| [`3ca8543f`](https://github.com/NixOS/nixpkgs/commit/3ca8543f34b6f1b8f544e2a98187cadc519829b3) | `python310Packages.teslajsonpy: 3.4.1 -> 3.5.0`                                          |
| [`967213e4`](https://github.com/NixOS/nixpkgs/commit/967213e4820148d6dd61293db592c642e93cb5f8) | `python310Packages.pyswitchbot: 0.23.0 -> 0.23.1`                                        |
| [`4daf9ab1`](https://github.com/NixOS/nixpkgs/commit/4daf9ab1344f91bafa961bc2caddd4633e928d42) | `python310Packages.pyswitchbot: 0.22.0 -> 0.23.0`                                        |
| [`c5a57326`](https://github.com/NixOS/nixpkgs/commit/c5a5732659a136a771f1c3c7a3ef2a5c15c60c0b) | `python310Packages.authlib: 1.1.0 -> 1.2.0`                                              |
| [`38b2a663`](https://github.com/NixOS/nixpkgs/commit/38b2a66318fc04a6f4c232d05de79f5170649fcd) | `python310Packages.aionanoleaf: add changelog to meta`                                   |
| [`6f05af91`](https://github.com/NixOS/nixpkgs/commit/6f05af913cd9a1a5ddd6abcf64948a9733482f46) | `ocamlPackages.otfm: 0.3.0 → 0.4.0`                                                      |
| [`66e349ba`](https://github.com/NixOS/nixpkgs/commit/66e349bad126e82e4140cc17b8ac01aead4bd52d) | `procyon: 0.6-prerelease -> 0.6.0`                                                       |
| [`04e53c4e`](https://github.com/NixOS/nixpkgs/commit/04e53c4efe97411b400d0c973a72515bbb05224d) | `python310Packages.aioshelly: 5.1.0 -> 5.1.1`                                            |
| [`6b4f0320`](https://github.com/NixOS/nixpkgs/commit/6b4f03205293c8c6ca885dd3784691d156c24026) | `python310Packages.aionanoleaf: 0.2.0 -> 0.2.1`                                          |
| [`4baa9eab`](https://github.com/NixOS/nixpkgs/commit/4baa9eab71b0b8e1c4cdb636f090edca265273e1) | `youtube-music: 0.17.0 -> 0.18.0`                                                        |
| [`82aa0aa5`](https://github.com/NixOS/nixpkgs/commit/82aa0aa57b6f0af468f0810c35629103ac388e4e) | `freshrss: 1.20.1 -> 1.20.2`                                                             |
| [`468a8f97`](https://github.com/NixOS/nixpkgs/commit/468a8f97d6fe57bd4ef9c073f1653b24ab3ec79b) | `ruff: 0.0.172 -> 0.0.173`                                                               |
| [`9928825c`](https://github.com/NixOS/nixpkgs/commit/9928825c026e3759aa0c78f887190c24f116cfa8) | `python3.pkgs.calver: init at 2022.6.26`                                                 |
| [`06ddab28`](https://github.com/NixOS/nixpkgs/commit/06ddab281295ec0d78d5596f561fa6e29990747c) | `terraform-providers.azurerm: 3.34.0 → 3.35.0`                                           |
| [`c8538f75`](https://github.com/NixOS/nixpkgs/commit/c8538f7503acd5fe197d501d21f8895dfde2b656) | `terraform-providers.minio: 1.9.1 → 1.10.0`                                              |
| [`60ba7f52`](https://github.com/NixOS/nixpkgs/commit/60ba7f52bc693f0041b304221682fc9ed7c2d430) | `terraform-providers.heroku: 5.1.8 → 5.1.9`                                              |
| [`a737919c`](https://github.com/NixOS/nixpkgs/commit/a737919c2938c43bcb9175d1fd92220a850061f3) | `terraform-providers.github: 5.11.0 → 5.12.0`                                            |
| [`d5550da2`](https://github.com/NixOS/nixpkgs/commit/d5550da2823400888375c7eb48caa73668481ab7) | `terraform-providers.aviatrix: 2.24.1 → 3.0.0`                                           |
| [`b49d4ffb`](https://github.com/NixOS/nixpkgs/commit/b49d4ffb243ce59fa5ac87bbe2559fdac7610e99) | `pythonPackages.parameterizedtestcase: drop`                                             |
| [`8e5192fb`](https://github.com/NixOS/nixpkgs/commit/8e5192fb89d4c167fe2ed7c6b97598615c44ba6b) | `mopidy: 3.4.0 -> 3.4.1`                                                                 |
| [`9c93f440`](https://github.com/NixOS/nixpkgs/commit/9c93f440d25a7d3542b2c56f94b003d4eae32cc2) | `credhub-cli: 2.9.8 -> 2.9.9`                                                            |
| [`8e36c2d5`](https://github.com/NixOS/nixpkgs/commit/8e36c2d5b624e803fdaae370e562fbd291c7f611) | `piping-server-rust: 0.14.1 -> 0.15.0`                                                   |
| [`c847a43b`](https://github.com/NixOS/nixpkgs/commit/c847a43b6747f88fc6e5a8b1d925b3fcc2b7cdda) | `sapling: fix nodejs path, add enableMinimal option`                                     |
| [`21e7ab0a`](https://github.com/NixOS/nixpkgs/commit/21e7ab0afcf44b8705944f177f59940c434f6c69) | `sapling: fix 'sl web' command`                                                          |
| [`37f2a530`](https://github.com/NixOS/nixpkgs/commit/37f2a530e1f1e9b83596a4ac5565a3ae232e969d) | `sapling: fix curl in buildInputs on darwin`                                             |
| [`95f9db8d`](https://github.com/NixOS/nixpkgs/commit/95f9db8d5fa86804a7f132590a583306446825df) | `modsecurity_standalone: 2.9.3 -> 2.9.6`                                                 |
| [`9ec5e7b3`](https://github.com/NixOS/nixpkgs/commit/9ec5e7b3027b8a36e4cbe5bf1d6860af039fc925) | `ruff: 0.0.171 -> 0.0.172`                                                               |
| [`d506af86`](https://github.com/NixOS/nixpkgs/commit/d506af866a97511db2df8644f7cf8fabfc88ecde) | `jackett: 0.20.2325 -> 0.20.2352`                                                        |
| [`4fabafb6`](https://github.com/NixOS/nixpkgs/commit/4fabafb699bc4fa91594fce7fd7eaf57c7fcdede) | `resholve: fold in python package deps`                                                  |
| [`2db8cdeb`](https://github.com/NixOS/nixpkgs/commit/2db8cdeb110c18b1b1340cb4b8a14edc4f6623ab) | `alsa-scarlett-gui: init at unstable-2022-08-11`                                         |
| [`1a9fb2bf`](https://github.com/NixOS/nixpkgs/commit/1a9fb2bf55746795233e4d830ac065b34502a52d) | `discord-canary: 0.0.144 -> 0.0.145`                                                     |
| [`5efd8de5`](https://github.com/NixOS/nixpkgs/commit/5efd8de503ef713b7f80148d03cde0aeb852ef8d) | `python2Packages.pygobject2: move to python2-modules`                                    |
| [`b5169b27`](https://github.com/NixOS/nixpkgs/commit/b5169b276b74e2891e183828464055678090503c) | `nextcloud-client: 3.6.2 -> 3.6.4`                                                       |
| [`2bb6a27d`](https://github.com/NixOS/nixpkgs/commit/2bb6a27de825cbdac4c7e083b8ebe163aeb61c7b) | `wpaperd: set platform to linux only`                                                    |
| [`c760e716`](https://github.com/NixOS/nixpkgs/commit/c760e716267ebb9a97429174e84594257796c561) | `python2Packages.pygobject3: remove`                                                     |
| [`4bd69308`](https://github.com/NixOS/nixpkgs/commit/4bd693080add1007bd55249deb34646a13f08819) | `python2Packages.gtkme: remove`                                                          |
| [`a9028840`](https://github.com/NixOS/nixpkgs/commit/a9028840efd5e12dee4d151de47b10983a5d8e7f) | `python2Packages.idna: remove`                                                           |
| [`d4288c8e`](https://github.com/NixOS/nixpkgs/commit/d4288c8e3ff5ada52390ae0bdd3de89a6054979c) | `ocamlPackages.carton,ocamlPackages.carton-git,ocamlPackages.carton-lwt: 0.4.4 -> 0.6.0` |
| [`9cf1be96`](https://github.com/NixOS/nixpkgs/commit/9cf1be96c99cb6f37f4d49558d5b779c1d3c75f0) | `abcmidi: 2022.09.01 -> 2022.12.05`                                                      |
| [`65aed3b3`](https://github.com/NixOS/nixpkgs/commit/65aed3b37f61653d4d60c997abf885b6dacd5a16) | `Allow to override the https settings`                                                   |
| [`29ffa5eb`](https://github.com/NixOS/nixpkgs/commit/29ffa5eb32e8ea0395d5cc6d3d21e37f50557f4c) | `kodiPackages.youtube: 6.8.18+matrix.1 → 6.8.22+matrix.1`                                |