### PR TITLE
chore(flake/nur): `d70f4425` -> `7a3b1230`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682642322,
-        "narHash": "sha256-quERYCegeyAQOwhD7E5UJaToIXL0CbXRXf4gny3SS5o=",
+        "lastModified": 1682653517,
+        "narHash": "sha256-tDTiEPUr5dVTGP1zxHaA8V3T9GDrIMjj7CgXyB2mg50=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d70f4425fb03d9564e13699eb332919060ff46ff",
+        "rev": "7a3b12307da146d298c1c6b7d89e241df6504431",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7a3b1230`](https://github.com/nix-community/NUR/commit/7a3b12307da146d298c1c6b7d89e241df6504431) | `` automatic update `` |
| [`b0af8de0`](https://github.com/nix-community/NUR/commit/b0af8de0aff3a70d7b83f9a65edaab93b942caac) | `` automatic update `` |