### PR TITLE
chore(flake/nur): `d000cdc0` -> `7d2892dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678944125,
-        "narHash": "sha256-3XoU0rO2azBRrOVQo+Vr3sKYNBrP4+qK6L+VLQrYkCk=",
+        "lastModified": 1678945329,
+        "narHash": "sha256-3JVDzX3npyUR1b/YhSCtaYo9L/Y5uHXZ06Tt97Czzhw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d000cdc051714e7b8deac8a2bab35a58b5cd8b6b",
+        "rev": "7d2892dda3459cdd02efc4c892f9014d88a56de2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7d2892dd`](https://github.com/nix-community/NUR/commit/7d2892dda3459cdd02efc4c892f9014d88a56de2) | `` automatic update `` |