### PR TITLE
chore(flake/nur): `a19dd223` -> `079d8afc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671785354,
-        "narHash": "sha256-fHgmJQyCNI9ZuRIdEQ+Jmni+A5VR3tWygmoeG1afmVs=",
+        "lastModified": 1671786197,
+        "narHash": "sha256-qxhQckdgt7Ailx5ynRWkOk8o9XKxNNgjs4Z/f5kX6MY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a19dd2231a00c10070560c74911df6e2b65d6b9b",
+        "rev": "079d8afc9f786446f7720401ee6922c7ecd3c5b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`079d8afc`](https://github.com/nix-community/NUR/commit/079d8afc9f786446f7720401ee6922c7ecd3c5b3) | `automatic update` |