### PR TITLE
chore(flake/emacs-overlay): `578051f8` -> `0331aed0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680118886,
-        "narHash": "sha256-uHcKDM/LkvOKc0ma3JIFLjnyvJRlIKVnIBa45vQO+2s=",
+        "lastModified": 1680144248,
+        "narHash": "sha256-Omsg29OYn5gqVBcpQnT9/z2JpQmAzXSnjVcf26JHe+s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "578051f829883262c9120d98fd71a80e4715afcb",
+        "rev": "0331aed08560a7cf4d70fd96ab0b4c79f5767a42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`0331aed0`](https://github.com/nix-community/emacs-overlay/commit/0331aed08560a7cf4d70fd96ab0b4c79f5767a42) | `` Updated repos/melpa `` |