### PR TITLE
chore(flake/nur): `f12317b3` -> `a45aba8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671828359,
-        "narHash": "sha256-Bv0WEYUT2dinK2Vwl9hVW91SAjZiOSVnqpVtU17xKBE=",
+        "lastModified": 1671839060,
+        "narHash": "sha256-LjPi1oRkjoFAsTFydofIQldgquPh+uciRQ6XPIY9+80=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f12317b3131341358a3549849d19cb85d5bbba79",
+        "rev": "a45aba8e8f1bfd2d02a6fe4a6767c09c303025b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a45aba8e`](https://github.com/nix-community/NUR/commit/a45aba8e8f1bfd2d02a6fe4a6767c09c303025b2) | `automatic update` |
| [`20912eb1`](https://github.com/nix-community/NUR/commit/20912eb1bec33ab749642de3ecb7c9ab19e2e1de) | `automatic update` |