### PR TITLE
chore(flake/home-manager): `564b82b3` -> `4295fdfa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -446,11 +446,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677013990,
-        "narHash": "sha256-HwAnE5MHsyLiRJp50KfDFPiiOZXI0Ts8hXpIh6yBilE=",
+        "lastModified": 1677104801,
+        "narHash": "sha256-2V5nKOYVFMYlseYdDKiEaww2xqcE0GtS1ax3SoUX99I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "564b82b3542026e7fb5d0da16c56ae3e40e5c9dd",
+        "rev": "4295fdfa6b0005c32f2e1f0b732faf5810c1bc7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message      |
| ----------------------------------------------------------------------------------------------------------- | ------------------- |
| [`4295fdfa`](https://github.com/nix-community/home-manager/commit/4295fdfa6b0005c32f2e1f0b732faf5810c1bc7f) | `avizo: add module` |