### PR TITLE
chore(flake/emacs-overlay): `269cf763` -> `1b6e5b25`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670494225,
-        "narHash": "sha256-Pb4ZfjIxBznbfTsWEkYc2FVB41yyfqh20nhmLk67LuI=",
+        "lastModified": 1670523171,
+        "narHash": "sha256-T8NRgu8jgyNwkwC6Ew31MIXM7RZ17ShA556ZgV5D9N0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "269cf7633d51bd316e00ba35467e8a5f5136d28c",
+        "rev": "1b6e5b25af402e9f2fd49cf210cada9444c32504",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`1b6e5b25`](https://github.com/nix-community/emacs-overlay/commit/1b6e5b25af402e9f2fd49cf210cada9444c32504) | `Updated repos/melpa` |
| [`2b62f775`](https://github.com/nix-community/emacs-overlay/commit/2b62f775f93ad31105f0cf286947c11a588698e8) | `Updated repos/emacs` |
| [`3306f7ef`](https://github.com/nix-community/emacs-overlay/commit/3306f7eff4ee529355e3b154458e3fe798f4bf92) | `Updated repos/elpa`  |