### PR TITLE
chore(flake/nixpkgs): `fd531dee` -> `db24d86d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -672,11 +672,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1681036984,
-        "narHash": "sha256-AbScJXshYzbeUKHh+Y3OICc3iAtr+NqJ3Xb81GW+ptU=",
+        "lastModified": 1681126633,
+        "narHash": "sha256-evQ3Ct/yJDSHej16Hiq+JfxRjgm9FXu/2LBxsyorGdE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fd531dee22c9a3d4336cc2da39e8dd905e8f3de4",
+        "rev": "db24d86dd8a4769c50d6b7295e81aa280cd93f35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                        |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`c46fd0ae`](https://github.com/NixOS/nixpkgs/commit/c46fd0ae27ca1d9a1d550d8bf7a659d2ca44e961) | `` python310Packages.hepunits: 2.3.1 -> 2.3.2 ``                                               |
| [`b115c3cb`](https://github.com/NixOS/nixpkgs/commit/b115c3cbb0d6f1bafcdf2661163d261dc4524cb7) | `` rust-analyzer-unwrapped: 2023-04-04 -> 2023-04-10 ``                                        |
| [`255794fa`](https://github.com/NixOS/nixpkgs/commit/255794fa53ba3a028e2be1106a64da0a61300bf9) | `` python310Packages.glfw: 2.5.7 -> 2.5.9 ``                                                   |
| [`76fc5cb1`](https://github.com/NixOS/nixpkgs/commit/76fc5cb1e42140d487376414805f56f7dab61f88) | `` kuro: init at 9.0.0 ``                                                                      |
| [`483c97df`](https://github.com/NixOS/nixpkgs/commit/483c97df606840b980a22aa7b812a002b0ce9c2e) | `` vscodium: 1.77.0.23093 -> 1.77.1.23095 ``                                                   |
| [`a2fc5cbc`](https://github.com/NixOS/nixpkgs/commit/a2fc5cbcac806308248f2b387f813e9165d5ebe4) | `` crystal: 1.7.2 -> 1.7.3 ``                                                                  |
| [`5b809932`](https://github.com/NixOS/nixpkgs/commit/5b80993258d9c36bcc693fa84b99d3586661765e) | `` python310Packages.lmdb: 1.4.0 -> 1.4.1 ``                                                   |
| [`44b12c38`](https://github.com/NixOS/nixpkgs/commit/44b12c38a239077b0f6a31ebbe345ed0b4e5bfbd) | `` python310Packages.quart: 0.18.3 -> 0.18.4 ``                                                |
| [`b7c83b21`](https://github.com/NixOS/nixpkgs/commit/b7c83b21010cf0b2f7b43db2b3d1ef11da76eb7f) | `` prometheus-bind-exporter: 0.6.0 -> 0.6.1 ``                                                 |
| [`a6075eaa`](https://github.com/NixOS/nixpkgs/commit/a6075eaa31068634b2f31d1db20df9949bad058f) | `` sngrep: 1.6.0 -> 1.7.0 ``                                                                   |
| [`619ca206`](https://github.com/NixOS/nixpkgs/commit/619ca2064f709582ef4710be2c18433241adfdd0) | `` luaPackages.luv: 1.43.0-0 -> 1.44.2-1 ``                                                    |
| [`00c7af0d`](https://github.com/NixOS/nixpkgs/commit/00c7af0dd611eb7592c8643f5d68886a89216eef) | `` nas: 1.9.4 -> 1.9.5 ``                                                                      |
| [`80e27c13`](https://github.com/NixOS/nixpkgs/commit/80e27c13d9ca582884ece69fdeafe8bbaf1df2df) | `` home-assistant: Pin notifications-android-tv at 0.1.5 ``                                    |
| [`80c11dc8`](https://github.com/NixOS/nixpkgs/commit/80c11dc8d89125e7d7feac39a2852040dbbf4abc) | `` talosctl: 1.3.6 -> 1.3.7 ``                                                                 |
| [`4580a38f`](https://github.com/NixOS/nixpkgs/commit/4580a38fec9851800b283780146e4379487ba8c5) | `` home-assistant: update component-packages ``                                                |
| [`566b3e38`](https://github.com/NixOS/nixpkgs/commit/566b3e38ab8cf9eea857e72fb78f4abb89fb2b28) | `` python3Packages.notifications-android-tv: init at 1.0.0 ``                                  |
| [`cceb111f`](https://github.com/NixOS/nixpkgs/commit/cceb111fa74ae02f8581d6d6a7cc41953b8a5495) | `` function-runner: 3.2.4 -> 3.3.0 ``                                                          |
| [`bebe1fe6`](https://github.com/NixOS/nixpkgs/commit/bebe1fe60bb734e217565ea853122224d9d1e86e) | `` comma: 1.5.0 -> 1.6.0 ``                                                                    |
| [`c320d104`](https://github.com/NixOS/nixpkgs/commit/c320d10418f66d6a694912308d7ef28924abf8d9) | `` buf: 1.16.0 -> 1.17.0 ``                                                                    |
| [`89ec2cbc`](https://github.com/NixOS/nixpkgs/commit/89ec2cbc86a5ce991118afa4d675b514cde8263d) | `` mlterm: 3.9.2 -> 3.9.3 ``                                                                   |
| [`d0538f62`](https://github.com/NixOS/nixpkgs/commit/d0538f6287e5f5225170b5b2be7a73a9357c4590) | `` mlterm: enableParallelBuilding ``                                                           |
| [`c97c59b8`](https://github.com/NixOS/nixpkgs/commit/c97c59b8778e4128586cfa80422a8df68bc0a0b8) | `` mlterm: indent ``                                                                           |
| [`40ccdecb`](https://github.com/NixOS/nixpkgs/commit/40ccdecb472bd1fbed47cdb9658b8d967d689e3c) | `` stripe-cli: 1.13.12 -> 1.14.0 ``                                                            |
| [`48669e91`](https://github.com/NixOS/nixpkgs/commit/48669e91f82f94b0c4f092951f9c355f0283903f) | `` freecad: set QT_QPA_PLATFORM=xcb ``                                                         |
| [`099b6650`](https://github.com/NixOS/nixpkgs/commit/099b6650dec36b4921d62812adea4bace9284aea) | `` kubernetes-polaris: 7.3.2 -> 7.4.1 ``                                                       |
| [`18111d5d`](https://github.com/NixOS/nixpkgs/commit/18111d5d7e16f154eda71f47c16415bc5093a698) | `` neovide: 0.10.3 -> 0.10.4 ``                                                                |
| [`db9b566c`](https://github.com/NixOS/nixpkgs/commit/db9b566c4f5d6380de458930f48a68e2881683b6) | `` flatpak: 1.14.2 -> 1.14.4 ``                                                                |
| [`8425b6d3`](https://github.com/NixOS/nixpkgs/commit/8425b6d377247004613c2761938ece59a545ee29) | `` python310Packages.types-protobuf: 4.22.0.0 -> 4.22.0.2 ``                                   |
| [`04b1a3f8`](https://github.com/NixOS/nixpkgs/commit/04b1a3f847e46ea2bbb46cca56dde37a536272c7) | `` nixos/auto-cpufreq: Avoid touching /etc ``                                                  |
| [`7a67e0f7`](https://github.com/NixOS/nixpkgs/commit/7a67e0f7243cca376ccbdbde4d99d9cdf3cb2f30) | `` python310Packages.google-cloud-spanner: 3.29.0 -> 3.30.0 ``                                 |
| [`0d8cf8b6`](https://github.com/NixOS/nixpkgs/commit/0d8cf8b60a6bba3196c80911d9096df076b1facb) | `` mpvScripts.acompressor: init at 0.35.1 ``                                                   |
| [`b9726714`](https://github.com/NixOS/nixpkgs/commit/b9726714a891e8d3cec938c8e905b0bfd40f6a95) | `` rust-analyzer-unwrapped: 2023-03-27 -> 2023-04-04 ``                                        |
| [`1380348e`](https://github.com/NixOS/nixpkgs/commit/1380348ea89ce3e2be4a92efeba10d15980b4607) | `` python310Packages.types-pytz: 2023.2.0.0 -> 2023.3.0.0 ``                                   |
| [`da0b0bc6`](https://github.com/NixOS/nixpkgs/commit/da0b0bc6a5d699a8a9ffbf9e1b19e8642307062a) | `` prusa-slicer: 2.5.1 -> 2.5.2 ``                                                             |
| [`5359173e`](https://github.com/NixOS/nixpkgs/commit/5359173eab5cd98ed24f3af990bb7c18bfcf88e5) | `` python310Packages.spyder-kernels: 2.4.2 -> 2.4.3 ``                                         |
| [`03417384`](https://github.com/NixOS/nixpkgs/commit/03417384e1837294e78d0cf41043d8c2b23eee52) | `` spotify-player: 0.12.1 -> 0.13.1 ``                                                         |
| [`7b198bc8`](https://github.com/NixOS/nixpkgs/commit/7b198bc8e67970510410e04690577c3c64ecfca2) | `` maintainers: add nicoo ``                                                                   |
| [`a280b3cf`](https://github.com/NixOS/nixpkgs/commit/a280b3cf1c5df12e7d264025587620b7ca0e455e) | `` multus-cni: 3.9.2 -> 3.9.3 ``                                                               |
| [`e4ac873f`](https://github.com/NixOS/nixpkgs/commit/e4ac873f10c7afd4f367ccf2071ddd010c7ce625) | `` vals: 0.23.0 -> 0.24.0 ``                                                                   |
| [`97795088`](https://github.com/NixOS/nixpkgs/commit/97795088e99574b53dfe344d8819497a92dcfe97) | `` brev-cli: 0.6.213 -> 0.6.215 ``                                                             |
| [`c2a37b06`](https://github.com/NixOS/nixpkgs/commit/c2a37b06dd468e97f64f76e4253f0aad27374a62) | `` fend: 1.1.5 -> 1.1.6 ``                                                                     |
| [`b96d7b5e`](https://github.com/NixOS/nixpkgs/commit/b96d7b5eadbd507def3d49492265b886309cbb12) | `` o: rename to orbiton ``                                                                     |
| [`a1ad8200`](https://github.com/NixOS/nixpkgs/commit/a1ad820020ce72dd9a580cfe37c293244143eefe) | `` juicefs: 1.0.3 -> 1.0.4 ``                                                                  |
| [`633ed6e9`](https://github.com/NixOS/nixpkgs/commit/633ed6e9ffd3e02c289cbd2d9d39e75dfcc7e447) | `` calibre: 6.11.0 -> 6.15.1 ``                                                                |
| [`97e9e9af`](https://github.com/NixOS/nixpkgs/commit/97e9e9afceaa12120d7540230a59b398dc8f9ec9) | `` zeekscript: init at 1.2.1 ``                                                                |
| [`018dc1da`](https://github.com/NixOS/nixpkgs/commit/018dc1da67f832a2834cd02db43263f599c65fb4) | `` cudatext: 1.189.0 -> 1.190.1 ``                                                             |
| [`bfc6014c`](https://github.com/NixOS/nixpkgs/commit/bfc6014c6dd1254482ed07e278a0a678047706c3) | `` python310Packages.gspread: 5.7.2 -> 5.8.0 ``                                                |
| [`c6b49b60`](https://github.com/NixOS/nixpkgs/commit/c6b49b60f5c400caefdfc16959ef263f06e3c293) | `` python310Packages.casbin: 1.18.0 -> 1.18.2 ``                                               |
| [`da0ac898`](https://github.com/NixOS/nixpkgs/commit/da0ac89808b652ab8ba8756047144ee13d58bc2f) | `` mongoc: 1.23.2 -> 1.23.3 ``                                                                 |
| [`c217fb60`](https://github.com/NixOS/nixpkgs/commit/c217fb605fca88042ff80af3f666521de7a8003e) | `` factorio: Add Wayland support ``                                                            |
| [`c5ef4af0`](https://github.com/NixOS/nixpkgs/commit/c5ef4af03f4838cb38d4c1c37b8d3d2a4c683407) | `` factorio: Formatting ``                                                                     |
| [`3c384353`](https://github.com/NixOS/nixpkgs/commit/3c384353a64ee069240af601aa6781bb556351cf) | `` qemu: 7.2.0 -> 7.2.1 ``                                                                     |
| [`d5da6e90`](https://github.com/NixOS/nixpkgs/commit/d5da6e90a054e1973c3e8fa9452f15ec82bcd972) | `` crosvm: 111.1 -> 112.0 ``                                                                   |
| [`502b08d3`](https://github.com/NixOS/nixpkgs/commit/502b08d315e671001244b7f440428868eedb76b6) | `` clash-meta: fix clash ``                                                                    |
| [`af3f488b`](https://github.com/NixOS/nixpkgs/commit/af3f488bace4890f82cab5345641fac7813985f2) | `` cargo-tarpaulin: 0.25.1 -> 0.25.2 ``                                                        |
| [`6b2b317f`](https://github.com/NixOS/nixpkgs/commit/6b2b317f70a73b09df240a212a0feccb60f21195) | `` o: 2.58.0 -> 2.60.5 ``                                                                      |
| [`f7658e0b`](https://github.com/NixOS/nixpkgs/commit/f7658e0bd0ee8fa7869208fa4f2537c318c2c2c6) | `` freefilesync: 12.1 -> 12.2 ``                                                               |
| [`3a22bccf`](https://github.com/NixOS/nixpkgs/commit/3a22bccf6388aafa95c6e183896c7512377cec80) | `` python310Packages.homeassistant-stubs: 2023.4.0 -> 2023.4.2 ``                              |
| [`f6bae434`](https://github.com/NixOS/nixpkgs/commit/f6bae434a2030ad8c9042ea7035e2f200090c38c) | `` python310Packages.gql: Relax websockets constraint ``                                       |
| [`a6f15abc`](https://github.com/NixOS/nixpkgs/commit/a6f15abc955e6bf2b800b7d6a68966ee53130c7f) | `` home-assistant: 2023.4.1 -> 2023.4.2 ``                                                     |
| [`c4041418`](https://github.com/NixOS/nixpkgs/commit/c4041418d53276e59b109da780aebba3b6969b7d) | `` python310Packages.zha-quirks: 0.0.95 -> 0.0.96 ``                                           |
| [`2409362d`](https://github.com/NixOS/nixpkgs/commit/2409362d04a7645c9abda0255de6b2bc9476e6bc) | `` python310Packages.zeroconf: 0.54.0 -> 0.56.0 ``                                             |
| [`f56e0dc6`](https://github.com/NixOS/nixpkgs/commit/f56e0dc6b1949dfcc996418e562c71edbd4f650a) | `` python310Packages.subarulink: 0.7.5 -> 0.7.6 ``                                             |
| [`bb2e919e`](https://github.com/NixOS/nixpkgs/commit/bb2e919ee791b08269215e256265dc2b0b4f00a3) | `` python310Packages.roombapy: 1.6.7 -> 1.6.8 ``                                               |
| [`ce5b6aba`](https://github.com/NixOS/nixpkgs/commit/ce5b6aba7ccb0eb94a8d5fd2e977897fe8fb4192) | `` python310Packages.amqtt: Relax websockets constraint ``                                     |
| [`59ef9d5f`](https://github.com/NixOS/nixpkgs/commit/59ef9d5fc8408dfeec1762c106c5c944e38bd4fa) | `` python310Packages.gcal-sync: 4.1.3 -> 4.1.4 ``                                              |
| [`d4506982`](https://github.com/NixOS/nixpkgs/commit/d450698227a3c9d133e509ef6d0a790463dba140) | `` python310Packages.flux-led: 0.28.36 -> 0.28.37 ``                                           |
| [`8a287701`](https://github.com/NixOS/nixpkgs/commit/8a287701c0cf2f68ef03c183776b41f79905ee7c) | `` python310Packages.env-canada: 0.5.30 -> 0.5.31 ``                                           |
| [`9b6158e0`](https://github.com/NixOS/nixpkgs/commit/9b6158e09257dffe2dd85b60c925fe0144bc1c91) | `` python310Packages.aioambient: 2022.10.0 -> 2023.04.0 ``                                     |
| [`fb3e0d01`](https://github.com/NixOS/nixpkgs/commit/fb3e0d018588bd559c215a961c5ec61d5b41dc89) | `` kotlin{-native}: 1.8.10 → 1.8.20 ``                                                         |
| [`bd81c94d`](https://github.com/NixOS/nixpkgs/commit/bd81c94de08beb58aa6a2f090f7e751961e9dbc6) | `` rustic-rs: add update script ``                                                             |
| [`5b84ccce`](https://github.com/NixOS/nixpkgs/commit/5b84ccce78843b2b13721c67aa9a3fa10eb14ac5) | `` exercism: add update script ``                                                              |
| [`89a0fabf`](https://github.com/NixOS/nixpkgs/commit/89a0fabf6a06a390a6a9d8791d16abfdac09e254) | `` ugrep: 3.11.0 -> 3.11.2 ``                                                                  |
| [`1a827d74`](https://github.com/NixOS/nixpkgs/commit/1a827d74d82ae0954f4f5ab9f6f366f7cd977283) | `` exploitdb: 2023-04-08 -> 2023-04-09 ``                                                      |
| [`f597cba1`](https://github.com/NixOS/nixpkgs/commit/f597cba178c8c63341360f973e5b8c8ed425c334) | `` kubescape: 2.2.5 -> 2.2.6 ``                                                                |
| [`a3f6d555`](https://github.com/NixOS/nixpkgs/commit/a3f6d55533380b3e94805499bcb1a9f516880a34) | `` pistol: 0.3.2 -> 0.3.3 ``                                                                   |
| [`8b1e0ff0`](https://github.com/NixOS/nixpkgs/commit/8b1e0ff0e7a82968f00ed6665c4956c2a2286f16) | `` python310Packages.zwave-me-ws: 0.3.6 -> 0.4.2 ``                                            |
| [`fa6b4799`](https://github.com/NixOS/nixpkgs/commit/fa6b4799a6a487faf0f588608855c54e534df0fe) | `` python310Packages.pontos: 23.4.0 -> 23.4.1 ``                                               |
| [`d816db9b`](https://github.com/NixOS/nixpkgs/commit/d816db9b96618a36522de395de072fb53240b8fb) | `` python310Packages.aiopyarr: add changelog to meta ``                                        |
| [`fd284a17`](https://github.com/NixOS/nixpkgs/commit/fd284a179f4d7e44ac506b556c6b0d77d9b0c5f0) | `` python310Packages.mkdocstrings: 0.20.0 -> 0.21.2 ``                                         |
| [`1516704b`](https://github.com/NixOS/nixpkgs/commit/1516704b0ddd783b48505f97c6206255d59691a4) | `` python310Packages.aiopyarr: 22.11.0 -> 23.4.0 ``                                            |
| [`f6ad3df1`](https://github.com/NixOS/nixpkgs/commit/f6ad3df1ecfc972c5a9b13e20369e6d66cd08fd3) | `` python310Packages.et_xmlfile: 1.0.1 -> 1.1 ``                                               |
| [`429aff60`](https://github.com/NixOS/nixpkgs/commit/429aff605527ad9a78140f97ee11e9cd306d6bb4) | `` python310Packages.et_xmlfile: move to pytestCheckHook ``                                    |
| [`b5f5ba93`](https://github.com/NixOS/nixpkgs/commit/b5f5ba93d6b299114d6a55a045737aaeb7e2c89f) | `` python310Packages.et_xmlfile: disable on unsupported releases ``                            |
| [`179eda92`](https://github.com/NixOS/nixpkgs/commit/179eda92f8145af9d56d738ce9628622bf6e9c65) | `` go-musicfox: 3.7.7 -> 4.0.0 ``                                                              |
| [`59a173d1`](https://github.com/NixOS/nixpkgs/commit/59a173d1c27dd4c777d7a26446459336e9bf9df5) | `` python310Packages.et_xmlfile: update homepage ``                                            |
| [`99a7b13a`](https://github.com/NixOS/nixpkgs/commit/99a7b13af8e2585a441316ac746824087a2a0a02) | `` python310Packages.et_xmlfile: add pythonImportsCheck ``                                     |
| [`7c03fd04`](https://github.com/NixOS/nixpkgs/commit/7c03fd0458a13b7499a12b244e2e218f3fc80576) | `` python310Packages.et_xmlfile: normalize pname ``                                            |
| [`0cb08723`](https://github.com/NixOS/nixpkgs/commit/0cb08723b60dcd5f67f1af047f684db280dfa74d) | `` maintainers: add tie ``                                                                     |
| [`88aded71`](https://github.com/NixOS/nixpkgs/commit/88aded71bb383c2fadcb621d5574ce629fccacb7) | `` ncspot: add extra features ``                                                               |
| [`bd8faee2`](https://github.com/NixOS/nixpkgs/commit/bd8faee2d532664fddee80c2c68298d0fdb55665) | `` cloud-nuke: 0.29.0 -> 0.29.2 ``                                                             |
| [`7f4db028`](https://github.com/NixOS/nixpkgs/commit/7f4db028810bf0acb1d30ae7b2bc33afda9faecd) | `` tflint: 0.45.0 -> 0.46.0 ``                                                                 |
| [`2918f416`](https://github.com/NixOS/nixpkgs/commit/2918f41670c3e2a19fbd8b61e359ffb0b644e33e) | `` luau: 0.570 -> 0.571 ``                                                                     |
| [`a14f65e9`](https://github.com/NixOS/nixpkgs/commit/a14f65e9c2fb5b1539ea3ee73e464dcca1aade1d) | `` gradience: init at 0.4.1 ``                                                                 |
| [`6e5ce485`](https://github.com/NixOS/nixpkgs/commit/6e5ce485536b190b76992a25e99f197844dbd3b0) | `` cloudlog: 2.4 -> 2.4.1 ``                                                                   |
| [`6e8d9512`](https://github.com/NixOS/nixpkgs/commit/6e8d951274a56f2e64922a091e4e6a8d722bd894) | `` go-bindata: 3.24.0 -> 4.0.2 ``                                                              |
| [`727f9f0f`](https://github.com/NixOS/nixpkgs/commit/727f9f0fbdbdf71b8d3b3aa87a6d3e482a72e8d2) | `` Revert "nixos/opengl: add mesaPackage option" ``                                            |
| [`dea29666`](https://github.com/NixOS/nixpkgs/commit/dea29666cb3e2b482ed327ec6c7780c25ab6b199) | `` depotdownloader: unbreak on aarch64-darwin ``                                               |
| [`2dbdc56a`](https://github.com/NixOS/nixpkgs/commit/2dbdc56a46547e6c257828d5e69048f41ebe4a66) | `` pkg: don't use vendored libelf ``                                                           |
| [`84077e13`](https://github.com/NixOS/nixpkgs/commit/84077e13db2fee23afd7176f622012ba232bd9ca) | `` pkg: 1.19.0 -> 1.19.1 ``                                                                    |
| [`a93f7c28`](https://github.com/NixOS/nixpkgs/commit/a93f7c28dd7a2e57666def8cd46d00c1349f3043) | `` wpaperd: 0.2.0 -> 0.3.0 ``                                                                  |
| [`1bf652ce`](https://github.com/NixOS/nixpkgs/commit/1bf652cedc21f2013dae5cd8be971b78be35aae5) | `` linux_xanmod_latest: 6.2.9 -> 6.2.10 ``                                                     |
| [`e60a8a81`](https://github.com/NixOS/nixpkgs/commit/e60a8a81a29d27159e6abfa3070703bb8f64307d) | `` linux_xanmod: 6.1.22 -> 6.1.23 ``                                                           |
| [`34f62593`](https://github.com/NixOS/nixpkgs/commit/34f625938c4285bbdef2b056258234a256b889fc) | `` material-kwin-decoration: unstable-2022-01-19 -> unstable-2023-01-15 ``                     |
| [`34763f48`](https://github.com/NixOS/nixpkgs/commit/34763f48370a3e46db2c0b1bdd8179c4de8f3ba9) | `` python310Packages.srt: 3.5.2 -> 3.5.3 ``                                                    |
| [`e3d10e25`](https://github.com/NixOS/nixpkgs/commit/e3d10e25e7fb794cf8db65fe1ae9de06b4796c93) | `` python310Packages.file-read-backwards: 2.0.0 -> 3.0.0 ``                                    |
| [`7b3729c4`](https://github.com/NixOS/nixpkgs/commit/7b3729c4c07bef3f14c4b67dce33e9004fc08a36) | `` libkrunfw: 3.10.0 -> 3.11.0 ``                                                              |
| [`a0883661`](https://github.com/NixOS/nixpkgs/commit/a0883661e66917c2f7010f2d6481b84e98d4e2b3) | `` python310Packages.pytorch-metric-learning: 2.0.1 -> 2.1.0 ``                                |
| [`6e8cce54`](https://github.com/NixOS/nixpkgs/commit/6e8cce5440e1df6ac41a0e10077c232a95115638) | `` python310Packages.islpy: 2022.2.1 -> 2023.1 ``                                              |
| [`82dd065f`](https://github.com/NixOS/nixpkgs/commit/82dd065f7ab665f3cda63bbe9d7c0d308b649d93) | `` swapspace: patch paths to binaries and install systemd unit file ``                         |
| [`b0004e6c`](https://github.com/NixOS/nixpkgs/commit/b0004e6c970d8f552daddced6f11c352e256b2a1) | `` swapspace: add Luflosi as maintainer ``                                                     |
| [`c884e209`](https://github.com/NixOS/nixpkgs/commit/c884e20976968fd747e383549817d1918e9cbc5e) | `` syncplay: render natively under Wayland ``                                                  |
| [`bb29926b`](https://github.com/NixOS/nixpkgs/commit/bb29926bc3273f2a1a9083c521b3ff9ee1df20b6) | `` python310Packages.marisa-trie: 0.7.8 -> 0.8.0 ``                                            |
| [`c33e1cf1`](https://github.com/NixOS/nixpkgs/commit/c33e1cf1a19d114ab1611cbacaa6b983fb6cc5ec) | `` python310Packages.pytest-testmon: 1.4.5 -> 2.0.2 ``                                         |
| [`d0403d92`](https://github.com/NixOS/nixpkgs/commit/d0403d923f630b551f29c2f66f2c88378b144868) | `` hplip: 3.22.6 -> 3.23.3 ``                                                                  |
| [`afd35a40`](https://github.com/NixOS/nixpkgs/commit/afd35a40e70a0f6ad635c72d10254f54068dd00a) | `` insomnia: Add gappsWrapperArgs to wrapProgram ``                                            |
| [`88e20414`](https://github.com/NixOS/nixpkgs/commit/88e204147e71c00127242f8e1e1690ee29fb064d) | `` okteto: 2.13.0 -> 2.14.2 ``                                                                 |
| [`5fd19c2e`](https://github.com/NixOS/nixpkgs/commit/5fd19c2e75fa62d6e4d8f4265f168f17d8107e51) | `` python310Packages.rapidfuzz: 2.14.0 -> 2.15.0 ``                                            |
| [`9d51da4f`](https://github.com/NixOS/nixpkgs/commit/9d51da4f53c3a70e9aaed2db30187c1d69426a40) | `` marwaita-manjaro: 10.3 -> 17.0 ``                                                           |
| [`7c0fa2f3`](https://github.com/NixOS/nixpkgs/commit/7c0fa2f34c838511a9a2fc9021b6552a72075c26) | `` python310Packages.dj-database-url: 1.2.0 -> 1.3.0 ``                                        |
| [`da35fafa`](https://github.com/NixOS/nixpkgs/commit/da35fafa08de9a118a51b92cc8d0644e1afe2a5f) | `` chickenPackages: Introduce overrides ``                                                     |
| [`85382d5b`](https://github.com/NixOS/nixpkgs/commit/85382d5b6848889dff5a721ee21d3edea4947fe7) | `` jenkins: 2.387.1 -> 2.387.2 ``                                                              |
| [`acebe7b9`](https://github.com/NixOS/nixpkgs/commit/acebe7b96a4757579d45fb40b6048f2e42b383ab) | `` python310Packages.transformers: 4.26.1 -> 4.27.4 ``                                         |
| [`01ceca76`](https://github.com/NixOS/nixpkgs/commit/01ceca76ac21b5df4196f2d0d029b932b16846ff) | `` zeal: 0.6.20221022 -> 0.6.1.20230320 ``                                                     |
| [`f4b0afe9`](https://github.com/NixOS/nixpkgs/commit/f4b0afe9f56ced1adce1f6bc65c91e0fc880c6c3) | `` pre-commit: 3.1.0 -> 3.2.1 ``                                                               |
| [`6f50798d`](https://github.com/NixOS/nixpkgs/commit/6f50798d26b1e6c486fae4a4a99ff40ee156a06d) | `` python310Packages.social-auth-core: 4.3.0 -> 4.4.1 ``                                       |
| [`4e72d111`](https://github.com/NixOS/nixpkgs/commit/4e72d111e92555e993dff69c6f230246c6ce1795) | `` raspa: init at 2.0.47 and add tests ``                                                      |
| [`35b698d0`](https://github.com/NixOS/nixpkgs/commit/35b698d0b2194038d0a2f279347053e5a10ea1fb) | `` mftrace: move texlive dependencies to tlDeps ``                                             |
| [`acb02e2f`](https://github.com/NixOS/nixpkgs/commit/acb02e2fab3b84601288af4524582f4049248a9b) | `` eukleides: move texlive dependencies to tlDeps ``                                           |
| [`57b2634a`](https://github.com/NixOS/nixpkgs/commit/57b2634ac1242bd8d34b6c78396b217c65418755) | `` texlive.combine: document how to create custom packages with pkgs and tlDeps attributes ``  |
| [`59661daf`](https://github.com/NixOS/nixpkgs/commit/59661dafb04b95b4e6d5933bfa2332949de46bbe) | `` texlive.combine: remove lib.unique in generating language and format configuration ``       |
| [`240cc599`](https://github.com/NixOS/nixpkgs/commit/240cc5994224b2ed8403feb5f8a05aea38121df3) | `` texlive.combine: move dependencies to attribute tlDeps, resolve them with genericClosure `` |
| [`2020863f`](https://github.com/NixOS/nixpkgs/commit/2020863f242ecdd0c6bf271da24a07f73fe18492) | `` sagetex: create pkgs fixpoint for texlive using mkDerivation ``                             |
| [`4319e1ce`](https://github.com/NixOS/nixpkgs/commit/4319e1ceb24d014b125f05e18f6a4bccec792e87) | `` noweb: create pkgs fixpoint for texlive using mkDerivation ``                               |
| [`2f7daea6`](https://github.com/NixOS/nixpkgs/commit/2f7daea6031264ee98757fab25e68b7a66931f73) | `` mftrace: create pkgs fixpoint for texlive using mkDerivation ``                             |
| [`6b2b9a0d`](https://github.com/NixOS/nixpkgs/commit/6b2b9a0de3f6d740d141ae3ffdf2a25ad598adf1) | `` eukleides: create pkgs fixpoint for texlive using mkDerivation ``                           |
| [`a66723d4`](https://github.com/NixOS/nixpkgs/commit/a66723d4bf4f66e5725b48eb64def872185eb3bf) | `` auto-multiple-choice: create pkgs fixpoint for texlive using mkDerivation ``                |
| [`6f6e74d2`](https://github.com/NixOS/nixpkgs/commit/6f6e74d2555372a6d2f722503c1a8bd8add152c7) | `` clash-meta: 1.14.2 -> 1.14.3 ``                                                             |
| [`0b39ed44`](https://github.com/NixOS/nixpkgs/commit/0b39ed44dd08d37a9364cd39bc20f097c1fb07b7) | `` carapace: add ldflags for version ``                                                        |
| [`deab2b3b`](https://github.com/NixOS/nixpkgs/commit/deab2b3bf768fc6158142e4d59e20ef016197438) | `` nixos/auto-cpufreq: Add configuration support. ``                                           |
| [`982cecf9`](https://github.com/NixOS/nixpkgs/commit/982cecf911134e7642489508907bcdf46efc8544) | `` tuckr: 0.7.1 -> 0.8.0 ``                                                                    |
| [`d505646d`](https://github.com/NixOS/nixpkgs/commit/d505646da5516457d258f88e76f02852e221bc03) | `` python310Packages.tree-sitter: init at 0.20.1 ``                                            |
| [`99f96687`](https://github.com/NixOS/nixpkgs/commit/99f9668726e337caa646734c88507538ec6455bf) | `` yuview: 2.12.1 -> 2.13 ``                                                                   |
| [`6f81910b`](https://github.com/NixOS/nixpkgs/commit/6f81910b71906a979580ffd33b51b5fc704aa9d2) | `` python310Packages.django-compression-middleware: 0.4.2 → 0.5.0 ``                           |
| [`ba0a1611`](https://github.com/NixOS/nixpkgs/commit/ba0a1611fcd67b826eaa8f7dc238105aec93d3c7) | `` nixos/nginx: fix warning about duplicate mime entry ``                                      |
| [`b34aec22`](https://github.com/NixOS/nixpkgs/commit/b34aec224d234a75adada4afd29326ac71842b97) | `` material-color-utilities-python: init at 0.1.5 ``                                           |
| [`a411a116`](https://github.com/NixOS/nixpkgs/commit/a411a116a5d91a8d7ce260a05fe48142366138e4) | `` openafs: Fix configure option; Add tools ``                                                 |
| [`8ec36277`](https://github.com/NixOS/nixpkgs/commit/8ec3627796ecc899e6f47f5bf3c3220856ead9c5) | `` tree-sitter: Add solidity, update grammars ``                                               |
| [`e90acad3`](https://github.com/NixOS/nixpkgs/commit/e90acad35f33b883b6627ec28998fe883e303b02) | `` python310Packages.aioresponses: don't depend on asynctest ``                                |
| [`f4140ff0`](https://github.com/NixOS/nixpkgs/commit/f4140ff0157fa7d8e3bcc53eb895f0d70a3e4224) | `` orthorobot: repair and cleanup ``                                                           |