### PR TITLE
chore(flake/nur): `7ae965bd` -> `21e8c94e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679367393,
-        "narHash": "sha256-yqs2lFQTw02QVtOo/gCwMEhCF3zAwHjZpnW7zZsMKhA=",
+        "lastModified": 1679367708,
+        "narHash": "sha256-Q6LX6gwAwE/I9vel2CRAZIlUCEIDCpcGxVjnSppAvIo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7ae965bde32b27e5b25fd54fb81a0211f401d2e9",
+        "rev": "21e8c94e2bd071333b068c3ebd890a3c0a3581ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`21e8c94e`](https://github.com/nix-community/NUR/commit/21e8c94e2bd071333b068c3ebd890a3c0a3581ad) | `` automatic update `` |