### PR TITLE
chore(flake/nur): `eab748b9` -> `d50e0a76`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678232741,
-        "narHash": "sha256-ViikQdLXfpkUeGmNY+FOrReO1t/uE8rdG1EyiVXiGPg=",
+        "lastModified": 1678239087,
+        "narHash": "sha256-TXjUW9y3a/fJ+9yT+jv+K6ElHemaVixMSOxqZRSli+c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eab748b9488799bf804a8f75d523fd32603098f8",
+        "rev": "d50e0a76e34c2e5029ba20ed89ff9ceecee5520f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d50e0a76`](https://github.com/nix-community/NUR/commit/d50e0a76e34c2e5029ba20ed89ff9ceecee5520f) | `` automatic update `` |