### PR TITLE
chore(flake/nur): `241b6ab4` -> `776010dc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676817898,
-        "narHash": "sha256-1yrNakg2qtOI9v/IFk+cYPEYtuoOQTsRvjG88tlhAVo=",
+        "lastModified": 1676820779,
+        "narHash": "sha256-/EmCS02RHZbpOXLuv+iItYkice2/yjsSq2r0yAKenHE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "241b6ab4dccc162906a265e421a537847b74e8e9",
+        "rev": "776010dc73870aa36e322411c47ede8155e1b2dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`776010dc`](https://github.com/nix-community/NUR/commit/776010dc73870aa36e322411c47ede8155e1b2dd) | `automatic update` |