### PR TITLE
chore(flake/nur): `07cba4b3` -> `c7643c2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676414777,
-        "narHash": "sha256-34vd+g+sxXK5wQLjdhCTK7GQJJD4skOgItXm7Ux9YSw=",
+        "lastModified": 1676427247,
+        "narHash": "sha256-TzrdkBf7sTPFBoma3FlEI2ZGUORJRdnaZt8lsJUlBH4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "07cba4b331bb3532e4d2e87600f68f6c4f630560",
+        "rev": "c7643c2ecb14ff6f59b8993aa1d07b4f031487b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c7643c2e`](https://github.com/nix-community/NUR/commit/c7643c2ecb14ff6f59b8993aa1d07b4f031487b0) | `automatic update` |