### PR TITLE
chore(flake/home-manager): `28698126` -> `fe1e2dee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -451,11 +451,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681250798,
-        "narHash": "sha256-fQMROyKzPFBPqJy9J4ffywm02ZuqAI0GW1O1QibVpdQ=",
+        "lastModified": 1681431470,
+        "narHash": "sha256-8XJSkvlWvM71nJWx+T4+R0ovSMhJUBFHL2KfGgis7Lw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "28698126bd825aff21cae9ffd15cf83e169051b0",
+        "rev": "fe1e2dee1955f130830536403c7564f4afc6edc0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`fe1e2dee`](https://github.com/nix-community/home-manager/commit/fe1e2dee1955f130830536403c7564f4afc6edc0) | `` home-manager: make sure Nix profiles path exists `` |