### PR TITLE
chore(flake/nur): `daa38f09` -> `03f31122`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677481183,
-        "narHash": "sha256-RGyoDav/1t3ExP/iHg4NTv0XstaZfQbhyUcYAG/2RRU=",
+        "lastModified": 1677482476,
+        "narHash": "sha256-1bz6XZziExkXb7UgCg//eAsoYmqmszIkz8lx4uHY/ms=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "daa38f090e64367c1584490d2e812a2b3e72b85d",
+        "rev": "03f31122668db42b46e08d06d7513e83cae315a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`03f31122`](https://github.com/nix-community/NUR/commit/03f31122668db42b46e08d06d7513e83cae315a9) | `automatic update` |