### PR TITLE
chore(flake/nur): `e8aa7b45` -> `902fd864`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672602363,
-        "narHash": "sha256-F7aRIolV+u4iHrGZ4uqrcrdDXsFPI1QJcgnhapNKEBo=",
+        "lastModified": 1672609578,
+        "narHash": "sha256-cy4Dbo2PvoV0vfaB103ujk6FVWlBLnjjctoTUARE26c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e8aa7b453c16a3e71604fdef322b28e5806fed3c",
+        "rev": "902fd864f4cf9b9da69bc57859a2b6fe1d220f7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`902fd864`](https://github.com/nix-community/NUR/commit/902fd864f4cf9b9da69bc57859a2b6fe1d220f7c) | `automatic update` |