### PR TITLE
chore(flake/nur): `3f062371` -> `14332aa1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678017088,
-        "narHash": "sha256-vpF90KcbiXdZhY3+Xt2YwsPh0ylJnr/eK6gJzyUvbvU=",
+        "lastModified": 1678021881,
+        "narHash": "sha256-oDMuTL2+uQPcn7YWFlcGROWRuFerjNhqLIupDJSnxyM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3f062371476c12826866d8d4754e50dbe1abed1d",
+        "rev": "14332aa189f845389ec28b729a4beb321e28b4e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`14332aa1`](https://github.com/nix-community/NUR/commit/14332aa189f845389ec28b729a4beb321e28b4e1) | `` automatic update `` |