### PR TITLE
chore(flake/nur): `cb16fafa` -> `c428e593`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678931826,
-        "narHash": "sha256-tPDf+Q51Ezjo78Qy1+3hZsUJtRyrsupBgma3EiE+okg=",
+        "lastModified": 1678938292,
+        "narHash": "sha256-D45bJov3GYq74oGzoRrZ1vkjRrUAGjWPPLOPb6iYN7g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cb16fafa7eaa8ade0eaa19dcd32fb5d6c258db4e",
+        "rev": "c428e5936586b0f0113eaae590a6415176ff8175",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c428e593`](https://github.com/nix-community/NUR/commit/c428e5936586b0f0113eaae590a6415176ff8175) | `` automatic update `` |