### PR TITLE
chore(flake/nur): `661a9358` -> `56b003d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676197247,
-        "narHash": "sha256-sPmIQooEOiWkjYPmjNqde+ml2NcDTockTQF2WdTSHK0=",
+        "lastModified": 1676202295,
+        "narHash": "sha256-pK1zMjK4ZjIIeJxAety+WqTBHQd7GGLpQcIq892W2H8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "661a9358da62de5d4bdd9b6d510a8c17084e04ac",
+        "rev": "56b003d44a26603aedcaa3c28b0da17797d0df1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`56b003d4`](https://github.com/nix-community/NUR/commit/56b003d44a26603aedcaa3c28b0da17797d0df1c) | `automatic update` |