### PR TITLE
chore(flake/nur): `cd0df3f8` -> `0eb18ae5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674286396,
-        "narHash": "sha256-btCa0JGdwmoowjAaGxSmuCAh3mxGJkhi5+L4E8mwNK0=",
+        "lastModified": 1674290152,
+        "narHash": "sha256-2FPfuRPknBrg2ZBBa3latWxbbComAXLizS1ShsJHuLc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cd0df3f8287b24f3e123a13c39c8d2b338037d66",
+        "rev": "0eb18ae5ae3a5ff8cdef5a0c956d11cc414d757f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0eb18ae5`](https://github.com/nix-community/NUR/commit/0eb18ae5ae3a5ff8cdef5a0c956d11cc414d757f) | `automatic update` |