### PR TITLE
chore(flake/nur): `f8efaa98` -> `ebbbb37c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673893530,
-        "narHash": "sha256-xgb3qDmuGztenIlfpX7oS7WM1vvB7uknTcUkMv2DGfw=",
+        "lastModified": 1673894764,
+        "narHash": "sha256-xMX2SuX44WNK2rg6r9rVUjXyNHymOg8UaPrYWggUsoI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f8efaa98487e2082c70743360af59107caa1dbb3",
+        "rev": "ebbbb37c475a65d623b9a997636dd3879c9530cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ebbbb37c`](https://github.com/nix-community/NUR/commit/ebbbb37c475a65d623b9a997636dd3879c9530cc) | `automatic update` |