### PR TITLE
chore(flake/emacs-overlay): `0505d6fa` -> `1a5a0d89`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672740976,
-        "narHash": "sha256-r+th+iHy+nwnxH0OjyZynjA+3yP1m1yH7e6QLFFYw8Y=",
+        "lastModified": 1672769487,
+        "narHash": "sha256-WD7RIDdFq5eO8JOb7L60fj/km/9Oee1+sqls/rJgawo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0505d6fa58724b02898c3ca2b7373dcf699ae3b5",
+        "rev": "1a5a0d8953242f28f66662285c7f7dab3d21d2ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`1a5a0d89`](https://github.com/nix-community/emacs-overlay/commit/1a5a0d8953242f28f66662285c7f7dab3d21d2ea) | `Updated repos/melpa` |
| [`e630ba3d`](https://github.com/nix-community/emacs-overlay/commit/e630ba3d2b79c4ab825b8c1beaa6362a31d4471b) | `Updated repos/emacs` |
| [`acee13c2`](https://github.com/nix-community/emacs-overlay/commit/acee13c2f8f5cb113d42925ca2cc91ff40e5f2af) | `Updated repos/elpa`  |