### PR TITLE
chore(flake/nixos-hardware): `2d440157` -> `c8e047a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -525,11 +525,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1677232326,
-        "narHash": "sha256-rAk2/80kLvA3yIMmSV86T1B4kNvwCFMSQ1FxXndaUB0=",
+        "lastModified": 1677438522,
+        "narHash": "sha256-Zrvu7wDCShTjuBLw1RnJDQnTrhxKyUJRvJTzF5dss0k=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "2d44015779cced4eec9df5b8dab238b9f6312cb2",
+        "rev": "c8e047a2333e40e678c90c6e50334af2b4ca7655",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                            |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`c0effe66`](https://github.com/NixOS/nixos-hardware/commit/c0effe665880b91e373ee0c7468e256805e8157a) | `Add profile for Dell XPS 15 7590 NVIDIA` |
| [`c37aed23`](https://github.com/NixOS/nixos-hardware/commit/c37aed2394f54568f5e3d56a7c61133672422eb8) | `Add NVIDIA config for Dell XPS 15 7590`  |