### PR TITLE
chore(flake/pre-commit-hooks): `2d947ef0` -> `d0ce0a86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -491,11 +491,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1672659856,
-        "narHash": "sha256-9vJvy5O87WyIYZGzFaHMeRTishV0SNDeSewvnyRCrMI=",
+        "lastModified": 1672734157,
+        "narHash": "sha256-uwUBnv0bN1SO4QVIo8KUx/jxRYCy7cW8kzZa+Qsrw9k=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "2d947ef03b7cba461aab65a5df1ede03be567068",
+        "rev": "d0ce0a861260493c6c21f16f59d25076f73cb931",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                          |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------- |
| [`9e8d1738`](https://github.com/cachix/pre-commit-hooks.nix/commit/9e8d17382dae1bcf68f4cf3ad08fbd04048e87d3) | `Allow to configure path to Cargo.toml` |