### PR TITLE
chore(flake/nur): `fb8edb74` -> `e369ab33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671810321,
-        "narHash": "sha256-dJz3s1B0opwxQ5u3pwczUjcUSY/RSsh9AgzMPNqRXQQ=",
+        "lastModified": 1671811449,
+        "narHash": "sha256-x3lmyHkfaDapYaMgKV3olLAxsdF36xvQFxnEUMVdydM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fb8edb7405ba8bac1757101df84e0eee106444a9",
+        "rev": "e369ab33b7d8efc7821335b1e369ae0a7cfa62c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e369ab33`](https://github.com/nix-community/NUR/commit/e369ab33b7d8efc7821335b1e369ae0a7cfa62c5) | `automatic update` |