### PR TITLE
chore(flake/nur): `4711c9bb` -> `f86fd886`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677354372,
-        "narHash": "sha256-yJQeIxHkJO7GOvEK24hv9K59eorGTrEgfNWjlrpBfPU=",
+        "lastModified": 1677361502,
+        "narHash": "sha256-LKwDLGyFEU7M+nYAzemvuZTVfo8lujFd5JSBWxuiQJk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4711c9bb1df2bf0fd103c46aa9465ebde8fd93c7",
+        "rev": "f86fd886eb8f3dc7948b6f8cd72de1fe1b5d80c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`f86fd886`](https://github.com/nix-community/NUR/commit/f86fd886eb8f3dc7948b6f8cd72de1fe1b5d80c6) | `automatic update` |