### PR TITLE
chore(flake/nur): `c91edfd9` -> `4cd4cc27`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673410128,
-        "narHash": "sha256-gza2xg4/v2EOlM2FEmqequ4wSxmTK1NBxMoqg1pBUUI=",
+        "lastModified": 1673423076,
+        "narHash": "sha256-Uprz5Kfp7F0bZLnLi5RjslNnqKt2l0mbctfDySf80ps=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c91edfd9e055e3b3cc7e63f5e026870b3071889d",
+        "rev": "4cd4cc279b2729c85ed4955c1052047aa33a6390",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4cd4cc27`](https://github.com/nix-community/NUR/commit/4cd4cc279b2729c85ed4955c1052047aa33a6390) | `automatic update` |