### PR TITLE
chore(flake/nur): `89e2b1f7` -> `4b6e3507`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682725548,
-        "narHash": "sha256-fQFuIfYeBYJLMIsRpcQcb31YKrqazE1Pr10Ew+JaTPM=",
+        "lastModified": 1682733909,
+        "narHash": "sha256-L8uqDsgT6sNT6Ar0wICDTRWz6+ke9zxTDU3tU0oo6mc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "89e2b1f70eef8ee3524aa9ade5f19cf8dd9728fb",
+        "rev": "4b6e35072d29c7822953ad314a33a12fae7f6bac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4b6e3507`](https://github.com/nix-community/NUR/commit/4b6e35072d29c7822953ad314a33a12fae7f6bac) | `` automatic update `` |