### PR TITLE
chore(flake/nur): `a4a794c6` -> `7f88883b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674612332,
-        "narHash": "sha256-DWNR5b6ZKtq+dzE7TioUikdgcBs56EEOFHxYa7zegpk=",
+        "lastModified": 1674619884,
+        "narHash": "sha256-eqobCLNXbnCqsyurqPHy/ow9Hgq9Of94zfR8eHIWhpA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a4a794c6b12c9dc547c7acad3fb12e4de7713cae",
+        "rev": "7f88883b459a2b16eb982bfa21e52e875a0c4e0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7f88883b`](https://github.com/nix-community/NUR/commit/7f88883b459a2b16eb982bfa21e52e875a0c4e0e) | `automatic update` |
| [`708decc2`](https://github.com/nix-community/NUR/commit/708decc2a9704bae481a6bc17b4901dea63543ef) | `automatic update` |
| [`059758a1`](https://github.com/nix-community/NUR/commit/059758a105e0921ff3916f03ca6cfd1cbeaf8153) | `automatic update` |
| [`5c20eb57`](https://github.com/nix-community/NUR/commit/5c20eb574d31b9fcf47cc406f1eda0cfc8cb0b5a) | `automatic update` |