### PR TITLE
chore(flake/nur): `87f04854` -> `573ea8ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676167960,
-        "narHash": "sha256-eOYd+NwP8rXwh5qABxU7ecCp50brMBVqRdg8hF0AEjM=",
+        "lastModified": 1676171086,
+        "narHash": "sha256-JKPQilJiPBXFuznvkI4KFm/MakcH1b/PasTiOc5LfrE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "87f04854b4b46abef3acceab7ab9f3db3bd44630",
+        "rev": "573ea8fff6b173d4b19da3b0a93ac58fe0e4796d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`573ea8ff`](https://github.com/nix-community/NUR/commit/573ea8fff6b173d4b19da3b0a93ac58fe0e4796d) | `automatic update` |