### PR TITLE
chore(flake/emacs-overlay): `914b123b` -> `cbec347e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680404285,
-        "narHash": "sha256-9yU5tqqgXUuut+rgo9KCzZJ7B++Pd9TgBCwAyNUqOSY=",
+        "lastModified": 1680430774,
+        "narHash": "sha256-hAlfG0fkxLTxq5dtqBVu0iWqHUo+OU04Vu1ChpTFw0g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "914b123b92a9692a1bb54d127033003dd272b9be",
+        "rev": "cbec347e20757eed8911282ea9d1fdd8d5b4bc9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`cbec347e`](https://github.com/nix-community/emacs-overlay/commit/cbec347e20757eed8911282ea9d1fdd8d5b4bc9b) | `` Updated repos/melpa `` |