### PR TITLE
chore(flake/nur): `94d81e13` -> `202792b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674706205,
-        "narHash": "sha256-N4oBFogjRwKifOilEaGjxitbaVRdj/Bzwg1wxJLSxtc=",
+        "lastModified": 1674711878,
+        "narHash": "sha256-UI7RGxBFMRxEPGAUx5O31WuKJrRsKessJZn2xuaipGM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "94d81e13aaf836121af8b23b10e3761f71026e5b",
+        "rev": "202792b4c8ebea99adc4ae7d7dfb9df2b4441ead",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`202792b4`](https://github.com/nix-community/NUR/commit/202792b4c8ebea99adc4ae7d7dfb9df2b4441ead) | `automatic update` |