### PR TITLE
chore(flake/emacs-overlay): `cfec7f95` -> `c4ebde39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680257010,
-        "narHash": "sha256-pNMB9sdoZOXEsszLD5TS0WG5Ysj2rVRmf92uxsxH/9A=",
+        "lastModified": 1680285224,
+        "narHash": "sha256-/Mudnn6D7bCarQoROhm+dF5plpxkMWKeUdcEloLf/ks=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cfec7f9501cc0e001f49d725a7cd733af7deb2ed",
+        "rev": "c4ebde39c21d85c402e615db225b57b5e27ed1d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`c4ebde39`](https://github.com/nix-community/emacs-overlay/commit/c4ebde39c21d85c402e615db225b57b5e27ed1d9) | `` Updated repos/melpa `` |