### PR TITLE
chore(flake/attic): `0bb3d001` -> `1a3b6513`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1676581287,
-        "narHash": "sha256-a/6ClchROZ5PoLz0WK42mkAkUtJlMDbe5QyyZZ7bomc=",
+        "lastModified": 1678041467,
+        "narHash": "sha256-qqHbiN0ZfEuZ2guMAW5T011TqgrPqGqNWlHtd8AXtQA=",
         "owner": "zhaofengli",
         "repo": "attic",
-        "rev": "0bb3d001365a5d75947a7a713dfd06307b3934d4",
+        "rev": "1a3b6513b02202198bb497608d0cedc45119799b",
         "type": "github"
       },
       "original": {
@@ -61,17 +61,16 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1673405853,
-        "narHash": "sha256-6Nq9DuOo+gE2I8z5UZaKuumykz2xxZ9JGYmUthOuwSA=",
+        "lastModified": 1677892403,
+        "narHash": "sha256-/Wi0L1spSWLFj+UQxN3j0mPYMoc7ZoAujpUF/juFVII=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "b13963c8c18026aa694acd98d14f66d24666f70b",
+        "rev": "105e27adb70a9890986b6d543a67761cbc1964a2",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "b13963c8c18026aa694acd98d14f66d24666f70b",
         "type": "github"
       }
     },
@@ -539,17 +538,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672428209,
-        "narHash": "sha256-eejhqkDz2cb2vc5VeaWphJz8UXNuoNoM8/Op8eWv2tQ=",
+        "lastModified": 1677852945,
+        "narHash": "sha256-liiVJjkBTuBTAkRW3hrI8MbPD2ImYzwUpa7kvteiKhM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "293a28df6d7ff3dec1e61e37cc4ee6e6c0fb0847",
+        "rev": "f5ffd5787786dde3a8bf648c7a1b5f78c4e01abb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "rev": "293a28df6d7ff3dec1e61e37cc4ee6e6c0fb0847",
         "type": "github"
       }
     },


### PR DESCRIPTION
| Commit                                                                                            | Message                                                           |
| ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`944b14ab`](https://github.com/zhaofengli/attic/commit/944b14abddf276bb4c0089b43ec95473846567a7) | `` .github/install-attic-ci.sh: Update ``                         |
| [`f36f01d4`](https://github.com/zhaofengli/attic/commit/f36f01d4317928ecf26d844ee79a7c14a5a842d1) | `` .github: Bump DetSys installer ``                              |
| [`63019bb2`](https://github.com/zhaofengli/attic/commit/63019bb208a568e779ab70488fcb00c651608b53) | `` client: rustfmt ``                                             |
| [`f0e91998`](https://github.com/zhaofengli/attic/commit/f0e9199817dd4ec7faac281280e328f4a72861da) | `` client/watch_store: Hide --no-closure in help ``               |
| [`0ee4f490`](https://github.com/zhaofengli/attic/commit/0ee4f4901b6ed45937cb267691f913a370b958a1) | `` nixos: Start atticd after nss-lookup for Postgres peer auth `` |
| [`22626efd`](https://github.com/zhaofengli/attic/commit/22626efd356cb3df7198d777b7be452c0d151859) | `` Trivial semver-incompatible upgrades ``                        |
| [`c3c7c10c`](https://github.com/zhaofengli/attic/commit/c3c7c10c055092ef707fb43c61e13c5aab31d302) | `` Upgrade toml ``                                                |
| [`97285de5`](https://github.com/zhaofengli/attic/commit/97285de54ff8f236dc8ef4f957363e8a4bb51af2) | `` Upgrade base64 ``                                              |
| [`7f62e92d`](https://github.com/zhaofengli/attic/commit/7f62e92d7161019614211d083b874b5524ecc6f8) | `` server: Upgrade fastcdc ``                                     |
| [`b6002b41`](https://github.com/zhaofengli/attic/commit/b6002b413c522064bc3c0932ac0232821f3b333b) | `` server: Upgrade aws-sdk-rust ``                                |
| [`18ca2cf2`](https://github.com/zhaofengli/attic/commit/18ca2cf29a5d8287d03ce00b534243c4d094d504) | `` Update deps ``                                                 |
| [`dbcf98b4`](https://github.com/zhaofengli/attic/commit/dbcf98b4e458d413b98454ffcdd1d55fd8c7b8ec) | `` flake.nix: Bump dependencies ``                                |
| [`2f5b2a56`](https://github.com/zhaofengli/attic/commit/2f5b2a56cf5bc399cfa9130915ef308a52ca01f6) | `` nixos: Suppress systemd-run's output in atticadm wrapper ``    |
| [`96824109`](https://github.com/zhaofengli/attic/commit/96824109c0a126536678cd2352f4c9ecd20b676c) | `` nixos: Allow configuring user and group names ``               |