### PR TITLE
chore(flake/emacs-overlay): `b63cf575` -> `b7102ef6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673838100,
-        "narHash": "sha256-iLNzJqL01hHuZcnxNoB7bqj65lfQtEAc7+krVW4R6ck=",
+        "lastModified": 1673864427,
+        "narHash": "sha256-7yQH2UAOW5si0D9ApcVFaif6+ZBPPBsY0iOEdHeirco=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b63cf575927c768ad4dbc4a70f64201e59cf3da6",
+        "rev": "b7102ef6e2389ef88c91b6f87fe2b981c0ecc567",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`b7102ef6`](https://github.com/nix-community/emacs-overlay/commit/b7102ef6e2389ef88c91b6f87fe2b981c0ecc567) | `Updated repos/melpa` |
| [`23513ddc`](https://github.com/nix-community/emacs-overlay/commit/23513ddc6941b1c6bd2dac46451e79d3237801ae) | `Updated repos/emacs` |