### PR TITLE
chore(flake/nur): `ab8cd578` -> `6205e630`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677308535,
-        "narHash": "sha256-66BgZxZ+MnxouwGRd0K9ue1G70r8jyR6l2neuMMiYjs=",
+        "lastModified": 1677325571,
+        "narHash": "sha256-tI8/v64+XGUcTLQh+66ry60kHwJrh47/xyN10WueEV0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ab8cd578fc38e3e797eaa98cd392b2f625a0f265",
+        "rev": "6205e6306a45198c1b7a9e479be075903ffb5f34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6205e630`](https://github.com/nix-community/NUR/commit/6205e6306a45198c1b7a9e479be075903ffb5f34) | `automatic update` |