### PR TITLE
chore(flake/nur): `46547105` -> `9870d30e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680579060,
-        "narHash": "sha256-fC17jiR2R5ubTxfpHOoWX4m0QMUKdCsrIBMNAyNvWtM=",
+        "lastModified": 1680579774,
+        "narHash": "sha256-JUS3TYkWDLX6aXEQpTReqzcpXiSd/ECjueMwPIRRQ/Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "46547105c4b2fe1a83a743af62ba88ae5b34b60e",
+        "rev": "9870d30e62ffc4990e135bcbb3d5df035940ba3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9870d30e`](https://github.com/nix-community/NUR/commit/9870d30e62ffc4990e135bcbb3d5df035940ba3f) | `` automatic update `` |