### PR TITLE
chore(flake/nur): `68b7580d` -> `952b85c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678208039,
-        "narHash": "sha256-n434C+BvKcEODhnM2QxFkbVjCPtfb536MIPcEOSM5j0=",
+        "lastModified": 1678218294,
+        "narHash": "sha256-iEmf0OUrQRxBgGDdRD/HlH3Gw0sBhxh+ZhtKxQiXstA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "68b7580d3b0efb6e4310b4867bf9809c40863971",
+        "rev": "952b85c63d1a9ed6b2fd1e2a54162e2debef7e63",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`952b85c6`](https://github.com/nix-community/NUR/commit/952b85c63d1a9ed6b2fd1e2a54162e2debef7e63) | `` automatic update `` |