### PR TITLE
chore(flake/nur): `c468956d` -> `10b4bf60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680932643,
-        "narHash": "sha256-vHkZJnPfA788UQ0zsfj4P09pVqBsn4niMp5qhN3ue28=",
+        "lastModified": 1680975999,
+        "narHash": "sha256-NAgciliJbKn46lPlkwWlnyPkwPyqpRP21E4zkcpcREY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c468956d1604fb0182d24448a1cb45ab948bf4ca",
+        "rev": "10b4bf606b86470efe66601fdacddbbb553fea8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`10b4bf60`](https://github.com/nix-community/NUR/commit/10b4bf606b86470efe66601fdacddbbb553fea8d) | `` automatic update `` |