### PR TITLE
chore(flake/home-manager): `da72e6fc` -> `5ffb0f1f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -446,11 +446,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676367705,
-        "narHash": "sha256-un5UbRat9TwruyImtwUGcKF823rCEp4fQxnsaLFL7CM=",
+        "lastModified": 1676801940,
+        "narHash": "sha256-ek3HwJVnQvzkRb7a5/4CjnV+H3/eGn3hOwSa2VNY7VQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "da72e6fc6b7dc0c3f94edbd310aae7cd95c678b5",
+        "rev": "5ffb0f1f818ff0d435b16a4934a24c6277d3fde7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`5ffb0f1f`](https://github.com/nix-community/home-manager/commit/5ffb0f1f818ff0d435b16a4934a24c6277d3fde7) | `tests: fix gnupg stub (#3685)` |