### PR TITLE
chore(flake/emacs-ement): `29b15fca` -> `64049a21`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -200,11 +200,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1678827445,
-        "narHash": "sha256-DICRTy4XmbP1DfnYYG6D0bjBJOpmEHwyWhzAX0KrpRg=",
+        "lastModified": 1679496785,
+        "narHash": "sha256-eeExG6CQ3YBpgIyODPDQ3yY5x6D6d79lP5udp5pvhLA=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "29b15fcae9c28414be1d6265cdfe2c20a30a1dcf",
+        "rev": "64049a21fac391bace1758e8ee65a74bc54c6219",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                  |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`64049a21`](https://github.com/alphapapa/ement.el/commit/64049a21fac391bace1758e8ee65a74bc54c6219) | `` Fix: (ement-leave/forget-room) Interactive prompts `` |