### PR TITLE
chore(flake/emacs-overlay): `0a570f81` -> `249d14bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671247521,
-        "narHash": "sha256-ABQrgpu++LQ9nVqDOhGZZbnfyhoASUfy8kU+pA9U9Sc=",
+        "lastModified": 1671268121,
+        "narHash": "sha256-LIOLFw5m2mYDjMo7eBB/cxYjhEqBnvQ8dpZvTjR6+Lo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0a570f813accfee8074a4486f14295c0badbec9f",
+        "rev": "249d14bdd55995eea2e0c9cfed8a230525faebde",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`249d14bd`](https://github.com/nix-community/emacs-overlay/commit/249d14bdd55995eea2e0c9cfed8a230525faebde) | `Updated repos/melpa` |