### PR TITLE
chore(flake/home-manager): `72ce74d3` -> `5e889b38`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -446,11 +446,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676892629,
-        "narHash": "sha256-rlvsqoSBO5dCwfnn7xvImYREidIPJaiFS3b54TZF4pU=",
+        "lastModified": 1676933022,
+        "narHash": "sha256-gLghsEHOy2W2ZmSwqNOyj2mSHe9SMpdcbqnoySlZnmY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "72ce74d3eae78a6b31538ea7ebe0c1fcf4a10f7a",
+        "rev": "5e889b385c43a8a72ada5ebc4888bbebb129b438",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message          |
| ----------------------------------------------------------------------------------------------------------- | ----------------------- |
| [`5e889b38`](https://github.com/nix-community/home-manager/commit/5e889b385c43a8a72ada5ebc4888bbebb129b438) | `mpd-mpris: add module` |