### PR TITLE
chore(flake/nur): `45cd749b` -> `e9bad900`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676278103,
-        "narHash": "sha256-zIQJSou9LnRjiBebGj82DbhHxU1/RmLN5h3wzUdFZf4=",
+        "lastModified": 1676288832,
+        "narHash": "sha256-DSmWMSdL4Wuj7y2KYVrYI6Vj1PyKzwi/ZthdjrN5fXQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "45cd749b957aa2a3f5fb3d4f3cfba58afae619cb",
+        "rev": "e9bad900605fa4b0c608d523a06655ac5fef7a7d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e9bad900`](https://github.com/nix-community/NUR/commit/e9bad900605fa4b0c608d523a06655ac5fef7a7d) | `automatic update` |
| [`d44ab24d`](https://github.com/nix-community/NUR/commit/d44ab24d70b4e0080630730c42793fdff8ea0ace) | `automatic update` |