### PR TITLE
chore(flake/emacs-ement): `f721fe3f` -> `8d55a637`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1669429180,
-        "narHash": "sha256-l/iC5IqxZl5FxjCtPNur/+6o5XajIqi9DRujTwG5nmo=",
+        "lastModified": 1671820625,
+        "narHash": "sha256-VRVwTzHvhUJasCSEzVoqx8MyOwEaUt6UsFzUYao3TA4=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "f721fe3fb408bc28a7dbcb296226d834fd2304e6",
+        "rev": "8d55a6375dce7beda8a15e510cff670c588bc29b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                      |
| --------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`58ea59e8`](https://github.com/alphapapa/ement.el/commit/58ea59e80c5a68098c83413c49622aa0b08d7579) | `Release: v0.5.2`                   |
| [`fbfa1d57`](https://github.com/alphapapa/ement.el/commit/fbfa1d5758cba226b1cafc4de99b9316387aea60) | `Fix: (ement-initial-sync-timeout)` |
| [`25a5dd47`](https://github.com/alphapapa/ement.el/commit/25a5dd47444a146e75351c8dbba7eecd05906e48) | `Meta: v0.5.2-pre`                  |