### PR TITLE
chore(flake/nur): `f5959c49` -> `e92d44a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675637118,
-        "narHash": "sha256-n8nFKQ2a3bboj9KfmfOIoGeL5brViJcvpr5s3Jbdi8Q=",
+        "lastModified": 1675655067,
+        "narHash": "sha256-WX6z8I0uKCTjbXhoxVyPvT0owJ6xItAwSFyRlM/FMUM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f5959c49540becedb9c5103195c3145a11751070",
+        "rev": "e92d44a0894637f9a392ed03c77792d7f8b5030e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e92d44a0`](https://github.com/nix-community/NUR/commit/e92d44a0894637f9a392ed03c77792d7f8b5030e) | `automatic update` |
| [`76cbb15f`](https://github.com/nix-community/NUR/commit/76cbb15fcc444eff9c55a4a8bf6f02accbcf2f78) | `automatic update` |
| [`e118d4b2`](https://github.com/nix-community/NUR/commit/e118d4b28b30c04d5f9c97785be4b6e4160319f1) | `automatic update` |