### PR TITLE
chore(flake/home-manager): `bf76afbb` -> `635bbcdd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -446,11 +446,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677437727,
-        "narHash": "sha256-1BoofKqPT08sLCtm2hzABocYrSwkc8GtmeDuvrIXdjc=",
+        "lastModified": 1677499486,
+        "narHash": "sha256-1QbZfuF+3ACjb22ZTZ1nlCTNCvY370g0D6cPEDZk0CI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bf76afbb06b77237507b5279d0d555e05b5cc7f7",
+        "rev": "635bbcdd6f8e11799f31d004f933fdb9cd3fff5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`635bbcdd`](https://github.com/nix-community/home-manager/commit/635bbcdd6f8e11799f31d004f933fdb9cd3fff5d) | ``modules/git: make options passed to `less(1)` for `diff-so-fancy` configurable (#3704)`` |