### PR TITLE
chore(flake/emacs-overlay): `b537e3cb` -> `4a14e8f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673374422,
-        "narHash": "sha256-Xr4cNdXM8y5WIX80tFxwSl5/Wk1BdwYSnMFGGbbdA1U=",
+        "lastModified": 1673402425,
+        "narHash": "sha256-snt6hZA5nUOzfj4ghqBNKEy2dil5xF4oTy6BYmbdk9Q=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b537e3cba7307729bf80cdc8ef2b176727cbb645",
+        "rev": "4a14e8f79e91636cdfc4cecc3f12cdc4cfe57a60",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`4a14e8f7`](https://github.com/nix-community/emacs-overlay/commit/4a14e8f79e91636cdfc4cecc3f12cdc4cfe57a60) | `Updated repos/melpa` |
| [`5425bafa`](https://github.com/nix-community/emacs-overlay/commit/5425bafa8a38e8c32198def4e07fed8cf68dcc98) | `Updated repos/elpa`  |