### PR TITLE
chore(flake/nur): `1f3ef72c` -> `37f0d22d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672508672,
-        "narHash": "sha256-VirrCZ6gtw9lHsFb50entNubOp2qrmb+EmI4nsPc3g8=",
+        "lastModified": 1672512268,
+        "narHash": "sha256-vcAYow0GaOpcsOVwkJIxMUr8uP/N6Kjxacrt6KpBGWc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1f3ef72c8052140aff61b6d4968f2ef2d428c9e4",
+        "rev": "37f0d22dae47ec66b6d880a42a96b0c798ee1fb7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`37f0d22d`](https://github.com/nix-community/NUR/commit/37f0d22dae47ec66b6d880a42a96b0c798ee1fb7) | `automatic update` |