### PR TITLE
chore(flake/nur): `ccf9b872` -> `21bda9a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671337747,
-        "narHash": "sha256-wIiTS4GebkbhyL+WYl8U3TcmLGwpQuv0/z1PEdno7W0=",
+        "lastModified": 1671392835,
+        "narHash": "sha256-iTlSRWA4Rqetjrs3no9zXlrlO4VtZut9T/KHrQw/Dw4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ccf9b872a81ec4ba8f79fd8e6c0b6f87a2548c20",
+        "rev": "21bda9a72e4f59aaa1dccb81400ac64304a22f0a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                   |
| -------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`21bda9a7`](https://github.com/nix-community/NUR/commit/21bda9a72e4f59aaa1dccb81400ac64304a22f0a) | `automatic update`               |
| [`d4ab4ad1`](https://github.com/nix-community/NUR/commit/d4ab4ad11963ffe8bc6021144d53f7d67aadf48d) | `automatic update`               |
| [`5d2f2033`](https://github.com/nix-community/NUR/commit/5d2f203353872f44ab33fa5927d82367356986b2) | `update every hour`              |
| [`421228e4`](https://github.com/nix-community/NUR/commit/421228e456c0fd2f74e571d1b5acbab5b46c5d6f) | `chore: rename update gh action` |