### PR TITLE
chore(flake/nur): `25eeb98c` -> `12ce41b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681818355,
-        "narHash": "sha256-A29uoPDtF3Jw5u9BDWhXyZxzhLrUURHJmR47cbO1zEo=",
+        "lastModified": 1682222997,
+        "narHash": "sha256-7PEtbnVsdj+wFiEA14NdwAcxHNlx6z4mJ6MCCWhLPJw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "25eeb98c8378d0d716816b05c8441953b84aec2f",
+        "rev": "12ce41b211b7a85975703b6c66868fdd8dc1e42a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                           |
| -------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`12ce41b2`](https://github.com/nix-community/NUR/commit/12ce41b211b7a85975703b6c66868fdd8dc1e42a) | `` automatic update ``            |
| [`ef83785b`](https://github.com/nix-community/NUR/commit/ef83785b22bf3c166886a1c1f7b56238b2d3854f) | `` automatic update ``            |
| [`56f2104a`](https://github.com/nix-community/NUR/commit/56f2104ae98978ae8d351a43f6f6226364d844aa) | `` automatic update ``            |
| [`c21c1cdc`](https://github.com/nix-community/NUR/commit/c21c1cdcae6cac4bfe240724fdcbaea96fb805ef) | `` automatic update ``            |
| [`3a3e4182`](https://github.com/nix-community/NUR/commit/3a3e418241e146631a7ca63f6bc48611d15d1806) | `` automatic update ``            |
| [`5a776f02`](https://github.com/nix-community/NUR/commit/5a776f020c16646cca4a2f17172ea10801509075) | `` automatic update ``            |
| [`dd38f553`](https://github.com/nix-community/NUR/commit/dd38f5536cf21f1020eb0d80c3c102edbfc51ba7) | `` automatic update ``            |
| [`fe2bdf88`](https://github.com/nix-community/NUR/commit/fe2bdf88ea839ca934412d8c9a7fad26893e481e) | `` automatic update ``            |
| [`115115e7`](https://github.com/nix-community/NUR/commit/115115e75d46e3ebe0d3872c4867f6dacd4b32d4) | `` automatic update ``            |
| [`dfa3fd58`](https://github.com/nix-community/NUR/commit/dfa3fd58c2afb16d6cd85ef84a4712309733071b) | `` automatic update ``            |
| [`7d0c2155`](https://github.com/nix-community/NUR/commit/7d0c215513c168d9fd6d02625680d68766fea17c) | `` automatic update ``            |
| [`e0262d1c`](https://github.com/nix-community/NUR/commit/e0262d1cfb3cddd09b90d4e8ff76b8abd857c32a) | `` automatic update ``            |
| [`6be66c0b`](https://github.com/nix-community/NUR/commit/6be66c0bc54cf8762c5e3853e2416c824ab1c145) | `` automatic update ``            |
| [`c36551b6`](https://github.com/nix-community/NUR/commit/c36551b646f278aa0a554520e5f4e5a52deb15bc) | `` automatic update ``            |
| [`21a2729c`](https://github.com/nix-community/NUR/commit/21a2729cab6efe46c9f5d7495778399853832ada) | `` automatic update ``            |
| [`11ae59ac`](https://github.com/nix-community/NUR/commit/11ae59ac0fc4393e0160b2a5ca363ff8dcb22cd2) | `` automatic update ``            |
| [`f4318792`](https://github.com/nix-community/NUR/commit/f431879273c2a5cf0a77b08a4dc1659f497c7efa) | `` automatic update ``            |
| [`698ed88a`](https://github.com/nix-community/NUR/commit/698ed88add2e72a486292aa66d41a316bf6c7631) | `` automatic update ``            |
| [`c2778754`](https://github.com/nix-community/NUR/commit/c2778754ec284fade289ce5c4ac82ffb48b2b97a) | `` automatic update ``            |
| [`5285a058`](https://github.com/nix-community/NUR/commit/5285a0586dfb6cd4631b8e5aeb017c3a4243f173) | `` automatic update ``            |
| [`be39fb95`](https://github.com/nix-community/NUR/commit/be39fb95b79397094e231cd0ecf4811f7942da85) | `` automatic update ``            |
| [`cf8e59af`](https://github.com/nix-community/NUR/commit/cf8e59aff724bb3cdbebc3f31327295bc139da59) | `` automatic update ``            |
| [`68e95af7`](https://github.com/nix-community/NUR/commit/68e95af7f39d789fc468a4239fba3d17c02f0ce3) | `` automatic update ``            |
| [`fa81af6e`](https://github.com/nix-community/NUR/commit/fa81af6edcbbefc2734d7ad4e14e20859127a0b1) | `` automatic update ``            |
| [`e46ebd58`](https://github.com/nix-community/NUR/commit/e46ebd58b81d3e605cf0ef81a49a8f52c99ddb7c) | `` automatic update ``            |
| [`93c67a03`](https://github.com/nix-community/NUR/commit/93c67a03eae4298d13af01a3ab4d0308d8999ca7) | `` automatic update ``            |
| [`800fdaac`](https://github.com/nix-community/NUR/commit/800fdaac41c9a2fd55a7a161700cc4e315511898) | `` automatic update ``            |
| [`5ea4cf7e`](https://github.com/nix-community/NUR/commit/5ea4cf7eafb21011352a3cf857edc2d7c5ccdf70) | `` automatic update ``            |
| [`0decfbe0`](https://github.com/nix-community/NUR/commit/0decfbe099053679bd97a3be47735a449ea3b851) | `` automatic update ``            |
| [`1fd420e8`](https://github.com/nix-community/NUR/commit/1fd420e869c3458c36115618786e8979b90c6254) | `` automatic update ``            |
| [`994d2df9`](https://github.com/nix-community/NUR/commit/994d2df9f5876aeb9d0cbf43cdf5a81bafeb0cad) | `` automatic update ``            |
| [`6e371d53`](https://github.com/nix-community/NUR/commit/6e371d53715ffd8342a2140bbf3a19e83433b405) | `` automatic update ``            |
| [`31a8744f`](https://github.com/nix-community/NUR/commit/31a8744f8badcddc6c64982b8fb6dccb43a66aec) | `` automatic update ``            |
| [`d337406a`](https://github.com/nix-community/NUR/commit/d337406a4e1dd8ce548599cafde4b1f8ae7c007b) | `` automatic update ``            |
| [`3192414f`](https://github.com/nix-community/NUR/commit/3192414f674599d58f43113c81602e092141d8eb) | `` automatic update ``            |
| [`a51c2efc`](https://github.com/nix-community/NUR/commit/a51c2efc17ac4cfe5ae33fcae7e94e1e770610dd) | `` automatic update ``            |
| [`425d117f`](https://github.com/nix-community/NUR/commit/425d117f80bc186c6e9e00494d15782cf24a4911) | `` automatic update ``            |
| [`1df86556`](https://github.com/nix-community/NUR/commit/1df865560116558946f2cb4b9402bb9091470080) | `` automatic update ``            |
| [`08ad2223`](https://github.com/nix-community/NUR/commit/08ad2223ae715dd4dd1ef9fcdcb00ae2122ad7d7) | `` automatic update ``            |
| [`26294c4e`](https://github.com/nix-community/NUR/commit/26294c4ed1b56ffa6c69929604d549e0e24ab960) | `` automatic update ``            |
| [`7c59897b`](https://github.com/nix-community/NUR/commit/7c59897be6e0e8cbff6a42b7f6491faf36a6f245) | `` automatic update ``            |
| [`3ad0df30`](https://github.com/nix-community/NUR/commit/3ad0df3046d87a9cba29a77564743df12b402979) | `` automatic update ``            |
| [`5056d561`](https://github.com/nix-community/NUR/commit/5056d561f299f595aceb67f80cd99e581c458f81) | `` automatic update ``            |
| [`5030bb76`](https://github.com/nix-community/NUR/commit/5030bb7652f5eb941877f2660e09770f2b939e86) | `` automatic update ``            |
| [`4e268adb`](https://github.com/nix-community/NUR/commit/4e268adbad1dcab4b04cc14968e2a8efcf0c1912) | `` automatic update ``            |
| [`8a625f2a`](https://github.com/nix-community/NUR/commit/8a625f2ab530f40c6fe50a33ccb760a85d772c70) | `` automatic update ``            |
| [`862a52dd`](https://github.com/nix-community/NUR/commit/862a52dd1f5d8f1c1be05afc3d41a22998b3c0f8) | `` automatic update ``            |
| [`1f8126f6`](https://github.com/nix-community/NUR/commit/1f8126f6df800930f8305d31cf63d04860649274) | `` automatic update ``            |
| [`3b5b6d3f`](https://github.com/nix-community/NUR/commit/3b5b6d3fe6514b8c716bada8a4de006a34e5959f) | `` automatic update ``            |
| [`fc78a865`](https://github.com/nix-community/NUR/commit/fc78a86506782b4b2ccbbf454ead74a94bf3f3fa) | `` automatic update ``            |
| [`2ff681f9`](https://github.com/nix-community/NUR/commit/2ff681f96e376a9e9b837e07e1b1aa50e18fb0dc) | `` automatic update ``            |
| [`28c0344a`](https://github.com/nix-community/NUR/commit/28c0344ab08f00bc0158b6f4cc7ba8deabf03875) | `` automatic update ``            |
| [`5a4f5ad0`](https://github.com/nix-community/NUR/commit/5a4f5ad0c8403b50fdc6ede8e3c62e5bd2c9896e) | `` add ionutnechita repository `` |
| [`e064870e`](https://github.com/nix-community/NUR/commit/e064870ebd528b132ac0e6e6dd4c607f64f8cd64) | `` add minion3665 repository ``   |
| [`4d58c6f2`](https://github.com/nix-community/NUR/commit/4d58c6f24679f9ff3f1b8fdadeaa417b7c4f49f2) | `` add LuisChDev repo ``          |