### PR TITLE
chore(flake/home-manager): `2bf15d38` -> `a8f5ca23`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -445,11 +445,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679385031,
-        "narHash": "sha256-G0/LQ5vzjKNHFHXP/3gNH5GVUKM1t4g+GFjV0lHieLM=",
+        "lastModified": 1679385383,
+        "narHash": "sha256-7N7gOnHwRfE3ckqxwXOE/gpTm8Ki7IElqKOMP5qpNTs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2bf15d3835030906e727abd0e1533b98a4fb916c",
+        "rev": "a8f5ca239f8f17ba68e75f97ba995f93c3f1a04b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`a8f5ca23`](https://github.com/nix-community/home-manager/commit/a8f5ca239f8f17ba68e75f97ba995f93c3f1a04b) | `` borgmatic: optionally exclude HM symlinks from backup `` |
| [`2ddd4e15`](https://github.com/nix-community/home-manager/commit/2ddd4e151d6d4ac56bb1c93f4b15b22dd2d9d0d5) | `` borgmatic: change type of extraConfigOption ``           |