### PR TITLE
chore(flake/nur): `2fabc504` -> `c22ebc53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674199941,
-        "narHash": "sha256-l16+t5cft/7SmwwKd3VHTD6Lk2ZIDo8MGu/zkok9Ack=",
+        "lastModified": 1674207288,
+        "narHash": "sha256-2AEbYHwXuLCMC+8/8QnQ3hsOzXqQCZaHIntSoWqwr2k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2fabc504984f757b694a1c2ef5101659f46638e5",
+        "rev": "c22ebc53097cea93955c3bf32179b69bad752fda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c22ebc53`](https://github.com/nix-community/NUR/commit/c22ebc53097cea93955c3bf32179b69bad752fda) | `automatic update` |