### PR TITLE
chore(flake/emacs-overlay): `581072bb` -> `e42a89b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676025076,
-        "narHash": "sha256-sdYhoZsLLwRXZebP6DYfIgQRjFA+itdNXaPuCWfJYkk=",
+        "lastModified": 1676048939,
+        "narHash": "sha256-Gz7hvalK7k92mYoGLMVhJnEyGeBARtF8y2q9x7SUHIs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "581072bb0d49768da9370056f7b6e7b761b5d8be",
+        "rev": "e42a89b8223b01c50b41121e3b22164ac626ec06",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`e42a89b8`](https://github.com/nix-community/emacs-overlay/commit/e42a89b8223b01c50b41121e3b22164ac626ec06) | `Updated repos/melpa` |