### PR TITLE
chore(flake/emacs-overlay): `81cbd33a` -> `07079075`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678616072,
-        "narHash": "sha256-BDH7FcW3QQaOVZQcGNVW1+XccBU9Wj4p2XG7SDjMVZQ=",
+        "lastModified": 1678641422,
+        "narHash": "sha256-UHx/ApmVXsS7RuTAdWH0DveMjXKjWoQVidC24No9VfA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "81cbd33afdf435e18d60bdbd82905fb097a0e622",
+        "rev": "070790758b238ffd1bdec058af75ab33243bf03b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`07079075`](https://github.com/nix-community/emacs-overlay/commit/070790758b238ffd1bdec058af75ab33243bf03b) | `` Updated repos/melpa `` |
| [`98128f96`](https://github.com/nix-community/emacs-overlay/commit/98128f965ee2f991cac2f1174c5f74bcbe40d71b) | `` Updated repos/elpa ``  |