### PR TITLE
chore(flake/nur): `e4c088de` -> `cc3da475`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -705,11 +705,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676770095,
-        "narHash": "sha256-aWL3g4deHxOH59F7L80jvOuesyq4IihRmZ/HY/XnEe0=",
+        "lastModified": 1676778419,
+        "narHash": "sha256-SFvpfxh9+/GKiflT/8+LRd3wDh9SBLK9OtsVyNeX4YU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e4c088deedc5766db11bd9a102980e179d876b25",
+        "rev": "cc3da475973899afc5b7eb504f23b04cb388fe66",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`cc3da475`](https://github.com/nix-community/NUR/commit/cc3da475973899afc5b7eb504f23b04cb388fe66) | `automatic update` |
| [`f0fe7c47`](https://github.com/nix-community/NUR/commit/f0fe7c477b01af1e96a8bff3dd198a13f4855eb7) | `automatic update` |
| [`6c5052c2`](https://github.com/nix-community/NUR/commit/6c5052c26b566491da36b67d16ab631f36307745) | `automatic update` |