### PR TITLE
chore(flake/emacs-overlay): `794b5765` -> `e016fab4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679283474,
-        "narHash": "sha256-vlJOZZ07XURH8ZZG6Eg/pOuUKhul5bcWkvd+nwrY0Yw=",
+        "lastModified": 1679307033,
+        "narHash": "sha256-D8SzlqiLApDCPDPDkRETRfqfB6pzSeRsckBOTIyn4EE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "794b5765f0dcab8a80d0875d1ee04aad9e220cb8",
+        "rev": "e016fab49d5bb9f4db4e0dfdf925395750d6b8bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`e016fab4`](https://github.com/nix-community/emacs-overlay/commit/e016fab49d5bb9f4db4e0dfdf925395750d6b8bc) | `` Updated repos/melpa `` |
| [`0acd590f`](https://github.com/nix-community/emacs-overlay/commit/0acd590f3b518dfc8354bf9ed5c82e1401c4e6b0) | `` Updated repos/emacs `` |