### PR TITLE
chore(flake/emacs-overlay): `7ecb77c7` -> `511d67a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679999154,
-        "narHash": "sha256-FYgB8LB3QEBT7s2l6tqqufd6oJ7L7nFbDg+7TFep2XM=",
+        "lastModified": 1680026592,
+        "narHash": "sha256-mcD1fa1maTO53HYd5R9+F5nhOJtO4aQcxs/ujLN50Bc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7ecb77c734114cd51f4f79b91725f3b6aae9f0cc",
+        "rev": "511d67a726e03efd7a974ef2ba6a3eb3c958ab6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`511d67a7`](https://github.com/nix-community/emacs-overlay/commit/511d67a726e03efd7a974ef2ba6a3eb3c958ab6c) | `` Updated repos/melpa `` |