### PR TITLE
chore(flake/home-manager): `81f16a1e` -> `6ea50104`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -446,11 +446,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676845259,
-        "narHash": "sha256-9Ile8/m1ZiKikgxCoEAWrUlUQ8lcLOBLmnAwBYDJofo=",
+        "lastModified": 1676846899,
+        "narHash": "sha256-hR8O1OxHi3XxcvnBXhiw8So54sXkQMxcJFu/KwK+EHU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "81f16a1e3c07bc3dffb9733f4ce5a344bf5b4c43",
+        "rev": "6ea501044b52fb98f9e37a5b4f79dc5de74c6c5c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                     |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`6ea50104`](https://github.com/nix-community/home-manager/commit/6ea501044b52fb98f9e37a5b4f79dc5de74c6c5c) | `ci: bump cachix/install-nix-action from 18 to 19` |
| [`ae6f1895`](https://github.com/nix-community/home-manager/commit/ae6f1895d561aa58f0c8f2bcb95100b5ce05ea18) | `Translate using Weblate (Portuguese)`             |
| [`bdcd1bde`](https://github.com/nix-community/home-manager/commit/bdcd1bde4e50466ebb9cd6c74e0adb5959014b76) | `Add translation using Weblate (Portuguese)`       |
| [`aa4c6850`](https://github.com/nix-community/home-manager/commit/aa4c685096b68f2d5efe5d9a63e5ce42a882af53) | `Translate using Weblate (Portuguese)`             |
| [`9e9a0e43`](https://github.com/nix-community/home-manager/commit/9e9a0e43fe6b5e47d77da1dd14b26d9b0326cb5d) | `owncloud-client: add package option`              |