### PR TITLE
chore(flake/nur): `233fbd96` -> `26954520`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676436316,
-        "narHash": "sha256-chemcxFTG+I7h0WURWa15XGje8BBmzWQa2MmZwZmG3M=",
+        "lastModified": 1676443773,
+        "narHash": "sha256-C+hag3jz5wMKK9qNI8vfVNNZSX66X9PAtjGfNyRDCm8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "233fbd9675641621a0d2f8e564f7fe677bf74696",
+        "rev": "26954520ec2df7d9d4137ec584412a6eb6a20f48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`26954520`](https://github.com/nix-community/NUR/commit/26954520ec2df7d9d4137ec584412a6eb6a20f48) | `automatic update` |