### PR TITLE
chore(flake/nur): `1ddd5cf5` -> `8a24db2b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676087160,
-        "narHash": "sha256-el2tNbWUhpz0IBoORS144xjMTi9WIqbQWRBmrsF4M64=",
+        "lastModified": 1676112304,
+        "narHash": "sha256-hJxdayJ6ezMO8Yb9ejA3uPzuzRAbIaP6PIV1o3ntzTA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1ddd5cf5cc7215ea63f1dee09016b53cc79034e5",
+        "rev": "8a24db2b200ac828e39af7d8da0d7c1bf8350a94",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8a24db2b`](https://github.com/nix-community/NUR/commit/8a24db2b200ac828e39af7d8da0d7c1bf8350a94) | `automatic update` |