### PR TITLE
chore(flake/nur): `cc3da475` -> `4f342d25`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -705,11 +705,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676778419,
-        "narHash": "sha256-SFvpfxh9+/GKiflT/8+LRd3wDh9SBLK9OtsVyNeX4YU=",
+        "lastModified": 1676779774,
+        "narHash": "sha256-bQmMB61YrkDk6vkGfYutzAf561wqqxivGx2SrIiyrRM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cc3da475973899afc5b7eb504f23b04cb388fe66",
+        "rev": "4f342d256446b8a948498c5179ea2ceef5ade47e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4f342d25`](https://github.com/nix-community/NUR/commit/4f342d256446b8a948498c5179ea2ceef5ade47e) | `automatic update` |