### PR TITLE
chore(flake/emacs-plz): `80aeae0d` -> `74536c53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -171,11 +171,11 @@
     "emacs-plz": {
       "flake": false,
       "locked": {
-        "lastModified": 1664214870,
-        "narHash": "sha256-GzIR7jMjCZuaO8k9ZG61qqdMAyIT8+61ZxGpLkZpHVw=",
+        "lastModified": 1670560637,
+        "narHash": "sha256-OqesFiwDXp9J2gWFCryuYjxTRHf5sk2UEkeDP/myMhM=",
         "owner": "alphapapa",
         "repo": "plz.el",
-        "rev": "80aeae0d201b06088d4b7543a603d97bdbccb948",
+        "rev": "74536c5396abe6be1691193dc3c816a2a73d4655",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                            | Commit Message                             |
| ------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`74536c53`](https://github.com/alphapapa/plz.el/commit/74536c5396abe6be1691193dc3c816a2a73d4655) | `Add: Handle HTTP proxy headers from Curl` |
| [`00a82492`](https://github.com/alphapapa/plz.el/commit/00a82492ae5b756eb2a007e965b22616c0a39476) | `Meta: v0.3-pre`                           |