### PR TITLE
chore(flake/nur): `979c87fa` -> `24a0377d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676468847,
-        "narHash": "sha256-ZXbDl2mUwHcM3Q5N+rWiJp4noavY5I85iqjM+KVowc8=",
+        "lastModified": 1676472424,
+        "narHash": "sha256-4URZYhEzoOFcYq2greK4QETCTcSDXHvplzB/QUyV2Gg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "979c87fa17dd3ba34b38b99ffc8d830a816dbc00",
+        "rev": "24a0377d409ef30afe37a4b9abd49567c01c0097",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`24a0377d`](https://github.com/nix-community/NUR/commit/24a0377d409ef30afe37a4b9abd49567c01c0097) | `automatic update` |