### PR TITLE
chore(flake/nur): `386e16ea` -> `6aa3a1c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678099658,
-        "narHash": "sha256-QNEtLZFCeQyjRqjOJY7jBfSJvtS0j9UajCB6RSDJLus=",
+        "lastModified": 1678103127,
+        "narHash": "sha256-jU+5ul/wvcHz9/ByyoNY2PmoGCC5ABcTXCqJJqDRAtY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "386e16ea372fffaa946199d1b7cb3f99e1a60c9a",
+        "rev": "6aa3a1c4a5393b0a787d613850bf87ea1ea946ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6aa3a1c4`](https://github.com/nix-community/NUR/commit/6aa3a1c4a5393b0a787d613850bf87ea1ea946ce) | `` automatic update `` |