### PR TITLE
chore(flake/nixos-hardware): `93350684` -> `88016c96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -341,11 +341,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1673390851,
-        "narHash": "sha256-dAhsJUIxfg5gWE+uQ3e0ICssS0QPQZt7Pa+75NKtAEw=",
+        "lastModified": 1673440569,
+        "narHash": "sha256-FQ5o0yI+MH9MgfseeGDsVIIpIqv3BCgq+0NzncuZ9Zo=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "9335068481026234c1f41079ad54e28ad92453de",
+        "rev": "88016c96c3c338aa801695cdd9f186820bcfe4d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message  |
| ----------------------------------------------------------------------------------------------------- | --------------- |
| [`62e8ddb9`](https://github.com/NixOS/nixos-hardware/commit/62e8ddb93f08487f63dbb339d1e572b214bf81d9) | `Deadnix fixes` |
| [`01d1f960`](https://github.com/NixOS/nixos-hardware/commit/01d1f9604e26953f43b77c2e173e31c9af8075dd) | `Update TODO's` |