### PR TITLE
chore(flake/nur): `9f800a13` -> `c921aa62`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679860038,
-        "narHash": "sha256-HxGuy5Ll4kj7jfn/6FD97rWI5JQWWpOkQpshm4//Ah0=",
+        "lastModified": 1679863610,
+        "narHash": "sha256-XeBBouFuQ5pgp0C6C7ZEu5ZAGeYQ/cVDSQQIUWFDlOA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9f800a13a0c862ad830a767243678ab7e5ff78e3",
+        "rev": "c921aa621201227946ba88caf73757864f1b22d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c921aa62`](https://github.com/nix-community/NUR/commit/c921aa621201227946ba88caf73757864f1b22d7) | `` automatic update `` |