### PR TITLE
chore(flake/nur): `e44a5db9` -> `d265d65d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677214038,
-        "narHash": "sha256-feoyTKjz8wFpmhX6ZHC/50U4ydi5AAKap6/pWPGnPuU=",
+        "lastModified": 1677217548,
+        "narHash": "sha256-Vd23DuJH46sJhNi8uSjtjjt4YuSd3EScYGAi70QP6V0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e44a5db9e77b0672683a1b21a409166c49ccaa4a",
+        "rev": "d265d65daf8523bfbfa13f9cfa5d87ef73ac426c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d265d65d`](https://github.com/nix-community/NUR/commit/d265d65daf8523bfbfa13f9cfa5d87ef73ac426c) | `automatic update` |