### PR TITLE
chore(flake/nur): `c4d98a84` -> `91477ea1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672084008,
-        "narHash": "sha256-+on/N7MvMa+nyKHrvoCsmyIHcONIaRVFJ/YnG1BdygU=",
+        "lastModified": 1672087584,
+        "narHash": "sha256-iVGHAnddzZ3THsUfItaLuU3y/iuavZuAbTKP2ryHygU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c4d98a84ce4284275581e6671225a7beaa7e3a64",
+        "rev": "91477ea1f2916e0da1070c99be8f3bb6e91ce3aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`91477ea1`](https://github.com/nix-community/NUR/commit/91477ea1f2916e0da1070c99be8f3bb6e91ce3aa) | `automatic update` |