### PR TITLE
chore(flake/nur): `6f0cb9a8` -> `941a1525`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677111071,
-        "narHash": "sha256-EcVe8xxkrMZaBWjH1vu/trejYyQL8U++bPckP+tZHgs=",
+        "lastModified": 1677116728,
+        "narHash": "sha256-qCV2oJ0u92v0EL9COb84SUziZKr0eTi6y7Bjzwj6ny8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6f0cb9a86feecb84a8bd6ebe4690eaba4523255c",
+        "rev": "941a15253d2b39f0494b9e336bb435bf373aa005",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`941a1525`](https://github.com/nix-community/NUR/commit/941a15253d2b39f0494b9e336bb435bf373aa005) | `automatic update` |
| [`4496ed91`](https://github.com/nix-community/NUR/commit/4496ed917f295914809a3db68151fcba05a4a533) | `automatic update` |