### PR TITLE
chore(flake/nur): `8bf7dd85` -> `b57955d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674690395,
-        "narHash": "sha256-6J3dZnvTZqTKma/EkbcX40Efj0irM3xN2PvmnkCfeFw=",
+        "lastModified": 1674701870,
+        "narHash": "sha256-C5eaowZAZr4tNfynqQzq6cW7WVdw//N9hAtYxjJopQQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8bf7dd8538ed9bd7a657bd1f59e8540fe5446306",
+        "rev": "b57955d6208a699651001eb616852424e31c550b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b57955d6`](https://github.com/nix-community/NUR/commit/b57955d6208a699651001eb616852424e31c550b) | `automatic update` |
| [`a7c206b3`](https://github.com/nix-community/NUR/commit/a7c206b34282af8fd0cdbed6c7bc8d807689ba3f) | `automatic update` |
| [`bafc9b2d`](https://github.com/nix-community/NUR/commit/bafc9b2d346326c81721aa05d3ce27c3e563117f) | `automatic update` |