### PR TITLE
chore(flake/nur): `1f7aa405` -> `e629eb30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676951140,
-        "narHash": "sha256-GqY4rN61SSeyfXgwbevh+d6J62bTbSkbrJdmWS3X6Ds=",
+        "lastModified": 1676952268,
+        "narHash": "sha256-6u8uxDibLkiw7Uu60ztZ0KP5eNUzdI2mUpdhxHx8uqE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1f7aa405d2d50943961a69a1e3ef215170731a51",
+        "rev": "e629eb30abfb07ed11c9fa296ac31e997b264e73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e629eb30`](https://github.com/nix-community/NUR/commit/e629eb30abfb07ed11c9fa296ac31e997b264e73) | `automatic update` |