### PR TITLE
chore(flake/nur): `c7011355` -> `900d9a45`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676261409,
-        "narHash": "sha256-MHMGy3/jBc7wd/YKddICbgpCJ2qAtjjmlZQFFHCUFr8=",
+        "lastModified": 1676270491,
+        "narHash": "sha256-GF6OZqQNRF5eIrlbiFCHbWKj/LThsi6kls3kSvGkMlY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c7011355e75a4a1818768ce1ac4c1aa5ada7eb6f",
+        "rev": "900d9a4560fdb9671cacbaaaf09c514573d9bf27",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`900d9a45`](https://github.com/nix-community/NUR/commit/900d9a4560fdb9671cacbaaaf09c514573d9bf27) | `automatic update` |