### PR TITLE
chore(flake/emacs-overlay): `20d72734` -> `3f8a6436`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678067973,
-        "narHash": "sha256-aTPEoFrdRiaABvmSr9JRSOkuVt4hRPk6tTH4jEBYRPo=",
+        "lastModified": 1678097883,
+        "narHash": "sha256-IG/v/syRMm0OLjT7F/naRjqN6bvAQEhlIlnS4U5y5EQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "20d727342f4c6db4be4faeaa413d246f7ee3bbc4",
+        "rev": "3f8a6436e158849050e711574a97126a6d3fec02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`3f8a6436`](https://github.com/nix-community/emacs-overlay/commit/3f8a6436e158849050e711574a97126a6d3fec02) | `` Updated repos/melpa `` |
| [`54094d69`](https://github.com/nix-community/emacs-overlay/commit/54094d69a885487ce759ceac0123b6d5f90905f1) | `` Updated repos/emacs `` |