### PR TITLE
chore(flake/nur): `7de093dc` -> `5b797856`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676002260,
-        "narHash": "sha256-bhluQURxkvZ0BjM8qKh9gjkTBeTUE7fhGXud4ITku7U=",
+        "lastModified": 1676011760,
+        "narHash": "sha256-lIX7eGzysyUDn6UJAPKihBG2TBVu0L0cFETD1PMXYOo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7de093dcd10677233f21fca6e8c31d7fb830e5bd",
+        "rev": "5b7978566c3e767c0b533290b7d3edfe630eaec8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5b797856`](https://github.com/nix-community/NUR/commit/5b7978566c3e767c0b533290b7d3edfe630eaec8) | `automatic update` |