### PR TITLE
chore(flake/emacs-overlay): `5b567bd4` -> `f417b108`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676689395,
-        "narHash": "sha256-ZeIFOYyYkFJMkETmO+UuEb2gJAsqlhfhXxolX1+RaRg=",
+        "lastModified": 1676715340,
+        "narHash": "sha256-dI12rcqngUZx6c8gHzlUDTByO4YJwRcAPqvPtIrfvo0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5b567bd46294ff2e30cd852e0239caebdf8e1676",
+        "rev": "f417b108302f2faf18f60a367c70c135ba7b848c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`f417b108`](https://github.com/nix-community/emacs-overlay/commit/f417b108302f2faf18f60a367c70c135ba7b848c) | `Updated repos/melpa` |
| [`1b6e8ce7`](https://github.com/nix-community/emacs-overlay/commit/1b6e8ce7dd323d7e01fdc122a8b96042d2218750) | `Updated repos/emacs` |