### PR TITLE
chore(flake/emacs-overlay): `b0c95db5` -> `0a570f81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671230871,
-        "narHash": "sha256-a/smqUrldWJfUGLcP7qVi7NfikFO08O8m+p9bb917Kc=",
+        "lastModified": 1671247521,
+        "narHash": "sha256-ABQrgpu++LQ9nVqDOhGZZbnfyhoASUfy8kU+pA9U9Sc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b0c95db59fef979eb72a29f5ad7e9f3c866c8ffd",
+        "rev": "0a570f813accfee8074a4486f14295c0badbec9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`0a570f81`](https://github.com/nix-community/emacs-overlay/commit/0a570f813accfee8074a4486f14295c0badbec9f) | `Updated repos/nongnu` |
| [`f6aea82e`](https://github.com/nix-community/emacs-overlay/commit/f6aea82ed51e17d1b36178620a3cff62340e2385) | `Updated repos/melpa`  |
| [`22f9d2f1`](https://github.com/nix-community/emacs-overlay/commit/22f9d2f1668314a9f5374d3c548c54237fda3572) | `Updated repos/emacs`  |