### PR TITLE
chore(flake/nur): `b4bf4264` -> `08b17ee4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671407130,
-        "narHash": "sha256-FWI4MNmx7WsKXfddAZjVoqzQYRfNB+59wbjrQ5DaSSw=",
+        "lastModified": 1671414958,
+        "narHash": "sha256-2Z60zXt5piUe3y43OrP+gt1Y8kYTRezfBAvO4UeWzA0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b4bf42641d5172ef174364e67f2da808cf1b7dd8",
+        "rev": "08b17ee4510eec2780a3c1a57a63bdfe88e82453",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`08b17ee4`](https://github.com/nix-community/NUR/commit/08b17ee4510eec2780a3c1a57a63bdfe88e82453) | `automatic update` |