### PR TITLE
chore(flake/nur): `a77465f7` -> `68b7580d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678200421,
-        "narHash": "sha256-IeXJef9y3jb4SP8cZbOiuMwyicxC4xFVrnjx3UptfeA=",
+        "lastModified": 1678208039,
+        "narHash": "sha256-n434C+BvKcEODhnM2QxFkbVjCPtfb536MIPcEOSM5j0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a77465f74999c4c3f71c6d629e08664b45426efe",
+        "rev": "68b7580d3b0efb6e4310b4867bf9809c40863971",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`68b7580d`](https://github.com/nix-community/NUR/commit/68b7580d3b0efb6e4310b4867bf9809c40863971) | `` automatic update `` |