### PR TITLE
chore(flake/nur): `776010dc` -> `efa4b0ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676820779,
-        "narHash": "sha256-/EmCS02RHZbpOXLuv+iItYkice2/yjsSq2r0yAKenHE=",
+        "lastModified": 1676831085,
+        "narHash": "sha256-oL6hH9DWc0OrOR/NDqBYi3rjZjXxgu24sP4wQlYqlmk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "776010dc73870aa36e322411c47ede8155e1b2dd",
+        "rev": "efa4b0ff2761f332483f97c40976abc605406b51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`efa4b0ff`](https://github.com/nix-community/NUR/commit/efa4b0ff2761f332483f97c40976abc605406b51) | `automatic update` |
| [`fc108872`](https://github.com/nix-community/NUR/commit/fc1088727a08fecc152344a03eba6a007b80b7ae) | `automatic update` |