### PR TITLE
chore(flake/nur): `619d4330` -> `4d298c4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672832749,
-        "narHash": "sha256-SNmSCYRvAwsEy1aSf7xeDkmQxrXe1CAW84J+jP1p3E4=",
+        "lastModified": 1672837503,
+        "narHash": "sha256-f3OtYbCOeyvT4URm2Mnb4QzGc8MKTvGuS/El8s5SeuA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "619d4330a8112bac86d2ee682dd611c73bf9c4e5",
+        "rev": "4d298c4ad80a333f2acbe475e06688d87a4a9ce7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4d298c4a`](https://github.com/nix-community/NUR/commit/4d298c4ad80a333f2acbe475e06688d87a4a9ce7) | `automatic update` |