### PR TITLE
chore(flake/nur): `733822d5` -> `00120bd0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674115409,
-        "narHash": "sha256-J3V7WnpGxufWISAIEVsXWyZG4ctGCc/BirImNSRl4Lc=",
+        "lastModified": 1674117493,
+        "narHash": "sha256-3X7K7CfTshJUMlUxGI2I2SJqKg9S1OFw4HhtYCe/vnw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "733822d5c73e8fe0fff0ada8ed5ee80844f8762f",
+        "rev": "00120bd037350362ad270e536d3cfd5efd404228",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`00120bd0`](https://github.com/nix-community/NUR/commit/00120bd037350362ad270e536d3cfd5efd404228) | `automatic update` |