### PR TITLE
chore(flake/nur): `44aff79a` -> `1696dded`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679576589,
-        "narHash": "sha256-TUliq3eMj/tC6tasqtkez4v+/2L1yzAh0UGnQKSfJLo=",
+        "lastModified": 1679586306,
+        "narHash": "sha256-YGNalFAOgxyoQ7I8ejte+TXLlYhgAYuzDeSCk1+t314=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "44aff79a1de96441dd7e3ee36f2fffae4da3ff18",
+        "rev": "1696dded28ce7bfc2f3179399ffb6b27c9ff2aba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1696dded`](https://github.com/nix-community/NUR/commit/1696dded28ce7bfc2f3179399ffb6b27c9ff2aba) | `` automatic update `` |