### PR TITLE
chore(flake/emacs-overlay): `d8baf8af` -> `233d2937`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671358416,
-        "narHash": "sha256-8AeYoYO7hQKIxjhLPurmHxPZBk6Fx1WrF6/omkWedWQ=",
+        "lastModified": 1671391530,
+        "narHash": "sha256-VrY2/9VD6hANT2XM/Y2GOm1AlGKeI5kD7vu61zih1ic=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d8baf8af22511e7526d9336eede54bbfa6aed13e",
+        "rev": "233d2937a35960459f8d0958548fccf67c060330",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`233d2937`](https://github.com/nix-community/emacs-overlay/commit/233d2937a35960459f8d0958548fccf67c060330) | `Updated repos/melpa` |
| [`54c91790`](https://github.com/nix-community/emacs-overlay/commit/54c9179039e173d5ce1cd26ed9ba77d4d3c1ff00) | `Updated repos/emacs` |