### PR TITLE
chore(flake/nur): `868b58f1` -> `8bf7dd85`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674686809,
-        "narHash": "sha256-frpLv4+MSOM8Vgpt12Rg7zJmQZ7yToFls2+joNzvOcg=",
+        "lastModified": 1674690395,
+        "narHash": "sha256-6J3dZnvTZqTKma/EkbcX40Efj0irM3xN2PvmnkCfeFw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "868b58f16b2547ea79d5a7c145840c1dc0e22d71",
+        "rev": "8bf7dd8538ed9bd7a657bd1f59e8540fe5446306",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8bf7dd85`](https://github.com/nix-community/NUR/commit/8bf7dd8538ed9bd7a657bd1f59e8540fe5446306) | `automatic update` |