### PR TITLE
chore(flake/nur): `c960f8ca` -> `db123456`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672476334,
-        "narHash": "sha256-y1Hb9FrF/PJaaEneN9x73BIR8eAl5jBn8Fafc+1FoI4=",
+        "lastModified": 1672487123,
+        "narHash": "sha256-MDRTDYfJ3fSxBbVAcNPyLO3BkbgDXsrU6+oWU3nVaDc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c960f8caf6b26f6f43b9a38b4e21c8e4bd6f5090",
+        "rev": "db1234560c98fc604c929fbbaae836e50b43e838",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`db123456`](https://github.com/nix-community/NUR/commit/db1234560c98fc604c929fbbaae836e50b43e838) | `automatic update` |