### PR TITLE
chore(flake/pre-commit-hooks): `ab608394` -> `61a35116`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -778,11 +778,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1675688762,
-        "narHash": "sha256-oit/SxMk0B380ASuztBGQLe8TttO1GJiXF8aZY9AYEc=",
+        "lastModified": 1677722096,
+        "narHash": "sha256-7mjVMvCs9InnrRybBfr5ohqcOz+pyEX8m22C1XsDilg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ab608394886fb04b8a5df3cb0bab2598400e3634",
+        "rev": "61a3511668891c68ebd19d40122150b98dc2fe3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                  |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
| [`f3ec38af`](https://github.com/cachix/pre-commit-hooks.nix/commit/f3ec38af440d08447929c62e8eed6426c04dd676) | `` chore(deps): bump cachix/install-nix-action from 19 to 20 ``          |
| [`f15232b7`](https://github.com/cachix/pre-commit-hooks.nix/commit/f15232b739b4f9c684991f1a50aef10e5d93fa3b) | `` options: add fail_fast and require_serial ``                          |
| [`ca42ec27`](https://github.com/cachix/pre-commit-hooks.nix/commit/ca42ec27cd5085063e712fc087730d35e60b1d5a) | `` [fix] do not try to access the internet when running cargo clippy ``  |
| [`d71e3d75`](https://github.com/cachix/pre-commit-hooks.nix/commit/d71e3d75ec0cc37d180238bfddd79b79ef02f177) | `` [feat] change usage of direnv to using nix-direnv instead of lorri `` |
| [`6b678da4`](https://github.com/cachix/pre-commit-hooks.nix/commit/6b678da4433ec0396de04da0c7026ce159b9449f) | `` add zprint ``                                                         |
| [`071c0ebe`](https://github.com/cachix/pre-commit-hooks.nix/commit/071c0ebed5c2b89b16090fea8d909084c2ad25fd) | `` latexindent: fix unknown command line option ``                       |
| [`d3b49e72`](https://github.com/cachix/pre-commit-hooks.nix/commit/d3b49e724549b7a83ae06d37f60a43998f02f453) | `` Add LaTeX pre-commit hooks to README ``                               |
| [`1e29fe23`](https://github.com/cachix/pre-commit-hooks.nix/commit/1e29fe23a76ccc3a54dcc7526127992737c7c6b2) | `` Add luacheck to README ``                                             |
| [`6727e1dd`](https://github.com/cachix/pre-commit-hooks.nix/commit/6727e1dd751125a59a60dd017f2649aa497c585c) | `` Add taplo fmt ``                                                      |
| [`2df88654`](https://github.com/cachix/pre-commit-hooks.nix/commit/2df88654ab016e36fbe99018dc2768a2256cfff5) | `` chore(deps): bump cachix/install-nix-action from 18 to 19 ``          |
| [`dc1c6013`](https://github.com/cachix/pre-commit-hooks.nix/commit/dc1c60138d190fecb08e306dda19ae1851194ba0) | `` Typo ``                                                               |
| [`4a7e21d5`](https://github.com/cachix/pre-commit-hooks.nix/commit/4a7e21d5a9fa7a4a5fc4c13d8dfcbaefccbea147) | `` Add a `dune/opam sync` hook ``                                        |
| [`9c637c9f`](https://github.com/cachix/pre-commit-hooks.nix/commit/9c637c9fe4d993c0ad77fa9658826273368140c6) | `` Add an `ocp-indent` hook ``                                           |
| [`57dd8898`](https://github.com/cachix/pre-commit-hooks.nix/commit/57dd88987b6b78a5013b7956fdcfc866ba69758b) | `` Mention `opam-lint` hook in README ``                                 |
| [`ee2ee47b`](https://github.com/cachix/pre-commit-hooks.nix/commit/ee2ee47bd77b98576ecea31c528d385c7a377ea1) | `` Add `opam lint` hook ``                                               |