### PR TITLE
chore(flake/sops-nix): `de6514f8` -> `5698b06b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -970,11 +970,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1681721408,
-        "narHash": "sha256-NWCbZKOQEXz1hA2YDFxdd+fVrrw9edbG1DvbbLf7KUY=",
+        "lastModified": 1681821695,
+        "narHash": "sha256-uwyBGo/9IALi97AfMuzkJroQQhV6hkybaZVdw6pRNG4=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "de6514f8fe1b3c2b57307569a0898bc4be9ae1c5",
+        "rev": "5698b06b0731a2c15ff8c2351644427f8ad33993",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`4de4d820`](https://github.com/Mic92/sops-nix/commit/4de4d820ba27a5741e611e2364c7c54e560fb5de) | `` fix scope in sops.templates; add relevant test ``              |
| [`37400a27`](https://github.com/Mic92/sops-nix/commit/37400a275dab894a9c07eeeca7f74e29b6349b53) | `` HM: make `secretsMountPoint` and `symlinkPath` configurable `` |