### PR TITLE
chore(flake/nur): `52021e45` -> `6ea6932b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674531964,
-        "narHash": "sha256-Q7+O42QcwvWh72FmXIrhuSXOZ7UrOgt78Xf+qOrHsW8=",
+        "lastModified": 1674533631,
+        "narHash": "sha256-Az15gMle0cRHTpu7xM2xgvDiK863/FXZ9QPvh7j9Pis=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "52021e4580977ae0f9fc5d7ac40d4c2baecb847e",
+        "rev": "6ea6932b3f6f675775352da7facfc83f4feb2ff5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6ea6932b`](https://github.com/nix-community/NUR/commit/6ea6932b3f6f675775352da7facfc83f4feb2ff5) | `automatic update` |