### PR TITLE
chore(flake/emacs-overlay): `6964a2e7` -> `9e922672`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671674264,
-        "narHash": "sha256-KwEPzJw2BXKy2+aSq5KgX0nFJJ5MheBbxKvW/6eOM3g=",
+        "lastModified": 1671705076,
+        "narHash": "sha256-HV9mPW5WAAAn+5agTkeiaJU43RQ9g1We/N4yY4D9bCA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6964a2e706251a3465b24e2593f7afea902e04a3",
+        "rev": "9e9226725def97c722597984175d6f1cb2ecc320",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                        |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
| [`9e922672`](https://github.com/nix-community/emacs-overlay/commit/9e9226725def97c722597984175d6f1cb2ecc320) | `Updated repos/melpa`                 |
| [`db424bb6`](https://github.com/nix-community/emacs-overlay/commit/db424bb6a20b7aff38533ca77840c51a8350b5bb) | `Updated repos/emacs`                 |
| [`00cdfbd3`](https://github.com/nix-community/emacs-overlay/commit/00cdfbd36d40d529003d521ab32ca570dfcd453e) | `emacs-lsp: bump + fix update script` |