### PR TITLE
chore(flake/nur): `dd11db8e` -> `70ace91c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677848441,
-        "narHash": "sha256-6fmYeeiOPLVJwHMWoHaiE4Xf9aCmC3B7VE2ZZNVpIqc=",
+        "lastModified": 1677850338,
+        "narHash": "sha256-18+RrDq3quU077ds0ju4wjI60XdTWWx85GZa07pPJ+E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd11db8e8c5b06a8b422a71dc94f2d2c4301e4f4",
+        "rev": "70ace91c628daa5370983fc0faa916d8874965c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`70ace91c`](https://github.com/nix-community/NUR/commit/70ace91c628daa5370983fc0faa916d8874965c6) | `` automatic update `` |
| [`95585f93`](https://github.com/nix-community/NUR/commit/95585f937d227ebd765bf797947ea8d2ed37768e) | `` automatic update `` |