### PR TITLE
chore(flake/nur): `49fcf380` -> `79184895`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675256703,
-        "narHash": "sha256-YI9prZQEhOZELFiaNv/ftUKF536aZO06vF2uKuRgiWQ=",
+        "lastModified": 1675266298,
+        "narHash": "sha256-YnOp5Bwz6P5ZUUP+6b0gfOHR5+6YXjBwejC+d+r+y/0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "49fcf38006a485c408479940c26ca9d2f7c95a4e",
+        "rev": "791848955787354a0d76abb004318bfad0462f07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`79184895`](https://github.com/nix-community/NUR/commit/791848955787354a0d76abb004318bfad0462f07) | `automatic update` |