### PR TITLE
chore(flake/emacs-overlay): `4b6761d8` -> `d5b7eee0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672369131,
-        "narHash": "sha256-7lwVUchk4I14t/u0Nb85yZR/neTrJHQGB1IDv7Oiay8=",
+        "lastModified": 1672395024,
+        "narHash": "sha256-M2h6laCnhPNWSe28ZZ23tQwzQZfIUnDFx8Y0ao+JQsM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4b6761d828a861526c3acb7712395986274cfd9e",
+        "rev": "d5b7eee098fe6a7b79b659fcf17834ca368c0bf9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`d5b7eee0`](https://github.com/nix-community/emacs-overlay/commit/d5b7eee098fe6a7b79b659fcf17834ca368c0bf9) | `Updated repos/nongnu` |
| [`8de6bdbf`](https://github.com/nix-community/emacs-overlay/commit/8de6bdbf7902c0650eeccc53b8efff7692165171) | `Updated repos/melpa`  |
| [`656363b3`](https://github.com/nix-community/emacs-overlay/commit/656363b34a83384866f558346210483edb02c4c8) | `Updated repos/emacs`  |