### PR TITLE
chore(flake/emacs-overlay): `72f13558` -> `2ee70907`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678559044,
-        "narHash": "sha256-5Ce/IjDdApIzGAr5Yuk5nemiAMPc2pSHnWnLGDHmTLI=",
+        "lastModified": 1678586532,
+        "narHash": "sha256-f1NFL6wjVusEXEhFpIzJk1H22bAPTDO4mSkWVMGUGuk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "72f135581fa189c5c3829bb668fcaf456850d9de",
+        "rev": "2ee70907d5395312b0fb5625007abf28c47603d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`2ee70907`](https://github.com/nix-community/emacs-overlay/commit/2ee70907d5395312b0fb5625007abf28c47603d0) | `` Updated repos/melpa `` |
| [`e9fbf7e7`](https://github.com/nix-community/emacs-overlay/commit/e9fbf7e781030b890d25bf582e20bd4235edb940) | `` Updated repos/elpa ``  |