### PR TITLE
chore(flake/nur): `812b62f2` -> `6d1298a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672267624,
-        "narHash": "sha256-TSs+RDrM0OfiyZyBVJRuApxxwnQDSGC0XM3Jn4gvFac=",
+        "lastModified": 1672279487,
+        "narHash": "sha256-f5eAV1r7XOitLS+FLpXzTF1+HcEoTK4D8SCkju37NkI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "812b62f2ef65bb8172d7d7eb39fe0aafa48e1fce",
+        "rev": "6d1298a6defe38e59d5e190148f2080ea947d780",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6d1298a6`](https://github.com/nix-community/NUR/commit/6d1298a6defe38e59d5e190148f2080ea947d780) | `automatic update` |