### PR TITLE
chore(flake/nur): `a2c6c745` -> `7ba7c028`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675723636,
-        "narHash": "sha256-HQm2NepeajlLjcZLTMmmaDhoRivFnR4E6fOL+AxM3Ig=",
+        "lastModified": 1675729540,
+        "narHash": "sha256-Zwc+tlBEAFp8fW+0uSLrBlLZGxKtP/kKf9TRYMaEzT4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a2c6c74542d31eac59fbe617c5ca70d1f8197b4c",
+        "rev": "7ba7c028915fffb94368c317dc8798f880bf4751",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7ba7c028`](https://github.com/nix-community/NUR/commit/7ba7c028915fffb94368c317dc8798f880bf4751) | `automatic update` |