### PR TITLE
chore(flake/emacs-overlay): `e29a31a6` -> `72ceefe3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670696056,
-        "narHash": "sha256-EGALu2eakpeiZ0ElmlEFcLxeBylj62ErWXnNZAN4M3Q=",
+        "lastModified": 1670724476,
+        "narHash": "sha256-sO6N+5h2kWtn0NyTfn930DhghFJrHUphTUMVYgqmsS8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e29a31a6f79cdd40088263bcc3edda29384ecf94",
+        "rev": "72ceefe367325f41481b85a1cb85df000352791b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`72ceefe3`](https://github.com/nix-community/emacs-overlay/commit/72ceefe367325f41481b85a1cb85df000352791b) | `Updated repos/nongnu` |
| [`341727fd`](https://github.com/nix-community/emacs-overlay/commit/341727fd5924eaaf8a05272becdbe5cd6499bd3f) | `Updated repos/melpa`  |