### PR TITLE
chore(flake/emacs-overlay): `fc0a9c42` -> `cbca5fd5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681925015,
-        "narHash": "sha256-19OXViH4zFPCZ9igAZCDmC4hw+yWEKZW9w6wrXvcAd8=",
+        "lastModified": 1681961408,
+        "narHash": "sha256-cyRnM35bdeUR6CX8INZClxCXbLsghhyb5vczNjjFeNE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fc0a9c421f8b1533317bca59867c18244487534a",
+        "rev": "cbca5fd577779cbb9228bcdc65474b8cdfe61a2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`cbca5fd5`](https://github.com/nix-community/emacs-overlay/commit/cbca5fd577779cbb9228bcdc65474b8cdfe61a2e) | `` Updated repos/melpa `` |
| [`43ac4bba`](https://github.com/nix-community/emacs-overlay/commit/43ac4bba4cd61cf0c8931fbda599b83e902468cf) | `` Updated repos/emacs `` |
| [`23f50315`](https://github.com/nix-community/emacs-overlay/commit/23f5031575b1975ffaefeb55102cbf3f608d9e07) | `` Updated repos/elpa ``  |