### PR TITLE
chore(flake/nur): `df6ed5cb` -> `42580716`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680777957,
-        "narHash": "sha256-rrZQkJq5sYihKWvWojJQ4POSDWbMgfU+HBCT+Gp9RUY=",
+        "lastModified": 1680784449,
+        "narHash": "sha256-ww+PEjkJ2U9Nw0wNehqEVYq6dLuF/byRNA27Nohw/o8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "df6ed5cb21baeb30d7d28b588e57ab11a311e572",
+        "rev": "42580716e4456e75eed992fda78ef290d53b61d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`42580716`](https://github.com/nix-community/NUR/commit/42580716e4456e75eed992fda78ef290d53b61d3) | `` automatic update `` |
| [`8b4fa8ff`](https://github.com/nix-community/NUR/commit/8b4fa8ff62146400a1bd14083864202ad99ab9d3) | `` automatic update `` |