### PR TITLE
chore(flake/nur): `4defa15f` -> `249c2674`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676933956,
-        "narHash": "sha256-NkLsYr+KWb0elFEmwIB2+QoN8Y0y0W6HyQp/PxthU+s=",
+        "lastModified": 1676947256,
+        "narHash": "sha256-ZzFLCGl9rNv5Q76L6wMOCl3d5Lfk5Ilvjl43NHVSxw8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4defa15fe7fe3b07200aded889cf6ab46ce47de2",
+        "rev": "249c267424a36c1270e3978cca38270a540d491a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`249c2674`](https://github.com/nix-community/NUR/commit/249c267424a36c1270e3978cca38270a540d491a) | `automatic update` |