### PR TITLE
chore(flake/emacs-overlay): `644ae3ce` -> `96fec8e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681165126,
-        "narHash": "sha256-Qte3CafN9PkT+hx6HBKqQoCeQAdOGi5ZEUByKQh1IX0=",
+        "lastModified": 1681183863,
+        "narHash": "sha256-2vIPmqFjsUs1Fkl5UYSTTm3btS/fnYghcDFqbTar5Ok=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "644ae3ce05ae9d42232bba9642d4eaa63bb062d3",
+        "rev": "96fec8e6cdb99a7a40e5d8f7f7449d7fee6d441f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`96fec8e6`](https://github.com/nix-community/emacs-overlay/commit/96fec8e6cdb99a7a40e5d8f7f7449d7fee6d441f) | `` Updated repos/melpa `` |
| [`acf157f5`](https://github.com/nix-community/emacs-overlay/commit/acf157f5400a62fd1506da20d257bcec07c040c7) | `` Updated repos/emacs `` |
| [`0030dec0`](https://github.com/nix-community/emacs-overlay/commit/0030dec0b386d7abd8425b93b0e47d90ebeb3d38) | `` Updated repos/elpa ``  |