### PR TITLE
chore(flake/nur): `570185bc` -> `b08e2f7c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672782814,
-        "narHash": "sha256-FgdhtReNHr+4Wan4k+yDA5a7AhjYGX/2LNOPI1lb1xI=",
+        "lastModified": 1672798002,
+        "narHash": "sha256-qtytrQwQ8DqyNwRvrEquN7ZXskW+XFS+n3CBoPHeT8o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "570185bc4758e6e6a630b059072c617195e71e1e",
+        "rev": "b08e2f7ca0adcb24b7a0407309740b9c297de0a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b08e2f7c`](https://github.com/nix-community/NUR/commit/b08e2f7ca0adcb24b7a0407309740b9c297de0a4) | `automatic update` |