### PR TITLE
chore(flake/nur): `174fc643` -> `679e4788`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678189563,
-        "narHash": "sha256-OchK0+lrPLQJPwLsooceQlWDpRqkc7kuYNWyiy+3ENI=",
+        "lastModified": 1678194459,
+        "narHash": "sha256-rW70+nemqv4R6tUB2rfhjgGDP6SdInjgWc5vDR+c9Ps=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "174fc643f476eca87a7ada71339033cf16242006",
+        "rev": "679e4788110e19c97b89d9621a243069d4394bfa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`679e4788`](https://github.com/nix-community/NUR/commit/679e4788110e19c97b89d9621a243069d4394bfa) | `` automatic update `` |