### PR TITLE
chore(flake/emacs-overlay): `076ee4ed` -> `6fa004ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673197839,
-        "narHash": "sha256-KbQR3/RKJ2ogl4yyJJhBTWzsqzG3uuYcPJ8/xRoXNnw=",
+        "lastModified": 1673233493,
+        "narHash": "sha256-Fv9pvTjzfo7k6MpPPA29E2K/iaarRJtCXLwwF1qu3JM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "076ee4edf295eb9543a1416186085aa2b67042af",
+        "rev": "6fa004ad6204ffcd746654ed60fd8dee394ff388",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`6fa004ad`](https://github.com/nix-community/emacs-overlay/commit/6fa004ad6204ffcd746654ed60fd8dee394ff388) | `Updated repos/melpa` |
| [`198ae94a`](https://github.com/nix-community/emacs-overlay/commit/198ae94a8dcd011480e0231cbfa8849419dbae55) | `Updated repos/emacs` |
| [`06ea0364`](https://github.com/nix-community/emacs-overlay/commit/06ea036435621202f39fe9213bf354ecc82c889a) | `Updated repos/elpa`  |