### PR TITLE
chore(flake/nur): `26bf8e1b` -> `2d1f6058`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677768464,
-        "narHash": "sha256-vOTqJHhpLLspPpQTg+mT0aWHT8ahNpBQ0CtN/sN0a7M=",
+        "lastModified": 1677786398,
+        "narHash": "sha256-EfZ7uZNcTbXi+zhbWOeW2a0/nuQG5xhS0LtS59a76Cc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "26bf8e1b216994e462928f5ca65d62e368afb3a6",
+        "rev": "2d1f6058a4a7c6a3aeb69e00a6a961b18ca9e103",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2d1f6058`](https://github.com/nix-community/NUR/commit/2d1f6058a4a7c6a3aeb69e00a6a961b18ca9e103) | `` automatic update `` |