### PR TITLE
chore(flake/nur): `d486bbbd` -> `d8044057`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676324777,
-        "narHash": "sha256-NaCIUq5Kcl/6LwvDnpNkb98qb1rthZMDNEvHYL2PU9w=",
+        "lastModified": 1676328308,
+        "narHash": "sha256-zA27l6aEGtYv+xBzdjYJ9a67o12SEQY5ZdWx5B4XzP4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d486bbbd3974a134d414f815f078e72558d7a985",
+        "rev": "d80440576256226d88b9f1cbc5174f535fdffdd1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d8044057`](https://github.com/nix-community/NUR/commit/d80440576256226d88b9f1cbc5174f535fdffdd1) | `automatic update` |