### PR TITLE
chore(flake/sops-nix): `27018a90` -> `128e9b29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -900,11 +900,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1677594933,
-        "narHash": "sha256-qUoODrgbHRDKcg5r1Wsck01zIsJyKi/G4R2YAQafXPQ=",
+        "lastModified": 1677833841,
+        "narHash": "sha256-yHZFGe7dhBE43FFWKiWc29NuveH+nfyTT6oKyFDEMys=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "27018a9084006b8371b1f833882adfb85bd23004",
+        "rev": "128e9b29ddd88ceb634a28f7dbbfee7b895f005f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`f78f64ec`](https://github.com/Mic92/sops-nix/commit/f78f64eccf253013687f68e5ec076707f420c53b) | `` phase out github literal in install instructions `` |