### PR TITLE
chore(flake/emacs-overlay): `d938b780` -> `e24f948b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676308357,
-        "narHash": "sha256-iHlVbnn/WkEbBF41YIMVBTWf/ldMCVrHKpL1nRO31R0=",
+        "lastModified": 1676344740,
+        "narHash": "sha256-L5Sv/lluCTpaUpPWErUICesRNbMX431+4EL5gFQG3lU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d938b780a3d8072aeac0178c46121060079ff217",
+        "rev": "e24f948ba5bcd5d8f4e6485a6e0102f2171541c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`e24f948b`](https://github.com/nix-community/emacs-overlay/commit/e24f948ba5bcd5d8f4e6485a6e0102f2171541c7) | `Updated repos/melpa` |
| [`d982609e`](https://github.com/nix-community/emacs-overlay/commit/d982609e8317cea8666631f2e9c3d308f0dd95a1) | `Updated repos/emacs` |
| [`46b97b3b`](https://github.com/nix-community/emacs-overlay/commit/46b97b3bcd0a5d484aa2a762e8dbfba39efda59c) | `Updated repos/elpa`  |