### PR TITLE
chore(flake/nur): `541c9594` -> `da1d4288`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674503088,
-        "narHash": "sha256-Zm3Ae5ucoexNflPIy7J5ww7kz90hNrVybKyHPzmJ1/Q=",
+        "lastModified": 1674512179,
+        "narHash": "sha256-v1oUX5ESkhQDKp7t2v8K8FS9qyAtSwMsdqs3xHswS+s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "541c959464d4e3cd86fcdd203317b04d84009a99",
+        "rev": "da1d4288a46f69a73e968f4ffda9dd28cf6fcb78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`da1d4288`](https://github.com/nix-community/NUR/commit/da1d4288a46f69a73e968f4ffda9dd28cf6fcb78) | `automatic update` |