### PR TITLE
chore(flake/nur): `f7edcc15` -> `ff5c3501`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677851111,
-        "narHash": "sha256-m7DIv3YPrgTor8ZDO2jA9F5RuY/tRw/zNwAPJADJd5Y=",
+        "lastModified": 1677869343,
+        "narHash": "sha256-X374vzfPsGlDzimEKPT/yvo2TYRa0CF02mKbGc36548=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f7edcc15b8e485f70d1826b231f134391a315d90",
+        "rev": "ff5c35016fcb249d1af68db3dc81f4f83f13ba7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ff5c3501`](https://github.com/nix-community/NUR/commit/ff5c35016fcb249d1af68db3dc81f4f83f13ba7f) | `` automatic update `` |
| [`91a1b8c6`](https://github.com/nix-community/NUR/commit/91a1b8c6da5e934c850e8f989759cd095ace9659) | `` automatic update `` |