### PR TITLE
chore(flake/nur): `69892a51` -> `a8aed37f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673734494,
-        "narHash": "sha256-gkw/tolENprKvnAuu5RxUBzLvS0IJ0V2/6lDos/1Xhc=",
+        "lastModified": 1673753731,
+        "narHash": "sha256-zXD8AuAIGNZUX4DngxATmebyL4phTNFfW9KGOofdvpM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "69892a512717bb5c457486154d37912cd98194ab",
+        "rev": "a8aed37f2f7e464a0be226c1e9074c107764653d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a8aed37f`](https://github.com/nix-community/NUR/commit/a8aed37f2f7e464a0be226c1e9074c107764653d) | `automatic update` |