### PR TITLE
chore(flake/nur): `872c3a68` -> `44ca5138`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672757186,
-        "narHash": "sha256-l7QzvRs7mkXGHF+f/LxS2pBvWXM1dFycKvX3fbCaEWQ=",
+        "lastModified": 1672758704,
+        "narHash": "sha256-E7ekSOOG4XrgSNCiZKjm/UM7sL26GB3W199JeLSwHCU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "872c3a6859cce739e7ec56d7102d19845516e005",
+        "rev": "44ca5138be803a2ec9735a0026fe8917b7e27483",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message            |
| -------------------------------------------------------------------------------------------------- | ------------------------- |
| [`44ca5138`](https://github.com/nix-community/NUR/commit/44ca5138be803a2ec9735a0026fe8917b7e27483) | `automatic update`        |
| [`7744cbd4`](https://github.com/nix-community/NUR/commit/7744cbd4a57af9b90532645fc228c728c1d4500e) | `Add berryp/nur-packages` |
| [`f126ec7e`](https://github.com/nix-community/NUR/commit/f126ec7ee2c4d445d5de1fe05744c0f6d3b50561) | `increase timeout to 15s` |