### PR TITLE
chore(flake/emacs-overlay): `ff0c1ead` -> `a242f161`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670580643,
-        "narHash": "sha256-1D1mObqPnPJUxDZP2pOEvlYpEHq2oT2wqwwe46Jh24c=",
+        "lastModified": 1670609945,
+        "narHash": "sha256-b3WZ2tCw2Ldm41R7BBd7bwWudtyz6bnegQl2CwRbwxs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ff0c1ead7f28972ba4b63ffc9353a132b163386a",
+        "rev": "a242f161c1d5d0610e6f11a4924656762e0094d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`a242f161`](https://github.com/nix-community/emacs-overlay/commit/a242f161c1d5d0610e6f11a4924656762e0094d6) | `Updated repos/melpa` |
| [`dd69f1ac`](https://github.com/nix-community/emacs-overlay/commit/dd69f1ac41341780a6a9b4561f7691772ab8ac0c) | `Updated repos/emacs` |