### PR TITLE
chore(flake/nur): `b45951cc` -> `f02576d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671937891,
-        "narHash": "sha256-Au+RVm9/19y8zGLhYFVyO8HDaPJDPIzgG6LysrUq5dU=",
+        "lastModified": 1671943579,
+        "narHash": "sha256-s0vIzgj9E1jXM5TeQIvVCyHMWJA2z6OXh4xc39xQWv0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b45951ccca42e5ce64cb21e0e3bc18e1064e6405",
+        "rev": "f02576d604862bc59db6642d874b532fac7ec319",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f02576d6`](https://github.com/nix-community/NUR/commit/f02576d604862bc59db6642d874b532fac7ec319) | `automatic update` |