### PR TITLE
chore(flake/emacs-overlay): `c595b26b` -> `d1ea6872`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674900836,
-        "narHash": "sha256-BKY3S87QXsWOVifmfLCZ8yf8F5qz/56YlDY3Nkyf0SU=",
+        "lastModified": 1674930931,
+        "narHash": "sha256-h8Uv+DvOAK01qm7WYe/qiBHOyeqlXyrI4edXHkouqRE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c595b26be85c85c352ac3f058f2726686ca3a1ee",
+        "rev": "d1ea6872b199edc680917a7248b596e532297538",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`d1ea6872`](https://github.com/nix-community/emacs-overlay/commit/d1ea6872b199edc680917a7248b596e532297538) | `Updated repos/nongnu` |
| [`8e79aca6`](https://github.com/nix-community/emacs-overlay/commit/8e79aca6bcc85a0b5d9e6c86d2bc9e16aecffd4b) | `Updated repos/melpa`  |
| [`ec0f7cfd`](https://github.com/nix-community/emacs-overlay/commit/ec0f7cfdd66b4c8849ce2dbdad953d8090132155) | `Updated repos/emacs`  |
| [`4e3f717b`](https://github.com/nix-community/emacs-overlay/commit/4e3f717b95d4acaa0afb82a3ae2292e75524efdb) | `Updated repos/elpa`   |