### PR TITLE
chore(flake/emacs-overlay): `76769a71` -> `4413eb27`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679115569,
-        "narHash": "sha256-LpNL6xxEiUFXvv+9MnaHDYTLv4gZateHuLgrxLcu2MA=",
+        "lastModified": 1679134471,
+        "narHash": "sha256-8G1LnD0y7RJ6h5TQSfg7NemP3jfw+LfpTQ7PHhBCcgA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "76769a7131ba3a1a71cac8ebcd862c77ebd359d3",
+        "rev": "4413eb27ed79fbd5ef50ea372c8fc28d6de2981b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`4413eb27`](https://github.com/nix-community/emacs-overlay/commit/4413eb27ed79fbd5ef50ea372c8fc28d6de2981b) | `` Updated repos/melpa `` |
| [`404da950`](https://github.com/nix-community/emacs-overlay/commit/404da9508532033a611505bb7269f3429d33b8a5) | `` Updated repos/emacs `` |