### PR TITLE
chore(flake/nur): `c21a1e05` -> `2d41e675`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679370157,
-        "narHash": "sha256-mJq56WfZLRAPRpsJPGaZTg58QvXBTYG5EQPweNQzRqE=",
+        "lastModified": 1679371720,
+        "narHash": "sha256-Ycicj6eKq14yrplwk+mSYl45unEJM/UgIKoxZWImT2c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c21a1e0582d782fecd1cece18b78e218bda9c3e2",
+        "rev": "2d41e675241d441483052e335a474b5377a3c20d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2d41e675`](https://github.com/nix-community/NUR/commit/2d41e675241d441483052e335a474b5377a3c20d) | `` automatic update `` |