### PR TITLE
chore(flake/nur): `2ddb9bfe` -> `8fabb370`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673037025,
-        "narHash": "sha256-EeHfJsQyjOn0i4l+s2Y+DOCURKTFJWlXhwa+XRdUXws=",
+        "lastModified": 1673056958,
+        "narHash": "sha256-SaBlOsrCVis2g4eN7JwyhwDm3lKa9jqon6Fyh0olcjM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2ddb9bfed795650a49c02babe72741ab2beb82ba",
+        "rev": "8fabb3705cb5bb3a27852e50aa85417aff85f296",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8fabb370`](https://github.com/nix-community/NUR/commit/8fabb3705cb5bb3a27852e50aa85417aff85f296) | `automatic update` |