### PR TITLE
chore(flake/emacs-overlay): `7ba9b9e2` -> `ece2d384`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678817767,
-        "narHash": "sha256-P+Al3yNlM53oL+kxtU853arGO8YsfZPXjXqB1exaPKo=",
+        "lastModified": 1678849203,
+        "narHash": "sha256-G+5oeUT+yoRM8HjNPGTLW3IhhgF0htFZhDyjBbt3+Is=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7ba9b9e2392d33071f06dcff9845b42f3096f7c3",
+        "rev": "ece2d384eaf91cfbc40c2c6ba84d9be08b381899",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`ece2d384`](https://github.com/nix-community/emacs-overlay/commit/ece2d384eaf91cfbc40c2c6ba84d9be08b381899) | `` Updated repos/melpa `` |
| [`f6d47a0b`](https://github.com/nix-community/emacs-overlay/commit/f6d47a0b68e177a695140772027392f6a0a9f3e1) | `` Updated repos/emacs `` |
| [`2eff4547`](https://github.com/nix-community/emacs-overlay/commit/2eff4547a841149cdf9f026e1823b5fc271fc48c) | `` Updated repos/elpa ``  |