### PR TITLE
chore(flake/nur): `88b89228` -> `053148f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681242349,
-        "narHash": "sha256-6APrZq+3LsiiQFC+ruTvdBgBxiE7yPev5ITKiwsgcpA=",
+        "lastModified": 1681246002,
+        "narHash": "sha256-SbgvrT49WDZWct+Q29gnuytjHnxjwFE0j/rr144PTB0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "88b89228037006ffd30afa5f275eda609629b430",
+        "rev": "053148f23e0086f667c437e1631c9dcefe23cd46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`053148f2`](https://github.com/nix-community/NUR/commit/053148f23e0086f667c437e1631c9dcefe23cd46) | `` automatic update `` |
| [`e28e4cdd`](https://github.com/nix-community/NUR/commit/e28e4cdde6b7eae7e9ad0919f217523204f2b83c) | `` automatic update `` |