### PR TITLE
chore(flake/nur): `a99be868` -> `503657d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675439111,
-        "narHash": "sha256-Zq3niWjpqxcmzIgktbMVmnxDE0tlulRyXgutZGmYJQQ=",
+        "lastModified": 1675453602,
+        "narHash": "sha256-6QwmEB4/yBYwmRfC22SvEKON6d4SNUpRdR1Szx5oMx0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a99be868d2c8b2f6107c31cdced9e78be2cca3ac",
+        "rev": "503657d637c7d27ee4ae15ade97b4d7b440fc1d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`503657d6`](https://github.com/nix-community/NUR/commit/503657d637c7d27ee4ae15ade97b4d7b440fc1d9) | `automatic update` |