### PR TITLE
chore(flake/nur): `ca760724` -> `dc7222b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677424397,
-        "narHash": "sha256-+MK5ELi7j+9Fj/pgkaHcboWf6gZxPpbA75THy3rh34I=",
+        "lastModified": 1677433483,
+        "narHash": "sha256-PLV1VCyIqry9ic2GLX+dcnxXmgcEf0hJBUhkIGtwaYA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ca7607240445b215f079d7d8b59b67bf648b50d6",
+        "rev": "dc7222b5d6059203c01d84cde33023c8e5a7108d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`dc7222b5`](https://github.com/nix-community/NUR/commit/dc7222b5d6059203c01d84cde33023c8e5a7108d) | `automatic update` |