### PR TITLE
chore(flake/nur): `152f4861` -> `5a09f766`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677903060,
-        "narHash": "sha256-g/D7Et2na+C3IBZaoVz9NGl+WNnRwcKmDU7Rbc+IPNg=",
+        "lastModified": 1677937538,
+        "narHash": "sha256-NNQVDenK6rmUH9XkmarlzZff8X53KTd1J/cbnyAD01Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "152f48615f3ac30c42e49acba2065af9b2c4b15d",
+        "rev": "5a09f766566ae6f2b0137b102ffc9484283dfeda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5a09f766`](https://github.com/nix-community/NUR/commit/5a09f766566ae6f2b0137b102ffc9484283dfeda) | `` automatic update `` |
| [`3215cf98`](https://github.com/nix-community/NUR/commit/3215cf98266e610a56a0ef1ec3025c68ee396e69) | `` automatic update `` |
| [`b3c4aa39`](https://github.com/nix-community/NUR/commit/b3c4aa39dcdb6d08c05a507963d5074a7e6cd7c1) | `` automatic update `` |
| [`ffb6cce3`](https://github.com/nix-community/NUR/commit/ffb6cce3f833c4ff79dee2e4f154bc795811cdcf) | `` automatic update `` |