### PR TITLE
chore(flake/nur): `1eaba2b5` -> `033df2a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677087980,
-        "narHash": "sha256-ILLukx8FztAg2dfFeOJADRf2B9DYkvsw4tcSr5kh9LI=",
+        "lastModified": 1677095144,
+        "narHash": "sha256-NLvr7zDKk3wgq+X3XJ8gJeMXcWSbWVIaDoAB9YJ2vm0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1eaba2b57f4a1fae970000ab4d74be12f5bdb432",
+        "rev": "033df2a0237c1afdd7abff406153fdcc5a201f03",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`033df2a0`](https://github.com/nix-community/NUR/commit/033df2a0237c1afdd7abff406153fdcc5a201f03) | `automatic update` |