### PR TITLE
chore(flake/nur): `7cc58cb5` -> `3bac06b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673667908,
-        "narHash": "sha256-xRN5JfJRwaLv4ooeauYs45WqItBVdA+D/ufq0W5QL0g=",
+        "lastModified": 1673669452,
+        "narHash": "sha256-ITyk48hWqKkdo1pQ9oYh+tG25S4iuB7K/VvTvORo1vM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7cc58cb58c50f4fc1413db774bcb6129abcbc2a1",
+        "rev": "3bac06b296d56510bfe11c42550ffb3c052f3421",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3bac06b2`](https://github.com/nix-community/NUR/commit/3bac06b296d56510bfe11c42550ffb3c052f3421) | `automatic update` |