### PR TITLE
chore(flake/home-manager): `a5a294a6` -> `6f9781b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682273416,
-        "narHash": "sha256-YvRc5TOyf92Fcvt6cYfsqxfjqalAUME3Klv4IbdhkBE=",
+        "lastModified": 1682333170,
+        "narHash": "sha256-yrJIk5/ONaX0QVQoq67DzNPW7epOuiwAM9FY9xFrE8k=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a5a294a622a7d3a837aaa145334e4d813c1bc5b1",
+        "rev": "6f9781b1b0cf3fedbe9d2d0a785aeec4d6085c10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`6f9781b1`](https://github.com/nix-community/home-manager/commit/6f9781b1b0cf3fedbe9d2d0a785aeec4d6085c10) | `` flake: Move tests back to devShells.*.tests (#3905) `` |