### PR TITLE
chore(flake/home-manager): `363c46b2` -> `cf662b6c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -445,11 +445,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679480702,
-        "narHash": "sha256-npuRD61YmxUPitI1TqKwlxLrU6iGl5E+BPT196LgUDo=",
+        "lastModified": 1679786039,
+        "narHash": "sha256-VNjswu0Q4bZOkWNuc0+dHvRdjUCj+MnDlRfw/Q0R3vI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "363c46b2480f1b73ec37cf68caac61f5daa82a2e",
+        "rev": "cf662b6c98a0da81e06066fff0ecf9cbd4627727",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                               |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`da325265`](https://github.com/nix-community/home-manager/commit/da325265b72b338647720b33df23d775aa73825d) | `` launchd: sync option definition with nix-darwin ``                 |
| [`2acea865`](https://github.com/nix-community/home-manager/commit/2acea86583ba10b67b36db135c94d6df1ae41d55) | `` launchd: make Launch Agents config a freeform setting ``           |
| [`d80bf24d`](https://github.com/nix-community/home-manager/commit/d80bf24dab1c1abb3c36e6e28cd30d27599a9620) | `` home-manager: error out when showing news in flake ``              |
| [`225d1fb7`](https://github.com/nix-community/home-manager/commit/225d1fb77e6c9f9be1ffd65c8e5eb9cf583aa698) | `` hstr: fix sorting in CODEOWNERS ``                                 |
| [`99680311`](https://github.com/nix-community/home-manager/commit/99680311f1d94632e75da1b8f78091220684b4bf) | `` hstr: add module ``                                                |
| [`3ace6a31`](https://github.com/nix-community/home-manager/commit/3ace6a31dd859710e7b7666a9d456b611f9376dc) | `` im/fcitx: drop as fcitx 4 has been removed from nixpkgs (#3804) `` |
| [`885a504f`](https://github.com/nix-community/home-manager/commit/885a504f80227b98d137a84a888bf7faa36d00dc) | `` syncthing: add Darwin support ``                                   |
| [`2f8d24b7`](https://github.com/nix-community/home-manager/commit/2f8d24b7f57fdd404defe84626b08f3318612f8c) | `` zoxide: enable nushell integration ``                              |
| [`a34aaad2`](https://github.com/nix-community/home-manager/commit/a34aaad2ae159b66306ced0cbfa1eefac8c4343e) | `` gpg: fix URL of key in test case ``                                |
| [`db37c537`](https://github.com/nix-community/home-manager/commit/db37c537603d1d45d022cc0666ad45197455b364) | `` docs: bump nmd ``                                                  |