### PR TITLE
chore(flake/emacs-overlay): `85df9c3f` -> `b32f0d1f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679884876,
-        "narHash": "sha256-cYuXmZ1ERKpDXIMKPDEJizjLV4zWONioGyV37W+r8yQ=",
+        "lastModified": 1679911404,
+        "narHash": "sha256-WGg0wXeJy/KpBE1bFkgYoDLrNOc+SL31tQ2fe36W48o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "85df9c3f99656b59d38305813c1c3ce95afdd5a2",
+        "rev": "b32f0d1f5553c19df3695667bb6b59aa54601aa0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`b32f0d1f`](https://github.com/nix-community/emacs-overlay/commit/b32f0d1f5553c19df3695667bb6b59aa54601aa0) | `` Updated repos/melpa `` |