### PR TITLE
chore(flake/nur): `811ec3c8` -> `13416263`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673120793,
-        "narHash": "sha256-qcWEuZ57sSJ1Vxu3ZyjlQv/ijigS0k3A7W3/wDazftk=",
+        "lastModified": 1673124312,
+        "narHash": "sha256-WKiiAzOxGODFXBSYpuy4Ek9CATdr9/GJioumbm93MSc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "811ec3c87437484e677dcf9a9f2011887e97ebaf",
+        "rev": "134162636795525f944dab219df5a73d60cf0ed7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`13416263`](https://github.com/nix-community/NUR/commit/134162636795525f944dab219df5a73d60cf0ed7) | `automatic update` |