### PR TITLE
chore(flake/nur): `4e85a81e` -> `7dc7930a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674152905,
-        "narHash": "sha256-6EMQnzddCApOfssGmiGnhzK6GL1A4AMjPt373lXd5Gc=",
+        "lastModified": 1674161108,
+        "narHash": "sha256-uvb/inA4MeFEBnOHVUlVRuV9sy7XAqqGh7zelQQalRo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4e85a81e881e204d6fd782950ce4d709c8c80336",
+        "rev": "7dc7930abbd57841368b299669e7a6dd3186ac7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7dc7930a`](https://github.com/nix-community/NUR/commit/7dc7930abbd57841368b299669e7a6dd3186ac7c) | `automatic update` |