### PR TITLE
chore(flake/nur): `6d1298a6` -> `8f2b21d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672279487,
-        "narHash": "sha256-f5eAV1r7XOitLS+FLpXzTF1+HcEoTK4D8SCkju37NkI=",
+        "lastModified": 1672285454,
+        "narHash": "sha256-yefYAIau0klMIvonMf8qy8JLafEa4+iC3VKpdzgW2g4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6d1298a6defe38e59d5e190148f2080ea947d780",
+        "rev": "8f2b21d53b0e4d7e6c81458e4832f2c664158552",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8f2b21d5`](https://github.com/nix-community/NUR/commit/8f2b21d53b0e4d7e6c81458e4832f2c664158552) | `automatic update` |