### PR TITLE
chore(flake/dendrite-demo-pinecone): `45514b8d` -> `05b2b65a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671038312,
-        "narHash": "sha256-ljT1n1ODN026Uufg3qm4IXdAJ4CAbYK9tqXNwAezfZI=",
+        "lastModified": 1671555360,
+        "narHash": "sha256-VtYckj/DUhZsZ+EQYi2zFZOFd0+6DIY9dCSDtX6CtjI=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "45514b8dfd7c1421b4177b16d8cdccbfee7ada5a",
+        "rev": "05b2b65af7f9922b2213c0ca5e7d4e0c5861fe7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                          | Commit Message       |
| --------------------------------------------------------------------------------------------------------------- | -------------------- |
| [`05b2b65a`](https://github.com/bbigras/dendrite-demo-pinecone/commit/05b2b65af7f9922b2213c0ca5e7d4e0c5861fe7f) | `flake.lock: Update` |