### PR TITLE
chore(flake/emacs-overlay): `9fe20594` -> `6fad8d32`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670782654,
-        "narHash": "sha256-kmkRRGA5RWmNtKt41hglN8xyo7EX5qSzWfe2YW1A+JM=",
+        "lastModified": 1670806177,
+        "narHash": "sha256-eKkVVO6lTopTRHDZ9HYXFGlS4Jt/bfzy5maKz8+zmQ8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9fe20594a0dce5fdba2f683d2c4cba3371ce7581",
+        "rev": "6fad8d32db4b3225e72ec8ca4bfc0de249f9c1be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message          |
| ------------------------------------------------------------------------------------------------------------ | ----------------------- |
| [`6fad8d32`](https://github.com/nix-community/emacs-overlay/commit/6fad8d32db4b3225e72ec8ca4bfc0de249f9c1be) | `Add tree-sitter-cmake` |