### PR TITLE
chore(flake/nur): `39126995` -> `636065b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672451966,
-        "narHash": "sha256-+iHE+4ebDmMGD7Dizg07WNviVWPNz8f+w8S6YgDuTzU=",
+        "lastModified": 1672458361,
+        "narHash": "sha256-pov5aBvk4Qu84yUa5B0s5J4nGJ+vSGubo3aINp82ixg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "39126995ec54a144c8e73785e6a0fadc70174b1e",
+        "rev": "636065b4d1655cbf87b7b3fff0f4b3a642d9ec58",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`636065b4`](https://github.com/nix-community/NUR/commit/636065b4d1655cbf87b7b3fff0f4b3a642d9ec58) | `automatic update` |