### PR TITLE
chore(flake/home-manager): `b9e3a298` -> `68ba5957`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -446,11 +446,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677783711,
-        "narHash": "sha256-eq5mOVk3gv5HITtLhPjKwi8bFnOaQplA3X0WFgHnmxE=",
+        "lastModified": 1678006026,
+        "narHash": "sha256-cGOfrU7JsKHAWXbPVDTOu2yyMb7GeWdUtJQNQSqht+w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b9e3a29864798d55ec1d6579ab97876bb1ee9664",
+        "rev": "68ba59578352815ac372b17fb3df9db39afb1407",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`68ba5957`](https://github.com/nix-community/home-manager/commit/68ba59578352815ac372b17fb3df9db39afb1407) | `` xfconf: fix dbus may not be started in the startup of NixOS. (#3707) `` |
| [`3c18113b`](https://github.com/nix-community/home-manager/commit/3c18113bd768ae925b383867d1821563391ecab6) | `` mpd: add `extraArgs` (#3735) ``                                         |