### PR TITLE
chore(flake/nur): `26954520` -> `b1c075ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676443773,
-        "narHash": "sha256-C+hag3jz5wMKK9qNI8vfVNNZSX66X9PAtjGfNyRDCm8=",
+        "lastModified": 1676466548,
+        "narHash": "sha256-1xyE3+a08VLHlwG7JByyTXoLjnICFdTDbbc/vf2FFJA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "26954520ec2df7d9d4137ec584412a6eb6a20f48",
+        "rev": "b1c075ba06df4374cdd433e9aad22ce508920a52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b1c075ba`](https://github.com/nix-community/NUR/commit/b1c075ba06df4374cdd433e9aad22ce508920a52) | `automatic update` |