### PR TITLE
chore(flake/nur): `efa4b0ff` -> `cdcd1c22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676831085,
-        "narHash": "sha256-oL6hH9DWc0OrOR/NDqBYi3rjZjXxgu24sP4wQlYqlmk=",
+        "lastModified": 1676835938,
+        "narHash": "sha256-ZCrtBSXouMv+GfHC4hqn2lFfDkcC1/jdbTQzDcE9nTk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "efa4b0ff2761f332483f97c40976abc605406b51",
+        "rev": "cdcd1c22a21f63bd6e7be554b950dcde420ccd2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`cdcd1c22`](https://github.com/nix-community/NUR/commit/cdcd1c22a21f63bd6e7be554b950dcde420ccd2e) | `automatic update` |