### PR TITLE
chore(flake/nur): `4d298c4a` -> `96f84fb5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672837503,
-        "narHash": "sha256-f3OtYbCOeyvT4URm2Mnb4QzGc8MKTvGuS/El8s5SeuA=",
+        "lastModified": 1672839904,
+        "narHash": "sha256-8b+Xxp1dCSi53Gnlbofwvmtgkl8u7Bh7Y1xu4zJrLV0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4d298c4ad80a333f2acbe475e06688d87a4a9ce7",
+        "rev": "96f84fb504a04d0da02d34b49a3438a21194cc86",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`96f84fb5`](https://github.com/nix-community/NUR/commit/96f84fb504a04d0da02d34b49a3438a21194cc86) | `automatic update` |