### PR TITLE
chore(flake/nur): `6f8988a9` -> `a28a512b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677012355,
-        "narHash": "sha256-ccE3BQPMA0R5fR3jJRX/CUa4FmcLSoK5RvUreTpT/HY=",
+        "lastModified": 1677031979,
+        "narHash": "sha256-7+BAR30kiYBL/bGxJIj5taUmbfoQtKjuBeAkWMkOhh8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6f8988a961627ad6a591095d0a360d51dc8098d8",
+        "rev": "a28a512b634a590f9771beab2b6dac067b42be09",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a28a512b`](https://github.com/nix-community/NUR/commit/a28a512b634a590f9771beab2b6dac067b42be09) | `automatic update` |