### PR TITLE
chore(flake/nur): `b474be30` -> `1b7d2861`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672375592,
-        "narHash": "sha256-SwiWuNLy1yC4gXe/J6a42Wq85UaPsynuVXMq7AUCzr0=",
+        "lastModified": 1672393622,
+        "narHash": "sha256-sa12NfBKaXs4o65/p9S/PB4GygzrBVIpWib+VYKfpTw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b474be30e1e798aa6e821ca92ce6d23f808979c2",
+        "rev": "1b7d2861b3939da8ef61ea4cd57b12456d32bfd1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1b7d2861`](https://github.com/nix-community/NUR/commit/1b7d2861b3939da8ef61ea4cd57b12456d32bfd1) | `automatic update` |