### PR TITLE
chore(flake/nur): `dc10ca2a` -> `a7d01288`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678887050,
-        "narHash": "sha256-vECTWGgcui/DcTEH57LcEVpQaS8VC0uPZEaiAkw3Uxk=",
+        "lastModified": 1678895237,
+        "narHash": "sha256-gPCvxzfdZbKUK2ohAOzgd8HnSw4tvwL65P7sMyq6Vus=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dc10ca2a249a3041deb1e074633d6f094818e886",
+        "rev": "a7d012884c6abb2be4fcfaa76bb9465e6e87b4f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a7d01288`](https://github.com/nix-community/NUR/commit/a7d012884c6abb2be4fcfaa76bb9465e6e87b4f0) | `` automatic update `` |