### PR TITLE
chore(flake/nur): `629c1a23` -> `e3c958a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679194982,
-        "narHash": "sha256-1/C5lYpRPR1Fbdi6bukLJMFTYcAcDP4gpMiHZebX8Ro=",
+        "lastModified": 1679197506,
+        "narHash": "sha256-95x0w8Nhhalz2SJkaAxPc7pntYL9NZIwQFnIlQQNYlk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "629c1a23a2f6c9452598e2e9f2ffc1c0c9343d79",
+        "rev": "e3c958a17ca6a7b337512aab8d63b055bff722eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e3c958a1`](https://github.com/nix-community/NUR/commit/e3c958a17ca6a7b337512aab8d63b055bff722eb) | `` automatic update `` |
| [`c753fb58`](https://github.com/nix-community/NUR/commit/c753fb581ce153a670c34a3fc6b53a7c7df85aee) | `` automatic update `` |
| [`62edb7bd`](https://github.com/nix-community/NUR/commit/62edb7bdb5d91ee92133425b9874301b3451b078) | `` automatic update `` |