### PR TITLE
chore(flake/emacs-overlay): `4e0b09e0` -> `383e063b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679422052,
-        "narHash": "sha256-E9mk222GxJUXqK2TP0umn5kk4BA6UOh8yck6aAB2iCg=",
+        "lastModified": 1679445721,
+        "narHash": "sha256-2Vxpqv1v1RphaZvQmT/+AI26oEDBRQsSfcCJrRLPBzQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4e0b09e0d1bcd0f4bf382d69846d1fdb32ba69d4",
+        "rev": "383e063be3ddb90aa8c123d54e9846d4d77fadd9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                               |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
| [`75502495`](https://github.com/nix-community/emacs-overlay/commit/755024956d0907f6252e33b722e4d38b3c9c3026) | `` hydra: keep one evaluation only `` |