### PR TITLE
chore(flake/nur): `28bdef10` -> `069ce6e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679870684,
-        "narHash": "sha256-rcAiiUydXbUAMJDKl/MABmOX7kpF3CTyA8EfD5CSgbM=",
+        "lastModified": 1679881994,
+        "narHash": "sha256-Hj/sUSNiEQwtjnW0QJf6mAO1/yGWGuM3OLvGTpQfc5Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "28bdef10e5f4529e1ef94b8929be449ce28e94c5",
+        "rev": "069ce6e74504eecf41ed783ebc8900c95d2a959f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`069ce6e7`](https://github.com/nix-community/NUR/commit/069ce6e74504eecf41ed783ebc8900c95d2a959f) | `` automatic update `` |