### PR TITLE
chore(flake/home-manager): `f1b1594e` -> `b0a36898`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673301981,
-        "narHash": "sha256-E5C8nqf+XCGJLQjT/w9d5U+GPg7/ZchbLSe9FXbaDDA=",
+        "lastModified": 1673306306,
+        "narHash": "sha256-wV99VV4kn0SIN1XeEIfnD0X7dZD9H5prk19XeFQKhso=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f1b1594e7b8503dba812c4c1b1392d39da32793d",
+        "rev": "b0a3689878d4c2e8a1b02cecf8319ba8c53da519",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`b0a36898`](https://github.com/nix-community/home-manager/commit/b0a3689878d4c2e8a1b02cecf8319ba8c53da519) | `Translate using Weblate (Lithuanian)`            |
| [`efb7b119`](https://github.com/nix-community/home-manager/commit/efb7b11974d711a4c72c0fa577724710b3b73ee7) | `Add translation using Weblate (Lithuanian)`      |
| [`6816934f`](https://github.com/nix-community/home-manager/commit/6816934f410a80bca858fa130790d4ac6e1a363a) | `Add translation using Weblate (Lithuanian)`      |
| [`19dccb46`](https://github.com/nix-community/home-manager/commit/19dccb46f41ecf96663a715a588b5101804c2990) | `Translate using Weblate (Chinese (Traditional))` |
| [`53441838`](https://github.com/nix-community/home-manager/commit/53441838615e4662bb9b69678157eba11cbe5fde) | `Translate using Weblate (Norwegian Bokmål)`      |