### PR TITLE
chore(flake/nur): `8a24db2b` -> `335c03ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676112304,
-        "narHash": "sha256-hJxdayJ6ezMO8Yb9ejA3uPzuzRAbIaP6PIV1o3ntzTA=",
+        "lastModified": 1676115886,
+        "narHash": "sha256-wXgo2+9OxHtAAc17NlFSYymqyzx4f2gh4ksG0M+1PLo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8a24db2b200ac828e39af7d8da0d7c1bf8350a94",
+        "rev": "335c03ee8c6ac3730e12c7c5f2176e3297915b57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`335c03ee`](https://github.com/nix-community/NUR/commit/335c03ee8c6ac3730e12c7c5f2176e3297915b57) | `automatic update` |