### PR TITLE
chore(flake/dendrite-demo-pinecone): `2e70afba` -> `6af6092e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672207780,
-        "narHash": "sha256-teGXzmMtsdW4VqReN+R3yYphR3zhMynABBBTIAfsm6c=",
+        "lastModified": 1672422128,
+        "narHash": "sha256-B9a5DFeZo55KANr2ZceraUa36BMlx2/W2euk4cjhaQs=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "2e70afbab1cad3f4c4c569e4e37bbf860a8ad403",
+        "rev": "6af6092ef8a416e3ba30ad89fa5de41b4da0cb62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                          | Commit Message       |
| --------------------------------------------------------------------------------------------------------------- | -------------------- |
| [`6af6092e`](https://github.com/bbigras/dendrite-demo-pinecone/commit/6af6092ef8a416e3ba30ad89fa5de41b4da0cb62) | `flake.lock: Update` |