### PR TITLE
chore(flake/emacs-overlay): `8365523d` -> `fa7dedfa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674099013,
-        "narHash": "sha256-B/SrOPS0oXrXDI7J/+EZyCYyuV75/y0FhffTkO5E2Po=",
+        "lastModified": 1674151952,
+        "narHash": "sha256-c0dwSGWi8LH2uBsv7ZJK11To1w8oFjTs+d2dtiusGug=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8365523d10c9fca0a232e5dfaaad783bf34ecf02",
+        "rev": "fa7dedfa5e1171a76ff78a1260064e1b20ec93bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`fa7dedfa`](https://github.com/nix-community/emacs-overlay/commit/fa7dedfa5e1171a76ff78a1260064e1b20ec93bb) | `Updated repos/melpa` |
| [`b39095ca`](https://github.com/nix-community/emacs-overlay/commit/b39095ca053853c7d00685e2c9172348e79e7c49) | `Updated repos/emacs` |
| [`1c782619`](https://github.com/nix-community/emacs-overlay/commit/1c78261981f409b60a23d8c246f6508bf1d6834b) | `Updated repos/elpa`  |