### PR TITLE
chore(flake/nur): `15111a58` -> `16441f51`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679503867,
-        "narHash": "sha256-c1QunuKTRqJGAfQZWF9pz1Ui2Q+g67mSbyEj8NpkhGA=",
+        "lastModified": 1679514299,
+        "narHash": "sha256-cyHOyrnUHfRoaGLX771e9sOn+dreu13X7ca5Xc5nHFM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "15111a582f3ac21ef7e3676b1473f9d350da0df0",
+        "rev": "16441f51e1ded08cc6bb5f168b06a6440f92b67d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`16441f51`](https://github.com/nix-community/NUR/commit/16441f51e1ded08cc6bb5f168b06a6440f92b67d) | `` automatic update `` |