### PR TITLE
chore(flake/nur): `f609c21a` -> `b34f9bde`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680583968,
-        "narHash": "sha256-1nSjH4Qs87kljnTSbFykrUwW8sdBCzUB7NKR8PRoatw=",
+        "lastModified": 1680588174,
+        "narHash": "sha256-MrMsiwohIrGx3R4qX/162+fqx8EQe5lpMc4YTahJDAQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f609c21aec93218fa92957fcc3fb56069a96262e",
+        "rev": "b34f9bde6cbcb5d50e638d08e7d3f9ed7b88340b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b34f9bde`](https://github.com/nix-community/NUR/commit/b34f9bde6cbcb5d50e638d08e7d3f9ed7b88340b) | `` automatic update `` |