### PR TITLE
chore(flake/emacs-overlay): `7276116f` -> `d524102f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675309900,
-        "narHash": "sha256-liDBB8HjXkJZ/WJ1hGDKuCl5QkPPJko9XY/eyxKd7lg=",
+        "lastModified": 1675334476,
+        "narHash": "sha256-p+lqeXl1GqNcNiBvDqXk7kNrIcOYPKm4crRUCU/vroA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7276116feb26bf3fc2834709a2ea2f6ed738cc52",
+        "rev": "d524102fb8d013a2c136ec09b51fb6fee886787c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`d524102f`](https://github.com/nix-community/emacs-overlay/commit/d524102fb8d013a2c136ec09b51fb6fee886787c) | `Updated repos/melpa` |
| [`9641261d`](https://github.com/nix-community/emacs-overlay/commit/9641261d49ec2ae07e46317431b5bdd3afd394af) | `Updated repos/emacs` |