### PR TITLE
chore(flake/home-manager): `d1d0ee37` -> `68eaf4b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681685177,
-        "narHash": "sha256-dpwwLJxMj7iPFWVnVE6kkv2OnDmZtJCtibZW6N9xzfU=",
+        "lastModified": 1681688069,
+        "narHash": "sha256-1w6zBfwxwMbyewUyqzSnZs8nwNqj6ZBVcP0rkCueyIo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d1d0ee37c315537cdcadbcf0f773694e9da0605d",
+        "rev": "68eaf4b577cfa8024fb910a1ce7d60385044f798",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                               |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`68eaf4b5`](https://github.com/nix-community/home-manager/commit/68eaf4b577cfa8024fb910a1ce7d60385044f798) | `` i3-sway: add option trayPadding (tray_padding) for bars (#3829) `` |