### PR TITLE
chore(flake/emacs-overlay): `0892b847` -> `03d8a6a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682047327,
-        "narHash": "sha256-R920a/y1xHOKFO0jo0FKaEmwROW2VjghdfOQw4ZYfnI=",
+        "lastModified": 1682057299,
+        "narHash": "sha256-KxzE4Shem5LjXxtS6mL7fuOie1F+VlSPU1FNmmt/Odk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0892b847937031b70e71b8bbdb4ab6055985789e",
+        "rev": "03d8a6a35ffc1d904b748bef806091c5e4ca5576",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                               |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
| [`d16c6c1f`](https://github.com/nix-community/emacs-overlay/commit/d16c6c1fb297d57aa4147e291ef06b650fa24061) | `` Use overrideScope' for override `` |