### PR TITLE
chore(flake/emacs-overlay): `6108369b` -> `240c1b5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672424856,
-        "narHash": "sha256-xCzvU4m0GabHeh0Y8rD+VbUVk4rwQ1s73d52vC5wE/0=",
+        "lastModified": 1672455421,
+        "narHash": "sha256-XxI5Wr0cOnIodntN+J1us/N7dbC9vJ46dG+uCQPByFk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6108369b3fa789e2b2683127043c0dd118009a73",
+        "rev": "240c1b5ebd1a675480cc203fdd98268166ff3fe2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`240c1b5e`](https://github.com/nix-community/emacs-overlay/commit/240c1b5ebd1a675480cc203fdd98268166ff3fe2) | `Updated repos/melpa` |
| [`92b2f5b4`](https://github.com/nix-community/emacs-overlay/commit/92b2f5b48798e389ea9fde1c8f322727b74f56fb) | `Updated repos/emacs` |
| [`70d208c5`](https://github.com/nix-community/emacs-overlay/commit/70d208c56da7a6fef7c3485c30aa9b0baa0e95cb) | `Updated repos/elpa`  |