### PR TITLE
chore(flake/emacs-overlay): `6b44cc8a` -> `0de52764`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674727661,
-        "narHash": "sha256-yiT8F+VrFS5xnDwfb6kLYitAztXuxiblhz8+AP6T28g=",
+        "lastModified": 1674788508,
+        "narHash": "sha256-GAZ7YuhlQPnEbDpa3fugIpyq2rOrylEKwZ8U+9/M7VY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6b44cc8a441bed3796e6ddc984745fcdeaba8aa4",
+        "rev": "0de52764b28fd1c0aaa9567203a62426957fb38b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`0de52764`](https://github.com/nix-community/emacs-overlay/commit/0de52764b28fd1c0aaa9567203a62426957fb38b) | `Updated repos/melpa` |
| [`f0c737fa`](https://github.com/nix-community/emacs-overlay/commit/f0c737faf06880ea4162202a4cfc259d7d971b12) | `Updated repos/emacs` |
| [`1c93656f`](https://github.com/nix-community/emacs-overlay/commit/1c93656f259af0ceb5738aecd67e3c1ee25e7a3a) | `Updated repos/elpa`  |
| [`acff9f41`](https://github.com/nix-community/emacs-overlay/commit/acff9f41c4962704acb8008e5ff5b90a43cf7758) | `Updated repos/melpa` |
| [`4506c1f3`](https://github.com/nix-community/emacs-overlay/commit/4506c1f3a966518bb3cd2a114ecdffb0e4eca960) | `Updated repos/emacs` |
| [`167eb388`](https://github.com/nix-community/emacs-overlay/commit/167eb3887a0774c2bbf33d679c05919298dfe343) | `Updated repos/elpa`  |