### PR TITLE
chore(flake/nur): `e9bad900` -> `cbf5cf6b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676288832,
-        "narHash": "sha256-DSmWMSdL4Wuj7y2KYVrYI6Vj1PyKzwi/ZthdjrN5fXQ=",
+        "lastModified": 1676293547,
+        "narHash": "sha256-LOLKtq0q/DcRHCyPV+TbuSb9LMCSaGTwbUV/O+elHoo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e9bad900605fa4b0c608d523a06655ac5fef7a7d",
+        "rev": "cbf5cf6be819bcf7e6c24b02f61eefd18d8375c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`cbf5cf6b`](https://github.com/nix-community/NUR/commit/cbf5cf6be819bcf7e6c24b02f61eefd18d8375c9) | `automatic update` |
| [`8be260eb`](https://github.com/nix-community/NUR/commit/8be260ebb1cf20ecb12dfd40c11496b4d77979d2) | `automatic update` |