### PR TITLE
chore(flake/home-manager): `d7eee202` -> `c55fa26c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671831633,
-        "narHash": "sha256-tANQOkJnlqK4M83KvvXFMFrIbR0xkloqXY5ruqzR3kE=",
+        "lastModified": 1671966569,
+        "narHash": "sha256-jbLgfSnmLchARBNFRvCic63CFQ9LAyvlXnBpc2kwjQc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d7eee202e597bc7789498a8664082cf0ffedaa8f",
+        "rev": "c55fa26ce05fee8e063db22918d05a73d430b2ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`c55fa26c`](https://github.com/nix-community/home-manager/commit/c55fa26ce05fee8e063db22918d05a73d430b2ea) | `home-manager: pass -L/--print-build-logs to nix build` |
| [`939731b8`](https://github.com/nix-community/home-manager/commit/939731b8cb75fb451170cb8f935186a6a7424444) | `cachix-agent: add module`                              |