### PR TITLE
chore(flake/nur): `e9202068` -> `ee52c734`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675218022,
-        "narHash": "sha256-Y4Zzff+rdELxXqJSjj6LHBtz5dSYtSmMH6FF8fqtjXw=",
+        "lastModified": 1675223742,
+        "narHash": "sha256-H0SsX7GxG39GjsMiR0Z9qFSfR6Ejq2CaPqZPPnqnVig=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e920206803e4321e897af4e6b7dbf77e2591f317",
+        "rev": "ee52c734eccd674bac82bf98e2902e69b903f636",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ee52c734`](https://github.com/nix-community/NUR/commit/ee52c734eccd674bac82bf98e2902e69b903f636) | `automatic update` |
| [`f0a66683`](https://github.com/nix-community/NUR/commit/f0a66683a54a368c96aef3e530dcc13c2e10dcf2) | `automatic update` |
| [`531b3faa`](https://github.com/nix-community/NUR/commit/531b3faae0a865900dc1b5eeeabdab0ef81f1f4b) | `automatic update` |