### PR TITLE
chore(flake/emacs-overlay): `c66c4f64` -> `b7ce6bbf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672883896,
-        "narHash": "sha256-jFDnE4NkS+wSrVwTwBLtgq6fg0MuZuVqhE9y9pCmaNU=",
+        "lastModified": 1672914976,
+        "narHash": "sha256-V24rc92fw1J3zYlLxALIAoM2TFPZzOpI5jiLeUZX4Kg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c66c4f6447c1b464c0a0fc97bcd689ead5dbf415",
+        "rev": "b7ce6bbf53b52f2059020ecf14127ffd1c375e90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`b7ce6bbf`](https://github.com/nix-community/emacs-overlay/commit/b7ce6bbf53b52f2059020ecf14127ffd1c375e90) | `Updated repos/melpa` |
| [`c26c90d9`](https://github.com/nix-community/emacs-overlay/commit/c26c90d90940390c81aa0fbffd847ec84348b873) | `Updated repos/emacs` |