### PR TITLE
chore(flake/nur): `5e1d2efd` -> `3ca14b2f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672937731,
-        "narHash": "sha256-LWFbNton6jCQUYSp0V+eZgAwVsYdgQ5c8hM/JMEU+LY=",
+        "lastModified": 1672940669,
+        "narHash": "sha256-nlDrIZ6R6Q0JC3S4wjNnWm7MgV5PAxBcCGZnEfNDWYs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5e1d2efd66bf5b197116a6c39fff5b9dbb27395a",
+        "rev": "3ca14b2fa9949e172930a90aa960f99beba5a3f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3ca14b2f`](https://github.com/nix-community/NUR/commit/3ca14b2fa9949e172930a90aa960f99beba5a3f7) | `automatic update` |