### PR TITLE
chore(flake/nur): `2f4463f4` -> `c350cdf6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679517993,
-        "narHash": "sha256-srUzbHMbnXtOmiLbSLY7yfxWJwPl1q8n7u0FPP+5Q5w=",
+        "lastModified": 1679521585,
+        "narHash": "sha256-SVPXnklZ/ZpXFvOeLS4onXIeiaDa0++rMPomA7Kb9U4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2f4463f4a08a4ba33b084cbc76b89cc8b2bd7f85",
+        "rev": "c350cdf6f17c3e0ba95bef6c338a758acf443201",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c350cdf6`](https://github.com/nix-community/NUR/commit/c350cdf6f17c3e0ba95bef6c338a758acf443201) | `` automatic update `` |