### PR TITLE
chore(flake/nur): `a28a512b` -> `f41a8ab8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677031979,
-        "narHash": "sha256-7+BAR30kiYBL/bGxJIj5taUmbfoQtKjuBeAkWMkOhh8=",
+        "lastModified": 1677039063,
+        "narHash": "sha256-W+IsVs0yLxGvbpDg7E2eNIwInKtmBM89+eeyvwTX1XU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a28a512b634a590f9771beab2b6dac067b42be09",
+        "rev": "f41a8ab86bdd71260887f514a1e130ed79620333",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f41a8ab8`](https://github.com/nix-community/NUR/commit/f41a8ab86bdd71260887f514a1e130ed79620333) | `automatic update` |
| [`2ef0ba56`](https://github.com/nix-community/NUR/commit/2ef0ba561190a6c60706e36a6f00efc71f0d5cea) | `automatic update` |