### PR TITLE
chore(flake/nixpkgs): `62433a48` -> `0f5996b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671021324,
-        "narHash": "sha256-MDB6TncBzBCvAgQmjNn14VIaO5wdbxExp8NGP990Udk=",
+        "lastModified": 1671108576,
+        "narHash": "sha256-6ggOL6KoaELNA1562tnPjtAnQ9SwsKRTgeuaXvPzCwI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "62433a4892603c523840a67e50b6631c37adb928",
+        "rev": "0f5996b524c91677891a432cc99c7567c7c402b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`0f5996b5`](https://github.com/NixOS/nixpkgs/commit/0f5996b524c91677891a432cc99c7567c7c402b1) | `below: don't use aliases`                                         |
| [`2230108f`](https://github.com/NixOS/nixpkgs/commit/2230108f55c9c810270b473298eec71139d7387e) | `python2Packages.typing: revert removal`                           |
| [`6ea94a2c`](https://github.com/NixOS/nixpkgs/commit/6ea94a2cf8dd622c980cc2821d05fb20ff6daadf) | `treewide: revert removal of references to pythonPackages.scandir` |
| [`8549e49c`](https://github.com/NixOS/nixpkgs/commit/8549e49c1833197f71e62e6d3f51bf72d4338ee2) | `python2Packages.scandir: revert removal`                          |
| [`1218bada`](https://github.com/NixOS/nixpkgs/commit/1218bada61121324257503524468e1036e7fc85b) | `onedrive: 2.4.21 -> 2.4.22`                                       |
| [`b28b8118`](https://github.com/NixOS/nixpkgs/commit/b28b8118f2b528f236133ffef79d0ad693f320a2) | `ocamlPackages.sha: 1.15.1 → 1.15.2`                               |
| [`062b7f42`](https://github.com/NixOS/nixpkgs/commit/062b7f42fdbb383f7d228d9b5444a720fba1d3ec) | `ocamlPackages.lustre-v6: 6.103.3 -> 6.107.1`                      |
| [`a715b7b9`](https://github.com/NixOS/nixpkgs/commit/a715b7b909978cca6f16993b9f8d68add4e132a2) | `v2ray-geoip: 202212080044 -> 202212150047`                        |
| [`5953f692`](https://github.com/NixOS/nixpkgs/commit/5953f6926f2d99b2056aa6513a9545e0b1b9d1d5) | `python310Packages.bashlex: 0.15 -> 0.16`                          |
| [`73a94273`](https://github.com/NixOS/nixpkgs/commit/73a9427360a30d36f0921c110d7a9ac95830a4e0) | `python310Packages.cartopy: 0.21.0 -> 0.21.1`                      |
| [`5c6b747f`](https://github.com/NixOS/nixpkgs/commit/5c6b747f087c7ba838de85f82d9f8eb8b0b52e6f) | `python310Packages.micloud: 0.5 -> 0.6`                            |
| [`03339a58`](https://github.com/NixOS/nixpkgs/commit/03339a584081c375450e8a061f29bf67ce27db01) | `python310Packages.safety: 2.3.3 -> 2.3.5`                         |
| [`9a6a5c7c`](https://github.com/NixOS/nixpkgs/commit/9a6a5c7cf9c13dddd1cef14b5a3ff812764af0a4) | `python310Packages.mastodon-py: 1.7.0 -> 1.8.0`                    |
| [`9630cb38`](https://github.com/NixOS/nixpkgs/commit/9630cb38d954aaf690e667ddf53db8d71f5c51ef) | `python310Packages.pikepdf: 6.2.4 -> 6.2.5`                        |
| [`f2711088`](https://github.com/NixOS/nixpkgs/commit/f2711088ee1ea543d737fee6dab06f7c028e4abb) | `python310Packages.bonsai: init at 5.1.1`                          |
| [`e0f2dcda`](https://github.com/NixOS/nixpkgs/commit/e0f2dcdab6245df76c56703275db924cf213d459) | `python310Packages.pyomo: 6.4.3 -> 6.4.4`                          |
| [`3dda6800`](https://github.com/NixOS/nixpkgs/commit/3dda6800a60a231b50221d2abc9bc075ba1f30f4) | `python310Packages.pynetbox: 6.6.2 -> 7.0.0`                       |
| [`f0f06846`](https://github.com/NixOS/nixpkgs/commit/f0f06846e95b7bb6f140a4d4eb999967cc08105e) | `python310Packages.pyrdfa3: patch CVE-2022-4396`                   |
| [`b3f9e498`](https://github.com/NixOS/nixpkgs/commit/b3f9e49833511db7c6e6e8f91c8b3490c6ffc45b) | `cargo-generate: 0.17.3 -> 0.17.4`                                 |
| [`dce61952`](https://github.com/NixOS/nixpkgs/commit/dce61952e202b11d43bc5b27c00d0c1e6bf2969d) | `qgis-ltr: drop unused xlibsWrapper inputs`                        |
| [`1666dc68`](https://github.com/NixOS/nixpkgs/commit/1666dc68b7edc3d5a9e65feac54a95dacdbcea92) | `qgis: drop unused xlibsWrapper inputs`                            |
| [`e6bac956`](https://github.com/NixOS/nixpkgs/commit/e6bac9563a12c3f106683e6f74cc24825ab62a71) | `steghide: init at 0.5.1.1`                                        |
| [`756a5e6b`](https://github.com/NixOS/nixpkgs/commit/756a5e6b74f786f08fa3a4c006b31fa316133566) | `CONTRIBUTING: loose squash merging rules (#204988)`               |
| [`410ae09c`](https://github.com/NixOS/nixpkgs/commit/410ae09cc3e50be539ac6cf1cdf5fe1fcf028266) | `github-runner: 2.299.1 -> 2.300.0 (#206107)`                      |
| [`dfac3e44`](https://github.com/NixOS/nixpkgs/commit/dfac3e4480ca83402940823ba9f78fe537ca9d6e) | `healthchecks: 2.4.1 -> 2.5`                                       |
| [`3bd200b2`](https://github.com/NixOS/nixpkgs/commit/3bd200b2aa21b8a7edae7eac921ae7bd2a121c4d) | `tmuxPlugins.fuzzback: init at unstable-2022-11-21`                |
| [`bfc60c93`](https://github.com/NixOS/nixpkgs/commit/bfc60c9362e3762bba03e7a3de56ffb672d7812b) | `nixos/wireplumber: assert hsphfpd to be disabled`                 |
| [`6de54be9`](https://github.com/NixOS/nixpkgs/commit/6de54be915b5d5bd73144f7ff897667dfe3dd4ea) | `below: init at 0.6.3`                                             |
| [`a3f4f11a`](https://github.com/NixOS/nixpkgs/commit/a3f4f11aed12406496db9cbd32595daf33be5895) | `tut: 1.0.24 -> 1.0.25`                                            |
| [`cb975170`](https://github.com/NixOS/nixpkgs/commit/cb97517032d8058a16f11a5f1cb1d2d7515551c4) | `todoist: 0.16.0 -> 0.17.0`                                        |
| [`ac4bf61b`](https://github.com/NixOS/nixpkgs/commit/ac4bf61b9a7ea60fd36f790d6c7a747ed4d8f6c5) | `terragrunt: 0.42.3 -> 0.42.4`                                     |
| [`22742335`](https://github.com/NixOS/nixpkgs/commit/22742335f18f26cd04c524b6ba23a89b2abda839) | `telegraf: 1.24.4 -> 1.25.0`                                       |
| [`351bd301`](https://github.com/NixOS/nixpkgs/commit/351bd3014791e221ad58e04d9499e202520c44d1) | `home-assistant: 2022.12.5 -> 2022.12.6`                           |
| [`a981c15a`](https://github.com/NixOS/nixpkgs/commit/a981c15a0e19957aa878335d29bcac67fa318c85) | `python3Packages.aioesphomeapi: 13.0.1 -> 13.0.2`                  |
| [`a7f7d5d6`](https://github.com/NixOS/nixpkgs/commit/a7f7d5d637cdd1daa7d4062debb87fcfa8b2e4bd) | `rapidfuzz-cpp: 1.10.1 -> 1.10.4`                                  |
| [`4938e72a`](https://github.com/NixOS/nixpkgs/commit/4938e72add339f76d795284cb5a3aae85d02ee53) | `gopls: 0.10.1 -> 0.11.0`                                          |
| [`fc78698d`](https://github.com/NixOS/nixpkgs/commit/fc78698ddd21e1b91acec4fb17aeda01737ba40e) | `rgp: 1.13.1 -> 1.14`                                              |
| [`4a817788`](https://github.com/NixOS/nixpkgs/commit/4a81778866439f47fa66bbe81142a47513a443b4) | `consul: 1.14.2 -> 1.14.3`                                         |
| [`480e4ebd`](https://github.com/NixOS/nixpkgs/commit/480e4ebdaa4a2abe3a1d6a0171984693bda18d1e) | `kubernetes-helm: 3.10.2 -> 3.10.3`                                |
| [`40fe7f93`](https://github.com/NixOS/nixpkgs/commit/40fe7f93306e3aa74f83cfa3f1dca24b1fe80279) | `tauon: 7.4.5 -> 7.4.6`                                            |
| [`e97506eb`](https://github.com/NixOS/nixpkgs/commit/e97506eb94e402fe8ada4729d1b77d3f6bf17a85) | `tar2ext4: 0.9.5 -> 0.9.6`                                         |
| [`3b9ab25c`](https://github.com/NixOS/nixpkgs/commit/3b9ab25c14c14fec8ad6a43d60eda300c15b1d03) | `bottles: 2022.11.14 -> 2022.12.14`                                |
| [`e2b79f08`](https://github.com/NixOS/nixpkgs/commit/e2b79f08bdc9de33df60edc214ddd6d6415caac5) | `gpsd: add listenany option`                                       |
| [`5046b3bd`](https://github.com/NixOS/nixpkgs/commit/5046b3bd1a23a1553a98412603bf86bdaaa56b09) | `librewolf: 107.0.1-2 -> 108.0-1`                                  |
| [`3627fc70`](https://github.com/NixOS/nixpkgs/commit/3627fc707fb6a07a75ad62166b7004ff987c347e) | `qovery-cli: 0.46.4 -> 0.46.7`                                     |
| [`7fb6e1e0`](https://github.com/NixOS/nixpkgs/commit/7fb6e1e05459f1261717197d0d68402776510578) | `qovery-cli: add changelog to meta`                                |
| [`6ebb38b6`](https://github.com/NixOS/nixpkgs/commit/6ebb38b66d312d6d2d19aea419900ba61b2a74ec) | `python310Packages.aioshelly: 5.1.1 -> 5.2.0`                      |
| [`a92a680e`](https://github.com/NixOS/nixpkgs/commit/a92a680e594c01210e849dc3c8bc0643124b4fa9) | `grype: 0.53.1 -> 0.54.0`                                          |
| [`9dd65f0e`](https://github.com/NixOS/nixpkgs/commit/9dd65f0e33ac8684933162093df4e6e19f43da0f) | `sonobuoy: 0.56.12 -> 0.56.13`                                     |
| [`a51b4764`](https://github.com/NixOS/nixpkgs/commit/a51b4764091db3f56d5ac143d4401224c019f695) | `shopify-themekit: 1.3.0 -> 1.3.1`                                 |
| [`21192f2c`](https://github.com/NixOS/nixpkgs/commit/21192f2cbadf5956e8ba6a7c2c2f476ecc113215) | `sbctl: 0.9 -> 0.10`                                               |
| [`93abeba9`](https://github.com/NixOS/nixpkgs/commit/93abeba9f150f55bda13696969dd8e8b59f029e3) | `rust-analyzer-unwrapped: 2022-12-05 -> 2022-12-12`                |
| [`428382fe`](https://github.com/NixOS/nixpkgs/commit/428382fe478f9742c69ad3da37c901e41b0f37bd) | `rtl8821cu: 2022-05-07 -> 2022-12-07`                              |
| [`074623d9`](https://github.com/NixOS/nixpkgs/commit/074623d912822e5ffa75090aba4c1e3d79273ca5) | `istioctl: 1.16.0 -> 1.16.1`                                       |
| [`d37dca5f`](https://github.com/NixOS/nixpkgs/commit/d37dca5f1474ee08df0e0f17ee2d6d5d39196ee9) | `nixos/tests/vaultwarden: Update selenium tests for 2022.10.0`     |
| [`5ad720fe`](https://github.com/NixOS/nixpkgs/commit/5ad720fef434cf51576b622840728c842227bda7) | `vaultwarden.webvault: 2022.11.1 -> 2022.10.0`                     |
| [`0497d5b9`](https://github.com/NixOS/nixpkgs/commit/0497d5b99f7d6b7282ab77c30f1f791a47b41566) | `vaultwarden: Add update script to keep web vault in sync`         |
| [`897fa059`](https://github.com/NixOS/nixpkgs/commit/897fa059a14d3f58dda09dab1db3f913c74fd936) | `polkit: only fix mocklibc when doing tests`                       |
| [`ce7ac9ba`](https://github.com/NixOS/nixpkgs/commit/ce7ac9ba4d289d73e5746361b15f3d5f59668605) | `oh-my-posh: 12.26.1 -> 12.26.2`                                   |
| [`6a108b2f`](https://github.com/NixOS/nixpkgs/commit/6a108b2f761dd5cc481852acb172804db20a56f8) | `gnome.mutter: use finalAttrs pattern`                             |
| [`7bb8a420`](https://github.com/NixOS/nixpkgs/commit/7bb8a4209534af23be677c5c20568a45ff4a663a) | `nixos/vim: fix example package`                                   |
| [`7131d183`](https://github.com/NixOS/nixpkgs/commit/7131d1832c0bcf3d9a20f1200105fe6519b714e9) | `gnome.mutter: Drop unneeded patch`                                |
| [`48beb95e`](https://github.com/NixOS/nixpkgs/commit/48beb95e210d9b5b6eaf59529d5d2dbb5960748f) | `linux_xanmod_latest: 6.0.7 -> 6.1.0`                              |
| [`9fcef193`](https://github.com/NixOS/nixpkgs/commit/9fcef1939c88c76599544f42aa8069fface4094f) | `linux_xanmod: 5.15.75 -> 5.15.81`                                 |
| [`dad3f747`](https://github.com/NixOS/nixpkgs/commit/dad3f747532dfcd982620a6f1f2a802134fbebdf) | `python3Packages.wandb: fix build`                                 |
| [`a65b7972`](https://github.com/NixOS/nixpkgs/commit/a65b7972dde1eb7e46ace60fb983f0a2f0b1bb4c) | `cpp-jwt: init at 1.4`                                             |
| [`1c3d404e`](https://github.com/NixOS/nixpkgs/commit/1c3d404e30226e9ecab4ed86d843c4377b21f489) | `vkbasalt: 0.3.2.6 -> 0.3.2.8`                                     |
| [`8eeed836`](https://github.com/NixOS/nixpkgs/commit/8eeed8360e766229d4d221a7f98db31491c4f4f4) | `python310Packages.pyairvisual: 2022.11.1 -> 2022.12.0`            |
| [`37e95078`](https://github.com/NixOS/nixpkgs/commit/37e95078fd4b3c2003cbac8e75dd209b78982b9d) | `python310Packages.mkdocstrings: add changelog to meta`            |
| [`155c741a`](https://github.com/NixOS/nixpkgs/commit/155c741a319f40f79d1d98cf71f444ba04290b82) | `python310Packages.mkdocstrings: 0.19.0 -> 0.19.1`                 |
| [`533ee911`](https://github.com/NixOS/nixpkgs/commit/533ee91117b857416fb3c8af5c083951d536d10c) | `nginxMainline: 1.23.2 -> 1.23.3`                                  |
| [`0ef86487`](https://github.com/NixOS/nixpkgs/commit/0ef86487fd01010a10aa633efbb79d968f388a8c) | `python310Packages.atenpdu: 0.3.5 -> 0.3.6`                        |
| [`4bdf1d69`](https://github.com/NixOS/nixpkgs/commit/4bdf1d6982a54c6eb93197841c6fd6c5243b37ef) | `imaginary: init at 1.2.4`                                         |
| [`fed6d1aa`](https://github.com/NixOS/nixpkgs/commit/fed6d1aaba36bea69e98810c615aed032ecdec32) | `acorn: init at 0.4.2`                                             |
| [`85ef2ebb`](https://github.com/NixOS/nixpkgs/commit/85ef2ebb5c3df0b4ec3ef9a0ff4036f71f6bef16) | `material-kwin-decorations: disable -Werror`                       |
| [`ad2ee81c`](https://github.com/NixOS/nixpkgs/commit/ad2ee81cad2d166f9c39d95223cdf974e99fca69) | `python3Packages.add-trailing-comma: 2.3.0 -> 2.4.0`               |
| [`9abe2d3b`](https://github.com/NixOS/nixpkgs/commit/9abe2d3b61c29cf5f24bc1361882a57577484ce0) | `ma1sd: 2.4.0 -> 2.5.0`                                            |
| [`a9617234`](https://github.com/NixOS/nixpkgs/commit/a96172348e95bd2d643817a1a86a8d03e791723d) | `transmission: add package option`                                 |
| [`26063c2a`](https://github.com/NixOS/nixpkgs/commit/26063c2a10597f971ddb53d6ebb9cbea8a1024cf) | `python310Packages.phik: 0.12.2 -> 0.12.3`                         |
| [`0509b93a`](https://github.com/NixOS/nixpkgs/commit/0509b93a6a7b5b451ab3d046e8bfd37b0a1f6c57) | `python310Packages.pglast: 3.17 -> 4.0`                            |
| [`512101d3`](https://github.com/NixOS/nixpkgs/commit/512101d325d204fc0d4301396156f45a59abc7c6) | `regclient: remove broken flag on darwin as it works`              |
| [`0227ca4e`](https://github.com/NixOS/nixpkgs/commit/0227ca4e88d13340aa2d2ff708262dc56f0b7625) | ``pulumi: disable flaky test `TestPendingDeleteOrder```            |
| [`1148b1ec`](https://github.com/NixOS/nixpkgs/commit/1148b1ec896b95b16bd54a0f137376896ba2f6c5) | `pwninit: 3.2.0 -> 3.3.0`                                          |
| [`d699da65`](https://github.com/NixOS/nixpkgs/commit/d699da6549a879b237bd0a04db79feb34fa2bc40) | `pscale: 0.124.0 -> 0.125.0`                                       |
| [`ff3c906d`](https://github.com/NixOS/nixpkgs/commit/ff3c906dbc04a27ddf09d23e7470f1ee4d1b65ac) | `proton-caller: 3.1.0 -> 3.1.1`                                    |
| [`e55d03ee`](https://github.com/NixOS/nixpkgs/commit/e55d03eeda2649384ffb00e6d6c9cf4017c49f4e) | ` python310Packages.param: add changelog to meta`                  |
| [`473a3e69`](https://github.com/NixOS/nixpkgs/commit/473a3e69132b51f6b7058bb709655d4ced6b5dd1) | `python310Packages.patiencediff: 0.2.10 -> 0.2.11`                 |
| [`ced85c11`](https://github.com/NixOS/nixpkgs/commit/ced85c118bba766a25c7d594f01c254516463c8f) | `python310Packages.param: 1.12.2 -> 1.12.3`                        |
| [`aa542116`](https://github.com/NixOS/nixpkgs/commit/aa54211664bbd4717c9effac5efc65a3c024e11c) | `pritunl-client: 1.3.3370.14 -> 1.3.3373.6`                        |
| [`a4b68c46`](https://github.com/NixOS/nixpkgs/commit/a4b68c46016e4f4840764760d64da43342ce01e2) | `python310Packages.pyotp: 2.7.0 -> 2.8.0`                          |
| [`79c00567`](https://github.com/NixOS/nixpkgs/commit/79c005677751bd9343a32c29b928558eeee31c8d) | `kidletime: Add dependency on wayland-protocols`                   |
| [`8a9769cb`](https://github.com/NixOS/nixpkgs/commit/8a9769cb060320d9947987c2e862b3143c4c1caa) | `ocamlPackages.batteries: 3.5.1 → 3.6.0`                           |
| [`96d06d98`](https://github.com/NixOS/nixpkgs/commit/96d06d98b7f53a1559d1df43fd24b4bef073a144) | `cinnamon.nemo: 5.6.0 -> 5.6.1`                                    |
| [`5b7b45b9`](https://github.com/NixOS/nixpkgs/commit/5b7b45b997b0d7343a6aa2f58d3b294aa96e50ce) | `cinnamon.muffin: 5.6.1 -> 5.6.2`                                  |
| [`8ceb9949`](https://github.com/NixOS/nixpkgs/commit/8ceb99497276d70d68638775cad681a993ef27a6) | `notcurses: 3.0.8 -> 3.0.9`                                        |
| [`9be43b7e`](https://github.com/NixOS/nixpkgs/commit/9be43b7e831d9a3d9c396f77d63a94cd1db7f819) | `nearcore: 1.29.3 -> 1.30.0`                                       |
| [`7c285da9`](https://github.com/NixOS/nixpkgs/commit/7c285da93b53f9922b39b1d115f0c1999540c31b) | `devbox: 0.1.1 -> 0.1.2`                                           |
| [`83fbfd92`](https://github.com/NixOS/nixpkgs/commit/83fbfd92b5ac3e72c52bca6f4afb2635236a1161) | `terraform-providers.tencentcloud: 1.79.1 → 1.79.2`                |
| [`ad3a304c`](https://github.com/NixOS/nixpkgs/commit/ad3a304cc2521cea147ad8a793914f678c9e4cf9) | `terraform-providers.helm: 2.7.1 → 2.8.0`                          |
| [`7386b47d`](https://github.com/NixOS/nixpkgs/commit/7386b47d297c23ba9ea0c55bdada9fd521a1b8c5) | `terraform-providers.consul: 2.16.2 → 2.17.0`                      |
| [`7be608ac`](https://github.com/NixOS/nixpkgs/commit/7be608ac68b6ccfbc27395cea6c58a9e3e71035c) | `python310Packages.nltk: 3.7 -> 3.8`                               |
| [`931ecfea`](https://github.com/NixOS/nixpkgs/commit/931ecfea08611de31c104e4a9ed77e22390c6ba3) | `jameica: add aarch64-linux support`                               |
| [`2d934cd9`](https://github.com/NixOS/nixpkgs/commit/2d934cd93a24fa329dd559acd5962c60db7392f7) | `minio-client: 2022-12-02T23-48-47Z -> 2022-12-13T00-23-28Z`       |
| [`8154d80c`](https://github.com/NixOS/nixpkgs/commit/8154d80cc5961af392283204e5079677997e1691) | `mergerfs: 2.33.5 -> 2.34.1`                                       |
| [`36f407c9`](https://github.com/NixOS/nixpkgs/commit/36f407c95c6ca6f0783bf9ba54e90135142549de) | `home-assistant: 2022.12.2 -> 2022.12.5`                           |
| [`31243a31`](https://github.com/NixOS/nixpkgs/commit/31243a31c5b3c0cfed3cf1a878f480ced246ba63) | `mendeley: added atila to maintainers`                             |
| [`ca598e04`](https://github.com/NixOS/nixpkgs/commit/ca598e048b5c54eda2015e8db0d28604e80b8ca3) | `mendeley: 1.19.5 -> 2.80.1`                                       |
| [`88ea7584`](https://github.com/NixOS/nixpkgs/commit/88ea7584c1bf74debb7d50f43e1d1ab28cf3877e) | `python3Packages.bleak-retry-connector: 2.10.1 -> 2.10.2`          |
| [`514effc2`](https://github.com/NixOS/nixpkgs/commit/514effc2cded28d5e621cae3188895e20d120128) | `python3Packages.PyChromecast: 13.0.3 -> 13.0.4`                   |
| [`5bce4605`](https://github.com/NixOS/nixpkgs/commit/5bce4605c4bdbbe3932fe2c181c04d326e59a3ee) | `libpg_query: 13-2.2.0 -> 14-3.0.0`                                |
| [`a2aa9225`](https://github.com/NixOS/nixpkgs/commit/a2aa9225b6185ab2144dd8f397b0bd429d30c075) | `pkgStatic.dash: fix build`                                        |
| [`a21d0265`](https://github.com/NixOS/nixpkgs/commit/a21d02653c0fd464e27fe9aaca68585b20c0ccf0) | `box64: 0.1.8 -> 0.2.0, add passthru.updateScript`                 |
| [`e16b45e8`](https://github.com/NixOS/nixpkgs/commit/e16b45e834cef35a6bf7039cae05f19c45e711ed) | `pulumi, pulumiPackages.pulumi-language-python: 3.48.0 -> 3.49.0`  |
| [`93a453e3`](https://github.com/NixOS/nixpkgs/commit/93a453e3b94bf1555479e3e9dc734db7ad6cf4e8) | `heimer: add changelog to meta`                                    |
| [`c2723da1`](https://github.com/NixOS/nixpkgs/commit/c2723da1eab107dfd70e09363ffe61424db91f0b) | `nixos/modules/profiles/base.nix: add nvme-cli`                    |
| [`040fc601`](https://github.com/NixOS/nixpkgs/commit/040fc601c489b2ee887002e8ec45056f59d4a157) | `zellij: 0.34.3 -> 0.34.4`                                         |
| [`7fdde189`](https://github.com/NixOS/nixpkgs/commit/7fdde1893bb4aec54a3ddc43533c6448aad22d46) | `kde-frameworks: 5.100 -> 5.101`                                   |
| [`9fb6ca96`](https://github.com/NixOS/nixpkgs/commit/9fb6ca9609ec11383d0e4f4138b66626e5384533) | `jellyfin-ffmpeg: 5.1.2-4 -> 5.1.2-5`                              |
| [`a950e5b2`](https://github.com/NixOS/nixpkgs/commit/a950e5b2dca868d06c356846c2d76e153a5aa875) | `heimer: 3.6.2 -> 3.6.3`                                           |
| [`87267bb8`](https://github.com/NixOS/nixpkgs/commit/87267bb8cff5041bb967a6b61c407083305287be) | `prismlauncher: 5.2 -> 6.0`                                        |
| [`3039dc51`](https://github.com/NixOS/nixpkgs/commit/3039dc51985cb681fe5a3ef9feb6b5a3518453d3) | `quickemu: 4.4 -> 4.5`                                             |
| [`4fa694ad`](https://github.com/NixOS/nixpkgs/commit/4fa694adf210b63f58380a5fb75d538acb38f5ec) | `govc: 0.29.0 -> 0.30.0`                                           |
| [`61d84e14`](https://github.com/NixOS/nixpkgs/commit/61d84e1441383164f289141b18323f66f211156f) | `goresym: 1.8 -> 2.0`                                              |
| [`72bb5fec`](https://github.com/NixOS/nixpkgs/commit/72bb5fec7484b20aaa4787dbea794ca22f2586ad) | `fd: skip flaky test, add figsoda as a maintainer`                 |
| [`179e20b4`](https://github.com/NixOS/nixpkgs/commit/179e20b4922a156042f17442fb91054c1d610c6f) | `libverto: init at 0.3.2`                                          |
| [`d2e71071`](https://github.com/NixOS/nixpkgs/commit/d2e710716a75a4e48ab86333f2c1766b07421c86) | `kubernetes-controller-tools: set version`                         |
| [`bdca4eb8`](https://github.com/NixOS/nixpkgs/commit/bdca4eb87ed855a6629a9ed4bcec7a5290d1d013) | `wtwitch: init at 2.6.0`                                           |
| [`a281c4ab`](https://github.com/NixOS/nixpkgs/commit/a281c4ab3ecf703bb2994299075f1ed2844c61d9) | `bird: 2.0.10 -> 2.0.11`                                           |
| [`7b6987ea`](https://github.com/NixOS/nixpkgs/commit/7b6987ea4e040338c7bb83eb89c0c9a2d176b698) | `hugin: use glew-egl to fix startup crash`                         |
| [`12afcda3`](https://github.com/NixOS/nixpkgs/commit/12afcda3c0f9d04dbdda5bfda02da28e5404484b) | `python310Packages.pyproject-metadata: 0.5.0 -> 0.6.1`             |
| [`c5b5dc00`](https://github.com/NixOS/nixpkgs/commit/c5b5dc0074b87098135000aa154a7d8f9e22fec8) | `python310Packages.pyproject-metadata: add changelog to meta`      |
| [`3836639c`](https://github.com/NixOS/nixpkgs/commit/3836639c13c483ec85fedd292d5363401be7266f) | `avahi: remove not required ? null from inputs`                    |
| [`89b5dddf`](https://github.com/NixOS/nixpkgs/commit/89b5dddf990fd7fe99528a972ff037002e8e3046) | `nixos/avahi: revert closing firewall port by default`             |
| [`f7860c59`](https://github.com/NixOS/nixpkgs/commit/f7860c59a374653b84d8403be06735cd3c6dc5f0) | `losslesscut-bin: 3.46.2 -> 3.48.2 and add aarch64-darwin support` |
| [`bd2a5f00`](https://github.com/NixOS/nixpkgs/commit/bd2a5f009a87fcfd33797b31407b4dfe2aee269b) | `losslesscut-bin: refactor the build expression`                   |
| [`be153331`](https://github.com/NixOS/nixpkgs/commit/be1533317c8100f6ed7b1c68f257c1f5d9e02ce2) | `intel-media-driver: 22.6.3 -> 22.6.4`                             |
| [`91dde6fc`](https://github.com/NixOS/nixpkgs/commit/91dde6fc89a9fb2baee53df5a389a92189983f75) | `python310Packages.numcodecs: remove explicit gcc8`                |
| [`e2c79b3e`](https://github.com/NixOS/nixpkgs/commit/e2c79b3e4a2d9e9ef4072417be10a8faf888d081) | `python310Packages.openrazer: 3.3.0 -> 3.5.1`                      |
| [`51e6f868`](https://github.com/NixOS/nixpkgs/commit/51e6f868385792422682131427228c74d1757760) | `remmina: add kwallet plugin support`                              |
| [`35c91b96`](https://github.com/NixOS/nixpkgs/commit/35c91b9630e73dc0960d951a9fd998fa04f4832b) | `php80.packages.php-parallel-lint: Fix build`                      |
| [`ab060f9d`](https://github.com/NixOS/nixpkgs/commit/ab060f9db9bc39218cf4bed7ec42ca5df4fab7a6) | `bupstash: 0.11.0 -> 0.12.0`                                       |