### PR TITLE
chore(flake/nur): `34e316c9` -> `c55a5032`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681224308,
-        "narHash": "sha256-nrl31HsC/U/9/h15WC52OTiqH0BZS/XYzXb7jQb58jY=",
+        "lastModified": 1681230810,
+        "narHash": "sha256-02bupTiYk8NPmM0nr4cwUqbQi1r3rUeWh3/7fbAmSUI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "34e316c9a828b6259278361d9bd47d4202ba0088",
+        "rev": "c55a50325629df16f1cac586e9839851741ffa84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c55a5032`](https://github.com/nix-community/NUR/commit/c55a50325629df16f1cac586e9839851741ffa84) | `` automatic update `` |
| [`db55a4bb`](https://github.com/nix-community/NUR/commit/db55a4bb61c21cea23d2430f844b422088e0abbe) | `` automatic update `` |