### PR TITLE
chore(flake/emacs-overlay): `ad814066` -> `d89f91c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671790997,
-        "narHash": "sha256-9Z36wBUxfhEtOfa4SekpJFckSK6XxOBBUAeqMlH7T7o=",
+        "lastModified": 1671818956,
+        "narHash": "sha256-+jt1dHKfxrWWHN3cz4mAW0zA57AQOXDgoTyz3nX6TK0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ad814066607eb2b9400f7f7dbb45eea5178d295c",
+        "rev": "d89f91c7c5ba124348e097c45f1bf8882f5c60be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`d89f91c7`](https://github.com/nix-community/emacs-overlay/commit/d89f91c7c5ba124348e097c45f1bf8882f5c60be) | `Updated repos/melpa` |
| [`7b4936ec`](https://github.com/nix-community/emacs-overlay/commit/7b4936ec6bb985770ef34a3cfe81b05cb3d3970e) | `Updated repos/emacs` |