### PR TITLE
chore(flake/nur): `ac4d2175` -> `af5c9be3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -754,11 +754,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681333982,
-        "narHash": "sha256-vBz1qB2ovTB1TXXM2FjKlbk76r6+yAJ4qaz/j9x7N3c=",
+        "lastModified": 1681337789,
+        "narHash": "sha256-wXQol1fxdaoGWPBdiWvC6BkcpYMJjIxQBPATfdhLtRk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ac4d217571c7c6fbe7f125814173fde7ceb88c23",
+        "rev": "af5c9be3ad1e526c2be879c5370c6d67449c98a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`af5c9be3`](https://github.com/nix-community/NUR/commit/af5c9be3ad1e526c2be879c5370c6d67449c98a6) | `` automatic update `` |