### PR TITLE
chore(flake/nur): `438834d6` -> `326044a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680501775,
-        "narHash": "sha256-QEDznKnM9RJK5SGNiCzrv+6q/bDhf8KTmRCbS0CstvM=",
+        "lastModified": 1680503793,
+        "narHash": "sha256-FOesRwTph953YBYybkxSQ5u1abFBPbyGfsJxJnUyi4w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "438834d66327f1f2b36204b2d7f3efb7ebccef20",
+        "rev": "326044a900d2b8a4a818cb1ed7c1526b0c578d4e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`326044a9`](https://github.com/nix-community/NUR/commit/326044a900d2b8a4a818cb1ed7c1526b0c578d4e) | `` automatic update `` |