### PR TITLE
chore(flake/nur): `661bfe57` -> `8dbcbd67`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673834776,
-        "narHash": "sha256-IZRrfTWEW3lfIA5hkd96VzJ7sNk3I/WsAzYrLWcMS0Q=",
+        "lastModified": 1673840195,
+        "narHash": "sha256-OZAWoQB6DCo7/JvnDwDm0Wm2HIvx/v/qMwwfWFhHw0A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "661bfe579c879782223971324dc7799266a2e35e",
+        "rev": "8dbcbd675b45ac2376ea555a4e28b928a67d2498",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8dbcbd67`](https://github.com/nix-community/NUR/commit/8dbcbd675b45ac2376ea555a4e28b928a67d2498) | `automatic update` |