### PR TITLE
chore(flake/emacs-overlay): `f3f76b7b` -> `c12e6782`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673892843,
-        "narHash": "sha256-c5YlWiJLvh6oS0ZpvhMiuo4N8zRw6PjPrzxTXvA0zuc=",
+        "lastModified": 1673926305,
+        "narHash": "sha256-A9Q7+fkdXMEeJNz4mnIAmJgJnfQ9ApKlmcIpN5OIS4w=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f3f76b7ba1359b070df55ae2c80c18d662fbd71f",
+        "rev": "c12e6782e78b831afe482daabf0d418bdd6a8c2d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`c12e6782`](https://github.com/nix-community/emacs-overlay/commit/c12e6782e78b831afe482daabf0d418bdd6a8c2d) | `Updated repos/nongnu` |
| [`5a1c44b7`](https://github.com/nix-community/emacs-overlay/commit/5a1c44b73d0b0c22559679073e901b793471861c) | `Updated repos/melpa`  |
| [`9ae9e7ec`](https://github.com/nix-community/emacs-overlay/commit/9ae9e7ec7d674bd8a7d16e1a7bfd57564a61a7f6) | `Updated repos/emacs`  |
| [`31042303`](https://github.com/nix-community/emacs-overlay/commit/31042303652c6264589a63a59f3cfeddf0701ca3) | `Updated repos/elpa`   |