### PR TITLE
chore(flake/nur): `f44f8622` -> `53a0ecbe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672667191,
-        "narHash": "sha256-Uws7w+8c33A1P4/Rx8TXyTyNytfTHCTcK5611GtRZz8=",
+        "lastModified": 1672670710,
+        "narHash": "sha256-fPnzf0mH5ljmU7CvQayGLyFC2EpIIYqh5b9G6431TuU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f44f8622f9aa1d5c764fdd7331104f9c9ae1e48c",
+        "rev": "53a0ecbe514888d3740ff14f1fa1f64a12750b9c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`53a0ecbe`](https://github.com/nix-community/NUR/commit/53a0ecbe514888d3740ff14f1fa1f64a12750b9c) | `automatic update` |