### PR TITLE
chore(flake/nur): `74c3d598` -> `f7069f86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677810156,
-        "narHash": "sha256-vGSQRfz6eXO5vuuiI+Njy2k53KhY9ero8qMnjvYxy0Y=",
+        "lastModified": 1677816699,
+        "narHash": "sha256-/EnPfiDuYmZXRnT7Z7Y1QW5IsOJQsDNvcCtpMvV0c9Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "74c3d598002a5db1c70cc07c20c970dd72b93d83",
+        "rev": "f7069f867c133196e39fab080fb8374ed5eda81e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f7069f86`](https://github.com/nix-community/NUR/commit/f7069f867c133196e39fab080fb8374ed5eda81e) | `` automatic update `` |