### PR TITLE
chore(flake/emacs-overlay): `3b1a5a94` -> `03e96559`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682240858,
-        "narHash": "sha256-BVF70SzD0kPkmWt3m9iF80BwPOz/Ql+vQOruTsR5pSw=",
+        "lastModified": 1682273796,
+        "narHash": "sha256-Kkf93sim8x4rFtX2erv93Tb2bPJyZef+HOMIagneMX0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3b1a5a9427c666f196aa7be5b8d4a5838e42a92a",
+        "rev": "03e96559076a11e14932734b5bcb16fd3ef114f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`03e96559`](https://github.com/nix-community/emacs-overlay/commit/03e96559076a11e14932734b5bcb16fd3ef114f1) | `` Updated repos/melpa `` |
| [`54173b7b`](https://github.com/nix-community/emacs-overlay/commit/54173b7b65053cb512649f5198f93dced3a7e6bf) | `` Updated repos/emacs `` |