### PR TITLE
chore(flake/home-manager): `e2c1756e` -> `9f4268e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -338,11 +338,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675462931,
-        "narHash": "sha256-JiOUSERBtA1lN/s9YTKGZoZ3XUicHDwr+C8swaPSh3M=",
+        "lastModified": 1675592602,
+        "narHash": "sha256-UUjFvvLIG2dkg0SW4ENK4pI5DWZUQ3cAiOYgo/zkoxQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e2c1756e3ae001ca8696912016dd31cb1503ccf3",
+        "rev": "9f4268e6b630497e289b18473775dff9c2d6635d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`9f4268e6`](https://github.com/nix-community/home-manager/commit/9f4268e6b630497e289b18473775dff9c2d6635d) | `firefox: support passing any json value to settings (#3580)` |
| [`e3f28ddb`](https://github.com/nix-community/home-manager/commit/e3f28ddb0dc270819b0a4b5563ca34bdc995721d) | `tmux: fix secureSocket environment variable (#3593)`         |
| [`6d2ba465`](https://github.com/nix-community/home-manager/commit/6d2ba4654d6fc7f7eac504938316889058b1fe0a) | `home-manager: pass --refresh to nix (#3624)`                 |
| [`ca69be93`](https://github.com/nix-community/home-manager/commit/ca69be9335def2e31525ea0dc7abd5062700f5ab) | `borgmatic: Do not inhibit idle in service (#3637)`           |
| [`ffc022b6`](https://github.com/nix-community/home-manager/commit/ffc022b6a7fcd8ae1d9310dc1713257f0aaf5f8e) | `vim-vint: add module (#3604)`                                |
| [`e716961d`](https://github.com/nix-community/home-manager/commit/e716961d780b70295076f1b16f9174ea31273f2a) | `modules: java: fix setting JAVA_HOME (#3638)`                |
| [`2ffc6d64`](https://github.com/nix-community/home-manager/commit/2ffc6d64961cb46d58d80fc344795837d6f227c2) | `tmux: mouse support (#3642)`                                 |