### PR TITLE
chore(flake/attic): `1a3b6513` -> `4d92e69f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1678041467,
-        "narHash": "sha256-qqHbiN0ZfEuZ2guMAW5T011TqgrPqGqNWlHtd8AXtQA=",
+        "lastModified": 1679445945,
+        "narHash": "sha256-UadTIRRA/okmLmdM+OzhCwSoovr72Pq0+3Tt7CAyYcg=",
         "owner": "zhaofengli",
         "repo": "attic",
-        "rev": "1a3b6513b02202198bb497608d0cedc45119799b",
+        "rev": "4d92e69fc1b279676f997e6b99d2cacc4d0a3e87",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                                             |
| ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`4d92e69f`](https://github.com/zhaofengli/attic/commit/4d92e69fc1b279676f997e6b99d2cacc4d0a3e87) | `` .github/install-attic-ci.sh: Update ``                           |
| [`f658c7e1`](https://github.com/zhaofengli/attic/commit/f658c7e1fe81480be22b2c7a0f6b57c0ebb6f943) | `` flake.nix: Minimize the closure size of attic-static ``          |
| [`3c58b2d2`](https://github.com/zhaofengli/attic/commit/3c58b2d2cef196f91303a0e477976f3114992e51) | `` ci-installer.nix: Only install the client ``                     |
| [`a8a30288`](https://github.com/zhaofengli/attic/commit/a8a30288fa4a7f3ce3cfa08fb558f7ffa15f2c1f) | `` flake.nix: Add attic-client-static package ``                    |
| [`cb493f29`](https://github.com/zhaofengli/attic/commit/cb493f2982099187964920712d020aa98a7922e8) | `` crane.nix: Make attic-client actually contain the client only `` |
| [`94a1d44a`](https://github.com/zhaofengli/attic/commit/94a1d44a10620f796c8ff06ba9f8acbbaaa7e6bd) | `` server: Only read PUT payload up to the claimed size ``          |
| [`ba8bd5d6`](https://github.com/zhaofengli/attic/commit/ba8bd5d66ce12907d28fde44b432113d9f2af82a) | `` Thanks clippy ``                                                 |
| [`2e68228f`](https://github.com/zhaofengli/attic/commit/2e68228fee5a2ca827fd8ac4501cec2b80a36241) | `` token: Enforce the same lint configs ``                          |
| [`63f64ee8`](https://github.com/zhaofengli/attic/commit/63f64ee8c43062e0ba1972d77aba15674ed2b097) | `` Revert bindgenHook workarounds ``                                |