### PR TITLE
chore(flake/nur): `ec838188` -> `0933742c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679441716,
-        "narHash": "sha256-mEStwdMDTLMhUaOfNPc0Ewbv2c4L80+ntzn/K4D2js0=",
+        "lastModified": 1679456680,
+        "narHash": "sha256-Zh7u1ygRWy83h2PdsjOqhqfUpQl2zIyBccbKesApjk4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ec838188022f96f77a62a32d267f138683755a4f",
+        "rev": "0933742c8990c356acaf92fbc0ca7b7b942f5b77",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0933742c`](https://github.com/nix-community/NUR/commit/0933742c8990c356acaf92fbc0ca7b7b942f5b77) | `` automatic update `` |
| [`61a6c61e`](https://github.com/nix-community/NUR/commit/61a6c61e4bd3490bc9fea6378aa1106e8da286dd) | `` automatic update `` |