### PR TITLE
chore(flake/emacs-overlay): `93d97996` -> `69067d7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674295993,
-        "narHash": "sha256-OCgU01IjoZTCjjZlUnfYbMH+hFwKdgxa9YFD/RkcNyI=",
+        "lastModified": 1674324522,
+        "narHash": "sha256-n3K0VXkv1BlZzdXMeMxe2jkJQHu3x8smw7WbrNZrJOo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "93d9799629140618a9b18930fd3e3d3d5b5fe452",
+        "rev": "69067d7a328f6e8542aefcdb440bb898cbdfd8a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`69067d7a`](https://github.com/nix-community/emacs-overlay/commit/69067d7a328f6e8542aefcdb440bb898cbdfd8a7) | `Updated repos/melpa` |
| [`3d15610c`](https://github.com/nix-community/emacs-overlay/commit/3d15610ce2f935b715de2afe1b4bad38f25e34da) | `Updated repos/emacs` |