### PR TITLE
chore(flake/nur): `329fa18a` -> `57bcbccc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677895201,
-        "narHash": "sha256-xCKfoGO8VCB0YnOGV/nkBeRoMdSayLcFan5IFv2T+8U=",
+        "lastModified": 1677902146,
+        "narHash": "sha256-nypPgEbeO+VyUhnwwVE+KueLfye4Aob6Ei7SN5NQDf4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "329fa18ae539293d1c8561f496310db9fb976f84",
+        "rev": "57bcbccc60fb811395ca01ddef11bd2bf6f2f91c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`57bcbccc`](https://github.com/nix-community/NUR/commit/57bcbccc60fb811395ca01ddef11bd2bf6f2f91c) | `` automatic update `` |
| [`96a87126`](https://github.com/nix-community/NUR/commit/96a871262e43c6601e6d6de9c984cd413e3235ef) | `` automatic update `` |