### PR TITLE
chore(flake/emacs-overlay): `b32f0d1f` -> `fc609cc5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679911404,
-        "narHash": "sha256-WGg0wXeJy/KpBE1bFkgYoDLrNOc+SL31tQ2fe36W48o=",
+        "lastModified": 1679939982,
+        "narHash": "sha256-COd5vcqB/Sh0C8pOrach6ks4RBdOOchF+LVLCPqU4vI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b32f0d1f5553c19df3695667bb6b59aa54601aa0",
+        "rev": "fc609cc57c97c8ddc1a5bb61b03c334b96880477",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`fc609cc5`](https://github.com/nix-community/emacs-overlay/commit/fc609cc57c97c8ddc1a5bb61b03c334b96880477) | `` Updated repos/melpa `` |
| [`8686f122`](https://github.com/nix-community/emacs-overlay/commit/8686f1227964525433254fd337421e0db1b9d7d3) | `` Updated repos/elpa ``  |