### PR TITLE
chore(flake/nur): `3197e5c8` -> `c960f8ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672462443,
-        "narHash": "sha256-a7jQ90dFLQp/IR+E0VIkHmAvif0JVnyEpAji7NKC0EE=",
+        "lastModified": 1672476334,
+        "narHash": "sha256-y1Hb9FrF/PJaaEneN9x73BIR8eAl5jBn8Fafc+1FoI4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3197e5c8dce9333c76e7a5c6b3c196039cc2f2cb",
+        "rev": "c960f8caf6b26f6f43b9a38b4e21c8e4bd6f5090",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c960f8ca`](https://github.com/nix-community/NUR/commit/c960f8caf6b26f6f43b9a38b4e21c8e4bd6f5090) | `automatic update` |