### PR TITLE
chore(flake/nixos-hardware): `f6610997` -> `556101ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1678095239,
-        "narHash": "sha256-4F6jovFJcwh6OkMsY94ZrHdrvVqZi1FX5pYv6V9LIQw=",
+        "lastModified": 1678397099,
+        "narHash": "sha256-5xq8YJe+h19TlD+EI4AE/3H3jcCcQ2AWU6CWBVc5tRc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f6610997b0fc5ea5f9e142c348fca27497efe1c7",
+        "rev": "556101ff85bd6e20900ec73ee525b935154bc8ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`e72756d0`](https://github.com/NixOS/nixos-hardware/commit/e72756d0b46832bfeabeef4635bfebe863114613) | `` Enable NVIDIA power management for Dell XPS 7590 ``                         |
| [`826a2714`](https://github.com/NixOS/nixos-hardware/commit/826a2714d788187b27ee519abc5284de54d12464) | `` nxp: imx8: Fix wrong paths to imx-uboot.nix file ``                         |
| [`0d8c8525`](https://github.com/NixOS/nixos-hardware/commit/0d8c852503581906dada5e8a22ca5d9248f87427) | `` zephyrus ga401: Enable nvidia powerManagement & modesetting (nvidia-drm) `` |
| [`5c55f242`](https://github.com/NixOS/nixos-hardware/commit/5c55f2428f571fe06e382c800454176b4f8b67f5) | `` zephyrus ga401: Enable asusd  services ``                                   |
| [`8732ed0a`](https://github.com/NixOS/nixos-hardware/commit/8732ed0a3629705be34295982ffd4bfb6bd07750) | `` 16ach6h: add amd cpu pstate ``                                              |
| [`b5416e91`](https://github.com/NixOS/nixos-hardware/commit/b5416e9171d95e7ed94abad325218f78a8fab5f8) | `` zephyrus ga401: change pc/ssd to pc/laptop/ssd ``                           |
| [`0b49fc77`](https://github.com/NixOS/nixos-hardware/commit/0b49fc7783e7125c8ec48abd2bb6bb902421f5f6) | `` zephyrus ga401: add amd cpu pstate ``                                       |
| [`56ad5526`](https://github.com/NixOS/nixos-hardware/commit/56ad55261c313f3736193fb6a10d71713de161c8) | `` zephyrus ga401: add amdgpu driver ``                                        |