### PR TITLE
chore(flake/nur): `f9a67871` -> `728c10fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675390386,
-        "narHash": "sha256-VK1EGF9+U2A72Gy5lgHHa6DaGOnx3Ml51E0TewYh5L8=",
+        "lastModified": 1675397338,
+        "narHash": "sha256-MQGfK2kXpaVk1Zzl9wTOstKufkUdSYOtVYeBgKQWNxI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f9a67871a7c1dcd424a20b6e3723eacc0704bc97",
+        "rev": "728c10fbdb5e3cf4d3f0d1bec92c7b2dc417d6c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`728c10fb`](https://github.com/nix-community/NUR/commit/728c10fbdb5e3cf4d3f0d1bec92c7b2dc417d6c1) | `automatic update` |