### PR TITLE
chore(flake/nur): `4bab2807` -> `84272c19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678109907,
-        "narHash": "sha256-JjnZcIIc0SvucX+p2PGtKZJ6MkFmztFTe3arA4te4g4=",
+        "lastModified": 1678111591,
+        "narHash": "sha256-Fh7gW1b47i0W5f4sdp3kuYMQzbQlx0FgrsgknGs9f5E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4bab2807ea63b31a173e7bcddf4373c37137b61a",
+        "rev": "84272c19e71d4024760582999fce274ca08ff4d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`84272c19`](https://github.com/nix-community/NUR/commit/84272c19e71d4024760582999fce274ca08ff4d6) | `` automatic update `` |