### PR TITLE
chore(flake/nur): `d6149026` -> `3c39aebc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676912029,
-        "narHash": "sha256-lDqSuy6ybYVmdyKAd+HDvn+BmS+0tk/qqd8p7Bn6Ago=",
+        "lastModified": 1676922285,
+        "narHash": "sha256-eittWOFNAvqFikyGdnyU8W+12QoMJYDZIUyztPEDzyY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d6149026a7d3011346ffa9161f7ef4f8b696a5bd",
+        "rev": "3c39aebcd09c9d6c257140e07f3d2beac4a83043",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3c39aebc`](https://github.com/nix-community/NUR/commit/3c39aebcd09c9d6c257140e07f3d2beac4a83043) | `automatic update` |