### PR TITLE
chore(flake/nur): `cbf5cf6b` -> `97e968b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676293547,
-        "narHash": "sha256-LOLKtq0q/DcRHCyPV+TbuSb9LMCSaGTwbUV/O+elHoo=",
+        "lastModified": 1676297796,
+        "narHash": "sha256-j+rDldOwaLTWnM5AcbbfZ1WpXdrH4oQ3XPEivV2n1qY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cbf5cf6be819bcf7e6c24b02f61eefd18d8375c9",
+        "rev": "97e968b24ea0fc2e1b1dd49a996364e1e4a9e1d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`97e968b2`](https://github.com/nix-community/NUR/commit/97e968b24ea0fc2e1b1dd49a996364e1e4a9e1d0) | `automatic update` |