### PR TITLE
chore(flake/templates): `2d6dcce2` -> `3ac7e8ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -747,11 +747,11 @@
     },
     "templates": {
       "locked": {
-        "lastModified": 1671651249,
-        "narHash": "sha256-IUXfgNkYxISUWqdWtJ0sGjSmpv9d5EVho7HCEElgBAM=",
+        "lastModified": 1676551231,
+        "narHash": "sha256-JS1o31ew90UiccpoQHxP84Wn0n7ClgyVpAsJV20Ep5E=",
         "owner": "NixOS",
         "repo": "templates",
-        "rev": "2d6dcce2f3898090c8eda16a16abdff8a80e8ebf",
+        "rev": "3ac7e8ba52feb2b89e943a6ce0f7a30d6faf81c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                                         |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
| [`3ac7e8ba`](https://github.com/NixOS/templates/commit/3ac7e8ba52feb2b89e943a6ce0f7a30d6faf81c6) | `Use pname+version, don't overwrite unpackPhase (#35)` |
| [`4d03901d`](https://github.com/NixOS/templates/commit/4d03901dae782a7ee71d6e59149ccdfefd973787) | `Add example for devShells in go-hello (#60)`          |
| [`e9951bb1`](https://github.com/NixOS/templates/commit/e9951bb1542b8c5b06cfbee7aafea04ab885ff2b) | ``update `haskell.nix` flake template (#57)``          |