### PR TITLE
chore(flake/nixpkgs): `c8018361` -> `d6b863fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -718,11 +718,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1682453498,
-        "narHash": "sha256-WoWiAd7KZt5Eh6n+qojcivaVpnXKqBsVgpixpV2L9CE=",
+        "lastModified": 1682526928,
+        "narHash": "sha256-2cKh4O6t1rQ8Ok+v16URynmb0rV7oZPEbXkU0owNLQs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c8018361fa1d1650ee8d4b96294783cf564e8a7f",
+        "rev": "d6b863fd9b7bb962e6f9fdf292419a775e772891",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                             |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`87559131`](https://github.com/NixOS/nixpkgs/commit/875591314cbb1b203c4a2fae4d8f505a928acb8f) | `` obs-studio-plugins.obs-source-clone: init at 0.1.3 ``            |
| [`f0a53c2e`](https://github.com/NixOS/nixpkgs/commit/f0a53c2ed3e9e44b62b737bbd8a25607254de27f) | `` maintainers: add flexiondotorg ``                                |
| [`be5f8fa5`](https://github.com/NixOS/nixpkgs/commit/be5f8fa5067cbf5ab1aa1d5d00d94a8ccddd1b6e) | `` paperless-ngx: 1.13.0 -> 1.14.0 ``                               |
| [`775f1496`](https://github.com/NixOS/nixpkgs/commit/775f14969bdb7dae7d182c862ddec0da5d1fa32c) | `` python3Packages.djangorestframework-guardian2: init at 0.5.0 ``  |
| [`5effdaaa`](https://github.com/NixOS/nixpkgs/commit/5effdaaa40166590c7cfba5041ed966168abcec2) | `` nixos/tests/snipe-it: init (#180772) ``                          |
| [`1d71d2e8`](https://github.com/NixOS/nixpkgs/commit/1d71d2e883e6152dd66f2f7634b7cffc1a7f0584) | `` buildBazelPackage: never append to fFetchAttrs.installPhase ``   |
| [`513e072b`](https://github.com/NixOS/nixpkgs/commit/513e072bcc6f017df85a7db607568616fe53eeb1) | `` gitlab: 15.10.2 -> 15.11.0 (#227258) ``                          |
| [`7a32a141`](https://github.com/NixOS/nixpkgs/commit/7a32a141db568abde9bc389845949dc2a454dfd3) | `` firefox: fix indentation ``                                      |
| [`bad5e4f4`](https://github.com/NixOS/nixpkgs/commit/bad5e4f489deca29c8d259e2a530746fe16b2e51) | `` firefox: enable pgo on musl ``                                   |
| [`94ccd5fd`](https://github.com/NixOS/nixpkgs/commit/94ccd5fdf85adbedf1284cc0b2dccb093bea1377) | `` pkgsMusl.firefox: fix build ``                                   |
| [`68cbd043`](https://github.com/NixOS/nixpkgs/commit/68cbd043bfaee7d66eb86c0b8b4b8f36f3a1c9c6) | `` typst: 0.2.0 -> 0.3.0 ``                                         |
| [`8560b81d`](https://github.com/NixOS/nixpkgs/commit/8560b81d18a45a362f6b2216f02c9aad5b4ba6b9) | `` libglibutil: 1.0.68 -> 1.0.69 ``                                 |
| [`92807f81`](https://github.com/NixOS/nixpkgs/commit/92807f81d72f3e842e6bb64de61b42f10258020e) | `` linkerd_edge: 23.3.4 -> 23.4.2 ``                                |
| [`171987b2`](https://github.com/NixOS/nixpkgs/commit/171987b2980d986732f0f710cf0e3361989f71c8) | `` salt: 3005.1 -> 3006.0 ``                                        |
| [`e068055c`](https://github.com/NixOS/nixpkgs/commit/e068055c01bcd5ec630b9f75c7aa999e3b7267d8) | `` foundationdb71: 7.1.26 -> 7.1.30 ``                              |
| [`be1e2802`](https://github.com/NixOS/nixpkgs/commit/be1e28024612051e1300b1ef7f325831185cad1a) | `` irrd: init at 4.2.6 (#210565) ``                                 |
| [`28398b3c`](https://github.com/NixOS/nixpkgs/commit/28398b3ca13f94118f6fce00d98b5f1fc5576a51) | `` termusic: 0.7.9 -> 0.7.10 ``                                     |
| [`e8d6be7a`](https://github.com/NixOS/nixpkgs/commit/e8d6be7a4b4f2db04ac013731260994a48de81d2) | `` xen: mark EOL ≤ 4.15, add known CVEs in nixpkgs ``               |
| [`a7d91e68`](https://github.com/NixOS/nixpkgs/commit/a7d91e68ac7a826c686148ee0dd39d5c64aee6d1) | `` erigon: 2.42.0 -> 2.43.0 ``                                      |
| [`6bd82c1d`](https://github.com/NixOS/nixpkgs/commit/6bd82c1d2513e0c1b2ec1fac74ff48fd056923b6) | `` firewalld-gui: 1.3.1 -> 1.3.2 ``                                 |
| [`61d49c47`](https://github.com/NixOS/nixpkgs/commit/61d49c476c32fccc87f9a206c525a43e11e2537b) | `` fonts (treewide): change self to finalAttrs ``                   |
| [`e4aa12d4`](https://github.com/NixOS/nixpkgs/commit/e4aa12d4f8625e5221fc5aa65c35c1f45416d4f8) | `` bmake: change self to finalAttrs ``                              |
| [`50d259e5`](https://github.com/NixOS/nixpkgs/commit/50d259e52c4a620fd5d24a9d0c33176c5fdedfff) | `` libbytesize: change self to finalAttrs ``                        |
| [`dfa3263a`](https://github.com/NixOS/nixpkgs/commit/dfa3263a1facbcb3463585aa5e78fbe4970ae770) | `` cgreen: change self to finalAttrs ``                             |
| [`cbe2d12c`](https://github.com/NixOS/nixpkgs/commit/cbe2d12c490060af82fd45832ba84231ad9aa61f) | `` yabasic: change self to finalAttrs ``                            |
| [`7439d61a`](https://github.com/NixOS/nixpkgs/commit/7439d61ae5f4fb8d1452ea3742468f8599f01bde) | `` xa: change self to finalAttrs ``                                 |
| [`8cb18516`](https://github.com/NixOS/nixpkgs/commit/8cb18516244dbe70b6989b763a940c84abd8e3fd) | `` dxa: change self to finalAttrs ``                                |
| [`12c35abc`](https://github.com/NixOS/nixpkgs/commit/12c35abc2955247e3603d21a26ac5e8cc9c7e185) | `` dev86: change self to finalAttrs ``                              |
| [`57804559`](https://github.com/NixOS/nixpkgs/commit/578045597a514af2c879e642693f212d6f8a3513) | `` prio: change self to finalAttrs ``                               |
| [`1d03c91a`](https://github.com/NixOS/nixpkgs/commit/1d03c91a97a209c22ebb86c66141bdacfb719495) | `` durden: change self to finalAttrs ``                             |
| [`8a97136a`](https://github.com/NixOS/nixpkgs/commit/8a97136a95fd3833b9ff0eeb2d099b62e3dbe37c) | `` cat9: change self to finalAttrs ``                               |
| [`dc1b9f6e`](https://github.com/NixOS/nixpkgs/commit/dc1b9f6ec6ab7d355a865119f5e2f0eac75cd9d7) | `` arcan: change self to finalAttrs ``                              |
| [`2d2c3c0b`](https://github.com/NixOS/nixpkgs/commit/2d2c3c0bda8a06572e67189b3dcb83d7efe19643) | `` ravedude: init at 0.1.5 ``                                       |
| [`fe91a464`](https://github.com/NixOS/nixpkgs/commit/fe91a464634fb66601fd93fb1cfbede3fa7dad64) | `` python310Packages.aioesphomeapi: 13.7.0 -> 13.7.2 ``             |
| [`81364e36`](https://github.com/NixOS/nixpkgs/commit/81364e36528e741a323cb694d068b6d88455a36f) | `` awscli2: 2.11.6 -> 2.11.15 ``                                    |
| [`dce3b1ee`](https://github.com/NixOS/nixpkgs/commit/dce3b1ee5dadf2e20542ea09101ca6cf257dddea) | `` notmuch: fix darwin build ``                                     |
| [`d5180de7`](https://github.com/NixOS/nixpkgs/commit/d5180de75405f0341cf55debd2341e981e9e937c) | `` bcc: disable libdebuginfod integration ``                        |
| [`407a062f`](https://github.com/NixOS/nixpkgs/commit/407a062f44f7101d6c55e95599c5bc451a2092fa) | `` python3Packages.ctap-keyring-device: fixup fido2 override ``     |
| [`46ef640e`](https://github.com/NixOS/nixpkgs/commit/46ef640edc64beb53dba0c1251eb004b8e2bdd6e) | `` python310Packages.zigpy: 0.54.1 -> 0.55.0 ``                     |
| [`6eb03407`](https://github.com/NixOS/nixpkgs/commit/6eb0340777c92b9f6e120ad25349d8053d3612c5) | `` appflowy: 0.1.2 -> 0.1.3 ``                                      |
| [`e3220320`](https://github.com/NixOS/nixpkgs/commit/e3220320ca78bdfdb0b78701015b1e1f7c9f4876) | `` python3Packages.fido2: 1.1.0 -> 1.1.1 ``                         |
| [`9ba06bcd`](https://github.com/NixOS/nixpkgs/commit/9ba06bcddb2bace9b9a205500352607984ca8f4c) | `` metals: 0.11.11 -> 0.11.12 ``                                    |
| [`15554e75`](https://github.com/NixOS/nixpkgs/commit/15554e75add8907763b67f7b6ca077835baa3a9e) | `` python3Packages.pyquery: skip test failing with new libxml2 ``   |
| [`28c6334a`](https://github.com/NixOS/nixpkgs/commit/28c6334afbeadb9fc8099ca3c647a5e438e4611d) | `` gdcm: fix build on darwin ``                                     |
| [`969403c9`](https://github.com/NixOS/nixpkgs/commit/969403c916267cf01ab5f49398066a9ad9f148b0) | `` nitter: unstable-2023-03-28 -> unstable-2023-04-21 ``            |
| [`e8ff797d`](https://github.com/NixOS/nixpkgs/commit/e8ff797d86b0afd7340f0a0d5244ae24cf6e26b7) | `` karax: fa4a2dc -> 5cf360c ``                                     |
| [`123b92da`](https://github.com/NixOS/nixpkgs/commit/123b92da6c94e3a63758d1aecf5f6fc5996d150a) | `` yosys-symbiflow: 2023.02.08 -> 1.20230425 ``                     |
| [`e3032b1d`](https://github.com/NixOS/nixpkgs/commit/e3032b1d788cc798127cd265acff5333090b1374) | `` surelog: 1.45 -> 1.57 ``                                         |
| [`d2831ca5`](https://github.com/NixOS/nixpkgs/commit/d2831ca5dacaae4bcc0f3df06dd59a1bf78238b0) | `` uhdm: 1.45 -> 1.57 ``                                            |
| [`1f799b8f`](https://github.com/NixOS/nixpkgs/commit/1f799b8fa48dd733809723fe37a94100c5c85826) | `` python311Packages.yalexs-ble: 2.1.14 -> 2.1.16 ``                |
| [`c9e32fdb`](https://github.com/NixOS/nixpkgs/commit/c9e32fdb23f4c62b57917d9bb7792d3854ca8135) | `` python311Packages.fe25519: 1.3.0 -> 1.4.0 ``                     |
| [`b4f893b9`](https://github.com/NixOS/nixpkgs/commit/b4f893b9a190bd2aa901224f3e3b7fa51d7a45f3) | `` python311Packages.ge25519: 1.3.0 -> 1.4.0 ``                     |
| [`37423561`](https://github.com/NixOS/nixpkgs/commit/37423561504776d861bb6cf613f266aec979806b) | `` python311Packages.identify: 2.5.22 -> 2.5.23 ``                  |
| [`a1ed8e8e`](https://github.com/NixOS/nixpkgs/commit/a1ed8e8e5527c7a89d1a137ffb2d3f7af1bc502f) | `` python310Packages.angr: 9.2.47 -> 9.2.48 ``                      |
| [`c464ef16`](https://github.com/NixOS/nixpkgs/commit/c464ef167df191923560d62bffb63dfe4b742f29) | `` python310Packages.cle: 9.2.47 -> 9.2.48 ``                       |
| [`3cf2c43b`](https://github.com/NixOS/nixpkgs/commit/3cf2c43b727f57a697ea7e4834d3d80fa3a093f3) | `` python310Packages.claripy: 9.2.47 -> 9.2.48 ``                   |
| [`a21211f0`](https://github.com/NixOS/nixpkgs/commit/a21211f002192541acce8bc645ff8c57fb6374d4) | `` python310Packages.pyvex: 9.2.47 -> 9.2.48 ``                     |
| [`570e5e3e`](https://github.com/NixOS/nixpkgs/commit/570e5e3e2334decc74fde36f722e7458912cbc98) | `` python310Packages.ailment: 9.2.47 -> 9.2.48 ``                   |
| [`bc9a2f67`](https://github.com/NixOS/nixpkgs/commit/bc9a2f67a26d13a3e6c6b340321ac3e27b516225) | `` python310Packages.archinfo: 9.2.47 -> 9.2.48 ``                  |
| [`e1beca45`](https://github.com/NixOS/nixpkgs/commit/e1beca457b25d7dd59c9815b06386cf34c7eedd9) | `` nats-server: 2.9.15 -> 2.9.16 ``                                 |
| [`d8250439`](https://github.com/NixOS/nixpkgs/commit/d8250439c7c80ae58ce4cb8c4e7027cdbafdf058) | `` wakatime: 1.70.1 -> 1.73.0 ``                                    |
| [`c0308364`](https://github.com/NixOS/nixpkgs/commit/c03083646af7ddff60774b9bd9fc49991e014d81) | `` typos: 1.13.18 -> 1.14.8 ``                                      |
| [`8616a408`](https://github.com/NixOS/nixpkgs/commit/8616a408c8e29fd0216319f9ab2f30e12660e5eb) | `` terraform-providers.snowflake: 0.62.0 -> 0.63.0 ``               |
| [`5acfc735`](https://github.com/NixOS/nixpkgs/commit/5acfc7357cde0fa2ef269f322c8b6bc8913f5555) | `` terraform-providers.linode: 1.30.0 -> 2.0.0 ``                   |
| [`e634cefd`](https://github.com/NixOS/nixpkgs/commit/e634cefd6430173de4699280f9c3f22fc64e1e51) | `` terraform-providers.http: 3.2.1 -> 3.3.0 ``                      |
| [`57eebd44`](https://github.com/NixOS/nixpkgs/commit/57eebd445974127367b2bf88e0cd1b093e90202f) | `` terraform-providers.grafana: 1.37.2 -> 1.38.0 ``                 |
| [`caf337e6`](https://github.com/NixOS/nixpkgs/commit/caf337e63e5035872321c13216378532adfb7323) | `` terraform-providers.baiducloud: 1.19.6 -> 1.19.7 ``              |
| [`6d9a7bc7`](https://github.com/NixOS/nixpkgs/commit/6d9a7bc741e815b2f8e169c7d2247649aebaeaaa) | `` ssh-to-age: 1.1.2 -> 1.1.3 ``                                    |
| [`ca2df7c7`](https://github.com/NixOS/nixpkgs/commit/ca2df7c70e8eec2aa512d5696226ec90347f61c6) | `` freecad: unpin vtk ``                                            |
| [`bab60a1c`](https://github.com/NixOS/nixpkgs/commit/bab60a1cf4feb455c20c7b77970cd8ae5e52d2a0) | `` datovka: 4.22.0 -> 4.22.1 ``                                     |
| [`27ae052c`](https://github.com/NixOS/nixpkgs/commit/27ae052ce0871efbe6bb0b2d5c60cde313a96ff7) | `` dart: 2.19.3 -> 2.19.6 ``                                        |
| [`e196ca50`](https://github.com/NixOS/nixpkgs/commit/e196ca505d28035227fb69b2d955a1b3d4333373) | `` gdcm: unpin vtk ``                                               |
| [`afc3c639`](https://github.com/NixOS/nixpkgs/commit/afc3c6398ba32eedd11c5292cd8227665cab17be) | `` rymdport: 3.3.2 -> 3.3.4 ``                                      |
| [`866bfbd0`](https://github.com/NixOS/nixpkgs/commit/866bfbd095e8977a869fb14eaf687df5be92160c) | `` python310Packages.heudiconv: 0.8.0 -> 0.12.2 ``                  |
| [`d606e611`](https://github.com/NixOS/nixpkgs/commit/d606e6118b6d49f37c9cba9d57a927b8353d1d1a) | `` dunst: 1.9.1 -> 1.9.2 ``                                         |
| [`9d5baf6d`](https://github.com/NixOS/nixpkgs/commit/9d5baf6d682675510f29af358c026ae7b8e3cc17) | `` deepin.deepin-draw: 5.11.7 -> 6.0.5 ``                           |
| [`6db9de6d`](https://github.com/NixOS/nixpkgs/commit/6db9de6dbf1c992c3ca20e536d064cc28c3adf3d) | `` zsh-nix-shell: 0.5.0 -> 0.6.0 ``                                 |
| [`a7f1ae46`](https://github.com/NixOS/nixpkgs/commit/a7f1ae46ac17fc2e70ae5c8ef9304adf2a461245) | `` mdbook-admonish: 1.8.0 -> 1.9.0 ``                               |
| [`d51f965f`](https://github.com/NixOS/nixpkgs/commit/d51f965f9d9cceeef6e964ab61680ea6241f9e57) | `` kubeone: 1.6.1 -> 1.6.2 ``                                       |
| [`6b1c191e`](https://github.com/NixOS/nixpkgs/commit/6b1c191ee72c4e938650e9f0128befb3125b165a) | `` cargo-expand: 1.0.47 -> 1.0.48 ``                                |
| [`91da67f2`](https://github.com/NixOS/nixpkgs/commit/91da67f2d9e7968705eb557ab9e6a1e8e6b54a8e) | `` phpunit: 10.1.0 -> 10.1.2 ``                                     |
| [`23e82b35`](https://github.com/NixOS/nixpkgs/commit/23e82b35d25756ea154bd28ddfbc665aa3560671) | `` cargo-llvm-lines: 0.4.26 -> 0.4.27 ``                            |
| [`c5f219c0`](https://github.com/NixOS/nixpkgs/commit/c5f219c0b27e67b3fea9950833022936ab51e4bb) | `` pocketbase: 0.13.4 -> 0.15.1 ``                                  |
| [`2cf69432`](https://github.com/NixOS/nixpkgs/commit/2cf69432d1f7242c020b9862201761a0a3bed94c) | `` xmrig-proxy: 6.19.0 -> 6.19.2 ``                                 |
| [`994e0a83`](https://github.com/NixOS/nixpkgs/commit/994e0a839191f8ac9d693fdbe7e6daa56bfdb831) | `` worker-build: 0.0.15 -> 0.0.16 ``                                |
| [`4c4d57b7`](https://github.com/NixOS/nixpkgs/commit/4c4d57b78da137b99c502463efbac5cdb13b3b37) | `` flowtime: init at 3.0 ``                                         |
| [`8f3637d7`](https://github.com/NixOS/nixpkgs/commit/8f3637d7d4a7cb1796d8a59c7980b9741ad584b8) | `` license-cli: init at 3.0.0 ``                                    |
| [`6102cdb0`](https://github.com/NixOS/nixpkgs/commit/6102cdb048a50ad0627b9bfffc7336e725ea6ed6) | `` libopenshot-audio: add Accelerate framework dependency ``        |
| [`1cb4eafe`](https://github.com/NixOS/nixpkgs/commit/1cb4eafe048251f7997c7509fda924fdb7790637) | `` cargo-make: 0.36.6 -> 0.36.7 ``                                  |
| [`50cd355b`](https://github.com/NixOS/nixpkgs/commit/50cd355baaf95bcfcfc14cc3cb719791517ec115) | `` ocenaudio: 3.11.22 -> 3.11.24 ``                                 |
| [`1ae87aa3`](https://github.com/NixOS/nixpkgs/commit/1ae87aa3ea7ca72bd1451c7e313c58f21816591d) | `` appgate-sdp: 6.1.2 -> 6.1.3 ``                                   |
| [`46e41a58`](https://github.com/NixOS/nixpkgs/commit/46e41a58c4bd2e46c4747c20d78ac0483da6132b) | `` azure-storage-azcopy: 10.18.0 -> 10.18.1 ``                      |
| [`89c1ba29`](https://github.com/NixOS/nixpkgs/commit/89c1ba29baa41ec6bc96982eef0b34231256b35d) | `` unciv: 4.6.4-patch2 -> 4.6.5 ``                                  |
| [`3f8fc9c2`](https://github.com/NixOS/nixpkgs/commit/3f8fc9c28b06d6815f2cb7c4f90b91948e5d6d36) | `` linuxPackages.nvidia_x11_legacy470: 470.161.03 -> 470.182.03 ``  |
| [`d4bde02d`](https://github.com/NixOS/nixpkgs/commit/d4bde02d3204f05d07ddade9fcb5efe3c86866f2) | `` gh: 2.27.0 -> 2.28.0 ``                                          |
| [`7f67635f`](https://github.com/NixOS/nixpkgs/commit/7f67635f6f76c8039225db45d058718bb2fab053) | `` infracost: 0.10.19 -> 0.10.20 ``                                 |
| [`78f0c1a4`](https://github.com/NixOS/nixpkgs/commit/78f0c1a4f6acff39bc882cb5a217c9640e8a5d96) | `` f3d: 1.3.1 -> 2.0.0 ``                                           |
| [`438c6c7c`](https://github.com/NixOS/nixpkgs/commit/438c6c7c587d5d470c5602302b9d32627b5d27ce) | `` jackett: 0.20.3920 -> 0.20.3990 ``                               |
| [`e9365c4a`](https://github.com/NixOS/nixpkgs/commit/e9365c4a4cdbda303453067d718a491703d6b9a0) | `` nushell: 0.78.0 -> 0.79.0 ``                                     |
| [`a7decb25`](https://github.com/NixOS/nixpkgs/commit/a7decb253ca1ec0173cfc4425fb405059bd65ca6) | `` pcl: unpin vtk ``                                                |
| [`998ca7e0`](https://github.com/NixOS/nixpkgs/commit/998ca7e00125e3a6a11fbc913c46691b63c4dbfe) | `` logseq: 0.9.3 -> 0.9.4 ``                                        |
| [`c118bf96`](https://github.com/NixOS/nixpkgs/commit/c118bf9672120c551fa418845d02825e235a4fc7) | `` palemoon: 32.1.0 -> 32.1.1 ``                                    |
| [`144e1ae7`](https://github.com/NixOS/nixpkgs/commit/144e1ae7d57921b9294fe9b1f54e46c127545b9f) | `` linuxPackages.nvidia_x11_production: 525.105.17 -> 525.116.03 `` |
| [`88d37af1`](https://github.com/NixOS/nixpkgs/commit/88d37af1e95e31ab21dd6832846424b7fde60876) | `` calc: use overlay-style overridable attributes ``                |
| [`c3a3f773`](https://github.com/NixOS/nixpkgs/commit/c3a3f7737a43ea66ec58436c8105f2729173e1a5) | `` calc: realign lists ``                                           |
| [`f4a6e456`](https://github.com/NixOS/nixpkgs/commit/f4a6e456c1d94218387a49c34b4f651fe6327a44) | `` calc: use hash instead of sha256 ``                              |
| [`580519cf`](https://github.com/NixOS/nixpkgs/commit/580519cfcda476f1408f03038a40762ceb460716) | `` calc: rewrite the arguments attrset ``                           |
| [`2137fe70`](https://github.com/NixOS/nixpkgs/commit/2137fe7093a1a8ed713b1a5df40c6bfef07eea7b) | `` calc: remove references to pname ``                              |
| [`fc519cb4`](https://github.com/NixOS/nixpkgs/commit/fc519cb40bb8b2978504814daf7a194f815d6da3) | `` calc: refactor meta ``                                           |