### PR TITLE
chore(flake/nur): `37aa8904` -> `f2647670`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672971053,
-        "narHash": "sha256-d2w/OvdsBkg7jf9n6diLASirdY0XstSqpUXPtWLfKrM=",
+        "lastModified": 1672976216,
+        "narHash": "sha256-fPGfnf1UKwu6NVkQToTnrpuqJ8Qj4AxnQLgy9fvtJ6M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "37aa8904d0a5687eb3eca8a72737e1e3e75113b3",
+        "rev": "f26476709bd7b81c6baaa92630fa9793f047f595",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f2647670`](https://github.com/nix-community/NUR/commit/f26476709bd7b81c6baaa92630fa9793f047f595) | `automatic update` |