### PR TITLE
chore(flake/nur): `b2bb2014` -> `d6149026`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676908488,
-        "narHash": "sha256-XlwIyMJXciRi0wj6AMkoV4Df3vjx3+/xvGzaop/Qt8A=",
+        "lastModified": 1676912029,
+        "narHash": "sha256-lDqSuy6ybYVmdyKAd+HDvn+BmS+0tk/qqd8p7Bn6Ago=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b2bb201408d5e107c0cbe38ed4a9b6e803b27809",
+        "rev": "d6149026a7d3011346ffa9161f7ef4f8b696a5bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d6149026`](https://github.com/nix-community/NUR/commit/d6149026a7d3011346ffa9161f7ef4f8b696a5bd) | `automatic update` |
| [`9fd8d9cb`](https://github.com/nix-community/NUR/commit/9fd8d9cbde5e2cff6d1daddf8d9026ebdff0a093) | `automatic update` |