### PR TITLE
chore(flake/emacs-overlay): `026850ab` -> `17c3e9f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679019135,
-        "narHash": "sha256-9nQRfvNVFI6VRJoZ4BW8w89KynnB8/LPHaCGQ6Wh3bw=",
+        "lastModified": 1679047875,
+        "narHash": "sha256-JERCRQKgAMPUdAh48lF7AjknHU0K8xzAetz9ftf4qQM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "026850ab444c29fd56566237e3f0328d63782bfd",
+        "rev": "17c3e9f9fd8ded3ba563aef83ab63c740200b79a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`17c3e9f9`](https://github.com/nix-community/emacs-overlay/commit/17c3e9f9fd8ded3ba563aef83ab63c740200b79a) | `` Updated repos/melpa `` |
| [`5e5413be`](https://github.com/nix-community/emacs-overlay/commit/5e5413be0186ff08e291b6cf59e45bd82fa28806) | `` Updated repos/emacs `` |