### PR TITLE
chore(flake/nur): `1f635df0` -> `993b34d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674016297,
-        "narHash": "sha256-uXfj2wnjAtHvGO25NrFHT2oO/NV4Mwyh0iCiudPhRIU=",
+        "lastModified": 1674021312,
+        "narHash": "sha256-kW00Hpb2jqX7zDHnw/us7DH4lChTa6DoVcZZrd9CKwE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1f635df09046f657e5ffaa6867d143e4ee926e31",
+        "rev": "993b34d7fc525534c59229312c1ff21a976def54",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`993b34d7`](https://github.com/nix-community/NUR/commit/993b34d7fc525534c59229312c1ff21a976def54) | `automatic update` |