### PR TITLE
chore(flake/emacs-overlay): `d85438fe` -> `a488b1a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673433023,
-        "narHash": "sha256-wF5qhT3UvGk1Ouog+wEvm21oeD6rvzXg+/wcfPJq0BI=",
+        "lastModified": 1673462692,
+        "narHash": "sha256-FsRQPqq1J0iPzJcaIiRl9weio3lyXM4w0Ae/RehI//E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d85438fe16bfef13004bc90a50661d0c74252970",
+        "rev": "a488b1a67be14ce00e26e580e10b7bcb67e4b46d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`a488b1a6`](https://github.com/nix-community/emacs-overlay/commit/a488b1a67be14ce00e26e580e10b7bcb67e4b46d) | `Updated repos/melpa` |
| [`1a3f5d63`](https://github.com/nix-community/emacs-overlay/commit/1a3f5d633ea962194f8ef7a2be8a592cae303040) | `Updated repos/emacs` |