### PR TITLE
chore(flake/emacs-overlay): `d23a3449` -> `1d2409ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674986945,
-        "narHash": "sha256-W94RR4mNk4GT5oWecO5RC5Pc78+pUNMHrkSwDHU+sPg=",
+        "lastModified": 1675015755,
+        "narHash": "sha256-4orQ2IM5xKueh3lV9HUdM0P/0DBRo6TZEAVo73/dZSk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d23a3449c8f26fb264402d3f7fb3fc7064b70e07",
+        "rev": "1d2409effbdebad47fb887ff6305f3da1fea5965",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`1d2409ef`](https://github.com/nix-community/emacs-overlay/commit/1d2409effbdebad47fb887ff6305f3da1fea5965) | `Updated repos/melpa` |
| [`c3eaa953`](https://github.com/nix-community/emacs-overlay/commit/c3eaa953604bf08cd7c8bca88d29c216976f5d27) | `Updated repos/emacs` |
| [`34e85ada`](https://github.com/nix-community/emacs-overlay/commit/34e85ada035c5a6851b09af573c12589a4f3953b) | `Updated repos/elpa`  |