### PR TITLE
chore(flake/emacs-plz): `fc8159a6` -> `7ea6175f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -269,11 +269,11 @@
     "emacs-plz": {
       "flake": false,
       "locked": {
-        "lastModified": 1681419256,
-        "narHash": "sha256-NaXAnQeN2Inm5HHqiDUjSRJyLuBtgkRrudmiXW5dvK8=",
+        "lastModified": 1681597650,
+        "narHash": "sha256-zsnoBH4vl3cKn5kX1rC0XB8hRNdP+LPYN2JVgBJKz/o=",
         "owner": "alphapapa",
         "repo": "plz.el",
-        "rev": "fc8159a6a9bf56d70614931bc50a7adf62707967",
+        "rev": "7ea6175f2c5a766d419e09b2ed898a1b6e926311",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                                        |
| ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`7ea6175f`](https://github.com/alphapapa/plz.el/commit/7ea6175f2c5a766d419e09b2ed898a1b6e926311) | `` Release: v0.5.3 ``                                          |
| [`973050f2`](https://github.com/alphapapa/plz.el/commit/973050f2249d951192b55d9d3f3e3e2bfcc85ef2) | `` Fix: (plz-queue) Move new slot to end ``                    |
| [`2bddc470`](https://github.com/alphapapa/plz.el/commit/2bddc47085a5144881b2f68dab19033b55805130) | `` Meta: v0.5.3-pre ``                                         |
| [`3b9b886c`](https://github.com/alphapapa/plz.el/commit/3b9b886cca1767f10666d57c4de6559db153d9b5) | `` Release: v0.5.2 ``                                          |
| [`fd214181`](https://github.com/alphapapa/plz.el/commit/fd2141814dd94c87880622b4f8bfa221c876effc) | `` Fix: (plz-clear) Only run queue's FINALLY when specified `` |
| [`c471f64b`](https://github.com/alphapapa/plz.el/commit/c471f64bda0b205d33a4005b058e36d361a2d316) | `` Meta: v0.5.2-pre ``                                         |
| [`6e52fbc9`](https://github.com/alphapapa/plz.el/commit/6e52fbc9f986b7c59251119d9485b3727c1e0f0c) | `` Release: v0.5.1 ``                                          |
| [`71e36fe2`](https://github.com/alphapapa/plz.el/commit/71e36fe27b4af04a3413ded4f570a361613deb71) | `` Fix: (plz-run) Only call queue's FINALLY when specified ``  |
| [`0a85c017`](https://github.com/alphapapa/plz.el/commit/0a85c01776c0d3798eb482e721f0edeeceb56469) | `` Meta: v0.5.1-pre ``                                         |