### PR TITLE
chore(flake/nur): `b69f265d` -> `331160ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673725454,
-        "narHash": "sha256-3OdJErYTfX59tShAFO+o+2tPfSRmH6oF8gb3w/dhT+g=",
+        "lastModified": 1673729100,
+        "narHash": "sha256-IGChMGp4rYtbAGU6qRKidE2iCUMHJMpfjcVaA9G6t4c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b69f265d1e31a56a121369199af41b98f40aa575",
+        "rev": "331160ff45ee830e7cdc6d35d209edede2ca4742",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`331160ff`](https://github.com/nix-community/NUR/commit/331160ff45ee830e7cdc6d35d209edede2ca4742) | `automatic update` |