### PR TITLE
chore(flake/nur): `97187e69` -> `35959898`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672289329,
-        "narHash": "sha256-yHtbWvoD0goiITMGsZ8Xppfhd5FuQN0aXz+0Ixc1jYw=",
+        "lastModified": 1672296452,
+        "narHash": "sha256-FiuIcRK5N4LzaYmUwcUKEE1R7Ooh5+oMOwDh7gmveZA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "97187e69598b4d613c4c07bfe379a5c6e0e62bf7",
+        "rev": "35959898a1f67cd858ed4302f18345ad4075baf4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`35959898`](https://github.com/nix-community/NUR/commit/35959898a1f67cd858ed4302f18345ad4075baf4) | `automatic update` |