### PR TITLE
chore(flake/pre-commit-hooks): `74966fec` -> `200790e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -491,11 +491,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1671391305,
-        "narHash": "sha256-U+v+K4C1NV6RXYMhCoUIZE8u8Y6vYrtwXgpBOilDzCE=",
+        "lastModified": 1671452357,
+        "narHash": "sha256-HqzXiQEegpRQ4VEl9pEPgHSIxhJrNJ27HfN1wOc7w2E=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "74966fec0b7f5d137ebe9897f32db94360fd3d5b",
+        "rev": "200790e9c77064c53eaf95805b013d96615ecc27",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`200790e9`](https://github.com/cachix/pre-commit-hooks.nix/commit/200790e9c77064c53eaf95805b013d96615ecc27) | `reduce closure size` |