### PR TITLE
chore(flake/nur): `9fd65afa` -> `3879b4a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679331329,
-        "narHash": "sha256-2NBrGchpZdRmhnXwnqXmFc688iesBX/H8/vY598HiVY=",
+        "lastModified": 1679334364,
+        "narHash": "sha256-9XirXJEO7/MPKrsahFoGuTkOLkRLykL5mDAJbhlzeBQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9fd65afa2b1e95c540c6be8f24fdfb18d63d4efd",
+        "rev": "3879b4a718c91af0e0bbcf93f8f897bbfaceca8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3879b4a7`](https://github.com/nix-community/NUR/commit/3879b4a718c91af0e0bbcf93f8f897bbfaceca8d) | `` automatic update `` |