### PR TITLE
chore(flake/nur): `9f654a0f` -> `fae26589`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680810288,
-        "narHash": "sha256-vQZgR+y2FD/EJsKPjVg/2INkEqU42LsSkfjThXyGyLk=",
+        "lastModified": 1680832188,
+        "narHash": "sha256-9gi2oiAgTMjm9NTDeYfOxFbg6a+rxOjLtDRyCpapFTg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9f654a0fcec0276fc74fff992bdc487ac54e3e6d",
+        "rev": "fae2658993385613fe5f2570df1ef282ab4e57ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fae26589`](https://github.com/nix-community/NUR/commit/fae2658993385613fe5f2570df1ef282ab4e57ed) | `` automatic update `` |