### PR TITLE
chore(flake/emacs-overlay): `29ec9b44` -> `1be00f42`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681241859,
-        "narHash": "sha256-V+vV2IqMU15Te5bWqyk1uFcO8SZ7xnlg7Os3VLEfTEw=",
+        "lastModified": 1681270840,
+        "narHash": "sha256-xYULk0ApWGgG/K1b+eJoF4sVGoic5zHw4zBvp7HQQWo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "29ec9b4431916ca379eba7770577812e8610e372",
+        "rev": "1be00f42d07320f4fd0230172ceb27ec40330f53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`1be00f42`](https://github.com/nix-community/emacs-overlay/commit/1be00f42d07320f4fd0230172ceb27ec40330f53) | `` Updated repos/melpa `` |
| [`f6e473f6`](https://github.com/nix-community/emacs-overlay/commit/f6e473f64a61d586b7f5cc01fac11834abf96934) | `` Updated repos/emacs `` |
| [`4cf48f29`](https://github.com/nix-community/emacs-overlay/commit/4cf48f29e6235612e5ccb3735b28aeedb02bdfb2) | `` Updated repos/elpa ``  |