### PR TITLE
chore(flake/nur): `96f84fb5` -> `75b33f6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672839904,
-        "narHash": "sha256-8b+Xxp1dCSi53Gnlbofwvmtgkl8u7Bh7Y1xu4zJrLV0=",
+        "lastModified": 1672847400,
+        "narHash": "sha256-8wx0hMvy1YRK2EPI83JQDnssRbp3QvS8OXATgWwG8bw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "96f84fb504a04d0da02d34b49a3438a21194cc86",
+        "rev": "75b33f6f6d1dcf68bb027260ff78478efd3ed9f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`75b33f6f`](https://github.com/nix-community/NUR/commit/75b33f6f6d1dcf68bb027260ff78478efd3ed9f4) | `automatic update` |
| [`0d35b8f5`](https://github.com/nix-community/NUR/commit/0d35b8f5b96fa04c93bb8ff4a6d579e999b95dad) | `automatic update` |