### PR TITLE
chore(flake/emacs-overlay): `240c1b5e` -> `27ecb795`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672455421,
-        "narHash": "sha256-XxI5Wr0cOnIodntN+J1us/N7dbC9vJ46dG+uCQPByFk=",
+        "lastModified": 1672481747,
+        "narHash": "sha256-fwWtmoN1t8cV0WBdpM8AKkQe6Y2Fhst3vC5UqGlz0ik=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "240c1b5ebd1a675480cc203fdd98268166ff3fe2",
+        "rev": "27ecb795fbcd192d09a07a647696a92bbb6138ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`27ecb795`](https://github.com/nix-community/emacs-overlay/commit/27ecb795fbcd192d09a07a647696a92bbb6138ff) | `Updated repos/melpa` |
| [`29710775`](https://github.com/nix-community/emacs-overlay/commit/297107759dabf44f3d3bde8c98dfc736d16e77b1) | `Updated repos/emacs` |