### PR TITLE
chore(flake/nur): `7c843785` -> `4103fbdf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671541304,
-        "narHash": "sha256-YDlK8nZpOk7YmOgs8LH6vnreXUx0p0GPxZXi6r6mJW4=",
+        "lastModified": 1671547500,
+        "narHash": "sha256-97hzIBBNDbva9eRj1WomM+pimxt7hVrH/yNjUfJSMJc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7c843785562856dfcc78dde7d7141d89a0309402",
+        "rev": "4103fbdf825891b4dc54a6bda72ef1757081444c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4103fbdf`](https://github.com/nix-community/NUR/commit/4103fbdf825891b4dc54a6bda72ef1757081444c) | `automatic update` |