### PR TITLE
chore(flake/nur): `3f2260cc` -> `1adcfc19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680358813,
-        "narHash": "sha256-D9WS1XExR/gcXFaUr8CC2jz7zW1CLzw6qGt5HTGtJYo=",
+        "lastModified": 1680360884,
+        "narHash": "sha256-PAIu0YkH+eche+r21F7NVZYj/nghrT2koEgErlbgDR8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3f2260ccd43d9949db41d5be7fb6aef00c0a35cc",
+        "rev": "1adcfc1974d48fb92c25e6fe859f54833ab70732",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1adcfc19`](https://github.com/nix-community/NUR/commit/1adcfc1974d48fb92c25e6fe859f54833ab70732) | `` automatic update `` |
| [`969fff5d`](https://github.com/nix-community/NUR/commit/969fff5d4b0481882ba106b43c35d7e1630b3ee6) | `` automatic update `` |