### PR TITLE
chore(flake/emacs-overlay): `ad8bf8e8` -> `6765dd75`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679332672,
-        "narHash": "sha256-m1nkUSjPuRr9DAJsLRP9KxHuLEUZ53Ghu3qKkI+MM3o=",
+        "lastModified": 1679363644,
+        "narHash": "sha256-m0BTLTw9kF6dLbB7NvpAiSrjAwB4sGAwzy/wklqTAiY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ad8bf8e87af4ed3c5493ee665c1deef5dccde36e",
+        "rev": "6765dd75a28251fff7129cf6e42af55c8984b722",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`6765dd75`](https://github.com/nix-community/emacs-overlay/commit/6765dd75a28251fff7129cf6e42af55c8984b722) | `` Updated repos/melpa `` |