### PR TITLE
chore(flake/nixos-hardware): `9bbcc37b` -> `525177a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -501,11 +501,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1676699914,
-        "narHash": "sha256-cM2Hd+odgCYWSUiYPZGW/4B+OI64S0lrdf9YR9ts9I4=",
+        "lastModified": 1676775543,
+        "narHash": "sha256-VI0e60l94RY9Sc90OwDZpOf/nyLy41n2ULK6I6YkoP8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "9bbcc37b011b0d925f3115888ea77f58487619b8",
+        "rev": "525177a78023e1363bee482f520d4f2471ada03a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                          |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`7c7a8f70`](https://github.com/NixOS/nixos-hardware/commit/7c7a8f70827d55361b7def502f38b8757e09065f) | `raspberry-pi/4: don't use an alias for the kernel pkg` |