### PR TITLE
chore(flake/nixos-hardware): `994584bb` -> `a4bc6670`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1679075297,
-        "narHash": "sha256-8TwS7NPQWW9iPejBwWzmjLnK8bQhdOMPpsj3KPAL6x8=",
+        "lastModified": 1679224149,
+        "narHash": "sha256-TSY37Zv0icF/aijR3/KWGLVBlnKKHlG9QTj7vHbF/UU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "994584bb26ffa1deeaf56099601ef4bcc487273e",
+        "rev": "a4bc66709604ab78abc575b60baa6d23ae027a59",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`98b4788c`](https://github.com/NixOS/nixos-hardware/commit/98b4788c85ba05714a92004a2771942da4c91c7a) | `` init morefine-m600 ``                                      |
| [`2f074d63`](https://github.com/NixOS/nixos-hardware/commit/2f074d636d1156302f58e67ef35905de08bac152) | `` onenetbook/4: remove stale iio-sensor-proxy <3.0 branch `` |
| [`bde6ca29`](https://github.com/NixOS/nixos-hardware/commit/bde6ca292c29ad3fa41ecbd052403f0663d41dc1) | `` onenetbook/4: update stylus patch for 6.1 ``               |