### PR TITLE
chore(flake/nur): `27816cf7` -> `82e2959e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681005240,
-        "narHash": "sha256-WzmfDO2XIyBvtzYZSU2jUuBoEbTRzxoMWH4w3YIJ2Ds=",
+        "lastModified": 1681011974,
+        "narHash": "sha256-ULmUJjAmXzgmEfEcGBbKWR97RShB5wfD8RylYeqARI8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "27816cf78a17aca6a06b37e7198b95c7556f580a",
+        "rev": "82e2959ef74f34d287dc3a6faab904a060f10787",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`82e2959e`](https://github.com/nix-community/NUR/commit/82e2959ef74f34d287dc3a6faab904a060f10787) | `` automatic update `` |