### PR TITLE
chore(flake/nur): `33080b3b` -> `b2bb2014`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676893626,
-        "narHash": "sha256-idYtqSQ/Q8uVNd0ugiVHahovEROdsylUL+C7zT3Co4U=",
+        "lastModified": 1676908488,
+        "narHash": "sha256-XlwIyMJXciRi0wj6AMkoV4Df3vjx3+/xvGzaop/Qt8A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "33080b3b073e2f820aaa1fce017dc7b9afc44cd8",
+        "rev": "b2bb201408d5e107c0cbe38ed4a9b6e803b27809",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b2bb2014`](https://github.com/nix-community/NUR/commit/b2bb201408d5e107c0cbe38ed4a9b6e803b27809) | `automatic update` |
| [`abeba1e2`](https://github.com/nix-community/NUR/commit/abeba1e272742dbfc002758a27ff1d4b6223130b) | `automatic update` |