### PR TITLE
chore(flake/nur): `4a37abee` -> `8e95edb3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672192866,
-        "narHash": "sha256-qyKhh27eIOFrSc+Gmhzgdh/G08/ekR1MclTvwMmCxmI=",
+        "lastModified": 1672194787,
+        "narHash": "sha256-bh5TQa2sBqvS6+RTlO0z416ml5N4qfzsfT0ndcE4pHs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4a37abeee90b4c8a64e95682494417373637559d",
+        "rev": "8e95edb3dc274ebdd96a28919c41c2ad233fb460",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8e95edb3`](https://github.com/nix-community/NUR/commit/8e95edb3dc274ebdd96a28919c41c2ad233fb460) | `automatic update` |