### PR TITLE
chore(flake/nur): `83361829` -> `a03842f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675784797,
-        "narHash": "sha256-EAPzqLPLY6pDxLQyZLOuRLnHjat2xrKnB4rZ8Lxi3KM=",
+        "lastModified": 1675791716,
+        "narHash": "sha256-RPVeXty0U/cfgt9MXtgKqZxhRvEDzdOKgKiEV691u2c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "83361829358a902395b736465676fa0e80807329",
+        "rev": "a03842f8e646c5f49688694ed1f5b0577d25d590",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a03842f8`](https://github.com/nix-community/NUR/commit/a03842f8e646c5f49688694ed1f5b0577d25d590) | `automatic update` |