### PR TITLE
chore(flake/nur): `a2f0cc0f` -> `4a413fc1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680361514,
-        "narHash": "sha256-gwtTUGr/8CS6kHxLBk9mqILNbgdTGFJhWlDldQxXvco=",
+        "lastModified": 1680363994,
+        "narHash": "sha256-De+RgewRxVS2giuEWVPPfr4W8DZajb+KfcUYTM9qpHE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a2f0cc0f9d14873f424275e9e60cc2813f728e32",
+        "rev": "4a413fc1f3ab3ff27581297f2fcb74fe899125fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4a413fc1`](https://github.com/nix-community/NUR/commit/4a413fc1f3ab3ff27581297f2fcb74fe899125fb) | `` automatic update `` |