### PR TITLE
chore(flake/emacs-overlay): `d9ddea54` -> `86863292`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672310162,
-        "narHash": "sha256-J42FJetIAOu91szWXI3AH+hvONemnZVVqU17+dHaaw8=",
+        "lastModified": 1672339665,
+        "narHash": "sha256-q12v34h7xhoJ3jx4RzwAGvuXxoLOESyjGA8CByxw+Dk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d9ddea546f88f021ee6ab6a587eea9fa7c185b0c",
+        "rev": "86863292e6c99256cde3f994b433055e3dff48cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`86863292`](https://github.com/nix-community/emacs-overlay/commit/86863292e6c99256cde3f994b433055e3dff48cc) | `Updated repos/melpa` |
| [`f0315cd7`](https://github.com/nix-community/emacs-overlay/commit/f0315cd760b9a98b6f9c5ae08ce78bf6c94f8920) | `Updated repos/emacs` |
| [`af6a79c2`](https://github.com/nix-community/emacs-overlay/commit/af6a79c2034dfe1a763254b86ddacea06bcc65fa) | `Updated repos/elpa`  |