### PR TITLE
chore(flake/nixos-hardware): `44ae00e0` -> `00d1c8da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1675933606,
-        "narHash": "sha256-y427VhPQHOKkYvkc9MMsL/2R7M11rQxzsRdRLM3htx8=",
+        "lastModified": 1676699427,
+        "narHash": "sha256-Z4d4Gwk4PlYaM4PGU3SSGzjWvm8hhuW91Kh5nvfxPyc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "44ae00e02e8036a66c08f4decdece7e3bbbefee2",
+        "rev": "00d1c8da9a24f8b04f3a6ee3a05169e514628d1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                 |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`b4bf2550`](https://github.com/NixOS/nixos-hardware/commit/b4bf2550b36654399b26fcf436744f198658d203) | `AMD: don't install OpenCL by enabling amdvlk` |
| [`1156f4d6`](https://github.com/NixOS/nixos-hardware/commit/1156f4d66eadbe2de96be3b3fabb6c39b94ebf5e) | `AMD: disable amdvlk install by default`       |