### PR TITLE
chore(flake/nixos-hardware): `157e1e4b` -> `d24ea777`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -525,11 +525,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1676908974,
-        "narHash": "sha256-o7sJTBeumorVIM/b1b/Q4q+WJn8Rou5kx8DEBbKOZJI=",
+        "lastModified": 1676924492,
+        "narHash": "sha256-78278eyP55JRFe7UCpmFwdkrTY6H2arzTpVeteWo8kM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "157e1e4b127b5cb37822be247e8ec37a7f475270",
+        "rev": "d24ea777c57b69c6b143cf11d83184ef71b0dbbf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`93030acc`](https://github.com/NixOS/nixos-hardware/commit/93030acc16854853024f67686d76b0cc463b56bd) | `p14s: do not include acpi_backlight on newer kernel versions`     |
| [`6f1da80b`](https://github.com/NixOS/nixos-hardware/commit/6f1da80bd034c550220ec9777bc52af9f5af762d) | ``lenovo/thinkpad/t520: reference in `README.md` and `flake.nix``` |
| [`51ec9ab5`](https://github.com/NixOS/nixos-hardware/commit/51ec9ab517ed69dfefd330ffd3973b485e24e3b0) | `lenovo/thinkpad/t520: create`                                     |