### PR TITLE
chore(flake/nur): `dfacc9ff` -> `071616cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679285393,
-        "narHash": "sha256-j+m6VJZsbN28vhVzbnQNECglrBWDOd7NXVFbIi1ikcw=",
+        "lastModified": 1679290994,
+        "narHash": "sha256-9lr4j5q/qs9XHOY4MkOWwmbVsnggZNoFW3mEdSV9TyM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dfacc9ff2861697c36660c5ad943656b5cc840f1",
+        "rev": "071616cc2caefaf5976a584f89f43d021e439b95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`071616cc`](https://github.com/nix-community/NUR/commit/071616cc2caefaf5976a584f89f43d021e439b95) | `` automatic update `` |