### PR TITLE
chore(flake/nur): `35787d48` -> `6366f996`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673323853,
-        "narHash": "sha256-FvWwAcV0PYQAAIKs6fcGQkr9BySxf810+OpovltQ1lI=",
+        "lastModified": 1673332109,
+        "narHash": "sha256-hSEvUYWtLbMiRzwuIb6bCWLhzZVqV4L7GDXpAaBiSw8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "35787d48e2c0104c56d9528337024b49b9338c69",
+        "rev": "6366f996e4f903a2b37148623155327a538e76e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6366f996`](https://github.com/nix-community/NUR/commit/6366f996e4f903a2b37148623155327a538e76e4) | `automatic update` |