### PR TITLE
chore(flake/nur): `37873ea3` -> `c468956d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680925189,
-        "narHash": "sha256-fvUnUetVs+rd3UJUwbz7iJR4FOCKKacZ+jr62QHN7Rg=",
+        "lastModified": 1680932643,
+        "narHash": "sha256-vHkZJnPfA788UQ0zsfj4P09pVqBsn4niMp5qhN3ue28=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "37873ea3385b62c9ab795fcd0aaa68863bd0c887",
+        "rev": "c468956d1604fb0182d24448a1cb45ab948bf4ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c468956d`](https://github.com/nix-community/NUR/commit/c468956d1604fb0182d24448a1cb45ab948bf4ca) | `` automatic update `` |