### PR TITLE
chore(flake/nur): `d8044057` -> `e014e89f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676328308,
-        "narHash": "sha256-zA27l6aEGtYv+xBzdjYJ9a67o12SEQY5ZdWx5B4XzP4=",
+        "lastModified": 1676331896,
+        "narHash": "sha256-ih3ehOL4wWaMko+ahkycoq8DQRodDqEbJVg6t7WY2PQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d80440576256226d88b9f1cbc5174f535fdffdd1",
+        "rev": "e014e89fdfbd65e1fb572f00ea71dc2a9513fe6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e014e89f`](https://github.com/nix-community/NUR/commit/e014e89fdfbd65e1fb572f00ea71dc2a9513fe6f) | `automatic update` |