### PR TITLE
chore(flake/nixpkgs): `7c656856` -> `53dad94e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -669,11 +669,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1680398059,
-        "narHash": "sha256-qtbKRe+pWuf5nNINdiCgn6EwOIQZxj0Ig/wybBpFNkQ=",
+        "lastModified": 1680487167,
+        "narHash": "sha256-9FNIqrxDZgSliGGN2XJJSvcDYmQbgOANaZA4UWnTdg4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7c656856e9eb863c4d21c83e2601dd77f95f6941",
+        "rev": "53dad94e874c9586e71decf82d972dfb640ef044",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`0bf0b2c5`](https://github.com/NixOS/nixpkgs/commit/0bf0b2c59d1656d8d0761d71f23c84711bcde7f0) | `` libamqpcpp: 4.3.20 -> 4.3.22 ``                                               |
| [`c348796b`](https://github.com/NixOS/nixpkgs/commit/c348796bd25bf6b10afea733e865901caecdd87b) | `` sentry-cli: 2.16.0 -> 2.16.1 ``                                               |
| [`5a3eb4f6`](https://github.com/NixOS/nixpkgs/commit/5a3eb4f6fee7f5b571ff6c66c6c5aac95de8a8a3) | `` nixos/users-groups: Fix password scheme validation ``                         |
| [`f521f461`](https://github.com/NixOS/nixpkgs/commit/f521f4613355f8628fe378dad4c41d3fd8886966) | `` linuxManualConfig: get rid of drvAttrs ``                                     |
| [`4efd3432`](https://github.com/NixOS/nixpkgs/commit/4efd34323c24f3db6593f3c13308378bbd845657) | `` terraform: remove `remove plugins` from postInstall ``                        |
| [`9ce1d14a`](https://github.com/NixOS/nixpkgs/commit/9ce1d14a8bdc071269b7a63d5bebe0804b871957) | `` terraform.withPlugins: switch to pname/version ``                             |
| [`e739dc50`](https://github.com/NixOS/nixpkgs/commit/e739dc508878e89f15c712c1aeb66df8db3e070d) | `` last: 1447 -> 1453 ``                                                         |
| [`865e0ff5`](https://github.com/NixOS/nixpkgs/commit/865e0ff515eb67ef6ce92802346273787024cb54) | `` atuin: fix darwin build ``                                                    |
| [`f443d2e5`](https://github.com/NixOS/nixpkgs/commit/f443d2e52384f33e08d6cbbea1953cd87e016250) | `` nongnu-packages: updated 2023-04-03 (from overlay) ``                         |
| [`faa0f0f9`](https://github.com/NixOS/nixpkgs/commit/faa0f0f942a365c60c18af5c762a439b18a99b34) | `` melpa-packages: updated 2023-04-03 (from overlay) ``                          |
| [`08389e35`](https://github.com/NixOS/nixpkgs/commit/08389e35bcdb6297759a4654b9da9c964d085d1c) | `` elpa-packages: updated 2023-04-03 (from overlay) ``                           |
| [`6f62b499`](https://github.com/NixOS/nixpkgs/commit/6f62b499cf23593bf0b6eb6957926f6202b4002e) | `` nixos/atuin: add maxHistoryLength ``                                          |
| [`23f97b82`](https://github.com/NixOS/nixpkgs/commit/23f97b8259ac0b10cb8f1251d035810a4333b64c) | `` circleci-cli: 0.1.25569 -> 0.1.25638 ``                                       |
| [`cfe29195`](https://github.com/NixOS/nixpkgs/commit/cfe29195c4c91ac9450f90f419196173f5eed220) | `` fzf: 0.38.0 -> 0.39.0 ``                                                      |
| [`149057f0`](https://github.com/NixOS/nixpkgs/commit/149057f02ea10c0c06188a765dd2c448bca1dae1) | `` maintainers: remove rencire ``                                                |
| [`87a181ea`](https://github.com/NixOS/nixpkgs/commit/87a181ea4c1709b45fd7ebeabec7dd646b361762) | `` hid-nintendo: refactor ``                                                     |
| [`078f88f2`](https://github.com/NixOS/nixpkgs/commit/078f88f29d1feb58831602a183a76aadf495daf7) | `` base16-shell-preview: refactor ``                                             |
| [`1a250d7b`](https://github.com/NixOS/nixpkgs/commit/1a250d7b10feba79bbd35e14b0f639dc580123e3) | `` argbash: refactor ``                                                          |
| [`4fea6d52`](https://github.com/NixOS/nixpkgs/commit/4fea6d5223562230df89c8fd4154c128463dbb66) | `` atuin: 13.0.1 -> 14.0.0 ``                                                    |
| [`b15e0f6c`](https://github.com/NixOS/nixpkgs/commit/b15e0f6c64eb252e232a46b891f115c3e13c9954) | `` python310Packages.pyskyqremote: 0.3.24 -> 0.3.25 ``                           |
| [`78c42d69`](https://github.com/NixOS/nixpkgs/commit/78c42d6943800cbf847c335449a95e16d054be72) | `` fits-cloudctl: 0.11.4 -> 0.11.5 ``                                            |
| [`d104ffce`](https://github.com/NixOS/nixpkgs/commit/d104ffce410f664b123d590163f544d6c15132cd) | `` automatic-timezoned: 1.0.78 -> 1.0.81 ``                                      |
| [`1111a6f0`](https://github.com/NixOS/nixpkgs/commit/1111a6f00105c4acb514bd8110b0450339dd7112) | `` nuclei: 2.9.0 -> 2.9.1 ``                                                     |
| [`1c0ebdf8`](https://github.com/NixOS/nixpkgs/commit/1c0ebdf89516e2c51a1d7f09b86d264c1dbcbf1e) | `` python310Packages.mmh3: 3.0.0 -> 3.1.0 ``                                     |
| [`cc065526`](https://github.com/NixOS/nixpkgs/commit/cc0655263f729e4dbb451b6d3493eb968d56bfae) | `` openasar: unstable-2023-01-13 -> unstable-2023-04-01 ``                       |
| [`8f511d49`](https://github.com/NixOS/nixpkgs/commit/8f511d49a692d2e8cd950aac20b0c71b6bc65ac2) | `` ferium: 4.3.4 -> 4.4.0 ``                                                     |
| [`39762330`](https://github.com/NixOS/nixpkgs/commit/39762330f5ac93cd7bd77763a03f40b9dddf35bc) | `` ddccontrol-db: 20230223 -> 20230328 ``                                        |
| [`ab6f21ad`](https://github.com/NixOS/nixpkgs/commit/ab6f21ad53eaecb6bbd89a638962f82ddd87f4f4) | `` opera: 96.0.4693.31 -> 97.0.4719.43 ``                                        |
| [`6ff8487d`](https://github.com/NixOS/nixpkgs/commit/6ff8487dfcc45779547a9a5b72556d9d93e99470) | `` podman-tui: 0.9.0 -> 0.9.1 ``                                                 |
| [`cdeff0a0`](https://github.com/NixOS/nixpkgs/commit/cdeff0a0b49542f532f21c2db23bf5d38aeac8bd) | `` python310Packages.pyatag: 3.5.1 -> 0.3.6.2 ``                                 |
| [`cbae0600`](https://github.com/NixOS/nixpkgs/commit/cbae06007d0a59e799d8a29b27f995fb7972d0f8) | `` python310Packages.pytest-instafail: disable on unsupported Python releases `` |
| [`0d327fef`](https://github.com/NixOS/nixpkgs/commit/0d327fef459d6617d0d547809256a6a1fd6849d2) | `` python310Packages.pytest-instafail: add missing input ``                      |
| [`3ebf1a36`](https://github.com/NixOS/nixpkgs/commit/3ebf1a36f6a3ee6ce62fdab5ada7d86a0ea167f5) | `` python310Packages.pytest-instafail: add changelog to meta ``                  |
| [`8f172ed1`](https://github.com/NixOS/nixpkgs/commit/8f172ed10a376e5611c173e293510dbe946aab4b) | `` nixos/grafana-image-renderer: fix setting name ``                             |
| [`28106320`](https://github.com/NixOS/nixpkgs/commit/28106320feee84ab0810f020ee04dc6aadace6be) | `` erigon: 2.40.1 -> 2.42.0 ``                                                   |
| [`5ba4f429`](https://github.com/NixOS/nixpkgs/commit/5ba4f4293dd1c0917180b254db31b3e4edd17c13) | `` chatgpt-retrieval-plugin: init module ``                                      |
| [`dfbe3f74`](https://github.com/NixOS/nixpkgs/commit/dfbe3f7465e90955ddb3fb5efb5899cc2e669a5a) | `` cyclonedds: 0.10.2 -> 0.10.3 ``                                               |
| [`ad70cebd`](https://github.com/NixOS/nixpkgs/commit/ad70cebdfd6c97f293a769c9f6af27a78e2e290c) | `` goxel: add fgaz to maintainers ``                                             |
| [`49410a7a`](https://github.com/NixOS/nixpkgs/commit/49410a7a6b068ae23f2247e3f9b24d47135d8ed0) | `` goxel: 0.10.8 -> 0.12.0 ``                                                    |
| [`a24fa7af`](https://github.com/NixOS/nixpkgs/commit/a24fa7af1395d75d4e00af34c142d67a60f6ff41) | `` lmms: Add support for Carla (#223103) ``                                      |
| [`49f12662`](https://github.com/NixOS/nixpkgs/commit/49f12662411b891806c5a35202f5e203da6ea969) | `` dotter: 0.12.14 -> 0.12.15 ``                                                 |
| [`405977f9`](https://github.com/NixOS/nixpkgs/commit/405977f9064aab729d10ed950a52c024d8aeae28) | `` dae: init at 0.1.5 ``                                                         |
| [`bcdaf9e9`](https://github.com/NixOS/nixpkgs/commit/bcdaf9e9a8e3602ebc1a8f88fdeaa959815ada68) | `` jetbrains: 2022.3 -> 2023.1 ``                                                |
| [`6e35ea32`](https://github.com/NixOS/nixpkgs/commit/6e35ea3298acc3ff475a937dfed5869c67e4e135) | `` python310Packages.pytest-instafail: 0.4.2 -> 0.5.0 ``                         |
| [`681f30ea`](https://github.com/NixOS/nixpkgs/commit/681f30eaaef8d695766a56ed5e0a906a34f1da23) | `` slic3r: fix slic3r for non-gnome users ``                                     |
| [`fd0e70e3`](https://github.com/NixOS/nixpkgs/commit/fd0e70e30fe23e6210e9645d8bb9b2d0095cd7c5) | `` python310Packages.google-api-python-client: update disabled ``                |
| [`f6c04688`](https://github.com/NixOS/nixpkgs/commit/f6c04688df766745e9f9ec87cf88a023f3ad7509) | `` python310Packages.google-api-python-client: 2.79.0 -> 2.83.0 ``               |
| [`c907a951`](https://github.com/NixOS/nixpkgs/commit/c907a951d73338e76dafc62f9a17cbd9aca018e1) | `` cf-terraforming: 0.11.0 -> 0.12.0 ``                                          |
| [`aa9b6166`](https://github.com/NixOS/nixpkgs/commit/aa9b61665b0146d40373a88630f030d54baa2c66) | `` drawio: 20.8.16 -> 21.1.2 ``                                                  |
| [`35705ed7`](https://github.com/NixOS/nixpkgs/commit/35705ed7cbbd15df4adaef5de146619d477075ac) | `` appflowy: 0.1.1 -> 0.1.2 ``                                                   |
| [`bccf438b`](https://github.com/NixOS/nixpkgs/commit/bccf438b419144f62d27799071b3ab8a5a81d174) | `` prisma-engines: removing myself from maintainers ``                           |
| [`0b9fa7fa`](https://github.com/NixOS/nixpkgs/commit/0b9fa7fa45db000f96b7da666396b7821509049c) | `` devspace: 6.3.1 -> 6.3.2 ``                                                   |
| [`f7ff3dcd`](https://github.com/NixOS/nixpkgs/commit/f7ff3dcd0c82d9d1b771c8e57472d1aec1fff88f) | `` chaos: 0.5.0 -> 0.5.1 ``                                                      |
| [`b68b696b`](https://github.com/NixOS/nixpkgs/commit/b68b696b26116bcc346c352a991d29913d842352) | `` cloudfox: 1.10.1 -> 1.10.2 ``                                                 |
| [`e2c0f0da`](https://github.com/NixOS/nixpkgs/commit/e2c0f0da768f6c21a9dc6a3d48cdc49b51b7a6e5) | `` brev-cli: 0.6.211 -> 0.6.213 ``                                               |
| [`6bbdd3f1`](https://github.com/NixOS/nixpkgs/commit/6bbdd3f13aa10ec5e35c618bb4002627d6398dd6) | `` boltbrowser: 2.1 -> 2.2 ``                                                    |
| [`2e0d1619`](https://github.com/NixOS/nixpkgs/commit/2e0d161973a155ba58450d400aa3f7e3ffdfb8f4) | `` terraform-providers.fastly: 4.1.2 → 4.2.0 ``                                  |
| [`437f757a`](https://github.com/NixOS/nixpkgs/commit/437f757af404ec07d4aabe396f3686d480eec202) | `` terraform-providers.ct: 0.11.0 → 0.12.0 ``                                    |
| [`2ebd32c6`](https://github.com/NixOS/nixpkgs/commit/2ebd32c66917d69e2694284bd43a33aa00863f2d) | `` ddosify: 0.15.3 -> 0.15.4 ``                                                  |
| [`e8b10284`](https://github.com/NixOS/nixpkgs/commit/e8b10284f32b32469d5f54433e5c5a75448b327b) | `` linux/default.nix: use mipsel.nix instead of longson.nix for mips32 ``        |
| [`463097e7`](https://github.com/NixOS/nixpkgs/commit/463097e77d11645fda491049c70838439f4b9bff) | `` vector: Update meta to latest ``                                              |
| [`17d559f6`](https://github.com/NixOS/nixpkgs/commit/17d559f6a7c7ffd18da3bf8456f50da4bc506b11) | `` haxePackages: refactor to improve readability ``                              |
| [`33ea46a5`](https://github.com/NixOS/nixpkgs/commit/33ea46a5f72967fb848ee148b2286400c699bd13) | `` exportarr: 1.1.0 -> 1.2.6 ``                                                  |
| [`f2d65f49`](https://github.com/NixOS/nixpkgs/commit/f2d65f49b2d62f4b0383ed65266d68f7c0e48739) | `` flyctl: 0.0.498 -> 0.0.500 ``                                                 |
| [`c59f6c75`](https://github.com/NixOS/nixpkgs/commit/c59f6c75b60b31d2349b35ddb2777d230d02cabe) | `` openroad: unstable-2022-07-19 -> unstable-2023-03-31 ``                       |
| [`3bfc7a91`](https://github.com/NixOS/nixpkgs/commit/3bfc7a919eb89e5c97df4b598f864c0bd76c62d5) | `` datree: 1.8.46 -> 1.8.47 ``                                                   |
| [`9471f734`](https://github.com/NixOS/nixpkgs/commit/9471f73484724c53873b6ce4e03c905b46f8582c) | `` cyberchef: 10.2.0 -> 10.4.0 ``                                                |
| [`0428b0d9`](https://github.com/NixOS/nixpkgs/commit/0428b0d9925f98563881153e495f62fe28736210) | `` copilot-cli: 1.26.0 -> 1.27.0 ``                                              |
| [`8dd72c03`](https://github.com/NixOS/nixpkgs/commit/8dd72c037cfc9ab12b0c43ec2b1edff65b53f2c5) | `` argocd-autopilot: 0.4.13 -> 0.4.15 ``                                         |
| [`1c4b047d`](https://github.com/NixOS/nixpkgs/commit/1c4b047d25e50841767db6cb892035d835da3d0b) | `` linkerd_edge: 23.3.3 -> 23.3.4 ``                                             |
| [`972f6856`](https://github.com/NixOS/nixpkgs/commit/972f685682e797dfede1cdd78af9531e369a874d) | `` liferea: 1.14.3 -> 1.14.4 ``                                                  |
| [`59036ec1`](https://github.com/NixOS/nixpkgs/commit/59036ec1321ca26f71d081605d794d4eb92832ec) | `` python310Packages.google-cloud-resource-manager: 1.9.0 -> 1.9.1 ``            |
| [`9ee646ee`](https://github.com/NixOS/nixpkgs/commit/9ee646eec758c176e0217ee6b7e7887a1b0dd634) | `` dooit: init at 1.0.1 ``                                                       |
| [`38eedd25`](https://github.com/NixOS/nixpkgs/commit/38eedd25c1508a95acd74464963ca3ec7c854f2f) | `` blackfire: 2.14.0 -> 2.14.2 ``                                                |
| [`ea61426b`](https://github.com/NixOS/nixpkgs/commit/ea61426b0da7e118c5d4d1d10b6f71ab6e23d4b7) | `` python310Packages.sentry-sdk: 1.17.0 -> 1.18.0 ``                             |
| [`b5fb7355`](https://github.com/NixOS/nixpkgs/commit/b5fb73555d9dea5f907ab8a6cb3edcc5f67bc60a) | `` python310Packages.neo4j: 5.6.0 -> 5.7.0 ``                                    |
| [`ad7ab914`](https://github.com/NixOS/nixpkgs/commit/ad7ab9141d8c611fad59f0b9e5c4d0718fee8db5) | `` python310Packages.mypy-boto3-s3: 1.26.99 -> 1.26.104 ``                       |
| [`c819f0ad`](https://github.com/NixOS/nixpkgs/commit/c819f0adc75eccb71d95df4bd7c23c06471ccf43) | `` python310Packages.holidays: 0.21 -> 0.21.13 ``                                |
| [`8b3012cc`](https://github.com/NixOS/nixpkgs/commit/8b3012cc0d9284b0e28b16b4240f7ac76367460a) | `` git-cinnabar: 0.5.11 -> 0.6.0 ``                                              |
| [`e93cb0ad`](https://github.com/NixOS/nixpkgs/commit/e93cb0ad0f5f044cd43cdbe61371ff450b908cc7) | `` prismlauncher: use ninja ``                                                   |
| [`cdb4da00`](https://github.com/NixOS/nixpkgs/commit/cdb4da00845b8bcd20589f27bd857603d1d8e370) | `` python310Packages.json-schema-for-humans: 0.44.3 -> 0.44.4 ``                 |
| [`72057a77`](https://github.com/NixOS/nixpkgs/commit/72057a77f97e754a4dc4f21182cce4e8d08bb129) | `` oculante: 0.6.41 -> 0.6.58 ``                                                 |
| [`7a8daab2`](https://github.com/NixOS/nixpkgs/commit/7a8daab25387e7460236d487c2c474313a85fd49) | `` python310Packages.fastai: 2.7.11 -> 2.7.12 ``                                 |
| [`e2e28aba`](https://github.com/NixOS/nixpkgs/commit/e2e28aba7d828aa7d6662be042a3e877ecb8844a) | `` python310Packages.discordpy: 2.1.0 -> 2.2.2 ``                                |
| [`71c9b6f2`](https://github.com/NixOS/nixpkgs/commit/71c9b6f26734fce44f3e2c9fe656544da714e9e5) | `` pulumi: 3.57.1 -> 3.60.1 ``                                                   |
| [`3e358eb0`](https://github.com/NixOS/nixpkgs/commit/3e358eb06d9ed9e6df2f787957241bd923a4a340) | `` victoriametrics: add `meta.mainProgram` ``                                    |
| [`3ae8b533`](https://github.com/NixOS/nixpkgs/commit/3ae8b5339d759ae17af107c44393839d5e4d8a1c) | `` victoriametrics: 1.84.0 -> 1.89.1 ``                                          |
| [`5823648b`](https://github.com/NixOS/nixpkgs/commit/5823648b620ff19df0efb7e27075ac0987337ccf) | `` python310Packages.types-retry: 0.9.9.2 -> 0.9.9.3 ``                          |
| [`d05c614c`](https://github.com/NixOS/nixpkgs/commit/d05c614c1e4b52f2a8e18bcb5ced3371776acc79) | `` python310Packages.transmission-rpc: 4.1.3 -> 4.1.4 ``                         |
| [`98ee323a`](https://github.com/NixOS/nixpkgs/commit/98ee323ad3048c94081bc9119dd55a39558c5671) | `` ocamlPackages.json-data-encoding: 0.11 → 0.12.1 ``                            |
| [`a4e784be`](https://github.com/NixOS/nixpkgs/commit/a4e784be15394acf25de63ad6d3bb79975ecd3d4) | `` parson: init at 1.5.1 ``                                                      |
| [`1e06c495`](https://github.com/NixOS/nixpkgs/commit/1e06c495141c21960366c4d8ed13fb1e49a00c24) | `` esbuild: 0.17.14 -> 0.17.15 ``                                                |
| [`a025a721`](https://github.com/NixOS/nixpkgs/commit/a025a721c305ee0a90ee795f4d72566d23fec732) | `` luau: 0.569 -> 0.570 ``                                                       |
| [`494ff189`](https://github.com/NixOS/nixpkgs/commit/494ff189e0922745e3686432d0b065feb3aa29d7) | `` xfce.thunar-archive-plugin: 0.5.0 -> 0.5.1 ``                                 |
| [`c45c861d`](https://github.com/NixOS/nixpkgs/commit/c45c861d99545d333d0bb921b954b4eafd1dce08) | `` python310Packages.hg-evolve: 11.0.0 -> 11.0.1 ``                              |
| [`848855c6`](https://github.com/NixOS/nixpkgs/commit/848855c6c8af98a74f3e0d9570aea17c79211ba1) | `` python310Packages.pyvesync: 2.1.1 -> 2.1.6 ``                                 |
| [`a1829ed7`](https://github.com/NixOS/nixpkgs/commit/a1829ed727cadd813ce64843b11f143f6599f326) | `` droidcam: 1.8.2 -> 1.9.0 ``                                                   |
| [`e04e24c5`](https://github.com/NixOS/nixpkgs/commit/e04e24c5e0513ba636d86180fa4aba5dfbf2e053) | `` freedv: 1.8.8 -> 1.8.8.1 ``                                                   |
| [`f54622fa`](https://github.com/NixOS/nixpkgs/commit/f54622faa042735baceb1ff524f64a680b46332a) | `` rpcs3: 0.0.27-14824-ad3e740c0 -> 0.0.27-14840-842edbcbe ``                    |
| [`1c7518ea`](https://github.com/NixOS/nixpkgs/commit/1c7518ea08bfc41c173aef3ea72825a6fed9fe26) | `` ipxe: unstable-2023-03-15 -> unstable-2023-03-30 ``                           |
| [`30c40221`](https://github.com/NixOS/nixpkgs/commit/30c402219f954a22bd50cc29e11b2584b7d19ef6) | `` python310Packages.azure-mgmt-appconfiguration: 2.2.0 -> 3.0.0 ``              |
| [`168c3b65`](https://github.com/NixOS/nixpkgs/commit/168c3b652eab1c8747bf1e02ae1172c22c697f8c) | `` chromiumDev: 113.0.5668.0 -> 113.0.5672.12 ``                                 |
| [`72306f13`](https://github.com/NixOS/nixpkgs/commit/72306f13681bfe801f5b2cdfe2cd52a8ff36fdef) | `` klipper: unstable-2023-03-15 -> unstable-2023-03-30 ``                        |
| [`7a9da552`](https://github.com/NixOS/nixpkgs/commit/7a9da552fbc512d04d4707bd075a3766f6f2dd26) | `` ocamlPackages.posix: 2.0.0 → 2.0.2 ``                                         |
| [`112b33c4`](https://github.com/NixOS/nixpkgs/commit/112b33c4f84855f23c2aad8cca9859c9a8c003a8) | `` python310Packages.zodbpickle: 2.6 -> 3.0.1 ``                                 |
| [`3593fb7f`](https://github.com/NixOS/nixpkgs/commit/3593fb7f36da5c7b499d635e49cd3c5475abb652) | `` hyperrogue: 12.1i -> 12.1l ``                                                 |
| [`61f1d420`](https://github.com/NixOS/nixpkgs/commit/61f1d420f8d818b6c9df5ed44a2da0642a3c59c3) | `` plantuml: 1.2023.4 -> 1.2023.5 ``                                             |
| [`7cd07d61`](https://github.com/NixOS/nixpkgs/commit/7cd07d61dcc41558d87c1b5f044bb5aa373d57db) | `` oven-media-engine: 0.15.5 -> 0.15.7 ``                                        |
| [`0cac23c7`](https://github.com/NixOS/nixpkgs/commit/0cac23c7bfee3ffbf2b5b54c670359f3cd4edde7) | `` Fix `NIXOS_OZONE_WL` not working with 1Password ``                            |
| [`1c4165f1`](https://github.com/NixOS/nixpkgs/commit/1c4165f174aa1f3a91c7f89778e9b1ad5180fa58) | `` rssguard: 4.3.2 -> 4.3.3 ``                                                   |
| [`228052d2`](https://github.com/NixOS/nixpkgs/commit/228052d28e80dc91d1e0e88ea1f77d4d773c35c5) | `` python310Packages.sasmodels: 1.0.6 -> 1.0.7 ``                                |
| [`7242246c`](https://github.com/NixOS/nixpkgs/commit/7242246c3f59e466cc062ccd6e6d0df799ec5f68) | `` polkadot: 0.9.39-1 -> 0.9.40 ``                                               |
| [`731aeffa`](https://github.com/NixOS/nixpkgs/commit/731aeffaf7815a429a3b3aa6ea12e73a1784394a) | `` aeolus: use aeolus-stops ``                                                   |
| [`f3fc0f14`](https://github.com/NixOS/nixpkgs/commit/f3fc0f14f9451780c6fb1d50ca125925625dac48) | `` aeolus-stops: init at 0.4.0 ``                                                |
| [`0b7ad90f`](https://github.com/NixOS/nixpkgs/commit/0b7ad90fb51198a8c3d6622f9400f68f5b068f9c) | `` python310Packages.python-telegram-bot: 20.1 -> 20.2 ``                        |
| [`4ec16be0`](https://github.com/NixOS/nixpkgs/commit/4ec16be06c59f3cbfeca9b5328b8cbcaabab418c) | `` python310Packages.types-python-dateutil: 2.8.19.8 -> 2.8.19.10 ``             |
| [`ac9174a5`](https://github.com/NixOS/nixpkgs/commit/ac9174a548614ba96852812aeb232080b62f13af) | `` aliases: document avoiding them within nixpkgs better ``                      |
| [`f004e977`](https://github.com/NixOS/nixpkgs/commit/f004e9779a24cbf09828d709f23ffa09c4b43df0) | `` quick-lint-js: 2.11.0 -> 2.12.0 ``                                            |