### PR TITLE
chore(flake/emacs-overlay): `c4ebde39` -> `ab7d9f93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680285224,
-        "narHash": "sha256-/Mudnn6D7bCarQoROhm+dF5plpxkMWKeUdcEloLf/ks=",
+        "lastModified": 1680313711,
+        "narHash": "sha256-ViAT9okh6wM1+McOvQviZdab8AntF8TbrzvjyH5wiVI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c4ebde39c21d85c402e615db225b57b5e27ed1d9",
+        "rev": "ab7d9f93e677950e37c5609de2ea36edc596ad36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                    |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
| [`8f19a025`](https://github.com/nix-community/emacs-overlay/commit/8f19a0251aa3f43de40b6f71d755b64c0b400c8b) | `` flake: add nixConfig for build cache `` |