### PR TITLE
chore(flake/nur): `35e253b2` -> `18b189eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673603123,
-        "narHash": "sha256-dNUDmwHoKEeLLoeHBuhKUYQ7DDRfv1CSmo7wpEYLgt4=",
+        "lastModified": 1673615086,
+        "narHash": "sha256-0ws4gyiJCOcLuwjPh84gVe1Ga+KD/c808WYRETZ4G9E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "35e253b2b9aae5b7590f63e00f7131dc6d6d0e71",
+        "rev": "18b189eba7cf5a4a7c9c5213e64ecdc27d585d76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`18b189eb`](https://github.com/nix-community/NUR/commit/18b189eba7cf5a4a7c9c5213e64ecdc27d585d76) | `automatic update` |