### PR TITLE
chore(flake/nur): `8f154326` -> `77ed1a89`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -754,11 +754,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681458261,
-        "narHash": "sha256-zFatUGLXa7YvvK78kjWw/9YiQL0UJ3ezlFwyBzBm35Y=",
+        "lastModified": 1681461010,
+        "narHash": "sha256-uMKcUXloiQxUgALmpD3Oqx1FpeCgEpVGSe+oZtkJU/0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8f15432686f6cbf9fca2ca13849ddaaacb363124",
+        "rev": "77ed1a8947019af587af04192fc0b90b1415f624",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                       |
| -------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`77ed1a89`](https://github.com/nix-community/NUR/commit/77ed1a8947019af587af04192fc0b90b1415f624) | `` automatic update ``        |
| [`409ec9f8`](https://github.com/nix-community/NUR/commit/409ec9f8e9da0bc477ed8cd0593f96466fefefd0) | `` Add 999eagle repository `` |