### PR TITLE
chore(flake/nur): `a787c828` -> `ecfbb03d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1670518674,
-        "narHash": "sha256-mFHgBF7ZialPRoL4y7C8CvOusfZwmYiZ9iGZ5BikXyQ=",
+        "lastModified": 1670519174,
+        "narHash": "sha256-cllJKMqAYsUhKdTlRn1NB83dWeRk2BSauHZQFZl0LgU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a787c828ffd154258c04c4ac9c7cf8fd2e9e486d",
+        "rev": "ecfbb03d9d32c8af6756f7ca9634c53767fcee77",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ecfbb03d`](https://github.com/nix-community/NUR/commit/ecfbb03d9d32c8af6756f7ca9634c53767fcee77) | `automatic update` |