### PR TITLE
chore(flake/emacs-plz): `e8eba6f0` -> `b6072ede`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -171,11 +171,11 @@
     "emacs-plz": {
       "flake": false,
       "locked": {
-        "lastModified": 1672522164,
-        "narHash": "sha256-rCGK48N36IdtQiZ9sckzwQ/0fJZKcjdQdSofjDzlmqw=",
+        "lastModified": 1672525865,
+        "narHash": "sha256-GVVDX0sASrl3Ivl87B9+fz/VBHp9bq9K6ZauVzoyVfo=",
         "owner": "alphapapa",
         "repo": "plz.el",
-        "rev": "e8eba6f0901321a40b00c45aa177e145606dddb2",
+        "rev": "b6072edeec1f0e2465d273db74a8f2f7726e6bce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                            | Commit Message                        |
| ------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`b6072ede`](https://github.com/alphapapa/plz.el/commit/b6072edeec1f0e2465d273db74a8f2f7726e6bce) | `Tests: Use both HTTP/1.1 and HTTP/2` |
| [`25a8d5ee`](https://github.com/alphapapa/plz.el/commit/25a8d5ee6427f803996c619ab6cafa5da8bfb932) | `Meta: v0.4-pre`                      |
| [`ecd1de2a`](https://github.com/alphapapa/plz.el/commit/ecd1de2a7967bd8bc61737078d717d0ee050b344) | `Release: v0.3`                       |
| [`cfd8a80d`](https://github.com/alphapapa/plz.el/commit/cfd8a80db538d44291ae26ff79974215f2ce667f) | `Docs: Add acknowledgements for #2`   |