### PR TITLE
chore(flake/nur): `21bda9a7` -> `d8098351`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671392835,
-        "narHash": "sha256-iTlSRWA4Rqetjrs3no9zXlrlO4VtZut9T/KHrQw/Dw4=",
+        "lastModified": 1671399982,
+        "narHash": "sha256-acZb9+zshcNjffSOzfvcn8XuS4f/JqzxEBFs2O13FXM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "21bda9a72e4f59aaa1dccb81400ac64304a22f0a",
+        "rev": "d809835190a9d047670049c1d50240790e04a705",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d8098351`](https://github.com/nix-community/NUR/commit/d809835190a9d047670049c1d50240790e04a705) | `automatic update` |