### PR TITLE
chore(flake/nur): `d6f942a2` -> `b45951cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671935087,
-        "narHash": "sha256-ySXYjf8IkVNZB34JYWY+pJDwnkET1d3i6BPe+9yYhFk=",
+        "lastModified": 1671937891,
+        "narHash": "sha256-Au+RVm9/19y8zGLhYFVyO8HDaPJDPIzgG6LysrUq5dU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d6f942a2493bb3a9c80f407e96cb27322b363bf2",
+        "rev": "b45951ccca42e5ce64cb21e0e3bc18e1064e6405",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b45951cc`](https://github.com/nix-community/NUR/commit/b45951ccca42e5ce64cb21e0e3bc18e1064e6405) | `automatic update` |