### PR TITLE
chore(flake/nur): `080eabc6` -> `35b1aab5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -754,11 +754,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681339014,
-        "narHash": "sha256-Gh18EBISyesyad/YSTBg57W0eCbocTWKfiNn0dMVZkY=",
+        "lastModified": 1681359126,
+        "narHash": "sha256-aL0iTn1R32h0Xq46xHfHT3WfChi74A1evXQegRnGycg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "080eabc69dc2e2589373842eb1d8fd57a76595a0",
+        "rev": "35b1aab59c4e79fd2cd02ffd3c67689bfa5a24d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`35b1aab5`](https://github.com/nix-community/NUR/commit/35b1aab59c4e79fd2cd02ffd3c67689bfa5a24d2) | `` automatic update `` |
| [`50483ca7`](https://github.com/nix-community/NUR/commit/50483ca74155b49af3abdb765d999b4fe49d7353) | `` automatic update `` |