### PR TITLE
chore(flake/emacs-overlay): `00fcdb0c` -> `48188e42`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675535718,
-        "narHash": "sha256-qwVBsj5THl+5kLZW8u55tgBq865XP6pV46k5g2OQNaY=",
+        "lastModified": 1675566773,
+        "narHash": "sha256-oKRu03Nd+yHO0fNM3CJaHGjdEF7yZtfAwt3l49kQaVQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "00fcdb0c7f33f88bd8c84bff7f281f09b9985480",
+        "rev": "48188e420b453dea7467f39a587e3a965c013815",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`48188e42`](https://github.com/nix-community/emacs-overlay/commit/48188e420b453dea7467f39a587e3a965c013815) | `Updated repos/melpa` |
| [`362fd889`](https://github.com/nix-community/emacs-overlay/commit/362fd8897c86ef4e59e58ba733488df05b6a36d6) | `Updated repos/emacs` |