### PR TITLE
chore(flake/emacs-overlay): `34bb46ef` -> `c89b34da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680858543,
-        "narHash": "sha256-M7pqqcDHd5pCFTaKnteyf9nn5nHXwDOLp9NECzAvvso=",
+        "lastModified": 1680893874,
+        "narHash": "sha256-d0t/czWsAuN5OdxgFJ7C+1WIPQP+uwYS3g/estSAa+c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "34bb46ef62a3069ac6cf8dca07cbfa1137822d20",
+        "rev": "c89b34da3461fe336dfed895d67d2b9d072a9b66",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`c89b34da`](https://github.com/nix-community/emacs-overlay/commit/c89b34da3461fe336dfed895d67d2b9d072a9b66) | `` Updated repos/melpa `` |
| [`7e317b12`](https://github.com/nix-community/emacs-overlay/commit/7e317b12b7668d9f34807542717dae1bce21a242) | `` Updated repos/emacs `` |