### PR TITLE
chore(flake/nur): `720ee12a` -> `c5870e77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678162292,
-        "narHash": "sha256-HZs2LdjkOsEqpD+Cy5IrHyZhIg9UB5KGfyigvYuZbIY=",
+        "lastModified": 1678167795,
+        "narHash": "sha256-kmzXaI/uDs+F5u9Bw5+zd3Q4LigQSUuziwniaMBMlYk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "720ee12acecaa3755bde5e7ccc8a47f4dc5aeaa0",
+        "rev": "c5870e779735595139340058f63ffe683600f99b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c5870e77`](https://github.com/nix-community/NUR/commit/c5870e779735595139340058f63ffe683600f99b) | `` automatic update `` |