### PR TITLE
chore(flake/nur): `731bf780` -> `fcbefcf2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679074862,
-        "narHash": "sha256-EQBoidJV1WXhdNoPZI+jwlArH/s8tyhR3higm042ABo=",
+        "lastModified": 1679082288,
+        "narHash": "sha256-HxgEELxJsBxjlKtx29r19VnrRzaj2Pj5WTdm/RWohhA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "731bf780bf68d86940c5e9bbd4af891f2bc0e773",
+        "rev": "fcbefcf2ffdeeffda1a8aa1b2a3763031f1996c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fcbefcf2`](https://github.com/nix-community/NUR/commit/fcbefcf2ffdeeffda1a8aa1b2a3763031f1996c8) | `` automatic update `` |