### PR TITLE
chore(flake/emacs-plz): `b62731f2` -> `4ed99c1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -171,11 +171,11 @@
     "emacs-plz": {
       "flake": false,
       "locked": {
-        "lastModified": 1670704728,
-        "narHash": "sha256-GHd+g6gD0rUzMAna/4qKHpqPRU4jhcMJTKAvPk480nw=",
+        "lastModified": 1672520026,
+        "narHash": "sha256-Q/T+ZU5G+Et6+4g3foRT5Xnhsg7OJXbZ8E7rnjyO/Mo=",
         "owner": "alphapapa",
         "repo": "plz.el",
-        "rev": "b62731f21d82d1cd31bc13874ae7d211b3e902a3",
+        "rev": "4ed99c1cbf4fb02be3646156e6cdaabfc4987a0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                            | Commit Message                              |
| ------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`4ed99c1c`](https://github.com/alphapapa/plz.el/commit/4ed99c1cbf4fb02be3646156e6cdaabfc4987a0f) | `Meta: Upgrade CI`                          |
| [`79349d59`](https://github.com/alphapapa/plz.el/commit/79349d59dfba1b7ace54fd294e280a2c71de3c37) | `Tidy: Replace words Ispell doesn't accept` |