### PR TITLE
chore(flake/nur): `d868fb89` -> `903c4f5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677556544,
-        "narHash": "sha256-ovD0wtZFEoukrJDCbG3MlmtLtU2kfA+QzacOpO5MdUU=",
+        "lastModified": 1677569824,
+        "narHash": "sha256-/AEGqmFNZUxChy8H921AiNGoLPEBf2IfK+/6fTTMUyA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d868fb8917694d695dcd9d88cf4b40c8eefd1677",
+        "rev": "903c4f5fe3566cf25dee33a4b1e87620fdfbe1ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`903c4f5f`](https://github.com/nix-community/NUR/commit/903c4f5fe3566cf25dee33a4b1e87620fdfbe1ea) | `automatic update` |
| [`6ce88798`](https://github.com/nix-community/NUR/commit/6ce88798bd57a379d9afcb77d45279fb67ae138b) | `automatic update` |