### PR TITLE
chore(flake/nur): `dbd64b66` -> `b8bb5f35`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679309270,
-        "narHash": "sha256-pEiq5/Ok2LzN+SWb0/OeUToeV4u5VVzVhGlmFCq5ud8=",
+        "lastModified": 1679319981,
+        "narHash": "sha256-lXAO8o4vRMcbo4xFJ0YT9Ov0raelwONpDYNhZDOvKRk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dbd64b667e36864478a39e2e78f467f2f66d3590",
+        "rev": "b8bb5f35adf23deedad9de7eb9d71c56195f3bed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b8bb5f35`](https://github.com/nix-community/NUR/commit/b8bb5f35adf23deedad9de7eb9d71c56195f3bed) | `` automatic update `` |