### PR TITLE
chore(flake/nur): `5ad9d0fc` -> `27b80aca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676216696,
-        "narHash": "sha256-mIg6ooQ3xtD5ULG4E/RwQqKdxIssYfSZHScXxloK3uI=",
+        "lastModified": 1676222837,
+        "narHash": "sha256-OjuH1YTaGykbQv9lZiwizfjIemaibIYPoEPi72K54P0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5ad9d0fcec2e3d26b0caa65e119025ef804d5a11",
+        "rev": "27b80acab77293332401d4826f65ceb6d5f99e41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`27b80aca`](https://github.com/nix-community/NUR/commit/27b80acab77293332401d4826f65ceb6d5f99e41) | `automatic update` |