### PR TITLE
chore(flake/nur): `77bf1ba2` -> `fcc624c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673442346,
-        "narHash": "sha256-pgvr0slrAlScouRB03fOVo0MMVMYnFiJDfWztCUeNVA=",
+        "lastModified": 1673462967,
+        "narHash": "sha256-n2lNm35knAvg4/b3NRu5VuNiqcWH6gE8HXlk7nG3/w4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "77bf1ba284c6c32ed5df9bb8a8288a9b14b6811a",
+        "rev": "fcc624c7cc0954966ea2bb49e54c392887bd445f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`fcc624c7`](https://github.com/nix-community/NUR/commit/fcc624c7cc0954966ea2bb49e54c392887bd445f) | `automatic update` |