### PR TITLE
chore(flake/nur): `65c4ce17` -> `a903b064`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678853464,
-        "narHash": "sha256-VWxIclfiH4nlRyII85OHi57aeRpUtJecaBWRhF+AshE=",
+        "lastModified": 1678862813,
+        "narHash": "sha256-Ikb1Jcbw7hIpoeap4p77AuESgk55Rm66L+p501AJ9Cw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "65c4ce1727b34a456a90862815749221e7624502",
+        "rev": "a903b064e7dea4b4177aef40ab9ab6e1c4d0f6a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a903b064`](https://github.com/nix-community/NUR/commit/a903b064e7dea4b4177aef40ab9ab6e1c4d0f6a4) | `` automatic update `` |