### PR TITLE
chore(flake/nur): `e6f9b2c0` -> `39126995`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672440374,
-        "narHash": "sha256-/Em9r9PhTr6284S+YuCDGIcUwG1LvHzc337t+yq0cn4=",
+        "lastModified": 1672451966,
+        "narHash": "sha256-+iHE+4ebDmMGD7Dizg07WNviVWPNz8f+w8S6YgDuTzU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e6f9b2c09dccbfcd969a55727a99b593c27b7e1c",
+        "rev": "39126995ec54a144c8e73785e6a0fadc70174b1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`39126995`](https://github.com/nix-community/NUR/commit/39126995ec54a144c8e73785e6a0fadc70174b1e) | `automatic update` |