### PR TITLE
chore(flake/darwin): `6349b99b` -> `852f451f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668784520,
-        "narHash": "sha256-gGgVAMwYPPmrfnvnoRi6OkEB5KRsNTb9uYzEceLdO/g=",
+        "lastModified": 1671015382,
+        "narHash": "sha256-Ag2zzhO2Cv2+bgKmbbbSua/hdktGT1GnMA2TX4K2EhI=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "6349b99bc2b96ded34d068a88c7c5ced406b7f7f",
+        "rev": "852f451fee7bc3a353b097f5f9d36a8d307c3416",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                                       |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`38463b15`](https://github.com/LnL7/nix-darwin/commit/38463b15ec224ebc81e3631c6fd6c499775dd230) | `darwin-rebuild: fixing logic error in if statement` |
| [`da843c0d`](https://github.com/LnL7/nix-darwin/commit/da843c0dde3462c96f13c69590cf47b87f91df95) | ``darwin-rebuild: use `--no-link` for flake builds`` |
| [`c148d28c`](https://github.com/LnL7/nix-darwin/commit/c148d28c67e5b3be15f3b22ff292d3273370208c) | `Add wg-quick module`                                |