### PR TITLE
chore(flake/sops-nix): `4cb35024` -> `de6514f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -970,11 +970,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1681717984,
-        "narHash": "sha256-Jj1eMGnl6RYN2j4OZla8Y/ViIcLWHvCetPMkvPpLTno=",
+        "lastModified": 1681721408,
+        "narHash": "sha256-NWCbZKOQEXz1hA2YDFxdd+fVrrw9edbG1DvbbLf7KUY=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "4cb3502465f3ace00713614bfdea30b7955ce9dd",
+        "rev": "de6514f8fe1b3c2b57307569a0898bc4be9ae1c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                            |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`d90636d4`](https://github.com/Mic92/sops-nix/commit/d90636d45f2f1b0a7d134e3109562e8c60868440) | `` Bump golang.org/x/crypto from 0.7.0 to 0.8.0 `` |