### PR TITLE
chore(flake/nixpkgs): `0f5996b5` -> `652e92b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671108576,
-        "narHash": "sha256-6ggOL6KoaELNA1562tnPjtAnQ9SwsKRTgeuaXvPzCwI=",
+        "lastModified": 1671722432,
+        "narHash": "sha256-ojcZUekIQeOZkHHzR81st7qxX99dB1Eaaq6PU5MNeKc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0f5996b524c91677891a432cc99c7567c7c402b1",
+        "rev": "652e92b8064949a11bc193b90b74cb727f2a1405",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`6e1b674a`](https://github.com/NixOS/nixpkgs/commit/6e1b674aa7c54fe99a3c3ff35b7b50b880b66eb2) | `hstr: 2.5 -> 2.6`                                            |
| [`abbe1233`](https://github.com/NixOS/nixpkgs/commit/abbe1233a4e75b11e669ba803b3022c086f05f50) | `miniupnpc: set meta.mainProgram`                             |
| [`9695efdf`](https://github.com/NixOS/nixpkgs/commit/9695efdfbad74c7eb18d35cd965b82cc6158e226) | `pantheon.gala: Backport various upstream fixes`              |
| [`ff08a6db`](https://github.com/NixOS/nixpkgs/commit/ff08a6db69ec9ed3baac80559c4070a492dea128) | `uxplay: 1.59 -> 1.60`                                        |
| [`61184e7e`](https://github.com/NixOS/nixpkgs/commit/61184e7ecc3a7d654e20ee204397d2dd0d2fd10a) | `xe-guest-utilities: remove references to /bin/sh`            |
| [`593d839e`](https://github.com/NixOS/nixpkgs/commit/593d839e8fadea1183e071186ae1b584792d4884) | `pdfstudio2022: 2022.1.1 -> 2022.1.3`                         |
| [`13e0b430`](https://github.com/NixOS/nixpkgs/commit/13e0b430e8d7e3dc2a1ca11d65b2abb61e00fab8) | `coqPackages.VST: 2.10 → 2.11.1`                              |
| [`300712c3`](https://github.com/NixOS/nixpkgs/commit/300712c3ff2e991d99f6b3a5ff516242ee8454c1) | `checkip: 0.44.0 -> 0.44.2`                                   |
| [`d0458492`](https://github.com/NixOS/nixpkgs/commit/d0458492f876a6354606580edf1e13742eafa0ef) | `tor: 0.4.7.11 -> 0.4.7.12`                                   |
| [`1ec3fe7f`](https://github.com/NixOS/nixpkgs/commit/1ec3fe7fb7ccc35cceb9444ac6c3c9206b411878) | `soco-cli: Set correct mainProgram`                           |
| [`f621c460`](https://github.com/NixOS/nixpkgs/commit/f621c460161972db451763ecc67a13defb9588a6) | `sbsigntool: support aarch64`                                 |
| [`1c00d7ae`](https://github.com/NixOS/nixpkgs/commit/1c00d7ae3121fde09ed8c0f02b94a9b7eb28a2df) | `sbsigntool: add raitobezarius as maintainer`                 |
| [`1b84946f`](https://github.com/NixOS/nixpkgs/commit/1b84946f07d35a338d0ea6c21cc6b44515f0e699) | `qt5.qtbase: remove ? null asserts`                           |
| [`c4ec5941`](https://github.com/NixOS/nixpkgs/commit/c4ec59415db444940f4a3fa1b8cad17451c0c351) | `supabase-cli: 1.27.0 -> 1.27.4`                              |
| [`0226ed48`](https://github.com/NixOS/nixpkgs/commit/0226ed488666bfbc23a0feb354aeb2315f254d46) | `supabase-cli: add updateScript`                              |
| [`caf4413e`](https://github.com/NixOS/nixpkgs/commit/caf4413e43e62861360e300473e664b2c167f018) | `saleae-logic-2: 2.4.2 -> 2.4.3`                              |
| [`4b1b11c6`](https://github.com/NixOS/nixpkgs/commit/4b1b11c64b4c90d680500fb64492424892516715) | `usql: 0.13.3 -> 0.13.4`                                      |
| [`2ffe90fd`](https://github.com/NixOS/nixpkgs/commit/2ffe90fd2eae51482e837480f8009a0a2fb2c9f5) | `luaPlugins: cleanups`                                        |
| [`8a81ad8f`](https://github.com/NixOS/nixpkgs/commit/8a81ad8fdacc5f7c2b2b80a1c7693e888f9f30a8) | `nixos/statsd: add missing module import`                     |
| [`b09138de`](https://github.com/NixOS/nixpkgs/commit/b09138de7622c4bff53c7a9124f29faa0e8ad99d) | `paho-mqtt-c: 1.3.11 → 1.3.12`                                |
| [`1502956a`](https://github.com/NixOS/nixpkgs/commit/1502956af296495b60b9ae86123466d63a2eee07) | `home-assistant: 2022.12.7 -> 2022.12.8`                      |
| [`56e2742e`](https://github.com/NixOS/nixpkgs/commit/56e2742e8c72cf8de7b0ee97634a107c39ca97a6) | `python310Packages.bluetooth-data-tools: 0.3.0 -> 0.3.1`      |
| [`5878195b`](https://github.com/NixOS/nixpkgs/commit/5878195b624ef100ae42dcb052b683211dcbe143) | `python310Packages.coqpit: 0.0.16 -> 0.0.17`                  |
| [`69ee8ee8`](https://github.com/NixOS/nixpkgs/commit/69ee8ee81aa2b79ffb22a347178b5988ed487b63) | `home-assistant: fix version hash for 2022.12.7`              |
| [`5354e33e`](https://github.com/NixOS/nixpkgs/commit/5354e33e4aa4552b482e30500ca44599899c1960) | `home-assistant: add version tester`                          |
| [`94bedc62`](https://github.com/NixOS/nixpkgs/commit/94bedc62e82942385acd9f4916d6041631edf315) | `fluxcd: 0.37.0 -> 0.38.1`                                    |
| [`b948496d`](https://github.com/NixOS/nixpkgs/commit/b948496d975bc5866b0c9b73af547a86ae4307e5) | `dtv-scan-tables: 2020-05-18 -> 2022-10-27`                   |
| [`c211b478`](https://github.com/NixOS/nixpkgs/commit/c211b4787e32bda82a995b61fe299404cd2657f8) | `tvheadend: refactor`                                         |
| [`8091f324`](https://github.com/NixOS/nixpkgs/commit/8091f32439823b1765454604d1afc8eff126681a) | `tvheadend: use python3`                                      |
| [`889395b1`](https://github.com/NixOS/nixpkgs/commit/889395b1588c53f025d72bd97965f42ee4c86a1f) | `calibre: Fix File Open Dialog`                               |
| [`e927cca3`](https://github.com/NixOS/nixpkgs/commit/e927cca3c1c64463ba7712cdcd6cb4931dc07b48) | `cyberchef: Specify supported platforms`                      |
| [`fdbbaf7a`](https://github.com/NixOS/nixpkgs/commit/fdbbaf7ac306abd068efd678c17a4474d4f66382) | `fzf-git-sh: init at unstable-2022-09-30`                     |
| [`154f31a3`](https://github.com/NixOS/nixpkgs/commit/154f31a39a1b7f6608242dc6b85b8cc10e07f032) | `github-runner: 2.300.0 -> 2.300.2`                           |
| [`832dea89`](https://github.com/NixOS/nixpkgs/commit/832dea892d9844201279353afad72f4d88718d3f) | `colima: 0.4.6 -> 0.5.0`                                      |
| [`bd3bae91`](https://github.com/NixOS/nixpkgs/commit/bd3bae91026d043deca13c4901e69bfa78823cfe) | `praat: 6.3.02 -> 6.3.03`                                     |
| [`ea1fe3fb`](https://github.com/NixOS/nixpkgs/commit/ea1fe3fb8f56015d74d4946a8cf5278f85fedf0e) | `python3Packages.caio: add changelog to meta`                 |
| [`34b81fa3`](https://github.com/NixOS/nixpkgs/commit/34b81fa3aabc269e763d8a800d5f7baae0cfcd6b) | `python310Packages.caio: 0.9.8 -> 0.9.11`                     |
| [`c59b2d51`](https://github.com/NixOS/nixpkgs/commit/c59b2d51c043b8a2fe21a9e3e52218400526633f) | `glooctl: 1.12.33 -> 1.12.37`                                 |
| [`3edd93c8`](https://github.com/NixOS/nixpkgs/commit/3edd93c8ee5292046e071e3edb02b7a2dd15ba87) | `pocketbase: 0.9.2 -> 0.10.1`                                 |
| [`b39d5afa`](https://github.com/NixOS/nixpkgs/commit/b39d5afa75621ad94db626baf8c6049525b62d49) | `php.packages.composer: 2.4.4 -> 2.5.0`                       |
| [`7be4467e`](https://github.com/NixOS/nixpkgs/commit/7be4467e14e71efa46f2f94b3b996e0863ee067a) | `brev-cli: 0.6.186 -> 0.6.197`                                |
| [`a97a75a7`](https://github.com/NixOS/nixpkgs/commit/a97a75a7b7baff4f57f91e8bf6ab3b3b617bbc6b) | `syncstorage-rs: make linux-only`                             |
| [`4cdcad6b`](https://github.com/NixOS/nixpkgs/commit/4cdcad6b26441baac19e817def6827d40f1e317e) | `nixos/firefox-syncserver: remove unnecessary service option` |
| [`13d72590`](https://github.com/NixOS/nixpkgs/commit/13d725908cf96edcb1527bbfbb238f566fc31b51) | `syncstorage-rs: 0.12.5 -> 0.13.1`                            |
| [`b48d0661`](https://github.com/NixOS/nixpkgs/commit/b48d06617180a138035d0a82bb81b463b5685062) | `python310Packages.pyrainbird: 0.6.3 -> 0.7.1`                |
| [`44ef7280`](https://github.com/NixOS/nixpkgs/commit/44ef728035a139e1099cfb1a8150b004a52e8be6) | `python310Packages.pyrainbird: add changelog to meta`         |
| [`5e76760c`](https://github.com/NixOS/nixpkgs/commit/5e76760cf3209ed1e73a09b39be17ce0938e4890) | `python310Packages.devolo-plc-api: 0.8.1 -> 0.9.0`            |
| [`9aae96f2`](https://github.com/NixOS/nixpkgs/commit/9aae96f2be2e207e1d542a402909cbd043fb8bfc) | `python310Packages.griffe: 0.25.0 -> 0.25.1`                  |
| [`393f315b`](https://github.com/NixOS/nixpkgs/commit/393f315b803322cad1037d266eb9168819a5adb0) | `slurm: 22.05.6.1 -> 22.05.7.1`                               |
| [`b9acf590`](https://github.com/NixOS/nixpkgs/commit/b9acf590134e0a79a6fecba8279c39f70261eadf) | `python310Packages.nomadnet: 0.2.8 -> 0.3.0`                  |
| [`ae32f2d3`](https://github.com/NixOS/nixpkgs/commit/ae32f2d3ee09ce2d8f3818518f6eafc5281fc599) | `python310Packages.lxmf: 0.2.6 -> 0.2.7`                      |
| [`dac3483c`](https://github.com/NixOS/nixpkgs/commit/dac3483c67b2cc2b2cb6245d6eb0306603b500f5) | `python310Packages.rns: 0.4.2 -> 0.4.3`                       |
| [`7bc19142`](https://github.com/NixOS/nixpkgs/commit/7bc191426a6e9e2468520b74ea0b2e1bc71f9bab) | `python310Packages.angr: 9.2.29 -> 9.2.30`                    |
| [`2b6774e9`](https://github.com/NixOS/nixpkgs/commit/2b6774e945752e77aae3a4cd6bb72d08c9c00565) | `python310Packages.cle: 9.2.29 -> 9.2.30`                     |
| [`059f81e3`](https://github.com/NixOS/nixpkgs/commit/059f81e38e0db4ed54544de0b0d43239106bf44a) | `python310Packages.claripy: 9.2.29 -> 9.2.30`                 |
| [`489566cf`](https://github.com/NixOS/nixpkgs/commit/489566cfe3929a9c2d1ab2cec76ac28f0f2e596e) | `python310Packages.pyvex: 9.2.29 -> 9.2.30`                   |
| [`cb674d89`](https://github.com/NixOS/nixpkgs/commit/cb674d89cc01dc773e430be8756f27b1fb9c1455) | `python310Packages.ailment: 9.2.29 -> 9.2.30`                 |
| [`ddbf186b`](https://github.com/NixOS/nixpkgs/commit/ddbf186bd0af98ded5d636222f4ffea43f3a5cc4) | `python310Packages.archinfo: 9.2.29 -> 9.2.30`                |
| [`efbce7d4`](https://github.com/NixOS/nixpkgs/commit/efbce7d4aa5ec2d766f21767779ec4c606fde767) | `cbqn: add enableReplxx option`                               |
| [`91b2c4bf`](https://github.com/NixOS/nixpkgs/commit/91b2c4bf92381c44bb7381a174bd15026b808f17) | `zrythm: add path for fallback icons`                         |
| [`c898a64d`](https://github.com/NixOS/nixpkgs/commit/c898a64d0978e6ab8dd3ecc3d1340cfd0acb27e5) | `cargo-tally: 1.0.18 -> 1.0.19 (#206591)`                     |
| [`1e0ae873`](https://github.com/NixOS/nixpkgs/commit/1e0ae873c79e832b65fd734dede7f3eaad28d157) | `xray: 1.6.1 -> 1.6.6-2 (#206692)`                            |
| [`0750d3b7`](https://github.com/NixOS/nixpkgs/commit/0750d3b74eb4b5d48b40548091c12ac9b0510a8c) | `vscode: 1.74.1 -> 1.74.2`                                    |
| [`fedacda0`](https://github.com/NixOS/nixpkgs/commit/fedacda0c63389369e7dce6ed7020994d78705c3) | `httpie: remove myself from maintainers, little cleanup`      |
| [`0f7b08da`](https://github.com/NixOS/nixpkgs/commit/0f7b08da99f361dd1ec934adc42351b5e87d66c1) | `openvswitch-lts: 2.17.3 -> 2.17.5`                           |
| [`050c526a`](https://github.com/NixOS/nixpkgs/commit/050c526a3645f51ecf4f53d029b6b64335394976) | `openvswitch: 3.0.1 -> 3.0.3`                                 |
| [`b5e3b7f1`](https://github.com/NixOS/nixpkgs/commit/b5e3b7f1319fcf99b4b5979356f6e9039d4e0a06) | `python310Packages.pytibber: 0.26.5 -> 0.26.6`                |
| [`30a5beb5`](https://github.com/NixOS/nixpkgs/commit/30a5beb52ca5796e5c93f1db8d5b966ac109f7d5) | `typeshare: 1.0.0 -> 1.0.1`                                   |
| [`354e0795`](https://github.com/NixOS/nixpkgs/commit/354e079535fc4c7a2a7cad2acbbee249cbfc2539) | `platformio: relax uvicorn constraint`                        |
| [`218e4677`](https://github.com/NixOS/nixpkgs/commit/218e4677631ec61602827aa7b639161ddb8c5d41) | `python3Packages.rmrl: switch to naturale0 fork`              |
| [`b2c377b2`](https://github.com/NixOS/nixpkgs/commit/b2c377b2e1d7b842417992b4a2d62bfeb764c035) | `python310Packages.pyinfra: add changelog to meta`            |
| [`7002248d`](https://github.com/NixOS/nixpkgs/commit/7002248d1b3c5e468859e28ff64c6978842bef4a) | `python310Packages.pyinfra: 2.5.3 -> 2.6`                     |
| [`c5e381b6`](https://github.com/NixOS/nixpkgs/commit/c5e381b6c231a518b3f95dfb55c66afee9618842) | `matrix-synapse: 1.73.0 -> 1.74.0`                            |
| [`f016079e`](https://github.com/NixOS/nixpkgs/commit/f016079e6c69b0a95c095418c8918818279bcdce) | `vimPlugins.ChatGPT-nvim: add dependencies in overrides`      |
| [`44b25a63`](https://github.com/NixOS/nixpkgs/commit/44b25a639f41bd528d842bf03dad436fd1ac205a) | `envoy: 1.23.1 -> 1.23.3`                                     |
| [`3c6d63d2`](https://github.com/NixOS/nixpkgs/commit/3c6d63d22ca8b57adc4120f7c1ea5262925c8c2d) | `rtw89-firmware: fixup build after rtw89 update`              |
| [`67a54c71`](https://github.com/NixOS/nixpkgs/commit/67a54c71074a382fa0da453958e0999e8650adce) | `python310Packages.httpie: disable failing tests`             |
| [`5ddd3c9f`](https://github.com/NixOS/nixpkgs/commit/5ddd3c9fe322c34710a7b6dcd1653c4555230970) | `python310Packages.sensor-state-data: 2.12.1 -> 2.13.0`       |
| [`40282eed`](https://github.com/NixOS/nixpkgs/commit/40282eed75b66fc2a0fb5a7c8555a43ed5cbee47) | `python310Packages.psrpcore: 0.2.0 -> 0.2.1`                  |
| [`557d7996`](https://github.com/NixOS/nixpkgs/commit/557d7996a5674909a8eb0447a7535e56e9e9567e) | `python310Packages.pyvicare: 2.21.0 -> 2.22.0`                |
| [`1c61a85f`](https://github.com/NixOS/nixpkgs/commit/1c61a85f444b993afb72de6a298557d19173f483) | `python310Packages.sensorpro-ble: 0.5.0 -> 0.5.1`             |
| [`8e66f81f`](https://github.com/NixOS/nixpkgs/commit/8e66f81f478167ee0d14a3a6dc1e740ca17de5a8) | `python310Packages.sensorpro-ble: add changelog to meta`      |
| [`07a08138`](https://github.com/NixOS/nixpkgs/commit/07a08138a7f8915f191f88eff97743a632a2922b) | `python310Packages.proxmoxer: 2.0.0 -> 2.0.1`                 |
| [`cddecb80`](https://github.com/NixOS/nixpkgs/commit/cddecb80fa2aae32678a52715e9f76dfe56c3c8f) | `ruff: 0.0.188 -> 0.0.189`                                    |
| [`83b2bf88`](https://github.com/NixOS/nixpkgs/commit/83b2bf88cf483803f074b96dccc262b77361d4b0) | `oneDNN: 2.7.1 -> 3.0`                                        |
| [`8ec25c79`](https://github.com/NixOS/nixpkgs/commit/8ec25c79d3e1f8bd729d5c81db08c100ca9889cb) | `dmarc-metrics-exporter: 0.6.1 -> 0.8.0`                      |
| [`29ad89a8`](https://github.com/NixOS/nixpkgs/commit/29ad89a851f2c5c811fe5282d0d3f2ba85ad3d8d) | `python3.pkgs.uvicorn: 0.18.2 -> 0.20.0`                      |
| [`13bd3271`](https://github.com/NixOS/nixpkgs/commit/13bd3271d8e0bd6c9eeac455a9e5a6aaf5e3766e) | `Link to documentation`                                      |
| [`353dd309`](https://github.com/NixOS/nixpkgs/commit/353dd309f5abcae04eb5c1ecd8b953226d0c1445) | `python3Packages.pywayland: 0.4.14 -> 0.4.15`                 |
| [`ec332c3f`](https://github.com/NixOS/nixpkgs/commit/ec332c3fa7da5a80f853335bdd6ac86b3cb51d76) | `maintainers: change @rodrgz e-mail`                          |
| [`128713b7`](https://github.com/NixOS/nixpkgs/commit/128713b727eb87d24dcdd1c06b7a9f6f18fa159e) | `python310Packages.httpie: add changelog to meta`             |
| [`27dd8e29`](https://github.com/NixOS/nixpkgs/commit/27dd8e291d30d0b4ea397ff82e41e170d2a87cc8) | `add teal-language-server + update lua modules (#205856)`     |
| [`b3c6c10f`](https://github.com/NixOS/nixpkgs/commit/b3c6c10f7f8c480a1d288e7534638b3224a59ddf) | `python310Packages.sentry-sdk: 1.12.0 -> 1.12.1`              |
| [`05a10e9d`](https://github.com/NixOS/nixpkgs/commit/05a10e9d9439aea5def148cab291845681bf23c2) | `nodePackages.prisma: 4.7.0 -> 4.8.0`                         |
| [`67b7f7e8`](https://github.com/NixOS/nixpkgs/commit/67b7f7e82e995f4b3142ffe585fd931b0426bc5c) | `python310Packages.webauthn: disable failing test`            |
| [`82e75d1b`](https://github.com/NixOS/nixpkgs/commit/82e75d1b8d1d4188516092c57727bfc20d3750d8) | `prisma-engines: 4.7.0 -> 4.8.0`                              |
| [`08f873b0`](https://github.com/NixOS/nixpkgs/commit/08f873b0c5aba1bfbee5d230d0e0488ebd81abde) | `python310Packages.webauthn: add changelog to meta`           |
| [`3c6ee2f1`](https://github.com/NixOS/nixpkgs/commit/3c6ee2f1ba8a0416c9c5ef8fd885a7c639cf7292) | `prospector: add changelog to meta`                           |
| [`fe2f65b8`](https://github.com/NixOS/nixpkgs/commit/fe2f65b8c4d7b2d315086e684c756ab1f234341c) | `prospector: 1.7.7 -> 1.8.3`                                  |
| [`a6404172`](https://github.com/NixOS/nixpkgs/commit/a640417220ce9d4e2a2a5fc413364ce0e319891f) | `python310Packages.pyatv: disable failing test`               |
| [`ed4d6411`](https://github.com/NixOS/nixpkgs/commit/ed4d6411c2ad4d06e8d0308f590085912bc7632e) | `maintainers: remove benwbooth`                               |
| [`c1c6565e`](https://github.com/NixOS/nixpkgs/commit/c1c6565edcbbd3ca187e38759929eb726a767bf6) | `xe-guest-utilities: 6.2.0 -> 7.30.0`                         |
| [`4778c3cd`](https://github.com/NixOS/nixpkgs/commit/4778c3cd3a65640078ebd4ec407d354d865f3aae) | `python310Packages.pep8-naming: 0.13.1 -> 0.13.3`             |
| [`5bfdf3cd`](https://github.com/NixOS/nixpkgs/commit/5bfdf3cdec9329dc36b02938d54ffe1b6da279b1) | `python310Packages.pep8-naming: add changelog to meta`        |
| [`9a3648d6`](https://github.com/NixOS/nixpkgs/commit/9a3648d6c1ff1ad42af21343327da18a83728b43) | `sqlfluff: 1.4.4 -> 1.4.5`                                    |
| [`0ae3b30c`](https://github.com/NixOS/nixpkgs/commit/0ae3b30cea3518c520d8402706707232b39f25cd) | `home-assistant: 2022.12.6 -> 2022.12.7`                      |
| [`ba6ba2b9`](https://github.com/NixOS/nixpkgs/commit/ba6ba2b90096dc49f448aa4d4d783b5081b1cc87) | `mimir: add update script`                                    |
| [`62795930`](https://github.com/NixOS/nixpkgs/commit/6279593053bff657ff4baa5672a2f68c7cb62cf7) | `mimir: 2.4.0 -> 2.5.0`                                       |
| [`259e70f3`](https://github.com/NixOS/nixpkgs/commit/259e70f3ead006b40355e2f2df7e1e00bffb1aad) | `mimir: drop left-overs from last revert`                     |
| [`c6b869b4`](https://github.com/NixOS/nixpkgs/commit/c6b869b45b41f2683e282d24a0f6f1cdef9b066d) | `sqlfluff: 1.4.3 -> 1.4.4`                                    |
| [`2c2f1519`](https://github.com/NixOS/nixpkgs/commit/2c2f1519b511fd0302ac49f8d4aeb4c252195216) | `kicad: 6.0.9 -> 6.0.10`                                      |
| [`8a6772fe`](https://github.com/NixOS/nixpkgs/commit/8a6772fee62923d0854f84a3fac0b8225e7a0e01) | `kicad: bunch of cleanup`                                     |
| [`1c3de7e3`](https://github.com/NixOS/nixpkgs/commit/1c3de7e308dac2798564ae9695a7b0fd1cb3a5c1) | `kicad-unstable: 2022-09-18 -> 2022-12-19`                    |
| [`ca058e37`](https://github.com/NixOS/nixpkgs/commit/ca058e37a6a52b7ac3f1767b3a7c9d8319b814c5) | `sabnzbd: 3.7.0 -> 3.7.1`                                     |
| [`40b8cdcd`](https://github.com/NixOS/nixpkgs/commit/40b8cdcd78b97193517fa6fa52a7a7039524e2a3) | `python310Packages.msgspec: 0.10.1 -> 0.11.0`                 |
| [`b9e07b7e`](https://github.com/NixOS/nixpkgs/commit/b9e07b7ef2c60baf29c8dc77d4e2c8edf33f3338) | `python310Packages.identify: 2.5.10 -> 2.5.11`                |
| [`ed28b99c`](https://github.com/NixOS/nixpkgs/commit/ed28b99cd3633ad1b84fd8356c625b7197d8c28e) | `bottles: 2022.12.14 -> 2022.12.14.1, fix GStreamer`          |
| [`3b9b3394`](https://github.com/NixOS/nixpkgs/commit/3b9b33941007764dfcb64664ef6f4cae373b0d69) | `sqlfluff: add changelog to meta`                             |
| [`1bf3622e`](https://github.com/NixOS/nixpkgs/commit/1bf3622e485e7fc724ca3e1fb98b0b2aa1fc14c3) | `iay: init at v0.4.0`                                         |
| [`be841aaf`](https://github.com/NixOS/nixpkgs/commit/be841aaf45d83de5373a1c8c359edd237d1d750e) | `terrrascan: add changelog to meta`                           |
| [`3d4687c6`](https://github.com/NixOS/nixpkgs/commit/3d4687c6cd8e2d521af5fbec520d4278f930877f) | `terrascan: 1.17.0 -> 1.17.1`                                 |
| [`22da9979`](https://github.com/NixOS/nixpkgs/commit/22da997959a22e1dffcde9cb2dfbabb4283e7111) | `python310Packages.spotipy: 2.21.0 -> 2.22.0`                 |
| [`de7a7cfb`](https://github.com/NixOS/nixpkgs/commit/de7a7cfb641e6a79274d99d132ef44bab3c82a9b) | `python310Packages.gios: 2.1.0 -> 2.3.0`                      |
| [`bf0a4f54`](https://github.com/NixOS/nixpkgs/commit/bf0a4f54420d39202a5d5b07d6fe7596c17c86de) | `python310Packages.gios: add changelog to meta`               |