### PR TITLE
chore(flake/nur): `ccc46054` -> `9ff18a6b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680126323,
-        "narHash": "sha256-rl6JvRLUXo5wJZXGH+Xfen99rHg+/Pcf3NwKLKJcxqs=",
+        "lastModified": 1680141386,
+        "narHash": "sha256-JXRwKUzxkumRsZTMak3oEYTeeFg5gapWDZRqk6YN6tw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ccc46054db4c7384f01f947821635fe085a704be",
+        "rev": "9ff18a6bd45c5c4cce25769c5f61147b5441583f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ff18a6b`](https://github.com/nix-community/NUR/commit/9ff18a6bd45c5c4cce25769c5f61147b5441583f) | `` automatic update `` |