### PR TITLE
chore(flake/nur): `9cf8b6ee` -> `e4bf8a93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678560291,
-        "narHash": "sha256-LOSShfvjsQ2satsIXIYGTJmnTd4DMhxnvYIVhcHfVpA=",
+        "lastModified": 1678563959,
+        "narHash": "sha256-u6i/iH28wsO4BCQoXiZWM65DVpxSCZF2gCYEusyagWk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9cf8b6ee00136cf39a3ec9af153e5ab980506664",
+        "rev": "e4bf8a939cfcbb21249f91cf923bb57cdb8febd4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e4bf8a93`](https://github.com/nix-community/NUR/commit/e4bf8a939cfcbb21249f91cf923bb57cdb8febd4) | `` automatic update `` |