### PR TITLE
chore(flake/emacs-overlay): `bc9ab6c1` -> `60fe647b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682650826,
-        "narHash": "sha256-20lvhUHt9UEDmS/L8+TFn4iCkZ4UtdvNi1MrMIDXjec=",
+        "lastModified": 1682673816,
+        "narHash": "sha256-C5zxg5AbMbX3UD2iiWL6fqvp/csTnk8JeXh6PHf7zOI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bc9ab6c16d0e56a8358c7e41b38711159d37b6b3",
+        "rev": "60fe647be71d6f433f4a8f9f22d7430bf0ef58a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`60fe647b`](https://github.com/nix-community/emacs-overlay/commit/60fe647be71d6f433f4a8f9f22d7430bf0ef58a4) | `` Updated repos/emacs `` |