### PR TITLE
chore(flake/nur): `fba7617b` -> `330e9055`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -754,11 +754,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681389526,
-        "narHash": "sha256-Nv9gQ7Tku9VsASun6vez/jJWaI28zWQSPzRz2E7k0Lg=",
+        "lastModified": 1681397150,
+        "narHash": "sha256-9wWdcT1rGvq62CmIAZGwycaGduYTEofijrsLpwgKUYo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fba7617b9633af78d75715b3f076b7329a6ca3dc",
+        "rev": "330e9055ae9626efc65222638ea7fa74f01a5159",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`330e9055`](https://github.com/nix-community/NUR/commit/330e9055ae9626efc65222638ea7fa74f01a5159) | `` automatic update `` |