### PR TITLE
chore(flake/nur): `eb6271d7` -> `e578f1ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672235207,
-        "narHash": "sha256-EQkcliYQLLrT2RoYv70XedTjezcp/W/a6NlzqSTNqDQ=",
+        "lastModified": 1672238814,
+        "narHash": "sha256-Smw3SBu9y9LaiBkZPvditOQP/s11qUrBDMAAYzj8VPg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eb6271d7114b4b6152f2363b08e1b2aff12d6ba0",
+        "rev": "e578f1caa6ff51a68cabac472f6f68e1d576c213",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e578f1ca`](https://github.com/nix-community/NUR/commit/e578f1caa6ff51a68cabac472f6f68e1d576c213) | `automatic update` |