### PR TITLE
chore(flake/nur): `73784fdd` -> `4fab353b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671489919,
-        "narHash": "sha256-YG4Hj4zQ3Is2Dz/4VkCoM0e6/0vKlrVfBQn8k2D4KX0=",
+        "lastModified": 1671493546,
+        "narHash": "sha256-llbUWXcHCeFh99wHPr7YAm7N9TxZooTHM2eFExlWCz4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "73784fdd4a398d6bc2de1cb60f9eba18f5837096",
+        "rev": "4fab353bbb696e5c33a12ed4e2bc8d918d301ec4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4fab353b`](https://github.com/nix-community/NUR/commit/4fab353bbb696e5c33a12ed4e2bc8d918d301ec4) | `automatic update` |