### PR TITLE
chore(flake/nur): `63f4e3fd` -> `ff52829d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679985779,
-        "narHash": "sha256-0Rj8GurCuUN0QJvwMiAC49xBkJkQKvJAAU8h+xPIXr4=",
+        "lastModified": 1679992994,
+        "narHash": "sha256-lpbx5ME5rgGvkUYt0/zdOV/dY0Z7KskjyaFlUXsWZpA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "63f4e3fdccac4bb905bb0ea8c71ecb0db528c807",
+        "rev": "ff52829daa5bc64a46ee8b580221f2a5b28fc039",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ff52829d`](https://github.com/nix-community/NUR/commit/ff52829daa5bc64a46ee8b580221f2a5b28fc039) | `` automatic update `` |