### PR TITLE
chore(flake/home-manager): `c59f0eac` -> `bb4b25b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -338,11 +338,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674556204,
-        "narHash": "sha256-HCRmkZsq01h2Evch08zpgE9jeHdMtGdT1okWotyvuhY=",
+        "lastModified": 1674771519,
+        "narHash": "sha256-U0W3S1nX6yEvLh3Vq70EORbmXecAKXfmEfCfaA4A+I8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c59f0eac51da91c6989fd13a68e156f63c0e60b6",
+        "rev": "bb4b25b302dbf0f527f190461b080b5262871756",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`bb4b25b3`](https://github.com/nix-community/home-manager/commit/bb4b25b302dbf0f527f190461b080b5262871756) | `bash: format using nixfmt`                                   |
| [`8f39c67c`](https://github.com/nix-community/home-manager/commit/8f39c67c4c87c137f33858123abadf70e4f00e76) | `ci: bump DeterminateSystems/update-flake-lock from 15 to 16` |
| [`7efca2ca`](https://github.com/nix-community/home-manager/commit/7efca2ca18062791cbaa838f4d3e23d629bb1473) | `files: allow disabling creation of a file`                   |