### PR TITLE
chore(flake/nixos-hardware): `df029cfe` -> `93350684`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -341,11 +341,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1673336835,
-        "narHash": "sha256-HMJ/Nt3+0MtgKfPfJSrC3/6yVAPQvZgv/7V9b49dG/c=",
+        "lastModified": 1673390851,
+        "narHash": "sha256-dAhsJUIxfg5gWE+uQ3e0ICssS0QPQZt7Pa+75NKtAEw=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "df029cfefc7494b399966cbb6b4fd692fa294fa3",
+        "rev": "9335068481026234c1f41079ad54e28ad92453de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`f67688dc`](https://github.com/NixOS/nixos-hardware/commit/f67688dcf5a3725bbf42746488027c8d039b9a0b) | `Add specialisation for Surface Laptop (AMD)`                                  |
| [`6832e876`](https://github.com/NixOS/nixos-hardware/commit/6832e876631de9212889f094d258f395adbf17cd) | `Add some doc comments`                                                        |
| [`2cd5ae60`](https://github.com/NixOS/nixos-hardware/commit/2cd5ae60b1c68dcbba0ce50d1c49d8082f88142a) | `Use URL to docs, instead of short-form`                                       |
| [`8e6d03d3`](https://github.com/NixOS/nixos-hardware/commit/8e6d03d3493bd3714e6e62c5a837f37850fc7807) | `Update OLD-BEHAVIOUR-DEPRECATION.md`                                          |
| [`42ec6296`](https://github.com/NixOS/nixos-hardware/commit/42ec6296f22f224849bfeb7cb12a138b81a1ac7d) | `fixup! Update Surface Pro 3 to reference microsoft/surface/surface-pro-intel` |
| [`80e8d29a`](https://github.com/NixOS/nixos-hardware/commit/80e8d29a9cd605f6230640f57b8f2a7833b6249f) | `Update Surface Go to depend on other PC modules`                              |
| [`7b721546`](https://github.com/NixOS/nixos-hardware/commit/7b721546842f5f5824d736ba68c5ad87a66b36e9) | `Update Surface Pro 3 to reference microsoft/surface/surface-pro-intel`        |
| [`de3ec805`](https://github.com/NixOS/nixos-hardware/commit/de3ec80522011e938a55c3964d9e1f8826215796) | `Add Surface Pro (Intel)`                                                      |
| [`30066d18`](https://github.com/NixOS/nixos-hardware/commit/30066d1886a111a917f82154ac90167b0042b29d) | `Tidy-up`                                                                      |
| [`63be2f98`](https://github.com/NixOS/nixos-hardware/commit/63be2f98546ae64aedb8716fa6b0771903f291a3) | `Update README.md to reference surface-go module`                              |
| [`ee8fef41`](https://github.com/NixOS/nixos-hardware/commit/ee8fef414961d3d04250a03cb5a071882f286f44) | `Use the module assertions option, instead`                                    |
| [`9d4505d4`](https://github.com/NixOS/nixos-hardware/commit/9d4505d4e11afd3c7037b74d87ace16fb047de06) | `Update README`                                                                |
| [`f00dee1f`](https://github.com/NixOS/nixos-hardware/commit/f00dee1fdfe2975c5f80dbb79a4e6ff8fee1d3c0) | `Remove the "deprecated" module`                                               |
| [`157a74d8`](https://github.com/NixOS/nixos-hardware/commit/157a74d8a47e46da908e1c1f22d645b2085343c1) | `"old" --> "deprecated"`                                                       |
| [`c1580f8d`](https://github.com/NixOS/nixos-hardware/commit/c1580f8d81c63ce2b3396d304f5db6fdaf782582) | `Update warning message`                                                       |
| [`9e1f0366`](https://github.com/NixOS/nixos-hardware/commit/9e1f036688f0a2abe0e2ec1504637de22c37661a) | `Fix README`                                                                   |
| [`9491d406`](https://github.com/NixOS/nixos-hardware/commit/9491d40621da9da9ce66cd239d7ee146510beb7e) | `README.md`                                                                    |
| [`cd560b1e`](https://github.com/NixOS/nixos-hardware/commit/cd560b1ec3498f0fc3c5d6b266e7c49b2677eebc) | `README.md`                                                                    |
| [`20cc3076`](https://github.com/NixOS/nixos-hardware/commit/20cc307602f461001a6de0e33f7a773a1c2f4f0a) | `Update README.md and flake.nix`                                               |
| [`c52e0880`](https://github.com/NixOS/nixos-hardware/commit/c52e0880de7100b0590dd3e3d39cbbc63ef45485) | `Add warning when importing microsoft/surface/ from now on`                    |
| [`cca1f047`](https://github.com/NixOS/nixos-hardware/commit/cca1f04705171080e18f8f270fc98d168811054f) | `Move the last of the code into ./microsoft/common/old`                        |
| [`5b27563b`](https://github.com/NixOS/nixos-hardware/commit/5b27563b0202d9fd70054552dcfbb2302a1dc5eb) | `Extract "surface-control" management into new option-enabled module`          |
| [`b8f4e971`](https://github.com/NixOS/nixos-hardware/commit/b8f4e971714112c72f05992bf63b3fa9cf117451) | `Extract IPTSd management into new option-enabled module`                      |
| [`391211b3`](https://github.com/NixOS/nixos-hardware/commit/391211b3511b3f3a2669691cfe54480eb17f3565) | `Extract _actually_ common code out of microsoft/surface/default.nix`          |
| [`7ff6c2fd`](https://github.com/NixOS/nixos-hardware/commit/7ff6c2fd67ed586f20dc4272279820a26cb996e6) | `Doc comment`                                                                  |
| [`bd17dc47`](https://github.com/NixOS/nixos-hardware/commit/bd17dc47068f10ee794da890092c5db5e265594e) | `Move files around...`                                                         |
| [`cca014c8`](https://github.com/NixOS/nixos-hardware/commit/cca014c8b07818dcf5d47bdb9fe908c505097c88) | `Fix README`                                                                   |
| [`d8df3d75`](https://github.com/NixOS/nixos-hardware/commit/d8df3d756af19a4889c50cd5eb8276795e79454d) | `Update README.md and flake.nix`                                               |
| [`210e621c`](https://github.com/NixOS/nixos-hardware/commit/210e621c62d00bed1e9e4d4839a39ce2e4f4e237) | `Create model specialisation for MS Surface Go`                                |
| [`36f3e30f`](https://github.com/NixOS/nixos-hardware/commit/36f3e30fff4c45d2b56e5b0e55b7a8157aab2633) | `README.md`                                                                    |
| [`330cdaa1`](https://github.com/NixOS/nixos-hardware/commit/330cdaa125bd8856d316e0c01428cbaee80be90a) | `README.md`                                                                    |
| [`6518a931`](https://github.com/NixOS/nixos-hardware/commit/6518a931507a4670bf8cdf78ef60168a1142e725) | `Update README.md and flake.nix`                                               |
| [`fb5ac772`](https://github.com/NixOS/nixos-hardware/commit/fb5ac7720795bfd8414be4594a5a07e64725049c) | `Add warning when importing microsoft/surface/ from now on`                    |
| [`ab0c9fe7`](https://github.com/NixOS/nixos-hardware/commit/ab0c9fe7ce53dca2cd870cfa57b45dd912c03800) | `Move the last of the code into ./microsoft/common/old`                        |
| [`f0835cb4`](https://github.com/NixOS/nixos-hardware/commit/f0835cb45cefc30b629c5ebbc99b04f305104562) | `Extract "surface-control" management into new option-enabled module`          |
| [`0ce988ea`](https://github.com/NixOS/nixos-hardware/commit/0ce988ea8a1d9fbc61128cf8d31b45af4b3d0138) | `Extract IPTSd management into new option-enabled module`                      |
| [`51122e95`](https://github.com/NixOS/nixos-hardware/commit/51122e95a1a79a076cbbaea572cca0f20e6c23d9) | `Extract _actually_ common code out of microsoft/surface/default.nix`          |
| [`5e6d5f2d`](https://github.com/NixOS/nixos-hardware/commit/5e6d5f2d8826fcd28dc164a9cc88120d81fc406f) | `Doc comment`                                                                  |
| [`03df3d2d`](https://github.com/NixOS/nixos-hardware/commit/03df3d2d530a69fe1d006c1a161f76885d3ffb2a) | `Move files around...`                                                         |