### PR TITLE
chore(flake/nur): `9c64c4ac` -> `b57d1058`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678988709,
-        "narHash": "sha256-H7dEPSCqraOK0Bf2cBayT1eKkQjHx0Xal8psGhmhB50=",
+        "lastModified": 1678999535,
+        "narHash": "sha256-J2xdscuBbn5CoTWH2c2/7lU59mqgZNxdtdt6YjUm6Cw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9c64c4ac3bfb5c8aad7694f892cf9418b40eaf47",
+        "rev": "b57d1058dc77e2e32c7c81c5ce1ea43119e616cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b57d1058`](https://github.com/nix-community/NUR/commit/b57d1058dc77e2e32c7c81c5ce1ea43119e616cc) | `` automatic update `` |