### PR TITLE
chore(flake/nur): `f966b49c` -> `e914bcdc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672323091,
-        "narHash": "sha256-DMhF52c1jK/33L3FwuPVBRkF89eANjuM2Pnq2KIOcVs=",
+        "lastModified": 1672325070,
+        "narHash": "sha256-KOMgKYCUTTCKsTQ2+N0IkcgiXKuugIVGzfTN6UEZSoU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f966b49cc4fc0afb25eda11f6327391d5ebe6253",
+        "rev": "e914bcdc68da7d0b96ea4645a3996e0efd735dcc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e914bcdc`](https://github.com/nix-community/NUR/commit/e914bcdc68da7d0b96ea4645a3996e0efd735dcc) | `automatic update` |