### PR TITLE
chore(flake/emacs-overlay): `7ef898e0` -> `d8baf8af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671346542,
-        "narHash": "sha256-XyysiznRxhHo0P+MgXz/Lnqmc0wIJHHaqpcrim0KPZA=",
+        "lastModified": 1671358416,
+        "narHash": "sha256-8AeYoYO7hQKIxjhLPurmHxPZBk6Fx1WrF6/omkWedWQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7ef898e0097d5b3ed0deed216a33ff5b18b5fae9",
+        "rev": "d8baf8af22511e7526d9336eede54bbfa6aed13e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`d8baf8af`](https://github.com/nix-community/emacs-overlay/commit/d8baf8af22511e7526d9336eede54bbfa6aed13e) | `Updated repos/nongnu` |
| [`196b8ae9`](https://github.com/nix-community/emacs-overlay/commit/196b8ae969df6550e4c39bf38b1186d897eb500b) | `Updated repos/melpa`  |
| [`dfb237dc`](https://github.com/nix-community/emacs-overlay/commit/dfb237dc6fe20ab963d0390dc153ad7efbd2a2a5) | `Updated repos/emacs`  |