### PR TITLE
chore(flake/nur): `6162aaee` -> `4b0963c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678902345,
-        "narHash": "sha256-FHlhX4PgfDT+RZRRXujHrlOy43RnXmnoHlWS9bKfZH8=",
+        "lastModified": 1678909598,
+        "narHash": "sha256-rqnlF+2zxLKbtXxYZohxlc3KaBxCLiJ5b/Fu6DLjPZc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6162aaeedbc8aced001f2e120d1ea75977b94ebf",
+        "rev": "4b0963c3bcbac6c13a2b4a4a49b91c124dbc5d9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4b0963c3`](https://github.com/nix-community/NUR/commit/4b0963c3bcbac6c13a2b4a4a49b91c124dbc5d9f) | `` automatic update `` |
| [`60a4dd5a`](https://github.com/nix-community/NUR/commit/60a4dd5ab558359c4d3d2f222b349ea3d02adfae) | `` automatic update `` |