### PR TITLE
chore(flake/nur): `b45d3c91` -> `3c5388af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672220751,
-        "narHash": "sha256-/RY8Nah5Hq6RfjXaFqSRuvfx115DkL1YfbGDa5pM6Ww=",
+        "lastModified": 1672228091,
+        "narHash": "sha256-QIB9u4WFCN5/SB+BGy0P2+/DYQxAbK6Eu5W/OQLgpSo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b45d3c91a26ff0e8e6575f862fdfb456b0e72c44",
+        "rev": "3c5388af8cdd5ac26ff894eda674375fe57b2635",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3c5388af`](https://github.com/nix-community/NUR/commit/3c5388af8cdd5ac26ff894eda674375fe57b2635) | `automatic update` |