### PR TITLE
chore(flake/nur): `ee52c734` -> `3df03249`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675223742,
-        "narHash": "sha256-H0SsX7GxG39GjsMiR0Z9qFSfR6Ejq2CaPqZPPnqnVig=",
+        "lastModified": 1675224693,
+        "narHash": "sha256-i4KxDM6OS0gAXqTrGn0sGXtulOZo7oDwGVOyAVm/lDI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ee52c734eccd674bac82bf98e2902e69b903f636",
+        "rev": "3df03249026f189c2312df9e896f531dc384f281",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3df03249`](https://github.com/nix-community/NUR/commit/3df03249026f189c2312df9e896f531dc384f281) | `automatic update` |