### PR TITLE
chore(flake/nur): `55b48a8a` -> `16bc1d32`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679064291,
-        "narHash": "sha256-QzBPZNylJxwnXkKLmhR3g8h3RuIL55P9Ya/BkimgWus=",
+        "lastModified": 1679067657,
+        "narHash": "sha256-CqEHDMfVDCEpJvPgMEXP3LNmqfWwZcjjrdkiOxSjjEk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "55b48a8a11ed20e93e9064a9a8de9c800a248068",
+        "rev": "16bc1d324502a100eff8a92a37093858677c17ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`16bc1d32`](https://github.com/nix-community/NUR/commit/16bc1d324502a100eff8a92a37093858677c17ad) | `` automatic update `` |