### PR TITLE
chore(flake/nur): `f5d5663f` -> `03155858`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676480121,
-        "narHash": "sha256-yJj6jShuxtxD0vOleKa6MFfZ4rTuiIS4aCwPwjGLnf0=",
+        "lastModified": 1676483082,
+        "narHash": "sha256-e/mULYGkIlepksMRCpYKni2ULOs6FQ7Zd9HcVRbWkog=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f5d5663f43cabf06f924352cbfc84c17c465c0d5",
+        "rev": "031558584a7508662417d0926ac3ec75def8afb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`03155858`](https://github.com/nix-community/NUR/commit/031558584a7508662417d0926ac3ec75def8afb8) | `automatic update` |