### PR TITLE
chore(flake/nur): `65a0e1ea` -> `c1228386`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671906277,
-        "narHash": "sha256-pfMBRnMfTcsWNX1i6/BbNMfhUgGOEfoPKxV/o2VUwtQ=",
+        "lastModified": 1671914668,
+        "narHash": "sha256-X7LzfyJLK2uHKFRxHbfkisdlvqkZ8XiwJ0apDAwJqqc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "65a0e1ea7606d872fcd43b28bdbed70d23cac041",
+        "rev": "c1228386b006e26cd666f6c673fd5d1d52cc1af7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c1228386`](https://github.com/nix-community/NUR/commit/c1228386b006e26cd666f6c673fd5d1d52cc1af7) | `automatic update` |