### PR TITLE
chore(flake/nur): `60252bbf` -> `3a44df6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677541496,
-        "narHash": "sha256-awtojyequg6dgTANUliNFQosXGND5y4Dnd2D/Utw65Y=",
+        "lastModified": 1677552313,
+        "narHash": "sha256-Em7bk/BUjU5I65EcdXqKaNg1pooqZ4lxs/cbAANfpIk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "60252bbf8bb32a6856c1de4adc772bfe6a1c3d93",
+        "rev": "3a44df6f2874e4e39ee13f03c92769e37e92f689",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`3a44df6f`](https://github.com/nix-community/NUR/commit/3a44df6f2874e4e39ee13f03c92769e37e92f689) | `automatic update` |