### PR TITLE
chore(flake/nur): `8b0585c5` -> `69155f0c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672616759,
-        "narHash": "sha256-Q+qFV69xPb+JL0BJHTER4cw76vOEBbXHhLNg6vAg3oo=",
+        "lastModified": 1672633239,
+        "narHash": "sha256-0nY7AhCQPa9MLqkBBVmZHd9DOzBks09hZaVRPay77fY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8b0585c5f982866000b0b34cd35bd69814e58123",
+        "rev": "69155f0ca02a38666214a4f2f02e49e2d4a47d72",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`69155f0c`](https://github.com/nix-community/NUR/commit/69155f0ca02a38666214a4f2f02e49e2d4a47d72) | `automatic update` |
| [`c0629b4c`](https://github.com/nix-community/NUR/commit/c0629b4cc5b2fad97dfce9e17c5e64fcdd7313ef) | `automatic update` |