### PR TITLE
chore(flake/emacs-overlay): `2052e031` -> `089d42b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672192965,
-        "narHash": "sha256-g5cux5D6M1ucHGUW1wToIWy/DJzoBsFDcp0j4QxH0y0=",
+        "lastModified": 1672224240,
+        "narHash": "sha256-RCY5b41sCu79h4olMoUuTIPNT9AxZRJpj3LSCJGxVhE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2052e031a352505b51d4e278c906bf653312a59b",
+        "rev": "089d42b5ec8dcea90e4748da482bb3a2178bc1a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`089d42b5`](https://github.com/nix-community/emacs-overlay/commit/089d42b5ec8dcea90e4748da482bb3a2178bc1a2) | `Updated repos/nongnu` |
| [`044ec940`](https://github.com/nix-community/emacs-overlay/commit/044ec940110982eb6d110cc6e9cbede8f6f196a6) | `Updated repos/melpa`  |
| [`6e48e5ac`](https://github.com/nix-community/emacs-overlay/commit/6e48e5ac6406ac60717e4118e09292de1b288ff4) | `Updated repos/emacs`  |