### PR TITLE
chore(flake/nur): `4b1aca84` -> `9779dbeb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677534402,
-        "narHash": "sha256-EdgUCJZXaOKzG/QqcxwSTQkNaiUqdoiPmqLH/oD8g04=",
+        "lastModified": 1677537724,
+        "narHash": "sha256-iMTNTV8A8HSM4zKxBc7xrYINfhpbNoVMmw4K0n+U3lE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4b1aca8474b496171843a7588827000775e5dc0e",
+        "rev": "9779dbeb87d1af7147c0f18339818150aea3c157",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`9779dbeb`](https://github.com/nix-community/NUR/commit/9779dbeb87d1af7147c0f18339818150aea3c157) | `automatic update` |