### PR TITLE
chore(flake/emacs-overlay): `e7032c47` -> `6a2222bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680578159,
-        "narHash": "sha256-gSx3uQvs3sQ2bE+7ypyB6nw4zdDoBCxBfdOWKSQySNg=",
+        "lastModified": 1680603650,
+        "narHash": "sha256-Cv3pUhow5yrty8Bs9y5E03BS10v0maNzq6NU/vaG6Jk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e7032c472f0223bb65a27cf3b38af5c935eba962",
+        "rev": "6a2222bf037ac02d79f28c5455ec62adad699560",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`6a2222bf`](https://github.com/nix-community/emacs-overlay/commit/6a2222bf037ac02d79f28c5455ec62adad699560) | `` Updated repos/melpa `` |