### PR TITLE
chore(flake/nur): `202792b4` -> `0c0f754e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674711878,
-        "narHash": "sha256-UI7RGxBFMRxEPGAUx5O31WuKJrRsKessJZn2xuaipGM=",
+        "lastModified": 1674726070,
+        "narHash": "sha256-vdVWBybsaBBmhWB2QWiE8Tecp32PjWHfYh1R2smKYKU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "202792b4c8ebea99adc4ae7d7dfb9df2b4441ead",
+        "rev": "0c0f754eec5eb9c5a19b8775bb7eb6ee6ef5fc85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0c0f754e`](https://github.com/nix-community/NUR/commit/0c0f754eec5eb9c5a19b8775bb7eb6ee6ef5fc85) | `automatic update` |