### PR TITLE
chore(flake/nur): `5ca63e86` -> `3780ef56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680889585,
-        "narHash": "sha256-cdbcCw/S3zO8Vdq2zHdrZKBXMUk3s+HrhNJhh2PACio=",
+        "lastModified": 1680891902,
+        "narHash": "sha256-1vS8yLmCWpFsNPQKUh4ks1Cp3vJYniXsd/H9rv9gCgk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5ca63e86f0faab5378e5dd19173415347ce63e0a",
+        "rev": "3780ef56e6aaa759488af6e90966844c32796578",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3780ef56`](https://github.com/nix-community/NUR/commit/3780ef56e6aaa759488af6e90966844c32796578) | `` automatic update `` |