### PR TITLE
chore(flake/nur): `069ce6e7` -> `c79f1595`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679881994,
-        "narHash": "sha256-Hj/sUSNiEQwtjnW0QJf6mAO1/yGWGuM3OLvGTpQfc5Q=",
+        "lastModified": 1679888740,
+        "narHash": "sha256-tOTqxwPuP2uvx6eGpcc4MhrYh3FZAyGrLoUQAu6t+u8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "069ce6e74504eecf41ed783ebc8900c95d2a959f",
+        "rev": "c79f1595bb268d8389aff96b607018a416e4e7ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c79f1595`](https://github.com/nix-community/NUR/commit/c79f1595bb268d8389aff96b607018a416e4e7ac) | `` automatic update `` |
| [`8fe6a4d1`](https://github.com/nix-community/NUR/commit/8fe6a4d1b8b51465b9ac6b5b47a86983831a7c22) | `` automatic update `` |