### PR TITLE
chore(flake/nur): `9bde3171` -> `a13614be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677243766,
-        "narHash": "sha256-a+2V68cLjb951pYBEGbQGEVBcgti40uWtxTVnzvGFhY=",
+        "lastModified": 1677277666,
+        "narHash": "sha256-XpLjEdvFexiK7m0pA/JYWSYmuKYVCrnVwq2hja7meOc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9bde3171aeb5954b7955fcb09b231f53caf76b54",
+        "rev": "a13614be5eec4d5c377bcd4da3f230349bd64afd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`a13614be`](https://github.com/nix-community/NUR/commit/a13614be5eec4d5c377bcd4da3f230349bd64afd) | `automatic update` |
| [`fc5270c3`](https://github.com/nix-community/NUR/commit/fc5270c36c50faca31b8c7d15d9ff414b097c268) | `automatic update` |