### PR TITLE
chore(flake/nixpkgs): `abe7316d` -> `85b08152`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -718,11 +718,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1681465517,
-        "narHash": "sha256-EasJh15/jcJNAHtq2SGbiADRXteURAnQbj1NqBoKkzU=",
+        "lastModified": 1681557730,
+        "narHash": "sha256-j2E3639kS3Qop2jQPyqWCdenZNaqIdxfoTvAHnGuAGI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "abe7316dd51a313ce528972b104f4f04f56eefc4",
+        "rev": "85b081528b937df4bfcaee80c3541b58f397df8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`cce076bd`](https://github.com/NixOS/nixpkgs/commit/cce076bd2437e95c06d3b56f4fa174a2e3c0fcbf) | `` kicad-unstable: 2023-03-29 -> 2023-04-14 ``                                             |
| [`534f790a`](https://github.com/NixOS/nixpkgs/commit/534f790a75b8b4a2f02da41d62f8b897f172c35a) | `` kicad: 7.0.1 -> 7.0.2 ``                                                                |
| [`b931b65d`](https://github.com/NixOS/nixpkgs/commit/b931b65d87e5d8bbe58fecdec21f6d9a95747f2a) | `` mmv-go: 0.1.4 -> 0.1.5 ``                                                               |
| [`44ccb54b`](https://github.com/NixOS/nixpkgs/commit/44ccb54b8a6e960d92c28f40ed0722e63a0d4f7c) | `` terraform-providers.tencentcloud: 1.80.2 -> 1.80.3 ``                                   |
| [`9fa47d9a`](https://github.com/NixOS/nixpkgs/commit/9fa47d9a8bc2e1d612fb1ec8a993e2df9245c548) | `` terraform-providers.pagerduty: 2.14.0 -> 2.14.1 ``                                      |
| [`e0fc7cd7`](https://github.com/NixOS/nixpkgs/commit/e0fc7cd7bc2f74fb71d510bb983b5ce9257d38d9) | `` terraform-providers.hcloud: 1.38.1 -> 1.38.2 ``                                         |
| [`0ec24099`](https://github.com/NixOS/nixpkgs/commit/0ec24099fc6e7bc52fa496b7f8b085b847df1acc) | `` terraform-providers.alicloud: 1.202.0 -> 1.203.0 ``                                     |
| [`17f9e6b0`](https://github.com/NixOS/nixpkgs/commit/17f9e6b098ee9d109a866e19dafdb9d223d60a00) | `` terraform-providers.flexibleengine: 1.36.1 -> 1.37.0 ``                                 |
| [`cc129fb3`](https://github.com/NixOS/nixpkgs/commit/cc129fb3f2d69802cb6175e0559c23bf1b87cf3d) | `` terraform-providers.aviatrix: 3.0.4 -> 3.0.5 ``                                         |
| [`73bac981`](https://github.com/NixOS/nixpkgs/commit/73bac9816428a9019f570b5571a179a5719aca4e) | `` act: 0.2.43 -> 0.2.44 ``                                                                |
| [`396932f6`](https://github.com/NixOS/nixpkgs/commit/396932f69170ff190fa3dd2ac0437181bf1f103a) | `` aliyun-cli: 3.0.160 -> 3.0.161 ``                                                       |
| [`e0c22ecf`](https://github.com/NixOS/nixpkgs/commit/e0c22ecf8eee86ce76add5f3d1abc055a9825598) | `` javaPackages: cleanup unused code ``                                                    |
| [`8204a95e`](https://github.com/NixOS/nixpkgs/commit/8204a95ef21d4509af5d30cf0ac48a05cee208f9) | `` openjdk: bootstrap headless variant with headless openjdk ``                            |
| [`e6955ade`](https://github.com/NixOS/nixpkgs/commit/e6955adeaa95330a622fc17cf868d172b9f4278d) | `` go-musicfox: 4.0.2 -> 4.0.3 ``                                                          |
| [`b5eaa9ff`](https://github.com/NixOS/nixpkgs/commit/b5eaa9ffd98d3dad25a1b60858bd2fbd68587a08) | `` stellarium: update darwin patches ``                                                    |
| [`83ed2b7e`](https://github.com/NixOS/nixpkgs/commit/83ed2b7e9a05a26e71a878793b8ca3a3e6212fef) | `` indilib: add aarch64-darwin support ``                                                  |
| [`27135d54`](https://github.com/NixOS/nixpkgs/commit/27135d545ee53d49f90c1c599afe74ff57e1c151) | `` python310Packages.pyqt6: build QtPrintSupport bindings on darwin ``                     |
| [`8ae1412f`](https://github.com/NixOS/nixpkgs/commit/8ae1412f8e881797b2b22e5425a97138fcd5d428) | `` cri-o: add conntrack-tools to wrapper ``                                                |
| [`7d03f1aa`](https://github.com/NixOS/nixpkgs/commit/7d03f1aa9f1b356064c6f12d619498a264df334b) | `` nixos/cri-o: add aufs, devmapper, and zfs to storageDrivers ``                          |
| [`a1995083`](https://github.com/NixOS/nixpkgs/commit/a19950835b716a72928df87604cf4c46097b5f14) | `` dnstwist: 20230402 -> 20230413 ``                                                       |
| [`fc9ebeae`](https://github.com/NixOS/nixpkgs/commit/fc9ebeae7cb4bbf9864694a5137170dbe1988ddf) | `` python310Packages.ocrmypdf: 14.0.4 -> 14.1.0 ``                                         |
| [`1f8eeba0`](https://github.com/NixOS/nixpkgs/commit/1f8eeba04f451f4c283511c9ff9d7cee7a50e5c9) | `` dataexplorer: 3.7.4 -> 3.7.6 ``                                                         |
| [`bfc75c74`](https://github.com/NixOS/nixpkgs/commit/bfc75c749141bd8272b9c68ca1d678dfe789f3cb) | `` libsForQt5.qtsystems: init at unstable-2019-01-03 (#214179) ``                          |
| [`ce6971f2`](https://github.com/NixOS/nixpkgs/commit/ce6971f2dd4977037dad445098d9e72e0d494d0b) | `` _1password-gui: improve update-script to be more flexible ``                            |
| [`c01aef29`](https://github.com/NixOS/nixpkgs/commit/c01aef2947d6b408354d8b1cf2c2a45e52ee6a6e) | `` _1password-gui: 8.10.0 -> 8.10.4, 8.10.1-19.BETA -> 8.10.5-10.BETA ``                   |
| [`bfdbd554`](https://github.com/NixOS/nixpkgs/commit/bfdbd5543cb472c8bbe0025901505d898126b19c) | `` python310Packages.cwl-upgrader: adjust inputs ``                                        |
| [`3a776e1e`](https://github.com/NixOS/nixpkgs/commit/3a776e1e30bc6d45847c9c7614788417a0a78097) | `` nixosTests.cage: fix OCR properly ``                                                    |
| [`ec71bbaa`](https://github.com/NixOS/nixpkgs/commit/ec71bbaa0a769ff717077557c7ae743b30cd501b) | `` vorta: 0.8.10 -> 0.8.12, add optional dependency for qtwayland on linux ``              |
| [`944a4d5a`](https://github.com/NixOS/nixpkgs/commit/944a4d5aa053e2939055b6a0784f180a95614849) | `` qdrant: 1.1.0 -> 1.1.1 ``                                                               |
| [`725de57b`](https://github.com/NixOS/nixpkgs/commit/725de57bce954bdc9ab300b5bd1e49e7e1813091) | `` python310Packages.cwl-utils: 0.23 -> 0.24 ``                                            |
| [`51ec9cb3`](https://github.com/NixOS/nixpkgs/commit/51ec9cb32b1b259f7cf0a4ffabdbee40a683222d) | `` tageditor: 3.7.8 -> 3.7.9 ``                                                            |
| [`3fa73885`](https://github.com/NixOS/nixpkgs/commit/3fa738854bba5b165da559e54f417c838daca166) | `` rust-script: 0.25.0 -> 0.26.0 ``                                                        |
| [`351cec5d`](https://github.com/NixOS/nixpkgs/commit/351cec5db3b7ca839779316a8b7c524ea8941f0f) | `` use subcommands in plugin updaters (#223164) ``                                         |
| [`3824e962`](https://github.com/NixOS/nixpkgs/commit/3824e9627c0542a3f9c3988ec68e54178f8a26dc) | `` tts: 0.12.0 -> 0.13.2 ``                                                                |
| [`bd969863`](https://github.com/NixOS/nixpkgs/commit/bd969863db31fa8c7fc4d67913956f4be3a80dc3) | `` python310Packages.accuweather: 0.5.0 -> 0.5.1 ``                                        |
| [`9600a18d`](https://github.com/NixOS/nixpkgs/commit/9600a18dc2d9cc75c2f64a94150f23acd35a1f71) | `` girara: fix cross compilation ``                                                        |
| [`a70aaf57`](https://github.com/NixOS/nixpkgs/commit/a70aaf57f455d9edc37a404a18af6f67481d5e1b) | `` sqlfluff: 2.0.3 -> 2.0.4 ``                                                             |
| [`75f03610`](https://github.com/NixOS/nixpkgs/commit/75f03610bac483a6883c529704af15a3609ef5ea) | `` qt6.qtwebengine: separate linux-only parts ``                                           |
| [`08c78eaa`](https://github.com/NixOS/nixpkgs/commit/08c78eaa64c0761ed7778fc5b10799c395efe7aa) | `` gpgme: fix cross, drop python2 ``                                                       |
| [`bd8c68fd`](https://github.com/NixOS/nixpkgs/commit/bd8c68fdec9d0999bf11ac8f6860ed4c85b8769b) | `` qt6: avoid building under /tmp on darwin ``                                             |
| [`ddd8604a`](https://github.com/NixOS/nixpkgs/commit/ddd8604a3bd33c3a25f56d613d458c26a84d42d2) | `` moveBuildTree: init ``                                                                  |
| [`4c5fa94f`](https://github.com/NixOS/nixpkgs/commit/4c5fa94f8a55dffb42c63a6a136be5eccbc35859) | `` fq: 0.4.0 -> 0.5.0 ``                                                                   |
| [`78cdc66d`](https://github.com/NixOS/nixpkgs/commit/78cdc66d62a60128c38b9f41a0c36906e1741be0) | `` signalbackup-tools: 20230413 -> 20230414 ``                                             |
| [`ab6c85f3`](https://github.com/NixOS/nixpkgs/commit/ab6c85f31cd64bded662e5db3ed259eaf714e32b) | `` gqrx: 2.15.9 -> 2.15.10 ``                                                              |
| [`a95ed9fe`](https://github.com/NixOS/nixpkgs/commit/a95ed9fe764c3ba2bf2d2fa223012c379cd6b32e) | `` Fix a small typo in the manual ``                                                       |
| [`2ba48cc8`](https://github.com/NixOS/nixpkgs/commit/2ba48cc8dee2249526efeda1d2c629a2ec625229) | `` nim: propagate Security framework to all nim packages on darwin ``                      |
| [`9bdc7448`](https://github.com/NixOS/nixpkgs/commit/9bdc7448410532f5ba90aac1a12128dc9c0889f6) | `` dolphin-emu: add more frameworks ``                                                     |
| [`b959eb07`](https://github.com/NixOS/nixpkgs/commit/b959eb07f597b7bbe61bad60c8454a992be7c57e) | `` ocamlPackages.morbig: take OCaml dependencies individually ``                           |
| [`f9b60771`](https://github.com/NixOS/nixpkgs/commit/f9b6077157180a453fdfda6b88fe06b01195da13) | `` goreleaser: 1.17.0 -> 1.17.1 ``                                                         |
| [`0135b7a5`](https://github.com/NixOS/nixpkgs/commit/0135b7a556ee60144b143b071724fa44348a188e) | `` nixos/peroxide: correct option doc ``                                                   |
| [`53b43eac`](https://github.com/NixOS/nixpkgs/commit/53b43eacde256ba8ea4113b898d2a9ba784fc595) | `` python3Packages.pythonocc-core: skip bulk update ``                                     |
| [`a58da07f`](https://github.com/NixOS/nixpkgs/commit/a58da07fc69dd9706c06aace7211108c55faaaef) | `` texlive: accept gracefully packages without pname or version (#226070) ``               |
| [`f5eb3289`](https://github.com/NixOS/nixpkgs/commit/f5eb32899d93fad8ac89bee50488ee25675af055) | `` logseq: 0.9.1 -> 0.9.2 ``                                                               |
| [`d4152833`](https://github.com/NixOS/nixpkgs/commit/d41528331437e2799eb229c51e51ff5d476a4e18) | `` python310Packages.homeassistant-stubs: 2023.4.2 -> 2023.4.4 ``                          |
| [`d421a8da`](https://github.com/NixOS/nixpkgs/commit/d421a8dadc663badea427c7cc6e88bb4804e7549) | `` maestro: 1.26.0 -> 1.26.1 ``                                                            |
| [`a1a3813f`](https://github.com/NixOS/nixpkgs/commit/a1a3813f7bdb163139f6b74a9892108013b869a3) | `` qt6: drop devTools attribute as they are no longer moved to the dev output ``           |
| [`0bad2288`](https://github.com/NixOS/nixpkgs/commit/0bad2288a751fc4023da1cf70902a2847100616d) | `` qt6.qttools: symlink bin to dev output ``                                               |
| [`e5ba8e71`](https://github.com/NixOS/nixpkgs/commit/e5ba8e7113e24828ee6ea94cad4f3ea89afbfb41) | `` qt6.qttools: fix embedded path to tools ``                                              |
| [`37e3fafb`](https://github.com/NixOS/nixpkgs/commit/37e3fafb41b16c8060a1c45cc984d4eefeb87855) | `` qt6.qtdeclarative: drop outdated workarounds ``                                         |
| [`91fb53dc`](https://github.com/NixOS/nixpkgs/commit/91fb53dce30b0c886c1b9d276eadfb08b419f403) | `` qt6.qtwebengine: remove outdated postFixup phase ``                                     |
| [`d69d20ba`](https://github.com/NixOS/nixpkgs/commit/d69d20baa363b977fcac1f72a5b416303e29796b) | `` libsForQt5.fcitx5-qt: fix reference to qt6.qtbase ``                                    |
| [`d2534851`](https://github.com/NixOS/nixpkgs/commit/d25348517e1e98cc1023b3b233f488c519c1cd77) | `` qt6.qtbase: fixup paths in setup hooks ``                                               |
| [`bf055053`](https://github.com/NixOS/nixpkgs/commit/bf05505377a62199ff4a7f15becd8159fbd5c23a) | `` qt6.qtbase: remove fixQmakeLibtool hook ``                                              |
| [`f9f2b3ae`](https://github.com/NixOS/nixpkgs/commit/f9f2b3ae42732f69abaf277bb6a0e2152a5a11c0) | `` qt6: fix references to qmake ``                                                         |
| [`d84e2bf0`](https://github.com/NixOS/nixpkgs/commit/d84e2bf05653e277c74afc1077f3126d403bf720) | `` qt6: do not move devTools to dev output ``                                              |
| [`5aa78f89`](https://github.com/NixOS/nixpkgs/commit/5aa78f89f029200ce4e882e29389fb6d58ccdee5) | `` qt6.qtbase: refresh patches ``                                                          |
| [`a73470ec`](https://github.com/NixOS/nixpkgs/commit/a73470ec4e053f5a1f51a5c46c5fbf4f29a020df) | `` go-musicfox: 4.0.1 -> 4.0.2 ``                                                          |
| [`4f8300ad`](https://github.com/NixOS/nixpkgs/commit/4f8300ad9ade4bb666e9d5e7089d57b48c417de6) | `` linuxPackages.nvidia_x11: add kiskae as maintainer ``                                   |
| [`18df1900`](https://github.com/NixOS/nixpkgs/commit/18df1900281e184505ca8712d5fb0859c63aa660) | `` maintainers: add kiskae ``                                                              |
| [`baab567c`](https://github.com/NixOS/nixpkgs/commit/baab567c8226f2c48f89b9c325ed959367b0f855) | `` chatgpt-cli: 1.1 -> 1.1.1 ``                                                            |
| [`d94ae302`](https://github.com/NixOS/nixpkgs/commit/d94ae302c69be52021d6b688679ac7b86d148712) | `` qt6.qtbase: do not embed compiler information into generated cmake files ``             |
| [`97a53879`](https://github.com/NixOS/nixpkgs/commit/97a538791c925979065b7f11d1676ef585360773) | `` qt6: set "moveToDev" to false ``                                                        |
| [`21a773c6`](https://github.com/NixOS/nixpkgs/commit/21a773c671453cadc508bdda884afcbd81435ea9) | `` qt6: drop cmake patch used for fixing cmake file generation ``                          |
| [`aa4692d5`](https://github.com/NixOS/nixpkgs/commit/aa4692d56635eb254c76620c7a1fd337fae1d065) | `` ramfetch: 1.1.0 -> 1.1.0a ``                                                            |
| [`4ab2cc86`](https://github.com/NixOS/nixpkgs/commit/4ab2cc8673e56da60d1aefa871572b1eed94c856) | `` kotlin-language-server: 1.3.1 -> 1.3.3 ``                                               |
| [`43e2460a`](https://github.com/NixOS/nixpkgs/commit/43e2460a44c61164e292225c25544c977619bc99) | `` ripasso-cursive: 0.6.2 -> 0.6.4 ``                                                      |
| [`1cfd9b71`](https://github.com/NixOS/nixpkgs/commit/1cfd9b7156e1454baa1a9304755107f7ec0e570a) | `` python310Packages.frigidaire: 0.18.5 -> 0.18.12 ``                                      |
| [`7a61a371`](https://github.com/NixOS/nixpkgs/commit/7a61a3710df25b6008d4e828468d6c9dd150a2e3) | `` lzwolf: fix build on SDL2_net-2.2 ``                                                    |
| [`63d9758c`](https://github.com/NixOS/nixpkgs/commit/63d9758cbf13ebdcfe6582e6b6e8b38c35837608) | `` cppcheck: 2.10.2 -> 2.10.3 ``                                                           |
| [`27e4ed7b`](https://github.com/NixOS/nixpkgs/commit/27e4ed7bc0519c74af3d47295f452e08bdb50b8d) | `` python3.pkgs.w1thermsensor: init at 2.0.0 ``                                            |
| [`d4839f0c`](https://github.com/NixOS/nixpkgs/commit/d4839f0c97f0c359ef727fdd68c75f1da524b50e) | `` krapslog: 0.5.0 -> 0.5.1 ``                                                             |
| [`37b11ce4`](https://github.com/NixOS/nixpkgs/commit/37b11ce43b842be48f10be8534a128c24b9942cc) | `` oxker: 0.2.5 -> 0.3.0 ``                                                                |
| [`6b16ca89`](https://github.com/NixOS/nixpkgs/commit/6b16ca897368d1e3bd846ebef502b6b56f6d3406) | `` python310Packages.dicom2nifti: 2.4.3 -> 2.4.8 ``                                        |
| [`da3d6939`](https://github.com/NixOS/nixpkgs/commit/da3d6939bcf0d0537163187051138cf408cf0a25) | `` probe-run: 0.3.7 -> 0.3.8 ``                                                            |
| [`23b160b3`](https://github.com/NixOS/nixpkgs/commit/23b160b370b5b8230808918e9061f8672b1f5c50) | `` linux-zen: 6.2.9-zen1 -> 6.2.11-zen1 ``                                                 |
| [`267e2e6e`](https://github.com/NixOS/nixpkgs/commit/267e2e6ef5507e46bf1e4cc97cc369b9983e72ce) | `` simdjson: 3.1.6 -> 3.1.7 ``                                                             |
| [`8ceb20e2`](https://github.com/NixOS/nixpkgs/commit/8ceb20e2244f4717080b171674d24966fecb27e1) | `` linux-lqx: 6.2.10-lqx1 -> 6.2.11-lqx3 ``                                                |
| [`2654955b`](https://github.com/NixOS/nixpkgs/commit/2654955bc42d0117f2930171ea8fe7073ac467d1) | `` home-assistant: 2023.4.3 -> 2023.4.4 ``                                                 |
| [`61f8e09e`](https://github.com/NixOS/nixpkgs/commit/61f8e09ed6bffad4b491c3f79ea6c07f8b561161) | `` python310Packages.python-homewizard-energy: 1.8.0 -> 2.0.1 ``                           |
| [`470e6c86`](https://github.com/NixOS/nixpkgs/commit/470e6c86ab00ffe39232c3151631d71ad57d2001) | `` python310Packages.aiolifx: 0.8.9 -> 0.8.10 ``                                           |
| [`df4d6e21`](https://github.com/NixOS/nixpkgs/commit/df4d6e21a1ca5d841b858375844a2f203b260244) | `` home-assistant: Handle illegal version specifiers more gracefully ``                    |
| [`a8c3ee36`](https://github.com/NixOS/nixpkgs/commit/a8c3ee36620c08c79bbe90f074cd30a3198870f0) | `` python310Packages.pikepdf: 7.1.2 -> 7.2.0 ``                                            |
| [`d77e1a6d`](https://github.com/NixOS/nixpkgs/commit/d77e1a6daf19eeb2419187e6be4d1190c2a35d91) | `` octavePackages.control: update 3.5.1 -> 3.5.2 ``                                        |
| [`7a458893`](https://github.com/NixOS/nixpkgs/commit/7a458893d5f101c8503c6ce4b2332e047d824a80) | `` asciinema-agg: 1.4.0 -> 1.4.1 ``                                                        |
| [`473a32c1`](https://github.com/NixOS/nixpkgs/commit/473a32c14ebd460d8999445b340b17f5cb4ff3f1) | `` typeshare: 1.4.0 -> 1.5.0 ``                                                            |
| [`019fd455`](https://github.com/NixOS/nixpkgs/commit/019fd455371037ddb4005152b3059b6404f5c73c) | `` doc: Fix the function locations always pointing to master ``                            |
| [`98c3d190`](https://github.com/NixOS/nixpkgs/commit/98c3d190b2bc732a211fb417a73b3cad7a33c83a) | `` nixos/openssh: Drop deprecated locations ``                                             |
| [`c9e348dd`](https://github.com/NixOS/nixpkgs/commit/c9e348dd3e87b94c01c7b94d2d23b4666a0f77bf) | `` pods: 1.0.6 -> 1.1.0 ``                                                                 |
| [`9e1be1c9`](https://github.com/NixOS/nixpkgs/commit/9e1be1c9fdc3b2ccdf7472db15ff1fa5547a3726) | `` artem: 1.1.5 -> 1.1.7 ``                                                                |
| [`b346f81f`](https://github.com/NixOS/nixpkgs/commit/b346f81ff1339d789c100f164d39b4dc3374b5ce) | `` git-dive: 0.1.5 -> 0.1.6 ``                                                             |
| [`342e1734`](https://github.com/NixOS/nixpkgs/commit/342e173470d7e3624fd76f5cfa52e3516f642b33) | `` exploitdb: 2023-04-11 -> 2023-04-13 ``                                                  |
| [`8b0eecfb`](https://github.com/NixOS/nixpkgs/commit/8b0eecfb96c5cf1323dd1ffc61f9801d20e7cf88) | `` jazz2: init at 1.8.0 ``                                                                 |
| [`061c7343`](https://github.com/NixOS/nixpkgs/commit/061c734301965aa4be118260df0c2d3b39a650ab) | `` komikku: 1.17.0 -> 1.18.0 ``                                                            |
| [`ecde4872`](https://github.com/NixOS/nixpkgs/commit/ecde48723a5d91a0f98ea4816f115345edf94441) | `` maintainers: add surfaceflinger ``                                                      |
| [`0c48c4a9`](https://github.com/NixOS/nixpkgs/commit/0c48c4a9865784b8936a2f5aab28d9154457448e) | `` doas-sudo-shim: init at 0.1.1 ``                                                        |
| [`0ab01c8a`](https://github.com/NixOS/nixpkgs/commit/0ab01c8aa656a9c2427073746b6c74cb6801da4e) | `` evcc: 0.115.0 -> 0.116.0 ``                                                             |
| [`d744ccc0`](https://github.com/NixOS/nixpkgs/commit/d744ccc04ba25fd1c19ef990cd33888ab00759ee) | `` cocoapods: 1.11.3 -> 1.12.0 ``                                                          |
| [`0ede6b97`](https://github.com/NixOS/nixpkgs/commit/0ede6b972e703d1b555d3ae2cc8bf35ea1719d90) | `` deepin.dde-file-manager: init at 6.0.13 ``                                              |
| [`ee4da217`](https://github.com/NixOS/nixpkgs/commit/ee4da217062c2e1ca2f86efa9dbc3d1f23d84263) | `` deepin.deepin-movie-reborn: Use absolute paths to ensure dynamic libraries are found `` |
| [`f674237d`](https://github.com/NixOS/nixpkgs/commit/f674237d9feaa4f766888355d4edd97a787254df) | `` kickoff: init at v0.7.0 ``                                                              |
| [`b261832a`](https://github.com/NixOS/nixpkgs/commit/b261832adff243e8f0e54da8d71b6bf8402922c2) | `` oven-media-engine: 0.15.7 -> 0.15.8 ``                                                  |
| [`e37ea2f1`](https://github.com/NixOS/nixpkgs/commit/e37ea2f136dc6437d2eced540896e69484771525) | `` python310Packages.nibabel: 5.0.1 -> 5.1.0 ``                                            |
| [`393343e2`](https://github.com/NixOS/nixpkgs/commit/393343e2fc32029b56d0b84683156bcb40b4cf63) | `` ps2eps: init at 1.70 ``                                                                 |
| [`e9bba1da`](https://github.com/NixOS/nixpkgs/commit/e9bba1da96d6f53e6e007a254d74e8ce655406e8) | `` goffice: fix cross ``                                                                   |
| [`0d49c624`](https://github.com/NixOS/nixpkgs/commit/0d49c6248493abca2c3075db2fa57958acd3b7f4) | `` maintainers: add quentin ``                                                             |
| [`69510f46`](https://github.com/NixOS/nixpkgs/commit/69510f467e33a48fd1ffd19f486671609c305a95) | `` fuse-7z-ng: set `meta.homepage` ``                                                      |
| [`644aa601`](https://github.com/NixOS/nixpkgs/commit/644aa6013d095c3996b1757c95fef295bbcbc571) | `` maintainers: add dsuetin ``                                                             |
| [`58af20bd`](https://github.com/NixOS/nixpkgs/commit/58af20bd05b6f1258505a4213ba9782f30bfbf2e) | `` elasticsearchPlugins: add analysis-kuromoji plugin ``                                   |
| [`5fbdef57`](https://github.com/NixOS/nixpkgs/commit/5fbdef572082948ca9c4aefffb9d09dbd50aedb8) | `` python3Packages.lightgbm: add GPU support ``                                            |
| [`53a63959`](https://github.com/NixOS/nixpkgs/commit/53a639594f138e9eb86759457c8a93a776a99441) | `` matrix-sdk-crypto-nodejs: convert cargoDeps to importCargoLock ``                       |
| [`2869364b`](https://github.com/NixOS/nixpkgs/commit/2869364b9b23f5ae0c284e670cd69a9aa42b38c4) | `` matrix-sdk-crypto-nodejs: 0.1.0-beta.2 -> 0.1.0-beta.3 ``                               |
| [`b30b9fda`](https://github.com/NixOS/nixpkgs/commit/b30b9fda485b2b9701172369f6c84830a3ab845c) | `` maintainer: add pyxels ``                                                               |
| [`2865b8f2`](https://github.com/NixOS/nixpkgs/commit/2865b8f2a320daad30021e39df3f3d70f1af4d76) | `` udisks: backport patch for crash on exit ``                                             |
| [`daa77caf`](https://github.com/NixOS/nixpkgs/commit/daa77caf9bf660c52858772d8aa4cf9ab08ffe92) | `` cc-wrapper: disable response files for ccache ``                                        |