### PR TITLE
chore(flake/emacs-overlay): `11328c7c` -> `00893eb4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682415743,
-        "narHash": "sha256-kCpHpWRJs5m5IOrY9T78NGO8ZEwMcUj/NhNX/lI0NQQ=",
+        "lastModified": 1682448247,
+        "narHash": "sha256-ND/5swYF+R/oGQm+Lrn7LtSi/+Gwr71PCg9G9th9seY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "11328c7c99e9b020b30b49536bd4eb62fef24e6f",
+        "rev": "00893eb4a9a6b68404da1a954057abe1a4b500b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`00893eb4`](https://github.com/nix-community/emacs-overlay/commit/00893eb4a9a6b68404da1a954057abe1a4b500b5) | `` Updated repos/melpa `` |
| [`eb64b0a7`](https://github.com/nix-community/emacs-overlay/commit/eb64b0a78614ef64efe0e28ff23462db750c9af8) | `` Updated repos/emacs `` |