### PR TITLE
chore(flake/nur): `2850c7c3` -> `962425a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672249585,
-        "narHash": "sha256-w8epHxp+exheS0aczurM9quxTvqCn5hTrFAvuTR9Yt8=",
+        "lastModified": 1672260287,
+        "narHash": "sha256-X1fsBLbEmfD6SKuJhKyX+7hJQgpPwSYAo8BwX3wgVos=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2850c7c39621ecd7c324d586749d05c66b4f18dc",
+        "rev": "962425a20ce0a5d241697be6aa23a3c4d70028f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`962425a2`](https://github.com/nix-community/NUR/commit/962425a20ce0a5d241697be6aa23a3c4d70028f3) | `automatic update` |
| [`43ffdfdc`](https://github.com/nix-community/NUR/commit/43ffdfdcbce29d08bc599b6ceafd39fdc8475685) | `automatic update` |