### PR TITLE
chore(flake/nur): `09b0bacb` -> `786103d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678725615,
-        "narHash": "sha256-2k0hh1KlOZj+3QQEsq/Yg37hZJHURerk4kUpgYROWWY=",
+        "lastModified": 1678727677,
+        "narHash": "sha256-PU3Qp5dD0zjei9v7P9CGWjEPYJESo/TPQ3esvF+hlbw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "09b0bacba18c9ad3d7b2a8337aa84a8ef1f6327e",
+        "rev": "786103d751807de6eba9d02051a7c1393b24cee1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`786103d7`](https://github.com/nix-community/NUR/commit/786103d751807de6eba9d02051a7c1393b24cee1) | `` automatic update `` |