### PR TITLE
chore(flake/nur): `4577b861` -> `bf4f1d29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682433577,
-        "narHash": "sha256-Yw5XgBnGxvcPar7YDqbKEGPWkU+F7cItIMX0QUEw8Vo=",
+        "lastModified": 1682446307,
+        "narHash": "sha256-WtvLBaH/Ma+of/JpZLFjz35SXZ5xbNAYmc30FE2LByQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4577b8615ee4e226b5fb63ce8b4eb9aeaca2ee15",
+        "rev": "bf4f1d29e517aef123b936c65c2be7d296ed99b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bf4f1d29`](https://github.com/nix-community/NUR/commit/bf4f1d29e517aef123b936c65c2be7d296ed99b2) | `` automatic update `` |