### PR TITLE
chore(flake/nur): `84272c19` -> `3136e0d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678111591,
-        "narHash": "sha256-Fh7gW1b47i0W5f4sdp3kuYMQzbQlx0FgrsgknGs9f5E=",
+        "lastModified": 1678113687,
+        "narHash": "sha256-yUade+oZI6VD4aCwM+voZhR9WoK9/Pq/QrAtCgvqGgw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "84272c19e71d4024760582999fce274ca08ff4d6",
+        "rev": "3136e0d3d3b3cecfcbc5c2da9dbadcdb20c87df1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3136e0d3`](https://github.com/nix-community/NUR/commit/3136e0d3d3b3cecfcbc5c2da9dbadcdb20c87df1) | `` automatic update `` |