### PR TITLE
chore(flake/emacs-overlay): `f0c91f45` -> `6b44cc8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674703676,
-        "narHash": "sha256-UzA+oObdYF1uS1MZIVhs2GrSOtST0AHUeWj3Dzfj8G4=",
+        "lastModified": 1674727661,
+        "narHash": "sha256-yiT8F+VrFS5xnDwfb6kLYitAztXuxiblhz8+AP6T28g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f0c91f4589afa6581c4c63cf909c8be68e55465b",
+        "rev": "6b44cc8a441bed3796e6ddc984745fcdeaba8aa4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`6b44cc8a`](https://github.com/nix-community/emacs-overlay/commit/6b44cc8a441bed3796e6ddc984745fcdeaba8aa4) | `Updated repos/nongnu` |
| [`c485a42c`](https://github.com/nix-community/emacs-overlay/commit/c485a42c9cba41b96ba216812e6d739c2f716009) | `Updated repos/melpa`  |