### PR TITLE
chore(flake/nur): `8e95edb3` -> `db78e77d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672194787,
-        "narHash": "sha256-bh5TQa2sBqvS6+RTlO0z416ml5N4qfzsfT0ndcE4pHs=",
+        "lastModified": 1672202773,
+        "narHash": "sha256-S/AoF4lM7p5NR6p5EOdzQjcnj5bQC6SYsnMjbrkspKM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8e95edb3dc274ebdd96a28919c41c2ad233fb460",
+        "rev": "db78e77d8a1412a8f65ef29ba56f6bfc7adcc14a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`db78e77d`](https://github.com/nix-community/NUR/commit/db78e77d8a1412a8f65ef29ba56f6bfc7adcc14a) | `automatic update` |