### PR TITLE
chore(flake/nur): `50f75c0f` -> `82bea7dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676866142,
-        "narHash": "sha256-v4uKs4er8TSzCGkLQN8TsyGeMpCA1FaIQdO4lL7dTA8=",
+        "lastModified": 1676875699,
+        "narHash": "sha256-PW2vrmEX9rx//OVinsjcfF58RXM67wN1T1+n6lqnP00=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "50f75c0f5658ecd3e6bee5ce0b652652911ffee8",
+        "rev": "82bea7dd030ba387eeab418449c1fa0c1c032a2c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`82bea7dd`](https://github.com/nix-community/NUR/commit/82bea7dd030ba387eeab418449c1fa0c1c032a2c) | `automatic update` |