### PR TITLE
chore(flake/nur): `5c3c404e` -> `afb990bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678762838,
-        "narHash": "sha256-JNoxIahkiOt4pyMVtfVo3FaK8hcwQacH27hUy6KhZm8=",
+        "lastModified": 1678766195,
+        "narHash": "sha256-etWmhOV7YnIplTZUuwzu6OAM4KW+tNU2o8Bt4H28LSo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5c3c404ee352cb0b39479e907daf369d8088a9e0",
+        "rev": "afb990bba332b8f16de61d9e3e551b1fd55ea247",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`afb990bb`](https://github.com/nix-community/NUR/commit/afb990bba332b8f16de61d9e3e551b1fd55ea247) | `` automatic update `` |
| [`82bb1cc4`](https://github.com/nix-community/NUR/commit/82bb1cc4ee64ad6f729abbe073f9f67b6f2a5458) | `` automatic update `` |