### PR TITLE
chore(flake/emacs-overlay): `77633dd3` -> `076ee4ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673168783,
-        "narHash": "sha256-LuZw82DsEiPtcsBI0JMyTaHLPbi/CNVAcIMNKH8VQXs=",
+        "lastModified": 1673197839,
+        "narHash": "sha256-KbQR3/RKJ2ogl4yyJJhBTWzsqzG3uuYcPJ8/xRoXNnw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "77633dd37d94ade8e927b519722ed5481e4c9425",
+        "rev": "076ee4edf295eb9543a1416186085aa2b67042af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`076ee4ed`](https://github.com/nix-community/emacs-overlay/commit/076ee4edf295eb9543a1416186085aa2b67042af) | `Updated repos/nongnu` |
| [`af506f49`](https://github.com/nix-community/emacs-overlay/commit/af506f49e0df0ce7d30f18a60f77d602601b15fd) | `Updated repos/melpa`  |