### PR TITLE
chore(flake/nur): `93305d0b` -> `de440811`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673199991,
-        "narHash": "sha256-E8VxpW3U4wy71n1EtLJVz7mxzNy+G8XUvlrLzmdlPcc=",
+        "lastModified": 1673203999,
+        "narHash": "sha256-V7rI42e6E1KTAkz8knDWzEzFJZEdKJigITi7jq7iTbE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "93305d0bf94942b055c4b65249aadd350db4bed7",
+        "rev": "de4408111c9710f76982b65387964cc1132aacac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`de440811`](https://github.com/nix-community/NUR/commit/de4408111c9710f76982b65387964cc1132aacac) | `automatic update` |
| [`bb5b3bef`](https://github.com/nix-community/NUR/commit/bb5b3bef4dbccb98e907a5c77c2b199408c266a6) | `automatic update` |