### PR TITLE
chore(flake/nixpkgs): `5ed48194` -> `1b1f5064`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674211260,
-        "narHash": "sha256-xU6Rv9sgnwaWK7tgCPadV6HhI2Y/fl4lKxJoG2+m9qs=",
+        "lastModified": 1674459583,
+        "narHash": "sha256-L0UZl/u2H3HGsrhN+by42c5kNYeKtdmJiPzIRvEVeiM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5ed481943351e9fd354aeb557679624224de38d5",
+        "rev": "1b1f50645af2a70dc93eae18bfd88d330bfbcf7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                    |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`ce563f61`](https://github.com/NixOS/nixpkgs/commit/ce563f610557f4e2659c9b3a567bbf46116736bf) | `gitprompt-rs: init at 0.3.0`                                     |
| [`290892dd`](https://github.com/NixOS/nixpkgs/commit/290892ddba7468398b6a0bf77ce29b8a00b7cd53) | `Revert "jdupes: 1.21.0 -> 1.21.1"`                               |
| [`20a1663e`](https://github.com/NixOS/nixpkgs/commit/20a1663e048047fd94f73a64157cec650c2906c1) | `fava: loosen cheroot version requirement`                        |
| [`0aeadf53`](https://github.com/NixOS/nixpkgs/commit/0aeadf53d3e4f7c8517db77479dc16ec059e5269) | `p2pool: 2.4 -> 2.7`                                              |
| [`109d610f`](https://github.com/NixOS/nixpkgs/commit/109d610f48744f410d78281cc9b9ed1b91c9aa4e) | `terraform-providers.gitlab: 15.7.1 → 15.8.0`                     |
| [`5b5ace4f`](https://github.com/NixOS/nixpkgs/commit/5b5ace4f17fa4eb790a84f883637713aea837382) | `bundler: 2.4.4 -> 2.4.5`                                         |
| [`a4e6fbc3`](https://github.com/NixOS/nixpkgs/commit/a4e6fbc3bf980af29c99f969106e8c34c1ebb687) | `gnome.empathy: drop`                                             |
| [`284370ec`](https://github.com/NixOS/nixpkgs/commit/284370ecf074a5b1b9efaca9952864ad3d4c80b8) | `shotwell: remove unused libchamplain dependency`                 |
| [`f85005c8`](https://github.com/NixOS/nixpkgs/commit/f85005c85e0d7daee4afe82eac73a7da7b856f6d) | `git-trim: unpin openssl_1_1`                                     |
| [`93da9ccc`](https://github.com/NixOS/nixpkgs/commit/93da9cccfacd6b94b0d0bcbe55a8d44c0d2aaf8c) | `journaldriver: unpin openssl_1_1`                                |
| [`f6d98679`](https://github.com/NixOS/nixpkgs/commit/f6d98679bb2fa6f65f1783e3488f2d615500df98) | `cliscord: unpin openssl_1_1`                                     |
| [`9f370f0f`](https://github.com/NixOS/nixpkgs/commit/9f370f0f74d2db2cf64c10ca7fa6f45fa6f1bd38) | `cargo-bisect-rustc: unpin openssl_1_1`                           |
| [`b289bfde`](https://github.com/NixOS/nixpkgs/commit/b289bfdeebdc39894b7bafca7f0a1e61b6979620) | `libosmium: 2.18.0 -> 2.19.0`                                     |
| [`1310cc0a`](https://github.com/NixOS/nixpkgs/commit/1310cc0ad72bddea49ed7ed199e1390a1d27cad0) | `ergo: 5.0.3 -> 5.0.6`                                            |
| [`9fd918d0`](https://github.com/NixOS/nixpkgs/commit/9fd918d07a7be106c2909b086633f8a8a0a290dc) | `bottom: 0.7.1 -> 0.8.0`                                          |
| [`a67632bd`](https://github.com/NixOS/nixpkgs/commit/a67632bda0fc7562785fe5d1c2495014c436ebf7) | ``doc/langauge-frameworks/beam: fix broken link to `elixir-ls```  |
| [`808663bd`](https://github.com/NixOS/nixpkgs/commit/808663bd02143086e23418244b969ffe23f2a912) | `nixos/uptime-kuma: add ping in path (#212001)`                   |
| [`fcc72779`](https://github.com/NixOS/nixpkgs/commit/fcc727798cd67905ba683af6f3d007f90e7b461e) | `python310Packages.google-cloud-asset: 3.16.0 -> 3.17.0`          |
| [`523e6200`](https://github.com/NixOS/nixpkgs/commit/523e62005a859bf1afe72f6b9ad2aec7b8ddb2ff) | `nixUnstable: bump to latest nix version`                         |
| [`b19185fd`](https://github.com/NixOS/nixpkgs/commit/b19185fdb2a5ffbbdb5689ef5ee30d17d208e217) | `libiconv: use libc header on NetBSD`                             |
| [`be622593`](https://github.com/NixOS/nixpkgs/commit/be62259393a3cff405b9d84015f1a60d9150b355) | `libcIconv: rename from glibcIconv`                               |
| [`ca390ee0`](https://github.com/NixOS/nixpkgs/commit/ca390ee0162b164d780a999e9d08ca5c15a766ba) | `vimPlugins.nvim-treesitter: update grammars`                     |
| [`b533ff3d`](https://github.com/NixOS/nixpkgs/commit/b533ff3d01cfc7dd22a7ead3c73f5929dd55675f) | `flyway: 9.7.0 -> 9.12.0`                                         |
| [`3ffdf241`](https://github.com/NixOS/nixpkgs/commit/3ffdf2419dc1dd3e26be8360097560a33c5321ab) | `vimPlugins.solarized-nvim: init at 2022-12-02`                   |
| [`843a1351`](https://github.com/NixOS/nixpkgs/commit/843a13514c0e49ea6a8b2a022fad54a5ac6e10d8) | `python310Packages.pytrafikverket: 0.2.2 -> 0.2.3`                |
| [`60d9b29e`](https://github.com/NixOS/nixpkgs/commit/60d9b29eb1972752d28a410533c1e15907758ce6) | `vimPlugins: resolve github repository redirects`                 |
| [`5dc8c24b`](https://github.com/NixOS/nixpkgs/commit/5dc8c24b3f7ca2155f7dbc9b4e52119f54bda138) | `vimPlugins: update`                                              |
| [`557679ed`](https://github.com/NixOS/nixpkgs/commit/557679ed84e59932fb89c20f431d27acead811cb) | `python310Packages.flux-led: 0.28.34 -> 0.28.35`                  |
| [`3bc27524`](https://github.com/NixOS/nixpkgs/commit/3bc27524abc4b5f5aaf6cfdc2bb6114f8276bd32) | `python310Packages.airthings-ble: 0.5.4 -> 0.5.5`                 |
| [`1dff4c3d`](https://github.com/NixOS/nixpkgs/commit/1dff4c3d81dd234693abbb3dfed94c802dd0b268) | `python310Packages.yalexs-ble: 1.12.5 -> 1.12.7`                  |
| [`707a15f5`](https://github.com/NixOS/nixpkgs/commit/707a15f5735dec32773a32e0f7d217d24dfd873e) | `python310Packages.python-bsblan: 0.5.8 -> 0.5.9`                 |
| [`1109b9d6`](https://github.com/NixOS/nixpkgs/commit/1109b9d6860afbefc8683f5107c2b0fb619b982d) | `python310Packages.python-bsblan: add changelog to meta`          |
| [`3094ec7d`](https://github.com/NixOS/nixpkgs/commit/3094ec7d17eaddb647b3ce9e62fe1030a0d35020) | `python310Packages.pytibber: 0.26.9 -> 0.26.11`                   |
| [`de3b8f45`](https://github.com/NixOS/nixpkgs/commit/de3b8f45ae7aa96830fc6915a91d1efbb941fe52) | `cpuid: 20221201 -> 20230120`                                     |
| [`b29703a4`](https://github.com/NixOS/nixpkgs/commit/b29703a4b12ca93395f6a4c95770ad92bac06960) | `python310Packages.tinydb: 4.7.0 -> 4.7.1`                        |
| [`6405c525`](https://github.com/NixOS/nixpkgs/commit/6405c525516a1e5bc115d5f307c8fd9dc2421d47) | `python3Packages.django-login-required-middleware: init at 0.9.0` |
| [`94ea920d`](https://github.com/NixOS/nixpkgs/commit/94ea920df96146ee43e1ff5694004d249d0772d3) | `python310Packages.videocr: use Levenshtein`                      |
| [`bccabe1d`](https://github.com/NixOS/nixpkgs/commit/bccabe1d8a176b59b72f4d168d602f7bd218221e) | `python310Packages.starlette: update dependencies`                |
| [`0db47bd5`](https://github.com/NixOS/nixpkgs/commit/0db47bd50ee411b5ca291e86f5daa0ee668a600a) | `kime: 2.5.6 -> 3.0.2`                                            |
| [`b56418cb`](https://github.com/NixOS/nixpkgs/commit/b56418cbcb6fcce17f8ced91ed2f2581b3c1c8b3) | `python3Packages.pygmt: fix build`                                |
| [`eaed2336`](https://github.com/NixOS/nixpkgs/commit/eaed23363a66bef2a164face57c6fd93b4a8560e) | `cdxgen: init at 6.0.14`                                          |
| [`38bc80cb`](https://github.com/NixOS/nixpkgs/commit/38bc80cb5a16106d7789c9bb4a84e8515dd28594) | `maintainers: add novenary`                                       |
| [`7eb82433`](https://github.com/NixOS/nixpkgs/commit/7eb824334de36d6fe7a15c95a958e00a50eac319) | `dhcpcd: avoid crash`                                             |
| [`098cdb20`](https://github.com/NixOS/nixpkgs/commit/098cdb205648a4da56c022954a4d816b292b4643) | `python310Packages.vector: adjust inputs`                         |
| [`e5dca172`](https://github.com/NixOS/nixpkgs/commit/e5dca17201e4a329f08a0342c50c5d538c5940a5) | `python311Packages.ansiwrap: patch test`                          |
| [`0f2b75bc`](https://github.com/NixOS/nixpkgs/commit/0f2b75bc9d1a0ca001bdfccf2390f2bcb8cfc1b5) | `syft: 0.62.3 -> 0.66.2`                                          |
| [`da775621`](https://github.com/NixOS/nixpkgs/commit/da775621419375dd377322fa53ba0675ccc17097) | `shopify-cli: 2.14.0 -> 2.34.0`                                   |
| [`1205b7ca`](https://github.com/NixOS/nixpkgs/commit/1205b7cac832e8767912ac2a7d88f308a16b8699) | `python310Packages.findpython: add changelog to meta`             |
| [`c9694c96`](https://github.com/NixOS/nixpkgs/commit/c9694c96802501afc99b0ebfe82677b6db128c6f) | `mdbook-katex: 0.3.2 -> 0.3.3`                                    |
| [`0dcb8c76`](https://github.com/NixOS/nixpkgs/commit/0dcb8c76c058682e1ce46ae86f2722563ddc969c) | `python310Packages.hahomematic: 2023.1.5 -> 2023.1.6`             |