### PR TITLE
chore(flake/emacs-overlay): `23488bbc` -> `8b3dc10f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682592091,
-        "narHash": "sha256-JQTGiWOhj+/ZoJfWPQ3vOYAXf0SsMtJuOPTvwArPyIg=",
+        "lastModified": 1682619063,
+        "narHash": "sha256-uxupASPiki6zWE2VJPqPfRT70TlH65dnWE73ZZLnAV8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "23488bbca5ea0012bafa2c75b88902b540ff9940",
+        "rev": "8b3dc10f7bb3a21853a9f085d7a20c1e57c814b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`8b3dc10f`](https://github.com/nix-community/emacs-overlay/commit/8b3dc10f7bb3a21853a9f085d7a20c1e57c814b8) | `` Updated repos/melpa `` |
| [`7c6b30cc`](https://github.com/nix-community/emacs-overlay/commit/7c6b30ccd55db6ce49fb9377bd3cb3bf605df1b8) | `` Updated repos/emacs `` |