### PR TITLE
chore(flake/nur): `679e4788` -> `a77465f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678194459,
-        "narHash": "sha256-rW70+nemqv4R6tUB2rfhjgGDP6SdInjgWc5vDR+c9Ps=",
+        "lastModified": 1678200421,
+        "narHash": "sha256-IeXJef9y3jb4SP8cZbOiuMwyicxC4xFVrnjx3UptfeA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "679e4788110e19c97b89d9621a243069d4394bfa",
+        "rev": "a77465f74999c4c3f71c6d629e08664b45426efe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a77465f7`](https://github.com/nix-community/NUR/commit/a77465f74999c4c3f71c6d629e08664b45426efe) | `` automatic update `` |