### PR TITLE
chore(flake/nur): `154db378` -> `517f8b1f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673807129,
-        "narHash": "sha256-DxFxVF/cqqc+DlQb41uovQEZgKqdG1C/mVb+B3TQzLc=",
+        "lastModified": 1673811967,
+        "narHash": "sha256-rEIWnGEIc9zoCN7yw8nJstTxWHSdKse7tEtkzp2XLZk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "154db3784e08ccdff2716114823c75c0fa0e4d05",
+        "rev": "517f8b1f7d837fc11e9e0498bb1e06b4db03a8e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`517f8b1f`](https://github.com/nix-community/NUR/commit/517f8b1f7d837fc11e9e0498bb1e06b4db03a8e7) | `automatic update` |