### PR TITLE
chore(flake/nur): `d9b56973` -> `5afe5e75`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674755094,
-        "narHash": "sha256-V0mpdqiP6u1r0eg4tnVATxl57RqS+QirkfGp0S7a9Xg=",
+        "lastModified": 1674800989,
+        "narHash": "sha256-vRUJhQTR2cIPXBJwAWlqL67GjqYvx8WpT8lzWIif5Oo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d9b569732923681cb4eb692d1021c0640fee7fb9",
+        "rev": "5afe5e755851b4d4a339eec4d6d701571c2140c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5afe5e75`](https://github.com/nix-community/NUR/commit/5afe5e755851b4d4a339eec4d6d701571c2140c5) | `automatic update` |
| [`43e094a4`](https://github.com/nix-community/NUR/commit/43e094a491c3bd36f82c916b45d27c6c2ab3b656) | `automatic update` |
| [`e69816d0`](https://github.com/nix-community/NUR/commit/e69816d0da1726e0fb5643c25f6e7af72974cbfa) | `automatic update` |
| [`04c45e78`](https://github.com/nix-community/NUR/commit/04c45e78201721148ef9330842fcfd562d9a7446) | `automatic update` |
| [`2d809d91`](https://github.com/nix-community/NUR/commit/2d809d91d70e26e983d61a50546947f3189d05bb) | `automatic update` |
| [`5a29d4f1`](https://github.com/nix-community/NUR/commit/5a29d4f1e6446e704403415364749f20dc350470) | `automatic update` |