### PR TITLE
chore(flake/emacs-overlay): `4bb9abd0` -> `391dca00`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676543864,
-        "narHash": "sha256-ZdPhRGbUb0cFWd+iYtoIH0CIslnnTH2fJNEkpbtJzJE=",
+        "lastModified": 1676571261,
+        "narHash": "sha256-T6HqQ310Rp+7qJ5X2uovNA5v/U+gXfa8Q1czSpEUbLc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4bb9abd04a46a7b52ff07af252204ca3ce6d337f",
+        "rev": "391dca00f29463ab817865d778db4852099b7066",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`391dca00`](https://github.com/nix-community/emacs-overlay/commit/391dca00f29463ab817865d778db4852099b7066) | `Updated repos/melpa` |
| [`dd71d40e`](https://github.com/nix-community/emacs-overlay/commit/dd71d40e286752a97e808ccb37911c3a2b3a35e8) | `Updated repos/emacs` |
| [`f2965a16`](https://github.com/nix-community/emacs-overlay/commit/f2965a16bd6a3e78b62d010554c302e553f6af6e) | `Updated repos/elpa`  |