### PR TITLE
chore(flake/nur): `079d8afc` -> `c705afd1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671786197,
-        "narHash": "sha256-qxhQckdgt7Ailx5ynRWkOk8o9XKxNNgjs4Z/f5kX6MY=",
+        "lastModified": 1671796039,
+        "narHash": "sha256-Pl37oXOt3GONjRwUZ8znchPytuqNIXu/VdMK1qMWpoc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "079d8afc9f786446f7720401ee6922c7ecd3c5b3",
+        "rev": "c705afd10e0080c69ffcf97a5e796df88ca44a00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c705afd1`](https://github.com/nix-community/NUR/commit/c705afd10e0080c69ffcf97a5e796df88ca44a00) | `automatic update` |
| [`eb763d5a`](https://github.com/nix-community/NUR/commit/eb763d5abcdf3b43e2f0d1fbaafe809e242c8bbd) | `automatic update` |