### PR TITLE
chore(flake/nur): `72fb9ddd` -> `7593a08f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672526717,
-        "narHash": "sha256-mbx3Mr4TsL7IObXXDCCFR6ith+skGu7Rk559C2QynVk=",
+        "lastModified": 1672544679,
+        "narHash": "sha256-vvM+3f0LZWxOP1W5pRjn+ErIf60dLrB4ijij6ML+nfg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "72fb9ddd874ef91e2bd2ea79081a2c2da81bd206",
+        "rev": "7593a08f825bca39bd73b1316f8dc7d8e0d63fcc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7593a08f`](https://github.com/nix-community/NUR/commit/7593a08f825bca39bd73b1316f8dc7d8e0d63fcc) | `automatic update` |