### PR TITLE
chore(flake/emacs-overlay): `af726f49` -> `815f5a9b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671160938,
-        "narHash": "sha256-6tTWOoxJ2k4cbAo8VZI71ytpaepDBRA+dA87N6e1c6o=",
+        "lastModified": 1671185799,
+        "narHash": "sha256-E/2hbEnV+A8GYo8aUJI2R0hLvAkrfUzGMhAEfmth1EQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "af726f4941acc7367d75bc8e35c2ad047fd727f9",
+        "rev": "815f5a9bd21891286f4d8ea7c9f08afa2cd6ac4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`815f5a9b`](https://github.com/nix-community/emacs-overlay/commit/815f5a9bd21891286f4d8ea7c9f08afa2cd6ac4b) | `Updated repos/melpa` |
| [`bc6e5900`](https://github.com/nix-community/emacs-overlay/commit/bc6e5900781577c1d472ef28548b7cb2bc42490e) | `Updated repos/emacs` |