### PR TITLE
chore(flake/emacs-overlay): `8be50d27` -> `72f13558`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678526395,
-        "narHash": "sha256-ZPqJVulMfFx3gXk1/ttRz1JPO5sDLOuhl5rGoic6TUc=",
+        "lastModified": 1678559044,
+        "narHash": "sha256-5Ce/IjDdApIzGAr5Yuk5nemiAMPc2pSHnWnLGDHmTLI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8be50d27360b033539b45cd3606a4278a55f69ec",
+        "rev": "72f135581fa189c5c3829bb668fcaf456850d9de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`72f13558`](https://github.com/nix-community/emacs-overlay/commit/72f135581fa189c5c3829bb668fcaf456850d9de) | `` Updated repos/melpa `` |
| [`4101f8cd`](https://github.com/nix-community/emacs-overlay/commit/4101f8cd15d81e6d88663f9396c104404875e61a) | `` Updated repos/emacs `` |
| [`1c9b950e`](https://github.com/nix-community/emacs-overlay/commit/1c9b950e82ac4f0e39cf6568c0e7b117a96d79ea) | `` Updated repos/elpa ``  |