### PR TITLE
chore(flake/nur): `c830ffcd` -> `ceefcf6a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678968065,
-        "narHash": "sha256-FYYQyf3osP15yQzpOGtuBDy0pgJi/ho9QXVKRlFPcHA=",
+        "lastModified": 1678971938,
+        "narHash": "sha256-OMK/wzQrQKcnLptPDPJqOtNu2UagoOGKx7eps7Hcwfo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c830ffcd1d371a5bb7a5c234ea23030e7425ec79",
+        "rev": "ceefcf6af1682817ace4dbc90807b7a69d50f63d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ceefcf6a`](https://github.com/nix-community/NUR/commit/ceefcf6af1682817ace4dbc90807b7a69d50f63d) | `` automatic update `` |