### PR TITLE
chore(flake/nur): `14feda3d` -> `f9a67871`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675373279,
-        "narHash": "sha256-gMrVLGFtCQKWj9zyBYa6WNHdACpvFDr70b1cFZN7ieo=",
+        "lastModified": 1675390386,
+        "narHash": "sha256-VK1EGF9+U2A72Gy5lgHHa6DaGOnx3Ml51E0TewYh5L8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "14feda3d14770b2bcea5dca20dee32110f910003",
+        "rev": "f9a67871a7c1dcd424a20b6e3723eacc0704bc97",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f9a67871`](https://github.com/nix-community/NUR/commit/f9a67871a7c1dcd424a20b6e3723eacc0704bc97) | `automatic update` |