### PR TITLE
chore(flake/nur): `1c18a019` -> `ab03e357`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679377414,
-        "narHash": "sha256-EmhOI9uFB8Owqaao/jeXTr6EiVIsRcE0Zxa5Eiv/z0A=",
+        "lastModified": 1679387298,
+        "narHash": "sha256-3x6GzkjyQP1MS1xDrumCg+gIUzJymWiq43s7gKkfzaI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1c18a01957ab6a3d45c56462e9d6dd7b66c58419",
+        "rev": "ab03e357b8a8aefa9da45eb5329fcf74c7f84297",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                              |
| -------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`ab03e357`](https://github.com/nix-community/NUR/commit/ab03e357b8a8aefa9da45eb5329fcf74c7f84297) | `` automatic update ``               |
| [`f7ed1fae`](https://github.com/nix-community/NUR/commit/f7ed1faed46f448c5fa3cfa2bf6c845aa5598819) | `` apply black to nur/index.py ``    |
| [`d45d22ca`](https://github.com/nix-community/NUR/commit/d45d22ca56f565403fc697243b9ec79120f6e3b0) | `` automatic update ``               |
| [`976719f8`](https://github.com/nix-community/NUR/commit/976719f803a3c1c0d4f9f5f33efb68268a4f5149) | `` automatic update ``               |
| [`c6b3fdbb`](https://github.com/nix-community/NUR/commit/c6b3fdbb78db9689065bf6b641ab4fdf73943d2d) | `` add infinitivewitch repository `` |