### PR TITLE
chore(flake/nur): `2d41e675` -> `1c18a019`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679371720,
-        "narHash": "sha256-Ycicj6eKq14yrplwk+mSYl45unEJM/UgIKoxZWImT2c=",
+        "lastModified": 1679377414,
+        "narHash": "sha256-EmhOI9uFB8Owqaao/jeXTr6EiVIsRcE0Zxa5Eiv/z0A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2d41e675241d441483052e335a474b5377a3c20d",
+        "rev": "1c18a01957ab6a3d45c56462e9d6dd7b66c58419",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1c18a019`](https://github.com/nix-community/NUR/commit/1c18a01957ab6a3d45c56462e9d6dd7b66c58419) | `` automatic update `` |