### PR TITLE
chore(flake/nur): `c240cb7a` -> `4763cf4f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672943155,
-        "narHash": "sha256-Gb4z+f2/hWbX2H6hb7V51rxu/UjV8yZLt3wriQix7D4=",
+        "lastModified": 1672948017,
+        "narHash": "sha256-XXk4IXKi1PjsofYCj39jKkTDEoMISucfcMzjHlo8Zu8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c240cb7aec973a227c2b6725fe2b6c45b2fcfc85",
+        "rev": "4763cf4f0ea23a5fc03af912268caa58a9c7ace2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4763cf4f`](https://github.com/nix-community/NUR/commit/4763cf4f0ea23a5fc03af912268caa58a9c7ace2) | `automatic update` |