### PR TITLE
chore(flake/nur): `5d977261` -> `37aa8904`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672958787,
-        "narHash": "sha256-LZQpBwO8K6dP0oVh9b+n0XpdcFGmjph0sSgriFZr+oY=",
+        "lastModified": 1672971053,
+        "narHash": "sha256-d2w/OvdsBkg7jf9n6diLASirdY0XstSqpUXPtWLfKrM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5d9772614c5a7c036f549578a5ea9223c610a90f",
+        "rev": "37aa8904d0a5687eb3eca8a72737e1e3e75113b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`37aa8904`](https://github.com/nix-community/NUR/commit/37aa8904d0a5687eb3eca8a72737e1e3e75113b3) | `automatic update` |