### PR TITLE
chore(flake/nur): `a93973a3` -> `4b8c2bae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678788009,
-        "narHash": "sha256-O9nMPCAly/lUJHqtz8IAa8sf4uuB/6arHDEyQoRXTyw=",
+        "lastModified": 1678816247,
+        "narHash": "sha256-Zz8+vqaAcuRxjJWG7zr2PrpEKQIxUVDbWlMBosOuxj8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a93973a3dd17284678ad6691dd38246b6ea3bf4f",
+        "rev": "4b8c2bae188553e8c5461e4824d732f86ec85a42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4b8c2bae`](https://github.com/nix-community/NUR/commit/4b8c2bae188553e8c5461e4824d732f86ec85a42) | `` automatic update `` |