### PR TITLE
chore(flake/nur): `7f88883b` -> `68342a62`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674619884,
-        "narHash": "sha256-eqobCLNXbnCqsyurqPHy/ow9Hgq9Of94zfR8eHIWhpA=",
+        "lastModified": 1674622026,
+        "narHash": "sha256-aGZfaqxai9WpsaMAiHxQjncR5i3M7s1vh40fQfn7mEg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7f88883b459a2b16eb982bfa21e52e875a0c4e0e",
+        "rev": "68342a628180aed9fbd516bc35ed44b244018ae4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`68342a62`](https://github.com/nix-community/NUR/commit/68342a628180aed9fbd516bc35ed44b244018ae4) | `automatic update` |