### PR TITLE
chore(flake/nur): `b0b4c6b7` -> `cc2a91cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675566832,
-        "narHash": "sha256-YHosZNmalnyxbPKsY427q4TUADdfMRl+4Ctkh9sBFcw=",
+        "lastModified": 1675575944,
+        "narHash": "sha256-f6pVHr3hHQkIh59/Pi4cFwWCkxKHoDindBnNGW4YHpA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b0b4c6b7ec83ed9872ea08c452bcd02eec513533",
+        "rev": "cc2a91cb6cd9688c6895029b328c4183cb72ecf6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`cc2a91cb`](https://github.com/nix-community/NUR/commit/cc2a91cb6cd9688c6895029b328c4183cb72ecf6) | `automatic update` |
| [`649832ab`](https://github.com/nix-community/NUR/commit/649832ab349979bbec355c7b8814f75df6efd1f1) | `automatic update` |
| [`b41d7270`](https://github.com/nix-community/NUR/commit/b41d7270eb664c767e4d2f8e5c5381fb8eac667f) | `automatic update` |
| [`9089f168`](https://github.com/nix-community/NUR/commit/9089f168ffb2b80a3a4de3d58e0186f9c3db3be3) | `automatic update` |