### PR TITLE
chore(flake/nixos-hardware): `f38f9a4c` -> `82ecc5b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1679765008,
-        "narHash": "sha256-VCkg/wC2e882suYDS5PDAemaMLYSOdFm4fsx2gowMR0=",
+        "lastModified": 1679944521,
+        "narHash": "sha256-SipdMlnCv/pDvo/j7ctEGqKvQSmn2gcoHSJgIVysXbk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f38f9a4c9b2b6f89a5778465e0afd166a8300680",
+        "rev": "82ecc5b88ffed8c0317c064dfd8f82f4b9882100",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`160e7e12`](https://github.com/NixOS/nixos-hardware/commit/160e7e12d7dcf8013f8ce9b3143d7b823764c813) | `` feat: add backlight support for rpi4 ``                       |
| [`3023004e`](https://github.com/NixOS/nixos-hardware/commit/3023004e9903bc2f726da7c4a6724cf55f45bfff) | `` raspberry-pi/4: Fix comments and indentation. ``              |
| [`bd6381e5`](https://github.com/NixOS/nixos-hardware/commit/bd6381e513123178593dc8af13b02afeacd912ba) | `` raspberry-pi/4: Add touch support for official 7" display. `` |