### PR TITLE
chore(flake/emacs-overlay): `ed643867` -> `42223acc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681095358,
-        "narHash": "sha256-Zf0nna4XRPwoix9XYdUBiRZgJ5PMopEktpSNqcUwv/I=",
+        "lastModified": 1681123469,
+        "narHash": "sha256-8W+Eb7Zpo2+ngfSriLTPpN3ZYc0kSeT+ulvT5FErOco=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ed6438672d7f9fcb2b11df7c0a626c24cc5f93d4",
+        "rev": "42223accdafd3e9803e2ce955c85903c86ab2b1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`42223acc`](https://github.com/nix-community/emacs-overlay/commit/42223accdafd3e9803e2ce955c85903c86ab2b1b) | `` Updated repos/nongnu `` |
| [`d25784b5`](https://github.com/nix-community/emacs-overlay/commit/d25784b571d9c45ba40ec09f749b6c19a863d253) | `` Updated repos/melpa ``  |
| [`a4eae3fc`](https://github.com/nix-community/emacs-overlay/commit/a4eae3fc578e0a008a15d04fe524231265bb27fa) | `` Updated repos/emacs ``  |