### PR TITLE
chore(flake/nur): `7a3b1230` -> `0debdae7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682653517,
-        "narHash": "sha256-tDTiEPUr5dVTGP1zxHaA8V3T9GDrIMjj7CgXyB2mg50=",
+        "lastModified": 1682670842,
+        "narHash": "sha256-xgPqeYZVMgCTtiBsgdfRizhr9YedyyaHmqtom5K7R1c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7a3b12307da146d298c1c6b7d89e241df6504431",
+        "rev": "0debdae70a437f91abf9327a055cd0a504738707",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                     |
| -------------------------------------------------------------------------------------------------- | --------------------------- |
| [`0debdae7`](https://github.com/nix-community/NUR/commit/0debdae70a437f91abf9327a055cd0a504738707) | `` automatic update ``      |
| [`d5a664d7`](https://github.com/nix-community/NUR/commit/d5a664d71386f5bca7a549ed293fe8d893db2b94) | `` automatic update ``      |
| [`87f9fc7d`](https://github.com/nix-community/NUR/commit/87f9fc7de035cfb70490ddaffc2b997115545c15) | `` automatic update ``      |
| [`57b992d1`](https://github.com/nix-community/NUR/commit/57b992d140d85d2be2bbdd077bc137f2cdc56cf4) | `` add badele repository `` |