### PR TITLE
chore(flake/emacs-overlay): `1046546c` -> `02b3e92f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676432229,
-        "narHash": "sha256-gzPjEWYsdGABvHEkwEgOvZ1gO7PVuZfUzozgvR1RWFA=",
+        "lastModified": 1676457594,
+        "narHash": "sha256-yUrueXbzu9eYN0CR9sviNOkRjb3BdapATib9rx/t6p4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1046546c5d006fbe854e7944cd784b16e0d9494a",
+        "rev": "02b3e92fb3f23fba90c25820f9b1b8b6bfb555d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`02b3e92f`](https://github.com/nix-community/emacs-overlay/commit/02b3e92fb3f23fba90c25820f9b1b8b6bfb555d0) | `Updated repos/melpa` |
| [`20d632bc`](https://github.com/nix-community/emacs-overlay/commit/20d632bc23372128c39f35754806306c117b9009) | `Updated repos/emacs` |