### PR TITLE
chore(flake/emacs-overlay): `233d2937` -> `838a1eb2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671391530,
-        "narHash": "sha256-VrY2/9VD6hANT2XM/Y2GOm1AlGKeI5kD7vu61zih1ic=",
+        "lastModified": 1671413296,
+        "narHash": "sha256-Wg0hFEjBHK44RJ3Trl5tacMR1ZDYseZhaksYb1jsJSE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "233d2937a35960459f8d0958548fccf67c060330",
+        "rev": "838a1eb25552b93841ba025c02c2a98062fcf22f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                     |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------- |
| [`ea098ae4`](https://github.com/nix-community/emacs-overlay/commit/ea098ae4c4e43ae76f2c5a39ab614749fe28e99f) | `Drop mkPgtkEmacs function`        |
| [`766e5a23`](https://github.com/nix-community/emacs-overlay/commit/766e5a23610edee0666b4a1a570543167e127d68) | `Use withPgtk = true in emacsPgtk` |