### PR TITLE
chore(flake/nur): `46a146da` -> `9386763c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674258277,
-        "narHash": "sha256-AK9H4OJfM6kukcG0kzA0ddMoLBzv8FSSKjBba4nSwWE=",
+        "lastModified": 1674266686,
+        "narHash": "sha256-Vjk4kvDpRjmLzrtk/Xydrd9jvknc8+4Cps0X3hxBX7Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "46a146dae20bbbb2a31197d670088b8544f0b8bc",
+        "rev": "9386763c5e4bb38975ca06f5530cbba84708d865",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9386763c`](https://github.com/nix-community/NUR/commit/9386763c5e4bb38975ca06f5530cbba84708d865) | `automatic update` |