### PR TITLE
chore(flake/nur): `37f0d22d` -> `3ec11773`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672512268,
-        "narHash": "sha256-vcAYow0GaOpcsOVwkJIxMUr8uP/N6Kjxacrt6KpBGWc=",
+        "lastModified": 1672515866,
+        "narHash": "sha256-xryYdsKTmcYv8bHRZJ1KStls5mbcyA4YyTUyNs+rttY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "37f0d22dae47ec66b6d880a42a96b0c798ee1fb7",
+        "rev": "3ec11773e835abc3239c6d0338cb9fdaa5189b96",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3ec11773`](https://github.com/nix-community/NUR/commit/3ec11773e835abc3239c6d0338cb9fdaa5189b96) | `automatic update` |