### PR TITLE
chore(flake/nur): `aafbf988` -> `36cba621`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673148975,
-        "narHash": "sha256-k8c5TtHkHm4mNsnHqmtQpiXQ8PT+vHkY2y5Yo3dXg+A=",
+        "lastModified": 1673177084,
+        "narHash": "sha256-bgvdWyOnZSMXWIq5lG4glhWX4XJTP0TojkTczvvRyyk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aafbf98872b130c7acc68a72e45145b169d633d6",
+        "rev": "36cba621b7dba7c540c2dd9103c4f791a24efad1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`36cba621`](https://github.com/nix-community/NUR/commit/36cba621b7dba7c540c2dd9103c4f791a24efad1) | `automatic update` |
| [`6aa0e789`](https://github.com/nix-community/NUR/commit/6aa0e789fb74346d6b0815a850a20d77545d1b26) | `automatic update` |
| [`da9d423c`](https://github.com/nix-community/NUR/commit/da9d423c6425cfc53c5b759b8c5486589b3d261f) | `automatic update` |