### PR TITLE
chore(flake/nur): `e1452cb6` -> `f50ccb61`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678614282,
-        "narHash": "sha256-xOdcIyqjSabQu16+kRDaetbRI2U9+HUhf2pbMIT9NZs=",
+        "lastModified": 1678635877,
+        "narHash": "sha256-bTOpuonfyP6Limkulowx5uBvVRuEg5AOhM/bWkpe0cI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e1452cb657eafdcc699c30bd85383f2488de8eb9",
+        "rev": "f50ccb61b35aba2b0ca881c0b3937ccf60647f15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f50ccb61`](https://github.com/nix-community/NUR/commit/f50ccb61b35aba2b0ca881c0b3937ccf60647f15) | `` automatic update `` |