### PR TITLE
chore(flake/emacs-overlay): `0a85b8e4` -> `3bf71846`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680745860,
-        "narHash": "sha256-TEmwHDRj96uMAhYIX8Ntf9kFoinpKtMB8R/uZ8xFLIw=",
+        "lastModified": 1680776402,
+        "narHash": "sha256-2NVwe1XTdBsatsD1evi2r7dvdylKOxSkn+cQxD9lwcU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0a85b8e407611de0994496dda6bce15bf280c190",
+        "rev": "3bf718469779e993ae41f0acf437e3ac42e394f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`3bf71846`](https://github.com/nix-community/emacs-overlay/commit/3bf718469779e993ae41f0acf437e3ac42e394f1) | `` Updated repos/melpa `` |
| [`976cd840`](https://github.com/nix-community/emacs-overlay/commit/976cd840f97149664bc826bbf2e3718d62fb019b) | `` Updated repos/emacs `` |