### PR TITLE
chore(flake/nur): `21afe9d6` -> `e54143ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671501822,
-        "narHash": "sha256-cach4RBBytVtdIxDvjgh6ANcyr30Vl/N8cdHzVSvVrY=",
+        "lastModified": 1671504933,
+        "narHash": "sha256-XoUOPXs7r3q9WuzLpuZNhB86gp3bkN1k+O1k+b5KShM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "21afe9d611f90c899fd1881955c918e63b2dc324",
+        "rev": "e54143ce16f72ef92a80626345815aeba1ee8a9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e54143ce`](https://github.com/nix-community/NUR/commit/e54143ce16f72ef92a80626345815aeba1ee8a9d) | `automatic update` |