### PR TITLE
chore(flake/home-manager): `4295fdfa` -> `664945b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -446,11 +446,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677104801,
-        "narHash": "sha256-2V5nKOYVFMYlseYdDKiEaww2xqcE0GtS1ax3SoUX99I=",
+        "lastModified": 1677276957,
+        "narHash": "sha256-/vhdNhQj2CWgqdfD2KLEZWDleOfen0t2EiaGiyivnJU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4295fdfa6b0005c32f2e1f0b732faf5810c1bc7f",
+        "rev": "664945b3e09b4551c4e63e16efebd493cf5eac74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                         |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`664945b3`](https://github.com/nix-community/home-manager/commit/664945b3e09b4551c4e63e16efebd493cf5eac74) | `starship: Use mkEnableOption (#3701)` |