### PR TITLE
chore(flake/nur): `587ee418` -> `74e7f3b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679110814,
-        "narHash": "sha256-thz766w8qrZwWMXgbdxEd4diiQRu7RsMNdRet9SNoFU=",
+        "lastModified": 1679118139,
+        "narHash": "sha256-n84P8u1tgxSuAPBJWKJf+MIHB5qlE9Z8ZBsMbCVdwn0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "587ee418d3eb47b35ff1711fe511211582078b7c",
+        "rev": "74e7f3b26a3fcb8a6e43b3989f5b31f599150310",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`74e7f3b2`](https://github.com/nix-community/NUR/commit/74e7f3b26a3fcb8a6e43b3989f5b31f599150310) | `` automatic update `` |
| [`3b88b5b1`](https://github.com/nix-community/NUR/commit/3b88b5b1b4be62982f5df80aff837aafc755d11b) | `` automatic update `` |