### PR TITLE
chore(flake/nur): `db123456` -> `1f3ef72c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672487123,
-        "narHash": "sha256-MDRTDYfJ3fSxBbVAcNPyLO3BkbgDXsrU6+oWU3nVaDc=",
+        "lastModified": 1672508672,
+        "narHash": "sha256-VirrCZ6gtw9lHsFb50entNubOp2qrmb+EmI4nsPc3g8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "db1234560c98fc604c929fbbaae836e50b43e838",
+        "rev": "1f3ef72c8052140aff61b6d4968f2ef2d428c9e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1f3ef72c`](https://github.com/nix-community/NUR/commit/1f3ef72c8052140aff61b6d4968f2ef2d428c9e4) | `automatic update` |