### PR TITLE
chore(flake/dendrite-demo-pinecone): `6af6092e` -> `5a6aeb95`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672422128,
-        "narHash": "sha256-B9a5DFeZo55KANr2ZceraUa36BMlx2/W2euk4cjhaQs=",
+        "lastModified": 1672514205,
+        "narHash": "sha256-WcG4TNUqUjC06Nwq9mtlPCKuhLzDewgIPjGQuI9gl30=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "6af6092ef8a416e3ba30ad89fa5de41b4da0cb62",
+        "rev": "5a6aeb953c70e7bc871459f7c3fb4cbfd61a3593",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                          | Commit Message       |
| --------------------------------------------------------------------------------------------------------------- | -------------------- |
| [`5a6aeb95`](https://github.com/bbigras/dendrite-demo-pinecone/commit/5a6aeb953c70e7bc871459f7c3fb4cbfd61a3593) | `flake.lock: Update` |