### PR TITLE
chore(flake/nixos-hardware): `9deb3748` -> `e462a4ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -341,11 +341,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1671227705,
-        "narHash": "sha256-GnSYc9/7JONw7NeL0arFL8+fkqhPOuvqX68KuIrvvbE=",
+        "lastModified": 1671228065,
+        "narHash": "sha256-Az/ig9LVL5xdqtyl4/CVKJIH1G7sP/9Ott2XnNyie0E=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "9deb37488fc0f5e1ff64a8c2a54b94d5fbab0bc4",
+        "rev": "e462a4baf75eeac639b4942481759de08a3bc94e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                    |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`b67160bb`](https://github.com/NixOS/nixos-hardware/commit/b67160bb7f479e5042eeadd4453517e2d27ebca6) | `cpu/amd/pstate: enable correctly on kernel 6.1+` |