### PR TITLE
chore(flake/nur): `21444b14` -> `bc5d86ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675867548,
-        "narHash": "sha256-ohwhoPKK1Srp8J7QqiGJD0tZhft2R7yze/oKlBB/yE0=",
+        "lastModified": 1675871100,
+        "narHash": "sha256-Bfx941/SyRN69XUroP7hHNX9HfZdlaJWPJ71Rp3eVSU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "21444b14f5d62279719185f21f1fe4807e1f8931",
+        "rev": "bc5d86edb5b7f804c9d83a90041fce4893c5e483",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`bc5d86ed`](https://github.com/nix-community/NUR/commit/bc5d86edb5b7f804c9d83a90041fce4893c5e483) | `automatic update` |