### PR TITLE
chore(flake/nur): `6f0415e8` -> `c6f902b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673370614,
-        "narHash": "sha256-Vh6Hj0azeM2tHpHXGHy3HWH+CO7eZ6Q3tV93S4JsxTk=",
+        "lastModified": 1673376528,
+        "narHash": "sha256-rnA2QGLQYjQOJwi0GUMV2CV+QhFob0TbnaOB+vEy0co=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6f0415e8ced0163b3c68238d667fe4bc4a86074d",
+        "rev": "c6f902b33d90e6af61c55ad9e46baad6315504b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c6f902b3`](https://github.com/nix-community/NUR/commit/c6f902b33d90e6af61c55ad9e46baad6315504b8) | `automatic update` |