### PR TITLE
chore(flake/nur): `77f1ece7` -> `c545aad9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672721161,
-        "narHash": "sha256-qDL0JpnB9SEo6vYvOrPTdFHKC4fbz0iexm2DI4EKbT0=",
+        "lastModified": 1672723642,
+        "narHash": "sha256-XjWY81QR1odpAJ73WNygJswT9aG8RKsNEARD2Eb4VOc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "77f1ece76aa502e39dab819432dd24d1b235e831",
+        "rev": "c545aad9a843627d188d5c7f3329576c8111adfa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c545aad9`](https://github.com/nix-community/NUR/commit/c545aad9a843627d188d5c7f3329576c8111adfa) | `automatic update` |
| [`a4c8f56a`](https://github.com/nix-community/NUR/commit/a4c8f56aef1b8e42959b85a43ee5ce117b68fed6) | `automatic update` |