### PR TITLE
chore(flake/nur): `c3a04803` -> `4a285867`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676522799,
-        "narHash": "sha256-iKY+HrS1kYv8djQuFjfJ70hJ/NuI/snrCAAhjnM30n0=",
+        "lastModified": 1676530882,
+        "narHash": "sha256-zQe//gb3gz1W7MFN405TAxX04rRQxwLpzVNFPERR+gc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c3a04803e5b55f782dec953a432dd3635eab0792",
+        "rev": "4a2858677136bf1fd0bb8534655b4c140f21641c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4a285867`](https://github.com/nix-community/NUR/commit/4a2858677136bf1fd0bb8534655b4c140f21641c) | `automatic update` |