### PR TITLE
chore(flake/emacs-overlay): `9e922672` -> `7f50dbe2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671705076,
-        "narHash": "sha256-HV9mPW5WAAAn+5agTkeiaJU43RQ9g1We/N4yY4D9bCA=",
+        "lastModified": 1671710439,
+        "narHash": "sha256-+M/BGsD2wQVQjTh10BYnqpIk9WmFH8HeBWkg8eBYjHo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9e9226725def97c722597984175d6f1cb2ecc320",
+        "rev": "7f50dbe28566a45d5cb6de04d4ea09a7184a5f9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                 |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------ |
| [`7535e2c0`](https://github.com/nix-community/emacs-overlay/commit/7535e2c08b91b471e10c09e5c5d6658f815df83c) | `Build emacsGit without Xcode` |