### PR TITLE
chore(flake/nur): `17405089` -> `46547105`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680573315,
-        "narHash": "sha256-qeAUIrmnrD16YLSB3TQvNgVaRV22m9tgrFPtEka4Cac=",
+        "lastModified": 1680579060,
+        "narHash": "sha256-fC17jiR2R5ubTxfpHOoWX4m0QMUKdCsrIBMNAyNvWtM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "17405089e3bd12d6d5247e6e1cc7e342e857733c",
+        "rev": "46547105c4b2fe1a83a743af62ba88ae5b34b60e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`46547105`](https://github.com/nix-community/NUR/commit/46547105c4b2fe1a83a743af62ba88ae5b34b60e) | `` automatic update `` |