### PR TITLE
chore(flake/emacs-overlay): `d2d7a3c5` -> `c595b26b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674874856,
-        "narHash": "sha256-RWFiIGbcvN13aj2MKETjoUt3upbAziNTdeW1AESOkWg=",
+        "lastModified": 1674900836,
+        "narHash": "sha256-BKY3S87QXsWOVifmfLCZ8yf8F5qz/56YlDY3Nkyf0SU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d2d7a3c5eb96fa6ca486b3adc0694295aedef6c7",
+        "rev": "c595b26be85c85c352ac3f058f2726686ca3a1ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`c595b26b`](https://github.com/nix-community/emacs-overlay/commit/c595b26be85c85c352ac3f058f2726686ca3a1ee) | `Updated repos/melpa` |
| [`fa8e052d`](https://github.com/nix-community/emacs-overlay/commit/fa8e052d22b0cb283ba6656559c62e2cb2fe049e) | `Updated repos/emacs` |