### PR TITLE
chore(flake/nur): `e1b1574c` -> `7531ccd2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676430869,
-        "narHash": "sha256-eUhk56gwbJ9yp8SAecIuwOtP0V2G/YiiIAz3b8edseg=",
+        "lastModified": 1676432746,
+        "narHash": "sha256-+RYyek9+ZXa226DEG/AK4FThTd8coUTtzRxxJvkw4kA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e1b1574c31392a74d9fd9a3e23a1b68d58ea5ab2",
+        "rev": "7531ccd2298354c81cfe55bc43e7f5fed77b248c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7531ccd2`](https://github.com/nix-community/NUR/commit/7531ccd2298354c81cfe55bc43e7f5fed77b248c) | `automatic update` |