### PR TITLE
chore(flake/emacs-overlay): `be34ec53` -> `794b5765`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679249359,
-        "narHash": "sha256-PPrfLfPOuk6fV3VAgb9CoH2QCo3xB9ai0dElZCcdss4=",
+        "lastModified": 1679283474,
+        "narHash": "sha256-vlJOZZ07XURH8ZZG6Eg/pOuUKhul5bcWkvd+nwrY0Yw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "be34ec53d305a01049f25b25740aeea6e5fa1005",
+        "rev": "794b5765f0dcab8a80d0875d1ee04aad9e220cb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`794b5765`](https://github.com/nix-community/emacs-overlay/commit/794b5765f0dcab8a80d0875d1ee04aad9e220cb8) | `` Updated repos/melpa `` |
| [`6a8ee095`](https://github.com/nix-community/emacs-overlay/commit/6a8ee0952cff99e31adf1e69ea96e53306ce5d25) | `` Updated repos/emacs `` |