### PR TITLE
chore(flake/emacs-overlay): `9d583f9b` -> `800685a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673706610,
-        "narHash": "sha256-zhY0KLj/7zzJuUc9Ci9rZnNMrwzSkZp+oPO3UBnKztg=",
+        "lastModified": 1673717181,
+        "narHash": "sha256-pAiFSFWD1p8CiTJaUOfQnsePuE5tag/RMIyltVdePRM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9d583f9b0e80136acd9d11185a9f1f5579a40cca",
+        "rev": "800685a0ad5dfa94d6e3fffb5ffa1a208ad8c76a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`800685a0`](https://github.com/nix-community/emacs-overlay/commit/800685a0ad5dfa94d6e3fffb5ffa1a208ad8c76a) | `Updated repos/melpa` |
| [`6d8a2ba3`](https://github.com/nix-community/emacs-overlay/commit/6d8a2ba38e84e0491c3d5a3d014a0dcdb7fdb31d) | `Updated repos/elpa`  |