### PR TITLE
chore(flake/nixpkgs): `5f9d1bb5` -> `4bb072f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -669,11 +669,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1679797994,
-        "narHash": "sha256-Kr/O/UlfqAtoFmkZeAaphsxogeaN8a/IugBApFzPfpk=",
+        "lastModified": 1679944645,
+        "narHash": "sha256-e5Qyoe11UZjVfgRfwNoSU57ZeKuEmjYb77B9IVW7L/M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5f9d1bb572e08ec432ae46c78581919d837a90f6",
+        "rev": "4bb072f0a8b267613c127684e099a70e1f6ff106",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                     |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| [`87d4e177`](https://github.com/NixOS/nixpkgs/commit/87d4e177760993d588d7a89aa9935c723945138c) | `` maintainers/team-list: add asymmetric to docs ``                                                         |
| [`c29ca670`](https://github.com/NixOS/nixpkgs/commit/c29ca6704dfd562e22bc60ad3d650d753f4bb22f) | `` mattermost: add environmentFile option to allow declarative secrets ``                                   |
| [`7159363f`](https://github.com/NixOS/nixpkgs/commit/7159363f5172a53286678ea84693570d3b35a9db) | `` linuxPackages.nvidia_x11_legacy340: Fix build on 6.1 ``                                                  |
| [`56fa7ab0`](https://github.com/NixOS/nixpkgs/commit/56fa7ab066165a2eb6274a0ab423b518e3e115b4) | `` nixos/tests/zfs: add zfsUnstable test for systemd-stage 1 ``                                             |
| [`64a4de85`](https://github.com/NixOS/nixpkgs/commit/64a4de856877a32e4f8f4863101e2cbbfdc6b62b) | `` zfsUnstable: make it compatible again with 6.2.8 and potentially 6.3 ``                                  |
| [`a3983c88`](https://github.com/NixOS/nixpkgs/commit/a3983c8856895190bcfc5f6b59f2f279059de1a3) | `` gitlab: 15.9.3 -> 15.10.0 (#223367) ``                                                                   |
| [`44780192`](https://github.com/NixOS/nixpkgs/commit/4478019214283d60518162c70ecf8e337520e18b) | `` urbit: 1.22 -> 2.0 ``                                                                                    |
| [`93baaff4`](https://github.com/NixOS/nixpkgs/commit/93baaff43466512c424911fcad7a49ee695c560a) | `` nfpm: add caarlos0 to maintainers list ``                                                                |
| [`bc805499`](https://github.com/NixOS/nixpkgs/commit/bc805499d9aef332715154581f94ef24fa35f81c) | `` timer: add caarlos0 to maintainers list ``                                                               |
| [`403affda`](https://github.com/NixOS/nixpkgs/commit/403affdafec92e24078b4b8ce9e13f8b66f31022) | `` domain-exporter: add caarlos0 to maintainer list ``                                                      |
| [`6cbbc163`](https://github.com/NixOS/nixpkgs/commit/6cbbc163798888916ec28e6a3ef75d58373739cb) | `` tasktimer: add caarlos0 to maintainers list ``                                                           |
| [`bc319601`](https://github.com/NixOS/nixpkgs/commit/bc3196013a3ffa4daa9b172063d0293a39bde295) | `` sccache: 0.4.0 -> 0.4.1 ``                                                                               |
| [`8a2c93e5`](https://github.com/NixOS/nixpkgs/commit/8a2c93e5b80ae8e93115628dff4a423a2ca395b7) | `` xfsprogs: 6.1.1 -> 6.2.0 ``                                                                              |
| [`147e04f2`](https://github.com/NixOS/nixpkgs/commit/147e04f2c892ba12f90ee5ece40832229f98cce9) | `` wezterm: 20230320-124340-559cb7b0 -> 20230326-111934-3666303c ``                                         |
| [`a188ce34`](https://github.com/NixOS/nixpkgs/commit/a188ce34366863de551a5721525a52a0aa38612a) | `` python310Packages.pyzerproc: remove asynctest ``                                                         |
| [`1b691903`](https://github.com/NixOS/nixpkgs/commit/1b6919037c1e5c7449901657a22a84fb9726b94e) | `` python310Packages.hahomematic: 2023.2.11 -> 2023.3.0 ``                                                  |
| [`7d7f8be0`](https://github.com/NixOS/nixpkgs/commit/7d7f8be0b776dd3f55fb16c2fa939fa2e1e25a68) | `` python310Packages.niapy: 2.0.4 -> 2.0.5 ``                                                               |
| [`bc80e23d`](https://github.com/NixOS/nixpkgs/commit/bc80e23d048ec46e224352e530b6a86ecd03d547) | `` python310Packages.pydeconz: 110 -> 111 ``                                                                |
| [`bb82199e`](https://github.com/NixOS/nixpkgs/commit/bb82199ebebf26c262712daaa90f2a3f53777d41) | `` python310Packages.yalexs-ble: 2.1.6 -> 2.1.10 ``                                                         |
| [`111ff168`](https://github.com/NixOS/nixpkgs/commit/111ff168c9b0dbdd8624a85f5d11632fc2da8848) | `` amass: 3.22.1 -> 3.22.2 ``                                                                               |
| [`f70568dd`](https://github.com/NixOS/nixpkgs/commit/f70568dd6d3babc3749796acc9ec58c7fcabf71c) | `` qovery-cli: 0.54.0 -> 0.55.0 ``                                                                          |
| [`3b865634`](https://github.com/NixOS/nixpkgs/commit/3b8656349258ff70c03e1bde168a962059ef6297) | `` mpd-mpris: 0.3.1 -> 0.4.0 ``                                                                             |
| [`9c7e5c7c`](https://github.com/NixOS/nixpkgs/commit/9c7e5c7c532d88f194a96d7711c580b363e556b4) | `` python3Packages.pymoo: 0.6.0 -> 0.6.0.1 (#223332) ``                                                     |
| [`822ae3e8`](https://github.com/NixOS/nixpkgs/commit/822ae3e89125fb2f709a237435713b020b00ab37) | `` nvidia-vaapi-driver: add `-Wno-error` ``                                                                 |
| [`ae3ac99d`](https://github.com/NixOS/nixpkgs/commit/ae3ac99d579b4d881813e7c94542123efec95d7e) | `` exhaustive: init at 0.10.0 ``                                                                            |
| [`59cf5102`](https://github.com/NixOS/nixpkgs/commit/59cf5102f01f0f6aa368a9ba82202edca86a1845) | `` onlyoffice-bin: fix icon location ``                                                                     |
| [`15292223`](https://github.com/NixOS/nixpkgs/commit/152922233a6aed02705998bdc3cd00515d30a611) | `` microsoft-edge: Rewrite update script to use latest version (#219395) ``                                 |
| [`0ad13637`](https://github.com/NixOS/nixpkgs/commit/0ad13637b7b4d2bd46b76161a666d36e15e2042a) | `` zcash: 5.3.0 -> 5.4.2 (#216422) ``                                                                       |
| [`83ae03de`](https://github.com/NixOS/nixpkgs/commit/83ae03de66e3b69ec9e34effd739d43c7971b496) | `` vimPlugins.nvim-treesitter: prefix version with 0.0.0+rev= ``                                            |
| [`ba9c441e`](https://github.com/NixOS/nixpkgs/commit/ba9c441efc98efa07ea52a1f017c943bb905f4f0) | `` vscode-extensions: nixpkgs-fmt format ``                                                                 |
| [`40c8ceba`](https://github.com/NixOS/nixpkgs/commit/40c8cebade44d2874453ed992a7ec2d50123a34d) | `` nixos/synapse: Fix incorrect module path after it was moved ``                                           |
| [`3be70b09`](https://github.com/NixOS/nixpkgs/commit/3be70b091b5af3a3c782bae4af8837267db65bc3) | `` vscode-extensions: upgrade in batch (#223308) ``                                                         |
| [`056be64f`](https://github.com/NixOS/nixpkgs/commit/056be64f11fe2ee33373f07abda4d8cf6fabf572) | `` nixos/podman: add example to enable network dns ``                                                       |
| [`0297a2db`](https://github.com/NixOS/nixpkgs/commit/0297a2db9a47c57128e30eaa9104a0a72a1cc268) | `` wezterm: 20221119-145034-49b9839f -> 20230320-124340-559cb7b0 ``                                         |
| [`744cfdaf`](https://github.com/NixOS/nixpkgs/commit/744cfdaf11096ae724e920107229d2ca59dafea8) | `` yq-go: 4.32.2 -> 4.33.1 ``                                                                               |
| [`82427c93`](https://github.com/NixOS/nixpkgs/commit/82427c93fe40596a482a279d32529a5e2a8711c9) | `` hip: 5.4.3 -> 5.4.4 ``                                                                                   |
| [`3bdb805c`](https://github.com/NixOS/nixpkgs/commit/3bdb805c5fb70bf30d0db3eb5655fe040e05b335) | `` xrootd: 5.5.3 -> 5.5.4 ``                                                                                |
| [`4361baa7`](https://github.com/NixOS/nixpkgs/commit/4361baa782dc3d3b35fd455a1adc370681d9187c) | `` trash-cli: 0.22.10.20 -> 0.23.2.13.2 ``                                                                  |
| [`eb123f6e`](https://github.com/NixOS/nixpkgs/commit/eb123f6e7c8860a30e9ef8ad88f4f3df264890ad) | `` typst: 22-03-21-2 -> 23-03-21-2 ``                                                                       |
| [`5c7757b1`](https://github.com/NixOS/nixpkgs/commit/5c7757b10b1347c23d141a5a0c5672a81f48fda7) | `` microbin: 1.1.0 -> 1.2.1, add figsoda as a maintainer ``                                                 |
| [`781f0f10`](https://github.com/NixOS/nixpkgs/commit/781f0f106aa39ad5491c62a8aae7e38e7ff8e363) | `` tauon: 7.6.0 -> 7.6.2 ``                                                                                 |
| [`b0fd7a31`](https://github.com/NixOS/nixpkgs/commit/b0fd7a3179772d1a640dfc9f00b3df8cc50873ec) | `` nixos/nftables: add release notes for checkRuleset option (#223283) ``                                   |
| [`c239772e`](https://github.com/NixOS/nixpkgs/commit/c239772ef27312876e585f8610de52883886e2e2) | `` nerdfix: init at 0.1.0 ``                                                                                |
| [`e6145346`](https://github.com/NixOS/nixpkgs/commit/e6145346d3a745536a1b79bc983c7fda43e8fdcc) | `` imagemagick: 7.1.1-4 -> 7.1.1-5 ``                                                                       |
| [`972b0fa8`](https://github.com/NixOS/nixpkgs/commit/972b0fa87ffc622a690461a43c1608bef5b776ee) | `` xdp-tools: fix hash of the patch ``                                                                      |
| [`83979742`](https://github.com/NixOS/nixpkgs/commit/83979742992859f01a78adc19ff47a4f1c4c6567) | `` hugin: add wrapGAppsHook ``                                                                              |
| [`761552c4`](https://github.com/NixOS/nixpkgs/commit/761552c4c30d714cec66422eaf032df025ddc6f9) | `` prometheus-postgres-exporter: 0.11.1 -> 0.12.0 ``                                                        |
| [`ea5208f0`](https://github.com/NixOS/nixpkgs/commit/ea5208f0e5fdf1b0343a207847e27fb37b62af92) | `` python310Packages.zha-quirks: remove asynctest ``                                                        |
| [`238eb47d`](https://github.com/NixOS/nixpkgs/commit/238eb47d6b4e6d031328eed425aa8f83c1b168e2) | `` miniupnpd: 2.3.1 -> 2.3.3 ``                                                                             |
| [`169ea380`](https://github.com/NixOS/nixpkgs/commit/169ea3800c8eb086439d95150aa50c2b43663e78) | `` python310Packages.zwave-me-ws: 0.3.1 -> 0.3.6 ``                                                         |
| [`4bd4a8d4`](https://github.com/NixOS/nixpkgs/commit/4bd4a8d462132e38417d2aaf9a1f98c2d1babd51) | `` python310Packages.lightwave2: 0.8.21 -> 0.8.22 ``                                                        |
| [`ef989867`](https://github.com/NixOS/nixpkgs/commit/ef989867aeb6acd08dcd40c132d33f80ce088a3d) | `` exploitdb: 2023-03-25 -> 2023-03-26 ``                                                                   |
| [`f3f0a132`](https://github.com/NixOS/nixpkgs/commit/f3f0a132fb82d2daa2a0133e8e679f689f92693e) | `` kmail: enable user feedback support ``                                                                   |
| [`b4c45042`](https://github.com/NixOS/nixpkgs/commit/b4c450422e8fbe35a2147ea6e9e774233d48969f) | `` pim-data-exporter: enable user feedback support ``                                                       |
| [`877f8b10`](https://github.com/NixOS/nixpkgs/commit/877f8b10c20350ab88a3256ef519a2a708bc5e78) | `` burpsuite: 2023.1.2 -> 2023.2.4 https://portswigger.net/burp/releases/professional-community-2023-2-4 `` |
| [`a2cb09e3`](https://github.com/NixOS/nixpkgs/commit/a2cb09e3047759070fc29c1abd70d3b8cc35ef91) | `` katana: add changelog to meta ``                                                                         |
| [`f7d6afe0`](https://github.com/NixOS/nixpkgs/commit/f7d6afe0db3a87175019f6bbeed7343cea86dc24) | `` mfc5890cncupswrapper: Fix illegal meta key ``                                                            |
| [`037cc92a`](https://github.com/NixOS/nixpkgs/commit/037cc92ae90957c3e4ab856093de2b369efc0e7e) | `` discover: build with user feedback support ``                                                            |
| [`c247a4f1`](https://github.com/NixOS/nixpkgs/commit/c247a4f1eb13ba9e9cd09db599de9a94b79540ee) | `` pim-sieve-editor: build with user feedback support ``                                                    |
| [`8c4c762d`](https://github.com/NixOS/nixpkgs/commit/8c4c762da229b5f7c83e3946eab8875df9dd88c6) | `` lighttpd: Disable tests for DES and MD5 ``                                                               |
| [`277320f4`](https://github.com/NixOS/nixpkgs/commit/277320f49efe9402bcb1fa3e371e4f4391104d48) | `` korganizer: build with user feedback support ``                                                          |
| [`1872ad4b`](https://github.com/NixOS/nixpkgs/commit/1872ad4bf8ce3df137197bcf042b035902eecb64) | `` kaddressbook: build with user feedback support ``                                                        |
| [`b8b8cfea`](https://github.com/NixOS/nixpkgs/commit/b8b8cfeab4c5006b0b049e60aee401f3c4645b52) | `` akregator: build with user feedback support ``                                                           |
| [`d26b2394`](https://github.com/NixOS/nixpkgs/commit/d26b239493dffa04cd9524b395c5d1143e5f0b70) | `` libreoffice/wrapper: Don't --chdir ``                                                                    |
| [`ca4a734f`](https://github.com/NixOS/nixpkgs/commit/ca4a734f86c0c64d11d8910c910c31433219c878) | `` maintainers: add Ben Kuhn (PR #223178) ``                                                                |
| [`4413ef0e`](https://github.com/NixOS/nixpkgs/commit/4413ef0e0cc0ca677f28f1ec99e1e6262cb94d9a) | `` radicale2: Disable weak crypt htpasswd test ``                                                           |
| [`38ac9d07`](https://github.com/NixOS/nixpkgs/commit/38ac9d077aabe8967c7119a6844abd3f24524f2a) | `` mfc5890cncupswrapper: init at 1.1.2-2 ``                                                                 |
| [`ab35899c`](https://github.com/NixOS/nixpkgs/commit/ab35899c9a3a8140fa9b64d3c50e15d58cb0dbfe) | `` werf: 1.2.214 -> 1.2.217 ``                                                                              |
| [`db461ccf`](https://github.com/NixOS/nixpkgs/commit/db461ccf9dcb91ec0ef6d71d956540541e6a27d9) | `` plasma-workspace: build with user feedback support ``                                                    |
| [`19582cb3`](https://github.com/NixOS/nixpkgs/commit/19582cb3329d9f461ade07214396456fdb3ed3df) | `` kate: build with user feedback support ``                                                                |
| [`fc6ff693`](https://github.com/NixOS/nixpkgs/commit/fc6ff6930257a261081436f47607c52fd34329ef) | `` dolphin: build with user feedback support ``                                                             |
| [`1d19eeef`](https://github.com/NixOS/nixpkgs/commit/1d19eeefeea4cb51d96592712acc4443c42efd0b) | `` nixos/opengl: fix wrong function application ``                                                          |
| [`81fdb1ae`](https://github.com/NixOS/nixpkgs/commit/81fdb1ae5ccec2c139b232f3d409d72a8480d7b6) | `` abcl: 1.9.0 -> 1.9.1 ``                                                                                  |
| [`501da627`](https://github.com/NixOS/nixpkgs/commit/501da627577660f187caab5c1025a9938aa17a51) | `` sonixd: 0.15.4 -> 0.15.5 ``                                                                              |
| [`70a99e3b`](https://github.com/NixOS/nixpkgs/commit/70a99e3b793c4908e95143e0913f8ef4fad830e4) | `` fcitx5-gtk: 5.0.22 -> 5.0.23 ``                                                                          |
| [`6198b309`](https://github.com/NixOS/nixpkgs/commit/6198b30952bb68899ba0f5ada3d2cbe3990177b0) | `` srain: 1.5.0 -> 1.5.1 ``                                                                                 |
| [`9022b97e`](https://github.com/NixOS/nixpkgs/commit/9022b97ed5c935db7dbba4a8a7c30d750f69f5d3) | `` python310Packages.yalexs-ble: 2.1.4 -> 2.1.6 ``                                                          |
| [`38655026`](https://github.com/NixOS/nixpkgs/commit/386550260996d834b544b61cb7ec12ad82429245) | `` drawing: add changelog to meta ``                                                                        |
| [`53afe093`](https://github.com/NixOS/nixpkgs/commit/53afe093767f53784c3da35cc3711778851b4835) | `` python310Packages.teslajsonpy: 3.7.5 -> 3.8.0 ``                                                         |
| [`8f1b3705`](https://github.com/NixOS/nixpkgs/commit/8f1b37050f0c0bbbb73b96f9b5dcfc07c8dd060c) | `` qovery-cli: 0.53.1 -> 0.54.0 ``                                                                          |
| [`adbd2bd4`](https://github.com/NixOS/nixpkgs/commit/adbd2bd4268c8d20aeaa0fdd5cdd687a25b783d3) | `` gnomeExtensions.EasyScreenCast: fix build ``                                                             |
| [`e664468e`](https://github.com/NixOS/nixpkgs/commit/e664468e773316a10eaa36a1b9fd8c89cae014ef) | `` prosody: 0.12.1 → 0.12.3 ``                                                                              |