### PR TITLE
chore(flake/nur): `03f31122` -> `d7eb6151`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677482476,
-        "narHash": "sha256-1bz6XZziExkXb7UgCg//eAsoYmqmszIkz8lx4uHY/ms=",
+        "lastModified": 1677494813,
+        "narHash": "sha256-Urv0rmcI+69mhQ4uw+/VcsVSJTtNTdkYoY8Ney54mCQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "03f31122668db42b46e08d06d7513e83cae315a9",
+        "rev": "d7eb615188daa97dac674034d304fc052b9fa044",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d7eb6151`](https://github.com/nix-community/NUR/commit/d7eb615188daa97dac674034d304fc052b9fa044) | `automatic update` |
| [`2d725a69`](https://github.com/nix-community/NUR/commit/2d725a690f808f90664e47ae048304ad43eb7fe1) | `automatic update` |