### PR TITLE
chore(flake/emacs-overlay): `88b2e9ed` -> `ea14c629`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -224,11 +224,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676797507,
-        "narHash": "sha256-alnN1I036Fb/qoMqnAtPEC/YaVLOXq4P7P1yU0cyPxg=",
+        "lastModified": 1676830175,
+        "narHash": "sha256-y3Z7+FRPPln6Ok3Grhp0puC8vMMvE7JrKRsZKixw7o4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "88b2e9eda133e593558680ffb6262203db193ac4",
+        "rev": "ea14c62958d96e0f7cfead9d09e097b1891bf7c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message        |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`ea14c629`](https://github.com/nix-community/emacs-overlay/commit/ea14c62958d96e0f7cfead9d09e097b1891bf7c4) | `Updated repos/melpa` |
| [`5c52a909`](https://github.com/nix-community/emacs-overlay/commit/5c52a909636b29ed9c76399e95d61d9a5341d57f) | `Updated repos/emacs` |
| [`314f3322`](https://github.com/nix-community/emacs-overlay/commit/314f3322d49483ca44bcf185931d9387df6d0183) | `Updated repos/elpa`  |