### PR TITLE
chore(flake/emacs-overlay): `03e96559` -> `052ee45a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682273796,
-        "narHash": "sha256-Kkf93sim8x4rFtX2erv93Tb2bPJyZef+HOMIagneMX0=",
+        "lastModified": 1682305635,
+        "narHash": "sha256-nbbZ2MWPDqqpJfHtmY3XBtSK3xGe4L21eDJ47bVzBcY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "03e96559076a11e14932734b5bcb16fd3ef114f1",
+        "rev": "052ee45a317aaa5b24be093fbde3afb504c8f55d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`052ee45a`](https://github.com/nix-community/emacs-overlay/commit/052ee45a317aaa5b24be093fbde3afb504c8f55d) | `` Updated repos/melpa `` |
| [`93f01504`](https://github.com/nix-community/emacs-overlay/commit/93f01504147484688a9170a099b04ea594590571) | `` Updated repos/emacs `` |
| [`f8a3a0e9`](https://github.com/nix-community/emacs-overlay/commit/f8a3a0e921822f24e15bf1b24e0de2a5b363f55c) | `` Updated repos/elpa ``  |