### PR TITLE
chore(flake/emacs-plz): `706cb910` -> `d9600cd5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
     "emacs-plz": {
       "flake": false,
       "locked": {
-        "lastModified": 1675558280,
-        "narHash": "sha256-++70w1HhDkTNnOW3RN7PAaDe5rAV+UxAx2BMb5P1o58=",
+        "lastModified": 1675814673,
+        "narHash": "sha256-tAagmxiKMLN7yb6X4xEALt5WPaUuYU4tlC5siTQODqM=",
         "owner": "alphapapa",
         "repo": "plz.el",
-        "rev": "706cb910ee508e1653002de7f1c5381600c421c0",
+        "rev": "d9600cd5d6fb6e9d5dca9c1f95e0ad965570e4b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                            | Commit Message                              |
| ------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`d9600cd5`](https://github.com/alphapapa/plz.el/commit/d9600cd5d6fb6e9d5dca9c1f95e0ad965570e4b9) | `Meta: Test also on Emacs 27.2, 28.1, 28.2` |
| [`ccd5e574`](https://github.com/alphapapa/plz.el/commit/ccd5e574ed6ccd22e4ead6a1d453afe9adc3a6ca) | `Meta: Enable testing of all branches`      |
| [`072ccf5f`](https://github.com/alphapapa/plz.el/commit/072ccf5f25a00b412c9c396e994e0219abbf907f) | `Change: Allow empty POST/PUT requests`     |
| [`28620c60`](https://github.com/alphapapa/plz.el/commit/28620c609ba59e4874a8a5ad13209ed3e022e8cb) | `Tests: (plz-head-without-headers) Fix`     |