### PR TITLE
chore(flake/nur): `702a8c4e` -> `70042259`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677286176,
-        "narHash": "sha256-TlL2W+AIazshP9fzzQQ8IaEH17AKAEPZbZ+iwriSayY=",
+        "lastModified": 1677291901,
+        "narHash": "sha256-gy2Ab3EjsSJwNeDWHu8dDxZi/F2misXAbUWNdqe4OwI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "702a8c4ecbe57a567342e1145f58bdbe9afeb19a",
+        "rev": "7004225966204acdb91dc45e04fba60c1a575883",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`70042259`](https://github.com/nix-community/NUR/commit/7004225966204acdb91dc45e04fba60c1a575883) | `automatic update` |
| [`64b51d4a`](https://github.com/nix-community/NUR/commit/64b51d4a4f3e56cf097360cf765f9ad39e2243b6) | `automatic update` |