### PR TITLE
chore(flake/nur): `ecb1c7f6` -> `a47f21df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677471031,
-        "narHash": "sha256-i9p9ZX2WmIV8f1KHB6p3dTm96wBIf7ceRvX3ReZo/o8=",
+        "lastModified": 1677478541,
+        "narHash": "sha256-RDxVq/KGs5pHPb3tpEa7RzgzD8OZwDkNlw9LQaeJ8gA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ecb1c7f696d20bd15f2b327652381b183ca48994",
+        "rev": "a47f21df7986889b33e58fd8e2c3c6e8a1a25d23",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message      |
| -------------------------------------------------------------------------------------------------- | ------------------- |
| [`a47f21df`](https://github.com/nix-community/NUR/commit/a47f21df7986889b33e58fd8e2c3c6e8a1a25d23) | `automatic update`  |
| [`a5e580be`](https://github.com/nix-community/NUR/commit/a5e580be250549dd0ace2512a419939e3aed5b56) | `Update repos.json` |