### PR TITLE
chore(flake/emacs-overlay): `09ebba15` -> `dc9d1a2f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676258056,
-        "narHash": "sha256-LhXVnPc+IPHupy7QexUrzYuloSGXvXEgvIkAlhFs+yY=",
+        "lastModified": 1676283171,
+        "narHash": "sha256-w+Ee7JiL88YJTH60NiVCY/BoeE0oFe9rbfpD8llmEtc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "09ebba158540ba3171b5f319b71427b51db8794b",
+        "rev": "dc9d1a2f5ccd547ea32f46313081827f05ec1dae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`dc9d1a2f`](https://github.com/nix-community/emacs-overlay/commit/dc9d1a2f5ccd547ea32f46313081827f05ec1dae) | `Updated repos/melpa` |
| [`8698300e`](https://github.com/nix-community/emacs-overlay/commit/8698300ee94b54337206b978c46ebcc1f9092de0) | `Updated repos/emacs` |