### PR TITLE
chore(flake/nur): `d98ef4e9` -> `fdfea01c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680738402,
-        "narHash": "sha256-fwZeYPmR20ma1RgDFpOjWsIYw3CZE7SQ7VZV+jDQc78=",
+        "lastModified": 1680746008,
+        "narHash": "sha256-CGJG7TGb7Bar5vbKvO6eEk7ISTmSwp6BK7lsOyryELc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d98ef4e9feb536c8cf673204fe474685baec779f",
+        "rev": "fdfea01c3d24e4d9bdde3d95f3f3bed0a4c9ccf1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fdfea01c`](https://github.com/nix-community/NUR/commit/fdfea01c3d24e4d9bdde3d95f3f3bed0a4c9ccf1) | `` automatic update `` |