### PR TITLE
chore(flake/nur): `335c03ee` -> `2528868b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676115886,
-        "narHash": "sha256-wXgo2+9OxHtAAc17NlFSYymqyzx4f2gh4ksG0M+1PLo=",
+        "lastModified": 1676120030,
+        "narHash": "sha256-kAkbZN5D1v4IP3ZJ4P4UaUXawiOLKCJT8OMyfQCwXCQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "335c03ee8c6ac3730e12c7c5f2176e3297915b57",
+        "rev": "2528868b6a66ba7c1b2e3b2f6985ade20f8c146b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2528868b`](https://github.com/nix-community/NUR/commit/2528868b6a66ba7c1b2e3b2f6985ade20f8c146b) | `automatic update` |