### PR TITLE
chore(flake/nur): `7f0adfd0` -> `437b8471`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680840616,
-        "narHash": "sha256-KKlPpGBP1r/TFX/88SSWpvJfIeb+yDMZa2ckQ2MrpAQ=",
+        "lastModified": 1680849049,
+        "narHash": "sha256-IkRvwpQqY0mdoORQbB1I2o7qmiFy2yrZ5F2tnDCm6Jc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7f0adfd033677a6a820c79000e18ae74a33fd964",
+        "rev": "437b8471b2fd19c9e0a40ba463202c75bf7a65d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`437b8471`](https://github.com/nix-community/NUR/commit/437b8471b2fd19c9e0a40ba463202c75bf7a65d3) | `` automatic update `` |