### PR TITLE
chore(flake/nur): `c379faee` -> `a2c6c745`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675716313,
-        "narHash": "sha256-m/foJPAm/M5rsciXtSBLFwuHh12BjIb0lj8R2Z8oOS0=",
+        "lastModified": 1675723636,
+        "narHash": "sha256-HQm2NepeajlLjcZLTMmmaDhoRivFnR4E6fOL+AxM3Ig=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c379faee753da143abb7ba78a4b0d0361552daf9",
+        "rev": "a2c6c74542d31eac59fbe617c5ca70d1f8197b4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a2c6c745`](https://github.com/nix-community/NUR/commit/a2c6c74542d31eac59fbe617c5ca70d1f8197b4c) | `automatic update` |