### PR TITLE
chore(flake/nur): `d79a045f` -> `f9f56579`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679147795,
-        "narHash": "sha256-7orY6tIH0eZjmLNVGW4ulNwWHD/WHuveMtAxslmkkkU=",
+        "lastModified": 1679149832,
+        "narHash": "sha256-Vgnq89MfMp5WUD22k8LvAq2FHiUO4wmjyeBfRIYZDAE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d79a045f0a1659a04249a13381896ee755c7c7af",
+        "rev": "f9f56579409e663b1a3b72f628fe14ab3415581c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f9f56579`](https://github.com/nix-community/NUR/commit/f9f56579409e663b1a3b72f628fe14ab3415581c) | `` automatic update `` |