### PR TITLE
chore(flake/nur): `81cee6fd` -> `5c3294bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677192448,
-        "narHash": "sha256-bqHXpEDxPnDF4tdBld2fL13ZtWNGsv/EINENxS+T1UM=",
+        "lastModified": 1677207835,
+        "narHash": "sha256-2OkE6mF8wlG2KZBTDE/Xn4ZGTObG5XENnTt3IYhgr7M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "81cee6fd1d178fca9ad861247cc9b15cd114f203",
+        "rev": "5c3294bc707760848471940650f0cd4c1f1915af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`5c3294bc`](https://github.com/nix-community/NUR/commit/5c3294bc707760848471940650f0cd4c1f1915af) | `automatic update` |
| [`b557e952`](https://github.com/nix-community/NUR/commit/b557e952bed4be48e8db111d684451e5fc51615c) | `automatic update` |
| [`2f0a9408`](https://github.com/nix-community/NUR/commit/2f0a94085df4764f360350d944a9124f79476f9c) | `automatic update` |