### PR TITLE
chore(flake/emacs-overlay): `20248af9` -> `02eea1bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681783787,
-        "narHash": "sha256-YqZd9wzx+io5FJnjgR4ADOYsB0NZJbFt1w99TbDfH3g=",
+        "lastModified": 1681814664,
+        "narHash": "sha256-9nCq5qypdOnmu8DjPjeKMMvyAQKaWOxBpf0mDr3RUtY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "20248af9c7408b3bb5d5db892a586de3e760834d",
+        "rev": "02eea1bf04605ef02eba5363d3cd578170f2b610",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`02eea1bf`](https://github.com/nix-community/emacs-overlay/commit/02eea1bf04605ef02eba5363d3cd578170f2b610) | `` Updated repos/nongnu `` |
| [`5ad38e37`](https://github.com/nix-community/emacs-overlay/commit/5ad38e37e0e76abdc95486c642013f54abba96c4) | `` Updated repos/melpa ``  |
| [`8c59dfc1`](https://github.com/nix-community/emacs-overlay/commit/8c59dfc130abf5bbc8609734b3da425fd5a7d1e7) | `` Updated repos/emacs ``  |