### PR TITLE
chore(flake/nur): `84c505c5` -> `52d74af6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678650360,
-        "narHash": "sha256-AllNURmGG6MdkPF9IhFuvEbOU7H8b0JXo/HYNplTH7c=",
+        "lastModified": 1678663679,
+        "narHash": "sha256-Iexny5c2UpK1MgpeNERJaNbyYwT5TieqJudEP8m33jI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "84c505c572229efd75f9a13b86198cf733f9a96e",
+        "rev": "52d74af602d7c5ef92ac3a4a8e9658cc6e4beb66",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`52d74af6`](https://github.com/nix-community/NUR/commit/52d74af602d7c5ef92ac3a4a8e9658cc6e4beb66) | `` automatic update `` |