### PR TITLE
chore(flake/nur): `a00cb948` -> `d1f0a3e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680212718,
-        "narHash": "sha256-mmY2i0PxKskyupNZOvjhh2rI4BOshRyoWbTMR2Hr5fs=",
+        "lastModified": 1680218758,
+        "narHash": "sha256-ztkuMsfs4NjTRZZZiPxfFJWF7r0nWHRWlYAf1fGX0ug=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a00cb94802111bbff6c94318a2330e2d53a3031e",
+        "rev": "d1f0a3e5f1780a0187a8e8ab6ec4056c5832781e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d1f0a3e5`](https://github.com/nix-community/NUR/commit/d1f0a3e5f1780a0187a8e8ab6ec4056c5832781e) | `` automatic update `` |