### PR TITLE
chore(flake/nur): `ebdb6023` -> `5234aa7e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680658826,
-        "narHash": "sha256-yu2sFQs+r8yiLCy+0KT64JPSf88/jw7xGQHRSLChsmc=",
+        "lastModified": 1680665690,
+        "narHash": "sha256-xGIsT6GuE3YAofw5mqQ6i41PLJ/WWuINEkWNRWwbD5I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ebdb6023d2cb72fd495f0d291aba70f8f9e38c48",
+        "rev": "5234aa7e811eda140802323b4ced8dfdc7a62725",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5234aa7e`](https://github.com/nix-community/NUR/commit/5234aa7e811eda140802323b4ced8dfdc7a62725) | `` automatic update `` |