### PR TITLE
chore(flake/nur): `415a1ed9` -> `241b6ab4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676811708,
-        "narHash": "sha256-rcKvUuW7+CElLX22tYOYzTFqsPG8yhLn1DDaYqomjmc=",
+        "lastModified": 1676817898,
+        "narHash": "sha256-1yrNakg2qtOI9v/IFk+cYPEYtuoOQTsRvjG88tlhAVo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "415a1ed97cb4550299f1a4522a6edd7c98bb1f12",
+        "rev": "241b6ab4dccc162906a265e421a537847b74e8e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`241b6ab4`](https://github.com/nix-community/NUR/commit/241b6ab4dccc162906a265e421a537847b74e8e9) | `automatic update` |