### PR TITLE
chore(flake/nur): `41dd00fb` -> `2a5a7622`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672558310,
-        "narHash": "sha256-AVPOZuaEHappNiIzwMwTFaiXr2oj2WFaV9u+ruAkh5w=",
+        "lastModified": 1672567407,
+        "narHash": "sha256-iS/zsRj/tnhg7vfffhpt+iSxfm+fK3FJPVDxvFCGp8I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "41dd00fb0be846ae2880d158e6bd5c262ee727b4",
+        "rev": "2a5a76227bba619d216becb367a9789de4c12a2f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                               |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`2a5a7622`](https://github.com/nix-community/NUR/commit/2a5a76227bba619d216becb367a9789de4c12a2f) | `automatic update`                           |
| [`6aa82e4b`](https://github.com/nix-community/NUR/commit/6aa82e4bcc159e9b56a20f32e739878c98629f5b) | `automatic update`                           |
| [`0ea48694`](https://github.com/nix-community/NUR/commit/0ea48694907bbbb2ca796038f1560a3211d9235b) | `automatic update`                           |
| [`cf4a6a79`](https://github.com/nix-community/NUR/commit/cf4a6a793002eeb4c3f1d4230cff6ace1154def6) | `add timsueberkrueb/nur-packages repository` |
| [`65e19598`](https://github.com/nix-community/NUR/commit/65e195986369bfa863615c93bbec6f6e252343d5) | `Add lunik1/nur-packages`                    |