### PR TITLE
chore(flake/nur): `abe32383` -> `a9f70143`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675309508,
-        "narHash": "sha256-A+dRnIkg/uaVobcfYTplM0BMtSNCyqxuD5vkzrH0Ibk=",
+        "lastModified": 1675311143,
+        "narHash": "sha256-iK7GDRWoseLg962e1EIQWLpdWVD4RmTsjlB1yIl95FI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "abe323838bfd57e5e2760f6d8bcfec6b515678d4",
+        "rev": "a9f701436c9c771859b80e1c088e3684346e98bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a9f70143`](https://github.com/nix-community/NUR/commit/a9f701436c9c771859b80e1c088e3684346e98bd) | `automatic update` |