### PR TITLE
chore(flake/emacs-overlay): `be43b00c` -> `4e9ef767`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678762797,
-        "narHash": "sha256-Gbgwt5V0ho6oSfG73PK0qpMIKPgbr2nsn129XXBYj90=",
+        "lastModified": 1678785163,
+        "narHash": "sha256-171jg5HjQeqEXv+l25O/HgMQ9XkCz19AHD4qnRkzpvs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "be43b00cc91fc9ab5bf804fa27dcc0b4ddea344a",
+        "rev": "4e9ef767be5f4fcb59cd0f908779cfc3729c1880",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`4e9ef767`](https://github.com/nix-community/emacs-overlay/commit/4e9ef767be5f4fcb59cd0f908779cfc3729c1880) | `` Updated repos/melpa `` |