### PR TITLE
chore(flake/nur): `9d70eeaf` -> `353b76dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671425251,
-        "narHash": "sha256-8XGmWrF+zpI9+sTCHCLo2gbd2Z/5lQ5rWbSoIjyk6GM=",
+        "lastModified": 1671471998,
+        "narHash": "sha256-IUZX7suSeN3aR/CQYTXS9sIE/snTfy2VGMYHBWEsWyQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9d70eeafc6cc2f97c5b769058d12631d74a994e3",
+        "rev": "353b76dd448b8a67b9429b81b48a73c62b1e8798",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`353b76dd`](https://github.com/nix-community/NUR/commit/353b76dd448b8a67b9429b81b48a73c62b1e8798) | `automatic update` |