### PR TITLE
chore(flake/nur): `99291dfa` -> `77bf1ba2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673437481,
-        "narHash": "sha256-R4cH9qqeRYr9VbK+5h8VoGLOie3rN01q8uj2JWpee5s=",
+        "lastModified": 1673442346,
+        "narHash": "sha256-pgvr0slrAlScouRB03fOVo0MMVMYnFiJDfWztCUeNVA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "99291dfa7af8328521994cb6e61248ce69b73dfc",
+        "rev": "77bf1ba284c6c32ed5df9bb8a8288a9b14b6811a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`77bf1ba2`](https://github.com/nix-community/NUR/commit/77bf1ba284c6c32ed5df9bb8a8288a9b14b6811a) | `automatic update` |