### PR TITLE
chore(flake/nur): `f512a1e8` -> `52624df5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675740935,
-        "narHash": "sha256-1vL/IuGZyvjgz2ASLIhcEA+BC1zKFLImzUY9c+rxyRQ=",
+        "lastModified": 1675746554,
+        "narHash": "sha256-MQpMQGh10NY8otjd73ofK1eYFgIbTiSfx+vEQNWeYh0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f512a1e85dbd95f1fecae97fbc2d95c90148f7d9",
+        "rev": "52624df57d3d34858ce7137ee857e02d4323ebfe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`52624df5`](https://github.com/nix-community/NUR/commit/52624df57d3d34858ce7137ee857e02d4323ebfe) | `automatic update` |
| [`4883a936`](https://github.com/nix-community/NUR/commit/4883a93609294c6034224e03985565d58baf7b8e) | `automatic update` |
| [`f9034bec`](https://github.com/nix-community/NUR/commit/f9034bec9a1500446932b126e3e8ac52051bd5ec) | `automatic update` |