### PR TITLE
chore(flake/nur): `f147ac90` -> `6117ebaf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672950886,
-        "narHash": "sha256-kzI/jf9/0SYreDinIXZ//S4qhw27gq6+YZ1x4BhvRFY=",
+        "lastModified": 1672955702,
+        "narHash": "sha256-ZU5k3APCm/3OAX2oNRdFRvPhw/9nfOTBCYql3qS8b/o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f147ac90edce3f61ca8bb5f883400267a1057987",
+        "rev": "6117ebaf745915aea2b5dca4e836a221894283cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6117ebaf`](https://github.com/nix-community/NUR/commit/6117ebaf745915aea2b5dca4e836a221894283cd) | `automatic update` |
| [`4036e014`](https://github.com/nix-community/NUR/commit/4036e014fcafac148261d14b32b2e69838399e41) | `automatic update` |