### PR TITLE
chore(flake/emacs-overlay): `fda6743a` -> `2f21bcd8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682474027,
-        "narHash": "sha256-VzSe1ACZY6fmbm2pNEUkOB3u8uRDdShFkJs80EGSUwU=",
+        "lastModified": 1682500007,
+        "narHash": "sha256-Wixa84xFuJ6MCPnbLeaQjyIBmfegOCEAxaZF4UBBtH0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fda6743a89b57e46e8ab46f9f2aa9d9e45914b1c",
+        "rev": "2f21bcd8f4ed2ab8954b5a0a624c50aa6c5b056e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`2f21bcd8`](https://github.com/nix-community/emacs-overlay/commit/2f21bcd8f4ed2ab8954b5a0a624c50aa6c5b056e) | `` Updated repos/melpa `` |