### PR TITLE
chore(flake/nur): `4ea87277` -> `aace938b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682581579,
-        "narHash": "sha256-wDf9GcyTbosGyVpxQJtMhX+i8C9Wa799u2vvQmMkZLI=",
+        "lastModified": 1682592337,
+        "narHash": "sha256-kujjY2nkzPkCHJpwheIwE6pRODmzq7mPeV44AwtDl5A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ea872776fe0790e4c6d8374a5b5f0391803aa0a",
+        "rev": "aace938bb73f431435454d6cf1759e15b009f9cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aace938b`](https://github.com/nix-community/NUR/commit/aace938bb73f431435454d6cf1759e15b009f9cd) | `` automatic update `` |
| [`120e2d2b`](https://github.com/nix-community/NUR/commit/120e2d2b7aea458f8afa6b11179068f57822e3d3) | `` automatic update `` |
| [`6a41a400`](https://github.com/nix-community/NUR/commit/6a41a40008705fbfbbbaf4f74ab15bf8d73d8d15) | `` automatic update `` |