### PR TITLE
chore(flake/nixpkgs): `677ed08a` -> `8ba56d7c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672350804,
-        "narHash": "sha256-jo6zkiCabUBn3ObuKXHGqqORUMH27gYDIFFfLq5P4wg=",
+        "lastModified": 1672525397,
+        "narHash": "sha256-WASDnyxHKWVrEe0dIzkpH+jzKlCKAk0husv0f/9pyxg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "677ed08a50931e38382dbef01cba08a8f7eac8f6",
+        "rev": "8ba56d7c0d7490680f2d51ba46a141eca7c46afa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                              |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| [`d6a592c0`](https://github.com/NixOS/nixpkgs/commit/d6a592c02e4b0b6cf0deeff144fe95a866dd6a21) | `mathematica: Add 13.1.0 webdoc=true source hash`                                                           |
| [`0ded4086`](https://github.com/NixOS/nixpkgs/commit/0ded4086d46062f6990644b393d0ba92e344f48a) | `highlight: fix cross-compilation`                                                                          |
| [`c653df75`](https://github.com/NixOS/nixpkgs/commit/c653df755957eb02b879c5d44c91d6d47a5e4b34) | `ghostie: mark broken on x86_64-darwin`                                                                     |
| [`5cd84972`](https://github.com/NixOS/nixpkgs/commit/5cd84972531758ec3bb813ba68487cc0132c6a22) | `geoserver: 2.21.2 -> 2.22.0`                                                                               |
| [`ee523770`](https://github.com/NixOS/nixpkgs/commit/ee5237701e9640c0b7d5bebae3fece4ada396e56) | `mathematica: document the command for calculating hashes`                                                  |
| [`9aaf7f19`](https://github.com/NixOS/nixpkgs/commit/9aaf7f19e856818e2c5283101ad10e8fa996cab6) | `rofimoji: 6.0.0 -> 6.1.0`                                                                                  |
| [`54c0e4c4`](https://github.com/NixOS/nixpkgs/commit/54c0e4c4bb095ff374f7a29879a92aa2954e2dd0) | `openai-whisper-cpp: init at 1.0.4`                                                                         |
| [`b2dd8052`](https://github.com/NixOS/nixpkgs/commit/b2dd805235fdd05d4d135f06b8d74e92db434601) | `pt2-clone: 1.55 -> 1.56`                                                                                   |
| [`d005961e`](https://github.com/NixOS/nixpkgs/commit/d005961e237244d42b319f4b8ffd073f6c7919f2) | `wlcs: init at 1.4.0`                                                                                       |
| [`28044d90`](https://github.com/NixOS/nixpkgs/commit/28044d9042ce1e243e5ac667865c906983f64170) | `texlab: 4.3.2 -> 5.0.0`                                                                                    |
| [`526bd9b6`](https://github.com/NixOS/nixpkgs/commit/526bd9b63ad5f44ff18fc7e52756c4832d36666d) | `python310Packages.thermobeacon-ble: 0.5.0 -> 0.6.0`                                                        |
| [`49255db2`](https://github.com/NixOS/nixpkgs/commit/49255db2db97d17c2b431ef27d4808ae7f8a97bb) | `python310Packages.motionblinds: 0.6.13 -> 0.6.14`                                                          |
| [`d46503e6`](https://github.com/NixOS/nixpkgs/commit/d46503e61b76490b2ecc6b0e659620f1b343faa0) | `python310Packages.motionblinds: add changelog to meta`                                                     |
| [`e875e558`](https://github.com/NixOS/nixpkgs/commit/e875e558bee1b667fca6be55a1fb27b2f2c807fd) | `python310Packages.thermobeacon-ble: 0.4.0 -> 0.5.0`                                                        |
| [`64769690`](https://github.com/NixOS/nixpkgs/commit/64769690ffcbc603a79c0d943ddeb470e1eaf26b) | `python310Packages.hahomematic: 2022.12.11 -> 2022.12.12`                                                   |
| [`63a687ad`](https://github.com/NixOS/nixpkgs/commit/63a687ad75da4e75d7342d522137c3d11cbcb1ad) | ` python310Packages.pytest-tap: fix copy-&-paste error`                                                     |
| [`517ff272`](https://github.com/NixOS/nixpkgs/commit/517ff272eed82b22e3621b7e9a0b9367fb6adf35) | `python3Packages.pytest-tap: add pythonImportsCheck`                                                        |
| [`bb33dedd`](https://github.com/NixOS/nixpkgs/commit/bb33dedd2eda20aaaa114a531db234fa1ef994c7) | `ocamlPackages.git-mirage,ocamlPackages.git-paf,ocamlPackages.git-unix,ocamlPackages.git: 3.10.0 -> 3.10.1` |
| [`89d7a569`](https://github.com/NixOS/nixpkgs/commit/89d7a56919146bdd9820a5fca61528dbd2140b90) | `ocamlPackages.mimic: 0.0.5 -> 0.0.6`                                                                       |
| [`8e041cf4`](https://github.com/NixOS/nixpkgs/commit/8e041cf40c40da7a9b5f50426ae67c7c84480e6f) | `ipscan: add changelog to meta`                                                                             |
| [`128e86cb`](https://github.com/NixOS/nixpkgs/commit/128e86cb93dde5fb9856e97aeaded276aa1f5782) | `python310Packages.wn: add changelog to emta`                                                               |
| [`1c1197c2`](https://github.com/NixOS/nixpkgs/commit/1c1197c2f759a058038b505c52b63e2041253384) | `python310Packages.chess: add changelog to meta`                                                            |
| [`6b20c874`](https://github.com/NixOS/nixpkgs/commit/6b20c8741ec29c720a213c281aeeb770cf5d259c) | `ugrep: add cahngelog to meta`                                                                              |
| [`7f37b4b2`](https://github.com/NixOS/nixpkgs/commit/7f37b4b22a284bca468cfde00eb3dc10077b9061) | `txr: 283 -> 284`                                                                                           |
| [`e999f057`](https://github.com/NixOS/nixpkgs/commit/e999f057050463ae9257cae9336e8e1d29c28e2b) | `obs-studio-plugins.obs-backgroundremoval: remove`                                                          |
| [`d6ec92f8`](https://github.com/NixOS/nixpkgs/commit/d6ec92f8bf9461d83441e2d230906ef1f7582afd) | `onnxruntime: 1.12.1 -> 1.13.1`                                                                             |
| [`53d2a65d`](https://github.com/NixOS/nixpkgs/commit/53d2a65dad16c8d8bd8818978c7041b440fe54be) | `jabcode: unstable-2021-02-16 -> unstable-2022-06-17`                                                       |
| [`3c2b53ed`](https://github.com/NixOS/nixpkgs/commit/3c2b53ed3bcec90ef199c9727b1881779e7c75d9) | `python310Packages.chess: 1.9.3 -> 1.9.4`                                                                   |
| [`bc91954e`](https://github.com/NixOS/nixpkgs/commit/bc91954e2d6a402602773570c599cfeb6fc977ae) | `python310Packages.roonapi: 0.1.1 -> 0.1.2`                                                                 |
| [`0d383507`](https://github.com/NixOS/nixpkgs/commit/0d383507228cd57927c0abb9f35bc4c4936a6d44) | `python310Packages.roonapi: add changelog to meta`                                                          |
| [`76c6349c`](https://github.com/NixOS/nixpkgs/commit/76c6349c9a16dc74c0cbde2dfc5bc9e5fceeb101) | `ghostie: init at 0.2.1`                                                                                    |
| [`6a4468a2`](https://github.com/NixOS/nixpkgs/commit/6a4468a2a69dfd98b631d8e4f2d49c506a96524d) | `libuchardet: 0.0.7 -> 0.0.8`                                                                               |
| [`9a9024f6`](https://github.com/NixOS/nixpkgs/commit/9a9024f6b7cd198b1cb21e5b5caf7a0ea83665e9) | `python310Packages.wn: 0.9.2 -> 0.9.3`                                                                      |
| [`b2e47ddd`](https://github.com/NixOS/nixpkgs/commit/b2e47ddd5c4a19a531e3c8b5069f24309f2c2424) | `ocamlPackages.ppx_tools: enable for OCaml 5 & use dune 3`                                                  |
| [`1b6a2945`](https://github.com/NixOS/nixpkgs/commit/1b6a2945a7cb6f6ed652af417ab9b9f5fe816068) | `mlib: 0.6.0 -> 0.7.0`                                                                                      |
| [`2decd4ef`](https://github.com/NixOS/nixpkgs/commit/2decd4ef94b5d136005e13a093af62ec5546521f) | `tile38: 1.30.1 -> 1.30.2`                                                                                  |
| [`eb96c7ab`](https://github.com/NixOS/nixpkgs/commit/eb96c7ab43872cf26952d4a57d4104cc3619cde3) | `sequoia-chameleon-gnupg: init at 0.1.1`                                                                    |
| [`3dd2e3f6`](https://github.com/NixOS/nixpkgs/commit/3dd2e3f65bd311ccbd4b273b529f59e8e7336cfd) | `cargo-temp: 0.2.13 -> 0.2.14`                                                                              |
| [`d2a9d972`](https://github.com/NixOS/nixpkgs/commit/d2a9d97206a33d8da11df61bf733432bd9f8256d) | `ugrep: 3.9.2 -> 3.9.3`                                                                                     |
| [`9269a0e1`](https://github.com/NixOS/nixpkgs/commit/9269a0e15385ce1a1b007b3c901499eb499549cc) | `awscli2: 2.9.10 -> 2.9.11`                                                                                 |
| [`cdc96736`](https://github.com/NixOS/nixpkgs/commit/cdc96736692642733febb476330b04f81e8b1edb) | `star-history: 1.0.6 -> 1.0.7`                                                                              |
| [`91f1be8c`](https://github.com/NixOS/nixpkgs/commit/91f1be8c2f54622b2e21fc56c6a7a6510111663a) | `go-mockery: 2.15.0 -> 2.16.0`                                                                              |
| [`9ff694ce`](https://github.com/NixOS/nixpkgs/commit/9ff694ce89028d631f85f183f184bfb1560b85cc) | `terraform-providers.huaweicloud: 1.43.0 → 1.44.0`                                                          |
| [`e14c7030`](https://github.com/NixOS/nixpkgs/commit/e14c7030647acf8783d164f42da2d05cc9067b2a) | `terraform-providers.baiducloud: 1.19.0 → 1.19.1`                                                           |
| [`75fe98c4`](https://github.com/NixOS/nixpkgs/commit/75fe98c4499cd8bf4e42838f33645d2c02afd3ce) | `python310Packages.pulumi-aws: 5.24.0 -> 5.25.0`                                                            |
| [`44089968`](https://github.com/NixOS/nixpkgs/commit/440899686d742821c07b43bf448c19380d9b9da9) | `rust-analyzer-unwrapped: 2022-12-19 -> 2022-12-26`                                                         |
| [`74403e3d`](https://github.com/NixOS/nixpkgs/commit/74403e3d446766bc0d0040d6d72df6a0dffd1598) | `ddosify: 0.10.0 -> 0.11.0`                                                                                 |
| [`ac825c57`](https://github.com/NixOS/nixpkgs/commit/ac825c5763199b756570216182d88354b65a5dc3) | `prometheus-nut-exporter: 2.5.0 -> 2.5.1`                                                                   |
| [`c2ad0e4b`](https://github.com/NixOS/nixpkgs/commit/c2ad0e4b8550713f7f5c493101040ed0ca016fe7) | `ipscan: 3.8.2 -> 3.9.0`                                                                                    |
| [`847f2007`](https://github.com/NixOS/nixpkgs/commit/847f20072d3d89a428be8e05682a2426173c4a0d) | `mdds: 2.0.2 -> 2.0.3`                                                                                      |
| [`1f8dd05e`](https://github.com/NixOS/nixpkgs/commit/1f8dd05e72adc4e33e43b233bab7c0872119379d) | ``blender: add `libwebp` to `buildInputs` (#208201)``                                                       |
| [`983ae504`](https://github.com/NixOS/nixpkgs/commit/983ae504c9bfd3a7a12cc63991c15e2825522ad8) | `dprint: 0.33.0 -> 0.34.1`                                                                                  |
| [`5bbfefc2`](https://github.com/NixOS/nixpkgs/commit/5bbfefc294d55fab93c89a65357cdebb7ddb34c8) | `haskellPackages.hls-call-hierarchy-plugin: Add assert to reenable on upstream fix`                         |
| [`4527d89f`](https://github.com/NixOS/nixpkgs/commit/4527d89f4e3456582e8633337853ee8c3c355438) | `texlive: 2021-final -> 2022.20221227 (#208313)`                                                            |
| [`cb2f60a2`](https://github.com/NixOS/nixpkgs/commit/cb2f60a2d13a9da2510fa172c0e69ccbf14f18b7) | `python310Packages.jc: 1.22.3 -> 1.22.4`                                                                    |
| [`f12a7d93`](https://github.com/NixOS/nixpkgs/commit/f12a7d932ddf7f4d0c5e0c5664dec08e718e67a8) | `binutils: gold is not available for riscv target`                                                          |
| [`7bc38b91`](https://github.com/NixOS/nixpkgs/commit/7bc38b9128f4865f28dfed16a044a58b707f337b) | `haskell.packages.ghc810.haskell-language-server: Fix eval`                                                 |
| [`43abebb7`](https://github.com/NixOS/nixpkgs/commit/43abebb728fcf9e3d74ff75841776f7d598210d4) | `python310Packages.django_hijack: add changelog to meta`                                                    |
| [`8a4a3622`](https://github.com/NixOS/nixpkgs/commit/8a4a3622cf89a5ac509c712b873785572388aaad) | `python310Packages.zodbpickle: add meta`                                                                    |
| [`184c247e`](https://github.com/NixOS/nixpkgs/commit/184c247e8edb74e4eef0fa57c926641238f76962) | `python310Packages.pycarwings2: 2.13 -> 2.14`                                                               |
| [`21c27341`](https://github.com/NixOS/nixpkgs/commit/21c2734135ec88e347ad6b5ef58bc768177bf7aa) | `imagemagick: 7.1.0-55 -> 7.1.0-56`                                                                         |
| [`170cf11b`](https://github.com/NixOS/nixpkgs/commit/170cf11b98cf18eb36302dc4098d411d6b375beb) | `gay: 1.2.8 -> 1.2.9`                                                                                       |
| [`8d8281cc`](https://github.com/NixOS/nixpkgs/commit/8d8281cc56ec5be9a399faa37bf45ac856d7f886) | `haskellPackages.brittany: Remove outdated override`                                                        |
| [`ef43bede`](https://github.com/NixOS/nixpkgs/commit/ef43bede6dbf2e316c2590a77f74d6cf852458f0) | `haskellPackages: mark builds failing on hydra as broken`                                                   |
| [`61e561d8`](https://github.com/NixOS/nixpkgs/commit/61e561d80fe3719ba23de36307ba200b820a94f5) | `cups-brother-hll2375dw: init at 4.0.0-1 (#204306)`                                                         |
| [`75da39a0`](https://github.com/NixOS/nixpkgs/commit/75da39a0d6154c21ebaaf38c8b6ba288fbc78c70) | `oxker: 0.1.9 -> 0.1.10`                                                                                    |
| [`08ff7cc5`](https://github.com/NixOS/nixpkgs/commit/08ff7cc5b766104ab876be55246f3a8e0404b17d) | `haskellPackages.hspec_2_7_10: Disable distribution of broken package`                                      |
| [`0f72dd1f`](https://github.com/NixOS/nixpkgs/commit/0f72dd1f0b4d831cad4f61730d2d60280d50fdce) | `haskellPackages: mark builds failing on hydra as broken`                                                   |
| [`2996b0e3`](https://github.com/NixOS/nixpkgs/commit/2996b0e32866079426ea68e424cab4b51a2407da) | `ansible-language-server: 1.0.3 -> 1.0.4`                                                                   |
| [`4907c947`](https://github.com/NixOS/nixpkgs/commit/4907c94717eb7add2935fa3df1acb52caa9fd571) | `ares: 130.1 -> 131`                                                                                        |
| [`1babf157`](https://github.com/NixOS/nixpkgs/commit/1babf157211be75da62e03e352d747b8d9121fa0) | `python310Packages.python-benedict: 0.27.1 -> 0.28.0`                                                       |
| [`c7667f19`](https://github.com/NixOS/nixpkgs/commit/c7667f198fb589dbd9d13860afce25e007edfb9a) | `cbqn: drop obsolete darwin flags`                                                                          |
| [`2f3f2c82`](https://github.com/NixOS/nixpkgs/commit/2f3f2c82c885685c0be594d0b055ed3cbdf61a22) | `cbqn: install headers and shared library`                                                                  |
| [`fda7b23b`](https://github.com/NixOS/nixpkgs/commit/fda7b23b323617ca249aacd5ef38667408e8bd3b) | `python3Packages.notion-client: init at 2.0.0`                                                              |
| [`3a7244f6`](https://github.com/NixOS/nixpkgs/commit/3a7244f68b17c22e3a08a79f0c82c1ebfc7df569) | `spaceship-prompt: add kyleondy as maintainer`                                                              |
| [`9295cc28`](https://github.com/NixOS/nixpkgs/commit/9295cc28c9c38430b14894f3912d70d3aecdf84a) | `python3Packages.pytest-tap: init at 3.3`                                                                   |
| [`e1de1a8b`](https://github.com/NixOS/nixpkgs/commit/e1de1a8bdf911c094eeef80e302e74eb399566c6) | `python310Packages.teslajsonpy: 3.7.0 -> 3.7.1`                                                             |
| [`4c40f4d0`](https://github.com/NixOS/nixpkgs/commit/4c40f4d0bc40daa4eaf3b4fb79d38ac056df8cc3) | `aliyun-cli: 3.0.140 -> 3.0.141`                                                                            |
| [`8c4865a9`](https://github.com/NixOS/nixpkgs/commit/8c4865a95027b539124a40dc1b7f2969360d81a3) | `haskell-modules/configuration-ghc-*.nix: Remove trailing whitespaces`                                      |
| [`d8258b73`](https://github.com/NixOS/nixpkgs/commit/d8258b73c0454d2974ed2c5ebde57feb5774a707) | `python310Packages.whodap: 0.1.6 -> 0.1.7`                                                                  |
| [`59479a3b`](https://github.com/NixOS/nixpkgs/commit/59479a3b04d205f62c1ab74d5e69cfba287674a9) | `python310Packages.whodap: add changelog to meta`                                                           |
| [`ed9016bc`](https://github.com/NixOS/nixpkgs/commit/ed9016bc71d302e2c1bf6da3d2c5beddfa4f1258) | `git-machete: add changelog to meta`                                                                        |
| [`de24bca8`](https://github.com/NixOS/nixpkgs/commit/de24bca86c7562d698d7a275dd0e20b99007c136) | `release-haskell: Pick correct versions for hlint and hls`                                                  |
| [`3b14e60b`](https://github.com/NixOS/nixpkgs/commit/3b14e60bab118d7935c56e0173e6fecfb0544980) | `haskell-language-server: Fix build for 1.9.0.0 for all ghc versions`                                       |
| [`dea47fa2`](https://github.com/NixOS/nixpkgs/commit/dea47fa228a4befa22bdda738f6348dd8a41e22c) | `linkerd_edge: 22.8.2 -> 22.12.1`                                                                           |
| [`c45eae43`](https://github.com/NixOS/nixpkgs/commit/c45eae43341be47dccd741aa2423a47d009b52d9) | `workcraft: 3.3.8 -> 3.3.9`                                                                                 |
| [`1453e676`](https://github.com/NixOS/nixpkgs/commit/1453e6761a27d95235b3a235025a990f928e9241) | ``ventoy-bin: remove `inherit (libsForQt5)` reference on all-packages.nix``                                 |
| [`5d6f4517`](https://github.com/NixOS/nixpkgs/commit/5d6f45172279af8822d44a4d748de3e3704a770b) | `neovim: 0.8.1 -> 0.8.2`                                                                                    |
| [`7809ece5`](https://github.com/NixOS/nixpkgs/commit/7809ece5ff9fd3790c89eb4e81d95f5aee12f351) | `skaffold: 2.0.3 -> 2.0.4`                                                                                  |
| [`88592518`](https://github.com/NixOS/nixpkgs/commit/88592518cd41832461bc8e3a52463ae21395ae00) | `hackgen-font: 2.7.1 -> 2.8.0`                                                                              |
| [`9cd4748e`](https://github.com/NixOS/nixpkgs/commit/9cd4748eb0fdb5999cfaf693a4bf89e4b5aad98e) | `python310Packages.types-dateutil: 2.8.19.2 -> 2.8.19.5`                                                    |
| [`ae12bebc`](https://github.com/NixOS/nixpkgs/commit/ae12bebc29e204a214abbb1e82faa2ff9da06556) | `python310Packages.zodbpickle: 2.4 -> 2.6`                                                                  |
| [`e15dec73`](https://github.com/NixOS/nixpkgs/commit/e15dec73ce321dfe5e3538225b2770a23f52cb13) | `python310Packages.django_hijack: 3.2.5 -> 3.2.6`                                                           |
| [`3bc282be`](https://github.com/NixOS/nixpkgs/commit/3bc282bec23b595f1d5c84d983e861827132a489) | `python310Packages.python3-saml: add changelog to meta`                                                     |
| [`d20e592f`](https://github.com/NixOS/nixpkgs/commit/d20e592f361a246ad5b64be2f8d4efbc3bb37bb4) | `python310Packages.pybravia: 0.2.4 -> 0.2.5`                                                                |
| [`5d68e848`](https://github.com/NixOS/nixpkgs/commit/5d68e8482f840f0760c5408a3d3c4fac83dabf32) | `garage: mark 0.8 broken on Darwin`                                                                         |
| [`e6597c8a`](https://github.com/NixOS/nixpkgs/commit/e6597c8ac5dea22baa2151b1fc7cef861c89b875) | `garage: mark 0.7.3 as EOL`                                                                                 |
| [`1db2175e`](https://github.com/NixOS/nixpkgs/commit/1db2175e7ab291b64590076dcad16354bdf6a6e3) | `nixos/garage: provide multiple versions to provide an upgrade path when using NixOS service`               |
| [`4dab14dd`](https://github.com/NixOS/nixpkgs/commit/4dab14dd3879bb233d79a29aaee73742777cfc5d) | `txr: 280 -> 283`                                                                                           |
| [`6fd11aec`](https://github.com/NixOS/nixpkgs/commit/6fd11aec999cc694c7706be382140f06a29d396c) | `androidenv: Fix system image download url for default type`                                                |
| [`2f688374`](https://github.com/NixOS/nixpkgs/commit/2f688374e08cbab0985d6bc36870369dfe040bcb) | `androidenv: fix missing packages in repo json (#208137)`                                                   |
| [`eb32539c`](https://github.com/NixOS/nixpkgs/commit/eb32539c9618d6314e82c69a508467fa44d28126) | `mopidy-musicbox-webclient: Slightly refactor (#207749)`                                                    |
| [`e40216fa`](https://github.com/NixOS/nixpkgs/commit/e40216fa1b52ca3034c803de8279a66bb9311361) | `vivaldi: add wayland support and remove missing libGLES.so error`                                          |
| [`38602ad5`](https://github.com/NixOS/nixpkgs/commit/38602ad5c3a73b92069879d2b127b91f265679c6) | `makePkgconfigItem: fix cross`                                                                              |
| [`e2cb520d`](https://github.com/NixOS/nixpkgs/commit/e2cb520d80c612868252df917a1822e5c45a07ec) | `python310Packages.labelbox: 3.33.1 -> 3.34.0`                                                              |
| [`f3009dd5`](https://github.com/NixOS/nixpkgs/commit/f3009dd57d0011bfaf30fe6325a0befb6672ca65) | `python310Packages.python3-saml: 1.14.0 -> 1.15.0`                                                          |
| [`c876f0c1`](https://github.com/NixOS/nixpkgs/commit/c876f0c146e9279a48fc5b88dca3438a43772d27) | `nixos/test-driver: quote some shell command lines`                                                         |
| [`4c45c3f8`](https://github.com/NixOS/nixpkgs/commit/4c45c3f8f23ff12ea6939c3edd911bf7eadbc385) | `nixos/test-driver: use ASCII single quotes everywhere`                                                     |
| [`0c761f74`](https://github.com/NixOS/nixpkgs/commit/0c761f74f0f0abc7c4fec12a68956964a658d72d) | `haskell.compiler.ghcjs: allow building with transformers-compat-0.7`                                       |
| [`00ca0971`](https://github.com/NixOS/nixpkgs/commit/00ca09719cebe8c46e8c2ac0f2d2f1963df3e2ba) | `haskell.compiler.ghcjs: drop stale override for webdriver`                                                 |
| [`439841cc`](https://github.com/NixOS/nixpkgs/commit/439841cc15cdc76523115eca65a10429167ce46b) | `haskellPackages.multistate: allow hspec == 2.9.*`                                                          |
| [`4c365aa9`](https://github.com/NixOS/nixpkgs/commit/4c365aa9fc8823ec420cf8a5b4e4f892ec6d5c4a) | `nixos/cloudfared: fix options that are required having defaults`                                           |
| [`1cee5ecf`](https://github.com/NixOS/nixpkgs/commit/1cee5ecfebfa99b99fcbf43e2dc1432a2e81b908) | `nixos/cloudflared: fix invalid systemd unit description`                                                   |
| [`a345802e`](https://github.com/NixOS/nixpkgs/commit/a345802ee99ad3e82932a39a367878346c9c749b) | `qovery-cli: 0.47.2 -> 0.48.1`                                                                              |
| [`1652a667`](https://github.com/NixOS/nixpkgs/commit/1652a667a5fde99c12eecb0232dae9177c74a53f) | `git-machete: 3.13.0 -> 3.13.2`                                                                             |
| [`22257ed5`](https://github.com/NixOS/nixpkgs/commit/22257ed5bb5d9d9e8d553cda581fdef04da0041e) | `python310Packages.pybravia: 0.2.3 -> 0.2.4`                                                                |
| [`a3585c82`](https://github.com/NixOS/nixpkgs/commit/a3585c8234db18cbcc626fcded549f2f6fc402e0) | `pythpn310Packages.pybravia: add changelog to meta`                                                         |
| [`01273fa9`](https://github.com/NixOS/nixpkgs/commit/01273fa9759bf36b99ee79ce50a212de7883958c) | `python310Packages.lightwave2: 0.8.17 -> 0.8.18`                                                            |
| [`4e760ddf`](https://github.com/NixOS/nixpkgs/commit/4e760ddf8c5db5b389de0cf79ed661c6f5b855ed) | `python310Packages.pyskyqremote: 0.3.22 -> 0.3.23`                                                          |
| [`a8bb3404`](https://github.com/NixOS/nixpkgs/commit/a8bb3404ec561bd63ebb34a9f7c7eb6d56e149fd) | `wslu: add changelog to meta`                                                                               |
| [`c788d138`](https://github.com/NixOS/nixpkgs/commit/c788d138f03050d751da884f752e58799384fbe9) | `pip-audit: 2.4.11 -> 2.4.12`                                                                               |
| [`fdae2bf6`](https://github.com/NixOS/nixpkgs/commit/fdae2bf6df1544be8bab2b336928407f225f03d9) | `mkgmap-splitter: 652 -> 653`                                                                               |
| [`f92ee1a5`](https://github.com/NixOS/nixpkgs/commit/f92ee1a512241509786b2467093d3d3216278b6d) | `john: unbreak on aarch64-darwin`                                                                           |
| [`60facffa`](https://github.com/NixOS/nixpkgs/commit/60facffaa9e20d6f5355fb6e12471cb748289bad) | `mtdutils: 2.1.4 -> 2.1.5`                                                                                  |
| [`d969909f`](https://github.com/NixOS/nixpkgs/commit/d969909f3f1a8af3c85d0daa8704199ad789617e) | `python310Packages.azure-mgmt-containerservice: add changelog to meta`                                      |
| [`ebe0608a`](https://github.com/NixOS/nixpkgs/commit/ebe0608ada392a4c7fa2762b0995e80891350eb7) | `nixos/openconnect: fix null cases for user and passwordFile options`                                       |
| [`dd6e0ab1`](https://github.com/NixOS/nixpkgs/commit/dd6e0ab1cff3e5e7f441c6699b42014b7865f09b) | `seabios: 1.16.0 -> 1.16.1`                                                                                 |
| [`f2ad82a0`](https://github.com/NixOS/nixpkgs/commit/f2ad82a06893c360fbbe016259a97853979be094) | `logseq: add changelog to meta`                                                                             |
| [`21e5373d`](https://github.com/NixOS/nixpkgs/commit/21e5373d9efeb1a4ea4ae1b6a7e87d50da530a63) | `logseq: 0.8.12 -> 0.8.15`                                                                                  |
| [`b490729b`](https://github.com/NixOS/nixpkgs/commit/b490729bb707e1cb75a684b8374f04e531919e07) | `gf2x: fix cross compilation`                                                                               |
| [`0f475e3c`](https://github.com/NixOS/nixpkgs/commit/0f475e3c0454be63d019f10ca0a7c39bea24eb1a) | `mpir: fix cross compilation`                                                                               |
| [`58faa444`](https://github.com/NixOS/nixpkgs/commit/58faa444c8f4ac0e55ccc7a57020977c85354d5b) | `uncrustify: 0.75.1 -> 0.76.0`                                                                              |
| [`e74582c9`](https://github.com/NixOS/nixpkgs/commit/e74582c9ffeabe2284a95938463c40286ff2cc2c) | `fzf: minor code tweaks (#208323)`                                                                          |
| [`aaf6118f`](https://github.com/NixOS/nixpkgs/commit/aaf6118fd5bd217d1d5aa7dad1fc37186bd22685) | `haskell-language-server: Fix build for 1.9.0.0`                                                            |
| [`899dbfd5`](https://github.com/NixOS/nixpkgs/commit/899dbfd561e3111d217896e63cf43b1a6563e02f) | `python310Packages.azure-mgmt-containerservice: 21.0.0 -> 21.1.0`                                           |
| [`7a997882`](https://github.com/NixOS/nixpkgs/commit/7a997882e0fdfdca9dbfc51f379c010902b8ffa6) | `python310Packages.pyarrow: disable failing test`                                                           |
| [`e3134c81`](https://github.com/NixOS/nixpkgs/commit/e3134c81808be1f9d8696539c2ce43a3b007153d) | `haskellPackages.graphql: remove no-longer-needed override`                                                 |
| [`e363dcd8`](https://github.com/NixOS/nixpkgs/commit/e363dcd8092de606201c285f3ced18e79a527e74) | `terraform-providers.tencentcloud: 1.79.2 → 1.79.3`                                                         |
| [`221f18ed`](https://github.com/NixOS/nixpkgs/commit/221f18edf8a5278dbfac2f74cdb189db5a7bbdb9) | `terraform-providers.gandi: 2.2.1 → 2.2.2`                                                                  |
| [`e82448e2`](https://github.com/NixOS/nixpkgs/commit/e82448e2384ccfc673ef117142e4ec29869cf8c4) | `terraform-providers.baiducloud: 1.18.4 → 1.19.0`                                                           |
| [`ee23ba6e`](https://github.com/NixOS/nixpkgs/commit/ee23ba6ea0594136359873eadab0e07a1ea4ef25) | `nomino: 1.3.0 -> 1.3.1`                                                                                    |
| [`0462f184`](https://github.com/NixOS/nixpkgs/commit/0462f1847dd34b9113747ff00531f62414bfa157) | `ruff: 0.0.200 -> 0.0.201`                                                                                  |