### PR TITLE
chore(flake/nur): `59bac530` -> `82b2397d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672854292,
-        "narHash": "sha256-yEOr5XLUpW7sOYMWIzlBOUMGoJmNaoe5Csot1/f3MvI=",
+        "lastModified": 1672856798,
+        "narHash": "sha256-fHbwk5qPWPiDssnDWAScDvlWVv215ym1lAR1U87bn8A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "59bac5300ebf4c647eedd86e0403ac7df8ec37fe",
+        "rev": "82b2397d1b0a9b053f45fb48d41b340cccfc1158",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`82b2397d`](https://github.com/nix-community/NUR/commit/82b2397d1b0a9b053f45fb48d41b340cccfc1158) | `automatic update` |