### PR TITLE
chore(flake/nur): `326044a9` -> `f9584e3b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680503793,
-        "narHash": "sha256-FOesRwTph953YBYybkxSQ5u1abFBPbyGfsJxJnUyi4w=",
+        "lastModified": 1680505766,
+        "narHash": "sha256-5E6ZFt13gJnKIZChTSMnKU1nKjuzyaQ7s1jUgVl85hs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "326044a900d2b8a4a818cb1ed7c1526b0c578d4e",
+        "rev": "f9584e3b5d8ea46f9b25631cbab588b14b7e0be0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f9584e3b`](https://github.com/nix-community/NUR/commit/f9584e3b5d8ea46f9b25631cbab588b14b7e0be0) | `` automatic update `` |