### PR TITLE
chore(flake/nur): `23b5a133` -> `d6f942a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671925605,
-        "narHash": "sha256-aqFkFm4Ry85Tetm+AjcJJt28akOsHPatFakgxtRJsIY=",
+        "lastModified": 1671935087,
+        "narHash": "sha256-ySXYjf8IkVNZB34JYWY+pJDwnkET1d3i6BPe+9yYhFk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "23b5a1330ec629561ae52d6df7e24d7852c91e16",
+        "rev": "d6f942a2493bb3a9c80f407e96cb27322b363bf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d6f942a2`](https://github.com/nix-community/NUR/commit/d6f942a2493bb3a9c80f407e96cb27322b363bf2) | `automatic update` |
| [`794c2285`](https://github.com/nix-community/NUR/commit/794c22851fd6ee48d3550e967441cce3f3ab22b0) | `automatic update` |