### PR TITLE
chore(flake/nur): `9f2a8c44` -> `15716a5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675182159,
-        "narHash": "sha256-NZsP5JMsH2Ruu6rephciknudEHRALbeJwIo55FX2bm8=",
+        "lastModified": 1675194334,
+        "narHash": "sha256-sqeMJo8cgzFooOY1SDSQOZkzopYlXH94gkfBe3wypqE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9f2a8c440a75d46b008fd4b4582702768a1168a4",
+        "rev": "15716a5e94e01e01fd06ed6e5091f399c457285a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`15716a5e`](https://github.com/nix-community/NUR/commit/15716a5e94e01e01fd06ed6e5091f399c457285a) | `automatic update` |