### PR TITLE
chore(flake/nur): `e019c54b` -> `81da935a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -754,11 +754,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681411586,
-        "narHash": "sha256-h1CANZ+gxrpdTHgiTGj6RBaTVCLbThx4wlC3ZzPkBv4=",
+        "lastModified": 1681413105,
+        "narHash": "sha256-RVurZLx/l83DOSB2Uy92kGyuhMOc+jEieHvjtJy4t90=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e019c54bf297f30bb0b716f47653e7134ea41880",
+        "rev": "81da935a918fa216295272c576705f816f0fc36a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`81da935a`](https://github.com/nix-community/NUR/commit/81da935a918fa216295272c576705f816f0fc36a) | `` automatic update `` |