### PR TITLE
chore(flake/nur): `7fa53a6a` -> `bafe7986`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672711079,
-        "narHash": "sha256-U72I1vNRRjGRrnLJpimWXargJcb2q8vcKoYMPRyTOA8=",
+        "lastModified": 1672715992,
+        "narHash": "sha256-FoaXdw/Rq9iC3EgHYquNkbTgG2aAwg9a14GRm9phgTA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7fa53a6ace7735e46383ebe0f3f50daf3927ab65",
+        "rev": "bafe7986d53a5905be03df22112d01fcc3626aa5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`bafe7986`](https://github.com/nix-community/NUR/commit/bafe7986d53a5905be03df22112d01fcc3626aa5) | `automatic update` |