### PR TITLE
chore(flake/emacs-overlay): `c67c5bfa` -> `d23a3449`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674961970,
-        "narHash": "sha256-cc81H8UnVTrjwA+TtTLBrB9C0MrTm48Wsx9eusPvWW8=",
+        "lastModified": 1674986945,
+        "narHash": "sha256-W94RR4mNk4GT5oWecO5RC5Pc78+pUNMHrkSwDHU+sPg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c67c5bfa005e083875d5b25bf96ffd24885985d4",
+        "rev": "d23a3449c8f26fb264402d3f7fb3fc7064b70e07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`d23a3449`](https://github.com/nix-community/emacs-overlay/commit/d23a3449c8f26fb264402d3f7fb3fc7064b70e07) | `Updated repos/melpa` |
| [`21b24958`](https://github.com/nix-community/emacs-overlay/commit/21b24958c1b60ebfa5a761ba2301686ee4784e0c) | `Updated repos/emacs` |