### PR TITLE
chore(flake/nur): `9779dbeb` -> `60252bbf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677537724,
-        "narHash": "sha256-iMTNTV8A8HSM4zKxBc7xrYINfhpbNoVMmw4K0n+U3lE=",
+        "lastModified": 1677541496,
+        "narHash": "sha256-awtojyequg6dgTANUliNFQosXGND5y4Dnd2D/Utw65Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9779dbeb87d1af7147c0f18339818150aea3c157",
+        "rev": "60252bbf8bb32a6856c1de4adc772bfe6a1c3d93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`60252bbf`](https://github.com/nix-community/NUR/commit/60252bbf8bb32a6856c1de4adc772bfe6a1c3d93) | `automatic update` |