### PR TITLE
chore(flake/emacs-overlay): `0d630ac0` -> `00fcdb0c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675501804,
-        "narHash": "sha256-+FWv8aC8wQ+1yuDa5GeLqOWB98tuhu/deTDVKh3yW2Y=",
+        "lastModified": 1675535718,
+        "narHash": "sha256-qwVBsj5THl+5kLZW8u55tgBq865XP6pV46k5g2OQNaY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0d630ac0f6430797b885a86a6699e8c75093c513",
+        "rev": "00fcdb0c7f33f88bd8c84bff7f281f09b9985480",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`00fcdb0c`](https://github.com/nix-community/emacs-overlay/commit/00fcdb0c7f33f88bd8c84bff7f281f09b9985480) | `Updated repos/melpa` |
| [`b481582f`](https://github.com/nix-community/emacs-overlay/commit/b481582f886a1589a5cf2b5912f51411dc2a32cb) | `Updated repos/emacs` |