### PR TITLE
chore(flake/emacs-overlay): `06d88ea2` -> `ebbb2251`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672110422,
-        "narHash": "sha256-IYR6XGwmgORfSIZYYywZmtRBoWROBjI5rZjgYmQGPJ4=",
+        "lastModified": 1672132398,
+        "narHash": "sha256-eiHIeVAv0/RioqX3N8FzMBNiDuj/PhwrxYbJbT+Yuu4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "06d88ea2a783a7c563ce57e62d794313ae1e4855",
+        "rev": "ebbb22510930b5153de22357518ebd8ce7ed93b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ebbb2251`](https://github.com/nix-community/emacs-overlay/commit/ebbb22510930b5153de22357518ebd8ce7ed93b3) | `Updated repos/melpa` |