### PR TITLE
chore(flake/emacs-overlay): `178e41eb` -> `0505d6fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672717097,
-        "narHash": "sha256-8Z5wBf0/4JIFh1CwxFtMxFgzV/0m6sPeIQl3bH/v7dg=",
+        "lastModified": 1672740976,
+        "narHash": "sha256-r+th+iHy+nwnxH0OjyZynjA+3yP1m1yH7e6QLFFYw8Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "178e41ebc708a2f11d9a87d54d519d24ab9a69ca",
+        "rev": "0505d6fa58724b02898c3ca2b7373dcf699ae3b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`0505d6fa`](https://github.com/nix-community/emacs-overlay/commit/0505d6fa58724b02898c3ca2b7373dcf699ae3b5) | `Updated repos/melpa` |
| [`88a4109e`](https://github.com/nix-community/emacs-overlay/commit/88a4109e9aa231f843284df8bc9913a754552a0b) | `Updated repos/emacs` |