### PR TITLE
chore(flake/nur): `bbc2a45d` -> `56849533`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1673992013,
-        "narHash": "sha256-P2b+EiAnOsY8AzAI2BZuRGfog7kQi2RhwMP9IR1vOZ0=",
+        "lastModified": 1674007968,
+        "narHash": "sha256-oecg5ZBNj6uXXCWpZXmyzw7pSbVrSRmpT0N77mlhCd4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bbc2a45deb1e7a775ab0b9074de00b596c3121e6",
+        "rev": "56849533fd0e303d89b54f8ac31adea6ecbd579d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`56849533`](https://github.com/nix-community/NUR/commit/56849533fd0e303d89b54f8ac31adea6ecbd579d) | `automatic update` |