### PR TITLE
chore(flake/nur): `25eaa45d` -> `19ef486c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675291594,
-        "narHash": "sha256-VghorRetN77L3B1bqxX/WsrkbX2RLBeMGeG6FvlMD1w=",
+        "lastModified": 1675305827,
+        "narHash": "sha256-6GYCFTAt9OeOQDwWxtl+W91G4ztkQYMAVt0QYJJ2RE8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "25eaa45d5311ca238f893565e715baa2cfcca37f",
+        "rev": "19ef486c2b748938a744cb2d04c2be2cfd8ebfb1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`19ef486c`](https://github.com/nix-community/NUR/commit/19ef486c2b748938a744cb2d04c2be2cfd8ebfb1) | `automatic update` |
| [`a5e26ad9`](https://github.com/nix-community/NUR/commit/a5e26ad9d9e8eb4fe56303397e16768272b77e91) | `automatic update` |