### PR TITLE
chore(flake/nur): `ea138c5e` -> `77f1a5bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675758928,
-        "narHash": "sha256-6QlyKPsgXtjMuKjcDVBCirrL3DQiRBxSPGn5MPA4mBg=",
+        "lastModified": 1675762417,
+        "narHash": "sha256-AZxmakT8tPLyuimIw0g+ZXM0GV7rn3FzGNFhZqPjnKc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ea138c5e0a573efe5ed5bf2dd5c64c9cffc7d048",
+        "rev": "77f1a5bfe756a3a864d4cc24d5c5aa154285d291",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`77f1a5bf`](https://github.com/nix-community/NUR/commit/77f1a5bfe756a3a864d4cc24d5c5aa154285d291) | `automatic update` |