### PR TITLE
chore(flake/emacs-overlay): `838a1eb2` -> `b178f5d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671413296,
-        "narHash": "sha256-Wg0hFEjBHK44RJ3Trl5tacMR1ZDYseZhaksYb1jsJSE=",
+        "lastModified": 1671418991,
+        "narHash": "sha256-I53dzPNjiBeSYKuXg7dowFUM5uwiZ/OwMNSsu+no44I=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "838a1eb25552b93841ba025c02c2a98062fcf22f",
+        "rev": "b178f5d0cfb97181ac1503f805ca7e0649202441",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`b178f5d0`](https://github.com/nix-community/emacs-overlay/commit/b178f5d0cfb97181ac1503f805ca7e0649202441) | `Updated repos/melpa` |
| [`54eb70a7`](https://github.com/nix-community/emacs-overlay/commit/54eb70a7a5c91212db0f94ad5227d080e251d366) | `Updated repos/emacs` |
| [`713c4b92`](https://github.com/nix-community/emacs-overlay/commit/713c4b92f2e539d5157ca4b08fd3e55f02068549) | `Updated repos/elpa`  |