### PR TITLE
chore(flake/emacs-overlay): `d5b7eee0` -> `6108369b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672395024,
-        "narHash": "sha256-M2h6laCnhPNWSe28ZZ23tQwzQZfIUnDFx8Y0ao+JQsM=",
+        "lastModified": 1672424856,
+        "narHash": "sha256-xCzvU4m0GabHeh0Y8rD+VbUVk4rwQ1s73d52vC5wE/0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d5b7eee098fe6a7b79b659fcf17834ca368c0bf9",
+        "rev": "6108369b3fa789e2b2683127043c0dd118009a73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`6108369b`](https://github.com/nix-community/emacs-overlay/commit/6108369b3fa789e2b2683127043c0dd118009a73) | `Updated repos/melpa` |
| [`ba9631e0`](https://github.com/nix-community/emacs-overlay/commit/ba9631e0becf8f4d0cff7bada4e49d57d34b53ec) | `Updated repos/emacs` |
| [`ff34ea9b`](https://github.com/nix-community/emacs-overlay/commit/ff34ea9bd39216ab86ca33042982948b7e2a2c5d) | `Updated repos/elpa`  |