### PR TITLE
chore(flake/nur): `3bf8b192` -> `43128bc2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677300403,
-        "narHash": "sha256-vcixX1xzBgSg/mzDzuOVPDnONpU9H8Os/c7PX2LsNa0=",
+        "lastModified": 1677307379,
+        "narHash": "sha256-qxjilHh3p9UmXczYiaItgEXopFUs6Eou2i5IrEOM/oY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3bf8b19290dd918d6a8430097f91d55ff0c11a8f",
+        "rev": "43128bc262b0275a4885383f3907bb200b0c60bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`43128bc2`](https://github.com/nix-community/NUR/commit/43128bc262b0275a4885383f3907bb200b0c60bb) | `automatic update` |