### PR TITLE
chore(flake/nur): `d2d70316` -> `7eb9eec5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676619352,
-        "narHash": "sha256-a9pQbtOcUYS9boD6+lQqPe0WzME0x8yzZk365w9XGbM=",
+        "lastModified": 1676633667,
+        "narHash": "sha256-Lao/f52stjtuifmNK0aFGUxOhAafSbiN+csI686DsDg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d2d70316f27384cf53e0f3c6cf2fd73e4744555a",
+        "rev": "7eb9eec5cb2a3ef77646cb451ce546c301ecf884",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`7eb9eec5`](https://github.com/nix-community/NUR/commit/7eb9eec5cb2a3ef77646cb451ce546c301ecf884) | `automatic update` |