### PR TITLE
chore(flake/nur): `ee61d517` -> `ad68a42e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674855963,
-        "narHash": "sha256-DYEoEf4+VimZvrBiJg2AkWg26vAKgKeavrmayqlBooc=",
+        "lastModified": 1674871779,
+        "narHash": "sha256-/t9cpZLUBsDbNyjdFAX3XbxqWdOK4fJeksyc2kA4kqo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ee61d5175c3666bee014b90a803fd4e730466a1a",
+        "rev": "ad68a42eb59e947e5fcbdf82e0fc264cf7617d29",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ad68a42e`](https://github.com/nix-community/NUR/commit/ad68a42eb59e947e5fcbdf82e0fc264cf7617d29) | `automatic update` |