### PR TITLE
chore(flake/emacs-overlay): `9066f92a` -> `2f6595fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673494149,
-        "narHash": "sha256-TitnT29bxDzckQfePsHMARtPS2TLHbLlf4FTgy9JdXw=",
+        "lastModified": 1673519917,
+        "narHash": "sha256-rq2D5F7i4LK97N8lOALPX5c23Guc/sJ/2xiW1Z+3gzI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9066f92a2f6334de8977240e221278aba8037d7a",
+        "rev": "2f6595feecd8a5b12068eacbfbaefc02c42c25bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`2f6595fe`](https://github.com/nix-community/emacs-overlay/commit/2f6595feecd8a5b12068eacbfbaefc02c42c25bd) | `Updated repos/nongnu` |
| [`e59c5c21`](https://github.com/nix-community/emacs-overlay/commit/e59c5c21e96e7b4da8e877446e98ae89120fe9dd) | `Updated repos/melpa`  |
| [`a2e8ecc3`](https://github.com/nix-community/emacs-overlay/commit/a2e8ecc377a751d4a5019f6b2d20ab350ece7e47) | `Updated repos/emacs`  |