### PR TITLE
chore(flake/nur): `7697cabf` -> `c0517098`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682307888,
-        "narHash": "sha256-GNTzP+EqyPt1Mpruqdmhtuc8KhKjhuVWn4FOcBhudBQ=",
+        "lastModified": 1682309301,
+        "narHash": "sha256-5E7nk7Bzzr8G/OjXFMkTZKQfN7S9sImaycm9dfhT0CE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7697cabff94f4b58a653036884179af13c78c6b4",
+        "rev": "c051709889ce5c4b69bf6432d064b4862cd8f2b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c0517098`](https://github.com/nix-community/NUR/commit/c051709889ce5c4b69bf6432d064b4862cd8f2b7) | `` automatic update `` |