### PR TITLE
chore(flake/nur): `d873a313` -> `342c8e2c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682574203,
-        "narHash": "sha256-pB3/3hlmeZ1JbKtsmHaptOoHKIfGgZTUarfifL/Fm+Y=",
+        "lastModified": 1682576338,
+        "narHash": "sha256-+I4oXCpugPSaZ7SKI35OLSF/hy+rlZ/iNOGvcjqM2h4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d873a3136de84a4984fb291b0f551f87d3833a38",
+        "rev": "342c8e2c9e72b2c3f6bd18f491e5b8bf7d5fcd9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`342c8e2c`](https://github.com/nix-community/NUR/commit/342c8e2c9e72b2c3f6bd18f491e5b8bf7d5fcd9a) | `` automatic update `` |