### PR TITLE
chore(flake/nur): `02b26d3e` -> `25b9a5fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671870129,
-        "narHash": "sha256-0e0m9Hdgdg8+y3iohmbfU8GFagyzZESVGZFQxhPr5mA=",
+        "lastModified": 1671871951,
+        "narHash": "sha256-3uAZSkoXVfK7aNKXQ1nZPRUk+3lWP8/bBixQIlLYelI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "02b26d3e5285c03fb45fc6ae904e42ee3d4ff78e",
+        "rev": "25b9a5fa1858ab6f5be8a24cfe6b9f5a3eb80d0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`25b9a5fa`](https://github.com/nix-community/NUR/commit/25b9a5fa1858ab6f5be8a24cfe6b9f5a3eb80d0c) | `automatic update` |