### PR TITLE
chore(flake/nur): `13e02218` -> `e44a5db9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677211927,
-        "narHash": "sha256-Fv/6docDbZ7Xfaz6TjtTY/9U+xwK93F7jH1ZeobRC6c=",
+        "lastModified": 1677214038,
+        "narHash": "sha256-feoyTKjz8wFpmhX6ZHC/50U4ydi5AAKap6/pWPGnPuU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "13e02218aa2e5a6a65d3a07152f7c03f93227f75",
+        "rev": "e44a5db9e77b0672683a1b21a409166c49ccaa4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`e44a5db9`](https://github.com/nix-community/NUR/commit/e44a5db9e77b0672683a1b21a409166c49ccaa4a) | `automatic update` |