### PR TITLE
chore(flake/nur): `35b3f7bb` -> `0949e356`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680864467,
-        "narHash": "sha256-md53Tkod2wp2QbXJEUYbq2I8Y6pJ43g+v6ymt3RbWyY=",
+        "lastModified": 1680868117,
+        "narHash": "sha256-EeVz0fGF8PqVhVbdTAY39OQi0BoeRR8nFdXB2RdiFdM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "35b3f7bbb4d343183aa37af9728be9dfcd023adc",
+        "rev": "0949e3562b60fccecd71e936bc281272c8f50e7e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0949e356`](https://github.com/nix-community/NUR/commit/0949e3562b60fccecd71e936bc281272c8f50e7e) | `` automatic update `` |