### PR TITLE
chore(flake/nur): `2d93ccd2` -> `822ccf6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678089079,
-        "narHash": "sha256-7csLzliiPNp8qWgM3lrZZlmnyK76Wk5RoECrCNMA6z8=",
+        "lastModified": 1678091232,
+        "narHash": "sha256-32c97Tiar0Qcxk3x5x9RcCoI+ZivbthO45mZTQRt/9Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2d93ccd26f17d01fa664b9a4a202c4b9bbee1cb2",
+        "rev": "822ccf6df03d6c7930cbea72c9fa51827222c297",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                            |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`821b2e83`](https://github.com/nix-community/NUR/commit/821b2e8354fd6070c8a62b4562d1049a0f5cadcd) | `` Bump cachix/install-nix-action from 19 to 20 `` |