### PR TITLE
chore(flake/nur): `8dbcbd67` -> `95007800`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673840195,
-        "narHash": "sha256-OZAWoQB6DCo7/JvnDwDm0Wm2HIvx/v/qMwwfWFhHw0A=",
+        "lastModified": 1673849575,
+        "narHash": "sha256-pfIiR5rTya6UIhpXIJ+q5c8bAP0oaE4VGOZ6rbL0+QA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8dbcbd675b45ac2376ea555a4e28b928a67d2498",
+        "rev": "950078008b25391405058da665b32894eae7b8e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`95007800`](https://github.com/nix-community/NUR/commit/950078008b25391405058da665b32894eae7b8e8) | `automatic update` |