### PR TITLE
chore(flake/nur): `b8d927e9` -> `52b8a712`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674878787,
-        "narHash": "sha256-03Kc5M4oKhmVYfXN4DAkCk9vYFpqg3VNA64LI4Z1DYg=",
+        "lastModified": 1674880751,
+        "narHash": "sha256-z3V7yaAGoibk2JXVDFWod8HQqp32FmxrdicNnGmUUY4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b8d927e973143619a3e8c7e3ec46066d197ee927",
+        "rev": "52b8a71232c39bf93bb3e1a9862e70bbeb2e1434",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`52b8a712`](https://github.com/nix-community/NUR/commit/52b8a71232c39bf93bb3e1a9862e70bbeb2e1434) | `automatic update` |