### PR TITLE
chore(flake/nur): `8d4f5c68` -> `ca4577c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681022139,
-        "narHash": "sha256-1732VcXsRDSWYOfYVqWEC81sGMqAxo4ZXn+NfevBanw=",
+        "lastModified": 1681029988,
+        "narHash": "sha256-+pt1qGWFF5e4hZhcSTLR2T0xaYwowH9RqF/jQiHxDOs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8d4f5c68b39a7751255ebe0c3847871e5d78137b",
+        "rev": "ca4577c3484a8b456f5c2905bcc07ee33c2d8677",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ca4577c3`](https://github.com/nix-community/NUR/commit/ca4577c3484a8b456f5c2905bcc07ee33c2d8677) | `` automatic update `` |