### PR TITLE
chore(flake/nur): `c24c3709` -> `446049db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672146123,
-        "narHash": "sha256-xUnLVFhi2dqvcQo8Xs2DrFD9V3tjcia4VZ/j/wWCWXI=",
+        "lastModified": 1672170288,
+        "narHash": "sha256-l9rtzxOeU3ZSBYDdzvDFha6gbzwyeKGmzeRtEPyYYd0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c24c370994643d1d3987ffdbf883fb7f36233690",
+        "rev": "446049db3597d3c4b3c1287712d37be193ba0730",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`446049db`](https://github.com/nix-community/NUR/commit/446049db3597d3c4b3c1287712d37be193ba0730) | `automatic update` |
| [`fb873a19`](https://github.com/nix-community/NUR/commit/fb873a192169aef848163720661e8e4a838b713f) | `automatic update` |