### PR TITLE
chore(flake/nur): `5f8e06fe` -> `3956b1d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673313906,
-        "narHash": "sha256-moQycUvrmS96DAJgbSKuanvdH27fGtkDh4o7EW5nb+E=",
+        "lastModified": 1673321736,
+        "narHash": "sha256-6QrABvo/dFRcYvk7krbOLDcPwQzbRij0qYbGDJwdqTQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5f8e06fee2a5afa5966130cb3d818996f27aaf50",
+        "rev": "3956b1d73f24651f821be4d73a65857e5846e4eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3956b1d7`](https://github.com/nix-community/NUR/commit/3956b1d73f24651f821be4d73a65857e5846e4eb) | `automatic update` |