### PR TITLE
chore(flake/flake-utils): `5aed5285` -> `3db36a8b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -365,11 +365,11 @@
     },
     "flake-utils_3": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                  |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`3db36a8b`](https://github.com/numtide/flake-utils/commit/3db36a8b464d0c4532ba1c7dda728f4576d6d073) | `` Bump cachix/install-nix-action from 18 to 19 (#87) `` |