### PR TITLE
chore(flake/nur): `e3c958a1` -> `609e8d04`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679197506,
-        "narHash": "sha256-95x0w8Nhhalz2SJkaAxPc7pntYL9NZIwQFnIlQQNYlk=",
+        "lastModified": 1679199302,
+        "narHash": "sha256-8t3pYy57aO/JssIO/wQ+GKtyhkUgrKUe95hr5BBg53s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e3c958a17ca6a7b337512aab8d63b055bff722eb",
+        "rev": "609e8d045f7de1a02ea0e366e810c5eeeae8fe70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`609e8d04`](https://github.com/nix-community/NUR/commit/609e8d045f7de1a02ea0e366e810c5eeeae8fe70) | `` automatic update `` |