### PR TITLE
chore(flake/nur): `f448a387` -> `35fea51e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674744377,
-        "narHash": "sha256-Dpfkckf4RDgfMndvImaiVCi/d5MzBoxJwoUrClN7/xY=",
+        "lastModified": 1674751968,
+        "narHash": "sha256-QtOpWWlrdPXQNnS1xYQPgmiVO5vbN7mCGhHO+rSBHWY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f448a38715d5fccbf70759f35ef58d26e5d4be81",
+        "rev": "35fea51e033d24efd3250295ba50fafafc9f117e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`35fea51e`](https://github.com/nix-community/NUR/commit/35fea51e033d24efd3250295ba50fafafc9f117e) | `automatic update` |