### PR TITLE
chore(flake/nur): `d8d78170` -> `81e377ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680288727,
-        "narHash": "sha256-6ILRtl3ZC7q1ERZCLcg/WqtR5qC7f64yNcvSkufkPlo=",
+        "lastModified": 1680290736,
+        "narHash": "sha256-n5JXRhNgCv8s0XtrcQXfKU7aX0J9PTob+V6IIpIFbIA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d8d7817074cedc24a4da9e092c31dabf3660535a",
+        "rev": "81e377ea2e54996a5cccb17f693a16290bda9555",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`81e377ea`](https://github.com/nix-community/NUR/commit/81e377ea2e54996a5cccb17f693a16290bda9555) | `` automatic update `` |
| [`0f448b28`](https://github.com/nix-community/NUR/commit/0f448b28c8d96ab4e45ab5877bb676fa766045ab) | `` automatic update `` |