### PR TITLE
chore(flake/emacs-overlay): `60fe647b` -> `0489c1bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682673816,
-        "narHash": "sha256-C5zxg5AbMbX3UD2iiWL6fqvp/csTnk8JeXh6PHf7zOI=",
+        "lastModified": 1682703588,
+        "narHash": "sha256-yCnluuXCCnQNSC3hxk76fSuSv9mS0+f3ag6vWNi2utQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "60fe647be71d6f433f4a8f9f22d7430bf0ef58a4",
+        "rev": "0489c1bbade20d3f95e2a96ba384bdc327ed9750",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`0489c1bb`](https://github.com/nix-community/emacs-overlay/commit/0489c1bbade20d3f95e2a96ba384bdc327ed9750) | `` Updated repos/emacs `` |
| [`80247cfc`](https://github.com/nix-community/emacs-overlay/commit/80247cfcaa45e07de7e7dc1536329ebaaea70382) | `` Updated repos/elpa ``  |