### PR TITLE
chore(flake/nur): `6be3ba90` -> `5c8b6739`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679425404,
-        "narHash": "sha256-AJyB0v2bVV8GwoU5Wd1wN0KOPb+VSe0e6sWyisYbWmY=",
+        "lastModified": 1679427980,
+        "narHash": "sha256-3vn1eNYLpQjNFlMx9UFtkhTHRIWuSQ5hxJrDdL2qjqU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6be3ba900e2f713b3b7540656df10163d9793330",
+        "rev": "5c8b673966e7d8a367b4c9f7c481d4fb79724ea3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5c8b6739`](https://github.com/nix-community/NUR/commit/5c8b673966e7d8a367b4c9f7c481d4fb79724ea3) | `` automatic update `` |
| [`eadcb6de`](https://github.com/nix-community/NUR/commit/eadcb6de1ff70db8857676a64b0f3ad518b84800) | `` automatic update `` |