### PR TITLE
chore(flake/nur): `ff5c3501` -> `81d603dc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677869343,
-        "narHash": "sha256-X374vzfPsGlDzimEKPT/yvo2TYRa0CF02mKbGc36548=",
+        "lastModified": 1677872811,
+        "narHash": "sha256-uxc+muzj+iSFHk9mfCEBskxYAIkgeAQruL7EiA7hT2I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ff5c35016fcb249d1af68db3dc81f4f83f13ba7f",
+        "rev": "81d603dc582272fa2ce9424b727c6e4527bf8f20",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`81d603dc`](https://github.com/nix-community/NUR/commit/81d603dc582272fa2ce9424b727c6e4527bf8f20) | `` automatic update `` |