### PR TITLE
chore(flake/emacs-overlay): `7279dc6f` -> `ff0c1ead`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670556527,
-        "narHash": "sha256-vNsC6COhRRepzzV+y1delpsbH1zFYuY6qxsNS61D6Qs=",
+        "lastModified": 1670580643,
+        "narHash": "sha256-1D1mObqPnPJUxDZP2pOEvlYpEHq2oT2wqwwe46Jh24c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7279dc6f75d0983a552eeacef992246c53473aea",
+        "rev": "ff0c1ead7f28972ba4b63ffc9353a132b163386a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ff0c1ead`](https://github.com/nix-community/emacs-overlay/commit/ff0c1ead7f28972ba4b63ffc9353a132b163386a) | `Updated repos/melpa` |
| [`971239d4`](https://github.com/nix-community/emacs-overlay/commit/971239d4dea81088c831fa3682d500c69ae3c0b3) | `Updated repos/emacs` |