### PR TITLE
chore(flake/nur): `fcc624c7` -> `1ee28866`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673462967,
-        "narHash": "sha256-n2lNm35knAvg4/b3NRu5VuNiqcWH6gE8HXlk7nG3/w4=",
+        "lastModified": 1673466346,
+        "narHash": "sha256-xQmR3V5l5hwHSWIOmWxqBUttmcgsUD7Da8sEpngW7/w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fcc624c7cc0954966ea2bb49e54c392887bd445f",
+        "rev": "1ee2886609567a210debe8b53520b12b9d7541f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1ee28866`](https://github.com/nix-community/NUR/commit/1ee2886609567a210debe8b53520b12b9d7541f8) | `automatic update` |