### PR TITLE
chore(flake/nur): `ecbb2fac` -> `c88ff2c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682513923,
-        "narHash": "sha256-4+c4SPcJtgXc0v0fYrJ2jX7TlznRkIFr0XMGh8En+bE=",
+        "lastModified": 1682541953,
+        "narHash": "sha256-fn0czyoHeMAnvyUiCJKEyya7sPBDF2uJgRZh/J8byx8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ecbb2facca7f983524810cdb13da9105450164a4",
+        "rev": "c88ff2c1ec6843434f2494ff830f5cee7e2cb1e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c88ff2c1`](https://github.com/nix-community/NUR/commit/c88ff2c1ec6843434f2494ff830f5cee7e2cb1e0) | `` automatic update `` |
| [`bf8f98b2`](https://github.com/nix-community/NUR/commit/bf8f98b2a74c7b73ef49e51dfbf68c7077db144f) | `` automatic update `` |