### PR TITLE
chore(flake/nixpkgs): `ac718d02` -> `b573a7f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -649,11 +649,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1678898370,
-        "narHash": "sha256-xTICr1j+uat5hk9FyuPOFGxpWHdJRibwZC+ATi0RbtE=",
+        "lastModified": 1679081381,
+        "narHash": "sha256-n4+SbrVohxbgbmOTkodfxc3d8W38OfKowD6YNA8j27o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ac718d02867a84b42522a0ece52d841188208f2c",
+        "rev": "b573a7f69484a7d213680abb70b4f95bdc28eee5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`2c503ae9`](https://github.com/NixOS/nixpkgs/commit/2c503ae9c57639d845120a163f7250cdba056fb4) | `` lagrange: 1.15.4 → 1.15.5 ``                                                            |
| [`33929959`](https://github.com/NixOS/nixpkgs/commit/3392995957160567e6ca1aa2982085520b985710) | `` the-foundation: 1.6.0 → 1.6.1 ``                                                        |
| [`66b62bf8`](https://github.com/NixOS/nixpkgs/commit/66b62bf8f3054a9992456ba8ce7ff3117558d9f8) | `` hyprland/wlroots: ping commit of nvidia patch ``                                        |
| [`c863a1be`](https://github.com/NixOS/nixpkgs/commit/c863a1beecb42dd20dbd69f5e22fbc809aac54e2) | `` babashka: 1.1.173 → 1.2.174 ``                                                          |
| [`f05d7d02`](https://github.com/NixOS/nixpkgs/commit/f05d7d022cfe88eb7d5fc396b96f12e3463ddafc) | `` buildGraalvmNativeImage: allow overwriting {build,install}Phase/nativeBuildInputs ``    |
| [`4177ddcf`](https://github.com/NixOS/nixpkgs/commit/4177ddcfd6284e18067dade38f0a438c60890fce) | `` doas: refactor config generation ``                                                     |
| [`23bc23f6`](https://github.com/NixOS/nixpkgs/commit/23bc23f6a5503e3a4b1765f195f3dfaa91bcb0d3) | `` python3Packages.zfec: Avoid using deprecated test runner ``                             |
| [`0410c5f7`](https://github.com/NixOS/nixpkgs/commit/0410c5f70d4da791f06b51e87e3ebf1b66713823) | `` pyvirtualdisplay: remove alias usage ``                                                 |
| [`a16e75fc`](https://github.com/NixOS/nixpkgs/commit/a16e75fcbdd620a5a69db89c0f65a8a6d1b31fdf) | `` electron-mail: 5.1.2 -> 5.1.6 ``                                                        |
| [`105443ed`](https://github.com/NixOS/nixpkgs/commit/105443edbb3497fd802279c9ec6d6b2b5ef0626f) | `` roon-server: 2.0-1223 -> 2.0-1234 ``                                                    |
| [`1785c6e8`](https://github.com/NixOS/nixpkgs/commit/1785c6e8a935bd74ce88d4672e72e3e4e8885c24) | `` hatch: switch to fetchPypi ``                                                           |
| [`c0143c82`](https://github.com/NixOS/nixpkgs/commit/c0143c82d1879e3f7778a09b235bf7059b284e59) | `` librepo: restrict platforms ``                                                          |
| [`efbd314c`](https://github.com/NixOS/nixpkgs/commit/efbd314c764d72460c20455e2c922f23ebe9827b) | `` mpv: fix patch hash ``                                                                  |
| [`bbe6e6da`](https://github.com/NixOS/nixpkgs/commit/bbe6e6da9b3d6259f185ae1ccaa9b8ab4fee3f01) | `` kitsas: 3.2.1 -> 4.0.3 ``                                                               |
| [`4b023832`](https://github.com/NixOS/nixpkgs/commit/4b023832f84119a67af511f40d6edb440a9064ae) | `` gimpPlugins.resynthesizer: Mark as broken for GIMP without Python 2 support ``          |
| [`69e4b68a`](https://github.com/NixOS/nixpkgs/commit/69e4b68ae91f27dad58647ec6b996bbda2439c60) | `` gimp: Expose Python 2 support ``                                                        |
| [`ed923bb6`](https://github.com/NixOS/nixpkgs/commit/ed923bb61dd373a536bb8608e2599a11e637fc19) | `` gimp: Use env attribute for environment variables ``                                    |
| [`df5faef6`](https://github.com/NixOS/nixpkgs/commit/df5faef631bf44b1153304581957f95b6c8c2a46) | `` cudatext: 1.187.0 -> 1.187.1 ``                                                         |
| [`29638c4a`](https://github.com/NixOS/nixpkgs/commit/29638c4a7ee8efdc764e5f77fd68e03e86926036) | `` gimp-with-plugins: Use consistent GIMP version ``                                       |
| [`94f5d6e5`](https://github.com/NixOS/nixpkgs/commit/94f5d6e5c2b9adf59330681bc661d70d0f7d964c) | `` gimp: Switch to finalAttrs ``                                                           |
| [`7cb73c9a`](https://github.com/NixOS/nixpkgs/commit/7cb73c9a299fb704da2654a8061f3c6956ec3c71) | `` python310Packages.azure-keyvault-certificates: 4.6.0 -> 4.7.0 ``                        |
| [`ba88a0bc`](https://github.com/NixOS/nixpkgs/commit/ba88a0bc5438f751e2b809ac9144f429ba7e2f96) | `` ballerina: fix JAVA_HOME ``                                                             |
| [`545b5d04`](https://github.com/NixOS/nixpkgs/commit/545b5d04f4c3eeb1804c6b58a9943779d9940969) | `` openmolcas: 22.10 -> 23.02 ``                                                           |
| [`8ad8f9d2`](https://github.com/NixOS/nixpkgs/commit/8ad8f9d26685898f266f03ae745d2b4421713531) | `` doc/stdenv: add quotes to run phases with newlines ``                                   |
| [`60bfab5d`](https://github.com/NixOS/nixpkgs/commit/60bfab5d57a2f01044248c0deef3ebbf6e6bb66a) | `` python310Packages.sexpdata: 0.0.4 -> 1.0.0 ``                                           |
| [`faa448fa`](https://github.com/NixOS/nixpkgs/commit/faa448fa764d49a3a0b5fce0d2381c061a12545a) | `` ferretdb: 0.9.2 -> 0.9.3 (#220997) ``                                                   |
| [`1a50c976`](https://github.com/NixOS/nixpkgs/commit/1a50c976b567f2e2e876244e58b2d6c94f00f28d) | `` python310Packages.screenlogicpy: 0.8.1 -> 0.8.2 ``                                      |
| [`145ce739`](https://github.com/NixOS/nixpkgs/commit/145ce7393311f1842a90b38eb8d89baa8888c8f6) | `` vulkan-caps-viewer: 3.28 -> 3.29 ``                                                     |
| [`7f54d0b1`](https://github.com/NixOS/nixpkgs/commit/7f54d0b183340447de9dcc034d225411f8ecc6f7) | `` linux/hardened/patches/6.1: 6.1.15-hardened1 -> 6.1.19-hardened1 ``                     |
| [`af4fcd5d`](https://github.com/NixOS/nixpkgs/commit/af4fcd5dd7bc9a69312f3ac5071288fda8b867c0) | `` linux/hardened/patches/5.4: 5.4.234-hardened1 -> 5.4.236-hardened1 ``                   |
| [`cce3af4c`](https://github.com/NixOS/nixpkgs/commit/cce3af4c1d034452ad3f46680a3bd7ac96e548e2) | `` linux/hardened/patches/5.15: 5.15.98-hardened1 -> 5.15.102-hardened1 ``                 |
| [`6c59d5d0`](https://github.com/NixOS/nixpkgs/commit/6c59d5d0013ec7471014254cfa0389fb92d47a8c) | `` linux/hardened/patches/5.10: 5.10.172-hardened1 -> 5.10.174-hardened1 ``                |
| [`dc74597f`](https://github.com/NixOS/nixpkgs/commit/dc74597f619ce8d9ec39758a498e91528c39bd69) | `` linux/hardened/patches/4.19: 4.19.275-hardened1 -> 4.19.277-hardened1 ``                |
| [`1a070205`](https://github.com/NixOS/nixpkgs/commit/1a07020574905518be227cd13d5818c091584867) | `` linux/hardened/patches/4.14: 4.14.307-hardened1 -> 4.14.309-hardened1 ``                |
| [`9eed8f7a`](https://github.com/NixOS/nixpkgs/commit/9eed8f7a51be6ec79783b24bd7e874ed6faca28b) | `` xmousepasteblock: 1.0 -> 1.3 ``                                                         |
| [`40cc0d05`](https://github.com/NixOS/nixpkgs/commit/40cc0d059604a5b8d7c50afda404c71ebe6629bf) | `` scala-cli: 0.2.0 -> 0.2.1 ``                                                            |
| [`5b284eff`](https://github.com/NixOS/nixpkgs/commit/5b284effd4efd011101a891895b9b43b69d1de36) | `` tixati: drop ``                                                                         |
| [`feaedbb3`](https://github.com/NixOS/nixpkgs/commit/feaedbb393285e3c3d11764c5031258057bcf543) | `` linux_latest-libre: 19102 -> 19109 ``                                                   |
| [`4c83fe7e`](https://github.com/NixOS/nixpkgs/commit/4c83fe7ec352c9b81cf8220bd1653a1bce970069) | `` linux: 6.2.6 -> 6.2.7 ``                                                                |
| [`8bef4ceb`](https://github.com/NixOS/nixpkgs/commit/8bef4cebd12958a99def5f7f31b47e6821c9438e) | `` linux: 6.1.19 -> 6.1.20 ``                                                              |
| [`2cca7474`](https://github.com/NixOS/nixpkgs/commit/2cca747420de0f3d4fb80a8c33ddb13b54e18fc5) | `` linux: 5.4.236 -> 5.4.237 ``                                                            |
| [`cf346bc9`](https://github.com/NixOS/nixpkgs/commit/cf346bc95aa593bd50e9accedbb81d0e5afacb2e) | `` linux: 5.15.102 -> 5.15.103 ``                                                          |
| [`2589986a`](https://github.com/NixOS/nixpkgs/commit/2589986af637ec19c38853091ed97adae65927df) | `` linux: 5.10.174 -> 5.10.175 ``                                                          |
| [`b244d570`](https://github.com/NixOS/nixpkgs/commit/b244d57064e5b585ba04f0cf56acdd33c2cd2c77) | `` linux: 4.19.277 -> 4.19.278 ``                                                          |
| [`0909bcf1`](https://github.com/NixOS/nixpkgs/commit/0909bcf14e4c631d6fccd49b027535ec7fd1967d) | `` linux: 4.14.309 -> 4.14.310 ``                                                          |
| [`fabe0f0b`](https://github.com/NixOS/nixpkgs/commit/fabe0f0bece463427c41edcb1d2bfd9ed720764d) | `` CuboCore.corekeyboard: fix build ``                                                     |
| [`0ba38371`](https://github.com/NixOS/nixpkgs/commit/0ba38371e2c84f10678b39914c60a02daa81c4f5) | `` bandwidth: 1.11.2 -> 1.11.2d ``                                                         |
| [`ef5c3f99`](https://github.com/NixOS/nixpkgs/commit/ef5c3f99ba804f1d359cafd55162ef83c77c9ef2) | `` hyprpicker: init at unstable-2023-03-09 ``                                              |
| [`1058e582`](https://github.com/NixOS/nixpkgs/commit/1058e582684ebafa9de8f877140698e3b07e1d58) | `` xdg-desktop-portal-hyprland: init at unstable-2023-03-16 ``                             |
| [`e7defd25`](https://github.com/NixOS/nixpkgs/commit/e7defd25163d47c69e31e4170ceb429e18d03cca) | `` hyprland: 0.6.1 -> 0.23.0beta ``                                                        |
| [`4c935d41`](https://github.com/NixOS/nixpkgs/commit/4c935d410fc8b5494c179e18b6df36a6bae5c707) | `` flexget: fix build ``                                                                   |
| [`ae8f6bfa`](https://github.com/NixOS/nixpkgs/commit/ae8f6bfab80130dcc43cf1d1c969809ccac02a9e) | `` vimPlugins.LazyVim: init at 2023-03-16 ``                                               |
| [`54dc7194`](https://github.com/NixOS/nixpkgs/commit/54dc719421a65f0978700cd614f5eef231ec229d) | `` python310Packages.glfw: disable on unsupported Python releases ``                       |
| [`5c4812d6`](https://github.com/NixOS/nixpkgs/commit/5c4812d6f640fc90348df148ca1ec82c1e1f9289) | `` python310Packages.glfw: add changelog to meta ``                                        |
| [`775e143c`](https://github.com/NixOS/nixpkgs/commit/775e143cd494e912eb6300c219e62f10b7020446) | `` hyprland-protocols: init at unstable-2023-01-13 ``                                      |
| [`857b50e5`](https://github.com/NixOS/nixpkgs/commit/857b50e5bfb143e7a6169d1c47ad0483acfb433a) | `` qovery-cli: 0.52.0 -> 0.52.2 ``                                                         |
| [`cb925289`](https://github.com/NixOS/nixpkgs/commit/cb925289109af00d6b1dbc00758edd8a0aa681ca) | `` rain: 1.2.0 -> 1.3.3 ``                                                                 |
| [`cce8dfae`](https://github.com/NixOS/nixpkgs/commit/cce8dfae835a3b906301782c362a021830ccffe0) | `` rnote: also build on Darwin ``                                                          |
| [`4eb1c2d2`](https://github.com/NixOS/nixpkgs/commit/4eb1c2d29937590d13da5a2bce7a867c9a391b77) | `` vimPlugins.clipboard-image-nvim: init at 2022-11-10 ``                                  |
| [`bd527314`](https://github.com/NixOS/nixpkgs/commit/bd52731407e7754b29c49a3b77b70bddffe78677) | `` vimPlugins.persistence-nvim: init at 2023-02-28 ``                                      |
| [`e07fc2b7`](https://github.com/NixOS/nixpkgs/commit/e07fc2b75093cc99ae72e7747a2d1a77363ec042) | `` v2ray-geoip: 202303090050 -> 202303160048 ``                                            |
| [`fff0a29d`](https://github.com/NixOS/nixpkgs/commit/fff0a29d9342d4384cdf833bd0b90ec89fccc4fb) | `` terraform-providers.aws: 4.58.0 → 4.59.0 ``                                             |
| [`dd0a4655`](https://github.com/NixOS/nixpkgs/commit/dd0a46551c4f258e1ecdc30f5841ecf6756bdb16) | `` terraform-providers.snowflake: 0.58.0 → 0.58.2 ``                                       |
| [`8a9e0095`](https://github.com/NixOS/nixpkgs/commit/8a9e0095f12913b61ac40717b7a73b39f0cd60e5) | `` terraform-providers.newrelic: 3.16.1 → 3.17.0 ``                                        |
| [`a170bba8`](https://github.com/NixOS/nixpkgs/commit/a170bba861771e3ea8973d26144c8f5d11526f09) | `` terraform-providers.fastly: 4.0.0 → 4.1.0 ``                                            |
| [`d112fd01`](https://github.com/NixOS/nixpkgs/commit/d112fd012c124216c6951d3e4080d0005accfaa1) | `` terraform-providers.buildkite: 0.11.0 → 0.11.1 ``                                       |
| [`8054b256`](https://github.com/NixOS/nixpkgs/commit/8054b256b20ccbe3da4b8f1b6623faba50ecb96a) | `` terraform-providers.bigip: 1.16.2 → 1.17.0 ``                                           |
| [`c08679a8`](https://github.com/NixOS/nixpkgs/commit/c08679a86c78160ccfc5c1a289a122992610ede7) | `` terraform-providers.azurerm: 3.47.0 → 3.48.0 ``                                         |
| [`8cddbf83`](https://github.com/NixOS/nixpkgs/commit/8cddbf831867299e25aa664d9d78365d9f97d577) | `` sigil: 1.9.20 -> 1.9.30 ``                                                              |
| [`553ef594`](https://github.com/NixOS/nixpkgs/commit/553ef59470dc3f1193be49181cbcca2bfb823eb3) | `` miniflux: 2.0.42 -> 2.0.43 ``                                                           |
| [`59d80179`](https://github.com/NixOS/nixpkgs/commit/59d8017931de74ca140d067ae6f218e41dad852f) | `` kubelogin: 0.0.27 -> 0.0.28 ``                                                          |
| [`e9e75f24`](https://github.com/NixOS/nixpkgs/commit/e9e75f243da9ac8a9ab980c9eefeeca1cd573b88) | `` du-dust: 0.8.4 -> 0.8.5 ``                                                              |
| [`07c990c5`](https://github.com/NixOS/nixpkgs/commit/07c990c5288b302a469d6ddaeb93b982940ca816) | `` usql: 0.13.10 -> 0.13.12 ``                                                             |
| [`300ee47a`](https://github.com/NixOS/nixpkgs/commit/300ee47a19cd8e88b6d7c4007bc56eda724f9458) | `` signal-desktop: 6.9.0 -> 6.10.1, signal-desktop-beta: 6.10.0-beta.1 -> 6.11.0-beta.2 `` |
| [`07b3dc4c`](https://github.com/NixOS/nixpkgs/commit/07b3dc4c7fe8d5451ac4c76edc4568014352f19a) | `` clojure: 1.11.1.1252 -> 1.11.1.1257 ``                                                  |
| [`b59764fd`](https://github.com/NixOS/nixpkgs/commit/b59764fd442df5a1b30eb18a476ab3cefd4d884a) | `` gci: 0.10.0 -> 0.10.1 ``                                                                |
| [`5c8c1281`](https://github.com/NixOS/nixpkgs/commit/5c8c1281f529e042040894944ce681f901268b9b) | `` mononoki: 1.5 -> 1.6 ``                                                                 |
| [`bd756e99`](https://github.com/NixOS/nixpkgs/commit/bd756e99f41b80b15fbc3c021edcec1c4ecd1971) | `` checkov: 2.3.95 -> 2.3.96 ``                                                            |
| [`17c43fa3`](https://github.com/NixOS/nixpkgs/commit/17c43fa32794efc44d3585b95a3ca735e2c60bca) | `` run: 0.11.1 -> 0.11.2 ``                                                                |
| [`3654d662`](https://github.com/NixOS/nixpkgs/commit/3654d66248f1cc82bedc0b735ad4da2f234a4509) | `` svls: 0.2.6 -> 0.2.7 ``                                                                 |
| [`644fd120`](https://github.com/NixOS/nixpkgs/commit/644fd120d4690daff731e022d69d8af610def513) | `` terraform: 1.4.1 -> 1.4.2 ``                                                            |
| [`a34a8766`](https://github.com/NixOS/nixpkgs/commit/a34a876635b79b5980e7a67fef25768ed7c93d4e) | `` metasploit: 6.3.7 -> 6.3.8 ``                                                           |
| [`f83a9831`](https://github.com/NixOS/nixpkgs/commit/f83a9831ea0230bdffaf5b1ab1a9ee933d1b2bb7) | `` python310Packages.identify: 2.5.20 -> 2.5.21 ``                                         |
| [`c4d3354d`](https://github.com/NixOS/nixpkgs/commit/c4d3354dce3a34f5d833895414c92dbe85cd8c2e) | `` python310Packages.tplink-omada-client: 1.1.3 -> 1.1.5 ``                                |
| [`2ca5f932`](https://github.com/NixOS/nixpkgs/commit/2ca5f932e32b73d2efc838a59057ea7585e4d9e7) | `` python310Packages.aliyun-python-sdk-dbfs: 2.0.6 -> 2.0.7 ``                             |
| [`91f2d41c`](https://github.com/NixOS/nixpkgs/commit/91f2d41c02d3e94ca87519060ab13f2e0ee409de) | `` python310Packages.fakeredis: 2.10.0 -> 2.10.1 ``                                        |
| [`65eae8ea`](https://github.com/NixOS/nixpkgs/commit/65eae8ea26d20ebcc239a16e976d5de918201898) | `` python310Packages.aiortm: 0.6.0 -> 0.6.2 ``                                             |
| [`f78b0b88`](https://github.com/NixOS/nixpkgs/commit/f78b0b88069221c2e11b49e877a452bc643ac043) | `` kubeseal: 0.19.5 -> 0.20.1 ``                                                           |
| [`2a35b867`](https://github.com/NixOS/nixpkgs/commit/2a35b86739e608c91e870bc43b121fb31b8043af) | `` subread: 2.0.3 -> 2.0.4 ``                                                              |
| [`01623bb3`](https://github.com/NixOS/nixpkgs/commit/01623bb3178b2ba7829bd7d14c05d0257b65737e) | `` changie: 1.11.1 -> 1.12.0 ``                                                            |
| [`25012d7b`](https://github.com/NixOS/nixpkgs/commit/25012d7bd2802d742bc2b4ab40c6d1da0dcb3425) | `` guile-ssh: 0.16.2 -> 0.16.3 ``                                                          |
| [`58ab7a74`](https://github.com/NixOS/nixpkgs/commit/58ab7a74ba36d739af96c66576a2fd159ad12585) | `` rnote: 0.5.16 -> 0.5.17 ``                                                              |
| [`fcd8cc42`](https://github.com/NixOS/nixpkgs/commit/fcd8cc42cc0e4e808005c7678c1fe6ff885a3e34) | `` python310Packages.google-cloud-bigquery: 3.6.0 -> 3.7.0 ``                              |
| [`82bee890`](https://github.com/NixOS/nixpkgs/commit/82bee8901744c1ef14da1dd59a8c37be0e5a3994) | `` driversi686Linux.amdvlk: 2023.Q1.2 -> 2023.Q1.3 ``                                      |
| [`d5db7595`](https://github.com/NixOS/nixpkgs/commit/d5db759557fb6ac579e79e8989328e8ddb31326b) | `` git-dive: 0.1.3 -> 0.1.4 ``                                                             |
| [`73354095`](https://github.com/NixOS/nixpkgs/commit/733540954a11c93f07b949a7f9eedb97c1d9f5e6) | `` zed: fix version ``                                                                     |
| [`80205291`](https://github.com/NixOS/nixpkgs/commit/802052919d4d714b7347cc1e80d9f62b0b0db585) | `` httpx: 1.2.8 -> 1.2.9 ``                                                                |
| [`949708b9`](https://github.com/NixOS/nixpkgs/commit/949708b93dd5fce29fb309ea30384c5e0f26aa67) | `` volk: apply cmake flags from homebrew ``                                                |
| [`c2670551`](https://github.com/NixOS/nixpkgs/commit/c26705518d34576023d55c90d50cf5d5e198cce5) | `` khoj: mark as broken on darwin ``                                                       |
| [`ffd4ea20`](https://github.com/NixOS/nixpkgs/commit/ffd4ea20cea7ec1bc295f333eda5333537b07244) | `` ocenaudio: restrict platforms ``                                                        |
| [`11ad9f6e`](https://github.com/NixOS/nixpkgs/commit/11ad9f6eaeb19fc2b2826c13d8dd2e4fd4b7dedd) | `` swayrbar: 0.3.4 -> 0.3.5 ``                                                             |