### PR TITLE
chore(flake/nur): `1380ea7c` -> `2555258b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677589680,
-        "narHash": "sha256-CjToE/2e+BY8RcOrgYRxhaCWyi778ww1E9Q5mh8mkCA=",
+        "lastModified": 1677597677,
+        "narHash": "sha256-kMzD7yM2CCufYGPeWnr/an34T/R+q0XhDc3ovRPnRAQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1380ea7c314d500441b8e4ec9e2dedc697f4c3a9",
+        "rev": "2555258bba1dd730da5f3a27240d6f526ee40c4e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                         |
| -------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`2555258b`](https://github.com/nix-community/NUR/commit/2555258bba1dd730da5f3a27240d6f526ee40c4e) | `automatic update`                     |
| [`7ff907b1`](https://github.com/nix-community/NUR/commit/7ff907b11d117c6a422949c406af008a0568e6c3) | `add liyangau/nur-packages repository` |