### PR TITLE
chore(flake/impermanence): `6138eb8e` -> `c3f7012d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -509,11 +509,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1675359654,
-        "narHash": "sha256-FPxzuvJkcO49g4zkWLSeuZkln54bLoTtrggZDJBH90I=",
+        "lastModified": 1682230841,
+        "narHash": "sha256-jEionNWM9y9h26bBsqjthDe7dN6yWsYzhGXMjIeUV7g=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "6138eb8e737bffabd4c8fc78ae015d4fd6a7e2fd",
+        "rev": "c3f7012dc38abf175ec7f6afe8f3ba019f386133",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`170e9b10`](https://github.com/nix-community/impermanence/commit/170e9b105dc6e859c0039d3fa7bd6970954f87d8) | `` README: Add matrix room link ``                                       |
| [`b4160ba7`](https://github.com/nix-community/impermanence/commit/b4160ba71debd3f796a4b0ba0e0c680a96013d0d) | `` nixos: Rewrite directory creation for saner default permissions ``    |
| [`d30c421e`](https://github.com/nix-community/impermanence/commit/d30c421e4ec2973a44abc2426968a43bc922cf98) | `` nixos: Change internal file and directory semantics ``                |
| [`cc00a2a5`](https://github.com/nix-community/impermanence/commit/cc00a2a52345e66c03cb9a925de8e1c05b2205c5) | `` nixos: Use coercedTo type rather than manually converting from str `` |
| [`d144e365`](https://github.com/nix-community/impermanence/commit/d144e365cf56d47e706a0d1300955af63c9f2d4f) | `` all: Line up lib inherits vertically ``                               |
| [`a65d7088`](https://github.com/nix-community/impermanence/commit/a65d7088db792ea5fe65385641e33e2bc0816154) | `` nixos: Use mkDefault to set the default directory permissions ``      |