### PR TITLE
chore(flake/nur): `2f71be78` -> `d1eb7164`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675201600,
-        "narHash": "sha256-cNyiHeaFa0FUSfJZZlMcGFhfQRg6KNYgSj94V8wAJLg=",
+        "lastModified": 1675205171,
+        "narHash": "sha256-ItHbdoLnYZxOO6OWn2pkLj8PQRgwq89LIaf8Cogx28w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2f71be786ab255a06e25d52cb5773ed34afe594a",
+        "rev": "d1eb71647c0fe8806aaa1c10a6389fb01978e964",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d1eb7164`](https://github.com/nix-community/NUR/commit/d1eb71647c0fe8806aaa1c10a6389fb01978e964) | `automatic update` |
| [`2ce9e539`](https://github.com/nix-community/NUR/commit/2ce9e53920912ac3cbf25dec3efb82bf157566dc) | `automatic update` |