### PR TITLE
chore(flake/nur): `ade37799` -> `8e8d296c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673016323,
-        "narHash": "sha256-vffmOdTtwzwj5X2ev49tOWgxj3r5dJ4DOl3Wcpj3eJQ=",
+        "lastModified": 1673024022,
+        "narHash": "sha256-AaoOemcGuPCFLoAL8o0tgmYojjBKb1jKrOJY2YgAcoQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ade37799d7bca792995d8172193ede4b183b0d4b",
+        "rev": "8e8d296cc5644027c8b9d214c584f26460f17d2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8e8d296c`](https://github.com/nix-community/NUR/commit/8e8d296cc5644027c8b9d214c584f26460f17d2e) | `automatic update` |