### PR TITLE
chore(flake/nixos-hardware): `dcbf93d5` -> `77de4cd0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -525,11 +525,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1677574432,
-        "narHash": "sha256-1Aun3MQ5T/HCw1ClzAiY+6boLQNY8Cg6jTOILrLkaJs=",
+        "lastModified": 1677591639,
+        "narHash": "sha256-DMlAyge+u3K+JOFLA5YfdjqagdAYJf29YGBWpy5izg4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "dcbf93d500c54cfee7a7c854c4669d404236a821",
+        "rev": "77de4cd09db4dbee9551ed2853cfcf113d7dc5ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`9fef72a2`](https://github.com/NixOS/nixos-hardware/commit/9fef72a2afd8f2e3b7a71e7af95fcab8f777d628) | `dell-xps-15-7590: enable fwupd and deep sleep`                    |
| [`d7a5d6a2`](https://github.com/NixOS/nixos-hardware/commit/d7a5d6a29abbc93fa2ee717dec08194d1db6f597) | `common/gpu/intel*: Migrate to common/gpu/intel/* and add disable` |