### PR TITLE
chore(flake/nur): `faa4d411` -> `b362784d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673489320,
-        "narHash": "sha256-rkXLo1ShKdCwXP+fEWUI4QzakGubNCHwtl3gEAiVufs=",
+        "lastModified": 1673492394,
+        "narHash": "sha256-tmJr6TTaRHfpvQ/oiF54HvB9t17g6PBp077MJKsz2+c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "faa4d411ba28aa0f9b4aa5b244f85edd3adbb0c3",
+        "rev": "b362784d1dddb74f852678c8aa2bb2265fc624aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b362784d`](https://github.com/nix-community/NUR/commit/b362784d1dddb74f852678c8aa2bb2265fc624aa) | `automatic update` |