### PR TITLE
chore(flake/nur): `8b944bd6` -> `ff379136`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681098170,
-        "narHash": "sha256-WjuSg6T1IOLLVfPzLBI06jblha0HXVCItxVxwNPYT1A=",
+        "lastModified": 1681104064,
+        "narHash": "sha256-ujSSOUkMcD8QHnralrJHWkXPdaj6CjFRb8G8UW0CmS4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8b944bd6bb2e9db1d1f3c6a28f2f19af27f26bb5",
+        "rev": "ff379136c2fe966353b2c601f45372a118edc393",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ff379136`](https://github.com/nix-community/NUR/commit/ff379136c2fe966353b2c601f45372a118edc393) | `` automatic update `` |