### PR TITLE
chore(flake/emacs-overlay): `ab7d9f93` -> `5342ef6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680313711,
-        "narHash": "sha256-ViAT9okh6wM1+McOvQviZdab8AntF8TbrzvjyH5wiVI=",
+        "lastModified": 1680318149,
+        "narHash": "sha256-vqPIFMTp//RWlXz+PjJpuhxgGZ6oUQ/xZCFhjhmMacs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ab7d9f93e677950e37c5609de2ea36edc596ad36",
+        "rev": "5342ef6d94113aff959bd01da5707cbe81ee2b25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`5342ef6d`](https://github.com/nix-community/emacs-overlay/commit/5342ef6d94113aff959bd01da5707cbe81ee2b25) | `` Updated repos/melpa `` |
| [`0ac6d8d8`](https://github.com/nix-community/emacs-overlay/commit/0ac6d8d8060786dfe53bdd725572ee5b020305d6) | `` Updated repos/elpa ``  |