### PR TITLE
chore(flake/nur): `656e6ba8` -> `887b9ebe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677297240,
-        "narHash": "sha256-hBuzGDXNiHUe7RKl7PM6s2cgHnVjd0DGw1iQUuA/QLE=",
+        "lastModified": 1677298224,
+        "narHash": "sha256-4SksJfpM/kW2PVeMpQLu9LtaqRxkyBIBbNmhLVLMpyk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "656e6ba825da4c6c1d95c148253d8b1c0e142c1c",
+        "rev": "887b9ebe6ffab746388fc0ccd161f199513f4a47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`887b9ebe`](https://github.com/nix-community/NUR/commit/887b9ebe6ffab746388fc0ccd161f199513f4a47) | `automatic update` |