### PR TITLE
chore(flake/nur): `cee2bb95` -> `fb8edb74`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671804501,
-        "narHash": "sha256-kj+EY4ChF1hmBf9fwZMa8sU52JS0itmOo0rQnOR2b5Q=",
+        "lastModified": 1671810321,
+        "narHash": "sha256-dJz3s1B0opwxQ5u3pwczUjcUSY/RSsh9AgzMPNqRXQQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cee2bb950b31e00f32e0143b780eda1bfb56a016",
+        "rev": "fb8edb7405ba8bac1757101df84e0eee106444a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`fb8edb74`](https://github.com/nix-community/NUR/commit/fb8edb7405ba8bac1757101df84e0eee106444a9) | `automatic update` |