### PR TITLE
chore(flake/nur): `920346f7` -> `eb33a19a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674112804,
-        "narHash": "sha256-eo9wUL6n2YkSRgvJ53gaZ4+cJbxnwlGvnRs7aI1QUxk=",
+        "lastModified": 1674114638,
+        "narHash": "sha256-km8EToEeAnl+Ye9tlumpTQ++z9jVoNxJIjaJytg978E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "920346f77a3caedf1ebe22b9818ab6cc15a3897a",
+        "rev": "eb33a19ade8067357e77f83ff0f7602bc3247794",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`eb33a19a`](https://github.com/nix-community/NUR/commit/eb33a19ade8067357e77f83ff0f7602bc3247794) | `automatic update` |