### PR TITLE
chore(flake/nur): `9957dd46` -> `1c62de16`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671507925,
-        "narHash": "sha256-aJPDR01sLIolwhqvt079fPWYXiIYH66FewZJ1qMkjpw=",
+        "lastModified": 1671511529,
+        "narHash": "sha256-4qyrFA6LIm4svGnOtAEnbCs609nfU3FW2qULw/SdcO8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9957dd46332ee71f5439a4b9021c4c60d7a3fc42",
+        "rev": "1c62de16ff1c1f4e10172af163a28a7430fe2d0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1c62de16`](https://github.com/nix-community/NUR/commit/1c62de16ff1c1f4e10172af163a28a7430fe2d0e) | `automatic update` |