### PR TITLE
chore(flake/nur): `3136e0d3` -> `9613bf1f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678113687,
-        "narHash": "sha256-yUade+oZI6VD4aCwM+voZhR9WoK9/Pq/QrAtCgvqGgw=",
+        "lastModified": 1678117608,
+        "narHash": "sha256-hgqRYieVMKmdW6/JIQxUxBvz1o0jea+VZPtvefeof+I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3136e0d3d3b3cecfcbc5c2da9dbadcdb20c87df1",
+        "rev": "9613bf1f8846150d3453d6ea69f538264148c68a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9613bf1f`](https://github.com/nix-community/NUR/commit/9613bf1f8846150d3453d6ea69f538264148c68a) | `` automatic update `` |