### PR TITLE
chore(flake/nur): `b6ef1a4a` -> `96bbe35a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677124445,
-        "narHash": "sha256-yZ5Kbio/xRdXULGY7zkPZh+aJRBbVepZNvfJ8mhoNFY=",
+        "lastModified": 1677125018,
+        "narHash": "sha256-WVVi3371qvjS1affELCsc8F9WpjaVDB5c83QajYGCJs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b6ef1a4a86e6f5acdc3c25072369b1b2786d415b",
+        "rev": "96bbe35afbd620b53a5b5e611f3ca90378a7eaa3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`96bbe35a`](https://github.com/nix-community/NUR/commit/96bbe35afbd620b53a5b5e611f3ca90378a7eaa3) | `automatic update` |