### PR TITLE
chore(flake/nur): `757e159c` -> `156b99e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676847279,
-        "narHash": "sha256-ou9wqsuFgqaPffMvm7RTrtFHiNljers0tiGbLhEsEXY=",
+        "lastModified": 1676861345,
+        "narHash": "sha256-sEMVvAdJ/HZcS6E0LkDitOxnfNgzq4pJizDJs22vRRM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "757e159cd01980e9a215b20208b6567c84e510a8",
+        "rev": "156b99e5b572cffc1059173a1ab7ea6533ed7498",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`156b99e5`](https://github.com/nix-community/NUR/commit/156b99e5b572cffc1059173a1ab7ea6533ed7498) | `automatic update` |
| [`a8bb09f3`](https://github.com/nix-community/NUR/commit/a8bb09f3b01b5ed164eea1bac654d3f3c03cf8aa) | `automatic update` |