### PR TITLE
chore(flake/nur): `5924d883` -> `23b5a133`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671918258,
-        "narHash": "sha256-B4dS4WDVlH9Weyma6ftuhpUSj/HtkXLnYg0mkXYXhL8=",
+        "lastModified": 1671925605,
+        "narHash": "sha256-aqFkFm4Ry85Tetm+AjcJJt28akOsHPatFakgxtRJsIY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5924d88389aa14bcc36af894d2b449cf8c53e380",
+        "rev": "23b5a1330ec629561ae52d6df7e24d7852c91e16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`23b5a133`](https://github.com/nix-community/NUR/commit/23b5a1330ec629561ae52d6df7e24d7852c91e16) | `automatic update` |