### PR TITLE
chore(flake/nur): `a35db378` -> `6f0cb9a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677105886,
-        "narHash": "sha256-kSA1YJzuI3ph9MOTUXIHdTZoID1yCeHI0BrA4GfxnRg=",
+        "lastModified": 1677111071,
+        "narHash": "sha256-EcVe8xxkrMZaBWjH1vu/trejYyQL8U++bPckP+tZHgs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a35db3784f64a0d51596ab7432df1a236523d439",
+        "rev": "6f0cb9a86feecb84a8bd6ebe4690eaba4523255c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6f0cb9a8`](https://github.com/nix-community/NUR/commit/6f0cb9a86feecb84a8bd6ebe4690eaba4523255c) | `automatic update` |
| [`1508dd3f`](https://github.com/nix-community/NUR/commit/1508dd3f54dbca5d0ec6c556b952dea771215d3a) | `automatic update` |
| [`b4d54c9d`](https://github.com/nix-community/NUR/commit/b4d54c9de9815fb53924433e4e8180e36dc41012) | `automatic update` |
| [`7b04c153`](https://github.com/nix-community/NUR/commit/7b04c15379834000cce40014028e0d371effc397) | `automatic update` |
| [`7d047465`](https://github.com/nix-community/NUR/commit/7d047465e650a7adb5c48a0f30d416fba85a6afe) | `automatic update` |