### PR TITLE
chore(flake/nur): `f2647670` -> `39bf665b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672976216,
-        "narHash": "sha256-fPGfnf1UKwu6NVkQToTnrpuqJ8Qj4AxnQLgy9fvtJ6M=",
+        "lastModified": 1672980082,
+        "narHash": "sha256-kq3aliudXEJjT2OnVQg8m4TaEMbhSlEZoMdtHxo3Dbw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f26476709bd7b81c6baaa92630fa9793f047f595",
+        "rev": "39bf665b7a988347812aa70f5c4f975c3efab2af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`39bf665b`](https://github.com/nix-community/NUR/commit/39bf665b7a988347812aa70f5c4f975c3efab2af) | `automatic update` |