### PR TITLE
chore(flake/darwin): `02591252` -> `a1ee4d33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -111,11 +111,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681154394,
-        "narHash": "sha256-avnu1K9AuouygBiwVKuDp6emiTET43az3rcpv0ctLjc=",
+        "lastModified": 1682009832,
+        "narHash": "sha256-QdNOeFE7sI+0ddqVfn9vQDCUs7OdxhJ7evo9sdyP82Y=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "025912529dd0b31dead95519e944ea05f1ad56f2",
+        "rev": "a1ee4d333b092bc055655fb06229eb3013755812",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                         |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`73ab8e0d`](https://github.com/LnL7/nix-darwin/commit/73ab8e0d702c9cdda3a92ba3ff95024ff2e70448) | `` Add/fix some launchd.plist options ``        |
| [`90b36a5e`](https://github.com/LnL7/nix-darwin/commit/90b36a5efe003a388451af2e0f41774bcdc0d658) | `` synergy: add options for TLS ``              |
| [`0cf7d413`](https://github.com/LnL7/nix-darwin/commit/0cf7d413898a975097a196e5ddb3f6a0f214234b) | `` fix(modules/fonts): ignore repeated fonts `` |