### PR TITLE
chore(flake/home-manager): `58b8685e` -> `2dcb61d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681765172,
-        "narHash": "sha256-BbI9rihPWc6hvrbu9B6EtOetRSHMp0IiwlCVFIKcmMk=",
+        "lastModified": 1681799488,
+        "narHash": "sha256-aAK/Mzf2yZ20stXkmPmtvtDQFy2XaEjAyZ3Fo56FbQc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "58b8685e47ce54b298c40aff7877ea9b875de0e6",
+        "rev": "2dcb61d396b45f10d9e0621a7358b361f94323ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`2dcb61d3`](https://github.com/nix-community/home-manager/commit/2dcb61d396b45f10d9e0621a7358b361f94323ff) | `` atuin: enable nushell integration `` |
| [`fa980cc9`](https://github.com/nix-community/home-manager/commit/fa980cc98529111c7aad713574d307e9b4f3e5ed) | `` batsignal: add module ``             |