### PR TITLE
chore(flake/nur): `7f09ac18` -> `b69f265d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673718268,
-        "narHash": "sha256-uy3y9J2Ve/ZCfKJczdza/Hghhmi5wzrg7+9n6WXkqAI=",
+        "lastModified": 1673725454,
+        "narHash": "sha256-3OdJErYTfX59tShAFO+o+2tPfSRmH6oF8gb3w/dhT+g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7f09ac18ca910d01880199d9f53b61da95d6fc34",
+        "rev": "b69f265d1e31a56a121369199af41b98f40aa575",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b69f265d`](https://github.com/nix-community/NUR/commit/b69f265d1e31a56a121369199af41b98f40aa575) | `automatic update` |