### PR TITLE
chore(flake/nur): `cf0bb820` -> `380f2b7e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682700396,
-        "narHash": "sha256-VvrLk6Ia9gvwPJ1uD81lRlxzXH7JUY0O9H0LJfr8IAk=",
+        "lastModified": 1682707498,
+        "narHash": "sha256-6odqZBbmrvIYZiwbzwxIMEwitI82OS4UZGwKiZ6OOPw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cf0bb82075a25b407b1592c18a3d3dd2cf87b1fb",
+        "rev": "380f2b7e07816e71e1f08e89e06191a54cf7531f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`380f2b7e`](https://github.com/nix-community/NUR/commit/380f2b7e07816e71e1f08e89e06191a54cf7531f) | `` automatic update `` |