### PR TITLE
chore(flake/emacs-overlay): `49fd7961` -> `1f20ccc1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671041954,
-        "narHash": "sha256-9PAshLuIOr+F9qbyDrmgQXLF+fWcCW4zJTud7yaqX2c=",
+        "lastModified": 1671074777,
+        "narHash": "sha256-SbOayyX/SkSTFY30ktqIPvwrWWTv2lOBVIdMZF0UbOY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "49fd7961fd9e46796ddf6e52a258f08bcd9ad4f8",
+        "rev": "1f20ccc1b8cb303a2651e9c18e1c65bfce8ce6d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`1f20ccc1`](https://github.com/nix-community/emacs-overlay/commit/1f20ccc1b8cb303a2651e9c18e1c65bfce8ce6d1) | `Updated repos/nongnu` |
| [`e42736e0`](https://github.com/nix-community/emacs-overlay/commit/e42736e0c404b29ed648662fb9f62f744309581e) | `Updated repos/melpa`  |
| [`dec7f00a`](https://github.com/nix-community/emacs-overlay/commit/dec7f00ad9b53137a6e9d14c8fa21742e043bdcb) | `Updated repos/emacs`  |
| [`706bea96`](https://github.com/nix-community/emacs-overlay/commit/706bea96aaa2266a2658c047d2da1b472fb1587d) | `Updated repos/elpa`   |