### PR TITLE
chore(flake/nur): `f50ccb61` -> `f2de7916`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678635877,
-        "narHash": "sha256-bTOpuonfyP6Limkulowx5uBvVRuEg5AOhM/bWkpe0cI=",
+        "lastModified": 1678639699,
+        "narHash": "sha256-vqIvVYl8miXpoXX+TGNwys0uHmafp3rayooEpkAtHh8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f50ccb61b35aba2b0ca881c0b3937ccf60647f15",
+        "rev": "f2de79168531c21e0c457fe5d0cf42e046b3b995",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f2de7916`](https://github.com/nix-community/NUR/commit/f2de79168531c21e0c457fe5d0cf42e046b3b995) | `` automatic update `` |