### PR TITLE
chore(flake/nur): `c2529542` -> `fba7617b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -754,11 +754,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681386290,
-        "narHash": "sha256-tjl52fTD+YevuexNVM2uz/bpvQzHwVigjdN+PtQiRuU=",
+        "lastModified": 1681389526,
+        "narHash": "sha256-Nv9gQ7Tku9VsASun6vez/jJWaI28zWQSPzRz2E7k0Lg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c252954217c2d1695e42daa8ac1a333495a28f1a",
+        "rev": "fba7617b9633af78d75715b3f076b7329a6ca3dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fba7617b`](https://github.com/nix-community/NUR/commit/fba7617b9633af78d75715b3f076b7329a6ca3dc) | `` automatic update `` |