### PR TITLE
chore(flake/emacs-overlay): `b7a13b83` -> `6964a2e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671646610,
-        "narHash": "sha256-3PkqA8X0ISwkKBqoZcRsLc3K6Q+gRTNoc7T8PSld/50=",
+        "lastModified": 1671674264,
+        "narHash": "sha256-KwEPzJw2BXKy2+aSq5KgX0nFJJ5MheBbxKvW/6eOM3g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b7a13b83ce72c7038d1871ccb63d055b23fc6021",
+        "rev": "6964a2e706251a3465b24e2593f7afea902e04a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`6964a2e7`](https://github.com/nix-community/emacs-overlay/commit/6964a2e706251a3465b24e2593f7afea902e04a3) | `Updated repos/nongnu` |
| [`05a0dbab`](https://github.com/nix-community/emacs-overlay/commit/05a0dbab720f96496aee098cfa9d40d92c0b8894) | `Updated repos/melpa`  |