### PR TITLE
chore(flake/nur): `2f533594` -> `9a348993`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678715119,
-        "narHash": "sha256-YAWboJjvV1yMD2bV2KNrqkFh8Fr93QHb9ulxEbQI+yc=",
+        "lastModified": 1678718021,
+        "narHash": "sha256-raLAKD3iFPvlwZdVc+Yvcyg/nj4ThFS7WyR4rsOL1yc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2f533594c7a14686c98faf7bb41c26610596feda",
+        "rev": "9a348993359741c561bcaadce759a92d293b7999",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9a348993`](https://github.com/nix-community/NUR/commit/9a348993359741c561bcaadce759a92d293b7999) | `` automatic update `` |