### PR TITLE
chore(flake/nur): `91477ea1` -> `33a91d14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672087584,
-        "narHash": "sha256-iVGHAnddzZ3THsUfItaLuU3y/iuavZuAbTKP2ryHygU=",
+        "lastModified": 1672091190,
+        "narHash": "sha256-enYk2ti1X53IlMrrgza9kSGGhNV+ZCNr1Sw3TNuonE4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "91477ea1f2916e0da1070c99be8f3bb6e91ce3aa",
+        "rev": "33a91d141173107de0b8c63ab326da817f4fea4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`33a91d14`](https://github.com/nix-community/NUR/commit/33a91d141173107de0b8c63ab326da817f4fea4d) | `automatic update` |