### PR TITLE
chore(flake/nixos-hardware): `46d00f2b` -> `f6610997`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1678092212,
-        "narHash": "sha256-AC3I2xhs/2vfVOM0TP8MNIhDKOxdsLDRk94EuqGbNjo=",
+        "lastModified": 1678095239,
+        "narHash": "sha256-4F6jovFJcwh6OkMsY94ZrHdrvVqZi1FX5pYv6V9LIQw=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "46d00f2b799ad6401e2f430b3fb3585d837b3bb3",
+        "rev": "f6610997b0fc5ea5f9e142c348fca27497efe1c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`630a8e3e`](https://github.com/NixOS/nixos-hardware/commit/630a8e3e4eea61d35524699f2f59dbc64886357d) | `` common/gpu/amd: use modesetting driver by default `` |
| [`ae64b45f`](https://github.com/NixOS/nixos-hardware/commit/ae64b45fc4c2d2af8d40ebe69704ccf57fca3b81) | `` Add Hardkernel HC4 support ``                        |