### PR TITLE
chore(flake/nur): `2e036fe1` -> `24650be8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680626862,
-        "narHash": "sha256-8SGVlUrcruHpoZbo328dfbOwZTj3GIibG8N1Cm6FPo0=",
+        "lastModified": 1680630507,
+        "narHash": "sha256-SoDZ5eIQaSYE8lnFzCtYEMd7Qby/ITi8VBo2nWfyUt0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2e036fe10e729f62cb86e9b97e1492318a925653",
+        "rev": "24650be8d2d9c38ebcca274563a3f10f6c148220",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`24650be8`](https://github.com/nix-community/NUR/commit/24650be8d2d9c38ebcca274563a3f10f6c148220) | `` automatic update `` |