### PR TITLE
chore(flake/nur): `941a1525` -> `1d761d11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677116728,
-        "narHash": "sha256-qCV2oJ0u92v0EL9COb84SUziZKr0eTi6y7Bjzwj6ny8=",
+        "lastModified": 1677120171,
+        "narHash": "sha256-sepOadcYgFDznfwr/j9SpQH6NiN/t/3WIREoSk2JN1c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "941a15253d2b39f0494b9e336bb435bf373aa005",
+        "rev": "1d761d11762e79f3393e8c8a6abe6e8edbf65b96",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1d761d11`](https://github.com/nix-community/NUR/commit/1d761d11762e79f3393e8c8a6abe6e8edbf65b96) | `automatic update` |
| [`eadb175a`](https://github.com/nix-community/NUR/commit/eadb175a6d006006c76840477b658473dbf84d91) | `automatic update` |