### PR TITLE
chore(flake/nur): `95007800` -> `4a9bc77b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673849575,
-        "narHash": "sha256-pfIiR5rTya6UIhpXIJ+q5c8bAP0oaE4VGOZ6rbL0+QA=",
+        "lastModified": 1673858859,
+        "narHash": "sha256-NYGSRzk5KY79igJisr1j++ApdE3StAj6p06buHFe2qY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "950078008b25391405058da665b32894eae7b8e8",
+        "rev": "4a9bc77b7d0866e7e6312f9e8b87bcb15ff7576a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4a9bc77b`](https://github.com/nix-community/NUR/commit/4a9bc77b7d0866e7e6312f9e8b87bcb15ff7576a) | `automatic update` |