### PR TITLE
chore(flake/nur): `677773f0` -> `b474be30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672371993,
-        "narHash": "sha256-5G5LvQYQEPt06FigOJSfIOsOAjmZeWcOqKW7J7WqDQ8=",
+        "lastModified": 1672375592,
+        "narHash": "sha256-SwiWuNLy1yC4gXe/J6a42Wq85UaPsynuVXMq7AUCzr0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "677773f0cc76cc62a4ebf2eeadc5f0d99c3096b2",
+        "rev": "b474be30e1e798aa6e821ca92ce6d23f808979c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b474be30`](https://github.com/nix-community/NUR/commit/b474be30e1e798aa6e821ca92ce6d23f808979c2) | `automatic update` |