### PR TITLE
chore(flake/nur): `d173c4e7` -> `e2f91d94`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681182128,
-        "narHash": "sha256-9AAbgYuTKnl2mMOgNzari10BFHEo5GtcYgawSnMdxqY=",
+        "lastModified": 1681184769,
+        "narHash": "sha256-ezTzc6GkICZfNbusWdboqQkHy2iDeaC6ji2P9cFGDXE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d173c4e70afe9ef528f7c394b0e2f277892ac942",
+        "rev": "e2f91d94669a4a7c6fde07b4fb3bb20627792900",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e2f91d94`](https://github.com/nix-community/NUR/commit/e2f91d94669a4a7c6fde07b4fb3bb20627792900) | `` automatic update `` |
| [`072de0d1`](https://github.com/nix-community/NUR/commit/072de0d1af4dab28ae6d7f4ac833b28192274eb3) | `` automatic update `` |