### PR TITLE
chore(flake/nur): `559a9e4c` -> `87ff834d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680102901,
-        "narHash": "sha256-jNrP0rUJ6VVFwQn5BssSfPbMmkYOxU5pXZIqw6Z9nPc=",
+        "lastModified": 1680111200,
+        "narHash": "sha256-QOABrphXOHLEqr73WZxNY4zb3CzxfwzGs24inz0fSWI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "559a9e4cbb55d3b4d90e2a85888e60245c0a9869",
+        "rev": "87ff834dbbe57b79d823b062d1eea40de9104e5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`87ff834d`](https://github.com/nix-community/NUR/commit/87ff834dbbe57b79d823b062d1eea40de9104e5b) | `` automatic update `` |