### PR TITLE
chore(flake/nur): `a7194d75` -> `16a52ef0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1670733021,
-        "narHash": "sha256-HQwU8r6hVM2fvI2i7yNP5/lISs+V5XrxtUiMLkCeuAM=",
+        "lastModified": 1670779394,
+        "narHash": "sha256-Ofto34JMmbUK3sFoO7aR+fed71IC1RFqQKpWQpyV0b4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a7194d7569f7cb5a63d34d205cdd8fa2f3225537",
+        "rev": "16a52ef00d1c4a060fd69a503e5607f227ce9c10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                   |
| -------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`16a52ef0`](https://github.com/nix-community/NUR/commit/16a52ef00d1c4a060fd69a503e5607f227ce9c10) | `automatic update`               |
| [`0ab7c4b3`](https://github.com/nix-community/NUR/commit/0ab7c4b31bd4784b76f07a9368ad218adbf10ba0) | `Format manifest`                |
| [`68dd4356`](https://github.com/nix-community/NUR/commit/68dd435610855cae7dddbd48e96a9d1f3102a671) | `Add my nur-packages repository` |