### PR TITLE
chore(flake/nur): `0949e356` -> `88dfb2d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680868117,
-        "narHash": "sha256-EeVz0fGF8PqVhVbdTAY39OQi0BoeRR8nFdXB2RdiFdM=",
+        "lastModified": 1680869916,
+        "narHash": "sha256-i0I51VBl/ysHBKiCwRZ7fMRPM4FCGBOdSJXsHG6NuQE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0949e3562b60fccecd71e936bc281272c8f50e7e",
+        "rev": "88dfb2d4c01fd31f83118fd4a3416181c173b893",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`88dfb2d4`](https://github.com/nix-community/NUR/commit/88dfb2d4c01fd31f83118fd4a3416181c173b893) | `` automatic update `` |