### PR TITLE
chore(flake/nur): `ace93f82` -> `6f1d9d38`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677332671,
-        "narHash": "sha256-2AzYk+vZHEyyZpM7UOE2+XOw34SsP2N/5E5gZddvFP0=",
+        "lastModified": 1677336410,
+        "narHash": "sha256-MUatp+RjIQD9Br0yRVMmZwZgSGnCVpmAxYuzj7NzPek=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ace93f8263bb10d4ec9281718d2d1d1eb024677a",
+        "rev": "6f1d9d380e7922cc302e2d21cb3615d918f4a001",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`6f1d9d38`](https://github.com/nix-community/NUR/commit/6f1d9d380e7922cc302e2d21cb3615d918f4a001) | `automatic update` |