### PR TITLE
chore(flake/nur): `c6f902b3` -> `2c47b2a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673376528,
-        "narHash": "sha256-rnA2QGLQYjQOJwi0GUMV2CV+QhFob0TbnaOB+vEy0co=",
+        "lastModified": 1673379985,
+        "narHash": "sha256-hhpNcVO6GkgSjIbgNc3tTLyIcvQByyY2VJhKye7kQVc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c6f902b33d90e6af61c55ad9e46baad6315504b8",
+        "rev": "2c47b2a0053cdb36cc08353f79eebf7a055fa18f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2c47b2a0`](https://github.com/nix-community/NUR/commit/2c47b2a0053cdb36cc08353f79eebf7a055fa18f) | `automatic update` |