### PR TITLE
chore(flake/nixpkgs): `53dad94e` -> `9c8ff8b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -669,11 +669,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1680487167,
-        "narHash": "sha256-9FNIqrxDZgSliGGN2XJJSvcDYmQbgOANaZA4UWnTdg4=",
+        "lastModified": 1680669251,
+        "narHash": "sha256-AVNE+0u4HlI3v96KCXE9risH7NKqj0QDLLfSckYXIbA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "53dad94e874c9586e71decf82d972dfb640ef044",
+        "rev": "9c8ff8b426a8b07b9e0a131ac3218740dc85ba1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`9c8ff8b4`](https://github.com/NixOS/nixpkgs/commit/9c8ff8b426a8b07b9e0a131ac3218740dc85ba1e) | `` terraform-providers.thunder: 1.1.0 → 1.2.0 ``                             |
| [`6c66419a`](https://github.com/NixOS/nixpkgs/commit/6c66419a9aa7ba0aa5b8c4c667c80d88671e1de4) | `` terraform-providers.tailscale: 0.13.6 → 0.13.7 ``                         |
| [`5d023ade`](https://github.com/NixOS/nixpkgs/commit/5d023ade0d034dbb86adc6302f092cd6b0977542) | `` terraform-providers.scaleway: 2.15.0 → 2.16.0 ``                          |
| [`60863fe6`](https://github.com/NixOS/nixpkgs/commit/60863fe66a37c9cf735427066a77eb8d718ff527) | `` terraform-providers.google-beta: 4.59.0 → 4.60.0 ``                       |
| [`6dea81e8`](https://github.com/NixOS/nixpkgs/commit/6dea81e897b4c9daa67032d9d43a45b94e205cb2) | `` terraform-providers.google: 4.59.0 → 4.60.0 ``                            |
| [`67be4042`](https://github.com/NixOS/nixpkgs/commit/67be4042545c723cf4d903fb56bcca5255697bae) | `` terraform-providers.github: 5.19.0 → 5.20.0 ``                            |
| [`6547c9db`](https://github.com/NixOS/nixpkgs/commit/6547c9dba2f0ecbbfd009e8614c406795659953e) | `` terraform-providers.cloudflare: 4.2.0 → 4.3.0 ``                          |
| [`08f8ec0d`](https://github.com/NixOS/nixpkgs/commit/08f8ec0d873fbc08da8ac90d2d217c57cbc060cf) | `` terraform-providers.bitbucket: 2.30.2 → 2.31.0 ``                         |
| [`68cd1172`](https://github.com/NixOS/nixpkgs/commit/68cd1172a99be45df412ea9bab168cc9c9a6dc5b) | `` terraform-providers.baiducloud: 1.19.5 → 1.19.6 ``                        |
| [`caa9102e`](https://github.com/NixOS/nixpkgs/commit/caa9102e5bca18efd8c9aacaf3fcd0d718f6fb2d) | `` terraform-providers.aci: 2.6.1 → 2.7.0 ``                                 |
| [`4a65e9f6`](https://github.com/NixOS/nixpkgs/commit/4a65e9f64e53fdca6eed31adba836717a11247d2) | `` go_1_19: 1.19.7 -> 1.19.8 ``                                              |
| [`e4f9d4f6`](https://github.com/NixOS/nixpkgs/commit/e4f9d4f62cb05cffaab1b1f27e57377432f927fd) | `` nixos/manual: fix cross-compilation ``                                    |
| [`bb4cec38`](https://github.com/NixOS/nixpkgs/commit/bb4cec38222882b0ba4f84e8eca3a2c369b7782b) | `` polar-bookshelf1: init at 1.100.14 ``                                     |
| [`d42cca51`](https://github.com/NixOS/nixpkgs/commit/d42cca51d7cba60393426d7e3caa2ba5510f3a2a) | `` Add maintainer ``                                                         |
| [`9764060c`](https://github.com/NixOS/nixpkgs/commit/9764060cf954d2233f5fc84531ad98094d8d7078) | `` labwc: 0.6.1 -> 0.6.2 ``                                                  |
| [`171558b9`](https://github.com/NixOS/nixpkgs/commit/171558b99d473150fa19a3cec352a53e5cefc5bd) | `` celluloid: 0.24 -> 0.25 ``                                                |
| [`2f90dc20`](https://github.com/NixOS/nixpkgs/commit/2f90dc20b9e2e15ec5fe5aca9e904774f7c88cc0) | `` zfxtop: 0.3.0 -> 0.3.2 ``                                                 |
| [`e7e93bd7`](https://github.com/NixOS/nixpkgs/commit/e7e93bd709044a98116f127bd820e76a227a5c6b) | `` docs/rust: prefer `ln -s` over `cp` ``                                    |
| [`14113cb0`](https://github.com/NixOS/nixpkgs/commit/14113cb0d0cfeaf7034f2cf237be55affefb5806) | `` bzip3: 1.2.3 -> 1.3.0 ``                                                  |
| [`7884a01e`](https://github.com/NixOS/nixpkgs/commit/7884a01ebfed4b4ee8abc39113d1417665b9b05a) | `` gh: 2.26.0 -> 2.26.1 ``                                                   |
| [`7a170a54`](https://github.com/NixOS/nixpkgs/commit/7a170a54d33381d504bdf510c2dfb7639995fcff) | `` maintainers: remove candyc1oud ``                                         |
| [`6d1ee759`](https://github.com/NixOS/nixpkgs/commit/6d1ee759c673c7b5df2747c288bd2d7229c0d688) | `` lux: 0.17.0 -> 0.17.2 ``                                                  |
| [`c15de994`](https://github.com/NixOS/nixpkgs/commit/c15de9948fa65c366ac8ed323244694325ce0fc7) | `` python3Packages.meraki: init at 1.30.0 ``                                 |
| [`6dba375c`](https://github.com/NixOS/nixpkgs/commit/6dba375c3c3cbed024b39d28fd4611db03654f27) | `` ventoy-bin-full: 1.0.89 -> 1.0.90 ``                                      |
| [`0bb82916`](https://github.com/NixOS/nixpkgs/commit/0bb829166035c9559851a96c813a21aa4be54c42) | `` gmic-qt: 3.2.2 -> 3.2.3 ``                                                |
| [`b3c599eb`](https://github.com/NixOS/nixpkgs/commit/b3c599ebb62ec6a637ecf13370a1c8e14560e84b) | `` cimg: 3.2.2 -> 3.2.3 ``                                                   |
| [`dc2c96df`](https://github.com/NixOS/nixpkgs/commit/dc2c96df1d5ee5da69f16b4b3f3f88eb010c63e3) | `` gmic: 3.2.2 -> 3.2.3 ``                                                   |
| [`4b7d7154`](https://github.com/NixOS/nixpkgs/commit/4b7d7154cded6481e82af8728cac731c98f226d0) | `` nushell: 0.77.1 -> 0.78.0 ``                                              |
| [`07137979`](https://github.com/NixOS/nixpkgs/commit/07137979536870707f4170325323118e7eab1170) | `` python310Packages.pychromecast: 13.0.6 -> 13.0.7 ``                       |
| [`6df3f671`](https://github.com/NixOS/nixpkgs/commit/6df3f671385b427a249efac7b0c8f323b8a35805) | `` python310Packages.goodwe: 0.2.30 -> 0.2.31 ``                             |
| [`4c40162c`](https://github.com/NixOS/nixpkgs/commit/4c40162cb5a4317df6250308c93761cc29d09c40) | `` clusterctl: 1.4.0 -> 1.4.1 ``                                             |
| [`54cb3a75`](https://github.com/NixOS/nixpkgs/commit/54cb3a75a9a2f8e99f417b817f3301ff5a400ee7) | `` vimv-rs: 1.8.0 -> 2.0.0 ``                                                |
| [`1e7ac24e`](https://github.com/NixOS/nixpkgs/commit/1e7ac24e9d4d2d93345370c0fce0f905313028bb) | `` python310Packages.types-requests: 2.28.11.16 -> 2.28.11.17 ``             |
| [`53c20eae`](https://github.com/NixOS/nixpkgs/commit/53c20eae380f5fbb820ddd67ad30feab6deca2d4) | `` Revert "bind: remove hard-coded `allow-query` config setting" ``          |
| [`4a9c7011`](https://github.com/NixOS/nixpkgs/commit/4a9c7011a18c90d9dee37fd1a994ac76a91de928) | `` gh: 2.25.1 -> 2.26.0 ``                                                   |
| [`246567a3`](https://github.com/NixOS/nixpkgs/commit/246567a3ad88e3119c2001e2fe78be233474cde0) | `` josm: 18678 -> 18700 ``                                                   |
| [`2831eb0a`](https://github.com/NixOS/nixpkgs/commit/2831eb0a083a08ccc76ae9b3727db66cb16b46ad) | `` tbls: 1.63.0 -> 1.64.0 ``                                                 |
| [`92dd06ae`](https://github.com/NixOS/nixpkgs/commit/92dd06ae1d8d710250b644bd776bb4f174044a39) | `` nu_scripts: init at unstable-2023-03-16 ``                                |
| [`cd1e297b`](https://github.com/NixOS/nixpkgs/commit/cd1e297b9327ff3242227264977e4bea2b747d81) | `` dune_3: 3.7.0 -> 3.7.1 ``                                                 |
| [`e507ac4b`](https://github.com/NixOS/nixpkgs/commit/e507ac4bdb0d81711900f6c9eefa78ebc28327f4) | `` sysdig: also update driver ``                                             |
| [`a3cff1f0`](https://github.com/NixOS/nixpkgs/commit/a3cff1f0527ba7a5be7ac7a802002c3dab267a94) | `` solc: 0.8.13 -> 0.8.19 (#219240) ``                                       |
| [`3f1bafb6`](https://github.com/NixOS/nixpkgs/commit/3f1bafb686905c1e97a7762c13ebd925d0c03b74) | `` plasma: 5.27.3 -> 5.27.4(.1) ``                                           |
| [`1f6987ce`](https://github.com/NixOS/nixpkgs/commit/1f6987ce7e4a1c88d3b38ff568a81822ed2c27e9) | `` fishPlugins.forgit: unstable-2022-10-14 -> 23.04.0 ``                     |
| [`46016871`](https://github.com/NixOS/nixpkgs/commit/460168712363202aaecc2bf608598f1a8957e43d) | `` buildFishPlugin: check if any .fish file exists in source ``              |
| [`2b21a945`](https://github.com/NixOS/nixpkgs/commit/2b21a945d997dbd79248d290a043f471ccdfffd7) | `` vimPlugins.autosave-nvim: init at 2022-10-13 ``                           |
| [`a143b6f4`](https://github.com/NixOS/nixpkgs/commit/a143b6f42494c1f1e9dbf446ebcf53741d1d3b95) | `` gptcommit: 0.1.15 -> 0.5.6 ``                                             |
| [`d273fa8b`](https://github.com/NixOS/nixpkgs/commit/d273fa8bb6e90fe98deb10323a909b7fcb9e5d78) | `` python3.pkgs.picobox: 2.2.0 -> 3.0.0 ``                                   |
| [`a3221987`](https://github.com/NixOS/nixpkgs/commit/a32219871ee0044f8cf033fbeb9506304deb9867) | `` python310Packages.lupa: disable on unsupported Python releases ``         |
| [`9ca9baab`](https://github.com/NixOS/nixpkgs/commit/9ca9baab512ca0bddd64029d55beafa93c85c988) | `` python310Packages.lupa: add changelog to meta ``                          |
| [`5ac23f93`](https://github.com/NixOS/nixpkgs/commit/5ac23f930cc5aeadc48e4d5827b645cf14ecdcfe) | `` python310Packages.lupa: 1.14.1 -> 2.0 ``                                  |
| [`00aab451`](https://github.com/NixOS/nixpkgs/commit/00aab4510243df735824d004a9fe569787dd57dc) | `` mozart: Simplify build thanks to the new sources format ``                |
| [`2f27b9cb`](https://github.com/NixOS/nixpkgs/commit/2f27b9cb0ced564c66ed16a18de271518b966acd) | `` qgis-ltr: 3.22.16 -> 3.28.5 ``                                            |
| [`acd90cdb`](https://github.com/NixOS/nixpkgs/commit/acd90cdb0716e1d7bbee72d35120f23310bf2069) | `` mozart: use llvmPackages_8 instead of llvmPackages_5 ``                   |
| [`6462ef85`](https://github.com/NixOS/nixpkgs/commit/6462ef85d8caefd4a27a09164c53017241547214) | `` coqPackages.coq-lsp: 0.1.6.1 for Coq 8.17 ``                              |
| [`21131995`](https://github.com/NixOS/nixpkgs/commit/21131995d9c949758ec4e37ff590a3cd3d9a0ce1) | `` coqPackages.serapi: 8.16.0+0.16.3 -> 8.17.0+0.17.0 ``                     |
| [`eb423a40`](https://github.com/NixOS/nixpkgs/commit/eb423a400e1013af3c8c73ad504edae675870506) | `` terraform-providers.vultr: 2.12.1 → 2.13.0 ``                             |
| [`e7cd1fd2`](https://github.com/NixOS/nixpkgs/commit/e7cd1fd2747d0aef6ea409117c5ad0656d26c6ea) | `` terraform-providers.snowflake: 0.60.0 → 0.61.0 ``                         |
| [`bef20f18`](https://github.com/NixOS/nixpkgs/commit/bef20f18bf1b64fa7b95ec8393b12e4bde673883) | `` terraform-providers.scaleway: 2.14.1 → 2.15.0 ``                          |
| [`17a7c500`](https://github.com/NixOS/nixpkgs/commit/17a7c5008287fca629d222b85b0a6e654a1362f7) | `` terraform-providers.github: 5.18.3 → 5.19.0 ``                            |
| [`1afb9035`](https://github.com/NixOS/nixpkgs/commit/1afb9035e9856de028eae94f3b48b6c69783c8e6) | `` terraform-providers.cloudamqp: 1.24.2 → 1.25.0 ``                         |
| [`a1510d8f`](https://github.com/NixOS/nixpkgs/commit/a1510d8fa4433b5daa143abdeee7e72d85ebc382) | `` terraform-providers.cloudfoundry: 0.50.6 → 0.50.7 ``                      |
| [`b46f7fb4`](https://github.com/NixOS/nixpkgs/commit/b46f7fb47ca16eb44ccf715c261ca6979ad247de) | `` sing-box: 1.2.1 -> 1.2.2 ``                                               |
| [`344ebdf2`](https://github.com/NixOS/nixpkgs/commit/344ebdf2e4ee1b62e7bd59fcc142bc313499308e) | `` python310Packages.fakeredis: 2.10.2 -> 2.10.3 ``                          |
| [`f5f0feca`](https://github.com/NixOS/nixpkgs/commit/f5f0feca54fbd8840403de84caa386c96d47e144) | `` python310Packages.bc-detect-secrets: 1.4.15 -> 1.4.16 ``                  |
| [`4a25cc47`](https://github.com/NixOS/nixpkgs/commit/4a25cc47534d8f66eb3a643e03bc6f9694b6518f) | `` trufflehog: 3.31.2 -> 3.31.3 ``                                           |
| [`7d6f837b`](https://github.com/NixOS/nixpkgs/commit/7d6f837b80a6b7714d51357ad7fa07a1cca3e25b) | `` harmonia: 0.6.0 -> 0.6.1 ``                                               |
| [`0b7f8761`](https://github.com/NixOS/nixpkgs/commit/0b7f87614bcf9882b46a3df538c357eba6517f73) | `` skopeo: add developer-guy to maintainers list ``                          |
| [`4c874b81`](https://github.com/NixOS/nixpkgs/commit/4c874b81b59da9ca1702365354e0fd922154994f) | `` skopeo: 1.11.1 --> 1.11.2 ``                                              |
| [`8b4505a8`](https://github.com/NixOS/nixpkgs/commit/8b4505a841c83cd4112a475d4e334d0404dda6d2) | `` nixos/rl-2305: mention elk6 removal ``                                    |
| [`3acb3d73`](https://github.com/NixOS/nixpkgs/commit/3acb3d73ae12e38dc69909b23efa36918232bd87) | `` elasticsearch-oss: remove ``                                              |
| [`426fbcb5`](https://github.com/NixOS/nixpkgs/commit/426fbcb5a6f110b4bc76a5cd2818e5254dbef8ba) | `` *beat6: remove ``                                                         |
| [`76ad0b1b`](https://github.com/NixOS/nixpkgs/commit/76ad0b1b7db9fd4cb62a176caa1e47a5b5671b33) | `` logstash6*: remove ``                                                     |
| [`09a6672b`](https://github.com/NixOS/nixpkgs/commit/09a6672bbfc240b6154474b135ba583c929859e4) | `` elasticsearch6*: remove ``                                                |
| [`1f874da9`](https://github.com/NixOS/nixpkgs/commit/1f874da97bae36f8594f1a839cd265113d097de1) | `` vimPlugins.vim-wakatime: fix build as vim plugin ``                       |
| [`3d3b0c27`](https://github.com/NixOS/nixpkgs/commit/3d3b0c27d1cc09d32154529817338b2ead7298d6) | `` cargo-llvm-cov: 0.5.11 -> 0.5.13 ``                                       |
| [`b5872242`](https://github.com/NixOS/nixpkgs/commit/b5872242a60774a96953d04695d74956889fb3be) | `` spotify: Add support for `NIXOS_OZONE_WL` ``                              |
| [`1e36c703`](https://github.com/NixOS/nixpkgs/commit/1e36c703b14366c0f4cabfd60d2f9884f330a812) | `` spotify: 1.1.84.716.gc5f8b819 -> 1.1.99.878.g1e4ccc6e ``                  |
| [`33c156c3`](https://github.com/NixOS/nixpkgs/commit/33c156c32e08b2e772008cb29b394f277563e9a7) | `` vimPlugins.blamer-nvim: init at 2021-11-17 ``                             |
| [`955503e4`](https://github.com/NixOS/nixpkgs/commit/955503e407f074daf23ecf605b4c0544242d3771) | `` vimv-rs: 1.7.7 -> 1.8.0 ``                                                |
| [`d9c613d7`](https://github.com/NixOS/nixpkgs/commit/d9c613d746e0b88ec9afc558368dd5422aff8448) | `` mediawiki: add support for postgresql ``                                  |
| [`1e02fa2d`](https://github.com/NixOS/nixpkgs/commit/1e02fa2d81fa6d7c4384bc0672a7648ce2f1050b) | `` ocamlPackages.jsonm: 1.0.1 → 1.0.2 ``                                     |
| [`9ddfa473`](https://github.com/NixOS/nixpkgs/commit/9ddfa473f5fc3e2dc24dfdb141bb333a30c932c6) | `` proteus: init at 1.2 (#224221) ``                                         |
| [`bde478a5`](https://github.com/NixOS/nixpkgs/commit/bde478a52f239ae334fb8e99b694e0555ec00f2b) | `` discord: remove maintainer (#224577) ``                                   |
| [`2cc4e028`](https://github.com/NixOS/nixpkgs/commit/2cc4e028292753cba509edf1f3841ce2096928a9) | `` python3Packages.cyclonedx-python-lib: 3.1.5 -> 4.0.0 ``                   |
| [`0783b500`](https://github.com/NixOS/nixpkgs/commit/0783b500fc9db4b1af8c121e41c39fe6c5198e98) | `` railway: 3.0.18 -> 3.0.19 ``                                              |
| [`2593f5e0`](https://github.com/NixOS/nixpkgs/commit/2593f5e033501ad7cb07ebab43bb33b4801959be) | `` chatgpt-cli: 0.6.0-beta -> 1.0.2 ``                                       |
| [`0e2804eb`](https://github.com/NixOS/nixpkgs/commit/0e2804eb3ed5708bbf2910ed673b147cf95b74bf) | `` arti: 1.1.2 -> 1.1.3 ``                                                   |
| [`09b49938`](https://github.com/NixOS/nixpkgs/commit/09b49938e548edfea863b443e5fb0fdd248174cc) | `` actionlint: 1.6.23 -> 1.6.24 ``                                           |
| [`adcbb9f5`](https://github.com/NixOS/nixpkgs/commit/adcbb9f514e42f37bdb30f865616d247152d8d84) | `` blesh: 2022-07-29 -> 0.3.4 ``                                             |
| [`34adc9e4`](https://github.com/NixOS/nixpkgs/commit/34adc9e4e30210200c322bae2965faa5c35a86de) | `` millet: 0.8.6 -> 0.8.7 ``                                                 |
| [`b9e93192`](https://github.com/NixOS/nixpkgs/commit/b9e9319236b0744d6b4ebe919caac8015db16657) | `` git-gone: 0.4.3 -> 0.5.0 ``                                               |
| [`b6641c22`](https://github.com/NixOS/nixpkgs/commit/b6641c2209354eb38d1f52c74cf89296cd0553a0) | `` tdesktop: override glibmm_2_68 to version 2.76.0 ``                       |
| [`baee1005`](https://github.com/NixOS/nixpkgs/commit/baee1005c9d5cf320d52be41e9ad905b2de7397b) | `` tdesktop: 4.6.5 -> 4.7.1 ``                                               |
| [`0521683e`](https://github.com/NixOS/nixpkgs/commit/0521683ef252c48b310d0779559f2081f26538ab) | `` pscale: 0.133.0 -> 0.134.0 ``                                             |
| [`cebe5de8`](https://github.com/NixOS/nixpkgs/commit/cebe5de8aff7c8de800a8c8636b339e11ba695bc) | `` python3.pkgs.pyarrow: fix build ``                                        |
| [`98d21463`](https://github.com/NixOS/nixpkgs/commit/98d2146331f49640ebb3e852e78cca0aa023e020) | `` beancount-language-server: 1.3.0 -> 1.3.1 ``                              |
| [`dcf9f37a`](https://github.com/NixOS/nixpkgs/commit/dcf9f37aef4143eb2b89c561150b4117598ff0a5) | `` celeste: 0.4.6 -> 0.5.2 ``                                                |
| [`82aeb5ec`](https://github.com/NixOS/nixpkgs/commit/82aeb5ec4094859b7c29f099dd12d8373983d45e) | `` abcmidi: 2023.03.15 -> 2023.03.24 ``                                      |
| [`c5f2c2c1`](https://github.com/NixOS/nixpkgs/commit/c5f2c2c17e844b6053a604ac6130097e224ddb06) | `` k3s_1_23: drop deprecated k3s version ``                                  |
| [`f60d291f`](https://github.com/NixOS/nixpkgs/commit/f60d291f64d4e722c582bbe060b6a664a8ab35fb) | `` lisp-modules: don't use mysql alias ``                                    |
| [`a182101a`](https://github.com/NixOS/nixpkgs/commit/a182101ae7dd15e8e79f046a2a7579540c88efed) | `` lisp-modules: don't use mysql-client alias ``                             |
| [`230939de`](https://github.com/NixOS/nixpkgs/commit/230939de785c26295fc038c04e5672b94d0fef24) | `` python311Packages.psycopg: Propagate typing-extensions unconditionally `` |
| [`5c5dc433`](https://github.com/NixOS/nixpkgs/commit/5c5dc43305f18857eb6b32ab165dc795f359716f) | `` python310Packages.psycopg: fix build with Cython 3.0.0b1 ``               |
| [`ce2fcc00`](https://github.com/NixOS/nixpkgs/commit/ce2fcc00e0abbb8ad85ceb6d7cd897d4782efd7b) | `` Remove maintainer from `maintainer-list.nix` ``                           |
| [`c8613122`](https://github.com/NixOS/nixpkgs/commit/c8613122a080456ae6a134cdaed2464a7faad309) | `` Remove maintainer from `tools/typesetting/htmldoc` ``                     |
| [`5da3f9d6`](https://github.com/NixOS/nixpkgs/commit/5da3f9d63615916de5fddc7fe3c4d1b327746ed4) | `` libdeltachat: 1.112.4 -> 1.112.5 ``                                       |
| [`ccbe18bb`](https://github.com/NixOS/nixpkgs/commit/ccbe18bbf718c06a27c0b1c5d6cce9ed503a2462) | `` meilisearch: 1.0.2 -> 1.1.0 ``                                            |
| [`c10f918f`](https://github.com/NixOS/nixpkgs/commit/c10f918f3dd01b7dbe7dacc81830295026c0557e) | `` maintainers/team-list: drop lnl7 from rust maintainer list ``             |
| [`42495043`](https://github.com/NixOS/nixpkgs/commit/4249504385852e1e53df9bd4fe0f97dcbbb4e050) | `` lutris: remove wine dependency ``                                         |
| [`a001b446`](https://github.com/NixOS/nixpkgs/commit/a001b446a25be51c5f0cf054c190334c53b77da2) | `` poetry: 1.4.1 -> 1.4.2 ``                                                 |
| [`f864bb2b`](https://github.com/NixOS/nixpkgs/commit/f864bb2b1176cc363dd55f7d0b6139b4a7fa3a02) | `` regreet: unstable-2023-03-19 -> 0.1.0 ``                                  |
| [`0d4a1f29`](https://github.com/NixOS/nixpkgs/commit/0d4a1f299be2622d84fdd312b2d7d23d382b6327) | `` python310Packages.peaqevcore: 13.4.15 -> 15.0.2 ``                        |
| [`069b4772`](https://github.com/NixOS/nixpkgs/commit/069b47722b3b2976e88526420a3735a028d155ae) | `` python310Packages.peaqevcore: 13.4.14 -> 13.4.15 ``                       |
| [`130219aa`](https://github.com/NixOS/nixpkgs/commit/130219aa1957033cdaada05f0e6c5531d3ec37c0) | `` python310Packages.iocextract: init at 1.15.1 ``                           |
| [`f8f13b50`](https://github.com/NixOS/nixpkgs/commit/f8f13b5059c9bdcc0b318941034c4a602d63a072) | `` helix: 22.11 -> 23.03 ``                                                  |
| [`fcf6c6eb`](https://github.com/NixOS/nixpkgs/commit/fcf6c6eb394513fc238490e2aabaebfc8bed28fb) | `` freenet: fix build by pinning gradle_7 ``                                 |
| [`a7ff41de`](https://github.com/NixOS/nixpkgs/commit/a7ff41dedb92c16061f0bee624c1ee577606a7c0) | `` ddnet: 16.8 -> 16.9 ``                                                    |
| [`1b5ba6d5`](https://github.com/NixOS/nixpkgs/commit/1b5ba6d5bd22ae637b30013fd016900b8a49e94e) | `` emacs.pkgs.jinx: build .so file ``                                        |
| [`dd2afe68`](https://github.com/NixOS/nixpkgs/commit/dd2afe681227be4b98f06cf603b11b310c440bef) | `` gotestwaf: fix version self-reporting ``                                  |
| [`3a864570`](https://github.com/NixOS/nixpkgs/commit/3a864570ba808663ea7d7072d6fe9aea93baeeb3) | `` gotestwaf: 0.3.1 -> 0.4.0 ``                                              |
| [`c9deaf22`](https://github.com/NixOS/nixpkgs/commit/c9deaf22c435861510396314f4b30f446c4e1f6b) | `` python310Packages.tensorflow-bin: mark insecure ``                        |
| [`47efd9d5`](https://github.com/NixOS/nixpkgs/commit/47efd9d5700a89b9e7258a332c45432656829243) | `` python310Packages.aiocoap: 0.4.5 -> 0.4.7 ``                              |
| [`6cf5d549`](https://github.com/NixOS/nixpkgs/commit/6cf5d549fe1141250cf4df7ab3f3697ea984b4dc) | `` nimble-unwrapped: Add missing Security framework buildInput ``            |
| [`8c119d26`](https://github.com/NixOS/nixpkgs/commit/8c119d2641a390d8eab2dfe87db57023a0cddff1) | `` python310Packages.adafruit-platformdetect: 3.42.0 -> 3.43.0 ``            |
| [`7ef9ebc2`](https://github.com/NixOS/nixpkgs/commit/7ef9ebc27baf1002d2d6fbbf3bbce9387383d676) | `` python310Packages.easyenergy: 0.2.3 -> 0.3.0 ``                           |
| [`6de4b340`](https://github.com/NixOS/nixpkgs/commit/6de4b3404f80a2ea0ee357d0ad1c1fb85e95b28e) | `` python310Packages.faraday-plugins: 1.10.0 -> 1.11.0 ``                    |
| [`5151d757`](https://github.com/NixOS/nixpkgs/commit/5151d75738784ee1c1a174948626d922a58953b6) | `` python310Packages.fastapi-mail: 1.2.6 -> 1.2.7 ``                         |
| [`6c9c6208`](https://github.com/NixOS/nixpkgs/commit/6c9c6208970b26927aaadca0aa991eb0b8a46d90) | `` python310Packages.google-cloud-bigquery-logging: 1.2.0 -> 1.2.1 ``        |
| [`a320db8d`](https://github.com/NixOS/nixpkgs/commit/a320db8d294eca7e14087e83677d4bf6808386f4) | `` python310Packages.griffe: 0.25.5 -> 0.26.0 ``                             |
| [`d2b00b0f`](https://github.com/NixOS/nixpkgs/commit/d2b00b0f55702aca18e65be77857adabf2c3553c) | `` python310Packages.meilisearch: 0.25.0 -> 0.26.0 ``                        |
| [`057ca085`](https://github.com/NixOS/nixpkgs/commit/057ca085321d1ccefaa4c6f4ae885ba4dba85642) | `` python310Packages.mkdocstrings-python: 0.8.3 -> 0.9.0 ``                  |
| [`22855521`](https://github.com/NixOS/nixpkgs/commit/22855521b77ede16d69bbe04d1cb7cbee578a080) | `` python310Packages.msgspec: 0.13.1 -> 0.14.0 ``                            |
| [`d10dffeb`](https://github.com/NixOS/nixpkgs/commit/d10dffebb213847cc50065a6c9701a949308e041) | `` python310Packages.python-gvm: 23.2.0 -> 23.4.0 ``                         |
| [`30d1f10b`](https://github.com/NixOS/nixpkgs/commit/30d1f10b2d4831970c0dbb1d1e5588d3dc4caa99) | `` python310Packages.shtab: 1.5.8 -> 1.6.0 ``                                |
| [`205fa27e`](https://github.com/NixOS/nixpkgs/commit/205fa27e47f81d19cda764b19544fd4ce5a887f7) | `` cdecrypt: init at 4.8 ``                                                  |
| [`3bd29fe7`](https://github.com/NixOS/nixpkgs/commit/3bd29fe7504735a7790ad2ed130890ad2c3418ca) | `` dnstwist: 20221213 -> 20230402 ``                                         |
| [`4b621009`](https://github.com/NixOS/nixpkgs/commit/4b6210095f2fc5dab6a9319c7b28a93eba5b8a4d) | `` python310Packages.xiaomi-ble: 0.16.4 -> 0.17.0 ``                         |
| [`402800cf`](https://github.com/NixOS/nixpkgs/commit/402800cf05195cc449704f28c0276aca50edd04a) | `` roon-server: 2.0-1234 -> 2.0-1244 ``                                      |
| [`8b601a11`](https://github.com/NixOS/nixpkgs/commit/8b601a118f40349c5507a0dee8366d0e32d6252c) | `` scream: optional `pcapSupport` ``                                         |
| [`4da422e2`](https://github.com/NixOS/nixpkgs/commit/4da422e269c3af48f0213689da26ac14e5f2c23d) | `` scream: fix dependencies for `jackSupport` ``                             |