### PR TITLE
chore(flake/nur): `349623e9` -> `21aeb2c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679244635,
-        "narHash": "sha256-/UZR31DEc8k9banJeJQgcCZ8HZQBVaxJQJ0hjtdNLNM=",
+        "lastModified": 1679247967,
+        "narHash": "sha256-xRG+RFHTi6sRXO3vVzbyXmwBgS5NdIJ8OxEOb/u9BsA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "349623e98a63453ee55fe88c3715b1f6d920a64f",
+        "rev": "21aeb2c533a08aa107e8c708bff7c765b5a1ea36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`21aeb2c5`](https://github.com/nix-community/NUR/commit/21aeb2c533a08aa107e8c708bff7c765b5a1ea36) | `` automatic update `` |