### PR TITLE
chore(flake/nur): `46271208` -> `b2246cfe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674819037,
-        "narHash": "sha256-FLb9zv8Jh9QNwIK/moAa591HhQDzTal6yHhoEO3MfxA=",
+        "lastModified": 1674823342,
+        "narHash": "sha256-5UFRwDX91nMcazWP7K8ZSpmXWUAhliKpVzFOJ1IHKHw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4627120867504e7d2d1a7d04f1c2291495cbb158",
+        "rev": "b2246cfe6601d580126f6d2fafb5df759357d85d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b2246cfe`](https://github.com/nix-community/NUR/commit/b2246cfe6601d580126f6d2fafb5df759357d85d) | `automatic update` |