### PR TITLE
chore(flake/emacs-overlay): `dce15e40` -> `ca95cddd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680517328,
-        "narHash": "sha256-7HHm4F5TIf1r/B/G6/XHWuKDn+QHcxgCzHQM0vpP46k=",
+        "lastModified": 1680546193,
+        "narHash": "sha256-x2pGiQcjy4yz1wGOfgP9LNkwDRgk1hB/1tpxZV4u914=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dce15e40f673c6ba58fc40a0a59587f19476b20b",
+        "rev": "ca95cddd3feec009600f570ccb05f27717c10fbb",
         "type": "github"
       },
       "original": {

--- a/users/bbigras/core/default.nix
+++ b/users/bbigras/core/default.nix
@@ -164,7 +164,7 @@
       natscli
       joplin-desktop
       just
-      # megasync
+      megasync
       yt-dlp
     ];
     shellAliases = {
@@ -240,7 +240,7 @@
   services = {
     # kdeconnect.enable = true;
     # spotifyd.enable = true;
-    # megasync.enable = true;
+    megasync.enable = true;
     syncthing.enable = true;
     easyeffects.enable = true;
     pantalaimon = {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`ca95cddd`](https://github.com/nix-community/emacs-overlay/commit/ca95cddd3feec009600f570ccb05f27717c10fbb) | `` Updated repos/melpa `` |
| [`9ca0640a`](https://github.com/nix-community/emacs-overlay/commit/9ca0640a176587a3ebee10d84621bfb327761638) | `` Updated repos/elpa ``  |