### PR TITLE
chore(flake/sops-nix): `ddc6f124` -> `00d5fd73`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -923,11 +923,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1681008913,
-        "narHash": "sha256-6C4BknF+cwCnl/A2fFdlAnc3LMV7f7XqOL09UhLZ9tA=",
+        "lastModified": 1681209176,
+        "narHash": "sha256-wyQokPpkNZnsl/bVf8m1428tfA0hJ0w/qexq4EizhTc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "ddc6f124cb9be22d2ba066064c28bc19039a6bce",
+        "rev": "00d5fd73756d424de5263b92235563bc06f2c6e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                       |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`31b95f64`](https://github.com/Mic92/sops-nix/commit/31b95f641efa4f9d3df96ad05aae49c97ec279de) | `` Bump DeterminateSystems/update-flake-lock from 18 to 19 `` |