### PR TITLE
chore(flake/emacs-overlay): `1b6e5b25` -> `7279dc6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670523171,
-        "narHash": "sha256-T8NRgu8jgyNwkwC6Ew31MIXM7RZ17ShA556ZgV5D9N0=",
+        "lastModified": 1670556527,
+        "narHash": "sha256-vNsC6COhRRepzzV+y1delpsbH1zFYuY6qxsNS61D6Qs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1b6e5b25af402e9f2fd49cf210cada9444c32504",
+        "rev": "7279dc6f75d0983a552eeacef992246c53473aea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message               |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------- |
| [`7279dc6f`](https://github.com/nix-community/emacs-overlay/commit/7279dc6f75d0983a552eeacef992246c53473aea) | `Add tree-sitter-dockerfile` |
| [`4559b97a`](https://github.com/nix-community/emacs-overlay/commit/4559b97a147399cb39ed3da7d3acf99a087ec581) | `Updated repos/nongnu`       |
| [`bbed443d`](https://github.com/nix-community/emacs-overlay/commit/bbed443de7f90e1d556d577769fce2ef8063b7cc) | `Updated repos/melpa`        |
| [`45140e7a`](https://github.com/nix-community/emacs-overlay/commit/45140e7a7d3c3ca461e2ea46a86d7ff505c0829a) | `Updated repos/emacs`        |
| [`fc2edb9d`](https://github.com/nix-community/emacs-overlay/commit/fc2edb9d2b4c38cf8f37a7ec6d22a3b5ea779976) | `Updated repos/elpa`         |