### PR TITLE
chore(flake/nur): `56849533` -> `1f635df0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674007968,
-        "narHash": "sha256-oecg5ZBNj6uXXCWpZXmyzw7pSbVrSRmpT0N77mlhCd4=",
+        "lastModified": 1674016297,
+        "narHash": "sha256-uXfj2wnjAtHvGO25NrFHT2oO/NV4Mwyh0iCiudPhRIU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "56849533fd0e303d89b54f8ac31adea6ecbd579d",
+        "rev": "1f635df09046f657e5ffaa6867d143e4ee926e31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1f635df0`](https://github.com/nix-community/NUR/commit/1f635df09046f657e5ffaa6867d143e4ee926e31) | `automatic update` |
| [`fd91483e`](https://github.com/nix-community/NUR/commit/fd91483ea3be06de185cfe1c8c0cfebf36185781) | `automatic update` |
| [`f7bb193d`](https://github.com/nix-community/NUR/commit/f7bb193ddda9b08fe048083ca87e7f0f6c5dc7d7) | `automatic update` |