### PR TITLE
chore(flake/nur): `894ce24a` -> `cd0df3f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674279993,
-        "narHash": "sha256-9E17kpNBUdCY3hSuuMo7OvtWj1dqoUH4iklPo3DqmmI=",
+        "lastModified": 1674286396,
+        "narHash": "sha256-btCa0JGdwmoowjAaGxSmuCAh3mxGJkhi5+L4E8mwNK0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "894ce24a55880534bbc8d45d421cf9b017dca35a",
+        "rev": "cd0df3f8287b24f3e123a13c39c8d2b338037d66",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`cd0df3f8`](https://github.com/nix-community/NUR/commit/cd0df3f8287b24f3e123a13c39c8d2b338037d66) | `automatic update` |