### PR TITLE
chore(flake/nur): `31d7bcfb` -> `043bf37f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674735208,
-        "narHash": "sha256-ZCtyfTO0wvYDkLIMQdkbXcFfPMFh64Z5V1d75xD7dIM=",
+        "lastModified": 1674738371,
+        "narHash": "sha256-YkB4nTeKgMKCxp0ZuZ6PzrvjBv8WrbdfOyhmcSxsHHc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "31d7bcfb1a4e9eb30ad7b0e4d9d6b0ec6bb95fa4",
+        "rev": "043bf37f6044a6c552a797cb426ce75703153d60",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`043bf37f`](https://github.com/nix-community/NUR/commit/043bf37f6044a6c552a797cb426ce75703153d60) | `automatic update` |