### PR TITLE
chore(flake/nur): `81e377ea` -> `6306a946`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680290736,
-        "narHash": "sha256-n5JXRhNgCv8s0XtrcQXfKU7aX0J9PTob+V6IIpIFbIA=",
+        "lastModified": 1680295594,
+        "narHash": "sha256-TDtVhi0wUnh2ZOAw/CBaFUKS5mbQ3IXy+nMBk8TDccI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "81e377ea2e54996a5cccb17f693a16290bda9555",
+        "rev": "6306a94646ce1d6d0a28dd24b6e8f0ad2a63e800",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6306a946`](https://github.com/nix-community/NUR/commit/6306a94646ce1d6d0a28dd24b6e8f0ad2a63e800) | `` automatic update `` |