### PR TITLE
chore(flake/nixos-hardware): `2a483ad9` -> `dcbf93d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -525,11 +525,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1677440795,
-        "narHash": "sha256-Kmjr95L42iioTItuA6nKCaObAXQvgRTPmj+62dx5OZg=",
+        "lastModified": 1677574432,
+        "narHash": "sha256-1Aun3MQ5T/HCw1ClzAiY+6boLQNY8Cg6jTOILrLkaJs=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "2a483ad9cd2d931ab52cd5f897c447beb8328bed",
+        "rev": "dcbf93d500c54cfee7a7c854c4669d404236a821",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                        |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`4f1565e5`](https://github.com/NixOS/nixos-hardware/commit/4f1565e56d51907b9a7e234a4763b3b4f8f0e7dd) | `Remove override of WiFi module for Dell XPS 15 7590` |