### PR TITLE
chore(flake/emacs-overlay): `20f5ce4d` -> `29a93f82`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681296483,
-        "narHash": "sha256-MC3z0GOKB92Y1uFFxBj7N9D49qKsOug+LzcJB2W8bEE=",
+        "lastModified": 1681323837,
+        "narHash": "sha256-t3hYyI8RCGtaXkwS7ds9XeBO3oiPAZtHgE0yQ1SxPIg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "20f5ce4dfacaf87234d6ab2b786dd008032edde1",
+        "rev": "29a93f82abd706561032c31ce59a0e94b3e7963f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`29a93f82`](https://github.com/nix-community/emacs-overlay/commit/29a93f82abd706561032c31ce59a0e94b3e7963f) | `` Updated repos/melpa `` |
| [`00f31a3b`](https://github.com/nix-community/emacs-overlay/commit/00f31a3be2f8d42cddd61b9a4e858eb1feae63e5) | `` Updated repos/emacs `` |
| [`3655d150`](https://github.com/nix-community/emacs-overlay/commit/3655d1502e02bafa2668a74e511166ce5415c247) | `` Updated repos/elpa ``  |