### PR TITLE
chore(flake/nur): `ecfbb03d` -> `9c8c60da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1670519174,
-        "narHash": "sha256-cllJKMqAYsUhKdTlRn1NB83dWeRk2BSauHZQFZl0LgU=",
+        "lastModified": 1670535859,
+        "narHash": "sha256-HTNyQyhj8U79ez/i32UFNfmB3R7YE21gPhAXD17LemU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ecfbb03d9d32c8af6756f7ca9634c53767fcee77",
+        "rev": "9c8c60da4bbb72b9ec5dfb745badf492a596be9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                    |
| -------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`9c8c60da`](https://github.com/nix-community/NUR/commit/9c8c60da4bbb72b9ec5dfb745badf492a596be9b) | `automatic update`                |
| [`08b739b5`](https://github.com/nix-community/NUR/commit/08b739b516dbc0107302c8d121dc923b89d7d2c1) | `formatted repos.json`            |
| [`1f40df32`](https://github.com/nix-community/NUR/commit/1f40df329f3505f9b885f8a65dc3c02b182ea3db) | `enable submodules for blakat360` |