### PR TITLE
chore(flake/emacs-overlay): `65c5d30a` -> `76769a71`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679104561,
-        "narHash": "sha256-JVyv+GeyJr7Zlxjt54sjHo90KpUGSUiVs/6tUBUuvQc=",
+        "lastModified": 1679115569,
+        "narHash": "sha256-LpNL6xxEiUFXvv+9MnaHDYTLv4gZateHuLgrxLcu2MA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "65c5d30a355533e3f0b7b6f0417270744978134e",
+        "rev": "76769a7131ba3a1a71cac8ebcd862c77ebd359d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`80a8537c`](https://github.com/nix-community/emacs-overlay/commit/80a8537cea678fe7f9e8e6c8ece67c1aec7bd65a) | `` add tree-sitter-html `` |