### PR TITLE
chore(flake/nur): `71f637bf` -> `92d84fac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680228994,
-        "narHash": "sha256-0PrOZd+iLtpPsg0puO2u1ag/4grnbw8cV++OlZ9vTUo=",
+        "lastModified": 1680231228,
+        "narHash": "sha256-ZZsCVY2qhAgEwGKTQcxC4TuxphCWtm0NguH0BFeiK44=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "71f637bf217f32fb72c9958ec9c4fbe04e57e955",
+        "rev": "92d84facf36c1a6798dd1b7d221615ccf0bc85e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`92d84fac`](https://github.com/nix-community/NUR/commit/92d84facf36c1a6798dd1b7d221615ccf0bc85e4) | `` automatic update `` |