### PR TITLE
chore(flake/nur): `f7ac7f63` -> `6f91e117`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678772564,
-        "narHash": "sha256-ALF3ir6y5hbNS25TWgc3iZinTF+/+4VZ06oHErZ2yZ8=",
+        "lastModified": 1678774631,
+        "narHash": "sha256-3wvE3XuLMMRiAM+dw2Jo8mQalOjEjed/964k6BMnVY0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f7ac7f6387896b142601deb1eb681e967f6b3d6e",
+        "rev": "6f91e11756ee1f2fd70897a03479d72bbb6a3358",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6f91e117`](https://github.com/nix-community/NUR/commit/6f91e11756ee1f2fd70897a03479d72bbb6a3358) | `` automatic update `` |