### PR TITLE
chore(flake/nur): `35b1aab5` -> `2c2e8f79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -754,11 +754,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681359126,
-        "narHash": "sha256-aL0iTn1R32h0Xq46xHfHT3WfChi74A1evXQegRnGycg=",
+        "lastModified": 1681369226,
+        "narHash": "sha256-tFI+qlP2oB1nYt6wCbcEYJMiWqt06IpkGC56Piv2SJU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "35b1aab59c4e79fd2cd02ffd3c67689bfa5a24d2",
+        "rev": "2c2e8f79e10527c99d1111f579529c31a5bfc699",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2c2e8f79`](https://github.com/nix-community/NUR/commit/2c2e8f79e10527c99d1111f579529c31a5bfc699) | `` automatic update `` |