### PR TITLE
chore(flake/pre-commit-hooks): `c77e64a5` -> `d3de8f69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -690,11 +690,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1678898370,
-        "narHash": "sha256-xTICr1j+uat5hk9FyuPOFGxpWHdJRibwZC+ATi0RbtE=",
+        "lastModified": 1681303793,
+        "narHash": "sha256-JEdQHsYuCfRL2PICHlOiH/2ue3DwoxUX7DJ6zZxZXFk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ac718d02867a84b42522a0ece52d841188208f2c",
+        "rev": "fe2ecaf706a5907b5e54d979fbde4924d84b65fc",
         "type": "github"
       },
       "original": {
@@ -803,11 +803,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1681227715,
-        "narHash": "sha256-kQZOoTa177VF5uk1JK7bA9ZTU5g6d5IuDp/6YdxUWao=",
+        "lastModified": 1681413034,
+        "narHash": "sha256-/t7OjNQcNkeWeSq/CFLYVBfm+IEnkjoSm9iKvArnUUI=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "c77e64a5adab96866ea97449a5a7a327d4629828",
+        "rev": "d3de8f69ca88fb6f8b09e5b598be5ac98d28ede5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                       |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------- |
| [`ea689b28`](https://github.com/cachix/pre-commit-hooks.nix/commit/ea689b28a76238aa89d8d8279cec5bfbb85a253a) | `` Cleaner errors when Topiary is absent ``   |
| [`543f806a`](https://github.com/cachix/pre-commit-hooks.nix/commit/543f806ac9363c5477cad65b16c93a6ce3e5d955) | `` `nix flake lock --update-input nixpkgs` `` |
| [`55ac7455`](https://github.com/cachix/pre-commit-hooks.nix/commit/55ac7455e3ce80152c7addb41bb4d1dd78abc0b1) | `` Add hook for `checkmake` ``                |