### PR TITLE
chore(flake/nur): `c2a8b34f` -> `24f84bd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680546433,
-        "narHash": "sha256-87tYLXUi5NNiEk+2luRBsIxcXP6ZwAVLlCRXhTqLIGw=",
+        "lastModified": 1680551134,
+        "narHash": "sha256-+Gqwg+uQhR+/3APMDErr7IYj5D0WjeWCJSMcyieUwX0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c2a8b34f3308925e06e3a8496e994a9bda6335d9",
+        "rev": "24f84bd74352b2f0c1f5eed55812e745923ef550",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`24f84bd7`](https://github.com/nix-community/NUR/commit/24f84bd74352b2f0c1f5eed55812e745923ef550) | `` automatic update `` |