### PR TITLE
chore(flake/emacs-overlay): `443cbd27` -> `03674806`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675704076,
-        "narHash": "sha256-5ATGnaD8ZSDxPqVDRl15uYI3Ws4vEMT/AxolDFXJrjY=",
+        "lastModified": 1675706098,
+        "narHash": "sha256-NPnQ9QIH98QSr98ZkCE5IxgWusJbcAfEl8HIDypKeh4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "443cbd27492b72b6568fee23974e0ee7f0d72ee3",
+        "rev": "03674806f66bfa3994fe368d063c11c02a2fa8c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------- |
| [`21539406`](https://github.com/nix-community/emacs-overlay/commit/215394062b3fc38d131fdf78725c1704e110ae19) | `allow tree-sitter grammars to be overridden` |