### PR TITLE
chore(flake/nur): `6d83652c` -> `4d2c7049`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673775971,
-        "narHash": "sha256-McSKY6kDbUbLfAQD+bDhBUx5qH6aZSWs0ZKCLkEu8ec=",
+        "lastModified": 1673804748,
+        "narHash": "sha256-nOoQBoPgqUHLKcrDzAjErPTefelsxW7VRNCdAJ/Lr7s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6d83652c7277244cd36db35b07a79bd773e79a88",
+        "rev": "4d2c70498900a21eace533a5427191c53963b9d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4d2c7049`](https://github.com/nix-community/NUR/commit/4d2c70498900a21eace533a5427191c53963b9d7) | `automatic update` |