### PR TITLE
chore(flake/emacs-overlay): `4413eb27` -> `a3abd804`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679134471,
-        "narHash": "sha256-8G1LnD0y7RJ6h5TQSfg7NemP3jfw+LfpTQ7PHhBCcgA=",
+        "lastModified": 1679163259,
+        "narHash": "sha256-o0L4V6f5oMsqFJkD/CYtzHA65s1ehZpLRi2BxLxOkS4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4413eb27ed79fbd5ef50ea372c8fc28d6de2981b",
+        "rev": "a3abd804a0f05d3d388a6efced4f7bf50792deb6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`a3abd804`](https://github.com/nix-community/emacs-overlay/commit/a3abd804a0f05d3d388a6efced4f7bf50792deb6) | `` Updated repos/melpa `` |
| [`31bd73d1`](https://github.com/nix-community/emacs-overlay/commit/31bd73d15a46a98d20e3f67641f6b766c2af655a) | `` Updated repos/emacs `` |