### PR TITLE
chore(flake/nur): `74e7f3b2` -> `a98f3013`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679118139,
-        "narHash": "sha256-n84P8u1tgxSuAPBJWKJf+MIHB5qlE9Z8ZBsMbCVdwn0=",
+        "lastModified": 1679121953,
+        "narHash": "sha256-UzGX36C5iHGHPaSuJxWL2ezmfc4NNwcnO6/bMoNEk9w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "74e7f3b26a3fcb8a6e43b3989f5b31f599150310",
+        "rev": "a98f30134c75cd570c2f14f1333e1b7e090bd1dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a98f3013`](https://github.com/nix-community/NUR/commit/a98f30134c75cd570c2f14f1333e1b7e090bd1dc) | `` automatic update `` |