### PR TITLE
chore(flake/emacs-overlay): `b9274d63` -> `708ee5c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678699176,
-        "narHash": "sha256-P1TIrWaTtunjjiaSNAv7X9Y1fele8BMqIZgHjCeE9bQ=",
+        "lastModified": 1678727270,
+        "narHash": "sha256-rAZYkM1TZNR1W2r59dY8KlZbbMy+wQt3auekXWDiti8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b9274d63c2bc76e062a269f533c9f4a2bbf1e1d8",
+        "rev": "708ee5c00dd0f9306ca336efc45cdfebd85791b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`708ee5c0`](https://github.com/nix-community/emacs-overlay/commit/708ee5c00dd0f9306ca336efc45cdfebd85791b8) | `` Updated repos/melpa `` |
| [`7ec12774`](https://github.com/nix-community/emacs-overlay/commit/7ec1277468a42d9ee4e1c96faaf295f73b6eaf7b) | `` Updated repos/elpa ``  |