### PR TITLE
chore(flake/nur): `843eac12` -> `d0f8d2dc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682451894,
-        "narHash": "sha256-2nJouuRIoQcK33O+Dg3N7T71mqm3JuBGrMqwEpgb7oI=",
+        "lastModified": 1682462796,
+        "narHash": "sha256-dZsfzxai91ATnLFesDtMh+n5Dm3m2xOU2TdawyJCLpQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "843eac12449217b275dfff70755dcf6906cc742d",
+        "rev": "d0f8d2dc74c65e13c476dfebb1b599d87d1db420",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d0f8d2dc`](https://github.com/nix-community/NUR/commit/d0f8d2dc74c65e13c476dfebb1b599d87d1db420) | `` automatic update `` |