### PR TITLE
chore(flake/nur): `da1d4288` -> `e8e9405c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674512179,
-        "narHash": "sha256-v1oUX5ESkhQDKp7t2v8K8FS9qyAtSwMsdqs3xHswS+s=",
+        "lastModified": 1674525977,
+        "narHash": "sha256-iSMYTvexjnzwn6rYBgz7rXUxo0dVeXWCtt6n1mmLXFs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "da1d4288a46f69a73e968f4ffda9dd28cf6fcb78",
+        "rev": "e8e9405c0246ccd1a5a9822f1f5254af25ae39e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e8e9405c`](https://github.com/nix-community/NUR/commit/e8e9405c0246ccd1a5a9822f1f5254af25ae39e6) | `automatic update` |