### PR TITLE
chore(flake/nur): `4bda1cb7` -> `cf674ae7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676229333,
-        "narHash": "sha256-js1EbWERt1texBKKScI9lE6bHfuM3fCp8Jesdmex7ek=",
+        "lastModified": 1676231165,
+        "narHash": "sha256-hlQS8XRucFsOAvBTotYn9a74hGka8ai6B/atARmcVoE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4bda1cb779064d0ddb23a99ffc6d6b72b83a7cef",
+        "rev": "cf674ae770218559b0ed9a98e36663b0858fb02f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`cf674ae7`](https://github.com/nix-community/NUR/commit/cf674ae770218559b0ed9a98e36663b0858fb02f) | `automatic update` |