### PR TITLE
chore(flake/emacs-overlay): `898c89ac` -> `524c8844`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672539288,
-        "narHash": "sha256-2OW813QnuZ4NkpRuDxi0OoUAJde6JP11A72jzQaEOqI=",
+        "lastModified": 1672567750,
+        "narHash": "sha256-Hz1b1TUJbzuLj0eR+LTSUqoGR2gkQdrm3uxru+0rVuY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "898c89ac1ea4f198a4fe96d37c6559f612b74648",
+        "rev": "524c884484c312b76cb4bc9fbf37eec66e2f8406",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`524c8844`](https://github.com/nix-community/emacs-overlay/commit/524c884484c312b76cb4bc9fbf37eec66e2f8406) | `Updated repos/melpa` |
| [`5c440de8`](https://github.com/nix-community/emacs-overlay/commit/5c440de888f0ca43c8a68784c6b34f55c3bf031e) | `Updated repos/emacs` |