### PR TITLE
chore(flake/emacs-overlay): `d1eecfd0` -> `be34ec53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679220587,
-        "narHash": "sha256-e7AcTQIkUblq9xUdUL2KzVOiJoYxHgrl5skX+FuoCg8=",
+        "lastModified": 1679249359,
+        "narHash": "sha256-PPrfLfPOuk6fV3VAgb9CoH2QCo3xB9ai0dElZCcdss4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d1eecfd0f159569736fca5ccb9584df334c27202",
+        "rev": "be34ec53d305a01049f25b25740aeea6e5fa1005",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`be34ec53`](https://github.com/nix-community/emacs-overlay/commit/be34ec53d305a01049f25b25740aeea6e5fa1005) | `` Updated repos/melpa `` |
| [`cbe3bfc8`](https://github.com/nix-community/emacs-overlay/commit/cbe3bfc811b8db9f71c4d8e847f1df9a404194ba) | `` Updated repos/emacs `` |