### PR TITLE
chore(flake/nur): `9ff18a6b` -> `4f748ba8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680141386,
-        "narHash": "sha256-JXRwKUzxkumRsZTMak3oEYTeeFg5gapWDZRqk6YN6tw=",
+        "lastModified": 1680155092,
+        "narHash": "sha256-fz9tWvyRJJLLfXdoxOHk+5LKGQ0fMQvxurf5+5RlQJA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ff18a6bd45c5c4cce25769c5f61147b5441583f",
+        "rev": "4f748ba8b8366e8f19318f428e9d1a58afcd9b0a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4f748ba8`](https://github.com/nix-community/NUR/commit/4f748ba8b8366e8f19318f428e9d1a58afcd9b0a) | `` automatic update `` |