### PR TITLE
chore(flake/nur): `8e8d296c` -> `0309c9ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673024022,
-        "narHash": "sha256-AaoOemcGuPCFLoAL8o0tgmYojjBKb1jKrOJY2YgAcoQ=",
+        "lastModified": 1673027195,
+        "narHash": "sha256-zCVgKvkZQfWpJa5Ayx+C7U0Oo/6dItv45BrZWMA1nHs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8e8d296cc5644027c8b9d214c584f26460f17d2e",
+        "rev": "0309c9ae2e0165aaafde2f5f61cf06c0c0ca990a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0309c9ae`](https://github.com/nix-community/NUR/commit/0309c9ae2e0165aaafde2f5f61cf06c0c0ca990a) | `automatic update` |