### PR TITLE
chore(flake/nur): `9b87a796` -> `8b0585c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672613084,
-        "narHash": "sha256-ClnTV5VxbZmLYBfWiS6fmsjfi4PyYLntgJV7mP0plUg=",
+        "lastModified": 1672616759,
+        "narHash": "sha256-Q+qFV69xPb+JL0BJHTER4cw76vOEBbXHhLNg6vAg3oo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9b87a7969fef18b7ffaa75b4d210cdb6003f4a69",
+        "rev": "8b0585c5f982866000b0b34cd35bd69814e58123",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8b0585c5`](https://github.com/nix-community/NUR/commit/8b0585c5f982866000b0b34cd35bd69814e58123) | `automatic update` |