### PR TITLE
chore(flake/nur): `d3f7cae2` -> `e4e64e3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671587904,
-        "narHash": "sha256-4yLBiRGFJ8T+4JqfFtDrMtnloHGNpdZOxKL4qoVwhFo=",
+        "lastModified": 1671594339,
+        "narHash": "sha256-QRhYu27IbIJCDo/WZ/pnuZffhnN4BDgsKwIpgtamkXA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d3f7cae2923641cba7c01afcd3d9d4981b8a8690",
+        "rev": "e4e64e3e126dd9566bc0da435422c1685f55e59f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e4e64e3e`](https://github.com/nix-community/NUR/commit/e4e64e3e126dd9566bc0da435422c1685f55e59f) | `automatic update` |
| [`39a8a633`](https://github.com/nix-community/NUR/commit/39a8a6332505a0f4de2575b06e4279bd45a8497c) | `automatic update` |