### PR TITLE
chore(flake/nur): `503657d6` -> `b8ff9a9d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675453602,
-        "narHash": "sha256-6QwmEB4/yBYwmRfC22SvEKON6d4SNUpRdR1Szx5oMx0=",
+        "lastModified": 1675463770,
+        "narHash": "sha256-iox2M74GvyCzoJkWkVJS+qBpHBaaKM5fKz8HrHiQgOY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "503657d637c7d27ee4ae15ade97b4d7b440fc1d9",
+        "rev": "b8ff9a9dca98c9181063b30d6f87346ff5a97294",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b8ff9a9d`](https://github.com/nix-community/NUR/commit/b8ff9a9dca98c9181063b30d6f87346ff5a97294) | `automatic update` |