### PR TITLE
chore(flake/nur): `b7f16d05` -> `d8d78170`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680284698,
-        "narHash": "sha256-5+FzB16dtB5UMB7+55ZqdFka1reF1zk+/y8MfOxXQrM=",
+        "lastModified": 1680288727,
+        "narHash": "sha256-6ILRtl3ZC7q1ERZCLcg/WqtR5qC7f64yNcvSkufkPlo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b7f16d052d8c95408ab6a069b1d0c540a64d5202",
+        "rev": "d8d7817074cedc24a4da9e092c31dabf3660535a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d8d78170`](https://github.com/nix-community/NUR/commit/d8d7817074cedc24a4da9e092c31dabf3660535a) | `` automatic update `` |
| [`fa1b5893`](https://github.com/nix-community/NUR/commit/fa1b58937742e5bece510894a56d27053203627f) | `` automatic update `` |
| [`7f5f7de9`](https://github.com/nix-community/NUR/commit/7f5f7de9caf3bfd67d23791ea4b66cd2d93f816e) | `` automatic update `` |