### PR TITLE
chore(flake/nur): `c428e593` -> `d3663140`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678938292,
-        "narHash": "sha256-D45bJov3GYq74oGzoRrZ1vkjRrUAGjWPPLOPb6iYN7g=",
+        "lastModified": 1678939859,
+        "narHash": "sha256-vmf0/ApR0XEnLJq1aU3OuzBV1pQUD9Z0IN2nnb4beZc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c428e5936586b0f0113eaae590a6415176ff8175",
+        "rev": "d366314098013524969589cc393dd0622a168eb1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d3663140`](https://github.com/nix-community/NUR/commit/d366314098013524969589cc393dd0622a168eb1) | `` automatic update `` |