### PR TITLE
chore(flake/nur): `97495005` -> `c4ffafad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678743978,
-        "narHash": "sha256-QArjB2jEIRS9WBXOwiAY0bxHiyOUjHn3e6sHsafgYpc=",
+        "lastModified": 1678747509,
+        "narHash": "sha256-ER2cs/M5aF06p9xu6ffu3k4Rjv6Gcw5GXCBDotgJY1U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9749500551ff4ae2699fd23bba8ff0c1d5044f7f",
+        "rev": "c4ffafad9e5d93da0bdb7c10fa2b6986c7341a00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c4ffafad`](https://github.com/nix-community/NUR/commit/c4ffafad9e5d93da0bdb7c10fa2b6986c7341a00) | `` automatic update `` |