### PR TITLE
chore(flake/nur): `bf8b8390` -> `6f0415e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673362655,
-        "narHash": "sha256-pPp/Xzae8sVkzNrZK7nWKQyunelF6aw2AfmzR2lRDzI=",
+        "lastModified": 1673370614,
+        "narHash": "sha256-Vh6Hj0azeM2tHpHXGHy3HWH+CO7eZ6Q3tV93S4JsxTk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bf8b8390f15f9bcfbb46b540e17ed5e6eb4ed4ec",
+        "rev": "6f0415e8ced0163b3c68238d667fe4bc4a86074d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6f0415e8`](https://github.com/nix-community/NUR/commit/6f0415e8ced0163b3c68238d667fe4bc4a86074d) | `automatic update` |