### PR TITLE
chore(flake/emacs-overlay): `d50df98a` -> `56367de0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671473381,
-        "narHash": "sha256-rdu5edAFieruBiPLpWaoHPu1+rbULyv98aheOffpLeQ=",
+        "lastModified": 1671505347,
+        "narHash": "sha256-3MJrDwlXrGLOKBqimyA9wYIBW1Wve4YScM2ffbvRrrw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d50df98aaf28405432814d3b1a15eaf0e133d04d",
+        "rev": "56367de0ad78e1f1db0946ae896e4017d9dde785",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`56367de0`](https://github.com/nix-community/emacs-overlay/commit/56367de0ad78e1f1db0946ae896e4017d9dde785) | `Updated repos/nongnu` |
| [`6511f9a3`](https://github.com/nix-community/emacs-overlay/commit/6511f9a3d0be0bbb7ef0183fb03f2b936fe42582) | `Updated repos/melpa`  |
| [`66c09dd3`](https://github.com/nix-community/emacs-overlay/commit/66c09dd318a5b8049064373bcefd118457f4d22b) | `Updated repos/emacs`  |