### PR TITLE
chore(flake/emacs-overlay): `c12e6782` -> `e98ec0df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673926305,
-        "narHash": "sha256-A9Q7+fkdXMEeJNz4mnIAmJgJnfQ9ApKlmcIpN5OIS4w=",
+        "lastModified": 1673952851,
+        "narHash": "sha256-2dv0rarxuQHp4YL7rx4TpWqKGglK+LlBqze+igCyqr4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c12e6782e78b831afe482daabf0d418bdd6a8c2d",
+        "rev": "e98ec0df74dbb00225850b7090b0fe59f12d9b01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`e98ec0df`](https://github.com/nix-community/emacs-overlay/commit/e98ec0df74dbb00225850b7090b0fe59f12d9b01) | `Updated repos/melpa` |
| [`e12bebac`](https://github.com/nix-community/emacs-overlay/commit/e12bebac0fcd6f882aecd4053207031103bb911f) | `Updated repos/emacs` |