### PR TITLE
chore(flake/nur): `27d50007` -> `7ac44865`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671019582,
-        "narHash": "sha256-Ki8iKDIc7c+vMhIU34dH+gCBqFnE2EbPWibGj0O1MS4=",
+        "lastModified": 1671035267,
+        "narHash": "sha256-Fm1V/rfGr2rCw8drF9VjsWibfd6KXbe52Iqur8vfw6s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "27d5000771adf5be0b91d9c3b9c04518e30f0fa6",
+        "rev": "7ac448653e67ac3e6d316400613fab642ede010b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message      |
| -------------------------------------------------------------------------------------------------- | ------------------- |
| [`7ac44865`](https://github.com/nix-community/NUR/commit/7ac448653e67ac3e6d316400613fab642ede010b) | `automatic update`  |
| [`a9362223`](https://github.com/nix-community/NUR/commit/a9362223784963ddf13ace8314b5f30110bb0fef) | `Update repos.json` |
| [`fd72aef0`](https://github.com/nix-community/NUR/commit/fd72aef0367970ff650162830a0b154899f34bfe) | `Update repos.json` |