### PR TITLE
chore(flake/nur): `d265d65d` -> `72c71ff1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677217548,
-        "narHash": "sha256-Vd23DuJH46sJhNi8uSjtjjt4YuSd3EScYGAi70QP6V0=",
+        "lastModified": 1677224679,
+        "narHash": "sha256-5B0GcCx9cXtxWJSQE+9O6jEqD43nESqujyhmrHis9Cg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d265d65daf8523bfbfa13f9cfa5d87ef73ac426c",
+        "rev": "72c71ff18e115a8439295b02c707a847d0413198",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`72c71ff1`](https://github.com/nix-community/NUR/commit/72c71ff18e115a8439295b02c707a847d0413198) | `automatic update` |