### PR TITLE
chore(flake/emacs-overlay): `2fa6cca2` -> `ba6ca039`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672630914,
-        "narHash": "sha256-LVIJDR3gyk5RhBndzWuEhUz0OPKqtwyOnoSCSxY9mtw=",
+        "lastModified": 1672650448,
+        "narHash": "sha256-hLChFfJFofjtswHd8wLo0z8TuHwDI/4ZzfmVvxCLFp8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2fa6cca26891f696c13fe910bb659ecd69ed3842",
+        "rev": "ba6ca0397eee6d322755d9128495010b70db790e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ba6ca039`](https://github.com/nix-community/emacs-overlay/commit/ba6ca0397eee6d322755d9128495010b70db790e) | `Updated repos/melpa` |