### PR TITLE
chore(flake/nur): `43917695` -> `1891f1f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678069037,
-        "narHash": "sha256-f8//91UHl+9c73ociE0ORDkeL1Kv8a2X3bbx0QwsCqU=",
+        "lastModified": 1678074416,
+        "narHash": "sha256-tBeGw3KmEgiADJUrVgkvavh9e1kOpvzHBvY9YugI/So=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4391769503ac21c49169c75ae0cfb9445cc6edb1",
+        "rev": "1891f1f46923cd0df13e16c4a5586196e2ccf10d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1891f1f4`](https://github.com/nix-community/NUR/commit/1891f1f46923cd0df13e16c4a5586196e2ccf10d) | `` automatic update `` |