### PR TITLE
chore(flake/nur): `21e8c94e` -> `c21a1e05`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679367708,
-        "narHash": "sha256-Q6LX6gwAwE/I9vel2CRAZIlUCEIDCpcGxVjnSppAvIo=",
+        "lastModified": 1679370157,
+        "narHash": "sha256-mJq56WfZLRAPRpsJPGaZTg58QvXBTYG5EQPweNQzRqE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "21e8c94e2bd071333b068c3ebd890a3c0a3581ad",
+        "rev": "c21a1e0582d782fecd1cece18b78e218bda9c3e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c21a1e05`](https://github.com/nix-community/NUR/commit/c21a1e0582d782fecd1cece18b78e218bda9c3e2) | `` automatic update `` |
| [`1f1ce8bb`](https://github.com/nix-community/NUR/commit/1f1ce8bb405eb45848e1b6d6541a1183558b7967) | `` automatic update `` |