### PR TITLE
chore(flake/nur): `d53e8452` -> `7123a4fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679979198,
-        "narHash": "sha256-SYK5vz/QBhPC2qdVxT4PimXSQxI6VW/cpSbdfCV89ks=",
+        "lastModified": 1679982184,
+        "narHash": "sha256-SewgBCZla1lSJJNwbhnTvMFYEdylwft627re/nct2h4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d53e845297b29577ad3dfa9728e1d68ac4eff8c6",
+        "rev": "7123a4fb38b67ec052e767c27a7f412b29d70423",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7123a4fb`](https://github.com/nix-community/NUR/commit/7123a4fb38b67ec052e767c27a7f412b29d70423) | `` automatic update `` |