### PR TITLE
chore(flake/nur): `a3d51a59` -> `88b89228`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681237662,
-        "narHash": "sha256-xnLeKBjWKJ3XPYEnjAeMePOQhAY3PR6ZVvVkR6wnhxs=",
+        "lastModified": 1681242349,
+        "narHash": "sha256-6APrZq+3LsiiQFC+ruTvdBgBxiE7yPev5ITKiwsgcpA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a3d51a59ff8f9947aa4afecde2cb63713bba38c1",
+        "rev": "88b89228037006ffd30afa5f275eda609629b430",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`88b89228`](https://github.com/nix-community/NUR/commit/88b89228037006ffd30afa5f275eda609629b430) | `` automatic update `` |