### PR TITLE
chore(flake/nur): `de440811` -> `15d0b646`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673203999,
-        "narHash": "sha256-V7rI42e6E1KTAkz8knDWzEzFJZEdKJigITi7jq7iTbE=",
+        "lastModified": 1673207072,
+        "narHash": "sha256-QikoKBLIrEOAY5KS/bFwKwsG1t4/iabt4MgG7/9gBRE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "de4408111c9710f76982b65387964cc1132aacac",
+        "rev": "15d0b646aac5ac9c01ece253650d0fc37e627176",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`15d0b646`](https://github.com/nix-community/NUR/commit/15d0b646aac5ac9c01ece253650d0fc37e627176) | `automatic update` |