### PR TITLE
chore(flake/emacs-overlay): `c1f6d037` -> `644ae3ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681159767,
-        "narHash": "sha256-4LYo/u8bDr7rdRZl7ZmZS3SBhU/VmPROUKaTh3dBYiA=",
+        "lastModified": 1681165126,
+        "narHash": "sha256-Qte3CafN9PkT+hx6HBKqQoCeQAdOGi5ZEUByKQh1IX0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c1f6d037d039fb3b5ff4a8a62342d8ac5238b504",
+        "rev": "644ae3ce05ae9d42232bba9642d4eaa63bb062d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                          |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`644ae3ce`](https://github.com/nix-community/emacs-overlay/commit/644ae3ce05ae9d42232bba9642d4eaa63bb062d3) | `` Fix comment ``                                |
| [`f73f92e0`](https://github.com/nix-community/emacs-overlay/commit/f73f92e01b6477dd56a628e251d265ee999f1afe) | `` Fix issue link for bug-reference-prog-mode `` |