### PR TITLE
chore(flake/emacs-overlay): `11f1b755` -> `ccc0a519`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674209471,
-        "narHash": "sha256-s32NbzdN9Y1vtf50ouRc8usBFl7ihQo1ABBOZoyBGes=",
+        "lastModified": 1674238463,
+        "narHash": "sha256-dbxxRhnVzov5dvQWB9FhhLOUJZ7WtNSaALn+7ZZYnpY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "11f1b755fb5b78d7af074fcffe7dfcced082305d",
+        "rev": "ccc0a51900aac43bd59743cb3fdccd76eb5e68d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ccc0a519`](https://github.com/nix-community/emacs-overlay/commit/ccc0a51900aac43bd59743cb3fdccd76eb5e68d6) | `Updated repos/melpa` |
| [`e989f32e`](https://github.com/nix-community/emacs-overlay/commit/e989f32e7b5c61fef125eaf5a54dd80a144287b0) | `Updated repos/emacs` |