### PR TITLE
chore(flake/nur): `82bea7dd` -> `8eed86b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676875699,
-        "narHash": "sha256-PW2vrmEX9rx//OVinsjcfF58RXM67wN1T1+n6lqnP00=",
+        "lastModified": 1676881774,
+        "narHash": "sha256-stzXICg0uAnn3fjOEwlFKJwzYd6Az8wdkoaVSajTroo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "82bea7dd030ba387eeab418449c1fa0c1c032a2c",
+        "rev": "8eed86b321cd5d233c3ad4bfbb82312b50c08b48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`8eed86b3`](https://github.com/nix-community/NUR/commit/8eed86b321cd5d233c3ad4bfbb82312b50c08b48) | `automatic update` |
| [`8fa6dc59`](https://github.com/nix-community/NUR/commit/8fa6dc592b965b651d71f0f40be52f9f1878e7ce) | `automatic update` |