### PR TITLE
chore(flake/nur): `7dcad7f6` -> `dd8425d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1677989242,
-        "narHash": "sha256-Xd6uEoHauAVP+aRwTFz7ASUhNVQ+s1LghJaVKDGaH48=",
+        "lastModified": 1677994994,
+        "narHash": "sha256-T2mTUPF1qUk3SY67rXr8Ol/qD7o3/VrIgO7S4PMMaNY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7dcad7f6b7ce15ba4fb6013deca282e7883ac3c3",
+        "rev": "dd8425d882bf5d14284405e4436a45806c18a201",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dd8425d8`](https://github.com/nix-community/NUR/commit/dd8425d882bf5d14284405e4436a45806c18a201) | `` automatic update `` |