### PR TITLE
chore(flake/emacs-overlay): `274a6049` -> `2164c881`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674498778,
-        "narHash": "sha256-a9g+0nq2MKhjkC7QxpU1IS71Kkc+1uvJkp17wVvlnTA=",
+        "lastModified": 1674529277,
+        "narHash": "sha256-/Zdi3AQoo2mkZgsgSp40QHcrErbBaE+RqWv+TL4uHGk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "274a6049a74c67f6105da9ea1b522d104eaf92dc",
+        "rev": "2164c8819a19ab33b280ca0c0575bd5a17829b7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`2164c881`](https://github.com/nix-community/emacs-overlay/commit/2164c8819a19ab33b280ca0c0575bd5a17829b7c) | `Updated repos/melpa` |
| [`eb9b7140`](https://github.com/nix-community/emacs-overlay/commit/eb9b71408585443276d52131a4d29a428edb44f7) | `Updated repos/emacs` |
| [`10b235ad`](https://github.com/nix-community/emacs-overlay/commit/10b235ada45ae980b2c8e72d1d1dd8cc70cc3d59) | `Updated repos/elpa`  |