### PR TITLE
chore(flake/nur): `353bd64b` -> `7562bd46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672593298,
-        "narHash": "sha256-inwoon2DSGjxrhH0nyjKYKTp23h5N3dCs0IedEX0YSg=",
+        "lastModified": 1672597476,
+        "narHash": "sha256-zri5jo/x+ZMqVVqiim1EBGqFc0L7LitJQBAs34Libl0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "353bd64b6c42772dba00b5be980d356755fe61b9",
+        "rev": "7562bd461140b98ecbafe4ff6800c6c4a29f96c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7562bd46`](https://github.com/nix-community/NUR/commit/7562bd461140b98ecbafe4ff6800c6c4a29f96c6) | `automatic update` |