### PR TITLE
chore(flake/nur): `a77112aa` -> `99291dfa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673426865,
-        "narHash": "sha256-zNoCWLOqq2X9d188BlIDG46KcTkQ8AGaY9g4yozl2Zs=",
+        "lastModified": 1673437481,
+        "narHash": "sha256-R4cH9qqeRYr9VbK+5h8VoGLOie3rN01q8uj2JWpee5s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a77112aa2598b741261a2af1383ac372e6f9c104",
+        "rev": "99291dfa7af8328521994cb6e61248ce69b73dfc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`99291dfa`](https://github.com/nix-community/NUR/commit/99291dfa7af8328521994cb6e61248ce69b73dfc) | `automatic update` |