### PR TITLE
chore(flake/nur): `fc2a9823` -> `d51f7d85`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674981967,
-        "narHash": "sha256-aSEQv63tfQ4+LAJBotBHaErtkLA6c01q4mY7xsKHg4U=",
+        "lastModified": 1674994733,
+        "narHash": "sha256-+73mJ5DwCZCh5sZlD5Pssbtfe88uIcZoO9Ob6KsVg40=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc2a9823dd0b99f740013ad480dae07a956b18e7",
+        "rev": "d51f7d8586ee0179e84617649f42f9a5646dd708",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d51f7d85`](https://github.com/nix-community/NUR/commit/d51f7d8586ee0179e84617649f42f9a5646dd708) | `automatic update` |