### PR TITLE
chore(flake/nur): `75b33f6f` -> `86adb76b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672847400,
-        "narHash": "sha256-8wx0hMvy1YRK2EPI83JQDnssRbp3QvS8OXATgWwG8bw=",
+        "lastModified": 1672851946,
+        "narHash": "sha256-AXsQ14NJn1Wqap7ELWs9soow7FBLsMELbWslzCkbT68=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "75b33f6f6d1dcf68bb027260ff78478efd3ed9f4",
+        "rev": "86adb76b9e898f47c57f10c271758000adde8b0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`86adb76b`](https://github.com/nix-community/NUR/commit/86adb76b9e898f47c57f10c271758000adde8b0f) | `automatic update` |