### PR TITLE
chore(flake/nur): `931b08d3` -> `7595b896`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671997473,
-        "narHash": "sha256-3uuXOTclJrA2qpx2fZ5Ff/Emv6oLULTPvjeDAs0GiBY=",
+        "lastModified": 1672008303,
+        "narHash": "sha256-YkGLlPZLOEnC0/Rk+4BNoTOBlIMuxcPJJnWxRl5B7RE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "931b08d3a2700f05f29fd60672f89eaaa6f5da01",
+        "rev": "7595b896530f3199a19d431d1702b3be2890f267",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7595b896`](https://github.com/nix-community/NUR/commit/7595b896530f3199a19d431d1702b3be2890f267) | `automatic update` |
| [`d29b79be`](https://github.com/nix-community/NUR/commit/d29b79beca61e64db33a26ea77035582b988850e) | `automatic update` |