### PR TITLE
chore(flake/nur): `bafe7986` -> `12ca56e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672715992,
-        "narHash": "sha256-FoaXdw/Rq9iC3EgHYquNkbTgG2aAwg9a14GRm9phgTA=",
+        "lastModified": 1672717483,
+        "narHash": "sha256-orWkZLsRwDVE3HB9N7sO638FyGeqW9I4uokAIR/NsU0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bafe7986d53a5905be03df22112d01fcc3626aa5",
+        "rev": "12ca56e3e280839227a62cdb2b745f3631f09a4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`12ca56e3`](https://github.com/nix-community/NUR/commit/12ca56e3e280839227a62cdb2b745f3631f09a4f) | `automatic update` |
| [`b13ced84`](https://github.com/nix-community/NUR/commit/b13ced8435359c0d24372620db3b4d36d98acd7f) | `automatic update` |