### PR TITLE
chore(flake/emacs-overlay): `e0f50595` -> `88b2e9ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -200,11 +200,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676775866,
-        "narHash": "sha256-8nrNfQMLIefUH3Hsy5CtKawafUieCWvCh0kjKXEVH/0=",
+        "lastModified": 1676797507,
+        "narHash": "sha256-alnN1I036Fb/qoMqnAtPEC/YaVLOXq4P7P1yU0cyPxg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e0f50595b9fdcda9713268969c08606952117c25",
+        "rev": "88b2e9eda133e593558680ffb6262203db193ac4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`88b2e9ed`](https://github.com/nix-community/emacs-overlay/commit/88b2e9eda133e593558680ffb6262203db193ac4) | `Updated repos/melpa` |