### PR TITLE
chore(flake/emacs-overlay): `203a7e8b` -> `d1eecfd0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679191415,
-        "narHash": "sha256-6QerBhRSzjMV2rxPwSvnJVkgkG4FxZfq5eIxmPZHxpg=",
+        "lastModified": 1679220587,
+        "narHash": "sha256-e7AcTQIkUblq9xUdUL2KzVOiJoYxHgrl5skX+FuoCg8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "203a7e8b0a534d10b35097f6de6efc6c71c57566",
+        "rev": "d1eecfd0f159569736fca5ccb9584df334c27202",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d1eecfd0`](https://github.com/nix-community/emacs-overlay/commit/d1eecfd0f159569736fca5ccb9584df334c27202) | `` Updated repos/nongnu `` |
| [`88341d85`](https://github.com/nix-community/emacs-overlay/commit/88341d85e77c7a415a7bf5e92446044d0b137ce5) | `` Updated repos/melpa ``  |
| [`45be34ac`](https://github.com/nix-community/emacs-overlay/commit/45be34ace5f56d72d498020fb87ec17a0e44ba84) | `` Updated repos/emacs ``  |