### PR TITLE
chore(flake/emacs-overlay): `a640fde2` -> `7311892e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678183951,
-        "narHash": "sha256-T0OVHgaLukTs0dFuIKZJ102dlsMp7X9trcQ4BIXh/Eg=",
+        "lastModified": 1678205684,
+        "narHash": "sha256-xf7E6Cv0Y3hHJxKe8XP6Jb4N6HoJmOH9ibXr+xYmXEI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a640fde298d0b55085267eb7bbbac0c529aec66e",
+        "rev": "7311892ed9b4ce09fdc4eb5663ad4a8ac6599278",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                 |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------- |
| [`b6f629b2`](https://github.com/nix-community/emacs-overlay/commit/b6f629b2ed81e67855334a42323e39eee45eb19e) | `` Codesign with pkgs.darwin.sigtool `` |