### PR TITLE
chore(flake/nur): `7595b896` -> `7dfdd139`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672008303,
-        "narHash": "sha256-YkGLlPZLOEnC0/Rk+4BNoTOBlIMuxcPJJnWxRl5B7RE=",
+        "lastModified": 1672020192,
+        "narHash": "sha256-Nr2SFYq/LG7cgYqpbGbZa34/kbW72ttWv2uLl5erZXM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7595b896530f3199a19d431d1702b3be2890f267",
+        "rev": "7dfdd1397d57cc2eeac8b1e65b9b0e32c933b834",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7dfdd139`](https://github.com/nix-community/NUR/commit/7dfdd1397d57cc2eeac8b1e65b9b0e32c933b834) | `automatic update` |