### PR TITLE
chore(flake/emacs-overlay): `3f8a6436` -> `c1355f8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678097883,
-        "narHash": "sha256-IG/v/syRMm0OLjT7F/naRjqN6bvAQEhlIlnS4U5y5EQ=",
+        "lastModified": 1678127991,
+        "narHash": "sha256-wsm36K1cCAKXiuETDXnSBi3A4si/fPRnGAO+OIXRazU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3f8a6436e158849050e711574a97126a6d3fec02",
+        "rev": "c1355f8ece3ec5f73b42776401e459a05b48a715",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`c1355f8e`](https://github.com/nix-community/emacs-overlay/commit/c1355f8ece3ec5f73b42776401e459a05b48a715) | `` Updated repos/melpa `` |
| [`8df8ecb7`](https://github.com/nix-community/emacs-overlay/commit/8df8ecb7a6e3b0105da1783e582a02c471a7d758) | `` Updated repos/emacs `` |