### PR TITLE
chore(flake/nur): `be416214` -> `720ee12a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678154784,
-        "narHash": "sha256-5IjPBitmGOgOJ1Dw/Upn2eA2kF37Uo1n3XNTZvLruvY=",
+        "lastModified": 1678162292,
+        "narHash": "sha256-HZs2LdjkOsEqpD+Cy5IrHyZhIg9UB5KGfyigvYuZbIY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "be416214f85a73f018a888de210eb9ae88df437b",
+        "rev": "720ee12acecaa3755bde5e7ccc8a47f4dc5aeaa0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`720ee12a`](https://github.com/nix-community/NUR/commit/720ee12acecaa3755bde5e7ccc8a47f4dc5aeaa0) | `` automatic update `` |
| [`1e415206`](https://github.com/nix-community/NUR/commit/1e4152061fe9bfb3635e0c606b8244e2f2bbeb07) | `` automatic update `` |
| [`fb418d62`](https://github.com/nix-community/NUR/commit/fb418d6298812d803ac6e4d133a5a29898e5d480) | `` automatic update `` |