### PR TITLE
chore(flake/ragenix): `92248738` -> `325733b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -696,11 +696,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1673786180,
-        "narHash": "sha256-5tu71eDtQVmVUorho/GKaCzr4cdmNpvG8ZYxMhDCVKY=",
+        "lastModified": 1675293936,
+        "narHash": "sha256-xaObOxlMiZ8noXbXWfoUJrCjVZ8oc9HBblc/MeCq7fc=",
         "owner": "yaxitech",
         "repo": "ragenix",
-        "rev": "92248738a21db5687744d9e7796cf2433b96a7a5",
+        "rev": "325733b734aa4cc4d6b19f1169e6672cad4128ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                            | Commit Message                                    |
| ------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`325733b7`](https://github.com/yaxitech/ragenix/commit/325733b734aa4cc4d6b19f1169e6672cad4128ca) | `Remove calls to obsolete header function (#124)` |