### PR TITLE
chore(flake/emacs-overlay): `fa7dedfa` -> `ad839f83`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674151952,
-        "narHash": "sha256-c0dwSGWi8LH2uBsv7ZJK11To1w8oFjTs+d2dtiusGug=",
+        "lastModified": 1674183700,
+        "narHash": "sha256-wUfHco2bQjE7bUzMPOhmEN2AQ8QkQ5xaPM0eCbij3lE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fa7dedfa5e1171a76ff78a1260064e1b20ec93bb",
+        "rev": "ad839f83ca7ceb0f5f0b301da847366ecf57ef49",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ad839f83`](https://github.com/nix-community/emacs-overlay/commit/ad839f83ca7ceb0f5f0b301da847366ecf57ef49) | `Updated repos/melpa` |
| [`87283bd5`](https://github.com/nix-community/emacs-overlay/commit/87283bd5f4e015177c8d5b91ca867f60a7575c8b) | `Updated repos/emacs` |
| [`ebc21994`](https://github.com/nix-community/emacs-overlay/commit/ebc21994026b61967b55556d8215a613a1bc9a41) | `Updated repos/elpa`  |