### PR TITLE
chore(flake/nur): `b25df321` -> `5e1d2efd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672908458,
-        "narHash": "sha256-M/sq9vN+O1fFlAEwCS+plJuLmbDy8K3ULh1SSysbDf4=",
+        "lastModified": 1672937731,
+        "narHash": "sha256-LWFbNton6jCQUYSp0V+eZgAwVsYdgQ5c8hM/JMEU+LY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b25df321856354c521b793ad3b7c30e77e15c93a",
+        "rev": "5e1d2efd66bf5b197116a6c39fff5b9dbb27395a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5e1d2efd`](https://github.com/nix-community/NUR/commit/5e1d2efd66bf5b197116a6c39fff5b9dbb27395a) | `automatic update` |