### PR TITLE
chore(flake/nur): `6205e630` -> `3566391f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677325571,
-        "narHash": "sha256-tI8/v64+XGUcTLQh+66ry60kHwJrh47/xyN10WueEV0=",
+        "lastModified": 1677330182,
+        "narHash": "sha256-HwY7ICxDfJ5GkwGnomCDgGM+nvvMP/oTCYbWHM1rTjw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6205e6306a45198c1b7a9e479be075903ffb5f34",
+        "rev": "3566391ff06734dcf8b032479e09ebc8a4f4e82b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3566391f`](https://github.com/nix-community/NUR/commit/3566391ff06734dcf8b032479e09ebc8a4f4e82b) | `automatic update` |