### PR TITLE
chore(flake/nur): `493d0033` -> `7697cabf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682296718,
-        "narHash": "sha256-AtP6L9klr1iSeqUDow2YJ7CPjEAQG7wgXMU8DY60/D0=",
+        "lastModified": 1682307888,
+        "narHash": "sha256-GNTzP+EqyPt1Mpruqdmhtuc8KhKjhuVWn4FOcBhudBQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "493d0033a8e9dcb9bbe3b8d48ab015325f7570d1",
+        "rev": "7697cabff94f4b58a653036884179af13c78c6b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7697cabf`](https://github.com/nix-community/NUR/commit/7697cabff94f4b58a653036884179af13c78c6b4) | `` automatic update `` |