### PR TITLE
chore(flake/nur): `61b6f811` -> `45cd749b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676273732,
-        "narHash": "sha256-aQGdVpnYZTMeDsvo3fXcCE47pubuNv0hBxXhSxdTv5Y=",
+        "lastModified": 1676278103,
+        "narHash": "sha256-zIQJSou9LnRjiBebGj82DbhHxU1/RmLN5h3wzUdFZf4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "61b6f811a8544670d3045a57d1b8874c0ec24445",
+        "rev": "45cd749b957aa2a3f5fb3d4f3cfba58afae619cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`45cd749b`](https://github.com/nix-community/NUR/commit/45cd749b957aa2a3f5fb3d4f3cfba58afae619cb) | `automatic update` |