### PR TITLE
chore(flake/nur): `8f2b9b98` -> `9ece51fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671651967,
-        "narHash": "sha256-KKU/P3Ndpqa7dRcl8r+Rv1NDNpQhi9aKb4e0TplVc9g=",
+        "lastModified": 1671680706,
+        "narHash": "sha256-4dsO1Ne45nEuVznGxnTOP/dAccm7bp4onwxDdxsZYUk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8f2b9b986a2c3911e4eb79c7d969a5e3e17632fe",
+        "rev": "9ece51fb51d653db9a0f071115c5c7711478cea5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9ece51fb`](https://github.com/nix-community/NUR/commit/9ece51fb51d653db9a0f071115c5c7711478cea5) | `automatic update` |