### PR TITLE
chore(flake/nur): `f9c13008` -> `272d64d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678878276,
-        "narHash": "sha256-IcsviGoUkhSESMdpbO/9BOfAknD6e8RoCqhTjlPo5K8=",
+        "lastModified": 1678885512,
+        "narHash": "sha256-2+4WspXsm8tDrnPpljz6rVZvyuKq4v9xXAvG3sY9+LQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f9c13008014265bfead072d738cf6acbd072162d",
+        "rev": "272d64d372ed2156cd06b6535d9b7fabdc5ab54f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`272d64d3`](https://github.com/nix-community/NUR/commit/272d64d372ed2156cd06b6535d9b7fabdc5ab54f) | `` automatic update `` |
| [`7733da94`](https://github.com/nix-community/NUR/commit/7733da94928c1ba68c1d9b2a99815f3fbf83e43a) | `` automatic update `` |