### PR TITLE
chore(flake/nur): `39bf665b` -> `3f105d6c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672980082,
-        "narHash": "sha256-kq3aliudXEJjT2OnVQg8m4TaEMbhSlEZoMdtHxo3Dbw=",
+        "lastModified": 1672981856,
+        "narHash": "sha256-3IKgjUJuibA9QzYpa/vZYntCrIPqOl4VrC1dBvOiHcM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "39bf665b7a988347812aa70f5c4f975c3efab2af",
+        "rev": "3f105d6ca63ce5399964c00e44054a332a5aa357",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3f105d6c`](https://github.com/nix-community/NUR/commit/3f105d6ca63ce5399964c00e44054a332a5aa357) | `automatic update` |