### PR TITLE
chore(flake/emacs-overlay): `ecf16600` -> `2f1662e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679595100,
-        "narHash": "sha256-FY2r9S3XbKdKOUXJHHNwUWc48eJtAcm2aaKD+ljPTKA=",
+        "lastModified": 1679628354,
+        "narHash": "sha256-byHgOMOkKSdibBYxHbgGaS/f+IKdbxok3m6z1iltewk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ecf16600106c319e7438803db9951eaa472d8513",
+        "rev": "2f1662e0ba2ea2c613a19093e17c53f42bf8fec1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`2f1662e0`](https://github.com/nix-community/emacs-overlay/commit/2f1662e0ba2ea2c613a19093e17c53f42bf8fec1) | `` Updated repos/melpa `` |
| [`6d5b550e`](https://github.com/nix-community/emacs-overlay/commit/6d5b550e749eaecf3235533e0a8c44e389f69f14) | `` Updated repos/emacs `` |