### PR TITLE
chore(flake/emacs-overlay): `86ea3268` -> `29ec9b44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681212122,
-        "narHash": "sha256-zyqlgECc+/MeCGnxpyDJ1K7r0t4OefuPtoEnorTBObc=",
+        "lastModified": 1681241859,
+        "narHash": "sha256-V+vV2IqMU15Te5bWqyk1uFcO8SZ7xnlg7Os3VLEfTEw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "86ea3268b55bb632de43a80a37501a3d05cdb224",
+        "rev": "29ec9b4431916ca379eba7770577812e8610e372",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`29ec9b44`](https://github.com/nix-community/emacs-overlay/commit/29ec9b4431916ca379eba7770577812e8610e372) | `` Updated repos/melpa `` |
| [`73ea60a2`](https://github.com/nix-community/emacs-overlay/commit/73ea60a234e4dabc5a9a48ac561ee9dcd974ea8d) | `` Updated repos/emacs `` |
| [`1a3221bb`](https://github.com/nix-community/emacs-overlay/commit/1a3221bb041067b0a4942af160d9c6d93e7596ac) | `` Updated repos/elpa ``  |