### PR TITLE
chore(flake/emacs-overlay): `6d54cfde` -> `2efd7c8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -224,11 +224,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677925058,
-        "narHash": "sha256-8Sd92ktTfxV7+3XJ2AVILU7dltWxu4jkh1EaWQsuC1k=",
+        "lastModified": 1677955337,
+        "narHash": "sha256-EKsucdkQfukG/2ArjjAipcz/Z+LYifkeY06LHONEBSg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6d54cfde44494da2396678d82bb61eeb0a3fa392",
+        "rev": "2efd7c8d60ce0750097bbd327ec083e3ce545b31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`2efd7c8d`](https://github.com/nix-community/emacs-overlay/commit/2efd7c8d60ce0750097bbd327ec083e3ce545b31) | `` Updated repos/melpa `` |
| [`fcb95481`](https://github.com/nix-community/emacs-overlay/commit/fcb95481fab79a0219de88deb44ba9e50932fa1c) | `` Updated repos/emacs `` |
| [`7a3a4e1b`](https://github.com/nix-community/emacs-overlay/commit/7a3a4e1b53e5ab8dfc037dd56382dc54cc46b0ac) | `` Updated repos/elpa ``  |