### PR TITLE
chore(flake/emacs-overlay): `e98ec0df` -> `5959aa48`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673952851,
-        "narHash": "sha256-2dv0rarxuQHp4YL7rx4TpWqKGglK+LlBqze+igCyqr4=",
+        "lastModified": 1673980895,
+        "narHash": "sha256-3ZWwTpvN8jaYJSb546Z92L02bZjnZje4cf1xhiqS038=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e98ec0df74dbb00225850b7090b0fe59f12d9b01",
+        "rev": "5959aa48e3406a4f74281e7dc6136460d0a55a2b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`5959aa48`](https://github.com/nix-community/emacs-overlay/commit/5959aa48e3406a4f74281e7dc6136460d0a55a2b) | `Updated repos/melpa` |
| [`c265dd3a`](https://github.com/nix-community/emacs-overlay/commit/c265dd3ae69a888d817b222ae34e6cae39ab59de) | `Updated repos/emacs` |
| [`6bfbd4bc`](https://github.com/nix-community/emacs-overlay/commit/6bfbd4bcaed62bf7f1a74343949094c4ea75348f) | `Updated repos/elpa`  |