### PR TITLE
chore(flake/nur): `e85d61db` -> `dd11db8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677837380,
-        "narHash": "sha256-2+/DFU+U3ZmeI4+P1u6lFm9OwCbcjrW8ihduxpKkPq0=",
+        "lastModified": 1677848441,
+        "narHash": "sha256-6fmYeeiOPLVJwHMWoHaiE4Xf9aCmC3B7VE2ZZNVpIqc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e85d61dbe4a582a3e048fd01fbdc72ae39102a0b",
+        "rev": "dd11db8e8c5b06a8b422a71dc94f2d2c4301e4f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dd11db8e`](https://github.com/nix-community/NUR/commit/dd11db8e8c5b06a8b422a71dc94f2d2c4301e4f4) | `` automatic update `` |
| [`32d897fb`](https://github.com/nix-community/NUR/commit/32d897fbf92588d4466ae2592fde8168fec25a0f) | `` automatic update `` |