### PR TITLE
chore(flake/nur): `5c8b6739` -> `e0e4d6ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679427980,
-        "narHash": "sha256-3vn1eNYLpQjNFlMx9UFtkhTHRIWuSQ5hxJrDdL2qjqU=",
+        "lastModified": 1679431248,
+        "narHash": "sha256-c3/TUm9B0ZU/oPPXf20bK/nm/eqImBDN+hVCLw/Vn+0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5c8b673966e7d8a367b4c9f7c481d4fb79724ea3",
+        "rev": "e0e4d6ab0ee8f719598e8ab7a69ac350c6d1000f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e0e4d6ab`](https://github.com/nix-community/NUR/commit/e0e4d6ab0ee8f719598e8ab7a69ac350c6d1000f) | `` automatic update `` |