### PR TITLE
chore(flake/emacs-overlay): `5342ef6d` -> `d7d53d72`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680318149,
-        "narHash": "sha256-vqPIFMTp//RWlXz+PjJpuhxgGZ6oUQ/xZCFhjhmMacs=",
+        "lastModified": 1680343205,
+        "narHash": "sha256-Zs/Pd2x7woxbGjSbmU3rzOLyXssMAyTbuoh3tPDyMbA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5342ef6d94113aff959bd01da5707cbe81ee2b25",
+        "rev": "d7d53d728dc68d0fca4601b4e155e746ce274098",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d7d53d72`](https://github.com/nix-community/emacs-overlay/commit/d7d53d728dc68d0fca4601b4e155e746ce274098) | `` Updated repos/nongnu `` |
| [`cd9eebce`](https://github.com/nix-community/emacs-overlay/commit/cd9eebcef6b9c65e9ee94b3024348b625dcfdba4) | `` Updated repos/melpa ``  |