### PR TITLE
chore(flake/emacs-overlay): `0331aed0` -> `a549967d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680144248,
-        "narHash": "sha256-Omsg29OYn5gqVBcpQnT9/z2JpQmAzXSnjVcf26JHe+s=",
+        "lastModified": 1680167433,
+        "narHash": "sha256-QEgA0Hu8/E7KQl3iXrXmp50Splg9uLiRWokJvzUq4Dc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0331aed08560a7cf4d70fd96ab0b4c79f5767a42",
+        "rev": "a549967dc06b94333892c335f48658fece6a6574",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`a549967d`](https://github.com/nix-community/emacs-overlay/commit/a549967dc06b94333892c335f48658fece6a6574) | `` Updated repos/melpa `` |