### PR TITLE
chore(flake/nur): `28e77afb` -> `33080b3b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676886367,
-        "narHash": "sha256-o8WZ+3SLbyD7vxtCqMez52oV+6vWjUcMm1yAgPhQrcY=",
+        "lastModified": 1676893626,
+        "narHash": "sha256-idYtqSQ/Q8uVNd0ugiVHahovEROdsylUL+C7zT3Co4U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "28e77afbd298625bdbf8df61461f947b4d7bd189",
+        "rev": "33080b3b073e2f820aaa1fce017dc7b9afc44cd8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`33080b3b`](https://github.com/nix-community/NUR/commit/33080b3b073e2f820aaa1fce017dc7b9afc44cd8) | `automatic update` |