### PR TITLE
chore(flake/nur): `8f7cc583` -> `7dcad7f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677988178,
-        "narHash": "sha256-MgyPa0UoEWrmEj+PlXuli08O8it1gtStzAZkOU7diCY=",
+        "lastModified": 1677989242,
+        "narHash": "sha256-Xd6uEoHauAVP+aRwTFz7ASUhNVQ+s1LghJaVKDGaH48=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8f7cc5836e565e1e8ee300852b712e5dfebe85dc",
+        "rev": "7dcad7f6b7ce15ba4fb6013deca282e7883ac3c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7dcad7f6`](https://github.com/nix-community/NUR/commit/7dcad7f6b7ce15ba4fb6013deca282e7883ac3c3) | `` automatic update `` |