### PR TITLE
chore(flake/nur): `a2e4e856` -> `b494fa6c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678524445,
-        "narHash": "sha256-uAqfGBPTexxdB09jSwzXFHL+gZldpmrq6UirAa3G/n0=",
+        "lastModified": 1678538274,
+        "narHash": "sha256-R/Tab4WPMjqLCT7ujtG4y0wmM249tRcRLueYikq40ew=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a2e4e85699daa4bf68c3412d30a8cb855b018de8",
+        "rev": "b494fa6c94a35ce826f4b6e5f4eb147387b70960",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b494fa6c`](https://github.com/nix-community/NUR/commit/b494fa6c94a35ce826f4b6e5f4eb147387b70960) | `` automatic update `` |