### PR TITLE
chore(flake/nur): `101939f3` -> `c87b1f0f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679104911,
-        "narHash": "sha256-9c8Cxw7Z0xXrMP81Gnn+YG5Y8fJOMMNLjLCVRTCjl8M=",
+        "lastModified": 1679106836,
+        "narHash": "sha256-ZmExdzHcqLuYW64lgMo+vsr+y0ohoxtgdO6+RqoCHRw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "101939f36d779614bc27f5aba15ffd384bc20935",
+        "rev": "c87b1f0f03cad7d74a503cf6b8220f13cde4e1c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c87b1f0f`](https://github.com/nix-community/NUR/commit/c87b1f0f03cad7d74a503cf6b8220f13cde4e1c0) | `` automatic update `` |