### PR TITLE
chore(flake/nur): `7fc3c8dd` -> `8970c13b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671896683,
-        "narHash": "sha256-9tje3hfd+dZotmwu1J5M0UPByLM8GwvagaEZ82A9Kgs=",
+        "lastModified": 1671903874,
+        "narHash": "sha256-Hu0qzIR5j4ulUnmv12pskHNA6IUCX7J+LelEREwILWE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7fc3c8dd01de5be703b3fdad91b39d36c6fd447b",
+        "rev": "8970c13bdf43ea27686a0cea3c8732b11366c998",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8970c13b`](https://github.com/nix-community/NUR/commit/8970c13bdf43ea27686a0cea3c8732b11366c998) | `automatic update` |
| [`56d3bed6`](https://github.com/nix-community/NUR/commit/56d3bed6480b5a03c6b7aef18b71574778590fba) | `automatic update` |