### PR TITLE
chore(flake/nur): `288b61ed` -> `60037844`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676696262,
-        "narHash": "sha256-t7vAR528t+XDKa3q1G6dWXoGRew2fo1BCykqRqWK3U8=",
+        "lastModified": 1676702898,
+        "narHash": "sha256-9OmuxTZFNKhNv2K8dc7rv8zbT7pFgDoUdEof9ljLfqY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "288b61ed03fbd2687bccfdb67d3ed7485549994e",
+        "rev": "60037844a33bd51e5d81de596766c19e0c910750",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`60037844`](https://github.com/nix-community/NUR/commit/60037844a33bd51e5d81de596766c19e0c910750) | `automatic update` |
| [`11e948c6`](https://github.com/nix-community/NUR/commit/11e948c6e1ccfbfa64ddbe48dc031d7d5f562151) | `automatic update` |
| [`c7b15189`](https://github.com/nix-community/NUR/commit/c7b1518960776a534b7dc0e10b9bbf381607e671) | `automatic update` |