### PR TITLE
chore(flake/nur): `0cf562c6` -> `7f800f76`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673339487,
-        "narHash": "sha256-EgZJpx0w2VGEw92+oY91PAKqr5CGgzvhybnOiQmrK2U=",
+        "lastModified": 1673341727,
+        "narHash": "sha256-afaHspU2hFw7OV2ZX2lQaNWN3cfEpRCIQNdQOUhIMqE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0cf562c685e07204db7e6746443f30704063b70c",
+        "rev": "7f800f76accc1536d42b7b3a117681d6250b7262",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7f800f76`](https://github.com/nix-community/NUR/commit/7f800f76accc1536d42b7b3a117681d6250b7262) | `automatic update` |