### PR TITLE
chore(flake/nur): `2e5df61a` -> `280c1d74`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671856402,
-        "narHash": "sha256-tDIaTQLQli0Vz3LIkxRgT5y2/lntKz6hhU7zNx5GdWw=",
+        "lastModified": 1671864380,
+        "narHash": "sha256-gGG9YO3G8f997S3dYN7lnIyYu89/tBKwVuBvO+/mE7s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2e5df61abccb3265b27582c41e67c16a937a3031",
+        "rev": "280c1d747b3412dde09ab03745ce69bb9fd4375f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`280c1d74`](https://github.com/nix-community/NUR/commit/280c1d747b3412dde09ab03745ce69bb9fd4375f) | `automatic update` |