### PR TITLE
chore(flake/nur): `459cff0b` -> `c08f7963`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673577816,
-        "narHash": "sha256-wD+2ja6oG0NeqZSBu6HhbK5EvtAwxi8OA1C9wqiw3pI=",
+        "lastModified": 1673581533,
+        "narHash": "sha256-+93pXY/RJKwmSoO4q55OvrJELB7NQ0tgA71lkY3Bfow=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "459cff0b6d49e9515ea9dbfc17ff67d58f8ee342",
+        "rev": "c08f7963fcc13a81eb9b87cbaa64e907950b7e7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c08f7963`](https://github.com/nix-community/NUR/commit/c08f7963fcc13a81eb9b87cbaa64e907950b7e7f) | `automatic update` |
| [`fcb8851d`](https://github.com/nix-community/NUR/commit/fcb8851d2898129fc9d17f2f0c88aa4954ad859d) | `automatic update` |