### PR TITLE
chore(flake/nur): `dde696e9` -> `e411b1cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682320606,
-        "narHash": "sha256-R9tB0d8huRFCPbwtlnc1RwUMU98Zs4TjqwiPHS+jCqw=",
+        "lastModified": 1682333764,
+        "narHash": "sha256-6UvrvO9k5nxiU+CCN0x6Zl/uKIrrQ+xzMLK1EEED1u8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dde696e9d66234fe8e86b7806fb21b43598e0568",
+        "rev": "e411b1cf10190b74ee0842aa0d1a857c52856315",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e411b1cf`](https://github.com/nix-community/NUR/commit/e411b1cf10190b74ee0842aa0d1a857c52856315) | `` automatic update `` |
| [`2fbd1856`](https://github.com/nix-community/NUR/commit/2fbd1856a42fe3d99ba39a3399acff8965ec5ccf) | `` automatic update `` |
| [`c591ca49`](https://github.com/nix-community/NUR/commit/c591ca49b30fee932e2e72b82aa8dda8895f3bc1) | `` ftbwiki: Init ``    |