### PR TITLE
chore(flake/nur): `3956b1d7` -> `35787d48`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673321736,
-        "narHash": "sha256-6QrABvo/dFRcYvk7krbOLDcPwQzbRij0qYbGDJwdqTQ=",
+        "lastModified": 1673323853,
+        "narHash": "sha256-FvWwAcV0PYQAAIKs6fcGQkr9BySxf810+OpovltQ1lI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3956b1d73f24651f821be4d73a65857e5846e4eb",
+        "rev": "35787d48e2c0104c56d9528337024b49b9338c69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`35787d48`](https://github.com/nix-community/NUR/commit/35787d48e2c0104c56d9528337024b49b9338c69) | `automatic update` |