### PR TITLE
chore(flake/nur): `b8bb5f35` -> `d92690e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679319981,
-        "narHash": "sha256-lXAO8o4vRMcbo4xFJ0YT9Ov0raelwONpDYNhZDOvKRk=",
+        "lastModified": 1679323679,
+        "narHash": "sha256-pf14ON4RD/4OGPDGJ/FwM7j918Iscoc2GQruHT0MHTc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b8bb5f35adf23deedad9de7eb9d71c56195f3bed",
+        "rev": "d92690e27e2101cedae583760c06fdd4212e658c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d92690e2`](https://github.com/nix-community/NUR/commit/d92690e27e2101cedae583760c06fdd4212e658c) | `` automatic update `` |