### PR TITLE
chore(flake/nur): `c705afd1` -> `9c84adeb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671796039,
-        "narHash": "sha256-Pl37oXOt3GONjRwUZ8znchPytuqNIXu/VdMK1qMWpoc=",
+        "lastModified": 1671800658,
+        "narHash": "sha256-TmHSq80jDLqSxYnevQYxKHQ4q+JBPv9oLh/XlPYBr3U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c705afd10e0080c69ffcf97a5e796df88ca44a00",
+        "rev": "9c84adeb21f209dec30f32458fe8a69ce36ec817",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9c84adeb`](https://github.com/nix-community/NUR/commit/9c84adeb21f209dec30f32458fe8a69ce36ec817) | `automatic update` |