### PR TITLE
chore(flake/nur): `c1228386` -> `5924d883`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671914668,
-        "narHash": "sha256-X7LzfyJLK2uHKFRxHbfkisdlvqkZ8XiwJ0apDAwJqqc=",
+        "lastModified": 1671918258,
+        "narHash": "sha256-B4dS4WDVlH9Weyma6ftuhpUSj/HtkXLnYg0mkXYXhL8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c1228386b006e26cd666f6c673fd5d1d52cc1af7",
+        "rev": "5924d88389aa14bcc36af894d2b449cf8c53e380",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5924d883`](https://github.com/nix-community/NUR/commit/5924d88389aa14bcc36af894d2b449cf8c53e380) | `automatic update` |