### PR TITLE
chore(flake/nur): `9f12cc7c` -> `ead722c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674049571,
-        "narHash": "sha256-ng1Fwe/3OLOFXVzXCgdocw1BxAJ7G/w5jBTbTok6gho=",
+        "lastModified": 1674053178,
+        "narHash": "sha256-drqJ1yBf0D3n1WVaTnWGZzcKAwqZlLO0CFnAiA9LOC0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9f12cc7c2886ccf3770739eaaf2fae5b8618ab76",
+        "rev": "ead722c656eeea55b8dd906237b4097b2fcb29f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ead722c6`](https://github.com/nix-community/NUR/commit/ead722c656eeea55b8dd906237b4097b2fcb29f5) | `automatic update` |