### PR TITLE
chore(flake/nur): `353b76dd` -> `167589d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671471998,
-        "narHash": "sha256-IUZX7suSeN3aR/CQYTXS9sIE/snTfy2VGMYHBWEsWyQ=",
+        "lastModified": 1671475548,
+        "narHash": "sha256-xxdtDsRGQfLvroEkoiEOp965Tx234wKC0s9NqmIA7X8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "353b76dd448b8a67b9429b81b48a73c62b1e8798",
+        "rev": "167589d47493d84cfab99eebb0c5ce3b966316b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`167589d4`](https://github.com/nix-community/NUR/commit/167589d47493d84cfab99eebb0c5ce3b966316b4) | `automatic update` |