### PR TITLE
chore(flake/emacs-overlay): `ab0f3828` -> `5b567bd4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676659814,
-        "narHash": "sha256-D58bW6z0NjqoRCQN8eTERkeN9hs6HBQufxaCPkmyPfs=",
+        "lastModified": 1676689395,
+        "narHash": "sha256-ZeIFOYyYkFJMkETmO+UuEb2gJAsqlhfhXxolX1+RaRg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ab0f3828a6305fe7fd8c4909e67c1c2107292486",
+        "rev": "5b567bd46294ff2e30cd852e0239caebdf8e1676",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`5b567bd4`](https://github.com/nix-community/emacs-overlay/commit/5b567bd46294ff2e30cd852e0239caebdf8e1676) | `Updated repos/melpa` |
| [`061e49c5`](https://github.com/nix-community/emacs-overlay/commit/061e49c50104a8478f9a24ee81c7ef62330f4281) | `Updated repos/emacs` |
| [`a880b28c`](https://github.com/nix-community/emacs-overlay/commit/a880b28c71dcc431656373821b0182aeab322408) | `Updated repos/elpa`  |