### PR TITLE
chore(flake/nur): `cb49a24f` -> `75cccc49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674330271,
-        "narHash": "sha256-TAapjB7/CBYxqJ082NhKxysKXVz51tsBGd3WzgfEfcw=",
+        "lastModified": 1674337509,
+        "narHash": "sha256-nXBhEGsrHcHZblYZgJracLO560Cms8lssz1rC4RKTaA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cb49a24f55107dae9ad55cbeb94d14e35e4a9453",
+        "rev": "75cccc4979ad10e02381d15a0f4f419ddaf5e2db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`75cccc49`](https://github.com/nix-community/NUR/commit/75cccc4979ad10e02381d15a0f4f419ddaf5e2db) | `automatic update` |