### PR TITLE
chore(flake/nur): `edf864ee` -> `60fe6cfd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674416684,
-        "narHash": "sha256-MFegUrcPkMWenfFP5AKdQEdASF5BO0bQ/GlqVUDeQN8=",
+        "lastModified": 1674446728,
+        "narHash": "sha256-8nHe/8Ey51OrK+0TCw9ioRyTJ3X8Y2wqhJk/+VJ3FnU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "edf864eef986830aba6b09a08d891816c2fb2b3a",
+        "rev": "60fe6cfd854e6b3e57ecae194bc760a6a8653314",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`60fe6cfd`](https://github.com/nix-community/NUR/commit/60fe6cfd854e6b3e57ecae194bc760a6a8653314) | `automatic update` |
| [`18ddd9da`](https://github.com/nix-community/NUR/commit/18ddd9da7edbf931cb7b29651832ee8c94d64b32) | `automatic update` |