### PR TITLE
chore(flake/nur): `b4d5a23d` -> `b2ebc637`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678250746,
-        "narHash": "sha256-y2zMq3nLmeUADiW+pzKdPcL0ef4yGnCWBL2lCQNncRs=",
+        "lastModified": 1678255271,
+        "narHash": "sha256-VEOnYtL5BxrxBvS+R2bVGNKab+fIvCHoLIlv2qSCM1E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b4d5a23d29441307454da9fecdb3dd7e06f30671",
+        "rev": "b2ebc637d698e4ab8895c9633260ba3b07909dfd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b2ebc637`](https://github.com/nix-community/NUR/commit/b2ebc637d698e4ab8895c9633260ba3b07909dfd) | `` automatic update `` |
| [`d3a3c600`](https://github.com/nix-community/NUR/commit/d3a3c600e8dcea22fe500ae608654bcb6bbb4818) | `` automatic update `` |