### PR TITLE
chore(flake/emacs-overlay): `02eea1bf` -> `7f4b9004`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681814664,
-        "narHash": "sha256-9nCq5qypdOnmu8DjPjeKMMvyAQKaWOxBpf0mDr3RUtY=",
+        "lastModified": 1681842970,
+        "narHash": "sha256-9A+RKQp3hA4WKLeU4bnstf+650d6b5JOf3XvHyQ/4SQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "02eea1bf04605ef02eba5363d3cd578170f2b610",
+        "rev": "7f4b90040296ed6faacbcd9933927852d020df75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`7f4b9004`](https://github.com/nix-community/emacs-overlay/commit/7f4b90040296ed6faacbcd9933927852d020df75) | `` Updated repos/melpa `` |
| [`5328b83d`](https://github.com/nix-community/emacs-overlay/commit/5328b83dd64512f94b73b0f1877c26048052a3c2) | `` Updated repos/emacs `` |