### PR TITLE
chore(flake/nur): `8f3aa478` -> `623ab5de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674353393,
-        "narHash": "sha256-otbV03gLOX/MxelbqWSEiMvKugX8sGvz9CpHKebJ6MA=",
+        "lastModified": 1674360560,
+        "narHash": "sha256-p/YGX2UVjyqQIm07OMMQQ2i+elWafbFexIPkROs0t9Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8f3aa4789df7f8d04cb3c2508c087cafc4c90d5d",
+        "rev": "623ab5debd683264eb5ede3754c6a13a7fa475ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`623ab5de`](https://github.com/nix-community/NUR/commit/623ab5debd683264eb5ede3754c6a13a7fa475ec) | `automatic update` |