### PR TITLE
chore(flake/nixpkgs): `fe2ecaf7` -> `abe7316d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -672,11 +672,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1681303793,
-        "narHash": "sha256-JEdQHsYuCfRL2PICHlOiH/2ue3DwoxUX7DJ6zZxZXFk=",
+        "lastModified": 1681465517,
+        "narHash": "sha256-EasJh15/jcJNAHtq2SGbiADRXteURAnQbj1NqBoKkzU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fe2ecaf706a5907b5e54d979fbde4924d84b65fc",
+        "rev": "abe7316dd51a313ce528972b104f4f04f56eefc4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
| [`a1924ebb`](https://github.com/NixOS/nixpkgs/commit/a1924ebbbfbf85815714ca18cad596a33cffe25e) | `` clippy: enable debug info ``                                                                                    |
| [`828a0e6c`](https://github.com/NixOS/nixpkgs/commit/828a0e6c020f116b5a93461c945f8e137e2b1a5e) | `` skopeo: 1.11.2 -> 1.12.0 ``                                                                                     |
| [`c8bc0326`](https://github.com/NixOS/nixpkgs/commit/c8bc0326b24c05e34f3e9d4d4de8af5009784a08) | `` crun: 1.8.3 -> 1.8.4 ``                                                                                         |
| [`0a78d512`](https://github.com/NixOS/nixpkgs/commit/0a78d5120545bb9e490098159240ccef9b1b3e22) | `` vscode-extensions.streetsidesoftware.code-spell-checker: 2.20.3 -> 2.20.4 ``                                    |
| [`e7d636f4`](https://github.com/NixOS/nixpkgs/commit/e7d636f41e74de704c9fa4bf9746f8b402ad7840) | `` openttd: 13.0 -> 13.1 ``                                                                                        |
| [`3eb3b323`](https://github.com/NixOS/nixpkgs/commit/3eb3b323ea35f3b81e321501da30c4e1aa49ee24) | `` feh: fix cross ``                                                                                               |
| [`3b9f29cb`](https://github.com/NixOS/nixpkgs/commit/3b9f29cbe6468a4751a2715a92b5be67aecff0f7) | `` terraform-providers.vultr: 2.13.0 -> 2.14.0 ``                                                                  |
| [`855438ca`](https://github.com/NixOS/nixpkgs/commit/855438ca16bbfa4e37959140dd4c41e066db4c64) | `` terraform-providers.thunder: 1.2.0 -> 1.2.1 ``                                                                  |
| [`e61f6a24`](https://github.com/NixOS/nixpkgs/commit/e61f6a2448de1084b74df5bfe9fd30743d22abe2) | `` terraform-providers.aws: 4.62.0 -> 4.63.0 ``                                                                    |
| [`dc05b1dc`](https://github.com/NixOS/nixpkgs/commit/dc05b1dcbfb7c1ee37a5da2ad07d971b1076682f) | `` terraform-providers.spotinst: 1.110.0 -> 1.112.0 ``                                                             |
| [`2e5a28cf`](https://github.com/NixOS/nixpkgs/commit/2e5a28cf997000e8e48ac0fd4690f911171eb633) | `` terraform-providers.pagerduty: 2.13.0 -> 2.14.0 ``                                                              |
| [`079355cf`](https://github.com/NixOS/nixpkgs/commit/079355cfbb847aaab2c5998e87219d6798655796) | `` terraform-providers.minio: 1.13.0 -> 1.14.0 ``                                                                  |
| [`97b740a4`](https://github.com/NixOS/nixpkgs/commit/97b740a426afcfe8e60ef9a2b88f8eed77a6638a) | `` terraform-providers.infoblox: 2.2.0 -> 2.3.0 ``                                                                 |
| [`da2fc999`](https://github.com/NixOS/nixpkgs/commit/da2fc99936d8c1dbf1734f0eb8b9ab5e9ed18b83) | `` terraform-providers.grafana: 1.37.0 -> 1.37.1 ``                                                                |
| [`7a701b78`](https://github.com/NixOS/nixpkgs/commit/7a701b78c6c16501a988e0db9c46bef62d642e1a) | `` terraform-providers.dnsimple: 0.17.0 -> 1.0.0 ``                                                                |
| [`a623aed0`](https://github.com/NixOS/nixpkgs/commit/a623aed09c136a37723ce0346cf6b47925b06127) | `` terraform-providers.azurerm: 3.51.0 -> 3.52.0 ``                                                                |
| [`d4c1b925`](https://github.com/NixOS/nixpkgs/commit/d4c1b925139c6142316f5174b6c63665ac67e4cd) | `` terraform-providers.azuread: 2.36.0 -> 2.37.0 ``                                                                |
| [`17902fc1`](https://github.com/NixOS/nixpkgs/commit/17902fc1c282bda66f666836d0de3476b5550f86) | `` terraform-providers.aviatrix: 3.0.3 -> 3.0.4 ``                                                                 |
| [`7b4a3549`](https://github.com/NixOS/nixpkgs/commit/7b4a3549ec7c6abd1561e27a2be4d0c7a10ae853) | `` joplin-desktop: Add support for `NIXOS_OZONE_WL` ``                                                             |
| [`69533762`](https://github.com/NixOS/nixpkgs/commit/695337622b84700a1eec3ffe714276ae98a6395c) | `` ocamlPackages.morbig: init at 0.11.0 ``                                                                         |
| [`e5c96621`](https://github.com/NixOS/nixpkgs/commit/e5c96621d87f02db4ebd817af1625a0ef30eda08) | `` signalbackup-tools: 20230404 -> 20230413 ``                                                                     |
| [`cf0db2e3`](https://github.com/NixOS/nixpkgs/commit/cf0db2e3ff97ee78314a855bf88dc5f39ddd82af) | `` libbytesize: 2.7 -> 2.8 ``                                                                                      |
| [`e7912c19`](https://github.com/NixOS/nixpkgs/commit/e7912c19a916bbc49838da494cdd657424f8f826) | `` nixVersions.unstable: 2.14.1 -> 2.15.0 ``                                                                       |
| [`484af2ff`](https://github.com/NixOS/nixpkgs/commit/484af2ff83ec84151e6e4e01bb7c0d147f2d5d89) | `` rustic-rs: 0.5.0 -> 0.5.1 ``                                                                                    |
| [`a9dc0f01`](https://github.com/NixOS/nixpkgs/commit/a9dc0f01a5bb499650a54e4f9e24d7e787275de0) | `` fastly: 8.2.1 -> 8.2.4 ``                                                                                       |
| [`aa246b2c`](https://github.com/NixOS/nixpkgs/commit/aa246b2c13d8a9d357c7bed36c74241172c5d865) | `` wasm-tools: 1.0.27 -> 1.0.30 ``                                                                                 |
| [`ca1400fd`](https://github.com/NixOS/nixpkgs/commit/ca1400fd933cba5a49bb2e59dfa5cbc8a454d711) | `` python310Packages.google-cloud-securitycenter: 1.19.1 -> 1.20.0 ``                                              |
| [`ffdc98b4`](https://github.com/NixOS/nixpkgs/commit/ffdc98b4b0df4aac4759bd2846e0197861dea5e4) | `` python310Packages.google-cloud-container: 2.19.0 -> 2.20.0 ``                                                   |
| [`c43f92d8`](https://github.com/NixOS/nixpkgs/commit/c43f92d8d5a13cce57ffe977f68d5264e1bf9965) | `` python310Packages.devolo-plc-api: 1.2.0 -> 1.3.0 ``                                                             |
| [`eda3223b`](https://github.com/NixOS/nixpkgs/commit/eda3223b431794755566dbe160f4afeef25fc1b3) | `` python310Packages.aio-pika: adjust inputs ``                                                                    |
| [`8a8b88f3`](https://github.com/NixOS/nixpkgs/commit/8a8b88f3da0f46ddad6078d9214297d3c5d55d28) | `` libnvme: 1.2 -> 1.4 ``                                                                                          |
| [`5fe45ebf`](https://github.com/NixOS/nixpkgs/commit/5fe45ebfeae9ee262771fc17cefdc5edf30f135c) | `` nvme-cli: 2.2.1 -> 2.4 ``                                                                                       |
| [`4b458656`](https://github.com/NixOS/nixpkgs/commit/4b458656f974cdafcde10083319a0cc4083214b7) | `` python310Packages.aiormq: 6.7.2 -> 6.7.4 ``                                                                     |
| [`8fb87b6f`](https://github.com/NixOS/nixpkgs/commit/8fb87b6f1cbf7f721b0038f0950920c1b6dd65ea) | `` newsboat: add passthru.updateScript ``                                                                          |
| [`1bf4cbfa`](https://github.com/NixOS/nixpkgs/commit/1bf4cbfa5e1dcf9ae8a77b5b57877d7c280a4dea) | `` qt6.qtconnectivity: fix build on darwin ``                                                                      |
| [`fbd1787e`](https://github.com/NixOS/nixpkgs/commit/fbd1787ee4e6b711887978ad46b0dced909fe9d6) | `` linux/hardened/patches/6.1: 6.1.22-hardened1 -> 6.1.24-hardened1 ``                                             |
| [`80189ff5`](https://github.com/NixOS/nixpkgs/commit/80189ff5f4ebb7fdfd29c65fab37c8bed8e8f984) | `` qovery-cli: 0.56.3 -> 0.57.1 ``                                                                                 |
| [`c292d1c5`](https://github.com/NixOS/nixpkgs/commit/c292d1c5eca0f82bef49df8f3a959c98c45df4b5) | `` linux/hardened/patches/5.4: 5.4.239-hardened1 -> 5.4.240-hardened1 ``                                           |
| [`74172b7f`](https://github.com/NixOS/nixpkgs/commit/74172b7fb241dff77116b1dd1d51c9545df92f67) | `` linux/hardened/patches/5.15: 5.15.105-hardened1 -> 5.15.107-hardened1 ``                                        |
| [`a7729282`](https://github.com/NixOS/nixpkgs/commit/a77292829247f6317485331b35957d6775ff5b4a) | `` linux/hardened/patches/5.10: 5.10.176-hardened1 -> 5.10.177-hardened1 ``                                        |
| [`1039cfa3`](https://github.com/NixOS/nixpkgs/commit/1039cfa3378a6a00b4caa25c4e5868a8df4d6ddc) | `` linux/hardened/patches/4.19: 4.19.279-hardened1 -> 4.19.280-hardened1 ``                                        |
| [`a26979b9`](https://github.com/NixOS/nixpkgs/commit/a26979b948f2288945d381d3f84c9deebff36970) | `` linux/hardened/patches/4.14: 4.14.311-hardened1 -> 4.14.312-hardened1 ``                                        |
| [`a3ebae52`](https://github.com/NixOS/nixpkgs/commit/a3ebae52fd207faf7a098299f25a0c35b6eb9a2e) | `` linux_latest-libre: 19160 -> 19172 ``                                                                           |
| [`5bc4e2fa`](https://github.com/NixOS/nixpkgs/commit/5bc4e2facb58565e0b275e98c81acb4cfdb01ef1) | `` linux: 6.2.10 -> 6.2.11 ``                                                                                      |
| [`4476457c`](https://github.com/NixOS/nixpkgs/commit/4476457c5c59c8fe5c2f0ce172994e7c435bea5c) | `` linux: 6.1.23 -> 6.1.24 ``                                                                                      |
| [`9b414a82`](https://github.com/NixOS/nixpkgs/commit/9b414a82f99667788e9ef6b97af0156c631b2e70) | `` linux: 5.15.106 -> 5.15.107 ``                                                                                  |
| [`14cf67d8`](https://github.com/NixOS/nixpkgs/commit/14cf67d80d1de15ca2f68616758aaef1804024c0) | `` python310Packages.adafruit-platformdetect: 3.45.0 -> 3.45.1 ``                                                  |
| [`90ccb38a`](https://github.com/NixOS/nixpkgs/commit/90ccb38adef32e81a0f9b023f733d7c523d1ee1d) | `` python310Packages.aiocsv: 1.2.3 -> 1.2.4 ``                                                                     |
| [`756e220e`](https://github.com/NixOS/nixpkgs/commit/756e220e1eb71ca1bb7210b82ae694ab62c7a9a2) | `` doc/.gitignore: add media ``                                                                                    |
| [`8eb3c604`](https://github.com/NixOS/nixpkgs/commit/8eb3c6044a3f737c085ae7696c5a68f9c57c2d75) | `` remmina: 1.4.29 -> 1.4.30 ``                                                                                    |
| [`331e2a1c`](https://github.com/NixOS/nixpkgs/commit/331e2a1c1075d4c3f2660da9210ee54ba93d7bda) | `` prometheus-smokeping-prober: cleanup version ``                                                                 |
| [`c556c242`](https://github.com/NixOS/nixpkgs/commit/c556c242bbf767667edbca22630f0f2c107a6bbe) | `` wv: set enableParallelBuilding=true ``                                                                          |
| [`4671d8cb`](https://github.com/NixOS/nixpkgs/commit/4671d8cbe374f0d525c55b624b646391c42ef0f4) | `` raycast: 1.49.2 -> 1.49.3 ``                                                                                    |
| [`80bdfe66`](https://github.com/NixOS/nixpkgs/commit/80bdfe66c454539710bd55bcc936d1f9fea1475f) | `` qnotero: fix desktop file ``                                                                                    |
| [`a1663fbd`](https://github.com/NixOS/nixpkgs/commit/a1663fbdf63c3c5e3c067f6403eaf97afe9ef070) | `` rustPlatform.buildRustPackage: fix auditable option when cargo-auditable is not provided to makeRustPlatform `` |
| [`f1837a0f`](https://github.com/NixOS/nixpkgs/commit/f1837a0faa13d5b0ac10b3918a2685176fcaf8c0) | `` session-desktop: 1.10.4 -> 1.10.8 ``                                                                            |
| [`d6481fa8`](https://github.com/NixOS/nixpkgs/commit/d6481fa812edd78d21a610c2acce77f74bc1dcae) | `` revolt-desktop: init at 1.0.6 ``                                                                                |
| [`cec3a441`](https://github.com/NixOS/nixpkgs/commit/cec3a44123bfc86693a48119f8233ff5ead6fc94) | `` auctex: fix build ``                                                                                            |
| [`35fd4065`](https://github.com/NixOS/nixpkgs/commit/35fd406515ca68ccadc9b875cec01c685291c53f) | `` relibc: fix build ``                                                                                            |
| [`cc7a61df`](https://github.com/NixOS/nixpkgs/commit/cc7a61df928b07b1d4cd933b3e032cbbe4d0af67) | `` vimPlugins.poimandres-nvim: init at 2023-02-17 ``                                                               |
| [`39eba1b0`](https://github.com/NixOS/nixpkgs/commit/39eba1b0ffdf8bd2cce95d4ceb37e02ba925c33d) | `` vimPlugins: update ``                                                                                           |
| [`a503b616`](https://github.com/NixOS/nixpkgs/commit/a503b6162f0a55e4510d022aa2677d025f3994f6) | `` qmk: 1.1.1 -> 1.1.2 ``                                                                                          |
| [`944697a2`](https://github.com/NixOS/nixpkgs/commit/944697a24d996901c46f4c56b2d435081158f179) | `` tektoncd-cli: 0.28.0 -> 0.30.1 ``                                                                               |
| [`6fc4e722`](https://github.com/NixOS/nixpkgs/commit/6fc4e722c468908cf5967308bf3b25a82169fab0) | `` nixos/prometheus-smartctl-exporter: fix evaluation after adding cfg.extraFlags ``                               |
| [`23f175d9`](https://github.com/NixOS/nixpkgs/commit/23f175d977e65def250a8493a2d93881e29e62fb) | `` path-of-building: init at 2.28.0-unstable-2023-04-09 ``                                                         |
| [`e3332597`](https://github.com/NixOS/nixpkgs/commit/e333259769a465709c1b36150a908717824d575f) | `` luaPackages.lua-curl: init at 0.3.13 ``                                                                         |
| [`6b208c25`](https://github.com/NixOS/nixpkgs/commit/6b208c257530ce39b07e945163700d4eb9f844c1) | `` networkmanager_strongswan: disable -Werror ``                                                                   |
| [`3b279c6c`](https://github.com/NixOS/nixpkgs/commit/3b279c6c18713065e21b5acdca3d13a900ad0158) | `` dec-decode: init at unstable-2022-12-24 ``                                                                      |
| [`9601701f`](https://github.com/NixOS/nixpkgs/commit/9601701f69d349c66faa79b83c98777c103e5716) | `` vimPlugins.nvim-treesitter.grammarPlugins: init ``                                                              |
| [`86a685ce`](https://github.com/NixOS/nixpkgs/commit/86a685ceb1af9fd80432b991f2c7731f34a8f77c) | `` nixos/maddy: Add option ensureCredentials ``                                                                    |
| [`d981e4c8`](https://github.com/NixOS/nixpkgs/commit/d981e4c876526d99c8cc729f530adeeabeda1809) | `` mercurial: 6.4 -> 6.4.1 ``                                                                                      |
| [`6302147d`](https://github.com/NixOS/nixpkgs/commit/6302147d48c5b6b95e492cf9c8e962c58059331c) | `` coqPackages.mathcomp-algebra-tactics 1.0.0 -> 1.1.1 ``                                                          |
| [`3ec278cf`](https://github.com/NixOS/nixpkgs/commit/3ec278cfaf6ed8d34ee894112c442d35500533f0) | `` qrcp: 0.10.0 -> 0.10.1 ``                                                                                       |
| [`c0c14e6f`](https://github.com/NixOS/nixpkgs/commit/c0c14e6fb1508402fac2d5c37b21a61d6ee2cdeb) | `` terraform-providers.hcloud: v1.38.0 -> v1.38.1 ``                                                               |
| [`735c2170`](https://github.com/NixOS/nixpkgs/commit/735c2170a480f77e6a404fbb8461072a7328e257) | `` adw-gtk3: 4.1 -> 4.5 ``                                                                                         |
| [`a5e267a7`](https://github.com/NixOS/nixpkgs/commit/a5e267a760a1ac805f0ec89c22e575276e84fd33) | `` python310Packages.zigpy-znp: Disable failing test ``                                                            |
| [`0944487c`](https://github.com/NixOS/nixpkgs/commit/0944487ccf770cb6bcf6a0f7e5130e5ead72e3f3) | `` clippy: use the right rustc when cross compiling ``                                                             |
| [`98427434`](https://github.com/NixOS/nixpkgs/commit/98427434d819bf6fc3b2b2d0aa3fff208872e3be) | `` polkadot: 0.9.40 -> 0.9.41 ``                                                                                   |
| [`78868322`](https://github.com/NixOS/nixpkgs/commit/788683220473ace68a0ce797fecd242280243ca1) | `` maestro: 1.25.0 -> 1.26.0 ``                                                                                    |
| [`b59c4b27`](https://github.com/NixOS/nixpkgs/commit/b59c4b27f36ef20e4b9e14703eeb29aa635f43cf) | `` promtail: restore journald support ``                                                                           |
| [`1aba349b`](https://github.com/NixOS/nixpkgs/commit/1aba349b349afe53ddb3d190cfe2a1e6f508c670) | `` python310Packages.ulid-transform: 0.6.0 -> 0.6.3 ``                                                             |
| [`44221206`](https://github.com/NixOS/nixpkgs/commit/442212062888148222d30bf3381a918fcae7033e) | `` webkitgtk: remove obsolete flags on darwin ``                                                                   |
| [`2d544199`](https://github.com/NixOS/nixpkgs/commit/2d5441995320c3663f682200462d2d3605100854) | `` home-assistant: 2023.4.2 -> 2023.4.3 ``                                                                         |
| [`9b432dd5`](https://github.com/NixOS/nixpkgs/commit/9b432dd5647f474196353110baf7c52cdbfb6c01) | `` python310Packages.env-canada: 0.5.31 -> 0.5.32 ``                                                               |
| [`ebd20843`](https://github.com/NixOS/nixpkgs/commit/ebd2084328b1f314ca9d0d4f07ad2ea11f8d8c50) | `` python310Packages.bellows: 0.35.0 -> 0.35.1 ``                                                                  |
| [`8dfdb13f`](https://github.com/NixOS/nixpkgs/commit/8dfdb13f654e7d6423cf64c7d795d254d8875062) | `` python310Packages.zha-quirks: 0.0.96 -> 0.0.97 ``                                                               |
| [`51fafd0b`](https://github.com/NixOS/nixpkgs/commit/51fafd0b425ae20ff61ddbe655c93095e90bc834) | `` python310Packages.zigpy: 0.54.0 -> 0.54.1 ``                                                                    |
| [`2e6eb06d`](https://github.com/NixOS/nixpkgs/commit/2e6eb06dc2a7cb609279bf58f469859987417cd8) | `` zellij: 0.35.2 -> 0.36.0 ``                                                                                     |
| [`61227c89`](https://github.com/NixOS/nixpkgs/commit/61227c892136fe7b2e7d216995146b4b16d91ffc) | `` vimPlugins.nvim-treesitter: update grammars ``                                                                  |
| [`5335b428`](https://github.com/NixOS/nixpkgs/commit/5335b4287e5d9af6c86583ad4d1bab885280ee4b) | `` vimPlugins.nvim-spider: init at 2023-04-12 ``                                                                   |
| [`8adf47d3`](https://github.com/NixOS/nixpkgs/commit/8adf47d32dddd8ccea08e1f2e7ba20c6b481b40f) | `` vimPlugins: update ``                                                                                           |
| [`451e9399`](https://github.com/NixOS/nixpkgs/commit/451e9399e39cad7a137bf0cb19c75da5bc3a70f1) | `` gitea: 1.19.0 -> 1.19.1 ``                                                                                      |
| [`6092709f`](https://github.com/NixOS/nixpkgs/commit/6092709f22a403b4ef5685828b03a1262d43268f) | `` Revert "Add LTS version of GnuPG and update libgcrypt to latest LTS version" ``                                 |
| [`7d54a86a`](https://github.com/NixOS/nixpkgs/commit/7d54a86a3654c71382c9c3f0c9d96ef875d7aeaf) | `` deno: 1.31.1 -> 1.32.3 ``                                                                                       |
| [`7275cfa7`](https://github.com/NixOS/nixpkgs/commit/7275cfa79b375d7d05346fece5953e650a5dc3fd) | `` grafana-agent: add indeednotjames as maintainer ``                                                              |
| [`845a6e97`](https://github.com/NixOS/nixpkgs/commit/845a6e97845d22be7a20b74b3d39a54e1d719b86) | `` nixos/grafana-agent: use `lib.getExe` as binary names changed between updates ``                                |
| [`bde538be`](https://github.com/NixOS/nixpkgs/commit/bde538be9f588200fb958f455b1d3e8f50d500f4) | `` grafana-agent: remove obsolete test fix in `preBuild` hook ``                                                   |
| [`4b9e3868`](https://github.com/NixOS/nixpkgs/commit/4b9e3868ebcb2e716b1f25efc4064eb075fa1f77) | `` grafana-agent: 0.30.2 -> 0.32.1 ``                                                                              |
| [`04be1e4a`](https://github.com/NixOS/nixpkgs/commit/04be1e4a9f62c6a595d999e7793e2eea295b00a0) | `` mangohud: use vendored vulkan-headers to fix build ``                                                           |
| [`4ba25efc`](https://github.com/NixOS/nixpkgs/commit/4ba25efc4e780b12b8e9768c297a23ddbb133e28) | `` twm: init at 0.1.1 ``                                                                                           |
| [`bc42752a`](https://github.com/NixOS/nixpkgs/commit/bc42752a6fc0afff45c08da69ee15fb7d9bad421) | `` plasma5Packages.kwin: 5.27.4 -> 5.27.4.1 ``                                                                     |
| [`eca81fb8`](https://github.com/NixOS/nixpkgs/commit/eca81fb8e00d62d6ab35792a13a572fb032ba303) | `` python310Packages.aioswitcher: 3.2.2 -> 3.3.0 ``                                                                |
| [`6086d857`](https://github.com/NixOS/nixpkgs/commit/6086d85777372ceae7f41501802d1884e9e024ef) | `` nixos/kubo: documentation suggestions ``                                                                        |
| [`5fb09c9e`](https://github.com/NixOS/nixpkgs/commit/5fb09c9e3a88dd9c291ea6aeab3b63923d325d6a) | `` nixos/kubo: Test Kubo restart after a crash ``                                                                  |
| [`4bd622cd`](https://github.com/NixOS/nixpkgs/commit/4bd622cd9d17d3fe2dedbc2adcb1eb45ecbff805) | `` nixos/kubo: unmount on service stop ``                                                                          |
| [`28949db4`](https://github.com/NixOS/nixpkgs/commit/28949db47e56fa276bcc8f25fd9482a8c4eb155e) | `` nixos/kubo: reenable FUSE test with workaround ``                                                               |
| [`4c49c707`](https://github.com/NixOS/nixpkgs/commit/4c49c707725397145127f032c75ea12dd439a79b) | `` codon: init at 0.15.5 ``                                                                                        |
| [`7c9778ff`](https://github.com/NixOS/nixpkgs/commit/7c9778ff076a2f9fe22e018943f228f72a2b0dd4) | `` xmp: minor cleanup ``                                                                                           |
| [`53b37c7e`](https://github.com/NixOS/nixpkgs/commit/53b37c7e4b15e3d79ed80175131e0a488ccf4f4b) | `` python310Packages.pyngrok: 5.2.2 -> 6.0.0 ``                                                                    |
| [`98f429a9`](https://github.com/NixOS/nixpkgs/commit/98f429a918f9ed028bb07b79e83c77a3fda91242) | `` python310Packages.peaqevcore: 15.2.1 -> 15.2.4 ``                                                               |
| [`1e5d5ebf`](https://github.com/NixOS/nixpkgs/commit/1e5d5ebf0c2deb368cf66621e77e0740ecf4f068) | `` pynitrokey: 0.4.34 -> 0.4.36 ``                                                                                 |
| [`95daa747`](https://github.com/NixOS/nixpkgs/commit/95daa7479513bef3e60fae32e15d85a68484aa49) | `` nixVersions.nix_2_15: init at 2.15.0 ``                                                                         |
| [`76271643`](https://github.com/NixOS/nixpkgs/commit/76271643885b400b1ad2d8c817f72dda4c71fef7) | `` python310Packages.omnikinverter: add changelog to meta ``                                                       |
| [`3a0bcff7`](https://github.com/NixOS/nixpkgs/commit/3a0bcff7df1c511a3817de1e02bec1c2dac1a6d1) | `` python310Packages.omnikinverter: 0.9.0 -> 0.9.1 ``                                                              |
| [`0fb0b2c6`](https://github.com/NixOS/nixpkgs/commit/0fb0b2c63e4d7aa50b300c89f0f78dc2b02092b7) | `` python310Packages.pontos: 23.4.1 -> 23.4.2 ``                                                                   |
| [`664877a5`](https://github.com/NixOS/nixpkgs/commit/664877a56397b136e050222505a5101dce2411a0) | `` netavark: 1.5.0 -> 1.6.0 ``                                                                                     |
| [`43e91f57`](https://github.com/NixOS/nixpkgs/commit/43e91f57d59a98c82354f4e70286b272b49642bc) | `` aardvark-dns: 1.5.0 -> 1.6.0 ``                                                                                 |
| [`c0d30b72`](https://github.com/NixOS/nixpkgs/commit/c0d30b72c2a3ec8ea62b4cc070a3a966da1b0eee) | `` terraform-providers.oci: 4.115.0 -> 4.116.0 ``                                                                  |
| [`361146b0`](https://github.com/NixOS/nixpkgs/commit/361146b0e74a0ae6d9c932cd8643fc5836a38cd7) | `` terraform-providers.scaleway: 2.16.2 -> 2.16.3 ``                                                               |
| [`16010785`](https://github.com/NixOS/nixpkgs/commit/16010785522173a0eb52ad1fbbbf3c1c1abfda55) | `` terraform-providers.random: 3.5.0 -> 3.5.1 ``                                                                   |
| [`7251bfa7`](https://github.com/NixOS/nixpkgs/commit/7251bfa76eecb18fa37def27d16f2d0924248c9b) | `` terraform-providers.pagerduty: 2.12.2 -> 2.13.0 ``                                                              |
| [`60c4d379`](https://github.com/NixOS/nixpkgs/commit/60c4d379646dd36307e029956c86d9c52bd7a47b) | `` terraform-providers.hcloud: 1.37.0 -> 1.38.0 ``                                                                 |
| [`cc042725`](https://github.com/NixOS/nixpkgs/commit/cc042725bce62ed822e1d719eef0a4916405e972) | `` terraform-providers.grafana: 1.36.1 -> 1.37.0 ``                                                                |
| [`3ebdf8d3`](https://github.com/NixOS/nixpkgs/commit/3ebdf8d35bcbc500d206eedc72c5817760e2ab64) | `` starship: 1.14.1 -> 1.14.2 ``                                                                                   |