### PR TITLE
chore(flake/nur): `9874ebfe` -> `80a865de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680320083,
-        "narHash": "sha256-zkAdAcUCnOeg8t5i7iCAxbsLKoyTmCg0+7dhkaKsex0=",
+        "lastModified": 1680327770,
+        "narHash": "sha256-rgzPcOe4IO193Xw2YXIQ1td5wNuOPhmOsg+Q4bbNpbQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9874ebfe9a373c192c0373c03f6a77c57f0aafaa",
+        "rev": "80a865de88e897b4990cc1ad9077100763b7953a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`80a865de`](https://github.com/nix-community/NUR/commit/80a865de88e897b4990cc1ad9077100763b7953a) | `` automatic update `` |