### PR TITLE
chore(flake/emacs-ement): `64049a21` -> `2ea81a00`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -200,11 +200,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1679496785,
-        "narHash": "sha256-eeExG6CQ3YBpgIyODPDQ3yY5x6D6d79lP5udp5pvhLA=",
+        "lastModified": 1680248356,
+        "narHash": "sha256-onHGRBMOm0zdpZ62doxN0yRMkhZrs771NuD0Ssej4wA=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "64049a21fac391bace1758e8ee65a74bc54c6219",
+        "rev": "2ea81a00572e96b4878f73f20abd841db07f6ed4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                               |
| --------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`2ea81a00`](https://github.com/alphapapa/ement.el/commit/2ea81a00572e96b4878f73f20abd841db07f6ed4) | `` Fix: Message format filter when writing replies `` |