### PR TITLE
chore(flake/nur): `2d1f6058` -> `6a0104e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677786398,
-        "narHash": "sha256-EfZ7uZNcTbXi+zhbWOeW2a0/nuQG5xhS0LtS59a76Cc=",
+        "lastModified": 1677793608,
+        "narHash": "sha256-RKaI/8eGSsTmcc160I5SRZQOSUy2gDy3/c6CDHOHjSI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2d1f6058a4a7c6a3aeb69e00a6a961b18ca9e103",
+        "rev": "6a0104e77878ab7a5ecf892af204652fb68d022d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6a0104e7`](https://github.com/nix-community/NUR/commit/6a0104e77878ab7a5ecf892af204652fb68d022d) | `` automatic update `` |