### PR TITLE
chore(flake/nur): `d443b061` -> `b1a609f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673062557,
-        "narHash": "sha256-bQDGlBxRNg+cEkpI/wxv+hCEUPjQsvCk/O8xhV2+oVQ=",
+        "lastModified": 1673066593,
+        "narHash": "sha256-pOc6MO2Ru0EuSr8Ctra1uh83T3SSYDD7EOt57Nmln64=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d443b061960b475c6cb225588a018f77b3bf03f0",
+        "rev": "b1a609f0300222e7e5aef19cda03c9a75099c1f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b1a609f0`](https://github.com/nix-community/NUR/commit/b1a609f0300222e7e5aef19cda03c9a75099c1f7) | `automatic update` |