### PR TITLE
chore(flake/nur): `992e74dd` -> `82e1807d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676580339,
-        "narHash": "sha256-FNqGP1pqQOCll6pVfJQxxsQwetmeQFalK0svjVChSXk=",
+        "lastModified": 1676584760,
+        "narHash": "sha256-ta7fNtkvtwJXnxKTZNBfp5S/LjkBvwpA9Bfz9oQ1cho=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "992e74dd6a893496457ede95972b45b60c075a7c",
+        "rev": "82e1807d3ff9adb53f25e21a050e3a762a76d091",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`82e1807d`](https://github.com/nix-community/NUR/commit/82e1807d3ff9adb53f25e21a050e3a762a76d091) | `automatic update` |