### PR TITLE
chore(flake/nur): `b86914d9` -> `661a9358`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676195542,
-        "narHash": "sha256-uZph1Hj2vmkPkvUBUpvwyJUsRVYgg39yyD9fWKUDOag=",
+        "lastModified": 1676197247,
+        "narHash": "sha256-sPmIQooEOiWkjYPmjNqde+ml2NcDTockTQF2WdTSHK0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b86914d9cd30dab76dbb90bbb954cea7f4618b17",
+        "rev": "661a9358da62de5d4bdd9b6d510a8c17084e04ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`661a9358`](https://github.com/nix-community/NUR/commit/661a9358da62de5d4bdd9b6d510a8c17084e04ac) | `automatic update` |
| [`630fb8e8`](https://github.com/nix-community/NUR/commit/630fb8e8bf5b02a1d8d3d91ae331a1482b940065) | `automatic update` |