### PR TITLE
chore(flake/emacs-overlay): `738b3cff` -> `a8d8372e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673116741,
-        "narHash": "sha256-7rJYbsrG7zM9U/3xTlCaDr7RhM5iArsg7Hfhxg1hkX0=",
+        "lastModified": 1673147030,
+        "narHash": "sha256-/FbActxEFN2Di2Z9ZrfR6Ose0bxO31AkSZ0malWzd8k=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "738b3cfffacf4234d6b6a0b39ce2355574687074",
+        "rev": "a8d8372eb02914ebb42e727f3ffa3765b4de0f4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`a8d8372e`](https://github.com/nix-community/emacs-overlay/commit/a8d8372eb02914ebb42e727f3ffa3765b4de0f4f) | `Updated repos/melpa` |
| [`e57369df`](https://github.com/nix-community/emacs-overlay/commit/e57369df9737216cf542639bf279960fd3b986f2) | `Updated repos/emacs` |
| [`79714c5f`](https://github.com/nix-community/emacs-overlay/commit/79714c5f674eb020cba9e3fad1f38ece2b7016c7) | `Updated repos/elpa`  |