### PR TITLE
chore(flake/home-manager): `c8cb60b8` -> `5e94669f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -445,11 +445,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678916824,
-        "narHash": "sha256-YPQAQ0x0wLvbQ/vaEj8o+0hRfbBNR0teTJ6QsG0yzw4=",
+        "lastModified": 1678957507,
+        "narHash": "sha256-t1yAoxlfhSjgeDGoQ1WJ0LBwVReL6y3QkAfJ3H+mOSs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c8cb60b8a15c90b2bbc416c182532620602edb48",
+        "rev": "5e94669f8ea8d697b1a00b916b2a86909f8c4ff5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`5e94669f`](https://github.com/nix-community/home-manager/commit/5e94669f8ea8d697b1a00b916b2a86909f8c4ff5) | `` home.pointerCursor: set common XCURSOR_* environment variables by default (#3663) `` |