### PR TITLE
chore(flake/emacs-overlay): `b991fd49` -> `a68a3753`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676139397,
-        "narHash": "sha256-ZaWCQC5HeLGI1Y/RYanXmOpF6veRSo5Kn0Zs3uKeinw=",
+        "lastModified": 1676171058,
+        "narHash": "sha256-zbLZy1kPoL+qua7JojveMOWCF0H50+BXlS+eL0mqLE0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b991fd49bf64e4631f7e52d4af7a253f18c4e1e4",
+        "rev": "a68a3753466c045db326a7f7b9a25b35a2935225",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`a68a3753`](https://github.com/nix-community/emacs-overlay/commit/a68a3753466c045db326a7f7b9a25b35a2935225) | `Updated repos/nongnu` |
| [`242a703e`](https://github.com/nix-community/emacs-overlay/commit/242a703e80efb74f868cdcb54cd809ee03431665) | `Updated repos/melpa`  |
| [`6e752a15`](https://github.com/nix-community/emacs-overlay/commit/6e752a15496137308e732e5107a19a701f215a99) | `Updated repos/emacs`  |
| [`5b908034`](https://github.com/nix-community/emacs-overlay/commit/5b908034d85f2f76fcc01953af2cb3405b9231e6) | `Updated repos/elpa`   |