### PR TITLE
chore(flake/nur): `98e40fd6` -> `f4a68a0c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679946383,
-        "narHash": "sha256-TEctanv8xNLjYNU+8pCJ0ABJAd5wX+d6fYA+SPyDeFs=",
+        "lastModified": 1679953503,
+        "narHash": "sha256-7EisGSvcIkWgQe7xipu53z4j9QHuWBGi3+ZAgMKuGLM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "98e40fd67200e55d6678444ec2cffd6acb6242a5",
+        "rev": "f4a68a0c246d6227ff146a1df2ea054a889a916e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f4a68a0c`](https://github.com/nix-community/NUR/commit/f4a68a0c246d6227ff146a1df2ea054a889a916e) | `` automatic update `` |