### PR TITLE
chore(flake/emacs-ement): `850f6b27` -> `d893fbc2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -201,11 +201,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1676670893,
-        "narHash": "sha256-Pdb+qLhFDtcdmS+M5zXM8SDBIUaB5JIMnzXdQTBgBzk=",
+        "lastModified": 1677044270,
+        "narHash": "sha256-fDVbXI0qXkE0AWkO+CkR/8It1oJGFvN9y8N1TPyhMpY=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "850f6b277226a6b164cce30ccaf6aa499fe46fe4",
+        "rev": "d893fbc2bf171ac1527e9cfe983ce6d9cae68672",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                  |
| --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`d893fbc2`](https://github.com/alphapapa/ement.el/commit/d893fbc2bf171ac1527e9cfe983ce6d9cae68672) | `Fix: (ement-room-bookmark-handler) Jump to end of room buffer` |
| [`f7b6a44b`](https://github.com/alphapapa/ement.el/commit/f7b6a44b59f6d4cc42c433ee8591b4bc71773c40) | `Fix: Formatting of unban events`                               |