### PR TITLE
chore(flake/sops-nix): `b6ab3c61` -> `41530212`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -512,11 +512,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1674352297,
-        "narHash": "sha256-OkAnJPrauEcUCrst4/3DKoQfUn2gXKuU6CFvhtMrLgg=",
+        "lastModified": 1675215157,
+        "narHash": "sha256-bdEmR5m4usTGPiLMfL56TMLOdig1ARYHlppxMZJ0/V4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "918b760070bb8f48cb511300fcd7e02e13058a2e",
+        "rev": "af10c1043b37230e8ac58c76d88c08742077e9c3",
         "type": "github"
       },
       "original": {
@@ -765,11 +765,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1674546403,
-        "narHash": "sha256-vkyNv0xzXuEnu9v52TUtRugNmQWIti8c2RhYnbLG71w=",
+        "lastModified": 1675284855,
+        "narHash": "sha256-JjeGl10X/HX5hf2H0CD7gokHeHWxH2jhgqki5/cWaxg=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "b6ab3c61e2ca5e07d1f4eb1b67304e2670ea230c",
+        "rev": "415302126e923d9a62eb2fe99ae768d826083e36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                                                                         |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`3109abd3`](https://github.com/Mic92/sops-nix/commit/3109abd37796004217e83b7e49bae2764d2b9272) | `add bors.toml`                                                                        |
| [`a88f9dd2`](https://github.com/Mic92/sops-nix/commit/a88f9dd22d9e9c17b8f859d44a85744d764750e6) | `Fix build of sops-install-secrets after https://github.com/NixOS/nixpkgs/pull/212800` |
| [`2265fc29`](https://github.com/Mic92/sops-nix/commit/2265fc29621908704f587b1ec3138e3a10fba702) | `flake.lock: Update`                                                                   |
| [`eb09a61d`](https://github.com/Mic92/sops-nix/commit/eb09a61dc95633924e2c54f420519dda0385dbba) | `format type: add dotenv and ini`                                                      |