### PR TITLE
chore(flake/nixpkgs): `64e0bf05` -> `33e0d99c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670751203,
-        "narHash": "sha256-XdoH1v3shKDGlrwjgrNX/EN8s3c+kQV7xY6cLCE8vcI=",
+        "lastModified": 1670841420,
+        "narHash": "sha256-mSEia1FzrsHbfqjorMyYiX8NXdDVeR1Pw1k55jMJlJY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64e0bf055f9d25928c31fb12924e59ff8ce71e60",
+        "rev": "33e0d99cbedf2acfd7340d2150837fbb28039a64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                          |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
| [`ea26cd3f`](https://github.com/NixOS/nixpkgs/commit/ea26cd3f0d27ef740f59671e1ea39d6dd1dc9b93) | `code-generator: init at 0.25.4`                                                                        |
| [`ffca9ffa`](https://github.com/NixOS/nixpkgs/commit/ffca9ffaaafb38c8979068cee98b2644bd3f14cb) | `ocamlPackages.uecc: 0.3 → 0.4`                                                                         |
| [`2542e776`](https://github.com/NixOS/nixpkgs/commit/2542e7765bea53d697d08730fb9ce21271b6a33f) | `clj-kondo: 2022.12.08 -> 2022.12.10`                                                                   |
| [`4fbc7a37`](https://github.com/NixOS/nixpkgs/commit/4fbc7a3783e0941593af26e39b75e05299bf75d3) | `phrase-cli: 2.6.0 -> 2.6.1`                                                                            |
| [`89aab97e`](https://github.com/NixOS/nixpkgs/commit/89aab97e63fe80d8598c9e38043450323795818b) | `asusctl: 4.5.5 -> 4.5.6`                                                                               |
| [`62e87cba`](https://github.com/NixOS/nixpkgs/commit/62e87cbada15fbb45f579c0b977ef8834212f3cd) | `aws-nuke: 2.20.0 -> 2.21.2`                                                                            |
| [`83e84a5e`](https://github.com/NixOS/nixpkgs/commit/83e84a5e94c2fdfe5164edb78d168f47dc114f3c) | `automatic-timezoned: 1.0.49 -> 1.0.50`                                                                 |
| [`00c12525`](https://github.com/NixOS/nixpkgs/commit/00c12525ac5047ebbfe9eeb4a3ae3a49d641f4f7) | `bencode: 0.5.0 -> 1.0.1`                                                                               |
| [`596fbeba`](https://github.com/NixOS/nixpkgs/commit/596fbebaab939de7b499f0cea33809406b142c4b) | `podman: add mac-helper patch`                                                                          |
| [`0483b2b2`](https://github.com/NixOS/nixpkgs/commit/0483b2b2e620a4afa74624e0ac173f1c7376fe27) | `catch2_3: 3.2.0 -> 3.2.1`                                                                              |
| [`7f220a04`](https://github.com/NixOS/nixpkgs/commit/7f220a0422e865735ff9d99cff32775859df23dd) | `nixos/installer/netboot-minimal: add missing lib`                                                      |
| [`a7111b1c`](https://github.com/NixOS/nixpkgs/commit/a7111b1c7a09f0751ac83afe686d7591440e8726) | `airwindows-lv2: 12.0 -> 14.0`                                                                          |
| [`6733594e`](https://github.com/NixOS/nixpkgs/commit/6733594eed26c4e29371555bb9e7f01ddb51518d) | `home-assistant: 2022.12.1 -> 2022.12.2`                                                                |
| [`61612712`](https://github.com/NixOS/nixpkgs/commit/616127128106294868c678d66e545030c1c61945) | `python3Packages.aiolifx-effects: 0.3.0 -> 0.3.1`                                                       |
| [`fb83ee7d`](https://github.com/NixOS/nixpkgs/commit/fb83ee7d26bee200b2bd6b69df390c57dee4b6af) | `python310Packages.calver: adopt and run tests`                                                         |
| [`0c4e3e0c`](https://github.com/NixOS/nixpkgs/commit/0c4e3e0c9709ff2e57f8912e8ed3bc6064d5eaf2) | `ooniprobe-cli: 3.16.5 -> 3.16.7`                                                                       |
| [`45874e67`](https://github.com/NixOS/nixpkgs/commit/45874e67018bd160525586f648c75ea084165119) | `openturns: fix build`                                                                                  |
| [`178bae00`](https://github.com/NixOS/nixpkgs/commit/178bae00c015566fb7f7da1b5051c5020e23a7de) | `python310Packages.hydra: 1.2.0 -> 1.3.0`                                                               |
| [`99d6867c`](https://github.com/NixOS/nixpkgs/commit/99d6867ce838d47acf0b0dd77a27b475575fbeba) | `esptool: compatibility with bitstring 4`                                                               |
| [`f963d5e2`](https://github.com/NixOS/nixpkgs/commit/f963d5e2d2db8e117af97e349435b1977320546b) | `esptool_3: compatibility with bitstring 4`                                                             |
| [`621ec5b3`](https://github.com/NixOS/nixpkgs/commit/621ec5b398a72d389aea98400618f1a44f3a1209) | `python310Packages.bitstring: 3.1.9 -> 4.0.1`                                                           |
| [`bb069d84`](https://github.com/NixOS/nixpkgs/commit/bb069d84b1e8dd8b6bb60e3368d0d77aa9a49f9c) | `ytfzf: 2.5.2 -> 2.5.3`                                                                                 |
| [`9d32b64d`](https://github.com/NixOS/nixpkgs/commit/9d32b64dee775d2bb8ade10fff2bfab84995272e) | `wander: remove unused fetchpatch`                                                                      |
| [`8904ad8e`](https://github.com/NixOS/nixpkgs/commit/8904ad8ed5d88cf0a576ab8e88acbc736d238e78) | `reaper: 6.66 -> 6.71`                                                                                  |
| [`632eb143`](https://github.com/NixOS/nixpkgs/commit/632eb1438177eb1a8847566b0d9ebc2faa942dd6) | `v2ray-geoip: 202212010055 -> 202212080044`                                                             |
| [`8d437243`](https://github.com/NixOS/nixpkgs/commit/8d437243868db3b0693c9369100f210827b8b4c7) | `unifi-protect-backup: 0.8.3 -> 0.8.7`                                                                  |
| [`bea895de`](https://github.com/NixOS/nixpkgs/commit/bea895dec1f221a56c7a637104428750cc9ad39f) | `ruff: 0.0.175 -> 0.0.176`                                                                              |
| [`449fda63`](https://github.com/NixOS/nixpkgs/commit/449fda63f5837443e6bfa3265efcb63a600c7728) | `python3.pkgs.autobahn: fix twisted compat`                                                             |
| [`95f8f85c`](https://github.com/NixOS/nixpkgs/commit/95f8f85c18d7fa5854092bb8f1f31cddfc95fe91) | `solo5: 0.7.4 -> 0.7.5`                                                                                 |
| [`0de0c691`](https://github.com/NixOS/nixpkgs/commit/0de0c691bf68327453e1aa6c0970340bb59106d9) | `drawio: 20.6.1 -> 20.6.2`                                                                              |
| [`b69e9be8`](https://github.com/NixOS/nixpkgs/commit/b69e9be8fd90d14558f48ba99859e22aef421fb3) | `python310Packages.hg-evolve: 10.5.2 -> 10.5.3`                                                         |
| [`80f20e75`](https://github.com/NixOS/nixpkgs/commit/80f20e75e85b3717a41aac16c6ff4d40625cb54c) | `python310Packages.wakeonlan: 2.1.0 -> 3.0.0`                                                           |
| [`50611d74`](https://github.com/NixOS/nixpkgs/commit/50611d740e8b89f2896a53e01a814848d7b4fc63) | `python310Packages.graphene: add changelog to meta`                                                     |
| [`7daf8fba`](https://github.com/NixOS/nixpkgs/commit/7daf8fbabc82dcb272a757f9e9ae71fc05c1bb21) | `python310Packages.aranet4: 2.1.2 -> 2.1.3`                                                             |
| [`f3aa3768`](https://github.com/NixOS/nixpkgs/commit/f3aa3768bc954f2aa5b2b17a1bd4bf83377cec88) | `python310Packages.graphene: 3.1.1 -> 3.2.0`                                                            |
| [`c0c48fe6`](https://github.com/NixOS/nixpkgs/commit/c0c48fe6ae178e6c125cd678f0b3af62aff00a1f) | `python310Packages.google-cloud-bigtable: 2.14.0 -> 2.14.1`                                             |
| [`2e85b267`](https://github.com/NixOS/nixpkgs/commit/2e85b267aafa5152c86a63a78d85cf7fd24aec47) | `nushell: do checks`                                                                                    |
| [`6b91d263`](https://github.com/NixOS/nixpkgs/commit/6b91d26308f47184815f8bc564ac0350e574b457) | `vimPlugins.nvim-treesitter: update grammars`                                                           |
| [`d3aa4d3b`](https://github.com/NixOS/nixpkgs/commit/d3aa4d3b4577dde3dbb2b5f3968f353551e8940a) | `vimPlugins.vim-monokai-tasty: init at 2022-11-25`                                                      |
| [`1b0ffeb9`](https://github.com/NixOS/nixpkgs/commit/1b0ffeb99382a42983df04b3f46ae70f91876faa) | `vimPlugins: update`                                                                                    |
| [`08d65176`](https://github.com/NixOS/nixpkgs/commit/08d651764f5955acd3800c65bff4934762dd2f41) | `v2raya: init at 2.0.0`                                                                                 |
| [`eee8cd06`](https://github.com/NixOS/nixpkgs/commit/eee8cd063f23d2946e6b61b4a6f03aa1c0a3ee2c) | `hysteria: 1.3.1 -> 1.3.2`                                                                              |
| [`1b810029`](https://github.com/NixOS/nixpkgs/commit/1b810029883bc947cb03638f609a4947558087c5) | `edgetx: 2.7.1 -> 2.7.2`                                                                                |
| [`c447a68b`](https://github.com/NixOS/nixpkgs/commit/c447a68b7e25a3276eed5a991b105325f8f2934d) | `prometheus-haproxy-exporter: 0.13.0 -> 0.14.0`                                                         |
| [`6befda01`](https://github.com/NixOS/nixpkgs/commit/6befda01a24371e7165da26094540c36bb6ccf6a) | `prometheus-fastly-exporter: 7.3.0 -> 7.4.0`                                                            |
| [`ca254328`](https://github.com/NixOS/nixpkgs/commit/ca254328b904fb97f84b70f8d96ad91c1785dd6f) | `vscode-extensions.kahole.magit: 0.6.18 -> 0.6.36`                                                      |
| [`32d3b1b5`](https://github.com/NixOS/nixpkgs/commit/32d3b1b5aa1cb1e7a20ab413ecc881bae4999968) | `tere: 1.3.0 -> 1.3.1`                                                                                  |
| [`1a1f3523`](https://github.com/NixOS/nixpkgs/commit/1a1f352310fc6058b2061ae7aece6949edeb1ed7) | `home-assistant: update component-packages`                                                             |
| [`bcd290f4`](https://github.com/NixOS/nixpkgs/commit/bcd290f427a28b7ff3a2405d83967d1894e83205) | `python310Packages.aiolivisi: init at 0.0.14`                                                           |
| [`dc71b050`](https://github.com/NixOS/nixpkgs/commit/dc71b0500dac7e070b282e082ecac250256b3b89) | `syncthingtray: 1.3.0 -> 1.3.1`                                                                         |
| [`fc4f3845`](https://github.com/NixOS/nixpkgs/commit/fc4f384532e3bcc8e119ffbc97d788386f65cc3e) | `home-assistant: update component-packages`                                                             |
| [`600bec87`](https://github.com/NixOS/nixpkgs/commit/600bec87813ed7cd0149799f2dd50c4f4eadd911) | `python310Packages.aranet4: init at 2.1.2`                                                              |
| [`3d644da4`](https://github.com/NixOS/nixpkgs/commit/3d644da44088a18d96bb0db5b2fdcfbbf6f63955) | `LAStools: 2.0.1 -> 2.0.2`                                                                              |
| [`a4985920`](https://github.com/NixOS/nixpkgs/commit/a4985920649696e26e6936a987cf5898a1679b13) | `cyclonedx-gomod: init at 1.3.0`                                                                        |
| [`d7219a1c`](https://github.com/NixOS/nixpkgs/commit/d7219a1c9dca0c600e997907b112e1e09acc8997) | `home-assistant: update component-packages`                                                             |
| [`9acb1fcf`](https://github.com/NixOS/nixpkgs/commit/9acb1fcfb6dacefec7caf49523ac13c41ab6ef30) | `ocamlPackages.sedlex: 2.6 → 3.0`                                                                       |
| [`7f63ad90`](https://github.com/NixOS/nixpkgs/commit/7f63ad9029e1ae8d9662c8370909205decc73a9e) | `ocamlPackages.piqi: support for sedlex ≥ 3.0`                                                          |
| [`6edacf9b`](https://github.com/NixOS/nixpkgs/commit/6edacf9b286655c98f064196edff3ff08b0e243f) | `offpunk: 1.7.1->1.8`                                                                                   |
| [`1f966060`](https://github.com/NixOS/nixpkgs/commit/1f966060ed1fec17457390d0b423fb491db2f842) | `offpunk: Move to sourcehut`                                                                            |
| [`6b57fa7d`](https://github.com/NixOS/nixpkgs/commit/6b57fa7d400ba65e9e22e570de2f8f2a9f4b8c6d) | `tlsx: 0.0.9 -> 1.0.0`                                                                                  |
| [`df6c7fe0`](https://github.com/NixOS/nixpkgs/commit/df6c7fe0fd861fc7ac178060c54a78a2c9f123ae) | `roswell: add changelog to meta`                                                                        |
| [`41e4f5a7`](https://github.com/NixOS/nixpkgs/commit/41e4f5a7fd65be7c9fe4eace50e83e56f0dd3fbc) | `python310Packages.python-benedict: 0.25.4 -> 0.27.1`                                                   |
| [`a348d2d3`](https://github.com/NixOS/nixpkgs/commit/a348d2d3659f4fe03bf0905101063a9a7e1f6892) | `python310Packages.fontmath: 0.9.2 -> 0.9.3`                                                            |
| [`8fe67e0c`](https://github.com/NixOS/nixpkgs/commit/8fe67e0c20e6428ca6e834b302068979adb4271a) | `python310Packages.python-decouple: init at 3.6`                                                        |
| [`1e6e735d`](https://github.com/NixOS/nixpkgs/commit/1e6e735d269538067489098e8f2a43826cd88fd8) | `python310Packages.python-benedict: add changelog to meta`                                              |
| [`a12c5f1e`](https://github.com/NixOS/nixpkgs/commit/a12c5f1e06d3ce4215cb0d393a0e1e67c0c247d2) | `python310Packages.malduck: 4.2.0 -> 4.3.0`                                                             |
| [`a3e65db4`](https://github.com/NixOS/nixpkgs/commit/a3e65db44aef97a691014b085721624a67c69a00) | `python310Packages.dnfile: init at 0.12.0`                                                              |
| [`48336e03`](https://github.com/NixOS/nixpkgs/commit/48336e0374a6d6e2efdf9351f0d0666f74e2c06e) | `snipe-it: add changelog to meta`                                                                       |
| [`e6a8af3e`](https://github.com/NixOS/nixpkgs/commit/e6a8af3e6b9d934866707a6440ed8977fbeaaf31) | `python310Packages.malduck: add changelog to meta`                                                      |
| [`77061274`](https://github.com/NixOS/nixpkgs/commit/7706127402d57850ca99b8b70c00404724379c0d) | `python310Packages.pyeconet: 0.1.16 -> 0.1.17`                                                          |
| [`8e7e106f`](https://github.com/NixOS/nixpkgs/commit/8e7e106fac79a55f34b1471fae03dd9b03345821) | `python310Packages.pyeconet: 0.1.15 -> 0.1.16`                                                          |
| [`77e91a3f`](https://github.com/NixOS/nixpkgs/commit/77e91a3f80f3f50ad3d69669108bfa66f62a0481) | `python310Packages.pyeconet: add changelog to meta`                                                     |
| [`b3e7f691`](https://github.com/NixOS/nixpkgs/commit/b3e7f69126bbc9e3255a7e08fd734137b0bcb5ff) | `python310Packages.pykeyatome: 2.1.0 -> 2.1.1`                                                          |
| [`8dd92828`](https://github.com/NixOS/nixpkgs/commit/8dd928280f516ab1ed883c9b6c68fd0e1a9d9888) | `python310Packages.pykeyatome: add changelog to meta`                                                   |
| [`56a34c94`](https://github.com/NixOS/nixpkgs/commit/56a34c940ed2e4284ef8653781db7cfbf7fe7def) | `python310Packages.teslajsonpy: 3.5.0 -> 3.5.1`                                                         |
| [`526c70d7`](https://github.com/NixOS/nixpkgs/commit/526c70d75f55558ec703d0ea03d71ad87b3dd955) | `python310Packages.peaqevcore: 9.0.1 -> 9.1.0`                                                          |
| [`3379e44a`](https://github.com/NixOS/nixpkgs/commit/3379e44a0be93db64da811e88debd7c0261881ed) | `python310Packages.home-assistant-bluetooth: 1.8.1 -> 1.9.0`                                            |
| [`464e17c1`](https://github.com/NixOS/nixpkgs/commit/464e17c11cacc6e2d68b26d24fa442ed4c208197) | `python310Packages.todoist-api-python: init at 2.0.2`                                                   |
| [`f6f0d0c1`](https://github.com/NixOS/nixpkgs/commit/f6f0d0c184c642e2305854c3bff0bc61465b5f31) | `python310Packages.life360: 5.4.0 -> 5.4.1`                                                             |
| [`0e88ae20`](https://github.com/NixOS/nixpkgs/commit/0e88ae207e53d73fb89dd919997ff62f31e1bf69) | `python310Packages.appthreat-vulnerability-db: 4.1.7 -> 4.1.8`                                          |
| [`1307b902`](https://github.com/NixOS/nixpkgs/commit/1307b9020b9a23779dc9409d3fbb7f5ebf149912) | `python310Packages.appthreat-vulnerability-db: 4.1.6 -> 4.1.7`                                          |
| [`9bd2b9a9`](https://github.com/NixOS/nixpkgs/commit/9bd2b9a95d09d81ff3f8a821e80b81e3efef3b53) | `git-workspace: 1.0.3 -> 1.1.0`                                                                         |
| [`5430b0ec`](https://github.com/NixOS/nixpkgs/commit/5430b0ece9ff933fde23753abcb9233dcf2f3d8c) | `snipe-it: 6.0.13 -> 6.0.14`                                                                            |
| [`a73d7d35`](https://github.com/NixOS/nixpkgs/commit/a73d7d35fca41241ebe10b8fb396e65603a16935) | `rtsp-simple-server: 0.20.2 -> 0.20.3`                                                                  |
| [`b88aa7d1`](https://github.com/NixOS/nixpkgs/commit/b88aa7d155400636531aa56478c2213aaa177696) | `roswell: 21.10.14.111 -> 22.12.14.112`                                                                 |
| [`52555a56`](https://github.com/NixOS/nixpkgs/commit/52555a5645da85b94ae794335535e44a5a211234) | `ruff: 0.0.173 -> 0.0.175`                                                                              |
| [`9d7139d8`](https://github.com/NixOS/nixpkgs/commit/9d7139d83cdfe8cd1f703831a9fc0d8a9947d163) | `pantheon.elementary-music: 7.0.0 -> 7.0.1`                                                             |
| [`ddb2541b`](https://github.com/NixOS/nixpkgs/commit/ddb2541b8a86960f170e36aea12ff5624620c586) | `primecount: add changelog to meta`                                                                     |
| [`1806785b`](https://github.com/NixOS/nixpkgs/commit/1806785beb2a1c4b84259d1688d04c1b33410852) | `python310Packages.todoist: add pythonImportsCheck`                                                     |
| [`2d919c10`](https://github.com/NixOS/nixpkgs/commit/2d919c1060f200e79ef896afbd993910a4ac79fd) | `dasel: 1.27.3 -> 2.0.2`                                                                                |
| [`9d29cd24`](https://github.com/NixOS/nixpkgs/commit/9d29cd2420bd393e3c614d8c7bff107ee67f4b55) | `libsForQt5.mauiPackages: 2.2.0 -> 2.2.1`                                                               |
| [`6deae326`](https://github.com/NixOS/nixpkgs/commit/6deae326bf1a966e9092b1caf5a4ea9b8aa0a23c) | `primesieve: add changelog to meta`                                                                     |
| [`f5e2b0da`](https://github.com/NixOS/nixpkgs/commit/f5e2b0daaf791cd671d8b77e3d579c780ded5410) | `selene: 0.23.0 -> 0.23.1`                                                                              |
| [`823462af`](https://github.com/NixOS/nixpkgs/commit/823462afcc241b9a97a2f01b300aa11bcd4d9366) | `duckstation: unstable-2022-11-18 -> unstable-2022-12-08`                                               |
| [`016aaa26`](https://github.com/NixOS/nixpkgs/commit/016aaa261d17cdfa1817a72c81f2c3039d750daa) | `primesieve: 8.0 -> 11.0`                                                                               |
| [`d5490032`](https://github.com/NixOS/nixpkgs/commit/d5490032d87d8ee6991a217070accb1ea0fa7fc7) | `primecount: 7.4 -> 7.6`                                                                                |
| [`a4960669`](https://github.com/NixOS/nixpkgs/commit/a49606696e32c106b4a203b95128930f3f65d185) | `nixos/alertmanager: fix renamed option`                                                                |
| [`e180f19d`](https://github.com/NixOS/nixpkgs/commit/e180f19dc92e1e5e5b2522074aafcf87c4023d7f) | `open-policy-agent: 0.47.0 -> 0.47.2`                                                                   |
| [`79eaf1db`](https://github.com/NixOS/nixpkgs/commit/79eaf1dbb9bfed9876088b3826f50645f6b0b39c) | `ocaml-ng.ocamlPackages_4_00_1.ocaml: use xorg.* packages directly instead of xlibsWrapper indirection` |
| [`29dc5b39`](https://github.com/NixOS/nixpkgs/commit/29dc5b3941d4e76fa521cc52d17384c6e27c9764) | `zellij: 0.33.0 -> 0.34.3`                                                                              |
| [`7fb128c1`](https://github.com/NixOS/nixpkgs/commit/7fb128c15a17ef46590e8e1129d7d945ddb8ff00) | `jay: init at unstable-2022-11-20`                                                                      |
| [`af2a04eb`](https://github.com/NixOS/nixpkgs/commit/af2a04eb3194d3e9aead88e9a55f1d15d797f4da) | `pyradio: add changelog to meta`                                                                        |
| [`ec7af32b`](https://github.com/NixOS/nixpkgs/commit/ec7af32b2f5c114e742aebbd5c56316f4eb51dfb) | `python310Packages.apycula: 0.4 -> 0.5.1`                                                               |
| [`7674933d`](https://github.com/NixOS/nixpkgs/commit/7674933d95d04b08c26db7eae180f0f1d9bf9259) | `pyradio: 0.8.9.31 -> 0.8.9.32`                                                                         |
| [`2aedc956`](https://github.com/NixOS/nixpkgs/commit/2aedc956a6b59551725ac3f3cc8aa36e592cd85e) | `luaPackages.nfd: fix build on darwin`                                                                  |
| [`4165ff32`](https://github.com/NixOS/nixpkgs/commit/4165ff32cfe7071d2a36f3cba0c85dc57d93d7a5) | `Release notes: fix typo`                                                                               |
| [`2b6bfed7`](https://github.com/NixOS/nixpkgs/commit/2b6bfed79c1082e0ab1aabac258f4785fa6fd659) | `nixos/lxc-container: undo some of the minimal profile stuff`                                           |
| [`218122fa`](https://github.com/NixOS/nixpkgs/commit/218122fa5c158ca244e842184dc894c6aba198ee) | `nixopsUnstable: mark certifi insecure`                                                                 |
| [`7825e0f1`](https://github.com/NixOS/nixpkgs/commit/7825e0f1ef17ef704a13e2960280d41d2dc18cd3) | `nixops: mark certifi insecure`                                                                         |
| [`b5b79d6a`](https://github.com/NixOS/nixpkgs/commit/b5b79d6a424382ecc4d3b576fc961d0bb30dd02d) | `tev: mark broken on darwin`                                                                            |
| [`23e1b557`](https://github.com/NixOS/nixpkgs/commit/23e1b5571582028c9c7c7bee09f5f9db9cd8af94) | `home-assistant: 2022.12.0 -> 2022.12.1`                                                                |
| [`b2bcd2ed`](https://github.com/NixOS/nixpkgs/commit/b2bcd2edc1ffbae4d183cf4951da77e6106369ba) | `python310Packages.PyChromecast: 13.0.1 -> 13.0.2`                                                      |
| [`e7ee5bf3`](https://github.com/NixOS/nixpkgs/commit/e7ee5bf36b147900c4ae6dddd9486826a844054e) | `nextcloud25: 25.0.1 -> 25.0.2`                                                                         |
| [`d54ee5ea`](https://github.com/NixOS/nixpkgs/commit/d54ee5eaca0d760c947fb785ff56888f8e46ab68) | `nextcloud24: 24.0.7 -> 24.0.8`                                                                         |
| [`9773732d`](https://github.com/NixOS/nixpkgs/commit/9773732ddcc8c1eea13f4059ccedfbca25b17690) | `trino-cli: reduce closure size by using headless JRE`                                                  |
| [`585934ed`](https://github.com/NixOS/nixpkgs/commit/585934ed1602ff42f3d7ebb1e8e3a81483bb348a) | `trino-cli: 392 -> 403`                                                                                 |
| [`6b396c29`](https://github.com/NixOS/nixpkgs/commit/6b396c292ce7b8195eda5adf18a04ff3ce0c7b55) | `gnome.zenity: relax meta.platforms`                                                                    |
| [`3e82f96a`](https://github.com/NixOS/nixpkgs/commit/3e82f96a2e901f0d453c41e1732123e8b795c386) | `mpdscribble: Support more platforms`                                                                   |
| [`6ea6e3ca`](https://github.com/NixOS/nixpkgs/commit/6ea6e3ca291627f0df808f397000422c964ca58c) | `fcitx5-with-addons: make fcitx5-lua addon optional`                                                    |
| [`6a2a1594`](https://github.com/NixOS/nixpkgs/commit/6a2a15948b3c5c8461be348ccc59b939f281ef0c) | `fcitx5-with-addons: fix not found liblua.so`                                                           |
| [`893c54b4`](https://github.com/NixOS/nixpkgs/commit/893c54b4a79acba8a1885349fba5d00ae40fa913) | `python310Packages.apache-beam: add compatibility with httplib2 0.21.0`                                 |
| [`c26a6397`](https://github.com/NixOS/nixpkgs/commit/c26a6397d60eaac0963ac34d63d035d674d68d75) | `vdirsyncer: Add passthru.tests.version`                                                                |
| [`63707b54`](https://github.com/NixOS/nixpkgs/commit/63707b54feb16663252b217f53fbfde032712cd5) | `vdirsyncer: 0.18.0->0.19.0`                                                                            |
| [`c3552b53`](https://github.com/NixOS/nixpkgs/commit/c3552b534046bdd9b8e333106ea819c153b0a9c8) | `stochas: 1.3.8 -> 1.3.9`                                                                               |
| [`5faeb3ba`](https://github.com/NixOS/nixpkgs/commit/5faeb3ba2db1f599ab55d48dddf4f1ff54eaa47f) | `factorio: fix review comments`                                                                         |
| [`75f2f8e7`](https://github.com/NixOS/nixpkgs/commit/75f2f8e753a07519713c3113f859a679c52045ce) | `passthrough config if there are no secrets defined`                                                    |
| [`1c2448d2`](https://github.com/NixOS/nixpkgs/commit/1c2448d27eef9db204497b8e7d8bfb02b79e0ef1) | `metamorphose2: remove misspelled buildInput attribute`                                                 |
| [`ad35d94e`](https://github.com/NixOS/nixpkgs/commit/ad35d94ecc75db6dccebe18d83cd71a92f3b16cb) | `xonsh: migrate to /etc/xonsh/xonshrc`                                                                  |
| [`9240dc4a`](https://github.com/NixOS/nixpkgs/commit/9240dc4a532404c130cb0e3ecdade184f30a8d40) | `atlassian-jira: 9.2.0 -> 9.4.0`                                                                        |
| [`d7ea8361`](https://github.com/NixOS/nixpkgs/commit/d7ea83612a285d49fed792382330de61a9900c8e) | `tt-rss-plugin-auth-ldap: unstable-2022-10-31 -> unstable-2022-11-30`                                   |
| [`7776a316`](https://github.com/NixOS/nixpkgs/commit/7776a31612f18700542513f95ed187d32faee339) | `dendrite: 0.10.7 -> 0.10.8`                                                                            |
| [`4642e8b1`](https://github.com/NixOS/nixpkgs/commit/4642e8b1332c68e97921ffdd775acd052cf30c67) | `python310Packages.logilab_astng: remove`                                                               |
| [`412e0fce`](https://github.com/NixOS/nixpkgs/commit/412e0fce5e2cc5d7d5ad771b67ea8a96f3e3b8ff) | `matrix-synapse-plugins.matrix-synapse-mjolnir-antispam: 1.5.0 -> 1.6.1`                                |
| [`277dab89`](https://github.com/NixOS/nixpkgs/commit/277dab8929e45ffc8b2921a043f50465293477c4) | `pineapple-pictures: 0.6.4 -> 0.6.5`                                                                    |
| [`df0200d5`](https://github.com/NixOS/nixpkgs/commit/df0200d5fb91a3f08e33d336b77b0cfa60574047) | `libpwquality: 1.4.4 -> 1.4.5`                                                                          |
| [`46514cc0`](https://github.com/NixOS/nixpkgs/commit/46514cc0d3c98f12b726d66b82ebc45e91c6f0e8) | `pomerium-cli: 0.19.0 -> 0.20.0`                                                                        |
| [`e5673f90`](https://github.com/NixOS/nixpkgs/commit/e5673f902522f47408d7ef3c88ee90d80fb0d4d7) | `pomerium: 0.19.1 -> 0.20.0`                                                                            |
| [`712c2080`](https://github.com/NixOS/nixpkgs/commit/712c208054ba08387f164e1acf7fd4732b4417b1) | `cdogs-sdl: 1.3.1 -> 1.4.0`                                                                             |
| [`51721c6b`](https://github.com/NixOS/nixpkgs/commit/51721c6b3873cd8d2506e5d766ab542c1574dc83) | `python3Packages.imageio: 2.22.1 -> 2.22.4`                                                             |
| [`57d1e946`](https://github.com/NixOS/nixpkgs/commit/57d1e946c663d89adb458a0d6075c72390075d8f) | `hmat-oss: 1.7.1 -> 1.8.1`                                                                              |
| [`c6e6d44f`](https://github.com/NixOS/nixpkgs/commit/c6e6d44fe5f6c4ee4350ed330eb7996b57232ed8) | `factorio: let us change mod settings`                                                                  |
| [`a1115f5e`](https://github.com/NixOS/nixpkgs/commit/a1115f5ea5a82c5758194e7ad72718237a85c1ba) | `factorio: make it easier to supply a custom versions.json`                                             |
| [`c3a0c554`](https://github.com/NixOS/nixpkgs/commit/c3a0c55434a0c0b043fb1cb0f9a862c78d6ff000) | `tracy: 0.8.2.1 -> 0.9`                                                                                 |
| [`0d9e314d`](https://github.com/NixOS/nixpkgs/commit/0d9e314d08633bb11b7b204f1639944354ca7e4f) | `ispc: 1.18.0 -> 1.18.1`                                                                                |