### PR TITLE
chore(flake/home-manager): `498c46ea` -> `54245e18`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672776592,
-        "narHash": "sha256-4L1Ger9CqQKNkvg5bxAtWNRWnuIZDvjE1Vgl+gFe1v0=",
+        "lastModified": 1672780900,
+        "narHash": "sha256-DxuSn6BdkZapIbg76xzYx1KhVPEZeBexMkt1q/sMVPA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "498c46ea5d7e05b74049730582153535be5a4c54",
+        "rev": "54245e1820caabd8a0b53ce4d47e4d0fefe04cd4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`54245e18`](https://github.com/nix-community/home-manager/commit/54245e1820caabd8a0b53ce4d47e4d0fefe04cd4) | `home.pointerCursor: use mkDefault to set XCURSOR_PATH (#3553)` |