### PR TITLE
chore(flake/nur): `e92d44a0` -> `20155f53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675655067,
-        "narHash": "sha256-WX6z8I0uKCTjbXhoxVyPvT0owJ6xItAwSFyRlM/FMUM=",
+        "lastModified": 1675656597,
+        "narHash": "sha256-9ZbdF9+4/k9kgqcapxNoIrtrTB9Yygq39Bs4XmbsG0k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e92d44a0894637f9a392ed03c77792d7f8b5030e",
+        "rev": "20155f5388ca02eef6fd58450bc016aba0243c63",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`20155f53`](https://github.com/nix-community/NUR/commit/20155f5388ca02eef6fd58450bc016aba0243c63) | `automatic update` |