### PR TITLE
chore(flake/nur): `d50e0a76` -> `31b06d2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678239087,
-        "narHash": "sha256-TXjUW9y3a/fJ+9yT+jv+K6ElHemaVixMSOxqZRSli+c=",
+        "lastModified": 1678241914,
+        "narHash": "sha256-yoKlea72xNLcjspan3BXhObpVMpXtYLfVhBxh5Og02U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d50e0a76e34c2e5029ba20ed89ff9ceecee5520f",
+        "rev": "31b06d2e38f5296d173c546e84f9777f52ef18d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`31b06d2e`](https://github.com/nix-community/NUR/commit/31b06d2e38f5296d173c546e84f9777f52ef18d5) | `` automatic update `` |