### PR TITLE
chore(flake/nur): `c88ff2c1` -> `4ac53a1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682541953,
-        "narHash": "sha256-fn0czyoHeMAnvyUiCJKEyya7sPBDF2uJgRZh/J8byx8=",
+        "lastModified": 1682558081,
+        "narHash": "sha256-dzez8eBDMVs9GhC5bAKm6avCxWRZmXLzHuv1U8nNVJQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c88ff2c1ec6843434f2494ff830f5cee7e2cb1e0",
+        "rev": "4ac53a1d6c73f1b326256da444bfbac53c317d76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4ac53a1d`](https://github.com/nix-community/NUR/commit/4ac53a1d6c73f1b326256da444bfbac53c317d76) | `` automatic update `` |
| [`6edb35d0`](https://github.com/nix-community/NUR/commit/6edb35d02b54aff92d7b91dcdc226d176b60f973) | `` automatic update `` |