### PR TITLE
chore(flake/nur): `9e53590a` -> `faa727cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676300643,
-        "narHash": "sha256-SCYSgm7UIzZzxPp6FTiz9nyYQJOo+4X1znPf8fL2D2s=",
+        "lastModified": 1676315798,
+        "narHash": "sha256-Tav70h8hy+v4jTUj6TjomUZYx6NlFPYcIzbOdukQDGo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9e53590ae92ae7b39ca989f37950903395997490",
+        "rev": "faa727cf3663a5de7dfae27546f4316c5e61388f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`faa727cf`](https://github.com/nix-community/NUR/commit/faa727cf3663a5de7dfae27546f4316c5e61388f) | `automatic update` |