### PR TITLE
chore(flake/emacs-overlay): `3c235db0` -> `48c24461`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680458320,
-        "narHash": "sha256-502u9UO8Q02NlR2ZyBCKQycw7G1clXmOJrn6Aa8pp3s=",
+        "lastModified": 1680489716,
+        "narHash": "sha256-OouDZADudEFQSaN1nGXOlIxnjhSYF9dJVePmkV2KLCs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3c235db06bb1493f39937e080447bf5bfac24f24",
+        "rev": "48c24461051f108c4dfdf4cdac54e6c5e3f479c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`48c24461`](https://github.com/nix-community/emacs-overlay/commit/48c24461051f108c4dfdf4cdac54e6c5e3f479c3) | `` Updated repos/nongnu `` |
| [`bd28dc9f`](https://github.com/nix-community/emacs-overlay/commit/bd28dc9f3e62796191fa3ba277a7eab011e9f8af) | `` Updated repos/melpa ``  |
| [`93e9a14c`](https://github.com/nix-community/emacs-overlay/commit/93e9a14c4d59ad6481418f76f4e8353b7c6129d8) | `` Updated repos/elpa ``   |