### PR TITLE
chore(flake/nur): `d51f7d85` -> `1955f5e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674994733,
-        "narHash": "sha256-+73mJ5DwCZCh5sZlD5Pssbtfe88uIcZoO9Ob6KsVg40=",
+        "lastModified": 1674999880,
+        "narHash": "sha256-mmALt2MFFLsJj0wddOxLqTg453wtPskS00U1TD120FA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d51f7d8586ee0179e84617649f42f9a5646dd708",
+        "rev": "1955f5e2c384d156efcc0b4ce7a0f635c3ea0997",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1955f5e2`](https://github.com/nix-community/NUR/commit/1955f5e2c384d156efcc0b4ce7a0f635c3ea0997) | `automatic update` |