### PR TITLE
chore(flake/nur): `623ab5de` -> `adf781cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674360560,
-        "narHash": "sha256-p/YGX2UVjyqQIm07OMMQQ2i+elWafbFexIPkROs0t9Q=",
+        "lastModified": 1674366687,
+        "narHash": "sha256-vh50FYxNg14YX3O6nbCupAVhUkeHbkoINdWNAAF3Anw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "623ab5debd683264eb5ede3754c6a13a7fa475ec",
+        "rev": "adf781cfacd700372a391544a63bada6ddf79ced",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`adf781cf`](https://github.com/nix-community/NUR/commit/adf781cfacd700372a391544a63bada6ddf79ced) | `automatic update` |