### PR TITLE
chore(flake/nur): `7dc7930a` -> `54708a8f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674161108,
-        "narHash": "sha256-uvb/inA4MeFEBnOHVUlVRuV9sy7XAqqGh7zelQQalRo=",
+        "lastModified": 1674180668,
+        "narHash": "sha256-gfEaQ3s16RkXRKxf0CdNZ+r3P1s2N4kkqU2VgDTL5pI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7dc7930abbd57841368b299669e7a6dd3186ac7c",
+        "rev": "54708a8f83964ff1e871b68a53ba648e432b45b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`54708a8f`](https://github.com/nix-community/NUR/commit/54708a8f83964ff1e871b68a53ba648e432b45b6) | `automatic update` |
| [`90ac4c96`](https://github.com/nix-community/NUR/commit/90ac4c961c6048489e614788e43eef1a2f0a9a2c) | `automatic update` |