### PR TITLE
chore(flake/nur): `835f1017` -> `98ece127`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677381663,
-        "narHash": "sha256-NllU41ItDjKMaxXT8XIwjDMZ1RNsGK+Jh8SPhN0z6WQ=",
+        "lastModified": 1677383307,
+        "narHash": "sha256-7Xm2jl8Pk0lbNYO3J//L/ToHMCPa+BR57iOFi6yaL14=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "835f1017e6a3c4a9db4d171652d9b6187d8c0501",
+        "rev": "98ece127a5b790aa56635034613a0ab72f6b9fe3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`98ece127`](https://github.com/nix-community/NUR/commit/98ece127a5b790aa56635034613a0ab72f6b9fe3) | `automatic update` |
| [`8686505c`](https://github.com/nix-community/NUR/commit/8686505c76b3feaa339c1843d7a3451131fea5f6) | `automatic update` |