### PR TITLE
chore(flake/nur): `4e0135e8` -> `894ce24a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674274500,
-        "narHash": "sha256-zFd85dld9Vcixrvn4cPvWvPJVjw38g+iYgJ19pG45js=",
+        "lastModified": 1674279993,
+        "narHash": "sha256-9E17kpNBUdCY3hSuuMo7OvtWj1dqoUH4iklPo3DqmmI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4e0135e8acac823bfb62689ab6c6b71b7f6ffad6",
+        "rev": "894ce24a55880534bbc8d45d421cf9b017dca35a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`894ce24a`](https://github.com/nix-community/NUR/commit/894ce24a55880534bbc8d45d421cf9b017dca35a) | `automatic update` |
| [`c00026a5`](https://github.com/nix-community/NUR/commit/c00026a59a5d47778188271aebd00803f5bda068) | `automatic update` |