### PR TITLE
chore(flake/emacs-overlay): `8d3626c8` -> `9b2084bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671937220,
-        "narHash": "sha256-PnfWw63INRH5mhg9EFOHjs9X7MusnfahCfZR3pzfeCw=",
+        "lastModified": 1671963313,
+        "narHash": "sha256-usgDsv330TnPquHO5umsRH2fgTsa1ksDUIuGnmu0qA4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8d3626c8bfc1ea3a88571dd07c2b9f0aaec9594d",
+        "rev": "9b2084bd40761de6be748981275bcfd35444c820",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`9b2084bd`](https://github.com/nix-community/emacs-overlay/commit/9b2084bd40761de6be748981275bcfd35444c820) | `Updated repos/melpa` |
| [`785d196f`](https://github.com/nix-community/emacs-overlay/commit/785d196ffa59eb260025cafa6025498dd6aede50) | `Updated repos/emacs` |