### PR TITLE
chore(flake/emacs-overlay): `39db4c58` -> `dff7ec23`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680633267,
-        "narHash": "sha256-9piZEQgXxjsrV5f3VtI6fRcXDjxVRAdpPU8L7UefLSA=",
+        "lastModified": 1680662217,
+        "narHash": "sha256-lcGg4qrpLluFs8FhUiS8jFZFVF3OOfSYAMM9HhhUUu8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "39db4c582a4935df06184da96d2315c01cd0613c",
+        "rev": "dff7ec237601b36f8469e27cf8fdf451e1b04c74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`dff7ec23`](https://github.com/nix-community/emacs-overlay/commit/dff7ec237601b36f8469e27cf8fdf451e1b04c74) | `` Updated repos/nongnu `` |
| [`cc8c7cbb`](https://github.com/nix-community/emacs-overlay/commit/cc8c7cbb74cdf2f409c061d2b82f7b4809d23b61) | `` Updated repos/melpa ``  |