### PR TITLE
chore(flake/nur): `a756fe1f` -> `9b4477d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681268171,
-        "narHash": "sha256-qtnK7PrJV4xdIQDc/d7BePbd894KLBrvnK9cUXgNB7A=",
+        "lastModified": 1681272608,
+        "narHash": "sha256-oU5iDI5oXj68lQd87VANfaZYDs2Ka16ggfchR77R8IM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a756fe1f670c50cc577b31e51a44ecff786e9492",
+        "rev": "9b4477d614ccee51ed3a5c166b08c6e8673c5456",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9b4477d6`](https://github.com/nix-community/NUR/commit/9b4477d614ccee51ed3a5c166b08c6e8673c5456) | `` automatic update `` |
| [`40817887`](https://github.com/nix-community/NUR/commit/408178875e10239cb33054cd66f35bdaca34c172) | `` automatic update `` |