### PR TITLE
chore(flake/nixpkgs): `555daa9d` -> `645bc49f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -718,11 +718,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1681828457,
-        "narHash": "sha256-o4Zvs309HOhrNeVloPKqangcKHobsggVt6GFbnEPZlQ=",
+        "lastModified": 1681920287,
+        "narHash": "sha256-+/d6XQQfhhXVfqfLROJoqj3TuG38CAeoT6jO1g9r1k0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "555daa9d339b3df75e58ee558a4fec98ea92521e",
+        "rev": "645bc49f34fa8eff95479f0345ff57e55b53437e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`7f6a225a`](https://github.com/NixOS/nixpkgs/commit/7f6a225a6a0cebf108b7dca5a32650087849411b) | `` live555: 2023.01.19 -> 2023.03.30 ``                                 |
| [`29ae6a1f`](https://github.com/NixOS/nixpkgs/commit/29ae6a1f3d7a8886b3772df4dc42a13817875c7d) | `` deltachat-desktop: 1.36.2 -> 1.36.3 ``                               |
| [`213f6aa8`](https://github.com/NixOS/nixpkgs/commit/213f6aa82cd943cfd898d7db2669e9a0a0a6c7ab) | `` libdeltachat: 1.112.6 -> 1.112.7 ``                                  |
| [`cafa2f02`](https://github.com/NixOS/nixpkgs/commit/cafa2f02fbbcade5c5c257c190061da555d90913) | `` root: enable root7 (#226351) ``                                      |
| [`ecf8dae2`](https://github.com/NixOS/nixpkgs/commit/ecf8dae25d5c0d344848b238aa342b073ef0b2a7) | `` hepmc3: 3.2.5 -> 3.2.6 (#226333) ``                                  |
| [`017fc7a6`](https://github.com/NixOS/nixpkgs/commit/017fc7a6e1e081e8d819abb79c4d9af4f8ebf9be) | `` php80Packages.psalm: 5.4.0 -> 5.9.0 ``                               |
| [`b979f3be`](https://github.com/NixOS/nixpkgs/commit/b979f3be1f956228058179315d56203e05fd679b) | `` firefox-unwrapped: Apply patch for mozbz#1803016 ``                  |
| [`55aa1bc3`](https://github.com/NixOS/nixpkgs/commit/55aa1bc36226e88765b700e16132365f269d9c67) | `` firefox-esr-102-unwrapped: Drop obsolete rust-cbindgen patch ``      |
| [`df00d693`](https://github.com/NixOS/nixpkgs/commit/df00d693ba45767a8897c65d7b389f9e54562294) | `` cpuminer: unbreak on aarch64-darwin ``                               |
| [`17b0b7d1`](https://github.com/NixOS/nixpkgs/commit/17b0b7d117b8a7cc83ce3383c60b32169f78cf7a) | `` nix-update: 0.16.0 -> 0.17.0 ``                                      |
| [`d2bb5407`](https://github.com/NixOS/nixpkgs/commit/d2bb5407d3dfebc8fccb44669bbb8d8d2f1cd7c4) | `` web-eid-app: init at 2.2.0 ``                                        |
| [`888d0a9a`](https://github.com/NixOS/nixpkgs/commit/888d0a9ab607c04432388caec37821c26c5ed357) | `` spice-gtk: fix build on darwin ``                                    |
| [`1db8313b`](https://github.com/NixOS/nixpkgs/commit/1db8313b4f992f37e84f8705493248c58785519f) | `` deno: 1.32.4 -> 1.32.5 ``                                            |
| [`fb689e03`](https://github.com/NixOS/nixpkgs/commit/fb689e03288cdf363623c9ac405d11f04659605c) | `` ejabberd: 21.04 -> 23.01 ``                                          |
| [`fac2a5c6`](https://github.com/NixOS/nixpkgs/commit/fac2a5c6c7173f8aee139ac79f311df1b040eaee) | `` ocamlPackages.lwt_camlp4: fix build ``                               |
| [`1fdff907`](https://github.com/NixOS/nixpkgs/commit/1fdff907c58d5ff69b00dc673fbcf7e5519fa7c1) | `` hydroxide: 0.2.25 -> 0.2.26 ``                                       |
| [`831cb5cc`](https://github.com/NixOS/nixpkgs/commit/831cb5ccd7cc07206c429155f8188a73d62ee179) | `` datree: 1.8.47 -> 1.8.65 ``                                          |
| [`5d456b31`](https://github.com/NixOS/nixpkgs/commit/5d456b3172958e9546734617a2d2c73979d2e94f) | `` go-audit: 1.1.1 -> 1.2.0 ``                                          |
| [`deb19e2a`](https://github.com/NixOS/nixpkgs/commit/deb19e2a774b56a1c71201866ed16437308b2aca) | `` python310Packages.django-dynamic-preferences: 1.14.0 -> 1.15.0 ``    |
| [`0a88af2a`](https://github.com/NixOS/nixpkgs/commit/0a88af2a72b78385d9d22a24370ece9d61df440c) | `` cargo-llvm-cov: 0.5.14 -> 0.5.16 ``                                  |
| [`32ef6c36`](https://github.com/NixOS/nixpkgs/commit/32ef6c3629272d6f9226cb5d32b74bd9979c82ab) | `` go: only include Darwin target dependencies when targeting Darwin `` |
| [`e84df556`](https://github.com/NixOS/nixpkgs/commit/e84df5564d7bf6159434d0f6096e2f699e82ae17) | `` etcd_3_4: 3.4.24 -> 3.4.25 ``                                        |
| [`b10a041f`](https://github.com/NixOS/nixpkgs/commit/b10a041f0d2e687942f22829cc5b80fc978f8a41) | `` terraform-providers.nutanix: 1.8.0 -> 1.8.1 ``                       |
| [`fcc085ae`](https://github.com/NixOS/nixpkgs/commit/fcc085aef782e12ed9ad96de547cd34e69c398c5) | `` terraform-providers.kafka: 0.5.2 -> 0.5.3 ``                         |
| [`57ab675e`](https://github.com/NixOS/nixpkgs/commit/57ab675e52cc8ffa4bb81fc5d9cc4dc21a24989f) | `` terraform-providers.github: 5.22.0 -> 5.23.0 ``                      |
| [`b9888113`](https://github.com/NixOS/nixpkgs/commit/b988811317fe40f043b9736ece3aae339d5f8a2c) | `` terraform-providers.dns: 3.2.4 -> 3.3.0 ``                           |
| [`52f946e5`](https://github.com/NixOS/nixpkgs/commit/52f946e5192d95bc6b3fd031a301b4df2189b3e0) | `` terraform-providers.buildkite: 0.14.0 -> 0.15.0 ``                   |
| [`a8a09705`](https://github.com/NixOS/nixpkgs/commit/a8a097055894f8cf010f2b7c345ba1c884076f54) | `` millet: 0.9.0 -> 0.9.3 ``                                            |
| [`8f283985`](https://github.com/NixOS/nixpkgs/commit/8f28398592d67b16f84b24fb7ed7d1d3ea689d9b) | `` python310Packages.grpcio-status: 1.53.0 -> 1.54.0 ``                 |
| [`c907b8ce`](https://github.com/NixOS/nixpkgs/commit/c907b8ce8aa92b2a96d2e885728a1d3d425761f6) | `` hstr: 3.0 -> 3.1 ``                                                  |
| [`acad2e4c`](https://github.com/NixOS/nixpkgs/commit/acad2e4ccdfb5c7c999fa50abd6448c76e9aadc3) | `` python310Packages.grpcio-tools: 1.53.0 -> 1.54.0 ``                  |
| [`c67aaac7`](https://github.com/NixOS/nixpkgs/commit/c67aaac7b84136b6f56cb4e63dbbddb7c35335a6) | `` dae: 0.1.5 -> 0.1.7 ``                                               |
| [`68d6bc84`](https://github.com/NixOS/nixpkgs/commit/68d6bc84cc688bca471169a6b82fc5c638a3ecc7) | `` esbuild: 0.17.16 -> 0.17.17 ``                                       |
| [`d9a9e87b`](https://github.com/NixOS/nixpkgs/commit/d9a9e87b110121f9e9f8d3e9cbaaf7a0d891b1f6) | `` dyff: 1.5.6 -> 1.5.7 ``                                              |
| [`57180cbe`](https://github.com/NixOS/nixpkgs/commit/57180cbe3193e55bc13d586ca93ac9130c93e95b) | `` brev-cli: 0.6.215 -> 0.6.217 ``                                      |
| [`b7af36c6`](https://github.com/NixOS/nixpkgs/commit/b7af36c6aadee5cc4a8534e802b77dacc91353ee) | `` hstr: 2.6 -> 3.0 ``                                                  |
| [`4c64b1a3`](https://github.com/NixOS/nixpkgs/commit/4c64b1a3c2fc1e84da77970bd110c455c1aea30f) | `` icewm: 3.3.2 -> 3.3.3 ``                                             |
| [`7cce9124`](https://github.com/NixOS/nixpkgs/commit/7cce91244936db61945a0d9fc06ac2b212a92c19) | `` python310Packages.onvif-zeep-async: 1.2.11 -> 1.3.0 ``               |
| [`d0b92d9c`](https://github.com/NixOS/nixpkgs/commit/d0b92d9cfc71efcace57b5cbd2c030f8ad71c8e0) | `` ocamlPackages.cohttp-top: init at 5.1.0 ``                           |
| [`6f5e6633`](https://github.com/NixOS/nixpkgs/commit/6f5e66339ca48b8c51fa3f9d16481d1d533311c3) | `` ocamlPackages.cohttp-lwt-jsoo: init at 5.1.0 ``                      |
| [`995ace10`](https://github.com/NixOS/nixpkgs/commit/995ace105bdd80f650693bd34d1f74614cf15764) | `` crystal: migrate to pcre2 on 1.8 ``                                  |
| [`ab7deda6`](https://github.com/NixOS/nixpkgs/commit/ab7deda6d092e482918307deb12af424e71ede0b) | `` deadnix: 1.0.0 -> 1.1.0 ``                                           |
| [`8df7387c`](https://github.com/NixOS/nixpkgs/commit/8df7387ce34aaa851bb46e48ea6e6c3664c50c41) | `` typst-lsp: 0.4.0 -> 0.4.1 ``                                         |
| [`7b6d5d41`](https://github.com/NixOS/nixpkgs/commit/7b6d5d41582ccb225bc0468573cae77f7f75b215) | `` nixos/neovim: add runtime file to etc/xdg/nvim (#221832) ``          |
| [`6d9b8796`](https://github.com/NixOS/nixpkgs/commit/6d9b8796028dde4e3b0c8bebac1666295b914e81) | `` playwright-driver: init at 1.30.1 (#223382) ``                       |
| [`2041e401`](https://github.com/NixOS/nixpkgs/commit/2041e40162bfaf932c5fef155bf18aaeb1c476b8) | `` crystal.buildCrystalPackage: ignore dwarf files ``                   |
| [`fb9d3a21`](https://github.com/NixOS/nixpkgs/commit/fb9d3a21e853de64e5a2d89c1386cb4d924abee5) | `` adguardhome: 0.107.28 -> 0.107.29 ``                                 |
| [`1370c128`](https://github.com/NixOS/nixpkgs/commit/1370c128819328284b47b00e7532a037ff69ef41) | `` nextcloudPackages: update ``                                         |
| [`04f4ba06`](https://github.com/NixOS/nixpkgs/commit/04f4ba06367fcd74d0272757d32320d64dc0b23b) | `` pika-backup: 0.5.2 -> 0.6.0 ``                                       |
| [`18a0deb9`](https://github.com/NixOS/nixpkgs/commit/18a0deb942fb58c57c03fb7c6d8eb47bb0f7cabe) | `` router: 1.15.0 -> 1.15.1 ``                                          |
| [`9ceb2cb4`](https://github.com/NixOS/nixpkgs/commit/9ceb2cb4ed16f7ac1bfe189868ef68b3334c1a2c) | `` railway: 3.0.19 -> 3.0.22 ``                                         |
| [`5294d2a3`](https://github.com/NixOS/nixpkgs/commit/5294d2a3791b0bdf9f56b6df24bcf9769d629369) | `` plex: 1.32.0.6918-6f393eda1 -> 1.32.0.6950-8521b7d99 ``              |
| [`e973bd02`](https://github.com/NixOS/nixpkgs/commit/e973bd0246d794fa48456e4e86ce78b380ef5ad7) | `` fluent-bit: 2.0.10 -> 2.0.11 ``                                      |
| [`a86baaa7`](https://github.com/NixOS/nixpkgs/commit/a86baaa7f49739c2bbb6f6f5bc4a2000415b9939) | `` glab: 1.26.0 -> 1.28.0 ``                                            |
| [`c92c69ed`](https://github.com/NixOS/nixpkgs/commit/c92c69ed15032c27c2420ab57b8ef9c242980ae9) | `` gitea-actions-runner: unstable-2023-03-18 -> 0.1.2 ``                |
| [`76675fb3`](https://github.com/NixOS/nixpkgs/commit/76675fb34455a3aa858748862adc1ce982875724) | `` nodePackages.keyoxide: fix darwin build ``                           |
| [`692a1e9c`](https://github.com/NixOS/nixpkgs/commit/692a1e9ccdf329a0e7e5d4ad0dfcf2aff21643cd) | `` kaniko: 1.9.1 -> 1.9.2 ``                                            |
| [`376aacef`](https://github.com/NixOS/nixpkgs/commit/376aacefb6252ac2c32d85a6010b8d3f86961ca8) | `` php80Packages.php-cs-fixer: 3.13.1 -> 3.16.0 ``                      |
| [`706060e4`](https://github.com/NixOS/nixpkgs/commit/706060e47d0808244bd33a27287cc53e21318666) | `` nixos/ivpn: init ``                                                  |
| [`c2f7d50a`](https://github.com/NixOS/nixpkgs/commit/c2f7d50aa90221bed4521ea1612f7d3d372dca40) | `` ivpn{,-service}: 3.10.0 -> 3.10.15, fix packaging. ``                |
| [`1b4e72e9`](https://github.com/NixOS/nixpkgs/commit/1b4e72e95ed806fbb1d47fe7d3b1a73bff3aad29) | `` ameba: fix build with Crystal 1.8 ``                                 |
| [`27226688`](https://github.com/NixOS/nixpkgs/commit/272266886c1b7029d3556b5b88e584ec4d1e9d04) | `` php82Packages.composer: 2.5.4 -> 2.5.5 ``                            |
| [`07c7ec4d`](https://github.com/NixOS/nixpkgs/commit/07c7ec4d1a3da1ed14f4d3479ab94a808e37a568) | `` sail-riscv-rv32,sail-riscv-rv64: fix build on x86_64-darwin ``       |
| [`e597eb63`](https://github.com/NixOS/nixpkgs/commit/e597eb631b84417af1d67c358f7d6d33a55b5ece) | `` nodePackages.firebase-tools: fix darwin build ``                     |
| [`348d8de2`](https://github.com/NixOS/nixpkgs/commit/348d8de2eb3eda4eeb66e4b4d35bd65bbe1cceb9) | `` ethq: init at 0.6.2 ``                                               |
| [`eac28f38`](https://github.com/NixOS/nixpkgs/commit/eac28f38d6b78743accda7831613700cfd236a5c) | `` treewide: fix lints ``                                               |
| [`81f75f95`](https://github.com/NixOS/nixpkgs/commit/81f75f95692ef62c4c9ee32ab84f4d166f165c8a) | `` androidenv: fix libgcc_s.so.1 -> not found ``                        |
| [`190163b9`](https://github.com/NixOS/nixpkgs/commit/190163b955202c926f65610910654d75c00d31a7) | `` qt6Packages.qtmqtt: init mdule at 6.5.0 ``                           |
| [`bcccfee6`](https://github.com/NixOS/nixpkgs/commit/bcccfee65972c20db6646f86357646b36809ec95) | `` tmux: add note for tmux-direct in module option ``                   |
| [`57485685`](https://github.com/NixOS/nixpkgs/commit/57485685fb3d20b0b980d747c97bfdd00d95aa7a) | `` dnscontrol: 3.31.0 -> 3.31.1 ``                                      |
| [`e7492b3f`](https://github.com/NixOS/nixpkgs/commit/e7492b3f1f379ee421374932a38cb0f2a089d167) | `` goreleaser: 1.17.1 -> 1.17.2 ``                                      |
| [`8c1e8195`](https://github.com/NixOS/nixpkgs/commit/8c1e81959914e8e2e382687007c1f56e3a07ed5a) | `` qt6.qtwebengine: add aarch64-darwin support ``                       |
| [`9684ea49`](https://github.com/NixOS/nixpkgs/commit/9684ea491023a27797dfbb6fe4ce3f1167fb4c2d) | `` ocamlPackages.arp: disable tests on Darwin ``                        |
| [`70cc7966`](https://github.com/NixOS/nixpkgs/commit/70cc7966aa62905e6b8f06b1503fb6fe2261fdfc) | `` crystal: include pcre even on pcre2 builds ``                        |
| [`f3738837`](https://github.com/NixOS/nixpkgs/commit/f3738837e347ac7abaacb05172dfabfc96de7f02) | `` mdcat: 2.0.0 -> 2.0.1 ``                                             |
| [`a860bc5e`](https://github.com/NixOS/nixpkgs/commit/a860bc5ec7f23b3a5ee2c783fbe1aac21ae85399) | `` exploitdb: 2023-04-15 -> 2023-04-18 ``                               |
| [`6e834aac`](https://github.com/NixOS/nixpkgs/commit/6e834aac739999977eb71049803c5a1b019494d8) | `` firefox-bin-unwrapped: 112.0 -> 112.0.1 ``                           |
| [`ce1fb2dc`](https://github.com/NixOS/nixpkgs/commit/ce1fb2dc8e63996110afbd79e11385704af5e7d1) | `` firefox-unwrapped: 112.0 -> 112.0.1 ``                               |
| [`454bae6d`](https://github.com/NixOS/nixpkgs/commit/454bae6d4afcce623632eb2efbd002da3c5ba8a0) | `` python310Packages.homeassistant-stubs: 2023.4.4 -> 2023.4.5 ``       |
| [`140e352d`](https://github.com/NixOS/nixpkgs/commit/140e352d0a483446947c4d93f7ff94995170b2cf) | `` home-assistant: Add backup dependency to default_config manifest ``  |
| [`86f61222`](https://github.com/NixOS/nixpkgs/commit/86f6122279ee105109546f59eccfb0c93cb78123) | `` mullvad-browser: fix installPhase issue ``                           |
| [`b4ca18c0`](https://github.com/NixOS/nixpkgs/commit/b4ca18c06053171188d68beaf00c748c2e2fe885) | `` vimPlugins.sort-nvim: init at 2023-04-12 ``                          |
| [`35f5549e`](https://github.com/NixOS/nixpkgs/commit/35f5549e29e0056eb379ad8d24475482bfd87d79) | `` crystal: require pcre2 ``                                            |
| [`977c51b0`](https://github.com/NixOS/nixpkgs/commit/977c51b0aeded0c93b09aa6b5f3f159a002aceae) | `` tabnine: 4.4.265 -> 4.4.282 ``                                       |
| [`c68733e9`](https://github.com/NixOS/nixpkgs/commit/c68733e92bbf7648d1a8fec573d39b83ece7bc62) | `` roon-server: 2.0-1244 -> 2.0-1259 ``                                 |
| [`59c60933`](https://github.com/NixOS/nixpkgs/commit/59c60933259c3ce44df19ce1ded8d298817f7b46) | `` vimPlugins.nvim-treesitter: update grammars ``                       |
| [`1b5623c7`](https://github.com/NixOS/nixpkgs/commit/1b5623c79dd52dab41805e4df61ab223933a0a9c) | `` vimPlugins: update ``                                                |
| [`e8e01894`](https://github.com/NixOS/nixpkgs/commit/e8e018946c72cc4cf75bcfc5771587680d61f4c0) | `` coldsnap: 0.5.0 -> 0.5.1 ``                                          |
| [`4998d831`](https://github.com/NixOS/nixpkgs/commit/4998d831b1e16382d0e12994224f57c29306b6d0) | `` goresym: 2.2 -> 2.3 ``                                               |
| [`0942f0a9`](https://github.com/NixOS/nixpkgs/commit/0942f0a96306a3a7df16030e899a1b55eebcc8e3) | `` fulcio: 1.1.0 -> 1.2.0 ``                                            |
| [`897106f7`](https://github.com/NixOS/nixpkgs/commit/897106f75cfa35405bcdf741d1ee3e3a6d860c24) | `` gnomeExtensions: auto-update ``                                      |
| [`7c9dac2b`](https://github.com/NixOS/nixpkgs/commit/7c9dac2bf2989045a7df084c5e15c297d101f630) | `` home-assistant: 2023.4.4 -> 2023.4.5 ``                              |
| [`e18ccd43`](https://github.com/NixOS/nixpkgs/commit/e18ccd43ad7ead49b38cd1fbd70b9db7677f8208) | `` fingerprintx: init at 1.1.8 ``                                       |
| [`e4d53d9d`](https://github.com/NixOS/nixpkgs/commit/e4d53d9d7268254d615fa9da6c45d71080bb74d0) | `` clj-kondo: 2023.03.17 -> 2023.04.14 ``                               |
| [`cdb1801e`](https://github.com/NixOS/nixpkgs/commit/cdb1801e28b8e908174b49468702feaabb4cbc34) | `` PageEdit: fix build on aarch64-darwin ``                             |
| [`ff8061e0`](https://github.com/NixOS/nixpkgs/commit/ff8061e062ac6a12e947523358d1fedb26423853) | `` OVMF: fix build on x86_64-darwin ``                                  |
| [`c987ccb0`](https://github.com/NixOS/nixpkgs/commit/c987ccb045a5d9f6171e02e2e41182f09023612a) | `` ocamlPackages.janeStreet: pin Dune to version 1 for OCaml < 4.08 ``  |
| [`971abff5`](https://github.com/NixOS/nixpkgs/commit/971abff5d5bed01e4e5f574282390c52f7b94aff) | `` ocamlPackages.async_ssl: remove broken ``                            |
| [`1d85cfbd`](https://github.com/NixOS/nixpkgs/commit/1d85cfbd778332b703846baf86350dd8dc72653e) | `` cachix-watch-store: restart indefinitely ``                          |
| [`3a483aee`](https://github.com/NixOS/nixpkgs/commit/3a483aee0ee304e4563dd38af9fa22f1bd0fdb4d) | `` spotify: add myself as a macOS maintainer ``                         |
| [`412a86d4`](https://github.com/NixOS/nixpkgs/commit/412a86d405029426ede0e65fb2fb49126c9e25c2) | `` tlsx: 1.0.6 -> 1.0.7 ``                                              |
| [`f4f1d260`](https://github.com/NixOS/nixpkgs/commit/f4f1d260f4b96cc8fe0af68f062d184f6aee4e8b) | `` vscode-extensions.mkhl.direnv: 0.10.1 -> 0.12.0 ``                   |
| [`79788c71`](https://github.com/NixOS/nixpkgs/commit/79788c71816f3b7d4d761504ef17a04a2421a6f2) | `` python310Packages.radian: 0.6.4 -> 0.6.5 ``                          |
| [`63c7dca1`](https://github.com/NixOS/nixpkgs/commit/63c7dca1490cdb3678092e8676989f5dfedbd485) | `` phpunit: 10.0.16 -> 10.1.0 ``                                        |
| [`d260cae0`](https://github.com/NixOS/nixpkgs/commit/d260cae0621216de05d521f9b300557da4273045) | `` goconvey: 1.7.2 -> 1.8.0 ``                                          |
| [`a89ddac4`](https://github.com/NixOS/nixpkgs/commit/a89ddac47116e9bacb966ff24ec26ac382a71da8) | `` infisical: init at 0.3.7 ``                                          |
| [`28b1c0c0`](https://github.com/NixOS/nixpkgs/commit/28b1c0c057b82113860878e14930e7f5f6f00a81) | `` python310packages.bytewax: init at 0.15.1 ``                         |
| [`7e0ad3d9`](https://github.com/NixOS/nixpkgs/commit/7e0ad3d95e732a18721751118c20a22acddba054) | `` maintainers: Add mslingsby ``                                        |
| [`cd1961c7`](https://github.com/NixOS/nixpkgs/commit/cd1961c70bc6366ff7b9dc75eb9f5d2d502648b7) | `` bazel-gazelle: 0.28.0 -> 0.30.0 ``                                   |
| [`9d025b89`](https://github.com/NixOS/nixpkgs/commit/9d025b891643cbac114ecc9c9c97552a81bcfd93) | `` pahole: add `nixosTests.bpf` to `passthru.tests` ``                  |
| [`f3f33456`](https://github.com/NixOS/nixpkgs/commit/f3f33456091dce36dba05b8bcb842ba0ef2db593) | `` ctlptl: 0.8.17 -> 0.8.18 ``                                          |