### PR TITLE
chore(flake/nur): `dda18737` -> `8be04745`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680022845,
-        "narHash": "sha256-jhEpDXfe7Z+PHk6BmF+GFM1LjcFYdG4mJKDWHSD6Syo=",
+        "lastModified": 1680025510,
+        "narHash": "sha256-P09dXvavJxJXpcXYUzJotInxI1QvuQwkrnwo4whu+BE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dda187379b5ba62dab5c6c4f7fce15c0702dcc0a",
+        "rev": "8be04745005ee91a3367e800b8a4457a1337b7c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8be04745`](https://github.com/nix-community/NUR/commit/8be04745005ee91a3367e800b8a4457a1337b7c0) | `` automatic update `` |