### PR TITLE
chore(flake/nur): `c2e2d491` -> `6b56336e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -754,11 +754,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681440980,
-        "narHash": "sha256-ZY+ifdzDHXP5aD+ze3X3298YtmUi7Rt+wX0vsHh5HD4=",
+        "lastModified": 1681443988,
+        "narHash": "sha256-dU91HudY9uESjdywd05cxJ0FR23WDfoOAMEEpOrdOzM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c2e2d4915338a546b4d4c55f32e703440f230e79",
+        "rev": "6b56336e09083f3cd382e1e60816f72f1a637c1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6b56336e`](https://github.com/nix-community/NUR/commit/6b56336e09083f3cd382e1e60816f72f1a637c1a) | `` automatic update `` |