### PR TITLE
chore(flake/nur): `ed94aa93` -> `56069a99`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679968526,
-        "narHash": "sha256-keM/n8vslGK4n5hg1F44L9ETW5TOSuUSgHkabwaCoWw=",
+        "lastModified": 1679974621,
+        "narHash": "sha256-oKr2h7gH6xOwr8pQs0EEJelQ1vddfqs2SLWuZVSTIOs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed94aa93340c108356c418f4fc932f821f441be7",
+        "rev": "56069a9944ea44cc1bb7fe2459b4ec5afa696611",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`56069a99`](https://github.com/nix-community/NUR/commit/56069a9944ea44cc1bb7fe2459b4ec5afa696611) | `` automatic update `` |