### PR TITLE
chore(flake/nur): `7e9a5b42` -> `0f06feb7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673935396,
-        "narHash": "sha256-AkimCjK8quWnfMTmSKORp2tCs1dAifJD1BEn3bYnS/w=",
+        "lastModified": 1673966768,
+        "narHash": "sha256-PNkLfSuWiyaQZgMRG3LbbJhARR7gTSkvF4HqlWoJ78E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7e9a5b42d68ca84a91e082ad325318e01456d2b5",
+        "rev": "0f06feb718cbe276a151cfd17ce5a6b90c67f145",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0f06feb7`](https://github.com/nix-community/NUR/commit/0f06feb718cbe276a151cfd17ce5a6b90c67f145) | `automatic update` |