### PR TITLE
chore(flake/nur): `4b0963c3` -> `43d96b06`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678909598,
-        "narHash": "sha256-rqnlF+2zxLKbtXxYZohxlc3KaBxCLiJ5b/Fu6DLjPZc=",
+        "lastModified": 1678913208,
+        "narHash": "sha256-QfAb2GDO5P2/LKSfYYV3ICJXJIYOuz1wyVZVmV/gnfU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4b0963c3bcbac6c13a2b4a4a49b91c124dbc5d9f",
+        "rev": "43d96b06b8d2b3f21f8c50d684220e4fe3a41a37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`43d96b06`](https://github.com/nix-community/NUR/commit/43d96b06b8d2b3f21f8c50d684220e4fe3a41a37) | `` automatic update `` |