### PR TITLE
chore(flake/emacs-overlay): `bc977d5c` -> `e962b871`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -224,11 +224,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677867078,
-        "narHash": "sha256-88QSWkOL6jSUBcrKyG13tirLvE4lZ+9iAiuQBvlFL48=",
+        "lastModified": 1677899304,
+        "narHash": "sha256-N4KP1zRvspQawpxFyvKvalO1tqV27rXpBolJlQ+xU2s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bc977d5c4f5c0463ac8f2bd13406625b80a18bae",
+        "rev": "e962b871a0b0984569506a576543eff8926d478f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`e962b871`](https://github.com/nix-community/emacs-overlay/commit/e962b871a0b0984569506a576543eff8926d478f) | `` Updated repos/melpa `` |
| [`978635af`](https://github.com/nix-community/emacs-overlay/commit/978635affa05e5e065d52b2d94d1f9dd9bd93e90) | `` Updated repos/emacs `` |