### PR TITLE
chore(flake/nixpkgs): `8ba56d7c` -> `0fc9fca9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672525397,
-        "narHash": "sha256-WASDnyxHKWVrEe0dIzkpH+jzKlCKAk0husv0f/9pyxg=",
+        "lastModified": 1672617983,
+        "narHash": "sha256-68WDiCBs631mbDDk4UAKdGURKcsfW6hjb7wgudTAe5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8ba56d7c0d7490680f2d51ba46a141eca7c46afa",
+        "rev": "0fc9fca9c8d43edd79d33fea0dd8409d7c4580f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                    |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`4d80df27`](https://github.com/NixOS/nixpkgs/commit/4d80df27c21b7f4e62f3f8d19f2ea660d85e6998) | `maintainers: update wesleyjrz email`                                             |
| [`f534a05a`](https://github.com/NixOS/nixpkgs/commit/f534a05aba33a533dfe6b071905d690a8aa707c3) | `age: 1.0.0 -> 1.1.1`                                                             |
| [`89a9ff18`](https://github.com/NixOS/nixpkgs/commit/89a9ff18f14970a8f4138fb6e7874e8a49d08840) | `nanosaur,nanosaur2,otto-matic: cleanup cmake build`                              |
| [`d6748dce`](https://github.com/NixOS/nixpkgs/commit/d6748dcee7e397c0f5ea2e8c1ffcac9078ea69df) | `vimPlugins.vim-mediawiki-editor: init at 2022-10-29`                             |
| [`79010d72`](https://github.com/NixOS/nixpkgs/commit/79010d72b95adac0969e3a084095d38ff4b4af76) | `vimPlugins: update`                                                              |
| [`af62c860`](https://github.com/NixOS/nixpkgs/commit/af62c860ec78e9c211f97ae6c48f7efb306402f0) | `ocamlPackages.imagelib: 20210511 → 20221222`                                     |
| [`108b7093`](https://github.com/NixOS/nixpkgs/commit/108b709361eea88dc90b319841b4350b1e0fded8) | `nurl: 0.2.1 -> 0.2.2`                                                            |
| [`c8104628`](https://github.com/NixOS/nixpkgs/commit/c8104628f4057f2b1842f6e31eaff2fe1d0eeda7) | `nixos/tests/installer/bcachefs: use ocr to type in password`                     |
| [`13b0e422`](https://github.com/NixOS/nixpkgs/commit/13b0e42202fa3919d551e2e130098c2b14e4b745) | `nixos/tests/installer: disable zfs for bcachefs tests`                           |
| [`dda48a50`](https://github.com/NixOS/nixpkgs/commit/dda48a504471e79b25d65491e1dcbeaf8e5609f5) | `linux_testing_bcachefs: 2022-10-31 -> 2022-12-29`                                |
| [`5d986f42`](https://github.com/NixOS/nixpkgs/commit/5d986f42d96981402a1e23d31bbce4f11e9db3c3) | `bcachefs-tools: unstable-2022-09-28 -> unstable-2022-12-29`                      |
| [`655e0725`](https://github.com/NixOS/nixpkgs/commit/655e07253340c2fcc2dbbd894f12362dc7950800) | `nixos/bcachefs: fix boot with systemd enabled initrd`                            |
| [`1e6cf6f3`](https://github.com/NixOS/nixpkgs/commit/1e6cf6f3dc967dbf1f20a5a7f3515dcaa316c22d) | `bcachefs-tools: add symlink for mount.bcachefs and fix runtime deps`             |
| [`40faf3f2`](https://github.com/NixOS/nixpkgs/commit/40faf3f2d457bbec2ed0d1780b1542233b469875) | `vimPlugins.nvim-treesitter: update grammars`                                     |
| [`5f7e5eca`](https://github.com/NixOS/nixpkgs/commit/5f7e5ecac6073330775e63848066b7c59811a4b3) | `vimPlugins.mediawiki-vim: init at 2015-11-15`                                    |
| [`2068a9fe`](https://github.com/NixOS/nixpkgs/commit/2068a9fee3544412bd73d00a877588ce831600d2) | `vimPlugins: update`                                                              |
| [`0e9fae2a`](https://github.com/NixOS/nixpkgs/commit/0e9fae2a3d7403e1f13aec610846b9d1d3f4928f) | `nil: 2022-12-01 -> 2023-01-01`                                                   |
| [`e6221703`](https://github.com/NixOS/nixpkgs/commit/e6221703364a62dc078c439af179bd70445ede46) | `wiki-tui: add changelog to meta`                                                 |
| [`c9ca13ce`](https://github.com/NixOS/nixpkgs/commit/c9ca13ce9abb2f872c1a24f49fcc027343146a98) | `chromium: Drop passthru.updateScript`                                            |
| [`b7431c54`](https://github.com/NixOS/nixpkgs/commit/b7431c54ac3181d602137f677ac89deca5d93ab9) | `chromiumDev: 110.0.5464.2 -> 110.0.5478.4`                                       |
| [`3a68bc8b`](https://github.com/NixOS/nixpkgs/commit/3a68bc8b9e92f303691df830b371e3af2b2641b2) | `wiki-tui: 0.6.0 -> 0.6.1`                                                        |
| [`26969c3a`](https://github.com/NixOS/nixpkgs/commit/26969c3a819dd44cd15812fb50af8127ce15675a) | `pkgsStatic.lm_sensors: fix build`                                                |
| [`6a31f1b3`](https://github.com/NixOS/nixpkgs/commit/6a31f1b36c468e81eb23a60619b63308642594a1) | `python3Packages.django-scim2: init at 0.17.3`                                    |
| [`4c24f626`](https://github.com/NixOS/nixpkgs/commit/4c24f62648ae848e7d14d3e6ddfc41daff3550d0) | `python3Packages.scim2-filter-parser: init at 0.4.0`                              |
| [`bd000ffb`](https://github.com/NixOS/nixpkgs/commit/bd000ffb9dec2933a59a8a9563b7d172441de07b) | `svg2pdf: 0.4.0 -> 0.4.1`                                                         |
| [`5a485131`](https://github.com/NixOS/nixpkgs/commit/5a485131fce1c7ab42cc43c3ae8ff8600c710883) | `sleuthkit: add changelog to meta`                                                |
| [`545e4f33`](https://github.com/NixOS/nixpkgs/commit/545e4f3375b04313b5f280ce4daf0a5e83d9c2ee) | `python310Packages.pdf2image: add changelog to meta`                              |
| [`809a6c15`](https://github.com/NixOS/nixpkgs/commit/809a6c151e57c48a003e02cff9a1fa0480c04846) | `python39Packages.schema-salad: add changelog to meta`                            |
| [`192f8444`](https://github.com/NixOS/nixpkgs/commit/192f844477576976f737fad3ace1c9d555d360b9) | `lib/trival: Bump oldestSupportedRelease to 2211`                                 |
| [`50281bc4`](https://github.com/NixOS/nixpkgs/commit/50281bc4c399f9b8b99e11beb3901031b0c3e7bb) | `python310Packages.beancount-parser: add changelog to emta`                       |
| [`4e6337bd`](https://github.com/NixOS/nixpkgs/commit/4e6337bdce10d6912ae031747fdce493399ea5a4) | `workflows/periodic-merge: Remove 22.05 jobs`                                     |
| [`13d44488`](https://github.com/NixOS/nixpkgs/commit/13d44488ec55a536934d05632ce20732e9ffdf9e) | `python310Packages.hcloud: add changelog to meta`                                 |
| [`91e936ef`](https://github.com/NixOS/nixpkgs/commit/91e936ef2e5cf4268b2c2a8cf432fedb95ff04e2) | `pwntools: 4.8.0 -> 4.9.0`                                                        |
| [`4af22aab`](https://github.com/NixOS/nixpkgs/commit/4af22aab8e239b1ca28da851755c6da1a35fc91b) | `stdenv/check-meta: do deep type checks`                                          |
| [`4df10deb`](https://github.com/NixOS/nixpkgs/commit/4df10debe79feba975631347b25f8699b7cd3554) | `lib/customisation.overrideDerivation: propagate evaluation condition`            |
| [`2c83122c`](https://github.com/NixOS/nixpkgs/commit/2c83122c1877b20728c8ae97faddbf2166f105cb) | ``treewide: fix broken `meta` attributes``                                        |
| [`7e7a2856`](https://github.com/NixOS/nixpkgs/commit/7e7a2856a2527b53edb0adedf1e4849568708e2e) | `python310Packages.pysmbc: add missing input`                                     |
| [`acee6744`](https://github.com/NixOS/nixpkgs/commit/acee67447e13badbe75a796b0fa7a5040028d9dc) | `python310Packages.pysmbc: disable on unsupported Python releases`                |
| [`faf1736d`](https://github.com/NixOS/nixpkgs/commit/faf1736dc409d24016968dd5f7763fa8292ce88f) | `COPYING: 2022 -> 2023`                                                           |
| [`8c94b289`](https://github.com/NixOS/nixpkgs/commit/8c94b2899674790edf724fe2991b375aa94909e1) | `ares: fix build on darwin`                                                       |
| [`cd3f5375`](https://github.com/NixOS/nixpkgs/commit/cd3f53759d2a4fd72d3c620b1e1764fe27aef98c) | `python310Packages.pysmbc: 1.0.23 -> 1.0.24`                                      |
| [`1ca08d4c`](https://github.com/NixOS/nixpkgs/commit/1ca08d4c638a89f2c82bec993f9ca4893faf3241) | `treesheets: unstable-2022-12-13 -> unstable-2022-12-30`                          |
| [`7e159b1a`](https://github.com/NixOS/nixpkgs/commit/7e159b1a6745f4d00f77aed23f007e134b0e9fb8) | `nixos/cloudflared: systemd dependency fix`                                       |
| [`3296813f`](https://github.com/NixOS/nixpkgs/commit/3296813f01a3464420f716c829d96ed5303ebf71) | `python310Packages.pdf2image: 1.16.0 -> 1.16.2`                                   |
| [`7cead1ff`](https://github.com/NixOS/nixpkgs/commit/7cead1ff76606c66fb9e2108a66b21adede23b44) | `sleuthkit: 4.11.1 -> 4.12.0`                                                     |
| [`a52297f2`](https://github.com/NixOS/nixpkgs/commit/a52297f256151c9a1334f77eee804b4829378f1b) | `moar: 1.11.1 -> 1.11.2`                                                          |
| [`90bd77b1`](https://github.com/NixOS/nixpkgs/commit/90bd77b1df27a238b2d8f862197d26b683d665c9) | `python310Packages.hcloud: 1.18.1 -> 1.18.2`                                      |
| [`ee8eebcb`](https://github.com/NixOS/nixpkgs/commit/ee8eebcbe4e0a0f7f5b03e1432b53b09f9632355) | `python310Packages.beancount-parser: 0.1.21 -> 0.1.23`                            |
| [`cbd1dc1e`](https://github.com/NixOS/nixpkgs/commit/cbd1dc1e725c4661c0ee556b8339b3c50d8a934c) | `nixos-rebuild: Treat any build/target host as non-local`                         |
| [`49647234`](https://github.com/NixOS/nixpkgs/commit/49647234f03b3c5d7b5eeefb534bfe61ceb1c74e) | `python39Packages.schema-salad: 8.3.20220913105718 -> 8.3.20221209165047`         |
| [`5be120ba`](https://github.com/NixOS/nixpkgs/commit/5be120bac3d30631cd903010b20fbc80a5d81eba) | `kubernetes-controller-tools: 0.10.0 -> 0.11.1`                                   |
| [`1c9d76c9`](https://github.com/NixOS/nixpkgs/commit/1c9d76c9a185d4248a00c6b831e647d7525258fc) | `benthos: 4.9.0 -> 4.11.0`                                                        |
| [`2724b570`](https://github.com/NixOS/nixpkgs/commit/2724b570b366f9fd43c7e8fca359a7ee51df7431) | `metabase: 0.44.5 -> 0.45.1`                                                      |
| [`aab1077f`](https://github.com/NixOS/nixpkgs/commit/aab1077f0e9cd077decf65309e11e7c2725bf566) | `goresym: 2.0 -> 2.1`                                                             |
| [`3d0cfa23`](https://github.com/NixOS/nixpkgs/commit/3d0cfa23e940addb4bdc01ac854b283a4286450b) | `sentry-cli: 2.10.0 -> 2.11.0`                                                    |
| [`644d7f10`](https://github.com/NixOS/nixpkgs/commit/644d7f100dd144263ec46cb8e8d1192af9cee5f9) | `libsolv: Build without RPM dependency on darwin (#205811)`                       |
| [`f294a276`](https://github.com/NixOS/nixpkgs/commit/f294a27605f3d2680c12848cf97b67df1d3f5fc0) | `ssh-to-age: 1.0.3 -> 1.1.0`                                                      |
| [`9713f75f`](https://github.com/NixOS/nixpkgs/commit/9713f75ffa0caf133adc27a91f1dba833c87c5fe) | `snappymail: 2.24.1 -> 2.24.3`                                                    |
| [`fad9d559`](https://github.com/NixOS/nixpkgs/commit/fad9d559a3d2a5ed34a1cb841e3d4bc5f7081ae5) | `nurl: 0.1.1 -> 0.2.1`                                                            |
| [`e0088016`](https://github.com/NixOS/nixpkgs/commit/e00880169fe1ff27eedcf38b5d94cfe708915743) | `vitess: 15.0.1 -> 15.0.2`                                                        |
| [`82319d48`](https://github.com/NixOS/nixpkgs/commit/82319d48dbcbba3648b153842e3119d9fcbf523a) | `whois: 5.5.14 -> 5.5.15`                                                         |
| [`69c69246`](https://github.com/NixOS/nixpkgs/commit/69c692467cb4ff3257302f75743aeaa97f13e674) | `flashrom: 1.2 -> 1.2.1`                                                          |
| [`ac949b88`](https://github.com/NixOS/nixpkgs/commit/ac949b889280f7258021d7af4e08d619bd7686a8) | `clhep: 2.4.6.2 -> 2.4.6.3`                                                       |
| [`51b1d853`](https://github.com/NixOS/nixpkgs/commit/51b1d853951e21200ec6ed5d7dd969cbaf25c0bc) | `tflint: 0.43.0 -> 0.44.1`                                                        |
| [`1d63f8c0`](https://github.com/NixOS/nixpkgs/commit/1d63f8c009883643630ef9f3a7986fae721ab201) | `litefs: 0.2.0 -> 0.3.0`                                                          |
| [`7741826a`](https://github.com/NixOS/nixpkgs/commit/7741826a4354d428bd9aac2ba9577794607d04e8) | `tippecanoe: 2.16.0 -> 2.17.0`                                                    |
| [`b75e7815`](https://github.com/NixOS/nixpkgs/commit/b75e7815790b383fccdfca4ba703b16cd0467cf3) | `furnace: 0.6pre2 -> 0.6pre3`                                                     |
| [`1b17afc8`](https://github.com/NixOS/nixpkgs/commit/1b17afc853d46a9868653110a75591d2e24a0445) | `star-history: 1.0.7 -> 1.0.8`                                                    |
| [`bab5a9ca`](https://github.com/NixOS/nixpkgs/commit/bab5a9ca87e0fbbb8a44378ca12b678655273848) | `xnec2c: init at 4.4.12`                                                          |
| [`ddcaff2d`](https://github.com/NixOS/nixpkgs/commit/ddcaff2da59cf9a1d2a55084af0e4bc05f1c8392) | `ruff: 0.0.204 -> 0.0.205`                                                        |
| [`56c5f3ce`](https://github.com/NixOS/nixpkgs/commit/56c5f3ceeca796382de879dbebc686cbf818c561) | `ruff: 0.0.203 -> 0.0.204`                                                        |
| [`7d6754a3`](https://github.com/NixOS/nixpkgs/commit/7d6754a309f60e82a26c5ad4408fd57a5c5e44f9) | `python39Packages.types-redis: 4.3.21.6 -> 4.3.21.7`                              |
| [`e85943f3`](https://github.com/NixOS/nixpkgs/commit/e85943f32e72a94fe88bdaaa9801fa56eed53c22) | `prometheus-xmpp-alerts: Fix broken binary`                                       |
| [`6fdbfe5a`](https://github.com/NixOS/nixpkgs/commit/6fdbfe5abe0e53f54631a489f4b927579d4a7d5c) | `eartag: 0.2.1 -> 0.3.1`                                                          |
| [`e2d79ecb`](https://github.com/NixOS/nixpkgs/commit/e2d79ecb3077db28812b2b8c41dc79ae954f6a07) | `cargo-tally: 1.0.20 -> 1.0.21`                                                   |
| [`f8f42c1f`](https://github.com/NixOS/nixpkgs/commit/f8f42c1f05cb0f65486c30291c25bad4dd3d5f33) | `ArchiSteamFarm: 5.3.2.4 -> 5.4.0.3, fix update script (again), little cleanups`  |
| [`cb98e26a`](https://github.com/NixOS/nixpkgs/commit/cb98e26aaff781ed48a1885e7a6423708fb564b8) | `lib: Add isStringLike`                                                           |
| [`d1038111`](https://github.com/NixOS/nixpkgs/commit/d103811173b7b608b2639af61d422736bf715a8e) | `lib.isStringLike: Remove use of list`                                            |
| [`d0d0f7d0`](https://github.com/NixOS/nixpkgs/commit/d0d0f7d0aaf1ea29f6fe269340186de12d697dea) | `lib: Add isPath`                                                                 |
| [`23c25d52`](https://github.com/NixOS/nixpkgs/commit/23c25d5231856e8cfd60049582c865da97bc5d44) | `lib.strings.isConvertibleWithToString: Refactor to reuse isStringLike`           |
| [`834f0d66`](https://github.com/NixOS/nixpkgs/commit/834f0d660a79e8f08c108237d76fc1b42024289b) | `lib.strings: isMoreCoercibleString -> isConvertibleWithToString`                 |
| [`872a24eb`](https://github.com/NixOS/nixpkgs/commit/872a24ebbc8056142f7930cc0f775237c4ca83f7) | `lib.strings: isSimpleCoercibleString -> isStringLike`                            |
| [`5b8de3d9`](https://github.com/NixOS/nixpkgs/commit/5b8de3d9d85c121fd027608fe0c049356c6eea30) | `nixos/self-deploy: Cleanup after types.path is not allowed to be a list anymore` |
| [`29efb2c4`](https://github.com/NixOS/nixpkgs/commit/29efb2c438ba2dd04d545c67a22d1e64576de9f4) | `lib.types.path: Do not allow lists of strings`                                   |
| [`fed5dc66`](https://github.com/NixOS/nixpkgs/commit/fed5dc66f80ae3a159a2449904ae067f60a04a67) | `treewide: isCoercibleToString -> isMoreCoercibleToString`                        |
| [`68b6443e`](https://github.com/NixOS/nixpkgs/commit/68b6443ed635a3e87a62a5a8dcfd05e952c93192) | `lib.strings: Rename isCoercibleToString -> isMoreCoercibleToString`              |
| [`3a4c9bdb`](https://github.com/NixOS/nixpkgs/commit/3a4c9bdbe619ed235aab005c5f162879c2ed6039) | `lib.types.anything: Use isSimpleCoercibleToString`                               |
| [`03063f65`](https://github.com/NixOS/nixpkgs/commit/03063f65a5d58fc0a72648d475101d86752725ba) | `lib.strings.toShellVar: Use isSimpleCoercibleString`                             |
| [`2b4a8db0`](https://github.com/NixOS/nixpkgs/commit/2b4a8db032643ae61a3b05c24d121e124e0f8414) | `lib.strings.isStorePath: Use isSimpleCoercibleToString`                          |
| [`67cfc7a8`](https://github.com/NixOS/nixpkgs/commit/67cfc7a8f68776cbd7cf73e3c79b4cdd3ea102c4) | `lib.strings: Add isSimpleCoercibleToString`                                      |
| [`a017cc79`](https://github.com/NixOS/nixpkgs/commit/a017cc7980592157f17bf77902c8be13f30182ec) | `pods: 1.0.0-rc.3 -> 1.0.1`                                                       |
| [`79e3c9f6`](https://github.com/NixOS/nixpkgs/commit/79e3c9f6157b70eb3f900d95ae2e249c07796032) | `cargo-tally: 1.0.19 -> 1.0.20`                                                   |
| [`412d4ebd`](https://github.com/NixOS/nixpkgs/commit/412d4ebdc427862cea812b7c0330cb50b74864a2) | `ruff: 0.0.201 -> 0.0.203`                                                        |
| [`27e22f63`](https://github.com/NixOS/nixpkgs/commit/27e22f63403d58c00c71c4e5e64541924c57a64f) | `mattermost: 7.5.1 -> 7.5.2`                                                      |
| [`c3993b8d`](https://github.com/NixOS/nixpkgs/commit/c3993b8d2d075ae6404e17fad549da77905268c9) | `lemmy-help: 0.10.0 -> 0.11.0`                                                    |
| [`d0b531b5`](https://github.com/NixOS/nixpkgs/commit/d0b531b5743f60cfeae75d55b1dffd62e97c0714) | `ArchiSteamFarm: build asf as single file, build plugins`                         |
| [`22ea90a4`](https://github.com/NixOS/nixpkgs/commit/22ea90a4d87b33101a72c2eff633472fb2e59171) | `.editorconfig: apply trailing whitespace removal`                                |
| [`e9804781`](https://github.com/NixOS/nixpkgs/commit/e98047818ecfa327aebc82733fd96800b0d344cb) | `.editorconfig: disallow trailing whitespace for markdown again`                  |
| [`518bede4`](https://github.com/NixOS/nixpkgs/commit/518bede442e8be0fc668811d84c7a6df78e5f4ce) | `xorg:xhost: 1.0.8 -> 1.0.9`                                                      |
| [`138d4389`](https://github.com/NixOS/nixpkgs/commit/138d4389cc1e2e22637ced70cf3a45c3eaa4f8f7) | ``wireguard-tools: move `iptables` to PATH suffix``                               |
| [`c4bd20a6`](https://github.com/NixOS/nixpkgs/commit/c4bd20a68602c22ef8a872c7c14ad69c13d4f503) | `nixos/wg-quick: add nftables test`                                               |
| [`dc1e00bd`](https://github.com/NixOS/nixpkgs/commit/dc1e00bd8bcf7040573a3a6721fd264d900d13d4) | ``nixos/wg-quick: use `networking.firewall.package```                             |
| [`42267486`](https://github.com/NixOS/nixpkgs/commit/422674866c40470b9af91fe438f982f7577f2667) | `firefox_decrypt: unstable-2021-12-29 -> unstable-2022-12-21`                     |
| [`b33b9122`](https://github.com/NixOS/nixpkgs/commit/b33b9122bc11a7b9c0b339bcabd0e287b2d4b7ff) | `mmctl: 7.5.1 -> 7.5.2`                                                           |
| [`cd5d9f62`](https://github.com/NixOS/nixpkgs/commit/cd5d9f62066a93b4a0c8169c2fa9f092faf8248b) | ``nix-bash-completions: don't handle the `nix` command``                          |
| [`0c21d777`](https://github.com/NixOS/nixpkgs/commit/0c21d777352f55c177f27f7e64683e0a7825142c) | `python3Packages.imageio: 2.22.4 -> 2.23.0`                                       |
| [`4f312b4d`](https://github.com/NixOS/nixpkgs/commit/4f312b4d13a04dfbd4c76d0cc0c3583087d5b144) | `simplescreenrecorder: Make available on more platforms`                          |
| [`d93e341a`](https://github.com/NixOS/nixpkgs/commit/d93e341a2745b9738802a472fb40cfd617a3d1f2) | `s2n-tls: 1.3.30 -> 1.3.31`                                                       |
| [`10afcc35`](https://github.com/NixOS/nixpkgs/commit/10afcc353001bd9b39a70c52e825f1e5adb0ab52) | `aws-c-mqtt: 0.8.1 -> 0.8.2`                                                      |
| [`8d649974`](https://github.com/NixOS/nixpkgs/commit/8d6499746489f84b073e1525cbd7603400fa04bb) | `dufs: skip checkPhase on darwin`                                                 |
| [`cf5ab019`](https://github.com/NixOS/nixpkgs/commit/cf5ab0191d8582c77a8062646afe6fa09b7d4748) | `nixos/nix-daemon: remove nixbld users if auto-allocating UIDs`                   |
| [`562c4541`](https://github.com/NixOS/nixpkgs/commit/562c45418116e85ef8f1ef0be17c378607994df3) | `aws-checksums: 0.1.13 -> 0.1.14`                                                 |
| [`299a2ed8`](https://github.com/NixOS/nixpkgs/commit/299a2ed8fcc72aa4baaee1a3af609b366ab05adc) | `aws-c-s3: 0.2.0 -> 0.2.1`                                                        |
| [`16e96c45`](https://github.com/NixOS/nixpkgs/commit/16e96c45c6957e7f0dd29fdbb5b63fa3db76bcfb) | `aws-c-http: 0.6.27 -> 0.6.28`                                                    |
| [`b6c36716`](https://github.com/NixOS/nixpkgs/commit/b6c367162cd3ad16ee1347e02466ad2faa90602e) | `nixos/nixos-enter: add full path for systemd-tmpfiles`                           |