### PR TITLE
chore(flake/nur): `7d4a55ee` -> `c11f1701`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682480039,
-        "narHash": "sha256-9rZYnWHFhW6RCpAJVR5p+NsbcckrhVZp40oweSk23CI=",
+        "lastModified": 1682483943,
+        "narHash": "sha256-UluyjqBMrr9wIZiu/vtNTos/NsHXNl6/STKf4Y6IhMM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7d4a55eec18363a573e854fd3cf75ab1c81f6997",
+        "rev": "c11f17011f42e16d8a5d9cea6d1b9b4a980d4805",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c11f1701`](https://github.com/nix-community/NUR/commit/c11f17011f42e16d8a5d9cea6d1b9b4a980d4805) | `` automatic update `` |