### PR TITLE
chore(flake/nur): `ead722c6` -> `ca61de8b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674053178,
-        "narHash": "sha256-drqJ1yBf0D3n1WVaTnWGZzcKAwqZlLO0CFnAiA9LOC0=",
+        "lastModified": 1674056681,
+        "narHash": "sha256-CS0CwyFk3FYK6QTNuVJFjqZGg5qo5FuvrcNHwJE31ww=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ead722c656eeea55b8dd906237b4097b2fcb29f5",
+        "rev": "ca61de8ba6f480b688a05b505c24495e88a4eb76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ca61de8b`](https://github.com/nix-community/NUR/commit/ca61de8ba6f480b688a05b505c24495e88a4eb76) | `automatic update` |