### PR TITLE
chore(flake/emacs-plz): `b6072ede` -> `fe226f40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
     "emacs-plz": {
       "flake": false,
       "locked": {
-        "lastModified": 1672525865,
-        "narHash": "sha256-GVVDX0sASrl3Ivl87B9+fz/VBHp9bq9K6ZauVzoyVfo=",
+        "lastModified": 1675553385,
+        "narHash": "sha256-L3kUekhT582Rfans2aOjUol5mkItg9KuZ5Nr6daj0oY=",
         "owner": "alphapapa",
         "repo": "plz.el",
-        "rev": "b6072edeec1f0e2465d273db74a8f2f7726e6bce",
+        "rev": "fe226f4074fdfa59a8d4f94d105e4ac657f460d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                            | Commit Message                                            |
| ------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`fe226f40`](https://github.com/alphapapa/plz.el/commit/fe226f4074fdfa59a8d4f94d105e4ac657f460d1) | `Add: HEAD method`                                        |
| [`f6892c6d`](https://github.com/alphapapa/plz.el/commit/f6892c6d6300889197de849f39b305c4c5a7602a) | `Change: Move --dump-header out of plz-curl-default-args` |