### PR TITLE
chore(flake/emacs-overlay): `800685a0` -> `3f8a6e83`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673717181,
-        "narHash": "sha256-pAiFSFWD1p8CiTJaUOfQnsePuE5tag/RMIyltVdePRM=",
+        "lastModified": 1673751961,
+        "narHash": "sha256-/hsZcTyvX6DNArzEZVaD/7l90VlaZIHTmOisCEW6SGI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "800685a0ad5dfa94d6e3fffb5ffa1a208ad8c76a",
+        "rev": "3f8a6e839a1574631e135a34c53e5e58ae81bd8e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`3f8a6e83`](https://github.com/nix-community/emacs-overlay/commit/3f8a6e839a1574631e135a34c53e5e58ae81bd8e) | `Updated repos/melpa` |
| [`91c70283`](https://github.com/nix-community/emacs-overlay/commit/91c70283d216e46d591652ea6139749c0b1b292b) | `Updated repos/emacs` |