### PR TITLE
chore(flake/nur): `a63bc596` -> `532fb69a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679628855,
-        "narHash": "sha256-i9nXrfoV4b3hO6TydSoNcrz8KXjaPrQnyPAWQwdt7Zs=",
+        "lastModified": 1679820330,
+        "narHash": "sha256-cqtHm801K6nQ+1MkxxCzRw3wPKyWFWXPmoCmen+IOH8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a63bc596e457bb67331764e48e4de16dd9819f8b",
+        "rev": "532fb69ad13a9a14e94f7c8dd3c0b1f1edf7db50",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`532fb69a`](https://github.com/nix-community/NUR/commit/532fb69ad13a9a14e94f7c8dd3c0b1f1edf7db50) | `` automatic update `` |
| [`360599e4`](https://github.com/nix-community/NUR/commit/360599e4c2f2d67ba466e7eb55c01a627c32d0d5) | `` automatic update `` |
| [`c3319d06`](https://github.com/nix-community/NUR/commit/c3319d060ebefce536a92774dbe559e506ebf511) | `` automatic update `` |
| [`c80597cd`](https://github.com/nix-community/NUR/commit/c80597cd0224b2cb1c87abec59bde84c993f102a) | `` automatic update `` |
| [`c8fe7c52`](https://github.com/nix-community/NUR/commit/c8fe7c52a61cbbf40d50a7d08aadc3870d06cff2) | `` automatic update `` |
| [`90edfe3f`](https://github.com/nix-community/NUR/commit/90edfe3fc697d95333fdb0d79cfd1598cd2aeaf8) | `` automatic update `` |
| [`34db080b`](https://github.com/nix-community/NUR/commit/34db080b9ef30ee93a55b38bb55720178c8ee5c2) | `` automatic update `` |
| [`8c6e45e0`](https://github.com/nix-community/NUR/commit/8c6e45e07810b6f0c71f5757422f77b96fae6021) | `` automatic update `` |
| [`0c67d472`](https://github.com/nix-community/NUR/commit/0c67d4721e5fc1a934f413927a467eef070c754c) | `` automatic update `` |
| [`abe49eae`](https://github.com/nix-community/NUR/commit/abe49eaeb48900219d9193f4fca2613716418558) | `` automatic update `` |
| [`22545903`](https://github.com/nix-community/NUR/commit/22545903fe98e70fecea771726fdda00e11fa036) | `` automatic update `` |
| [`70aca14f`](https://github.com/nix-community/NUR/commit/70aca14fa935a08c6f617add259b6e6b05f88c70) | `` automatic update `` |
| [`51ec8e4d`](https://github.com/nix-community/NUR/commit/51ec8e4d4115486974c612c4e63bcb98c6ff06c0) | `` automatic update `` |
| [`03c1a2ca`](https://github.com/nix-community/NUR/commit/03c1a2ca016cd0bca45bd9a8a74a428c3c242e00) | `` automatic update `` |
| [`52907d05`](https://github.com/nix-community/NUR/commit/52907d05e9d017092da0cec9ff1100b3aca7edf2) | `` automatic update `` |
| [`7792734a`](https://github.com/nix-community/NUR/commit/7792734a492e0e53c9c70711fa61d415924f4edc) | `` automatic update `` |
| [`b69d3533`](https://github.com/nix-community/NUR/commit/b69d353307bb4e8706496f5055ae804f87af0e4a) | `` automatic update `` |
| [`cada49f2`](https://github.com/nix-community/NUR/commit/cada49f2b3fee8b5e050da8f339406cd378b7282) | `` automatic update `` |
| [`277d6279`](https://github.com/nix-community/NUR/commit/277d62795b7ee00a4b9ec37f1973d1f234ef06f5) | `` automatic update `` |
| [`e8d6653c`](https://github.com/nix-community/NUR/commit/e8d6653c35f03240c48470102bfd4f513056da3a) | `` automatic update `` |
| [`cd65825c`](https://github.com/nix-community/NUR/commit/cd65825ce34de40b7d7ad4a75604b90d0dcef242) | `` automatic update `` |
| [`9bac0d14`](https://github.com/nix-community/NUR/commit/9bac0d14fc7379792bf889c407b161c0ca6d6e76) | `` automatic update `` |
| [`662369b0`](https://github.com/nix-community/NUR/commit/662369b09ee8972728adfa8a70d5450c2cb60ace) | `` automatic update `` |
| [`a41906b0`](https://github.com/nix-community/NUR/commit/a41906b0668676bfa22ae3b45e6ddb13b22ac38a) | `` automatic update `` |
| [`6b2727a0`](https://github.com/nix-community/NUR/commit/6b2727a0d2a228bd60d7b266125ecfe735c9ea31) | `` automatic update `` |
| [`2cd23c2a`](https://github.com/nix-community/NUR/commit/2cd23c2a269fd3ebbb3a312e19e2e56ad770da7f) | `` automatic update `` |
| [`02fe4ead`](https://github.com/nix-community/NUR/commit/02fe4ead56489bd62b2967c51e0f1dda2ff6066f) | `` automatic update `` |
| [`f7b2df13`](https://github.com/nix-community/NUR/commit/f7b2df130900f973ebb6c6d33101ff531e8a3a92) | `` automatic update `` |
| [`3b66de86`](https://github.com/nix-community/NUR/commit/3b66de868912e73ec592362ede343ed9fff660bd) | `` automatic update `` |
| [`08a3dfbf`](https://github.com/nix-community/NUR/commit/08a3dfbfe090ffba5dcddba2f022587213c2626b) | `` automatic update `` |
| [`39d7a481`](https://github.com/nix-community/NUR/commit/39d7a481b9c2f0796468a30d77c9a05eac78f832) | `` automatic update `` |
| [`c0a7cf8b`](https://github.com/nix-community/NUR/commit/c0a7cf8bf282cd590ed24384fe9d94d137c3a166) | `` automatic update `` |
| [`231cc2c2`](https://github.com/nix-community/NUR/commit/231cc2c2bd730bca2d5c6a393ecd88c352d7ab78) | `` automatic update `` |
| [`fc32207b`](https://github.com/nix-community/NUR/commit/fc32207b8e7def548d5f5c1acb010f8b59df16d4) | `` automatic update `` |