### PR TITLE
chore(flake/nur): `4b0b9073` -> `94aa9d22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676517184,
-        "narHash": "sha256-aeKcKvyDQX1G6iqSnainCJGjKy9d7lGbkMigiM3su1g=",
+        "lastModified": 1676520686,
+        "narHash": "sha256-NV7jfV/JFzR4QqjthLKZVnAzO0pkDEKbYkmiRspqa8M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4b0b90737218503ed087c04a6be49fce595a12cd",
+        "rev": "94aa9d22877d92fa0c2dbfb083f8c3e19354f3b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`94aa9d22`](https://github.com/nix-community/NUR/commit/94aa9d22877d92fa0c2dbfb083f8c3e19354f3b7) | `automatic update` |