### PR TITLE
chore(flake/emacs-overlay): `a242f161` -> `3a0b5dd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670609945,
-        "narHash": "sha256-b3WZ2tCw2Ldm41R7BBd7bwWudtyz6bnegQl2CwRbwxs=",
+        "lastModified": 1670637348,
+        "narHash": "sha256-4FLOEi02WS+St6i1MSUxGfA32FL1SFIpwWCDsABAZkk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a242f161c1d5d0610e6f11a4924656762e0094d6",
+        "rev": "3a0b5dd7756173e63c2bbbe70dd5484a7463257d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`3a0b5dd7`](https://github.com/nix-community/emacs-overlay/commit/3a0b5dd7756173e63c2bbbe70dd5484a7463257d) | `Updated repos/melpa` |