### PR TITLE
chore(flake/nur): `e989a316` -> `5f230496`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675601947,
-        "narHash": "sha256-7XGfMkBOCIP9Vc6kCqXfaCYBxTsOnZHLEPveum4k3DE=",
+        "lastModified": 1675615704,
+        "narHash": "sha256-2jAEyl0GOiEYGn+8zTff5a0kP62I3Ov1zZ5VLOC3O3Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e989a316e71c98ebac6a3ef7a110e8fec2622a91",
+        "rev": "5f23049682d27a942b1589d6f4d6badec9a980bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5f230496`](https://github.com/nix-community/NUR/commit/5f23049682d27a942b1589d6f4d6badec9a980bc) | `automatic update` |