### PR TITLE
chore(flake/emacs-overlay): `6fa004ad` -> `070389cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673233493,
-        "narHash": "sha256-Fv9pvTjzfo7k6MpPPA29E2K/iaarRJtCXLwwF1qu3JM=",
+        "lastModified": 1673256023,
+        "narHash": "sha256-bU/SNZYv1q3QfuaR9Hyh0hhOxxP3Y3p+/D5hJEpMDJY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6fa004ad6204ffcd746654ed60fd8dee394ff388",
+        "rev": "070389cdd38008ad49d8097e18817db7cd6ddc2b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`070389cd`](https://github.com/nix-community/emacs-overlay/commit/070389cdd38008ad49d8097e18817db7cd6ddc2b) | `Updated repos/melpa` |