### PR TITLE
chore(flake/nur): `8f768601` -> `45104f31`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675812476,
-        "narHash": "sha256-TPa1y3ljjMVIgRlHr7hyoXZr3bP6sJLr9LSDxKU3DWQ=",
+        "lastModified": 1675822344,
+        "narHash": "sha256-vCX0TKqhKbGsd9NFdJtaTv22WAY8+UhMi0ml7t/wkU0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8f76860148b8df4f9a024082e21234b44ae7d386",
+        "rev": "45104f315b2b0adfc49c9815dbca88df5cc0c33d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`45104f31`](https://github.com/nix-community/NUR/commit/45104f315b2b0adfc49c9815dbca88df5cc0c33d) | `automatic update` |