### PR TITLE
chore(flake/emacs-overlay): `b70f136e` -> `5efe1164`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675937476,
-        "narHash": "sha256-DPd4/LjcaVouSTbLSnUa2oig+teH1bFGOvBIDw2MESA=",
+        "lastModified": 1675962557,
+        "narHash": "sha256-tHel6AybT7/7dVgPqb31IV6OjJ/OwfaMo2Z0Kuxv4m8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b70f136e1c59d3733684d9bd9893d9153f810be3",
+        "rev": "5efe11646cbbd9c16c70cdf738104714252848b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`5efe1164`](https://github.com/nix-community/emacs-overlay/commit/5efe11646cbbd9c16c70cdf738104714252848b0) | `Updated repos/melpa` |