### PR TITLE
chore(flake/emacs-overlay): `3bf71846` -> `9b6821c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680776402,
-        "narHash": "sha256-2NVwe1XTdBsatsD1evi2r7dvdylKOxSkn+cQxD9lwcU=",
+        "lastModified": 1680805492,
+        "narHash": "sha256-Yz2yYpl/f2MnhRBgz5AAaAvFweDAhzJwqO79567JNhY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3bf718469779e993ae41f0acf437e3ac42e394f1",
+        "rev": "9b6821c510a5ab2a8358b34b9e6b8303eddc3e38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`9b6821c5`](https://github.com/nix-community/emacs-overlay/commit/9b6821c510a5ab2a8358b34b9e6b8303eddc3e38) | `` Updated repos/melpa `` |
| [`2f631af1`](https://github.com/nix-community/emacs-overlay/commit/2f631af12a169c9d4b455c6e892a1fbe9c5b8a50) | `` Updated repos/emacs `` |
| [`38a4cd63`](https://github.com/nix-community/emacs-overlay/commit/38a4cd63e3cb6e7e044cd60282093a037f1ebd09) | `` Updated repos/elpa ``  |