### PR TITLE
chore(flake/emacs-overlay): `61e8c316` -> `f877d256`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670836048,
-        "narHash": "sha256-Vd2tQbji47OoH1YPCW+Vzu3ggw1uBcAFHCK1CEBntzo=",
+        "lastModified": 1670868733,
+        "narHash": "sha256-BtQcQA9pDFV43WY7EtsqtzmOHJe496vbDZWGFgd9gYQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "61e8c3167cd2a748a7a805caca3ae5756b2b6eb5",
+        "rev": "f877d2569e1e9c6dd225f6674ef2f8777582215f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`f877d256`](https://github.com/nix-community/emacs-overlay/commit/f877d2569e1e9c6dd225f6674ef2f8777582215f) | `Updated repos/nongnu` |
| [`811fd5be`](https://github.com/nix-community/emacs-overlay/commit/811fd5be2bc3f973760854b525e42221ddaf72e9) | `Updated repos/melpa`  |
| [`5e73ace8`](https://github.com/nix-community/emacs-overlay/commit/5e73ace8e46e94329f9e95f9c904ac6a9b5e0738) | `Updated repos/emacs`  |