### PR TITLE
chore(flake/nur): `87ab15f5` -> `575437e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677076915,
-        "narHash": "sha256-cVq33KpUCZe3SZo5WcweDemMR2EONPzIBAmDdTLvLQw=",
+        "lastModified": 1677084824,
+        "narHash": "sha256-zx6tP0QCrENZNj8ECwVSlXc2rgJTCaWCbxjex9aKLPg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "87ab15f5b7f02c45f097e40879c2636953da575e",
+        "rev": "575437e85bcad63616e1473042ced3bc57686d87",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`575437e8`](https://github.com/nix-community/NUR/commit/575437e85bcad63616e1473042ced3bc57686d87) | `automatic update` |