### PR TITLE
chore(flake/nixpkgs): `8f40f2f9` -> `5f9d1bb5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -649,11 +649,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1679705136,
-        "narHash": "sha256-MDlZUR7wJ3PlPtqwwoGQr3euNOe0vdSSteVVOef7tBY=",
+        "lastModified": 1679797994,
+        "narHash": "sha256-Kr/O/UlfqAtoFmkZeAaphsxogeaN8a/IugBApFzPfpk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8f40f2f90b9c9032d1b824442cfbbe0dbabd0dbd",
+        "rev": "5f9d1bb572e08ec432ae46c78581919d837a90f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`487f0f92`](https://github.com/NixOS/nixpkgs/commit/487f0f928384cbda4f05645284e1051c33502f75) | `` linux-rt_6_1: init at 6.1.19-rt8 (#222174) ``                                           |
| [`f8cbc3c2`](https://github.com/NixOS/nixpkgs/commit/f8cbc3c2811337e08b02c9113f01a0f70b900bf4) | `` tree-wide: convert rust with git deps to importCargoLock ``                             |
| [`f3a1640e`](https://github.com/NixOS/nixpkgs/commit/f3a1640e49f093c42322944675930eb1fe136ac4) | `` docs/rust: add note about git dependencies ``                                           |
| [`4329de12`](https://github.com/NixOS/nixpkgs/commit/4329de1264ecb7cca8709dc1984b86beb11bcc4e) | `` rustPlatform.fetchCargoTarball: fail on git dependencies ``                             |
| [`0cd595cd`](https://github.com/NixOS/nixpkgs/commit/0cd595cdb3b4f39ef5b903b64b45534ea9bc63ff) | `` buildLuaPackage: throw instead of marking as broken package ``                          |
| [`1e9adf3b`](https://github.com/NixOS/nixpkgs/commit/1e9adf3b4e2b1fb6c10d87c6c8bb84d6ebd7c3a7) | `` python310Packages.roombapy: add changelog to meta ``                                    |
| [`ff1488f2`](https://github.com/NixOS/nixpkgs/commit/ff1488f2a5aa80dc1dee26203df5372ba79608e8) | `` python310Packages.roombapy: 1.6.6 -> 1.6.7 ``                                           |
| [`c1d66cc9`](https://github.com/NixOS/nixpkgs/commit/c1d66cc9f65041d9b9fe246ccf6ebbaa86026a61) | `` python310Packages.getmac: 0.9.2 -> 0.9.3 ``                                             |
| [`49ad9ffd`](https://github.com/NixOS/nixpkgs/commit/49ad9ffdae14238573897f725b889c24fe895fa9) | `` sonivox: init at 3.6.11 ``                                                              |
| [`5f11d982`](https://github.com/NixOS/nixpkgs/commit/5f11d982d1ae361dd9941c3f54c7192fd3f25c5d) | `` python310Packages.accessible-pygments: 0.0.3 -> 0.0.4 ``                                |
| [`932391ea`](https://github.com/NixOS/nixpkgs/commit/932391ea3a15bd19bce81c4d967758f562e77e6a) | `` python310Packages.aio-pika: 9.0.4 -> 9.0.5 ``                                           |
| [`34aef860`](https://github.com/NixOS/nixpkgs/commit/34aef860a553cb684e942754c269e95cebf2062e) | `` cjdns: use system libsodium ``                                                          |
| [`5ce282e5`](https://github.com/NixOS/nixpkgs/commit/5ce282e57e6f265ac81b964ecc0e6cf16c5aa07f) | `` rustPlatform.importCargoLock: follow symlinks when copying tree ``                      |
| [`37b31d4a`](https://github.com/NixOS/nixpkgs/commit/37b31d4a2fdf9f83a92636da377f4ed37fc02c8e) | `` rustPlatform.importCargoLock: always fetch submodules when builtins.fetchGit is used `` |
| [`f4f4c8bc`](https://github.com/NixOS/nixpkgs/commit/f4f4c8bca28b2449c0343b8d1caf31b98cad3b30) | `` maintainers/scripts/convert-to-import-cargo-lock: fetch submodules ``                   |
| [`34c848fe`](https://github.com/NixOS/nixpkgs/commit/34c848fe08c45e475a1c310401a29d37efd46a74) | `` maintainers/scripts/convert-to-import-cargo-lock: don't add duplicate outputHashes ``   |
| [`71302829`](https://github.com/NixOS/nixpkgs/commit/71302829763a4e27274cad2292783213917a6f13) | `` maintainers/scripts/convert-to-import-cargo-lock: init ``                               |
| [`bb4dbd02`](https://github.com/NixOS/nixpkgs/commit/bb4dbd0287bc0d48f56c38db303289f418d07db9) | `` metasploit: 6.3.8 -> 6.3.9 ``                                                           |
| [`78bc6faf`](https://github.com/NixOS/nixpkgs/commit/78bc6faf84142aa3ac730544268c170c12e0adbc) | `` rust-script: 0.22.0 -> 0.23.0 ``                                                        |
| [`c484d7a5`](https://github.com/NixOS/nixpkgs/commit/c484d7a51638c0fb3e3413f0a240b17e2725f890) | `` tessen: unstable-2022-08-04 -> 2.2.0 ``                                                 |
| [`2a111776`](https://github.com/NixOS/nixpkgs/commit/2a111776123086ab91472211dfef3dddbb75454d) | `` exploitdb: 2023-03-23 -> 2023-03-25 ``                                                  |
| [`f956c799`](https://github.com/NixOS/nixpkgs/commit/f956c79911024a19e15dfc3fa3a0c84f740213d2) | `` python310Packages.identify: 2.5.21 -> 2.5.22 ``                                         |
| [`6c2206c8`](https://github.com/NixOS/nixpkgs/commit/6c2206c8f050caa67a7998558940f95c8a88a56d) | `` python310Packages.mailchecker: 5.0.7 -> 5.0.8 ``                                        |
| [`38ceedbb`](https://github.com/NixOS/nixpkgs/commit/38ceedbbec59746cf66bed10625867c9737fbea6) | `` python310Packages.pynuki: add changelog to meta ``                                      |
| [`1a173c89`](https://github.com/NixOS/nixpkgs/commit/1a173c89426ab705aac55872740362bc1a0b6cfd) | `` cowsay: add COWPATH wrapper ``                                                          |
| [`66d13701`](https://github.com/NixOS/nixpkgs/commit/66d137011769b65a5d4610e71e959a7d3439bfb2) | `` python310Packages.yalexs-ble: 2.1.2 -> 2.1.4 ``                                         |
| [`b5399018`](https://github.com/NixOS/nixpkgs/commit/b53990181747324806a9edcdd35542cd16afc023) | `` cargo-expand: 1.0.43 -> 1.0.46 ``                                                       |
| [`978e39e7`](https://github.com/NixOS/nixpkgs/commit/978e39e78e3a8263267c1d419d12fea5d1a46910) | `` python310Packages.pynuki: 1.6.1 -> 1.6.2 ``                                             |
| [`4482c705`](https://github.com/NixOS/nixpkgs/commit/4482c70530d39818e49367013528f0162c31e6c4) | `` nixos/kanata: notify systemd when starting up is finished ``                            |
| [`a7717edb`](https://github.com/NixOS/nixpkgs/commit/a7717edb0778299cb7d342206a2fc34c31156a75) | `` kanata: 1.2.0 -> 1.3.0 ``                                                               |
| [`86b34419`](https://github.com/NixOS/nixpkgs/commit/86b34419483aada7a964f5d79cba41aad332373d) | `` visidata: 2.10.2 -> 2.11 ``                                                             |
| [`54063f72`](https://github.com/NixOS/nixpkgs/commit/54063f720bcaa3ee4063553e91860cb321671be4) | `` ginkgo: 2.9.1 -> 2.9.2 ``                                                               |
| [`532a2b35`](https://github.com/NixOS/nixpkgs/commit/532a2b35ed4341c24d5b2cf7507d6c97b97be499) | `` river-luatile: init at v0.1.1 ``                                                        |
| [`4250b2a6`](https://github.com/NixOS/nixpkgs/commit/4250b2a66172ae5b6a0e47ec32cd602481a25404) | `` signalbackup-tools: fix x86_64-darwin build ``                                          |
| [`0f87b32e`](https://github.com/NixOS/nixpkgs/commit/0f87b32eb18e4fe3d19aa40176abbb996354ca88) | `` jc: 1.23.0 -> 1.23.1 ``                                                                 |
| [`8b0faba3`](https://github.com/NixOS/nixpkgs/commit/8b0faba367f833e9233172860233fe2b7e3eb503) | `` python310Packages.scmrepo: 0.1.16 -> 0.1.17 ``                                          |
| [`74e02366`](https://github.com/NixOS/nixpkgs/commit/74e02366778e816e6f3981c9d4a625ebf25f1e54) | `` qovery-cli: 0.52.2 -> 0.53.1 ``                                                         |
| [`21db59f4`](https://github.com/NixOS/nixpkgs/commit/21db59f4484d51783bdaa8705ce2862dc69b99bc) | `` dmlive: unstable-2022-11-19 -> 5.2.0 ``                                                 |
| [`eb2ade40`](https://github.com/NixOS/nixpkgs/commit/eb2ade40d17d3ef97b90b431e7e79bbac4e6e070) | `` treewide: migrate more packages to scons_latest ``                                      |
| [`29ad0041`](https://github.com/NixOS/nixpkgs/commit/29ad0041260b2b33953eccde02a7e50db34ba7b2) | `` pdns-recursor: 4.8.2 -> 4.8.3 ``                                                        |
| [`b58a559d`](https://github.com/NixOS/nixpkgs/commit/b58a559da25918bbc846ca9b4ee0d2e142a543b3) | `` sbctl: 0.10 -> 0.11 ``                                                                  |
| [`deb7dc3f`](https://github.com/NixOS/nixpkgs/commit/deb7dc3fdc9b0f8a55c5acf1277aa8f4e63d17ce) | `` treewide: replace scons_latest with scons ``                                            |
| [`9c724505`](https://github.com/NixOS/nixpkgs/commit/9c724505fa2037a7bd3192ef20aa0035a78e63f5) | `` gnucash: Apply patches that compilation w/ newer glib/gcc ``                            |
| [`47bc96d2`](https://github.com/NixOS/nixpkgs/commit/47bc96d270866687de431b92db1ad9fe4baaec30) | `` logseq: bump electron version ``                                                        |
| [`79933d1e`](https://github.com/NixOS/nixpkgs/commit/79933d1e3d26077787e9b0184b5215c7e12cc3ce) | `` Revert "logseq: Fix publishing graph" ``                                                |
| [`4ae95d78`](https://github.com/NixOS/nixpkgs/commit/4ae95d7842835dda2bd87a8cd4457cd735e57083) | `` aaphoto: fix darwin build ``                                                            |
| [`20309b8d`](https://github.com/NixOS/nixpkgs/commit/20309b8dc87ac1244f1f9c78708c25bd3a87a6c8) | `` borgmatic: 1.7.8 -> 1.7.9 ``                                                            |
| [`a78a1e50`](https://github.com/NixOS/nixpkgs/commit/a78a1e5097cccf7ac1af8ffd713d940cdf73b2d8) | `` xorg.mkfontscale: 1.2.1 -> 1.2.2 ``                                                     |
| [`989c5aa9`](https://github.com/NixOS/nixpkgs/commit/989c5aa9eaabc7c06ccb1461116facd5ad013618) | `` snes9x: 1.61 -> 1.62 ``                                                                 |
| [`71ee5f45`](https://github.com/NixOS/nixpkgs/commit/71ee5f457b1f73ffdf55c66e65fce712662dc992) | `` python310Packages.mypy-boto3-builder: 7.13.0 -> 7.14.2 ``                               |
| [`0def1ab8`](https://github.com/NixOS/nixpkgs/commit/0def1ab8fa66998156a7bf2a147fc7dee04ab00e) | `` python310Packages.yalexs-ble: 2.1.1 -> 2.1.2 ``                                         |
| [`42e89d06`](https://github.com/NixOS/nixpkgs/commit/42e89d0620bdb36e2f315cb824f7836750d80777) | `` crun: 1.8.2 -> 1.8.3 ``                                                                 |
| [`35272957`](https://github.com/NixOS/nixpkgs/commit/35272957f5dc1da9f82be9975f5ab6fc68e8bb0f) | `` bat: 0.22.1 -> 0.23.0 ``                                                                |
| [`8b2dd593`](https://github.com/NixOS/nixpkgs/commit/8b2dd593fe5707e81bdbd844ad2ea543082ab19d) | `` wiki-js: 2.5.297 -> 2.5.298 ``                                                          |
| [`4cbd1c56`](https://github.com/NixOS/nixpkgs/commit/4cbd1c569bd02cceb7540b6b744931dadea5ae34) | `` grpc-client-cli: 1.17.0 -> 1.18.0 ``                                                    |
| [`bb8484aa`](https://github.com/NixOS/nixpkgs/commit/bb8484aab0c08eaad8d2ddc056eb0111a760f979) | `` jwx: 2.0.8 -> 2.0.9 ``                                                                  |
| [`ec49c987`](https://github.com/NixOS/nixpkgs/commit/ec49c9872d5ee9b59ec5fbdc9c2a632482e915b4) | `` nginx-sso: 0.25.0 -> 0.26.0 ``                                                          |
| [`9a9ec053`](https://github.com/NixOS/nixpkgs/commit/9a9ec053ab6d1225b00cc9d4961be8cb68c89333) | `` pantheon.elementary-gtk-theme: 7.0.1 -> 7.1.0 ``                                        |
| [`78b77c8c`](https://github.com/NixOS/nixpkgs/commit/78b77c8c8930c59439cce947080a76a025b32915) | `` flyctl: 0.0.492 -> 0.0.498 ``                                                           |
| [`fa316730`](https://github.com/NixOS/nixpkgs/commit/fa3167309773ec710c2de62bb08533ab411d0590) | `` chezmoi: 2.32.0 -> 2.33.0 ``                                                            |
| [`06438d56`](https://github.com/NixOS/nixpkgs/commit/06438d56bc4e25a0be2cb2e94fca8c55f4458bce) | `` cloud-nuke: 0.27.0 -> 0.27.1 ``                                                         |
| [`92cc3224`](https://github.com/NixOS/nixpkgs/commit/92cc3224d974ed0bd34e2e5cfe0463820fbf0959) | `` ansible-doctor: 2.0.1 -> 2.0.2 ``                                                       |
| [`2995dcb3`](https://github.com/NixOS/nixpkgs/commit/2995dcb3a25bcbbc951a65c47376dffd04cf1411) | `` rocm-comgr: 5.4.3 -> 5.4.4 ``                                                           |
| [`798e23be`](https://github.com/NixOS/nixpkgs/commit/798e23beab9b5cba4d6f05e8b243e1d4535770f3) | `` libdeltachat: 1.111.0 -> 1.112.0 ``                                                     |
| [`619c77f0`](https://github.com/NixOS/nixpkgs/commit/619c77f075310858a9ff7004cc3ede0c7eb1453e) | `` algolia-cli: 1.3.1 -> 1.3.2 ``                                                          |
| [`bd8ca215`](https://github.com/NixOS/nixpkgs/commit/bd8ca21522e13f40046bc6659737c0d7c73ae9c1) | `` sierra-breeze-enhanced: 1.3.1 -> 1.3.3 ``                                               |
| [`090dca22`](https://github.com/NixOS/nixpkgs/commit/090dca22c245299063a69dc2a36cf7fc9c7c6cd5) | `` coursier: 2.1.0-RC6 -> 2.1.0 ``                                                         |
| [`3e6ccb7c`](https://github.com/NixOS/nixpkgs/commit/3e6ccb7ca6d6a852a53f4f578ed7915553f31171) | `` mark: 8.8 -> 8.9 ``                                                                     |
| [`d7f41d45`](https://github.com/NixOS/nixpkgs/commit/d7f41d45ac17dcbf9d53314906bac32263a4ab10) | `` squawk: 0.21.0 -> 0.22.0 ``                                                             |
| [`6be0dbeb`](https://github.com/NixOS/nixpkgs/commit/6be0dbeb1fedb858a0ec997e04990a8928d71606) | `` esbuild: 0.17.12 -> 0.17.13 ``                                                          |
| [`b5ccc5d0`](https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f) | `` terraform-providers.tencentcloud: 1.79.17 → 1.79.18 ``                                  |
| [`2f0f85c5`](https://github.com/NixOS/nixpkgs/commit/2f0f85c5a0a6848839fd748809c2dde009a3c39e) | `` terraform-providers.azurerm: 3.48.0 → 3.49.0 ``                                         |
| [`6e957a8e`](https://github.com/NixOS/nixpkgs/commit/6e957a8e69a954637c87dc042538412bf20e9528) | `` terraform-providers.ovh: 0.28.1 → 0.29.0 ``                                             |
| [`5b1d219a`](https://github.com/NixOS/nixpkgs/commit/5b1d219a815643afce1a6a0a707fa3597491c39a) | `` terraform-providers.opennebula: 1.1.1 → 1.2.0 ``                                        |
| [`933cedfa`](https://github.com/NixOS/nixpkgs/commit/933cedfa77c2a88878c5b7dd9fef7aaa6765fe48) | `` terraform-providers.newrelic: 3.18.0 → 3.18.1 ``                                        |
| [`e4ef2e16`](https://github.com/NixOS/nixpkgs/commit/e4ef2e1675c560a1664664845db0c33e28fd2106) | `` komga: 0.164.0 -> 0.165.0 ``                                                            |
| [`ab693050`](https://github.com/NixOS/nixpkgs/commit/ab693050668acfff5ea4a4670d3f410a9b8a1010) | `` .github/workflows/update-terraform-providers.yml: various ``                            |
| [`fe65b0e3`](https://github.com/NixOS/nixpkgs/commit/fe65b0e360449b35a8f5cc27b0737b6df0c41c99) | `` python310Packages.ansible-later: 3.2.0 -> 3.2.1 ``                                      |
| [`0894977a`](https://github.com/NixOS/nixpkgs/commit/0894977a3fbaced5f9b0a006fb8158ef683e15be) | `` kubeone: 1.6.0 -> 1.6.1 ``                                                              |
| [`1935178d`](https://github.com/NixOS/nixpkgs/commit/1935178de81e9cd0c19ca6311a9e4dab135bb805) | `` scons: default to latest ``                                                             |
| [`6705da37`](https://github.com/NixOS/nixpkgs/commit/6705da37dde57eca549c9ec57fd949a3d713833e) | `` stt: lzma -> xz ``                                                                      |
| [`43254386`](https://github.com/NixOS/nixpkgs/commit/43254386a469c179b0972e8b3bc21fbf7792846c) | `` signalbackup-tools: clang14Stdenv -> llvmPackages_14.stdenv ``                          |
| [`0c4948cd`](https://github.com/NixOS/nixpkgs/commit/0c4948cde75dba764a6c4ebfb61f9c79d1ca6854) | `` luaPackages.lua-resty-session: mark broken ``                                           |
| [`29bbff83`](https://github.com/NixOS/nixpkgs/commit/29bbff83a58ae76d9b22bcecd3a04bc33a0c0ea3) | `` djhtml: use python3Packages.callPackage ``                                              |
| [`27b9b54f`](https://github.com/NixOS/nixpkgs/commit/27b9b54fe8743e237cec3baa039353e41cbae565) | `` aws-workspaces: libusb -> libusb1 ``                                                    |
| [`8e174bb3`](https://github.com/NixOS/nixpkgs/commit/8e174bb3a0b9068e062f6435f350b9b157ff96c8) | `` python310Packages.dissect: 3.4 -> 3.5 ``                                                |
| [`cf863d5d`](https://github.com/NixOS/nixpkgs/commit/cf863d5d851b6d5a33230ff665e248c9abe125f2) | `` python310Packages.dissect-squashfs: 1.0 -> 1.1 ``                                       |
| [`13283c1c`](https://github.com/NixOS/nixpkgs/commit/13283c1cdf7f3fb774b210d09230871179ede0f4) | `` python310Packages.dissect-executable: 1.1 -> 1.2 ``                                     |
| [`38485675`](https://github.com/NixOS/nixpkgs/commit/38485675692cc3916fc6e195bb399e48bbce6670) | `` python310Packages.dissect-thumbcache: 1.2 -> 1.3 ``                                     |
| [`aa690dad`](https://github.com/NixOS/nixpkgs/commit/aa690dadadc192593f79cfb78ef2290ba1667f3b) | `` python310Packages.acquire: 3.4 -> 3.5 ``                                                |
| [`d9f76760`](https://github.com/NixOS/nixpkgs/commit/d9f767600fb2f5f0b7e7159cd8638c0701ad6bfc) | `` lib/customisation: callPackageWith should abort with errors ``                          |
| [`274cbb9c`](https://github.com/NixOS/nixpkgs/commit/274cbb9c4eca68509b50d97c069282193521f27f) | `` python310Packages.dissect-target: disable failing tests ``                              |
| [`96ccc11a`](https://github.com/NixOS/nixpkgs/commit/96ccc11a6324c16bef22cffac04ce37a6e55ed17) | `` python310Packages.dissect-thumbcache: disable failing tests ``                          |
| [`e2d257f9`](https://github.com/NixOS/nixpkgs/commit/e2d257f9886df5a3193feb3d24250267db79bdff) | `` python310Packages.dissect-xfs: 3.3 -> 3.4 ``                                            |
| [`3908228e`](https://github.com/NixOS/nixpkgs/commit/3908228e7e24964d9cace30af273ca449c7103c6) | `` python310Packages.dissect-volume: 3.3 -> 3.4 ``                                         |
| [`6d92b346`](https://github.com/NixOS/nixpkgs/commit/6d92b346c4d75e34cca4e0b0bc4b211d92fe330d) | `` python310Packages.dissect-vmfs: 3.3 -> 3.4 ``                                           |
| [`66997b1d`](https://github.com/NixOS/nixpkgs/commit/66997b1d4999d4e3a3453b526bf4672c1dcc4d05) | `` python310Packages.dissect-util: 3.6 -> 3.7 ``                                           |
| [`381a2b86`](https://github.com/NixOS/nixpkgs/commit/381a2b8604371e21ea18104fca7689c74d045992) | `` python310Packages.dissect-target: 3.7 -> 3.8 ``                                         |
| [`5abac894`](https://github.com/NixOS/nixpkgs/commit/5abac894fbf819fcc30fc88316efcb2173ab8526) | `` python310Packages.dissect-sql: 3.3 -> 3.4 ``                                            |
| [`63531407`](https://github.com/NixOS/nixpkgs/commit/635314077e247608518026e01dc352ac8e3dfaa6) | `` python310Packages.dissect-shellitem: 3.3 -> 3.4 ``                                      |
| [`6defe8ec`](https://github.com/NixOS/nixpkgs/commit/6defe8ec8f2ac2fa4ecf3df53660fa9dc6237da9) | `` python310Packages.dissect-regf: 3.3 -> 3.4 ``                                           |
| [`924897f2`](https://github.com/NixOS/nixpkgs/commit/924897f2d81069b2156abf96c20d2d945b689583) | `` python310Packages.dissect-ole: 3.3 -> 3.4 ``                                            |
| [`aa88040a`](https://github.com/NixOS/nixpkgs/commit/aa88040a6acb8c9e034588b6d4ae945876caf8b0) | `` python310Packages.dissect-ntfs: 3.3 -> 3.4 ``                                           |
| [`ae80eea2`](https://github.com/NixOS/nixpkgs/commit/ae80eea2cf561b6e754b6e2b0ca5cad3ca5fd2b2) | `` python310Packages.dissect-hypervisor: 3.5 -> 3.6 ``                                     |
| [`ae077ace`](https://github.com/NixOS/nixpkgs/commit/ae077aced7daf709a44cf75a4b427022578f3977) | `` python310Packages.dissect-ffs: 3.3 -> 3.4 ``                                            |
| [`778c9025`](https://github.com/NixOS/nixpkgs/commit/778c90250d1277a3fa47b1eaea9f47ca3ade2a26) | `` python310Packages.dissect-fat: 3.3 -> 3.4 ``                                            |
| [`9d9a75af`](https://github.com/NixOS/nixpkgs/commit/9d9a75af7d7e9e85aeb478d832f1784ef0303ea6) | `` python310Packages.dissect-extfs: 3.3 -> 3.4 ``                                          |
| [`edb7e080`](https://github.com/NixOS/nixpkgs/commit/edb7e080d2af69e9c05ade524ea2de6f93afa2fc) | `` python310Packages.dissect-evidence: 3.3 -> 3.4 ``                                       |
| [`834ef917`](https://github.com/NixOS/nixpkgs/commit/834ef9179df239adf8e7e9cdb290bac8187973c2) | `` python310Packages.dissect-eventlog: 3.3 -> 3.4 ``                                       |
| [`da3ad933`](https://github.com/NixOS/nixpkgs/commit/da3ad933525119184b68f8b91c471e30de42c18a) | `` python310Packages.dissect-etl: 3.3 -> 3.4 ``                                            |
| [`e31ec2a4`](https://github.com/NixOS/nixpkgs/commit/e31ec2a4380a3245b8a48467c6498fb61bf4bffb) | `` python310Packages.dissect-esedb: 3.5 -> 3.6 ``                                          |
| [`c19d45bc`](https://github.com/NixOS/nixpkgs/commit/c19d45bcebde8b96eea8e5715aa124e11871f71a) | `` python310Packages.dissect-cstruct: 3.5 -> 3.6 ``                                        |
| [`30f158a4`](https://github.com/NixOS/nixpkgs/commit/30f158a47e4eda469dd5a39dd4f6251a39f5b6d1) | `` python310Packages.dissect-clfs: 1.3 -> 1.4 ``                                           |
| [`37ce12c6`](https://github.com/NixOS/nixpkgs/commit/37ce12c6c97e3db2630995bbaf9e25b5da8d5c0d) | `` python310Packages.dissect-cim: 3.4 -> 3.5 ``                                            |
| [`780669da`](https://github.com/NixOS/nixpkgs/commit/780669daf57856d62e672de050324a75f1a66c81) | `` treewide: don't hardcode /nix/store (no rebuilds changes) ``                            |
| [`76ca62d6`](https://github.com/NixOS/nixpkgs/commit/76ca62d658eb749e4851e45d74c985febcb10bf4) | `` tailscale: 1.38.1 -> 1.38.2 ``                                                          |
| [`74ef0ee3`](https://github.com/NixOS/nixpkgs/commit/74ef0ee319dfd77e0d775e71c07a8082869d31ee) | `` mongodb-6_0: 6.0.1 -> 6.0.5 ``                                                          |
| [`bc60e48b`](https://github.com/NixOS/nixpkgs/commit/bc60e48be72c486c8c25068c3d9cdcbb5cac3623) | `` fractal: 4.4.0 -> 4.4.2 ``                                                              |
| [`55c8f4b9`](https://github.com/NixOS/nixpkgs/commit/55c8f4b968f62d5757d57fb451cbfc5dfc3ea3c9) | `` python310Packages.mypy-boto3-s3: 1.26.62 -> 1.26.97.post2 ``                            |
| [`3568a52d`](https://github.com/NixOS/nixpkgs/commit/3568a52d85e73be5d8cafbc6ed9845ddb063fc36) | `` yaralyzer: relax python-dotenv constraint ``                                            |
| [`29389b42`](https://github.com/NixOS/nixpkgs/commit/29389b421e4ea8ef4539144914af62b0f71e5f32) | `` yara: 4.2.3 -> 4.3.0 ``                                                                 |
| [`19a8c53c`](https://github.com/NixOS/nixpkgs/commit/19a8c53c10e0cbd54b22ed353bfeacbd90fb240c) | `` pantheon.gala: Backport various upstream fixes ``                                       |
| [`111b847e`](https://github.com/NixOS/nixpkgs/commit/111b847eb9c68cfb6d4028f3865e99bfc4fc652e) | `` _1password: 2.15.0 -> 2.16.0 ``                                                         |
| [`f0304914`](https://github.com/NixOS/nixpkgs/commit/f0304914329f5ac47f374015240054eb11fb5301) | `` rage: 0.9.0 -> 0.9.1 ``                                                                 |
| [`123a7700`](https://github.com/NixOS/nixpkgs/commit/123a7700c3cc473401359f20c169c591d4dcee42) | `` sing-box: 1.1.7 -> 1.2.0 ``                                                             |
| [`6048912d`](https://github.com/NixOS/nixpkgs/commit/6048912d8bdb899d05ce413b5edfe61a45f22ed8) | `` nixos/woodpecker-*: add myself as maintainer ``                                         |
| [`67de7d10`](https://github.com/NixOS/nixpkgs/commit/67de7d105ea6b400d66628b703c69fa171b9f08a) | `` nixos/woodpecker-agents: per-agent 'enable' option ``                                   |
| [`cd116db4`](https://github.com/NixOS/nixpkgs/commit/cd116db45e8e31e01f9c20d4fbb7785febed74d8) | `` nixos/woodpecker-agents: bind network files ``                                          |
| [`eb3bea63`](https://github.com/NixOS/nixpkgs/commit/eb3bea6359b56048835f2a31bb1505eb6f793908) | `` nixos/woodpecker-agents: simplify 'extraGroups' handling ``                             |
| [`c3afdb82`](https://github.com/NixOS/nixpkgs/commit/c3afdb82db6c9c9157329e3b74cc514fecedf441) | `` nixos/woodpecker-agents: use list for environment files ``                              |
| [`745329fc`](https://github.com/NixOS/nixpkgs/commit/745329fc27e89a903518fa8c477ec960929d2bd1) | `` brave: 1.49.120 -> 1.49.128 ``                                                          |
| [`e4f5f1b7`](https://github.com/NixOS/nixpkgs/commit/e4f5f1b7187162c15b1a35df8772375cf878ab19) | `` nixos/woodpecker: refactor to multi-agents setup ``                                     |
| [`c6c2c7a2`](https://github.com/NixOS/nixpkgs/commit/c6c2c7a293cb8816c42d20049c6d5e78916cb24d) | `` ffmpeg_6: init at 6.0 ``                                                                |
| [`8b2f2042`](https://github.com/NixOS/nixpkgs/commit/8b2f20425d041180bc1187b0a844b7e8df029f10) | `` godot_4: 4.0-stable -> 4.0.1-stable ``                                                  |
| [`bfcb4838`](https://github.com/NixOS/nixpkgs/commit/bfcb48388aae477c065bf0e194fe7513148a5a03) | `` yewtube: 2.9.2 -> 2.10.1 ``                                                             |
| [`d3eda58a`](https://github.com/NixOS/nixpkgs/commit/d3eda58a2d9188020b78772e28138bdcd4d9927a) | `` cppcheck: enable strictDeps ``                                                          |
| [`084fd533`](https://github.com/NixOS/nixpkgs/commit/084fd533740d946f783778b3d9931c600b976422) | `` mongodb-4_2: Add cache alignment fix for aarch64 ``                                     |
| [`982e914e`](https://github.com/NixOS/nixpkgs/commit/982e914e5786dbbd4935e244c010f5d8994f6eeb) | `` mongodb: Mark anything older than 6.0 broken on aarch64-darwin ``                       |
| [`211a9638`](https://github.com/NixOS/nixpkgs/commit/211a963855e0d6716d40babc4ded8f7aa707d401) | `` tsm-client: 8.1.17.0 -> 8.1.17.2 ``                                                     |
| [`cceff04c`](https://github.com/NixOS/nixpkgs/commit/cceff04ce9c2c4cc3eab27a10dd220cc5c381b3d) | `` mongodb-4_2: 4.2.19 -> 4.2.24 ``                                                        |
| [`cc6ef4ea`](https://github.com/NixOS/nixpkgs/commit/cc6ef4ea2a55cf96f63c85814c854dde47dab2e7) | `` nvidia-vaapi-driver: 0.0.8 -> 0.0.9 ``                                                  |
| [`f95c20d7`](https://github.com/NixOS/nixpkgs/commit/f95c20d77d5275a0fe4d2809bbb6e10d5492b93f) | `` nixos/fcitx5: init tests ``                                                             |
| [`6d951523`](https://github.com/NixOS/nixpkgs/commit/6d951523ad424c077d60bcd57e9a53bc9dd56e5d) | `` mlterm: update fcitx dependency to fcitx5 ``                                            |
| [`4e8ad00a`](https://github.com/NixOS/nixpkgs/commit/4e8ad00ae81e70f4e4db7dfc7e67d9c853f0d6b6) | `` fcitx: remove packages and update documentations and aliases to fcitx5 ``               |
| [`051b74fe`](https://github.com/NixOS/nixpkgs/commit/051b74fe7d7398c24fee4d703bd1e32a88b68393) | `` nixos/fcitx: deprecated, and suggestions to use fcitx5 instead ``                       |