### PR TITLE
chore(flake/emacs-overlay): `ece2d384` -> `bc4f7dd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678849203,
-        "narHash": "sha256-G+5oeUT+yoRM8HjNPGTLW3IhhgF0htFZhDyjBbt3+Is=",
+        "lastModified": 1678876729,
+        "narHash": "sha256-BztirKPaKQ2mQRO0MTVMJTytNvgREuf78yS9LDXgo/k=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ece2d384eaf91cfbc40c2c6ba84d9be08b381899",
+        "rev": "bc4f7dd7633bdefc2080b79fd12f171b85d3a1d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`bc4f7dd7`](https://github.com/nix-community/emacs-overlay/commit/bc4f7dd7633bdefc2080b79fd12f171b85d3a1d5) | `` Updated repos/melpa `` |
| [`5c38e5cd`](https://github.com/nix-community/emacs-overlay/commit/5c38e5cde506bb748c6d699228ee405d33e28384) | `` Updated repos/emacs `` |