### PR TITLE
chore(flake/nur): `046233c5` -> `895fc6da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674094257,
-        "narHash": "sha256-ZWgGwXX9XSX8Le+d7oFyIQZZwAHG/1wDZyP6yTXaVR8=",
+        "lastModified": 1674102025,
+        "narHash": "sha256-sIUXvTv1L1kElDWP5XdWxTisivBVJ01kmq1Alql5SCw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "046233c583b8a939036f968fafa94f713e6326ff",
+        "rev": "895fc6da151fe71469185c3d9f447db53c9be871",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`895fc6da`](https://github.com/nix-community/NUR/commit/895fc6da151fe71469185c3d9f447db53c9be871) | `automatic update` |
| [`5c584423`](https://github.com/nix-community/NUR/commit/5c584423c9639efb30cc50149f87e163a0dc4bd3) | `automatic update` |