### PR TITLE
chore(flake/emacs-overlay): `56367de0` -> `74a1e57f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671505347,
-        "narHash": "sha256-3MJrDwlXrGLOKBqimyA9wYIBW1Wve4YScM2ffbvRrrw=",
+        "lastModified": 1671533088,
+        "narHash": "sha256-l4xY/ck8CyJUkx+od66OXoLB2iXzFqMmv6o4Cbj730E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "56367de0ad78e1f1db0946ae896e4017d9dde785",
+        "rev": "74a1e57fc7228d715c666172ffe11e38ab31e312",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`74a1e57f`](https://github.com/nix-community/emacs-overlay/commit/74a1e57fc7228d715c666172ffe11e38ab31e312) | `Updated repos/melpa` |
| [`44cba6f3`](https://github.com/nix-community/emacs-overlay/commit/44cba6f3eaf4dfaf7190c3d69bcb322eac75b729) | `Updated repos/emacs` |