### PR TITLE
chore(flake/emacs-overlay): `e5e0b480` -> `3b1a5a94`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682215176,
-        "narHash": "sha256-3zhMIQMImELKCBoLmRCYpuINv4OT8xlSGbae33mzCRg=",
+        "lastModified": 1682240858,
+        "narHash": "sha256-BVF70SzD0kPkmWt3m9iF80BwPOz/Ql+vQOruTsR5pSw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e5e0b4800341c436ba1973593d4641e7f6cb52e7",
+        "rev": "3b1a5a9427c666f196aa7be5b8d4a5838e42a92a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`3b1a5a94`](https://github.com/nix-community/emacs-overlay/commit/3b1a5a9427c666f196aa7be5b8d4a5838e42a92a) | `` Updated repos/melpa `` |