### PR TITLE
chore(flake/nur): `0bba7bdb` -> `619e73b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673496602,
-        "narHash": "sha256-J2omGvYZDaGupS/pVlkvQlMvnTLb1AN+LKn5OeYwKBg=",
+        "lastModified": 1673500866,
+        "narHash": "sha256-MrzvPUnCqtt6G43DcBDU0O+cnB0lhH9btZIIZnjYAJ8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0bba7bdb0a2fe1dc4abfbd36908c669024baaf1d",
+        "rev": "619e73b02a9a539a2449e5384c6d4c5863f3c5aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`619e73b0`](https://github.com/nix-community/NUR/commit/619e73b02a9a539a2449e5384c6d4c5863f3c5aa) | `automatic update` |
| [`635b6c85`](https://github.com/nix-community/NUR/commit/635b6c85ffb52df41e02a6fce4833a23562f53b8) | `automatic update` |