### PR TITLE
chore(flake/nur): `9de97562` -> `835f1017`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677380976,
-        "narHash": "sha256-uGhWAaKX6wy9wW1cGGaj6zJ57w9ZTiGSXZxckrCxCvY=",
+        "lastModified": 1677381663,
+        "narHash": "sha256-NllU41ItDjKMaxXT8XIwjDMZ1RNsGK+Jh8SPhN0z6WQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9de975629786bbea712a4b4b3ddd1cff72500e2f",
+        "rev": "835f1017e6a3c4a9db4d171652d9b6187d8c0501",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`835f1017`](https://github.com/nix-community/NUR/commit/835f1017e6a3c4a9db4d171652d9b6187d8c0501) | `automatic update` |