### PR TITLE
chore(flake/nur): `5f230496` -> `a0aeaa6c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675615704,
-        "narHash": "sha256-2jAEyl0GOiEYGn+8zTff5a0kP62I3Ov1zZ5VLOC3O3Y=",
+        "lastModified": 1675619121,
+        "narHash": "sha256-bTY45nvkrWFvDti5CROWG9uRSr2RavO3mSB32T8P9y4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5f23049682d27a942b1589d6f4d6badec9a980bc",
+        "rev": "a0aeaa6c72d38e81767dce7d11a84561b7e56126",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a0aeaa6c`](https://github.com/nix-community/NUR/commit/a0aeaa6c72d38e81767dce7d11a84561b7e56126) | `automatic update` |