### PR TITLE
chore(flake/emacs-overlay): `5efe1164` -> `f7e1ecfa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675962557,
-        "narHash": "sha256-tHel6AybT7/7dVgPqb31IV6OjJ/OwfaMo2Z0Kuxv4m8=",
+        "lastModified": 1675998416,
+        "narHash": "sha256-dDtAPBis5RNtGg6oAtZQXBPnyf7e28pCDxgiz4yoEkg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5efe11646cbbd9c16c70cdf738104714252848b0",
+        "rev": "f7e1ecfac86dbb780449f3d5cf9d292df473cbee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`f7e1ecfa`](https://github.com/nix-community/emacs-overlay/commit/f7e1ecfac86dbb780449f3d5cf9d292df473cbee) | `Updated repos/nongnu` |
| [`b3aba0b7`](https://github.com/nix-community/emacs-overlay/commit/b3aba0b7082196d5f621267ff08b135f501073a2) | `Updated repos/melpa`  |
| [`71e56eeb`](https://github.com/nix-community/emacs-overlay/commit/71e56eeb054c4414de9b9de1482ca1bb780f9fc3) | `Updated repos/emacs`  |