### PR TITLE
chore(flake/emacs-overlay): `25bc792c` -> `558a102c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676196577,
-        "narHash": "sha256-nzXTh2VQZDyzIc6ed2+qoRT/FUKkQQAaLEFPy2MKB+A=",
+        "lastModified": 1676226118,
+        "narHash": "sha256-Iy7rsdxN94XK9ifJJEPwlCHvEYTtAyhsXDsmst6aGJ4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "25bc792c9fe3ab354e7b51539b4da72ac821dde9",
+        "rev": "558a102c165bdf22782cd8c5db2e0fb9578ddc0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`558a102c`](https://github.com/nix-community/emacs-overlay/commit/558a102c165bdf22782cd8c5db2e0fb9578ddc0e) | `Updated repos/melpa` |
| [`d8c60bfb`](https://github.com/nix-community/emacs-overlay/commit/d8c60bfbaf71b57608744633346ec3f413257b7c) | `Updated repos/emacs` |
| [`74669061`](https://github.com/nix-community/emacs-overlay/commit/746690618d8e259949c97c8c04efc6c67b25b8ce) | `Updated repos/elpa`  |