### PR TITLE
chore(flake/nur): `ee91675b` -> `00e75a6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675806285,
-        "narHash": "sha256-s2UNSRVUSu3srjIUuWlFEznu9Gpeh9CFPeYJQgXxS94=",
+        "lastModified": 1675809932,
+        "narHash": "sha256-D5O1lxSrhrACfbgr4PiE1khL4JI2u39/wLw1kBg52zY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ee91675b2b155b274137fe6d2d3a6e29a63a862f",
+        "rev": "00e75a6dcdb34a01dc5a77f1d22b427fd80f9c89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`00e75a6d`](https://github.com/nix-community/NUR/commit/00e75a6dcdb34a01dc5a77f1d22b427fd80f9c89) | `automatic update` |