### PR TITLE
chore(flake/nur): `2e6da006` -> `44aff79a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679557124,
-        "narHash": "sha256-W1lSEOJW5dmv4FhMxZWcr5ZFwvImKbE19sIIAAfdMbo=",
+        "lastModified": 1679576589,
+        "narHash": "sha256-TUliq3eMj/tC6tasqtkez4v+/2L1yzAh0UGnQKSfJLo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2e6da00695e553ed8b16a50b300b5906483a3bb9",
+        "rev": "44aff79a1de96441dd7e3ee36f2fffae4da3ff18",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`44aff79a`](https://github.com/nix-community/NUR/commit/44aff79a1de96441dd7e3ee36f2fffae4da3ff18) | `` automatic update `` |