### PR TITLE
chore(flake/nur): `6da0b8e8` -> `da817767`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678121717,
-        "narHash": "sha256-+uF5hs8B8U5MwJX/bNQwCjE+CCEJTbtfe4JuidqKuDU=",
+        "lastModified": 1678122405,
+        "narHash": "sha256-+Je+A9E1iGFNqnqEbM6eeOXPxRBK/fQkiUYsUvw+/Fc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6da0b8e8613971c2094bcf525beafac3a6b46970",
+        "rev": "da8177671936ddec7a333948a04049615e34930c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`da817767`](https://github.com/nix-community/NUR/commit/da8177671936ddec7a333948a04049615e34930c) | `` automatic update `` |