### PR TITLE
chore(flake/nur): `56b003d4` -> `2f199ce2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676202295,
-        "narHash": "sha256-pK1zMjK4ZjIIeJxAety+WqTBHQd7GGLpQcIq892W2H8=",
+        "lastModified": 1676204408,
+        "narHash": "sha256-AaDm6PVTfiuNaf+2U9cEmnqeDm2mj/CZRKUePoOyXS0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "56b003d44a26603aedcaa3c28b0da17797d0df1c",
+        "rev": "2f199ce2679c6a7937da78f8d85613d035f09986",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2f199ce2`](https://github.com/nix-community/NUR/commit/2f199ce2679c6a7937da78f8d85613d035f09986) | `automatic update` |