### PR TITLE
chore(flake/nur): `43d96b06` -> `40cbb3e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678913208,
-        "narHash": "sha256-QfAb2GDO5P2/LKSfYYV3ICJXJIYOuz1wyVZVmV/gnfU=",
+        "lastModified": 1678915555,
+        "narHash": "sha256-U4BDXptYZH2j59syOxuAbkpioKxqW+bC3LbJK+Tofw8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "43d96b06b8d2b3f21f8c50d684220e4fe3a41a37",
+        "rev": "40cbb3e28ea69c29375f6e0d01988caf50244f1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`40cbb3e2`](https://github.com/nix-community/NUR/commit/40cbb3e28ea69c29375f6e0d01988caf50244f1f) | `` automatic update `` |