### PR TITLE
chore(flake/nur): `ceefcf6a` -> `aac111b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678971938,
-        "narHash": "sha256-OMK/wzQrQKcnLptPDPJqOtNu2UagoOGKx7eps7Hcwfo=",
+        "lastModified": 1678974469,
+        "narHash": "sha256-3LxxHvt42mf0EqDlAGVe0IzN2CK6nY+jOLJFiFkBNiY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ceefcf6af1682817ace4dbc90807b7a69d50f63d",
+        "rev": "aac111b07bec72e3d7a1e83fcfd146930da70b57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aac111b0`](https://github.com/nix-community/NUR/commit/aac111b07bec72e3d7a1e83fcfd146930da70b57) | `` automatic update `` |