### PR TITLE
chore(flake/sops-nix): `4d16c187` -> `5dc97109`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -765,11 +765,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1675566616,
-        "narHash": "sha256-Wki1ffvQUIB044M9ltjOxpXJGsqnQiVQPvMpQ0RiEBE=",
+        "lastModified": 1675758931,
+        "narHash": "sha256-RqYnUQ4I+CUjkYe1MrWSyt6vYKEZ7sHhTw7vrsjJyvc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "4d16c18787ba8ff80c1ff8db25c5ca56f68ceed3",
+        "rev": "5dc9710905bcd8d3fa4b8912a120d9a2f9fe25e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                                 |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`fe523618`](https://github.com/Mic92/sops-nix/commit/fe5236182a500357a2070cf96f56605b19dc3c66) | `Bump cachix/install-nix-action from 18 to 19` |