### PR TITLE
chore(flake/nur): `573ea8ff` -> `e669d02e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676171086,
-        "narHash": "sha256-JKPQilJiPBXFuznvkI4KFm/MakcH1b/PasTiOc5LfrE=",
+        "lastModified": 1676185168,
+        "narHash": "sha256-tTwuFUfT9jaon7rGoYaEgsYq17WCo35zukt15w7FsyQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "573ea8fff6b173d4b19da3b0a93ac58fe0e4796d",
+        "rev": "e669d02efdda27481eaeced3b17e9b2179985a37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e669d02e`](https://github.com/nix-community/NUR/commit/e669d02efdda27481eaeced3b17e9b2179985a37) | `automatic update` |