### PR TITLE
chore(flake/nur): `422de8d6` -> `43917695`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678065130,
-        "narHash": "sha256-5zvrg+QeTK1Hhi1dNfPiRdARXcO1hj43HGTqqWUM0NU=",
+        "lastModified": 1678069037,
+        "narHash": "sha256-f8//91UHl+9c73ociE0ORDkeL1Kv8a2X3bbx0QwsCqU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "422de8d6de5e87633020178b1bdd2cc64c3afe1d",
+        "rev": "4391769503ac21c49169c75ae0cfb9445cc6edb1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`43917695`](https://github.com/nix-community/NUR/commit/4391769503ac21c49169c75ae0cfb9445cc6edb1) | `` automatic update `` |