### PR TITLE
chore(flake/pre-commit-hooks): `3e42a775` -> `53e76695`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -491,11 +491,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1674075316,
-        "narHash": "sha256-0uZuAcYBpNJLxr7n5O0vhwn3rSLpUTm9M5WGgmNQ+wM=",
+        "lastModified": 1674122161,
+        "narHash": "sha256-9QM4rvgUSEwO8DWtJN9sR/afEqrH1s3b6ACsZT5wiAM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "3e42a77571cc0463efa470dbcffa063977a521ab",
+        "rev": "53e766957b73298fa68b47478c48cbcc005cc18a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message             |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ffe68508`](https://github.com/cachix/pre-commit-hooks.nix/commit/ffe68508c7e17b1d2a2a11a56fb4d743edcda6c9) | `Reorder ruff arg`         |
| [`677c994b`](https://github.com/cachix/pre-commit-hooks.nix/commit/677c994b4a91e20bcbd009f354109af101e70ed4) | `Fix missing ruff`         |
| [`7abd9af7`](https://github.com/cachix/pre-commit-hooks.nix/commit/7abd9af70dcbf8d3d5b6ffe9143ccdb788716ebb) | `Update modules/hooks.nix` |
| [`fffce9e8`](https://github.com/cachix/pre-commit-hooks.nix/commit/fffce9e8c6f6bc0c7ffa171b5609792329b7140d) | `Update modules/hooks.nix` |
| [`e5e17563`](https://github.com/cachix/pre-commit-hooks.nix/commit/e5e175632dece2b7a7773b837d1f540fc8a6b568) | `Add Ruff`                 |