### PR TITLE
chore(flake/emacs-overlay): `a24cd789` -> `1195f952`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680924368,
-        "narHash": "sha256-s125UlZWcJy+GFsQbJ3dBFMnYbyrbCGjjXsaNmm/mqA=",
+        "lastModified": 1680944922,
+        "narHash": "sha256-Lkt2uvLOzPzz65uKf0ljpU95mRIgCeONqjjpelIVGCw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a24cd78969ad2a9e369b559df8ce586a22b3442d",
+        "rev": "1195f952f1d610244a4b1b8b0b9dbd13ef6d553c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`1195f952`](https://github.com/nix-community/emacs-overlay/commit/1195f952f1d610244a4b1b8b0b9dbd13ef6d553c) | `` Updated repos/melpa `` |