### PR TITLE
chore(flake/nur): `8819599f` -> `438834d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680491851,
-        "narHash": "sha256-Zys8s8f7csCTaNJdNHG7Gb8Sp9df+BFWGpDvTMNOk1w=",
+        "lastModified": 1680501775,
+        "narHash": "sha256-QEDznKnM9RJK5SGNiCzrv+6q/bDhf8KTmRCbS0CstvM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8819599fc11ef2b99e24cb44596db6f5d3a33c7e",
+        "rev": "438834d66327f1f2b36204b2d7f3efb7ebccef20",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`438834d6`](https://github.com/nix-community/NUR/commit/438834d66327f1f2b36204b2d7f3efb7ebccef20) | `` automatic update `` |