### PR TITLE
chore(flake/nur): `e54143ce` -> `9957dd46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671504933,
-        "narHash": "sha256-XoUOPXs7r3q9WuzLpuZNhB86gp3bkN1k+O1k+b5KShM=",
+        "lastModified": 1671507925,
+        "narHash": "sha256-aJPDR01sLIolwhqvt079fPWYXiIYH66FewZJ1qMkjpw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e54143ce16f72ef92a80626345815aeba1ee8a9d",
+        "rev": "9957dd46332ee71f5439a4b9021c4c60d7a3fc42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9957dd46`](https://github.com/nix-community/NUR/commit/9957dd46332ee71f5439a4b9021c4c60d7a3fc42) | `automatic update` |