### PR TITLE
chore(flake/nur): `72092b9c` -> `0bba7bdb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673494635,
-        "narHash": "sha256-kKIpVBDRa7/AQICA3k+LxGT4d5yn9Bh0LPvo0OMfv4o=",
+        "lastModified": 1673496602,
+        "narHash": "sha256-J2omGvYZDaGupS/pVlkvQlMvnTLb1AN+LKn5OeYwKBg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "72092b9c11c74da6a10c9652c6b5acf5f57ca103",
+        "rev": "0bba7bdb0a2fe1dc4abfbd36908c669024baaf1d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0bba7bdb`](https://github.com/nix-community/NUR/commit/0bba7bdb0a2fe1dc4abfbd36908c669024baaf1d) | `automatic update` |