### PR TITLE
chore(flake/nur): `446049db` -> `6ec5c83d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672170288,
-        "narHash": "sha256-l9rtzxOeU3ZSBYDdzvDFha6gbzwyeKGmzeRtEPyYYd0=",
+        "lastModified": 1672173994,
+        "narHash": "sha256-xz35m/kwDTtE6TMYYeqb68mdxDyxZu7UGZqaqj3SS4U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "446049db3597d3c4b3c1287712d37be193ba0730",
+        "rev": "6ec5c83d9142b8ccfa8d768cd44473e489ec0481",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6ec5c83d`](https://github.com/nix-community/NUR/commit/6ec5c83d9142b8ccfa8d768cd44473e489ec0481) | `automatic update` |