### PR TITLE
chore(flake/nur): `156b99e5` -> `50f75c0f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676861345,
-        "narHash": "sha256-sEMVvAdJ/HZcS6E0LkDitOxnfNgzq4pJizDJs22vRRM=",
+        "lastModified": 1676866142,
+        "narHash": "sha256-v4uKs4er8TSzCGkLQN8TsyGeMpCA1FaIQdO4lL7dTA8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "156b99e5b572cffc1059173a1ab7ea6533ed7498",
+        "rev": "50f75c0f5658ecd3e6bee5ce0b652652911ffee8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`50f75c0f`](https://github.com/nix-community/NUR/commit/50f75c0f5658ecd3e6bee5ce0b652652911ffee8) | `automatic update` |
| [`00622920`](https://github.com/nix-community/NUR/commit/006229209530a61de929ade5fb77c394665fd2ae) | `automatic update` |
| [`9fc0aff2`](https://github.com/nix-community/NUR/commit/9fc0aff2ce41db85d511d6b7d46858622ee35283) | `automatic update` |
| [`e59d7eb0`](https://github.com/nix-community/NUR/commit/e59d7eb07d9c0fdb676d35310b1591e32c7ad018) | `automatic update` |
| [`d7055f8f`](https://github.com/nix-community/NUR/commit/d7055f8f674d6daef6e26d770dfd825e4b30e754) | `automatic update` |