### PR TITLE
chore(flake/nur): `e914bcdc` -> `1047e46f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672325070,
-        "narHash": "sha256-KOMgKYCUTTCKsTQ2+N0IkcgiXKuugIVGzfTN6UEZSoU=",
+        "lastModified": 1672340698,
+        "narHash": "sha256-v/cdTYcBGb0fg3Bl/Sl1hfoh8dFpgNVyuTvYzpFZRLs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e914bcdc68da7d0b96ea4645a3996e0efd735dcc",
+        "rev": "1047e46f1cd96fc495e7702db75d4bf35c1c819f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1047e46f`](https://github.com/nix-community/NUR/commit/1047e46f1cd96fc495e7702db75d4bf35c1c819f) | `automatic update` |