### PR TITLE
chore(flake/nur): `9e7b1db2` -> `138ac1cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678590203,
-        "narHash": "sha256-xdWD2t0HVU2QsYva+GfGDs9pEgB7QZFp81oFOJy+ez4=",
+        "lastModified": 1678592726,
+        "narHash": "sha256-YWppO4olOGJPWA2KzyQlSjafkqowEspvxEyTlaviKAM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9e7b1db297926129a7e5e1d9549befc22ffc73d9",
+        "rev": "138ac1cb0fc01abab8706796f377fc771b2e0a64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`138ac1cb`](https://github.com/nix-community/NUR/commit/138ac1cb0fc01abab8706796f377fc771b2e0a64) | `` automatic update `` |
| [`f84de9e7`](https://github.com/nix-community/NUR/commit/f84de9e762f4cbd1a633f62360e015d424cc90db) | `` automatic update `` |