### PR TITLE
chore(flake/nur): `6aa3a1c4` -> `a1b0df6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678103127,
-        "narHash": "sha256-jU+5ul/wvcHz9/ByyoNY2PmoGCC5ABcTXCqJJqDRAtY=",
+        "lastModified": 1678107241,
+        "narHash": "sha256-hIRu8mUv5WQkXUhI3/6eI6sQFboWgYpxhxAncMNdAv4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6aa3a1c4a5393b0a787d613850bf87ea1ea946ce",
+        "rev": "a1b0df6d4a7bf1bf4f6b6d7436c2bde51206302c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a1b0df6d`](https://github.com/nix-community/NUR/commit/a1b0df6d4a7bf1bf4f6b6d7436c2bde51206302c) | `` automatic update `` |