### PR TITLE
chore(flake/nur): `2f199ce2` -> `5ad9d0fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676204408,
-        "narHash": "sha256-AaDm6PVTfiuNaf+2U9cEmnqeDm2mj/CZRKUePoOyXS0=",
+        "lastModified": 1676216696,
+        "narHash": "sha256-mIg6ooQ3xtD5ULG4E/RwQqKdxIssYfSZHScXxloK3uI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2f199ce2679c6a7937da78f8d85613d035f09986",
+        "rev": "5ad9d0fcec2e3d26b0caa65e119025ef804d5a11",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5ad9d0fc`](https://github.com/nix-community/NUR/commit/5ad9d0fcec2e3d26b0caa65e119025ef804d5a11) | `automatic update` |