### PR TITLE
chore(flake/nur): `7f1f8cc5` -> `79f84fb6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672760777,
-        "narHash": "sha256-4mVaKRR0/FzxF7uxaDIX/qs88tiwP6bjwgpEH50yCM0=",
+        "lastModified": 1672768069,
+        "narHash": "sha256-vodnquhOQ1aZHl+hNbhDTsGnh8ZKp+RHQ2vDl9wx7ko=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7f1f8cc5180639d294966b6fe2faac449bff3457",
+        "rev": "79f84fb68b67b2ffb8defca9a18e07bae32dc8e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`79f84fb6`](https://github.com/nix-community/NUR/commit/79f84fb68b67b2ffb8defca9a18e07bae32dc8e0) | `automatic update` |