### PR TITLE
chore(flake/emacs-overlay): `64730859` -> `42fdbe13`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673777494,
-        "narHash": "sha256-/42vpn/x47AZaxClHpiUP0UafpnwWzfdhOjmLcnvKpg=",
+        "lastModified": 1673808115,
+        "narHash": "sha256-cyGvQWw8DuUzhVu9Q/nAhEAzHj6OEmZFD191dhVbYoU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "64730859c8decadbbc7f9b133af438306c441c3f",
+        "rev": "42fdbe1322a4d9bdafa68b9ec94f477994d7b919",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`42fdbe13`](https://github.com/nix-community/emacs-overlay/commit/42fdbe1322a4d9bdafa68b9ec94f477994d7b919) | `Updated repos/melpa` |
| [`0626733c`](https://github.com/nix-community/emacs-overlay/commit/0626733cfc6acdadd3a2685063d7100c25b23b1e) | `Updated repos/emacs` |
| [`0856ec24`](https://github.com/nix-community/emacs-overlay/commit/0856ec24f3bef9d778dbc7513d32c7db17301ecc) | `Updated repos/elpa`  |