### PR TITLE
chore(flake/nur): `0298f92a` -> `a2947572`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681034908,
-        "narHash": "sha256-cy4wCdYVYixbmeaxyyEpE5U/8BlL7cUsMevHx8agfow=",
+        "lastModified": 1681040705,
+        "narHash": "sha256-iC+jMkZckSK60dbVvzQ6jtg9/0MKWnFvixlliaLbYnk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0298f92a76b8a3dc0eff417124750ef75c018a5e",
+        "rev": "a2947572d4f734e5347aabd04ce6fffb8a91dc28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a2947572`](https://github.com/nix-community/NUR/commit/a2947572d4f734e5347aabd04ce6fffb8a91dc28) | `` automatic update `` |