### PR TITLE
chore(flake/nixos-hardware): `d24ea777` -> `2d440157`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -525,11 +525,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1676924492,
-        "narHash": "sha256-78278eyP55JRFe7UCpmFwdkrTY6H2arzTpVeteWo8kM=",
+        "lastModified": 1677232326,
+        "narHash": "sha256-rAk2/80kLvA3yIMmSV86T1B4kNvwCFMSQ1FxXndaUB0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d24ea777c57b69c6b143cf11d83184ef71b0dbbf",
+        "rev": "2d44015779cced4eec9df5b8dab238b9f6312cb2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                  |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`fb4ff625`](https://github.com/NixOS/nixos-hardware/commit/fb4ff6250eaff6e82eb13ad7fe705a45c24390dd) | `t14s,p14s: remove rtw89-firmware if linux-firmware new enough` |