### PR TITLE
chore(flake/emacs-ement): `41a5a6b5` -> `6a372ef2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -200,11 +200,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1680254141,
-        "narHash": "sha256-wluruadkdPgrXL7UWI5I3jP5VSTIabxtLaNRQhU6xBc=",
+        "lastModified": 1680267026,
+        "narHash": "sha256-DoIVPixq/mi71oL/v1X2UifUyLB9EZkAdT99JyZW3LY=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "41a5a6b589b3016e2f9fbc9746a1bf482e69cfb5",
+        "rev": "6a372ef28ec641a8e3663648fe1dea423c0cb2ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                              |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`6a372ef2`](https://github.com/alphapapa/ement.el/commit/6a372ef28ec641a8e3663648fe1dea423c0cb2ef) | `` Fix: (ement-room-membership-events--update) Deduplicate events `` |
| [`446a64c1`](https://github.com/alphapapa/ement.el/commit/446a64c1bb1d17e0093e894becdf98f1e5c53635) | `` Meta: v0.8.2-pre ``                                               |