### PR TITLE
chore(flake/nur): `68342a62` -> `e1877e2f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674622026,
-        "narHash": "sha256-aGZfaqxai9WpsaMAiHxQjncR5i3M7s1vh40fQfn7mEg=",
+        "lastModified": 1674625543,
+        "narHash": "sha256-KZnSivnI7Kby9uTEIMwRwszR1cBLxIIj8TDOPgqnU/g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "68342a628180aed9fbd516bc35ed44b244018ae4",
+        "rev": "e1877e2ff3d4403099d9845af09047f8ee47ac63",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e1877e2f`](https://github.com/nix-community/NUR/commit/e1877e2ff3d4403099d9845af09047f8ee47ac63) | `automatic update` |