### PR TITLE
chore(flake/nur): `637e2988` -> `47f036ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679849267,
-        "narHash": "sha256-AVcqq8qHp7WOYBJY5loLog0O4icNayrd0D9hwtpAnQQ=",
+        "lastModified": 1679855826,
+        "narHash": "sha256-2JzuDaYcjqYPEhkgFZXkC3/CY9v4K6W7CedshrOyaF0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "637e2988a940a4ae8a094970fddb60a7a9e6732a",
+        "rev": "47f036acb6835e5a0e49f0ffc2d9c1d502f36be6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`47f036ac`](https://github.com/nix-community/NUR/commit/47f036acb6835e5a0e49f0ffc2d9c1d502f36be6) | `` automatic update `` |