### PR TITLE
chore(flake/nur): `a56c5fa1` -> `f12317b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671824730,
-        "narHash": "sha256-S8fMIiJp7iJJB1+Tl2qsLo9D1/GJyeE6m1/p/xLo9UU=",
+        "lastModified": 1671828359,
+        "narHash": "sha256-Bv0WEYUT2dinK2Vwl9hVW91SAjZiOSVnqpVtU17xKBE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a56c5fa1a63bd077d11f80315cb3d2ea6c508084",
+        "rev": "f12317b3131341358a3549849d19cb85d5bbba79",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f12317b3`](https://github.com/nix-community/NUR/commit/f12317b3131341358a3549849d19cb85d5bbba79) | `automatic update` |