### PR TITLE
chore(flake/nix-index-database): `c93f2e0b` -> `375ed1ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -509,11 +509,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681392449,
-        "narHash": "sha256-Ld8n4QiqfDegqnRBq5LZ+kryENyEGNif/LBjwhqXopc=",
+        "lastModified": 1681460490,
+        "narHash": "sha256-uA5IvXUPV3LboIyjGrPYvNuaShxWR7hDjZC6aXY5z4o=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "c93f2e0bfe779601be514e1bca3b02443d4ce46b",
+        "rev": "375ed1ce48ee67f528fda03acdf99fd542df41c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                      |
| --------------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`2089565c`](https://github.com/Mic92/nix-index-database/commit/2089565c0ef92510d4c8ef7e88a70b31f5ffd544) | `` Use pkgs.stdenv.system `` |