### PR TITLE
chore(flake/nixos-hardware): `c8e047a2` -> `2a483ad9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -525,11 +525,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1677438522,
-        "narHash": "sha256-Zrvu7wDCShTjuBLw1RnJDQnTrhxKyUJRvJTzF5dss0k=",
+        "lastModified": 1677440795,
+        "narHash": "sha256-Kmjr95L42iioTItuA6nKCaObAXQvgRTPmj+62dx5OZg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "c8e047a2333e40e678c90c6e50334af2b4ca7655",
+        "rev": "2a483ad9cd2d931ab52cd5f897c447beb8328bed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                         |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`4bf15d3d`](https://github.com/NixOS/nixos-hardware/commit/4bf15d3dfd6ae9a1e2c6389fae0b5d7a16f639bf) | `Enable thermald for Dell XPS 15 7590` |