### PR TITLE
chore(flake/nur): `d7a59b9f` -> `f07c1951`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679341557,
-        "narHash": "sha256-cMj6zzH0cUdd2nMLvplQDO5cfViZB33WApPHtKVDHXI=",
+        "lastModified": 1679348834,
+        "narHash": "sha256-3j0KXPL3KaQ/tWujcKs0LlZr1/DFSL1huhr4L8uCE9w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d7a59b9f787b1ded42c76969ae3c720024687a24",
+        "rev": "f07c19512d134a81bae944b8b98231ce4d6f718f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f07c1951`](https://github.com/nix-community/NUR/commit/f07c19512d134a81bae944b8b98231ce4d6f718f) | `` automatic update `` |