### PR TITLE
chore(flake/nur): `46b3c1b6` -> `46c75c11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677461185,
-        "narHash": "sha256-ZaR0UZoqweLjVWoZfqkpDHmTsi2Dvfo5L6J8RQncxbY=",
+        "lastModified": 1677469568,
+        "narHash": "sha256-lLE5ZMRn9iI2pIrY8815jtORwio2O1XIEhrDLtciItQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "46b3c1b656f1161b10aa12b79bbba308606d9ec1",
+        "rev": "46c75c11e58a78d99f0addd703b978f284a463a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`46c75c11`](https://github.com/nix-community/NUR/commit/46c75c11e58a78d99f0addd703b978f284a463a0) | `automatic update` |