### PR TITLE
chore(flake/nur): `51ca4999` -> `4ddce2dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671738259,
-        "narHash": "sha256-gZjRnAp0F4YNJj+P1oce5IYxlwtGqy1hhRLNvwwSwlc=",
+        "lastModified": 1671749225,
+        "narHash": "sha256-PzgsGkOxle2GoNYdNACVMvtpJVd3Y/iHgNenZBJZOmk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "51ca4999fe188e43e0a11f9b118b2147126e50f1",
+        "rev": "4ddce2dd737c401ec975a7c0917fa712c46bde6d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4ddce2dd`](https://github.com/nix-community/NUR/commit/4ddce2dd737c401ec975a7c0917fa712c46bde6d) | `automatic update` |