### PR TITLE
chore(flake/emacs-overlay): `48c44fe8` -> `20c47d24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681009521,
-        "narHash": "sha256-CoxF0OcipRC3p64XnMecGEnWywZMMgRxOCCZtw9GmYA=",
+        "lastModified": 1681036684,
+        "narHash": "sha256-zun/b14VTsA2QytRPBfmIJeixERNaUIBkLIE9DYEheQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "48c44fe806d73dbe376be665250659cffaef3610",
+        "rev": "20c47d24ebe8fa16d4c2ac79286631cf92101781",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`20c47d24`](https://github.com/nix-community/emacs-overlay/commit/20c47d24ebe8fa16d4c2ac79286631cf92101781) | `` Updated repos/melpa `` |
| [`5aef1631`](https://github.com/nix-community/emacs-overlay/commit/5aef16311ea92339e432e7bf8858f6dcff00468b) | `` Updated repos/emacs `` |