### PR TITLE
chore(flake/nur): `696f8ada` -> `1ed724ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679550248,
-        "narHash": "sha256-oa0EhHoOdAr61ypq9EjEhBF+2n7l6rffUdUyEG03Yds=",
+        "lastModified": 1679552778,
+        "narHash": "sha256-2/P5JjyUuu+z7hihKMljSTSlv4iHccBI8UXy/maXIjU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "696f8ada818d3a42e80460b024589a62270b827f",
+        "rev": "1ed724eeb6688c6caf1cbc0ffb46af9543079ebd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1ed724ee`](https://github.com/nix-community/NUR/commit/1ed724eeb6688c6caf1cbc0ffb46af9543079ebd) | `` automatic update `` |