### PR TITLE
chore(flake/nur): `c754d318` -> `d72c7cb4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679542568,
-        "narHash": "sha256-IJSRBSQDb+J+MVKTjzmITCTouiyevIQay3KmVnWykzY=",
+        "lastModified": 1679544603,
+        "narHash": "sha256-Ps/ObwyUzgh3wcVVHsRvrGWHZk+rYcSrnZ5su/jqW6A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c754d318d664308953633b4f0f4b523d8799f1ae",
+        "rev": "d72c7cb413d5a4b68fb26536cb9521d4ca96d9cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d72c7cb4`](https://github.com/nix-community/NUR/commit/d72c7cb413d5a4b68fb26536cb9521d4ca96d9cd) | `` automatic update `` |