### PR TITLE
chore(flake/nur): `a13614be` -> `9bcde0a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677277666,
-        "narHash": "sha256-XpLjEdvFexiK7m0pA/JYWSYmuKYVCrnVwq2hja7meOc=",
+        "lastModified": 1677278769,
+        "narHash": "sha256-qkBRZ8ZZpt9FhdKelGfO6pD83T+KYE0VJsWAYBpOtOg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a13614be5eec4d5c377bcd4da3f230349bd64afd",
+        "rev": "9bcde0a0f5d4dccec3cb85b5fa9f3d18284ffcd7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9bcde0a0`](https://github.com/nix-community/NUR/commit/9bcde0a0f5d4dccec3cb85b5fa9f3d18284ffcd7) | `automatic update` |