### PR TITLE
chore(flake/sops-nix): `83fe25c8` -> `a0fb6ed1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -619,11 +619,11 @@
     },
     "nixpkgs-stable_4": {
       "locked": {
-        "lastModified": 1677367679,
-        "narHash": "sha256-pOMXi7F9tcHls06Qv+7XCPASTJeXu47Jhd0Pk9du8T4=",
+        "lastModified": 1677560965,
+        "narHash": "sha256-Tqwt5alTtMnbYUPKCYRYZqlfbjprLgDWqjMhXpFMQ6k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ea736343e4d4a052e023d54b23334cf685de479c",
+        "rev": "40968a3aa489191cf4b7ba85cf2a54d8a75c8daa",
         "type": "github"
       },
       "original": {
@@ -900,11 +900,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1677381477,
-        "narHash": "sha256-NLzWgll+Q0Af8gI1ha34OHt7Y1GtOMYhCWQWV9LXE9Y=",
+        "lastModified": 1677573918,
+        "narHash": "sha256-fx8+LgLNXF1lUv9j/cqxpDzFfYGB/wDy2qsq3Bk4pqU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "83fe25c8019db8216f5c6ffc65b394707784b4f3",
+        "rev": "a0fb6ed1b93b0b8dd2effb86678677eb30221450",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                                                          |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`4e50640b`](https://github.com/Mic92/sops-nix/commit/4e50640bac00be17e0469bbe800ee3dd2c3990d1) | `go: drop deprecated ioutil`                                            |
| [`8da6068e`](https://github.com/Mic92/sops-nix/commit/8da6068e916e46ab6bcbd0fcfdffea2d352454f1) | `bump go version`                                                       |
| [`c2776fac`](https://github.com/Mic92/sops-nix/commit/c2776fac5f6dfed1911f3cbd5c9bf8e0bc530d49) | `bump flakes`                                                           |
| [`4acf6638`](https://github.com/Mic92/sops-nix/commit/4acf66389b0ad6d449d41918870b865005a5c2b1) | `update vendorSha256`                                                   |
| [`7423f3fe`](https://github.com/Mic92/sops-nix/commit/7423f3fe9e2de181fda1fc1e3fd25593298a222b) | `Bump golang.org/x/sys from 0.0.0-20220708085239-5a0f0661e09d to 0.5.0` |