### PR TITLE
chore(flake/nur): `d3663140` -> `d000cdc0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678939859,
-        "narHash": "sha256-vmf0/ApR0XEnLJq1aU3OuzBV1pQUD9Z0IN2nnb4beZc=",
+        "lastModified": 1678944125,
+        "narHash": "sha256-3XoU0rO2azBRrOVQo+Vr3sKYNBrP4+qK6L+VLQrYkCk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d366314098013524969589cc393dd0622a168eb1",
+        "rev": "d000cdc051714e7b8deac8a2bab35a58b5cd8b6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d000cdc0`](https://github.com/nix-community/NUR/commit/d000cdc051714e7b8deac8a2bab35a58b5cd8b6b) | `` automatic update `` |