### PR TITLE
chore(flake/sops-nix): `2253120d` -> `32187b33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -585,11 +585,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1673147300,
-        "narHash": "sha256-gR9OEfTzWfL6vG0qkbn1TlBAOlg4LuW8xK/u0V41Ihc=",
+        "lastModified": 1673481602,
+        "narHash": "sha256-P80X38fOM2MtoYdgkyuksGOQPDhIhNJW2W2jMeMIZzE=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "2253120d2a6147e57bafb5c689e086221df8032f",
+        "rev": "32187b33ac6ec9b628dcd08dd941a715e6241dda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                                                                      |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`7e0e6790`](https://github.com/Mic92/sops-nix/commit/7e0e6790503c7bd7a51eff0c7442a2c3a1e09ddb) | `Update pkgs/sops-init-gpg-key/sops-init-gpg-key`                                   |
| [`0ef86b61`](https://github.com/Mic92/sops-nix/commit/0ef86b61ee4944bf8f41faba087adff5015e0f87) | `Update pkgs/sops-init-gpg-key/sops-init-gpg-key`                                   |
| [`08a2634b`](https://github.com/Mic92/sops-nix/commit/08a2634b42c98490bb9b23eb52886edca1023638) | `Add documentation for sops-init-gpg-key with a Curved25119 key to the README file` |
| [`965743c6`](https://github.com/Mic92/sops-nix/commit/965743c6789c75ad1ac17cf61441155114ae4c79) | `Add optional generation of Curve25519 type GPG keys`                               |