### PR TITLE
chore(flake/emacs-overlay): `249d14bd` -> `d4a1b408`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671268121,
-        "narHash": "sha256-LIOLFw5m2mYDjMo7eBB/cxYjhEqBnvQ8dpZvTjR6+Lo=",
+        "lastModified": 1671302311,
+        "narHash": "sha256-hmIyqg/XslXbJlEDQGJ30w39rznodekc4ZuSuwEh3SQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "249d14bdd55995eea2e0c9cfed8a230525faebde",
+        "rev": "d4a1b408a76e760dcad125916f4c75496f161018",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`d4a1b408`](https://github.com/nix-community/emacs-overlay/commit/d4a1b408a76e760dcad125916f4c75496f161018) | `Updated repos/nongnu` |
| [`ac897e92`](https://github.com/nix-community/emacs-overlay/commit/ac897e92fbd826af47541efc65a186bff1159960) | `Updated repos/melpa`  |
| [`e369f1a0`](https://github.com/nix-community/emacs-overlay/commit/e369f1a08bd2a9ba7735673f351d6167f58a5883) | `Updated repos/emacs`  |