### PR TITLE
chore(flake/nur): `63f31030` -> `70b1947e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676610570,
-        "narHash": "sha256-Uo/rwZCcXXQiAa06UOwkGcp7KbQeBhTvIFeaXQCOHP4=",
+        "lastModified": 1676616525,
+        "narHash": "sha256-KmummxbhXIP9gQdxwfNUR6NNm020SBihRoPd4fBJhyE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "63f31030a1820cd626709a26cbc2ba6138c4ec15",
+        "rev": "70b1947e00dec6eb13c005fb7cd68859f5473e39",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`70b1947e`](https://github.com/nix-community/NUR/commit/70b1947e00dec6eb13c005fb7cd68859f5473e39) | `automatic update` |