### PR TITLE
chore(flake/emacs-overlay): `a68a3753` -> `25bc792c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676171058,
-        "narHash": "sha256-zbLZy1kPoL+qua7JojveMOWCF0H50+BXlS+eL0mqLE0=",
+        "lastModified": 1676196577,
+        "narHash": "sha256-nzXTh2VQZDyzIc6ed2+qoRT/FUKkQQAaLEFPy2MKB+A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a68a3753466c045db326a7f7b9a25b35a2935225",
+        "rev": "25bc792c9fe3ab354e7b51539b4da72ac821dde9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`25bc792c`](https://github.com/nix-community/emacs-overlay/commit/25bc792c9fe3ab354e7b51539b4da72ac821dde9) | `Updated repos/melpa` |
| [`1fc9a171`](https://github.com/nix-community/emacs-overlay/commit/1fc9a1716a00967a14c12f3ead2fffdf63934f42) | `Updated repos/emacs` |