### PR TITLE
chore(flake/nur): `fc27c087` -> `72fa78ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681145129,
-        "narHash": "sha256-KYHgnNyKuprPxgFiEh/wTmByQNOi6uZ7OF9iKL5wqA8=",
+        "lastModified": 1681148712,
+        "narHash": "sha256-ZJfPSerD4hNGGhenNTIhDhZd30Y9L3mNPdd7ZkoGcsQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc27c087a5c712b03a4efba0182340625382f66e",
+        "rev": "72fa78ad581a0d20773f694a8c15c385df97240f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`72fa78ad`](https://github.com/nix-community/NUR/commit/72fa78ad581a0d20773f694a8c15c385df97240f) | `` automatic update `` |