### PR TITLE
chore(flake/emacs-overlay): `db19c252` -> `ffab139d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675043741,
-        "narHash": "sha256-UxE/nFHE/YY3tRUvu0FcVNh1D24guzKbh97Q8S0mrrk=",
+        "lastModified": 1675075385,
+        "narHash": "sha256-gdQlEHTUur6bQNU63H8AHwrKhoSZLwlS6KxTZMZfCYQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "db19c25226deb094871cc4d1944cf24dd74730f0",
+        "rev": "ffab139d704bdec0c1d894f667c0fb9fe6261b80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ffab139d`](https://github.com/nix-community/emacs-overlay/commit/ffab139d704bdec0c1d894f667c0fb9fe6261b80) | `Updated repos/melpa` |
| [`ee1f91d5`](https://github.com/nix-community/emacs-overlay/commit/ee1f91d538ac4c09eb7f7c007846f6bef1950a41) | `Updated repos/emacs` |