### PR TITLE
chore(flake/nur): `2528868b` -> `3df08f8f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676120030,
-        "narHash": "sha256-kAkbZN5D1v4IP3ZJ4P4UaUXawiOLKCJT8OMyfQCwXCQ=",
+        "lastModified": 1676129501,
+        "narHash": "sha256-NaVluBS4mAKAiupGwgggWVzsEI9mLo5THyR3RKiaxik=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2528868b6a66ba7c1b2e3b2f6985ade20f8c146b",
+        "rev": "3df08f8f90a3201c60a2002eecb24c126c9f1c6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3df08f8f`](https://github.com/nix-community/NUR/commit/3df08f8f90a3201c60a2002eecb24c126c9f1c6b) | `automatic update` |