### PR TITLE
chore(flake/nur): `8f6a8a96` -> `52e6a774`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679458153,
-        "narHash": "sha256-SLh4q5TOe3D0M3VadutIaoTdrX4qzPqEgDlKp79SpXk=",
+        "lastModified": 1679463968,
+        "narHash": "sha256-SBNgZb/Gc/9RbEvxz+jQ2o6nWNt1gzTwAw16lShT/ho=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8f6a8a960217ea6822ee2bfb00f844bf14363653",
+        "rev": "52e6a7748992cde538e52f3fa4737f64b5bec03d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`52e6a774`](https://github.com/nix-community/NUR/commit/52e6a7748992cde538e52f3fa4737f64b5bec03d) | `` automatic update `` |