### PR TITLE
chore(flake/emacs-overlay): `03674806` -> `6020998b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675706098,
-        "narHash": "sha256-NPnQ9QIH98QSr98ZkCE5IxgWusJbcAfEl8HIDypKeh4=",
+        "lastModified": 1675741628,
+        "narHash": "sha256-CzEIAC5t2AM9tAaHLKC3EnB582OY4X8d9WiEMzUOJBU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "03674806f66bfa3994fe368d063c11c02a2fa8c3",
+        "rev": "6020998bf96c71e24b628fa24721492266b66d5c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`6020998b`](https://github.com/nix-community/emacs-overlay/commit/6020998bf96c71e24b628fa24721492266b66d5c) | `Updated repos/melpa` |
| [`b46c1569`](https://github.com/nix-community/emacs-overlay/commit/b46c1569262843fe490663fa74f052f28b904bdb) | `Updated repos/emacs` |
| [`087f65ec`](https://github.com/nix-community/emacs-overlay/commit/087f65ecbc35a0b92389a217a1356494dcaeb9b4) | `Updated repos/elpa`  |