### PR TITLE
chore(flake/nur): `b3f14ad8` -> `013b0500`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672735525,
-        "narHash": "sha256-w7wAs+ffjNd7KumTbCol2CYrE3LKk0NViQrCuTpIcCs=",
+        "lastModified": 1672746354,
+        "narHash": "sha256-hlL1WZwUEE9xvuZvBS39HfLz6tvwKjxI4sQnZuH39Ns=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b3f14ad882413dd6d34886af7abe693f03e90afa",
+        "rev": "013b0500c1dc33bf57de073d2915cc5e07c9e2d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`013b0500`](https://github.com/nix-community/NUR/commit/013b0500c1dc33bf57de073d2915cc5e07c9e2d9) | `automatic update` |