### PR TITLE
chore(flake/nur): `d1eb7164` -> `e927e12e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675205171,
-        "narHash": "sha256-ItHbdoLnYZxOO6OWn2pkLj8PQRgwq89LIaf8Cogx28w=",
+        "lastModified": 1675208749,
+        "narHash": "sha256-WkZLPwwVwx6BCEomnQ8+4dLol5qIofLQmA0TqgUvTbY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d1eb71647c0fe8806aaa1c10a6389fb01978e964",
+        "rev": "e927e12ebaa8aed183c170b57739281408874198",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e927e12e`](https://github.com/nix-community/NUR/commit/e927e12ebaa8aed183c170b57739281408874198) | `automatic update` |