### PR TITLE
chore(flake/nur): `c938b6ca` -> `4bda1cb7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676223771,
-        "narHash": "sha256-b3HgLF5umYVjInGK9DKutG2WQEJ+ltcIbwfmu0JsVYc=",
+        "lastModified": 1676229333,
+        "narHash": "sha256-js1EbWERt1texBKKScI9lE6bHfuM3fCp8Jesdmex7ek=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c938b6ca205278fd43370fd75267d7b48673f0b2",
+        "rev": "4bda1cb779064d0ddb23a99ffc6d6b72b83a7cef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4bda1cb7`](https://github.com/nix-community/NUR/commit/4bda1cb779064d0ddb23a99ffc6d6b72b83a7cef) | `automatic update` |