### PR TITLE
chore(flake/emacs-overlay): `d59511b8` -> `8fa53f45`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672801534,
-        "narHash": "sha256-ObnE8PJBM1X/FakyGPPLMO3Xm0Kgn7wpRDDwuo958iw=",
+        "lastModified": 1672827364,
+        "narHash": "sha256-4MIl0vZ35IVcJiKPlJFsAQaqd/krV5XNv8bWaqW0s8o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d59511b86c8090d92f501ffabbd4b2b804ad1da6",
+        "rev": "8fa53f45e6ae0e3b120f4fed99517f34c0311502",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`8fa53f45`](https://github.com/nix-community/emacs-overlay/commit/8fa53f45e6ae0e3b120f4fed99517f34c0311502) | `Updated repos/melpa` |
| [`47e1b0a7`](https://github.com/nix-community/emacs-overlay/commit/47e1b0a7ec48a59e6f7d5b135a1be352d5d43aab) | `Updated repos/emacs` |