### PR TITLE
chore(flake/nur): `e927e12e` -> `e9202068`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675208749,
-        "narHash": "sha256-WkZLPwwVwx6BCEomnQ8+4dLol5qIofLQmA0TqgUvTbY=",
+        "lastModified": 1675218022,
+        "narHash": "sha256-Y4Zzff+rdELxXqJSjj6LHBtz5dSYtSmMH6FF8fqtjXw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e927e12ebaa8aed183c170b57739281408874198",
+        "rev": "e920206803e4321e897af4e6b7dbf77e2591f317",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e9202068`](https://github.com/nix-community/NUR/commit/e920206803e4321e897af4e6b7dbf77e2591f317) | `automatic update` |