### PR TITLE
chore(flake/nur): `8858815c` -> `f512a1e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675735674,
-        "narHash": "sha256-0okaObtd7ll0X5SdX25oAXfvncYi5guWnXd/8oWn448=",
+        "lastModified": 1675740935,
+        "narHash": "sha256-1vL/IuGZyvjgz2ASLIhcEA+BC1zKFLImzUY9c+rxyRQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8858815c140bc26d50f6243817c9b13ae1347c92",
+        "rev": "f512a1e85dbd95f1fecae97fbc2d95c90148f7d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f512a1e8`](https://github.com/nix-community/NUR/commit/f512a1e85dbd95f1fecae97fbc2d95c90148f7d9) | `automatic update` |
| [`963fdd82`](https://github.com/nix-community/NUR/commit/963fdd829015a226ec948dfc07f3767b7acdd632) | `automatic update` |