### PR TITLE
chore(flake/nur): `54708a8f` -> `c745a46e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674180668,
-        "narHash": "sha256-gfEaQ3s16RkXRKxf0CdNZ+r3P1s2N4kkqU2VgDTL5pI=",
+        "lastModified": 1674186995,
+        "narHash": "sha256-+5/HT1OgeNTzUaJ2fPw7LlbMfmaQM6OvG5Lr1Szc2FI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "54708a8f83964ff1e871b68a53ba648e432b45b6",
+        "rev": "c745a46e8ba08780be19e0f01ff0d23564b438e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c745a46e`](https://github.com/nix-community/NUR/commit/c745a46e8ba08780be19e0f01ff0d23564b438e3) | `automatic update` |