### PR TITLE
chore(flake/nur): `11b51d79` -> `9e53590a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676299525,
-        "narHash": "sha256-Vfq69BTPfb/GFWXP7egnr8whvM3r26i00sSJza+QvWg=",
+        "lastModified": 1676300643,
+        "narHash": "sha256-SCYSgm7UIzZzxPp6FTiz9nyYQJOo+4X1znPf8fL2D2s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "11b51d793149faf5cd62a4e82699a71f1b2ffb94",
+        "rev": "9e53590ae92ae7b39ca989f37950903395997490",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9e53590a`](https://github.com/nix-community/NUR/commit/9e53590ae92ae7b39ca989f37950903395997490) | `automatic update` |