### PR TITLE
chore(flake/home-manager): `e7055057` -> `8745cc9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672259254,
-        "narHash": "sha256-SVBrOHtjPnQ14opI9dCaAqf1hPlBm8J6FJkM2kEAWrI=",
+        "lastModified": 1672262207,
+        "narHash": "sha256-o7h3bneTsk0d5yKeUynX00kspE2ioIuL40LzZ7EXars=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e70550577f3d2f0596669d1e30d63cb67b4f7f8d",
+        "rev": "8745cc9a21658260437b20968278f16565021662",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`8745cc9a`](https://github.com/nix-community/home-manager/commit/8745cc9a21658260437b20968278f16565021662) | `parcellite: add basic test case`     |
| [`d38dbec8`](https://github.com/nix-community/home-manager/commit/d38dbec8094681a02812adda752f934c3489b6db) | `parcellite: add extraOptions option` |