### PR TITLE
chore(flake/nur): `3751b2c4` -> `20e63b52`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673245867,
-        "narHash": "sha256-kM9fYm4yElMEiRioOMuDfTRKjmY3X/RiLCfSs7NntXc=",
+        "lastModified": 1673250692,
+        "narHash": "sha256-7kmSyPPQ8ZKOaRbqzqN0BHiOnB2z8+jFq9+kwh3lR10=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3751b2c4b4c94d0fdc1c3afa0a8979d6d6f215ef",
+        "rev": "20e63b52053e799318da50df1d7e2fb51c542ea6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`20e63b52`](https://github.com/nix-community/NUR/commit/20e63b52053e799318da50df1d7e2fb51c542ea6) | `automatic update` |
| [`ce5302f2`](https://github.com/nix-community/NUR/commit/ce5302f2558223a8270bc8f832110b315f121fbd) | `automatic update` |