### PR TITLE
chore(flake/nur): `a964f0e6` -> `a00cb948`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680205534,
-        "narHash": "sha256-tStRnbt9bSlmQagn1Z4u1J3HlggxVIfStXPl70evqjk=",
+        "lastModified": 1680212718,
+        "narHash": "sha256-mmY2i0PxKskyupNZOvjhh2rI4BOshRyoWbTMR2Hr5fs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a964f0e626f52b4110d9c14197d649eef6ff5e89",
+        "rev": "a00cb94802111bbff6c94318a2330e2d53a3031e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a00cb948`](https://github.com/nix-community/NUR/commit/a00cb94802111bbff6c94318a2330e2d53a3031e) | `` automatic update `` |