### PR TITLE
chore(flake/emacs-plz): `7ea6175f` -> `367c6a5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -269,11 +269,11 @@
     "emacs-plz": {
       "flake": false,
       "locked": {
-        "lastModified": 1681597650,
-        "narHash": "sha256-zsnoBH4vl3cKn5kX1rC0XB8hRNdP+LPYN2JVgBJKz/o=",
+        "lastModified": 1681612107,
+        "narHash": "sha256-WbT0Lq/aYVsfesj+RqHsf81D6VXYvzyFFsCOBddujbE=",
         "owner": "alphapapa",
         "repo": "plz.el",
-        "rev": "7ea6175f2c5a766d419e09b2ed898a1b6e926311",
+        "rev": "367c6a5a9a4bf320dcccb54bdd80ac46aa8be06f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                                   |
| ------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`367c6a5a`](https://github.com/alphapapa/plz.el/commit/367c6a5a9a4bf320dcccb54bdd80ac46aa8be06f) | `` Release: v0.5.4 ``                                     |
| [`94b52539`](https://github.com/alphapapa/plz.el/commit/94b52539685d2d6607f437246a5353542800e295) | `` Fix: (plz-run) Only run FINALLY afer queue is empty `` |
| [`341744e7`](https://github.com/alphapapa/plz.el/commit/341744e7c14bfcd5643c8bb2cbdf084245e0d806) | `` Meta: v0.5.4-pre ``                                    |