### PR TITLE
chore(flake/nur): `b87197ca` -> `80761b98`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674574136,
-        "narHash": "sha256-1VZkgpWft6Ifs35aIAry1vHUGLzxUe5M2eBvHhYVByA=",
+        "lastModified": 1674582384,
+        "narHash": "sha256-5KDJBOV4XL5vI8PfldYUc3bXit0FQYMqK8Hq0KNu9Ss=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b87197cac6c38db9e32d76c6f286fee98e2ba752",
+        "rev": "80761b98153ae3e77c16f9399c69250cff06b90a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`80761b98`](https://github.com/nix-community/NUR/commit/80761b98153ae3e77c16f9399c69250cff06b90a) | `automatic update` |