### PR TITLE
chore(flake/nur): `a59e9a03` -> `66144f55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676347905,
-        "narHash": "sha256-YhOdSFjQVTlyrUSYjYOF3ZeYmbhe7hcLPbRR8FQ+c3o=",
+        "lastModified": 1676353469,
+        "narHash": "sha256-6/fPVMarS7AhUs5H743mFJ4z99zoRlsT9uIFmp8miA8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a59e9a032896ffa7e5d95c2075b0a28258f29c21",
+        "rev": "66144f556f52fbf861461fbd0c32a86b3c08b406",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`66144f55`](https://github.com/nix-community/NUR/commit/66144f556f52fbf861461fbd0c32a86b3c08b406) | `automatic update` |