### PR TITLE
chore(flake/emacs-overlay): `928bc690` -> `b20d8af9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676084271,
-        "narHash": "sha256-fx26F3sC425Y+IMLH2VDySgtyWURCjY6iZ22CcEMRZY=",
+        "lastModified": 1676111709,
+        "narHash": "sha256-ebKZbX48BYpqjR8yp67dVQMG/I7pu4na/X/tvxsmivs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "928bc690506ebe43982fc896e30aff902f6dc784",
+        "rev": "b20d8af970870a47bd5462824a3b09b477dc774a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`b20d8af9`](https://github.com/nix-community/emacs-overlay/commit/b20d8af970870a47bd5462824a3b09b477dc774a) | `Updated repos/melpa` |
| [`ef9967ba`](https://github.com/nix-community/emacs-overlay/commit/ef9967ba8bb412b38521150c445628e2823221ed) | `Updated repos/emacs` |