### PR TITLE
chore(flake/nur): `ce94b3d5` -> `931b08d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671975941,
-        "narHash": "sha256-n5fEPkVVarOnmO70xxuMFlMwYiNQGEaFm/k1ebx/vMo=",
+        "lastModified": 1671997473,
+        "narHash": "sha256-3uuXOTclJrA2qpx2fZ5Ff/Emv6oLULTPvjeDAs0GiBY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ce94b3d5d00080485f7a6dba0243a21d10c69273",
+        "rev": "931b08d3a2700f05f29fd60672f89eaaa6f5da01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`931b08d3`](https://github.com/nix-community/NUR/commit/931b08d3a2700f05f29fd60672f89eaaa6f5da01) | `automatic update` |