### PR TITLE
chore(flake/nur): `3c39aebc` -> `9cef3b7f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676922285,
-        "narHash": "sha256-eittWOFNAvqFikyGdnyU8W+12QoMJYDZIUyztPEDzyY=",
+        "lastModified": 1676929409,
+        "narHash": "sha256-4LUaFJmKEpuXhQmh5rzSFcZQbVr1AUkyLADvgeH3NdQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3c39aebcd09c9d6c257140e07f3d2beac4a83043",
+        "rev": "9cef3b7fcb53851e72b1073fe381f3b3b6f1b1b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9cef3b7f`](https://github.com/nix-community/NUR/commit/9cef3b7fcb53851e72b1073fe381f3b3b6f1b1b5) | `automatic update` |