### PR TITLE
chore(flake/nur): `12ca56e3` -> `77f1ece7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672717483,
-        "narHash": "sha256-orWkZLsRwDVE3HB9N7sO638FyGeqW9I4uokAIR/NsU0=",
+        "lastModified": 1672721161,
+        "narHash": "sha256-qDL0JpnB9SEo6vYvOrPTdFHKC4fbz0iexm2DI4EKbT0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "12ca56e3e280839227a62cdb2b745f3631f09a4f",
+        "rev": "77f1ece76aa502e39dab819432dd24d1b235e831",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`77f1ece7`](https://github.com/nix-community/NUR/commit/77f1ece76aa502e39dab819432dd24d1b235e831) | `automatic update` |