### PR TITLE
chore(flake/emacs-ement): `f8e3fa5f` -> `28de42d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1673196427,
-        "narHash": "sha256-4i33O9Ea0fxCikLgRVh0CSZ0Zm9NrkDAQZK1M4BWn4g=",
+        "lastModified": 1673226582,
+        "narHash": "sha256-CkPzdDzrN1xPZtbGowJaLMl3Z/h6yDyAB6TDPYsP0lU=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "f8e3fa5f3ad3e126ebbbbfb572e1279154b6d3e1",
+        "rev": "28de42d653cc1e254cc3dccfcb685db947cdde4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                     |
| --------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`28de42d6`](https://github.com/alphapapa/ement.el/commit/28de42d653cc1e254cc3dccfcb685db947cdde4c) | `Fix: (ement-view-space) Autoload` |