### PR TITLE
chore(flake/nur): `45042a60` -> `2860ab34`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677962693,
-        "narHash": "sha256-wENUjfaSjXmXiRcEBfhGcaHHnDch8bK2iMJHbRjzx/4=",
+        "lastModified": 1677966287,
+        "narHash": "sha256-t+lpOeHlAGCgjzS2JP/hSxdZRTFmzy5E8l+gbr4R4RY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "45042a60782a3d0f480c0fa15d840f369d6c3ad1",
+        "rev": "2860ab344d033a877e6a03f1c33cb4b7b5e05ddf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2860ab34`](https://github.com/nix-community/NUR/commit/2860ab344d033a877e6a03f1c33cb4b7b5e05ddf) | `` automatic update `` |