### PR TITLE
chore(flake/nur): `b08e2f7c` -> `ca6ee784`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672798002,
-        "narHash": "sha256-qtytrQwQ8DqyNwRvrEquN7ZXskW+XFS+n3CBoPHeT8o=",
+        "lastModified": 1672803877,
+        "narHash": "sha256-eGbue6yNzMpGTbAbT6NevsIWyHKuz6Q8oS58Wcl+HWA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b08e2f7ca0adcb24b7a0407309740b9c297de0a4",
+        "rev": "ca6ee78491030ab5aa38642f130c42deb364742a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ca6ee784`](https://github.com/nix-community/NUR/commit/ca6ee78491030ab5aa38642f130c42deb364742a) | `automatic update` |
| [`0cd7bb74`](https://github.com/nix-community/NUR/commit/0cd7bb74c6522a262fbff034165b8b9630547213) | `automatic update` |