### PR TITLE
chore(flake/emacs-overlay): `bc4f7dd7` -> `2e45b7cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678876729,
-        "narHash": "sha256-BztirKPaKQ2mQRO0MTVMJTytNvgREuf78yS9LDXgo/k=",
+        "lastModified": 1678904018,
+        "narHash": "sha256-70rkZAdsgg3rUobATcK5NeG7YpSpkeMENdLZsWSIfJY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bc4f7dd7633bdefc2080b79fd12f171b85d3a1d5",
+        "rev": "2e45b7cbdc64c3e56655cc097b17d8bdb3fbc1a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`2e45b7cb`](https://github.com/nix-community/emacs-overlay/commit/2e45b7cbdc64c3e56655cc097b17d8bdb3fbc1a7) | `` Updated repos/melpa `` |
| [`77103acc`](https://github.com/nix-community/emacs-overlay/commit/77103acc098c96e3a1a13878f0b32fe732b7b2d6) | `` Updated repos/emacs `` |