### PR TITLE
chore(flake/emacs-overlay): `7606cc4b` -> `fbe8bd5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681376791,
-        "narHash": "sha256-vIhbKlSLiJuy3Zx5w8Pp7cPEuftLXn6fX8VPEkiEfzk=",
+        "lastModified": 1681409862,
+        "narHash": "sha256-s3KjT5vcOn5dYO68R3sGftHvFn05ELU8/Ec7bvqquJs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7606cc4b272b55d800c5b62adff217e5833db045",
+        "rev": "fbe8bd5e0226b57911c1f30dc26e3bec57c2e1a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`fbe8bd5e`](https://github.com/nix-community/emacs-overlay/commit/fbe8bd5e0226b57911c1f30dc26e3bec57c2e1a4) | `` Updated repos/melpa `` |
| [`5fef114d`](https://github.com/nix-community/emacs-overlay/commit/5fef114d0a2bce6c2b1373f379889dd33cc9f22c) | `` Updated repos/emacs `` |
| [`c295a5c8`](https://github.com/nix-community/emacs-overlay/commit/c295a5c882c2d3a6039c0204657f3fef8da79ab4) | `` Updated repos/elpa ``  |