### PR TITLE
chore(flake/nur): `ebbbb37c` -> `1fcd2ed6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673894764,
-        "narHash": "sha256-xMX2SuX44WNK2rg6r9rVUjXyNHymOg8UaPrYWggUsoI=",
+        "lastModified": 1673901956,
+        "narHash": "sha256-kGtiirJ8bEugRJDgKnqj8Fdkv7k+pfCsaTYGmGvToBw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ebbbb37c475a65d623b9a997636dd3879c9530cc",
+        "rev": "1fcd2ed63dc6d739d640372af87375494a45f180",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1fcd2ed6`](https://github.com/nix-community/NUR/commit/1fcd2ed63dc6d739d640372af87375494a45f180) | `automatic update` |
| [`ed386a88`](https://github.com/nix-community/NUR/commit/ed386a884fbce9316f90cd9f4d13a03ac9ec90ec) | `automatic update` |