### PR TITLE
chore(flake/nur): `82b2397d` -> `09702166`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672856798,
-        "narHash": "sha256-fHbwk5qPWPiDssnDWAScDvlWVv215ym1lAR1U87bn8A=",
+        "lastModified": 1672859320,
+        "narHash": "sha256-hH0V04uRUGBfypTXMRHk1/DAgkKK1ubGeBlEJC2xv0I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "82b2397d1b0a9b053f45fb48d41b340cccfc1158",
+        "rev": "0970216687daa6c78495b5a5130e00327aff44f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                                                         |
| -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`09702166`](https://github.com/nix-community/NUR/commit/0970216687daa6c78495b5a5130e00327aff44f7) | `automatic update`                                                     |
| [`83e1bc5c`](https://github.com/nix-community/NUR/commit/83e1bc5ca2029a7d662c21872ca2311c8bf44411) | `Utilise file option to avoid excessive nixpkgs loading & rename repo` |
| [`9461d0c1`](https://github.com/nix-community/NUR/commit/9461d0c1e223e56f4f1ee0ca8652fef19477e4c9) | `Run format-manifest`                                                  |
| [`1b0fdb91`](https://github.com/nix-community/NUR/commit/1b0fdb915ca065d4e17c345badc5493b8b45865c) | `Resolve incorrect username`                                           |