### PR TITLE
chore(flake/nur): `1a858b7a` -> `a19dd223`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671761139,
-        "narHash": "sha256-uJoQx7x6O5hi4A2hIJ37hjt13vWuO+tm1arJjv0s/bc=",
+        "lastModified": 1671785354,
+        "narHash": "sha256-fHgmJQyCNI9ZuRIdEQ+Jmni+A5VR3tWygmoeG1afmVs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1a858b7a17de0a45d25c749fb8e222b1e7ce1225",
+        "rev": "a19dd2231a00c10070560c74911df6e2b65d6b9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                |
| -------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`a19dd223`](https://github.com/nix-community/NUR/commit/a19dd2231a00c10070560c74911df6e2b65d6b9b) | `automatic update`            |
| [`1a30ef84`](https://github.com/nix-community/NUR/commit/1a30ef8429813431cc66084278970aec618067c6) | `new endpoint for nur-update` |
| [`3a5f3717`](https://github.com/nix-community/NUR/commit/3a5f3717d0b71ecdda7658e3bd54bc9ebeb408d5) | `automatic update`            |