### PR TITLE
chore(flake/nur): `2390880f` -> `13e02218`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677209833,
-        "narHash": "sha256-LiC4v1cr4JhRH1Za8yue4jKOINJ3NxlGznJP2rO1mpY=",
+        "lastModified": 1677211927,
+        "narHash": "sha256-Fv/6docDbZ7Xfaz6TjtTY/9U+xwK93F7jH1ZeobRC6c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2390880f68c7f26376fd2cd95afdf2e62d6ca032",
+        "rev": "13e02218aa2e5a6a65d3a07152f7c03f93227f75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`13e02218`](https://github.com/nix-community/NUR/commit/13e02218aa2e5a6a65d3a07152f7c03f93227f75) | `automatic update` |