### PR TITLE
chore(flake/nur): `82e1807d` -> `872cfba6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676584760,
-        "narHash": "sha256-ta7fNtkvtwJXnxKTZNBfp5S/LjkBvwpA9Bfz9oQ1cho=",
+        "lastModified": 1676597347,
+        "narHash": "sha256-jSgx0yNPajW4JddkbPxrUUPKM/H+Is4DjnrZEUKBk8o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "82e1807d3ff9adb53f25e21a050e3a762a76d091",
+        "rev": "872cfba641b00bdc0b3db0607b81d971f94a5dbd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`872cfba6`](https://github.com/nix-community/NUR/commit/872cfba641b00bdc0b3db0607b81d971f94a5dbd) | `automatic update` |