### PR TITLE
chore(flake/sops-nix): `898fc4a4` -> `27018a90`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -900,11 +900,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1677574718,
-        "narHash": "sha256-QGP5KVa95B70gt+eeqA90XLqXakQzv+d8KeQLhATffU=",
+        "lastModified": 1677594933,
+        "narHash": "sha256-qUoODrgbHRDKcg5r1Wsck01zIsJyKi/G4R2YAQafXPQ=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "898fc4a434ebde01f2a8c7d0184bad872ea6b41c",
+        "rev": "27018a9084006b8371b1f833882adfb85bd23004",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                                                          |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`cce10065`](https://github.com/Mic92/sops-nix/commit/cce10065eb87b6bbf2af2abd3db1325efe2678fc) | `bump vendorSha256`                                                     |
| [`0b7603d8`](https://github.com/Mic92/sops-nix/commit/0b7603d808c5e06c66e79459645a52fdfa237295) | `Bump golang.org/x/net from 0.0.0-20220706163947-c90051bbdb60 to 0.7.0` |