### PR TITLE
chore(flake/nur): `cfef6b0e` -> `97495005`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678736733,
-        "narHash": "sha256-XMqRLhFTgtn/QLRXWE1J/ESGJJbnxSlqEL3ThvSHDX8=",
+        "lastModified": 1678743978,
+        "narHash": "sha256-QArjB2jEIRS9WBXOwiAY0bxHiyOUjHn3e6sHsafgYpc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cfef6b0e312480d27fd2624a34e71dd6d3cff116",
+        "rev": "9749500551ff4ae2699fd23bba8ff0c1d5044f7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`97495005`](https://github.com/nix-community/NUR/commit/9749500551ff4ae2699fd23bba8ff0c1d5044f7f) | `` automatic update `` |