### PR TITLE
chore(flake/nur): `c0517098` -> `08e8360b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682309301,
-        "narHash": "sha256-5E7nk7Bzzr8G/OjXFMkTZKQfN7S9sImaycm9dfhT0CE=",
+        "lastModified": 1682319022,
+        "narHash": "sha256-v5pkzaE8ygTEyK4Sqtwn+hgMxXfo+kySRBQenPD+P2o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c051709889ce5c4b69bf6432d064b4862cd8f2b7",
+        "rev": "08e8360bdeda32317aa4060c8c5b2c55136ae82b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`08e8360b`](https://github.com/nix-community/NUR/commit/08e8360bdeda32317aa4060c8c5b2c55136ae82b) | `` automatic update `` |