### PR TITLE
chore(flake/nur): `27b80aca` -> `c938b6ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676222837,
-        "narHash": "sha256-OjuH1YTaGykbQv9lZiwizfjIemaibIYPoEPi72K54P0=",
+        "lastModified": 1676223771,
+        "narHash": "sha256-b3HgLF5umYVjInGK9DKutG2WQEJ+ltcIbwfmu0JsVYc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "27b80acab77293332401d4826f65ceb6d5f99e41",
+        "rev": "c938b6ca205278fd43370fd75267d7b48673f0b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c938b6ca`](https://github.com/nix-community/NUR/commit/c938b6ca205278fd43370fd75267d7b48673f0b2) | `automatic update` |