### PR TITLE
chore(flake/nur): `0d4edd2a` -> `72677d48`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676358365,
-        "narHash": "sha256-Y+z5Pt0OOUEzjCWtCQEsN7bHyPxB0uhg7vZVPnzF1eM=",
+        "lastModified": 1676360078,
+        "narHash": "sha256-p08jYnaYZKNcmRz4g8d2g7Xjx/jGDc8e97AAoMQuiK4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0d4edd2a25f20a890dfcab1f28b6e14479b281a1",
+        "rev": "72677d48bca8c0c736f6bfad66cc2cab0b77b249",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`72677d48`](https://github.com/nix-community/NUR/commit/72677d48bca8c0c736f6bfad66cc2cab0b77b249) | `automatic update` |