### PR TITLE
chore(flake/emacs-overlay): `fcce0d8d` -> `3897ea6c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672970476,
-        "narHash": "sha256-k5b2tmh8IvqgaN2SSR5zm+YEQwUpToCmDB4Xfq6Skug=",
+        "lastModified": 1673001430,
+        "narHash": "sha256-hdOp341jGP/2aVjH8UX3gtlwZ54PI6SMtPx6xhOdBpg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fcce0d8df02b4657ed413cf9991a0d81852569de",
+        "rev": "3897ea6c4604c54f168d2f67bc5c2f91305b3b4e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`3897ea6c`](https://github.com/nix-community/emacs-overlay/commit/3897ea6c4604c54f168d2f67bc5c2f91305b3b4e) | `Updated repos/melpa` |
| [`3b3242d4`](https://github.com/nix-community/emacs-overlay/commit/3b3242d4eddce4ef16bdab6764ee6d7b22a15978) | `Updated repos/emacs` |