### PR TITLE
chore(flake/nur): `4f748ba8` -> `eb051c3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680155092,
-        "narHash": "sha256-fz9tWvyRJJLLfXdoxOHk+5LKGQ0fMQvxurf5+5RlQJA=",
+        "lastModified": 1680158915,
+        "narHash": "sha256-LZjEepk+PgX7qjZcihG535iDY60C0p6f5iSbTJNVRV8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4f748ba8b8366e8f19318f428e9d1a58afcd9b0a",
+        "rev": "eb051c3ef26639b40c80127cf4c5c98fdab68505",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eb051c3e`](https://github.com/nix-community/NUR/commit/eb051c3ef26639b40c80127cf4c5c98fdab68505) | `` automatic update `` |