### PR TITLE
chore(flake/dendrite-demo-pinecone): `e3722847` -> `30aca111`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
     "dendrite": {
       "flake": false,
       "locked": {
-        "lastModified": 1676903325,
-        "narHash": "sha256-m3nPbmqp3m9+rbLkn//RhpzBAp2qwX6VTDT2VA0jkrs=",
+        "lastModified": 1677594953,
+        "narHash": "sha256-fRG7SBPxttO+uaD+jpdz/6XfbzfD2MTSJZiorW8uEyc=",
         "owner": "matrix-org",
         "repo": "dendrite",
-        "rev": "c8ca23acdb0f80a01dfcd9babe6fff5abb372279",
+        "rev": "f1ccfcf1504c27cbaaecbc28ec26299d785d2695",
         "type": "github"
       },
       "original": {
@@ -159,11 +159,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1676904085,
-        "narHash": "sha256-B0+jYJDzthMEshSDi/ouN9rzKqEmQA1jwDvQOSi6KzI=",
+        "lastModified": 1677782475,
+        "narHash": "sha256-gkoTfE79+/Bdrnz4I2ypfYQypJ4CNX7tzrt080jA8IE=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "e372284799b71a2028891e0e4c082d1fac962e44",
+        "rev": "30aca111f1345d55fd6054f4a43726ef3e2da3c5",
         "type": "github"
       },
       "original": {
@@ -635,11 +635,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1676790509,
-        "narHash": "sha256-W9uWAWokgS8US8rJf79qBLS2M+ZgIscfoz+KsNE7VGQ=",
+        "lastModified": 1677534593,
+        "narHash": "sha256-PuZSAHeq4/9pP/uYH1FcagQ3nLm/DrDrvKi/xC9glvw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a1291d0d020a200c7ce3c48e96090bfa4890a475",
+        "rev": "3ad64d9e2d5bf80c877286102355b1625891ae9a",
         "type": "github"
       },
       "original": {
@@ -756,11 +756,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1676879534,
-        "narHash": "sha256-HU4RXcwsAX1u7AUbGOBDxkYQkeODcn+HZjXqKa1y/hk=",
+        "lastModified": 1677160285,
+        "narHash": "sha256-tBzpCjMP+P3Y3nKLYvdBkXBg3KvTMo3gvi8tLQaqXVY=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "c9495f017f67a11e9c9909b032dc7762dfc853cf",
+        "rev": "2bd861ab81469428d9c823ef72c4bb08372dd2c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                  |
| --------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`30aca111`](https://github.com/bbigras/dendrite-demo-pinecone/commit/30aca111f1345d55fd6054f4a43726ef3e2da3c5) | `` flake.lock: Update `` |