### PR TITLE
chore(flake/sops-nix): `41530212` -> `a81ce6c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -512,11 +512,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1675215157,
-        "narHash": "sha256-bdEmR5m4usTGPiLMfL56TMLOdig1ARYHlppxMZJ0/V4=",
+        "lastModified": 1675265860,
+        "narHash": "sha256-PZNqc4ZnTRT34NsHJYbXn+Yhghh56l8HEXn39SMpGNc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "af10c1043b37230e8ac58c76d88c08742077e9c3",
+        "rev": "a3a1400571e3b9ccc270c2e8d36194cf05aab6ce",
         "type": "github"
       },
       "original": {
@@ -765,11 +765,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1675284855,
-        "narHash": "sha256-JjeGl10X/HX5hf2H0CD7gokHeHWxH2jhgqki5/cWaxg=",
+        "lastModified": 1675288837,
+        "narHash": "sha256-76s8TLENa4PzWDeuIpEF78gqeUrXi6rEJJaKEAaJsXw=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "415302126e923d9a62eb2fe99ae768d826083e36",
+        "rev": "a81ce6c961480b3b93498507074000c589bd9d60",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                                            |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`24e51949`](https://github.com/Mic92/sops-nix/commit/24e51949ebacac49bf8de506e420c785157ade44) | `automerge flake-updates with bors`                       |
| [`3c8cf2ec`](https://github.com/Mic92/sops-nix/commit/3c8cf2ecb8033b8de1de6f64588677d6ea5cc26d) | `drop mergify`                                            |
| [`955f7cb1`](https://github.com/Mic92/sops-nix/commit/955f7cb1b5fa85fbe3e930e68dc8525784c54490) | `bors: drop createPullRequest`                            |
| [`c10480e7`](https://github.com/Mic92/sops-nix/commit/c10480e7a78db0013c91e007bc36a8e635e4c7e1) | `ci: also run when pushing to branches`                   |
| [`f234b0c8`](https://github.com/Mic92/sops-nix/commit/f234b0c865f5009f34e4e12b443e85fbb812c3f9) | `TestIsValidFormat: don't use deprecated golang function` |
| [`64431c9f`](https://github.com/Mic92/sops-nix/commit/64431c9fc4b841eaa66a2b08e81c9d0f6e639f01) | `flake.lock: Update`                                      |