### PR TITLE
chore(flake/nur): `369b37fa` -> `d873a313`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682566457,
-        "narHash": "sha256-tKz1W1iZx6HkNJL6WjlMbpzo163S1JKPUvarRl2Glng=",
+        "lastModified": 1682574203,
+        "narHash": "sha256-pB3/3hlmeZ1JbKtsmHaptOoHKIfGgZTUarfifL/Fm+Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "369b37fa6731a10a3d30213b3fc7a0242d88cde1",
+        "rev": "d873a3136de84a4984fb291b0f551f87d3833a38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d873a313`](https://github.com/nix-community/NUR/commit/d873a3136de84a4984fb291b0f551f87d3833a38) | `` automatic update `` |