### PR TITLE
chore(flake/nur): `ab01cc5b` -> `21444b14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675861489,
-        "narHash": "sha256-zxeMQIONeu3PoInBWNvnlZiX049GLj0TlvDGATvvRJQ=",
+        "lastModified": 1675867548,
+        "narHash": "sha256-ohwhoPKK1Srp8J7QqiGJD0tZhft2R7yze/oKlBB/yE0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ab01cc5b4afe27f11894684ec8aca3ed3c972fce",
+        "rev": "21444b14f5d62279719185f21f1fe4807e1f8931",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`21444b14`](https://github.com/nix-community/NUR/commit/21444b14f5d62279719185f21f1fe4807e1f8931) | `automatic update` |