### PR TITLE
chore(flake/nur): `9fb539e7` -> `f44f8622`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672663262,
-        "narHash": "sha256-0b/7Uzm2lnjENv9YCPNDp0TU0zyt4gFv/j7fOu0ZaAY=",
+        "lastModified": 1672667191,
+        "narHash": "sha256-Uws7w+8c33A1P4/Rx8TXyTyNytfTHCTcK5611GtRZz8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9fb539e7061d7b5b56d0bbf9f33f3b753904c901",
+        "rev": "f44f8622f9aa1d5c764fdd7331104f9c9ae1e48c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f44f8622`](https://github.com/nix-community/NUR/commit/f44f8622f9aa1d5c764fdd7331104f9c9ae1e48c) | `automatic update` |