### PR TITLE
chore(flake/nur): `25532084` -> `8d4fb65c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675889104,
-        "narHash": "sha256-y+dbyqT0fG12Quz+3An9tX7YDp8ECvLUfzL1+kKv17s=",
+        "lastModified": 1675896409,
+        "narHash": "sha256-wbjvE3mDFTAC2Ox8/eNe6rULCVDvnkljRtcA+lSRNfs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "25532084181df9ea13551576233ab3e680525d2b",
+        "rev": "8d4fb65c75b81d6126237595405319899d07f23b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8d4fb65c`](https://github.com/nix-community/NUR/commit/8d4fb65c75b81d6126237595405319899d07f23b) | `automatic update` |