### PR TITLE
chore(flake/nur): `faa727cf` -> `ceb21024`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676315798,
-        "narHash": "sha256-Tav70h8hy+v4jTUj6TjomUZYx6NlFPYcIzbOdukQDGo=",
+        "lastModified": 1676317613,
+        "narHash": "sha256-tDKRyuoNz9b0dulVxPxDQa9TPJEJ7kGOfgF/11wx9IU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "faa727cf3663a5de7dfae27546f4316c5e61388f",
+        "rev": "ceb21024ae4eb1d2af1840eb34231d46520a8642",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`ceb21024`](https://github.com/nix-community/NUR/commit/ceb21024ae4eb1d2af1840eb34231d46520a8642) | `automatic update` |