### PR TITLE
chore(flake/flake-compat): `00939922` -> `35bb57c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1668681692,
-        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                 | Commit Message                        |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------- |
| [`43bfa87a`](https://github.com/edolstra/flake-compat/commit/43bfa87aa2f32792b32b84e00ec9af91a4c79e85) | ``Apply nix#7207 `_type = "flake";``` |