### PR TITLE
chore(flake/darwin): `adb8ac04` -> `267040e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671196037,
-        "narHash": "sha256-2+J98SeczFWonbqFLMEAQC7vZEe6I2gM17XYvEmG52I=",
+        "lastModified": 1671891118,
+        "narHash": "sha256-+GJYiT7QbfA306ex4sGMlFB8Ts297pn3OdQ9kTd4aDw=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "adb8ac0453c8b2c40f5bffb578453dbaee838952",
+        "rev": "267040e7a2b8644f1fdfcf57b7e808c286dbdc7b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                                       |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`023af2a1`](https://github.com/LnL7/nix-darwin/commit/023af2a1a2448aa8d255b3c4f470b8b474155ed2) | `Remove inaccurate notice for uninstaller in README` |