### PR TITLE
chore(flake/emacs-overlay): `ed004536` -> `c66c4f64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672852603,
-        "narHash": "sha256-i5QlHEHG/T4Pp150a6cZe76EcgW/IePPiaRGcIyTBrE=",
+        "lastModified": 1672883896,
+        "narHash": "sha256-jFDnE4NkS+wSrVwTwBLtgq6fg0MuZuVqhE9y9pCmaNU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ed0045366fc3bcc7ecd3dccdbf66c2cfa979fe18",
+        "rev": "c66c4f6447c1b464c0a0fc97bcd689ead5dbf415",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`c66c4f64`](https://github.com/nix-community/emacs-overlay/commit/c66c4f6447c1b464c0a0fc97bcd689ead5dbf415) | `Updated repos/melpa` |