### PR TITLE
chore(flake/nur): `c8a97c47` -> `55b1e364`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -705,11 +705,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676727992,
-        "narHash": "sha256-6ENqec+nlvKhrbJh4ok8ytOcufcjrinTHxh2HJj6y44=",
+        "lastModified": 1676761669,
+        "narHash": "sha256-Ks69EkyPBlsUya2CCdKdDoz8OuhxQygK+zSkjnWf2lw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c8a97c47eef60bf0151d27290d39bbe1101f4b27",
+        "rev": "55b1e364ffd5545fadf4c22f1cd26a2665d2c43a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`55b1e364`](https://github.com/nix-community/NUR/commit/55b1e364ffd5545fadf4c22f1cd26a2665d2c43a) | `automatic update` |
| [`6cfd8709`](https://github.com/nix-community/NUR/commit/6cfd8709d990b6e85f9ba4efe98d299ba2dd6df4) | `automatic update` |