### PR TITLE
chore(flake/nur): `322b8fab` -> `f162d471`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680764363,
-        "narHash": "sha256-eLzhhVrGrUyUVqNT45WTIuu0/ZLmXYQNVxImxhTJW3c=",
+        "lastModified": 1680765161,
+        "narHash": "sha256-VIc+SkzGuwaEpwDmveq755GAcxCSJlLrmbrrG8vm8bg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "322b8fab81cab337b4b6af272e1b30da0df99ae5",
+        "rev": "f162d471cb2b4d23f79e9bcdd0db2940ef103c64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f162d471`](https://github.com/nix-community/NUR/commit/f162d471cb2b4d23f79e9bcdd0db2940ef103c64) | `` automatic update `` |
| [`ead70882`](https://github.com/nix-community/NUR/commit/ead70882411c7fcf0e6980ca5c579e5b95c8b086) | `` automatic update `` |