### PR TITLE
chore(flake/emacs-overlay): `6fad8d32` -> `290e3660`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670806177,
-        "narHash": "sha256-eKkVVO6lTopTRHDZ9HYXFGlS4Jt/bfzy5maKz8+zmQ8=",
+        "lastModified": 1670814230,
+        "narHash": "sha256-6biw+X0TCS8vyZcKAOaaYjaxPOkxBZuVdH1fzxDx8WU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6fad8d32db4b3225e72ec8ca4bfc0de249f9c1be",
+        "rev": "290e366022a72225fed4f378e525de955c2edce5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`290e3660`](https://github.com/nix-community/emacs-overlay/commit/290e366022a72225fed4f378e525de955c2edce5) | `Updated repos/nongnu` |
| [`88fdfc09`](https://github.com/nix-community/emacs-overlay/commit/88fdfc0924959842b8d155a7f4b14056c3aa1d18) | `Updated repos/melpa`  |
| [`48c2fe6b`](https://github.com/nix-community/emacs-overlay/commit/48c2fe6b2798fd6297bedf0b290632019e00869e) | `Updated repos/emacs`  |