### PR TITLE
chore(flake/emacs-overlay): `c873175c` -> `af726f49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671128331,
-        "narHash": "sha256-oa3HZNgyAWEx09eElSISpRCltgYqHshjphJ9eeTO6As=",
+        "lastModified": 1671160938,
+        "narHash": "sha256-6tTWOoxJ2k4cbAo8VZI71ytpaepDBRA+dA87N6e1c6o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c873175c2f8d96cd77c5b6552f411ddd0959e483",
+        "rev": "af726f4941acc7367d75bc8e35c2ad047fd727f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`af726f49`](https://github.com/nix-community/emacs-overlay/commit/af726f4941acc7367d75bc8e35c2ad047fd727f9) | `Updated repos/melpa` |
| [`77579c71`](https://github.com/nix-community/emacs-overlay/commit/77579c7153a8b50c073df0954140386c24a43789) | `Updated repos/emacs` |