### PR TITLE
chore(flake/emacs-overlay): `f7e1ecfa` -> `581072bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675998416,
-        "narHash": "sha256-dDtAPBis5RNtGg6oAtZQXBPnyf7e28pCDxgiz4yoEkg=",
+        "lastModified": 1676025076,
+        "narHash": "sha256-sdYhoZsLLwRXZebP6DYfIgQRjFA+itdNXaPuCWfJYkk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f7e1ecfac86dbb780449f3d5cf9d292df473cbee",
+        "rev": "581072bb0d49768da9370056f7b6e7b761b5d8be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`581072bb`](https://github.com/nix-community/emacs-overlay/commit/581072bb0d49768da9370056f7b6e7b761b5d8be) | `Updated repos/melpa` |
| [`4e14b32a`](https://github.com/nix-community/emacs-overlay/commit/4e14b32a700efeff5d15a5577fbca8d22e461795) | `Updated repos/emacs` |