### PR TITLE
chore(flake/nur): `00d2b9c1` -> `f966b49c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672318904,
-        "narHash": "sha256-PxecAaPQhze8qV+sIwGF3A32On8FFMMdYPGqhOItb2o=",
+        "lastModified": 1672323091,
+        "narHash": "sha256-DMhF52c1jK/33L3FwuPVBRkF89eANjuM2Pnq2KIOcVs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "00d2b9c10bf1de1479eddcbb5957ead7dc1f084b",
+        "rev": "f966b49cc4fc0afb25eda11f6327391d5ebe6253",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f966b49c`](https://github.com/nix-community/NUR/commit/f966b49cc4fc0afb25eda11f6327391d5ebe6253) | `automatic update` |