### PR TITLE
chore(flake/nur): `93e5e544` -> `8819599f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680464750,
-        "narHash": "sha256-20bP0roHuVhncvCIu1FTkfKJ1QIKxG1IxfmBjKOiP3c=",
+        "lastModified": 1680491851,
+        "narHash": "sha256-Zys8s8f7csCTaNJdNHG7Gb8Sp9df+BFWGpDvTMNOk1w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "93e5e544f84b56d4b6bee62e0242e93ce5f11dee",
+        "rev": "8819599fc11ef2b99e24cb44596db6f5d3a33c7e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8819599f`](https://github.com/nix-community/NUR/commit/8819599fc11ef2b99e24cb44596db6f5d3a33c7e) | `` automatic update `` |