### PR TITLE
chore(flake/sops-nix): `51fdbd2d` -> `b6ab3c61`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -585,11 +585,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1674356914,
-        "narHash": "sha256-gY5vsvZD7u2vQhrFU89kKHrwTVfsbJermcpeiXVbzXA=",
+        "lastModified": 1674546403,
+        "narHash": "sha256-vkyNv0xzXuEnu9v52TUtRugNmQWIti8c2RhYnbLG71w=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "51fdbd2d6fc2a7ba318e823a12609276bcc4dbe9",
+        "rev": "b6ab3c61e2ca5e07d1f4eb1b67304e2670ea230c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                                            |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`1bdd0227`](https://github.com/Mic92/sops-nix/commit/1bdd02270f2ab2c53725d8c522b9c41f5fd1b73d) | `Bump DeterminateSystems/update-flake-lock from 15 to 16` |