### PR TITLE
chore(flake/emacs-overlay): `ea9cedde` -> `8c20f1b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675620534,
-        "narHash": "sha256-Slw7pdqK0BK0NQmavEA1gAW4gb3+VZfDRyPi94Xt0bU=",
+        "lastModified": 1675652727,
+        "narHash": "sha256-j6zbFpOBAnyj4OZ+DL4FzpcZlj5L/QG8Ve6fwYkn2mQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ea9ceddec99ab3c66017ab3104fb86863e26154a",
+        "rev": "8c20f1b7fbed3744c5a4c46381781f14c1001269",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`8c20f1b7`](https://github.com/nix-community/emacs-overlay/commit/8c20f1b7fbed3744c5a4c46381781f14c1001269) | `Updated repos/melpa` |
| [`cb76f25c`](https://github.com/nix-community/emacs-overlay/commit/cb76f25c777004ec105d2305f19f101ea846abb9) | `Updated repos/emacs` |
| [`eab435bd`](https://github.com/nix-community/emacs-overlay/commit/eab435bdceac66ee1276173e7c3eab38aa0530cc) | `Updated repos/elpa`  |