### PR TITLE
chore(flake/nur): `846a7de9` -> `40b313a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680173255,
-        "narHash": "sha256-E7FlD9ldQx5t6o5J19ovdtRfPVKbUzLkLdEeajcaM88=",
+        "lastModified": 1680174407,
+        "narHash": "sha256-KOjhz1phVfY6lzAjcDBMjTJmKRemPKviwF/FeHs3muc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "846a7de90029a42bcfb1c4662117a2b3e856c747",
+        "rev": "40b313a12cd1609ef60d85f1d83e0af19ff91f64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`40b313a1`](https://github.com/nix-community/NUR/commit/40b313a12cd1609ef60d85f1d83e0af19ff91f64) | `` automatic update `` |