### PR TITLE
chore(flake/nur): `a1b0df6d` -> `4bab2807`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678107241,
-        "narHash": "sha256-hIRu8mUv5WQkXUhI3/6eI6sQFboWgYpxhxAncMNdAv4=",
+        "lastModified": 1678109907,
+        "narHash": "sha256-JjnZcIIc0SvucX+p2PGtKZJ6MkFmztFTe3arA4te4g4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a1b0df6d4a7bf1bf4f6b6d7436c2bde51206302c",
+        "rev": "4bab2807ea63b31a173e7bcddf4373c37137b61a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4bab2807`](https://github.com/nix-community/NUR/commit/4bab2807ea63b31a173e7bcddf4373c37137b61a) | `` automatic update `` |