### PR TITLE
chore(flake/nur): `e464d1a8` -> `ee91675b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675805231,
-        "narHash": "sha256-BUV8ZWXN4Gphm+u+8YBKnbuY0RVH23jfRdwFCzsk2bg=",
+        "lastModified": 1675806285,
+        "narHash": "sha256-s2UNSRVUSu3srjIUuWlFEznu9Gpeh9CFPeYJQgXxS94=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e464d1a8d810f948715b8d3cdc81afb3c8d08970",
+        "rev": "ee91675b2b155b274137fe6d2d3a6e29a63a862f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ee91675b`](https://github.com/nix-community/NUR/commit/ee91675b2b155b274137fe6d2d3a6e29a63a862f) | `automatic update` |