### PR TITLE
chore(flake/nur): `8f2b21d5` -> `97187e69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672285454,
-        "narHash": "sha256-yefYAIau0klMIvonMf8qy8JLafEa4+iC3VKpdzgW2g4=",
+        "lastModified": 1672289329,
+        "narHash": "sha256-yHtbWvoD0goiITMGsZ8Xppfhd5FuQN0aXz+0Ixc1jYw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8f2b21d53b0e4d7e6c81458e4832f2c664158552",
+        "rev": "97187e69598b4d613c4c07bfe379a5c6e0e62bf7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`97187e69`](https://github.com/nix-community/NUR/commit/97187e69598b4d613c4c07bfe379a5c6e0e62bf7) | `automatic update` |