### PR TITLE
chore(flake/nur): `4fb4e5c1` -> `f8392983`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678499681,
-        "narHash": "sha256-fRVddVFXnSDkHFDm4PZnZDPGQpIRr+e+F/8bSxRCFOk=",
+        "lastModified": 1678505978,
+        "narHash": "sha256-Xc9A8nlKjF7FKCnTZ4HVYkdnsXR6m/PQw2rXwbBb724=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4fb4e5c1293b428a76338f317e964ca93b5b51bb",
+        "rev": "f8392983dbde30b3f50e43eeb3358acec09eb07f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f8392983`](https://github.com/nix-community/NUR/commit/f8392983dbde30b3f50e43eeb3358acec09eb07f) | `` automatic update `` |
| [`f20710af`](https://github.com/nix-community/NUR/commit/f20710af1e617b97befde7aca6ef7a1ad71e4729) | `` automatic update `` |