### PR TITLE
chore(flake/nur): `9f9298f9` -> `bf8b8390`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673356028,
-        "narHash": "sha256-s/sIlr1U0kuHgrOEBY+1D4t70HVkOstkb4MGI0cECFA=",
+        "lastModified": 1673362655,
+        "narHash": "sha256-pPp/Xzae8sVkzNrZK7nWKQyunelF6aw2AfmzR2lRDzI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9f9298f9c63c57ac069d1b1d95434b9a6fded6c0",
+        "rev": "bf8b8390f15f9bcfbb46b540e17ed5e6eb4ed4ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`bf8b8390`](https://github.com/nix-community/NUR/commit/bf8b8390f15f9bcfbb46b540e17ed5e6eb4ed4ec) | `automatic update` |