### PR TITLE
chore(flake/nur): `3bac06b2` -> `54252f1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673669452,
-        "narHash": "sha256-ITyk48hWqKkdo1pQ9oYh+tG25S4iuB7K/VvTvORo1vM=",
+        "lastModified": 1673675147,
+        "narHash": "sha256-sSGAGJy824JyyPAXXbdSLPvtDv+EtFvMjVhzlUU2Qrs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3bac06b296d56510bfe11c42550ffb3c052f3421",
+        "rev": "54252f1df660dc3c0800bce91a3161bd6ae18027",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`54252f1d`](https://github.com/nix-community/NUR/commit/54252f1df660dc3c0800bce91a3161bd6ae18027) | `automatic update` |