### PR TITLE
chore(flake/nur): `adc55da3` -> `ed7843e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680633894,
-        "narHash": "sha256-Eg06DdxZ4NBi6jg4cnrcCB+rzmjBBnL7Tc896MDdTB4=",
+        "lastModified": 1680637534,
+        "narHash": "sha256-muMaPjXx10Ye5DJ1/zg9iDJP6gCmeRa44jCFmDZWz3g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "adc55da37c89c05cc1a4da622303671bacd44af7",
+        "rev": "ed7843e1ba3263fa7317b8c5a55c70e6d6a6a0b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ed7843e1`](https://github.com/nix-community/NUR/commit/ed7843e1ba3263fa7317b8c5a55c70e6d6a6a0b7) | `` automatic update `` |