### PR TITLE
chore(flake/nur): `d7160194` -> `f5befc65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671684349,
-        "narHash": "sha256-cisQitVGk1yDgBzrlYtYS0HccytL5bxEWSX0qip+Q6k=",
+        "lastModified": 1671698744,
+        "narHash": "sha256-9CH9xBusM94Cy5/YNNgyobnHYNC0cy6OAPZhfWdRk0o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d716019416a787dd7e4df2ba71dee40137dfa8a3",
+        "rev": "f5befc65590bcb9fa2ac92e69be8a99c4e66a8e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f5befc65`](https://github.com/nix-community/NUR/commit/f5befc65590bcb9fa2ac92e69be8a99c4e66a8e5) | `automatic update` |
| [`32e8b64e`](https://github.com/nix-community/NUR/commit/32e8b64e382eae3ad8a3136a9c8d7b126f008510) | `automatic update` |