### PR TITLE
chore(flake/nur): `cc1f7b56` -> `2fabc504`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674196063,
-        "narHash": "sha256-LhjgHUpQiQgJ1Hxbv1ghuJNQNMqJUfNQFlealIsrQQk=",
+        "lastModified": 1674199941,
+        "narHash": "sha256-l16+t5cft/7SmwwKd3VHTD6Lk2ZIDo8MGu/zkok9Ack=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cc1f7b56adc09a33834e5d35e990b41bcf704726",
+        "rev": "2fabc504984f757b694a1c2ef5101659f46638e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2fabc504`](https://github.com/nix-community/NUR/commit/2fabc504984f757b694a1c2ef5101659f46638e5) | `automatic update` |