### PR TITLE
chore(flake/nur): `711c9af9` -> `8814b947`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682682371,
-        "narHash": "sha256-n1vJPk8xO98r92kXTZ6rdlLDVn/HqYQLtcVdSOduduQ=",
+        "lastModified": 1682686658,
+        "narHash": "sha256-h2gpcWIEcO5CYfdLFBvxI59cOS65YJejpxVqdh1sZGU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "711c9af9499fa692d327a631c47bd8dfa56a9b17",
+        "rev": "8814b947eb4f10b1f26ed7cb7b067c58b28b065a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8814b947`](https://github.com/nix-community/NUR/commit/8814b947eb4f10b1f26ed7cb7b067c58b28b065a) | `` automatic update `` |