### PR TITLE
chore(flake/nur): `01d2b4d3` -> `89e2b1f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682718356,
-        "narHash": "sha256-hQPKYdzLnjc3pTuvsqMUD+7VH2anMbVkK6+NfyLPXa8=",
+        "lastModified": 1682725548,
+        "narHash": "sha256-fQFuIfYeBYJLMIsRpcQcb31YKrqazE1Pr10Ew+JaTPM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "01d2b4d3d6887cb2219896e6482b84b39f61b6a3",
+        "rev": "89e2b1f70eef8ee3524aa9ade5f19cf8dd9728fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`89e2b1f7`](https://github.com/nix-community/NUR/commit/89e2b1f70eef8ee3524aa9ade5f19cf8dd9728fb) | `` automatic update `` |