### PR TITLE
chore(flake/emacs-overlay): `8ef04704` -> `9adcd178`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678964687,
-        "narHash": "sha256-vjeY+BTunVWMMJVaCK5hxHoMQ7eY1aTneJ1k1BiKCG8=",
+        "lastModified": 1678990527,
+        "narHash": "sha256-mbSgwu13v8X/Mqle0rBien6QHpVm7Cxka9ObpMRZSLU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8ef04704d889883de041707302738d599e986981",
+        "rev": "9adcd1787f765eee44bc27d9c930c53260982c98",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`9adcd178`](https://github.com/nix-community/emacs-overlay/commit/9adcd1787f765eee44bc27d9c930c53260982c98) | `` Updated repos/melpa `` |
| [`5c840b9c`](https://github.com/nix-community/emacs-overlay/commit/5c840b9c86d188d3ac6075cec3c553f163363966) | `` Updated repos/emacs `` |
| [`05a71fc0`](https://github.com/nix-community/emacs-overlay/commit/05a71fc0f7370673f3a967838b5772e42930f41f) | `` Updated repos/elpa ``  |