### PR TITLE
chore(flake/nur): `cd05d78d` -> `fa953d38`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680181430,
-        "narHash": "sha256-TbfgYS/dfokkE6TpT4edfVzbb645ldRJCyG/uPQAngg=",
+        "lastModified": 1680183987,
+        "narHash": "sha256-ww5/H0ZmV8ztnrDaL7GX2zLW82yURgrTebGEd4nTx6Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cd05d78dbd105b8eee90e32c92efa04191c61544",
+        "rev": "fa953d3867d6f133eb4d72234d8dd0fa68d007e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fa953d38`](https://github.com/nix-community/NUR/commit/fa953d3867d6f133eb4d72234d8dd0fa68d007e0) | `` automatic update `` |