### PR TITLE
chore(flake/nur): `2c2e8f79` -> `c2529542`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -754,11 +754,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681369226,
-        "narHash": "sha256-tFI+qlP2oB1nYt6wCbcEYJMiWqt06IpkGC56Piv2SJU=",
+        "lastModified": 1681386290,
+        "narHash": "sha256-tjl52fTD+YevuexNVM2uz/bpvQzHwVigjdN+PtQiRuU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2c2e8f79e10527c99d1111f579529c31a5bfc699",
+        "rev": "c252954217c2d1695e42daa8ac1a333495a28f1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c2529542`](https://github.com/nix-community/NUR/commit/c252954217c2d1695e42daa8ac1a333495a28f1a) | `` automatic update `` |