### PR TITLE
chore(flake/emacs-overlay): `a549967d` -> `fe007ea8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680167433,
-        "narHash": "sha256-QEgA0Hu8/E7KQl3iXrXmp50Splg9uLiRWokJvzUq4Dc=",
+        "lastModified": 1680199993,
+        "narHash": "sha256-Tvcz9gBjiijgB1EeUffpASPNhrDDn4HRpZkoLgkrWrc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a549967dc06b94333892c335f48658fece6a6574",
+        "rev": "fe007ea85bdbf5f188467fd019a64632ab0dbe41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`fe007ea8`](https://github.com/nix-community/emacs-overlay/commit/fe007ea85bdbf5f188467fd019a64632ab0dbe41) | `` Updated repos/melpa `` |
| [`e1ee934c`](https://github.com/nix-community/emacs-overlay/commit/e1ee934ce007fd1a5f928f03448e50344af583e8) | `` Updated repos/elpa ``  |