### PR TITLE
chore(flake/nur): `bf2c0fd2` -> `6162aaee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678897863,
-        "narHash": "sha256-JEOSfdlZcy0Y5bCdsOAcOSr57nQIO+OS2FVDeclfdsk=",
+        "lastModified": 1678902345,
+        "narHash": "sha256-FHlhX4PgfDT+RZRRXujHrlOy43RnXmnoHlWS9bKfZH8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bf2c0fd2a06d581234da1cc8d731efecb6934035",
+        "rev": "6162aaeedbc8aced001f2e120d1ea75977b94ebf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6162aaee`](https://github.com/nix-community/NUR/commit/6162aaeedbc8aced001f2e120d1ea75977b94ebf) | `` automatic update `` |