### PR TITLE
chore(flake/nur): `88dfb2d4` -> `e3157bf0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680869916,
-        "narHash": "sha256-i0I51VBl/ysHBKiCwRZ7fMRPM4FCGBOdSJXsHG6NuQE=",
+        "lastModified": 1680878697,
+        "narHash": "sha256-CKdUnm3Nuh0rWLXq9p/FHTop7SkYOO+4XRgRGumxc0M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "88dfb2d4c01fd31f83118fd4a3416181c173b893",
+        "rev": "e3157bf0c8429092a4b84e45504ed8e3efb3a8d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e3157bf0`](https://github.com/nix-community/NUR/commit/e3157bf0c8429092a4b84e45504ed8e3efb3a8d3) | `` automatic update `` |
| [`271a010b`](https://github.com/nix-community/NUR/commit/271a010baf081a16744c7fc8833db56a5ce36264) | `` automatic update `` |