### PR TITLE
chore(flake/nur): `ca6ee784` -> `498cadbe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672803877,
-        "narHash": "sha256-eGbue6yNzMpGTbAbT6NevsIWyHKuz6Q8oS58Wcl+HWA=",
+        "lastModified": 1672807544,
+        "narHash": "sha256-fYseOl11yf0iZq3osgGpLos/8Q9CyWlvE7QOPuaDnLI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ca6ee78491030ab5aa38642f130c42deb364742a",
+        "rev": "498cadbe39b8b843540ea01e9b22d06fc9ad7de3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`498cadbe`](https://github.com/nix-community/NUR/commit/498cadbe39b8b843540ea01e9b22d06fc9ad7de3) | `automatic update` |