### PR TITLE
chore(flake/nur): `6e572579` -> `8b390936`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674452759,
-        "narHash": "sha256-ylJQP65t/c+QxRy+bVLsxyzWYd6fhx+0K5aeHuOyfNU=",
+        "lastModified": 1674474419,
+        "narHash": "sha256-TYD1VtUWBc1lIMy/a8/NeHjRj3pT362/vMBylsl9P88=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6e57257984bc8c95ef168b706b1e7d0a814277fc",
+        "rev": "8b390936e350bbb647decc1ff62a00c51009ce1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8b390936`](https://github.com/nix-community/NUR/commit/8b390936e350bbb647decc1ff62a00c51009ce1c) | `automatic update` |