### PR TITLE
chore(flake/home-manager): `e386ec64` -> `e60080dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -445,11 +445,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679394816,
-        "narHash": "sha256-1V1esJt2YAxsKmRuGuB62RF5vhDAVFDvJXVNhtEO22A=",
+        "lastModified": 1679469671,
+        "narHash": "sha256-UrJJTOKTDji8f9aXqVrfmIphuAxeg8eYhzLuEDRxVCc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e386ec640e16dc91120977285cb8c72c77078164",
+        "rev": "e60080ddfb45f6e667d8cac3ca20922ddbaf4e5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                            |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`e60080dd`](https://github.com/nix-community/home-manager/commit/e60080ddfb45f6e667d8cac3ca20922ddbaf4e5b) | `` listenbrainz-mpd: add module `` |