### PR TITLE
chore(flake/nur): `f74d6f14` -> `d3f7cae2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671579926,
-        "narHash": "sha256-33siGI+/zVbIhAgOu1vIiT/V6j4qN+jxjVWopifvwC8=",
+        "lastModified": 1671587904,
+        "narHash": "sha256-4yLBiRGFJ8T+4JqfFtDrMtnloHGNpdZOxKL4qoVwhFo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f74d6f145c1c5bae8f765b874e56437a283d0322",
+        "rev": "d3f7cae2923641cba7c01afcd3d9d4981b8a8690",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d3f7cae2`](https://github.com/nix-community/NUR/commit/d3f7cae2923641cba7c01afcd3d9d4981b8a8690) | `automatic update` |