### PR TITLE
chore(flake/emacs-overlay): `475c58ac` -> `ea9cedde`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675587943,
-        "narHash": "sha256-bCfges+8ZsSETsDPJXgolLYGd87ZXe4jouOdLhgHH0Q=",
+        "lastModified": 1675620534,
+        "narHash": "sha256-Slw7pdqK0BK0NQmavEA1gAW4gb3+VZfDRyPi94Xt0bU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "475c58aca32b60826f2e9ac75b78006d5cecf6b5",
+        "rev": "ea9ceddec99ab3c66017ab3104fb86863e26154a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ea9cedde`](https://github.com/nix-community/emacs-overlay/commit/ea9ceddec99ab3c66017ab3104fb86863e26154a) | `Updated repos/melpa` |
| [`5fd9ac22`](https://github.com/nix-community/emacs-overlay/commit/5fd9ac2245753d68d4f22739860889d37a0b71c3) | `Updated repos/emacs` |
| [`2413b096`](https://github.com/nix-community/emacs-overlay/commit/2413b09697ce3273884e71f37c7e91c075dd5072) | `Updated repos/elpa`  |