### PR TITLE
chore(flake/nur): `56ccc517` -> `ebdb6023`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680644782,
-        "narHash": "sha256-kXeQt2qAa0LG5NW4QCDZ4j+Vm7Vx910Zxja4g+OtGko=",
+        "lastModified": 1680658826,
+        "narHash": "sha256-yu2sFQs+r8yiLCy+0KT64JPSf88/jw7xGQHRSLChsmc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "56ccc517348d67dfc8fdd83826a9d47c2b465e95",
+        "rev": "ebdb6023d2cb72fd495f0d291aba70f8f9e38c48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ebdb6023`](https://github.com/nix-community/NUR/commit/ebdb6023d2cb72fd495f0d291aba70f8f9e38c48) | `` automatic update `` |