### PR TITLE
chore(flake/nur): `42580716` -> `9c771dcf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680784449,
-        "narHash": "sha256-ww+PEjkJ2U9Nw0wNehqEVYq6dLuF/byRNA27Nohw/o8=",
+        "lastModified": 1680796037,
+        "narHash": "sha256-k6WFB09mp9Q/rkztyUMWVvtKBE/9ale9NBecygH+OcE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "42580716e4456e75eed992fda78ef290d53b61d3",
+        "rev": "9c771dcff7c88bee1ff4b8ed35a691f9045c0bd5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9c771dcf`](https://github.com/nix-community/NUR/commit/9c771dcff7c88bee1ff4b8ed35a691f9045c0bd5) | `` automatic update `` |