### PR TITLE
chore(flake/emacs-overlay): `ddfaed7f` -> `d9ddea54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672283270,
-        "narHash": "sha256-mEhhc78LeXhNMKYawGg48vUY+1CfQI+Du8g7tKaA7h4=",
+        "lastModified": 1672310162,
+        "narHash": "sha256-J42FJetIAOu91szWXI3AH+hvONemnZVVqU17+dHaaw8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ddfaed7f3b59d7590d94c5ea781e5ab8a58bc961",
+        "rev": "d9ddea546f88f021ee6ab6a587eea9fa7c185b0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`d9ddea54`](https://github.com/nix-community/emacs-overlay/commit/d9ddea546f88f021ee6ab6a587eea9fa7c185b0c) | `Updated repos/melpa` |
| [`d180321c`](https://github.com/nix-community/emacs-overlay/commit/d180321cd3992dd71477192163f27348a5aa31cd) | `Updated repos/emacs` |