### PR TITLE
chore(flake/nur): `67892cbc` -> `9570cfc6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680754279,
-        "narHash": "sha256-Fg87INxT7Z9FSqKUzz+s8Uj4OlbmoLV4jdgyVY4CTuk=",
+        "lastModified": 1680758135,
+        "narHash": "sha256-gmTwQ6VHbXAfXbBgeqXZyyuEb0Hhroi8IOM/nokBOwM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "67892cbc59ae24528f5a3bb3faa97c478290b76a",
+        "rev": "9570cfc60f7ca32fdcdc4292f1e24ea5c62977bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9570cfc6`](https://github.com/nix-community/NUR/commit/9570cfc60f7ca32fdcdc4292f1e24ea5c62977bd) | `` automatic update `` |