### PR TITLE
chore(flake/home-manager): `21ca88f3` -> `d1d0ee37`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681617561,
-        "narHash": "sha256-Fyf2sBz3CK9SuptsN4+Brf62jMfd99BlyijJD5HAtcg=",
+        "lastModified": 1681685177,
+        "narHash": "sha256-dpwwLJxMj7iPFWVnVE6kkv2OnDmZtJCtibZW6N9xzfU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "21ca88f3a98f15e4791c82697745e3698ad883d8",
+        "rev": "d1d0ee37c315537cdcadbcf0f773694e9da0605d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`d1d0ee37`](https://github.com/nix-community/home-manager/commit/d1d0ee37c315537cdcadbcf0f773694e9da0605d) | `` home-manager: ignore errors from notify-send `` |