### PR TITLE
chore(flake/nur): `d7b060c9` -> `33b05dbb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677228508,
-        "narHash": "sha256-yDvMd/7KRxtJdDwaPOYt60y7FyqJ6V08mrpcUhNJT5Q=",
+        "lastModified": 1677231948,
+        "narHash": "sha256-GGPUhY8Yu9GveaLaa8LD3oBG7+Fe1ksUJ/JimQ8qvXM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d7b060c9c49c18be0362975b94d489bc75810e39",
+        "rev": "33b05dbbb227ff4ade606f8647987fa8498525ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`33b05dbb`](https://github.com/nix-community/NUR/commit/33b05dbbb227ff4ade606f8647987fa8498525ca) | `automatic update` |