### PR TITLE
chore(flake/nur): `8d056f1d` -> `edf864ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674413114,
-        "narHash": "sha256-2RlXfiEpxU2g1jWbaPNO4l5326loa1sOiuNJEXJmjYw=",
+        "lastModified": 1674416684,
+        "narHash": "sha256-MFegUrcPkMWenfFP5AKdQEdASF5BO0bQ/GlqVUDeQN8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8d056f1dcb00381dd7f79d3fd5485ed84fa811e3",
+        "rev": "edf864eef986830aba6b09a08d891816c2fb2b3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`edf864ee`](https://github.com/nix-community/NUR/commit/edf864eef986830aba6b09a08d891816c2fb2b3a) | `automatic update` |