### PR TITLE
chore(flake/nur): `e14930ec` -> `3196d331`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672875891,
-        "narHash": "sha256-5A4e/Uc6aWQmMsYnMOffLg766weMfCakxo2AnQXrJco=",
+        "lastModified": 1672878992,
+        "narHash": "sha256-26x2a7Kut9F4QzFXOR0HwtxXnMh34KfsxAhuOYit6tU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e14930ece703757a928cb62327d4157bb30a7a90",
+        "rev": "3196d3313a6b66b90a6bd2a681a03f1ea074f333",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3196d331`](https://github.com/nix-community/NUR/commit/3196d3313a6b66b90a6bd2a681a03f1ea074f333) | `automatic update` |
| [`59bf68c0`](https://github.com/nix-community/NUR/commit/59bf68c0663b7bface7846eb82bbe11e231b4090) | `automatic update` |