### PR TITLE
chore(flake/nur): `881c9e54` -> `63f31030`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676609231,
-        "narHash": "sha256-cHjnEGVM4kQWNVccQwFPNDOSeOw3iuHra5CyV/TtkXA=",
+        "lastModified": 1676610570,
+        "narHash": "sha256-Uo/rwZCcXXQiAa06UOwkGcp7KbQeBhTvIFeaXQCOHP4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "881c9e5408959b3460ee01edc6e851bbadbf6dce",
+        "rev": "63f31030a1820cd626709a26cbc2ba6138c4ec15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`63f31030`](https://github.com/nix-community/NUR/commit/63f31030a1820cd626709a26cbc2ba6138c4ec15) | `automatic update` |