### PR TITLE
chore(flake/nur): `8814b947` -> `0a00b6ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682686658,
-        "narHash": "sha256-h2gpcWIEcO5CYfdLFBvxI59cOS65YJejpxVqdh1sZGU=",
+        "lastModified": 1682696758,
+        "narHash": "sha256-JD8IjJ2jK9HKhbzhlI/Y0KHrJ8vFYrQF+P3ZZd2RvzQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8814b947eb4f10b1f26ed7cb7b067c58b28b065a",
+        "rev": "0a00b6ba11a2840719cc17d2c9f442dea1d6f64b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0a00b6ba`](https://github.com/nix-community/NUR/commit/0a00b6ba11a2840719cc17d2c9f442dea1d6f64b) | `` automatic update `` |