### PR TITLE
chore(flake/home-manager): `ebb21e1b` -> `72ce74d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -446,11 +446,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676875407,
-        "narHash": "sha256-OiAKoWMW1x4zaUo5BCOwz21Edr8N4IGzo4zC9i70kc4=",
+        "lastModified": 1676892629,
+        "narHash": "sha256-rlvsqoSBO5dCwfnn7xvImYREidIPJaiFS3b54TZF4pU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ebb21e1bf6b921a60ee314c4246785b61f5ecbf2",
+        "rev": "72ce74d3eae78a6b31538ea7ebe0c1fcf4a10f7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`72ce74d3`](https://github.com/nix-community/home-manager/commit/72ce74d3eae78a6b31538ea7ebe0c1fcf4a10f7a) | `qt: auto-detect style package from name (#3692)` |