### PR TITLE
chore(flake/nur): `b80f82aa` -> `af9df147`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675134159,
-        "narHash": "sha256-Z3Ts+bh8kCtJytbCtKf95NsoM/DNL4Ek54Qseo3u/gY=",
+        "lastModified": 1675136345,
+        "narHash": "sha256-x2nY7E3J5um+OMVBT8ahEUXPHTyzdws4FIxoJ79CvYQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b80f82aa47d6f0a9a9665913d5ef43cc128e9e09",
+        "rev": "af9df147753f07e15a8d2e13bb77d4c653798618",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`af9df147`](https://github.com/nix-community/NUR/commit/af9df147753f07e15a8d2e13bb77d4c653798618) | `automatic update` |
| [`dee3b337`](https://github.com/nix-community/NUR/commit/dee3b337bf9e383e68e83a578c027181f5e171ff) | `automatic update` |