### PR TITLE
chore(flake/emacs-overlay): `2e45b7cb` -> `a0d2c39e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678904018,
-        "narHash": "sha256-70rkZAdsgg3rUobATcK5NeG7YpSpkeMENdLZsWSIfJY=",
+        "lastModified": 1678936514,
+        "narHash": "sha256-6MSLtpEgSH2taCYuTkmu3qZWVB1U/OlRDEV6huLX5dc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2e45b7cbdc64c3e56655cc097b17d8bdb3fbc1a7",
+        "rev": "a0d2c39ee3fb673e0626213461d989418b1b1b7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`a0d2c39e`](https://github.com/nix-community/emacs-overlay/commit/a0d2c39ee3fb673e0626213461d989418b1b1b7f) | `` Updated repos/nongnu `` |
| [`a06c0e8c`](https://github.com/nix-community/emacs-overlay/commit/a06c0e8c9838ddf905f784ac4908de1c6e81dcbc) | `` Updated repos/melpa ``  |
| [`b512d516`](https://github.com/nix-community/emacs-overlay/commit/b512d516c72a29501dcbdf5c6a429dc3732ac446) | `` Updated repos/emacs ``  |
| [`b0e84f7e`](https://github.com/nix-community/emacs-overlay/commit/b0e84f7e4a1df7f69b020eb9c1ff4382b68a3c76) | `` Updated repos/elpa ``   |