### PR TITLE
chore(flake/nur): `aac111b0` -> `baf932ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678974469,
-        "narHash": "sha256-3LxxHvt42mf0EqDlAGVe0IzN2CK6nY+jOLJFiFkBNiY=",
+        "lastModified": 1678985808,
+        "narHash": "sha256-dPTbw633knkRgFdocyKR+MSnbABOWTSb12otM96hVTc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aac111b07bec72e3d7a1e83fcfd146930da70b57",
+        "rev": "baf932ed7a4605a750868cc302286d2a7dcf9ac1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`baf932ed`](https://github.com/nix-community/NUR/commit/baf932ed7a4605a750868cc302286d2a7dcf9ac1) | `` automatic update `` |
| [`8888f20e`](https://github.com/nix-community/NUR/commit/8888f20e3047320731ad905be02418738b0319c9) | `` automatic update `` |