### PR TITLE
chore(flake/emacs-overlay): `c89b34da` -> `a24cd789`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680893874,
-        "narHash": "sha256-d0t/czWsAuN5OdxgFJ7C+1WIPQP+uwYS3g/estSAa+c=",
+        "lastModified": 1680924368,
+        "narHash": "sha256-s125UlZWcJy+GFsQbJ3dBFMnYbyrbCGjjXsaNmm/mqA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c89b34da3461fe336dfed895d67d2b9d072a9b66",
+        "rev": "a24cd78969ad2a9e369b559df8ce586a22b3442d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`a24cd789`](https://github.com/nix-community/emacs-overlay/commit/a24cd78969ad2a9e369b559df8ce586a22b3442d) | `` Updated repos/melpa `` |
| [`444d1de5`](https://github.com/nix-community/emacs-overlay/commit/444d1de55d7cf3df7ceeb6509b562df8873c1bd9) | `` Updated repos/emacs `` |