### PR TITLE
chore(flake/home-manager): `93f5cb24` -> `4e79c6a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -448,11 +448,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681127522,
-        "narHash": "sha256-Eo4dd0AmKshM+A6msQRMwT42QvWGNxa8RjmZ4tY7g9E=",
+        "lastModified": 1681162249,
+        "narHash": "sha256-jh5fLaTxR5XowXA0CN/1Gs2qbvVdmdPCSeO424XWZLI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "93f5cb2482dd20e57eb8ca6c819cdad9738f98a0",
+        "rev": "4e79c6a414ce59fd1a53ab77899c77ab87774e6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`4e79c6a4`](https://github.com/nix-community/home-manager/commit/4e79c6a414ce59fd1a53ab77899c77ab87774e6b) | `` ci: bump DeterminateSystems/update-flake-lock from 18 to 19 `` |