### PR TITLE
chore(flake/nixpkgs): `33e0d99c` -> `1710ed1f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670841420,
-        "narHash": "sha256-mSEia1FzrsHbfqjorMyYiX8NXdDVeR1Pw1k55jMJlJY=",
+        "lastModified": 1670929434,
+        "narHash": "sha256-n5UBO6XBV4h3TB7FYu2yAuNQMEYOrQyKeODUwKe06ow=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "33e0d99cbedf2acfd7340d2150837fbb28039a64",
+        "rev": "1710ed1f6f8ceb75cf7d1cf55ee0cc21760e1c7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                                         |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
| [`7fedb7f3`](https://github.com/NixOS/nixpkgs/commit/7fedb7f3324ccd1c2bb69338147c4f3eabfafd73) | `kyverno: 1.8.3 -> 1.8.4`                                                                                              |
| [`d2449c76`](https://github.com/NixOS/nixpkgs/commit/d2449c7695217bc67f607158393ee1634ae15609) | `mutagen-compose: 0.16.2 -> 0.16.3`                                                                                    |
| [`b037e632`](https://github.com/NixOS/nixpkgs/commit/b037e632e8fd70176f91e8fbc548bd18f5733612) | `pocketbase: 0.9.0 -> 0.9.2`                                                                                           |
| [`81503a91`](https://github.com/NixOS/nixpkgs/commit/81503a91c8b74fa2a4dfd2c21c2232d00dce8d34) | `python310Packages.pytest-filter-subpackage: add changelog to meta`                                                    |
| [`058d817f`](https://github.com/NixOS/nixpkgs/commit/058d817fd4d6956ff23cdb3129a3b29799142937) | `python3Packages.autopep8: patch for pycodestyle-2.10.0`                                                               |
| [`f0dda807`](https://github.com/NixOS/nixpkgs/commit/f0dda807b29b61d1ab4ec44662767d0f9bd221b3) | `ocamlPackages.merlin: 4.6 → 4.7`                                                                                      |
| [`5f5d24c5`](https://github.com/NixOS/nixpkgs/commit/5f5d24c55f2f59d5499c89492c5f68ce9c338542) | `terraform-providers.pagerduty: 2.6.4 → 2.7.0`                                                                         |
| [`c6ac6db4`](https://github.com/NixOS/nixpkgs/commit/c6ac6db431c1505215947978965a2516fe2531ec) | `terraform-providers.grafana: 1.31.1 → 1.32.0`                                                                         |
| [`01bd3f3e`](https://github.com/NixOS/nixpkgs/commit/01bd3f3e24550b640020e3f42cf2f08263a42986) | `terraform-providers.google-beta: 4.45.0 → 4.46.0`                                                                     |
| [`b0f7bbe9`](https://github.com/NixOS/nixpkgs/commit/b0f7bbe9e46fdd9ef4d4ad6c3458308a345ed6e5) | `terraform-providers.google: 4.45.0 → 4.46.0`                                                                          |
| [`4332592c`](https://github.com/NixOS/nixpkgs/commit/4332592cafdff3f7504e9166d2362c5f3716f726) | `terraform-providers.alicloud: 1.193.1 → 1.194.0`                                                                      |
| [`58bbc587`](https://github.com/NixOS/nixpkgs/commit/58bbc58725545597058907aa1081c77b8402ef9c) | `terraform-providers.argocd: 4.1.0 → 4.2.0`                                                                            |
| [`bd71a881`](https://github.com/NixOS/nixpkgs/commit/bd71a88128d05a68b2bd962ebecd24b91d96ca3f) | `ginkgo: 2.5.1 -> 2.6.0`                                                                                               |
| [`75a9a064`](https://github.com/NixOS/nixpkgs/commit/75a9a06486cb21d96edff0f75cda278744d528bb) | `ghorg: 1.9.0 -> 1.9.1`                                                                                                |
| [`6f4d63b2`](https://github.com/NixOS/nixpkgs/commit/6f4d63b20543430d4d86bae4ba0f52764e3a6234) | `srvc: 0.8.0 -> 0.9.0`                                                                                                 |
| [`f4edf5db`](https://github.com/NixOS/nixpkgs/commit/f4edf5dbb9a5b08e1087315b225db5426328121a) | `python310Packages.pytest-filter-subpackage: 0.1.1 -> 0.1.2`                                                           |
| [`c2720ceb`](https://github.com/NixOS/nixpkgs/commit/c2720cebe7eacb1b637c1906b4ab6e8c09a0ab98) | `python3Packges.tensorflow: workaround buggy std::optional detection in abseil-cpp`                                    |
| [`508b7cb3`](https://github.com/NixOS/nixpkgs/commit/508b7cb367e545d168f2f6f07536e4a6e8596342) | `python3Packages.tensorflow: fix overrides needed for darwin`                                                          |
| [`1d0b181e`](https://github.com/NixOS/nixpkgs/commit/1d0b181e2fb96136ae8b755114b7f7d1799f44e5) | `slurp: fix cross compilation after https://github.com/emersion/slurp/commit/e5fe57abcc3a1a9f25c9e488f952ba1900afafe4` |
| [`6450cba8`](https://github.com/NixOS/nixpkgs/commit/6450cba8b68f14dbd63dbf8319de779f1d2bce6a) | `xgboost: adding self to maintainers list`                                                                             |
| [`f5c7a97d`](https://github.com/NixOS/nixpkgs/commit/f5c7a97d534a6cd0a5774e9f3a5fd045f998374d) | `cbqn: remove unnecessary darwin build flag`                                                                           |
| [`8514b2d6`](https://github.com/NixOS/nixpkgs/commit/8514b2d62a593a9539fcb7a63c346500711b61d5) | `python310Packages.appthreat-vulnerability-db: 4.1.11 -> 4.1.12`                                                       |
| [`51ce0ddd`](https://github.com/NixOS/nixpkgs/commit/51ce0ddd48aa653583ad8c15ce6a61f70ab69a15) | `vimPlugins.vim-teal: init at 2021-01-05`                                                                              |
| [`fe7d02b5`](https://github.com/NixOS/nixpkgs/commit/fe7d02b5f09ecc421b04d68e57b13038e3ec7875) | `git-team: 1.8.0 -> 1.8.1`                                                                                             |
| [`ea393e26`](https://github.com/NixOS/nixpkgs/commit/ea393e2697944ca3306d2c359e12338f575b9cf0) | `cirrus-cli: 0.92.0 -> 0.92.1`                                                                                         |
| [`ac962507`](https://github.com/NixOS/nixpkgs/commit/ac96250768795ae53aa14067e2ceb4306e7c658d) | `vimPlugins.winbar-nvim: init at 2022-07-18`                                                                           |
| [`ee017f0c`](https://github.com/NixOS/nixpkgs/commit/ee017f0c68e4e593e3e37b1ca6a5952db08a886d) | `vimPlugins.lspsaga-nvim-original: init at 2022-12-12`                                                                 |
| [`cd44ef37`](https://github.com/NixOS/nixpkgs/commit/cd44ef375fefe8a99e6edb1705464394bc8dcca0) | `vimPlugins: update`                                                                                                   |
| [`845ac5dc`](https://github.com/NixOS/nixpkgs/commit/845ac5dc21634595f65a624e883e2b5cf14ac900) | `docs: generate docs`                                                                                                  |
| [`3f275272`](https://github.com/NixOS/nixpkgs/commit/3f2752723f642c3a2cade8e26c0a9f5e32b5e221) | `gzdoom: 4.8.2 -> 4.10.0`                                                                                              |
| [`c04f46c9`](https://github.com/NixOS/nixpkgs/commit/c04f46c96397eab978c1d20ad6901c3f6a3a862b) | `zmusic: init at 1.1.11`                                                                                               |
| [`5766b2b5`](https://github.com/NixOS/nixpkgs/commit/5766b2b5e2fea889f9ad8e8b1afeff06103dabd9) | `newsflash: 2.2.2 -> 2.2.3`                                                                                            |
| [`7db82980`](https://github.com/NixOS/nixpkgs/commit/7db82980f1ed7fcbf324a72376a5ffd94b1691df) | `purescript: 0.15.6 -> 0.15.7`                                                                                         |
| [`495b7190`](https://github.com/NixOS/nixpkgs/commit/495b71906c2b63e90ef7dbed334222c00c82738d) | `docs: added missing semicolon in example`                                                                             |
| [`0348abd7`](https://github.com/NixOS/nixpkgs/commit/0348abd7fc538b3c6be4889c68a102d889416a8a) | `cpm-cmake: use github source`                                                                                         |
| [`568e01e6`](https://github.com/NixOS/nixpkgs/commit/568e01e675d136c05c31bda743dcf64d849d63d3) | `cmake: incorporate darwin and libsForQt5 into its expression`                                                         |
| [`ae339869`](https://github.com/NixOS/nixpkgs/commit/ae339869beaf30072fe68e47049e3b4920b93ad1) | `delve: set meta.mainProgram`                                                                                          |
| [`f5d555c2`](https://github.com/NixOS/nixpkgs/commit/f5d555c28ea5ba734604dd14433e556f77370eac) | `teams: add figsoda to the vim team and codeowners`                                                                    |
| [`c53f7181`](https://github.com/NixOS/nixpkgs/commit/c53f71817bd738d62add4359c0411bcfbd56f09b) | `cargo-modules: 0.7.0 -> 0.7.1`                                                                                        |
| [`105607e1`](https://github.com/NixOS/nixpkgs/commit/105607e11799140c8883b1b889e34ce4f6ec9194) | `delve: 1.20.0 -> 1.20.1`                                                                                              |
| [`ea588cd3`](https://github.com/NixOS/nixpkgs/commit/ea588cd3640f4de19f840dd9933174a017612151) | `kodiPackages.youtube: 6.8.22+matrix.1 -> 6.8.23+matrix.1`                                                             |
| [`659eadaf`](https://github.com/NixOS/nixpkgs/commit/659eadaf12fe7be4e13999f853260a571a169468) | `jackett: 0.20.2352 -> 0.20.2365`                                                                                      |
| [`c9563115`](https://github.com/NixOS/nixpkgs/commit/c9563115f333a88a0898449621e7e5c4d26ee6fe) | `nuclei: 2.8.2 -> 2.8.3`                                                                                               |
| [`0a8826e7`](https://github.com/NixOS/nixpkgs/commit/0a8826e7582cf357c1248e10653fd946e6570f99) | `clightning: 22.11 -> 22.11.1`                                                                                         |
| [`c0a50076`](https://github.com/NixOS/nixpkgs/commit/c0a50076f29e5023358a12e5f1067e034644e7e9) | `changie: 1.10.0 -> 1.10.1`                                                                                            |
| [`6b27ccc1`](https://github.com/NixOS/nixpkgs/commit/6b27ccc1fb7f39321fec23680e6394938e523e9d) | `sysdig: 0.29.3 -> 0.30.2`                                                                                             |
| [`729486a6`](https://github.com/NixOS/nixpkgs/commit/729486a6670feeb91c4305f0090e1a03cd28ca96) | `wine, winetricks: add updateScript`                                                                                   |
| [`d6f4f458`](https://github.com/NixOS/nixpkgs/commit/d6f4f4584ae5f04c4f5caf7574106025b34ab883) | `nixos/botamusique: allow syscalls in the @resources group`                                                            |
| [`0927d7e8`](https://github.com/NixOS/nixpkgs/commit/0927d7e8893670960a1922ee35e1d2c3e473cf6d) | `lib2geom: fix tests on i686`                                                                                          |
| [`578bd38b`](https://github.com/NixOS/nixpkgs/commit/578bd38b65db7c2f92a04066134134ff1bfbc9ae) | `rambox: 0.7.9 -> 2.0.9`                                                                                               |
| [`709a8136`](https://github.com/NixOS/nixpkgs/commit/709a81362c77b9e09718a962084b8ca0a53dc569) | `xonsh: 0.13.3 -> 0.13.4`                                                                                              |
| [`68c2954e`](https://github.com/NixOS/nixpkgs/commit/68c2954ea5644f2924c523b9d9b4c6f8d543e846) | `bitcoin: 24.0 -> 24.0.1`                                                                                              |
| [`101c6852`](https://github.com/NixOS/nixpkgs/commit/101c685296f97d6c19df6be36ab5b9cc4bee0cd9) | `autosuspend: 4.2.0 -> 4.3.0`                                                                                          |
| [`11061c6d`](https://github.com/NixOS/nixpkgs/commit/11061c6ddf20e54ce3d51eca5291367f0a2297a0) | `plantuml-server: 1.2022.13 -> 1.2022.14`                                                                              |
| [`ebb5623e`](https://github.com/NixOS/nixpkgs/commit/ebb5623e04adcac6ea289baff97bc77b56b6b6f0) | `clojure: 1.11.1.1200 -> 1.11.1.1208`                                                                                  |
| [`d9411df6`](https://github.com/NixOS/nixpkgs/commit/d9411df65bea20d202be54a78543c4f868c500ea) | `soundOfSorting: incorporate darwin into its expression`                                                               |
| [`7f00403e`](https://github.com/NixOS/nixpkgs/commit/7f00403e5f6ae1a743d3f7ddc8ed232403dc6407) | `mpv-unwrapped: incorporate darwin into its expression`                                                                |
| [`0cbaaf47`](https://github.com/NixOS/nixpkgs/commit/0cbaaf47d5d718be70d40a09b940eb805036a73a) | `wxSVG: incorporate darwin into its expression`                                                                        |
| [`d8e45aef`](https://github.com/NixOS/nixpkgs/commit/d8e45aef2aa4b9217ead6dcdb9b67bbf76373f44) | `plan9port: incorporate darwin into its expression`                                                                    |
| [`e88150fa`](https://github.com/NixOS/nixpkgs/commit/e88150faaa3afc1b948300b9f2197b1fe7520439) | `ftgl: incorporate darwin into its expression`                                                                         |
| [`0c293b2d`](https://github.com/NixOS/nixpkgs/commit/0c293b2dd7fc3a5458edb2a6d181a56e38c8f642) | `aegisub: incorporate darwin into its expression`                                                                      |
| [`28a54761`](https://github.com/NixOS/nixpkgs/commit/28a5476184f8f8a78b7414a9a1bc482ccc7b5b36) | `treewide: remove e-user from maintainers`                                                                             |
| [`c2366647`](https://github.com/NixOS/nixpkgs/commit/c23666473c8bf88a46ea24444a6c40a5dacb16bd) | `doc: Remove all section numbers`                                                                                      |
| [`f4793e27`](https://github.com/NixOS/nixpkgs/commit/f4793e27c55360b4eec6bffd915af53bdbd78524) | `appthreat-depscan: 3.2.7 -> 3.3.0`                                                                                    |
| [`095d61f3`](https://github.com/NixOS/nixpkgs/commit/095d61f3e96f95a1e330a7c0c4d458839b56b0b4) | `openasar: unstable-2022-12-01 -> unstable-2022-12-11`                                                                 |
| [`f6919f62`](https://github.com/NixOS/nixpkgs/commit/f6919f6299a2f924dec1772d67c8c062b60e912e) | `fcitx5: remove global with`                                                                                           |
| [`ee0d2e1f`](https://github.com/NixOS/nixpkgs/commit/ee0d2e1f7c72edc888e4d51c75d955a4a85c97f9) | `python310Packages.yalexs-ble: 1.11.3 -> 1.11.4`                                                                       |
| [`082372df`](https://github.com/NixOS/nixpkgs/commit/082372df5a5c8a0d08c9cad6eab32f6401404e56) | `python310Packages.yalexs-ble: 1.11.2 -> 1.11.3`                                                                       |
| [`3082a900`](https://github.com/NixOS/nixpkgs/commit/3082a90095f9cd3ecf26dc142e4b48d927fcb9fd) | `python310Packages.yalexs-ble: 1.11.1 -> 1.11.2`                                                                       |
| [`b0e0d0ce`](https://github.com/NixOS/nixpkgs/commit/b0e0d0ce7799e978ee6bb534938dea04dcab2cd3) | `python310Packages.yalexs-ble: 1.11.0 -> 1.11.1`                                                                       |
| [`25511005`](https://github.com/NixOS/nixpkgs/commit/25511005d353b23c5e09fffdbef3d997264193c7) | `python310Packages.yalexs-ble: 1.10.3 -> 1.11.0`                                                                       |
| [`170b2221`](https://github.com/NixOS/nixpkgs/commit/170b2221a4da46837201d26dd30e3e6ed38ac805) | `python310Packages.griffe: 0.24.1 -> 0.25.0`                                                                           |
| [`132ac650`](https://github.com/NixOS/nixpkgs/commit/132ac650012fe7062cad1f8db67ddf577a0571e6) | `wiki-js: 2.5.292 -> 2.5.294`                                                                                          |
| [`233eac77`](https://github.com/NixOS/nixpkgs/commit/233eac778b28fa37aef2376c04ed0f6e0bdc0088) | `python310Packages.hahomematic: 2022.12.1 -> 2022.12.2`                                                                |
| [`373f74f9`](https://github.com/NixOS/nixpkgs/commit/373f74f918419981b37d225baa9f05c8d7c79fc0) | `python310Packages.lupupy: 0.2.1 -> 0.2.3`                                                                             |
| [`1d17ca13`](https://github.com/NixOS/nixpkgs/commit/1d17ca131e7a769112cb57184e7dc17a4bba9bb5) | `python310Packages.pyvicare: 2.20.0 -> 2.21.0`                                                                         |
| [`2c4de226`](https://github.com/NixOS/nixpkgs/commit/2c4de226587fed1ec7d1a8def3b0ac8ca542f21d) | `python310Packages.appthreat-vulnerability-db: 4.1.8 -> 4.1.11`                                                        |
| [`c3b18f64`](https://github.com/NixOS/nixpkgs/commit/c3b18f64e6494c57aaa767e6a1768646e68fd2b2) | `python310Packages.aioqsw: 0.2.2 -> 0.3.1`                                                                             |
| [`c70263ec`](https://github.com/NixOS/nixpkgs/commit/c70263ec3ce2679c92bdc3661833c6929371f06d) | `python310Packages.aioqsw: add changelog to meta`                                                                      |
| [`7765d08b`](https://github.com/NixOS/nixpkgs/commit/7765d08b5206c481a56ceb9bedff60154b7ad4d8) | `amass: 3.21.1 -> 3.21.2`                                                                                              |
| [`94166d15`](https://github.com/NixOS/nixpkgs/commit/94166d15c1604484506b55c1cf84225df5dab7b1) | `flexget: add changelog to meta`                                                                                       |
| [`eaa43948`](https://github.com/NixOS/nixpkgs/commit/eaa4394823006000c135e89664be72df59e00271) | `flexget: 3.5.9 -> 3.5.10`                                                                                             |
| [`8782ccac`](https://github.com/NixOS/nixpkgs/commit/8782ccac95b375dae4d38132065edbfe21be5a00) | `shfmt: 3.5.1 -> 3.6.0`                                                                                                |
| [`609ef3f7`](https://github.com/NixOS/nixpkgs/commit/609ef3f74ebf5c91162948d771ac32f80c77c7db) | `linux: add 6.1`                                                                                                       |
| [`bd35bc1f`](https://github.com/NixOS/nixpkgs/commit/bd35bc1f873a09f0b8c7fbf1a3860a9debe45a05) | `signal-desktop-beta: reinit at 6.1.0-beta.1`                                                                          |
| [`b980f12b`](https://github.com/NixOS/nixpkgs/commit/b980f12b66e427befb784123e4512ea09535e1cb) | `knot-dns: 3.2.3 -> 3.2.4`                                                                                             |
| [`a05192a4`](https://github.com/NixOS/nixpkgs/commit/a05192a4769ea3292ba2364be389c68239493731) | `ruff: 0.0.176 -> 0.0.177`                                                                                             |
| [`7e6e7b69`](https://github.com/NixOS/nixpkgs/commit/7e6e7b6936ef1b57554064838ba7fc5c8a062314) | `felix-fm: 2.1.1 -> 2.2.0`                                                                                             |
| [`b09e866b`](https://github.com/NixOS/nixpkgs/commit/b09e866b851d1cf76080c6991fa011357fd54f22) | `miniupnpc: install binaries and manpages`                                                                             |
| [`1dd03283`](https://github.com/NixOS/nixpkgs/commit/1dd0328344af0fe49fd06d39dd9fa5fcebbefd7a) | `appflowy: 0.0.8 -> 0.0.8.1`                                                                                           |
| [`bceabe0c`](https://github.com/NixOS/nixpkgs/commit/bceabe0ca9eee6a461168b0d409683bfc69310b2) | `amberol: 0.9.1 -> 0.9.2`                                                                                              |
| [`75d7299d`](https://github.com/NixOS/nixpkgs/commit/75d7299df1438a2f96fa6f47ef454a2cb41e6be3) | `Revert "rocm-llvm: enable clang-tools-extra for clang-tidy"`                                                          |
| [`90e3db28`](https://github.com/NixOS/nixpkgs/commit/90e3db28758406b25ea941bc971a3e1ae5a294ab) | `composable_kernel: unstable-2022-11-19 → unstable-2022-12-08`                                                         |
| [`fbb79459`](https://github.com/NixOS/nixpkgs/commit/fbb79459e6f57e8c7e1fe0419e9e90960879c517) | `composable_kernel: use unstableGitUpdater`                                                                            |
| [`463ca676`](https://github.com/NixOS/nixpkgs/commit/463ca6768c129e71ba9cb7870dc04bf2683f4df9) | `miopen: disable fetching KDBs by default`                                                                             |
| [`9b98f843`](https://github.com/NixOS/nixpkgs/commit/9b98f8433af210894f4bd9d6a76a1602fb9419ae) | `rocm-related: create and use a generic updater script`                                                                |
| [`72f5af19`](https://github.com/NixOS/nixpkgs/commit/72f5af191f2c799131bfb67398a12301e7663239) | `fetchGitHub: inherit owner and repo for use with rocmUpdateScript`                                                    |
| [`c770b44a`](https://github.com/NixOS/nixpkgs/commit/c770b44aff6e7eb7e19c64e4442fe2332af9d7b4) | `nixos/cloudflared: init`                                                                                              |
| [`2fbf439b`](https://github.com/NixOS/nixpkgs/commit/2fbf439bf21dc35b4d2385f28a7be3cde7b8580d) | `tsm-client: 8.1.15.1 -> 8.1.17.0`                                                                                     |
| [`9b52b756`](https://github.com/NixOS/nixpkgs/commit/9b52b75600653899d5b08c85bed4d80ae094f0bd) | `diffoscope: 225 -> 228`                                                                                               |
| [`c03c334e`](https://github.com/NixOS/nixpkgs/commit/c03c334ee31aeaa700204ff85aa52cba6f4b0fd0) | `librem: 2.9.0 -> 2.10.0`                                                                                              |
| [`6603ebb0`](https://github.com/NixOS/nixpkgs/commit/6603ebb0e5d59c20a5a179342c050a690623b9a4) | `groestlcoin: 23.0 -> 24.0.1`                                                                                          |
| [`820c539e`](https://github.com/NixOS/nixpkgs/commit/820c539e86629a875a56f77200edbc9328718eec) | `linux_logo: 6.0 -> 6.01`                                                                                              |
| [`c492cf49`](https://github.com/NixOS/nixpkgs/commit/c492cf49d1766efbe4eb8a166cf824a9e794f0bb) | `gajim: 1.5.3 → 1.5.4`                                                                                                 |
| [`929ba985`](https://github.com/NixOS/nixpkgs/commit/929ba985be80ebe53096bcffe9de6c71e64ccf1f) | `discord: 0.0.21 -> 0.0.22`                                                                                            |
| [`e4d2c760`](https://github.com/NixOS/nixpkgs/commit/e4d2c760beabe517824c5b881b0dd084bcbe61f9) | `awscli2: 2.9.4 -> 2.9.6`                                                                                              |
| [`33a5eb7b`](https://github.com/NixOS/nixpkgs/commit/33a5eb7be13f3ef0366be6d1d7435a809c51ade4) | `rocm-related: 5.3.3 → 5.4.0`                                                                                          |
| [`97e2e764`](https://github.com/NixOS/nixpkgs/commit/97e2e764e699f0bb136a5f7c266eb273ea8fcb54) | `jobber: init at 1.4.4`                                                                                                |
| [`370593ba`](https://github.com/NixOS/nixpkgs/commit/370593baf8cc557bb2126e8bead1a7ca5b40bd9e) | `olaris-server: init at 0.4.0`                                                                                         |
| [`d32346df`](https://github.com/NixOS/nixpkgs/commit/d32346df9a42870f1e70ab60155b9ab6fbe3c061) | `emptty: init at 0.9.0`                                                                                                |
| [`58be1bf4`](https://github.com/NixOS/nixpkgs/commit/58be1bf4577132ef8dcbf1efa6427a0679b9b634) | `ddclient: 3.9.1 -> 3.10.0`                                                                                            |
| [`e4a160eb`](https://github.com/NixOS/nixpkgs/commit/e4a160eb7f1910695779e31577ea9d29c54a6339) | `perlPackages.IOSocketINET6: rename to match expected name from upstream name`                                         |
| [`1c81d6c3`](https://github.com/NixOS/nixpkgs/commit/1c81d6c33aed674aebdeb8e16312e64b01e0a765) | `discord: add libglvnd and fix electron flags`                                                                         |
| [`2427e9a0`](https://github.com/NixOS/nixpkgs/commit/2427e9a0cce12c0550d04e4feae73a6a8ce41545) | `python310Packages.pysqlcipher3: fix build`                                                                            |
| [`833155db`](https://github.com/NixOS/nixpkgs/commit/833155db7ec45f6b9ebd023f350b05f7c368421f) | `geckodriver: 0.31.0 -> 0.32.0`                                                                                        |