### PR TITLE
chore(flake/home-manager): `e60080dd` -> `486ba3de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -445,11 +445,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679469671,
-        "narHash": "sha256-UrJJTOKTDji8f9aXqVrfmIphuAxeg8eYhzLuEDRxVCc=",
+        "lastModified": 1679470414,
+        "narHash": "sha256-SVJ7xHCv35Vv50IBd3GnPxunoySOqnQXnntjXOgls7Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e60080ddfb45f6e667d8cac3ca20922ddbaf4e5b",
+        "rev": "486ba3de4ecca3ef8371c20b0c53866d61e97dbd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                 |
| ----------------------------------------------------------------------------------------------------------- | ----------------------- |
| [`486ba3de`](https://github.com/nix-community/home-manager/commit/486ba3de4ecca3ef8371c20b0c53866d61e97dbd) | `` copyq: add module `` |