### PR TITLE
chore(flake/nur): `1955f5e2` -> `0fac6f8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674999880,
-        "narHash": "sha256-mmALt2MFFLsJj0wddOxLqTg453wtPskS00U1TD120FA=",
+        "lastModified": 1675032287,
+        "narHash": "sha256-zAykcNSuqQKGbIDhCyft598am9KSlM3uVTorJw0IiNo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1955f5e2c384d156efcc0b4ce7a0f635c3ea0997",
+        "rev": "0fac6f8a6838ebc1824f7a749b8b7a3d61439633",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`0fac6f8a`](https://github.com/nix-community/NUR/commit/0fac6f8a6838ebc1824f7a749b8b7a3d61439633) | `automatic update` |