### PR TITLE
chore(flake/emacs-overlay): `add5c977` -> `4e0b09e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679389595,
-        "narHash": "sha256-FEMLDJWfPszmdCu+uomkhTxlOqAL3dFl9y2RBbobF54=",
+        "lastModified": 1679422052,
+        "narHash": "sha256-E9mk222GxJUXqK2TP0umn5kk4BA6UOh8yck6aAB2iCg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "add5c977ba4e6a78d00b8f25277809e2301a5c29",
+        "rev": "4e0b09e0d1bcd0f4bf382d69846d1fdb32ba69d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`4e0b09e0`](https://github.com/nix-community/emacs-overlay/commit/4e0b09e0d1bcd0f4bf382d69846d1fdb32ba69d4) | `` Updated repos/melpa `` |
| [`c5daaa10`](https://github.com/nix-community/emacs-overlay/commit/c5daaa10a6808458ca70826498221b5f89740ff4) | `` Updated repos/emacs `` |
| [`926962cf`](https://github.com/nix-community/emacs-overlay/commit/926962cf96199a08feb820670e95c840a6759b79) | `` Updated repos/elpa ``  |