### PR TITLE
chore(flake/emacs-overlay): `a0d2c39e` -> `8ef04704`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678936514,
-        "narHash": "sha256-6MSLtpEgSH2taCYuTkmu3qZWVB1U/OlRDEV6huLX5dc=",
+        "lastModified": 1678964687,
+        "narHash": "sha256-vjeY+BTunVWMMJVaCK5hxHoMQ7eY1aTneJ1k1BiKCG8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a0d2c39ee3fb673e0626213461d989418b1b1b7f",
+        "rev": "8ef04704d889883de041707302738d599e986981",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`8ef04704`](https://github.com/nix-community/emacs-overlay/commit/8ef04704d889883de041707302738d599e986981) | `` Updated repos/melpa `` |
| [`384290ad`](https://github.com/nix-community/emacs-overlay/commit/384290ad45e9e40a6d59bec2a5716690b6dafdd1) | `` Updated repos/emacs `` |