### PR TITLE
chore(flake/pre-commit-hooks): `d8480d44` -> `a6a5e1fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1680796877,
-        "narHash": "sha256-2Cep1iSIM1H+BJYp792YAPWedTAnmrYTIVPhnPPDaCY=",
+        "lastModified": 1680865110,
+        "narHash": "sha256-SOBuUZe+icM5zqeEBGRY/fM6BDanEySw4Ph9TQgC3MY=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "d8480d44ffd2e1b5440a3cf74ce6fb299557e9a0",
+        "rev": "a6a5e1fa5327a8809c51bc6c69407b8a76f1a4ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
| [`e08722ae`](https://github.com/cachix/pre-commit-hooks.nix/commit/e08722ae02335f3ef562246e021742825c4f66b8) | `` gptcommit: Improve error when package is missing `` |
| [`9c4ab9dd`](https://github.com/cachix/pre-commit-hooks.nix/commit/9c4ab9ddbd514ef86abe04129ca643e6c15e7c9a) | `` Remove unnecessary optionalAttrs in gptcommit ``    |