### PR TITLE
chore(flake/nur): `d791d4ca` -> `f52f7204`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673300756,
-        "narHash": "sha256-rOU/gXMWR19WGcxCB7acyuXmk6X9+k9GEOi9puP7HW4=",
+        "lastModified": 1673302756,
+        "narHash": "sha256-OJKhVToh76n+nQwMUlj//idqjAvJsN14kgJjOJoIWGg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d791d4ca1886c4dcb52f0f2615c249960bd5e822",
+        "rev": "f52f7204e090eab88b7bb23dd4fff40b86b84655",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f52f7204`](https://github.com/nix-community/NUR/commit/f52f7204e090eab88b7bb23dd4fff40b86b84655) | `automatic update` |