### PR TITLE
chore(flake/nur): `d39f90fc` -> `34d19713`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678668976,
-        "narHash": "sha256-SMS7Z1ddVTFbHqazruqtK5000rYk53s0RxatZiwi33c=",
+        "lastModified": 1678686147,
+        "narHash": "sha256-CffWcdfUx5F44CUpFat/MGZ0vZGin7lRAtUlyh70vbs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d39f90fc61640efe73cbfba7af658e71e49e337b",
+        "rev": "34d1971361ad5c8644d40e8530469677d4b0f8b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`34d19713`](https://github.com/nix-community/NUR/commit/34d1971361ad5c8644d40e8530469677d4b0f8b8) | `` automatic update `` |