### PR TITLE
chore(flake/nur): `09a7db6f` -> `55e5553c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680894406,
-        "narHash": "sha256-GyWaw9HfKOEGPJawbAjnwc9QZhEKdwkDgPSCBWaDQBA=",
+        "lastModified": 1680896721,
+        "narHash": "sha256-qYb1Au/XFn4vMWfVP3N9cHzja/3FHbgXl3Fnpk4KWS0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "09a7db6f8f6e58c91404711431b106b297a34da6",
+        "rev": "55e5553c3a67720961d8be737e65b0b05e6ffab6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`55e5553c`](https://github.com/nix-community/NUR/commit/55e5553c3a67720961d8be737e65b0b05e6ffab6) | `` automatic update `` |