### PR TITLE
chore(flake/nur): `22eafe11` -> `8ebf4468`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674888299,
-        "narHash": "sha256-5g0shs1K4vxmv3W8SqgI7cmSnlotT4AWmxdBO9tvmTM=",
+        "lastModified": 1674928887,
+        "narHash": "sha256-CK7Ohk8hmxJGkQgt68MDsBz/Mromk362yjphP4L8dBA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "22eafe11a555362dadd49b3f76b1ceae7e17e4d1",
+        "rev": "8ebf4468167f7be80d16bc2327c09a9f93208d22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8ebf4468`](https://github.com/nix-community/NUR/commit/8ebf4468167f7be80d16bc2327c09a9f93208d22) | `automatic update` |
| [`3f056601`](https://github.com/nix-community/NUR/commit/3f056601e64b94cbeb68138323b75d92615ac8d8) | `automatic update` |
| [`0230b631`](https://github.com/nix-community/NUR/commit/0230b631c025c767653cacae223980ac05ecce20) | `automatic update` |