### PR TITLE
chore(flake/emacs-overlay): `1a5a0d89` -> `d59511b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672769487,
-        "narHash": "sha256-WD7RIDdFq5eO8JOb7L60fj/km/9Oee1+sqls/rJgawo=",
+        "lastModified": 1672801534,
+        "narHash": "sha256-ObnE8PJBM1X/FakyGPPLMO3Xm0Kgn7wpRDDwuo958iw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1a5a0d8953242f28f66662285c7f7dab3d21d2ea",
+        "rev": "d59511b86c8090d92f501ffabbd4b2b804ad1da6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`d59511b8`](https://github.com/nix-community/emacs-overlay/commit/d59511b86c8090d92f501ffabbd4b2b804ad1da6) | `Updated repos/melpa` |
| [`41e808eb`](https://github.com/nix-community/emacs-overlay/commit/41e808eba509a9e6e7f0ffcea9806ae0b803646d) | `Updated repos/emacs` |
| [`ac50f86e`](https://github.com/nix-community/emacs-overlay/commit/ac50f86ecfbce8ed5377ede8d6fd2c8dd19669e8) | `Updated repos/elpa`  |