### PR TITLE
chore(flake/nur): `09d7afde` -> `c034160f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675140103,
-        "narHash": "sha256-bhciJA71FAvBGmg0mu6M8nVk25usM0wfkZ0ywGKC6bg=",
+        "lastModified": 1675149106,
+        "narHash": "sha256-n/WCjr8wpEQwpN/tpcCiWAzU9lXqqIlih7bMFNbE5mw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "09d7afdeac34cd07a4cf85ec9f3d490504121721",
+        "rev": "c034160f9c4c46316f9f036d19cd2ad1c9d9c7eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c034160f`](https://github.com/nix-community/NUR/commit/c034160f9c4c46316f9f036d19cd2ad1c9d9c7eb) | `automatic update` |