### PR TITLE
chore(flake/emacs-overlay): `d0d9310e` -> `c02cfe11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674032919,
-        "narHash": "sha256-5tHaGJsZW6EXHAPogAbHObk6OKWmLDRSkpbAmLtgol8=",
+        "lastModified": 1674061743,
+        "narHash": "sha256-4xz24XJlAqRRjN2+HFUeaJn7CPqpO8N/TQLNinLLv7c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d0d9310e383f25872db7dea6a2b60dbc13db9ee4",
+        "rev": "c02cfe11649018c3e31c8c4a4d91233b1e62d487",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`c02cfe11`](https://github.com/nix-community/emacs-overlay/commit/c02cfe11649018c3e31c8c4a4d91233b1e62d487) | `Updated repos/melpa` |