### PR TITLE
chore(flake/nur): `33904523` -> `26313ce1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671597980,
-        "narHash": "sha256-Xm5+CiE3LXfmFz+3z6jzsycEWSRF3BB0Ohk3Io9T+1s=",
+        "lastModified": 1671615014,
+        "narHash": "sha256-A22R51XkhQuQam/KBE/ANkL9hGA+AD45fdB1HY7iHM0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "339045235c747cc6ef00562f38276fc30602a8ca",
+        "rev": "26313ce1d78497163e0a67ff82bfe9fb582681bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                |
| -------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`26313ce1`](https://github.com/nix-community/NUR/commit/26313ce1d78497163e0a67ff82bfe9fb582681bd) | `automatic update`            |
| [`2efe8068`](https://github.com/nix-community/NUR/commit/2efe8068f8d6b8f0377d7f1fda3888a9adf067ca) | `automatic update`            |
| [`d1c6524b`](https://github.com/nix-community/NUR/commit/d1c6524b3a4e72b422b887cec50ea75a81442caf) | `add nodeselector repository` |
| [`4b952683`](https://github.com/nix-community/NUR/commit/4b95268336ba469bd5803a80f878c8cfbed5d5e5) | `add souxd-nur repository`    |