### PR TITLE
chore(flake/nur): `57bcbccc` -> `152f4861`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677902146,
-        "narHash": "sha256-nypPgEbeO+VyUhnwwVE+KueLfye4Aob6Ei7SN5NQDf4=",
+        "lastModified": 1677903060,
+        "narHash": "sha256-g/D7Et2na+C3IBZaoVz9NGl+WNnRwcKmDU7Rbc+IPNg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "57bcbccc60fb811395ca01ddef11bd2bf6f2f91c",
+        "rev": "152f48615f3ac30c42e49acba2065af9b2c4b15d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`152f4861`](https://github.com/nix-community/NUR/commit/152f48615f3ac30c42e49acba2065af9b2c4b15d) | `` automatic update `` |