### PR TITLE
chore(flake/nur): `34d19713` -> `72574fad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678686147,
-        "narHash": "sha256-CffWcdfUx5F44CUpFat/MGZ0vZGin7lRAtUlyh70vbs=",
+        "lastModified": 1678689976,
+        "narHash": "sha256-vO/pwqWbMn3p3NcSPyyXnLzVbj1AVOl7jOdJYIEuuXE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "34d1971361ad5c8644d40e8530469677d4b0f8b8",
+        "rev": "72574fad001b66cbada4dbf7f7a36f95974e1787",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`72574fad`](https://github.com/nix-community/NUR/commit/72574fad001b66cbada4dbf7f7a36f95974e1787) | `` automatic update `` |
| [`78949f20`](https://github.com/nix-community/NUR/commit/78949f204caf25c33c2b30fc110faddb3ec3622c) | `` automatic update `` |