### PR TITLE
chore(flake/home-manager): `664945b3` -> `693d76ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -446,11 +446,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677276957,
-        "narHash": "sha256-/vhdNhQj2CWgqdfD2KLEZWDleOfen0t2EiaGiyivnJU=",
+        "lastModified": 1677400245,
+        "narHash": "sha256-+/oDZltWUhYFYcIRjH0F5lSNWcBj+4o5kzmDSheiLRw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "664945b3e09b4551c4e63e16efebd493cf5eac74",
+        "rev": "693d76eeb84124cc3110793ff127aeab3832f95c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`693d76ee`](https://github.com/nix-community/home-manager/commit/693d76eeb84124cc3110793ff127aeab3832f95c) | `programs.gpg: update references to respective manpages (#3648)` |