### PR TITLE
chore(flake/nur): `40fb6685` -> `0f49603a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679280501,
-        "narHash": "sha256-KNTYnWnRZgjEIfHtcOUCDeNoZwr8HWaHRJoRiv9K7Ho=",
+        "lastModified": 1679283873,
+        "narHash": "sha256-aFJU7U+0zf56PMDaGEOAGNznd7RU4BzchRSRwseBjY4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "40fb6685594739db32c3fac6559335ad23b11dc4",
+        "rev": "0f49603a8327b573aec3a288b8f8eb1e61bd18fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0f49603a`](https://github.com/nix-community/NUR/commit/0f49603a8327b573aec3a288b8f8eb1e61bd18fc) | `` automatic update `` |
| [`5a71f0ec`](https://github.com/nix-community/NUR/commit/5a71f0ec362ce57c8befa470175c8d4dbc88932e) | `` automatic update `` |