### PR TITLE
chore(flake/emacs-overlay): `d5316379` -> `53018b60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674580065,
-        "narHash": "sha256-W26KWFlnuUGiNG6ZvdT6IwilqE5nlNv8IsKMNiHFfTM=",
+        "lastModified": 1674615852,
+        "narHash": "sha256-FcZ42T0m+CVbNyqHsmjixlFzuCevZXsbPBG/3JtoBak=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d53163791c6c6fdb0132339f0fca01a3593ece87",
+        "rev": "53018b60fc15aaac1722031e50b043883b74fcd0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`53018b60`](https://github.com/nix-community/emacs-overlay/commit/53018b60fc15aaac1722031e50b043883b74fcd0) | `Updated repos/melpa` |
| [`15f7310f`](https://github.com/nix-community/emacs-overlay/commit/15f7310fafeb01d9e574c49037105d2aaf46ae4c) | `Updated repos/emacs` |
| [`05b466b9`](https://github.com/nix-community/emacs-overlay/commit/05b466b981a7b2d559a441927c1f660a6752a025) | `Updated repos/elpa`  |