### PR TITLE
chore(flake/nur): `5e93de01` -> `e4621745`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678045044,
-        "narHash": "sha256-esjHAlTrXSk+y9KFVE8rm/FyKpGABsGRqwf7b3ufudc=",
+        "lastModified": 1678049172,
+        "narHash": "sha256-2r6M9f2VIFVPjXZDZDp7JTCxXjZM+7SVeRkeZLyg1nc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5e93de01f2ac007666e9c3b479d1cabfd7093cfc",
+        "rev": "e4621745dd6b02efb177ef9a4be0ea0fbf3e774b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e4621745`](https://github.com/nix-community/NUR/commit/e4621745dd6b02efb177ef9a4be0ea0fbf3e774b) | `` automatic update `` |