### PR TITLE
chore(flake/emacs-overlay): `184ae9c3` -> `50771a21`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674359560,
-        "narHash": "sha256-gobqd75ujP/zFH6kSZNB3bA3YS4NMXWpZgMo1RAFEdk=",
+        "lastModified": 1674378536,
+        "narHash": "sha256-ZX97WirFX7GYY2t1NO9+/8E+PjBieOwjPQu1gvlZ7BI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "184ae9c371a6251564e0b07391f7e9aaf310f002",
+        "rev": "50771a213ea23c0ad1de68d8eaa2e3734ff05223",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`50771a21`](https://github.com/nix-community/emacs-overlay/commit/50771a213ea23c0ad1de68d8eaa2e3734ff05223) | `Updated repos/melpa` |