### PR TITLE
chore(flake/emacs-overlay): `8e8c7ab6` -> `4bb9abd0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676516909,
-        "narHash": "sha256-wcOs073lEtXZ0uXssoopIzjdFOPSyEvePz2vBjElNeE=",
+        "lastModified": 1676543864,
+        "narHash": "sha256-ZdPhRGbUb0cFWd+iYtoIH0CIslnnTH2fJNEkpbtJzJE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8e8c7ab6874c97b4d1c23a5a204b6743b40cee78",
+        "rev": "4bb9abd04a46a7b52ff07af252204ca3ce6d337f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`4bb9abd0`](https://github.com/nix-community/emacs-overlay/commit/4bb9abd04a46a7b52ff07af252204ca3ce6d337f) | `Updated repos/melpa` |
| [`79108ea2`](https://github.com/nix-community/emacs-overlay/commit/79108ea2e8bfa497cbecb18540dec7e79d2d1e14) | `Updated repos/emacs` |