### PR TITLE
chore(flake/emacs-overlay): `1d2409ef` -> `db19c252`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675015755,
-        "narHash": "sha256-4orQ2IM5xKueh3lV9HUdM0P/0DBRo6TZEAVo73/dZSk=",
+        "lastModified": 1675043741,
+        "narHash": "sha256-UxE/nFHE/YY3tRUvu0FcVNh1D24guzKbh97Q8S0mrrk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1d2409effbdebad47fb887ff6305f3da1fea5965",
+        "rev": "db19c25226deb094871cc4d1944cf24dd74730f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`db19c252`](https://github.com/nix-community/emacs-overlay/commit/db19c25226deb094871cc4d1944cf24dd74730f0) | `Updated repos/melpa` |
| [`41530312`](https://github.com/nix-community/emacs-overlay/commit/4153031275d1db12a40e6882b09a8e5dfafa1f36) | `Updated repos/elpa`  |