### PR TITLE
chore(flake/nur): `98c45c08` -> `4b0b9073`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676510790,
-        "narHash": "sha256-sxESNeXem1bSxAAnmq3xlo9pvNi79Cjj1lD/7RzneA4=",
+        "lastModified": 1676517184,
+        "narHash": "sha256-aeKcKvyDQX1G6iqSnainCJGjKy9d7lGbkMigiM3su1g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "98c45c0849c52ea1a7ca546487d9af5f4b145d84",
+        "rev": "4b0b90737218503ed087c04a6be49fce595a12cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4b0b9073`](https://github.com/nix-community/NUR/commit/4b0b90737218503ed087c04a6be49fce595a12cd) | `automatic update` |
| [`79bac231`](https://github.com/nix-community/NUR/commit/79bac2316e5507faf88b82c1c1b1bddf3f9ba2e7) | `automatic update` |