### PR TITLE
chore(flake/nur): `20b68174` -> `9924928f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673583073,
-        "narHash": "sha256-XG/zsSlxjZy+XERsapjgyZqWX/tQ6b3bqs4g4jtSOnU=",
+        "lastModified": 1673599710,
+        "narHash": "sha256-MikSu5h1F6E+8c/QdB0Q/sVjyUmCWgXb/y76nU3NALY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "20b681740a762e3e80c2458dc02e391eb85881fb",
+        "rev": "9924928f53803e7146edfac4c33e41b287206cd2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9924928f`](https://github.com/nix-community/NUR/commit/9924928f53803e7146edfac4c33e41b287206cd2) | `automatic update` |