### PR TITLE
chore(flake/nur): `ac7a6f0e` -> `a5e3e0ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675529301,
-        "narHash": "sha256-upLPV9gqFnfkwwZQfKEJDLXMv5lyeIpTOXCXFjPN2zA=",
+        "lastModified": 1675543471,
+        "narHash": "sha256-+P+Bbae6KDNud6i/NhTCxPQrCLoqwi+YOECvFjbmcC4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ac7a6f0e289c4690f808f0865a0e7f766670bdfe",
+        "rev": "a5e3e0ffd0df3fd6a21b1e195981ca95dcf8f3bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a5e3e0ff`](https://github.com/nix-community/NUR/commit/a5e3e0ffd0df3fd6a21b1e195981ca95dcf8f3bb) | `automatic update` |