### PR TITLE
chore(flake/nur): `757744d8` -> `4ccc52b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677400920,
-        "narHash": "sha256-s+Now//Yr9KTpJnD2AcRA6jxE2eFJ5ETy4srg4kxlfU=",
+        "lastModified": 1677413983,
+        "narHash": "sha256-5hoT4n1E1rPoOtqCJA9twNsjPLcLOdvjLPga9wZBHbI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "757744d8d4d4c87d32d669572da135fd1b4bcd14",
+        "rev": "4ccc52b49ff2719b1d8a97b61d9d7b32487829ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4ccc52b4`](https://github.com/nix-community/NUR/commit/4ccc52b49ff2719b1d8a97b61d9d7b32487829ff) | `automatic update` |