### PR TITLE
chore(flake/emacs-overlay): `5959aa48` -> `455cefa9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673980895,
-        "narHash": "sha256-3ZWwTpvN8jaYJSb546Z92L02bZjnZje4cf1xhiqS038=",
+        "lastModified": 1674011383,
+        "narHash": "sha256-rladstiR3XB93BtvPcrrDUgxd5V9c/jqRwIUcqxjCZQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5959aa48e3406a4f74281e7dc6136460d0a55a2b",
+        "rev": "455cefa9eabee05a6a8ea55654d2f87dfb93a879",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`455cefa9`](https://github.com/nix-community/emacs-overlay/commit/455cefa9eabee05a6a8ea55654d2f87dfb93a879) | `Updated repos/melpa` |
| [`311eeac7`](https://github.com/nix-community/emacs-overlay/commit/311eeac77b110462c1f80c93c1cc2f444689d53c) | `Updated repos/emacs` |
| [`7f6e264e`](https://github.com/nix-community/emacs-overlay/commit/7f6e264e13f11b263db626b7210f3b603af08ec9) | `Updated repos/elpa`  |