### PR TITLE
chore(flake/nur): `4d0cc1d2` -> `87d0c5ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674035258,
-        "narHash": "sha256-Vrhgl48xGheSnXH2JPSSF1vgvh7d7gCQ7GlhvF8z8ho=",
+        "lastModified": 1674046168,
+        "narHash": "sha256-5ffayoK//QsJYYhq0roW47e+ogz2AdV0+dKgvhG4FRM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4d0cc1d259083861c68298566ed34772dd57e4d9",
+        "rev": "87d0c5acda6b08d96134dc2c7c96f0e6e38e8375",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`87d0c5ac`](https://github.com/nix-community/NUR/commit/87d0c5acda6b08d96134dc2c7c96f0e6e38e8375) | `automatic update` |