### PR TITLE
chore(flake/home-manager): `1b8bf5c3` -> `2bf15d38`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -445,11 +445,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679265143,
-        "narHash": "sha256-5RDMW+O4owjdPz7t4K4YxH2fOHCNOcyVmSiKRUikiv0=",
+        "lastModified": 1679385031,
+        "narHash": "sha256-G0/LQ5vzjKNHFHXP/3gNH5GVUKM1t4g+GFjV0lHieLM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1b8bf5c3270386a1b6850bd77d79dbdbaf0d7a7c",
+        "rev": "2bf15d3835030906e727abd0e1533b98a4fb916c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`2bf15d38`](https://github.com/nix-community/home-manager/commit/2bf15d3835030906e727abd0e1533b98a4fb916c) | `` docs: reference Stylix in 3rd-party extensions ``     |
| [`7720f200`](https://github.com/nix-community/home-manager/commit/7720f200ea3eb9ad21646354afac0644dd011ca6) | `` home-manager: make generated home.nix more helpful `` |
| [`c509a7d5`](https://github.com/nix-community/home-manager/commit/c509a7d5ff58ee91e73246bf8b9af5308339cc00) | `` Translate using Weblate (Ukrainian) ``                |
| [`abc8378e`](https://github.com/nix-community/home-manager/commit/abc8378e213e62c500047d923266f9b20ca1c181) | `` Translate using Weblate (Spanish) ``                  |
| [`69bf0fed`](https://github.com/nix-community/home-manager/commit/69bf0fedbe1d0cd80946d23e762fea78761e6018) | `` Translate using Weblate (Swedish) ``                  |
| [`7217ca16`](https://github.com/nix-community/home-manager/commit/7217ca165b33ab3e002cc7a79ce16fd1a1500ff1) | `` Update translation files ``                           |