### PR TITLE
chore(flake/emacs-overlay): `1114c22a` -> `4de9f486`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673667358,
-        "narHash": "sha256-29xEYwKyYQQzpmN7bdCGRTNiSazkpFF6UWYx2RYaKJo=",
+        "lastModified": 1673691460,
+        "narHash": "sha256-Xlwq4MRvELs86fzvQfwfL1vxLTOwUu1mxbnegly+JnQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1114c22aeb13c1c2344f237ec57bf155c9fc1a8f",
+        "rev": "4de9f486cff63cc6508d425da10e2ed32fde8c55",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`4de9f486`](https://github.com/nix-community/emacs-overlay/commit/4de9f486cff63cc6508d425da10e2ed32fde8c55) | `Updated repos/melpa` |
| [`e6679463`](https://github.com/nix-community/emacs-overlay/commit/e66794634ab3a380ffecc9275c8bf28380f61ff5) | `Updated repos/emacs` |