### PR TITLE
chore(flake/nur): `6b616dbc` -> `7de093dc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675992609,
-        "narHash": "sha256-LgHmi3uDce3dB4gPwFIy8d+D0jwP9rOF92M2MikraqY=",
+        "lastModified": 1676002260,
+        "narHash": "sha256-bhluQURxkvZ0BjM8qKh9gjkTBeTUE7fhGXud4ITku7U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6b616dbc402a05b9cd385e4f2d4454ad9f0a769e",
+        "rev": "7de093dcd10677233f21fca6e8c31d7fb830e5bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7de093dc`](https://github.com/nix-community/NUR/commit/7de093dcd10677233f21fca6e8c31d7fb830e5bd) | `automatic update` |
| [`5f09d9df`](https://github.com/nix-community/NUR/commit/5f09d9df7c4c57ffb432c2db3fc1d8471fa964d5) | `automatic update` |