### PR TITLE
chore(flake/nur): `a98f3013` -> `592d6e88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679121953,
-        "narHash": "sha256-UzGX36C5iHGHPaSuJxWL2ezmfc4NNwcnO6/bMoNEk9w=",
+        "lastModified": 1679129127,
+        "narHash": "sha256-xxIgpCf0vLp9IHIijc9mwA2pEbc+jEywvt4D4Emdfr4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a98f30134c75cd570c2f14f1333e1b7e090bd1dc",
+        "rev": "592d6e8871ffdc28a50604649a58fdbdf7ccedd7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`592d6e88`](https://github.com/nix-community/NUR/commit/592d6e8871ffdc28a50604649a58fdbdf7ccedd7) | `` automatic update `` |