### PR TITLE
chore(flake/nur): `e9088dc6` -> `15111a58`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679482366,
-        "narHash": "sha256-88K2ABCsdsVwq6Go/uEn/fds1fUeeeoixOALjrrUI0Q=",
+        "lastModified": 1679503867,
+        "narHash": "sha256-c1QunuKTRqJGAfQZWF9pz1Ui2Q+g67mSbyEj8NpkhGA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e9088dc6f9f289fbff984744ad04dccbd5c1f8ac",
+        "rev": "15111a582f3ac21ef7e3676b1473f9d350da0df0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`15111a58`](https://github.com/nix-community/NUR/commit/15111a582f3ac21ef7e3676b1473f9d350da0df0) | `` automatic update `` |