### PR TITLE
chore(flake/nur): `669f50a8` -> `d4f106f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673552708,
-        "narHash": "sha256-tiUdNSu8C9g0DhocFWljX3vns84Z0rZ/LBHaUxaU+ew=",
+        "lastModified": 1673573125,
+        "narHash": "sha256-IRugFlbNBehq7y+mvL5t/5hgxUqncFoHPzzOR6xrrfQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "669f50a8708d1e147ddbf3f45b14e07754de65a8",
+        "rev": "d4f106f2c9dcc895e5d93930d3a543b6817bf502",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d4f106f2`](https://github.com/nix-community/NUR/commit/d4f106f2c9dcc895e5d93930d3a543b6817bf502) | `automatic update` |