### PR TITLE
chore(flake/nur): `331160ff` -> `69892a51`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673729100,
-        "narHash": "sha256-IGChMGp4rYtbAGU6qRKidE2iCUMHJMpfjcVaA9G6t4c=",
+        "lastModified": 1673734494,
+        "narHash": "sha256-gkw/tolENprKvnAuu5RxUBzLvS0IJ0V2/6lDos/1Xhc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "331160ff45ee830e7cdc6d35d209edede2ca4742",
+        "rev": "69892a512717bb5c457486154d37912cd98194ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`69892a51`](https://github.com/nix-community/NUR/commit/69892a512717bb5c457486154d37912cd98194ab) | `automatic update` |