### PR TITLE
chore(flake/emacs-overlay): `fc341b52` -> `868a2b03`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673321657,
-        "narHash": "sha256-XAw+aEX6Q2ckm0ukoiBVBv2ShVv0bPc/SIh0SQiAk+g=",
+        "lastModified": 1673341693,
+        "narHash": "sha256-Mgu6tAuIU+VVFHAdTKOaj6rGsT68StOchSpXGUkFBBI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fc341b52fe5837ef313cfe79eea7e2a05b6efffa",
+        "rev": "868a2b036b1cc5a599cb8739fb8c6b696f455b39",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`868a2b03`](https://github.com/nix-community/emacs-overlay/commit/868a2b036b1cc5a599cb8739fb8c6b696f455b39) | `Updated repos/melpa` |