### PR TITLE
chore(flake/nur): `99bc34da` -> `0d9214b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673755893,
-        "narHash": "sha256-5sD9At2yWkIEMz4Haqz8E3GnbxIYOY2uU7Ot8ukXlhQ=",
+        "lastModified": 1673762217,
+        "narHash": "sha256-zy0M4cU7He9kMFpocumQWtU2OmJfvByq/lXVegzZx4g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "99bc34da9d3ca463ee6f7a91bc1e853e6b2a3051",
+        "rev": "0d9214b8db66df7d3dac2725abb891d80938e921",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0d9214b8`](https://github.com/nix-community/NUR/commit/0d9214b8db66df7d3dac2725abb891d80938e921) | `automatic update` |