### PR TITLE
chore(flake/nur): `64c55d9b` -> `8f7cc583`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677983493,
-        "narHash": "sha256-bsyuK3GtmN6A0486itzYcnaQz50nXAiIgo+YRwHsKrY=",
+        "lastModified": 1677988178,
+        "narHash": "sha256-MgyPa0UoEWrmEj+PlXuli08O8it1gtStzAZkOU7diCY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "64c55d9bbcd68bdc9f625733f7f6cb26e4a1f348",
+        "rev": "8f7cc5836e565e1e8ee300852b712e5dfebe85dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8f7cc583`](https://github.com/nix-community/NUR/commit/8f7cc5836e565e1e8ee300852b712e5dfebe85dc) | `` automatic update `` |