### PR TITLE
chore(flake/nur): `a0aeaa6c` -> `73e7c3f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675619121,
-        "narHash": "sha256-bTY45nvkrWFvDti5CROWG9uRSr2RavO3mSB32T8P9y4=",
+        "lastModified": 1675622679,
+        "narHash": "sha256-yLeWnUZ+g+GmCaw+J1oS2bmlv99BqNik2tX7IJetSVo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a0aeaa6c72d38e81767dce7d11a84561b7e56126",
+        "rev": "73e7c3f9557877c3173cd31126454df7b882b39d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`73e7c3f9`](https://github.com/nix-community/NUR/commit/73e7c3f9557877c3173cd31126454df7b882b39d) | `automatic update` |