### PR TITLE
chore(flake/nur): `1656be40` -> `ca760724`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677423332,
-        "narHash": "sha256-UNPqTy3zY6LlIZ/5CXw5xXTwP7fy/Di3HuK2spsqJng=",
+        "lastModified": 1677424397,
+        "narHash": "sha256-+MK5ELi7j+9Fj/pgkaHcboWf6gZxPpbA75THy3rh34I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1656be4011d65537bf82ab140c6190b9f57fdb21",
+        "rev": "ca7607240445b215f079d7d8b59b67bf648b50d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                         |
| -------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`ca760724`](https://github.com/nix-community/NUR/commit/ca7607240445b215f079d7d8b59b67bf648b50d6) | `automatic update`                     |
| [`95f3af67`](https://github.com/nix-community/NUR/commit/95f3af67ab0cbec73b24e7926441a6363498cd12) | `automatic update`                     |
| [`712120f1`](https://github.com/nix-community/NUR/commit/712120f1cfaa3c4fce6343a30b8be309723bbb6c) | `add etu repository`                   |
| [`1c3303cc`](https://github.com/nix-community/NUR/commit/1c3303ccae48601ec3f9084e93c0e5c281183363) | `README.md: fix typo, errror -> error` |