### PR TITLE
chore(flake/nur): `52624df5` -> `19be7c1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675746554,
-        "narHash": "sha256-MQpMQGh10NY8otjd73ofK1eYFgIbTiSfx+vEQNWeYh0=",
+        "lastModified": 1675748672,
+        "narHash": "sha256-zZ40cbNJuZMC00PNU99A2zxuv7xbMNc9EF5n5JRlt+k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "52624df57d3d34858ce7137ee857e02d4323ebfe",
+        "rev": "19be7c1b5c06d36b510311f9c574de8897dbc50e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`19be7c1b`](https://github.com/nix-community/NUR/commit/19be7c1b5c06d36b510311f9c574de8897dbc50e) | `automatic update` |