### PR TITLE
chore(flake/nur): `ba39867d` -> `629c1a23`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679183149,
-        "narHash": "sha256-4RSJ9rYeA447ub8OCd19NaqFOx63I32Ba638MJyyzlw=",
+        "lastModified": 1679194982,
+        "narHash": "sha256-1/C5lYpRPR1Fbdi6bukLJMFTYcAcDP4gpMiHZebX8Ro=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ba39867dd6fa1d492e2bb1295a02e0fdbb2778de",
+        "rev": "629c1a23a2f6c9452598e2e9f2ffc1c0c9343d79",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`629c1a23`](https://github.com/nix-community/NUR/commit/629c1a23a2f6c9452598e2e9f2ffc1c0c9343d79) | `` automatic update `` |