### PR TITLE
chore(flake/emacs-ement): `d6c9e0a9` -> `52ae2a13`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -201,11 +201,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1677257564,
-        "narHash": "sha256-R+EFF3Ns18BoYqLSPpWSVo8HyNWjRM6VzqtbTY7QKKA=",
+        "lastModified": 1677259352,
+        "narHash": "sha256-NLRIHolL3qzTQyaPwgJAm6S31bjh0vKsRi5R0QGxbZI=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "d6c9e0a909674064f94b23579c01c491e8eedd6a",
+        "rev": "52ae2a13cbe29dfb23e338f4d75e966d947c95fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                |
| --------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`52ae2a13`](https://github.com/alphapapa/ement.el/commit/52ae2a13cbe29dfb23e338f4d75e966d947c95fc) | `Fix: (ement-room.el) Byte-compiler warnings` |
| [`42921a07`](https://github.com/alphapapa/ement.el/commit/42921a072bf9b74b88b5a2ea4d56103cba421ab4) | `Meta: v0.7-pre`                              |
| [`6b70f37f`](https://github.com/alphapapa/ement.el/commit/6b70f37f8cf909ac7e02d85acc3010b008861cba) | `Release: v0.6`                               |