### PR TITLE
chore(flake/nur): `fdfbf992` -> `fb7b8b11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681051550,
-        "narHash": "sha256-VNVLffB36V512jLCfWIDGfLUm6qsTHenWYLfGORMtJQ=",
+        "lastModified": 1681055105,
+        "narHash": "sha256-HETUDbn1DpeeLwV5lND1j72jI9nb0S3ax61iz6IGNO4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fdfbf992fa532d3e1b37ce42a81fcbff78f5c6a7",
+        "rev": "fb7b8b11eef494b17fdfdb6a298768f1be02ddcf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fb7b8b11`](https://github.com/nix-community/NUR/commit/fb7b8b11eef494b17fdfdb6a298768f1be02ddcf) | `` automatic update `` |