### PR TITLE
chore(flake/nur): `73e94e48` -> `5dad5d9f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680053220,
-        "narHash": "sha256-dvbgKiH9owSMns4yWlwfhAkT1duED1DtyYCoTgm6h2Q=",
+        "lastModified": 1680055191,
+        "narHash": "sha256-nlLiuUm+gQaqOIV8u1yIxhMn7vRkiF1Mcsro2z+0His=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "73e94e48eac65da8b9aeb20e77f6fe385715e4f5",
+        "rev": "5dad5d9fd77f468c7d7bb9f7c414215df3afcfb6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5dad5d9f`](https://github.com/nix-community/NUR/commit/5dad5d9fd77f468c7d7bb9f7c414215df3afcfb6) | `` automatic update `` |