### PR TITLE
chore(flake/nur): `0933742c` -> `8f6a8a96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679456680,
-        "narHash": "sha256-Zh7u1ygRWy83h2PdsjOqhqfUpQl2zIyBccbKesApjk4=",
+        "lastModified": 1679458153,
+        "narHash": "sha256-SLh4q5TOe3D0M3VadutIaoTdrX4qzPqEgDlKp79SpXk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0933742c8990c356acaf92fbc0ca7b7b942f5b77",
+        "rev": "8f6a8a960217ea6822ee2bfb00f844bf14363653",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8f6a8a96`](https://github.com/nix-community/NUR/commit/8f6a8a960217ea6822ee2bfb00f844bf14363653) | `` automatic update `` |