### PR TITLE
chore(flake/emacs-overlay): `9b6821c5` -> `d092f0b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680805492,
-        "narHash": "sha256-Yz2yYpl/f2MnhRBgz5AAaAvFweDAhzJwqO79567JNhY=",
+        "lastModified": 1680837678,
+        "narHash": "sha256-/D6QX77D366TPj01S8SVv54+JCnAs8XibUSnm5dh9t0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9b6821c510a5ab2a8358b34b9e6b8303eddc3e38",
+        "rev": "d092f0b653985d6cb1d7c828ff2ac602a36b7e4e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`d092f0b6`](https://github.com/nix-community/emacs-overlay/commit/d092f0b653985d6cb1d7c828ff2ac602a36b7e4e) | `` Updated repos/melpa `` |
| [`dd270ae6`](https://github.com/nix-community/emacs-overlay/commit/dd270ae65d57737567dc6a16e16ce934b59817bf) | `` Updated repos/emacs `` |