### PR TITLE
chore(flake/emacs-overlay): `4e9ef767` -> `7ba9b9e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678785163,
-        "narHash": "sha256-171jg5HjQeqEXv+l25O/HgMQ9XkCz19AHD4qnRkzpvs=",
+        "lastModified": 1678817767,
+        "narHash": "sha256-P+Al3yNlM53oL+kxtU853arGO8YsfZPXjXqB1exaPKo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4e9ef767be5f4fcb59cd0f908779cfc3729c1880",
+        "rev": "7ba9b9e2392d33071f06dcff9845b42f3096f7c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`7ba9b9e2`](https://github.com/nix-community/emacs-overlay/commit/7ba9b9e2392d33071f06dcff9845b42f3096f7c3) | `` Updated repos/melpa `` |
| [`05a327d6`](https://github.com/nix-community/emacs-overlay/commit/05a327d6bfdbdb61b2b5b80f6b3ee50d1652aa6e) | `` Updated repos/emacs `` |