### PR TITLE
chore(flake/nur): `e1877e2f` -> `3c493356`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674625543,
-        "narHash": "sha256-KZnSivnI7Kby9uTEIMwRwszR1cBLxIIj8TDOPgqnU/g=",
+        "lastModified": 1674629174,
+        "narHash": "sha256-f1gNBoDdlpkAEeKPqiC9/DSHLCAR25C48cFa0MYAJuQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e1877e2ff3d4403099d9845af09047f8ee47ac63",
+        "rev": "3c493356aeeee496fa19d9472d7149750a4a7c73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3c493356`](https://github.com/nix-community/NUR/commit/3c493356aeeee496fa19d9472d7149750a4a7c73) | `automatic update` |