### PR TITLE
chore(flake/nur): `3318ac1f` -> `7741a0ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678832470,
-        "narHash": "sha256-j7M3YqRIwXrONWSpfJpIqvijfWMiKGx3XUqfVCeSfBU=",
+        "lastModified": 1678845360,
+        "narHash": "sha256-unfUkdl/FoTn//tmX15lGLT0qXl74Bw5SGF+kS7mWtA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3318ac1f94e1675ffdcf640d5c2a4c8987f31093",
+        "rev": "7741a0eeffcd0dd4c8c3a7a05ad8a4d4a03bb118",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7741a0ee`](https://github.com/nix-community/NUR/commit/7741a0eeffcd0dd4c8c3a7a05ad8a4d4a03bb118) | `` automatic update `` |