### PR TITLE
chore(flake/nur): `7304bded` -> `de973296`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680559945,
-        "narHash": "sha256-GDUqRL/2WQ1bxsgS9QHmH/Au8rdMjk79ryQEvJcTeME=",
+        "lastModified": 1680563542,
+        "narHash": "sha256-1bWUGkKIUjE4tZv2xtwoyGbH35xdpPhfrXb7j5BY4CQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7304bdedcf4eca8482d91f267695a5bc9cb1425e",
+        "rev": "de9732961d262ab1f39a12317b8936702d211fa8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`de973296`](https://github.com/nix-community/NUR/commit/de9732961d262ab1f39a12317b8936702d211fa8) | `` automatic update `` |
| [`b088513d`](https://github.com/nix-community/NUR/commit/b088513dd4739a9a6336548de6a61f40207f3e6f) | `` automatic update `` |