### PR TITLE
chore(flake/nur): `29fadc09` -> `552822b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672868764,
-        "narHash": "sha256-J58CmiLGHO2hEuei0MIIxgXI4KYl1bKtquOHd3pVTG0=",
+        "lastModified": 1672872270,
+        "narHash": "sha256-c2Al8DUAumXESM/WITWDJKqoWLrDZ9mCSYx5/mzKeZc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "29fadc09162bd683556b0032e8a649f26e12ec2c",
+        "rev": "552822b1dc35e48ca3e523026997b21e8b371c10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`552822b1`](https://github.com/nix-community/NUR/commit/552822b1dc35e48ca3e523026997b21e8b371c10) | `automatic update` |