### PR TITLE
chore(flake/nur): `08e8360b` -> `dde696e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682319022,
-        "narHash": "sha256-v5pkzaE8ygTEyK4Sqtwn+hgMxXfo+kySRBQenPD+P2o=",
+        "lastModified": 1682320606,
+        "narHash": "sha256-R9tB0d8huRFCPbwtlnc1RwUMU98Zs4TjqwiPHS+jCqw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "08e8360bdeda32317aa4060c8c5b2c55136ae82b",
+        "rev": "dde696e9d66234fe8e86b7806fb21b43598e0568",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dde696e9`](https://github.com/nix-community/NUR/commit/dde696e9d66234fe8e86b7806fb21b43598e0568) | `` automatic update `` |