### PR TITLE
chore(flake/nur): `1c62de16` -> `47cbd0e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671511529,
-        "narHash": "sha256-4qyrFA6LIm4svGnOtAEnbCs609nfU3FW2qULw/SdcO8=",
+        "lastModified": 1671525951,
+        "narHash": "sha256-F+yOQ0P/ojF+HuQQaM7pK9U1ouzqo991NUzVqS8CA7M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1c62de16ff1c1f4e10172af163a28a7430fe2d0e",
+        "rev": "47cbd0e42ab46ae603132e4f813cf1c848aa311d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`47cbd0e4`](https://github.com/nix-community/NUR/commit/47cbd0e42ab46ae603132e4f813cf1c848aa311d) | `automatic update` |