### PR TITLE
chore(flake/nur): `ded6b15a` -> `9fb539e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672659988,
-        "narHash": "sha256-ACMYNBkZ+2QWmIX4WUvzMyLpVMiI7yf4Mu4tUgRorbY=",
+        "lastModified": 1672663262,
+        "narHash": "sha256-0b/7Uzm2lnjENv9YCPNDp0TU0zyt4gFv/j7fOu0ZaAY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ded6b15ad7900f373687ce3382f1d011a2e27a02",
+        "rev": "9fb539e7061d7b5b56d0bbf9f33f3b753904c901",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9fb539e7`](https://github.com/nix-community/NUR/commit/9fb539e7061d7b5b56d0bbf9f33f3b753904c901) | `automatic update` |
| [`f2c2455b`](https://github.com/nix-community/NUR/commit/f2c2455b9b9edb9eb7f3ca8836348b9888ded281) | `automatic update` |
| [`909bc469`](https://github.com/nix-community/NUR/commit/909bc469c1896e7ca0b669cce172e6dcf0527b18) | `automatic update` |
| [`52a34bba`](https://github.com/nix-community/NUR/commit/52a34bbacffd39e9652d3b874c5e642e84fa51dc) | `automatic update` |
| [`ed329dfb`](https://github.com/nix-community/NUR/commit/ed329dfbc75127b267416e5dc4a21fb92001a632) | `automatic update` |