### PR TITLE
chore(flake/emacs-overlay): `3420e1ab` -> `cd34501a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676599381,
-        "narHash": "sha256-KN2Mtr6ZCXqII9htgYOpBpm3uJoTz1/PYUb/aDwMiZA=",
+        "lastModified": 1676628719,
+        "narHash": "sha256-yZM1hLxPS3OuKNduQSWmiYLAjIZeJ7ExWbCL3A3bi0U=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3420e1ab815febd56f0b960d15b4c9aa58053b9f",
+        "rev": "cd34501a9bcec341533c7131af77572456c100d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`cd34501a`](https://github.com/nix-community/emacs-overlay/commit/cd34501a9bcec341533c7131af77572456c100d8) | `Updated repos/melpa` |
| [`df1be7cd`](https://github.com/nix-community/emacs-overlay/commit/df1be7cd6ddb3d4d7818e51abede310bdee99ad0) | `Updated repos/emacs` |