### PR TITLE
chore(flake/emacs-overlay): `6158c43e` -> `b0c95db5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671216032,
-        "narHash": "sha256-ZpjJpesuqeRsYF6hniJdrxG1BNVmIkHhlT8XIz1qZlk=",
+        "lastModified": 1671230871,
+        "narHash": "sha256-a/smqUrldWJfUGLcP7qVi7NfikFO08O8m+p9bb917Kc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6158c43e32fa81eb3a5b208c89ae6d1b5e60a806",
+        "rev": "b0c95db59fef979eb72a29f5ad7e9f3c866c8ffd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                  |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------- |
| [`b0c95db5`](https://github.com/nix-community/emacs-overlay/commit/b0c95db59fef979eb72a29f5ad7e9f3c866c8ffd) | `Add more tree-sitter grammars` |