### PR TITLE
chore(flake/nur): `f0c98fda` -> `73f7d44a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675476263,
-        "narHash": "sha256-uAthSMn3kDYk5nUUV2j0WD78yV8canKTO/U9NYEaoEk=",
+        "lastModified": 1675480276,
+        "narHash": "sha256-7Gqs3qn71lqFP/1DGTuuecl4mB099Ab2QdLDAtUGtsc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f0c98fda72fb603a90e1c3dd5065ec8280494a39",
+        "rev": "73f7d44ab77613e89facf52dd2355c7800c0e966",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`73f7d44a`](https://github.com/nix-community/NUR/commit/73f7d44ab77613e89facf52dd2355c7800c0e966) | `automatic update` |