### PR TITLE
chore(flake/emacs-overlay): `03d8a6a3` -> `372c8287`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682057299,
-        "narHash": "sha256-KxzE4Shem5LjXxtS6mL7fuOie1F+VlSPU1FNmmt/Odk=",
+        "lastModified": 1682073345,
+        "narHash": "sha256-YvDFqY65Vcvxce2i07bUHhPvZ7YGZ/cVWEtsgBGnkIg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "03d8a6a35ffc1d904b748bef806091c5e4ca5576",
+        "rev": "372c8287a251f2a4dc7a1929f6368ba78582c3a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`372c8287`](https://github.com/nix-community/emacs-overlay/commit/372c8287a251f2a4dc7a1929f6368ba78582c3a2) | `` Updated repos/melpa `` |
| [`2d6d615f`](https://github.com/nix-community/emacs-overlay/commit/2d6d615f64e6789ca10f050d369f759bcfdf0058) | `` Updated repos/emacs `` |