### PR TITLE
chore(flake/nur): `1030781c` -> `eb7ad2ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679035694,
-        "narHash": "sha256-kOnBBDZXoAzdm4oocqiEHJ90TrGA6utPO5cK01f4YOE=",
+        "lastModified": 1679039592,
+        "narHash": "sha256-YCPrqC9PTNU6HOi/VLQRXGX5NjPidHnL+nqKdf1AB/8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1030781c6a8af34e8c6a99c6415ce993ab628849",
+        "rev": "eb7ad2ad2734e3849fd74fab626ef6ad06122960",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eb7ad2ad`](https://github.com/nix-community/NUR/commit/eb7ad2ad2734e3849fd74fab626ef6ad06122960) | `` automatic update `` |