### PR TITLE
chore(flake/emacs-overlay): `0fe268a3` -> `b70f136e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675908293,
-        "narHash": "sha256-Lo0QVYvsSwQ08KgDph0iZczk3Bztv1tOZDNx24vknRU=",
+        "lastModified": 1675937476,
+        "narHash": "sha256-DPd4/LjcaVouSTbLSnUa2oig+teH1bFGOvBIDw2MESA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0fe268a3b03ab9ef7a77363c64247030ee3902a7",
+        "rev": "b70f136e1c59d3733684d9bd9893d9153f810be3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`b70f136e`](https://github.com/nix-community/emacs-overlay/commit/b70f136e1c59d3733684d9bd9893d9153f810be3) | `Updated repos/melpa` |
| [`c4cf66c3`](https://github.com/nix-community/emacs-overlay/commit/c4cf66c30122a0807d6dc91c5c8ec0ca650ecd24) | `Updated repos/emacs` |