### PR TITLE
chore(flake/nur): `bebe11dc` -> `bb5046d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677498393,
-        "narHash": "sha256-98lmY0UYnsAKpdzpZtxA0lQi0+tCvvrQGw23aSvh9N8=",
+        "lastModified": 1677500098,
+        "narHash": "sha256-NJKdmPAXdFi+1TGZU0CYnIQXPtq4eSELb9szUvPzhzo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bebe11dc49a62a8b1c0edbd07de8e6b9886228cf",
+        "rev": "bb5046d43cf0f481e27202b2083172b76315e3a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`bb5046d4`](https://github.com/nix-community/NUR/commit/bb5046d43cf0f481e27202b2083172b76315e3a6) | `automatic update` |