### PR TITLE
chore(flake/nur): `dde9c0b9` -> `b80f82aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675133004,
-        "narHash": "sha256-ZGuJ+M5t4Q6OjFrAkEncMsZwaIHUp2V0axNw7S/Qxyk=",
+        "lastModified": 1675134159,
+        "narHash": "sha256-Z3Ts+bh8kCtJytbCtKf95NsoM/DNL4Ek54Qseo3u/gY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dde9c0b9de05fbc66aed375f247a0c72bd24a1c3",
+        "rev": "b80f82aa47d6f0a9a9665913d5ef43cc128e9e09",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b80f82aa`](https://github.com/nix-community/NUR/commit/b80f82aa47d6f0a9a9665913d5ef43cc128e9e09) | `automatic update` |