### PR TITLE
chore(flake/emacs-overlay): `ebbb2251` -> `08a79765`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672132398,
-        "narHash": "sha256-eiHIeVAv0/RioqX3N8FzMBNiDuj/PhwrxYbJbT+Yuu4=",
+        "lastModified": 1672160852,
+        "narHash": "sha256-BrhJWbDJ0SklDxHZHSpCfRlcJZnEp0vVhb6ICBRVFYw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ebbb22510930b5153de22357518ebd8ce7ed93b3",
+        "rev": "08a79765bbc6c1b967cd2d7ebd123910044b9463",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`08a79765`](https://github.com/nix-community/emacs-overlay/commit/08a79765bbc6c1b967cd2d7ebd123910044b9463) | `Updated repos/melpa` |
| [`dba6e04a`](https://github.com/nix-community/emacs-overlay/commit/dba6e04ab5479beadf0d5b8b6c1b4bbf3717b41e) | `Updated repos/elpa`  |