### PR TITLE
chore(flake/emacs-overlay): `cd34501a` -> `ab0f3828`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676628719,
-        "narHash": "sha256-yZM1hLxPS3OuKNduQSWmiYLAjIZeJ7ExWbCL3A3bi0U=",
+        "lastModified": 1676659814,
+        "narHash": "sha256-D58bW6z0NjqoRCQN8eTERkeN9hs6HBQufxaCPkmyPfs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cd34501a9bcec341533c7131af77572456c100d8",
+        "rev": "ab0f3828a6305fe7fd8c4909e67c1c2107292486",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ab0f3828`](https://github.com/nix-community/emacs-overlay/commit/ab0f3828a6305fe7fd8c4909e67c1c2107292486) | `Updated repos/melpa` |
| [`647872bf`](https://github.com/nix-community/emacs-overlay/commit/647872bf6698e0b4aeb6e0d48bc9d080ad9d1355) | `Updated repos/emacs` |