### PR TITLE
chore(flake/nur): `d3758ce2` -> `be416214`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678150106,
-        "narHash": "sha256-fX6BSxmTE4Ly65oUc/L8jZ7it1iLKnzfMenV8QQEBBA=",
+        "lastModified": 1678154784,
+        "narHash": "sha256-5IjPBitmGOgOJ1Dw/Upn2eA2kF37Uo1n3XNTZvLruvY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d3758ce272e76ba56ae1c35a1d827b7728b08432",
+        "rev": "be416214f85a73f018a888de210eb9ae88df437b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`be416214`](https://github.com/nix-community/NUR/commit/be416214f85a73f018a888de210eb9ae88df437b) | `` automatic update `` |