### PR TITLE
chore(flake/emacs-overlay): `ad13678f` -> `85df9c3f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679853645,
-        "narHash": "sha256-nT/2eZ+utyl81F6mJn8q+FfCmVg86xZ/DtPDNJzUg6E=",
+        "lastModified": 1679884876,
+        "narHash": "sha256-cYuXmZ1ERKpDXIMKPDEJizjLV4zWONioGyV37W+r8yQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ad13678fbd40413eabba0c6d5001d7af3a026cb8",
+        "rev": "85df9c3f99656b59d38305813c1c3ce95afdd5a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`85df9c3f`](https://github.com/nix-community/emacs-overlay/commit/85df9c3f99656b59d38305813c1c3ce95afdd5a2) | `` Updated repos/melpa `` |
| [`5c9d5a6c`](https://github.com/nix-community/emacs-overlay/commit/5c9d5a6c4d3442d729607b4b36e6376397b0f913) | `` Updated repos/elpa ``  |