### PR TITLE
chore(flake/nur): `5d3891a0` -> `004688f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677040854,
-        "narHash": "sha256-2GU5/lCLPyhbqoEwqMMNOoYe8gaBFKwHbjK8OygMXnA=",
+        "lastModified": 1677051354,
+        "narHash": "sha256-r5adVQTxUVLzg4wm5rr/p1g0wXB2u3c0SYvcNAGxUgQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5d3891a02e3812510cfa975833a7e7138c63dcf0",
+        "rev": "004688f099616a6e5e077fbb1aebb5c921ac3bfa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`004688f0`](https://github.com/nix-community/NUR/commit/004688f099616a6e5e077fbb1aebb5c921ac3bfa) | `automatic update` |
| [`03b28b5b`](https://github.com/nix-community/NUR/commit/03b28b5bac8f98f0b4bfea1420e0f2fd65722617) | `automatic update` |