### PR TITLE
chore(flake/nur): `e629eb30` -> `3dfd8075`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676952268,
-        "narHash": "sha256-6u8uxDibLkiw7Uu60ztZ0KP5eNUzdI2mUpdhxHx8uqE=",
+        "lastModified": 1677004016,
+        "narHash": "sha256-V+I5y9lOSK7BCDD6Q1QIm8FJynnOuCCAVN1hhqtDa5I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e629eb30abfb07ed11c9fa296ac31e997b264e73",
+        "rev": "3dfd8075276e6b2a2d9f74198bb82c0a7652d172",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3dfd8075`](https://github.com/nix-community/NUR/commit/3dfd8075276e6b2a2d9f74198bb82c0a7652d172) | `automatic update` |
| [`eb65539c`](https://github.com/nix-community/NUR/commit/eb65539c885d8e0ccfa9d508904772de904e9256) | `automatic update` |