### PR TITLE
chore(flake/nur): `5179162e` -> `9874ebfe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680314024,
-        "narHash": "sha256-AKy7OiInIvw2Gw3D+Z058zy8VEy0W+AVEZ8bfeykIBg=",
+        "lastModified": 1680320083,
+        "narHash": "sha256-zkAdAcUCnOeg8t5i7iCAxbsLKoyTmCg0+7dhkaKsex0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5179162e2b455e46d311eddafa4c84c88f461255",
+        "rev": "9874ebfe9a373c192c0373c03f6a77c57f0aafaa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9874ebfe`](https://github.com/nix-community/NUR/commit/9874ebfe9a373c192c0373c03f6a77c57f0aafaa) | `` automatic update `` |