### PR TITLE
chore(flake/nur): `ece154c0` -> `94e4f3a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676673997,
-        "narHash": "sha256-sKGidVsfTCVF4qbXGwtRCMDJLom5C4KimcU5AJydHxY=",
+        "lastModified": 1676677570,
+        "narHash": "sha256-TVb+vo2mJI+zLD/BdjihbBcZnNVK0DljvYynozV8qs4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ece154c0e261ab39516199478f5d5c486b239cd8",
+        "rev": "94e4f3a585fd2f6cefa9208b74b545e9fae4e402",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`94e4f3a5`](https://github.com/nix-community/NUR/commit/94e4f3a585fd2f6cefa9208b74b545e9fae4e402) | `automatic update` |