### PR TITLE
chore(flake/nur): `824c203f` -> `d6355001`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675707913,
-        "narHash": "sha256-q1V94RwcXH77Lk0tQzsox42HtAsKygOXZhdNy5HnBYg=",
+        "lastModified": 1675712704,
+        "narHash": "sha256-SrX7TxtZgitaMEqrkFWjhLIQDP8K35Up00416pNGjXs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "824c203f1d757b3f56aba954262db3366f7c069a",
+        "rev": "d6355001dfde853628d686982d93fcac8f3a47af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d6355001`](https://github.com/nix-community/NUR/commit/d6355001dfde853628d686982d93fcac8f3a47af) | `automatic update` |