### PR TITLE
chore(flake/emacs-overlay): `4c0a35e8` -> `2afeb059`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682154745,
-        "narHash": "sha256-oLN4vmK3ssPzB94X7gzsBky50j5AOqg6Kv+f9pBARe0=",
+        "lastModified": 1682187467,
+        "narHash": "sha256-Mh2ETdqfFLflMK1hKgxVVE3/A/4xhG10FXst+piVla4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4c0a35e80513bd77fdf8291a820f8eea844be56c",
+        "rev": "2afeb0596418d37aa3feb7203cc37a11c10c83fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`2afeb059`](https://github.com/nix-community/emacs-overlay/commit/2afeb0596418d37aa3feb7203cc37a11c10c83fe) | `` Updated repos/melpa `` |
| [`1e9fb0a0`](https://github.com/nix-community/emacs-overlay/commit/1e9fb0a0913fac6f29307042fa08967c7ffd19bd) | `` Updated repos/emacs `` |
| [`39c7507e`](https://github.com/nix-community/emacs-overlay/commit/39c7507e5b88a62b8fffde2712bc5ea40253b8e4) | `` Updated repos/elpa ``  |