### PR TITLE
chore(flake/nur): `c7643c2e` -> `e1b1574c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676427247,
-        "narHash": "sha256-TzrdkBf7sTPFBoma3FlEI2ZGUORJRdnaZt8lsJUlBH4=",
+        "lastModified": 1676430869,
+        "narHash": "sha256-eUhk56gwbJ9yp8SAecIuwOtP0V2G/YiiIAz3b8edseg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c7643c2ecb14ff6f59b8993aa1d07b4f031487b0",
+        "rev": "e1b1574c31392a74d9fd9a3e23a1b68d58ea5ab2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e1b1574c`](https://github.com/nix-community/NUR/commit/e1b1574c31392a74d9fd9a3e23a1b68d58ea5ab2) | `automatic update` |