### PR TITLE
chore(flake/nur): `86adb76b` -> `59bac530`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672851946,
-        "narHash": "sha256-AXsQ14NJn1Wqap7ELWs9soow7FBLsMELbWslzCkbT68=",
+        "lastModified": 1672854292,
+        "narHash": "sha256-yEOr5XLUpW7sOYMWIzlBOUMGoJmNaoe5Csot1/f3MvI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "86adb76b9e898f47c57f10c271758000adde8b0f",
+        "rev": "59bac5300ebf4c647eedd86e0403ac7df8ec37fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`59bac530`](https://github.com/nix-community/NUR/commit/59bac5300ebf4c647eedd86e0403ac7df8ec37fe) | `automatic update` |