### PR TITLE
chore(flake/nur): `5a09f766` -> `82df3207`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677937538,
-        "narHash": "sha256-NNQVDenK6rmUH9XkmarlzZff8X53KTd1J/cbnyAD01Q=",
+        "lastModified": 1677959175,
+        "narHash": "sha256-AotkiE0UtXUlZbn9k4mpxMlmix0EdVLUFNh2sH41eSw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5a09f766566ae6f2b0137b102ffc9484283dfeda",
+        "rev": "82df3207ee43f53926db70a9139302b5444c1236",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`82df3207`](https://github.com/nix-community/NUR/commit/82df3207ee43f53926db70a9139302b5444c1236) | `` automatic update `` |