### PR TITLE
chore(flake/nur): `9dd8a2c4` -> `bbc2a45d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673984840,
-        "narHash": "sha256-xujSSIvmCsBhsAPlk79ya68AVZXcLsS/nnxWvU8Mf54=",
+        "lastModified": 1673992013,
+        "narHash": "sha256-P2b+EiAnOsY8AzAI2BZuRGfog7kQi2RhwMP9IR1vOZ0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9dd8a2c468ae1c92ebb99cad0396281eed5bbd33",
+        "rev": "bbc2a45deb1e7a775ab0b9074de00b596c3121e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`bbc2a45d`](https://github.com/nix-community/NUR/commit/bbc2a45deb1e7a775ab0b9074de00b596c3121e6) | `automatic update` |