### PR TITLE
chore(flake/nur): `895fc6da` -> `920346f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674102025,
-        "narHash": "sha256-sIUXvTv1L1kElDWP5XdWxTisivBVJ01kmq1Alql5SCw=",
+        "lastModified": 1674112804,
+        "narHash": "sha256-eo9wUL6n2YkSRgvJ53gaZ4+cJbxnwlGvnRs7aI1QUxk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "895fc6da151fe71469185c3d9f447db53c9be871",
+        "rev": "920346f77a3caedf1ebe22b9818ab6cc15a3897a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`920346f7`](https://github.com/nix-community/NUR/commit/920346f77a3caedf1ebe22b9818ab6cc15a3897a) | `automatic update` |