### PR TITLE
chore(flake/emacs-overlay): `42223acc` -> `334255ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681123469,
-        "narHash": "sha256-8W+Eb7Zpo2+ngfSriLTPpN3ZYc0kSeT+ulvT5FErOco=",
+        "lastModified": 1681154322,
+        "narHash": "sha256-hZrHAWBPPYtoecoM4Rb2jrHeJnzDBr0PdvoAbsa8xqA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "42223accdafd3e9803e2ce955c85903c86ab2b1b",
+        "rev": "334255cac589f8fac99d7cd584413971dc9debe1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`334255ca`](https://github.com/nix-community/emacs-overlay/commit/334255cac589f8fac99d7cd584413971dc9debe1) | `` Updated repos/melpa `` |
| [`6185ec1e`](https://github.com/nix-community/emacs-overlay/commit/6185ec1e92adb153d0de3abc703149693d66a450) | `` Updated repos/emacs `` |
| [`583f06bf`](https://github.com/nix-community/emacs-overlay/commit/583f06bf5997648fedb8510faaa68f111c1775d6) | `` Updated repos/elpa ``  |