### PR TITLE
chore(flake/nur): `e4e64e3e` -> `33904523`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671594339,
-        "narHash": "sha256-QRhYu27IbIJCDo/WZ/pnuZffhnN4BDgsKwIpgtamkXA=",
+        "lastModified": 1671597980,
+        "narHash": "sha256-Xm5+CiE3LXfmFz+3z6jzsycEWSRF3BB0Ohk3Io9T+1s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e4e64e3e126dd9566bc0da435422c1685f55e59f",
+        "rev": "339045235c747cc6ef00562f38276fc30602a8ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`33904523`](https://github.com/nix-community/NUR/commit/339045235c747cc6ef00562f38276fc30602a8ca) | `automatic update` |