### PR TITLE
chore(flake/pre-commit-hooks): `b7ca8f6f` -> `56cd2d47`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -846,11 +846,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1681831107,
-        "narHash": "sha256-pXl3DPhhul9NztSetUJw2fcN+RI3sGOYgKu29xpgnqw=",
+        "lastModified": 1682326782,
+        "narHash": "sha256-wj7p7iEwQXAfTZ6QokAe0dMbpQk5u7ympDnaiPvbv1w=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "b7ca8f6fff42f6af75c17f9438fed1686b7d855d",
+        "rev": "56cd2d47a9c937be98ab225cf014b450f1533cdb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                       |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------- |
| [`5514a012`](https://github.com/cachix/pre-commit-hooks.nix/commit/5514a012fae43028263006fa66e73a7f16969e87) | `` Add hook for `dune fmt` `` |
| [`63131a6d`](https://github.com/cachix/pre-commit-hooks.nix/commit/63131a6dc6c129b49200908ab35099c2a4cc1d15) | `` Update hook description `` |
| [`871a56c3`](https://github.com/cachix/pre-commit-hooks.nix/commit/871a56c37ae559023b5c4de70197d5ec3d1081b6) | `` Update README file ``      |
| [`b17f6ad4`](https://github.com/cachix/pre-commit-hooks.nix/commit/b17f6ad45c40a48a254d4cc383081abca259bfde) | `` Add tflint hook ``         |