### PR TITLE
chore(flake/nur): `c350cdf6` -> `d4906c2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679521585,
-        "narHash": "sha256-SVPXnklZ/ZpXFvOeLS4onXIeiaDa0++rMPomA7Kb9U4=",
+        "lastModified": 1679525154,
+        "narHash": "sha256-Afqsg/fRFQoR/CIRqBnu8JdsIjQcWNmGfzO/NOmS/Zc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c350cdf6f17c3e0ba95bef6c338a758acf443201",
+        "rev": "d4906c2ed98762a275cb7edb800c950ba2f46ce5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d4906c2e`](https://github.com/nix-community/NUR/commit/d4906c2ed98762a275cb7edb800c950ba2f46ce5) | `` automatic update `` |