### PR TITLE
chore(flake/nur): `872cfba6` -> `9c316707`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676597347,
-        "narHash": "sha256-jSgx0yNPajW4JddkbPxrUUPKM/H+Is4DjnrZEUKBk8o=",
+        "lastModified": 1676600198,
+        "narHash": "sha256-efEKkM8XTun6hUg05NSnhsxE8qdlj/xmVXFzlZNb9Os=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "872cfba641b00bdc0b3db0607b81d971f94a5dbd",
+        "rev": "9c316707ceda93ed197745355703384372d7a5f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9c316707`](https://github.com/nix-community/NUR/commit/9c316707ceda93ed197745355703384372d7a5f8) | `automatic update` |