### PR TITLE
chore(flake/nur): `cdcd1c22` -> `757e159c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676835938,
-        "narHash": "sha256-ZCrtBSXouMv+GfHC4hqn2lFfDkcC1/jdbTQzDcE9nTk=",
+        "lastModified": 1676847279,
+        "narHash": "sha256-ou9wqsuFgqaPffMvm7RTrtFHiNljers0tiGbLhEsEXY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cdcd1c22a21f63bd6e7be554b950dcde420ccd2e",
+        "rev": "757e159cd01980e9a215b20208b6567c84e510a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`757e159c`](https://github.com/nix-community/NUR/commit/757e159cd01980e9a215b20208b6567c84e510a8) | `automatic update` |
| [`ccad3ce0`](https://github.com/nix-community/NUR/commit/ccad3ce0d4c6676932c7b2e9c5a09c2572ba3824) | `automatic update` |