### PR TITLE
chore(flake/nur): `a04998a8` -> `8f3aa478`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674344653,
-        "narHash": "sha256-3KcyCP4Bc7UXv/FdSSZtckwFo3gBFfNVOIhVrl0hTMo=",
+        "lastModified": 1674353393,
+        "narHash": "sha256-otbV03gLOX/MxelbqWSEiMvKugX8sGvz9CpHKebJ6MA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a04998a8cab427a3382d4407b3190108623aa169",
+        "rev": "8f3aa4789df7f8d04cb3c2508c087cafc4c90d5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8f3aa478`](https://github.com/nix-community/NUR/commit/8f3aa4789df7f8d04cb3c2508c087cafc4c90d5d) | `automatic update` |