### PR TITLE
chore(flake/nur): `94aa9d22` -> `c3a04803`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676520686,
-        "narHash": "sha256-NV7jfV/JFzR4QqjthLKZVnAzO0pkDEKbYkmiRspqa8M=",
+        "lastModified": 1676522799,
+        "narHash": "sha256-iKY+HrS1kYv8djQuFjfJ70hJ/NuI/snrCAAhjnM30n0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "94aa9d22877d92fa0c2dbfb083f8c3e19354f3b7",
+        "rev": "c3a04803e5b55f782dec953a432dd3635eab0792",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c3a04803`](https://github.com/nix-community/NUR/commit/c3a04803e5b55f782dec953a432dd3635eab0792) | `automatic update` |