### PR TITLE
chore(flake/nur): `c08f7963` -> `20b68174`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673581533,
-        "narHash": "sha256-+93pXY/RJKwmSoO4q55OvrJELB7NQ0tgA71lkY3Bfow=",
+        "lastModified": 1673583073,
+        "narHash": "sha256-XG/zsSlxjZy+XERsapjgyZqWX/tQ6b3bqs4g4jtSOnU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c08f7963fcc13a81eb9b87cbaa64e907950b7e7f",
+        "rev": "20b681740a762e3e80c2458dc02e391eb85881fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`20b68174`](https://github.com/nix-community/NUR/commit/20b681740a762e3e80c2458dc02e391eb85881fb) | `automatic update` |