### PR TITLE
chore(flake/nur): `ceb21024` -> `d486bbbd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676317613,
-        "narHash": "sha256-tDKRyuoNz9b0dulVxPxDQa9TPJEJ7kGOfgF/11wx9IU=",
+        "lastModified": 1676324777,
+        "narHash": "sha256-NaCIUq5Kcl/6LwvDnpNkb98qb1rthZMDNEvHYL2PU9w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ceb21024ae4eb1d2af1840eb34231d46520a8642",
+        "rev": "d486bbbd3974a134d414f815f078e72558d7a985",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d486bbbd`](https://github.com/nix-community/NUR/commit/d486bbbd3974a134d414f815f078e72558d7a985) | `automatic update` |