### PR TITLE
chore(flake/emacs-overlay): `b9f58617` -> `23488bbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682564884,
-        "narHash": "sha256-2Rq+qvKjg7ceLUN+C4VGZtFMJ2tAbDSNt7QjxSYoj0M=",
+        "lastModified": 1682592091,
+        "narHash": "sha256-JQTGiWOhj+/ZoJfWPQ3vOYAXf0SsMtJuOPTvwArPyIg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b9f58617837bb55201c526a8c37976d0ff25aebd",
+        "rev": "23488bbca5ea0012bafa2c75b88902b540ff9940",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`23488bbc`](https://github.com/nix-community/emacs-overlay/commit/23488bbca5ea0012bafa2c75b88902b540ff9940) | `` Updated repos/melpa `` |
| [`39501a3c`](https://github.com/nix-community/emacs-overlay/commit/39501a3cf1e833c922e8ed70594c9741ce357c22) | `` Updated repos/emacs `` |