### PR TITLE
chore(flake/nur): `3276d028` -> `c6244939`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672343191,
-        "narHash": "sha256-Uv2LcMVtpUqUfGEcDx2D0qGiGxukpgG8eX8lp8mPKTM=",
+        "lastModified": 1672350295,
+        "narHash": "sha256-QQ/1Uu1mRXxv4bOol2yahn9yhAliZ+yoih31WaKk3fE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3276d028b6da88a2f4edebb6de6ee7e7c922a155",
+        "rev": "c62449395531df754f2a1640e56dd0c81fbf5e90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c6244939`](https://github.com/nix-community/NUR/commit/c62449395531df754f2a1640e56dd0c81fbf5e90) | `automatic update` |