### PR TITLE
chore(flake/nur): `b871a5a7` -> `7cb4acd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679420098,
-        "narHash": "sha256-0i8bQwAi+Knog4jFnBCTIf3Zt3QGZBE6KzG1ckwJ8UE=",
+        "lastModified": 1679423094,
+        "narHash": "sha256-kKk1B+o5OG4EMqbAn5u7dvBVFfiZxx+7JcJ6MvxnGOk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b871a5a75d1ac2c2bebc8fcde1ff77c4450915d0",
+        "rev": "7cb4acd7d3b6c7897afca76a32925d762042b55f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7cb4acd7`](https://github.com/nix-community/NUR/commit/7cb4acd7d3b6c7897afca76a32925d762042b55f) | `` automatic update `` |
| [`5dfe86dd`](https://github.com/nix-community/NUR/commit/5dfe86dddb2ccee6cb433505895b91d0cf230c1d) | `` automatic update `` |
| [`0fa4ff4f`](https://github.com/nix-community/NUR/commit/0fa4ff4f6c954075ed3ee665f41cb94fce7d2321) | `` automatic update `` |