### PR TITLE
chore(flake/impermanence): `5df9108b` -> `6138eb8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -375,11 +375,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1668668915,
-        "narHash": "sha256-QjY4ZZbs9shwO4LaLpvlU2bO9J1juYhO9NtV3nrbnYQ=",
+        "lastModified": 1675359654,
+        "narHash": "sha256-FPxzuvJkcO49g4zkWLSeuZkln54bLoTtrggZDJBH90I=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "5df9108b346f8a42021bf99e50de89c9caa251c3",
+        "rev": "6138eb8e737bffabd4c8fc78ae015d4fd6a7e2fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`ba22f42f`](https://github.com/nix-community/impermanence/commit/ba22f42f53cfff4614797cb9472d710c4ff39bbc) | `nixos: Mount binds after the persistent storage path` |
| [`a0b6d84f`](https://github.com/nix-community/impermanence/commit/a0b6d84f54438c2219d28d6e6a9460bbccb36f00) | `nixos: Recommend persisting /var/lib/nixos`           |