### PR TITLE
chore(flake/emacs-overlay): `1cb44099` -> `c2698d13`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671876553,
-        "narHash": "sha256-bx0syKpE5p8Pzz4/yoLX7d3K74Ou85PQsYt9ALx0S2w=",
+        "lastModified": 1671906134,
+        "narHash": "sha256-1f50ttvpjHBV+vl1FPf8UjokaQIGHIzYKoHZQjmSrLg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1cb4409944f776fbf9ca79bbd25cd8f4c3b70069",
+        "rev": "c2698d134aa2f1c1ba491f851d6c1a0114a4b1e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`c2698d13`](https://github.com/nix-community/emacs-overlay/commit/c2698d134aa2f1c1ba491f851d6c1a0114a4b1e6) | `Updated repos/melpa` |
| [`0192f376`](https://github.com/nix-community/emacs-overlay/commit/0192f376436e4ba88b2125d26f403a5605bf59b3) | `Updated repos/emacs` |