### PR TITLE
chore(flake/nur): `39f8d3cb` -> `7f09ac18`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673711115,
-        "narHash": "sha256-RY2xKMbs+GDbH3mszx5NsJ9HbVVSa9w6qUItE6UDcGQ=",
+        "lastModified": 1673718268,
+        "narHash": "sha256-uy3y9J2Ve/ZCfKJczdza/Hghhmi5wzrg7+9n6WXkqAI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "39f8d3cbd719478c3505de5f31a7000404ee6c42",
+        "rev": "7f09ac18ca910d01880199d9f53b61da95d6fc34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7f09ac18`](https://github.com/nix-community/NUR/commit/7f09ac18ca910d01880199d9f53b61da95d6fc34) | `automatic update` |