### PR TITLE
chore(flake/nur): `636065b4` -> `3197e5c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672458361,
-        "narHash": "sha256-pov5aBvk4Qu84yUa5B0s5J4nGJ+vSGubo3aINp82ixg=",
+        "lastModified": 1672462443,
+        "narHash": "sha256-a7jQ90dFLQp/IR+E0VIkHmAvif0JVnyEpAji7NKC0EE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "636065b4d1655cbf87b7b3fff0f4b3a642d9ec58",
+        "rev": "3197e5c8dce9333c76e7a5c6b3c196039cc2f2cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3197e5c8`](https://github.com/nix-community/NUR/commit/3197e5c8dce9333c76e7a5c6b3c196039cc2f2cb) | `automatic update` |
| [`1d56ccd4`](https://github.com/nix-community/NUR/commit/1d56ccd43673b12d8cd053722a02f6c783c28f56) | `automatic update` |