### PR TITLE
chore(flake/emacs-overlay): `4e52b36e` -> `f86e3962`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681982560,
-        "narHash": "sha256-ardbw9Wm75DfjAUBalCPT+pggurhEAQo6mGxVzWfQuo=",
+        "lastModified": 1682016312,
+        "narHash": "sha256-TWTsYM7vg2aWLpa2Lbiv9L4y86PeOn3GFAsdheMoyt4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4e52b36ed3f08db0843e161a5f64343d8fb4b35a",
+        "rev": "f86e3962f7b01ffb470b08c0cf95b6ca85516432",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`f86e3962`](https://github.com/nix-community/emacs-overlay/commit/f86e3962f7b01ffb470b08c0cf95b6ca85516432) | `` Updated repos/melpa `` |
| [`787f334a`](https://github.com/nix-community/emacs-overlay/commit/787f334aed9bb8c373e49a0b0f62da67ed982d22) | `` Updated repos/emacs `` |