### PR TITLE
chore(flake/nur): `132b707f` -> `87f04854`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676155475,
-        "narHash": "sha256-yLnAQiIVzSy2daV0V9ckr6TB9hBaxdwGd2WKtKlVFrA=",
+        "lastModified": 1676167960,
+        "narHash": "sha256-eOYd+NwP8rXwh5qABxU7ecCp50brMBVqRdg8hF0AEjM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "132b707f6e960bb56c34a08f0d660bdea2084cce",
+        "rev": "87f04854b4b46abef3acceab7ab9f3db3bd44630",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`87f04854`](https://github.com/nix-community/NUR/commit/87f04854b4b46abef3acceab7ab9f3db3bd44630) | `automatic update` |