### PR TITLE
chore(flake/emacs-ement): `28de42d6` -> `850f6b27`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1673226582,
-        "narHash": "sha256-CkPzdDzrN1xPZtbGowJaLMl3Z/h6yDyAB6TDPYsP0lU=",
+        "lastModified": 1676670893,
+        "narHash": "sha256-Pdb+qLhFDtcdmS+M5zXM8SDBIUaB5JIMnzXdQTBgBzk=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "28de42d653cc1e254cc3dccfcb685db947cdde4c",
+        "rev": "850f6b277226a6b164cce30ccaf6aa499fe46fe4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                 |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`850f6b27`](https://github.com/alphapapa/ement.el/commit/850f6b277226a6b164cce30ccaf6aa499fe46fe4) | `Fix: (ement--sync) Retry for HTTP 502 errors` |