### PR TITLE
chore(flake/nur): `8d5fbaea` -> `922394c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679352354,
-        "narHash": "sha256-uvdCsfooo/fVsaoK+4vLJ1VlKaInTpRu9l1VqOhi86o=",
+        "lastModified": 1679355957,
+        "narHash": "sha256-PYmndBexU7F/RMRXHUPrXojGjFpN1erT75Cylm/NVLw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8d5fbaeae27de678b9a10a00443be9c00a1dd9dd",
+        "rev": "922394c0034879cc6525e1a17c76316be815454a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`922394c0`](https://github.com/nix-community/NUR/commit/922394c0034879cc6525e1a17c76316be815454a) | `` automatic update `` |