### PR TITLE
chore(flake/nur): `1e7181b5` -> `868b58f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674679506,
-        "narHash": "sha256-QTq21QzB3js8+8R8rEOOyBp6UEKmNzXSZSUae6XcXSk=",
+        "lastModified": 1674686809,
+        "narHash": "sha256-frpLv4+MSOM8Vgpt12Rg7zJmQZ7yToFls2+joNzvOcg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1e7181b58e88c9a190b44ffd09898caad7d97f11",
+        "rev": "868b58f16b2547ea79d5a7c145840c1dc0e22d71",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`868b58f1`](https://github.com/nix-community/NUR/commit/868b58f16b2547ea79d5a7c145840c1dc0e22d71) | `automatic update` |