### PR TITLE
chore(flake/sops-nix): `1da7257b` -> `2c582843`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -900,11 +900,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1676776227,
-        "narHash": "sha256-CSBeyGiDMYDw/nmafLfuu0ErVu7rzGoWIQwm2NkQQKY=",
+        "lastModified": 1676959847,
+        "narHash": "sha256-KZS6sIsMXiNyN7jW45MrEo95iEXj6nMLKvxgxO181no=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "1da7257baa1d6801c45d9d3dedae7ce79c0e6498",
+        "rev": "2c5828439d718a6cddd9a511997d9ac7626a4aff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                              |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`cf3d4c28`](https://github.com/Mic92/sops-nix/commit/cf3d4c28550c3fc1ccdf4b96b511fedf826371d1) | `drop warning on tmpfs for XDG_RUNTIME_DIR` |