### PR TITLE
chore(flake/nur): `d0f8d2dc` -> `f21610e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682462796,
-        "narHash": "sha256-dZsfzxai91ATnLFesDtMh+n5Dm3m2xOU2TdawyJCLpQ=",
+        "lastModified": 1682469450,
+        "narHash": "sha256-3p5eZJyLomaFjz718SWV9anj0uezvotHZArU9wuE1so=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d0f8d2dc74c65e13c476dfebb1b599d87d1db420",
+        "rev": "f21610e763905caad115f26d6c4e1e09ca6a5158",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f21610e7`](https://github.com/nix-community/NUR/commit/f21610e763905caad115f26d6c4e1e09ca6a5158) | `` automatic update `` |