### PR TITLE
chore(flake/nur): `a47f21df` -> `daa38f09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677478541,
-        "narHash": "sha256-RDxVq/KGs5pHPb3tpEa7RzgzD8OZwDkNlw9LQaeJ8gA=",
+        "lastModified": 1677481183,
+        "narHash": "sha256-RGyoDav/1t3ExP/iHg4NTv0XstaZfQbhyUcYAG/2RRU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a47f21df7986889b33e58fd8e2c3c6e8a1a25d23",
+        "rev": "daa38f090e64367c1584490d2e812a2b3e72b85d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`daa38f09`](https://github.com/nix-community/NUR/commit/daa38f090e64367c1584490d2e812a2b3e72b85d) | `automatic update` |
| [`029a0ab7`](https://github.com/nix-community/NUR/commit/029a0ab71443d125ee1b21c9a54f84d18828a91c) | `automatic update` |