### PR TITLE
chore(flake/nur): `35ce8711` -> `1380ea7c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677581318,
-        "narHash": "sha256-QL9qwTIV5nMtcbXgWfImeTedtnkX1mrgFoX5frY2CV8=",
+        "lastModified": 1677589680,
+        "narHash": "sha256-CjToE/2e+BY8RcOrgYRxhaCWyi778ww1E9Q5mh8mkCA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "35ce8711babd18d4f6b1c36cf77dbe7575095956",
+        "rev": "1380ea7c314d500441b8e4ec9e2dedc697f4c3a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message     |
| -------------------------------------------------------------------------------------------------- | ------------------ |
| [`1380ea7c`](https://github.com/nix-community/NUR/commit/1380ea7c314d500441b8e4ec9e2dedc697f4c3a9) | `automatic update` |