### PR TITLE
chore(flake/emacs-overlay): `558a102c` -> `d2d0f3f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676226118,
-        "narHash": "sha256-Iy7rsdxN94XK9ifJJEPwlCHvEYTtAyhsXDsmst6aGJ4=",
+        "lastModified": 1676253403,
+        "narHash": "sha256-e+UfeIcTeghzArhZvDqx3KG00T3JuqVVAPdCV74q6Sk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "558a102c165bdf22782cd8c5db2e0fb9578ddc0e",
+        "rev": "d2d0f3f92dce4bf5aad0e05bcfe7af2ef2dcf610",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                                          |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
| [`e725980d`](https://github.com/nix-community/emacs-overlay/commit/e725980d7fa44d2d7f4c93c348b9e14b2e3fb8a0) | ``flake: Add `emacsPackagesFor`, `emacsWithPackages*` to `lib` output`` |