### PR TITLE
chore(flake/nur): `45562cfb` -> `541c9594`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674499613,
-        "narHash": "sha256-x8pMg+q0FfYbryAzpM4g0j43Pp1o2ZxB7q62yu1SWoE=",
+        "lastModified": 1674503088,
+        "narHash": "sha256-Zm3Ae5ucoexNflPIy7J5ww7kz90hNrVybKyHPzmJ1/Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "45562cfbaaebb460703b79cf0d141c2abf334d43",
+        "rev": "541c959464d4e3cd86fcdd203317b04d84009a99",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`541c9594`](https://github.com/nix-community/NUR/commit/541c959464d4e3cd86fcdd203317b04d84009a99) | `automatic update` |