### PR TITLE
chore(flake/nur): `df53c374` -> `41e71e31`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680536833,
-        "narHash": "sha256-PnpEC25dQVGvorscIT7P1emyBch1ACMBzXNsd92j+XY=",
+        "lastModified": 1680541604,
+        "narHash": "sha256-zxkL2AnJiuu9r8S3dkMr3Rw2pDb9Asp4cLqYfzPEERQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "df53c3744aba91a2526622e87284b270caac5b80",
+        "rev": "41e71e31e66599e07592c8f55199e04d217adf80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                 |
| -------------------------------------------------------------------------------------------------- | ----------------------- |
| [`41e71e31`](https://github.com/nix-community/NUR/commit/41e71e31e66599e07592c8f55199e04d217adf80) | `` automatic update ``  |
| [`40f9d612`](https://github.com/nix-community/NUR/commit/40f9d6128a60524a4c82e897e8e147589d93e761) | `` add jj repository `` |