### PR TITLE
chore(flake/emacs-overlay): `50771a21` -> `9bf1cacc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674378536,
-        "narHash": "sha256-ZX97WirFX7GYY2t1NO9+/8E+PjBieOwjPQu1gvlZ7BI=",
+        "lastModified": 1674411415,
+        "narHash": "sha256-7flTx/xmfUy85eUQdq6Z0VLKYwJ5t0DH0AyzbKOYQ58=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "50771a213ea23c0ad1de68d8eaa2e3734ff05223",
+        "rev": "9bf1cacc38c1d03ae379e1b008c52f2d999e7a8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`9bf1cacc`](https://github.com/nix-community/emacs-overlay/commit/9bf1cacc38c1d03ae379e1b008c52f2d999e7a8d) | `Updated repos/nongnu` |
| [`fa16809c`](https://github.com/nix-community/emacs-overlay/commit/fa16809cea4b20dd786f70c18f2b9007e3dc763c) | `Updated repos/melpa`  |
| [`92524fd2`](https://github.com/nix-community/emacs-overlay/commit/92524fd243f9a1f7c25215458787995dade10ec7) | `Updated repos/emacs`  |
| [`eebaab5f`](https://github.com/nix-community/emacs-overlay/commit/eebaab5f383cc523aacfc976c195bac7d31e3441) | `Updated repos/elpa`   |