### PR TITLE
chore(flake/nur): `d1aee2b5` -> `349623e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679242615,
-        "narHash": "sha256-6D5sAGnH6Ow/I/JxlYtBe5NHOCTth6ucZMLaVi9CeFw=",
+        "lastModified": 1679244635,
+        "narHash": "sha256-/UZR31DEc8k9banJeJQgcCZ8HZQBVaxJQJ0hjtdNLNM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d1aee2b50f09e913dbc7400fb30af51bf205dec9",
+        "rev": "349623e98a63453ee55fe88c3715b1f6d920a64f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`349623e9`](https://github.com/nix-community/NUR/commit/349623e98a63453ee55fe88c3715b1f6d920a64f) | `` automatic update `` |