### PR TITLE
chore(flake/nur): `9cef3b7f` -> `4defa15f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676929409,
-        "narHash": "sha256-4LUaFJmKEpuXhQmh5rzSFcZQbVr1AUkyLADvgeH3NdQ=",
+        "lastModified": 1676933956,
+        "narHash": "sha256-NkLsYr+KWb0elFEmwIB2+QoN8Y0y0W6HyQp/PxthU+s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9cef3b7fcb53851e72b1073fe381f3b3b6f1b1b5",
+        "rev": "4defa15fe7fe3b07200aded889cf6ab46ce47de2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4defa15f`](https://github.com/nix-community/NUR/commit/4defa15fe7fe3b07200aded889cf6ab46ce47de2) | `automatic update` |
| [`63fb83a8`](https://github.com/nix-community/NUR/commit/63fb83a8ec1dae8048a4603ff5969f78408b4db6) | `automatic update` |