### PR TITLE
chore(flake/nur): `4c1b2031` -> `8d4f5c68`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681021472,
-        "narHash": "sha256-wRG3yVaWWPQjo7BN2ANjBh8mNGxZMLPUt9eFSnrwhdk=",
+        "lastModified": 1681022139,
+        "narHash": "sha256-1732VcXsRDSWYOfYVqWEC81sGMqAxo4ZXn+NfevBanw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4c1b203171554e619d5085c1facbef57531d80c1",
+        "rev": "8d4f5c68b39a7751255ebe0c3847871e5d78137b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8d4f5c68`](https://github.com/nix-community/NUR/commit/8d4f5c68b39a7751255ebe0c3847871e5d78137b) | `` automatic update `` |