### PR TITLE
chore(flake/nur): `575437e8` -> `1eaba2b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677084824,
-        "narHash": "sha256-zx6tP0QCrENZNj8ECwVSlXc2rgJTCaWCbxjex9aKLPg=",
+        "lastModified": 1677087980,
+        "narHash": "sha256-ILLukx8FztAg2dfFeOJADRf2B9DYkvsw4tcSr5kh9LI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "575437e85bcad63616e1473042ced3bc57686d87",
+        "rev": "1eaba2b57f4a1fae970000ab4d74be12f5bdb432",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1eaba2b5`](https://github.com/nix-community/NUR/commit/1eaba2b57f4a1fae970000ab4d74be12f5bdb432) | `automatic update` |