### PR TITLE
chore(flake/nur): `a5e3e0ff` -> `acb6e79b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675543471,
-        "narHash": "sha256-+P+Bbae6KDNud6i/NhTCxPQrCLoqwi+YOECvFjbmcC4=",
+        "lastModified": 1675544542,
+        "narHash": "sha256-Csl1i+q7YHIE8uHEaDeZ4DuSk4dwDM1DMriIwsIc69s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a5e3e0ffd0df3fd6a21b1e195981ca95dcf8f3bb",
+        "rev": "acb6e79bd96112f46b0be1627f147df660f93dcc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`acb6e79b`](https://github.com/nix-community/NUR/commit/acb6e79bd96112f46b0be1627f147df660f93dcc) | `automatic update` |