### PR TITLE
chore(flake/nur): `2e50ae6d` -> `8d29d9c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678955011,
-        "narHash": "sha256-dlN+8TR5cgrALQBDnEBHRatLfkp7cnml7ggtR02Dd0Y=",
+        "lastModified": 1678958227,
+        "narHash": "sha256-0zJbyQEJAQT8ugDLfvKnEmP8U/ALcvGbLFF+Cwjbw60=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2e50ae6dbdda3a310d96da11e47fd56f3ff51e12",
+        "rev": "8d29d9c1e4b012d56d0da67f4bcb6109c141d82b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8d29d9c1`](https://github.com/nix-community/NUR/commit/8d29d9c1e4b012d56d0da67f4bcb6109c141d82b) | `` automatic update `` |