### PR TITLE
chore(flake/emacs-overlay): `194e3548` -> `3b89af68`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670955596,
-        "narHash": "sha256-WqBGuNZCCvh7Pkl2Dmb1n6/wyFuWcXLVWA0LiTQUk8M=",
+        "lastModified": 1670987371,
+        "narHash": "sha256-McLYfQ9DkTr0mjMH/D5lYfEPolO0Ws5QDfmwxDhTcYs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "194e3548ba5e081b5b496f66738dfb8ad8159c4a",
+        "rev": "3b89af681919a4235ee0aefcdcdb1dc39935129c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`3b89af68`](https://github.com/nix-community/emacs-overlay/commit/3b89af681919a4235ee0aefcdcdb1dc39935129c) | `Updated repos/nongnu` |
| [`81a7ac1c`](https://github.com/nix-community/emacs-overlay/commit/81a7ac1c3d363ce5bdb716d63819a61e53eeb11c) | `Updated repos/melpa`  |
| [`a55b3879`](https://github.com/nix-community/emacs-overlay/commit/a55b3879c0984535b825737af294418d3fca58b1) | `Updated repos/emacs`  |