### PR TITLE
chore(flake/home-manager): `305daba4` -> `b9e3a298`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -446,11 +446,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677533532,
-        "narHash": "sha256-2Ie47MONhIFOxvbLmwhmCCe/IoVDVd7YnoK61vu5Xy8=",
+        "lastModified": 1677783711,
+        "narHash": "sha256-eq5mOVk3gv5HITtLhPjKwi8bFnOaQplA3X0WFgHnmxE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "305daba44a9df57738cffc67c08129005a25579a",
+        "rev": "b9e3a29864798d55ec1d6579ab97876bb1ee9664",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                      |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`b9e3a298`](https://github.com/nix-community/home-manager/commit/b9e3a29864798d55ec1d6579ab97876bb1ee9664) | `` recoll: fix generation of string lists ``                                 |
| [`547a3bc8`](https://github.com/nix-community/home-manager/commit/547a3bc8d464cb2a22e4cf0dbbb746f8c654151a) | `` git: allow tags to be unsigned when signing.signByDefault=true (#3479) `` |
| [`db1c2262`](https://github.com/nix-community/home-manager/commit/db1c22626ad1058834f043eae7d80bbf2a8e1532) | `` mako: programs.mako -> services.mako (#3265) ``                           |
| [`f8077880`](https://github.com/nix-community/home-manager/commit/f8077880359b72bbd290ee216b105f200a6f7cc7) | `` docs: add chapter on 3rd-party extensions ``                              |
| [`ef7d3165`](https://github.com/nix-community/home-manager/commit/ef7d316578367ed7732a21eede6c79546a36124f) | `` exa: always configure `exa` alias (#3721) ``                              |
| [`ddcbf676`](https://github.com/nix-community/home-manager/commit/ddcbf676ba422ae3dc0c386bc5001acbebbf0b0d) | `` specialization: fix `name` conflict inside NixOS module (#3718) ``        |
| [`9438e56a`](https://github.com/nix-community/home-manager/commit/9438e56a7b7df5e02091027dccdd8d86768f1a2d) | `` .github: pin nix 2.13 in workflows (#3720) ``                             |
| [`4bac3418`](https://github.com/nix-community/home-manager/commit/4bac34186886f8d484791702f32ec371f8c7a81e) | `` `exa`: add more options (#3505) ``                                        |