### PR TITLE
chore(flake/nur): `7dec78f7` -> `dda18737`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680014770,
-        "narHash": "sha256-Vh3vzS1Nrz3KnNVbtfPoVa4pRVv01GWh9OYYpgzVOfs=",
+        "lastModified": 1680022845,
+        "narHash": "sha256-jhEpDXfe7Z+PHk6BmF+GFM1LjcFYdG4mJKDWHSD6Syo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7dec78f7ec6823c800afdc0b32d562b15ba954d3",
+        "rev": "dda187379b5ba62dab5c6c4f7fce15c0702dcc0a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dda18737`](https://github.com/nix-community/NUR/commit/dda187379b5ba62dab5c6c4f7fce15c0702dcc0a) | `` automatic update `` |