### PR TITLE
chore(flake/nur): `546520ea` -> `790763ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674963970,
-        "narHash": "sha256-r1sprKFlDLEpqkfKljrEx91mXaJQ+peLCOyiRDFg3j0=",
+        "lastModified": 1674974682,
+        "narHash": "sha256-5+6uPK6xPIXARWwudCdcfLIp8wURIzveiTwi5rn0FHA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "546520ea8522e989db65410d6783bedeab2771af",
+        "rev": "790763ba5471ecc3089366a19da6f9752a68d9f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`790763ba`](https://github.com/nix-community/NUR/commit/790763ba5471ecc3089366a19da6f9752a68d9f3) | `automatic update` |