### PR TITLE
chore(flake/nixpkgs): `1603d115` -> `60c1d71f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -649,11 +649,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1679172431,
-        "narHash": "sha256-XEh5gIt5otaUbEAPUY5DILUTyWe1goAyeqQtmwaFPyI=",
+        "lastModified": 1679262748,
+        "narHash": "sha256-DQCrrAFrkxijC6haUzOC5ZoFqpcv/tg2WxnyW3np1Cc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1603d11595a232205f03d46e635d919d1e1ec5b9",
+        "rev": "60c1d71f2ba4c80178ec84523c2ca0801522e0a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`2daba989`](https://github.com/NixOS/nixpkgs/commit/2daba98981f9320de1be3a10d9bf37c0b77094e3) | `` workflows: check maintainers sortedness on pull_request_target ``         |
| [`40035456`](https://github.com/NixOS/nixpkgs/commit/40035456cf8842e54823336771484a4ed2dd48a9) | `` archi: fix gtk errors (#220080) ``                                        |
| [`043b2de6`](https://github.com/NixOS/nixpkgs/commit/043b2de66ea73af325749c169033c63bd650fe34) | `` authenticator: 4.1.6 -> 4.2.0 ``                                          |
| [`314ea512`](https://github.com/NixOS/nixpkgs/commit/314ea5125abdf7c426a0380fd44ca06fb2bdbb48) | `` kcov: 38 -> 41 (#220464) ``                                               |
| [`0f3519bb`](https://github.com/NixOS/nixpkgs/commit/0f3519bb0fd81ac3f45f12fc02a14d1cd70d6e1c) | `` buildkite-agent: 3.44.0 -> 3.45.0 (#221741) ``                            |
| [`62b3fd5f`](https://github.com/NixOS/nixpkgs/commit/62b3fd5fd2f2a93f6ff13a95df548ca7fe84c28b) | `` plasma5: move excludePackages option for consistency ``                   |
| [`e131d80a`](https://github.com/NixOS/nixpkgs/commit/e131d80a118f7ec7d1b6ece2b6001490b6920887) | `` d2: 0.2.4 -> 0.2.5 ``                                                     |
| [`f5003fa4`](https://github.com/NixOS/nixpkgs/commit/f5003fa49094ae68c80176e293bfec79cdc629cc) | `` quisk: migrate to wxPython_4_2 ``                                         |
| [`7ee8aa80`](https://github.com/NixOS/nixpkgs/commit/7ee8aa8039163c53f30be582040098f4165d27c1) | `` neovimUtils: only set packpath/rtp as needed ``                           |
| [`a1e27cf0`](https://github.com/NixOS/nixpkgs/commit/a1e27cf0e95c28dbd0bf2517b0f4981ca7bffdde) | `` sage: add libpng to sagelib ``                                            |
| [`c13d98c7`](https://github.com/NixOS/nixpkgs/commit/c13d98c7bf5077b147f7962e331b7e35f53eb690) | `` sage: import python package upgrade fixes ``                              |
| [`c8f36065`](https://github.com/NixOS/nixpkgs/commit/c8f360654fc1c340cb1bee126dbd47dfb4bc720e) | `` hipfort: 5.4.2 -> 5.4.3 ``                                                |
| [`8c118951`](https://github.com/NixOS/nixpkgs/commit/8c118951d586847f6c996ce718737b79017aa330) | `` nixos/doc: fix .well-known example for matrix-synapse ``                  |
| [`cb541d5e`](https://github.com/NixOS/nixpkgs/commit/cb541d5e526c59dd168534a47da6f643893ab297) | `` datree: 1.8.39 -> 1.8.42 ``                                               |
| [`906084c5`](https://github.com/NixOS/nixpkgs/commit/906084c5646b6fdc4604b0a4b538b419a7fb6d23) | `` crowdin-cli: 3.10.0 -> 3.10.1 ``                                          |
| [`6cd98434`](https://github.com/NixOS/nixpkgs/commit/6cd98434a19da6ebf0e8681675e4a39fbe62918a) | `` sonic-visualiser: 4.2 -> 4.5.1 (#217931) ``                               |
| [`aec22295`](https://github.com/NixOS/nixpkgs/commit/aec2229553a64b222273f222de7c34fae7f37930) | `` sqlcmd: init at 0.15.3 ``                                                 |
| [`832a6df0`](https://github.com/NixOS/nixpkgs/commit/832a6df04c8da2e1750f12f288ffde68bc078e1a) | `` agate: 3.2.4 → 3.3.0 ``                                                   |
| [`befd10e4`](https://github.com/NixOS/nixpkgs/commit/befd10e4fc61d904cdd1f8cf7b50403d8f44704a) | `` worker-build: 0.0.13 -> 0.0.14 ``                                         |
| [`21affa5f`](https://github.com/NixOS/nixpkgs/commit/21affa5ff131c0c277a053a2a9c22520e7a3d1e1) | `` trf: init at 4.09.1 ``                                                    |
| [`5e487cd3`](https://github.com/NixOS/nixpkgs/commit/5e487cd3b0b125c9e06f5191810905a15ded09bb) | `` goreman: 0.3.13 -> 0.3.14 (#221767) ``                                    |
| [`3dc0323b`](https://github.com/NixOS/nixpkgs/commit/3dc0323baed79a478a91e71e42932737a46b042b) | `` nixos/manual: apply options preprocessing to full manual ``               |
| [`e0766668`](https://github.com/NixOS/nixpkgs/commit/e0766668c2a9ebe4e2b1d7e58f1932b6c46870ad) | `` printrun: 2.0.0rc5 -> 2.0.0 ``                                            |
| [`cef96af0`](https://github.com/NixOS/nixpkgs/commit/cef96af0e6189c8e2036aaf4b39cf523646d4a82) | `` v2raya: 2.0.0 -> 2.0.2 ``                                                 |
| [`2eefc791`](https://github.com/NixOS/nixpkgs/commit/2eefc791b4a2171bbbc1f70d4519405a6ad3f782) | `` nkeys: add changelog to meta ``                                           |
| [`9625629f`](https://github.com/NixOS/nixpkgs/commit/9625629f5691f7707f38bf893c3490d43669a7c7) | `` tailscale: reduce closure size via ldflags ``                             |
| [`73d2bec9`](https://github.com/NixOS/nixpkgs/commit/73d2bec90f3344963b4d9677e95d8d5e322966e0) | `` tailscale: fix invalid version number ``                                  |
| [`380c03e4`](https://github.com/NixOS/nixpkgs/commit/380c03e4558a976a57e65af65a0f56a23e97f688) | `` woeusb-ng: 0.2.10 -> 0.2.12 ``                                            |
| [`7d0bd09e`](https://github.com/NixOS/nixpkgs/commit/7d0bd09e9a9c864aa79a376aede37af16d7c6894) | `` arduino-cli: 0.29.0 -> 0.31.0 ``                                          |
| [`dc206cd6`](https://github.com/NixOS/nixpkgs/commit/dc206cd60d972610bfcb23f573fca7e777f992c9) | `` python310Packages.transaction: add pythonImportsCheck ``                  |
| [`a13f97be`](https://github.com/NixOS/nixpkgs/commit/a13f97beff2e1125161c8f3f7fb97bc1fa88df89) | `` python310Packages.transaction: disable on unsupported Python releases ``  |
| [`f6db656a`](https://github.com/NixOS/nixpkgs/commit/f6db656aaefb1ff1e744099c93e92acaad44aa96) | `` python310Packages.transaction: update meta ``                             |
| [`bb487772`](https://github.com/NixOS/nixpkgs/commit/bb4877725877a891343efcc4f53c049c31b6363f) | `` sniffnet: update changelog entry ``                                       |
| [`1283da92`](https://github.com/NixOS/nixpkgs/commit/1283da924bcb995d5a2dfd853f3527fa6f82ac2e) | `` iir1: fix package name ``                                                 |
| [`ff7a2c8a`](https://github.com/NixOS/nixpkgs/commit/ff7a2c8a0aab1bfa0465c06a7e27ad18d07ff0ac) | `` goa: 3.11.0 -> 3.11.2 ``                                                  |
| [`5a019593`](https://github.com/NixOS/nixpkgs/commit/5a019593dd7ccee991dee49c6204629e36bc92f4) | `` python311Packages.faraday-agent-parameters-types: disable failing test `` |
| [`cf625fa3`](https://github.com/NixOS/nixpkgs/commit/cf625fa3e8816492a25c42beec68f9da36ccf28b) | `` cirrus-cli: 0.95.0 -> 0.96.0 ``                                           |
| [`be2eb1ec`](https://github.com/NixOS/nixpkgs/commit/be2eb1eca736079b19ec9faa39f374574d8050c2) | `` libslirp: add debug info ``                                               |
| [`efb0a655`](https://github.com/NixOS/nixpkgs/commit/efb0a655fe13b420811c17239779a2891f3eb87e) | `` wgpu-utils: 0.15.1 -> 0.15.2 ``                                           |
| [`89a0d571`](https://github.com/NixOS/nixpkgs/commit/89a0d57186bf54dc693c6a9fa8f2d7e6fc9394ed) | `` vscode-extensions.chris-hayes.chatgpt-reborn: init at 3.10.2 ``           |
| [`f00e9c17`](https://github.com/NixOS/nixpkgs/commit/f00e9c1737a523308c7b2f9a0afb10fee85e5a15) | `` python310Packages.lightwave2: 0.8.19 -> 0.8.21 ``                         |
| [`6c70dbc5`](https://github.com/NixOS/nixpkgs/commit/6c70dbc516b14a9979e1e57d9d0dad0ea8743a27) | `` loxodo: migrate to wxPython_4_2 ``                                        |
| [`4fe97384`](https://github.com/NixOS/nixpkgs/commit/4fe9738427daeee176cd8991cfd5b4ec66762381) | `` mavproxy: migrate to wxPython_4_2 ``                                      |
| [`48b0aa71`](https://github.com/NixOS/nixpkgs/commit/48b0aa71646b3600f37dfa258c9fe16d7bb6747f) | `` nixos/sssd: create symlinks in /etc to fix sssctl ``                      |
| [`06d4e7da`](https://github.com/NixOS/nixpkgs/commit/06d4e7da21ec170fc4fab16a228365f2aa802e5b) | `` openpgp-card-tools: 0.9.1 -> 0.9.2 ``                                     |
| [`fe21fe6b`](https://github.com/NixOS/nixpkgs/commit/fe21fe6bf27704db98d3315fd50bd2629976724d) | `` croc: 9.6.3 -> 9.6.4 ``                                                   |
| [`899318a6`](https://github.com/NixOS/nixpkgs/commit/899318a6a8cbc04653060ee58dcc66940983b0fe) | `` nkeys: 0.3.0 -> 0.4.4 ``                                                  |
| [`4595e2f2`](https://github.com/NixOS/nixpkgs/commit/4595e2f2a6d6cf35769ec169a6046853f4c22188) | `` trivy: 0.38.2 -> 0.38.3 ``                                                |
| [`11ee54c2`](https://github.com/NixOS/nixpkgs/commit/11ee54c22af3e440523a39eab78e980847010a3d) | `` unciv: 4.5.8 -> 4.5.9 ``                                                  |
| [`57accc03`](https://github.com/NixOS/nixpkgs/commit/57accc032c86c800afafcb54192f5c23ecea7cf7) | `` icon-library: fix darwin build ``                                         |
| [`c2afc92c`](https://github.com/NixOS/nixpkgs/commit/c2afc92cc2599afc6edd1e38971d2be1ae4c56ba) | `` patchelfUnstable: unstable-2023-03-07 -> unstable-2023-03-18 ``           |
| [`506984c8`](https://github.com/NixOS/nixpkgs/commit/506984c87413b620596ebf7c037fe1628fcc6a51) | `` kodiPackages.youtube: 7.0.0 -> 7.0.1 ``                                   |
| [`a3d80f22`](https://github.com/NixOS/nixpkgs/commit/a3d80f227aab51d7b072af12ae4d459f39e0ca45) | `` iosevka-bin: 21.0.0 -> 21.1.0 ``                                          |
| [`9fbe7ae4`](https://github.com/NixOS/nixpkgs/commit/9fbe7ae457b9a77749d1b609e23af68de1b84131) | `` flexget: 3.5.31 -> 3.5.33 ``                                              |
| [`44adc091`](https://github.com/NixOS/nixpkgs/commit/44adc0918b5626da24acf7403b9f4d79c60e916f) | `` flexget: fix build ``                                                     |
| [`5a05160f`](https://github.com/NixOS/nixpkgs/commit/5a05160f7671434e1c833b1b01284b876e04eca4) | `` alsa-project: refactor ``                                                 |
| [`532ed9ed`](https://github.com/NixOS/nixpkgs/commit/532ed9ed82c84948b1ac9fe2848a680138429313) | `` alsa-tools: remove python-dependent tools ``                              |
| [`46aaa79b`](https://github.com/NixOS/nixpkgs/commit/46aaa79b50b0e437004d57edcda18abc18c10e98) | `` terraform-providers.postgresql: 1.18.0 → 1.19.0 ``                        |
| [`374a0df5`](https://github.com/NixOS/nixpkgs/commit/374a0df587d796bc35fd286637166ebd8964fb6b) | `` terraform-providers.argocd: 4.3.0 → 5.0.0 ``                              |
| [`12b437b5`](https://github.com/NixOS/nixpkgs/commit/12b437b5e37478232da18af7c4004a401465571d) | `` gifski: 1.10.0 -> 1.10.3 ``                                               |
| [`83f7d261`](https://github.com/NixOS/nixpkgs/commit/83f7d26104caf5417c501b1b7afc323e583d1e7b) | `` flyctl: 0.0.484 -> 0.0.492 ``                                             |
| [`72fe4b5b`](https://github.com/NixOS/nixpkgs/commit/72fe4b5bd994a82ea08ba97284b64e3ca6198955) | `` geoipupdate: 4.10.0 -> 4.11.1 ``                                          |
| [`4db65a7e`](https://github.com/NixOS/nixpkgs/commit/4db65a7ec4c8049d65714e5bc2fc268da5ed79f2) | `` cbqn: 2022-11-27 -> 2023-02-01 ``                                         |
| [`6f900b71`](https://github.com/NixOS/nixpkgs/commit/6f900b718a30a03a01c5902b858d32b03543f5a8) | `` revive: 1.3.0 -> 1.3.1 ``                                                 |
| [`f788cbcd`](https://github.com/NixOS/nixpkgs/commit/f788cbcd1bb1c3854b9b1bf3189462ea87b285e9) | `` python310Packages.schema-salad: disable network test ``                   |
| [`5772f8e6`](https://github.com/NixOS/nixpkgs/commit/5772f8e64a544264ceda2727495ad55a22c56864) | `` zef: 0.18.0 -> 0.18.1 ``                                                  |
| [`fad64b6a`](https://github.com/NixOS/nixpkgs/commit/fad64b6af627d31cd7baf76ac42911e1806c9d85) | `` your-editor: 1504 -> 1505 ``                                              |
| [`8dfcacdf`](https://github.com/NixOS/nixpkgs/commit/8dfcacdf41322961756d7678b9a90c86b316283e) | `` python310Packages.aardwolf: fix darwin build ``                           |
| [`0939bbb4`](https://github.com/NixOS/nixpkgs/commit/0939bbb487b8f705fb85eb7a11e43648a9eed37b) | `` cargo-vet: 0.3.0 -> 0.5.1 ``                                              |
| [`2874535c`](https://github.com/NixOS/nixpkgs/commit/2874535c73417e5f1ae6f457b68ab844ae018ff8) | `` theme-jade1: 1.14 -> 1.15 ``                                              |
| [`3756776f`](https://github.com/NixOS/nixpkgs/commit/3756776f1d167451343da095025df0d167721be6) | `` babashka: 1.2.174 -> 1.3.176 ``                                           |
| [`59719899`](https://github.com/NixOS/nixpkgs/commit/59719899b49966a50c99ac1f52a2f935fe8033cc) | `` ruff: 0.0.248 -> 0.0.257 ``                                               |
| [`349900ec`](https://github.com/NixOS/nixpkgs/commit/349900ecde18c80f2cacc1faa0c17e4ceadbef83) | `` tmux-mem-cpu-load: 3.6.0 -> 3.6.1 ``                                      |
| [`ff84b181`](https://github.com/NixOS/nixpkgs/commit/ff84b1819c64bc9a639d3b834cdcf8a26148ec43) | `` cln: fix darwin aarch build ``                                            |
| [`880a65dd`](https://github.com/NixOS/nixpkgs/commit/880a65ddebf751aea633a9cad5f2de48c1c73313) | `` jumpy: 0.5.1 -> 0.6.0 (#221921) ``                                        |
| [`7291ce08`](https://github.com/NixOS/nixpkgs/commit/7291ce0804e783a418d9adac5c6839da71c6c5bf) | `` python310Packages.aws-lambda-builders: disable network tests ``           |
| [`4fb9ea83`](https://github.com/NixOS/nixpkgs/commit/4fb9ea8370933d2a3297e736282ecee54326a150) | `` cargo-update: set meta.changelog ``                                       |
| [`3807dfa1`](https://github.com/NixOS/nixpkgs/commit/3807dfa1f2a509813bbec126e0490f5db3e5eed8) | `` cargo-update: fix build on darwin ``                                      |
| [`9d8ebe75`](https://github.com/NixOS/nixpkgs/commit/9d8ebe75a4aba9b285ecb6aa655eefa9c4ad2ab3) | `` bom: init at 0.4.1 ``                                                     |
| [`d8b456b1`](https://github.com/NixOS/nixpkgs/commit/d8b456b1db6325877bcc93dbe5b20dcb318b4981) | `` ddosify: 0.15.0 -> 0.15.1 ``                                              |
| [`50bce543`](https://github.com/NixOS/nixpkgs/commit/50bce543006f50b614c94f6c9e78913173927f09) | `` werf: 1.2.207 -> 1.2.212 ``                                               |
| [`b2660189`](https://github.com/NixOS/nixpkgs/commit/b26601892073c10593e2b6ebf3b65e7e034519e0) | `` sniffnet: 1.1.1 -> 1.1.2 ``                                               |
| [`9087a3b0`](https://github.com/NixOS/nixpkgs/commit/9087a3b0f2a5c263c488bc142371d08a396b629d) | `` jackett: 0.20.3599 -> 0.20.3627 ``                                        |
| [`f967d005`](https://github.com/NixOS/nixpkgs/commit/f967d005f762bc209ba6d2c36d985d71edb136a5) | `` telegraf: 1.25.1 -> 1.26.0 ``                                             |
| [`68cb767b`](https://github.com/NixOS/nixpkgs/commit/68cb767b94f7f53d6abe93cbd02d3b25b5437f18) | `` freenet: build01494 -> 01497 ``                                           |
| [`0e19cb58`](https://github.com/NixOS/nixpkgs/commit/0e19cb589ee7642899b0ec6c5ec82a17de1ce757) | `` cargo-update: 11.1.2 -> 12.0.0 ``                                         |
| [`00759031`](https://github.com/NixOS/nixpkgs/commit/007590313787ea34a145a0dae0fa10b9454122ed) | `` minidsp: init at 0.1.9 ``                                                 |
| [`2c76d9ce`](https://github.com/NixOS/nixpkgs/commit/2c76d9ce17ead0cd663b03e6ce4f2e07da250b84) | `` bcompare: fix missing ldd ``                                              |
| [`4d7acf61`](https://github.com/NixOS/nixpkgs/commit/4d7acf618420f2499aac082b4333474de88ca339) | `` timeline: migrate to wxPython_4_2 ``                                      |
| [`611df492`](https://github.com/NixOS/nixpkgs/commit/611df4920baebb7e606a63fc9325f1a83ebf36ac) | `` python310Packages.azure-storage-file-share: 12.11.0 -> 12.11.1 ``         |
| [`81aca8ff`](https://github.com/NixOS/nixpkgs/commit/81aca8ff98400fea38f0c30ce0ef85d0c726b9da) | `` libvirt: add missing 'ssh' to $PATH ``                                    |
| [`05c1c2d8`](https://github.com/NixOS/nixpkgs/commit/05c1c2d8ac7e9a8ab56d2d4d33b4c7d36b260cdf) | `` python310Packages.transaction: 3.0.1 -> 3.1.0 ``                          |
| [`c19b09c2`](https://github.com/NixOS/nixpkgs/commit/c19b09c24314ce694c427518c885bf2e4574135e) | `` tdesktop: fix aarch64 build failures ``                                   |
| [`f379fc01`](https://github.com/NixOS/nixpkgs/commit/f379fc011c1682646f88e6030adb91f5c519c486) | `` vscode-extensions: re-establish alphabetical order ``                     |
| [`9ec72407`](https://github.com/NixOS/nixpkgs/commit/9ec72407a4e81c31387132d62993161a0ca58eaa) | `` vscode-extensions: remove 'with' and normalize lib usage ``               |
| [`d7fd0bc9`](https://github.com/NixOS/nixpkgs/commit/d7fd0bc91419dc4b816c873cc66c8fa0dca35569) | `` haskell: ghc94 packages should point to ghc944 ``                         |
| [`891812fd`](https://github.com/NixOS/nixpkgs/commit/891812fd2b5254abd253d987062205119e115077) | `` fastly: 8.0.0 -> 8.1.0 ``                                                 |
| [`0e7ee9c4`](https://github.com/NixOS/nixpkgs/commit/0e7ee9c4b2021451c3da43fb7b7180b07edc8fc4) | `` viceroy: 0.3.5 -> 0.4.0 ``                                                |
| [`208f77f2`](https://github.com/NixOS/nixpkgs/commit/208f77f2afdc97fac41cbf39c426ff81e2344f35) | `` python310Packages.adblock: add changelog to meta ``                       |
| [`bbe659d1`](https://github.com/NixOS/nixpkgs/commit/bbe659d13378c49e29aa2abca9e4b665ff8cce09) | `` sqlfluff: 2.0.0 -> 2.0.1 ``                                               |
| [`53f8c023`](https://github.com/NixOS/nixpkgs/commit/53f8c023759aba23c75999132aa6e3530c116e3b) | `` playonlinux: migrate to wxPython_4_2 ``                                   |
| [`45a79440`](https://github.com/NixOS/nixpkgs/commit/45a7944007aa7a9a63a290683b35b65c21ca3036) | `` python310Packages.aeppl: 0.1.2 -> 0.1.3 ``                                |
| [`f3b75ef3`](https://github.com/NixOS/nixpkgs/commit/f3b75ef3ce58f8b91a53848f590a37f89bb54148) | `` mafft: 7.508 -> 7.515 ``                                                  |
| [`45dd09ff`](https://github.com/NixOS/nixpkgs/commit/45dd09ffc2a4d08e49bf222013b08122e1991d86) | `` nanomq: 0.15.5 → 0.16.3 ``                                                |
| [`fb837521`](https://github.com/NixOS/nixpkgs/commit/fb837521132d08e774e1eef42a0b52ca93a46ffb) | `` skeema: Fix build on x86_64-darwin ``                                     |
| [`75e178d5`](https://github.com/NixOS/nixpkgs/commit/75e178d56abae3aeff2349e05a20701771f0667f) | `` yt-dlp: add/propagate secretstorage ``                                    |
| [`d99eb5e0`](https://github.com/NixOS/nixpkgs/commit/d99eb5e079fba0c29a1c63f8d0e21f02321dddf9) | `` cachix: 1.3.1 -> 1.3.3 ``                                                 |
| [`81a72db5`](https://github.com/NixOS/nixpkgs/commit/81a72db597d12ff1c9cc404fbf021e0c15212b48) | `` akonadi-contacts: propagate grantleetheme ``                              |
| [`eeacc131`](https://github.com/NixOS/nixpkgs/commit/eeacc13114cf1a4c7570fcedd7b79799b1c9c16c) | `` python310Packages.aesara: update format and disable failing tests ``      |
| [`f08f903e`](https://github.com/NixOS/nixpkgs/commit/f08f903ea5554c1737f55a3d06804bd691258f2f) | `` spacebar: remove gcc9 hack ``                                             |
| [`b07f4b04`](https://github.com/NixOS/nixpkgs/commit/b07f4b040e3683f83c2dc5824abd22f2b92a0a5b) | `` grantleetheme: fix outputs definition ``                                  |
| [`9d6d028f`](https://github.com/NixOS/nixpkgs/commit/9d6d028f2bf983f9e1b47e3c3e31d65f30157a43) | `` erlang-ls: Set `meta.mainProgram` ``                                      |
| [`7a6801d8`](https://github.com/NixOS/nixpkgs/commit/7a6801d8dd652f02190a877185fb2689cc63dd40) | `` obs-studio-plugins.obs-pipewire-audio-capture: 1.0.5 -> 1.1.0 ``          |
| [`b38d7e5e`](https://github.com/NixOS/nixpkgs/commit/b38d7e5ea69188678aa28061b98e182a380ee9c5) | `` miniupnpd: add nixosTests.upnp to passthru.tests ``                       |
| [`83cb6c00`](https://github.com/NixOS/nixpkgs/commit/83cb6c00f0353a5a88e9cfea57bc8fac0d872573) | `` miniupnpd: use iptables-legacy ``                                         |
| [`e5ca54ba`](https://github.com/NixOS/nixpkgs/commit/e5ca54ba8f676b73eb3b74c1836b6e0ab9c6d3ed) | `` ktextaddons: init at 1.1.0 ``                                             |
| [`493cf90d`](https://github.com/NixOS/nixpkgs/commit/493cf90d16a1790358e54ffbe4b9055a9dc19446) | `` dpkg: 1.21.1ubuntu2.1 -> 1.21.21ubuntu1 ``                                |
| [`ccaa6078`](https://github.com/NixOS/nixpkgs/commit/ccaa6078baed0531eeeb6e788febe81aba461d65) | `` nixos/gitlab: Fix error when GitLab Pages is not enabled ``               |
| [`bba33d60`](https://github.com/NixOS/nixpkgs/commit/bba33d60fc1d855c5b50a353b95ed39cdfeced51) | `` paperwork: Patch broken libreoffice path ``                               |
| [`7a6722ee`](https://github.com/NixOS/nixpkgs/commit/7a6722eeb8dcc5486a609e9c0e4ed655dc116760) | `` python310Packages.python-songpal: add changelog to meta ``                |
| [`2d4c695e`](https://github.com/NixOS/nixpkgs/commit/2d4c695eda68f21cb113678e1aff7db24ed096b8) | `` python310Packages.adafruit-platformdetect: 3.41.0 -> 3.42.0 ``            |
| [`4bee2256`](https://github.com/NixOS/nixpkgs/commit/4bee225605d3e062915c3689581fa9c761d9ba48) | `` exploitdb: 2023-03-15 -> 2023-03-17 ``                                    |
| [`5f85863f`](https://github.com/NixOS/nixpkgs/commit/5f85863f1e7c29f7769e2aad0ab80bf0717e1125) | `` feroxbuster: 2.7.1 -> 2.9.1 ``                                            |