### PR TITLE
chore(flake/nur): `3ca14b2f` -> `c240cb7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672940669,
-        "narHash": "sha256-nlDrIZ6R6Q0JC3S4wjNnWm7MgV5PAxBcCGZnEfNDWYs=",
+        "lastModified": 1672943155,
+        "narHash": "sha256-Gb4z+f2/hWbX2H6hb7V51rxu/UjV8yZLt3wriQix7D4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3ca14b2fa9949e172930a90aa960f99beba5a3f7",
+        "rev": "c240cb7aec973a227c2b6725fe2b6c45b2fcfc85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c240cb7a`](https://github.com/nix-community/NUR/commit/c240cb7aec973a227c2b6725fe2b6c45b2fcfc85) | `automatic update` |