### PR TITLE
chore(flake/nur): `4e2aef6a` -> `0298f92a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681033518,
-        "narHash": "sha256-vpczl9hpS+0mZr7ToCiue2JNKuKTZDTKQgBcD8leI4Q=",
+        "lastModified": 1681034908,
+        "narHash": "sha256-cy4wCdYVYixbmeaxyyEpE5U/8BlL7cUsMevHx8agfow=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4e2aef6ac074c768f9f3f44dcb754b7585427846",
+        "rev": "0298f92a76b8a3dc0eff417124750ef75c018a5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0298f92a`](https://github.com/nix-community/NUR/commit/0298f92a76b8a3dc0eff417124750ef75c018a5e) | `` automatic update `` |