### PR TITLE
chore(flake/nur): `886cfdf6` -> `09b0bacb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678722342,
-        "narHash": "sha256-ina7rwgUjqAQpU77k7uVogv8P65g6OfQz26AR3KiHS0=",
+        "lastModified": 1678725615,
+        "narHash": "sha256-2k0hh1KlOZj+3QQEsq/Yg37hZJHURerk4kUpgYROWWY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "886cfdf62dfdd8eb4a7eccf26bc1ae6c392695af",
+        "rev": "09b0bacba18c9ad3d7b2a8337aa84a8ef1f6327e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`09b0bacb`](https://github.com/nix-community/NUR/commit/09b0bacba18c9ad3d7b2a8337aa84a8ef1f6327e) | `` automatic update `` |