### PR TITLE
chore(flake/nur): `8b390936` -> `d6534c1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674474419,
-        "narHash": "sha256-TYD1VtUWBc1lIMy/a8/NeHjRj3pT362/vMBylsl9P88=",
+        "lastModified": 1674478388,
+        "narHash": "sha256-j3YnLCHbuuwUwuIwxjdCyBTcqcKX4Ou8J9kFOlrolBQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8b390936e350bbb647decc1ff62a00c51009ce1c",
+        "rev": "d6534c1dbc8045a989f4e51b755f9ee62e2df239",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d6534c1d`](https://github.com/nix-community/NUR/commit/d6534c1dbc8045a989f4e51b755f9ee62e2df239) | `automatic update` |