### PR TITLE
chore(flake/nur): `a998fbc8` -> `546520ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674958303,
-        "narHash": "sha256-o/o7fRQbUPMFOklqpEeMfs6SbJPDtZdFsaky3oT9OYE=",
+        "lastModified": 1674963970,
+        "narHash": "sha256-r1sprKFlDLEpqkfKljrEx91mXaJQ+peLCOyiRDFg3j0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a998fbc8615d6481ee82b147ce1c7a6bb5e44c01",
+        "rev": "546520ea8522e989db65410d6783bedeab2771af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`546520ea`](https://github.com/nix-community/NUR/commit/546520ea8522e989db65410d6783bedeab2771af) | `automatic update` |