### PR TITLE
chore(flake/nur): `e411b1cf` -> `506e43c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682333764,
-        "narHash": "sha256-6UvrvO9k5nxiU+CCN0x6Zl/uKIrrQ+xzMLK1EEED1u8=",
+        "lastModified": 1682336717,
+        "narHash": "sha256-7TROsv5bJC3l1z2VV5b5UFjuXtU19tGOG01674yBNYM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e411b1cf10190b74ee0842aa0d1a857c52856315",
+        "rev": "506e43c1bc9692be0cbf91740432cf8d5b647877",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`506e43c1`](https://github.com/nix-community/NUR/commit/506e43c1bc9692be0cbf91740432cf8d5b647877) | `` automatic update `` |