### PR TITLE
chore(flake/nur): `82f99780` -> `07cba4b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676411221,
-        "narHash": "sha256-XPZNzPYtAlCEQ7tpYbbxHrgSQNFILeeUEvU9ospCS7s=",
+        "lastModified": 1676414777,
+        "narHash": "sha256-34vd+g+sxXK5wQLjdhCTK7GQJJD4skOgItXm7Ux9YSw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "82f997805b79b533ff9b8a7fc151b85a3001a714",
+        "rev": "07cba4b331bb3532e4d2e87600f68f6c4f630560",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`07cba4b3`](https://github.com/nix-community/NUR/commit/07cba4b331bb3532e4d2e87600f68f6c4f630560) | `automatic update` |