### PR TITLE
chore(flake/emacs-overlay): `61d7fd1a` -> `f948eb91`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681559549,
-        "narHash": "sha256-3swAHgDrsLyW23yNsdlI0rK0b8sLN2kWZw+ZGeTvq9w=",
+        "lastModified": 1681582295,
+        "narHash": "sha256-Fg/eT2nuGDilyDFWmV8nvdzdKy07DTQ2VXOSLRLvTPk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "61d7fd1a57eae85003001a53df2680f34182b259",
+        "rev": "f948eb91ff33ead565b32d4e4e9cb17ab304c0b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`f948eb91`](https://github.com/nix-community/emacs-overlay/commit/f948eb91ff33ead565b32d4e4e9cb17ab304c0b4) | `` Updated repos/melpa `` |
| [`4e39df03`](https://github.com/nix-community/emacs-overlay/commit/4e39df0374084e3172c02bcfb65e2c654560c388) | `` Updated repos/emacs `` |