### PR TITLE
chore(flake/nixpkgs): `9c8ff8b4` -> `0e19daa5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -669,11 +669,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1680669251,
-        "narHash": "sha256-AVNE+0u4HlI3v96KCXE9risH7NKqj0QDLLfSckYXIbA=",
+        "lastModified": 1680758185,
+        "narHash": "sha256-sCVWwfnk7zEX8Z+OItiH+pcSklrlsLZ4TJTtnxAYREw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9c8ff8b426a8b07b9e0a131ac3218740dc85ba1e",
+        "rev": "0e19daa510e47a40e06257e205965f3b96ce0ac9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                                                                                                  |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| [`0e19daa5`](https://github.com/NixOS/nixpkgs/commit/0e19daa510e47a40e06257e205965f3b96ce0ac9) | `` terraform-providers.spotinst: 1.108.0 -> 1.109.0 ``                                                                                                                                   |
| [`4275780f`](https://github.com/NixOS/nixpkgs/commit/4275780f5f05e0f961280cb6abf46cd9680faae2) | `` terraform-providers.oci: 4.114.0 -> 4.115.0 ``                                                                                                                                        |
| [`8258b965`](https://github.com/NixOS/nixpkgs/commit/8258b9655ff4b3a956a4e25a2a4c769a9ff04afc) | `` terraform-providers.scaleway: 2.16.0 -> 2.16.2 ``                                                                                                                                     |
| [`50d96537`](https://github.com/NixOS/nixpkgs/commit/50d96537e448ae3aa11526f412233f490d642f25) | `` terraform-providers.pagerduty: 2.11.2 -> 2.11.3 ``                                                                                                                                    |
| [`cf8385b6`](https://github.com/NixOS/nixpkgs/commit/cf8385b6d159b87ce8994c1dcb0851328901e856) | `` terraform-providers.ibm: 1.51.0 -> 1.52.0 ``                                                                                                                                          |
| [`69f7ad76`](https://github.com/NixOS/nixpkgs/commit/69f7ad76ac3f6b69a7b2316399c258b417a6f6a3) | `` terraform-providers.newrelic: 3.20.0 -> 3.20.1 ``                                                                                                                                     |
| [`71028c60`](https://github.com/NixOS/nixpkgs/commit/71028c602abec6387c11d66b0ba05e25e49eb721) | `` terraform-providers.google-beta: 4.60.0 -> 4.60.1 ``                                                                                                                                  |
| [`fb21d123`](https://github.com/NixOS/nixpkgs/commit/fb21d12350166a7f70a6cbb2cacf0563eb832e4a) | `` terraform-providers.google: 4.60.0 -> 4.60.1 ``                                                                                                                                       |
| [`0e4477c9`](https://github.com/NixOS/nixpkgs/commit/0e4477c9137032b7c195dbc280bed02b8e5ec54a) | `` python310Packages.docformatter: 1.5.1 -> 1.6.0 ``                                                                                                                                     |
| [`f6e6b942`](https://github.com/NixOS/nixpkgs/commit/f6e6b942e345c7e373c1997247ac5abde97b190f) | `` libdeltachat: 1.112.5 -> 1.112.6 ``                                                                                                                                                   |
| [`bc0e5c12`](https://github.com/NixOS/nixpkgs/commit/bc0e5c1205626614288a9187b854ec93982afbc2) | `` poetry2nix: 1.40.1 -> 1.41.0 ``                                                                                                                                                       |
| [`dbad09df`](https://github.com/NixOS/nixpkgs/commit/dbad09df4491a3d3c093f6d7af204ea1c992c301) | `` vscode: 1.77.0 -> 1.77.1 ``                                                                                                                                                           |
| [`96e569cb`](https://github.com/NixOS/nixpkgs/commit/96e569cb29daa8dbcec62d4c6f947d40fd4a8a76) | `` citra: nightly 1765 -> 1873, canary 2146 -> 2440 (#224337) ``                                                                                                                         |
| [`3e6210d2`](https://github.com/NixOS/nixpkgs/commit/3e6210d2a5aa6cb3a100604c69df25deb583c06f) | `` firefox: take makeBinaryWrapper from buildPackages ``                                                                                                                                 |
| [`14604986`](https://github.com/NixOS/nixpkgs/commit/14604986ad7794de7f82b9620600214555a42a4a) | `` linux-kernels: linux_mptcp_95 was deprecated in aliases.nix and does not exist in packages anymore. While attribute-missing-errors are aborting, throw can be caught with tryEval. `` |
| [`476fde08`](https://github.com/NixOS/nixpkgs/commit/476fde08afe6fe0541d35b0a564200079209bf03) | `` default-crate-overrides.nix: prost-build needs protobuf ``                                                                                                                            |
| [`6b615f3c`](https://github.com/NixOS/nixpkgs/commit/6b615f3ca5d133ef62b48bfb7ce14f79a6945ee4) | `` evcc: 0.114.1 -> 0.115.0 ``                                                                                                                                                           |
| [`1e67c00b`](https://github.com/NixOS/nixpkgs/commit/1e67c00b61d8f4098b25a13377ba0f055b6a0620) | `` enumer: 1.5.7 -> 1.5.8 ``                                                                                                                                                             |
| [`88ea1aca`](https://github.com/NixOS/nixpkgs/commit/88ea1acabef8a95da8bfdb314d75830aff8cadfa) | `` python310Packages.spacy-transformers: relax deps ``                                                                                                                                   |
| [`da6f3042`](https://github.com/NixOS/nixpkgs/commit/da6f3042c97a353b01d26947178dc282c405f383) | `` blender: add aarch64-linux support (#224771) ``                                                                                                                                       |
| [`2bb1ae36`](https://github.com/NixOS/nixpkgs/commit/2bb1ae361f89f0a13fd66a66b322e791d17d5c88) | `` python310Packages.nitime: minor maintenance ``                                                                                                                                        |
| [`644fbbe0`](https://github.com/NixOS/nixpkgs/commit/644fbbe01f592cad1a5ade1f0dd561dfb06a3b4a) | `` python310Packages.aiounifi: 44 -> 45 ``                                                                                                                                               |
| [`6817b72c`](https://github.com/NixOS/nixpkgs/commit/6817b72ca3cdb8e5edd9ff84a1dc549de1c683f3) | `` lisp-modules: set maintainers to the lisp team ``                                                                                                                                     |
| [`8c5b8838`](https://github.com/NixOS/nixpkgs/commit/8c5b8838e693b16e0337a630ae419ce468bf7f25) | `` adguardhome: 0.107.26 -> 0.107.27 ``                                                                                                                                                  |
| [`7fa28593`](https://github.com/NixOS/nixpkgs/commit/7fa285932c9b17ab27677b8bbcad432cc2c9ff44) | `` clasp-common-lisp: set correct platforms ``                                                                                                                                           |
| [`af4d85ba`](https://github.com/NixOS/nixpkgs/commit/af4d85ba89438a88d69e41729222ef427f051623) | `` mtools: 4.0.42 -> 4.0.43 ``                                                                                                                                                           |
| [`dbd2e951`](https://github.com/NixOS/nixpkgs/commit/dbd2e9514884e88772da40fb3dcf46be65db5a6f) | `` mtools: add update script ``                                                                                                                                                          |
| [`01051d8e`](https://github.com/NixOS/nixpkgs/commit/01051d8eb6f5396f3c9e0819b7dc0a6c21e2a3a4) | `` fheroes2: include desktop entry ``                                                                                                                                                    |
| [`44b62979`](https://github.com/NixOS/nixpkgs/commit/44b62979c7406c313bdbef249e0e53d05a7fac13) | `` lisp-modules: reduce number of packages build on Hydra ``                                                                                                                             |
| [`cc2a49fc`](https://github.com/NixOS/nixpkgs/commit/cc2a49fc3afd31666d9b11842adcc1fb1b4fbe16) | `` crispyDoom: 5.12.0 -> 6.0 ``                                                                                                                                                          |
| [`d179bf5a`](https://github.com/NixOS/nixpkgs/commit/d179bf5a96a57a68dcca548c992b5e9b5ee5818f) | `` gptfdisk: Backport upstream fix for popt 1.19 ``                                                                                                                                      |
| [`9de75c8b`](https://github.com/NixOS/nixpkgs/commit/9de75c8bbead82764554823312182307d014f1d2) | `` nixos/smokeping: use /etc/smokeping.conf ``                                                                                                                                           |
| [`3d6ae762`](https://github.com/NixOS/nixpkgs/commit/3d6ae762e772ee84d801bb7e58f6e34c27d91505) | `` snes9x-gtk: 1.62.1 -> 1.62.3 ``                                                                                                                                                       |
| [`bcf7befe`](https://github.com/NixOS/nixpkgs/commit/bcf7befedfe5f7509a50e581531b6185b7aa52a0) | `` lispPackages: dont recurse into attrs ``                                                                                                                                              |
| [`c5a3aeba`](https://github.com/NixOS/nixpkgs/commit/c5a3aeba6fe5bd254334aa3119902d7c2487b110) | `` bilibili: init at 1.9.2-1 ``                                                                                                                                                          |
| [`2ce47167`](https://github.com/NixOS/nixpkgs/commit/2ce47167bc264eb598a0cd03848603a73d6b8b07) | `` maintainers: add jedsek ``                                                                                                                                                            |
| [`d7eabb37`](https://github.com/NixOS/nixpkgs/commit/d7eabb378151db123706a24b170d7e783b35f80a) | `` gcc-arm-embedded: add myself to maintainers ``                                                                                                                                        |
| [`7fae5a80`](https://github.com/NixOS/nixpkgs/commit/7fae5a802b4aac751c41a404c44c9f550e8bfe5c) | `` gcc-arm-embedded: fix arm-none-eabi-gdb error ``                                                                                                                                      |
| [`2b8d42a7`](https://github.com/NixOS/nixpkgs/commit/2b8d42a720c016426c52500701d10b0930d215c7) | `` uptime-kuma: 1.20.0 -> 1.21.2 ``                                                                                                                                                      |
| [`2e601f71`](https://github.com/NixOS/nixpkgs/commit/2e601f71d7debe7814971efac7dbab725a7b072d) | `` brlcad: init at 7.34.0 ``                                                                                                                                                             |
| [`7116dd2f`](https://github.com/NixOS/nixpkgs/commit/7116dd2fe7957ea40f58ec904563d08922876ccc) | `` linja-sike: init at 5.0 (#194819) ``                                                                                                                                                  |
| [`68618ee1`](https://github.com/NixOS/nixpkgs/commit/68618ee152faf3badf3a581b773caaf36f369fff) | `` linux_xanmod: 6.2.7 -> 6.2.9 ``                                                                                                                                                       |
| [`dd24376b`](https://github.com/NixOS/nixpkgs/commit/dd24376b8529b2577aaead35a1e3dd2f9e52be4b) | `` linux_xanmod: 6.1.20 -> 6.1.22 ``                                                                                                                                                     |
| [`1ee2c5c9`](https://github.com/NixOS/nixpkgs/commit/1ee2c5c9ebf564f88d6bbc26bd8d2dd376106b6a) | `` buildBazelPackage: allow buildAttrs and fetchAttrs to override inherited attrs ``                                                                                                     |
| [`0e681fb6`](https://github.com/NixOS/nixpkgs/commit/0e681fb60086300ee42b76df4e53be3e45fa9ba0) | `` matrix-hookshot: 3.0.1 -> 3.2.0 ``                                                                                                                                                    |
| [`27f407b4`](https://github.com/NixOS/nixpkgs/commit/27f407b4bbaf29a3c5b9daa0a69f01bb9659e74c) | `` tracee: 0.11.0 -> 0.13.0 ``                                                                                                                                                           |
| [`ce7730aa`](https://github.com/NixOS/nixpkgs/commit/ce7730aa87b97b1ee92c7651de420bd293c0e32e) | `` mastodon: 4.1.1 -> 4.1.2 ``                                                                                                                                                           |
| [`5804b7fb`](https://github.com/NixOS/nixpkgs/commit/5804b7fb5fa07ac9b3720a19aa207edfb1521133) | `` vscodium: 1.76.2.23074 -> 1.77.0.23093 ``                                                                                                                                             |
| [`134c32d7`](https://github.com/NixOS/nixpkgs/commit/134c32d770297081d2dcde06c2a6a4deafc87c00) | `` gnome.eog: unbreak on darwin ``                                                                                                                                                       |
| [`89911c1b`](https://github.com/NixOS/nixpkgs/commit/89911c1b6d0a579a5b90f304523b0c064eeaea07) | `` viceroy: 0.4.1 -> 0.4.2 ``                                                                                                                                                            |
| [`19b62c5b`](https://github.com/NixOS/nixpkgs/commit/19b62c5b4b93203bb356664ed02dcfb17df69e05) | `` unciv: 4.5.13 -> 4.5.15 ``                                                                                                                                                            |
| [`ca6c0e3b`](https://github.com/NixOS/nixpkgs/commit/ca6c0e3b87ebea84009a9bf8e3882e95c7ad1326) | `` darwin: recurseIntoAttrs ``                                                                                                                                                           |
| [`325cb4e4`](https://github.com/NixOS/nixpkgs/commit/325cb4e48350e5129facdb2de34c1f111fff28b0) | `` jcli: 0.0.41 -> 0.0.42 ``                                                                                                                                                             |
| [`92376558`](https://github.com/NixOS/nixpkgs/commit/92376558f6837bd05834bfdaaa747574c3c99069) | `` python310Packages.pygmt: equalize ``                                                                                                                                                  |
| [`4fc52a4a`](https://github.com/NixOS/nixpkgs/commit/4fc52a4ab92bd25dba2ea0fa26a0974fc91bcd06) | `` python310Packages.pygmt: update disabled ``                                                                                                                                           |
| [`3ac2acfe`](https://github.com/NixOS/nixpkgs/commit/3ac2acfe88c35d9b063b400f5114af0d136b06ad) | `` python310Packages.pygmt: add changelog to meta ``                                                                                                                                     |
| [`3bd7ee3b`](https://github.com/NixOS/nixpkgs/commit/3bd7ee3b835bd075fe74fcc94711c0ad0eaf1e24) | `` python310Packages.appthreat-vulnerability-db: 5.0.1 -> 5.0.3 ``                                                                                                                       |
| [`f80bf9ab`](https://github.com/NixOS/nixpkgs/commit/f80bf9ab05b5abb4f0664ae53720396afabc2560) | `` ocamlPackages.qcheck: fix for OCaml ≥ 5.0 ``                                                                                                                                          |
| [`eee0652b`](https://github.com/NixOS/nixpkgs/commit/eee0652b6b558cec01d7fb1490f4a520f08c246f) | `` ocamlPackages.pratter: use Dune 3 ``                                                                                                                                                  |
| [`543d5310`](https://github.com/NixOS/nixpkgs/commit/543d53100e992fc6f894b2dc5d06ec65734f3be4) | `` ocamlPackages.iter: use Dune 3 ``                                                                                                                                                     |
| [`1c09f02c`](https://github.com/NixOS/nixpkgs/commit/1c09f02cc679cbab38c15f29ed235b00668586b1) | `` ocamlPackages.syslog-message: use Dune 3 ``                                                                                                                                           |
| [`8787829c`](https://github.com/NixOS/nixpkgs/commit/8787829c48a602a239182c0a4d0510109579fd47) | `` ocamlPackages.qtest: use Dune 3 ``                                                                                                                                                    |
| [`7979b4c7`](https://github.com/NixOS/nixpkgs/commit/7979b4c793ab5b93d5910ed877dde3ac731cb8be) | `` ocamlPackages.stringext: use Dune 3 ``                                                                                                                                                |
| [`cdf5720a`](https://github.com/NixOS/nixpkgs/commit/cdf5720ae27e3165412b62886b12d012cbd692ae) | `` ocamlPackages.uri: use Dune 3 ``                                                                                                                                                      |
| [`9100134b`](https://github.com/NixOS/nixpkgs/commit/9100134ba9902515c6d26f8ac03f1605e29fa405) | `` ocamlPackages.caqti: use Dune 3 ``                                                                                                                                                    |
| [`b6bc7b2d`](https://github.com/NixOS/nixpkgs/commit/b6bc7b2d79385520ddc70b118b902f5bb9da1667) | `` python310Packages.nitime: 0.9 -> 0.10.1 ``                                                                                                                                            |
| [`ed6a9ec8`](https://github.com/NixOS/nixpkgs/commit/ed6a9ec8fee0e8b94a0058637f3bbb9560fa9da6) | `` vifm: 0.12.1 -> 0.13 ``                                                                                                                                                               |
| [`20044799`](https://github.com/NixOS/nixpkgs/commit/20044799c06374ef1e16139940bd3b145496b4bc) | `` bundix: 2.5.1 -> 2.5.2 ``                                                                                                                                                             |
| [`f3e62ad4`](https://github.com/NixOS/nixpkgs/commit/f3e62ad4e426c676896fe091cefac2ba793dc809) | `` maintainers/teams: set githubTeams for rust ``                                                                                                                                        |
| [`64a9e244`](https://github.com/NixOS/nixpkgs/commit/64a9e244cddffad3151ad7e2e4c98ea840c933fd) | `` maintainers/teams: set githubTeams for golang ``                                                                                                                                      |
| [`533016a5`](https://github.com/NixOS/nixpkgs/commit/533016a5faf71ed0a388b7c53d9c92c95e01defa) | `` python310Packages.db-dtypes: 1.0.5 -> 1.1.1 ``                                                                                                                                        |
| [`3f6146e5`](https://github.com/NixOS/nixpkgs/commit/3f6146e5ca9e7dcd1f83c4140a9298d50b5cdf07) | `` ocamlPackages.rdbg: 1.196.12 → 1.199.0 ``                                                                                                                                             |
| [`6693a96f`](https://github.com/NixOS/nixpkgs/commit/6693a96f339ee0ca31348d92759c32dc1e16ae5d) | `` opentelemetry-collector: 0.71.0 -> 0.74.0 ``                                                                                                                                          |
| [`17af0c2e`](https://github.com/NixOS/nixpkgs/commit/17af0c2ea3e70c04d4cbfd601b25afa51e96733a) | `` media-downloader: 2.9.0 -> 3.1.0 ``                                                                                                                                                   |
| [`563f4ede`](https://github.com/NixOS/nixpkgs/commit/563f4edea598063b874489688a6c885c6f4567ce) | `` scalr-cli: 0.14.5 -> 0.15.1 ``                                                                                                                                                        |
| [`440b4de5`](https://github.com/NixOS/nixpkgs/commit/440b4de588d950e7fcf7add3b049fb209f097367) | `` buildBazelPackage: support multiple targets ``                                                                                                                                        |
| [`6cfe7a88`](https://github.com/NixOS/nixpkgs/commit/6cfe7a889f9cd2d207c7ea4e468db89a5b241ca9) | `` otpclient: 3.1.5 -> 3.1.6 ``                                                                                                                                                          |
| [`03dc88e1`](https://github.com/NixOS/nixpkgs/commit/03dc88e1f9860c638721bd38ee1879d803046e68) | `` ruff: 0.0.260 -> 0.0.261 ``                                                                                                                                                           |
| [`f8e7efd9`](https://github.com/NixOS/nixpkgs/commit/f8e7efd9745c2146e7844428a747e05d8bbde77f) | `` python310Packages.docstring-to-markdown: 0.11 -> 0.12 ``                                                                                                                              |
| [`ad890a81`](https://github.com/NixOS/nixpkgs/commit/ad890a81d7236e0de151ef90a153eff8d2c166bf) | `` vimPlugins.nvim-treesitter: update grammars ``                                                                                                                                        |
| [`31de9b13`](https://github.com/NixOS/nixpkgs/commit/31de9b134e5abd7955b787550a7aba66dac8e6d4) | `` vimPlugins.telescope-zf-native-nvim: init at 2023-03-15 ``                                                                                                                            |
| [`bad81075`](https://github.com/NixOS/nixpkgs/commit/bad81075ea8f345b6d51af181b05aca9c0e2f387) | `` vimPlugins: resolve github repository redirects ``                                                                                                                                    |
| [`4a9463d5`](https://github.com/NixOS/nixpkgs/commit/4a9463d51ccd7e21eecf80316481ed2fff2ae9b0) | `` pantheon.elementary-terminal: 6.1.1 -> 6.1.2 ``                                                                                                                                       |
| [`16c33c9c`](https://github.com/NixOS/nixpkgs/commit/16c33c9c991eacf3bd265aa3f274cefae50cb289) | `` vimPlugins: update ``                                                                                                                                                                 |
| [`3296a5dc`](https://github.com/NixOS/nixpkgs/commit/3296a5dc5fdf39886669b31b60c91160751458b6) | `` pantheon.sideload: 6.1.0 -> 6.2.0 ``                                                                                                                                                  |
| [`d96029d5`](https://github.com/NixOS/nixpkgs/commit/d96029d5b5b0661c3389dacd4cce4adf82d141f7) | `` pantheon.switchboard-plug-onlineaccounts: 6.5.1 -> 6.5.2 ``                                                                                                                           |
| [`fb85a157`](https://github.com/NixOS/nixpkgs/commit/fb85a157c63dad94f8d3b5702119498b99ededb8) | `` pantheon.gala: 7.0.1 -> 7.0.2 ``                                                                                                                                                      |
| [`3095200a`](https://github.com/NixOS/nixpkgs/commit/3095200a3efae7967df0bc331e4df1112df3d325) | `` python310Packages.pygmt: 0.8.0 -> 0.9.0 ``                                                                                                                                            |
| [`f42b9fd7`](https://github.com/NixOS/nixpkgs/commit/f42b9fd74544bfcbabef8a8efd8ea388741cff0e) | `` maintainers/scripts/update.nix: Remove unicode from message and comply with CONTRIBUTING.md ``                                                                                        |
| [`8059809f`](https://github.com/NixOS/nixpkgs/commit/8059809feae52730f2c6bbf652666330e5ec91ae) | `` typst: 23-03-28 -> 0.1 ``                                                                                                                                                             |
| [`b830360c`](https://github.com/NixOS/nixpkgs/commit/b830360c9fa98d578c34fcf7b711f8babe21df77) | `` chromium: 111.0.5563.146 -> 112.0.5615.49 ``                                                                                                                                          |
| [`88297afc`](https://github.com/NixOS/nixpkgs/commit/88297afce09af0563c583dcb48a452336ebaf6a8) | `` chromiumDev: 113.0.5672.12 -> 113.0.5672.24 ``                                                                                                                                        |
| [`1d187379`](https://github.com/NixOS/nixpkgs/commit/1d18737910491b629b6912b3af094eaae305b661) | `` python310Packages.mwdblib: add changelog to meta ``                                                                                                                                   |
| [`c5012f14`](https://github.com/NixOS/nixpkgs/commit/c5012f145ae48bd3e49418b6332ccacf2cafbc22) | `` python310Packages.mwdblib: 4.3.1 -> 4.4.0 ``                                                                                                                                          |
| [`ec8cbfef`](https://github.com/NixOS/nixpkgs/commit/ec8cbfef443f1bfc9868f8039eefc259133b4aec) | `` grype: 0.60.0 -> 0.61.0 ``                                                                                                                                                            |
| [`44b291cb`](https://github.com/NixOS/nixpkgs/commit/44b291cbec8864062869cb14d2bb27d1e6a891b3) | `` python310Packages.angr: 9.2.44 -> 9.2.45 ``                                                                                                                                           |
| [`18f154b2`](https://github.com/NixOS/nixpkgs/commit/18f154b27d737a0159920b9bdf4b555c05275177) | `` python310Packages.cle: 9.2.44 -> 9.2.45 ``                                                                                                                                            |
| [`7b62888f`](https://github.com/NixOS/nixpkgs/commit/7b62888f814cabb2e663b5c35092c497e83bef23) | `` python310Packages.claripy: 9.2.44 -> 9.2.45 ``                                                                                                                                        |
| [`69b9de33`](https://github.com/NixOS/nixpkgs/commit/69b9de334d88a6e3c33f78cb3d4568d0399da988) | `` python310Packages.pyvex: 9.2.44 -> 9.2.45 ``                                                                                                                                          |
| [`591ba97f`](https://github.com/NixOS/nixpkgs/commit/591ba97f6584c91bf2487bde139d07c2b2372a73) | `` python310Packages.ailment: 9.2.44 -> 9.2.45 ``                                                                                                                                        |
| [`e91de945`](https://github.com/NixOS/nixpkgs/commit/e91de945b92910665bd8a25884cc73dc0f67c59c) | `` python310Packages.archinfo: 9.2.44 -> 9.2.45 ``                                                                                                                                       |
| [`162ca510`](https://github.com/NixOS/nixpkgs/commit/162ca510540b7b1a599ae0ef88d45c32a8f45b8d) | `` scraper: 0.15.0 -> 0.16.0 ``                                                                                                                                                          |
| [`3ec7b3b9`](https://github.com/NixOS/nixpkgs/commit/3ec7b3b91f7854bed5490c969a234c11b82a27fd) | `` python310Packages.notus-scanner: unstable-2021-09-05 -> 22.4.5 ``                                                                                                                     |
| [`947007c1`](https://github.com/NixOS/nixpkgs/commit/947007c1c4b81e3a4649956982fa6ca646a5f2b1) | `` sentry-native: 0.6.0 -> 0.6.1 ``                                                                                                                                                      |
| [`81ce33c7`](https://github.com/NixOS/nixpkgs/commit/81ce33c7ed921ddfa4d6a1f8afdaee72aa58fba3) | `` sniffnet: 1.1.2 -> 1.1.3 ``                                                                                                                                                           |
| [`8b663f50`](https://github.com/NixOS/nixpkgs/commit/8b663f501c328bd8eb03f5177a60d18695d80c9b) | `` cinny-desktop: update license (mit -> agpl3Only) ``                                                                                                                                   |
| [`cc758eea`](https://github.com/NixOS/nixpkgs/commit/cc758eea86da2fd6167578034ebf0ba0e8cb7762) | `` cinny-desktop: 2.2.4 -> 2.2.6 ``                                                                                                                                                      |
| [`ca0335c0`](https://github.com/NixOS/nixpkgs/commit/ca0335c064e5cc5fd643be34e427c297da91f75a) | `` chickenPackages_5: Remove ocaml dependency, switch to TOML ``                                                                                                                         |
| [`3545373f`](https://github.com/NixOS/nixpkgs/commit/3545373f306600c20874ccb8d4c79071e0aec6f8) | `` maintainers: add konst-aa ``                                                                                                                                                          |
| [`d02bedbe`](https://github.com/NixOS/nixpkgs/commit/d02bedbe289de759c86ebed542dbe4e175e2b987) | `` chickenPackages_5: overhaul ecosystem ``                                                                                                                                              |
| [`bf48945e`](https://github.com/NixOS/nixpkgs/commit/bf48945e2ea30233f075854d960b748b70b26847) | `` ttdl: 3.7.0 -> 3.7.1 ``                                                                                                                                                               |
| [`f5f4a50d`](https://github.com/NixOS/nixpkgs/commit/f5f4a50de5e55a84c1b353b92c4c46aeb0bd5288) | `` libcef: remove i686-linux from platforms ``                                                                                                                                           |
| [`85977002`](https://github.com/NixOS/nixpkgs/commit/8597700299b29e28944dcf8e25e142abe6a62b27) | `` rml: use prefixKey ``                                                                                                                                                                 |
| [`47c38620`](https://github.com/NixOS/nixpkgs/commit/47c386205d2cbebb6f6b2b4874a7bdc4a589e4ef) | `` restinio: refactor ``                                                                                                                                                                 |
| [`6dcb25a0`](https://github.com/NixOS/nixpkgs/commit/6dcb25a078b70db9e88f5e4ada8bdb1784d4bc20) | `` license-scanner: init at 0.10.0 ``                                                                                                                                                    |
| [`47428f1a`](https://github.com/NixOS/nixpkgs/commit/47428f1a16d4c35ab712c67529110412ca97a556) | `` mediawiki: Expose test variants individually ``                                                                                                                                       |
| [`bfdf33d1`](https://github.com/NixOS/nixpkgs/commit/bfdf33d13e467d524d96aa3b6e0211b34ac81e25) | `` qownnotes: 23.2.4 -> 23.4.0 ``                                                                                                                                                        |
| [`04e8e101`](https://github.com/NixOS/nixpkgs/commit/04e8e1010434c02f59dbf5be5ec35764c5fa8ed7) | `` mediawiki: 1.39.2 -> 1.39.3 ``                                                                                                                                                        |
| [`e965c5cc`](https://github.com/NixOS/nixpkgs/commit/e965c5cc5f9b6d39f118f939fe8fa7024178a621) | `` netbox_3_3: 3.3.9 -> 3.3.10 ``                                                                                                                                                        |
| [`03497d4a`](https://github.com/NixOS/nixpkgs/commit/03497d4ab4c6dc383130d83ba5a469f58379692b) | `` netbox: introduce common function for generic packages, mark 3.3.9 EOL ``                                                                                                             |
| [`c1081bf2`](https://github.com/NixOS/nixpkgs/commit/c1081bf20b18c1e004ca063dba108cfd824c7da1) | `` netbox: 3.4.6 -> 3.4.7 ``                                                                                                                                                             |
| [`78eb4d64`](https://github.com/NixOS/nixpkgs/commit/78eb4d64e70b95389670f24d8b00631db00653b3) | `` netbox_3_3: init ``                                                                                                                                                                   |
| [`6e054138`](https://github.com/NixOS/nixpkgs/commit/6e054138b05670b2285ec815be44ef683e9bc1da) | `` netbox: 3.4.5 -> 3.4.6 ``                                                                                                                                                             |
| [`8dbfb9e2`](https://github.com/NixOS/nixpkgs/commit/8dbfb9e263b80ac3ca83896a2305a0e5f82ece5c) | `` netbox: 3.4.3 -> 3.4.5 ``                                                                                                                                                             |
| [`eeb17fca`](https://github.com/NixOS/nixpkgs/commit/eeb17fca1c436efbf05609f0050a868e737dca6b) | `` netbox: 3.4.2 -> 3.4.3 ``                                                                                                                                                             |
| [`52f3031f`](https://github.com/NixOS/nixpkgs/commit/52f3031f23ee770c986307ce0577c7feb5812474) | `` netbox: 3.4.1 -> 3.4.2 ``                                                                                                                                                             |
| [`70e95c69`](https://github.com/NixOS/nixpkgs/commit/70e95c699a21cfa453441fbe939672d50a4926aa) | `` nixos/doc: add release notes for NetBox changes ``                                                                                                                                    |
| [`94976398`](https://github.com/NixOS/nixpkgs/commit/949763988a53fa6155087c436eaf295495b1105a) | `` nixos/tests/netbox: test through proxy, REST API, GraphQL, LDAP integration ``                                                                                                        |
| [`36a550c6`](https://github.com/NixOS/nixpkgs/commit/36a550c6f9fd5b7a2300c3b9d4d1b698858fe18d) | `` nixos/netbox: RFC42-style options ``                                                                                                                                                  |
| [`2cb6dc90`](https://github.com/NixOS/nixpkgs/commit/2cb6dc90acfa16a37c055f6786de06a031f12326) | `` formats.pythonVars: init ``                                                                                                                                                           |
| [`bc4b08ac`](https://github.com/NixOS/nixpkgs/commit/bc4b08acbe7f40ecdf0cabb90d8833092e6c233d) | `` netbox: 3.3.9 -> 3.4.1 ``                                                                                                                                                             |
| [`9e104018`](https://github.com/NixOS/nixpkgs/commit/9e1040188af5d54a2e6e1f17cfa899535bcdd774) | `` ngtcp2-gnutls: 0.13.0 -> 0.13.1 ``                                                                                                                                                    |
| [`2a36db55`](https://github.com/NixOS/nixpkgs/commit/2a36db554b1fa7ceaf273a02cb11ed5fde49eaf0) | `` knot-dns: 3.2.5 -> 3.2.6 ``                                                                                                                                                           |
| [`d8548211`](https://github.com/NixOS/nixpkgs/commit/d85482117b5d91de773afee13219ecc0b91ffb0e) | `` vitess: 16.0.0 -> 16.0.1 ``                                                                                                                                                           |
| [`36aa2c86`](https://github.com/NixOS/nixpkgs/commit/36aa2c864bbb0a641f5cdcfcb780dbe5d7854722) | `` faudio: 23.03 -> 23.04 ``                                                                                                                                                             |
| [`a6028bae`](https://github.com/NixOS/nixpkgs/commit/a6028bae0341b528c805651e864d1b9394ddde9a) | `` netbird: 0.14.4 -> 0.14.6 ``                                                                                                                                                          |
| [`1e54b37c`](https://github.com/NixOS/nixpkgs/commit/1e54b37c8d88b6edd543177a895cb01a241c734a) | `` wasabiwallet: 2.0.2.2 -> 2.0.3 ``                                                                                                                                                     |
| [`6789f0bb`](https://github.com/NixOS/nixpkgs/commit/6789f0bb62dd744d456dbb47f2878b7d5e75a630) | `` pritunl-client: 1.3.3477.58 -> 1.3.3484.2 ``                                                                                                                                          |
| [`471ca583`](https://github.com/NixOS/nixpkgs/commit/471ca58383dd662cb90e85ab51ea559a7b93fba6) | `` minizinc: 2.7.0 -> 2.7.1 ``                                                                                                                                                           |
| [`c28cde3a`](https://github.com/NixOS/nixpkgs/commit/c28cde3aacc920375e86adcc40d75dfb0e5c9d78) | `` zigbee2mqtt: 1.30.2 -> 1.30.3 ``                                                                                                                                                      |
| [`b033a361`](https://github.com/NixOS/nixpkgs/commit/b033a3614995a2f140c7e3dc7e1c338eb2fed95c) | `` valent: unstable-2023-03-02 -> unstable-2023-03-31 ``                                                                                                                                 |
| [`824c9ac5`](https://github.com/NixOS/nixpkgs/commit/824c9ac5c977ed67c20b9fae7e16c50d124dd55c) | `` nix-prefetch-docker: handle overrides correctly ``                                                                                                                                    |
| [`e505ffd2`](https://github.com/NixOS/nixpkgs/commit/e505ffd2512844f36da45bb129555f831e34fe58) | `` llvmPackages_git: apply #190936 (fix pkgsStatic LLVM build) ``                                                                                                                        |
| [`55fae22f`](https://github.com/NixOS/nixpkgs/commit/55fae22f98c2fa0d83cf773045fc0452f705e1d4) | `` osi: Change license to epl20 ``                                                                                                                                                       |
| [`eae93980`](https://github.com/NixOS/nixpkgs/commit/eae9398010a6fd99971cd8047538186b8c0f3276) | `` clp: Change license to epl20 ``                                                                                                                                                       |
| [`788c8a63`](https://github.com/NixOS/nixpkgs/commit/788c8a630a3bb67da70e4a6b6cec3db212495727) | `` deepin.util-dfm: init at 1.2.7 ``                                                                                                                                                     |
| [`aa945d4c`](https://github.com/NixOS/nixpkgs/commit/aa945d4c2264f88323bc03d3af102d668e7b73cd) | `` wakapi: 2.6.2 -> 2.7.0 ``                                                                                                                                                             |
| [`3524ecfe`](https://github.com/NixOS/nixpkgs/commit/3524ecfed257fa1e70cfcc5349dd74df91b13866) | `` d2: 0.2.6 -> 0.3.0 ``                                                                                                                                                                 |
| [`eb16b4ff`](https://github.com/NixOS/nixpkgs/commit/eb16b4ff4b64c361f28af9bee6ecfae91d20727a) | `` arkade: 0.9.5 -> 0.9.6 ``                                                                                                                                                             |
| [`a0405f0a`](https://github.com/NixOS/nixpkgs/commit/a0405f0aa64994236abdf558ba7739df9dbe2391) | `` teleport: 12.1.0 -> 12.1.5 ``                                                                                                                                                         |