### PR TITLE
chore(flake/nur): `32f2fc31` -> `82f99780`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676385929,
-        "narHash": "sha256-qaIM1TBKKQ+FTTuUpr2AfUP8NQ6q8QwL1BEaYHG9Gls=",
+        "lastModified": 1676411221,
+        "narHash": "sha256-XPZNzPYtAlCEQ7tpYbbxHrgSQNFILeeUEvU9ospCS7s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "32f2fc312516b3b2b47708105c8fc87cea1df5d2",
+        "rev": "82f997805b79b533ff9b8a7fc151b85a3001a714",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`82f99780`](https://github.com/nix-community/NUR/commit/82f997805b79b533ff9b8a7fc151b85a3001a714) | `automatic update` |
| [`b7256775`](https://github.com/nix-community/NUR/commit/b72567753901a2b872b877b79b082bb2c59373a8) | `automatic update` |
| [`6975fbaf`](https://github.com/nix-community/NUR/commit/6975fbaffe66d2c0794a5639d1fb70c3ddb9e1a0) | `automatic update` |