### PR TITLE
chore(flake/nur): `244abbb0` -> `3751b2c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673242896,
-        "narHash": "sha256-cCnfsPkZPYmY3C5rcaq8jrKAdPHto2yuR3L0AAmeFdE=",
+        "lastModified": 1673245867,
+        "narHash": "sha256-kM9fYm4yElMEiRioOMuDfTRKjmY3X/RiLCfSs7NntXc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "244abbb074b561cc5c9cb88bd7791d084d9829d0",
+        "rev": "3751b2c4b4c94d0fdc1c3afa0a8979d6d6f215ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3751b2c4`](https://github.com/nix-community/NUR/commit/3751b2c4b4c94d0fdc1c3afa0a8979d6d6f215ef) | `automatic update` |