### PR TITLE
chore(flake/emacs-overlay): `42fdbe13` -> `b63cf575`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673808115,
-        "narHash": "sha256-cyGvQWw8DuUzhVu9Q/nAhEAzHj6OEmZFD191dhVbYoU=",
+        "lastModified": 1673838100,
+        "narHash": "sha256-iLNzJqL01hHuZcnxNoB7bqj65lfQtEAc7+krVW4R6ck=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "42fdbe1322a4d9bdafa68b9ec94f477994d7b919",
+        "rev": "b63cf575927c768ad4dbc4a70f64201e59cf3da6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`b63cf575`](https://github.com/nix-community/emacs-overlay/commit/b63cf575927c768ad4dbc4a70f64201e59cf3da6) | `Updated repos/nongnu` |
| [`aad52b34`](https://github.com/nix-community/emacs-overlay/commit/aad52b340375a4dd8e4916306c0cdd52caacd725) | `Updated repos/melpa`  |
| [`c5f01edf`](https://github.com/nix-community/emacs-overlay/commit/c5f01edf49f54bfce90cd978121b496b51dbd886) | `Updated repos/emacs`  |