### PR TITLE
chore(flake/nur): `9b083d56` -> `12cab6ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677828239,
-        "narHash": "sha256-iPwLIeGnmCN6kMO8afAMBTF95To0ZI+nM2ZSoLoAqfM=",
+        "lastModified": 1677828933,
+        "narHash": "sha256-XMZ/obovXUX/6yDtHkwLIH5XSUKN8hxrm3qAJSKslMo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9b083d56a313b6b25c926a9b06619fce1fa3d7e7",
+        "rev": "12cab6ff5eb3992fa43269ee58c48bbe20734206",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`12cab6ff`](https://github.com/nix-community/NUR/commit/12cab6ff5eb3992fa43269ee58c48bbe20734206) | `` automatic update `` |