### PR TITLE
chore(flake/emacs-overlay): `27625286` -> `88dcf530`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675389821,
-        "narHash": "sha256-Z6HjMqbM+0mQNnETH2lMROT9CA6CqAF8R27ylf3r/lk=",
+        "lastModified": 1675419601,
+        "narHash": "sha256-Zt6VnU6CLxaISGmPNMGiD0A9BcgcXJTEuX196M11RYw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "27625286ac637065286c1372d0eae66e3d16c146",
+        "rev": "88dcf53013b1f8f0a6a1766fc76ed181e0a6a8db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`88dcf530`](https://github.com/nix-community/emacs-overlay/commit/88dcf53013b1f8f0a6a1766fc76ed181e0a6a8db) | `Updated repos/melpa` |
| [`43c6ad70`](https://github.com/nix-community/emacs-overlay/commit/43c6ad70d8209ca65af056360a687e73c4166d05) | `Updated repos/emacs` |