### PR TITLE
chore(flake/emacs-overlay): `6e51884a` -> `9fe20594`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670753410,
-        "narHash": "sha256-UnqNXgpr8fvGMFObOrxij8iFGpRo5j5hJRUCLpLTpvQ=",
+        "lastModified": 1670782654,
+        "narHash": "sha256-kmkRRGA5RWmNtKt41hglN8xyo7EX5qSzWfe2YW1A+JM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6e51884abe30b5c57ad248b1a8196929dfbbe029",
+        "rev": "9fe20594a0dce5fdba2f683d2c4cba3371ce7581",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`9fe20594`](https://github.com/nix-community/emacs-overlay/commit/9fe20594a0dce5fdba2f683d2c4cba3371ce7581) | `Updated repos/melpa` |
| [`eaca39aa`](https://github.com/nix-community/emacs-overlay/commit/eaca39aa568d361a8c080e71a2d158b7f550c4f6) | `Updated repos/emacs` |
| [`bcfc4049`](https://github.com/nix-community/emacs-overlay/commit/bcfc40496862d0ed0d93a53dc977a5d412f64c94) | `Updated repos/elpa`  |