### PR TITLE
chore(flake/nur): `b2ebc637` -> `45b5d4f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678255271,
-        "narHash": "sha256-VEOnYtL5BxrxBvS+R2bVGNKab+fIvCHoLIlv2qSCM1E=",
+        "lastModified": 1678481086,
+        "narHash": "sha256-YiJPAiOQJjFfQwUWbJv4NyPtFWtOIOO669lB54QPB0w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b2ebc637d698e4ab8895c9633260ba3b07909dfd",
+        "rev": "45b5d4f27def51908527191ed5dcae537de97a75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`45b5d4f2`](https://github.com/nix-community/NUR/commit/45b5d4f27def51908527191ed5dcae537de97a75) | `` automatic update `` |
| [`c42668f7`](https://github.com/nix-community/NUR/commit/c42668f7a0b12b3482e7e8808c3aa8481ef965b1) | `` automatic update `` |
| [`ac1c0e66`](https://github.com/nix-community/NUR/commit/ac1c0e66e1b9b9c8b74242759d7536c4fb5321c7) | `` automatic update `` |
| [`7a776551`](https://github.com/nix-community/NUR/commit/7a77655138a8dd524979f77db094f405b2310576) | `` automatic update `` |
| [`d0be1f32`](https://github.com/nix-community/NUR/commit/d0be1f32e91d0d3f5a61c18d8a53269cb7bde705) | `` automatic update `` |
| [`cc2223c1`](https://github.com/nix-community/NUR/commit/cc2223c13f097d8238ec97d7d1a87101b9cccaa4) | `` automatic update `` |
| [`4a89c27a`](https://github.com/nix-community/NUR/commit/4a89c27a86e8abb86e2b8043a62738f3bf6b4e88) | `` automatic update `` |
| [`dcc6f199`](https://github.com/nix-community/NUR/commit/dcc6f199f4d1fed374f9ed0f3cee2bc995b39916) | `` automatic update `` |
| [`b28b63c9`](https://github.com/nix-community/NUR/commit/b28b63c97d96308f1195f10cbeded13404aab2e3) | `` automatic update `` |
| [`d8e7ee3d`](https://github.com/nix-community/NUR/commit/d8e7ee3d5c5f47adf0139103c9055075a360a650) | `` automatic update `` |
| [`c4fea7bf`](https://github.com/nix-community/NUR/commit/c4fea7bfacbea6b72da3ddafb41b33ef1ddae3bb) | `` automatic update `` |
| [`63520608`](https://github.com/nix-community/NUR/commit/635206085c5a429d5459b955e84e0f29242313a1) | `` automatic update `` |
| [`54542ebd`](https://github.com/nix-community/NUR/commit/54542ebdc305cb30059bc9886c394e5df9e37d8e) | `` automatic update `` |
| [`39f460d0`](https://github.com/nix-community/NUR/commit/39f460d03b2faf38131cf8ff5ab19fe5848fc23c) | `` automatic update `` |
| [`ae361296`](https://github.com/nix-community/NUR/commit/ae3612965891321559e354bfa9deabfbf0729b4f) | `` automatic update `` |
| [`6f1f1fce`](https://github.com/nix-community/NUR/commit/6f1f1fcec2ea6b1cb23a5101cb2b5138c238962a) | `` automatic update `` |
| [`0f2e0826`](https://github.com/nix-community/NUR/commit/0f2e08262ac9edde0606ebedcd50c5523b2c5e19) | `` automatic update `` |
| [`3e708271`](https://github.com/nix-community/NUR/commit/3e708271a206f4c3bf0559715f5db1e2ffa395c2) | `` automatic update `` |
| [`ca454bfe`](https://github.com/nix-community/NUR/commit/ca454bfe203ce42dbeac2ecae7035372df82258b) | `` automatic update `` |
| [`bbef74f8`](https://github.com/nix-community/NUR/commit/bbef74f8ace8a5c0e6d7da6ef9d553efe1cbd56c) | `` automatic update `` |
| [`e1b8d41d`](https://github.com/nix-community/NUR/commit/e1b8d41da646195c4eef1c23f9918f7a8dedf6c3) | `` automatic update `` |
| [`347c26fc`](https://github.com/nix-community/NUR/commit/347c26fcb8e1ea05fa38a38f1f8a3e5b0305c59a) | `` automatic update `` |
| [`ebca8d5a`](https://github.com/nix-community/NUR/commit/ebca8d5a58cadcdaa757306a150731d633865e25) | `` automatic update `` |
| [`b33d65a5`](https://github.com/nix-community/NUR/commit/b33d65a5c68ec21607f3867b67fa90c457bc43c6) | `` automatic update `` |
| [`1d684f25`](https://github.com/nix-community/NUR/commit/1d684f257412592d344f19fa1d4a4937a3bc78f8) | `` automatic update `` |
| [`93d5ff75`](https://github.com/nix-community/NUR/commit/93d5ff755043618fa53f5112f6b3462eb5a35cdd) | `` automatic update `` |
| [`472f7797`](https://github.com/nix-community/NUR/commit/472f779737b13191532323602da0c1635cdd27ee) | `` automatic update `` |
| [`c5d4149c`](https://github.com/nix-community/NUR/commit/c5d4149cdb91794cec9894dd59e4b43941fe4712) | `` automatic update `` |
| [`ba739041`](https://github.com/nix-community/NUR/commit/ba739041e344d295d9e045620f7a1b5e748b9682) | `` automatic update `` |
| [`864e370f`](https://github.com/nix-community/NUR/commit/864e370f1ba42303a60c13ee8c8139697b483846) | `` automatic update `` |
| [`fc66688b`](https://github.com/nix-community/NUR/commit/fc66688b4a56184061191482536f1d8de3aea462) | `` automatic update `` |
| [`74f84da8`](https://github.com/nix-community/NUR/commit/74f84da87fc481dfdb050fa029e952553440f979) | `` automatic update `` |
| [`55b25f42`](https://github.com/nix-community/NUR/commit/55b25f42bdb74a819c77b6439d66e6cab2b56769) | `` automatic update `` |
| [`f8daf074`](https://github.com/nix-community/NUR/commit/f8daf074d279cff4c0b3c3b8dc60af803fbb030c) | `` automatic update `` |
| [`56103093`](https://github.com/nix-community/NUR/commit/561030932ceebe2904904992a83c5ca22c11a541) | `` automatic update `` |
| [`17107385`](https://github.com/nix-community/NUR/commit/1710738596d3150a09518f5c0636e274e6832294) | `` automatic update `` |
| [`8c5caff1`](https://github.com/nix-community/NUR/commit/8c5caff1357c409f0f85310e9ab79a7878d8685d) | `` automatic update `` |