### PR TITLE
chore(flake/nur): `9386763c` -> `4e0135e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674266686,
-        "narHash": "sha256-Vjk4kvDpRjmLzrtk/Xydrd9jvknc8+4Cps0X3hxBX7Y=",
+        "lastModified": 1674274500,
+        "narHash": "sha256-zFd85dld9Vcixrvn4cPvWvPJVjw38g+iYgJ19pG45js=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9386763c5e4bb38975ca06f5530cbba84708d865",
+        "rev": "4e0135e8acac823bfb62689ab6c6b71b7f6ffad6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4e0135e8`](https://github.com/nix-community/NUR/commit/4e0135e8acac823bfb62689ab6c6b71b7f6ffad6) | `automatic update` |