### PR TITLE
chore(flake/nur): `9b4477d6` -> `4962f643`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681272608,
-        "narHash": "sha256-oU5iDI5oXj68lQd87VANfaZYDs2Ka16ggfchR77R8IM=",
+        "lastModified": 1681278261,
+        "narHash": "sha256-hXJGXX9WMI4iW5I3YH8aal8xQqtVt42AF3KI/wXEKqk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9b4477d614ccee51ed3a5c166b08c6e8673c5456",
+        "rev": "4962f643d0656e3c65e03901baf0316598e6da2d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4962f643`](https://github.com/nix-community/NUR/commit/4962f643d0656e3c65e03901baf0316598e6da2d) | `` automatic update `` |