### PR TITLE
chore(flake/nur): `5a7a3044` -> `95e5b3b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677512767,
-        "narHash": "sha256-/raxglvz1g/MiWVsKuFUZIsK3wjLITlPYm6MiB7sX20=",
+        "lastModified": 1677516954,
+        "narHash": "sha256-14ZNKbEwLNiWOAcE3PgWPFzpTUztpxEX9GH2QgIC8DA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5a7a304487f3d2ed30ea26f67605ff4c0378e04f",
+        "rev": "95e5b3b4b68a5abe3f19e647f34107ff9fe26c30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`95e5b3b4`](https://github.com/nix-community/NUR/commit/95e5b3b4b68a5abe3f19e647f34107ff9fe26c30) | `automatic update` |