### PR TITLE
chore(flake/emacs-overlay): `86863292` -> `4b6761d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672339665,
-        "narHash": "sha256-q12v34h7xhoJ3jx4RzwAGvuXxoLOESyjGA8CByxw+Dk=",
+        "lastModified": 1672369131,
+        "narHash": "sha256-7lwVUchk4I14t/u0Nb85yZR/neTrJHQGB1IDv7Oiay8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "86863292e6c99256cde3f994b433055e3dff48cc",
+        "rev": "4b6761d828a861526c3acb7712395986274cfd9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`4b6761d8`](https://github.com/nix-community/emacs-overlay/commit/4b6761d828a861526c3acb7712395986274cfd9e) | `Updated repos/melpa` |
| [`e3cb87d5`](https://github.com/nix-community/emacs-overlay/commit/e3cb87d5f5e6c49690221b939c36b4eca89d77b3) | `Updated repos/emacs` |