### PR TITLE
chore(flake/emacs-overlay): `1e9e9e62` -> `d2d7a3c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674843012,
-        "narHash": "sha256-ri1RbS/YahqeYhkvz3LyJe8A5y3udLSGWirKHVvPlH4=",
+        "lastModified": 1674874856,
+        "narHash": "sha256-RWFiIGbcvN13aj2MKETjoUt3upbAziNTdeW1AESOkWg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1e9e9e62a5a37c262b4f31ee8cc97d40894d1874",
+        "rev": "d2d7a3c5eb96fa6ca486b3adc0694295aedef6c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`d2d7a3c5`](https://github.com/nix-community/emacs-overlay/commit/d2d7a3c5eb96fa6ca486b3adc0694295aedef6c7) | `Updated repos/melpa` |
| [`c577999f`](https://github.com/nix-community/emacs-overlay/commit/c577999f68405386c9c81a5cf5d75ebbe5ebe640) | `Updated repos/emacs` |
| [`0ce6f349`](https://github.com/nix-community/emacs-overlay/commit/0ce6f349ab23a420490a23b1f331e14e709d9c0a) | `Updated repos/elpa`  |