### PR TITLE
chore(flake/nur): `eb33a19a` -> `733822d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674114638,
-        "narHash": "sha256-km8EToEeAnl+Ye9tlumpTQ++z9jVoNxJIjaJytg978E=",
+        "lastModified": 1674115409,
+        "narHash": "sha256-J3V7WnpGxufWISAIEVsXWyZG4ctGCc/BirImNSRl4Lc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eb33a19ade8067357e77f83ff0f7602bc3247794",
+        "rev": "733822d5c73e8fe0fff0ada8ed5ee80844f8762f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`733822d5`](https://github.com/nix-community/NUR/commit/733822d5c73e8fe0fff0ada8ed5ee80844f8762f) | `automatic update` |