### PR TITLE
chore(flake/emacs-overlay): `96fec8e6` -> `86ea3268`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681183863,
-        "narHash": "sha256-2vIPmqFjsUs1Fkl5UYSTTm3btS/fnYghcDFqbTar5Ok=",
+        "lastModified": 1681212122,
+        "narHash": "sha256-zyqlgECc+/MeCGnxpyDJ1K7r0t4OefuPtoEnorTBObc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "96fec8e6cdb99a7a40e5d8f7f7449d7fee6d441f",
+        "rev": "86ea3268b55bb632de43a80a37501a3d05cdb224",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`86ea3268`](https://github.com/nix-community/emacs-overlay/commit/86ea3268b55bb632de43a80a37501a3d05cdb224) | `` Updated repos/melpa `` |
| [`63c896e1`](https://github.com/nix-community/emacs-overlay/commit/63c896e1efb1a75cb54523b79ddda02562b56bd5) | `` Updated repos/emacs `` |