### PR TITLE
chore(flake/emacs-overlay): `ffab139d` -> `5c7ac97e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675075385,
-        "narHash": "sha256-gdQlEHTUur6bQNU63H8AHwrKhoSZLwlS6KxTZMZfCYQ=",
+        "lastModified": 1675102309,
+        "narHash": "sha256-E+qY0zgTkgnc9TllbwxrCN7I6DqiDDTPx1Zt90982wA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ffab139d704bdec0c1d894f667c0fb9fe6261b80",
+        "rev": "5c7ac97e616c6d162c086d417a221831fd871ef3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`5c7ac97e`](https://github.com/nix-community/emacs-overlay/commit/5c7ac97e616c6d162c086d417a221831fd871ef3) | `Updated repos/melpa` |
| [`917df605`](https://github.com/nix-community/emacs-overlay/commit/917df605c7218b7d306d4194d967ba58bc24fa7e) | `Updated repos/emacs` |
| [`f40b555b`](https://github.com/nix-community/emacs-overlay/commit/f40b555b6d0c68dad9a149c3e71e7b7733883634) | `Updated repos/elpa`  |