### PR TITLE
chore(flake/nur): `fdf23c41` -> `7afb8a57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679057742,
-        "narHash": "sha256-qp/AjqTI1lXF4VSOp4StDarXbgTiKJVyTm1wcVVzygI=",
+        "lastModified": 1679060033,
+        "narHash": "sha256-RsD6V8+caJsPoZevlKRUivG72WeZu1fzF6FukH++Bnw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fdf23c41ce6d454416300040b9445d4cbb78ab5c",
+        "rev": "7afb8a575341f778e7ce95294d10556f5dc04299",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7afb8a57`](https://github.com/nix-community/NUR/commit/7afb8a575341f778e7ce95294d10556f5dc04299) | `` automatic update `` |
| [`faa6987e`](https://github.com/nix-community/NUR/commit/faa6987e9e4b8a8b9e5f70264867ffa7588e6451) | `` automatic update `` |
| [`acbc4311`](https://github.com/nix-community/NUR/commit/acbc431152fd2a8867713a43424edead1df3ed5f) | `` automatic update `` |