### PR TITLE
chore(flake/nur): `7ad0f767` -> `abe32383`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675306909,
-        "narHash": "sha256-oOuNT7dy4JOEmOWl/WptD+0vNKp1xjLAegLcH0vOlag=",
+        "lastModified": 1675309508,
+        "narHash": "sha256-A+dRnIkg/uaVobcfYTplM0BMtSNCyqxuD5vkzrH0Ibk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7ad0f7672c0ee4a6c33a98bf8b790ef596086b49",
+        "rev": "abe323838bfd57e5e2760f6d8bcfec6b515678d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`abe32383`](https://github.com/nix-community/NUR/commit/abe323838bfd57e5e2760f6d8bcfec6b515678d4) | `automatic update` |
| [`e2200fae`](https://github.com/nix-community/NUR/commit/e2200faede260c7f0c8f325f5fadb518b0d66dd1) | `automatic update` |