### PR TITLE
chore(flake/nur): `00e75a6d` -> `8f768601`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675809932,
-        "narHash": "sha256-D5O1lxSrhrACfbgr4PiE1khL4JI2u39/wLw1kBg52zY=",
+        "lastModified": 1675812476,
+        "narHash": "sha256-TPa1y3ljjMVIgRlHr7hyoXZr3bP6sJLr9LSDxKU3DWQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "00e75a6dcdb34a01dc5a77f1d22b427fd80f9c89",
+        "rev": "8f76860148b8df4f9a024082e21234b44ae7d386",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8f768601`](https://github.com/nix-community/NUR/commit/8f76860148b8df4f9a024082e21234b44ae7d386) | `automatic update` |