### PR TITLE
chore(flake/home-manager): `275ab728` -> `ab25abf9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674250603,
-        "narHash": "sha256-SBolFspxBHpW3hCCDNAFXUiO2mucmkVmf17UmSIK3Cs=",
+        "lastModified": 1674477719,
+        "narHash": "sha256-tciutt7rulypHZfbXp2j+5K6exyVAtsxF2//2J9BSvI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "275ab728912006eecb549338a50f24f294a7cfb7",
+        "rev": "ab25abf9e5c07b3c90d78aa06c44a4085ecba003",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message               |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`ab25abf9`](https://github.com/nix-community/home-manager/commit/ab25abf9e5c07b3c90d78aa06c44a4085ecba003) | `flake.lock: Update (#3549)` |