### PR TITLE
chore(flake/emacs-overlay): `8f8c0340` -> `d7f3a694`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -224,11 +224,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678012622,
-        "narHash": "sha256-AymXH9TpqT5qjadkO35MLg8hZmuEcLqfesOPWC3FRjE=",
+        "lastModified": 1678036130,
+        "narHash": "sha256-1a2gFHK/S7RrUNgXudDpRKMTna6d3BqLuYhrmPEnlvg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8f8c03401b8ce5c6a98790dd2ec4add9db5ef633",
+        "rev": "d7f3a69423caab0703cf303baa27160842c2cdde",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`d7f3a694`](https://github.com/nix-community/emacs-overlay/commit/d7f3a69423caab0703cf303baa27160842c2cdde) | `` Updated repos/melpa `` |
| [`fb263bab`](https://github.com/nix-community/emacs-overlay/commit/fb263bab8d5a41d3015c0f830dbce5ca0bd3d9e4) | `` Updated repos/elpa ``  |