### PR TITLE
chore(flake/nur): `7ba7c028` -> `8858815c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675729540,
-        "narHash": "sha256-Zwc+tlBEAFp8fW+0uSLrBlLZGxKtP/kKf9TRYMaEzT4=",
+        "lastModified": 1675735674,
+        "narHash": "sha256-0okaObtd7ll0X5SdX25oAXfvncYi5guWnXd/8oWn448=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7ba7c028915fffb94368c317dc8798f880bf4751",
+        "rev": "8858815c140bc26d50f6243817c9b13ae1347c92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8858815c`](https://github.com/nix-community/NUR/commit/8858815c140bc26d50f6243817c9b13ae1347c92) | `automatic update` |