### PR TITLE
chore(flake/nur): `f4a68a0c` -> `b3a33663`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679953503,
-        "narHash": "sha256-7EisGSvcIkWgQe7xipu53z4j9QHuWBGi3+ZAgMKuGLM=",
+        "lastModified": 1679957108,
+        "narHash": "sha256-FZ4cZQ1Ax5ffBkL/1aizP/r3ecUYgU4WmPs+drOR53c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f4a68a0c246d6227ff146a1df2ea054a889a916e",
+        "rev": "b3a33663802d7560dd544a8cd53d75e70297a632",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b3a33663`](https://github.com/nix-community/NUR/commit/b3a33663802d7560dd544a8cd53d75e70297a632) | `` automatic update `` |