### PR TITLE
chore(flake/nixpkgs): `60c1d71f` -> `19cf008b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -649,11 +649,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1679262748,
-        "narHash": "sha256-DQCrrAFrkxijC6haUzOC5ZoFqpcv/tg2WxnyW3np1Cc=",
+        "lastModified": 1679437018,
+        "narHash": "sha256-vOuiDPLHSEo/7NkiWtxpHpHgoXoNmrm+wkXZ6a072Fc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "60c1d71f2ba4c80178ec84523c2ca0801522e0a6",
+        "rev": "19cf008bb18e47b6e3b4e16e32a9a4bdd4b45f7e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`c353833b`](https://github.com/NixOS/nixpkgs/commit/c353833b9551c460836605bc7f2c3b08dd8fa907) | `` firefox-bin-unwrapped: Update 111.0.1 hashes ``                              |
| [`4d770893`](https://github.com/NixOS/nixpkgs/commit/4d77089308e9477e5e3737a9648d3a2042981002) | `` firefox-unwrapped: Update 111.0.1 hash ``                                    |
| [`8dc1ebbf`](https://github.com/NixOS/nixpkgs/commit/8dc1ebbfa66faa822140c07dc7b146f810e67109) | `` gh: 2.25.0 -> 2.25.1 ``                                                      |
| [`441cbfcf`](https://github.com/NixOS/nixpkgs/commit/441cbfcfd284298efc1123f2431b42763ec8a437) | `` erlang: normalize version name ``                                            |
| [`e400f935`](https://github.com/NixOS/nixpkgs/commit/e400f93529cb4ad6e095e42b17b303f5003f6f26) | `` aeron: init at 1.40.0 (#191663) ``                                           |
| [`c448edd4`](https://github.com/NixOS/nixpkgs/commit/c448edd408c94759cd0131d24fc1439254adc319) | `` nvme-cli: meta.mainProgram ``                                                |
| [`0e37115f`](https://github.com/NixOS/nixpkgs/commit/0e37115f122905d785a1ffcf29f1afb2b47b3913) | `` komikku: add infinitivewitch as maintainer ``                                |
| [`ea9b9f93`](https://github.com/NixOS/nixpkgs/commit/ea9b9f938677b1c9c2cf99ea16ea9545d826a1cd) | `` maintainers: add infinitivewitch as maintainer ``                            |
| [`dc1fda49`](https://github.com/NixOS/nixpkgs/commit/dc1fda492a425398c64a2807c71ab243851ab060) | `` cimg,gmic,gmic-qt: add lilyinstarlight to maintainers ``                     |
| [`fc457d46`](https://github.com/NixOS/nixpkgs/commit/fc457d46c43eac9b3f5d2bfdaa1c4f19d1bb5c4e) | `` gmic: update license to cecill21 ``                                          |
| [`126b3d60`](https://github.com/NixOS/nixpkgs/commit/126b3d60f6379820a958c54bb727145762b506b6) | `` gmic-qt: 3.2.1 -> 3.2.2 ``                                                   |
| [`6d535955`](https://github.com/NixOS/nixpkgs/commit/6d5359557f3841310af4b7fd74226264d4e663e3) | `` gmic: 3.2.1 -> 3.2.2 ``                                                      |
| [`cbb7ab9b`](https://github.com/NixOS/nixpkgs/commit/cbb7ab9b791879604e303cd7ba25cde07bf02ee0) | `` cimg: 3.2.1 -> 3.2.2 ``                                                      |
| [`e31eb9a5`](https://github.com/NixOS/nixpkgs/commit/e31eb9a58d62043cdc9ba7db8b6b2dd19f6e1c5d) | `` dart: Make update script atomic ``                                           |
| [`c96165bf`](https://github.com/NixOS/nixpkgs/commit/c96165bf64376212b5a816828c9a3a36affd94d0) | `` tauon: 7.5.0 -> 7.6.0 ``                                                     |
| [`99d924f1`](https://github.com/NixOS/nixpkgs/commit/99d924f1c3453e87b833d884e899e159870f2c62) | `` ldid: openssl_1_1 -> openssl ``                                              |
| [`10d99268`](https://github.com/NixOS/nixpkgs/commit/10d99268086aaa8ce1f0d448e27835ab6c7d27c3) | `` sbsigntool: 0.9.4 -> 0.9.5 ``                                                |
| [`cd9d0542`](https://github.com/NixOS/nixpkgs/commit/cd9d054201a3c91762f719648f1c81c3d4ed9589) | `` woob: 3.0->3.3.1 ``                                                          |
| [`4d59df09`](https://github.com/NixOS/nixpkgs/commit/4d59df09de5136f5c6ffed8d6ef6b2ad78648cad) | `` woob: add tests.version ``                                                   |
| [`35bed7ef`](https://github.com/NixOS/nixpkgs/commit/35bed7ef35d11700bb449fcacf80033e5fe383e5) | `` bqn386: init at unstable-2022-05-16 ``                                       |
| [`2771596f`](https://github.com/NixOS/nixpkgs/commit/2771596f491eb538171226b5fd6f8d87945e4a6a) | `` stripe-cli: 1.10.3 -> 1.13.12 ``                                             |
| [`fedc9837`](https://github.com/NixOS/nixpkgs/commit/fedc9837343482896a0d9f76fc4f1b54cc4b3643) | `` linuxManualConfig: add pahole to moduleBuildDependencies ``                  |
| [`39c344c8`](https://github.com/NixOS/nixpkgs/commit/39c344c893bdb55a64c25765612c60edd415a28b) | `` nixos/console: let the kernel pick the default font ``                       |
| [`4787ebf7`](https://github.com/NixOS/nixpkgs/commit/4787ebf7ae2ab071389be7ff86cf38edeee7e9f8) | `` nixos/hidpi: remove ``                                                       |
| [`b9bb4e54`](https://github.com/NixOS/nixpkgs/commit/b9bb4e5448385db8f97b1a3a323e93cb6705ff5b) | `` nfpm: 2.26.0 -> 2.27.1 ``                                                    |
| [`e47ee5de`](https://github.com/NixOS/nixpkgs/commit/e47ee5de2ac7059bc8fb18a20b9e2a25d323cfc6) | `` lefthook: 1.3.6 -> 1.3.7 ``                                                  |
| [`2744625b`](https://github.com/NixOS/nixpkgs/commit/2744625b512bbda41ed6e4f2b8072c0ab970f0c8) | `` lefthook: 1.3.5 -> 1.3.6 ``                                                  |
| [`90074803`](https://github.com/NixOS/nixpkgs/commit/90074803e6bbb8044d5738be08db11d9e85141fe) | `` docs/stdenv: Document updateScript features ``                               |
| [`d0e8c708`](https://github.com/NixOS/nixpkgs/commit/d0e8c7087d32d04d4c637db23ee4033aaaa207c1) | `` docs/stdenv: Document updateScript execution ``                              |
| [`eed7f2c4`](https://github.com/NixOS/nixpkgs/commit/eed7f2c4cd29b046006940f67cc3c01f8ababf94) | `` firefox-bin-unwrapped: 111.0 -> 111.0.1 ``                                   |
| [`c8f0a393`](https://github.com/NixOS/nixpkgs/commit/c8f0a3939d95bf39af85435e5e16e41969fc7145) | `` firefox-unwrapped: 111.0 -> 111.0.1 ``                                       |
| [`8ed83a22`](https://github.com/NixOS/nixpkgs/commit/8ed83a22628119ad97f9ef8ace3b2f49e1bab23c) | `` cloudfox: 1.10.0 -> 1.10.1 ``                                                |
| [`90f4daba`](https://github.com/NixOS/nixpkgs/commit/90f4daba7e15a207b383bdb369d99fea34f8dff0) | `` jenkins: fix passthru.updateScript ``                                        |
| [`43c7420f`](https://github.com/NixOS/nixpkgs/commit/43c7420fbdcfae3699b09657e5e43573d03c68b3) | `` jenkins: 2.375.3 -> 2.387.1 ``                                               |
| [`cc66f022`](https://github.com/NixOS/nixpkgs/commit/cc66f02246052f8035a27c94c08fc723e0171443) | `` disfetch: 3.6 -> 3.7 ``                                                      |
| [`daf33aca`](https://github.com/NixOS/nixpkgs/commit/daf33aca55f06d5f8cab69b904ad36b4916c0416) | `` gitea-actions-runner: unstable-2023-02-08 -> unstable-2023-03-18 ``          |
| [`db935a7e`](https://github.com/NixOS/nixpkgs/commit/db935a7eaf28e47649431b205ab78b5a3159058d) | `` terraform-providers.ucloud: 1.34.1 → 1.35.1 ``                               |
| [`7123b137`](https://github.com/NixOS/nixpkgs/commit/7123b137c8fa77f6982e7136e3509ffd90c0bcb7) | `` terraform-providers.ksyun: 1.3.67 → 1.3.68 ``                                |
| [`e1b22d4e`](https://github.com/NixOS/nixpkgs/commit/e1b22d4e42583dc875ba0b1530c088f20f4f3fdb) | `` terraform-providers.checkly: 1.6.4 → 1.6.5 ``                                |
| [`401cead6`](https://github.com/NixOS/nixpkgs/commit/401cead6cb5ffd009326756029274c82d3d77a3f) | `` moar: 1.11.4 -> 1.13.0 ``                                                    |
| [`746b9cf0`](https://github.com/NixOS/nixpkgs/commit/746b9cf0d811c6efbbaa28721804674a8219e865) | `` yq-go: 4.31.2 -> 4.32.2 ``                                                   |
| [`d671c860`](https://github.com/NixOS/nixpkgs/commit/d671c860d58c4e6e07df27a6345607e77ea933fd) | `` svtplay-dl: 4.18 -> 4.19 ``                                                  |
| [`a1d4a1ca`](https://github.com/NixOS/nixpkgs/commit/a1d4a1cad16c0aa74bc7fb67918ba421c2ea2b70) | `` eksctl: 0.133.0 -> 0.134.0 ``                                                |
| [`862cc4ac`](https://github.com/NixOS/nixpkgs/commit/862cc4acbdf93464b8b16d7f29a5509a416df530) | `` poetryPlugins.poetry-plugin-up: 0.2.1 -> 0.3.0 ``                            |
| [`fc6ce1d2`](https://github.com/NixOS/nixpkgs/commit/fc6ce1d262abb7f3b2dbe5c9f386a269aa667e4a) | `` poetry: 1.4.0 -> 1.4.1 ``                                                    |
| [`fae66ed8`](https://github.com/NixOS/nixpkgs/commit/fae66ed86c453c875329b097c1e16a7c617551bb) | `` python310Packages.installer: 0.6.0 -> 0.7.0 ``                               |
| [`8ea4f3b8`](https://github.com/NixOS/nixpkgs/commit/8ea4f3b8140bf44cb482884e51b6a89bae09819b) | `` terragrunt: 0.44.5 -> 0.45.0 ``                                              |
| [`3e1c9020`](https://github.com/NixOS/nixpkgs/commit/3e1c90207af2202db2490e5ea775b0a2f5582332) | `` imagemagick: add rhendric to maintainers ``                                  |
| [`6a6bed8f`](https://github.com/NixOS/nixpkgs/commit/6a6bed8f9bd18ba8a616343cdc743875efef5cc6) | `` pop-launcher: mark linux-only ``                                             |
| [`fcc22eff`](https://github.com/NixOS/nixpkgs/commit/fcc22effb0906cc59ff3167ab52dae6f3a79f853) | `` maintainers: add rhendric ``                                                 |
| [`57fcc338`](https://github.com/NixOS/nixpkgs/commit/57fcc3386c99bd8530608941916cca85a6c2f76f) | `` rootbar: mark broken on darwin ``                                            |
| [`220cd939`](https://github.com/NixOS/nixpkgs/commit/220cd9391917d0350cf67e9c8e79501c3264c4cc) | `` rustypaste: fix darwin build ``                                              |
| [`83990d93`](https://github.com/NixOS/nixpkgs/commit/83990d93c46e0c0c836156a5f75e762df52c3135) | `` imagemagick: 7.1.1-3 -> 7.1.1-4 ``                                           |
| [`6312640e`](https://github.com/NixOS/nixpkgs/commit/6312640e83d7f093d5f41898a600b738127a0747) | `` python310Packages.pygls: fix darwin on hydra ``                              |
| [`1e5a60fe`](https://github.com/NixOS/nixpkgs/commit/1e5a60fe7d3cf336f3ac75f1e3180f469d4e635a) | `` speedtest-rs: fix darwin build ``                                            |
| [`94fad43b`](https://github.com/NixOS/nixpkgs/commit/94fad43baa369baf5bdd2fd19ae7a00aa606ffc4) | `` go-musicfox: 3.7.3 -> 3.7.5 ``                                               |
| [`c4ee55d6`](https://github.com/NixOS/nixpkgs/commit/c4ee55d6617a9c8e6bd7a5e66356a38ae211e8f0) | `` nethack-qt: fix darwin build ``                                              |
| [`97904d53`](https://github.com/NixOS/nixpkgs/commit/97904d53232b53c40a672cd0dcfd2c613c2514cf) | `` minixml: fix darwin build ``                                                 |
| [`6ad224ce`](https://github.com/NixOS/nixpkgs/commit/6ad224ce9a610cbf0a617908d9eca8fb54b5d813) | `` mellowplayer: mark broken on darwin ``                                       |
| [`68d28d94`](https://github.com/NixOS/nixpkgs/commit/68d28d948467458b64f9021803e127d394395251) | `` havoc: mark as broken on darwin ``                                           |
| [`41135131`](https://github.com/NixOS/nixpkgs/commit/41135131a4cfdd70e906f0983632096c780e4cb2) | `` gh: 2.24.3 -> 2.25.0 ``                                                      |
| [`3f9ad8bf`](https://github.com/NixOS/nixpkgs/commit/3f9ad8bfe2af6327130726d739fcd9b46a63a08b) | `` maintainers: add atkrad ``                                                   |
| [`d5f74b29`](https://github.com/NixOS/nixpkgs/commit/d5f74b29987affbbe8c7d71c52e7774f89ad1c38) | `` naabu: 2.1.3 -> 2.1.4 ``                                                     |
| [`1f24ebb4`](https://github.com/NixOS/nixpkgs/commit/1f24ebb428c036ebc01b9da6b106b79f93957d6d) | `` elixir-ls: rename elixir_ls to elixir-ls ``                                  |
| [`bca2472c`](https://github.com/NixOS/nixpkgs/commit/bca2472c1e9826513da1c7c39546c2c273f2008c) | `` wails: 2.4.0 -> 2.4.1 ``                                                     |
| [`64362896`](https://github.com/NixOS/nixpkgs/commit/64362896c88f761a30d4012151e410e1765fbc66) | `` php82: 8.2.3 -> 8.2.4 ``                                                     |
| [`a5c90b89`](https://github.com/NixOS/nixpkgs/commit/a5c90b896d479d4247117fb01bf53bcfee8507d9) | `` php81: 8.1.16 -> 8.1.17 ``                                                   |
| [`d2629daf`](https://github.com/NixOS/nixpkgs/commit/d2629daf0d6def4c8828f20225d187dd7c9c4445) | `` php.packages.composer: 2.5.1 -> 2.5.4 ``                                     |
| [`6599eca8`](https://github.com/NixOS/nixpkgs/commit/6599eca8717fa84fde54ebf8f0bed44a17cbf3e5) | `` scalr-cli: init at 0.14.5 ``                                                 |
| [`f2f7589c`](https://github.com/NixOS/nixpkgs/commit/f2f7589c1c1dbf6c7905a711cf914cb1d320ab06) | `` maintainers: add dylanmtaylor ``                                             |
| [`f01862e2`](https://github.com/NixOS/nixpkgs/commit/f01862e271cac854e8e90eb9c6a273a1035901e0) | `` gitea.data-compressed: improve drv name ``                                   |
| [`88c4a670`](https://github.com/NixOS/nixpkgs/commit/88c4a670e65b01dd98ed054f70147fb7fd744daf) | `` slimserver: remove phile314 as maintainer ``                                 |
| [`c24515de`](https://github.com/NixOS/nixpkgs/commit/c24515de8fa7f78b50a578df15b67982a39b6cf0) | `` firebird-emu: 1.5 -> 1.6 ``                                                  |
| [`e12230e7`](https://github.com/NixOS/nixpkgs/commit/e12230e71628a460bf82a8477242280868efe799) | `` why3: 1.5.1 → 1.6.0; ocamlPackages.lambdapi: 2.2.1 → 2.3.1 (#220986) ``      |
| [`336e5cc1`](https://github.com/NixOS/nixpkgs/commit/336e5cc12618d4dc8ff178e750350fda22357927) | `` seaweedfs: 3.43 -> 3.44 ``                                                   |
| [`48be87c5`](https://github.com/NixOS/nixpkgs/commit/48be87c5543799f397ad952355eee9d9094bad02) | `` erdtree: 1.3.0 -> 1.6.0, add figsoda as a maintainer ``                      |
| [`ee71bbc2`](https://github.com/NixOS/nixpkgs/commit/ee71bbc2f7eeffccd422011c5e4dd503a8feebcb) | `` libsvm: 3.25 -> 3.31 ``                                                      |
| [`36abb0e5`](https://github.com/NixOS/nixpkgs/commit/36abb0e53b987661fd916885e34ca2a2ea7613ae) | `` dart: add update script ``                                                   |
| [`27cbc356`](https://github.com/NixOS/nixpkgs/commit/27cbc35640f72aa5546fed0a72f09e778911a22a) | `` codeql: make substitution include the aarch path ``                          |
| [`e0371f9d`](https://github.com/NixOS/nixpkgs/commit/e0371f9d20bc08b2ac72813e83d1e678442bd30e) | `` mastodon: 4.1.0 -> 4.1.1 ``                                                  |
| [`2af44e35`](https://github.com/NixOS/nixpkgs/commit/2af44e355256e7a9d7377acfd4aeb3153dbffd81) | `` watchman: add version to binary ``                                           |
| [`424c98bf`](https://github.com/NixOS/nixpkgs/commit/424c98bf7852bdf208bc19068e98b0d7ba6c9aea) | `` nixos/gollum: fix deprecation warning ``                                     |
| [`6d2eaecc`](https://github.com/NixOS/nixpkgs/commit/6d2eaecc8c29c54705d0f69db186c278e423b5a7) | `` gollum: 5.3.0 -> 5.3.1 ``                                                    |
| [`2676c648`](https://github.com/NixOS/nixpkgs/commit/2676c648eaa25553d4c89ec4042ce0813d350eb1) | `` fastnetmon-advanced: init at 2.0.335 (#218609) ``                            |
| [`0112d0bd`](https://github.com/NixOS/nixpkgs/commit/0112d0bdfa02c635c341cb09264648ef8a935700) | `` hyprpicker: Fix eval with aliases disabled ``                                |
| [`a22e80f5`](https://github.com/NixOS/nixpkgs/commit/a22e80f516cee794083fa6e83c32e1222d934371) | ``  ledger-live-desktop: 2.54.0 -> 2.55.0  ``                                   |
| [`2b37a482`](https://github.com/NixOS/nixpkgs/commit/2b37a4822c57187c5fe50bc7480108571da7be7a) | `` osu-lazer-bin: adding support for darwin systems ``                          |
| [`2c5b18dc`](https://github.com/NixOS/nixpkgs/commit/2c5b18dc0b33164a928e6830b69659e58d143d4d) | `` osu-lazer: 2023.301.0 -> 2023.305.0 ``                                       |
| [`466240f8`](https://github.com/NixOS/nixpkgs/commit/466240f8cbe39cbeb6d02d2a2039297e348e1a4e) | `` osu-lazer-bin: 2023.301.0 -> 2023.305.0 ``                                   |
| [`72f784db`](https://github.com/NixOS/nixpkgs/commit/72f784dbbe5511cb2433a369212212e56a7d9c72) | `` balena-cli: fix linux binary with patchelf ``                                |
| [`9180097c`](https://github.com/NixOS/nixpkgs/commit/9180097c41486bed157f73327be0ba772b21e659) | `` sonarr: 3.0.9.1549 -> 3.0.10.1567 ``                                         |
| [`5a35e7ea`](https://github.com/NixOS/nixpkgs/commit/5a35e7ea4aa482075316a5a2fd1cea0e9dbfbae3) | `` nixpkgs-review: 2.8.0 -> 2.9.0 ``                                            |
| [`7cee2ad5`](https://github.com/NixOS/nixpkgs/commit/7cee2ad598c1c4437b6f578cd75722853784d2b1) | `` hplip: fix broken/hardcoded paths in .desktop files ``                       |
| [`93beb1e9`](https://github.com/NixOS/nixpkgs/commit/93beb1e9169c7087bd2d51885abd22f8759b9a6e) | `` haxe_3_2, haxe_3_4: drop ``                                                  |
| [`0810a6e0`](https://github.com/NixOS/nixpkgs/commit/0810a6e018ee759de935e25a330f7710f2c4ca9c) | `` nixos/prometheus.alertmanagerIrcRelay: init ``                               |
| [`c1f45a9a`](https://github.com/NixOS/nixpkgs/commit/c1f45a9ae60ee12657705dbe43ed34f42aa3dbbc) | `` open-watcom-v2-unwrapped: unstable-2023-01-30 -> unstable-2023-03-20 ``      |
| [`0de90269`](https://github.com/NixOS/nixpkgs/commit/0de9026953c195a29681ddba7526faf652271a27) | `` miriway: unstable-2023-02-18 -> unstable-2023-03-17 ``                       |
| [`a92ddfb5`](https://github.com/NixOS/nixpkgs/commit/a92ddfb549058b6c0b7480d7c2dacd91fc8e06a0) | `` sidplayfp: 2.4.0 -> 2.4.1 ``                                                 |
| [`c7a96220`](https://github.com/NixOS/nixpkgs/commit/c7a96220a3b94a6b6dfdbd42c3957b7e90f3621d) | `` python310Packages.aiomusiccast: 0.14.7 -> 0.14.8 ``                          |
| [`8aa9c822`](https://github.com/NixOS/nixpkgs/commit/8aa9c82256e957b98e3057f245a32f105db7d31a) | `` vscode-extensions.streetsidesoftware.code-spell-checker: 2.19.0 -> 2.20.3 `` |
| [`656709bc`](https://github.com/NixOS/nixpkgs/commit/656709bceb2d9f86c5b971f0ec53bbfbac0de543) | `` pkgsMusl.xterm: fix build (#220731) ``                                       |
| [`068c6de7`](https://github.com/NixOS/nixpkgs/commit/068c6de7f6f6658219a846e835cba1f9bf18e591) | `` vimPlugins.nvim-treesitter: update grammars ``                               |
| [`f58a0dc2`](https://github.com/NixOS/nixpkgs/commit/f58a0dc2d4450b95ea1fd79f366388a0ccd58ddd) | `` vimPlugins.openscad-nvim: init at 2022-04-15 ``                              |
| [`e32f3c7e`](https://github.com/NixOS/nixpkgs/commit/e32f3c7ea9b3ae7cc4d1447fe917d2d96eba3587) | `` vimPlugins: update ``                                                        |
| [`f129d39c`](https://github.com/NixOS/nixpkgs/commit/f129d39c779f090a2ee1e284f479e1450e767458) | `` nix-init: 0.1.1 -> 0.2.0 ``                                                  |
| [`238d4c33`](https://github.com/NixOS/nixpkgs/commit/238d4c33349143212f7ae925750ac09e8633463f) | `` b4: 0.12.1 -> 0.12.2 ``                                                      |
| [`7ebafc91`](https://github.com/NixOS/nixpkgs/commit/7ebafc91abe22556231ea59fb8fcf805b20c844f) | `` hello-wayland: unstable-2020-07-27 -> unstable-2023-03-16 ``                 |
| [`5c5f7103`](https://github.com/NixOS/nixpkgs/commit/5c5f710388f0d94a222c91c79c0c812d2b65fdde) | `` gitea: 1.18.5 -> 1.19.0 ``                                                   |
| [`96c5fc94`](https://github.com/NixOS/nixpkgs/commit/96c5fc940c78a9fee1455249e341b37223cdeee6) | `` sniffnet: replace libGL with vulkan-loader ``                                |
| [`ca226caf`](https://github.com/NixOS/nixpkgs/commit/ca226cafce2081eed6525674d3c2b1570d2ceae7) | `` gpu-viewer: init at 2.26 ``                                                  |
| [`bc6e8aba`](https://github.com/NixOS/nixpkgs/commit/bc6e8aba91c55ad20dabf732974d63b2168e3361) | `` liblinear: 2.43 -> 2.46 ``                                                   |
| [`6715882c`](https://github.com/NixOS/nixpkgs/commit/6715882cb7a82eea378646eb2c4b02f698fbc88c) | `` cargo-about: 0.5.4 -> 0.5.5 ``                                               |
| [`90116fa8`](https://github.com/NixOS/nixpkgs/commit/90116fa82f56467620762e1aaf1f4501eeeadc42) | `` argc: 0.15.0 -> 0.15.1 ``                                                    |
| [`acde26c9`](https://github.com/NixOS/nixpkgs/commit/acde26c95a126acc3036d0ffab58da98e570216b) | `` linuxKernel.kernels.linux_lqx: 6.2.6-lqx1 -> 6.2.7-lqx1 ``                   |
| [`b64eb5bb`](https://github.com/NixOS/nixpkgs/commit/b64eb5bbbf3ee58a84bd426f85da15c6ae020e1e) | `` limesurvey: 3.27.33+220125 -> 5.6.9+230306 ``                                |
| [`4678ba64`](https://github.com/NixOS/nixpkgs/commit/4678ba645491c24597e9b75eddd83fd65f0832e6) | `` linuxKernel.kernels.linux_zen: 6.2.6-zen1 -> 6.2.7-zen1 ``                   |
| [`32abfcc9`](https://github.com/NixOS/nixpkgs/commit/32abfcc92306345b124aa2201d337d5c6f2a7469) | `` build(deps): bump cachix/install-nix-action from 19 to 20 ``                 |
| [`663caaa6`](https://github.com/NixOS/nixpkgs/commit/663caaa684c07484b6fa63df882db237cfc903e6) | `` linux_testing_bcachefs: mark broken on aarch64 ``                            |
| [`cdd6211a`](https://github.com/NixOS/nixpkgs/commit/cdd6211abba5bc20248fd16da8f1da6af2fcdee0) | `` linux_testing_bcachefs: fix meta ``                                          |
| [`8c719d58`](https://github.com/NixOS/nixpkgs/commit/8c719d58e19838a605bd1bb634602fc0996087f6) | `` linux_4_14_hardened: mark broken ``                                          |