### PR TITLE
chore(flake/nur): `ee2f730d` -> `e164e649`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682275879,
-        "narHash": "sha256-x7R3LsNG1vI2mapnSbOZ6tVbky7CVcuntaHEuUjgRDY=",
+        "lastModified": 1682278318,
+        "narHash": "sha256-miBdYX8y9fsCawn8OD/GSd2vPoVz8fy4qP6yAKBQLWY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ee2f730d8e79896e83181ecab6ffcd8d94bde8c6",
+        "rev": "e164e6490cd2308ef665b7511229c46dea2a01da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e164e649`](https://github.com/nix-community/NUR/commit/e164e6490cd2308ef665b7511229c46dea2a01da) | `` automatic update `` |