### PR TITLE
chore(flake/emacs-overlay): `0a91697a` -> `ed643867`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681064080,
-        "narHash": "sha256-GxdIRsOPimDi7Hh3eUtVuWWIVHcPGzw/LCbl75a5Fj4=",
+        "lastModified": 1681095358,
+        "narHash": "sha256-Zf0nna4XRPwoix9XYdUBiRZgJ5PMopEktpSNqcUwv/I=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0a91697aae6acefe1d5c9b3654ea273b53539380",
+        "rev": "ed6438672d7f9fcb2b11df7c0a626c24cc5f93d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`ed643867`](https://github.com/nix-community/emacs-overlay/commit/ed6438672d7f9fcb2b11df7c0a626c24cc5f93d4) | `` Updated repos/melpa `` |
| [`74d55aaa`](https://github.com/nix-community/emacs-overlay/commit/74d55aaacdad518fb96c4f70a535cc2804743c57) | `` Updated repos/emacs `` |