### PR TITLE
chore(flake/emacs-overlay): `cc6ed01e` -> `0a1e1819`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680058124,
-        "narHash": "sha256-CjvvSrByLpk2ZHldq7KYBfIxCsVkyH9vptm3axErWvk=",
+        "lastModified": 1680086171,
+        "narHash": "sha256-Tj7eumxksqqs+0Spb4xzscFDzIErp2SukEys/g9pXxk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cc6ed01ef2d28fae346fe537f67956d986bab5e7",
+        "rev": "0a1e1819a33ead41c54d329f172129f9b0b301f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`0a1e1819`](https://github.com/nix-community/emacs-overlay/commit/0a1e1819a33ead41c54d329f172129f9b0b301f3) | `` Updated repos/melpa `` |