### PR TITLE
chore(flake/emacs-overlay): `21bc6afe` -> `49fd7961`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671012915,
-        "narHash": "sha256-kdhp6pAT69M1q85bljqhFI8iWSRMJ58DGOY23kCFK6I=",
+        "lastModified": 1671041954,
+        "narHash": "sha256-9PAshLuIOr+F9qbyDrmgQXLF+fWcCW4zJTud7yaqX2c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "21bc6afe66d63036cb4d5dba77473f55b61a9524",
+        "rev": "49fd7961fd9e46796ddf6e52a258f08bcd9ad4f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`49fd7961`](https://github.com/nix-community/emacs-overlay/commit/49fd7961fd9e46796ddf6e52a258f08bcd9ad4f8) | `Updated repos/melpa` |
| [`6080d46a`](https://github.com/nix-community/emacs-overlay/commit/6080d46a220dd393c56d555286dee75488abbe2c) | `Updated repos/emacs` |
| [`66cd81c0`](https://github.com/nix-community/emacs-overlay/commit/66cd81c0ec485ec4b1fcaaedaef2e238231d9413) | `Updated repos/elpa`  |