### PR TITLE
chore(flake/emacs-overlay): `75f08c34` -> `b7a13b83`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671617692,
-        "narHash": "sha256-XvzdVbu4xyIUx11iF7UZYFpDRhalxpmdjc0i/DBBvJc=",
+        "lastModified": 1671646610,
+        "narHash": "sha256-3PkqA8X0ISwkKBqoZcRsLc3K6Q+gRTNoc7T8PSld/50=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "75f08c349147a291cb18ef3dba2e87e129d467be",
+        "rev": "b7a13b83ce72c7038d1871ccb63d055b23fc6021",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`b7a13b83`](https://github.com/nix-community/emacs-overlay/commit/b7a13b83ce72c7038d1871ccb63d055b23fc6021) | `Updated repos/melpa` |
| [`374a5b86`](https://github.com/nix-community/emacs-overlay/commit/374a5b8673c0ec6166ded1736e6b01cf994a49e9) | `Updated repos/emacs` |