### PR TITLE
chore(flake/nur): `2266b84b` -> `4887a711`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681136856,
-        "narHash": "sha256-qBvW07MLYZ1af7qkZoK4jUnfHf/7nIchIbdkW3C8kgg=",
+        "lastModified": 1681138984,
+        "narHash": "sha256-Om/pWs0eIvzBgqMBs0Fb0T925UBZfqtjVPffdi+yQi0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2266b84bc1ea8c88169fa9a894f8d1bfc92bf879",
+        "rev": "4887a7118ab0d4b2f6f9870a40d32612cd5bb72b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4887a711`](https://github.com/nix-community/NUR/commit/4887a7118ab0d4b2f6f9870a40d32612cd5bb72b) | `` automatic update `` |