### PR TITLE
chore(flake/nur): `a46f7074` -> `f7ac7f63`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678767121,
-        "narHash": "sha256-CgOA6QMo7qU1Ze5OL+wDYtineN2vDJnp4MiVjTeIoek=",
+        "lastModified": 1678772564,
+        "narHash": "sha256-ALF3ir6y5hbNS25TWgc3iZinTF+/+4VZ06oHErZ2yZ8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a46f7074d9b138b24c8793a342d7ce9fd9d31f6b",
+        "rev": "f7ac7f6387896b142601deb1eb681e967f6b3d6e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f7ac7f63`](https://github.com/nix-community/NUR/commit/f7ac7f6387896b142601deb1eb681e967f6b3d6e) | `` automatic update `` |