### PR TITLE
chore(flake/nur): `a16abc72` -> `702a8c4e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677283054,
-        "narHash": "sha256-UhiXm4UuJWTSAy45beVB9ifYi2LfQAn5Ux6xkdkBXjU=",
+        "lastModified": 1677286176,
+        "narHash": "sha256-TlL2W+AIazshP9fzzQQ8IaEH17AKAEPZbZ+iwriSayY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a16abc72ebb69acc6dfd743f5964f8416c442792",
+        "rev": "702a8c4ecbe57a567342e1145f58bdbe9afeb19a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`702a8c4e`](https://github.com/nix-community/NUR/commit/702a8c4ecbe57a567342e1145f58bdbe9afeb19a) | `automatic update` |