### PR TITLE
chore(flake/nur): `b1a609f0` -> `3243a5c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673066593,
-        "narHash": "sha256-pOc6MO2Ru0EuSr8Ctra1uh83T3SSYDD7EOt57Nmln64=",
+        "lastModified": 1673096483,
+        "narHash": "sha256-cy/VPYpwSQE1X9z6lqdP9i0vATZmkg4vBHWByKwq1b0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b1a609f0300222e7e5aef19cda03c9a75099c1f7",
+        "rev": "3243a5c1672f795a18cc3d5ffeb279fdd1723203",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3243a5c1`](https://github.com/nix-community/NUR/commit/3243a5c1672f795a18cc3d5ffeb279fdd1723203) | `automatic update` |
| [`e6323efd`](https://github.com/nix-community/NUR/commit/e6323efd524826eb3c478ed46a2a8d9555d75009) | `automatic update` |
| [`9ff8013c`](https://github.com/nix-community/NUR/commit/9ff8013cd85847e2fda7461647fd7f5785d8ecf7) | `automatic update` |
| [`1815a820`](https://github.com/nix-community/NUR/commit/1815a8200c649fc9750463144366943b926827de) | `automatic update` |
| [`6a2908f4`](https://github.com/nix-community/NUR/commit/6a2908f496e479940f8f7b459817b8346ed2f35a) | `automatic update` |