### PR TITLE
chore(flake/home-manager): `e412025f` -> `0e9e86b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670970889,
-        "narHash": "sha256-TWJo3/X3Q3r+HeX16QN4FE6ddBpGtAboymSEF+4Nnc0=",
+        "lastModified": 1671202909,
+        "narHash": "sha256-82bLIOpdI+UE9OMs97n0YiYOvQ3Ul2DkFEp+4x4hLkI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e412025fffdcd6219ddd21c65d9a1b90005ce508",
+        "rev": "0e9e86b1794c1003db38ee77437b2522d700174e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message         |
| ----------------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0e9e86b1`](https://github.com/nix-community/home-manager/commit/0e9e86b1794c1003db38ee77437b2522d700174e) | `megasync: add module` |