### PR TITLE
chore(flake/emacs-ement): `6a372ef2` -> `27929d80`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -200,11 +200,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1680267026,
-        "narHash": "sha256-DoIVPixq/mi71oL/v1X2UifUyLB9EZkAdT99JyZW3LY=",
+        "lastModified": 1680770304,
+        "narHash": "sha256-hQ3YNmkoX/g4/JeMlCkwc1G+x9xHazMhtBmHTekSNz0=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "6a372ef28ec641a8e3663648fe1dea423c0cb2ef",
+        "rev": "27929d80ff2d9ea01b3f5ca673a9190956d06ea9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                        |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`27929d80`](https://github.com/alphapapa/ement.el/commit/27929d80ff2d9ea01b3f5ca673a9190956d06ea9) | `` Add: (ement-room-timestamp-header-align) `` |
| [`835a261c`](https://github.com/alphapapa/ement.el/commit/835a261cada1d4d9ff9b4a6f11c0d87506e1807e) | `` Meta: v0.9-pre ``                           |
| [`fc48543b`](https://github.com/alphapapa/ement.el/commit/fc48543b5396a8d24850e104f62a50cb1008b4c7) | `` Release: v0.8.2 ``                          |