### PR TITLE
chore(flake/emacs-overlay): `708ee5c0` -> `be43b00c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678727270,
-        "narHash": "sha256-rAZYkM1TZNR1W2r59dY8KlZbbMy+wQt3auekXWDiti8=",
+        "lastModified": 1678762797,
+        "narHash": "sha256-Gbgwt5V0ho6oSfG73PK0qpMIKPgbr2nsn129XXBYj90=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "708ee5c00dd0f9306ca336efc45cdfebd85791b8",
+        "rev": "be43b00cc91fc9ab5bf804fa27dcc0b4ddea344a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`be43b00c`](https://github.com/nix-community/emacs-overlay/commit/be43b00cc91fc9ab5bf804fa27dcc0b4ddea344a) | `` Updated repos/melpa `` |
| [`22bbcc54`](https://github.com/nix-community/emacs-overlay/commit/22bbcc544b6e44e809a5ad457abc031be6ff8bb7) | `` Updated repos/emacs `` |
| [`ea6f78e2`](https://github.com/nix-community/emacs-overlay/commit/ea6f78e2bc0eefa4a34bc9577318ed23b50b9d5b) | `` Updated repos/elpa ``  |