### PR TITLE
chore(flake/nur): `3c493356` -> `4e97b9c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674629174,
-        "narHash": "sha256-f1gNBoDdlpkAEeKPqiC9/DSHLCAR25C48cFa0MYAJuQ=",
+        "lastModified": 1674638507,
+        "narHash": "sha256-RM5hb9LEYtE5yOm3iiAga6b7HIt0vZfk+W+iT6qLMpI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3c493356aeeee496fa19d9472d7149750a4a7c73",
+        "rev": "4e97b9c6e06c726bf4b5c31efc290efa9501a629",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message            |
| -------------------------------------------------------------------------------------------------- | ------------------------- |
| [`3a586706`](https://github.com/nix-community/NUR/commit/3a586706b8e41c50f11ea1940b7d9c7820fa1d38) | `add arteneko repository` |