### PR TITLE
chore(flake/emacs-overlay): `cd444d8f` -> `b281ef33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672596595,
-        "narHash": "sha256-nddXDfyfdC30tde6r1iDWtOQz3y/LLmnS+BS4dwz2Y0=",
+        "lastModified": 1672624639,
+        "narHash": "sha256-JEH+QRAXbvKJCOZJhDKXCwysKpEk/TQ1Ur3rM4CLMHU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cd444d8f2d284c90a1e898bd102a40176e6dfcfa",
+        "rev": "b281ef3306bd37ac1c8ed7e83fcb241f6757a61c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                     |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------- |
| [`b281ef33`](https://github.com/nix-community/emacs-overlay/commit/b281ef3306bd37ac1c8ed7e83fcb241f6757a61c) | `Alphabetize tree-sitter grammars` |
| [`e4651781`](https://github.com/nix-community/emacs-overlay/commit/e465178187fd62eaed9c7637e7315e0800e02209) | `Add tree-sitter-ruby`             |