### PR TITLE
chore(flake/nur): `c681bdb7` -> `2e5df61a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671846864,
-        "narHash": "sha256-/S2+5FaxAE6Hm2XDERnBNrMJ69+DWwFMnGnbBlhQHAQ=",
+        "lastModified": 1671856402,
+        "narHash": "sha256-tDIaTQLQli0Vz3LIkxRgT5y2/lntKz6hhU7zNx5GdWw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c681bdb79981f57351e75ea7c7e2b28e9371fa9b",
+        "rev": "2e5df61abccb3265b27582c41e67c16a937a3031",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2e5df61a`](https://github.com/nix-community/NUR/commit/2e5df61abccb3265b27582c41e67c16a937a3031) | `automatic update` |
| [`67e33586`](https://github.com/nix-community/NUR/commit/67e3358654147a67fa40bf443ccbdde4860a4412) | `automatic update` |
| [`9aca4764`](https://github.com/nix-community/NUR/commit/9aca4764fea3f051bd416d30d42d74535aa23d11) | `automatic update` |