### PR TITLE
chore(flake/emacs-overlay): `02b3e92f` -> `fb1cdbb0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676457594,
-        "narHash": "sha256-yUrueXbzu9eYN0CR9sviNOkRjb3BdapATib9rx/t6p4=",
+        "lastModified": 1676484851,
+        "narHash": "sha256-IQtPR+ObyNgh+Gc5rvfPUD3Xe7jsWk6jTMSwU6YOdHs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "02b3e92fb3f23fba90c25820f9b1b8b6bfb555d0",
+        "rev": "fb1cdbb0a12d7f0e0e50022c405aca7c856dd233",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`fb1cdbb0`](https://github.com/nix-community/emacs-overlay/commit/fb1cdbb0a12d7f0e0e50022c405aca7c856dd233) | `Updated repos/melpa` |
| [`a35caf05`](https://github.com/nix-community/emacs-overlay/commit/a35caf05221c71616925c114a2c85f07b41a9813) | `Updated repos/emacs` |
| [`6a8a9e25`](https://github.com/nix-community/emacs-overlay/commit/6a8a9e252f54563d3f0207ec7c0df3b5c48f8a80) | `Updated repos/elpa`  |