### PR TITLE
chore(flake/nur): `a8aed37f` -> `99bc34da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673753731,
-        "narHash": "sha256-zXD8AuAIGNZUX4DngxATmebyL4phTNFfW9KGOofdvpM=",
+        "lastModified": 1673755893,
+        "narHash": "sha256-5sD9At2yWkIEMz4Haqz8E3GnbxIYOY2uU7Ot8ukXlhQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a8aed37f2f7e464a0be226c1e9074c107764653d",
+        "rev": "99bc34da9d3ca463ee6f7a91bc1e853e6b2a3051",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`99bc34da`](https://github.com/nix-community/NUR/commit/99bc34da9d3ca463ee6f7a91bc1e853e6b2a3051) | `automatic update` |