### PR TITLE
chore(flake/nur): `20155f53` -> `25b2e89c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675656597,
-        "narHash": "sha256-9ZbdF9+4/k9kgqcapxNoIrtrTB9Yygq39Bs4XmbsG0k=",
+        "lastModified": 1675662331,
+        "narHash": "sha256-lM5VQ+wcSSoom5ErG02Z4powVb9cycbikwR01Ui02qw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "20155f5388ca02eef6fd58450bc016aba0243c63",
+        "rev": "25b2e89ce39e5d2da0349bda386c0aeb16b6782b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`25b2e89c`](https://github.com/nix-community/NUR/commit/25b2e89ce39e5d2da0349bda386c0aeb16b6782b) | `automatic update` |