### PR TITLE
chore(flake/nur): `dc65dc16` -> `66930523`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674838254,
-        "narHash": "sha256-hgQtznuSaTSc3LsMhcLSABo13pZmzyCTbgHdIz1+muA=",
+        "lastModified": 1674848689,
+        "narHash": "sha256-EDVqy+4Vr0a3xrv+y7WFadmokO53EEAAIWr249k3LUM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dc65dc160e680b3bc11b22527fc4925d9663f105",
+        "rev": "669305238f287604316f306bf4af33943bd479ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`66930523`](https://github.com/nix-community/NUR/commit/669305238f287604316f306bf4af33943bd479ec) | `automatic update` |