### PR TITLE
chore(flake/nur): `16441f51` -> `2f4463f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679514299,
-        "narHash": "sha256-cyHOyrnUHfRoaGLX771e9sOn+dreu13X7ca5Xc5nHFM=",
+        "lastModified": 1679517993,
+        "narHash": "sha256-srUzbHMbnXtOmiLbSLY7yfxWJwPl1q8n7u0FPP+5Q5w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "16441f51e1ded08cc6bb5f168b06a6440f92b67d",
+        "rev": "2f4463f4a08a4ba33b084cbc76b89cc8b2bd7f85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2f4463f4`](https://github.com/nix-community/NUR/commit/2f4463f4a08a4ba33b084cbc76b89cc8b2bd7f85) | `` automatic update `` |