### PR TITLE
chore(flake/emacs-overlay): `e0bec9f7` -> `b7dc7516`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679540305,
-        "narHash": "sha256-W+9askXWmuEl2eKPvMG61ZpuygAWW0Unw7bbpja2Rsw=",
+        "lastModified": 1679566703,
+        "narHash": "sha256-tkxW2TskrxlnTdEePAIs7YnR6DmxIiXu/AFG3Kin5d8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e0bec9f768c938411adbc3861ae712cf38bf5a0a",
+        "rev": "b7dc7516ce741436e0925c00641b5bcc3a8582d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b7dc7516`](https://github.com/nix-community/emacs-overlay/commit/b7dc7516ce741436e0925c00641b5bcc3a8582d0) | `` Updated repos/nongnu `` |
| [`4e10a0d3`](https://github.com/nix-community/emacs-overlay/commit/4e10a0d3162df3a540e93c037f730d0e30fae7c1) | `` Updated repos/melpa ``  |
| [`e38fef8f`](https://github.com/nix-community/emacs-overlay/commit/e38fef8f1a8e9933422e86012583aeff69e79e2c) | `` Updated repos/emacs ``  |