### PR TITLE
chore(flake/nur): `0eb18ae5` -> `ca66f7c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674290152,
-        "narHash": "sha256-2FPfuRPknBrg2ZBBa3latWxbbComAXLizS1ShsJHuLc=",
+        "lastModified": 1674308735,
+        "narHash": "sha256-9biyeQ439FR4FYCHlKych5by7UrwU/Qr/63R13L9M/4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0eb18ae5ae3a5ff8cdef5a0c956d11cc414d757f",
+        "rev": "ca66f7c9b8c233305f7635dd9c9f73f0e3c4e9fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ca66f7c9`](https://github.com/nix-community/NUR/commit/ca66f7c9b8c233305f7635dd9c9f73f0e3c4e9fe) | `automatic update` |