### PR TITLE
chore(flake/nur): `8ebf4468` -> `be36aaf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674928887,
-        "narHash": "sha256-CK7Ohk8hmxJGkQgt68MDsBz/Mromk362yjphP4L8dBA=",
+        "lastModified": 1674935082,
+        "narHash": "sha256-dmC6iKS2biE9Pl+kCvvR7jdrZCC/rX5U5vfk3NdMS1o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8ebf4468167f7be80d16bc2327c09a9f93208d22",
+        "rev": "be36aaf543b636d7e62f65e55dabe932730f3f7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`be36aaf5`](https://github.com/nix-community/NUR/commit/be36aaf543b636d7e62f65e55dabe932730f3f7a) | `automatic update` |