### PR TITLE
chore(flake/emacs-overlay): `d89c71d8` -> `a640fde2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678154976,
-        "narHash": "sha256-o2XXwTT4AS4hjD1uZZRHuSiP7DQWq1tbuqln1ZvskyE=",
+        "lastModified": 1678183951,
+        "narHash": "sha256-T0OVHgaLukTs0dFuIKZJ102dlsMp7X9trcQ4BIXh/Eg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d89c71d82edf170629279d731e0772feb5037f4c",
+        "rev": "a640fde298d0b55085267eb7bbbac0c529aec66e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`a640fde2`](https://github.com/nix-community/emacs-overlay/commit/a640fde298d0b55085267eb7bbbac0c529aec66e) | `` Updated repos/melpa `` |
| [`ed5144de`](https://github.com/nix-community/emacs-overlay/commit/ed5144de86fd37328e0eddfaffd2f2b9731148ab) | `` Updated repos/emacs `` |