### PR TITLE
chore(flake/nur): `e4621745` -> `4abf9227`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678049172,
-        "narHash": "sha256-2r6M9f2VIFVPjXZDZDp7JTCxXjZM+7SVeRkeZLyg1nc=",
+        "lastModified": 1678050917,
+        "narHash": "sha256-26csjHjxU3QbTUckcFAkMlBla2MaA5Bmk80xpeJQfXk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e4621745dd6b02efb177ef9a4be0ea0fbf3e774b",
+        "rev": "4abf92279fc9b21aa11a4e494509cb5d407b3fad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4abf9227`](https://github.com/nix-community/NUR/commit/4abf92279fc9b21aa11a4e494509cb5d407b3fad) | `` automatic update `` |