### PR TITLE
chore(flake/nur): `47f036ac` -> `9f800a13`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679855826,
-        "narHash": "sha256-2JzuDaYcjqYPEhkgFZXkC3/CY9v4K6W7CedshrOyaF0=",
+        "lastModified": 1679860038,
+        "narHash": "sha256-HxGuy5Ll4kj7jfn/6FD97rWI5JQWWpOkQpshm4//Ah0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "47f036acb6835e5a0e49f0ffc2d9c1d502f36be6",
+        "rev": "9f800a13a0c862ad830a767243678ab7e5ff78e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9f800a13`](https://github.com/nix-community/NUR/commit/9f800a13a0c862ad830a767243678ab7e5ff78e3) | `` automatic update `` |