### PR TITLE
chore(flake/deploy-rs): `2a3c5f70` -> `a5619f56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -116,11 +116,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668797197,
-        "narHash": "sha256-0w6iD3GSSQbIeSFVDzAAQZB+hDq670ZTms3d9XI+BtM=",
+        "lastModified": 1672327199,
+        "narHash": "sha256-pFlngSHXKBhAmbaKZ4FYtu57LLunG+vWdL7a5vw1RvQ=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "2a3c5f70eee04a465aa534d8bd4fcc9bb3c4a8ce",
+        "rev": "a5619f5660a00f58c2b7c16d89058e92327ac9b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                               |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`a5619f56`](https://github.com/serokell/deploy-rs/commit/a5619f5660a00f58c2b7c16d89058e92327ac9b8) | `Build every profile first, then push (#158)`                                |
| [`35135237`](https://github.com/serokell/deploy-rs/commit/351352374c452de0378d6c22baf1745f02ae6c52) | `Automatically update flake.lock to the latest version (#152)`               |
| [`068372aa`](https://github.com/serokell/deploy-rs/commit/068372aad18f04122bbdb836e36c655c157ebe71) | ``Add new activation strategy `boot` as equivalent to `nixos-rebuild boot``` |