### PR TITLE
chore(flake/emacs-overlay): `b20d8af9` -> `b991fd49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676111709,
-        "narHash": "sha256-ebKZbX48BYpqjR8yp67dVQMG/I7pu4na/X/tvxsmivs=",
+        "lastModified": 1676139397,
+        "narHash": "sha256-ZaWCQC5HeLGI1Y/RYanXmOpF6veRSo5Kn0Zs3uKeinw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b20d8af970870a47bd5462824a3b09b477dc774a",
+        "rev": "b991fd49bf64e4631f7e52d4af7a253f18c4e1e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`b991fd49`](https://github.com/nix-community/emacs-overlay/commit/b991fd49bf64e4631f7e52d4af7a253f18c4e1e4) | `Updated repos/melpa` |
| [`ccf9eeb3`](https://github.com/nix-community/emacs-overlay/commit/ccf9eeb3b7653998f2359bd1a0334d5f760f5573) | `Updated repos/emacs` |
| [`8c7bcb6c`](https://github.com/nix-community/emacs-overlay/commit/8c7bcb6c7f20f90a94a06814fa70772345cd2e11) | `Updated repos/elpa`  |