### PR TITLE
chore(flake/nur): `ca66f7c9` -> `0903f983`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674308735,
-        "narHash": "sha256-9biyeQ439FR4FYCHlKych5by7UrwU/Qr/63R13L9M/4=",
+        "lastModified": 1674323067,
+        "narHash": "sha256-0H1N8URgJCZvO/79GgMzgUCz5s9Xbo6EedUHKrggJXg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ca66f7c9b8c233305f7635dd9c9f73f0e3c4e9fe",
+        "rev": "0903f98379da0d4e56b26833a81680eedb9a54ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0903f983`](https://github.com/nix-community/NUR/commit/0903f98379da0d4e56b26833a81680eedb9a54ac) | `automatic update` |