### PR TITLE
chore(flake/nur): `2860ab34` -> `9fdbb0a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677966287,
-        "narHash": "sha256-t+lpOeHlAGCgjzS2JP/hSxdZRTFmzy5E8l+gbr4R4RY=",
+        "lastModified": 1677973494,
+        "narHash": "sha256-9W9pQuXlq+A42t36KPfzjgZmwba8QdFP5/AHzeB4DWM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2860ab344d033a877e6a03f1c33cb4b7b5e05ddf",
+        "rev": "9fdbb0a9d6cd04ef3307328f0a93e3e14e16564e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9fdbb0a9`](https://github.com/nix-community/NUR/commit/9fdbb0a9d6cd04ef3307328f0a93e3e14e16564e) | `` automatic update `` |