### PR TITLE
chore(flake/emacs-overlay): `3b89af68` -> `21bc6afe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670987371,
-        "narHash": "sha256-McLYfQ9DkTr0mjMH/D5lYfEPolO0Ws5QDfmwxDhTcYs=",
+        "lastModified": 1671012915,
+        "narHash": "sha256-kdhp6pAT69M1q85bljqhFI8iWSRMJ58DGOY23kCFK6I=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3b89af681919a4235ee0aefcdcdb1dc39935129c",
+        "rev": "21bc6afe66d63036cb4d5dba77473f55b61a9524",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`21bc6afe`](https://github.com/nix-community/emacs-overlay/commit/21bc6afe66d63036cb4d5dba77473f55b61a9524) | `Updated repos/nongnu` |
| [`fbc7b794`](https://github.com/nix-community/emacs-overlay/commit/fbc7b7949f173ccfa63b81883517eb24e7c7ae2c) | `Updated repos/melpa`  |
| [`e31afe71`](https://github.com/nix-community/emacs-overlay/commit/e31afe71f86d75fdf82c6096babdf3c083e48193) | `Updated repos/emacs`  |