### PR TITLE
chore(flake/nur): `7531ccd2` -> `233fbd96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676432746,
-        "narHash": "sha256-+RYyek9+ZXa226DEG/AK4FThTd8coUTtzRxxJvkw4kA=",
+        "lastModified": 1676436316,
+        "narHash": "sha256-chemcxFTG+I7h0WURWa15XGje8BBmzWQa2MmZwZmG3M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7531ccd2298354c81cfe55bc43e7f5fed77b248c",
+        "rev": "233fbd9675641621a0d2f8e564f7fe677bf74696",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`233fbd96`](https://github.com/nix-community/NUR/commit/233fbd9675641621a0d2f8e564f7fe677bf74696) | `automatic update` |
| [`4de0917d`](https://github.com/nix-community/NUR/commit/4de0917da6b0f3e4a0ac2c34341dae2a7332cfc9) | `automatic update` |