### PR TITLE
chore(flake/nur): `9a8b28a9` -> `c7011355`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676251563,
-        "narHash": "sha256-itLKR2Haeh5wQ6dxkuZ8L5gwp3+CAggpN+w2e7cLQPg=",
+        "lastModified": 1676261409,
+        "narHash": "sha256-MHMGy3/jBc7wd/YKddICbgpCJ2qAtjjmlZQFFHCUFr8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9a8b28a9d6611f6af9f7abb3e690fc755d6906fe",
+        "rev": "c7011355e75a4a1818768ce1ac4c1aa5ada7eb6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c7011355`](https://github.com/nix-community/NUR/commit/c7011355e75a4a1818768ce1ac4c1aa5ada7eb6f) | `automatic update` |
| [`28bd70ad`](https://github.com/nix-community/NUR/commit/28bd70ade9ade8289f384eaa0cf490c37d011ace) | `automatic update` |