### PR TITLE
chore(flake/nur): `faff5cb4` -> `e9088dc6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679474776,
-        "narHash": "sha256-pW1PHyQGd+cfTmxnVhTqHgH29bY9VD/xaLcxMrpUgHk=",
+        "lastModified": 1679482366,
+        "narHash": "sha256-88K2ABCsdsVwq6Go/uEn/fds1fUeeeoixOALjrrUI0Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "faff5cb41f55eed61baf3ff7bd13bf14b813f4bc",
+        "rev": "e9088dc6f9f289fbff984744ad04dccbd5c1f8ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e9088dc6`](https://github.com/nix-community/NUR/commit/e9088dc6f9f289fbff984744ad04dccbd5c1f8ac) | `` automatic update `` |
| [`45fef8f0`](https://github.com/nix-community/NUR/commit/45fef8f0173df2fcf6a73ce81f078aa815885c2d) | `` automatic update `` |