### PR TITLE
chore(flake/nur): `2c47b2a0` -> `37767497`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673379985,
-        "narHash": "sha256-hhpNcVO6GkgSjIbgNc3tTLyIcvQByyY2VJhKye7kQVc=",
+        "lastModified": 1673402863,
+        "narHash": "sha256-z2NsQ/pD2swxXM1c2ECIzckcjILHuMTela9Ya0prm5c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2c47b2a0053cdb36cc08353f79eebf7a055fa18f",
+        "rev": "3776749755337174bbdd9d0b51adf31b5e42e5e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`37767497`](https://github.com/nix-community/NUR/commit/3776749755337174bbdd9d0b51adf31b5e42e5e8) | `automatic update` |