### PR TITLE
chore(flake/nur): `441b5d22` -> `b6ef1a4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677120569,
-        "narHash": "sha256-1MMwcKYpiBubuMbGx7Vi3ifukOuLjPMiG4BFOoB2XME=",
+        "lastModified": 1677124445,
+        "narHash": "sha256-yZ5Kbio/xRdXULGY7zkPZh+aJRBbVepZNvfJ8mhoNFY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "441b5d22fe4cbfacff96bed88cee4cf5860a5635",
+        "rev": "b6ef1a4a86e6f5acdc3c25072369b1b2786d415b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`b6ef1a4a`](https://github.com/nix-community/NUR/commit/b6ef1a4a86e6f5acdc3c25072369b1b2786d415b) | `automatic update` |
| [`37370c52`](https://github.com/nix-community/NUR/commit/37370c525aaf6a85281c64ec1d8f2523e57937b0) | `automatic update` |