### PR TITLE
chore(flake/nur): `12ce41b2` -> `ee2f730d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682222997,
-        "narHash": "sha256-7PEtbnVsdj+wFiEA14NdwAcxHNlx6z4mJ6MCCWhLPJw=",
+        "lastModified": 1682275879,
+        "narHash": "sha256-x7R3LsNG1vI2mapnSbOZ6tVbky7CVcuntaHEuUjgRDY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "12ce41b211b7a85975703b6c66868fdd8dc1e42a",
+        "rev": "ee2f730d8e79896e83181ecab6ffcd8d94bde8c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ee2f730d`](https://github.com/nix-community/NUR/commit/ee2f730d8e79896e83181ecab6ffcd8d94bde8c6) | `` automatic update `` |
| [`ff366b05`](https://github.com/nix-community/NUR/commit/ff366b0540d52dd1514bc3f86961f7fa6f833530) | `` automatic update `` |
| [`6df95f14`](https://github.com/nix-community/NUR/commit/6df95f14c4148452fa83878d6b541ac4df7f8ffd) | `` automatic update `` |