### PR TITLE
chore(flake/nur): `81d603dc` -> `ecf0789d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677872811,
-        "narHash": "sha256-uxc+muzj+iSFHk9mfCEBskxYAIkgeAQruL7EiA7hT2I=",
+        "lastModified": 1677876371,
+        "narHash": "sha256-/614mgqPw8ZPHoeBRWh7UTSENXIfi2bjMagXctAlFsY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "81d603dc582272fa2ce9424b727c6e4527bf8f20",
+        "rev": "ecf0789d737e5a90f5f2326302df6f33b303e210",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ecf0789d`](https://github.com/nix-community/NUR/commit/ecf0789d737e5a90f5f2326302df6f33b303e210) | `` automatic update `` |