### PR TITLE
chore(flake/nur): `42d6ec4d` -> `c7f87667`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678131994,
-        "narHash": "sha256-bEB7DttJFIg7M7jv76cHnZLNv/gO0qE1UshDm7zHgmQ=",
+        "lastModified": 1678142810,
+        "narHash": "sha256-kV5k5z6erO1eE+sx9FQe//mm18qscWV+fth+QcqlAuQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "42d6ec4d9e8205a5f166ad659f10dd441bc85512",
+        "rev": "c7f87667c17a391e9627793a0c3fc9b971daa608",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c7f87667`](https://github.com/nix-community/NUR/commit/c7f87667c17a391e9627793a0c3fc9b971daa608) | `` automatic update `` |