### PR TITLE
chore(flake/nur): `2e008307` -> `264d4951`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672994937,
-        "narHash": "sha256-GX6ckwdZ7LYLnfWnAMQ96mfPD4cNzoZsoYMnm/aL6t0=",
+        "lastModified": 1673010110,
+        "narHash": "sha256-ocPZRFBp1m/vy+OlxgmuSyACz5cUAq3g5WbvgRaVeq4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2e00830769413534be969673c7ef618d73e22f04",
+        "rev": "264d49517bbcc1ec74a007b39c6689fcdc471265",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`264d4951`](https://github.com/nix-community/NUR/commit/264d49517bbcc1ec74a007b39c6689fcdc471265) | `automatic update` |