### PR TITLE
chore(flake/darwin): `3db1d870` -> `87b9d090`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672753581,
-        "narHash": "sha256-EIi2tqHoje5cE9WqH23ZghW28NOOWSUM7tcxKE1U9KI=",
+        "lastModified": 1673295039,
+        "narHash": "sha256-AsdYgE8/GPwcelGgrntlijMg4t3hLFJFCRF3tL5WVjA=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "3db1d870b04b13411f56ab1a50cd32b001f56433",
+        "rev": "87b9d090ad39b25b2400029c64825fc2a8868943",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                         |
| ------------------------------------------------------------------------------------------------ | -------------------------------------- |
| [`e3c24b5e`](https://github.com/LnL7/nix-darwin/commit/e3c24b5e0c5e82f930125e0a3a99fd2608394d9e) | `Test submodule support`               |
| [`5452c8c6`](https://github.com/LnL7/nix-darwin/commit/5452c8c638b59b5d6b123d81d3fa6bad07d00617) | `Add support for submodules in flakes` |