### PR TITLE
chore(flake/nur): `0c0f754e` -> `31d7bcfb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674726070,
-        "narHash": "sha256-vdVWBybsaBBmhWB2QWiE8Tecp32PjWHfYh1R2smKYKU=",
+        "lastModified": 1674735208,
+        "narHash": "sha256-ZCtyfTO0wvYDkLIMQdkbXcFfPMFh64Z5V1d75xD7dIM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0c0f754eec5eb9c5a19b8775bb7eb6ee6ef5fc85",
+        "rev": "31d7bcfb1a4e9eb30ad7b0e4d9d6b0ec6bb95fa4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`31d7bcfb`](https://github.com/nix-community/NUR/commit/31d7bcfb1a4e9eb30ad7b0e4d9d6b0ec6bb95fa4) | `automatic update` |