### PR TITLE
chore(flake/nur): `20798b5d` -> `26bf8e1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677603389,
-        "narHash": "sha256-UTWPoqml2DEif09RfO3waLSqdsEsPFNvTkL5RxZ8KS4=",
+        "lastModified": 1677768464,
+        "narHash": "sha256-vOTqJHhpLLspPpQTg+mT0aWHT8ahNpBQ0CtN/sN0a7M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "20798b5dc4491c701020d1897e09dbdfeb0b265b",
+        "rev": "26bf8e1b216994e462928f5ca65d62e368afb3a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`26bf8e1b`](https://github.com/nix-community/NUR/commit/26bf8e1b216994e462928f5ca65d62e368afb3a6) | `` automatic update `` |
| [`45fff32e`](https://github.com/nix-community/NUR/commit/45fff32e171ddaa8e250be6205f7331ad4bc5fa8) | `` automatic update `` |
| [`9ed74cb1`](https://github.com/nix-community/NUR/commit/9ed74cb17ad9cae04afd4745dc06fbea72981c5c) | `` automatic update `` |
| [`43b3d068`](https://github.com/nix-community/NUR/commit/43b3d068d77851cd9c4c976e4433b4945b9e21c8) | `` automatic update `` |
| [`cd9b4447`](https://github.com/nix-community/NUR/commit/cd9b444723fa6231c2fc4277efcea9a4dffb0ced) | `` automatic update `` |
| [`3316130f`](https://github.com/nix-community/NUR/commit/3316130f522e182e601bf7f47c73b07b3ae3a1dd) | `` automatic update `` |
| [`93355830`](https://github.com/nix-community/NUR/commit/93355830fc68eebf766f28c76c247977c1a6efcb) | `` automatic update `` |
| [`0ed2dfb6`](https://github.com/nix-community/NUR/commit/0ed2dfb612571bec41b21349933c141d7f5706ac) | `` automatic update `` |
| [`bb75c526`](https://github.com/nix-community/NUR/commit/bb75c52671ad6729b75de2bdb19ed12dc01eed49) | `` automatic update `` |
| [`7801982b`](https://github.com/nix-community/NUR/commit/7801982b04c6c7c6a30e4cc6b96c1403853424ee) | `` automatic update `` |
| [`84eb4f31`](https://github.com/nix-community/NUR/commit/84eb4f31d9e9cf9c3c9d560c1d9cb0e1044a8064) | `` automatic update `` |
| [`d5b688e2`](https://github.com/nix-community/NUR/commit/d5b688e216d97c438896d631e89e27dc66d5e28d) | `` automatic update `` |
| [`ad4928ad`](https://github.com/nix-community/NUR/commit/ad4928adc9c7e0205cd924b5250ecbb12547886e) | `` automatic update `` |
| [`7fc717a3`](https://github.com/nix-community/NUR/commit/7fc717a348f793cb7aae84a998d22abecfdf7280) | `` automatic update `` |
| [`23dc343c`](https://github.com/nix-community/NUR/commit/23dc343c9ef9bd61ccda66f84c6be5acc7e1171f) | `` automatic update `` |
| [`e2144c92`](https://github.com/nix-community/NUR/commit/e2144c92d40e82258b37be8928471f4583a8cbc3) | `` automatic update `` |
| [`78ce352a`](https://github.com/nix-community/NUR/commit/78ce352a7c738331d5e8549890fd76e3d410164a) | `` automatic update `` |
| [`458246a5`](https://github.com/nix-community/NUR/commit/458246a5098156e4d8be62de85a03feec6a2e4fe) | `` automatic update `` |
| [`6f0fe109`](https://github.com/nix-community/NUR/commit/6f0fe10949c4e40dc9b992176c874fdd748458cc) | `` automatic update `` |
| [`f8d97768`](https://github.com/nix-community/NUR/commit/f8d977683096512ca4290a5a8965b20f1a7224cc) | `` automatic update `` |
| [`e8767c28`](https://github.com/nix-community/NUR/commit/e8767c28a57bf8278f6a1047f465ba8cb1ac454e) | `` automatic update `` |
| [`471f23c2`](https://github.com/nix-community/NUR/commit/471f23c2b9cbfaf0384cc0e456cc27823e30ba09) | `` automatic update `` |