### PR TITLE
chore(flake/nur): `4103fbdf` -> `4d282c4f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671547500,
-        "narHash": "sha256-97hzIBBNDbva9eRj1WomM+pimxt7hVrH/yNjUfJSMJc=",
+        "lastModified": 1671576377,
+        "narHash": "sha256-vwH0VXUp8LfXGpn/G5ylj6Dp4cddRPBAQjX7ffGA8xw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4103fbdf825891b4dc54a6bda72ef1757081444c",
+        "rev": "4d282c4feb278c44f083776ce655fcd4c20e8ccd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4d282c4f`](https://github.com/nix-community/NUR/commit/4d282c4feb278c44f083776ce655fcd4c20e8ccd) | `automatic update` |