### PR TITLE
chore(flake/nur): `3e531640` -> `898adb55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671882360,
-        "narHash": "sha256-vTa5luC2FnDN5Z/zVv0lHynzaA8MC+/BJOmXFrmzHVs=",
+        "lastModified": 1671893061,
+        "narHash": "sha256-ZtG0t7+AoviY+eUTVUJK1kiKtNx8XVet3+gMNq44MnU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3e531640bcdaaed1293fde20958c76a66acfb797",
+        "rev": "898adb55e324245bd32bd5702decda4aa6471f7d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`898adb55`](https://github.com/nix-community/NUR/commit/898adb55e324245bd32bd5702decda4aa6471f7d) | `automatic update` |