### PR TITLE
chore(flake/nur): `1047e46f` -> `3276d028`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672340698,
-        "narHash": "sha256-v/cdTYcBGb0fg3Bl/Sl1hfoh8dFpgNVyuTvYzpFZRLs=",
+        "lastModified": 1672343191,
+        "narHash": "sha256-Uv2LcMVtpUqUfGEcDx2D0qGiGxukpgG8eX8lp8mPKTM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1047e46f1cd96fc495e7702db75d4bf35c1c819f",
+        "rev": "3276d028b6da88a2f4edebb6de6ee7e7c922a155",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3276d028`](https://github.com/nix-community/NUR/commit/3276d028b6da88a2f4edebb6de6ee7e7c922a155) | `automatic update` |