### PR TITLE
chore(flake/nur): `0ccae629` -> `3f062371`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678011492,
-        "narHash": "sha256-4B5sS1oTqjdGv+7m8DKhyy4FJCW3X0vPdGYXs+cBcGE=",
+        "lastModified": 1678017088,
+        "narHash": "sha256-vpF90KcbiXdZhY3+Xt2YwsPh0ylJnr/eK6gJzyUvbvU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0ccae6295a76639b018d70acf62b16afa1b3e961",
+        "rev": "3f062371476c12826866d8d4754e50dbe1abed1d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3f062371`](https://github.com/nix-community/NUR/commit/3f062371476c12826866d8d4754e50dbe1abed1d) | `` automatic update `` |
| [`d6793572`](https://github.com/nix-community/NUR/commit/d679357251593264cf79646ccd9210c9e8ed6872) | `` automatic update `` |