### PR TITLE
chore(flake/emacs-overlay): `00893eb4` -> `fda6743a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682448247,
-        "narHash": "sha256-ND/5swYF+R/oGQm+Lrn7LtSi/+Gwr71PCg9G9th9seY=",
+        "lastModified": 1682474027,
+        "narHash": "sha256-VzSe1ACZY6fmbm2pNEUkOB3u8uRDdShFkJs80EGSUwU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "00893eb4a9a6b68404da1a954057abe1a4b500b5",
+        "rev": "fda6743a89b57e46e8ab46f9f2aa9d9e45914b1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`fda6743a`](https://github.com/nix-community/emacs-overlay/commit/fda6743a89b57e46e8ab46f9f2aa9d9e45914b1c) | `` Updated repos/nongnu `` |
| [`bae48bfe`](https://github.com/nix-community/emacs-overlay/commit/bae48bfe86c45919da81a9b915215160591d2d1b) | `` Updated repos/melpa ``  |
| [`78ab22df`](https://github.com/nix-community/emacs-overlay/commit/78ab22dfae186ef31c2ecc7c9e44dd79997cf06c) | `` Updated repos/elpa ``   |