### PR TITLE
chore(flake/home-manager): `866a4ddc` -> `7026e1a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674080704,
-        "narHash": "sha256-nOJjN7ZnqUMGB/SnArIK2VCxCTc5f2GDv1/TbeNp3TE=",
+        "lastModified": 1674082145,
+        "narHash": "sha256-4IpEt5Jc6VrNcpIcrKMCZAyeJMLXaaHk+yOV9HusO/A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "866a4ddcb3d3f21b1a0ce9dc1accd1704ecabbb9",
+        "rev": "7026e1a934abfa02623c9870378dbcdac3cd7f80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`7026e1a9`](https://github.com/nix-community/home-manager/commit/7026e1a934abfa02623c9870378dbcdac3cd7f80) | `gpg-agent: fix SSH support for fish` |