### PR TITLE
chore(flake/nur): `edcfc58c` -> `677773f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672369072,
-        "narHash": "sha256-Ck637/Zkq0fMr+I/43LXVvKC5OcKHEg05jFJ959P2FA=",
+        "lastModified": 1672371993,
+        "narHash": "sha256-5G5LvQYQEPt06FigOJSfIOsOAjmZeWcOqKW7J7WqDQ8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "edcfc58ce23c8d87cffc6feb63e215244d2d5ec4",
+        "rev": "677773f0cc76cc62a4ebf2eeadc5f0d99c3096b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`677773f0`](https://github.com/nix-community/NUR/commit/677773f0cc76cc62a4ebf2eeadc5f0d99c3096b2) | `automatic update` |