### PR TITLE
chore(flake/nur): `d0585ac2` -> `3ccb2c06`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674942275,
-        "narHash": "sha256-H4E1M7erhF3JKm8S3OnjAUrPHJCEVrmwrDW/tbNCL60=",
+        "lastModified": 1674945972,
+        "narHash": "sha256-BfNnYn3iKm6tL4HLDtk/X0f6uPWTToVPxiNe9asWDmk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d0585ac23ddf3385a5a51768b9ab8ca8ade0a137",
+        "rev": "3ccb2c06d5be111aa3bbc36c7f30dd10a69b9a7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3ccb2c06`](https://github.com/nix-community/NUR/commit/3ccb2c06d5be111aa3bbc36c7f30dd10a69b9a7a) | `automatic update` |