### PR TITLE
chore(flake/emacs-overlay): `dad2876c` -> `00993d05`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681670469,
-        "narHash": "sha256-z6ZYEA9QNTbL1PYxd0KEXn41HTxjd2udduS+gRLVY7U=",
+        "lastModified": 1681700379,
+        "narHash": "sha256-ssWUELEnntWblhbUhy9niCv06q7nZCYgfUka5qYac3U=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dad2876c31059cd5b32e9272864409a69a10e62e",
+        "rev": "00993d057b699a7a9921942d75eca18c191a19ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`00993d05`](https://github.com/nix-community/emacs-overlay/commit/00993d057b699a7a9921942d75eca18c191a19ad) | `` Updated repos/melpa `` |
| [`50c62e5f`](https://github.com/nix-community/emacs-overlay/commit/50c62e5f77a2aed1c6ae7e1779518a6177085a41) | `` Updated repos/emacs `` |