### PR TITLE
chore(flake/emacs-overlay): `089d42b5` -> `8ad6bfa7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672224240,
-        "narHash": "sha256-RCY5b41sCu79h4olMoUuTIPNT9AxZRJpj3LSCJGxVhE=",
+        "lastModified": 1672247295,
+        "narHash": "sha256-nzwcwy6LVOLcqemTCUoJJp6nafCpcvyCG+T76Bb5OXM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "089d42b5ec8dcea90e4748da482bb3a2178bc1a2",
+        "rev": "8ad6bfa7413d59d408bf1ea8680a03b17a949082",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`8ad6bfa7`](https://github.com/nix-community/emacs-overlay/commit/8ad6bfa7413d59d408bf1ea8680a03b17a949082) | `Updated repos/melpa` |
| [`13852936`](https://github.com/nix-community/emacs-overlay/commit/1385293665202c9dee786efcd34705a034b155ff) | `Updated repos/elpa`  |