### PR TITLE
chore(flake/nur): `e014e89f` -> `88847707`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676331896,
-        "narHash": "sha256-ih3ehOL4wWaMko+ahkycoq8DQRodDqEbJVg6t7WY2PQ=",
+        "lastModified": 1676340803,
+        "narHash": "sha256-JIFl/LfSg16Qj6t/CbILz1aAwaP4B7W8Srb9dpENrSw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e014e89fdfbd65e1fb572f00ea71dc2a9513fe6f",
+        "rev": "88847707c270b20b31edc3055dacaa5567c8ddc2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`88847707`](https://github.com/nix-community/NUR/commit/88847707c270b20b31edc3055dacaa5567c8ddc2) | `automatic update` |