### PR TITLE
chore(flake/nur): `9b2edf2e` -> `55246f50`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675165489,
-        "narHash": "sha256-3jYlBngdJfT3aEuNzNfvUAx3tHoVFfN7Nw+4jSvMYqQ=",
+        "lastModified": 1675168758,
+        "narHash": "sha256-QJGSDRSQA13xvDS9k6+Gw+uEC/xCPMG8Zswfc/2GSyA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9b2edf2ed1ebd33068cb20d9fc0b7412cebc7d91",
+        "rev": "55246f50464663fbb5ccd54491f4630eddef7067",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`55246f50`](https://github.com/nix-community/NUR/commit/55246f50464663fbb5ccd54491f4630eddef7067) | `automatic update` |