### PR TITLE
chore(flake/nur): `a4b55594` -> `cc1f7b56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674187495,
-        "narHash": "sha256-d4MDKJStJ8tLkWbQ7qOaHdMerZfJKSkxA+PlPpFp4ng=",
+        "lastModified": 1674196063,
+        "narHash": "sha256-LhjgHUpQiQgJ1Hxbv1ghuJNQNMqJUfNQFlealIsrQQk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a4b555942a4dba9a22020b2290645266c7534325",
+        "rev": "cc1f7b56adc09a33834e5d35e990b41bcf704726",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`cc1f7b56`](https://github.com/nix-community/NUR/commit/cc1f7b56adc09a33834e5d35e990b41bcf704726) | `automatic update` |