### PR TITLE
chore(flake/nur): `5fe5c545` -> `213776f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674128840,
-        "narHash": "sha256-LTCrL6jEW/ZJugZeo0D7Jh5tQZbKVwwS+Z1MhMfGAoQ=",
+        "lastModified": 1674133491,
+        "narHash": "sha256-GGYCbZK+gsUgGMTZIiFK2bkC3bW0JYUar9bv8Aht6Jk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5fe5c545b161011ee594d7e8e5b1c4d3cca33b39",
+        "rev": "213776f68ca48ad17f8261903be39c7a190b3dbb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`213776f6`](https://github.com/nix-community/NUR/commit/213776f68ca48ad17f8261903be39c7a190b3dbb) | `automatic update` |
| [`7fb22656`](https://github.com/nix-community/NUR/commit/7fb226563b31f21bd59db217ae79b257812bb948) | `automatic update` |