### PR TITLE
chore(flake/nixos-hardware): `0517e81e` -> `ca29e25c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -341,11 +341,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1672566874,
-        "narHash": "sha256-/lmz3/xzdghGSFeCcTiKMjbj0uRmUqTZhh4HHeUJ++g=",
+        "lastModified": 1672644464,
+        "narHash": "sha256-RYlvRMcQNT7FDoDkViijQBHg9g+blsB+U6AvL/gAsPI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "0517e81e8ce24a0f4f9eebedbd7bbefcac97c058",
+        "rev": "ca29e25c39b8e117d4d76a81f1e229824a9b3a26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`6517e0ef`](https://github.com/NixOS/nixos-hardware/commit/6517e0efcbbb061b212df461dd782b0056a96f39) | `asus-zephyrus-ga402: fix mic mute button` |