### PR TITLE
chore(flake/nur): `55b1e364` -> `80e38742`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -705,11 +705,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676761669,
-        "narHash": "sha256-Ks69EkyPBlsUya2CCdKdDoz8OuhxQygK+zSkjnWf2lw=",
+        "lastModified": 1676764026,
+        "narHash": "sha256-L2++5+YbJ/0Kox9QZZK+aEW6njMUqVJC/ng/litioD4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "55b1e364ffd5545fadf4c22f1cd26a2665d2c43a",
+        "rev": "80e38742e1b4551dcf1f916ec28c0eb7fb10f50a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`80e38742`](https://github.com/nix-community/NUR/commit/80e38742e1b4551dcf1f916ec28c0eb7fb10f50a) | `automatic update` |