### PR TITLE
chore(flake/home-manager): `079a33a0` -> `dd99675e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672332064,
-        "narHash": "sha256-jEWx4skRUHnt+8sJNtK6GOGTlUa9mMeZNaMS5z5jgCE=",
+        "lastModified": 1672349765,
+        "narHash": "sha256-Ul3lSGglgHXhgU3YNqsNeTlRH1pqxbR64h+2hM+HtnM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "079a33a0152a39c41e862a7576fa6d57d4b5dbc2",
+        "rev": "dd99675ee81fef051809bc87d67eb07f5ba022e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                              |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`dd99675e`](https://github.com/nix-community/home-manager/commit/dd99675ee81fef051809bc87d67eb07f5ba022e8) | ``vim,neovim: add `defaultEditor` (#3496)``                                 |
| [`c8f63223`](https://github.com/nix-community/home-manager/commit/c8f6322303486ab597be92f4b815969e1446438f) | ``home-environment: use `lazyAttrsOf` for `home.sessionVariables` (#3541)`` |