### PR TITLE
chore(flake/nur): `ac900a40` -> `1030781c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679031703,
-        "narHash": "sha256-jFQozIfeBUGS5mu4t6bQycmAJVlMvkKIqacoKYmX+m4=",
+        "lastModified": 1679035694,
+        "narHash": "sha256-kOnBBDZXoAzdm4oocqiEHJ90TrGA6utPO5cK01f4YOE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ac900a403d4703872fbd0e617b4a20c80a36dcdf",
+        "rev": "1030781c6a8af34e8c6a99c6415ce993ab628849",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1030781c`](https://github.com/nix-community/NUR/commit/1030781c6a8af34e8c6a99c6415ce993ab628849) | `` automatic update `` |