### PR TITLE
chore(flake/nur): `8bad262d` -> `67892cbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680752432,
-        "narHash": "sha256-9mNe7xpcRceL/aTQe9rKngRZFuJNbmqRFkNaqFXLmYg=",
+        "lastModified": 1680754279,
+        "narHash": "sha256-Fg87INxT7Z9FSqKUzz+s8Uj4OlbmoLV4jdgyVY4CTuk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8bad262ded6036446fc492e7cd7615fa904cee30",
+        "rev": "67892cbc59ae24528f5a3bb3faa97c478290b76a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`67892cbc`](https://github.com/nix-community/NUR/commit/67892cbc59ae24528f5a3bb3faa97c478290b76a) | `` automatic update `` |