### PR TITLE
chore(flake/nixos-hardware): `1f606727` -> `488931ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -341,11 +341,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1671106796,
-        "narHash": "sha256-moAUZMJeGmZAccpZYbAbNVTsmLTkhNU3CdatGg1oKUE=",
+        "lastModified": 1671183612,
+        "narHash": "sha256-Q6so0tBGEb9Bhx++FP6cJQ+K83hOZ99ffmcdcWtDS14=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "1f6067272161d03d1c9f0b46fbf7cb090d016a9c",
+        "rev": "488931efb69a50307fa0d71e23e78c8706909416",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                   |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`b35c93e8`](https://github.com/NixOS/nixos-hardware/commit/b35c93e8a22eaa5aa755e8faa6c9070731d3b78b) | `Add mkDefault to services.xserver.videoDrivers = [ "amdgpu" ];` |