### PR TITLE
chore(flake/nur): `91b692ce` -> `db05a5e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672041076,
-        "narHash": "sha256-QqE5Dfy49MemW0D/LTWHy70pwmTnuP+NzRCsw/rQlCo=",
+        "lastModified": 1672073588,
+        "narHash": "sha256-0Nh0X60a1R7YK4sKLC6+gc2M7ofXYZ3K4bOUgRiZk7w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "91b692cee3fc0b5d3627f33a0b6f177aa0d6a420",
+        "rev": "db05a5e18de3bb4a6a7c08b3443318b947221165",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`db05a5e1`](https://github.com/nix-community/NUR/commit/db05a5e18de3bb4a6a7c08b3443318b947221165) | `automatic update` |
| [`0457d302`](https://github.com/nix-community/NUR/commit/0457d302f72e13b29dcf914f19b9616cbec5e44e) | `automatic update` |