### PR TITLE
chore(flake/nur): `eb051c3e` -> `846a7de9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680158915,
-        "narHash": "sha256-LZjEepk+PgX7qjZcihG535iDY60C0p6f5iSbTJNVRV8=",
+        "lastModified": 1680173255,
+        "narHash": "sha256-E7FlD9ldQx5t6o5J19ovdtRfPVKbUzLkLdEeajcaM88=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eb051c3ef26639b40c80127cf4c5c98fdab68505",
+        "rev": "846a7de90029a42bcfb1c4662117a2b3e856c747",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`846a7de9`](https://github.com/nix-community/NUR/commit/846a7de90029a42bcfb1c4662117a2b3e856c747) | `` automatic update `` |
| [`9fff8970`](https://github.com/nix-community/NUR/commit/9fff89705083d5f94d37088a74871eccb33b4b74) | `` automatic update `` |