### PR TITLE
chore(flake/emacs-overlay): `ccd2eed0` -> `42ddff33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675760822,
-        "narHash": "sha256-9owpi6vpxuts448nLswx4Ub2qnpx8TuxPsfu5mFCijM=",
+        "lastModified": 1675790520,
+        "narHash": "sha256-UvbfxnUhHkGEHDJ4rU2JNa3KKryxzemU3DNxSEYtm2g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ccd2eed0dfea3511d38c99baa229200165d2b897",
+        "rev": "42ddff336887c2dabc271a2a8c0336da1fba18f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`42ddff33`](https://github.com/nix-community/emacs-overlay/commit/42ddff336887c2dabc271a2a8c0336da1fba18f3) | `Updated repos/melpa` |
| [`913d3f9d`](https://github.com/nix-community/emacs-overlay/commit/913d3f9daf265d3e36b3820b2187b1d14f6cf589) | `Updated repos/elpa`  |