### PR TITLE
chore(flake/sops-nix): `a0fb6ed1` -> `898fc4a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -900,11 +900,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1677573918,
-        "narHash": "sha256-fx8+LgLNXF1lUv9j/cqxpDzFfYGB/wDy2qsq3Bk4pqU=",
+        "lastModified": 1677574718,
+        "narHash": "sha256-QGP5KVa95B70gt+eeqA90XLqXakQzv+d8KeQLhATffU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "a0fb6ed1b93b0b8dd2effb86678677eb30221450",
+        "rev": "898fc4a434ebde01f2a8c7d0184bad872ea6b41c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                                                             |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`a75b5e09`](https://github.com/Mic92/sops-nix/commit/a75b5e093fe4aabbf87856efec80a83bb1bf08f5) | `Bump golang.org/x/crypto from 0.0.0-20220622213112-05595931fe9d to 0.6.0` |