### PR TITLE
chore(flake/emacs-ement): `d33ec2a5` -> `d6c9e0a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -201,11 +201,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1677086240,
-        "narHash": "sha256-Bn+Jyw6RCEZPmL/oVpDw/qYGR2jnqcqKd9Bk8AQJ4FU=",
+        "lastModified": 1677257564,
+        "narHash": "sha256-R+EFF3Ns18BoYqLSPpWSVo8HyNWjRM6VzqtbTY7QKKA=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "d33ec2a5476bd12685a222b63f1e31092978efd9",
+        "rev": "d6c9e0a909674064f94b23579c01c491e8eedd6a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                             |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`46b9243c`](https://github.com/alphapapa/ement.el/commit/46b9243c9cc63bdd36097d99769c7b08b43c7819) | `Docs: Update changelog`                                   |
| [`680be429`](https://github.com/alphapapa/ement.el/commit/680be429cf61edcfb55f472b94a89b121570770d) | `Change: (ement-room-image-keymap) Inherit from image-map` |
| [`d28314b5`](https://github.com/alphapapa/ement.el/commit/d28314b54bfade1e5fb63e5dd7296f01de726f9d) | `Docs: Update changelog`                                   |
| [`b7f11a45`](https://github.com/alphapapa/ement.el/commit/b7f11a45be6be2606356b8d0e0a5143a4c12b409) | `conduit fix`                                              |