### PR TITLE
chore(flake/nur): `902fd864` -> `9b87a796`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672609578,
-        "narHash": "sha256-cy4Dbo2PvoV0vfaB103ujk6FVWlBLnjjctoTUARE26c=",
+        "lastModified": 1672613084,
+        "narHash": "sha256-ClnTV5VxbZmLYBfWiS6fmsjfi4PyYLntgJV7mP0plUg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "902fd864f4cf9b9da69bc57859a2b6fe1d220f7c",
+        "rev": "9b87a7969fef18b7ffaa75b4d210cdb6003f4a69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9b87a796`](https://github.com/nix-community/NUR/commit/9b87a7969fef18b7ffaa75b4d210cdb6003f4a69) | `automatic update` |