### PR TITLE
chore(flake/nixpkgs): `1710ed1f` -> `62433a48`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670929434,
-        "narHash": "sha256-n5UBO6XBV4h3TB7FYu2yAuNQMEYOrQyKeODUwKe06ow=",
+        "lastModified": 1671021324,
+        "narHash": "sha256-MDB6TncBzBCvAgQmjNn14VIaO5wdbxExp8NGP990Udk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1710ed1f6f8ceb75cf7d1cf55ee0cc21760e1c7a",
+        "rev": "62433a4892603c523840a67e50b6631c37adb928",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                   |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`59bcb2e3`](https://github.com/NixOS/nixpkgs/commit/59bcb2e371eb96638143a3c177ba4191cb0b2a00) | `perlPackages.SysVirt: 8.9.0 -> 8.10.0`                                          |
| [`af7927c8`](https://github.com/NixOS/nixpkgs/commit/af7927c8430d61db7511ffdba579889751513c59) | `vimPlugins.nvim-treesitter: add missing meta entries`                           |
| [`5e117045`](https://github.com/NixOS/nixpkgs/commit/5e117045934fa1b49f68465a52ff105b2911a391) | `nixos/ntfy-sh: fix & expose nixos test`                                         |
| [`1b746236`](https://github.com/NixOS/nixpkgs/commit/1b74623693cc01fadf2b4fb5e8805b74fb884377) | `ntfy-sh: expose updateScript, update node packages`                             |
| [`54a72985`](https://github.com/NixOS/nixpkgs/commit/54a7298517566b45f7adcd69a47441e5856f3dfc) | `qFlipper: 1.2.1 -> 1.2.2`                                                       |
| [`308f2df4`](https://github.com/NixOS/nixpkgs/commit/308f2df4d8e79fbc9b1ee06f1989ace35efb33f7) | `python310Packages.py-vapid: disable on older Python releases`                   |
| [`f291676c`](https://github.com/NixOS/nixpkgs/commit/f291676cac41942990a2c659f80e71196eb2ed35) | `python310Packages.omegaconf: add changelog to meta`                             |
| [`bc556c9f`](https://github.com/NixOS/nixpkgs/commit/bc556c9f40994d7140f39d36f1b2a9616b820032) | `python310Packages.metakernel: add missing input`                                |
| [`332debee`](https://github.com/NixOS/nixpkgs/commit/332debee1d8a2cc52020fc363841f0d261cb0f92) | `python310Packages.jedi: add changelog to meta`                                  |
| [`1a1a65f8`](https://github.com/NixOS/nixpkgs/commit/1a1a65f88224d79960a02bce5dd32ace97922918) | `python310Packages.metakernel: add changelog to meta`                            |
| [`28ba4691`](https://github.com/NixOS/nixpkgs/commit/28ba469101d71d8c4576400d3b3b8f6bc6ef1401) | `python310Packages.jedi: 0.18.1 -> 0.18.2`                                       |
| [`fbcb8414`](https://github.com/NixOS/nixpkgs/commit/fbcb841415d8004de3ce6ee07b5df4371172bd4b) | `python310Packages.pytest-remotedata: add changelog to meta`                     |
| [`b1648e3b`](https://github.com/NixOS/nixpkgs/commit/b1648e3b6a94264087b714b390eb40f9b6649c65) | `ocaml-ng.ocamlPackages_5_0: 5.0.0-β2 → 5.0.0-rc1`                               |
| [`07def67e`](https://github.com/NixOS/nixpkgs/commit/07def67e0ad13a969937b88d4d0ebf5409d6422d) | `python310Packages.pytest-remotedata: 0.3.3 -> 0.4.0`                            |
| [`ca33b477`](https://github.com/NixOS/nixpkgs/commit/ca33b47760fbdd0764f9c25537d75461a66d20ac) | `open-policy-agent: 0.47.2 -> 0.47.3`                                            |
| [`037e57cb`](https://github.com/NixOS/nixpkgs/commit/037e57cbafa882034c7bf3a20ac90170339e55f2) | `cinnamon.mint-themes: 2.0.7 -> 2.0.8`                                           |
| [`e588c1fa`](https://github.com/NixOS/nixpkgs/commit/e588c1faed9d7a5836c6a3ed2a856465a80459cb) | `python310Packages.omegaconf: 2.2.3 -> 2.3.0`                                    |
| [`03354f45`](https://github.com/NixOS/nixpkgs/commit/03354f45abe4241a2bdacf569f0711c53b2bb8e6) | `plasma5: Help D-Bus find kactivitymanagerd`                                     |
| [`34b2fcfd`](https://github.com/NixOS/nixpkgs/commit/34b2fcfd19c370d88e6ac9d6a37a1110e441b0ad) | `plasma5: Enable PipeWire by default`                                            |
| [`69cd1a14`](https://github.com/NixOS/nixpkgs/commit/69cd1a14924fd393b39ee2b2df7b6adc59691ab7) | `kalendar: fix missing dependencies`                                             |
| [`04d8085f`](https://github.com/NixOS/nixpkgs/commit/04d8085f743bfd61466f5e4f7b319b0faea34c32) | `ksmtp: Update  patch`                                                           |
| [`1bd7a3fb`](https://github.com/NixOS/nixpkgs/commit/1bd7a3fb1c9956d300b48ee327d785afc3ea608c) | `colord-kde: move to kde gear packages`                                          |
| [`ca7d9064`](https://github.com/NixOS/nixpkgs/commit/ca7d9064032744ab6febc605ea2ee052e0df025b) | `kde-gear: 22.08.3 -> 22.12.0`                                                   |
| [`43cf3dbe`](https://github.com/NixOS/nixpkgs/commit/43cf3dbe08ba78fbd3fe4b460fba474204f6fd0f) | `mlt: 7.8.0 -> 7.12.0`                                                           |
| [`ac4820ac`](https://github.com/NixOS/nixpkgs/commit/ac4820acaa74786a9450f779fef7c387a9e2f732) | `d2: 0.1.0 -> 0.1.1`                                                             |
| [`f98e6d62`](https://github.com/NixOS/nixpkgs/commit/f98e6d62900864259ee3f1d82a91baa5a7309a90) | `unifi7: 7.2.95 -> 7.3.76`                                                       |
| [`97707d68`](https://github.com/NixOS/nixpkgs/commit/97707d681ac2abdd7b86eea1ab04dfb87fbd3f5d) | `python310Packages.moderngl: 5.7.3 -> 5.7.4`                                     |
| [`39ec9364`](https://github.com/NixOS/nixpkgs/commit/39ec93644a54cf93b3ddb6c032178b549bf3ea08) | `python310Packages.metakernel: 0.29.2 -> 0.29.4`                                 |
| [`952dc38c`](https://github.com/NixOS/nixpkgs/commit/952dc38c4e3f28e69dec735f365a2403a4dd2471) | `python310Packages.meshtastic: 2.0.5 -> 2.0.6`                                   |
| [`04eb9165`](https://github.com/NixOS/nixpkgs/commit/04eb9165133e375372e49a753efc2ebc3821cf00) | `python310Packages.mautrix: 0.18.8 -> 0.18.9`                                    |
| [`91ccc070`](https://github.com/NixOS/nixpkgs/commit/91ccc070208d5a27df308dad2e751209e69d9aba) | `cloudflared: 2022.8.2 -> 2022.11.1, add tests and additional platforms`         |
| [`c3ed133c`](https://github.com/NixOS/nixpkgs/commit/c3ed133cb94407c7bcead0dc9e2b7b773b9db9ea) | `python310Packages.line_profiler: 4.0.1 -> 4.0.2`                                |
| [`942da19c`](https://github.com/NixOS/nixpkgs/commit/942da19c56600f094a1de5a652254801f5bd4696) | `mcfly: 0.6.1 -> 0.7.0`                                                          |
| [`e3e35e40`](https://github.com/NixOS/nixpkgs/commit/e3e35e40579a9ac0ed8493168c2b66f5791e4bb7) | `maintainers: add piperswe`                                                      |
| [`d6cfb0f5`](https://github.com/NixOS/nixpkgs/commit/d6cfb0f5e6831647353057fad574dd9e1b2c65e2) | `sqlite: add 'tracker' package to list of tests`                                 |
| [`88c89e9a`](https://github.com/NixOS/nixpkgs/commit/88c89e9a7f20a5fe15fba6cfec6725ef1886a173) | `python3Packages.xgboost: unbreak`                                               |
| [`a6886cf9`](https://github.com/NixOS/nixpkgs/commit/a6886cf9b390100d830a322eac225444ba0ae903) | `xgboost: 1.5.2 -> 1.7.2`                                                        |
| [`9833d56c`](https://github.com/NixOS/nixpkgs/commit/9833d56c2483c3635339b1636dee61b52e3378fc) | `treewide: mark packages broken that never built on PLATFORM`                    |
| [`ffd69736`](https://github.com/NixOS/nixpkgs/commit/ffd697364fdd28e3bf02f396a2a84fcca413c699) | `python310Packages.deploykit: add pythonImportsCheck`                            |
| [`051dd317`](https://github.com/NixOS/nixpkgs/commit/051dd317287b49a0878955dcbd5507e65cd89b7f) | `python310Packages.deploykit: add changelog to meta`                             |
| [`1626e6f2`](https://github.com/NixOS/nixpkgs/commit/1626e6f20ac8ec4b50c0735eb2551a66b6cd2e85) | `python310Packages.angr: 9.2.28 -> 9.2.29`                                       |
| [`d5901ce0`](https://github.com/NixOS/nixpkgs/commit/d5901ce00389f5e7e1ba14ed282c7826d35f4b2d) | `python310Packages.cle: 9.2.28 -> 9.2.29`                                        |
| [`0aca1cf7`](https://github.com/NixOS/nixpkgs/commit/0aca1cf79aa45c68fe9e8a99b22129452b3d9a5b) | `python310Packages.claripy: 9.2.28 -> 9.2.29`                                    |
| [`83523ab0`](https://github.com/NixOS/nixpkgs/commit/83523ab04d59bf3504c3a5611b597c4998aa0f61) | `python310Packages.pyvex: 9.2.28 -> 9.2.29`                                      |
| [`d578d6b5`](https://github.com/NixOS/nixpkgs/commit/d578d6b5288473b638c4cfc3106c6f50760b2cd7) | `python310Packages.ailment: 9.2.28 -> 9.2.29`                                    |
| [`dc71f6d0`](https://github.com/NixOS/nixpkgs/commit/dc71f6d033b13e78182736966ecd25f50a843207) | `python310Packages.archinfo: 9.2.28 -> 9.2.29`                                   |
| [`2c78bbbb`](https://github.com/NixOS/nixpkgs/commit/2c78bbbbb45e4854cf714968cdc293c3f31ceba4) | `reg: Fix aarch64-darwin build`                                                  |
| [`7b50756d`](https://github.com/NixOS/nixpkgs/commit/7b50756d8297f16b4aa27e518f578cde9e718c0d) | `ruff: 0.0.177 -> 0.0.179`                                                       |
| [`44daadff`](https://github.com/NixOS/nixpkgs/commit/44daadff50522b16018e71c86f33a50ab1960953) | `proj: add package tests`                                                        |
| [`b18950b7`](https://github.com/NixOS/nixpkgs/commit/b18950b7c39a7fbb9e4450fce36e74e95c94d753) | `starship: 1.11.0 -> 1.12.0`                                                     |
| [`db7e799e`](https://github.com/NixOS/nixpkgs/commit/db7e799ebb90d37e0785a17448326a7bb93049da) | `fn-cli: 0.6.22 -> 0.6.23`                                                       |
| [`9cea1456`](https://github.com/NixOS/nixpkgs/commit/9cea14567fc63dc38c2cf9e3318e85b3adaee1e1) | `citations: init at 0.5.1`                                                       |
| [`d474f888`](https://github.com/NixOS/nixpkgs/commit/d474f8888421150b506d813851f557f579d8346b) | `maintainers: add benediktbroich`                                                |
| [`28c1f459`](https://github.com/NixOS/nixpkgs/commit/28c1f459e8b1b06420bfaa2f59c4638b40750b5c) | `megapixels: 1.5.2 -> 1.6.0`                                                     |
| [`16875b3e`](https://github.com/NixOS/nixpkgs/commit/16875b3e7be8380c29af192cc8ff1debae6d311a) | `hjson-go: add changelog to meta`                                                |
| [`713b5c27`](https://github.com/NixOS/nixpkgs/commit/713b5c27ab0b0de01b779ed24b2ff6fe7172fedb) | `hjson-go: 4.2.0 -> 4.3.0`                                                       |
| [`0668224e`](https://github.com/NixOS/nixpkgs/commit/0668224e7fdd032e4058772bb1c7fba83b57cd3f) | `banking: 0.5.1 -> 0.6.0`                                                        |
| [`93e4170a`](https://github.com/NixOS/nixpkgs/commit/93e4170a3e9388afcea73ab2346fcdc37f068587) | `python310Packages.pycodestyle: fix meta.changelog`                              |
| [`db417854`](https://github.com/NixOS/nixpkgs/commit/db4178543cf40bb4ae1a907e8b9679dbc879ac76) | `pyproj: 3.4.0 -> 3.4.1`                                                         |
| [`d3c2574c`](https://github.com/NixOS/nixpkgs/commit/d3c2574cc46089c8af04660a2263f4e39acb7e0a) | `zellij: 0.34.3 -> 0.34.4`                                                       |
| [`1b299a2e`](https://github.com/NixOS/nixpkgs/commit/1b299a2e6cfcb6fccccc07dbbd9e1e7bb3e30816) | `ea: init at 0.2.1 (#204816)`                                                    |
| [`2b99a45f`](https://github.com/NixOS/nixpkgs/commit/2b99a45fe4dee378669e340cc221ce9cb0113507) | `kubeone: add changelog to meta`                                                 |
| [`87529be5`](https://github.com/NixOS/nixpkgs/commit/87529be5ee4f1f847e512d2d55aec3cc14905850) | `kube-score: add changelog to meta`                                              |
| [`5b8d33eb`](https://github.com/NixOS/nixpkgs/commit/5b8d33eb302c0112adf83c15933db0b6afe0f7e0) | `python3.pkgs.deploykit: 1.0.1 -> 1.0.2`                                         |
| [`f6dbd52c`](https://github.com/NixOS/nixpkgs/commit/f6dbd52c8588ff52f74a2b2009f745570f39f3ab) | `kubeone: 1.5.3 -> 1.5.4`                                                        |
| [`20e51b30`](https://github.com/NixOS/nixpkgs/commit/20e51b30ea8769b17fa042aab163bdb0aca90325) | `kube-score: 1.14.0 -> 1.16.0`                                                   |
| [`46dce1eb`](https://github.com/NixOS/nixpkgs/commit/46dce1ebc2f6f3dfff9df0346e80e5457745cfd0) | `python310Packages.zadnegoale: 0.6.5 -> 0.7.0`                                   |
| [`423b8fc8`](https://github.com/NixOS/nixpkgs/commit/423b8fc89337df4fa4b6af928330c17ef51930e0) | `python310Packages.zadnegoale: add changelog to meta`                            |
| [`efbd9031`](https://github.com/NixOS/nixpkgs/commit/efbd9031a8e807776013b3df69b28298f72e7b11) | `python310Packages.zha-quirks: 0.0.88 -> 0.0.89`                                 |
| [`f14e2b26`](https://github.com/NixOS/nixpkgs/commit/f14e2b2609da5cc0fd821cb9b96067102ec82832) | `python310Packages.bluetooth-auto-recovery: 0.5.5 -> 1.0.0`                      |
| [`f5225bdd`](https://github.com/NixOS/nixpkgs/commit/f5225bdd3a0a1752e5edde00860ecbe45ce2689d) | `python310Packages.pyoverkiz: 1.7.1 -> 1.7.2`                                    |
| [`2e943fc0`](https://github.com/NixOS/nixpkgs/commit/2e943fc060032e3b4e3dc028ba1acbe8f2446afd) | `resholve: use stripped-down python27`                                           |
| [`5315838a`](https://github.com/NixOS/nixpkgs/commit/5315838a26b3f5491a4b65d1b107d53ae9d80af7) | `wireplumber: 0.4.12 -> 0.4.13`                                                  |
| [`9a70465b`](https://github.com/NixOS/nixpkgs/commit/9a70465be7aeed940c6ec2db9de65ec4b288331b) | `python310Packages.hahomematic: 2022.12.2 -> 2022.12.3`                          |
| [`2afa2a25`](https://github.com/NixOS/nixpkgs/commit/2afa2a25ad1540e64565f6a312d417f3d07ae5bf) | `python310Packages.graphene: 3.2.0 -> 3.2.1`                                     |
| [`35e2079b`](https://github.com/NixOS/nixpkgs/commit/35e2079bd5a3c5a213068c9fae1fa766cf1fb249) | `ocamlPackages.pyml: 20220615 → 20220905`                                        |
| [`beaf7262`](https://github.com/NixOS/nixpkgs/commit/beaf7262e6a1d8276eccc93b3fd9ea2dd2e11470) | `ocamlPackages.stdcompat: 18 → 19`                                               |
| [`c913b406`](https://github.com/NixOS/nixpkgs/commit/c913b406e3029ac5597634a6bbe0b3ad5a39fe06) | `gleam: 0.25.0 -> 0.25.1`                                                        |
| [`7b37acd9`](https://github.com/NixOS/nixpkgs/commit/7b37acd9bab693262f67d1511fe64abb92527e32) | `jove: 4.17.4.7 -> 4.17.4.8`                                                     |
| [`ca01321f`](https://github.com/NixOS/nixpkgs/commit/ca01321f0572552adc10845dc069cb8dfac0c1d8) | `python310Packages.jupyterlab: 3.5.0 -> 3.5.1 (#205023)`                         |
| [`4cb98810`](https://github.com/NixOS/nixpkgs/commit/4cb98810baf7960d28576edfc39a7df8aa8ccb18) | `packer: 1.8.4 -> 1.8.5 (#205879)`                                               |
| [`7673d511`](https://github.com/NixOS/nixpkgs/commit/7673d5110f3f12c2fb058b8e8a08a29179704de3) | `firefox-esr-unwrapped: 102.5.0esr -> 102.6.0esr`                                |
| [`980cc45e`](https://github.com/NixOS/nixpkgs/commit/980cc45e15cfff107634524735735d960947eed1) | `imagemagick: 7.1.0-53 -> 7.1.0-54`                                              |
| [`8fb4a5b3`](https://github.com/NixOS/nixpkgs/commit/8fb4a5b389864e657e20214275953fde840f73e5) | `pjsip-jami: patch for CVE`                                                      |
| [`62e1d58a`](https://github.com/NixOS/nixpkgs/commit/62e1d58a6fbced03205afd00ec0e896d2ac26c45) | `trivial-builders.writeShellApplication: use unwrapped pandoc`                   |
| [`3b3f77b1`](https://github.com/NixOS/nixpkgs/commit/3b3f77b1815388c6a320265ea4262dadb47914ed) | `inkscape: 1.2.1 → 1.2.2`                                                        |
| [`4c9a5864`](https://github.com/NixOS/nixpkgs/commit/4c9a58643fcf87f36d8ef57604f318aca6bab2be) | `lib2geom: 1.2 → 1.2.2`                                                          |
| [`b20aa7ff`](https://github.com/NixOS/nixpkgs/commit/b20aa7ffb85b7ca71d50061acdab5ffe86156136) | `vimPlugins.forms: remove unused with`                                           |
| [`24fdc402`](https://github.com/NixOS/nixpkgs/commit/24fdc402751a61fcde65230e6fe2469a9673efa1) | `vimPlugins.skim-vim: fix dependencies`                                          |
| [`32e71f7f`](https://github.com/NixOS/nixpkgs/commit/32e71f7f2ab029132d528ec56d9ed00696e3733d) | `sic-image-cli: 0.20.0 -> 0.20.1`                                                |
| [`d25c7aa2`](https://github.com/NixOS/nixpkgs/commit/d25c7aa2f08b1e7f1efa59086906c54a2f3bfdab) | `python310Packages.PyChromecast: 13.0.2 -> 13.0.3`                               |
| [`547c3341`](https://github.com/NixOS/nixpkgs/commit/547c334142c7283cde59385d0e7f00817ba8c634) | `nerdctl: 1.0.0 -> 1.1.0`                                                        |
| [`33881cc5`](https://github.com/NixOS/nixpkgs/commit/33881cc55864ebfa5c0bcb21d2ebf30338000de3) | `khard: Add passthru.tests.version`                                              |
| [`18289a67`](https://github.com/NixOS/nixpkgs/commit/18289a67b03f02876065a06f34c3acd52be25127) | `khard: 0.17.0->0.18.0`                                                          |
| [`85f91f3f`](https://github.com/NixOS/nixpkgs/commit/85f91f3f47229eb0a3cdbee1f97abe3a390d0469) | `firefox*: 107.0.1 -> 108.0`                                                     |
| [`2c840708`](https://github.com/NixOS/nixpkgs/commit/2c8407089b399e0796678d440289eee829298f42) | `sgx-sdk: pin to openssl_1_1`                                                    |
| [`89df194c`](https://github.com/NixOS/nixpkgs/commit/89df194cbf0f38123bce7f913f1efde54c233568) | `toml11: init at 3.7.1`                                                          |
| [`d7c4e4ff`](https://github.com/NixOS/nixpkgs/commit/d7c4e4ff63f9f3ee7587d828d50b38d6ce4e639b) | `zsh-forgit: 22.11.0 -> 22.12.0`                                                 |
| [`8e832b78`](https://github.com/NixOS/nixpkgs/commit/8e832b78fdb99c22e254a001028f84a5cb1a81ee) | `element-{web,desktop}: 1.11.15 -> 1.11.16`                                      |
| [`1f0f9ada`](https://github.com/NixOS/nixpkgs/commit/1f0f9ada8614c59717bf8e9e342c4d1c71df84fe) | `weka: 3.9.2 -> 3.9.6`                                                           |
| [`529a6969`](https://github.com/NixOS/nixpkgs/commit/529a6969ac7390a275ddfeb8b18e3b231c44ef4c) | `s2n-tls: 1.3.29 -> 1.3.30`                                                      |
| [`7776739d`](https://github.com/NixOS/nixpkgs/commit/7776739d6590219ff39f9145c59f674105506420) | `python310Packages.geopandas: add changelog to meta`                             |
| [`d9f5e185`](https://github.com/NixOS/nixpkgs/commit/d9f5e18533809c24846199604faa3feafb43bccd) | `prometheus-xmpp-alerts: 0.5.3 -> 0.5.6`                                         |
| [`64dfa559`](https://github.com/NixOS/nixpkgs/commit/64dfa559041eeac2459fef26d07db6e035c20e4a) | `python310Packages.aiohttp-openmetrics: init at 0.0.11`                          |
| [`89f8ab0e`](https://github.com/NixOS/nixpkgs/commit/89f8ab0e19f8c0a564de62079878acf502e32294) | `python3Packages.geopandas: 0.12.1 → 0.12.2`                                     |
| [`d8f6360c`](https://github.com/NixOS/nixpkgs/commit/d8f6360c160b88fdbf08c1e52ab659af92bbb65f) | `chromiumBeta: 109.0.5414.25 -> 109.0.5414.36`                                   |
| [`50e4fd18`](https://github.com/NixOS/nixpkgs/commit/50e4fd186916c1ce02cdfc2a761f7ba08aeb9928) | `python310Packages.py-vapid: 1.8.2 -> 1.9.0`                                     |
| [`73fddfcc`](https://github.com/NixOS/nixpkgs/commit/73fddfcc38fa5c57f8897b2c7165a818b9bc9dc2) | `dosbox: fix build on darwin`                                                    |
| [`fedd4d02`](https://github.com/NixOS/nixpkgs/commit/fedd4d02f5d06d0846c60232ee9fc8bebf846783) | `pinocchio: fix build on x86_64-darwin`                                          |
| [`561083d2`](https://github.com/NixOS/nixpkgs/commit/561083d21b8599eb966adc91471892eefde5ef3b) | `crocoddyl, python3Packages.crocoddyl: init at 1.9.0`                            |
| [`2192f88c`](https://github.com/NixOS/nixpkgs/commit/2192f88c20c2b23a6f22de5ba3cc2589554174f5) | `example-robot-data, python3Packages.example-robot-data: init at 4.0.3`          |
| [`217f72ac`](https://github.com/NixOS/nixpkgs/commit/217f72acc3d3c4e9fb18fba74bb65ba02d8b89ba) | `pinocchio, python3Packages.pinocchio: init at 2.6.12`                           |
| [`cd11ab58`](https://github.com/NixOS/nixpkgs/commit/cd11ab58c56a56a97ac86394c261a39b9e5c579d) | `python3Packages.eigenpy: init at 2.8.1`                                         |
| [`09dad325`](https://github.com/NixOS/nixpkgs/commit/09dad325e747a74c2da5699b7796ab670a16eab4) | `gnome.lightsoff: add darwin support`                                            |
| [`9384db3a`](https://github.com/NixOS/nixpkgs/commit/9384db3a7acd6c42911b9bc85dc804cd98e8f2e8) | `gnome.iagno: add darwin support`                                                |
| [`436ae017`](https://github.com/NixOS/nixpkgs/commit/436ae01708544d80785246b10f3085ac31b4e611) | `gnome.gnome-tetravex: add darwin support`                                       |
| [`c44d56a9`](https://github.com/NixOS/nixpkgs/commit/c44d56a93fa31107f3dae2d3c44bf48d99d078c2) | `gnome.gnome-taquin: add darwin support`                                         |
| [`ce94e877`](https://github.com/NixOS/nixpkgs/commit/ce94e8776893c5818b80059fa84d621717500846) | `gnome.gnome-sudoku: add darwin support`                                         |
| [`eececd00`](https://github.com/NixOS/nixpkgs/commit/eececd0079d9bc8cbeff950b4d21e417d0d929af) | `qqwing: add darwin support`                                                     |
| [`d2e1ec44`](https://github.com/NixOS/nixpkgs/commit/d2e1ec446e0594b927483bdddccf0644c9724f3f) | `gnome.gnome-robots: add darwin support`                                         |
| [`8bf5d95e`](https://github.com/NixOS/nixpkgs/commit/8bf5d95eb7fb504ce785c8ead430515137ef0ef7) | `gnome.gnome-mines: add darwin support`                                          |
| [`da5fa08c`](https://github.com/NixOS/nixpkgs/commit/da5fa08c699aca46e6537da6c72f0006a49c897e) | `gnome.gnome-mahjongg: add darwin support`                                       |
| [`24ae8152`](https://github.com/NixOS/nixpkgs/commit/24ae8152a402e8f1e0dfb984005cbcbf429a6902) | `gnome.gnome-klotski: add darwin support`                                        |
| [`90602c66`](https://github.com/NixOS/nixpkgs/commit/90602c66e3acba91335ff45d7bda27cf61ad4bee) | `gnome.gnome-chess: add darwin support`                                          |
| [`b857855b`](https://github.com/NixOS/nixpkgs/commit/b857855b0e24f0128f1d6d8a53849268e76bc736) | `gnome.four-in-a-row: add darwin support`                                        |
| [`58d1860e`](https://github.com/NixOS/nixpkgs/commit/58d1860ed85e0612a2003c26838166483b456ef5) | `gnome.five-or-more: add darwin support`                                         |
| [`48bc7784`](https://github.com/NixOS/nixpkgs/commit/48bc7784ab34a517a597dcbee0dec4d0a23a4a7d) | `rl-2305: Mention services.fwupd.daemonSettings`                                 |
| [`c4ae704b`](https://github.com/NixOS/nixpkgs/commit/c4ae704be63c52069e97df7adc8b1183005e16a8) | `nixos/fwupd: Make daemon.conf structured`                                       |
| [`a899f747`](https://github.com/NixOS/nixpkgs/commit/a899f74775f43761f66667cd6658ec150e383ab5) | `petsc: reenable stackprotector on aarch64-darwin`                               |
| [`6545a924`](https://github.com/NixOS/nixpkgs/commit/6545a9245d94e71e63982c1c2877ec2bae79702d) | `python310Packages.spsdk: 1.6.3 -> 1.8.0`                                        |
| [`78746f56`](https://github.com/NixOS/nixpkgs/commit/78746f5621ee65a381b4be1d309c65a79d48c3e6) | `python310Packages.click-command-tree: init at 1.1.0`                            |
| [`0f362f6c`](https://github.com/NixOS/nixpkgs/commit/0f362f6cc05883521cfaa1fda8ca54f40efae692) | `minecraft-server-hibernation: init at 2.4.10`                                   |
| [`f9743988`](https://github.com/NixOS/nixpkgs/commit/f9743988adab260740f30950614ef88c3a9d3ef9) | `linuxPackages.hyperv-daemons: add path conditions for kvp and vss`              |
| [`7e0c2c18`](https://github.com/NixOS/nixpkgs/commit/7e0c2c183533c41761811b2fbd17accd061e7ad5) | `libvirt: add changelog to meta`                                                 |
| [`32c854e0`](https://github.com/NixOS/nixpkgs/commit/32c854e0e41eddd0758257c6e13ae567bd42204a) | `libvirt: 8.9.0 -> 8.10.0`                                                       |
| [`f4e55630`](https://github.com/NixOS/nixpkgs/commit/f4e55630539a4481ed373bdfcd77d264088ada02) | `firefox-devedition-bin-unwrapped: 107.0b9 -> 108.0b9`                           |
| [`b4adc07d`](https://github.com/NixOS/nixpkgs/commit/b4adc07d7dca1f765489be94ee026cac5d0d82d4) | `firefox-beta-bin-unwrapped: 107.0b9 -> 108.0b9`                                 |
| [`531207e3`](https://github.com/NixOS/nixpkgs/commit/531207e37c87f212d0a669b369bbd495834e7730) | `reuse: add Luflosi as maintainer`                                               |
| [`33448e2d`](https://github.com/NixOS/nixpkgs/commit/33448e2db25955d7a932b430f832103bbaafa380) | `reuse: 1.0.0 -> 1.1.0`                                                          |
| [`8a892ef8`](https://github.com/NixOS/nixpkgs/commit/8a892ef88376036225c910276712536ce9139bd1) | `minetest: put the app in $out/Applications/ to let it appear in /Applications/` |
| [`02590ae0`](https://github.com/NixOS/nixpkgs/commit/02590ae0639f8f7f17ef2812d191f4b29fb77e87) | `thumbdrives: init at 0.3.1`                                                     |
| [`d215aedb`](https://github.com/NixOS/nixpkgs/commit/d215aedb48e3ede553f60f098c0a44114687949c) | `ntfy-sh: 1.28.0 -> 1.29.1`                                                      |
| [`a09bb2d5`](https://github.com/NixOS/nixpkgs/commit/a09bb2d5e50093c7f9db03bac558053db6807596) | `headlines: init at 0.7.2`                                                       |
| [`13c891ef`](https://github.com/NixOS/nixpkgs/commit/13c891efa5309d1555fda72132ab4806609aff17) | `easyeffects: 6.3.0 -> 7.0.0`                                                    |
| [`bab1ba48`](https://github.com/NixOS/nixpkgs/commit/bab1ba485c5c46c964e003fae943e2461d748d9c) | `superd: init at 0.7`                                                            |
| [`49d249ed`](https://github.com/NixOS/nixpkgs/commit/49d249ed0a4739a43bfd9f7197e458c6538aeb2e) | `sweethome3d: 6.6 -> 7.0.2`                                                      |