### PR TITLE
chore(flake/nur): `db4ef2c4` -> `406fd471`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680367512,
-        "narHash": "sha256-nAfiQzAzEepi+69sw1JKwpXzYOYqayshKc9Z+wA4Ku8=",
+        "lastModified": 1680376851,
+        "narHash": "sha256-EUbNrIalEL+B+Q69jU3xHP830BLw6/vF/jRx7Utd2jQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "db4ef2c4d2a8986fd0f04c537b2e8894b5f6fe08",
+        "rev": "406fd471a900da6fc85ccf5c5a64db857f19fd8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`406fd471`](https://github.com/nix-community/NUR/commit/406fd471a900da6fc85ccf5c5a64db857f19fd8f) | `` automatic update `` |
| [`8c8de597`](https://github.com/nix-community/NUR/commit/8c8de59786690bddb80bc9a1a719200817718a52) | `` automatic update `` |