### PR TITLE
chore(flake/nur): `4887a711` -> `fc27c087`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681138984,
-        "narHash": "sha256-Om/pWs0eIvzBgqMBs0Fb0T925UBZfqtjVPffdi+yQi0=",
+        "lastModified": 1681145129,
+        "narHash": "sha256-KYHgnNyKuprPxgFiEh/wTmByQNOi6uZ7OF9iKL5wqA8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4887a7118ab0d4b2f6f9870a40d32612cd5bb72b",
+        "rev": "fc27c087a5c712b03a4efba0182340625382f66e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fc27c087`](https://github.com/nix-community/NUR/commit/fc27c087a5c712b03a4efba0182340625382f66e) | `` automatic update `` |