### PR TITLE
chore(flake/ragenix): `a948e70b` -> `d818eb3c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -516,11 +516,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1671439058,
-        "narHash": "sha256-zn5BCd8dBDJiYZzHweGgxkSqwODRZQCWANTq977lOLA=",
+        "lastModified": 1671643845,
+        "narHash": "sha256-eQBxD8IH/h8q/Y/14H9mdnIzeqH1pZHzKgBjqH/qV1U=",
         "owner": "yaxitech",
         "repo": "ragenix",
-        "rev": "a948e70b1a5df44f442d41b5771ee33d4f87b78b",
+        "rev": "d818eb3cc0d47eca9f330ea27be1332bbdf15ece",
         "type": "github"
       },
       "original": {
@@ -564,11 +564,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667271616,
-        "narHash": "sha256-qR43NUFFoKfDRro3M1SarTYVfTn8WvWznGJX5eNCNZw=",
+        "lastModified": 1671589280,
+        "narHash": "sha256-FmJ4SC+Ewi1iMhdtRcrwirMfvW7h2jakT7ILLo9BVws=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3cbe6891588e1efad2491f87a54be26aeed1fac0",
+        "rev": "bfc54bcf98dacdc649c88a82bf14d00b399aa3bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                            | Commit Message               |
| ------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`d818eb3c`](https://github.com/yaxitech/ragenix/commit/d818eb3cc0d47eca9f330ea27be1332bbdf15ece) | `Update flake inputs (#118)` |