### PR TITLE
chore(flake/home-manager): `950aace4` -> `176e4553`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673341058,
-        "narHash": "sha256-jya1TL6p34IO6zcsSava/zizRqeh7fULCM+A1yRRbaU=",
+        "lastModified": 1673343300,
+        "narHash": "sha256-5Xdj6kpXYMie0MlnGwqK5FaMdsedxvyuakWtyKB3zaQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "950aace44e23327a9df1c93fa799a0421091f04a",
+        "rev": "176e455371a8371586e8a3ff0d56ee9f3ca2324e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`176e4553`](https://github.com/nix-community/home-manager/commit/176e455371a8371586e8a3ff0d56ee9f3ca2324e) | `home-manager: Add home-manager search path to EXTRA_NIX_PATH (#3241)` |