### PR TITLE
chore(flake/nur): `922394c0` -> `dc7708ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679355957,
-        "narHash": "sha256-PYmndBexU7F/RMRXHUPrXojGjFpN1erT75Cylm/NVLw=",
+        "lastModified": 1679364425,
+        "narHash": "sha256-wS22jV0LQZqcu4bfD0rICZ8y5XVRrY5vKCuxhvOUD2Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "922394c0034879cc6525e1a17c76316be815454a",
+        "rev": "dc7708ac876554733b25283acdd55415c7147625",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dc7708ac`](https://github.com/nix-community/NUR/commit/dc7708ac876554733b25283acdd55415c7147625) | `` automatic update `` |
| [`4adb8d24`](https://github.com/nix-community/NUR/commit/4adb8d24394fc0108e4fed80079386ba7f7b70a5) | `` automatic update `` |