### PR TITLE
chore(flake/sops-nix): `5dc97109` -> `8fec29b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -765,11 +765,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1675758931,
-        "narHash": "sha256-RqYnUQ4I+CUjkYe1MrWSyt6vYKEZ7sHhTw7vrsjJyvc=",
+        "lastModified": 1675872570,
+        "narHash": "sha256-RPH3CeTv7ixC2WcYiKyhmIgoH/9tur4Kr+3Vg/pleQk=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "5dc9710905bcd8d3fa4b8912a120d9a2f9fe25e5",
+        "rev": "8fec29b009c19538e68d5d814ec74e04f662fbd1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                                      |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`e4b99135`](https://github.com/Mic92/sops-nix/commit/e4b99135e5581fc37548fd00d802c817e5f66b69) | `Home-maager: support init and dotenv`              |
| [`a45636d7`](https://github.com/Mic92/sops-nix/commit/a45636d7a573d3eae033cffd9115d429a8e83ea9) | `readme: improve`                                   |
| [`716ccf81`](https://github.com/Mic92/sops-nix/commit/716ccf81479cd5ee9830a4531470e5be6f7f31d6) | `sops-install-secrets: disable unittest for darwin` |
| [`c4ff0f37`](https://github.com/Mic92/sops-nix/commit/c4ff0f37ef9aaec84cd6d15156a2cd4a1aa0ed28) | `Save launchd logs`                                 |
| [`c3d2a46e`](https://github.com/Mic92/sops-nix/commit/c3d2a46e44ae3aeb7f4f1c92216b95270f7e5cd4) | `Disable systemd service outside of Linux`          |
| [`466d0391`](https://github.com/Mic92/sops-nix/commit/466d03919097d800b9231ed8eff22e4ad07c348b) | `darwin/home-manager: %r dir`                       |
| [`98834d95`](https://github.com/Mic92/sops-nix/commit/98834d958bee6bb6c98637927f8fa679c771b550) | `darwin: impl MountSecretFs`                        |
| [`58ceff1f`](https://github.com/Mic92/sops-nix/commit/58ceff1f7bb1b69e2ac8ffdb8ca22ab5fc9e0b98) | `darwin: workaround missing user`                   |
| [`e6ccc740`](https://github.com/Mic92/sops-nix/commit/e6ccc740d8a5becc9d900b3fb459fbda0bd1c915) | `darwin: impl SecureSymlinkChown`                   |
| [`783af739`](https://github.com/Mic92/sops-nix/commit/783af739d2590df51d11766cf144580862a56564) | `fix go tests for darwin`                           |
| [`4f3d45c0`](https://github.com/Mic92/sops-nix/commit/4f3d45c0583f65aa064ddfb2c3c385d3a1ad414a) | `go files for darwin`                               |
| [`68d25e68`](https://github.com/Mic92/sops-nix/commit/68d25e682bbd6be8ad00b7d8e006d2c012eb5e11) | `Update README.md`                                  |
| [`5e580b4b`](https://github.com/Mic92/sops-nix/commit/5e580b4bdd9efc7bb50e1a0f93a0bba2442fe16c) | `Fix missing spaces in script`                      |
| [`2124bcbb`](https://github.com/Mic92/sops-nix/commit/2124bcbb8aef83498ffd1fea590ac8ee1dd4cd95) | `Expose home manager module in flake`               |
| [`7f38c981`](https://github.com/Mic92/sops-nix/commit/7f38c981624c7c47b70beec797693b410c5ca2f2) | `More review fixups`                                |
| [`8b404812`](https://github.com/Mic92/sops-nix/commit/8b4048123e33bb4f5e1f84907d34c9b5b630d3c7) | `Add a launchd service to the home-manager module`  |
| [`3afa9ca5`](https://github.com/Mic92/sops-nix/commit/3afa9ca55376708edbbb243fe03d776736cb9c06) | `Fixup review comments`                             |
| [`acaf36a1`](https://github.com/Mic92/sops-nix/commit/acaf36a1bfd32063aa86ed4c19adc5119dc5ed62) | `Implement home-manager support`                    |