### PR TITLE
chore(flake/nur): `c745a46e` -> `a4b55594`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674186995,
-        "narHash": "sha256-+5/HT1OgeNTzUaJ2fPw7LlbMfmaQM6OvG5Lr1Szc2FI=",
+        "lastModified": 1674187495,
+        "narHash": "sha256-d4MDKJStJ8tLkWbQ7qOaHdMerZfJKSkxA+PlPpFp4ng=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c745a46e8ba08780be19e0f01ff0d23564b438e3",
+        "rev": "a4b555942a4dba9a22020b2290645266c7534325",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a4b55594`](https://github.com/nix-community/NUR/commit/a4b555942a4dba9a22020b2290645266c7534325) | `automatic update` |