### PR TITLE
chore(flake/nur): `a6b7602c` -> `76db5efa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676636203,
-        "narHash": "sha256-1fxThinWfMdghwfMiXpYJ+BrTjkSoTnajQTdPmmsmJo=",
+        "lastModified": 1676647414,
+        "narHash": "sha256-FzF/3HiREuJ+7M7Gz0BYFpBpzNX3j4PO012aheCr89Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a6b7602c5dc36102994d76e68be8d3bc930baab7",
+        "rev": "76db5efaff7a17e6a2f7135d74ebbc9f591354ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                                 |
| -------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`7e07aba9`](https://github.com/nix-community/NUR/commit/7e07aba9caf703494d7f169585eebb75c6ab7d19) | `fix home-manager example`                     |
| [`99620937`](https://github.com/nix-community/NUR/commit/99620937511796b31eb1fa9954ad8bbdc37288a1) | `Bump cachix/install-nix-action from 18 to 19` |