### PR TITLE
chore(flake/nur): `da817767` -> `07cc87c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678122405,
-        "narHash": "sha256-+Je+A9E1iGFNqnqEbM6eeOXPxRBK/fQkiUYsUvw+/Fc=",
+        "lastModified": 1678124794,
+        "narHash": "sha256-aB6c7GY33fgVTqqqgZHO6Dr8SzFvjMxOEEGrnkTYYXI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "da8177671936ddec7a333948a04049615e34930c",
+        "rev": "07cc87c1c7cc6706e7835ea5d146a4b834ea9317",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`07cc87c1`](https://github.com/nix-community/NUR/commit/07cc87c1c7cc6706e7835ea5d146a4b834ea9317) | `` automatic update `` |