### PR TITLE
chore(flake/nur): `a9ac1b12` -> `630945f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680080610,
-        "narHash": "sha256-e5GOM6FHXXPu4byNAiLQDKu/REVM2MtDH5QJ/C/JQbI=",
+        "lastModified": 1680095198,
+        "narHash": "sha256-dw8LKnmiUwnFlK9cq+lS+g88LCeXBFeZ/cDAMArMdOA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a9ac1b12b58122c9c1ba4cbdfd444f5ba080fe36",
+        "rev": "630945f9efb382ba793d2777d1f43e33a5e552f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`630945f9`](https://github.com/nix-community/NUR/commit/630945f9efb382ba793d2777d1f43e33a5e552f6) | `` automatic update `` |