### PR TITLE
chore(flake/nur): `0fa7fc93` -> `570185bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672775123,
-        "narHash": "sha256-qAFRtfAodOhQNuoQiUYB8Rzq0+C+bdRwlmigZ1fbcMQ=",
+        "lastModified": 1672782814,
+        "narHash": "sha256-FgdhtReNHr+4Wan4k+yDA5a7AhjYGX/2LNOPI1lb1xI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0fa7fc9329450df5e1ccf88aae193214f671367a",
+        "rev": "570185bc4758e6e6a630b059072c617195e71e1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`570185bc`](https://github.com/nix-community/NUR/commit/570185bc4758e6e6a630b059072c617195e71e1e) | `automatic update` |
| [`c0e86b84`](https://github.com/nix-community/NUR/commit/c0e86b84e3118edb48ace8fbef71d04ee3f0538a) | `automatic update` |