### PR TITLE
chore(flake/nur): `64a9e2b6` -> `b45d3c91`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672212779,
-        "narHash": "sha256-hJHpceQIoyTTvZyzImH2SUrG4Ob6bjraDLPTwJXDRI8=",
+        "lastModified": 1672220751,
+        "narHash": "sha256-/RY8Nah5Hq6RfjXaFqSRuvfx115DkL1YfbGDa5pM6Ww=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "64a9e2b6b07f8e5067f8e9e67f9a787a58e4c901",
+        "rev": "b45d3c91a26ff0e8e6575f862fdfb456b0e72c44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b45d3c91`](https://github.com/nix-community/NUR/commit/b45d3c91a26ff0e8e6575f862fdfb456b0e72c44) | `automatic update` |