### PR TITLE
chore(flake/emacs-overlay): `4de9f486` -> `9d583f9b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673691460,
-        "narHash": "sha256-Xlwq4MRvELs86fzvQfwfL1vxLTOwUu1mxbnegly+JnQ=",
+        "lastModified": 1673706610,
+        "narHash": "sha256-zhY0KLj/7zzJuUc9Ci9rZnNMrwzSkZp+oPO3UBnKztg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4de9f486cff63cc6508d425da10e2ed32fde8c55",
+        "rev": "9d583f9b0e80136acd9d11185a9f1f5579a40cca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                           |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
| [`9974b66e`](https://github.com/nix-community/emacs-overlay/commit/9974b66ebe46235d583d8724c0ab2ed2b3acf395) | `Add nixpkgs input and create lock file` |