### PR TITLE
chore(flake/nur): `9b1e20dc` -> `e6f9b2c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672429577,
-        "narHash": "sha256-Bahu0cACVjcW2RukNlYZFElb1Khyk+k35qIqkk0A1r4=",
+        "lastModified": 1672440374,
+        "narHash": "sha256-/Em9r9PhTr6284S+YuCDGIcUwG1LvHzc337t+yq0cn4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9b1e20dc34af1fc2d3218b8d902f7bb51ddfe200",
+        "rev": "e6f9b2c09dccbfcd969a55727a99b593c27b7e1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e6f9b2c0`](https://github.com/nix-community/NUR/commit/e6f9b2c09dccbfcd969a55727a99b593c27b7e1c) | `automatic update` |