### PR TITLE
chore(flake/nur): `ab6300a5` -> `5ca63e86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680885954,
-        "narHash": "sha256-J8muXOoFQe3dfeyf4hVY3VIAXOCuL5h3C+NzMif6wLs=",
+        "lastModified": 1680889585,
+        "narHash": "sha256-cdbcCw/S3zO8Vdq2zHdrZKBXMUk3s+HrhNJhh2PACio=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ab6300a55a492abcfb23cb2dc3d3adc299f1d950",
+        "rev": "5ca63e86f0faab5378e5dd19173415347ce63e0a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5ca63e86`](https://github.com/nix-community/NUR/commit/5ca63e86f0faab5378e5dd19173415347ce63e0a) | `` automatic update `` |