### PR TITLE
chore(flake/nur): `7c232864` -> `98e4e284`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680255902,
-        "narHash": "sha256-HpVSjIJ9SVlRZ9re1Wt8i69i6xBz/ZxosAmdM9mAZ8s=",
+        "lastModified": 1680262333,
+        "narHash": "sha256-5/U8eGL+H8qS4XsJHt3pnvMFS2j5p0Uy0F3VEJsnZzU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7c2328644214339bba4ddc61037e9dbfe99123c0",
+        "rev": "98e4e284278bf7160ee47d3e7feef3a45a84fbc0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`98e4e284`](https://github.com/nix-community/NUR/commit/98e4e284278bf7160ee47d3e7feef3a45a84fbc0) | `` automatic update `` |