### PR TITLE
chore(flake/nur): `c4ffafad` -> `39b443e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678747509,
-        "narHash": "sha256-ER2cs/M5aF06p9xu6ffu3k4Rjv6Gcw5GXCBDotgJY1U=",
+        "lastModified": 1678751087,
+        "narHash": "sha256-ASZTEN362ZaTOFX+7GhuvLZScG7aI/czI1M5a8EXBEI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c4ffafad9e5d93da0bdb7c10fa2b6986c7341a00",
+        "rev": "39b443e2040ba9a18356c5a89c3f3295b3da230d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`39b443e2`](https://github.com/nix-community/NUR/commit/39b443e2040ba9a18356c5a89c3f3295b3da230d) | `` automatic update `` |