### PR TITLE
chore(flake/nur): `baf932ed` -> `9c64c4ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678985808,
-        "narHash": "sha256-dPTbw633knkRgFdocyKR+MSnbABOWTSb12otM96hVTc=",
+        "lastModified": 1678988709,
+        "narHash": "sha256-H7dEPSCqraOK0Bf2cBayT1eKkQjHx0Xal8psGhmhB50=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "baf932ed7a4605a750868cc302286d2a7dcf9ac1",
+        "rev": "9c64c4ac3bfb5c8aad7694f892cf9418b40eaf47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9c64c4ac`](https://github.com/nix-community/NUR/commit/9c64c4ac3bfb5c8aad7694f892cf9418b40eaf47) | `` automatic update `` |