### PR TITLE
chore(flake/nur): `7d2892dd` -> `eab41186`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678945329,
-        "narHash": "sha256-3JVDzX3npyUR1b/YhSCtaYo9L/Y5uHXZ06Tt97Czzhw=",
+        "lastModified": 1678952793,
+        "narHash": "sha256-a7FaJZKnBF3fw0g2vzq88GhqGjgk7k9YEArm24Cj/Q0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7d2892dda3459cdd02efc4c892f9014d88a56de2",
+        "rev": "eab411863f3d12b9662964ee40e589f2c65d42c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eab41186`](https://github.com/nix-community/NUR/commit/eab411863f3d12b9662964ee40e589f2c65d42c9) | `` automatic update `` |