### PR TITLE
chore(flake/home-manager): `17868834` -> `f1b1594e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672980560,
-        "narHash": "sha256-Pzx7az57SiUS1xhvKesTb1rhO9w9lWy9mecIqVjcKzo=",
+        "lastModified": 1673301981,
+        "narHash": "sha256-E5C8nqf+XCGJLQjT/w9d5U+GPg7/ZchbLSe9FXbaDDA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1786883425208d3bf726ab6a1889beddeb46cdbc",
+        "rev": "f1b1594e7b8503dba812c4c1b1392d39da32793d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`f1b1594e`](https://github.com/nix-community/home-manager/commit/f1b1594e7b8503dba812c4c1b1392d39da32793d) | `docs: bump nmd`                                                      |
| [`69806e93`](https://github.com/nix-community/home-manager/commit/69806e937881c75269e058daecf49d9c39bd034e) | `files: avoid surprises when linking files (#3018)`                   |
| [`4f0c1afb`](https://github.com/nix-community/home-manager/commit/4f0c1afba75e2c3910cf4037f2b51025902cab24) | `firefox: remove https-everywhere from example`                       |
| [`684bdb38`](https://github.com/nix-community/home-manager/commit/684bdb386cec7d4f16e0da9f694c8ab50ad2cf2a) | `i3: remove i3/i3-gaps distinction (#3563)`                           |
| [`9e565f0d`](https://github.com/nix-community/home-manager/commit/9e565f0d9d41c19a94f55af205c328ec5177fc0a) | `docs: bump nmd`                                                      |
| [`2cff1c76`](https://github.com/nix-community/home-manager/commit/2cff1c764209c79d0a09a19384bfef285bc42ef1) | ``ncmpcpp: Allow `str` type values for `mpdMusicDir` option (#3565)`` |
| [`709a87fe`](https://github.com/nix-community/home-manager/commit/709a87fe3300fc791734956125c4666a4fd42c69) | `docs: bump nmd`                                                      |