### PR TITLE
chore(flake/nur): `afb990bb` -> `a46f7074`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678766195,
-        "narHash": "sha256-etWmhOV7YnIplTZUuwzu6OAM4KW+tNU2o8Bt4H28LSo=",
+        "lastModified": 1678767121,
+        "narHash": "sha256-CgOA6QMo7qU1Ze5OL+wDYtineN2vDJnp4MiVjTeIoek=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "afb990bba332b8f16de61d9e3e551b1fd55ea247",
+        "rev": "a46f7074d9b138b24c8793a342d7ce9fd9d31f6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a46f7074`](https://github.com/nix-community/NUR/commit/a46f7074d9b138b24c8793a342d7ce9fd9d31f6b) | `` automatic update `` |