### PR TITLE
chore(flake/nur): `35fea51e` -> `d9b56973`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674751968,
-        "narHash": "sha256-QtOpWWlrdPXQNnS1xYQPgmiVO5vbN7mCGhHO+rSBHWY=",
+        "lastModified": 1674755094,
+        "narHash": "sha256-V0mpdqiP6u1r0eg4tnVATxl57RqS+QirkfGp0S7a9Xg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "35fea51e033d24efd3250295ba50fafafc9f117e",
+        "rev": "d9b569732923681cb4eb692d1021c0640fee7fb9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d9b56973`](https://github.com/nix-community/NUR/commit/d9b569732923681cb4eb692d1021c0640fee7fb9) | `automatic update` |