### PR TITLE
chore(flake/emacs-ement): `d893fbc2` -> `d33ec2a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -201,11 +201,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1677044270,
-        "narHash": "sha256-fDVbXI0qXkE0AWkO+CkR/8It1oJGFvN9y8N1TPyhMpY=",
+        "lastModified": 1677086240,
+        "narHash": "sha256-Bn+Jyw6RCEZPmL/oVpDw/qYGR2jnqcqKd9Bk8AQJ4FU=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "d893fbc2bf171ac1527e9cfe983ce6d9cae68672",
+        "rev": "d33ec2a5476bd12685a222b63f1e31092978efd9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                         |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`d33ec2a5`](https://github.com/alphapapa/ement.el/commit/d33ec2a5476bd12685a222b63f1e31092978efd9) | `Tidy: Long line`                                                      |
| [`ce645fdf`](https://github.com/alphapapa/ement.el/commit/ce645fdf748f64c6bb7a4f75dbb25f7533d3aee8) | `Fix: (ement-room--format-membership-events) Rejected, minor refactor` |