### PR TITLE
chore(flake/nur): `ab03e357` -> `97e5c4b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679387298,
-        "narHash": "sha256-3x6GzkjyQP1MS1xDrumCg+gIUzJymWiq43s7gKkfzaI=",
+        "lastModified": 1679390561,
+        "narHash": "sha256-KycgI2skDinbAB7T4Il7g/43nUVqJela9nyqTC7BXHI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ab03e357b8a8aefa9da45eb5329fcf74c7f84297",
+        "rev": "97e5c4b46ff73b51b2a58f8caa58c58dd01b549f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`97e5c4b4`](https://github.com/nix-community/NUR/commit/97e5c4b46ff73b51b2a58f8caa58c58dd01b549f) | `` automatic update `` |