### PR TITLE
chore(flake/nur): `81b2cbb4` -> `8d056f1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674397913,
-        "narHash": "sha256-33cxEVL+GRswsnxLQZZPunXnCdEfhlIwC9gWB2IlIFY=",
+        "lastModified": 1674413114,
+        "narHash": "sha256-2RlXfiEpxU2g1jWbaPNO4l5326loa1sOiuNJEXJmjYw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "81b2cbb472fa892b14f64329f7b9661276e11f09",
+        "rev": "8d056f1dcb00381dd7f79d3fd5485ed84fa811e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8d056f1d`](https://github.com/nix-community/NUR/commit/8d056f1dcb00381dd7f79d3fd5485ed84fa811e3) | `automatic update` |