### PR TITLE
chore(flake/home-manager): `53bd74f7` -> `ae79840b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681690464,
-        "narHash": "sha256-x8pw8KAb9TJsszbCHUBK2bWvgYPlCjwHMV1dF95eZPs=",
+        "lastModified": 1681746824,
+        "narHash": "sha256-TRe6SAYqTEyWmHwg5gpAj3arebje/OVi7z9yLqZRYqg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "53bd74f786934997e7f6a5ed9741b226e511e508",
+        "rev": "ae79840bc756e97f9750fc70448ae0efc1b8dcc3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`ae79840b`](https://github.com/nix-community/home-manager/commit/ae79840bc756e97f9750fc70448ae0efc1b8dcc3) | `` doc: replace invalid link (#3881) `` |