### PR TITLE
chore(flake/nur): `c79f1595` -> `61be68ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679888740,
-        "narHash": "sha256-tOTqxwPuP2uvx6eGpcc4MhrYh3FZAyGrLoUQAu6t+u8=",
+        "lastModified": 1679895879,
+        "narHash": "sha256-uatZMqNe5ABV/A/RdKDgKJ8OHR5y61IBcP/d0a2f6ag=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c79f1595bb268d8389aff96b607018a416e4e7ac",
+        "rev": "61be68ab07a6c47787a8943f1529f85cd0ca4223",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`61be68ab`](https://github.com/nix-community/NUR/commit/61be68ab07a6c47787a8943f1529f85cd0ca4223) | `` automatic update `` |