### PR TITLE
chore(flake/nur): `dc8b44b8` -> `91b692ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672029949,
-        "narHash": "sha256-v8iKDYuHtV3FDWYj5WNXwPKdl8alJCQ+5hGwFCXF6Ac=",
+        "lastModified": 1672041076,
+        "narHash": "sha256-QqE5Dfy49MemW0D/LTWHy70pwmTnuP+NzRCsw/rQlCo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dc8b44b8626e48fb48c7857e1a75414cb8739617",
+        "rev": "91b692cee3fc0b5d3627f33a0b6f177aa0d6a420",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`91b692ce`](https://github.com/nix-community/NUR/commit/91b692cee3fc0b5d3627f33a0b6f177aa0d6a420) | `automatic update` |
| [`7ddefd42`](https://github.com/nix-community/NUR/commit/7ddefd42455456b81354030e0d6d5d231cb0b67d) | `automatic update` |
| [`564a94b1`](https://github.com/nix-community/NUR/commit/564a94b162a1f1a003783536ac311281341e9275) | `automatic update` |
| [`2a7edd67`](https://github.com/nix-community/NUR/commit/2a7edd67560fc07503237608fa0ea36e76050b48) | `automatic update` |