### PR TITLE
chore(flake/nur): `db05a5e1` -> `04dec646`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672073588,
-        "narHash": "sha256-0Nh0X60a1R7YK4sKLC6+gc2M7ofXYZ3K4bOUgRiZk7w=",
+        "lastModified": 1672080362,
+        "narHash": "sha256-7ukOxBohvKd+g+U/B2OXCbzM+EwYAWA2M3CNL1oMjPM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "db05a5e18de3bb4a6a7c08b3443318b947221165",
+        "rev": "04dec6463a3e54a6519c72315c9071e0b90a14e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`04dec646`](https://github.com/nix-community/NUR/commit/04dec6463a3e54a6519c72315c9071e0b90a14e1) | `automatic update` |