### PR TITLE
chore(flake/nur): `7f800f76` -> `9f9298f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673341727,
-        "narHash": "sha256-afaHspU2hFw7OV2ZX2lQaNWN3cfEpRCIQNdQOUhIMqE=",
+        "lastModified": 1673356028,
+        "narHash": "sha256-s/sIlr1U0kuHgrOEBY+1D4t70HVkOstkb4MGI0cECFA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7f800f76accc1536d42b7b3a117681d6250b7262",
+        "rev": "9f9298f9c63c57ac069d1b1d95434b9a6fded6c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9f9298f9`](https://github.com/nix-community/NUR/commit/9f9298f9c63c57ac069d1b1d95434b9a6fded6c0) | `automatic update` |