### PR TITLE
chore(flake/nur): `d67c890f` -> `7c843785`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671533103,
-        "narHash": "sha256-AtYVnkWVYMyTTXNOI+6x66EMpm+SvnYscd5QQBIZ3ak=",
+        "lastModified": 1671541304,
+        "narHash": "sha256-YDlK8nZpOk7YmOgs8LH6vnreXUx0p0GPxZXi6r6mJW4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d67c890fc1096b9c8706c1c46f8e3fec06add355",
+        "rev": "7c843785562856dfcc78dde7d7141d89a0309402",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7c843785`](https://github.com/nix-community/NUR/commit/7c843785562856dfcc78dde7d7141d89a0309402) | `automatic update` |