### PR TITLE
chore(flake/home-manager): `defd16c5` -> `7224d7c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -445,11 +445,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678185531,
-        "narHash": "sha256-S9UgBQJcbf7rfy4I5FxvAmGjHeYq82dc3SBTPktbrt8=",
+        "lastModified": 1678464939,
+        "narHash": "sha256-pRMlwOUkO1OwSi7qF6XR/zcocWy/ZYxXgbYWvnZQO9k=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "defd16c5d5b271ff6cd7f72a108f711ebf31c936",
+        "rev": "7224d7c54c5fc74cdf60b208af6148ed3295aa32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                       |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`7224d7c5`](https://github.com/nix-community/home-manager/commit/7224d7c54c5fc74cdf60b208af6148ed3295aa32) | `` zellij: fix typo ``                                                        |
| [`c03d1e75`](https://github.com/nix-community/home-manager/commit/c03d1e75a1e5e10384e2836cdd6537a4e94be89a) | `` zellij: switch config lang from yaml to kdl for 0.32.0 ``                  |
| [`fce9dbfe`](https://github.com/nix-community/home-manager/commit/fce9dbfeb4fa0b0878cf4ebd375d4f2b5acc87b0) | `` lib: add generator for KDL ``                                              |
| [`36999b8d`](https://github.com/nix-community/home-manager/commit/36999b8d19eb6eebb41983ef017d7e0095316af2) | `` docs: simplify flake-specific instructions in the documentation (#3737) `` |
| [`f6981648`](https://github.com/nix-community/home-manager/commit/f69816489d5bcd1329c50fb4a7035a9a9dc19a3b) | `` home-manager: handle missing per-user profiles directory ``                |
| [`0f3dfc16`](https://github.com/nix-community/home-manager/commit/0f3dfc16d0e62f568bf08056de1a37832e900c32) | `` home-manager: fix nix-env uninstall command ``                             |