### PR TITLE
chore(flake/nur): `4d282c4f` -> `f74d6f14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671576377,
-        "narHash": "sha256-vwH0VXUp8LfXGpn/G5ylj6Dp4cddRPBAQjX7ffGA8xw=",
+        "lastModified": 1671579926,
+        "narHash": "sha256-33siGI+/zVbIhAgOu1vIiT/V6j4qN+jxjVWopifvwC8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4d282c4feb278c44f083776ce655fcd4c20e8ccd",
+        "rev": "f74d6f145c1c5bae8f765b874e56437a283d0322",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f74d6f14`](https://github.com/nix-community/NUR/commit/f74d6f145c1c5bae8f765b874e56437a283d0322) | `automatic update` |