### PR TITLE
chore(flake/nur): `f02576d6` -> `2221b717`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671943579,
-        "narHash": "sha256-s0vIzgj9E1jXM5TeQIvVCyHMWJA2z6OXh4xc39xQWv0=",
+        "lastModified": 1671950788,
+        "narHash": "sha256-B08BgBLUMA5LC4Wp1VDZyfY+602D2iGrtPKEbOgh4xc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f02576d604862bc59db6642d874b532fac7ec319",
+        "rev": "2221b71796fb5586c5e4ab6544a65f57f203693e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2221b717`](https://github.com/nix-community/NUR/commit/2221b71796fb5586c5e4ab6544a65f57f203693e) | `automatic update` |