### PR TITLE
chore(flake/ragenix): `325733b7` -> `66b9ea7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -779,11 +779,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1675293936,
-        "narHash": "sha256-xaObOxlMiZ8noXbXWfoUJrCjVZ8oc9HBblc/MeCq7fc=",
+        "lastModified": 1676741265,
+        "narHash": "sha256-p/uhhDeHsqivf021lEPwAKPhgEDY2cBtKT1zLj+4jAg=",
         "owner": "yaxitech",
         "repo": "ragenix",
-        "rev": "325733b734aa4cc4d6b19f1169e6672cad4128ca",
+        "rev": "66b9ea7d182b0d03fc95e18cec9e2e446741d99f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                            | Commit Message                               |
| ------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`66b9ea7d`](https://github.com/yaxitech/ragenix/commit/66b9ea7d182b0d03fc95e18cec9e2e446741d99f) | `Get format in line with clippy 1.67 (#125)` |