### PR TITLE
chore(flake/nur): `7d89a398` -> `65c4ce17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678851726,
-        "narHash": "sha256-zVYyBvxM8HINzKPCZzqXTkFsO6mfC9o3EnGXryf4k7U=",
+        "lastModified": 1678853464,
+        "narHash": "sha256-VWxIclfiH4nlRyII85OHi57aeRpUtJecaBWRhF+AshE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7d89a3989a9a2081bcb3f254e108099cb094aa34",
+        "rev": "65c4ce1727b34a456a90862815749221e7624502",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`65c4ce17`](https://github.com/nix-community/NUR/commit/65c4ce1727b34a456a90862815749221e7624502) | `` automatic update `` |