### PR TITLE
chore(flake/nur): `c597d73a` -> `ac4d2175`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -754,11 +754,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681328758,
-        "narHash": "sha256-/NFZxPLC0Aa90ix6AZBE8YvNGB27vh72yhZCFrwfVss=",
+        "lastModified": 1681333982,
+        "narHash": "sha256-vBz1qB2ovTB1TXXM2FjKlbk76r6+yAJ4qaz/j9x7N3c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c597d73a06cb4a8c8af38a4a47786ea362bcefcb",
+        "rev": "ac4d217571c7c6fbe7f125814173fde7ceb88c23",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ac4d2175`](https://github.com/nix-community/NUR/commit/ac4d217571c7c6fbe7f125814173fde7ceb88c23) | `` automatic update `` |