### PR TITLE
chore(flake/nur): `f9f56579` -> `23289b0e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679149832,
-        "narHash": "sha256-Vgnq89MfMp5WUD22k8LvAq2FHiUO4wmjyeBfRIYZDAE=",
+        "lastModified": 1679152739,
+        "narHash": "sha256-95gKWTXDCvI3vJiENdYXGWUcGUwlqifmJ9khtGaS74c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f9f56579409e663b1a3b72f628fe14ab3415581c",
+        "rev": "23289b0eef35567ccd3d951d40440524a05dd0a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                             |
| -------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`23289b0e`](https://github.com/nix-community/NUR/commit/23289b0eef35567ccd3d951d40440524a05dd0a7) | `` automatic update ``              |
| [`ae26f055`](https://github.com/nix-community/NUR/commit/ae26f055215143e2efa7f03aaabdd488099a47d2) | `` Remove JayRovacsek repository `` |