### PR TITLE
chore(flake/nur): `ff52829d` -> `b5a3b22f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679992994,
-        "narHash": "sha256-lpbx5ME5rgGvkUYt0/zdOV/dY0Z7KskjyaFlUXsWZpA=",
+        "lastModified": 1680000299,
+        "narHash": "sha256-pIkdzNAMiMGx2ZpWhO58cwPJkD+LbeLM9lzFuvM1A/w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ff52829daa5bc64a46ee8b580221f2a5b28fc039",
+        "rev": "b5a3b22f118d285ad1152f9fac6bd49ac648a10b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b5a3b22f`](https://github.com/nix-community/NUR/commit/b5a3b22f118d285ad1152f9fac6bd49ac648a10b) | `` automatic update `` |