### PR TITLE
chore(flake/nur): `3ec11773` -> `72fb9ddd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672515866,
-        "narHash": "sha256-xryYdsKTmcYv8bHRZJ1KStls5mbcyA4YyTUyNs+rttY=",
+        "lastModified": 1672526717,
+        "narHash": "sha256-mbx3Mr4TsL7IObXXDCCFR6ith+skGu7Rk559C2QynVk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3ec11773e835abc3239c6d0338cb9fdaa5189b96",
+        "rev": "72fb9ddd874ef91e2bd2ea79081a2c2da81bd206",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`72fb9ddd`](https://github.com/nix-community/NUR/commit/72fb9ddd874ef91e2bd2ea79081a2c2da81bd206) | `automatic update` |