### PR TITLE
chore(flake/nur): `850aa776` -> `872c3a68`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672751104,
-        "narHash": "sha256-eEND+UA8d/VqgbacflfJ2bJX8X3OBknBMk6QELbMdkU=",
+        "lastModified": 1672757186,
+        "narHash": "sha256-l7QzvRs7mkXGHF+f/LxS2pBvWXM1dFycKvX3fbCaEWQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "850aa776e7e4bad4edf23e4460554007b8c7c87a",
+        "rev": "872c3a6859cce739e7ec56d7102d19845516e005",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`872c3a68`](https://github.com/nix-community/NUR/commit/872c3a6859cce739e7ec56d7102d19845516e005) | `automatic update` |