### PR TITLE
chore(flake/emacs-overlay): `d2d0f3f9` -> `2cb7ec2f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676253403,
-        "narHash": "sha256-e+UfeIcTeghzArhZvDqx3KG00T3JuqVVAPdCV74q6Sk=",
+        "lastModified": 1676254132,
+        "narHash": "sha256-ccSm+XLJQzCnqXhwPkQZ9Xfa5pfiVnJbMfmfVP7Gbak=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d2d0f3f92dce4bf5aad0e05bcfe7af2ef2dcf610",
+        "rev": "2cb7ec2f6dc53efbbb817ec57a4d103e07a59656",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`2cb7ec2f`](https://github.com/nix-community/emacs-overlay/commit/2cb7ec2f6dc53efbbb817ec57a4d103e07a59656) | `flake.nix: cosmetics` |