### PR TITLE
chore(flake/emacs-overlay): `4c7a22c0` -> `274a6049`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674470598,
-        "narHash": "sha256-cZoTj+LmqYGiwphMWd5sKouOYKNZ28dcxsSfveFnsQo=",
+        "lastModified": 1674498778,
+        "narHash": "sha256-a9g+0nq2MKhjkC7QxpU1IS71Kkc+1uvJkp17wVvlnTA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4c7a22c05b1380808391b6bf43688a44bbfb7353",
+        "rev": "274a6049a74c67f6105da9ea1b522d104eaf92dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`274a6049`](https://github.com/nix-community/emacs-overlay/commit/274a6049a74c67f6105da9ea1b522d104eaf92dc) | `Updated repos/melpa` |
| [`c953dd08`](https://github.com/nix-community/emacs-overlay/commit/c953dd08d06a3aab40b8f1d0b6b0ee431f57b1d3) | `Updated repos/emacs` |
| [`b4f5a551`](https://github.com/nix-community/emacs-overlay/commit/b4f5a551558f272382a85bff003ebe34957faec5) | `Updated repos/elpa`  |