### PR TITLE
chore(flake/nur): `e9f2d6c5` -> `fead0ed2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671641637,
-        "narHash": "sha256-SSn2THbvj5U82EjzhoneT3XiS7RxhvMX2I5/XmcU4Zc=",
+        "lastModified": 1671644666,
+        "narHash": "sha256-dy/TivkveDB9MBtgoQib+/XQoc+1bLAE12E1ob9Nl/s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e9f2d6c5fc651a904a8e654ec5bc5d35489954b1",
+        "rev": "fead0ed2e6a77aebfa21f29dd14a2ff266b7c6d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`fead0ed2`](https://github.com/nix-community/NUR/commit/fead0ed2e6a77aebfa21f29dd14a2ff266b7c6d5) | `automatic update` |