### PR TITLE
chore(flake/nur): `72574fad` -> `dd0cc2eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678689976,
-        "narHash": "sha256-vO/pwqWbMn3p3NcSPyyXnLzVbj1AVOl7jOdJYIEuuXE=",
+        "lastModified": 1678694428,
+        "narHash": "sha256-P6EimAgsZCLhCio57pJBqHMLyzi+cf9Ss4vDhSgGD4A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "72574fad001b66cbada4dbf7f7a36f95974e1787",
+        "rev": "dd0cc2ebaff719aa357e827e29d5d092539ae399",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dd0cc2eb`](https://github.com/nix-community/NUR/commit/dd0cc2ebaff719aa357e827e29d5d092539ae399) | `` automatic update `` |