### PR TITLE
chore(flake/nur): `20c8c6b8` -> `5c3c404e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678758709,
-        "narHash": "sha256-sZ5YQ8QXU7RPvpHhMFxLRvYgvxYrz90eODuIEYEQSIg=",
+        "lastModified": 1678762838,
+        "narHash": "sha256-JNoxIahkiOt4pyMVtfVo3FaK8hcwQacH27hUy6KhZm8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "20c8c6b85d60f6ea5b80e13337154ca8ead261ed",
+        "rev": "5c3c404ee352cb0b39479e907daf369d8088a9e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5c3c404e`](https://github.com/nix-community/NUR/commit/5c3c404ee352cb0b39479e907daf369d8088a9e0) | `` automatic update `` |