### PR TITLE
chore(flake/emacs-overlay): `cbca5fd5` -> `4e52b36e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681961408,
-        "narHash": "sha256-cyRnM35bdeUR6CX8INZClxCXbLsghhyb5vczNjjFeNE=",
+        "lastModified": 1681982560,
+        "narHash": "sha256-ardbw9Wm75DfjAUBalCPT+pggurhEAQo6mGxVzWfQuo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cbca5fd577779cbb9228bcdc65474b8cdfe61a2e",
+        "rev": "4e52b36ed3f08db0843e161a5f64343d8fb4b35a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`4e52b36e`](https://github.com/nix-community/emacs-overlay/commit/4e52b36ed3f08db0843e161a5f64343d8fb4b35a) | `` Updated repos/melpa `` |