### PR TITLE
chore(flake/nur): `264d4951` -> `ade37799`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673010110,
-        "narHash": "sha256-ocPZRFBp1m/vy+OlxgmuSyACz5cUAq3g5WbvgRaVeq4=",
+        "lastModified": 1673016323,
+        "narHash": "sha256-vffmOdTtwzwj5X2ev49tOWgxj3r5dJ4DOl3Wcpj3eJQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "264d49517bbcc1ec74a007b39c6689fcdc471265",
+        "rev": "ade37799d7bca792995d8172193ede4b183b0d4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ade37799`](https://github.com/nix-community/NUR/commit/ade37799d7bca792995d8172193ede4b183b0d4b) | `automatic update` |
| [`db791574`](https://github.com/nix-community/NUR/commit/db7915740ef34ddb823869c94472e5d8dfcb339b) | `automatic update` |
| [`b5ffe50c`](https://github.com/nix-community/NUR/commit/b5ffe50cd71ecd1dd637f2567a9f27082604d364) | `automatic update` |