### PR TITLE
chore(flake/nur): `39b443e2` -> `20c8c6b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678751087,
-        "narHash": "sha256-ASZTEN362ZaTOFX+7GhuvLZScG7aI/czI1M5a8EXBEI=",
+        "lastModified": 1678758709,
+        "narHash": "sha256-sZ5YQ8QXU7RPvpHhMFxLRvYgvxYrz90eODuIEYEQSIg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "39b443e2040ba9a18356c5a89c3f3295b3da230d",
+        "rev": "20c8c6b85d60f6ea5b80e13337154ca8ead261ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`20c8c6b8`](https://github.com/nix-community/NUR/commit/20c8c6b85d60f6ea5b80e13337154ca8ead261ed) | `` automatic update `` |