### PR TITLE
chore(flake/nur): `69155f0c` -> `65ff12f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672633239,
-        "narHash": "sha256-0nY7AhCQPa9MLqkBBVmZHd9DOzBks09hZaVRPay77fY=",
+        "lastModified": 1672635614,
+        "narHash": "sha256-zUZFJe6YUBF0XAHl4/ZDojhxEaFTklKXNhqBDMXfn+8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "69155f0ca02a38666214a4f2f02e49e2d4a47d72",
+        "rev": "65ff12f2eb0857f2777211e40093d932e24ae992",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`65ff12f2`](https://github.com/nix-community/NUR/commit/65ff12f2eb0857f2777211e40093d932e24ae992) | `automatic update` |