### PR TITLE
chore(flake/nur): `a6ff7d25` -> `b587dc5c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679600805,
-        "narHash": "sha256-/dACLCKi5LaEP6idzXUyoG8LnZnRtFf9HlLGhiJCNz8=",
+        "lastModified": 1679607945,
+        "narHash": "sha256-L8upAhtdt9lZduU/8LL+O3uzSzNNFpiRAZuRoQmNwJc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a6ff7d25d3bff4f6c7f74af5ca36700606fb60bc",
+        "rev": "b587dc5c03d6421bf3ea867c2a94057ca8c67456",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b587dc5c`](https://github.com/nix-community/NUR/commit/b587dc5c03d6421bf3ea867c2a94057ca8c67456) | `` automatic update `` |