### PR TITLE
chore(flake/nur): `983c8626` -> `6f733276`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675829180,
-        "narHash": "sha256-cxqKO352NH6d38IaJWNSI4QiDSqfQfJ2Ah0iYWaSwws=",
+        "lastModified": 1675831408,
+        "narHash": "sha256-kqOAn0XEr4e742BIMQ96qk37ExkD/rt3fxTG2QvFT8c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "983c862637feb1633e2945e71216e69a2d482507",
+        "rev": "6f73327605df3f240c1ecdd87e2d4a5b3bb0957c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6f733276`](https://github.com/nix-community/NUR/commit/6f73327605df3f240c1ecdd87e2d4a5b3bb0957c) | `automatic update` |