### PR TITLE
chore(flake/nur): `822ccf6d` -> `e077c428`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678091232,
-        "narHash": "sha256-32c97Tiar0Qcxk3x5x9RcCoI+ZivbthO45mZTQRt/9Q=",
+        "lastModified": 1678093275,
+        "narHash": "sha256-paOVuCTKg73Ta1pNXvhmyzcAlob6RQMrvcOSsbWfnaY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "822ccf6df03d6c7930cbea72c9fa51827222c297",
+        "rev": "e077c4283fc48c0f51823132bf7140dac7dd7573",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e077c428`](https://github.com/nix-community/NUR/commit/e077c4283fc48c0f51823132bf7140dac7dd7573) | `` automatic update `` |
| [`c26081d3`](https://github.com/nix-community/NUR/commit/c26081d3acfc6fa7fd7a7f45a7184737cbc61054) | `` automatic update `` |