### PR TITLE
chore(flake/nur): `95e5b3b4` -> `4b1aca84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677516954,
-        "narHash": "sha256-14ZNKbEwLNiWOAcE3PgWPFzpTUztpxEX9GH2QgIC8DA=",
+        "lastModified": 1677534402,
+        "narHash": "sha256-EdgUCJZXaOKzG/QqcxwSTQkNaiUqdoiPmqLH/oD8g04=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "95e5b3b4b68a5abe3f19e647f34107ff9fe26c30",
+        "rev": "4b1aca8474b496171843a7588827000775e5dc0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`4b1aca84`](https://github.com/nix-community/NUR/commit/4b1aca8474b496171843a7588827000775e5dc0e) | `automatic update` |