### PR TITLE
chore(flake/nur): `71742956` -> `d3758ce2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678147971,
-        "narHash": "sha256-Dw+2KwdNVBkFSO6kLiTF9FSQAO3x1nAjNYhk9RcO2J4=",
+        "lastModified": 1678150106,
+        "narHash": "sha256-fX6BSxmTE4Ly65oUc/L8jZ7it1iLKnzfMenV8QQEBBA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "71742956ab20f692fc238ed5f96e88b57737548e",
+        "rev": "d3758ce272e76ba56ae1c35a1d827b7728b08432",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d3758ce2`](https://github.com/nix-community/NUR/commit/d3758ce272e76ba56ae1c35a1d827b7728b08432) | `` automatic update `` |