### PR TITLE
chore(flake/emacs-overlay): `b281ef33` -> `2fa6cca2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672624639,
-        "narHash": "sha256-JEH+QRAXbvKJCOZJhDKXCwysKpEk/TQ1Ur3rM4CLMHU=",
+        "lastModified": 1672630914,
+        "narHash": "sha256-LVIJDR3gyk5RhBndzWuEhUz0OPKqtwyOnoSCSxY9mtw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b281ef3306bd37ac1c8ed7e83fcb241f6757a61c",
+        "rev": "2fa6cca26891f696c13fe910bb659ecd69ed3842",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`2fa6cca2`](https://github.com/nix-community/emacs-overlay/commit/2fa6cca26891f696c13fe910bb659ecd69ed3842) | `Updated repos/nongnu` |
| [`523f0621`](https://github.com/nix-community/emacs-overlay/commit/523f062104b48f5e0a46bb7c0fd77a486eaa8fda) | `Updated repos/melpa`  |
| [`3fcb8573`](https://github.com/nix-community/emacs-overlay/commit/3fcb8573583cf5d70299cf93eeef92fab8f979e0) | `Updated repos/emacs`  |
| [`9ffea899`](https://github.com/nix-community/emacs-overlay/commit/9ffea899b1125bb4459da2fbb7a3a61e9ff0f8a6) | `Updated repos/elpa`   |