### PR TITLE
chore(flake/nur): `1dc471e6` -> `9de97562`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677378055,
-        "narHash": "sha256-nHuCColxrrXMdrLgPjt5/5UA+m7lZB50nHCBcIS4mfA=",
+        "lastModified": 1677380976,
+        "narHash": "sha256-uGhWAaKX6wy9wW1cGGaj6zJ57w9ZTiGSXZxckrCxCvY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1dc471e62bcacb66711f84b5455f0d6fd4cfc5bf",
+        "rev": "9de975629786bbea712a4b4b3ddd1cff72500e2f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9de97562`](https://github.com/nix-community/NUR/commit/9de975629786bbea712a4b4b3ddd1cff72500e2f) | `automatic update` |