### PR TITLE
chore(flake/nur): `0ecb23ed` -> `9dd8a2c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673980897,
-        "narHash": "sha256-ByJ+2HqutI2L1TpOeM/S6PHx5NBnq2m9MFoqsqFgFrY=",
+        "lastModified": 1673984840,
+        "narHash": "sha256-xujSSIvmCsBhsAPlk79ya68AVZXcLsS/nnxWvU8Mf54=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0ecb23ed6a12c1c929f1b5d1eb073edfd798f321",
+        "rev": "9dd8a2c468ae1c92ebb99cad0396281eed5bbd33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9dd8a2c4`](https://github.com/nix-community/NUR/commit/9dd8a2c468ae1c92ebb99cad0396281eed5bbd33) | `automatic update` |