### PR TITLE
chore(flake/emacs-overlay): `0489c1bb` -> `b04a264d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682703588,
-        "narHash": "sha256-yCnluuXCCnQNSC3hxk76fSuSv9mS0+f3ag6vWNi2utQ=",
+        "lastModified": 1682737663,
+        "narHash": "sha256-gXEP1Sy9LrQdD2y7sqQUumJvqiRWX3CJpEEJ9JOBUro=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0489c1bbade20d3f95e2a96ba384bdc327ed9750",
+        "rev": "b04a264d5f566ce27e1d62eeae3eabaaa8e942ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b04a264d`](https://github.com/nix-community/emacs-overlay/commit/b04a264d5f566ce27e1d62eeae3eabaaa8e942ef) | `` Updated repos/nongnu `` |
| [`550e5eed`](https://github.com/nix-community/emacs-overlay/commit/550e5eed7794258c7b2c95d8db6f1f6ba305aeab) | `` Updated repos/emacs ``  |