### PR TITLE
chore(flake/nur): `c5a4f3ce` -> `1ddd5cf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676069077,
-        "narHash": "sha256-HXLX921XdhFCnnBK4HLMKxZLn/qBsO+2OB3QfogVEmw=",
+        "lastModified": 1676087160,
+        "narHash": "sha256-el2tNbWUhpz0IBoORS144xjMTi9WIqbQWRBmrsF4M64=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c5a4f3ce0d13892cb778b936e72633f045470d62",
+        "rev": "1ddd5cf5cc7215ea63f1dee09016b53cc79034e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1ddd5cf5`](https://github.com/nix-community/NUR/commit/1ddd5cf5cc7215ea63f1dee09016b53cc79034e5) | `automatic update` |
| [`b786a5c6`](https://github.com/nix-community/NUR/commit/b786a5c682ddf090a72ed672235badbac04b33e9) | `automatic update` |