### PR TITLE
chore(flake/nur): `c034160f` -> `a70671b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675149106,
-        "narHash": "sha256-n/WCjr8wpEQwpN/tpcCiWAzU9lXqqIlih7bMFNbE5mw=",
+        "lastModified": 1675150393,
+        "narHash": "sha256-xG6slo+n2kwjTDa+ZhH9HojocXMR4hVNlHcoi0wgyTk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c034160f9c4c46316f9f036d19cd2ad1c9d9c7eb",
+        "rev": "a70671b404b4f39117e71a7328abfae776300200",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a70671b4`](https://github.com/nix-community/NUR/commit/a70671b404b4f39117e71a7328abfae776300200) | `automatic update` |