### PR TITLE
chore(flake/emacs-overlay): `3b912580` -> `20248af9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681751556,
-        "narHash": "sha256-+ht3wdxYhanqknByZRk5OubrSw/0a+kwzqGLZN25aRw=",
+        "lastModified": 1681783787,
+        "narHash": "sha256-YqZd9wzx+io5FJnjgR4ADOYsB0NZJbFt1w99TbDfH3g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3b912580d054557e959d0b282fd12f5c473103f3",
+        "rev": "20248af9c7408b3bb5d5db892a586de3e760834d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`20248af9`](https://github.com/nix-community/emacs-overlay/commit/20248af9c7408b3bb5d5db892a586de3e760834d) | `` Updated repos/emacs `` |
| [`cd22b696`](https://github.com/nix-community/emacs-overlay/commit/cd22b6969b0cd3113ae8b742a88e5f274524435e) | `` Updated repos/elpa ``  |