### PR TITLE
chore(flake/emacs-overlay): `f417b108` -> `18a770f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -200,11 +200,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676715340,
-        "narHash": "sha256-dI12rcqngUZx6c8gHzlUDTByO4YJwRcAPqvPtIrfvo0=",
+        "lastModified": 1676744319,
+        "narHash": "sha256-4tivaq1yc6hvDVVtKWT7HF6Oe5chnAHrwe5GCMoQY6E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f417b108302f2faf18f60a367c70c135ba7b848c",
+        "rev": "18a770f432280e4c60bf6127f176ea5ca72ce2e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`18a770f4`](https://github.com/nix-community/emacs-overlay/commit/18a770f432280e4c60bf6127f176ea5ca72ce2e6) | `Updated repos/melpa` |
| [`8bf4496a`](https://github.com/nix-community/emacs-overlay/commit/8bf4496a7db1bcedfb75cbb02da2f33939ec50f9) | `Updated repos/emacs` |
| [`1729c790`](https://github.com/nix-community/emacs-overlay/commit/1729c7900f035100c954a1537733a8b0095f0d54) | `Updated repos/elpa`  |