### PR TITLE
chore(flake/emacs-overlay): `ba6ca039` -> `9ef42377`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672650448,
-        "narHash": "sha256-hLChFfJFofjtswHd8wLo0z8TuHwDI/4ZzfmVvxCLFp8=",
+        "lastModified": 1672683054,
+        "narHash": "sha256-evGMoWB8dbgK2d4MB4J3fXeLRKCzkyfiTH7JrgYPYuk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ba6ca0397eee6d322755d9128495010b70db790e",
+        "rev": "9ef42377c7985840cfb65b5b9403e518d7d97afb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`9ef42377`](https://github.com/nix-community/emacs-overlay/commit/9ef42377c7985840cfb65b5b9403e518d7d97afb) | `Updated repos/nongnu` |
| [`b7c9a32d`](https://github.com/nix-community/emacs-overlay/commit/b7c9a32d384b007916769e969b4ca56ecefc721d) | `Updated repos/melpa`  |
| [`4bab411f`](https://github.com/nix-community/emacs-overlay/commit/4bab411f17128c335f603b1bfc69f4a1b34ada0c) | `Updated repos/emacs`  |
| [`af77f8ab`](https://github.com/nix-community/emacs-overlay/commit/af77f8abd56f0190008cd6e33806d1fa6eedd946) | `Updated repos/elpa`   |