### PR TITLE
chore(flake/nur): `73e7c3f9` -> `f5959c49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675622679,
-        "narHash": "sha256-yLeWnUZ+g+GmCaw+J1oS2bmlv99BqNik2tX7IJetSVo=",
+        "lastModified": 1675637118,
+        "narHash": "sha256-n8nFKQ2a3bboj9KfmfOIoGeL5brViJcvpr5s3Jbdi8Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "73e7c3f9557877c3173cd31126454df7b882b39d",
+        "rev": "f5959c49540becedb9c5103195c3145a11751070",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f5959c49`](https://github.com/nix-community/NUR/commit/f5959c49540becedb9c5103195c3145a11751070) | `automatic update` |
| [`22745520`](https://github.com/nix-community/NUR/commit/2274552055feccfed6f5e93fec105b683261e484) | `automatic update` |