### PR TITLE
chore(flake/nur): `37767497` -> `7dd1b073`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673402863,
-        "narHash": "sha256-z2NsQ/pD2swxXM1c2ECIzckcjILHuMTela9Ya0prm5c=",
+        "lastModified": 1673408664,
+        "narHash": "sha256-k7IrPa55WkCyV3ThGiLCh8LhV8ZtlAy3QQL7fKvEQoo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3776749755337174bbdd9d0b51adf31b5e42e5e8",
+        "rev": "7dd1b07397b9e5112700249a3ef225d4e1a4d920",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7dd1b073`](https://github.com/nix-community/NUR/commit/7dd1b07397b9e5112700249a3ef225d4e1a4d920) | `automatic update` |
| [`4950e9d2`](https://github.com/nix-community/NUR/commit/4950e9d2b257ac271f36d80a83aebac05612fce1) | `automatic update` |