### PR TITLE
chore(flake/nur): `ca320e60` -> `05791717`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676134189,
-        "narHash": "sha256-fyoKi75ULngVwM9AeoeE+SVsF7tvZfsB7uHrQVTXXWw=",
+        "lastModified": 1676139885,
+        "narHash": "sha256-l/iEYXtjuNYf+Mtk0nDNsdAwWKg6tKEPxgGxKfIFvFA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ca320e602787fd5ad55e748c392de9693c2f0f93",
+        "rev": "0579171707429321536463be2e40a4aae876974b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`05791717`](https://github.com/nix-community/NUR/commit/0579171707429321536463be2e40a4aae876974b) | `automatic update` |