### PR TITLE
chore(flake/nur): `5dad5d9f` -> `96bc9030`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680055191,
-        "narHash": "sha256-nlLiuUm+gQaqOIV8u1yIxhMn7vRkiF1Mcsro2z+0His=",
+        "lastModified": 1680058784,
+        "narHash": "sha256-KysBW4vTOODh1tVVd5d0fY06z4VqnNNwmeBvRtVNmR0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5dad5d9fd77f468c7d7bb9f7c414215df3afcfb6",
+        "rev": "96bc90302dbd0b442f32db6ef8adbb09ca543f82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`96bc9030`](https://github.com/nix-community/NUR/commit/96bc90302dbd0b442f32db6ef8adbb09ca543f82) | `` automatic update `` |