### PR TITLE
chore(flake/nur): `1b4eb512` -> `b8d927e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674877120,
-        "narHash": "sha256-JIaLtLJkxyaTMlXArIdc7rsHv9yDX9vU2956ngtrkiY=",
+        "lastModified": 1674878787,
+        "narHash": "sha256-03Kc5M4oKhmVYfXN4DAkCk9vYFpqg3VNA64LI4Z1DYg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1b4eb5127dc408c884ad86fb015eccc9abb11baa",
+        "rev": "b8d927e973143619a3e8c7e3ec46066d197ee927",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b8d927e9`](https://github.com/nix-community/NUR/commit/b8d927e973143619a3e8c7e3ec46066d197ee927) | `automatic update` |