### PR TITLE
chore(flake/emacs-overlay): `391dca00` -> `3420e1ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676571261,
-        "narHash": "sha256-T6HqQ310Rp+7qJ5X2uovNA5v/U+gXfa8Q1czSpEUbLc=",
+        "lastModified": 1676599381,
+        "narHash": "sha256-KN2Mtr6ZCXqII9htgYOpBpm3uJoTz1/PYUb/aDwMiZA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "391dca00f29463ab817865d778db4852099b7066",
+        "rev": "3420e1ab815febd56f0b960d15b4c9aa58053b9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message         |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`3420e1ab`](https://github.com/nix-community/emacs-overlay/commit/3420e1ab815febd56f0b960d15b4c9aa58053b9f) | `Updated repos/nongnu` |
| [`424e98fb`](https://github.com/nix-community/emacs-overlay/commit/424e98fb8193af6d96cd8ba91adefb43b0c1c6eb) | `Updated repos/melpa`  |