### PR TITLE
chore(flake/emacs-overlay): `e42a89b8` -> `928bc690`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676048939,
-        "narHash": "sha256-Gz7hvalK7k92mYoGLMVhJnEyGeBARtF8y2q9x7SUHIs=",
+        "lastModified": 1676084271,
+        "narHash": "sha256-fx26F3sC425Y+IMLH2VDySgtyWURCjY6iZ22CcEMRZY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e42a89b8223b01c50b41121e3b22164ac626ec06",
+        "rev": "928bc690506ebe43982fc896e30aff902f6dc784",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`928bc690`](https://github.com/nix-community/emacs-overlay/commit/928bc690506ebe43982fc896e30aff902f6dc784) | `Updated repos/melpa` |
| [`8caf1c59`](https://github.com/nix-community/emacs-overlay/commit/8caf1c59131a246bb99fc93bea4bd6112509b38d) | `Updated repos/emacs` |
| [`8960d6c7`](https://github.com/nix-community/emacs-overlay/commit/8960d6c78973d3ff733972474d770dc0c5bdfc7d) | `Updated repos/elpa`  |