### PR TITLE
chore(flake/nixpkgs): `0e19daa5` -> `d9f759f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -669,11 +669,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1680758185,
-        "narHash": "sha256-sCVWwfnk7zEX8Z+OItiH+pcSklrlsLZ4TJTtnxAYREw=",
+        "lastModified": 1680945546,
+        "narHash": "sha256-8FuaH5t/aVi/pR1XxnF0qi4WwMYC+YxlfdsA0V+TEuQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0e19daa510e47a40e06257e205965f3b96ce0ac9",
+        "rev": "d9f759f2ea8d265d974a6e1259bd510ac5844c5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`e779b823`](https://github.com/NixOS/nixpkgs/commit/e779b8233f55b9b5525daffdd98f7b0ffd749742) | `` python310Packages.ansible-doctor: 2.0.3 -> 2.0.4 ``                                          |
| [`5947116c`](https://github.com/NixOS/nixpkgs/commit/5947116ce70c833ab05564a244b0edbea514416b) | `` terraform-providers.newrelic: 3.20.1 -> 3.20.2 ``                                            |
| [`3c7d4703`](https://github.com/NixOS/nixpkgs/commit/3c7d47031eb3195287f6a39655456de933fbdf7e) | `` terraform-providers.huaweicloud: 1.47.0 -> 1.47.1 ``                                         |
| [`42f239e0`](https://github.com/NixOS/nixpkgs/commit/42f239e0ff9ef4f5e06e011b4e64ce9f4bed2d28) | `` terraform-providers.argocd: 5.0.1 -> 5.1.0 ``                                                |
| [`c0f788dc`](https://github.com/NixOS/nixpkgs/commit/c0f788dc0c92168b6ec16c01116febf1d825f3f4) | `` terraform-providers.dnsimple: 0.16.3 -> 0.17.0 ``                                            |
| [`83c7a01c`](https://github.com/NixOS/nixpkgs/commit/83c7a01cb4280c0e406519b2b5ecd32c19fc195b) | `` stratis-cli: 3.5.0 -> 3.5.1 ``                                                               |
| [`b31b88d7`](https://github.com/NixOS/nixpkgs/commit/b31b88d74fd95127be2b66fd169e2a7cb035f6d6) | `` harePackages.hare: remove patch ``                                                           |
| [`89467c17`](https://github.com/NixOS/nixpkgs/commit/89467c17512955ded5bd219a95fecb269ba51d04) | `` python310Packages.chacha20poly1305-reuseable: 0.0.4 -> 0.2.2 ``                              |
| [`aff526b4`](https://github.com/NixOS/nixpkgs/commit/aff526b461713b7cca8f9e6d21b435c6b9dcfcd4) | `` gh: 2.26.1 -> 2.27.0 ``                                                                      |
| [`f642e1bd`](https://github.com/NixOS/nixpkgs/commit/f642e1bd749dedaa0e057ce751d76f417b7f18e1) | `` python310Packages.sqlmap: 1.7.3 -> 1.7.4 ``                                                  |
| [`66d6701f`](https://github.com/NixOS/nixpkgs/commit/66d6701fc96a8c58df47626212f1abd088f567b4) | `` fcitx5-mozc: wrapQtApp for mozc_tool (#224077) ``                                            |
| [`d019e49c`](https://github.com/NixOS/nixpkgs/commit/d019e49c2cd53188b73cfe5ab7795fe6a8a545ef) | `` howard-hinnant-date: fix pkg-config variable substitutions ``                                |
| [`095f66f2`](https://github.com/NixOS/nixpkgs/commit/095f66f2d3f0f86b6a4f4ad930a1b76bd44225f9) | `` haskellPackages: mark builds failing on hydra as broken ``                                   |
| [`273b77bf`](https://github.com/NixOS/nixpkgs/commit/273b77bfcff1fbb1e8d9d840e0b2ed0f90da6d80) | `` kubo: 0.19.0 -> 0.19.1 ``                                                                    |
| [`0c3482b4`](https://github.com/NixOS/nixpkgs/commit/0c3482b405a0db5ec65fa432d29c2170a0836484) | `` lagrange: 1.15.7 -> 1.15.8 ``                                                                |
| [`2f06e8f2`](https://github.com/NixOS/nixpkgs/commit/2f06e8f2a998444603a5402d4d4ee63c5d333ab4) | `` pdns-recursor: 4.8.3 -> 4.8.4 (#225063) ``                                                   |
| [`af32997a`](https://github.com/NixOS/nixpkgs/commit/af32997ae484a1fa694d87723a89c28f4549ab8c) | `` alacritty: fix cross ``                                                                      |
| [`1ac05e99`](https://github.com/NixOS/nixpkgs/commit/1ac05e999b6919f4c917e1300f95043b2a9d0fb1) | `` python310Packages.torchaudio: init at 2.0.1 (#224323) ``                                     |
| [`c0615e86`](https://github.com/NixOS/nixpkgs/commit/c0615e86d1e78f500d54d76f341e0a200909b0cd) | `` blender: allow dynamically linked embree (#225168) ``                                        |
| [`e42d62b7`](https://github.com/NixOS/nixpkgs/commit/e42d62b7a2702fce668069110d791ee59b0a634c) | `` python310Packages.pyswitchbot: 0.37.5 -> 0.37.6 ``                                           |
| [`01fbc666`](https://github.com/NixOS/nixpkgs/commit/01fbc66669f8148d9347b01ea520adf3de4a832a) | `` python3Packages.deepl: init at 1.13.0 ``                                                     |
| [`47e4e366`](https://github.com/NixOS/nixpkgs/commit/47e4e3669ff5da617439df92623ab1007345a643) | `` goda: 0.5.5 -> 0.5.6 ``                                                                      |
| [`1173a1c1`](https://github.com/NixOS/nixpkgs/commit/1173a1c198b734f26e129a208e632e074d3d3777) | `` abcl: explicit update script + makeWrapper ``                                                |
| [`056d45c3`](https://github.com/NixOS/nixpkgs/commit/056d45c3207bd5cbc7dee87782530ffabadad409) | `` python310Packages.slowapi: 0.1.7 -> 0.1.8 ``                                                 |
| [`0f0c7b49`](https://github.com/NixOS/nixpkgs/commit/0f0c7b4993eaa300f8dcbede7405acce8a20d5fd) | `` python310Packages.app-model: 0.1.2 -> 0.1.4 ``                                               |
| [`909a397a`](https://github.com/NixOS/nixpkgs/commit/909a397a80b141e0f9680b479e93a2fc0977c07b) | `` trufflehog: 3.31.3 -> 3.31.4 ``                                                              |
| [`991f5472`](https://github.com/NixOS/nixpkgs/commit/991f5472e9fa9a1d815dd536882b0e6cc7f9593a) | `` exploitdb: 2023-04-06 -> 2023-04-07 ``                                                       |
| [`e37f7e59`](https://github.com/NixOS/nixpkgs/commit/e37f7e59e3eca55319aa4a327ea17dea808d5143) | `` python310Packages.dsmr-parser: 1.2.0 -> 1.2.1 ``                                             |
| [`adf82e5e`](https://github.com/NixOS/nixpkgs/commit/adf82e5e13fe4fd8fdc2b8f3101c8ce56dec108b) | `` python310Packages.reolink-aio: 0.5.10 -> 0.5.11 ``                                           |
| [`905b5d01`](https://github.com/NixOS/nixpkgs/commit/905b5d01f1bda815f5e92c4d2dc7c30862b72379) | `` python310Packages.lsassy: 3.1.6 -> 3.1.7 ``                                                  |
| [`23cff796`](https://github.com/NixOS/nixpkgs/commit/23cff796c4404695ecb670d81f5b12244c7e7e91) | `` android-studio: set meta.mainProgram ``                                                      |
| [`10a28ebd`](https://github.com/NixOS/nixpkgs/commit/10a28ebd9c1dd0b61753792d9fbc8f3c8baeb62a) | `` python310Packages.bc-detect-secrets: 1.4.16 -> 1.4.19 ``                                     |
| [`f2589ad2`](https://github.com/NixOS/nixpkgs/commit/f2589ad2624c68e1b7c1541166490f8cb1e49808) | `` functiontrace: init at 0.3.7 ``                                                              |
| [`a5195d53`](https://github.com/NixOS/nixpkgs/commit/a5195d531540d767943a922ac6f6200f2fd2c2e6) | `` deepin.gio-qt: 0.0.11 -> 0.0.12 ``                                                           |
| [`9ec82987`](https://github.com/NixOS/nixpkgs/commit/9ec829878ad365d7488341d24e0803f565cd9637) | `` python310Packages.pykulersky: 0.5.4 -> 0.5.5 ``                                              |
| [`6ee021d9`](https://github.com/NixOS/nixpkgs/commit/6ee021d96433d4e1a636e5d117afe5cff157b577) | `` python310Packages.pyzerproc: 0.4.11 -> 0.4.12 ``                                             |
| [`0ccf77dd`](https://github.com/NixOS/nixpkgs/commit/0ccf77ddcda8d00a3ecba75cf58e3d7cd1d3e6aa) | `` python3Packages.calysto-scheme: init at 1.4.7 ``                                             |
| [`a7b0ca02`](https://github.com/NixOS/nixpkgs/commit/a7b0ca02b97aea2b92c8a0b1b4451c87ac2ebde1) | `` python3Packages.calysto: init at 1.0.6 ``                                                    |
| [`0952faad`](https://github.com/NixOS/nixpkgs/commit/0952faad43b0d56ab40039d6f21a04e49b8dac97) | `` python3Packages.yasi: init at 2.1.2 ``                                                       |
| [`09d8f40c`](https://github.com/NixOS/nixpkgs/commit/09d8f40cc3ea3c007e25256d9c75271410c5a55d) | `` tensorflow-bin: 2.11.0 -> 2.12.0 ``                                                          |
| [`dacdc849`](https://github.com/NixOS/nixpkgs/commit/dacdc849f06a6e58e1a3f4d2a5a9d8881fc8c99a) | `` openrct2: 0.4.3 -> 0.4.4 ``                                                                  |
| [`0bf0d21e`](https://github.com/NixOS/nixpkgs/commit/0bf0d21e9b10694b003ea48cf92562373e7c0208) | `` v4l2-relayd: init at 0.1.3 ``                                                                |
| [`fc6c5c71`](https://github.com/NixOS/nixpkgs/commit/fc6c5c71b4c571aa0bef04b04f66780f1e88730f) | `` v4l2loopback: unstable-2022-08-05 -> unstable-2023-02-19 ``                                  |
| [`e3802695`](https://github.com/NixOS/nixpkgs/commit/e3802695c8d5f610b871a51d47330c40a2ec5676) | `` gst_all_1.icamerasrc: 20221209 -> 2023-03-09 ``                                              |
| [`7b17c672`](https://github.com/NixOS/nixpkgs/commit/7b17c6722d226ff26794155a057ac0d44eeb4075) | `` ipu6-camera-hal: 2023-01-09 -> 2023-02-08 ``                                                 |
| [`62c69e9f`](https://github.com/NixOS/nixpkgs/commit/62c69e9f3a73befb160cfe0cd3f77f5559fa7a71) | `` ipu6-camera-bin: 2022-11-12 -> 2023-02-08 ``                                                 |
| [`44c59fea`](https://github.com/NixOS/nixpkgs/commit/44c59fea72a9654ab2ea4cd655fa6f36574d5d18) | `` linuxPackages.ipu6-drivers: add patch to make driver work with unpatched kernel >= 6.1.7 ``  |
| [`ecbaab1c`](https://github.com/NixOS/nixpkgs/commit/ecbaab1c136768a842013e7d48add51607f7ef80) | `` mercurial: 6.3.3 -> 6.4 ``                                                                   |
| [`e6c5f4cf`](https://github.com/NixOS/nixpkgs/commit/e6c5f4cff886a131b74be494405e0d6a4c740518) | `` telegram-desktop: rename from tdesktop ``                                                    |
| [`74b703f5`](https://github.com/NixOS/nixpkgs/commit/74b703f59df672b350aa5287d1a1619634995326) | `` hare: unstable-2023-02-08 -> unstable-2023-03-15 ``                                          |
| [`01e22546`](https://github.com/NixOS/nixpkgs/commit/01e2254652b2ad0e276dce175fc0c855cf37c255) | `` harec: unstable-2023-02-08 -> unstable-2023-02-18 ``                                         |
| [`6b556aed`](https://github.com/NixOS/nixpkgs/commit/6b556aed2c084ccf3f3505d9a7fab8f9db3e1a13) | `` nodePackages.pnpm: 7.29.1 -> 8.1.1 ``                                                        |
| [`b9c07582`](https://github.com/NixOS/nixpkgs/commit/b9c075828886e56546b3005176bca0a577417a33) | `` rke2: init at 1.26.3+rke2r1 ``                                                               |
| [`c816bd50`](https://github.com/NixOS/nixpkgs/commit/c816bd50aa41bd3ab4adfeb62ac918566076d59f) | `` nixos/hyprland: init (#221730) ``                                                            |
| [`c54e3334`](https://github.com/NixOS/nixpkgs/commit/c54e33345f87140fdc95f0950d0e8c42ba5b318b) | `` linuxPackages.ipu6-drivers: 2023-01-17 -> 2023-02-20 ``                                      |
| [`429c8adc`](https://github.com/NixOS/nixpkgs/commit/429c8adc9b7d1c75ce2b2921a95614840977611d) | `` quickjs: fix build on darwin ``                                                              |
| [`0fc1d95c`](https://github.com/NixOS/nixpkgs/commit/0fc1d95c95f08e692929eeac675d27686c65cf40) | `` cargo-zigbuild: 0.16.5 -> 0.16.6 ``                                                          |
| [`3e55ce61`](https://github.com/NixOS/nixpkgs/commit/3e55ce6120b5922df59cc467ba5f1fed79bb0c7a) | `` nixpkgs-review: 2.9.0 -> 2.9.1 ``                                                            |
| [`8302e073`](https://github.com/NixOS/nixpkgs/commit/8302e0731dc6acaf5d1cad7388925efbcc9c9238) | `` fava: 1.24.3 -> 1.24.4 ``                                                                    |
| [`e2d6bcaf`](https://github.com/NixOS/nixpkgs/commit/e2d6bcafe69761c4e982d51f90bdc86d089fa6b7) | `` CODEOWNERS: Add @infinisil to pkgs/pkgs-lib ``                                               |
| [`1311d342`](https://github.com/NixOS/nixpkgs/commit/1311d342bb2386f592767b9848b9a0c4ae37d3e3) | `` txtpbfmt: unstable-2023-01-18 -> unstable-2023-03-28 ``                                      |
| [`62b9c6cb`](https://github.com/NixOS/nixpkgs/commit/62b9c6cb218ed8e8840c13b25056158e7338a082) | `` gptcommit: 0.5.6 -> 0.5.7 ``                                                                 |
| [`5b903249`](https://github.com/NixOS/nixpkgs/commit/5b903249fb7d43351e61f12aaaf77f1132f9b414) | `` out-of-tree: 1.4.0 -> 2.0.4 ``                                                               |
| [`24e899c8`](https://github.com/NixOS/nixpkgs/commit/24e899c83d3a2cf91f03d7edc2bf507ef0638aed) | `` python3Packages.imageio: 2.26.0 -> 2.27.0 ``                                                 |
| [`7dfe64b5`](https://github.com/NixOS/nixpkgs/commit/7dfe64b5946a26813c2764e3931d36a73c4a7fc1) | `` cinnamon.cinnamon-desktop: 5.6.1 -> 5.6.2 ``                                                 |
| [`b392d9b8`](https://github.com/NixOS/nixpkgs/commit/b392d9b827cf4bb52141ab86e4202ec340f0b181) | `` pkgsMusl.systemd: update patches (#225050) ``                                                |
| [`5af866f0`](https://github.com/NixOS/nixpkgs/commit/5af866f0bfcc77cb77f473c3c6194db9bed84373) | `` linux: 6.2.9 -> 6.2.10 ``                                                                    |
| [`93e2b6f4`](https://github.com/NixOS/nixpkgs/commit/93e2b6f4fc150674af2d06e381ac5fe8624dcbc6) | `` linux: 6.1.22 -> 6.1.23 ``                                                                   |
| [`222002fe`](https://github.com/NixOS/nixpkgs/commit/222002fe198ed83e24d8925c33d7f76ce3fe7a1b) | `` ocamlPackages.lwt_ssl: 1.1.3 → 1.2.0 (#225107) ``                                            |
| [`283fe51b`](https://github.com/NixOS/nixpkgs/commit/283fe51bfcc7accecd233b485f7257318251eee5) | `` tailscale: 1.38.3 -> 1.38.4 ``                                                               |
| [`0c355fe2`](https://github.com/NixOS/nixpkgs/commit/0c355fe2d1736bf1b910f42a1490836bec1b038e) | `` libpg_query: avoid hard-coding dynamic library file extensions ``                            |
| [`955cf9d5`](https://github.com/NixOS/nixpkgs/commit/955cf9d5dde0105399505b7dea462edf1706713d) | `` weston: 11.0.0 -> 11.0.1 ``                                                                  |
| [`c17904b9`](https://github.com/NixOS/nixpkgs/commit/c17904b9802a35acf088ee315b669bd4be8f7633) | `` neovim: more flexibility in startup commands ``                                              |
| [`fabfca72`](https://github.com/NixOS/nixpkgs/commit/fabfca721cc10fc0bbdca72de931c2d51ff3b003) | `` deepin: don't need prefix qt5integration for all application ``                              |
| [`436784e6`](https://github.com/NixOS/nixpkgs/commit/436784e69f59609133ded9c4961f09a0cccb52ec) | `` linux/hardened/patches/6.1: 6.1.21-hardened1 -> 6.1.22-hardened1 ``                          |
| [`c7934832`](https://github.com/NixOS/nixpkgs/commit/c79348322c18d18d38f4cb603c195adc3033322e) | `` linux/hardened/patches/5.4: 5.4.238-hardened1 -> 5.4.239-hardened1 ``                        |
| [`e73b4ae4`](https://github.com/NixOS/nixpkgs/commit/e73b4ae45e1670be7b788b15b328d57b3207075b) | `` linux/hardened/patches/5.15: 5.15.104-hardened1 -> 5.15.105-hardened1 ``                     |
| [`44beef0a`](https://github.com/NixOS/nixpkgs/commit/44beef0adab2cb49e26ef8edb862b3e22f22c7b6) | `` linux: 5.4.239 -> 5.4.240 ``                                                                 |
| [`4c09c305`](https://github.com/NixOS/nixpkgs/commit/4c09c3057e5fed9a97993cd41cc2b1717b73dc3b) | `` linux: 5.15.105 -> 5.15.106 ``                                                               |
| [`05a73ef5`](https://github.com/NixOS/nixpkgs/commit/05a73ef536caf6bc7334d8aa1b88265960774e30) | `` linux: 5.10.176 -> 5.10.177 ``                                                               |
| [`d58a83c7`](https://github.com/NixOS/nixpkgs/commit/d58a83c7edeb055e2f0cb7e632f9a5cd579ecf88) | `` linux: 4.19.279 -> 4.19.280 ``                                                               |
| [`8f6a2c47`](https://github.com/NixOS/nixpkgs/commit/8f6a2c4734167818b743e26f53eb4f42c103446d) | `` linux: 4.14.311 -> 4.14.312 ``                                                               |
| [`82d4de8e`](https://github.com/NixOS/nixpkgs/commit/82d4de8ecf4baf5621e83ac7a7caa5ea3c76a430) | `` emacs: mark meta.broken if cross ``                                                          |
| [`e70f2d48`](https://github.com/NixOS/nixpkgs/commit/e70f2d487bf5337a696545830c0bd4fbed7d0308) | `` typst: 0.1 -> 0.1.0 ``                                                                       |
| [`07bfa152`](https://github.com/NixOS/nixpkgs/commit/07bfa152b657bf5bbff766fe5e1abadb74577ca3) | `` libreoffice-still: Disable more failing tests ``                                             |
| [`16135aec`](https://github.com/NixOS/nixpkgs/commit/16135aec3fb57f3527252427d3875d21c620efd6) | `` vlc: fetch patch from a specific commit ``                                                   |
| [`edbacc42`](https://github.com/NixOS/nixpkgs/commit/edbacc42de6c82070f85ee603cc34450c431baf4) | `` maintainers: add zygot ``                                                                    |
| [`976e8546`](https://github.com/NixOS/nixpkgs/commit/976e85466510636a83eaac6efa3b813ba1a004b4) | `` Update pkgs/applications/audio/streamripper/default.nix ``                                   |
| [`8ea7f661`](https://github.com/NixOS/nixpkgs/commit/8ea7f661a8085a076fbdcec20f785fe6078df94e) | `` terraform-providers.ksyun: remove ``                                                         |
| [`12cafa18`](https://github.com/NixOS/nixpkgs/commit/12cafa188bedb742b48531611f843f3c5c832453) | `` terraform-providers.yandex: 0.88.0 -> 0.89.0 ``                                              |
| [`e789a7a6`](https://github.com/NixOS/nixpkgs/commit/e789a7a66c1ee19dd4425a019be8cb82cf3d25e3) | `` terraform-providers.tencentcloud: 1.80.0 -> 1.80.1 ``                                        |
| [`c85eccbb`](https://github.com/NixOS/nixpkgs/commit/c85eccbba093d5392819f9c9d6683a108cf87965) | `` terraform-providers.spotinst: 1.109.0 -> 1.110.0 ``                                          |
| [`89983939`](https://github.com/NixOS/nixpkgs/commit/89983939b71bee75bcc9916215a0ab8d2da066c9) | `` terraform-providers.opentelekomcloud: 1.34.0 -> 1.34.1 ``                                    |
| [`3a83f63a`](https://github.com/NixOS/nixpkgs/commit/3a83f63ac37f5612f1c78e7a30f166328ce39892) | `` terraform-providers.pagerduty: 2.11.3 -> 2.12.1 ``                                           |
| [`3d1af52b`](https://github.com/NixOS/nixpkgs/commit/3d1af52b075f9ee881c890ceb53afa870d6096f5) | `` terraform-providers.google-beta: 4.60.1 -> 4.60.2 ``                                         |
| [`85f5388e`](https://github.com/NixOS/nixpkgs/commit/85f5388ed7f3189e1f6c2dbc23312add80586120) | `` terraform-providers.aws: 4.61.0 -> 4.62.0 ``                                                 |
| [`495be935`](https://github.com/NixOS/nixpkgs/commit/495be9354470f1c163d1a66a501abe829bb3ee40) | `` terraform-providers.google: 4.60.1 -> 4.60.2 ``                                              |
| [`c7c81056`](https://github.com/NixOS/nixpkgs/commit/c7c81056bfaf07c123ac24099cd01e6f8cf28b4f) | `` terraform-providers.github: 5.20.0 -> 5.21.1 ``                                              |
| [`f1e7775e`](https://github.com/NixOS/nixpkgs/commit/f1e7775e0cb9848c91da552f8bd45ab61debff73) | `` terraform-providers.ct: 0.12.0 -> 0.13.0 ``                                                  |
| [`ca4281bc`](https://github.com/NixOS/nixpkgs/commit/ca4281bc588dfba19b215e9ec6f2e93e60012d95) | `` terraform-providers.buildkite: 0.12.2 -> 0.14.0 ``                                           |
| [`325d6f51`](https://github.com/NixOS/nixpkgs/commit/325d6f51754d4c070be894872ebd51eeca879b60) | `` terraform-providers.azurerm: 3.50.0 -> 3.51.0 ``                                             |
| [`9df9bf8d`](https://github.com/NixOS/nixpkgs/commit/9df9bf8df9f42a8e4c2fda5e99ec36ad23838846) | `` terraform-providers.aiven: 4.2.0 -> 4.2.1 ``                                                 |
| [`8b6b7bac`](https://github.com/NixOS/nixpkgs/commit/8b6b7bac050a5528299b98828e7f0b91e783cb85) | `` rocm-cmake: 5.4.3 -> 5.4.4 ``                                                                |
| [`3c1c5600`](https://github.com/NixOS/nixpkgs/commit/3c1c5600e895409df2e19a142aa4d72717a912f7) | `` bind: replace hard-coded `allow-query` zone setting with a real zone parameter. (#224776) `` |
| [`da32ad66`](https://github.com/NixOS/nixpkgs/commit/da32ad668de5ff436c049332c4df23ec5b2f5d87) | `` clojure: 1.11.1.1262 -> 1.11.1.1273 ``                                                       |
| [`a8e45050`](https://github.com/NixOS/nixpkgs/commit/a8e4505015938d0c61e9c54e057e8ceba5ce0931) | `` scala-cli: 0.2.1 -> 1.0.0-RC1 ``                                                             |
| [`3f70428b`](https://github.com/NixOS/nixpkgs/commit/3f70428b1c546bcf0cf5aa6bf3cdcb346c823119) | `` glusterfs: 10.1 -> 10.3 ``                                                                   |
| [`6231435e`](https://github.com/NixOS/nixpkgs/commit/6231435e1150a6f3b81b1691c1f2d5462d9752a9) | `` worker-build: 0.0.14 -> 0.0.15 ``                                                            |
| [`a08a67a5`](https://github.com/NixOS/nixpkgs/commit/a08a67a563d1285fb306159a92bb33b2c4e8ce7f) | `` tpm2-abrmd: support cross compilation ``                                                     |
| [`d3bfe908`](https://github.com/NixOS/nixpkgs/commit/d3bfe908177d2aa6dd33a3bdbeb944276fea08e3) | `` copyq: 6.4.0 -> 7.0.0 ``                                                                     |
| [`4e7d68aa`](https://github.com/NixOS/nixpkgs/commit/4e7d68aa63f809edcf589081d9a18693597b38b2) | `` libjcat: support cross compilation ``                                                        |
| [`4f8d22c1`](https://github.com/NixOS/nixpkgs/commit/4f8d22c137d0244dbd30e0c3b57d8004dca8b2c2) | `` rapidfuzz-cpp: disable tests when cross compiling ``                                         |
| [`2231d488`](https://github.com/NixOS/nixpkgs/commit/2231d4882472033c2f7a2042531af3e82421b6a8) | `` librest (0.8): don't build docs when cross compiling ``                                      |
| [`c82580fd`](https://github.com/NixOS/nixpkgs/commit/c82580fd11955f020104fc839da032534a582e1e) | `` libHX: move libtool into nativeBuildInputs to unbreak cross compilation ``                   |
| [`38f82eb8`](https://github.com/NixOS/nixpkgs/commit/38f82eb826a792d78ae836932513e000ff5d0d83) | `` libchamplain: don't build docs when cross compiling ``                                       |
| [`4fa1ac31`](https://github.com/NixOS/nixpkgs/commit/4fa1ac3121138d45dc3949563fab44c8fb1f10f4) | `` fuzzel: add pkg-config to depsBuildBuild to support cross compilation ``                     |
| [`8b2521bd`](https://github.com/NixOS/nixpkgs/commit/8b2521bdae89126497fa6f139fb9d030d5d13184) | `` nixos/darwin-builder: add disk space options (#224480) ``                                    |
| [`e71b304b`](https://github.com/NixOS/nixpkgs/commit/e71b304b5ed45c9af7c900b1bd3abb605341f0cf) | `` yamlfmt: 0.8.0 -> 0.9.0 ``                                                                   |
| [`07d6f8aa`](https://github.com/NixOS/nixpkgs/commit/07d6f8aaeb03ac8221fc936d978e2cc55d170d1e) | `` swayest-workstyle: 1.3.2 -> 1.3.3 ``                                                         |
| [`48f0235c`](https://github.com/NixOS/nixpkgs/commit/48f0235c7d0ea1c8d72053e78baf0803177c6af9) | `` mkvtoolnix: 74.0.0 -> 75.0.0 ``                                                              |
| [`25f427c7`](https://github.com/NixOS/nixpkgs/commit/25f427c739d12cbb2a0e09754136d0412de7e7d4) | `` whatsapp-for-linux: 1.6.1 -> 1.6.2 ``                                                        |
| [`6eab7447`](https://github.com/NixOS/nixpkgs/commit/6eab744741273e19c91190c921951956b9b2d242) | `` chatgpt-cli: 1.0.2 -> 1.1 ``                                                                 |