### PR TITLE
chore(flake/nur): `962425a2` -> `812b62f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672260287,
-        "narHash": "sha256-X1fsBLbEmfD6SKuJhKyX+7hJQgpPwSYAo8BwX3wgVos=",
+        "lastModified": 1672267624,
+        "narHash": "sha256-TSs+RDrM0OfiyZyBVJRuApxxwnQDSGC0XM3Jn4gvFac=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "962425a20ce0a5d241697be6aa23a3c4d70028f3",
+        "rev": "812b62f2ef65bb8172d7d7eb39fe0aafa48e1fce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`812b62f2`](https://github.com/nix-community/NUR/commit/812b62f2ef65bb8172d7d7eb39fe0aafa48e1fce) | `automatic update` |