### PR TITLE
chore(flake/home-manager): `17198cf5` -> `40ebb621`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -448,11 +448,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681468923,
-        "narHash": "sha256-+X2oO4juRVhQRs002mn8km6PODccIRiz09c2K1xtSpY=",
+        "lastModified": 1681586243,
+        "narHash": "sha256-vdP79IZuDZVNSl4RN1LgEuab1Tkbv4gCxiE8VLdRf7U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "17198cf5ae27af5b647c7dac58d935a7d0dbd189",
+        "rev": "40ebb62101c83de81e5fd7c3cfe5cea2ed21b1ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`40ebb621`](https://github.com/nix-community/home-manager/commit/40ebb62101c83de81e5fd7c3cfe5cea2ed21b1ad) | `` swaylock: add platform assertion ``        |
| [`2df3d5d3`](https://github.com/nix-community/home-manager/commit/2df3d5d39c5ef3a4eebe80d478d75c9e20d5c820) | `` swaylock: add enable and package option `` |
| [`75f4f362`](https://github.com/nix-community/home-manager/commit/75f4f362e1b5ebdc4076fcbdb4188b4fd736187c) | `` git-sync: fix test ``                      |