### PR TITLE
chore(flake/nur): `167df43c` -> `f19dcea1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675089990,
-        "narHash": "sha256-VN70n9I7A4b9kmKoND1ACxWoNyK436Xw9QJJrzer9x0=",
+        "lastModified": 1675107978,
+        "narHash": "sha256-amNM84snUqaAGcL5n2bCWu02/LpHNENiYnoFUejgJrE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "167df43c426fb5a39086691f59bda8b6ee3f7b73",
+        "rev": "f19dcea1d7b1412aacafdd861d578d77a14cda8e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f19dcea1`](https://github.com/nix-community/NUR/commit/f19dcea1d7b1412aacafdd861d578d77a14cda8e) | `automatic update` |
| [`f784e280`](https://github.com/nix-community/NUR/commit/f784e280fb43d0a95edfdc4f35b20fdb3dd8b720) | `automatic update` |