### PR TITLE
chore(flake/nixpkgs): `fad51abd` -> `677ed08a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671983799,
-        "narHash": "sha256-Z2Ro6hFPZHkBqkVXY5/aBUzxi5xizQGvuHQ9+T5B/ks=",
+        "lastModified": 1672350804,
+        "narHash": "sha256-jo6zkiCabUBn3ObuKXHGqqORUMH27gYDIFFfLq5P4wg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fad51abd42ca17a60fc1d4cb9382e2d79ae31836",
+        "rev": "677ed08a50931e38382dbef01cba08a8f7eac8f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                               |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`677ed08a`](https://github.com/NixOS/nixpkgs/commit/677ed08a50931e38382dbef01cba08a8f7eac8f6) | `maintainers: quasigod-io -> michaelBelsanti`                                |
| [`b9cbb8a4`](https://github.com/NixOS/nixpkgs/commit/b9cbb8a4e6b125b399f3439abb56186c355cf78c) | `dvc: remove anthonyroussel from maintainers`                                |
| [`1516d7a5`](https://github.com/NixOS/nixpkgs/commit/1516d7a5117b23b7d334d803386e335fa505d2c9) | `python310Packages.pontos: 22.12.1 -> 22.12.3`                               |
| [`cd8d465e`](https://github.com/NixOS/nixpkgs/commit/cd8d465eddf1bd6414aee20cf932628f4ec1db28) | ``mgba: remove `inherit (libsForQt5)` reference on all-packages.nix``        |
| [`eefcc2ae`](https://github.com/NixOS/nixpkgs/commit/eefcc2ae8edfe87b997f078528a2c78ec2b4110e) | `way-displays: 1.6.0 -> 1.6.2`                                               |
| [`964e4e3d`](https://github.com/NixOS/nixpkgs/commit/964e4e3db3aa583d41edb6de354fae505d9c18fe) | `python310Packages.sanic: 22.9.1 -> 22.12.0`                                 |
| [`10e2de42`](https://github.com/NixOS/nixpkgs/commit/10e2de42108558105e838250a2abccf139e657eb) | ``php.extensions.xdebug: update `src` attribute``                            |
| [`0ded0f9b`](https://github.com/NixOS/nixpkgs/commit/0ded0f9be140387338b1f318ede6fe69b8097cbd) | ``php.extensions.swoole: update `src` attribute``                            |
| [`4c5efee1`](https://github.com/NixOS/nixpkgs/commit/4c5efee1da232e98bd0998cf7e67908171e715b1) | ``php.extensions.redis: update `src` attribute``                             |
| [`5e4eb3ca`](https://github.com/NixOS/nixpkgs/commit/5e4eb3caa1648950db06ea83d710a7d3e3b5cd9d) | ``php.extensions.pcov: update `src` attribute``                              |
| [`9501edfe`](https://github.com/NixOS/nixpkgs/commit/9501edfefb5363d5454ce0e9bea1007af78b5218) | `php.extensions.openswoole: 4.12.0 -> 22.0.0`                                |
| [`e8d9e7e9`](https://github.com/NixOS/nixpkgs/commit/e8d9e7e90886c3012d589a6ae8b6e104795ba8ee) | ``php.extensions.gnupg: update `src` attribute``                             |
| [`4ff2402e`](https://github.com/NixOS/nixpkgs/commit/4ff2402e2affd1ab25ff542d73b2926c57107afc) | ``php.extensions.ds: update `src` attribute``                                |
| [`8d68955f`](https://github.com/NixOS/nixpkgs/commit/8d68955f99b2ad19023f23073d75e8c3e643b845) | ``php.extensions.couchbase: update `src` attribute``                         |
| [`4557de03`](https://github.com/NixOS/nixpkgs/commit/4557de030973252d8d30350298714af22c946e5d) | ``php.extensions.ast: update `src` attribute``                               |
| [`51e1f610`](https://github.com/NixOS/nixpkgs/commit/51e1f61039fb163a4bb2aff601010f6f1246b1a3) | ``php.extensions.apcu: update `src` attribute``                              |
| [`0dcce69b`](https://github.com/NixOS/nixpkgs/commit/0dcce69be6bca6e3bac7713567c917a7af52756a) | `php.extensions.amqp: 1.11.0beta -> 1.11.0`                                  |
| [`e28920b4`](https://github.com/NixOS/nixpkgs/commit/e28920b49ee19482302c376d8d492429c54fe6b0) | `php.packages.psysh: 0.11.8 -> 0.11.10`                                      |
| [`22256671`](https://github.com/NixOS/nixpkgs/commit/22256671ba05ac36d9bbb4ef10ea88c78c76347a) | `php.packages.psalm: 4.29.0 -> 5.4.0`                                        |
| [`f9868dcf`](https://github.com/NixOS/nixpkgs/commit/f9868dcf62e429b875af501f2dad6fd739d0246e) | `php.packages.phpstan: 1.8.6 -> 1.9.4`                                       |
| [`9f9d76be`](https://github.com/NixOS/nixpkgs/commit/9f9d76be973fa9cf785cfbf300e63abffa75f0a5) | `php.packages.phpmd: 2.8.2 -> 2.13.0`                                        |
| [`7276d00b`](https://github.com/NixOS/nixpkgs/commit/7276d00b8f52bb9bb90690896b46ed78eae1e0f8) | `php.packages.phpcs: 3.6.0 -> 3.7.1`                                         |
| [`cafba5ff`](https://github.com/NixOS/nixpkgs/commit/cafba5ff2407cb880fadef06cb8856ab2666b9a1) | `php.packages.phpcbf: 3.6.0 -> 3.7.1`                                        |
| [`70b8963e`](https://github.com/NixOS/nixpkgs/commit/70b8963e8ffc6b455351d80efadc2faf4f804628) | `php.packages.phive: 0.15.0 -> 0.15.2`                                       |
| [`d3f87fcf`](https://github.com/NixOS/nixpkgs/commit/d3f87fcff625235cdf2b2f914fee7a332bbe68bb) | ``php.packages.phing: update `src` url``                                     |
| [`dbe4b291`](https://github.com/NixOS/nixpkgs/commit/dbe4b291c6e9a4edd858c8762375de2f50e6e1fd) | `php.packages.php-cs-fixer: 3.11.0 -> 3.13.1`                                |
| [`7383933b`](https://github.com/NixOS/nixpkgs/commit/7383933b87161cfabbbf805510f2dcb62e93e025) | `php.packages.grumphp: 1.8.1 -> 1.15.0`                                      |
| [`50b6e06b`](https://github.com/NixOS/nixpkgs/commit/50b6e06bfe8c7d0d1a753e24820be913ab548012) | ``php.packages.composer: update `src` attribute``                            |
| [`7fc6b0e4`](https://github.com/NixOS/nixpkgs/commit/7fc6b0e4a4aedb049d88b156a80d798c8d6a1f7a) | `php.packages.box: 4.1.0 -> 4.2.0`                                           |
| [`8cd511dd`](https://github.com/NixOS/nixpkgs/commit/8cd511dde1f7c19ebd9d1d075b013487aba686fd) | ``feat: add `passthru` flags in PHP extension builder``                      |
| [`e772351a`](https://github.com/NixOS/nixpkgs/commit/e772351a7267c065be6ebb6ea5fd3088fda40985) | `stylish: init at unstable-2022-12-05`                                       |
| [`7308bb68`](https://github.com/NixOS/nixpkgs/commit/7308bb68b364efca6f29ef63a6adae633694e32e) | `python310Packages.plexapi: add changelog to meta`                           |
| [`1b0bcfbe`](https://github.com/NixOS/nixpkgs/commit/1b0bcfbef131a4a589d546dc28a5c7e0ce70b23e) | `python310Packages.quantiphy-eval: fix typo`                                 |
| [`0b2353ba`](https://github.com/NixOS/nixpkgs/commit/0b2353bad6aeafeffb3a050cfa18b359ef9855f6) | `python310Packages.quantiphy-eval: disable pythonImportsCheck`               |
| [`2ce4af2f`](https://github.com/NixOS/nixpkgs/commit/2ce4af2f1cd721bfd8cfbb2c89b2df560dd6bf65) | `python310Packages.tidyexc:  disable on unsupported Python releases`         |
| [`b0d10bb3`](https://github.com/NixOS/nixpkgs/commit/b0d10bb3a2b61ded17bad25bb1102f6b8ac00922) | `python310Packages.quantiphy: add changelog to meta`                         |
| [`2118355e`](https://github.com/NixOS/nixpkgs/commit/2118355ed050f2323c83d378612cde33cc080dd8) | `python310Packages.quantiphy-eval: add changelog to meta`                    |
| [`b29c7906`](https://github.com/NixOS/nixpkgs/commit/b29c7906f8a0bd70166a9680a320e6dddc94519d) | `python3Packages.emborg: add changelog to meta`                              |
| [`c60a8f3f`](https://github.com/NixOS/nixpkgs/commit/c60a8f3fbae08f80a4daac5a7088513406a85061) | `osu-lazer: update description to mention osu-lazer-bin`                     |
| [`fcfdd268`](https://github.com/NixOS/nixpkgs/commit/fcfdd268ca3e73022b8b5a8bf3504552b18e19bf) | `osu-lazer-bin: init at 2022.1228.0`                                         |
| [`c870b0d0`](https://github.com/NixOS/nixpkgs/commit/c870b0d0435883adb6d45e15289134dc1e75beef) | `python310Packages.plexapi: 4.13.1 -> 4.13.2`                                |
| [`1448b8f7`](https://github.com/NixOS/nixpkgs/commit/1448b8f7a29bc208df83294b15de07b705761ef0) | `python310Packages.holidays: 0.17.2 -> 0.18`                                 |
| [`a9ad69de`](https://github.com/NixOS/nixpkgs/commit/a9ad69dee95a684ec6ff26268f2b35d5ddf6f21c) | ``nixos/nginx: add release notes for `recommendedBrotliSettings```           |
| [`4a7d0140`](https://github.com/NixOS/nixpkgs/commit/4a7d0140a081effbf6274fee957049871dcfc8c6) | `nixos/nginx: add recommended brotli settings`                               |
| [`f3e20dbf`](https://github.com/NixOS/nixpkgs/commit/f3e20dbfb08a29a55960f13c9d6f17e5492fda39) | `nginxModules.brotli: unstable-2020-04-23 -> unstable-2022-04-29`            |
| [`8e6d35ff`](https://github.com/NixOS/nixpkgs/commit/8e6d35ff34a288d72af11c67c1aeadc8dc466788) | `quark-engine: add changelog to meta`                                        |
| [`eda8b3da`](https://github.com/NixOS/nixpkgs/commit/eda8b3da203ece011d5cc3a433692b9edcf3bdc2) | `python310Packages.meshtastic: 2.0.7 -> 2.0.8`                               |
| [`354f6e9b`](https://github.com/NixOS/nixpkgs/commit/354f6e9b7c4d484ffc96b2541320968955f0c475) | `qq: init at 2.0.3-543`                                                      |
| [`1d461519`](https://github.com/NixOS/nixpkgs/commit/1d4615190a3c23767c57a3a35b09d7e04142c36f) | `python310Packages.simplisafe-python: 2022.12.0 -> 2022.12.1`                |
| [`61c4b90a`](https://github.com/NixOS/nixpkgs/commit/61c4b90a5029828e2b9e16358b300f8e1476d108) | `pip-audit: 2.4.10 -> 2.4.11`                                                |
| [`baec53f6`](https://github.com/NixOS/nixpkgs/commit/baec53f6b5db6dbbaa79cf546c3a3dd5d886fe77) | `python310Packages.meross-iot: 0.4.5.0 -> 0.4.5.2`                           |
| [`ce6e8270`](https://github.com/NixOS/nixpkgs/commit/ce6e8270ce1e75c8a9e685591edd71e9c2c5e35e) | `python310Packages.meross-iot: add changelog to meta`                        |
| [`a9b64306`](https://github.com/NixOS/nixpkgs/commit/a9b64306a17db1e79b0837df36b3400a84f012d3) | `python310Packages.fastapi-mail: 1.2.2 -> 1.2.4`                             |
| [`de1b8b9c`](https://github.com/NixOS/nixpkgs/commit/de1b8b9c0f7fda33bec7466d90d0f781bf1cae39) | `Update nixos/modules/services/monitoring/uptime-kuma.nix`                   |
| [`971b57a8`](https://github.com/NixOS/nixpkgs/commit/971b57a8cdc2d1f9c1da7f1d3d331f9f07de54de) | `python310Packages.aiosmtplib: 1.1.7 -> 2.0.0`                               |
| [`738b2689`](https://github.com/NixOS/nixpkgs/commit/738b26895c1441ad12536c5e8245326f3d6f2621) | `python310Packages.scmrepo: 0.1.4 -> 0.1.5`                                  |
| [`66a0e923`](https://github.com/NixOS/nixpkgs/commit/66a0e92362a69031abad8baee187514d914e1d9b) | `maintainers: add tchab`                                                     |
| [`930b0dfb`](https://github.com/NixOS/nixpkgs/commit/930b0dfbc1e2208d43bbba165709f44fad4e638b) | ``darwin.builder: Remove trailing `'` from host key``                        |
| [`dba49a43`](https://github.com/NixOS/nixpkgs/commit/dba49a43a08eb3b384c37a0ccb94530d6d974158) | `nixos/test-driver: add optional address arg to wait_for_{open,closed}_port` |
| [`3dba3580`](https://github.com/NixOS/nixpkgs/commit/3dba35804ec1abbb06d91d56d9b1d14be63b7873) | `osu-lazer: 2022.1101.0 -> 2022.1228.0`                                      |
| [`25bb5549`](https://github.com/NixOS/nixpkgs/commit/25bb55495b38f70715bbaabf88ef45d50cbd7e8b) | `nixos/supergfxd: make config file read/write`                               |
| [`16dffc3f`](https://github.com/NixOS/nixpkgs/commit/16dffc3fbec3585eab9483e907974b9a16ad8aae) | `python310Packages.apprise: 1.2.0 -> 1.2.1`                                  |
| [`5dd4e858`](https://github.com/NixOS/nixpkgs/commit/5dd4e858c5f44384301e68c514d6537bfd47d7b0) | `python310Packages.apprise: add changelog to meta`                           |
| [`253b18cf`](https://github.com/NixOS/nixpkgs/commit/253b18cfda8372a59018af0694fa245a7d669fd7) | `python310Packages.pyisy: add changelog to meta`                             |
| [`569edaf2`](https://github.com/NixOS/nixpkgs/commit/569edaf213c60183ad16b67f418370b422134b89) | `python310Packages.aioairzone: 0.5.1 -> 0.5.2`                               |
| [`9373cfe5`](https://github.com/NixOS/nixpkgs/commit/9373cfe54877da199cf308d8eaa8b582dac61214) | `python310Packages.aioairzone: add changelog to meta`                        |
| [`9a189df0`](https://github.com/NixOS/nixpkgs/commit/9a189df056224eab22347bb3119e0bfc90661e49) | `python310Packages.pynetgear: 0.10.8 -> 0.10.9`                              |
| [`f50d8492`](https://github.com/NixOS/nixpkgs/commit/f50d8492e49bfeddd898c1f44ffb25a9f690cac7) | `python310Packages.pynetgear: add changelog to meta`                         |
| [`d879125d`](https://github.com/NixOS/nixpkgs/commit/d879125d61a0be8ecb2afddaca8f2b0530db0260) | `top-level: remove readline6 attr`                                           |
| [`c98e2e13`](https://github.com/NixOS/nixpkgs/commit/c98e2e13da72782d9d863af2cf53b0eb70747b4d) | `khal: fix build failure`                                                    |
| [`8f83a652`](https://github.com/NixOS/nixpkgs/commit/8f83a6524a579ff965fabdc7683361631273398e) | `python310Packages.aiohomekit: 2.4.2 -> 2.4.3`                               |
| [`466f70c5`](https://github.com/NixOS/nixpkgs/commit/466f70c549cedfc0a8733d68d77de578432dba41) | `python310Packages.asyncssh: add changelog to meta`                          |
| [`c8669133`](https://github.com/NixOS/nixpkgs/commit/c86691332715d861353e5a5cd651b0a8f0a6a0d7) | `openrsync: init at unstable-2022-05-08`                                     |
| [`8d846736`](https://github.com/NixOS/nixpkgs/commit/8d846736fafe648ff5868872485f827ecd19e1e4) | `python310Packages.aiohomekit: 2.4.1 -> 2.4.2`                               |
| [`e4520aad`](https://github.com/NixOS/nixpkgs/commit/e4520aada3930ea161d0ad9e00716a413ff85b7a) | `python310Packages.asyncssh: 2.12.0 -> 2.13.0`                               |
| [`1fe5d059`](https://github.com/NixOS/nixpkgs/commit/1fe5d05974a519384a27b94432e0b6bd7126f655) | `python310Packages.fastecdsa: add changelog to meta`                         |
| [`2e208519`](https://github.com/NixOS/nixpkgs/commit/2e20851982d65ea6394dc1794ec7dc2f4288140a) | `raider: init at 1.3.1`                                                      |
| [`5941a713`](https://github.com/NixOS/nixpkgs/commit/5941a7131829dce93a9fdc1693b3bd6a9d866e3c) | `reaper: 6.71 -> 6.73`                                                       |
| [`d34338ea`](https://github.com/NixOS/nixpkgs/commit/d34338eaf0db692cfc0b94b8196a466c85ad4186) | `blueprint-compiler: 0.2.0 -> 0.6.0`                                         |
| [`768b2586`](https://github.com/NixOS/nixpkgs/commit/768b2586aa947f3004def461ac05ce74e7a03f54) | `python310Packages.fastecdsa: 2.2.3 -> 2.3.1`                                |
| [`881a04b8`](https://github.com/NixOS/nixpkgs/commit/881a04b85a27066af2c708ea6177877869a22db1) | `python310Packages.pyface: 7.4.3 -> 7.4.4`                                   |
| [`3fc5b4b8`](https://github.com/NixOS/nixpkgs/commit/3fc5b4b8d66369c0100744c7ab8b5422b22d7277) | `kodi: 19.4 -> 19.5`                                                         |
| [`bfd10b62`](https://github.com/NixOS/nixpkgs/commit/bfd10b629d4994083cb25c00c67c2d778d8f317e) | `parsec-bin: fix desktop entry exec and icon`                                |
| [`51809df3`](https://github.com/NixOS/nixpkgs/commit/51809df3028ad65ff81b2badf7fef04bd9ed5921) | `nixos/tests/zfs: Test requestEncryptionCredentials as a list.`              |
| [`22b6f785`](https://github.com/NixOS/nixpkgs/commit/22b6f785a7a233765541f1d448d546eeed305e3e) | `nixos/tests/zfs: Represent real world usage better`                         |
| [`109dcb6b`](https://github.com/NixOS/nixpkgs/commit/109dcb6baa78a6017cb999e405e2944b1a3c50e3) | `terraform-providers.ksyun: 1.3.61 → 1.3.62`                                 |
| [`54c113ce`](https://github.com/NixOS/nixpkgs/commit/54c113cebc739cf42acb2886f7613a1a8c84fd43) | `terraform-providers.cloudflare: 3.30.0 → 3.31.0`                            |
| [`5189e844`](https://github.com/NixOS/nixpkgs/commit/5189e84497f008566328b16c2e8abda90fb535cc) | `terraform-providers.bitbucket: 2.26.0 → 2.27.0`                             |
| [`e13125d4`](https://github.com/NixOS/nixpkgs/commit/e13125d4b5e04c483251d345dc953f46628ed7f4) | `ruff: 0.0.198 -> 0.0.199`                                                   |
| [`71e2cb9e`](https://github.com/NixOS/nixpkgs/commit/71e2cb9e72adf578e651466f9d81bd26a5dfb517) | `hydra_unstable: unstable-2022-12-05 -> 2022-12-23`                          |
| [`7e0588b2`](https://github.com/NixOS/nixpkgs/commit/7e0588b2fba3dfedd583933eff8bd6820b073483) | `nixos/grafana: listen on localhost by default (again)`                      |
| [`826bc3f0`](https://github.com/NixOS/nixpkgs/commit/826bc3f07447bd62ed4a195334fdc89f64fdbea7) | `audacity: 3.2.2 -> 3.2.3 (#208066)`                                         |
| [`b07de91c`](https://github.com/NixOS/nixpkgs/commit/b07de91cdeab0c170851f2947d52b9dc22d993de) | `python310Packages.awscrt: 0.16.1 -> 0.16.3`                                 |
| [`ef9b04ec`](https://github.com/NixOS/nixpkgs/commit/ef9b04ec5fe9bad204381e217ca150cec242e128) | `lib.types.loaOf: Update comment to say deprecate instead of remove`         |
| [`9af74cc7`](https://github.com/NixOS/nixpkgs/commit/9af74cc7096baa29e64edb2179604bcf494e55f3) | `Revert "lib/types: remove loaOf"`                                           |
| [`d29ebc00`](https://github.com/NixOS/nixpkgs/commit/d29ebc00db1907fd28db64c296baee4857aac1e9) | `gogdl: Add updateScript`                                                    |
| [`b4d850f3`](https://github.com/NixOS/nixpkgs/commit/b4d850f36fad7c3c20932be2c7e5b8cbc87211d5) | `epr: 2.3.0b -> 2.4.13`                                                      |
| [`f6273da7`](https://github.com/NixOS/nixpkgs/commit/f6273da7c43ebe3f4acdd13a87042b2172c5c348) | `talosctl: 1.3.0 -> 1.3.1`                                                   |
| [`2087e7e6`](https://github.com/NixOS/nixpkgs/commit/2087e7e67b05a7065de53b47a50dfbdb1282e528) | `psol: combine into one file`                                                |
| [`be19cfc4`](https://github.com/NixOS/nixpkgs/commit/be19cfc4d3dc1806097c628dd403b6e722e47b9d) | `python310Packages.ariadne: 0.16.1 -> 0.17.0`                                |
| [`b4232eae`](https://github.com/NixOS/nixpkgs/commit/b4232eae0696a3d5db9d5d8489b6873b60ecc82c) | `python310Packages.ariadne: add changelog to meta`                           |
| [`db612e88`](https://github.com/NixOS/nixpkgs/commit/db612e882d6b577ffc2b608e55962f91025df7f6) | `ergochat: 2.10.0 -> 2.11.0`                                                 |
| [`9bce3f43`](https://github.com/NixOS/nixpkgs/commit/9bce3f4342babac9d4b276c78b3d0bab7bdd37ba) | `python310Packages.unearth: add changelog to meta`                           |
| [`5066f089`](https://github.com/NixOS/nixpkgs/commit/5066f089f885a12c0dc44ca610885f3e9f695b43) | `python310Packages.statsmodels: 0.13.4 -> 0.13.5`                            |
| [`c2a92301`](https://github.com/NixOS/nixpkgs/commit/c2a92301eef731b6253d4bd5510f4c90e18fca1e) | `python310Packages.distrax: mark as broken`                                  |
| [`f2e075db`](https://github.com/NixOS/nixpkgs/commit/f2e075db78b1e71c990edf10b5c5b8993ae4e2c2) | `python310Packages.unearth: 0.6.1 -> 0.7.0`                                  |
| [`0207af19`](https://github.com/NixOS/nixpkgs/commit/0207af197f27734f57e1a3c7f75e4023683398b6) | `python310Packages.plotnine: 0.9.0 -> 0.10.1`                                |
| [`780be3d6`](https://github.com/NixOS/nixpkgs/commit/780be3d6171f42beaabc8d286cef067d3804495b) | `python310Packages.mizani: 0.7.4 -> 0.8.1`                                   |
| [`748ead90`](https://github.com/NixOS/nixpkgs/commit/748ead902a04f1622d994d9c0f6daf0dd5b4ba87) | `python310Packages.mizani: add changelog to meta`                            |
| [`ead1253f`](https://github.com/NixOS/nixpkgs/commit/ead1253f6ad46532c31709039ff7e0906bd4b268) | `python310Packages.plotnine: add changelog to meta`                          |
| [`451fbb18`](https://github.com/NixOS/nixpkgs/commit/451fbb186b239b012f6dd06a7f64f58779d9e0f6) | `nixos/hedgedoc: update features note with hedgedoc (#199053)`               |
| [`cd74ac90`](https://github.com/NixOS/nixpkgs/commit/cd74ac90f511496fbdfacbb5eb8bb2039aa8a9d4) | `legendary-gl: Add updateScript`                                             |
| [`590321a5`](https://github.com/NixOS/nixpkgs/commit/590321a5defbbabe96f8def70013d5b45406dee4) | `lua54Packages: set the alias`                                               |
| [`94b9bb2b`](https://github.com/NixOS/nixpkgs/commit/94b9bb2bc69576a54861d7a2871d786f93e2ad1e) | `olive-editor: resolve missing QPainterPath issue`                           |
| [`da40dbd1`](https://github.com/NixOS/nixpkgs/commit/da40dbd19583179f78f894e003851971d83b906d) | `scala-cli: move assert to build time`                                       |
| [`1ffa32b6`](https://github.com/NixOS/nixpkgs/commit/1ffa32b6c50d5867e16fc72573be6c6011dd0a66) | `legendary-gl: 0.20.30 -> 0.20.31`                                           |
| [`04ba2aaf`](https://github.com/NixOS/nixpkgs/commit/04ba2aaf83d2c1663f8f94cdb79248b979bb6497) | `heroic: 2.4.3 -> 2.5.2`                                                     |
| [`eb50ebfe`](https://github.com/NixOS/nixpkgs/commit/eb50ebfe82ff410faed51d45253809810bd984b6) | `olm: 3.2.13 -> 3.2.14`                                                      |
| [`2444db44`](https://github.com/NixOS/nixpkgs/commit/2444db4477dca6e74f6bc0946f373a1c3e36153e) | `vintagestory: 1.17.4 -> 1.17.9`                                             |
| [`276c9042`](https://github.com/NixOS/nixpkgs/commit/276c904216d1f63fabadea3938938c8376b7d9c6) | `python310Packages.sqlobject: 3.10.0 -> 3.10.1`                              |
| [`4c214a1c`](https://github.com/NixOS/nixpkgs/commit/4c214a1c22a2135b73ff190effc03c573baa8b5b) | `python310Packages.hahomematic: 2022.12.9 -> 2022.12.11`                     |
| [`16fe46f4`](https://github.com/NixOS/nixpkgs/commit/16fe46f48e6a7ca155fd4f7a9644a6413dfd04ac) | `process-cpp: init at unstable-2021-05-11`                                   |
| [`9bea1020`](https://github.com/NixOS/nixpkgs/commit/9bea102076ab715ba7766263298c4d9753a4240b) | `psi-plus: 1.5.1642 -> 1.5.1644`                                             |
| [`c9b08a57`](https://github.com/NixOS/nixpkgs/commit/c9b08a57cd6ba74374b14e174e468940bf52af66) | `python310Packages.fireflyalgorithm: add changelog to meta`                  |
| [`bbbb7a79`](https://github.com/NixOS/nixpkgs/commit/bbbb7a79cd05f8cfe483616f1edeb6679ae94e72) | `python3Packges.pyicu: rename from PyICU`                                    |
| [`78555d75`](https://github.com/NixOS/nixpkgs/commit/78555d7540db828a8bbcd708263b6439470a9abe) | `matrix-synapse: Use improved user search`                                   |
| [`b86d1f49`](https://github.com/NixOS/nixpkgs/commit/b86d1f49363d299128433a2489f03cdee9dc22a8) | `python310Packages.fireflyalgorithm: 0.3.3 -> 0.3.4`                         |
| [`b2025a30`](https://github.com/NixOS/nixpkgs/commit/b2025a306f8ef05ed7f98141466a29d13797c9cd) | `superd: 0.7 -> 0.7.1`                                                       |
| [`dbeea537`](https://github.com/NixOS/nixpkgs/commit/dbeea53715caf8730d6acf7d8b6a38d589daf12f) | `maestral-gui: 1.6.4 -> 1.6.5`                                               |
| [`d62ef663`](https://github.com/NixOS/nixpkgs/commit/d62ef66317fe1eddfe404a1f1b62c19b4522ecc8) | `python3Packages.maestral: 1.6.4 -> 1.6.5`                                   |
| [`1f573777`](https://github.com/NixOS/nixpkgs/commit/1f573777e36bb3c9e29d47f3c2f010e1efbddb03) | `vimPlugins.rest-nvim: add treesitter dependencies`                          |
| [`025d862b`](https://github.com/NixOS/nixpkgs/commit/025d862be6a2231278fc68246b3d5b67f7228e6e) | `vimPlugins.orgmode: add treesitter dependencies`                            |
| [`9499f943`](https://github.com/NixOS/nixpkgs/commit/9499f943dd2735d721892c3506fe7f9a2c69fb82) | `haskellPackages: mark builds failing on hydra as broken`                    |
| [`253f19bf`](https://github.com/NixOS/nixpkgs/commit/253f19bf957ecc442481d567582514a202c819d8) | `maestral-gui: 1.6.3 -> 1.6.4`                                               |
| [`3a58dfb3`](https://github.com/NixOS/nixpkgs/commit/3a58dfb33e083278b0215a8a0f693dcbe25c04b7) | `python3Packages.maestral: 1.6.3 -> 1.6.4`                                   |
| [`7fb1be82`](https://github.com/NixOS/nixpkgs/commit/7fb1be82f4e180da9b53fb06de4d91c43b605b0f) | `libwebsockets: build static library only when necessary`                    |
| [`7e74ec53`](https://github.com/NixOS/nixpkgs/commit/7e74ec53da20c288f9a45047e67e8227d95b2a55) | `libwebsockets: use multiple outputs`                                        |
| [`d3f1d149`](https://github.com/NixOS/nixpkgs/commit/d3f1d1491233e4a92add5cdc958a82981766f3a8) | `haskellPackages: mark builds failing on hydra as broken`                    |
| [`76aaf902`](https://github.com/NixOS/nixpkgs/commit/76aaf902a52f3df46d4f7852627c9603251eee63) | `bsnes-hd: unbreak on x86_64-darwin`                                         |