### PR TITLE
chore(flake/nur): `1891f1f4` -> `957ba23f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678074416,
-        "narHash": "sha256-tBeGw3KmEgiADJUrVgkvavh9e1kOpvzHBvY9YugI/So=",
+        "lastModified": 1678075806,
+        "narHash": "sha256-1Gb1OnrjS/U61FOItxz0iHwUITUk6x9PC3N4DD/hE1E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1891f1f46923cd0df13e16c4a5586196e2ccf10d",
+        "rev": "957ba23f6975010c976329c1a772cd15d3afce72",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`957ba23f`](https://github.com/nix-community/NUR/commit/957ba23f6975010c976329c1a772cd15d3afce72) | `` automatic update `` |