### PR TITLE
chore(flake/dendrite-demo-pinecone): `2d4423df` -> `de9b012e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -60,11 +60,11 @@
     "dendrite": {
       "flake": false,
       "locked": {
-        "lastModified": 1675515939,
-        "narHash": "sha256-kTPcx2l1mpo4Pm/ICZa138UnyYy0TetIU2ovbXupaxc=",
+        "lastModified": 1676375267,
+        "narHash": "sha256-OBWADUeQRF01jZTODhkriDXHFXdAe8cfw0pkU/barwg=",
         "owner": "matrix-org",
         "repo": "dendrite",
-        "rev": "cf254ba0445e2509f77f41dbec69f632b126b847",
+        "rev": "11d9b9db0e96c51c1430d451d23cf5ae9f36e4ee",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1675788437,
-        "narHash": "sha256-eOf8Z4uHbFnIARlM6bLEJu2ExkvnrCzs/Wbe0ZMmDAQ=",
+        "lastModified": 1676560471,
+        "narHash": "sha256-D51s5azvs1FVvSJXtPXWOoEInXJhz7cJotSYkp2CDdE=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "2d4423df68f907b8c245cf2995b2fd2083517415",
+        "rev": "de9b012ed9bc311a3d9ca41389a1cdebde9ab3d8",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {
@@ -431,11 +431,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675698036,
-        "narHash": "sha256-BgsQkQewdlQi8gapJN4phpxkI/FCE/2sORBaFcYbp/A=",
+        "lastModified": 1676487294,
+        "narHash": "sha256-fbD0tVsowxAUXwfw2C9EdEAH8UEJNsCm0zJcfkJy3Pg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1046c7b92e908a1202c0f1ba3fc21d19e1cf1b62",
+        "rev": "63b5955814db30d2e2ff7157aaa5665b502ed2f4",
         "type": "github"
       },
       "original": {
@@ -616,11 +616,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1675688762,
-        "narHash": "sha256-oit/SxMk0B380ASuztBGQLe8TttO1GJiXF8aZY9AYEc=",
+        "lastModified": 1676513100,
+        "narHash": "sha256-MK39nQV86L2ag4TmcK5/+r1ULpzRLPbbfvWbPvIoYJE=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ab608394886fb04b8a5df3cb0bab2598400e3634",
+        "rev": "5f0cba88ac4d6dd8cad5c6f6f1540b3d6a21a798",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                          | Commit Message       |
| --------------------------------------------------------------------------------------------------------------- | -------------------- |
| [`de9b012e`](https://github.com/bbigras/dendrite-demo-pinecone/commit/de9b012ed9bc311a3d9ca41389a1cdebde9ab3d8) | `flake: update`      |
| [`2da4ba39`](https://github.com/bbigras/dendrite-demo-pinecone/commit/2da4ba3930690861d68c936055f127a969c38310) | `flake.lock: Update` |