### PR TITLE
chore(flake/nur): `003d914d` -> `b4d5a23d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678248650,
-        "narHash": "sha256-s07do/y14DyQKxOvasW8Hv0OxSXRFBBEgC+jMcxFONA=",
+        "lastModified": 1678250746,
+        "narHash": "sha256-y2zMq3nLmeUADiW+pzKdPcL0ef4yGnCWBL2lCQNncRs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "003d914d87d8270e99d412fa9115aca7d0f6f9b8",
+        "rev": "b4d5a23d29441307454da9fecdb3dd7e06f30671",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b4d5a23d`](https://github.com/nix-community/NUR/commit/b4d5a23d29441307454da9fecdb3dd7e06f30671) | `` automatic update `` |