### PR TITLE
chore(flake/nur): `92d84fac` -> `5d408660`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680231228,
-        "narHash": "sha256-ZZsCVY2qhAgEwGKTQcxC4TuxphCWtm0NguH0BFeiK44=",
+        "lastModified": 1680234288,
+        "narHash": "sha256-mYpUNhSBfAYRjikhqj1njDHkwPQ2t4eWSu/oKCVh6dM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "92d84facf36c1a6798dd1b7d221615ccf0bc85e4",
+        "rev": "5d40866061ec77c9e2c2b0bd28594a0efb5f6fad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5d408660`](https://github.com/nix-community/NUR/commit/5d40866061ec77c9e2c2b0bd28594a0efb5f6fad) | `` automatic update `` |
| [`bb7ecfce`](https://github.com/nix-community/NUR/commit/bb7ecfcecfc565a3a44f2870420032afefa66e00) | `` automatic update `` |
| [`a4bb85b8`](https://github.com/nix-community/NUR/commit/a4bb85b80daa2cd8ba46d92e351f37151e7b374e) | `` automatic update `` |