### PR TITLE
chore(flake/nur): `35959898` -> `0ed9892b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672296452,
-        "narHash": "sha256-FiuIcRK5N4LzaYmUwcUKEE1R7Ooh5+oMOwDh7gmveZA=",
+        "lastModified": 1672310591,
+        "narHash": "sha256-ryk/QeUl9+PkFBb42V4Bi+Ez5JupnKnHdgkBTL0a9bY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "35959898a1f67cd858ed4302f18345ad4075baf4",
+        "rev": "0ed9892bcb9e38753da3787e7aa390025e7fa9fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0ed9892b`](https://github.com/nix-community/NUR/commit/0ed9892bcb9e38753da3787e7aa390025e7fa9fd) | `automatic update` |