### PR TITLE
chore(flake/nur): `aa5687d6` -> `73784fdd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671479100,
-        "narHash": "sha256-dYh61DMUo0QWyFeSMzeYe3dMGLIehCnyevNTJGGyyhs=",
+        "lastModified": 1671489919,
+        "narHash": "sha256-YG4Hj4zQ3Is2Dz/4VkCoM0e6/0vKlrVfBQn8k2D4KX0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aa5687d6ff2f916d08fe0a4a9a84edc86867df43",
+        "rev": "73784fdd4a398d6bc2de1cb60f9eba18f5837096",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`73784fdd`](https://github.com/nix-community/NUR/commit/73784fdd4a398d6bc2de1cb60f9eba18f5837096) | `automatic update` |