### PR TITLE
chore(flake/darwin): `87b9d090` -> `99d4187d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,11 +81,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673295039,
-        "narHash": "sha256-AsdYgE8/GPwcelGgrntlijMg4t3hLFJFCRF3tL5WVjA=",
+        "lastModified": 1680266963,
+        "narHash": "sha256-IW/lzbUCOcldLHWHjNSg1YoViDnZOmz0ZJL7EH9OkV8=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "87b9d090ad39b25b2400029c64825fc2a8868943",
+        "rev": "99d4187d11be86b49baa3a1aec0530004072374f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                     |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------- |
| [`8699abe9`](https://github.com/LnL7/nix-darwin/commit/8699abe98f93aca6733c7c694a908f4d25fc4d90) | `` fix(wg-quick): builtins function typo `` |