### PR TITLE
chore(flake/emacs-overlay): `abaa2799` -> `8a5f05e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681496228,
-        "narHash": "sha256-Ti6Yb32Y9KfvVuljEKZrSh+cWTZAjyh1SlO0zKNuwZw=",
+        "lastModified": 1681529180,
+        "narHash": "sha256-1VeDR6LTzXM8//jbl16RtAa0p/p96ahXMqVbE99WPqA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "abaa27998067fe47f28ba75e43225481101a9607",
+        "rev": "8a5f05e13f0254b5f85368b03cb5e9aeebc40474",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`8a5f05e1`](https://github.com/nix-community/emacs-overlay/commit/8a5f05e13f0254b5f85368b03cb5e9aeebc40474) | `` Updated repos/nongnu `` |
| [`58fbc819`](https://github.com/nix-community/emacs-overlay/commit/58fbc819635daef829809f1e8d3e37961e5670a1) | `` Updated repos/melpa ``  |
| [`e7ae8c04`](https://github.com/nix-community/emacs-overlay/commit/e7ae8c04fe3785459c87a4725c229bd4e421e5d0) | `` Updated repos/emacs ``  |
| [`3575e7de`](https://github.com/nix-community/emacs-overlay/commit/3575e7def8673bb5560adc0b4331f43d7dbbe781) | `` Updated repos/elpa ``   |