### PR TITLE
chore(flake/flake-utils): `93a2b84f` -> `411e8764`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -364,11 +364,11 @@
     },
     "flake-utils_3": {
       "locked": {
-        "lastModified": 1678901627,
-        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "lastModified": 1680776469,
+        "narHash": "sha256-3CXUDK/3q/kieWtdsYpDOBJw3Gw4Af6x+2EiSnIkNQw=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "rev": "411e8764155aa9354dbcd6d5faaeb97e9e3dce24",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                  |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`411e8764`](https://github.com/numtide/flake-utils/commit/411e8764155aa9354dbcd6d5faaeb97e9e3dce24) | `` Bump cachix/install-nix-action from 19 to 20 (#89) `` |