### PR TITLE
chore(flake/emacs-overlay): `8fa53f45` -> `ed004536`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672827364,
-        "narHash": "sha256-4MIl0vZ35IVcJiKPlJFsAQaqd/krV5XNv8bWaqW0s8o=",
+        "lastModified": 1672852603,
+        "narHash": "sha256-i5QlHEHG/T4Pp150a6cZe76EcgW/IePPiaRGcIyTBrE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8fa53f45e6ae0e3b120f4fed99517f34c0311502",
+        "rev": "ed0045366fc3bcc7ecd3dccdbf66c2cfa979fe18",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ed004536`](https://github.com/nix-community/emacs-overlay/commit/ed0045366fc3bcc7ecd3dccdbf66c2cfa979fe18) | `Updated repos/melpa` |