### PR TITLE
chore(flake/nur): `61be68ab` -> `c4cfddf7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679895879,
-        "narHash": "sha256-uatZMqNe5ABV/A/RdKDgKJ8OHR5y61IBcP/d0a2f6ag=",
+        "lastModified": 1679900348,
+        "narHash": "sha256-WqWlr9n1qOO3XggFvJy9l1yNQ6Yfk3Oenah5++4Pn18=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "61be68ab07a6c47787a8943f1529f85cd0ca4223",
+        "rev": "c4cfddf79e5d427bd52430e75b708058d89ee663",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c4cfddf7`](https://github.com/nix-community/NUR/commit/c4cfddf79e5d427bd52430e75b708058d89ee663) | `` automatic update `` |