### PR TITLE
chore(flake/nur): `7e869a6a` -> `c3885268`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676605164,
-        "narHash": "sha256-eYKDCY+jymXA1KNGNInG7+Qf1z8ME4K2YPnlwR79sxs=",
+        "lastModified": 1676606806,
+        "narHash": "sha256-XbaunOfFfHKB76IxiWAdzNZNoeTC+wg/7d6FaggdeFI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7e869a6a3522ef6a62b26bb44f573f85e82d7b19",
+        "rev": "c388526848b89147b3ff8dac39e15ada2983a947",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`c3885268`](https://github.com/nix-community/NUR/commit/c388526848b89147b3ff8dac39e15ada2983a947) | `automatic update` |