### PR TITLE
chore(flake/nur): `98e4e284` -> `eb98f623`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680262333,
-        "narHash": "sha256-5/U8eGL+H8qS4XsJHt3pnvMFS2j5p0Uy0F3VEJsnZzU=",
+        "lastModified": 1680273924,
+        "narHash": "sha256-cNqO4tHNaaZ4rjb+FMmIpqzutFBYwlpcTfgDYcB9+/4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "98e4e284278bf7160ee47d3e7feef3a45a84fbc0",
+        "rev": "eb98f623e3922ab7b8861623b5202604bc3d33bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eb98f623`](https://github.com/nix-community/NUR/commit/eb98f623e3922ab7b8861623b5202604bc3d33bf) | `` automatic update `` |