### PR TITLE
chore(flake/emacs-overlay): `2f1662e0` -> `5b1efd39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679628354,
-        "narHash": "sha256-byHgOMOkKSdibBYxHbgGaS/f+IKdbxok3m6z1iltewk=",
+        "lastModified": 1679825980,
+        "narHash": "sha256-BhVM99y4WA7pwlQWRX8YM6f4O6y4QbxVh9tC1KXPchs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2f1662e0ba2ea2c613a19093e17c53f42bf8fec1",
+        "rev": "5b1efd399025dce8db4c40b2a63f9519759e325b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`5b1efd39`](https://github.com/nix-community/emacs-overlay/commit/5b1efd399025dce8db4c40b2a63f9519759e325b) | `` Updated repos/nongnu `` |
| [`5de5ad97`](https://github.com/nix-community/emacs-overlay/commit/5de5ad97ea026a6e82211e7d57c3d053028998a8) | `` Updated repos/melpa ``  |
| [`6d102076`](https://github.com/nix-community/emacs-overlay/commit/6d102076ba21d3de08f12d21aba9eabcbb40b502) | `` Updated repos/melpa ``  |
| [`1b3e8c2b`](https://github.com/nix-community/emacs-overlay/commit/1b3e8c2b9e38693457cc61422c57f99433a975ef) | `` Updated repos/elpa ``   |
| [`4cfff14a`](https://github.com/nix-community/emacs-overlay/commit/4cfff14a2a5c856e74a1d03bb9bed548ee220a93) | `` Updated repos/melpa ``  |
| [`edd4e53e`](https://github.com/nix-community/emacs-overlay/commit/edd4e53eac41bf568856c3728ef0f640411f5e5f) | `` Updated repos/melpa ``  |
| [`a8909157`](https://github.com/nix-community/emacs-overlay/commit/a8909157cb93113fc9e984fe128ed384341744fa) | `` Updated repos/emacs ``  |
| [`380c0628`](https://github.com/nix-community/emacs-overlay/commit/380c0628d530cca8aac5e271ef0a25dfc22e1779) | `` Updated repos/elpa ``   |
| [`702b1724`](https://github.com/nix-community/emacs-overlay/commit/702b1724ead7b6eec28bfc5e1404c26a57a3b248) | `` Updated repos/melpa ``  |
| [`bd71ade9`](https://github.com/nix-community/emacs-overlay/commit/bd71ade9f0aca320fbfcff5d720d57d41f9eafcd) | `` Updated repos/emacs ``  |
| [`f03b1722`](https://github.com/nix-community/emacs-overlay/commit/f03b172233e1bf1fb2ffbc543b86aae00fbad444) | `` Updated repos/nongnu `` |
| [`3b18fc0b`](https://github.com/nix-community/emacs-overlay/commit/3b18fc0bd1bbac76e285c7482cf452f29d838a5e) | `` Updated repos/melpa ``  |