### PR TITLE
chore(flake/nur): `e1778429` -> `ac7a6f0e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675525582,
-        "narHash": "sha256-LLeZRJtBKiqdgo3y9f17QrgURiBXnJ5uWXG/qmNGv9E=",
+        "lastModified": 1675529301,
+        "narHash": "sha256-upLPV9gqFnfkwwZQfKEJDLXMv5lyeIpTOXCXFjPN2zA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e1778429b420c2bc1771c80bf7bdb3a8485620ed",
+        "rev": "ac7a6f0e289c4690f808f0865a0e7f766670bdfe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ac7a6f0e`](https://github.com/nix-community/NUR/commit/ac7a6f0e289c4690f808f0865a0e7f766670bdfe) | `automatic update` |