### PR TITLE
chore(flake/nixpkgs): `4bb072f0` -> `9a6aabc4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -669,11 +669,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1679944645,
-        "narHash": "sha256-e5Qyoe11UZjVfgRfwNoSU57ZeKuEmjYb77B9IVW7L/M=",
+        "lastModified": 1680125544,
+        "narHash": "sha256-mlqo1r+TZUOuypWdrZHluxWL+E5WzXlUXNZ9Y0WLDFU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bb072f0a8b267613c127684e099a70e1f6ff106",
+        "rev": "9a6aabc4740790ef3bbb246b86d029ccf6759658",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`5e316226`](https://github.com/NixOS/nixpkgs/commit/5e3162264755f9eb670b912d42c7ae9c1b549408) | `` mpd-discord-rpc: 1.5.4b -> 1.6.0 ``                                                |
| [`29fe8367`](https://github.com/NixOS/nixpkgs/commit/29fe836787d92927bb5aa2956aa9fc6051fd4845) | `` vimPlugins.sg-nvim: fix cargoHash ``                                               |
| [`cc787bb2`](https://github.com/NixOS/nixpkgs/commit/cc787bb2342b18ef6f89521ef343c64e8952d80d) | `` open-policy-agent: v0.48.0 -> v0.50.2 ``                                           |
| [`b3158ad3`](https://github.com/NixOS/nixpkgs/commit/b3158ad3052c974e183d2de8be486f8ee76e53fc) | `` vimPlugins.nvim-treesitter: update grammars ``                                     |
| [`0e6f72b1`](https://github.com/NixOS/nixpkgs/commit/0e6f72b1356768794078fac8e07f56e32fab0a62) | `` vimPlugins.nvim-treesitter-endwise: init at 2022-09-26 ``                          |
| [`9d2374df`](https://github.com/NixOS/nixpkgs/commit/9d2374df14b3b4dea133d0c022beac669bed1d49) | `` vimPlugins.auto-hlsearch-nvim: init at 2023-03-04 ``                               |
| [`dfa10982`](https://github.com/NixOS/nixpkgs/commit/dfa10982fd52596fb1fc3a8d9919d2815ed2833e) | `` vimPlugins: update ``                                                              |
| [`a4981ae2`](https://github.com/NixOS/nixpkgs/commit/a4981ae2cf9cf5e8f2a6c290de5d8f39e43f8300) | `` x42-plugins: 20221119 -> 20230315 (#223669) ``                                     |
| [`34cbbab6`](https://github.com/NixOS/nixpkgs/commit/34cbbab6b13361703058b0166dee214248d4a8a9) | `` cudatext: 1.188.0 -> 1.189.0 ``                                                    |
| [`edb43b6b`](https://github.com/NixOS/nixpkgs/commit/edb43b6b6091453c8cdff54d33774be2dc98fa97) | `` cinny: 2.2.4 -> 2.2.6 ``                                                           |
| [`d0d41097`](https://github.com/NixOS/nixpkgs/commit/d0d4109767453015891a2aa339ea2068d7b17000) | `` python310Packages.psautohint: Disable a couple of flaky tests ``                   |
| [`f1d3de40`](https://github.com/NixOS/nixpkgs/commit/f1d3de408d5a4868282865fd1baea169ba398b69) | `` firefox-devedition-unwrapped: 112.0b7 -> 112.0b8 ``                                |
| [`b75ec298`](https://github.com/NixOS/nixpkgs/commit/b75ec298fa991ca83556ccd181277f46f5b79005) | `` firefox-beta-unwrapped: 112.0b7 -> 112.0b8 ``                                      |
| [`a87d88dd`](https://github.com/NixOS/nixpkgs/commit/a87d88dd06df16c62eba9b2aa2ac5bfe9a3dbaab) | `` firefox-devedition-bin-unwrapped: 112.0b6 -> 112.0b8 ``                            |
| [`2264928e`](https://github.com/NixOS/nixpkgs/commit/2264928e6f95238a86d5361effc64b45c79c9166) | `` firefox-beta-bin-unwrapped: 112.0b3 -> 112.0b8 ``                                  |
| [`2f73fede`](https://github.com/NixOS/nixpkgs/commit/2f73fede2ab74d688627a94e51d32ef3391ce422) | `` calcmysky: unstable-2023-02-11 -> 0.3.0 ``                                         |
| [`49fc798b`](https://github.com/NixOS/nixpkgs/commit/49fc798b251045b8377e9dd91d00db3153fd1dff) | `` leanify: support darwin ``                                                         |
| [`49d3f1b6`](https://github.com/NixOS/nixpkgs/commit/49d3f1b606ef95b0208d96c7a31611b66662beeb) | `` v2ray-geoip: 202303230043 -> 202303272340 ``                                       |
| [`1ef879bc`](https://github.com/NixOS/nixpkgs/commit/1ef879bc4f9c1e1352b7cb3e56b2d62f1ee07a05) | `` python3Packages.blis: 0.9.1 -> 0.7.9 ``                                            |
| [`e57d0144`](https://github.com/NixOS/nixpkgs/commit/e57d0144546d9935729eca6c33451c3ca85da69a) | `` mastodon: update ruby package ``                                                   |
| [`6642821c`](https://github.com/NixOS/nixpkgs/commit/6642821c6348045c9cf1b369e28466979a3fd26a) | `` element-desktop: 1.11.25 -> 1.11.26 ``                                             |
| [`bbc73440`](https://github.com/NixOS/nixpkgs/commit/bbc734403716fd00534a970eb615848ddc96a6ca) | `` rocm-smi: 5.4.3 -> 5.4.4 ``                                                        |
| [`7af78753`](https://github.com/NixOS/nixpkgs/commit/7af7875382e2e33fd8e84d545bdbf53f66fbebdf) | `` typst-lsp: init at 0.3.0 ``                                                        |
| [`6534a3ae`](https://github.com/NixOS/nixpkgs/commit/6534a3aeaade8137ed189b684d3d1ca1a9af6977) | `` rust-hypervisor-firmware: check if path exists ``                                  |
| [`ea7e7a19`](https://github.com/NixOS/nixpkgs/commit/ea7e7a190e1ab27895c82b7340037191633f2c7d) | `` nchat: 3.17 -> 3.39 ``                                                             |
| [`25d326fd`](https://github.com/NixOS/nixpkgs/commit/25d326fd25e72f7dcea521791842379ec56651ab) | `` perlPackages.CryptOpenSSLX509: unbreak on aarch64-darwin ``                        |
| [`c3769c7f`](https://github.com/NixOS/nixpkgs/commit/c3769c7fbac8c69d8b58666ed200afebd2acd0f0) | `` perlPackages.CryptOpenSSLRSA: unbreak on aarch64-darwin ``                         |
| [`2c83e565`](https://github.com/NixOS/nixpkgs/commit/2c83e565c1a88d5dcdb67e6a39adfbb9f3ea3206) | `` perlPackages.CryptOpenSSLRandom: unbreak on aarch64-darwin ``                      |
| [`6ca1fd30`](https://github.com/NixOS/nixpkgs/commit/6ca1fd3038b2f6613e489ada1afeeefa96688495) | `` runc: 1.1.4 -> 1.1.5 ``                                                            |
| [`7dc21afa`](https://github.com/NixOS/nixpkgs/commit/7dc21afa839a63a3c91dc5e8faa1bc5193289219) | `` dalfox: 2.8.2 -> 2.9.0 ``                                                          |
| [`16a46343`](https://github.com/NixOS/nixpkgs/commit/16a463433854b4494248a098142ca451a0ac7f73) | `` grype: 0.59.1 -> 0.60.0 ``                                                         |
| [`776df53b`](https://github.com/NixOS/nixpkgs/commit/776df53b59f1b13470e81371377f88d23a14463c) | `` warzone2100: 4.3.3 -> 4.3.4 ``                                                     |
| [`27b7d334`](https://github.com/NixOS/nixpkgs/commit/27b7d334e46a1e04871bd06f98591d38efb5df6a) | `` warzone2100: add updateScript ``                                                   |
| [`28182088`](https://github.com/NixOS/nixpkgs/commit/28182088aaa3ad593b838b1e9a9f42dc90da9fff) | `` python310Packages.dpath: update disabled ``                                        |
| [`f398b52c`](https://github.com/NixOS/nixpkgs/commit/f398b52c5b3923393c3fedfc1fffea76c2a424b8) | `` setbfree: build GUI ``                                                             |
| [`1074e51f`](https://github.com/NixOS/nixpkgs/commit/1074e51f1502d31c6b21e0ffb0a66e1e5a6b8301) | `` python310Packages.dpath: add changelog to meta ``                                  |
| [`ac56fc8a`](https://github.com/NixOS/nixpkgs/commit/ac56fc8ac3cafbad0f85aa3530533c64358e785f) | `` python310Packages.pyaussiebb: add changelog to meta ``                             |
| [`3c150996`](https://github.com/NixOS/nixpkgs/commit/3c1509969ee60754159f97b1d1bb1d3bdd8715f0) | `` python310Packages.pyaussiebb: 0.0.15 -> 0.0.16 ``                                  |
| [`30b98b83`](https://github.com/NixOS/nixpkgs/commit/30b98b833e2441c3e133aebc6def87f0f9b31ba6) | `` exploitdb: 2023-03-28 -> 2023-03-29 ``                                             |
| [`b8749458`](https://github.com/NixOS/nixpkgs/commit/b8749458f043920b5f234eefa8349a437cef681e) | `` python310Packages.yara-python: 4.2.3 -> 4.3.0 ``                                   |
| [`9f2b4357`](https://github.com/NixOS/nixpkgs/commit/9f2b4357c144f4fd9f95694b7624e159f8163c74) | `` postgresql: save rebuilds of existing packages ``                                  |
| [`e2fb6517`](https://github.com/NixOS/nixpkgs/commit/e2fb65175228a992f196f3b1700a53e18602e7f6) | `` nixos/postgresql: fix enableJIT ``                                                 |
| [`a5a715bb`](https://github.com/NixOS/nixpkgs/commit/a5a715bb249ee4e531d7e743f5a4e4234dd29346) | `` postgresql_jit: fix darwin build ``                                                |
| [`608cb375`](https://github.com/NixOS/nixpkgs/commit/608cb37533f25a049d9363f7053890fdab6076eb) | `` nixos/tests/postgresql: fix deprecation warning ``                                 |
| [`43dbeae0`](https://github.com/NixOS/nixpkgs/commit/43dbeae02d74eafc91ad269ebe9363ff5aed1842) | `` postgresql: pass through JIT-enabled variant of non-JIT postgres and vice versa `` |
| [`2282fa73`](https://github.com/NixOS/nixpkgs/commit/2282fa73a1d654c3c7b7429d8de49947c11bd0e1) | `` postgresql: implement opt-in JIT support ``                                        |
| [`fd9ea566`](https://github.com/NixOS/nixpkgs/commit/fd9ea56630a2c8a807a75e1149176b3184cc4fc0) | `` python310Packages.gradient: update postPatch section ``                            |
| [`e68e28ef`](https://github.com/NixOS/nixpkgs/commit/e68e28ef86ca1c215eae1460cfcedb2e6f410503) | `` python310Packages.angr: 9.2.43 -> 9.2.44 ``                                        |
| [`d7ff296c`](https://github.com/NixOS/nixpkgs/commit/d7ff296ced54a280ac842c165420b9804f81a134) | `` python310Packages.cle: 9.2.43 -> 9.2.44 ``                                         |
| [`54ba8a53`](https://github.com/NixOS/nixpkgs/commit/54ba8a534b83d8a818847b1c4acd1422c91fd577) | `` python310Packages.claripy: 9.2.43 -> 9.2.44 ``                                     |
| [`8505db1b`](https://github.com/NixOS/nixpkgs/commit/8505db1b374cb674fd8b8517aa6e8014a280d518) | `` python310Packages.pyvex: 9.2.43 -> 9.2.44 ``                                       |
| [`5c35bc0c`](https://github.com/NixOS/nixpkgs/commit/5c35bc0c4c81882d5f9780f913efeb4727454c51) | `` python310Packages.ailment: 9.2.43 -> 9.2.44 ``                                     |
| [`38a8a345`](https://github.com/NixOS/nixpkgs/commit/38a8a34575ffb11acd9262264ff952df57df40a3) | `` python310Packages.archinfo: 9.2.43 -> 9.2.44 ``                                    |
| [`43f45fe2`](https://github.com/NixOS/nixpkgs/commit/43f45fe24fd9cce3c9011c5f53cfddbe979abd39) | `` zsh: fix the guard variable for /etc/set-environment ``                            |
| [`f7b99008`](https://github.com/NixOS/nixpkgs/commit/f7b9900897869fb7035cbdd2cb64f53084d7d3b4) | `` rust-analyzer-unwrapped: 2023-03-20 -> 2023-03-27 ``                               |
| [`7c69b2bb`](https://github.com/NixOS/nixpkgs/commit/7c69b2bbaed370f4e73cd3f18afeea16c92a6fd4) | `` python310Packages.google-cloud-bigquery-storage: 2.19.0 -> 2.19.1 ``               |
| [`4929fad3`](https://github.com/NixOS/nixpkgs/commit/4929fad3c7e11acfdb53d70cabf69f254000a54d) | `` liferea: 1.14.2 -> 1.14.3 ``                                                       |
| [`a2e172e0`](https://github.com/NixOS/nixpkgs/commit/a2e172e0f8019611b4c6601b9eab7e300d5f3437) | `` resvg: 0.29.0 -> 0.30.0 ``                                                         |
| [`f0940dac`](https://github.com/NixOS/nixpkgs/commit/f0940dac89fcd5b0e12b517161cc46b4772ca318) | `` fastly: 8.1.0 -> 8.1.2 ``                                                          |
| [`58f88f61`](https://github.com/NixOS/nixpkgs/commit/58f88f61b3700731a7418082fb56b87d32b58e7f) | `` jetbrains: add libxcrypt-legacy ``                                                 |
| [`777a7125`](https://github.com/NixOS/nixpkgs/commit/777a7125e8463950d202d6162d26016bcd43f81c) | `` terraform-providers.snowflake: 0.59.0 → 0.60.0 ``                                  |
| [`e4a8b3f5`](https://github.com/NixOS/nixpkgs/commit/e4a8b3f5bf00acae0be59f5650753c4d9624b4e4) | `` terraform-providers.newrelic: 3.18.1 → 3.19.0 ``                                   |
| [`07b26727`](https://github.com/NixOS/nixpkgs/commit/07b267273acefbf9c2bfe55c1fadbc8f2ed20745) | `` terraform-providers.hcloud: 1.36.2 → 1.37.0 ``                                     |
| [`c9480b5e`](https://github.com/NixOS/nixpkgs/commit/c9480b5eb2283807b42eae3d24590b74e9ee44ef) | `` terraform-providers.google-beta: 4.58.0 → 4.59.0 ``                                |
| [`c7bbb4cd`](https://github.com/NixOS/nixpkgs/commit/c7bbb4cddb3c1e77040539bbbc95960eb74a3cb8) | `` terraform-providers.google: 4.58.0 → 4.59.0 ``                                     |
| [`a23cbeda`](https://github.com/NixOS/nixpkgs/commit/a23cbedae8699d6e9b15c3d473930ffc69258d4c) | `` terraform-providers.buildkite: 0.12.1 → 0.12.2 ``                                  |
| [`ece09807`](https://github.com/NixOS/nixpkgs/commit/ece09807949084314b31d15603c2632dfc719060) | `` clusterctl: 1.3.5 -> 1.4.0 ``                                                      |
| [`4831d420`](https://github.com/NixOS/nixpkgs/commit/4831d420c2a71b2e28088be404540adf658ba263) | `` cinnamon.xapp: 2.4.2 -> 2.4.3 ``                                                   |
| [`9afb29b2`](https://github.com/NixOS/nixpkgs/commit/9afb29b2b1ce550cfaf1942b0965206ba73aa657) | `` cinnamon.nemo: 5.6.4 -> 5.6.5 ``                                                   |
| [`aa6fd7cb`](https://github.com/NixOS/nixpkgs/commit/aa6fd7cb0652a28bae024fbbc25946aa9ed5d185) | `` pomerium: 0.21.2 -> 0.21.3 ``                                                      |
| [`f94262af`](https://github.com/NixOS/nixpkgs/commit/f94262af16a8fcf9ce46bf8755a4e3d879e58f52) | `` xfce.xfce4-session: 4.18.1 -> 4.18.2 ``                                            |
| [`fed88087`](https://github.com/NixOS/nixpkgs/commit/fed88087449ef8c2b9e2774c49c71fbb2c01944c) | `` xfce.xfce4-screensaver: 4.18.0 -> 4.18.1 ``                                        |
| [`228930c7`](https://github.com/NixOS/nixpkgs/commit/228930c7b4ad2f00c4021ef5c79e7ec0553800e0) | `` xfce.xfce4-pulseaudio-plugin: 0.4.5 -> 0.4.6 ``                                    |
| [`a9eaebb6`](https://github.com/NixOS/nixpkgs/commit/a9eaebb6c2512f57fe0993281a202d9e1f8019e3) | `` xfce.xfce4-panel: 4.18.2 -> 4.18.3 ``                                              |
| [`ccc42e27`](https://github.com/NixOS/nixpkgs/commit/ccc42e27f6db363fc948b4bd11c140038ecfaf36) | `` xfce.libxfce4ui: 4.18.2 -> 4.18.3 ``                                               |
| [`2e5274f9`](https://github.com/NixOS/nixpkgs/commit/2e5274f9342f969c10ee7ca47cfe288b7922c13a) | `` golangci-lint-langserver: 0.0.7 -> 0.0.8 ``                                        |
| [`fad6f1f1`](https://github.com/NixOS/nixpkgs/commit/fad6f1f185d2f376a65984e0f9fdc24463a9e9b7) | `` xfce.garcon: 4.18.0 -> 4.18.1 ``                                                   |
| [`4a6f9a7b`](https://github.com/NixOS/nixpkgs/commit/4a6f9a7bd647d21ff2629cd94ae8e24a3743b8e2) | `` raysession: init at 0.13.1 (#222628) ``                                            |
| [`ee0efdd6`](https://github.com/NixOS/nixpkgs/commit/ee0efdd6a02063bc66729d867c7c6b3375d8e80f) | `` patchance: init at 1.0.0 (#222623) ``                                              |
| [`1ff621cf`](https://github.com/NixOS/nixpkgs/commit/1ff621cf56e80869ed27f203835eab8ad85d408b) | `` tonelib-noisereducer: init at 1.2.0 (#222124) ``                                   |
| [`8373cbec`](https://github.com/NixOS/nixpkgs/commit/8373cbec30e973e5adb7287b83a42d29bd13bdba) | `` nextcloudPackages: update ``                                                       |
| [`b0879b8d`](https://github.com/NixOS/nixpkgs/commit/b0879b8d71897f46f99c19fa79e2952d15bbd444) | `` libepoxy: fix darwin build ``                                                      |
| [`604f4225`](https://github.com/NixOS/nixpkgs/commit/604f42256805ef2e492d2f781093830af4f046f4) | `` boxxy: 0.6.0 -> 0.6.2 ``                                                           |
| [`106a3849`](https://github.com/NixOS/nixpkgs/commit/106a384972d6d62ef7b66f34b7308d8fb77c4d05) | `` python310Packages.malduck: mark as broken ``                                       |
| [`70bb55ea`](https://github.com/NixOS/nixpkgs/commit/70bb55ea8b0a190daf3dc669feeb4541898eeddb) | `` boxxy: 0.5.1 -> 0.6.0 (#223486) ``                                                 |
| [`9cd3bf56`](https://github.com/NixOS/nixpkgs/commit/9cd3bf560847c86d234acbba7e9b5de599434b39) | `` python310Packages.databricks-sql-connector: mark as broken ``                      |
| [`d86e9911`](https://github.com/NixOS/nixpkgs/commit/d86e9911cd9051fc671215fd51295507beeeb48b) | `` nixos/modules/config/resolvconf.nix: skip systemPackages if disabled ``            |
| [`9821e338`](https://github.com/NixOS/nixpkgs/commit/9821e338d4eeaadbbef77a6155b87af0e1e0b4bb) | `` vimPlugins.copilot-vim: set default g:copilot_node_command ``                      |
| [`11f0c4f8`](https://github.com/NixOS/nixpkgs/commit/11f0c4f8a5a03cbce64ff5f147e1fc4e377b0aae) | `` python310Packages.peaqevcore: 13.4.1 -> 13.4.2 ``                                  |
| [`6cd5a6ef`](https://github.com/NixOS/nixpkgs/commit/6cd5a6ef1118b8563bfd908805a074b389420d8b) | `` python310Packages.mypy-boto3-s3: 1.26.97.post2 -> 1.26.99 ``                       |
| [`6dbc66c6`](https://github.com/NixOS/nixpkgs/commit/6dbc66c6abe6880c485094ec5bb77aa65381649f) | `` python310Packages.mypy-boto3-builder: 7.14.2 -> 7.14.4 ``                          |
| [`9b7eb167`](https://github.com/NixOS/nixpkgs/commit/9b7eb1679d299b9ef9962e425ae488faf7618171) | `` dontgo403: fix typo ``                                                             |
| [`1ff4c764`](https://github.com/NixOS/nixpkgs/commit/1ff4c76452e110cda89e8577b7468e36307db800) | `` python310Packages.python-socketio: 5.7.2 -> 5.8.0 ``                               |
| [`14e2d57d`](https://github.com/NixOS/nixpkgs/commit/14e2d57dbe15070a9357ba3f4849edc4fc7810dc) | `` python310Packages.python-engineio: 4.3.4 -> 4.4.0 ``                               |
| [`92f28dae`](https://github.com/NixOS/nixpkgs/commit/92f28daedeab851b5538e50e8efc352ba524b0a8) | `` blender: 3.3.1 -> 3.4.1 (#223478) ``                                               |
| [`b18bad8c`](https://github.com/NixOS/nixpkgs/commit/b18bad8c2cd0bb685ae3a86613736bb5b59f03ce) | `` python310Packages.ytmusicapi: add changelog to meta ``                             |
| [`496fc0e2`](https://github.com/NixOS/nixpkgs/commit/496fc0e2db10246e03835b7fed2c44f6cbfad158) | `` python310Packages.yfinance: 0.2.12 -> 0.2.14 ``                                    |
| [`4f6a8765`](https://github.com/NixOS/nixpkgs/commit/4f6a8765e94d83a66f3355d3d44f3f3bbebc8c19) | `` python310Packages.ytmusicapi: 0.25.0 -> 0.25.1 ``                                  |
| [`0a020955`](https://github.com/NixOS/nixpkgs/commit/0a020955feee03192fcd8f0911a7f7765031e57c) | `` python310Packages.yaramod: 3.19.0 -> 3.19.1 ``                                     |
| [`6592df62`](https://github.com/NixOS/nixpkgs/commit/6592df62339d853df563b2066364570925fc0487) | `` matrix-commander: 3.5.0 > 6.0.1 (#223371) ``                                       |