### PR TITLE
chore(flake/emacs-overlay): `53018b60` -> `be2e9cae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674615852,
-        "narHash": "sha256-FcZ42T0m+CVbNyqHsmjixlFzuCevZXsbPBG/3JtoBak=",
+        "lastModified": 1674667405,
+        "narHash": "sha256-1T05VqlUrUkOx2A1dCXds+/eu0l3Vp4smCUz+VgKONE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "53018b60fc15aaac1722031e50b043883b74fcd0",
+        "rev": "be2e9caec9ec4aae477e59af4bc9e38999e4f1f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`be2e9cae`](https://github.com/nix-community/emacs-overlay/commit/be2e9caec9ec4aae477e59af4bc9e38999e4f1f4) | `Updated repos/melpa` |
| [`f38bcebf`](https://github.com/nix-community/emacs-overlay/commit/f38bcebf77442ae05f37c67a7ce93f9135ce5af5) | `Updated repos/elpa`  |