### PR TITLE
chore(flake/nur): `3fce435c` -> `0ecb23ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673970363,
-        "narHash": "sha256-Aa1Qy4J4IfGYMMqOyWWcGDmqj5QnZ2efR4tM/Aigi2k=",
+        "lastModified": 1673980897,
+        "narHash": "sha256-ByJ+2HqutI2L1TpOeM/S6PHx5NBnq2m9MFoqsqFgFrY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3fce435cafe58e287d874e2957c5609bc50b7a49",
+        "rev": "0ecb23ed6a12c1c929f1b5d1eb073edfd798f321",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0ecb23ed`](https://github.com/nix-community/NUR/commit/0ecb23ed6a12c1c929f1b5d1eb073edfd798f321) | `automatic update` |