### PR TITLE
chore(flake/nur): `00120bd0` -> `5fe5c545`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674117493,
-        "narHash": "sha256-3X7K7CfTshJUMlUxGI2I2SJqKg9S1OFw4HhtYCe/vnw=",
+        "lastModified": 1674128840,
+        "narHash": "sha256-LTCrL6jEW/ZJugZeo0D7Jh5tQZbKVwwS+Z1MhMfGAoQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "00120bd037350362ad270e536d3cfd5efd404228",
+        "rev": "5fe5c545b161011ee594d7e8e5b1c4d3cca33b39",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5fe5c545`](https://github.com/nix-community/NUR/commit/5fe5c545b161011ee594d7e8e5b1c4d3cca33b39) | `automatic update` |