### PR TITLE
chore(flake/nur): `14232774` -> `353bd64b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672586588,
-        "narHash": "sha256-eb0A4CTJ/7kIoIgeHQ6/ZI1eqZxn29RmQm1/fzQ52is=",
+        "lastModified": 1672593298,
+        "narHash": "sha256-inwoon2DSGjxrhH0nyjKYKTp23h5N3dCs0IedEX0YSg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "14232774b842fb4f1a2144c5b698af3516d7cee3",
+        "rev": "353bd64b6c42772dba00b5be980d356755fe61b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`353bd64b`](https://github.com/nix-community/NUR/commit/353bd64b6c42772dba00b5be980d356755fe61b9) | `automatic update` |