### PR TITLE
chore(flake/nur): `b494fa6c` -> `4b214f24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678538274,
-        "narHash": "sha256-R/Tab4WPMjqLCT7ujtG4y0wmM249tRcRLueYikq40ew=",
+        "lastModified": 1678539242,
+        "narHash": "sha256-QXAKpK50+ATIPJmZjigD2+2JQWxLhqsuqD68vx96FRo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b494fa6c94a35ce826f4b6e5f4eb147387b70960",
+        "rev": "4b214f249b0aa2d62b6153c1c3f3a2d95705cb57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4b214f24`](https://github.com/nix-community/NUR/commit/4b214f249b0aa2d62b6153c1c3f3a2d95705cb57) | `` automatic update `` |