### PR TITLE
chore(flake/sops-nix): `7cff56b4` -> `1568702d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -900,11 +900,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1677987270,
-        "narHash": "sha256-NRqhY8jbrmP1C6oiVqv1T0T1r560eo4ZpmEdHoQmKj4=",
+        "lastModified": 1678440572,
+        "narHash": "sha256-zfL09Yy6H7QQwfacCPL0gOfWpVkTbE5jXJh5oZmGf8g=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "7cff56b43952edc5a2c212076d5fc922f764240f",
+        "rev": "1568702de0d2488c1e77011a9044de7fadec80c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                       |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`f32ee4fa`](https://github.com/Mic92/sops-nix/commit/f32ee4fac1e759151af59ddbefba3db762d2d024) | `` fix(readme): keygroups in .sops.yaml examples ``           |
| [`bdccb322`](https://github.com/Mic92/sops-nix/commit/bdccb322d5bc85cad8d0cc122cbf691dccaed0fa) | `` corrects small typo ``                                     |
| [`a96085e2`](https://github.com/Mic92/sops-nix/commit/a96085e2b4a51c94987bc73f87e4ed2d06e3f267) | `` Bump cachix/install-nix-action from 19 to 20 ``            |
| [`b2301f32`](https://github.com/Mic92/sops-nix/commit/b2301f3274433d87b6fd77f7a751509bf239ef62) | `` Bump DeterminateSystems/update-flake-lock from 16 to 17 `` |