### PR TITLE
chore(flake/nur): `0f06feb7` -> `3fce435c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673966768,
-        "narHash": "sha256-PNkLfSuWiyaQZgMRG3LbbJhARR7gTSkvF4HqlWoJ78E=",
+        "lastModified": 1673970363,
+        "narHash": "sha256-Aa1Qy4J4IfGYMMqOyWWcGDmqj5QnZ2efR4tM/Aigi2k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0f06feb718cbe276a151cfd17ce5a6b90c67f145",
+        "rev": "3fce435cafe58e287d874e2957c5609bc50b7a49",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3fce435c`](https://github.com/nix-community/NUR/commit/3fce435cafe58e287d874e2957c5609bc50b7a49) | `automatic update` |