### PR TITLE
chore(flake/nixpkgs): `19cf008b` -> `8f40f2f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -649,11 +649,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1679437018,
-        "narHash": "sha256-vOuiDPLHSEo/7NkiWtxpHpHgoXoNmrm+wkXZ6a072Fc=",
+        "lastModified": 1679705136,
+        "narHash": "sha256-MDlZUR7wJ3PlPtqwwoGQr3euNOe0vdSSteVVOef7tBY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "19cf008bb18e47b6e3b4e16e32a9a4bdd4b45f7e",
+        "rev": "8f40f2f90b9c9032d1b824442cfbbe0dbabd0dbd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`8f40f2f9`](https://github.com/NixOS/nixpkgs/commit/8f40f2f90b9c9032d1b824442cfbbe0dbabd0dbd) | `` i3status-rust: set 'meta.mainProgram' ``                                         |
| [`1fdbbc36`](https://github.com/NixOS/nixpkgs/commit/1fdbbc364a90c4a0b6dd22bb1ee8cbc7681bf087) | `` zf: init at 0.8.0 ``                                                             |
| [`3386631c`](https://github.com/NixOS/nixpkgs/commit/3386631c483510279cfb640f11115a80e2851fa7) | `` authelia: split out main and web to separate files ``                            |
| [`818e73fc`](https://github.com/NixOS/nixpkgs/commit/818e73fc43415f26b4fc224c32088171a88d34c4) | `` nixos/authelia: init tests ``                                                    |
| [`6373a396`](https://github.com/NixOS/nixpkgs/commit/6373a3966b206a904d8b9bcbc19ae4b0491a5712) | `` nixos/authelia: init module ``                                                   |
| [`fb44ef6f`](https://github.com/NixOS/nixpkgs/commit/fb44ef6f0a1f44ce54ccc01ef0d63d9c2850bd04) | `` authelia: init at 4.37.5 ``                                                      |
| [`8e09dec9`](https://github.com/NixOS/nixpkgs/commit/8e09dec9eefee49d4cedc8be7b1ac01862b9ca67) | `` librep: fix darwin build ``                                                      |
| [`cbb3c713`](https://github.com/NixOS/nixpkgs/commit/cbb3c7139fb7994f98ce399d355126b9620ecd23) | `` robodoc: fix darwin build ``                                                     |
| [`b8d64fb3`](https://github.com/NixOS/nixpkgs/commit/b8d64fb322936bfecda34a1a631591046d63e583) | `` expected-lite: 0.6.2 -> 0.6.3 ``                                                 |
| [`82c79411`](https://github.com/NixOS/nixpkgs/commit/82c79411b739314f0cc48f746c4f58a9b5027cb5) | `` fuse-overlayfs: 1.10 -> 1.11 ``                                                  |
| [`731f904a`](https://github.com/NixOS/nixpkgs/commit/731f904a5abfb92f047ae9060a9437017974e20a) | `` oxigraph: 0.3.13 -> 0.3.14 ``                                                    |
| [`fd887b0d`](https://github.com/NixOS/nixpkgs/commit/fd887b0d35d16c16c0c9f36cb97982d22f0029c1) | `` datree: 1.8.42 -> 1.8.45 ``                                                      |
| [`cb13d3f0`](https://github.com/NixOS/nixpkgs/commit/cb13d3f04bf6d112d3772b5c01f7567fab8b133c) | `` mullvad-vpn: 2023.1 -> 2023.2 ``                                                 |
| [`fef4baca`](https://github.com/NixOS/nixpkgs/commit/fef4baca37dd8d1e81e52b4a24a50e0bec942af9) | `` nixos/ssh: Update github.com host key in programs.ssh.knownHostsFiles example `` |
| [`25056cca`](https://github.com/NixOS/nixpkgs/commit/25056cca5a3d9d7c71e3c59621df59fd0d2f0ca2) | `` esphome: 2023.3.0 -> 2023.3.1 ``                                                 |
| [`f1458f44`](https://github.com/NixOS/nixpkgs/commit/f1458f445ed4ef2ecbdffeeb13c8ef97496545cf) | `` rocclr: 5.4.3 -> 5.4.4 ``                                                        |
| [`8b4ba702`](https://github.com/NixOS/nixpkgs/commit/8b4ba7023538316d77c0aa22084947c6553a21de) | `` nextcloud25: 25.0.4 -> 25.0.5 ``                                                 |
| [`f9bf71d5`](https://github.com/NixOS/nixpkgs/commit/f9bf71d5f1eef470c8c932058f5c879e113090f4) | `` nextcloud24: 24.0.10 -> 24.0.11 ``                                               |
| [`7c4188ac`](https://github.com/NixOS/nixpkgs/commit/7c4188ac9a1acb345f874e3e023ccafa1b9f0943) | `` qt5.overrideScope': only add when allowAliases is enabled ``                     |
| [`99ff2516`](https://github.com/NixOS/nixpkgs/commit/99ff25161d6bd2ab72709706e0da8382b1613da2) | `` linkerd_edge: 23.3.2 -> 23.3.3 ``                                                |
| [`ebe821f6`](https://github.com/NixOS/nixpkgs/commit/ebe821f636a64d3e67c2970a5fae924b6e054180) | `` snd: 23.1 -> 23.2 ``                                                             |
| [`e1fa54a5`](https://github.com/NixOS/nixpkgs/commit/e1fa54a56982c5874f6941703c8b760541e40db1) | `` jetbrains: build and minor version updates ``                                    |
| [`22ba0262`](https://github.com/NixOS/nixpkgs/commit/22ba026243ef00bc49409e0b5d68811055977808) | `` laszip: init at 0.2.1 ``                                                         |
| [`da4f17a2`](https://github.com/NixOS/nixpkgs/commit/da4f17a2a6f5baa48bd86348a7f1ecd5889e1589) | `` laspy: init at 2.3.0 ``                                                          |
| [`00766fe9`](https://github.com/NixOS/nixpkgs/commit/00766fe9ea6da19a5a44893d3ceac3292b7d6222) | `` jackett: 0.20.3627 -> 0.20.3670 ``                                               |
| [`739310ad`](https://github.com/NixOS/nixpkgs/commit/739310ad284e97df41663aabfd633f548795df5c) | `` nova-filters: patch against scons_latest ``                                      |
| [`f6aa4144`](https://github.com/NixOS/nixpkgs/commit/f6aa4144d0c38231d8c383facf40f63b13759bb5) | `` jetbrains: 2022.3.2 -> 2022.3.3 ``                                               |
| [`9cce4017`](https://github.com/NixOS/nixpkgs/commit/9cce401726ed61b92cf8f86ba9eed5cf3a1d4d9a) | `` sconsPackages.scons_latest: 4.1.0 -> 4.5.2 ``                                    |
| [`bb674938`](https://github.com/NixOS/nixpkgs/commit/bb674938fcde5afd279a9749b6888ce3f2f4b614) | `` rocm-device-libs: 5.4.3 -> 5.4.4 ``                                              |
| [`22ce075f`](https://github.com/NixOS/nixpkgs/commit/22ce075f1c3ffb413dfc53b10ff3e577b5b15941) | `` dir2opus: delete ``                                                              |
| [`00efb050`](https://github.com/NixOS/nixpkgs/commit/00efb050080402560259e208bf4fd5c7ffb63024) | `` freefilesync: add desktop items ``                                               |
| [`8a5a0837`](https://github.com/NixOS/nixpkgs/commit/8a5a08373f5af5cf6d042df6b7bfe01a6e35957f) | `` firefox-beta-unwrapped: init at 112.0b6 ``                                       |
| [`80168add`](https://github.com/NixOS/nixpkgs/commit/80168addbea2f90d2929f088c58ecb65243c6557) | `` firefox-devedition-unwrapped: init at 112.0b6 ``                                 |
| [`462484d4`](https://github.com/NixOS/nixpkgs/commit/462484d4a7eefdbf6da4b35e2000518ec5b59731) | `` gnustep.projectcenter: 0.6.2 -> 0.7.0 ``                                         |
| [`830dbba7`](https://github.com/NixOS/nixpkgs/commit/830dbba75df7d071d0c827b95e50e69c5a016143) | `` ocamlPackages.digestif: 1.1.3 → 1.1.4 ``                                         |
| [`02d56449`](https://github.com/NixOS/nixpkgs/commit/02d564498703e5a6edb48f99674cdaaaee509949) | `` ocamlPackages.digestif: 1.1.2 → 1.1.3 ``                                         |
| [`ec013463`](https://github.com/NixOS/nixpkgs/commit/ec0134632ceca175a3a9c1e2783512234abc5bba) | `` ocamlPackages.tezos-base58: use Dune 3 ``                                        |
| [`9cff76c4`](https://github.com/NixOS/nixpkgs/commit/9cff76c41b24a64c8a755f7ca2f5a3e6d9d9bcc9) | `` kora-icon-theme: 1.5.4 -> 1.5.6 ``                                               |
| [`bc7aed2b`](https://github.com/NixOS/nixpkgs/commit/bc7aed2b1aae4b85656aff0c906ef3be1fa09d93) | `` gauche: mark not broken on darwin ``                                             |
| [`a72763b0`](https://github.com/NixOS/nixpkgs/commit/a72763b088d127fb08ba68707168aa5d6eb5e7bb) | `` broot: 1.20.2 -> 1.21.1 ``                                                       |
| [`4c7c8a68`](https://github.com/NixOS/nixpkgs/commit/4c7c8a68a095940ac71f2c675edc8e4c2f70b680) | `` gnustep.make: allow overriding preConfigure in gsmakeDerivation ``               |
| [`89150fa9`](https://github.com/NixOS/nixpkgs/commit/89150fa9d5a26e00198ad8a0e1a6f53c13addf94) | `` muparserx: mark not broken on darwin ``                                          |
| [`ae0ea562`](https://github.com/NixOS/nixpkgs/commit/ae0ea562ab92f920ccae00ee5a0e958a3eb2978f) | `` vimPlugins.magma-nvim-goose: add python dependencies ``                          |
| [`1759bb92`](https://github.com/NixOS/nixpkgs/commit/1759bb92484c30242f57e4aea5159091791958a9) | `` rpcs3: 0.0.27-14812-cf5346c26 -> 0.0.27-14824-ad3e740c0 ``                       |
| [`e1b3f157`](https://github.com/NixOS/nixpkgs/commit/e1b3f1570281a35951cac47a6031d1f08d5a8dad) | `` python310Packages.vehicle: add changelog to meta ``                              |
| [`28f08572`](https://github.com/NixOS/nixpkgs/commit/28f08572b38557ec079f2557f7d85617e947110d) | `` python310Packages.vehicle: 0.4.0 -> 1.0.0 ``                                     |
| [`e37ab444`](https://github.com/NixOS/nixpkgs/commit/e37ab4441ef177d21a0c8f986dcbc0150ff4fd5f) | `` libtoxcore: mark not broken on darwin ``                                         |
| [`dab9aa3c`](https://github.com/NixOS/nixpkgs/commit/dab9aa3cf1e6401e6e3bd51cc70efa98677efbe2) | `` libffcall: mark not broken on darwin ``                                          |
| [`632daeee`](https://github.com/NixOS/nixpkgs/commit/632daeee456fb066858afb2e11c13d215a2cfc57) | `` libcutl: fix darwin build ``                                                     |
| [`6cd5fdf8`](https://github.com/NixOS/nixpkgs/commit/6cd5fdf84ed95e34301506c8daa7de28065e93b8) | `` v2ray-geoip: 202303160048 -> 202303230043 ``                                     |
| [`2c4c61b6`](https://github.com/NixOS/nixpkgs/commit/2c4c61b6cd789785842845ed8c0bfc6e35deedcc) | `` python3Packages.pnglatex: init at 1.1 ``                                         |
| [`89fea7c8`](https://github.com/NixOS/nixpkgs/commit/89fea7c828c79bb822a29bdaa29fb33697641ba6) | `` djhtml: init at 3.0.5 ``                                                         |
| [`1de64cb0`](https://github.com/NixOS/nixpkgs/commit/1de64cb0984473f61d4944733465ab8383fc1161) | `` python310Packages.timezonefinder: 6.1.9 -> 6.1.10 ``                             |
| [`219f9706`](https://github.com/NixOS/nixpkgs/commit/219f970602fe5068b14ad4f825ec348e6f8839a6) | `` python310Packages.aioopenexchangerates: 0.4.1 -> 0.4.2 ``                        |
| [`477de8d9`](https://github.com/NixOS/nixpkgs/commit/477de8d913e6e9b10ba1bb8c405002cada95e832) | `` olive-editor: don't use the alias openimageio2 ``                                |
| [`56d14854`](https://github.com/NixOS/nixpkgs/commit/56d1485452cf7b3eeab36fdb00ae15947b46322b) | `` buildkit: 0.11.4 -> 0.11.5 ``                                                    |
| [`304c2c58`](https://github.com/NixOS/nixpkgs/commit/304c2c58ea34bdbf1d1d7f892e0038d1531feb03) | `` link-grammar: not broken on darwin ``                                            |
| [`5de3ce4d`](https://github.com/NixOS/nixpkgs/commit/5de3ce4de5f474f8e56e459abd9cd3d0ecef9d92) | `` kubernetes: 1.26.1 -> 1.26.3 ``                                                  |
| [`b7cfb021`](https://github.com/NixOS/nixpkgs/commit/b7cfb0212de208688dd3c5f66ab571405182e19a) | `` python310Packages.aiortm: 0.6.2 -> 0.6.3 ``                                      |
| [`9396d090`](https://github.com/NixOS/nixpkgs/commit/9396d090e3ef14372af65db65fdd693938f7528c) | `` python310Packages.asyncstdlib: add changelog to meta ``                          |
| [`d9196ff0`](https://github.com/NixOS/nixpkgs/commit/d9196ff00977d5542f2fea0b4e7e585645e7a090) | `` sqlfluff: 2.0.1 -> 2.0.2 ``                                                      |
| [`a2a08fe2`](https://github.com/NixOS/nixpkgs/commit/a2a08fe28618fbc45a89e7c6ffcac25948a5ecd4) | `` python310Packages.asyncstdlib: 3.10.5 -> 3.10.6 ``                               |
| [`aae1b60e`](https://github.com/NixOS/nixpkgs/commit/aae1b60ebb095b49d974a350e45006a017280a1e) | `` python310Packages.twitterapi: add changelog to meta ``                           |
| [`69a5a6f1`](https://github.com/NixOS/nixpkgs/commit/69a5a6f177120bd7beb5b90c0d339c9f65bdab36) | `` python310Packages.twitterapi: 2.8.1 -> 2.8.2 ``                                  |
| [`b7d9a0ae`](https://github.com/NixOS/nixpkgs/commit/b7d9a0ae60f5ae846be6f70d08d8103bcff5355d) | `` python310Packages.sendgrid: add changelog to meta ``                             |
| [`8cb3d442`](https://github.com/NixOS/nixpkgs/commit/8cb3d4421684894098fbc7278ce44d9199740580) | `` proxify: add changelog to meta ``                                                |
| [`b4786d7e`](https://github.com/NixOS/nixpkgs/commit/b4786d7e116c19f7446aa5e280e5d427650e0e7d) | `` python310Packages.twilio: 7.16.5 -> 7.17.0 ``                                    |
| [`2e36cc9a`](https://github.com/NixOS/nixpkgs/commit/2e36cc9ad2924d5e0d2ba4ff7fb068275ac15dbb) | `` python310Packages.sendgrid: 6.9.7 -> 6.10.0 ``                                   |
| [`22dafb7f`](https://github.com/NixOS/nixpkgs/commit/22dafb7f2a3936c3be0516fa132016564927ab19) | `` proxify: 0.0.8 -> 0.0.9 ``                                                       |
| [`e33b761b`](https://github.com/NixOS/nixpkgs/commit/e33b761b1d1b25af2f795dc8fb1fa2494594c7f3) | `` llvmPackages_rocm.llvm: 5.4.3 -> 5.4.4 ``                                        |
| [`ad6a206d`](https://github.com/NixOS/nixpkgs/commit/ad6a206d1bf507656beb8b977c6434721a3ab5a1) | `` sonic-lineup: fix build (#222408) ``                                             |
| [`13507da3`](https://github.com/NixOS/nixpkgs/commit/13507da345589a2de155a83ff1b79a63437c9abf) | `` check-meta.nix: fix self-contradictory error messages ``                         |
| [`3bfa9ed7`](https://github.com/NixOS/nixpkgs/commit/3bfa9ed74d7dae0700404346c4eb04d7c2b3b78b) | `` lsp-plugins: 1.2.5 -> 1.2.6 (#222835) ``                                         |
| [`396157ef`](https://github.com/NixOS/nixpkgs/commit/396157ef673b6e0aee669853418d4d343cda8639) | `` fetch-scm: 0.1.5 -> 0.1.6 ``                                                     |
| [`5dab7f3a`](https://github.com/NixOS/nixpkgs/commit/5dab7f3a24eaa3159e479d01dc81610185e94073) | `` python310Packages.scmrepo: 0.1.15 -> 0.1.16 ``                                   |
| [`c86b1a0b`](https://github.com/NixOS/nixpkgs/commit/c86b1a0bca28e5459530bef49afe127fd874a077) | `` rustPlatform.importCargoLock: handle workspace Cargo.toml false positives ``     |
| [`d7c0dbd0`](https://github.com/NixOS/nixpkgs/commit/d7c0dbd04e5f497fe70539fee4998f447a457ea0) | `` python310Packages.dateparser: 1.1.7 -> 1.1.8 ``                                  |
| [`ef87683d`](https://github.com/NixOS/nixpkgs/commit/ef87683d19e0f7ca73834e70f3fba91f8cf19ac7) | `` terraform-providers.aws: 4.59.0 → 4.60.0 ``                                      |
| [`65f57ae0`](https://github.com/NixOS/nixpkgs/commit/65f57ae084723e05db47ec2ae76e4d9f4f1bb940) | `` terraform-providers.yandex: 0.87.0 → 0.88.0 ``                                   |
| [`2f89fafb`](https://github.com/NixOS/nixpkgs/commit/2f89fafb6398c0292155baf5412509561c08d8d8) | `` terraform-providers.tfe: 0.42.0 → 0.43.0 ``                                      |
| [`f4ed51c2`](https://github.com/NixOS/nixpkgs/commit/f4ed51c2ef77507a7a443c299279cc1547e59c17) | `` terraform-providers.sumologic: 2.21.0 → 2.22.0 ``                                |
| [`fa24dcba`](https://github.com/NixOS/nixpkgs/commit/fa24dcba8b48c8ad768635fff13959a05449fc80) | `` terraform-providers.opentelekomcloud: 1.33.2 → 1.34.0 ``                         |
| [`70f9902a`](https://github.com/NixOS/nixpkgs/commit/70f9902aceab6c9837347f07a9872b1985327837) | `` terraform-providers.kubernetes: 2.18.1 → 2.19.0 ``                               |
| [`3aa18ef3`](https://github.com/NixOS/nixpkgs/commit/3aa18ef3080e8b6d601c4ecf412b82161f271cc6) | `` terraform-providers.dnsimple: 0.16.2 → 0.16.3 ``                                 |
| [`21877777`](https://github.com/NixOS/nixpkgs/commit/21877777c0c61fe3caa4c9e0b3424a9bf7e53352) | `` rocm-opencl-runtime: 5.4.3 -> 5.4.4 ``                                           |
| [`9081d55c`](https://github.com/NixOS/nixpkgs/commit/9081d55c2b398befd7a744b37b12c4df8df5ea23) | `` libgbinder: 1.1.32 -> 1.1.33 ``                                                  |
| [`df9b4a57`](https://github.com/NixOS/nixpkgs/commit/df9b4a57c11c115b50c752b1e64186fdeaec7453) | `` fsarchiver: 0.8.6 -> 0.8.7 ``                                                    |
| [`c2c7c04a`](https://github.com/NixOS/nixpkgs/commit/c2c7c04a55f9eab8f0177795acd76f75255f7883) | `` cargo-expand: 1.0.39 -> 1.0.43 ``                                                |
| [`f1d1ce27`](https://github.com/NixOS/nixpkgs/commit/f1d1ce278d41754bc7b7fc36e948b625418ad2bf) | `` qdrant: 1.0.3 -> 1.1.0 ``                                                        |
| [`2146bad5`](https://github.com/NixOS/nixpkgs/commit/2146bad5d5b5c604b65936810bad5dfb4ff51797) | `` monit: add support for darwin. ``                                                |
| [`e5ba3d7c`](https://github.com/NixOS/nixpkgs/commit/e5ba3d7c7d081b35508885485bca43f3f7fdc0a7) | `` rivet: 3.1.6 -> 3.1.7 ``                                                         |
| [`4a7db597`](https://github.com/NixOS/nixpkgs/commit/4a7db5979478060b3a6dbd320d61be226e024ec8) | `` unciv: 4.5.9 -> 4.5.10 ``                                                        |
| [`9e9d6245`](https://github.com/NixOS/nixpkgs/commit/9e9d6245e9e0f3524d6b95dbc368b22fe913188e) | `` ttdl: 3.6.5 -> 3.7.0 ``                                                          |
| [`87e5d2c6`](https://github.com/NixOS/nixpkgs/commit/87e5d2c6462974816610cad3fbc8753bf3263d06) | `` pritunl-client: 1.3.3467.51 -> 1.3.3474.95 ``                                    |
| [`096cb0ea`](https://github.com/NixOS/nixpkgs/commit/096cb0ea379786b8f0e1ba06ed4285f4b5503545) | `` poetry2nix: 1.39.1 -> 1.40.0 ``                                                  |
| [`c2b02ab7`](https://github.com/NixOS/nixpkgs/commit/c2b02ab7be9ed1eee21e6b03957541ea795c22d8) | `` ryzenadj: 0.12.0 -> 0.13.0 ``                                                    |