### PR TITLE
chore(flake/emacs-overlay): `175bdcda` -> `7ecb77c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679972850,
-        "narHash": "sha256-v305AJXmfod3QeNwOpSizEpY1fI/j0vTtDHf3uFe8K8=",
+        "lastModified": 1679999154,
+        "narHash": "sha256-FYgB8LB3QEBT7s2l6tqqufd6oJ7L7nFbDg+7TFep2XM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "175bdcda0f5c11b09152fd5c2f82cf42c79eb3f0",
+        "rev": "7ecb77c734114cd51f4f79b91725f3b6aae9f0cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`7ecb77c7`](https://github.com/nix-community/emacs-overlay/commit/7ecb77c734114cd51f4f79b91725f3b6aae9f0cc) | `` Updated repos/nongnu `` |
| [`ea56800a`](https://github.com/nix-community/emacs-overlay/commit/ea56800a2f0d9433b1a14e7a3ce368880f9d7c8d) | `` Updated repos/melpa ``  |