### PR TITLE
chore(flake/nur): `013b0500` -> `850aa776`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672746354,
-        "narHash": "sha256-hlL1WZwUEE9xvuZvBS39HfLz6tvwKjxI4sQnZuH39Ns=",
+        "lastModified": 1672751104,
+        "narHash": "sha256-eEND+UA8d/VqgbacflfJ2bJX8X3OBknBMk6QELbMdkU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "013b0500c1dc33bf57de073d2915cc5e07c9e2d9",
+        "rev": "850aa776e7e4bad4edf23e4460554007b8c7c87a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`850aa776`](https://github.com/nix-community/NUR/commit/850aa776e7e4bad4edf23e4460554007b8c7c87a) | `automatic update` |