### PR TITLE
chore(flake/nur): `067daef0` -> `af27ccbf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675899898,
-        "narHash": "sha256-7ScL3XdFNg6W4wbqZ2ADLCmLNl+Sm7UgEDRQhvCjViU=",
+        "lastModified": 1675915765,
+        "narHash": "sha256-6zoZlZ0luB99SxqaaU8GVs1fFpTJEoCwLsWQX2ZdS8s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "067daef07d6c87939ead3c7100e72bd2bdc7b090",
+        "rev": "af27ccbf979a8cc63f0373fad42cabc14073d9e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`af27ccbf`](https://github.com/nix-community/NUR/commit/af27ccbf979a8cc63f0373fad42cabc14073d9e5) | `automatic update` |
| [`59e36434`](https://github.com/nix-community/NUR/commit/59e364346a75ee13cf8aa9235837102f21509ba3) | `automatic update` |
| [`57f48978`](https://github.com/nix-community/NUR/commit/57f4897886841be6f2de42214576ea10d055fb9d) | `automatic update` |