### PR TITLE
chore(flake/emacs-overlay): `8130908e` -> `d72442b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682101184,
-        "narHash": "sha256-88Hx8BKIJ/JqbKqqCz8kBI1lXb77I//pECdZyBLuVjI=",
+        "lastModified": 1682134456,
+        "narHash": "sha256-jYPaCCyF4P9aFD7RN4oraT/5bLhZIPy5GX0SKB1j7eQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8130908eb877b81252a5e66a44e9a3bab42793c7",
+        "rev": "d72442b2a1932963373e8bab80adfc6aad33c1b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`d72442b2`](https://github.com/nix-community/emacs-overlay/commit/d72442b2a1932963373e8bab80adfc6aad33c1b0) | `` Updated repos/melpa `` |
| [`8482e1be`](https://github.com/nix-community/emacs-overlay/commit/8482e1be6c012c2c8d98ec8a49c7e393b4d14dd2) | `` Updated repos/emacs `` |