### PR TITLE
chore(flake/nur): `4ccc52b4` -> `1656be40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677413983,
-        "narHash": "sha256-5hoT4n1E1rPoOtqCJA9twNsjPLcLOdvjLPga9wZBHbI=",
+        "lastModified": 1677423332,
+        "narHash": "sha256-UNPqTy3zY6LlIZ/5CXw5xXTwP7fy/Di3HuK2spsqJng=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ccc52b49ff2719b1d8a97b61d9d7b32487829ff",
+        "rev": "1656be4011d65537bf82ab140c6190b9f57fdb21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                              |
| -------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`bc43001b`](https://github.com/nix-community/NUR/commit/bc43001bc4f79880836bc567cf9fae046322e788) | `automatic update`                          |
| [`2c648503`](https://github.com/nix-community/NUR/commit/2c648503e3d6bfdb0898aa1b57896a15b9f58a8f) | `automatic update`                          |
| [`97151c03`](https://github.com/nix-community/NUR/commit/97151c038ae5b1b55cdeda4428f6d5951bf470c5) | `automatic update`                          |
| [`538de0f5`](https://github.com/nix-community/NUR/commit/538de0f584a53797c241bb74a28c3e900efc47b9) | `add Ruixi-rebirth/nur-packages repository` |