### PR TITLE
chore(flake/emacs-overlay): `c470756d` -> `abaa2799`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681469204,
-        "narHash": "sha256-956ICeSR5FW42lphKWtE8YKDZtVD5GUjxjD6ogSCDT4=",
+        "lastModified": 1681496228,
+        "narHash": "sha256-Ti6Yb32Y9KfvVuljEKZrSh+cWTZAjyh1SlO0zKNuwZw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c470756d69bc9195d0ddc1fcd70110376fc93473",
+        "rev": "abaa27998067fe47f28ba75e43225481101a9607",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`abaa2799`](https://github.com/nix-community/emacs-overlay/commit/abaa27998067fe47f28ba75e43225481101a9607) | `` Updated repos/melpa `` |
| [`12308581`](https://github.com/nix-community/emacs-overlay/commit/1230858106f7bc2ec6397e07ce09202fe1084b67) | `` Updated repos/emacs `` |
| [`9fb7466c`](https://github.com/nix-community/emacs-overlay/commit/9fb7466c3fefc6332c7aef2f7fdb1667a47f3bfb) | `` Updated repos/elpa ``  |