### PR TITLE
chore(flake/emacs-overlay): `08a79765` -> `2052e031`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672160852,
-        "narHash": "sha256-BrhJWbDJ0SklDxHZHSpCfRlcJZnEp0vVhb6ICBRVFYw=",
+        "lastModified": 1672192965,
+        "narHash": "sha256-g5cux5D6M1ucHGUW1wToIWy/DJzoBsFDcp0j4QxH0y0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "08a79765bbc6c1b967cd2d7ebd123910044b9463",
+        "rev": "2052e031a352505b51d4e278c906bf653312a59b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`2052e031`](https://github.com/nix-community/emacs-overlay/commit/2052e031a352505b51d4e278c906bf653312a59b) | `Updated repos/melpa` |
| [`0ba3a153`](https://github.com/nix-community/emacs-overlay/commit/0ba3a153eb5f1865eafb62cce5f3943438a79310) | `Updated repos/elpa`  |