### PR TITLE
chore(flake/nur): `aa9cd286` -> `353e8906`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681175762,
-        "narHash": "sha256-q+BX6Vdrq68RsYKm5n/VYd1w6Z1X1DeATyc4rvB4STE=",
+        "lastModified": 1681181765,
+        "narHash": "sha256-tsKmEChFiqgmbFrD+yVl6I4RDCZAvrIkgMTiu/t7eg0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aa9cd28698b8f01a4e17fc161a93b8f9030f3a05",
+        "rev": "353e89069b8da1046543900db66e72a05a682253",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`353e8906`](https://github.com/nix-community/NUR/commit/353e89069b8da1046543900db66e72a05a682253) | `` automatic update `` |
| [`aea2d203`](https://github.com/nix-community/NUR/commit/aea2d203d4fbaa1752df12c473870712d00326df) | `` automatic update `` |