### PR TITLE
chore(flake/nur): `7cb4acd7` -> `6be3ba90`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679423094,
-        "narHash": "sha256-kKk1B+o5OG4EMqbAn5u7dvBVFfiZxx+7JcJ6MvxnGOk=",
+        "lastModified": 1679425404,
+        "narHash": "sha256-AJyB0v2bVV8GwoU5Wd1wN0KOPb+VSe0e6sWyisYbWmY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7cb4acd7d3b6c7897afca76a32925d762042b55f",
+        "rev": "6be3ba900e2f713b3b7540656df10163d9793330",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6be3ba90`](https://github.com/nix-community/NUR/commit/6be3ba900e2f713b3b7540656df10163d9793330) | `` automatic update `` |