### PR TITLE
chore(flake/nur): `dcb9bbb7` -> `7cc58cb5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673661479,
-        "narHash": "sha256-zdM1dKVrtQyHfMUKQJSrm1xrQbdrA4yFdS/bODZSHPs=",
+        "lastModified": 1673667908,
+        "narHash": "sha256-xRN5JfJRwaLv4ooeauYs45WqItBVdA+D/ufq0W5QL0g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dcb9bbb764666a4ecc94d8319aed1ffb5f8efe82",
+        "rev": "7cc58cb58c50f4fc1413db774bcb6129abcbc2a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7cc58cb5`](https://github.com/nix-community/NUR/commit/7cc58cb58c50f4fc1413db774bcb6129abcbc2a1) | `automatic update` |
| [`940c3066`](https://github.com/nix-community/NUR/commit/940c306636f21f4f92039dc4fb04df6d38ac197e) | `automatic update` |