### PR TITLE
chore(flake/nur): `480130b4` -> `9b083d56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677822387,
-        "narHash": "sha256-3xCDPLsA9VCHE/KucSkle6OkozvSWbFloa9fbv3IU2c=",
+        "lastModified": 1677828239,
+        "narHash": "sha256-iPwLIeGnmCN6kMO8afAMBTF95To0ZI+nM2ZSoLoAqfM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "480130b4264c0f5f58a2fbf7c170ff81fb2179ac",
+        "rev": "9b083d56a313b6b25c926a9b06619fce1fa3d7e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9b083d56`](https://github.com/nix-community/NUR/commit/9b083d56a313b6b25c926a9b06619fce1fa3d7e7) | `` automatic update `` |