### PR TITLE
chore(flake/emacs-overlay): `815f5a9b` -> `6158c43e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671185799,
-        "narHash": "sha256-E/2hbEnV+A8GYo8aUJI2R0hLvAkrfUzGMhAEfmth1EQ=",
+        "lastModified": 1671216032,
+        "narHash": "sha256-ZpjJpesuqeRsYF6hniJdrxG1BNVmIkHhlT8XIz1qZlk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "815f5a9bd21891286f4d8ea7c9f08afa2cd6ac4b",
+        "rev": "6158c43e32fa81eb3a5b208c89ae6d1b5e60a806",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`6158c43e`](https://github.com/nix-community/emacs-overlay/commit/6158c43e32fa81eb3a5b208c89ae6d1b5e60a806) | `Updated repos/melpa` |
| [`4bd4accc`](https://github.com/nix-community/emacs-overlay/commit/4bd4acccbed7961c038592e932432dcac103193d) | `Updated repos/emacs` |
| [`1147eaab`](https://github.com/nix-community/emacs-overlay/commit/1147eaabf15edecfc405bace11c35bf2051a46d4) | `Updated repos/elpa`  |