### PR TITLE
chore(flake/emacs-overlay): `660ddee3` -> `c470756d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681440992,
-        "narHash": "sha256-jORqjaOuaEkwekvq5M2xxkve07cxCjSzZpc9u9fcKn4=",
+        "lastModified": 1681469204,
+        "narHash": "sha256-956ICeSR5FW42lphKWtE8YKDZtVD5GUjxjD6ogSCDT4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "660ddee3c3280a08590e999b1d08af4b4fc82b6b",
+        "rev": "c470756d69bc9195d0ddc1fcd70110376fc93473",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`c470756d`](https://github.com/nix-community/emacs-overlay/commit/c470756d69bc9195d0ddc1fcd70110376fc93473) | `` Updated repos/melpa `` |
| [`9ed40859`](https://github.com/nix-community/emacs-overlay/commit/9ed408593f084113877fb09b7869f55582bd2808) | `` Updated repos/emacs `` |