### PR TITLE
chore(flake/emacs-overlay): `b7dc7516` -> `ecf16600`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679566703,
-        "narHash": "sha256-tkxW2TskrxlnTdEePAIs7YnR6DmxIiXu/AFG3Kin5d8=",
+        "lastModified": 1679595100,
+        "narHash": "sha256-FY2r9S3XbKdKOUXJHHNwUWc48eJtAcm2aaKD+ljPTKA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b7dc7516ce741436e0925c00641b5bcc3a8582d0",
+        "rev": "ecf16600106c319e7438803db9951eaa472d8513",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`ecf16600`](https://github.com/nix-community/emacs-overlay/commit/ecf16600106c319e7438803db9951eaa472d8513) | `` Updated repos/melpa `` |
| [`592ef280`](https://github.com/nix-community/emacs-overlay/commit/592ef280f170e323058944d1c9ee20a3fd7cd471) | `` Updated repos/emacs `` |