### PR TITLE
chore(flake/nur): `dc7708ac` -> `7ae965bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679364425,
-        "narHash": "sha256-wS22jV0LQZqcu4bfD0rICZ8y5XVRrY5vKCuxhvOUD2Q=",
+        "lastModified": 1679367393,
+        "narHash": "sha256-yqs2lFQTw02QVtOo/gCwMEhCF3zAwHjZpnW7zZsMKhA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dc7708ac876554733b25283acdd55415c7147625",
+        "rev": "7ae965bde32b27e5b25fd54fb81a0211f401d2e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7ae965bd`](https://github.com/nix-community/NUR/commit/7ae965bde32b27e5b25fd54fb81a0211f401d2e9) | `` automatic update `` |
| [`d738be96`](https://github.com/nix-community/NUR/commit/d738be96b312b3bc04327e78a46cd95b2b6e2bf9) | `` automatic update `` |