### PR TITLE
chore(flake/nur): `e578f1ca` -> `2850c7c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672238814,
-        "narHash": "sha256-Smw3SBu9y9LaiBkZPvditOQP/s11qUrBDMAAYzj8VPg=",
+        "lastModified": 1672249585,
+        "narHash": "sha256-w8epHxp+exheS0aczurM9quxTvqCn5hTrFAvuTR9Yt8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e578f1caa6ff51a68cabac472f6f68e1d576c213",
+        "rev": "2850c7c39621ecd7c324d586749d05c66b4f18dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2850c7c3`](https://github.com/nix-community/NUR/commit/2850c7c39621ecd7c324d586749d05c66b4f18dc) | `automatic update` |