### PR TITLE
chore(flake/emacs-overlay): `d1ea6872` -> `c67c5bfa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674930931,
-        "narHash": "sha256-h8Uv+DvOAK01qm7WYe/qiBHOyeqlXyrI4edXHkouqRE=",
+        "lastModified": 1674961970,
+        "narHash": "sha256-cc81H8UnVTrjwA+TtTLBrB9C0MrTm48Wsx9eusPvWW8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d1ea6872b199edc680917a7248b596e532297538",
+        "rev": "c67c5bfa005e083875d5b25bf96ffd24885985d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`c67c5bfa`](https://github.com/nix-community/emacs-overlay/commit/c67c5bfa005e083875d5b25bf96ffd24885985d4) | `Updated repos/nongnu` |
| [`a1ba95fe`](https://github.com/nix-community/emacs-overlay/commit/a1ba95fe5dc8b7dd493f86a5a3cbf0e4385a03c7) | `Updated repos/melpa`  |
| [`64851c8f`](https://github.com/nix-community/emacs-overlay/commit/64851c8f5701cd00995d27f6a018395fdaa86ba3) | `Updated repos/emacs`  |
| [`e805bcc2`](https://github.com/nix-community/emacs-overlay/commit/e805bcc20a956215d70bb2d44032d4d4d6fcfdcd) | `Updated repos/elpa`   |