### PR TITLE
chore(flake/nur): `e3157bf0` -> `ab6300a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680878697,
-        "narHash": "sha256-CKdUnm3Nuh0rWLXq9p/FHTop7SkYOO+4XRgRGumxc0M=",
+        "lastModified": 1680885954,
+        "narHash": "sha256-J8muXOoFQe3dfeyf4hVY3VIAXOCuL5h3C+NzMif6wLs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e3157bf0c8429092a4b84e45504ed8e3efb3a8d3",
+        "rev": "ab6300a55a492abcfb23cb2dc3d3adc299f1d950",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ab6300a5`](https://github.com/nix-community/NUR/commit/ab6300a55a492abcfb23cb2dc3d3adc299f1d950) | `` automatic update `` |