### PR TITLE
chore(flake/nur): `b6291bf3` -> `bcd40311`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680043626,
-        "narHash": "sha256-OYvKBQ82PKf8Ot0vAW4L4Hi0zgzixRl4+EgOdplBQB0=",
+        "lastModified": 1680047099,
+        "narHash": "sha256-VTJVCR3bEERy/ZhfN77F5C3Dfc95/TnCU1OwvLbdlng=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b6291bf3886e9f89072d63d1c7d502128f0b2f08",
+        "rev": "bcd4031114bc3cd2118d839bb30ee7681af8594e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bcd40311`](https://github.com/nix-community/NUR/commit/bcd4031114bc3cd2118d839bb30ee7681af8594e) | `` automatic update `` |