### PR TITLE
chore(flake/emacs-overlay): `8d3390e6` -> `cfcf2398`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680690049,
-        "narHash": "sha256-4049xEWNBdpkF/bDV50CIVbyUp3UbweG69XJXBSTjeY=",
+        "lastModified": 1680724968,
+        "narHash": "sha256-/qVcKZnkHe7xUa/NC9gnU7m1NDg0wXUN8nwz2k+ewOc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8d3390e69f6f850f33e7b70d2c7a4b83c5f69871",
+        "rev": "cfcf2398c07242a3c3aa389cfb9efe703ad661db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`cfcf2398`](https://github.com/nix-community/emacs-overlay/commit/cfcf2398c07242a3c3aa389cfb9efe703ad661db) | `` Updated repos/melpa `` |
| [`f8d8eb4b`](https://github.com/nix-community/emacs-overlay/commit/f8d8eb4ba39c78cbf20b5142b2cb4ec7e0e58b34) | `` Updated repos/emacs `` |