### PR TITLE
chore(flake/nur): `3b00f4f6` -> `d98ef4e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680733457,
-        "narHash": "sha256-f1Nauq99MkuqhmnVf8121h3fShJsAdgH6CZWwLKTiDI=",
+        "lastModified": 1680738402,
+        "narHash": "sha256-fwZeYPmR20ma1RgDFpOjWsIYw3CZE7SQ7VZV+jDQc78=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3b00f4f63c99160731ec2a6e4f55b3876b8531e2",
+        "rev": "d98ef4e9feb536c8cf673204fe474685baec779f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d98ef4e9`](https://github.com/nix-community/NUR/commit/d98ef4e9feb536c8cf673204fe474685baec779f) | `` automatic update `` |