### PR TITLE
chore(flake/emacs-overlay): `fb1cdbb0` -> `8e8c7ab6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676484851,
-        "narHash": "sha256-IQtPR+ObyNgh+Gc5rvfPUD3Xe7jsWk6jTMSwU6YOdHs=",
+        "lastModified": 1676516909,
+        "narHash": "sha256-wcOs073lEtXZ0uXssoopIzjdFOPSyEvePz2vBjElNeE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fb1cdbb0a12d7f0e0e50022c405aca7c856dd233",
+        "rev": "8e8c7ab6874c97b4d1c23a5a204b6743b40cee78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`8e8c7ab6`](https://github.com/nix-community/emacs-overlay/commit/8e8c7ab6874c97b4d1c23a5a204b6743b40cee78) | `Updated repos/melpa` |