### PR TITLE
chore(flake/nur): `97e968b2` -> `11b51d79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676297796,
-        "narHash": "sha256-j+rDldOwaLTWnM5AcbbfZ1WpXdrH4oQ3XPEivV2n1qY=",
+        "lastModified": 1676299525,
+        "narHash": "sha256-Vfq69BTPfb/GFWXP7egnr8whvM3r26i00sSJza+QvWg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "97e968b24ea0fc2e1b1dd49a996364e1e4a9e1d0",
+        "rev": "11b51d793149faf5cd62a4e82699a71f1b2ffb94",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`11b51d79`](https://github.com/nix-community/NUR/commit/11b51d793149faf5cd62a4e82699a71f1b2ffb94) | `automatic update` |