### PR TITLE
chore(flake/emacs-overlay): `a488b1a6` -> `9066f92a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673462692,
-        "narHash": "sha256-FsRQPqq1J0iPzJcaIiRl9weio3lyXM4w0Ae/RehI//E=",
+        "lastModified": 1673494149,
+        "narHash": "sha256-TitnT29bxDzckQfePsHMARtPS2TLHbLlf4FTgy9JdXw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a488b1a67be14ce00e26e580e10b7bcb67e4b46d",
+        "rev": "9066f92a2f6334de8977240e221278aba8037d7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`9066f92a`](https://github.com/nix-community/emacs-overlay/commit/9066f92a2f6334de8977240e221278aba8037d7a) | `Updated repos/melpa` |
| [`40948df7`](https://github.com/nix-community/emacs-overlay/commit/40948df73aec8b6cf0c6ff24af619e86f3ad8522) | `Updated repos/emacs` |
| [`5cab6df9`](https://github.com/nix-community/emacs-overlay/commit/5cab6df93a5eccccbee9613bb25b85296f15e03c) | `Updated repos/elpa`  |