### PR TITLE
chore(flake/nur): `8f1d5240` -> `7e9a5b42`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673929842,
-        "narHash": "sha256-azN5e/zLkZh9QjfVl7XCBD5rbbYqUye+QThuzUi7TXE=",
+        "lastModified": 1673935396,
+        "narHash": "sha256-AkimCjK8quWnfMTmSKORp2tCs1dAifJD1BEn3bYnS/w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8f1d524069ac45a16808062ddd7764f7fdd7e878",
+        "rev": "7e9a5b42d68ca84a91e082ad325318e01456d2b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7e9a5b42`](https://github.com/nix-community/NUR/commit/7e9a5b42d68ca84a91e082ad325318e01456d2b5) | `automatic update` |