### PR TITLE
chore(flake/nur): `a0223f52` -> `92c7cc3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674485204,
-        "narHash": "sha256-D1qhXQ+ANBos9lm/ZRg+PnaIK3M0wyayiMRN/IdT6xI=",
+        "lastModified": 1674498307,
+        "narHash": "sha256-kyuICVhc38sqWxIN5/+X1BmnEHYzKKF441gmFf7E7K4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a0223f5262385bd2b5bfb34d1b8b6d78dcfda60a",
+        "rev": "92c7cc3ec96461341171c1c69b7339aa14c4bed0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`92c7cc3e`](https://github.com/nix-community/NUR/commit/92c7cc3ec96461341171c1c69b7339aa14c4bed0) | `automatic update` |