### PR TITLE
chore(flake/nur): `3ceef82b` -> `3b00f4f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680700233,
-        "narHash": "sha256-Dw9LHgf1Op1RDdFrpRmedQdk68Y8TabPVKBcP8LohUQ=",
+        "lastModified": 1680733457,
+        "narHash": "sha256-f1Nauq99MkuqhmnVf8121h3fShJsAdgH6CZWwLKTiDI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3ceef82b54a96d64613181507c8a60271a5f5414",
+        "rev": "3b00f4f63c99160731ec2a6e4f55b3876b8531e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3b00f4f6`](https://github.com/nix-community/NUR/commit/3b00f4f63c99160731ec2a6e4f55b3876b8531e2) | `` automatic update `` |