### PR TITLE
chore(flake/nur): `8c8503d6` -> `81b2cbb4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674392326,
-        "narHash": "sha256-wt7bk6SL712k7ODfi28QM+L6PM3p2TtgBrBNiTNQ0bE=",
+        "lastModified": 1674397913,
+        "narHash": "sha256-33cxEVL+GRswsnxLQZZPunXnCdEfhlIwC9gWB2IlIFY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8c8503d60647ccbe959b2cc153f2679b48e48cbf",
+        "rev": "81b2cbb472fa892b14f64329f7b9661276e11f09",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`81b2cbb4`](https://github.com/nix-community/NUR/commit/81b2cbb472fa892b14f64329f7b9661276e11f09) | `automatic update` |