### PR TITLE
chore(flake/nur): `a03842f8` -> `e464d1a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675791716,
-        "narHash": "sha256-RPVeXty0U/cfgt9MXtgKqZxhRvEDzdOKgKiEV691u2c=",
+        "lastModified": 1675805231,
+        "narHash": "sha256-BUV8ZWXN4Gphm+u+8YBKnbuY0RVH23jfRdwFCzsk2bg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a03842f8e646c5f49688694ed1f5b0577d25d590",
+        "rev": "e464d1a8d810f948715b8d3cdc81afb3c8d08970",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e464d1a8`](https://github.com/nix-community/NUR/commit/e464d1a8d810f948715b8d3cdc81afb3c8d08970) | `automatic update` |