### PR TITLE
chore(flake/nur): `431361ea` -> `495702b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677440685,
-        "narHash": "sha256-dFO3dHHPbm5cTluC9MIYywZDg633Oqoiz7HVpct+mho=",
+        "lastModified": 1677444387,
+        "narHash": "sha256-1BqEJH0RvsrgmIqEXgrj730I1/yo80y0/CJUsH7ZyJo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "431361ea015ef094b8035d0729e1b493048e3b81",
+        "rev": "495702b4207b66536365e4296bbac896074354ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`495702b4`](https://github.com/nix-community/NUR/commit/495702b4207b66536365e4296bbac896074354ef) | `automatic update` |