### PR TITLE
chore(flake/dendrite-demo-pinecone): `30aca111` -> `65efe783`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -159,11 +159,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1677782475,
-        "narHash": "sha256-gkoTfE79+/Bdrnz4I2ypfYQypJ4CNX7tzrt080jA8IE=",
+        "lastModified": 1677790295,
+        "narHash": "sha256-uDpk9d++Mc1EQgGbMe20bD6DF/la+DwvMrS9nVVvfUc=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "30aca111f1345d55fd6054f4a43726ef3e2da3c5",
+        "rev": "65efe783660c66d39f31b0f42f1cb2d1052d4318",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                         |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`65efe783`](https://github.com/bbigras/dendrite-demo-pinecone/commit/65efe783660c66d39f31b0f42f1cb2d1052d4318) | `` chore(deps): bump cachix/install-nix-action from 18 to 20 `` |