### PR TITLE
chore(flake/nur): `f9584e3b` -> `92fb2df9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680505766,
-        "narHash": "sha256-5E6ZFt13gJnKIZChTSMnKU1nKjuzyaQ7s1jUgVl85hs=",
+        "lastModified": 1680521023,
+        "narHash": "sha256-VTiLcMkmeyIRkZOryDI3roGRE/UlcDNMIfXuzBlZhVQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f9584e3b5d8ea46f9b25631cbab588b14b7e0be0",
+        "rev": "92fb2df9498672b5ca971395caa529d1e212c77b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`92fb2df9`](https://github.com/nix-community/NUR/commit/92fb2df9498672b5ca971395caa529d1e212c77b) | `` automatic update `` |