### PR TITLE
chore(flake/emacs-overlay): `5fb59e49` -> `f4ed3f57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671987997,
-        "narHash": "sha256-A7ukMZj/NJ8vgMP6p1ldEZK0OD1rarTiNEsRYkiw0YA=",
+        "lastModified": 1672019890,
+        "narHash": "sha256-mcQf2cpV+aUMsE8WZubqGayWoHXGSRqGPdRlNT25YW8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5fb59e496f0b080f3e2b4a9586cd5afda50e3189",
+        "rev": "f4ed3f57816ae096dc3ec5cfeed4374706da4324",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`f4ed3f57`](https://github.com/nix-community/emacs-overlay/commit/f4ed3f57816ae096dc3ec5cfeed4374706da4324) | `Updated repos/nongnu` |
| [`b666adfa`](https://github.com/nix-community/emacs-overlay/commit/b666adfa16346297668dd0b0f1e396d635856fa6) | `Updated repos/melpa`  |