### PR TITLE
chore(flake/nur): `8a35714f` -> `8f154326`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -754,11 +754,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681454031,
-        "narHash": "sha256-JOamj7vKkFRp5mJ7FKt5dPfCmWj33sZLnBGDt15c/sc=",
+        "lastModified": 1681458261,
+        "narHash": "sha256-zFatUGLXa7YvvK78kjWw/9YiQL0UJ3ezlFwyBzBm35Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8a35714f0be00235e2a1c8b759e6dc3888763d8b",
+        "rev": "8f15432686f6cbf9fca2ca13849ddaaacb363124",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8f154326`](https://github.com/nix-community/NUR/commit/8f15432686f6cbf9fca2ca13849ddaaacb363124) | `` automatic update `` |