### PR TITLE
chore(flake/nur): `c77b7be3` -> `f0ed41ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674639255,
-        "narHash": "sha256-626i2++bDLbinRYhdxy5TzrTeJeHvGKitRN1VRiDbhk=",
+        "lastModified": 1674643487,
+        "narHash": "sha256-uYMivqp6uJKfli5m98XzfkzGjNQj4sI/jTkgyTHzamc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c77b7be330eb9f17323738e83cd6801b1b6202e9",
+        "rev": "f0ed41ff1712482b8e849ad0693918a8a482af8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f0ed41ff`](https://github.com/nix-community/NUR/commit/f0ed41ff1712482b8e849ad0693918a8a482af8d) | `automatic update` |