### PR TITLE
chore(flake/emacs-overlay): `f31b9a13` -> `0e8abd1a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673578893,
-        "narHash": "sha256-0C6Brn1Pe3cDM6r8xQjZNz71LgRm5LoWYaXLrqA2c5U=",
+        "lastModified": 1673602276,
+        "narHash": "sha256-MdtgFTSRTxWQtZAsv061haJh1iRKwORtUl2V6vWA9CY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f31b9a13f881c0e8bc844fa8273daef2128f9510",
+        "rev": "0e8abd1a198a954a1206b0306c10285da76a1d1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                             |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
| [`02dd2126`](https://github.com/nix-community/emacs-overlay/commit/02dd212638014b3c856b11e457ba87119cdc9522) | `Updated repos/melpa`                      |
| [`699dd6e9`](https://github.com/nix-community/emacs-overlay/commit/699dd6e9999e3977490eb75490f1fa155fa5c319) | `Remove special casing for nongnuPackages` |