### PR TITLE
chore(flake/nur): `728c10fb` -> `48a5b6e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675397338,
-        "narHash": "sha256-MQGfK2kXpaVk1Zzl9wTOstKufkUdSYOtVYeBgKQWNxI=",
+        "lastModified": 1675401726,
+        "narHash": "sha256-SOG0unCuN8OwqALj0yHOfyuQcy1XaMlSLljgo3xqABw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "728c10fbdb5e3cf4d3f0d1bec92c7b2dc417d6c1",
+        "rev": "48a5b6e224fc2ecc023d1655c1da9bf3105ba1ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`48a5b6e2`](https://github.com/nix-community/NUR/commit/48a5b6e224fc2ecc023d1655c1da9bf3105ba1ff) | `automatic update` |