### PR TITLE
chore(flake/nur): `56069a99` -> `d53e8452`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679974621,
-        "narHash": "sha256-oKr2h7gH6xOwr8pQs0EEJelQ1vddfqs2SLWuZVSTIOs=",
+        "lastModified": 1679979198,
+        "narHash": "sha256-SYK5vz/QBhPC2qdVxT4PimXSQxI6VW/cpSbdfCV89ks=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "56069a9944ea44cc1bb7fe2459b4ec5afa696611",
+        "rev": "d53e845297b29577ad3dfa9728e1d68ac4eff8c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d53e8452`](https://github.com/nix-community/NUR/commit/d53e845297b29577ad3dfa9728e1d68ac4eff8c6) | `` automatic update `` |