### PR TITLE
chore(flake/nur): `af6cc023` -> `cfcabc96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680378299,
-        "narHash": "sha256-CW9gh+qb7aIZZgn58p0JuQryZKQ/Ax1AKm5ckUKerbU=",
+        "lastModified": 1680385507,
+        "narHash": "sha256-J13T9FE4rv4AMTGGoNdHe6ZelsrLDugtVCZEZr3DhCY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "af6cc023f909c2f03c5da153e7cc8e44e29370c1",
+        "rev": "cfcabc96779054449e1a4f23d4df9ccf910e6940",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cfcabc96`](https://github.com/nix-community/NUR/commit/cfcabc96779054449e1a4f23d4df9ccf910e6940) | `` automatic update `` |