### PR TITLE
chore(flake/nur): `ed7843e1` -> `56ccc517`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680637534,
-        "narHash": "sha256-muMaPjXx10Ye5DJ1/zg9iDJP6gCmeRa44jCFmDZWz3g=",
+        "lastModified": 1680644782,
+        "narHash": "sha256-kXeQt2qAa0LG5NW4QCDZ4j+Vm7Vx910Zxja4g+OtGko=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed7843e1ba3263fa7317b8c5a55c70e6d6a6a0b7",
+        "rev": "56ccc517348d67dfc8fdd83826a9d47c2b465e95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`56ccc517`](https://github.com/nix-community/NUR/commit/56ccc517348d67dfc8fdd83826a9d47c2b465e95) | `` automatic update `` |