### PR TITLE
chore(flake/nur): `5c3294bc` -> `2390880f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677207835,
-        "narHash": "sha256-2OkE6mF8wlG2KZBTDE/Xn4ZGTObG5XENnTt3IYhgr7M=",
+        "lastModified": 1677209833,
+        "narHash": "sha256-LiC4v1cr4JhRH1Za8yue4jKOINJ3NxlGznJP2rO1mpY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5c3294bc707760848471940650f0cd4c1f1915af",
+        "rev": "2390880f68c7f26376fd2cd95afdf2e62d6ca032",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`2390880f`](https://github.com/nix-community/NUR/commit/2390880f68c7f26376fd2cd95afdf2e62d6ca032) | `automatic update` |
| [`f27de54c`](https://github.com/nix-community/NUR/commit/f27de54c69ede8323eb5060225238a4b8aabcb01) | `automatic update` |