### PR TITLE
chore(flake/nur): `18516973` -> `f3fd5ac3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678145346,
-        "narHash": "sha256-spBYSVIkg9D2+YL0r+++ewuQ3opNd0ltn/moBDRQ+QU=",
+        "lastModified": 1678147275,
+        "narHash": "sha256-Ar1gat4aydNY1WfOs8xbaRHKZqS50YbkP7XrofyScD8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "185169739f63273cbabed51d4bb134ca66dd09a0",
+        "rev": "f3fd5ac34014abc99fa053f3880450e6780e0769",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f3fd5ac3`](https://github.com/nix-community/NUR/commit/f3fd5ac34014abc99fa053f3880450e6780e0769) | `` automatic update `` |