### PR TITLE
chore(flake/nur): `7593a08f` -> `17e3c740`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672544679,
-        "narHash": "sha256-vvM+3f0LZWxOP1W5pRjn+ErIf60dLrB4ijij6ML+nfg=",
+        "lastModified": 1672546603,
+        "narHash": "sha256-gtmPhRmt87LJuVj31+48qLCcA3Xq1mE14SZzyV3Ihy0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7593a08f825bca39bd73b1316f8dc7d8e0d63fcc",
+        "rev": "17e3c740b4a37d034d8f3bbfedbc765a899054f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`17e3c740`](https://github.com/nix-community/NUR/commit/17e3c740b4a37d034d8f3bbfedbc765a899054f3) | `automatic update` |