### PR TITLE
chore(flake/emacs-overlay): `0e1a47ea` -> `c873175c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671099536,
-        "narHash": "sha256-e0VCSDEg1NCfqf17A36pccksqYF+m1NCcc0p+cOP89M=",
+        "lastModified": 1671128331,
+        "narHash": "sha256-oa3HZNgyAWEx09eElSISpRCltgYqHshjphJ9eeTO6As=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0e1a47eadd23dc5669f056f28de606c9d00a1c29",
+        "rev": "c873175c2f8d96cd77c5b6552f411ddd0959e483",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`c873175c`](https://github.com/nix-community/emacs-overlay/commit/c873175c2f8d96cd77c5b6552f411ddd0959e483) | `Updated repos/melpa` |
| [`e0a9de13`](https://github.com/nix-community/emacs-overlay/commit/e0a9de13f4334f174e07baced0965adfffc6dcc9) | `Updated repos/emacs` |