### PR TITLE
chore(flake/emacs-overlay): `a8d8372e` -> `77633dd3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673147030,
-        "narHash": "sha256-/FbActxEFN2Di2Z9ZrfR6Ose0bxO31AkSZ0malWzd8k=",
+        "lastModified": 1673168783,
+        "narHash": "sha256-LuZw82DsEiPtcsBI0JMyTaHLPbi/CNVAcIMNKH8VQXs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a8d8372eb02914ebb42e727f3ffa3765b4de0f4f",
+        "rev": "77633dd37d94ade8e927b519722ed5481e4c9425",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`77633dd3`](https://github.com/nix-community/emacs-overlay/commit/77633dd37d94ade8e927b519722ed5481e4c9425) | `Updated repos/melpa` |