### PR TITLE
chore(flake/nur): `edbedc36` -> `2f533594`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678712694,
-        "narHash": "sha256-UwbrOI00CXErCvDDko7MW5w/jDvVi3kH1FT+VvXyZAs=",
+        "lastModified": 1678715119,
+        "narHash": "sha256-YAWboJjvV1yMD2bV2KNrqkFh8Fr93QHb9ulxEbQI+yc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "edbedc3600f87cc5f04a4fb2eeb448991fd8eafb",
+        "rev": "2f533594c7a14686c98faf7bb41c26610596feda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2f533594`](https://github.com/nix-community/NUR/commit/2f533594c7a14686c98faf7bb41c26610596feda) | `` automatic update `` |