### PR TITLE
chore(flake/emacs-overlay): `c41dee3c` -> `06d88ea2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672078214,
-        "narHash": "sha256-ureC8JmF9kkh9DZ9TczxWBeGeGNrP2Qu4/LqvMOM84w=",
+        "lastModified": 1672110422,
+        "narHash": "sha256-IYR6XGwmgORfSIZYYywZmtRBoWROBjI5rZjgYmQGPJ4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c41dee3c8ab52ce197ec6bdb614ba8e9459f6a0f",
+        "rev": "06d88ea2a783a7c563ce57e62d794313ae1e4855",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`06d88ea2`](https://github.com/nix-community/emacs-overlay/commit/06d88ea2a783a7c563ce57e62d794313ae1e4855) | `Updated repos/melpa` |
| [`f172a005`](https://github.com/nix-community/emacs-overlay/commit/f172a0050e6a7558d8f59ca6e353515389cf2ad9) | `Updated repos/emacs` |
| [`b42f258a`](https://github.com/nix-community/emacs-overlay/commit/b42f258adddd337952c6ad745ffe02a8a8f1e858) | `Updated repos/elpa`  |