### PR TITLE
chore(flake/emacs-overlay): `3c1fbbbe` -> `898c89ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672511436,
-        "narHash": "sha256-31i+SGmBdZTLz9BsCB5dOXff/xe+tei5sujgdrSJIss=",
+        "lastModified": 1672539288,
+        "narHash": "sha256-2OW813QnuZ4NkpRuDxi0OoUAJde6JP11A72jzQaEOqI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3c1fbbbe250bde48a947099ae61534f018290ff4",
+        "rev": "898c89ac1ea4f198a4fe96d37c6559f612b74648",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`898c89ac`](https://github.com/nix-community/emacs-overlay/commit/898c89ac1ea4f198a4fe96d37c6559f612b74648) | `Updated repos/melpa` |
| [`eb92f8cb`](https://github.com/nix-community/emacs-overlay/commit/eb92f8cbb45c9923fb61031c28040c19f78f92dd) | `Updated repos/elpa`  |