### PR TITLE
chore(flake/nur): `380f2b7e` -> `01d2b4d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682707498,
-        "narHash": "sha256-6odqZBbmrvIYZiwbzwxIMEwitI82OS4UZGwKiZ6OOPw=",
+        "lastModified": 1682718356,
+        "narHash": "sha256-hQPKYdzLnjc3pTuvsqMUD+7VH2anMbVkK6+NfyLPXa8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "380f2b7e07816e71e1f08e89e06191a54cf7531f",
+        "rev": "01d2b4d3d6887cb2219896e6482b84b39f61b6a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`01d2b4d3`](https://github.com/nix-community/NUR/commit/01d2b4d3d6887cb2219896e6482b84b39f61b6a3) | `` automatic update `` |
| [`04e5f3c2`](https://github.com/nix-community/NUR/commit/04e5f3c21d683c5ab012ef59aecbfd42e49349fe) | `` automatic update `` |