### PR TITLE
chore(flake/emacs-overlay): `b7ce6bbf` -> `6024c026`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672914976,
-        "narHash": "sha256-V24rc92fw1J3zYlLxALIAoM2TFPZzOpI5jiLeUZX4Kg=",
+        "lastModified": 1672944096,
+        "narHash": "sha256-N/aVG8Wac0N+3d5XDNNHPfKtnd3QX4cXA8M5UzeO+CI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b7ce6bbf53b52f2059020ecf14127ffd1c375e90",
+        "rev": "6024c026ffb3d6ed3a1d79fe07be965147cb43b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`6024c026`](https://github.com/nix-community/emacs-overlay/commit/6024c026ffb3d6ed3a1d79fe07be965147cb43b8) | `Updated repos/melpa` |
| [`0b2f8790`](https://github.com/nix-community/emacs-overlay/commit/0b2f8790dccea9ae4ce0a43f137fd4b002f70b1b) | `Updated repos/emacs` |
| [`df9951ad`](https://github.com/nix-community/emacs-overlay/commit/df9951ada0956ca46b0b25493178392090664d9e) | `Updated repos/elpa`  |