### PR TITLE
chore(flake/nur): `444b9316` -> `811ec3c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673113554,
-        "narHash": "sha256-sUsOEfzGbPMThXrmNsPIvdlG3Dru8cy33BQC+Tl6PLM=",
+        "lastModified": 1673120793,
+        "narHash": "sha256-qcWEuZ57sSJ1Vxu3ZyjlQv/ijigS0k3A7W3/wDazftk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "444b9316aec5d207d1d2cac9aa8a6593ce902e80",
+        "rev": "811ec3c87437484e677dcf9a9f2011887e97ebaf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`811ec3c8`](https://github.com/nix-community/NUR/commit/811ec3c87437484e677dcf9a9f2011887e97ebaf) | `automatic update` |