### PR TITLE
chore(flake/nur): `19be7c1b` -> `ea138c5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675748672,
-        "narHash": "sha256-zZ40cbNJuZMC00PNU99A2zxuv7xbMNc9EF5n5JRlt+k=",
+        "lastModified": 1675758928,
+        "narHash": "sha256-6QlyKPsgXtjMuKjcDVBCirrL3DQiRBxSPGn5MPA4mBg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "19be7c1b5c06d36b510311f9c574de8897dbc50e",
+        "rev": "ea138c5e0a573efe5ed5bf2dd5c64c9cffc7d048",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                   |
| -------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`c5af1e60`](https://github.com/nix-community/NUR/commit/c5af1e608e87b9d7e4807c661c44e48b68477ebc) | `Change own repository location` |