### PR TITLE
chore(flake/emacs-overlay): `0dfa1616` -> `61d7fd1a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681550392,
-        "narHash": "sha256-2ZC8ZDGZ4SCgN0jXStY6ScwcgR9KjN3DFJImVdTLhI8=",
+        "lastModified": 1681559549,
+        "narHash": "sha256-3swAHgDrsLyW23yNsdlI0rK0b8sLN2kWZw+ZGeTvq9w=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0dfa16169942b7e524a353b07f8643d57524a6e6",
+        "rev": "61d7fd1a57eae85003001a53df2680f34182b259",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                           |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
| [`87d3eb48`](https://github.com/nix-community/emacs-overlay/commit/87d3eb48b7cdc4fa82b7bdc2b1e7964c82518c61) | `` Path fixes resulting from libgccjit changes `` |