### PR TITLE
chore(flake/nur): `e8e9405c` -> `52021e45`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674525977,
-        "narHash": "sha256-iSMYTvexjnzwn6rYBgz7rXUxo0dVeXWCtt6n1mmLXFs=",
+        "lastModified": 1674531964,
+        "narHash": "sha256-Q7+O42QcwvWh72FmXIrhuSXOZ7UrOgt78Xf+qOrHsW8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e8e9405c0246ccd1a5a9822f1f5254af25ae39e6",
+        "rev": "52021e4580977ae0f9fc5d7ac40d4c2baecb847e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`52021e45`](https://github.com/nix-community/NUR/commit/52021e4580977ae0f9fc5d7ac40d4c2baecb847e) | `automatic update` |