### PR TITLE
chore(flake/nur): `592d6e88` -> `768717e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679129127,
-        "narHash": "sha256-xxIgpCf0vLp9IHIijc9mwA2pEbc+jEywvt4D4Emdfr4=",
+        "lastModified": 1679133788,
+        "narHash": "sha256-qAAoW0hfYzr3boWPben0dcS9TjLO6PJJa6JPxnEgycs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "592d6e8871ffdc28a50604649a58fdbdf7ccedd7",
+        "rev": "768717e2740ea04b7fba6218b2675eea59fdcc5f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`768717e2`](https://github.com/nix-community/NUR/commit/768717e2740ea04b7fba6218b2675eea59fdcc5f) | `` automatic update `` |