### PR TITLE
chore(flake/nur): `db78e77d` -> `64a9e2b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672202773,
-        "narHash": "sha256-S/AoF4lM7p5NR6p5EOdzQjcnj5bQC6SYsnMjbrkspKM=",
+        "lastModified": 1672212779,
+        "narHash": "sha256-hJHpceQIoyTTvZyzImH2SUrG4Ob6bjraDLPTwJXDRI8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "db78e77d8a1412a8f65ef29ba56f6bfc7adcc14a",
+        "rev": "64a9e2b6b07f8e5067f8e9e67f9a787a58e4c901",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`64a9e2b6`](https://github.com/nix-community/NUR/commit/64a9e2b6b07f8e5067f8e9e67f9a787a58e4c901) | `automatic update` |