### PR TITLE
chore(flake/nur): `4b27c311` -> `8b944bd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681073162,
-        "narHash": "sha256-gqr+Yj9PutcmiJIWFfXsS4St3ZYAfYXHHTK5b8SZPhQ=",
+        "lastModified": 1681098170,
+        "narHash": "sha256-WjuSg6T1IOLLVfPzLBI06jblha0HXVCItxVxwNPYT1A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4b27c31190417d4d3d9165cd9305e1c704be2587",
+        "rev": "8b944bd6bb2e9db1d1f3c6a28f2f19af27f26bb5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8b944bd6`](https://github.com/nix-community/NUR/commit/8b944bd6bb2e9db1d1f3c6a28f2f19af27f26bb5) | `` automatic update `` |
| [`a639069c`](https://github.com/nix-community/NUR/commit/a639069c44c8858ac96003e56ce59f83184bc05f) | `` automatic update `` |