### PR TITLE
chore(flake/nur): `282978ad` -> `74eb8945`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673127964,
-        "narHash": "sha256-SH2PeqMw7T8uokVHFUyJAcQCCE2HaQDS8RtlInLwjWY=",
+        "lastModified": 1673135142,
+        "narHash": "sha256-MbuboZRD4JWcOQYIUOvyZJBcuB2cbzJAfVXoOhtvt50=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "282978ad047cbfefa2c77cf3bdd2b048ff61237c",
+        "rev": "74eb89458aaf07720118c75580697f9c864f0b88",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`74eb8945`](https://github.com/nix-community/NUR/commit/74eb89458aaf07720118c75580697f9c864f0b88) | `automatic update` |