### PR TITLE
chore(flake/emacs-overlay): `00993d05` -> `12ba135e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681700379,
-        "narHash": "sha256-ssWUELEnntWblhbUhy9niCv06q7nZCYgfUka5qYac3U=",
+        "lastModified": 1681726870,
+        "narHash": "sha256-7apuYEE6AyInhvjsX/XwQZqDP7v/f9TZzUHIBjXZEUY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "00993d057b699a7a9921942d75eca18c191a19ad",
+        "rev": "12ba135e863d25ffc3d80f05678ef7deacfd3689",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`12ba135e`](https://github.com/nix-community/emacs-overlay/commit/12ba135e863d25ffc3d80f05678ef7deacfd3689) | `` Updated repos/melpa `` |
| [`183e347a`](https://github.com/nix-community/emacs-overlay/commit/183e347a7e0f61bd68e3b4ae99901eac96330791) | `` Updated repos/emacs `` |