### PR TITLE
chore(flake/nur): `fdfea01c` -> `8bad262d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680746008,
-        "narHash": "sha256-CGJG7TGb7Bar5vbKvO6eEk7ISTmSwp6BK7lsOyryELc=",
+        "lastModified": 1680752432,
+        "narHash": "sha256-9mNe7xpcRceL/aTQe9rKngRZFuJNbmqRFkNaqFXLmYg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fdfea01c3d24e4d9bdde3d95f3f3bed0a4c9ccf1",
+        "rev": "8bad262ded6036446fc492e7cd7615fa904cee30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8bad262d`](https://github.com/nix-community/NUR/commit/8bad262ded6036446fc492e7cd7615fa904cee30) | `` automatic update `` |
| [`afc4b04e`](https://github.com/nix-community/NUR/commit/afc4b04e6359956a2e7df7932d00ddaba950f58d) | `` automatic update `` |