### PR TITLE
chore(flake/emacs-overlay): `5bd6b435` -> `93d97996`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674270221,
-        "narHash": "sha256-hKPiLGZswRWwBLjY269NFdILWFLl1bhCfPl9l/t+L0w=",
+        "lastModified": 1674295993,
+        "narHash": "sha256-OCgU01IjoZTCjjZlUnfYbMH+hFwKdgxa9YFD/RkcNyI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5bd6b435915e95101a2400fa552e4f6f282e74b6",
+        "rev": "93d9799629140618a9b18930fd3e3d3d5b5fe452",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`93d97996`](https://github.com/nix-community/emacs-overlay/commit/93d9799629140618a9b18930fd3e3d3d5b5fe452) | `Updated repos/melpa` |
| [`57455eac`](https://github.com/nix-community/emacs-overlay/commit/57455eacf1239a4b1842c05c33faeaa458aa11f9) | `Updated repos/emacs` |