### PR TITLE
chore(flake/nur): `36c3694e` -> `a4a794c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674596784,
-        "narHash": "sha256-/qtYSPEwgtQshi9JykeRYFoj7qDbJCQV6WeEQe/0qmQ=",
+        "lastModified": 1674612332,
+        "narHash": "sha256-DWNR5b6ZKtq+dzE7TioUikdgcBs56EEOFHxYa7zegpk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "36c3694e5241aa1af8973691abb2f9e8abb644c1",
+        "rev": "a4a794c6b12c9dc547c7acad3fb12e4de7713cae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a4a794c6`](https://github.com/nix-community/NUR/commit/a4a794c6b12c9dc547c7acad3fb12e4de7713cae) | `automatic update` |