### PR TITLE
chore(flake/emacs-overlay): `a201dcf3` -> `04c69f9d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671560587,
-        "narHash": "sha256-adehTlcTpds4Dd/GN+JIZn+XGiDfIyW/E/ObvTQlEdQ=",
+        "lastModified": 1671593498,
+        "narHash": "sha256-q7dFB64LNADOXr9jD5OGzV5BKxAS6JX08Dl1FiU9Ptc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a201dcf3d712cf6d3934b396d523041781ff9589",
+        "rev": "04c69f9d921e5090965f92842f225734652835e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`04c69f9d`](https://github.com/nix-community/emacs-overlay/commit/04c69f9d921e5090965f92842f225734652835e0) | `Updated repos/nongnu` |
| [`5508c1bb`](https://github.com/nix-community/emacs-overlay/commit/5508c1bb56768e5c583ac72a2e71bf957f2e6697) | `Updated repos/melpa`  |
| [`7cb61586`](https://github.com/nix-community/emacs-overlay/commit/7cb61586b4bcf08df6d0f030cef42cfe843b2862) | `Updated repos/emacs`  |