### PR TITLE
chore(flake/nur): `210b7e5a` -> `cee2bb95`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671803284,
-        "narHash": "sha256-5Ed5UyZWFxKFuvyuU5axR3V2uU+ddYJ9Vbg2MxFTgm4=",
+        "lastModified": 1671804501,
+        "narHash": "sha256-kj+EY4ChF1hmBf9fwZMa8sU52JS0itmOo0rQnOR2b5Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "210b7e5a2f4e13954bc22e1ee415ec376ff2de14",
+        "rev": "cee2bb950b31e00f32e0143b780eda1bfb56a016",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`cee2bb95`](https://github.com/nix-community/NUR/commit/cee2bb950b31e00f32e0143b780eda1bfb56a016) | `automatic update` |