### PR TITLE
chore(flake/nur): `869861db` -> `20e41d58`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678031199,
-        "narHash": "sha256-cToImoRICh6yIyaGnOdlHFUST6KChPQ6g73r2hAECEI=",
+        "lastModified": 1678035097,
+        "narHash": "sha256-pif710u07qaRUb+NvtdxbdrU0PLhnkb+hw+NUpEpsDE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "869861dbf1b23e3d56a35b480c2ae65683181113",
+        "rev": "20e41d58bd9408923fc9e98347d1c8866a0dcce5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`20e41d58`](https://github.com/nix-community/NUR/commit/20e41d58bd9408923fc9e98347d1c8866a0dcce5) | `` automatic update `` |