### PR TITLE
chore(flake/nur): `342c8e2c` -> `4ea87277`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682576338,
-        "narHash": "sha256-+I4oXCpugPSaZ7SKI35OLSF/hy+rlZ/iNOGvcjqM2h4=",
+        "lastModified": 1682581579,
+        "narHash": "sha256-wDf9GcyTbosGyVpxQJtMhX+i8C9Wa799u2vvQmMkZLI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "342c8e2c9e72b2c3f6bd18f491e5b8bf7d5fcd9a",
+        "rev": "4ea872776fe0790e4c6d8374a5b5f0391803aa0a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4ea87277`](https://github.com/nix-community/NUR/commit/4ea872776fe0790e4c6d8374a5b5f0391803aa0a) | `` automatic update `` |