### PR TITLE
chore(flake/emacs-overlay): `3a0b5dd7` -> `67b8eb82`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670637348,
-        "narHash": "sha256-4FLOEi02WS+St6i1MSUxGfA32FL1SFIpwWCDsABAZkk=",
+        "lastModified": 1670666916,
+        "narHash": "sha256-B8m9HPJNvmEOjGSmqxWhePKh7i0sy4Q63jQqpliGwcY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3a0b5dd7756173e63c2bbbe70dd5484a7463257d",
+        "rev": "67b8eb822dbb8e51d45f6b0663b4442b1601ffda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`67b8eb82`](https://github.com/nix-community/emacs-overlay/commit/67b8eb822dbb8e51d45f6b0663b4442b1601ffda) | `Updated repos/melpa` |
| [`99bdadf6`](https://github.com/nix-community/emacs-overlay/commit/99bdadf6d39d0678f26cd4e4f134bdfb4c8304cc) | `Updated repos/emacs` |