### PR TITLE
chore(flake/nur): `60eddbce` -> `333fc428`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675694740,
-        "narHash": "sha256-2Z+xOpoyPiwFAswvbaF2CthOSwfk5xQPo/RPUpqUGIU=",
+        "lastModified": 1675698287,
+        "narHash": "sha256-YvtoiSaB1cQPRI3R6xgmHErS2cWS1E21CMYuEW7EQaQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "60eddbce6e4c210bb7de147f33e35f4c5c89273e",
+        "rev": "333fc42800261343d45a0a16fc72bcbec6672dd1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`333fc428`](https://github.com/nix-community/NUR/commit/333fc42800261343d45a0a16fc72bcbec6672dd1) | `automatic update` |