### PR TITLE
chore(flake/emacs-overlay): `2ee70907` -> `81cbd33a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678586532,
-        "narHash": "sha256-f1NFL6wjVusEXEhFpIzJk1H22bAPTDO4mSkWVMGUGuk=",
+        "lastModified": 1678616072,
+        "narHash": "sha256-BDH7FcW3QQaOVZQcGNVW1+XccBU9Wj4p2XG7SDjMVZQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2ee70907d5395312b0fb5625007abf28c47603d0",
+        "rev": "81cbd33afdf435e18d60bdbd82905fb097a0e622",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`81cbd33a`](https://github.com/nix-community/emacs-overlay/commit/81cbd33afdf435e18d60bdbd82905fb097a0e622) | `` Updated repos/melpa `` |
| [`67621315`](https://github.com/nix-community/emacs-overlay/commit/676213157a9cf906329e4fa40484f5f5da5ce7be) | `` Updated repos/emacs `` |