### PR TITLE
chore(flake/nur): `f2de7916` -> `b53da717`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678639699,
-        "narHash": "sha256-vqIvVYl8miXpoXX+TGNwys0uHmafp3rayooEpkAtHh8=",
+        "lastModified": 1678645498,
+        "narHash": "sha256-YZt1Gcj1qpC405bs3dT6EZ7n8HHiA9skZ7yEhDunJpQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f2de79168531c21e0c457fe5d0cf42e046b3b995",
+        "rev": "b53da717aab1283d3ad9e0530a1ae54c75bd2cd1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b53da717`](https://github.com/nix-community/NUR/commit/b53da717aab1283d3ad9e0530a1ae54c75bd2cd1) | `` automatic update `` |