### PR TITLE
chore(flake/nur): `c5870e77` -> `059e5a60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678167795,
-        "narHash": "sha256-kmzXaI/uDs+F5u9Bw5+zd3Q4LigQSUuziwniaMBMlYk=",
+        "lastModified": 1678171752,
+        "narHash": "sha256-LG+E99NZCpFtoPtmjAzjB4j430t3bjMR+E7X+Bwc5dk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c5870e779735595139340058f63ffe683600f99b",
+        "rev": "059e5a606347dd2a4661dc2521d3432140ef9f35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`059e5a60`](https://github.com/nix-community/NUR/commit/059e5a606347dd2a4661dc2521d3432140ef9f35) | `` automatic update `` |