### PR TITLE
chore(flake/emacs-plz): `e39c4034` -> `706cb910`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
     "emacs-plz": {
       "flake": false,
       "locked": {
-        "lastModified": 1675557661,
-        "narHash": "sha256-1VZQVfBWI9tEllxsC+7wMP+cHGDXtINKIzxiE72hHmA=",
+        "lastModified": 1675558280,
+        "narHash": "sha256-++70w1HhDkTNnOW3RN7PAaDe5rAV+UxAx2BMb5P1o58=",
         "owner": "alphapapa",
         "repo": "plz.el",
-        "rev": "e39c403467ce032ef6c577eb889b38bf5f0457ab",
+        "rev": "706cb910ee508e1653002de7f1c5381600c421c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                            | Commit Message                            |
| ------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`706cb910`](https://github.com/alphapapa/plz.el/commit/706cb910ee508e1653002de7f1c5381600c421c0) | `Tidy: Byte-compilation on older Emacsen` |
| [`9fb8d5c8`](https://github.com/alphapapa/plz.el/commit/9fb8d5c8452bc59d73c46c8739d8d71cb7984ccb) | `Docs: Tidy`                              |