### PR TITLE
chore(flake/nur): `af9df147` -> `09d7afde`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675136345,
-        "narHash": "sha256-x2nY7E3J5um+OMVBT8ahEUXPHTyzdws4FIxoJ79CvYQ=",
+        "lastModified": 1675140103,
+        "narHash": "sha256-bhciJA71FAvBGmg0mu6M8nVk25usM0wfkZ0ywGKC6bg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "af9df147753f07e15a8d2e13bb77d4c653798618",
+        "rev": "09d7afdeac34cd07a4cf85ec9f3d490504121721",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`09d7afde`](https://github.com/nix-community/NUR/commit/09d7afdeac34cd07a4cf85ec9f3d490504121721) | `automatic update` |
| [`d94d2453`](https://github.com/nix-community/NUR/commit/d94d24538441c83d21a5236520295efc34b02e7a) | `automatic update` |