### PR TITLE
chore(flake/emacs-overlay): `67b8eb82` -> `e29a31a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670666916,
-        "narHash": "sha256-B8m9HPJNvmEOjGSmqxWhePKh7i0sy4Q63jQqpliGwcY=",
+        "lastModified": 1670696056,
+        "narHash": "sha256-EGALu2eakpeiZ0ElmlEFcLxeBylj62ErWXnNZAN4M3Q=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "67b8eb822dbb8e51d45f6b0663b4442b1601ffda",
+        "rev": "e29a31a6f79cdd40088263bcc3edda29384ecf94",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`e29a31a6`](https://github.com/nix-community/emacs-overlay/commit/e29a31a6f79cdd40088263bcc3edda29384ecf94) | `Updated repos/melpa` |
| [`75d4ce9b`](https://github.com/nix-community/emacs-overlay/commit/75d4ce9b88538cb5b86cb62c63372bae12510df1) | `Updated repos/emacs` |
| [`10340eb1`](https://github.com/nix-community/emacs-overlay/commit/10340eb1ef82fbfdc21885761703589c16364b1d) | `Updated repos/elpa`  |