### PR TITLE
chore(flake/nur): `f3fd5ac3` -> `71742956`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678147275,
-        "narHash": "sha256-Ar1gat4aydNY1WfOs8xbaRHKZqS50YbkP7XrofyScD8=",
+        "lastModified": 1678147971,
+        "narHash": "sha256-Dw+2KwdNVBkFSO6kLiTF9FSQAO3x1nAjNYhk9RcO2J4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f3fd5ac34014abc99fa053f3880450e6780e0769",
+        "rev": "71742956ab20f692fc238ed5f96e88b57737548e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`71742956`](https://github.com/nix-community/NUR/commit/71742956ab20f692fc238ed5f96e88b57737548e) | `` automatic update `` |