### PR TITLE
chore(flake/nur): `41b9298e` -> `4095c197`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680036301,
-        "narHash": "sha256-xpuvpz3kOOIkn6L291enEXVzJWNIwk3OMe5f8kcVvUE=",
+        "lastModified": 1680039938,
+        "narHash": "sha256-ghgsx4EXyPZUIwDknttfxPkDpuYjpI7940BhhMy9R6Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "41b9298e9aa838da5d545b87e4802cbea37e7b3d",
+        "rev": "4095c197d0817326b526787fe54f37a2760b7f8a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4095c197`](https://github.com/nix-community/NUR/commit/4095c197d0817326b526787fe54f37a2760b7f8a) | `` automatic update `` |