### PR TITLE
chore(flake/sops-nix): `9e98f7a4` -> `ac6df5bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -618,11 +618,11 @@
     },
     "nixpkgs-stable_4": {
       "locked": {
-        "lastModified": 1678582009,
-        "narHash": "sha256-J8QzUOOv3/y97q19pGOz28gLC3lAUy1c4bWpsi5D460=",
+        "lastModified": 1679139072,
+        "narHash": "sha256-Gtw2Yj8DfETie3u7iHv1y5Wt+plGRmp6nTQ0EEfaPho=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c34fc09c77172c4189df4594a0749e25a23cdd9b",
+        "rev": "08ef7dc8334521605a5c8b7086cc248e74ee338b",
         "type": "github"
       },
       "original": {
@@ -899,11 +899,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1678590185,
-        "narHash": "sha256-scvu8HegWwbcvPKjh6M1DnpPYAv4EnP1krsRPItoQ+E=",
+        "lastModified": 1679152338,
+        "narHash": "sha256-gOVlCY84Ybbrzi3E8PEK/gOoxANYeU5f8Nm7uNPbjSo=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "9e98f7a442b0e318de9cce757675c2ab922bdf2b",
+        "rev": "ac6df5bc51439401a0257db4205b3df66b76da0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                  |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`332f95d2`](https://github.com/Mic92/sops-nix/commit/332f95d2db4944dfb354c6c357a893212309dbe8) | `` drop nixosModule in favour of nixosModules.default `` |
| [`215dcb71`](https://github.com/Mic92/sops-nix/commit/215dcb71e7f066bb55265be9556fd9ebc385907b) | `` drop flake defaultPackage ``                          |
| [`55d5e5cb`](https://github.com/Mic92/sops-nix/commit/55d5e5cb0beba5e07a41f3087da8c30740993d6c) | `` bump vendorSha256 ``                                  |
| [`7fbbdb5f`](https://github.com/Mic92/sops-nix/commit/7fbbdb5f73740057c64c4f3df32f9b4a3994b292) | `` Bump golang.org/x/crypto from 0.6.0 to 0.7.0 ``       |
| [`95d9e958`](https://github.com/Mic92/sops-nix/commit/95d9e958ba1d7f7c9e0f1147ee8cf9e7d0c9f36b) | `` update bors.toml ``                                   |
| [`fc6bd2bd`](https://github.com/Mic92/sops-nix/commit/fc6bd2bdfedf2a67d41cc6339ffa241375832941) | `` drop deprecated overlay/devShell output ``            |
| [`f5256e20`](https://github.com/Mic92/sops-nix/commit/f5256e20817da9094d7530fc55f2d73ddc26dda9) | `` bump vendorSha256 ``                                  |
| [`bc224089`](https://github.com/Mic92/sops-nix/commit/bc2240899818312c5284f225966c6a9ce61843bc) | `` flake.lock: Update ``                                 |
| [`fb481fc6`](https://github.com/Mic92/sops-nix/commit/fb481fc6e18814930e96fd10ee9d5b7cf1512709) | `` Bump golang.org/x/sys from 0.5.0 to 0.6.0 ``          |
| [`39d8d19f`](https://github.com/Mic92/sops-nix/commit/39d8d19f48c884ca3a7c7bde54545c1975616b39) | `` Bump github.com/joho/godotenv from 1.4.0 to 1.5.1 ``  |