### PR TITLE
chore(flake/emacs-overlay): `42ddff33` -> `d6123813`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675790520,
-        "narHash": "sha256-UvbfxnUhHkGEHDJ4rU2JNa3KKryxzemU3DNxSEYtm2g=",
+        "lastModified": 1675826859,
+        "narHash": "sha256-KZYZIe3EZwuZYqrSYPrIzHuHHs/41NbKCu3o8dYUtSQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "42ddff336887c2dabc271a2a8c0336da1fba18f3",
+        "rev": "d612381359e395796526040f4bfd3c469bb384a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`d6123813`](https://github.com/nix-community/emacs-overlay/commit/d612381359e395796526040f4bfd3c469bb384a5) | `Updated repos/nongnu` |
| [`af05d7d8`](https://github.com/nix-community/emacs-overlay/commit/af05d7d8611d835111235890bf53bf1578153881) | `Updated repos/melpa`  |
| [`14d32596`](https://github.com/nix-community/emacs-overlay/commit/14d32596959c43802ce2eea26c1a8c9f751e3a13) | `Updated repos/emacs`  |
| [`ffeea040`](https://github.com/nix-community/emacs-overlay/commit/ffeea04060148f3f3907fd940dce0fb7b55b8bb3) | `Updated repos/elpa`   |