### PR TITLE
chore(flake/flake-utils): `411e8764` -> `946da791`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -364,11 +364,11 @@
     },
     "flake-utils_3": {
       "locked": {
-        "lastModified": 1680776469,
-        "narHash": "sha256-3CXUDK/3q/kieWtdsYpDOBJw3Gw4Af6x+2EiSnIkNQw=",
+        "lastModified": 1680946745,
+        "narHash": "sha256-KqGlwg9UTDsFBZZB8wzXgMnc8XQm95LtSbFvBsnqkPI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "411e8764155aa9354dbcd6d5faaeb97e9e3dce24",
+        "rev": "946da791763db1c306b86a8bd3828bf5814a1247",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                      |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`946da791`](https://github.com/numtide/flake-utils/commit/946da791763db1c306b86a8bd3828bf5814a1247) | `` Update documentation for the `systems` argument of `simpleFlake` (#92) `` |