### PR TITLE
chore(flake/nur): `4ce343cd` -> `a59e9a03`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676346351,
-        "narHash": "sha256-enORr2xkx5WPY1g+XgJjGphxUA80j7+/+NZKv+yGjv0=",
+        "lastModified": 1676347905,
+        "narHash": "sha256-YhOdSFjQVTlyrUSYjYOF3ZeYmbhe7hcLPbRR8FQ+c3o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ce343cda41f1c49446ed9b4075136fa7ddcd14f",
+        "rev": "a59e9a032896ffa7e5d95c2075b0a28258f29c21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a59e9a03`](https://github.com/nix-community/NUR/commit/a59e9a032896ffa7e5d95c2075b0a28258f29c21) | `automatic update` |