### PR TITLE
chore(flake/emacs-ement): `b9c219a7` -> `5bb6c930`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -200,11 +200,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1678076827,
-        "narHash": "sha256-gv2qzV3fkMNUzDCK56Yvto9YJo1aXfS0P2ctGp7O348=",
+        "lastModified": 1678081732,
+        "narHash": "sha256-CIWVpEtfxPfTCEDm9tKNx3BcWD926SL3Qxs38DeluDo=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "b9c219a777da8635631e2860a3e36d8588707699",
+        "rev": "5bb6c930ff29f22263018b5dff7b45669b8357f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                            |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`5bb6c930`](https://github.com/alphapapa/ement.el/commit/5bb6c930ff29f22263018b5dff7b45669b8357f5) | `` Release: v0.7 ``                                                |
| [`66b32b9e`](https://github.com/alphapapa/ement.el/commit/66b32b9e17a45836f608dca4e082df9b0766adad) | `` Fix: (ement--sync) Retry for network timeouts ``                |
| [`ca3aed22`](https://github.com/alphapapa/ement.el/commit/ca3aed2207876785427a671911ae36f0a1c19733) | `` Fix: (ement-room-list, -revert) Don't display when reverting `` |
| [`f000c3cc`](https://github.com/alphapapa/ement.el/commit/f000c3ccd2840ef368875c99b1c3c6e64f01302a) | `` Fix: (ement--room-at-point) Return room instead of string ``    |