### PR TITLE
chore(flake/nur): `8aef3f7f` -> `d67c890f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671529459,
-        "narHash": "sha256-DTW+FZ4xkjAFgkC3Yuj2JT1oX9I0QsIVRgsOGFh1Rf8=",
+        "lastModified": 1671533103,
+        "narHash": "sha256-AtYVnkWVYMyTTXNOI+6x66EMpm+SvnYscd5QQBIZ3ak=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8aef3f7f5c66f5a1d847303878a584561c4cf41f",
+        "rev": "d67c890fc1096b9c8706c1c46f8e3fec06add355",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d67c890f`](https://github.com/nix-community/NUR/commit/d67c890fc1096b9c8706c1c46f8e3fec06add355) | `automatic update` |