### PR TITLE
chore(flake/emacs-overlay): `d72442b2` -> `4c0a35e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682134456,
-        "narHash": "sha256-jYPaCCyF4P9aFD7RN4oraT/5bLhZIPy5GX0SKB1j7eQ=",
+        "lastModified": 1682154745,
+        "narHash": "sha256-oLN4vmK3ssPzB94X7gzsBky50j5AOqg6Kv+f9pBARe0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d72442b2a1932963373e8bab80adfc6aad33c1b0",
+        "rev": "4c0a35e80513bd77fdf8291a820f8eea844be56c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`4c0a35e8`](https://github.com/nix-community/emacs-overlay/commit/4c0a35e80513bd77fdf8291a820f8eea844be56c) | `` Updated repos/melpa `` |