### PR TITLE
chore(flake/emacs-overlay): `f877d256` -> `832ce469`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670868733,
-        "narHash": "sha256-BtQcQA9pDFV43WY7EtsqtzmOHJe496vbDZWGFgd9gYQ=",
+        "lastModified": 1670896926,
+        "narHash": "sha256-8HTSTmUAT85nUp2LPnIxWg5XybarZC8OQCQIuva4LFI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f877d2569e1e9c6dd225f6674ef2f8777582215f",
+        "rev": "832ce4696acba9b6c353495d4f6fd751107f4eca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`832ce469`](https://github.com/nix-community/emacs-overlay/commit/832ce4696acba9b6c353495d4f6fd751107f4eca) | `Updated repos/melpa` |
| [`19377d6d`](https://github.com/nix-community/emacs-overlay/commit/19377d6d61b8a2f11f990eae08333835eeafe844) | `Updated repos/elpa`  |