### PR TITLE
chore(flake/nur): `88ead35b` -> `1e7181b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674675980,
-        "narHash": "sha256-ADKU4NVBlfSTaA72UEikhjR4ZUzBDAXKN1tdsj4Kt6Y=",
+        "lastModified": 1674679506,
+        "narHash": "sha256-QTq21QzB3js8+8R8rEOOyBp6UEKmNzXSZSUae6XcXSk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "88ead35b837f13f16225add777ba246d13505b29",
+        "rev": "1e7181b58e88c9a190b44ffd09898caad7d97f11",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1e7181b5`](https://github.com/nix-community/NUR/commit/1e7181b58e88c9a190b44ffd09898caad7d97f11) | `automatic update` |