### PR TITLE
chore(flake/home-manager): `5160039e` -> `342fd40c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681971090,
-        "narHash": "sha256-3j0M63GkG6GGny9e+C//GyuDCx1IwrurD27S0YI+GQY=",
+        "lastModified": 1682070020,
+        "narHash": "sha256-0FM7tUDbtM4LJ3krmOppiC6SYOsh6mZg7asfzzPGSOc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5160039edca28a7e66bad0cfc72a07c91d6768ad",
+        "rev": "342fd40ccb642736e7d4268f61befe14d71ce7a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`342fd40c`](https://github.com/nix-community/home-manager/commit/342fd40ccb642736e7d4268f61befe14d71ce7a8) | `` home-manager: fix config file variable check (#3901) `` |