### PR TITLE
chore(flake/nur): `952b85c6` -> `15e2403d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678218294,
-        "narHash": "sha256-iEmf0OUrQRxBgGDdRD/HlH3Gw0sBhxh+ZhtKxQiXstA=",
+        "lastModified": 1678221928,
+        "narHash": "sha256-m1pwayWF9O/pK7iiX4UQBrflvdLtmbDpjwmRMPvlniA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "952b85c63d1a9ed6b2fd1e2a54162e2debef7e63",
+        "rev": "15e2403d7288984b9e53bf9a92483574f1aafe42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`15e2403d`](https://github.com/nix-community/NUR/commit/15e2403d7288984b9e53bf9a92483574f1aafe42) | `` automatic update `` |