### PR TITLE
chore(flake/emacs-overlay): `8ad6bfa7` -> `ddfaed7f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672247295,
-        "narHash": "sha256-nzwcwy6LVOLcqemTCUoJJp6nafCpcvyCG+T76Bb5OXM=",
+        "lastModified": 1672283270,
+        "narHash": "sha256-mEhhc78LeXhNMKYawGg48vUY+1CfQI+Du8g7tKaA7h4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8ad6bfa7413d59d408bf1ea8680a03b17a949082",
+        "rev": "ddfaed7f3b59d7590d94c5ea781e5ab8a58bc961",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`ddfaed7f`](https://github.com/nix-community/emacs-overlay/commit/ddfaed7f3b59d7590d94c5ea781e5ab8a58bc961) | `Updated repos/nongnu` |
| [`e30cc7d7`](https://github.com/nix-community/emacs-overlay/commit/e30cc7d7ffe40b25fee518c6549fd4893322519d) | `Updated repos/melpa`  |
| [`4dfd78ce`](https://github.com/nix-community/emacs-overlay/commit/4dfd78ce893fa7c030d0df4b79f426b778387beb) | `Updated repos/emacs`  |
| [`48c4a0b2`](https://github.com/nix-community/emacs-overlay/commit/48c4a0b231b49f3304730482c828c46f958d5352) | `Updated repos/elpa`   |