### PR TITLE
chore(flake/emacs-overlay): `ccc0a519` -> `5bd6b435`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674238463,
-        "narHash": "sha256-dbxxRhnVzov5dvQWB9FhhLOUJZ7WtNSaALn+7ZZYnpY=",
+        "lastModified": 1674270221,
+        "narHash": "sha256-hKPiLGZswRWwBLjY269NFdILWFLl1bhCfPl9l/t+L0w=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ccc0a51900aac43bd59743cb3fdccd76eb5e68d6",
+        "rev": "5bd6b435915e95101a2400fa552e4f6f282e74b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`5bd6b435`](https://github.com/nix-community/emacs-overlay/commit/5bd6b435915e95101a2400fa552e4f6f282e74b6) | `Add tree-sitter-html` |
| [`cfc908b1`](https://github.com/nix-community/emacs-overlay/commit/cfc908b14fda2b7065e9841382ca82024791cc05) | `Updated repos/nongnu` |
| [`1c84fffb`](https://github.com/nix-community/emacs-overlay/commit/1c84fffbf6214e002bd90bee9a1e4c7f3845f6c2) | `Updated repos/melpa`  |
| [`8bf1584f`](https://github.com/nix-community/emacs-overlay/commit/8bf1584f2569a2c252d8d7d577a1c20652a75f93) | `Updated repos/emacs`  |