### PR TITLE
chore(flake/nur): `5afe5e75` -> `46271208`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674800989,
-        "narHash": "sha256-vRUJhQTR2cIPXBJwAWlqL67GjqYvx8WpT8lzWIif5Oo=",
+        "lastModified": 1674819037,
+        "narHash": "sha256-FLb9zv8Jh9QNwIK/moAa591HhQDzTal6yHhoEO3MfxA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5afe5e755851b4d4a339eec4d6d701571c2140c5",
+        "rev": "4627120867504e7d2d1a7d04f1c2291495cbb158",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`46271208`](https://github.com/nix-community/NUR/commit/4627120867504e7d2d1a7d04f1c2291495cbb158) | `automatic update` |