### PR TITLE
chore(flake/nur): `7123a4fb` -> `63f4e3fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679982184,
-        "narHash": "sha256-SewgBCZla1lSJJNwbhnTvMFYEdylwft627re/nct2h4=",
+        "lastModified": 1679985779,
+        "narHash": "sha256-0Rj8GurCuUN0QJvwMiAC49xBkJkQKvJAAU8h+xPIXr4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7123a4fb38b67ec052e767c27a7f412b29d70423",
+        "rev": "63f4e3fdccac4bb905bb0ea8c71ecb0db528c807",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`63f4e3fd`](https://github.com/nix-community/NUR/commit/63f4e3fdccac4bb905bb0ea8c71ecb0db528c807) | `` automatic update `` |