### PR TITLE
chore(flake/nur): `6c2b7021` -> `df53c374`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680533244,
-        "narHash": "sha256-dX6T8bczprc/cwXo0Jek0uFN/xtBW+P2pLiIZhJZi78=",
+        "lastModified": 1680536833,
+        "narHash": "sha256-PnpEC25dQVGvorscIT7P1emyBch1ACMBzXNsd92j+XY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6c2b7021a19a007697b42f83c0d8a1fa75087dee",
+        "rev": "df53c3744aba91a2526622e87284b270caac5b80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`df53c374`](https://github.com/nix-community/NUR/commit/df53c3744aba91a2526622e87284b270caac5b80) | `` automatic update `` |