### PR TITLE
chore(flake/nixos-hardware): `26c9dbdc` -> `157e1e4b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -525,11 +525,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1676886000,
-        "narHash": "sha256-t7nxEvJb4ISR7u54YADZiZi9EaKHJKbXQjyyf00Q8TA=",
+        "lastModified": 1676908974,
+        "narHash": "sha256-o7sJTBeumorVIM/b1b/Q4q+WJn8Rou5kx8DEBbKOZJI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "26c9dbdc92abc370510be78889942f38a272d705",
+        "rev": "157e1e4b127b5cb37822be247e8ec37a7f475270",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                            |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`75b6ec47`](https://github.com/NixOS/nixos-hardware/commit/75b6ec4775ddfe657f19d02bee7f063bd7229620) | `Add NXP i.MX8 SOC family support.`       |
| [`576be211`](https://github.com/NixOS/nixos-hardware/commit/576be211f095c3305110a83c579f006ee42799cc) | `lenovo/legion/16ach6h: disable thermald` |