### PR TITLE
chore(flake/nur): `9fdbb0a9` -> `5ce3b96e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677973494,
-        "narHash": "sha256-9W9pQuXlq+A42t36KPfzjgZmwba8QdFP5/AHzeB4DWM=",
+        "lastModified": 1677982081,
+        "narHash": "sha256-xRaDtIW/R8N2u2g9LiAxDjvVaqmM0V2s6cQxoh1Dk3w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9fdbb0a9d6cd04ef3307328f0a93e3e14e16564e",
+        "rev": "5ce3b96e3e529caf6176627dc725c43c3ca246e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5ce3b96e`](https://github.com/nix-community/NUR/commit/5ce3b96e3e529caf6176627dc725c43c3ca246e7) | `` automatic update `` |