### PR TITLE
chore(flake/nur): `5b48bb79` -> `c5a4f3ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676049970,
-        "narHash": "sha256-rMc6QOh7/uonHZ+uiFkOTQ+x45aiNPrkhQ988Citp/M=",
+        "lastModified": 1676069077,
+        "narHash": "sha256-HXLX921XdhFCnnBK4HLMKxZLn/qBsO+2OB3QfogVEmw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5b48bb79d924a9e654658d19d9383e1658d0aba7",
+        "rev": "c5a4f3ce0d13892cb778b936e72633f045470d62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c5a4f3ce`](https://github.com/nix-community/NUR/commit/c5a4f3ce0d13892cb778b936e72633f045470d62) | `automatic update` |
| [`6c21c500`](https://github.com/nix-community/NUR/commit/6c21c500e293843baa20abb49d25265c1a66e628) | `automatic update` |
| [`610b3d56`](https://github.com/nix-community/NUR/commit/610b3d566f0d2b40afbe1b95ae98c1fa5fd3a5eb) | `automatic update` |