### PR TITLE
chore(flake/nur): `059e5a60` -> `5595b40f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678171752,
-        "narHash": "sha256-LG+E99NZCpFtoPtmjAzjB4j430t3bjMR+E7X+Bwc5dk=",
+        "lastModified": 1678186038,
+        "narHash": "sha256-AKTu4ljAATFsaVqRaqk05uVvew3lqA5dmgC+aSOsUjQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "059e5a606347dd2a4661dc2521d3432140ef9f35",
+        "rev": "5595b40f0a8544435296b4f7cd37642a3f8f3fdb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5595b40f`](https://github.com/nix-community/NUR/commit/5595b40f0a8544435296b4f7cd37642a3f8f3fdb) | `` automatic update `` |