### PR TITLE
chore(flake/nur): `d7eb6151` -> `bebe11dc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677494813,
-        "narHash": "sha256-Urv0rmcI+69mhQ4uw+/VcsVSJTtNTdkYoY8Ney54mCQ=",
+        "lastModified": 1677498393,
+        "narHash": "sha256-98lmY0UYnsAKpdzpZtxA0lQi0+tCvvrQGw23aSvh9N8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d7eb615188daa97dac674034d304fc052b9fa044",
+        "rev": "bebe11dc49a62a8b1c0edbd07de8e6b9886228cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`bebe11dc`](https://github.com/nix-community/NUR/commit/bebe11dc49a62a8b1c0edbd07de8e6b9886228cf) | `automatic update` |