### PR TITLE
chore(flake/nur): `eb98f623` -> `b7f16d05`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680273924,
-        "narHash": "sha256-cNqO4tHNaaZ4rjb+FMmIpqzutFBYwlpcTfgDYcB9+/4=",
+        "lastModified": 1680284698,
+        "narHash": "sha256-5+FzB16dtB5UMB7+55ZqdFka1reF1zk+/y8MfOxXQrM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eb98f623e3922ab7b8861623b5202604bc3d33bf",
+        "rev": "b7f16d052d8c95408ab6a069b1d0c540a64d5202",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b7f16d05`](https://github.com/nix-community/NUR/commit/b7f16d052d8c95408ab6a069b1d0c540a64d5202) | `` automatic update `` |