### PR TITLE
chore(flake/emacs-overlay): `72ceefe3` -> `6e51884a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670724476,
-        "narHash": "sha256-sO6N+5h2kWtn0NyTfn930DhghFJrHUphTUMVYgqmsS8=",
+        "lastModified": 1670753410,
+        "narHash": "sha256-UnqNXgpr8fvGMFObOrxij8iFGpRo5j5hJRUCLpLTpvQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "72ceefe367325f41481b85a1cb85df000352791b",
+        "rev": "6e51884abe30b5c57ad248b1a8196929dfbbe029",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`6e51884a`](https://github.com/nix-community/emacs-overlay/commit/6e51884abe30b5c57ad248b1a8196929dfbbe029) | `Updated repos/melpa` |
| [`712685d2`](https://github.com/nix-community/emacs-overlay/commit/712685d28c3774170b1856b9ed3cfa17a787d0c1) | `Updated repos/emacs` |