### PR TITLE
chore(flake/nur): `6ec5c83d` -> `4a37abee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672173994,
-        "narHash": "sha256-xz35m/kwDTtE6TMYYeqb68mdxDyxZu7UGZqaqj3SS4U=",
+        "lastModified": 1672192866,
+        "narHash": "sha256-qyKhh27eIOFrSc+Gmhzgdh/G08/ekR1MclTvwMmCxmI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6ec5c83d9142b8ccfa8d768cd44473e489ec0481",
+        "rev": "4a37abeee90b4c8a64e95682494417373637559d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4a37abee`](https://github.com/nix-community/NUR/commit/4a37abeee90b4c8a64e95682494417373637559d) | `automatic update` |