### PR TITLE
chore(flake/nur): `e0e4d6ab` -> `ec838188`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679431248,
-        "narHash": "sha256-c3/TUm9B0ZU/oPPXf20bK/nm/eqImBDN+hVCLw/Vn+0=",
+        "lastModified": 1679441716,
+        "narHash": "sha256-mEStwdMDTLMhUaOfNPc0Ewbv2c4L80+ntzn/K4D2js0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e0e4d6ab0ee8f719598e8ab7a69ac350c6d1000f",
+        "rev": "ec838188022f96f77a62a32d267f138683755a4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ec838188`](https://github.com/nix-community/NUR/commit/ec838188022f96f77a62a32d267f138683755a4f) | `` automatic update `` |