### PR TITLE
chore(flake/nur): `47cbd0e4` -> `8aef3f7f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671525951,
-        "narHash": "sha256-F+yOQ0P/ojF+HuQQaM7pK9U1ouzqo991NUzVqS8CA7M=",
+        "lastModified": 1671529459,
+        "narHash": "sha256-DTW+FZ4xkjAFgkC3Yuj2JT1oX9I0QsIVRgsOGFh1Rf8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "47cbd0e42ab46ae603132e4f813cf1c848aa311d",
+        "rev": "8aef3f7f5c66f5a1d847303878a584561c4cf41f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8aef3f7f`](https://github.com/nix-community/NUR/commit/8aef3f7f5c66f5a1d847303878a584561c4cf41f) | `automatic update` |