### PR TITLE
chore(flake/nur): `a2947572` -> `4c261179`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681040705,
-        "narHash": "sha256-iC+jMkZckSK60dbVvzQ6jtg9/0MKWnFvixlliaLbYnk=",
+        "lastModified": 1681044942,
+        "narHash": "sha256-iQ8E59cXuOVJgrJ0mU91a7egtH9wxTsrH3/VWr74QOQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a2947572d4f734e5347aabd04ce6fffb8a91dc28",
+        "rev": "4c261179f695d50c59e675f81c09ae30494a80c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4c261179`](https://github.com/nix-community/NUR/commit/4c261179f695d50c59e675f81c09ae30494a80c9) | `` automatic update `` |