### PR TITLE
chore(flake/nur): `ccdddaed` -> `b871a5a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679417220,
-        "narHash": "sha256-vnxmwSXdgvw8LrRXEznMxbjLlvV1un1UUIrd/oaROl4=",
+        "lastModified": 1679420098,
+        "narHash": "sha256-0i8bQwAi+Knog4jFnBCTIf3Zt3QGZBE6KzG1ckwJ8UE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ccdddaedf535efd166318bcbcfc0edecc469d467",
+        "rev": "b871a5a75d1ac2c2bebc8fcde1ff77c4450915d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b871a5a7`](https://github.com/nix-community/NUR/commit/b871a5a75d1ac2c2bebc8fcde1ff77c4450915d0) | `` automatic update `` |