### PR TITLE
chore(flake/nur): `72c71ff1` -> `d7b060c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677224679,
-        "narHash": "sha256-5B0GcCx9cXtxWJSQE+9O6jEqD43nESqujyhmrHis9Cg=",
+        "lastModified": 1677228508,
+        "narHash": "sha256-yDvMd/7KRxtJdDwaPOYt60y7FyqJ6V08mrpcUhNJT5Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "72c71ff18e115a8439295b02c707a847d0413198",
+        "rev": "d7b060c9c49c18be0362975b94d489bc75810e39",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d7b060c9`](https://github.com/nix-community/NUR/commit/d7b060c9c49c18be0362975b94d489bc75810e39) | `automatic update` |