### PR TITLE
chore(flake/emacs-overlay): `6024c026` -> `fcce0d8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672944096,
-        "narHash": "sha256-N/aVG8Wac0N+3d5XDNNHPfKtnd3QX4cXA8M5UzeO+CI=",
+        "lastModified": 1672970476,
+        "narHash": "sha256-k5b2tmh8IvqgaN2SSR5zm+YEQwUpToCmDB4Xfq6Skug=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6024c026ffb3d6ed3a1d79fe07be965147cb43b8",
+        "rev": "fcce0d8df02b4657ed413cf9991a0d81852569de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`fcce0d8d`](https://github.com/nix-community/emacs-overlay/commit/fcce0d8df02b4657ed413cf9991a0d81852569de) | `Updated repos/nongnu` |
| [`e6415620`](https://github.com/nix-community/emacs-overlay/commit/e641562007b44a6dd12e2fbea3f9e10f02ddd6a9) | `Updated repos/melpa`  |
| [`e8119023`](https://github.com/nix-community/emacs-overlay/commit/e811902390ea0ab4ae8ae7c84f3a938d5dc662b1) | `Updated repos/elpa`   |