### PR TITLE
chore(flake/attic): `efa15b97` -> `171c89fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1680646146,
-        "narHash": "sha256-NH+EhLFYDwLQ01BqfTwGvZAjfmZynnP1xxPjqH0XJss=",
+        "lastModified": 1681335578,
+        "narHash": "sha256-yIZqE6WpkgAllsJ7IAbn8k6IRz/0CS/xp6IR+8yrEP8=",
         "owner": "zhaofengli",
         "repo": "attic",
-        "rev": "efa15b9788add910f6e8409dddfb7bb69c2ad201",
+        "rev": "171c89fbe0f099e8bf6e466a1a1a12578f703f0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                                |
| ------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`171c89fb`](https://github.com/zhaofengli/attic/commit/171c89fbe0f099e8bf6e466a1a1a12578f703f0e) | `` flake.nix: Add /etc/passwd to attic-server-image `` |
| [`6a064f90`](https://github.com/zhaofengli/attic/commit/6a064f904ea1e0ab9c425f25f409b7a5852cae0b) | `` client/watch_store: Refactor main loop ``           |
| [`c686b2c1`](https://github.com/zhaofengli/attic/commit/c686b2c1ea751aee7c80f695321f1f11ecb1da4e) | `` Increase narinfo size limit to 1MiB ``              |