### PR TITLE
chore(flake/nur): `b362784d` -> `72092b9c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673492394,
-        "narHash": "sha256-tmJr6TTaRHfpvQ/oiF54HvB9t17g6PBp077MJKsz2+c=",
+        "lastModified": 1673494635,
+        "narHash": "sha256-kKIpVBDRa7/AQICA3k+LxGT4d5yn9Bh0LPvo0OMfv4o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b362784d1dddb74f852678c8aa2bb2265fc624aa",
+        "rev": "72092b9c11c74da6a10c9652c6b5acf5f57ca103",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`72092b9c`](https://github.com/nix-community/NUR/commit/72092b9c11c74da6a10c9652c6b5acf5f57ca103) | `automatic update` |