### PR TITLE
chore(flake/nur): `071616cc` -> `dbd64b66`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679290994,
-        "narHash": "sha256-9lr4j5q/qs9XHOY4MkOWwmbVsnggZNoFW3mEdSV9TyM=",
+        "lastModified": 1679309270,
+        "narHash": "sha256-pEiq5/Ok2LzN+SWb0/OeUToeV4u5VVzVhGlmFCq5ud8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "071616cc2caefaf5976a584f89f43d021e439b95",
+        "rev": "dbd64b667e36864478a39e2e78f467f2f66d3590",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dbd64b66`](https://github.com/nix-community/NUR/commit/dbd64b667e36864478a39e2e78f467f2f66d3590) | `` automatic update `` |