### PR TITLE
chore(flake/emacs-overlay): `2cb7ec2f` -> `09ebba15`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676254132,
-        "narHash": "sha256-ccSm+XLJQzCnqXhwPkQZ9Xfa5pfiVnJbMfmfVP7Gbak=",
+        "lastModified": 1676258056,
+        "narHash": "sha256-LhXVnPc+IPHupy7QexUrzYuloSGXvXEgvIkAlhFs+yY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2cb7ec2f6dc53efbbb817ec57a4d103e07a59656",
+        "rev": "09ebba158540ba3171b5f319b71427b51db8794b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`09ebba15`](https://github.com/nix-community/emacs-overlay/commit/09ebba158540ba3171b5f319b71427b51db8794b) | `Updated repos/melpa` |
| [`87ecbb91`](https://github.com/nix-community/emacs-overlay/commit/87ecbb91060cb6c9c69161b9abf4de924cefc99a) | `Updated repos/emacs` |