### PR TITLE
chore(flake/home-manager): `b832390d` -> `62cc5d81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -445,11 +445,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678967335,
-        "narHash": "sha256-oFppZaAVRA0G/aVPvjtWaQI5EQ2dZ5LgbEKfsBmKQgA=",
+        "lastModified": 1679058760,
+        "narHash": "sha256-l6gRnsrIEvgq0TzQDxhbRv2ra1ky4Zhj0PuCXd3H+ik=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b832390db376fbbf44115904cfab6680fb42e076",
+        "rev": "62cc5d815cfa288afe5f82b732ad727f2809fef9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`62cc5d81`](https://github.com/nix-community/home-manager/commit/62cc5d815cfa288afe5f82b732ad727f2809fef9) | `` .github: bump install-nix-action (#3723) ``                         |
| [`c7231c06`](https://github.com/nix-community/home-manager/commit/c7231c06e97170f7834922af698bca4ea3016753) | `` starship: condition nushell integration on nushell 0.73+ (#3776) `` |