### PR TITLE
chore(flake/nur): `ab35a180` -> `0ccae629`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678005937,
-        "narHash": "sha256-58VEgZZTW8n6z6aojgxkIrPQ+jGU4KxnKVQjkbo63Z4=",
+        "lastModified": 1678011492,
+        "narHash": "sha256-4B5sS1oTqjdGv+7m8DKhyy4FJCW3X0vPdGYXs+cBcGE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ab35a180b3f8ec9c5fca339d19e98fea634941ee",
+        "rev": "0ccae6295a76639b018d70acf62b16afa1b3e961",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0ccae629`](https://github.com/nix-community/NUR/commit/0ccae6295a76639b018d70acf62b16afa1b3e961) | `` automatic update `` |