### PR TITLE
chore(flake/nur): `87d0c5ac` -> `9f12cc7c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674046168,
-        "narHash": "sha256-5ffayoK//QsJYYhq0roW47e+ogz2AdV0+dKgvhG4FRM=",
+        "lastModified": 1674049571,
+        "narHash": "sha256-ng1Fwe/3OLOFXVzXCgdocw1BxAJ7G/w5jBTbTok6gho=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "87d0c5acda6b08d96134dc2c7c96f0e6e38e8375",
+        "rev": "9f12cc7c2886ccf3770739eaaf2fae5b8618ab76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9f12cc7c`](https://github.com/nix-community/NUR/commit/9f12cc7c2886ccf3770739eaaf2fae5b8618ab76) | `automatic update` |