### PR TITLE
chore(flake/nur): `cd23dc0a` -> `d868fb89`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677554129,
-        "narHash": "sha256-IcIHbTSvnXmuLKHJNSoVnMxhx0NlrL6aDS4zIIZNMf8=",
+        "lastModified": 1677556544,
+        "narHash": "sha256-ovD0wtZFEoukrJDCbG3MlmtLtU2kfA+QzacOpO5MdUU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cd23dc0ae321f0ec2aee586435218583d4f9ca9c",
+        "rev": "d868fb8917694d695dcd9d88cf4b40c8eefd1677",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`d868fb89`](https://github.com/nix-community/NUR/commit/d868fb8917694d695dcd9d88cf4b40c8eefd1677) | `automatic update` |
| [`1ec16952`](https://github.com/nix-community/NUR/commit/1ec1695294543a5bc9dd4a2883958df4280fbe96) | `automatic update` |