### PR TITLE
chore(flake/nur): `4abf9227` -> `716074f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678050917,
-        "narHash": "sha256-26csjHjxU3QbTUckcFAkMlBla2MaA5Bmk80xpeJQfXk=",
+        "lastModified": 1678056369,
+        "narHash": "sha256-uTm5WNE6u3cjSmAbqV3WVt7vIYkJ8Tg6fgYmjYRPYtA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4abf92279fc9b21aa11a4e494509cb5d407b3fad",
+        "rev": "716074f750700c6e2917017c9d51e494babf58ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`716074f7`](https://github.com/nix-community/NUR/commit/716074f750700c6e2917017c9d51e494babf58ff) | `` automatic update `` |