### PR TITLE
chore(flake/nur): `c57ade18` -> `17b8d380`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682391343,
-        "narHash": "sha256-O60/IbdnMzOFDrdjwd7eWIQeqLaMn02FRRnN/TD9axA=",
+        "lastModified": 1682394281,
+        "narHash": "sha256-Tg7agIbNtvflqCLzKU92AQZX+6jaENyx8M+9nIoziPk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c57ade1882ba37cb49735f1b62d0c5d08e3a2aef",
+        "rev": "17b8d38095704ca19fa06029d657613a9eaf4150",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`17b8d380`](https://github.com/nix-community/NUR/commit/17b8d38095704ca19fa06029d657613a9eaf4150) | `` automatic update `` |
| [`560b6771`](https://github.com/nix-community/NUR/commit/560b677114eabfbbe3b01ad932f5a372c4781a33) | `` automatic update `` |