### PR TITLE
chore(flake/emacs-overlay): `759e4f1d` -> `7ef898e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671332745,
-        "narHash": "sha256-woIfOrwF9mBaHicuU3N+W/DBgGEA9C2w/t1jGp8Hg+g=",
+        "lastModified": 1671346542,
+        "narHash": "sha256-XyysiznRxhHo0P+MgXz/Lnqmc0wIJHHaqpcrim0KPZA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "759e4f1d0e2ac706bd6ac22af793b1f7d02aabc6",
+        "rev": "7ef898e0097d5b3ed0deed216a33ff5b18b5fae9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                                  |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
| [`355e3328`](https://github.com/nix-community/emacs-overlay/commit/355e3328075735ea93d5dd1d29884d251e45529e) | `Add tree-sitter-rust`                                          |
| [`e38a4d0a`](https://github.com/nix-community/emacs-overlay/commit/e38a4d0ac4cfb473da82859b4494aea1f993517c) | `fixes segfaults that only occur on aarch64-linux (issue #264)` |