### PR TITLE
chore(flake/nixpkgs): `d6b863fd` -> `937a9d1e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -718,11 +718,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1682526928,
-        "narHash": "sha256-2cKh4O6t1rQ8Ok+v16URynmb0rV7oZPEbXkU0owNLQs=",
+        "lastModified": 1682692304,
+        "narHash": "sha256-9/lyXN2BpHw+1xE+D2ySBSLMCHWqiWu5tPHBMRDib8M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d6b863fd9b7bb962e6f9fdf292419a775e772891",
+        "rev": "937a9d1ee7b1351d8c55fff6611a8edf6e7c1c37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`f873350a`](https://github.com/NixOS/nixpkgs/commit/f873350afdb4627f520161cf850007e102287c6c) | `` wio: remove ``                                                               |
| [`cfe96dbf`](https://github.com/NixOS/nixpkgs/commit/cfe96dbfce8bd62dcd4a8ad62cb79dec140b1a62) | `` python310Packages.blobfile: 2.0.1 -> 2.0.2 ``                                |
| [`1d1d5d27`](https://github.com/NixOS/nixpkgs/commit/1d1d5d272490cdb80e25e2c8f24fd6000ca57a07) | `` gnat-bootstrap: add meta.sourceProvenance ``                                 |
| [`ffb470ec`](https://github.com/NixOS/nixpkgs/commit/ffb470ec45671f97e57a29d2e8c852ccf589ce47) | `` raysession: Add bash to buildInputs ``                                       |
| [`9a495b4f`](https://github.com/NixOS/nixpkgs/commit/9a495b4f8cc6c407ae64f6bbf56ea593a1fdc56f) | `` vimPlugins.statuscol-nvim: init at 2023-04-23 ``                             |
| [`3ec0efcd`](https://github.com/NixOS/nixpkgs/commit/3ec0efcd3a6e1561b098384b007813e1cfdd1a65) | `` elementsd-simplicity: init at unstable-2023-04-18 ``                         |
| [`4f9626b6`](https://github.com/NixOS/nixpkgs/commit/4f9626b6dd098154c6e0ead13855fe01a8829186) | `` treewide: fix zig version overrides for cross ``                             |
| [`5e871533`](https://github.com/NixOS/nixpkgs/commit/5e871533c4a488319b9cb98d7a525c356459d36c) | `` verilator: 5.006 -> 5.008 ``                                                 |
| [`6a086197`](https://github.com/NixOS/nixpkgs/commit/6a086197c2d34075d43bdbe6b1243f97f6222115) | `` verilator: wrap with glibc LOCALE_ARCHIVE iff stdenv.isLinux ``              |
| [`0369edb2`](https://github.com/NixOS/nixpkgs/commit/0369edb22db7d2a0e97d090b8d04d0142c9256c9) | `` python310Packages.python-engineio: 4.4.0 -> 4.4.1 ``                         |
| [`c480720e`](https://github.com/NixOS/nixpkgs/commit/c480720ef057fa2d2ac23f25fa51a6234a1e1e8e) | `` python310Packages.pontos: 23.4.7 -> 23.4.9 ``                                |
| [`15e3a50b`](https://github.com/NixOS/nixpkgs/commit/15e3a50bd354dfa561eaae222159832829834f65) | `` nixos/binfmt: add loongarch64-linux ``                                       |
| [`b522b5a8`](https://github.com/NixOS/nixpkgs/commit/b522b5a8876761363bc024c3a279b0ded9620bea) | `` bintools: set dynamic linker ``                                              |
| [`094b2891`](https://github.com/NixOS/nixpkgs/commit/094b2891aa9e3f33094f0233b14a34104a9b84db) | `` gdb: enable debuginfod support only on platforms with elfutils support ``    |
| [`d7b3b861`](https://github.com/NixOS/nixpkgs/commit/d7b3b861360231d315c85a9839040a9dd22e7969) | `` python310Packages.isbnlib: add changelog to meta ``                          |
| [`993b95d3`](https://github.com/NixOS/nixpkgs/commit/993b95d373a409fcff820ac501baf12bee4527f6) | `` python310Packages.isbnlib: 3.10.13 -> 3.10.14 ``                             |
| [`f017b54b`](https://github.com/NixOS/nixpkgs/commit/f017b54bd9407b39461c6ee6e27bde179e9d10ae) | `` python310Packages.google-auth: 2.17.1 -> 2.17.3 ``                           |
| [`e6ba9a96`](https://github.com/NixOS/nixpkgs/commit/e6ba9a964dbcdd54b370b1dfc6c895c79603db05) | `` python310Packages.graphene: 3.2.1 -> 3.2.2 ``                                |
| [`248e9380`](https://github.com/NixOS/nixpkgs/commit/248e9380d357ab671c60268809fa2a3c0f049f13) | `` python310Packages.google-cloud-dlp: 3.12.0 -> 3.12.1 ``                      |
| [`8ab043b1`](https://github.com/NixOS/nixpkgs/commit/8ab043b1ee8220de4d21f8f4e93049e5b0ab040a) | `` python310Packages.google-cloud-pubsub: 2.15.0 -> 2.16.0 ``                   |
| [`b6d266bd`](https://github.com/NixOS/nixpkgs/commit/b6d266bd9c2b5ddb203f51f400e2cf1fddac8fc0) | `` python310Packages.google-cloud-spanner: 3.31.0 -> 3.32.0 ``                  |
| [`45539fc2`](https://github.com/NixOS/nixpkgs/commit/45539fc2fd6399bf1596e43346acaa7fc32e8786) | `` python310Packages.google-resumable-media: 2.4.1 -> 2.5.0 ``                  |
| [`d4e911c1`](https://github.com/NixOS/nixpkgs/commit/d4e911c101b465a9c2ce6f9b031cb48432a54093) | `` python310Packages.gvm-tools: 23.3.0 -> 23.4.0 ``                             |
| [`0e95899a`](https://github.com/NixOS/nixpkgs/commit/0e95899ab52ad9e33097f6743df21fa804ea3459) | `` python310Packages.hahomematic: 2023.4.2 -> 2023.4.4 ``                       |
| [`74631a6a`](https://github.com/NixOS/nixpkgs/commit/74631a6abede04c119bbcfd3844eecacaaf2677e) | `` python310Packages.bumps: add changelog to meta ``                            |
| [`9e781988`](https://github.com/NixOS/nixpkgs/commit/9e7819884b50535f2bbbf4f93ab1727ee2a4c27e) | `` python310Packages.bumps: 0.9.0 -> 0.9.1 ``                                   |
| [`452166c9`](https://github.com/NixOS/nixpkgs/commit/452166c9c06bcb9bd5451157a16c328d9ca688c9) | `` python310Packages.bellows: 0.35.1 -> 0.35.2 ``                               |
| [`fdfea5fb`](https://github.com/NixOS/nixpkgs/commit/fdfea5fba41226b83c144bed0d84cd97cde10d88) | `` gnomeExtensions.pop-shell: unstable-2023-04-05 -> unstable-2023-04-27 ``     |
| [`51ba5098`](https://github.com/NixOS/nixpkgs/commit/51ba50985ac3aa264b27698d8a642a944d29abea) | `` wasmtime: 8.0.0 -> 8.0.1 ``                                                  |
| [`44e13c8d`](https://github.com/NixOS/nixpkgs/commit/44e13c8d1a1e9677835e05f3e25994fca5f46daf) | `` firefox-devedition-unwrapped: 113.0b4 -> 113.0b9 ``                          |
| [`fe10fae6`](https://github.com/NixOS/nixpkgs/commit/fe10fae686e1ebef69390b611f62df3949c5d58f) | `` firefox-beta-unwrapped: 113.0b4 -> 113.0b9 ``                                |
| [`0446823a`](https://github.com/NixOS/nixpkgs/commit/0446823a9e1cb6b064404b3251f29ff7ea8ec820) | `` firefox-devedition-bin-unwrapped: 113.0b7 -> 113.0b9 ``                      |
| [`609322a8`](https://github.com/NixOS/nixpkgs/commit/609322a84beefa100ca0b5efe0056820ddeee052) | `` firefox-beta-bin-unwrapped: 113.0b7 -> 113.0b9 ``                            |
| [`03bdc1b2`](https://github.com/NixOS/nixpkgs/commit/03bdc1b2aeebf8f79cc2bfc8b5707fcac448f99a) | `` tlsx: 1.0.7 -> 1.0.8 ``                                                      |
| [`6eeb9510`](https://github.com/NixOS/nixpkgs/commit/6eeb951035db67602bf0c29aa8b1226e92a3344e) | `` qovery-cli: 0.58.7 -> 0.58.8 ``                                              |
| [`29e34828`](https://github.com/NixOS/nixpkgs/commit/29e34828c0c53fc87340a375c985be0787522e8c) | `` python310Packages.zha-quirks: 0.0.97 -> 0.0.98 ``                            |
| [`2086b377`](https://github.com/NixOS/nixpkgs/commit/2086b377cfb5565f443c0a47e224cecbdaafad98) | `` nixos/nginx: serve the status page on localhost servers ``                   |
| [`aed5c11a`](https://github.com/NixOS/nixpkgs/commit/aed5c11a9dde6d075888a1cf6f12b966f3ed1656) | `` python310Packages.axis: 47 -> 48 ``                                          |
| [`43b53fcf`](https://github.com/NixOS/nixpkgs/commit/43b53fcfe1603c27a73b241ce2a321e87dc4bd63) | `` exploitdb: 2023-04-26 -> 2023-04-28 ``                                       |
| [`9ff557ea`](https://github.com/NixOS/nixpkgs/commit/9ff557eaaea77c00c6de660e13614af758abbff5) | `` python310Packages.auth0-python: add changelog to meta ``                     |
| [`76f942fb`](https://github.com/NixOS/nixpkgs/commit/76f942fb4ae52330615bc200390bee9f8a898d8b) | `` python310Packages.auth0-python: 4.0.0 -> 4.1.1 ``                            |
| [`357dde4b`](https://github.com/NixOS/nixpkgs/commit/357dde4ba4248438cc97472469cd030e3418e0c2) | `` python310Packages.aiobiketrax: allow later auth0-python releases ``          |
| [`7e7df60c`](https://github.com/NixOS/nixpkgs/commit/7e7df60c5211221841c103d9631d80414f485341) | `` werf: 1.2.224 -> 1.2.225 ``                                                  |
| [`a285f491`](https://github.com/NixOS/nixpkgs/commit/a285f49156d819ad8a9e2cc298e880e3b7f56851) | `` python310Packages.flask-httpauth:  add changelog to meta ``                  |
| [`a18cff22`](https://github.com/NixOS/nixpkgs/commit/a18cff224c9a25ae9b241d4b75a1402a8a52534c) | `` python310Packages.flask-httpauth: update disabled ``                         |
| [`c63ff3f6`](https://github.com/NixOS/nixpkgs/commit/c63ff3f64bfdd7ec0d480a76f2fe7b72798d65dd) | `` python310Packages.dj-database-url: add pythonImportsCheck ``                 |
| [`3a5e025f`](https://github.com/NixOS/nixpkgs/commit/3a5e025fb3765d4a83a4eefadd70e4c4b07eadca) | `` python310Packages.dj-database-url: disable on unsupported Python releases `` |
| [`333e5b3a`](https://github.com/NixOS/nixpkgs/commit/333e5b3a378f92133ba84c47e5e7b351a2311985) | `` python310Packages.dj-database-url: update meta ``                            |
| [`29fe6018`](https://github.com/NixOS/nixpkgs/commit/29fe601881270d4e40a6108139dd63cec3961629) | `` klayout: 0.28.6 -> 0.28.7 ``                                                 |
| [`1a56e08b`](https://github.com/NixOS/nixpkgs/commit/1a56e08b2ebced6bbb4146fd801b5d963fec67f3) | `` terraform-providers.aws: 4.64.0 -> 4.65.0 ``                                 |
| [`e6182303`](https://github.com/NixOS/nixpkgs/commit/e6182303debe5421bc3fd431a32a151c1d794678) | `` terraform-providers.vcd: 3.8.2 -> 3.9.0 ``                                   |
| [`0a104ab5`](https://github.com/NixOS/nixpkgs/commit/0a104ab5d4e0a11ccffa403da84af5a7da7848ea) | `` terraform-providers.utils: 1.7.1 -> 1.8.0 ``                                 |
| [`300517ba`](https://github.com/NixOS/nixpkgs/commit/300517ba68977dfd4c1dc4a693e9cce29821e182) | `` terraform-providers.spotinst: 1.113.0 -> 1.115.0 ``                          |
| [`6c15136d`](https://github.com/NixOS/nixpkgs/commit/6c15136d2361d45cea69f9dce0f3eaff10e38640) | `` terraform-providers.grafana: 1.38.0 -> 1.39.0 ``                             |
| [`b42acb70`](https://github.com/NixOS/nixpkgs/commit/b42acb70a39c3507e8521d65da2d470bd1e0f62b) | `` terraform-providers.azuread: 2.37.2 -> 2.38.0 ``                             |
| [`b4825235`](https://github.com/NixOS/nixpkgs/commit/b4825235e5a903103a92d28bfd9519b199b3b2a0) | `` terraform-providers.akamai: 3.5.0 -> 3.6.0 ``                                |
| [`47165a93`](https://github.com/NixOS/nixpkgs/commit/47165a937f7d8a44d9e1a88befd4b192e2c2f801) | `` esphome: 2023.4.1 -> 2023.4.2 ``                                             |
| [`8a6d7b7e`](https://github.com/NixOS/nixpkgs/commit/8a6d7b7ed8637e71b60cf549332781eaad5ca13b) | `` mysql_jdbc: 8.0.31 -> 8.0.33 ``                                              |
| [`323a7261`](https://github.com/NixOS/nixpkgs/commit/323a7261632e64241ce0e7a5478a0157566aca1b) | `` gotktrix: unstable-2022-09-29 -> unstable-2023-04-05 ``                      |
| [`a1a68c39`](https://github.com/NixOS/nixpkgs/commit/a1a68c39b6a8a584ef3aaafe541fdba5cb68512c) | `` cliam: 2.0.0 -> 2.2.0 ``                                                     |
| [`56724e7f`](https://github.com/NixOS/nixpkgs/commit/56724e7f0f92d081ea7df2bd314fe35be835d83e) | `` prometheus-zfs-exporter: 2.2.7 -> 2.2.8 ``                                   |
| [`97db4671`](https://github.com/NixOS/nixpkgs/commit/97db4671b060f50e9ebc7bae3e93b9ab81eda828) | `` temporal: 1.20.0 -> 1.20.2 ``                                                |
| [`b18cc3cd`](https://github.com/NixOS/nixpkgs/commit/b18cc3cd549d953bf8fa7a334b10b94e9bce84f0) | `` circt: 1.37.0 -> 1.40.0 ``                                                   |
| [`c4624fac`](https://github.com/NixOS/nixpkgs/commit/c4624facaac04500f0fb61992bdf22298e0386b0) | `` rssguard: 4.3.3 -> 4.3.4 ``                                                  |
| [`6e94929e`](https://github.com/NixOS/nixpkgs/commit/6e94929e1c45e07d37a90eeeed9aa714d3ff04a8) | `` python310Packages.dj-database-url: 1.3.0 -> 2.0.0 ``                         |
| [`33eb6b69`](https://github.com/NixOS/nixpkgs/commit/33eb6b69c08652c8a0fe2a01545e2762c487337d) | `` python310Packages.azure-mgmt-apimanagement: 3.0.0 -> 4.0.0 ``                |
| [`5f96b025`](https://github.com/NixOS/nixpkgs/commit/5f96b02564ba14a716c73d92ce79f2b40ab0ef53) | `` nushellPlugins.query: fix build from broken hash ``                          |
| [`c7063f17`](https://github.com/NixOS/nixpkgs/commit/c7063f174301df27f50a7d71186bf5ae2ae0e87f) | `` nuscripts: unstable-2023-03-16 -> unstable-2023-04-26 ``                     |
| [`8b3d3f57`](https://github.com/NixOS/nixpkgs/commit/8b3d3f57d366d9c7070821bc75a1f64aa18b9ed7) | `` python310Packages.opencensus: 0.11.1 -> 0.11.2 ``                            |
| [`f947792c`](https://github.com/NixOS/nixpkgs/commit/f947792cdfdbbf291eeb67a6e1363db7a7178abd) | `` miniserve: 0.23.1 -> 0.23.2 ``                                               |
| [`f29bb09f`](https://github.com/NixOS/nixpkgs/commit/f29bb09f7dd0a3120236bb900fa882be7c4060b4) | `` kphotoalbum: 5.9.1 -> 5.10.0 ``                                              |
| [`29da0c2f`](https://github.com/NixOS/nixpkgs/commit/29da0c2ff9147a6aed96fc91209122e70374032d) | `` sic-image-cli: 0.22.1 -> 0.22.2 ``                                           |
| [`41b6e138`](https://github.com/NixOS/nixpkgs/commit/41b6e138619e7c05f364fb2448731f077889389d) | `` geoserver: 2.22.2 -> 2.23.0 ``                                               |
| [`48613c42`](https://github.com/NixOS/nixpkgs/commit/48613c429552de293714b9e6aa98714ab9a71a45) | `` flyctl: 0.0.522 -> 0.0.539 ``                                                |
| [`27e2eaa9`](https://github.com/NixOS/nixpkgs/commit/27e2eaa9dbe8504bf030bbf0277466fc8b3f0b83) | `` ddosify: 0.16.2 -> 0.16.6 ``                                                 |
| [`80f5b1d7`](https://github.com/NixOS/nixpkgs/commit/80f5b1d792febbb25e8fa7e2332b6bc85dfeed9b) | `` node-problem-detector: 0.8.12 -> 0.8.13 ``                                   |
| [`4bd3d74a`](https://github.com/NixOS/nixpkgs/commit/4bd3d74a9d7fc19daeb3d7e35f53dcbf818ec294) | `` icingaweb2-ipl: 0.11.0 -> 0.11.1 ``                                          |
| [`03256edc`](https://github.com/NixOS/nixpkgs/commit/03256edc24f14082ac014de513aed8cc774a2a02) | `` viceroy: 0.4.2 -> 0.4.5 ``                                                   |
| [`0ddb4295`](https://github.com/NixOS/nixpkgs/commit/0ddb429523ab0db4f03ac7952bd26f694b03add2) | `` mediamtx: 0.22.0 -> 0.22.2 ``                                                |
| [`5bb2db67`](https://github.com/NixOS/nixpkgs/commit/5bb2db672fe9e7da8085ba6bd1b622c32ca4a0ca) | `` python310Packages.flask-httpauth: 4.7.0 -> 4.8.0 ``                          |
| [`af661f3b`](https://github.com/NixOS/nixpkgs/commit/af661f3be7e995a3f7ae17e29938ceea80263c88) | `` Revert "root: fix build on aarch64-darwin" ``                                |
| [`fbd71c48`](https://github.com/NixOS/nixpkgs/commit/fbd71c4856cff61fe3fb1c82f13f1590f9069781) | `` dtrx: 8.5.0 -> 8.5.1 ``                                                      |
| [`b1b7370f`](https://github.com/NixOS/nixpkgs/commit/b1b7370ffc97ea757242f31eaf7a8fdad620caf0) | `` python310Packages.python-vlc: 3.0.18121 -> 3.0.18122 ``                      |
| [`0605bc45`](https://github.com/NixOS/nixpkgs/commit/0605bc45228425974b33347fa03303e24f1b1d3b) | `` python310Packages.annoy: add changelog to meta ``                            |
| [`f187ab6a`](https://github.com/NixOS/nixpkgs/commit/f187ab6ae8fe445bf09ec3eb6a9253e48d2ce493) | `` python310Packages.annoy: 1.17.1 -> 1.17.2 ``                                 |
| [`fd48d7c3`](https://github.com/NixOS/nixpkgs/commit/fd48d7c336fc0dea84c25289b7ea4f0f1263bb4f) | `` linuxPackages.nvidia_x11_vulkan_beta: 525.47.18 -> 525.47.22 ``              |
| [`c1d21c3e`](https://github.com/NixOS/nixpkgs/commit/c1d21c3e01bb4eaf32d426136f9a3c70567fbaf2) | `` python310Packages.aiomisc: 17.0.8 -> 17.1.4 ``                               |
| [`25a7da07`](https://github.com/NixOS/nixpkgs/commit/25a7da075ccc5da4e7defae265e959178320d745) | `` python310Packages.appthreat-vulnerability-db: 5.0.4 -> 5.1.1 ``              |
| [`c10a195a`](https://github.com/NixOS/nixpkgs/commit/c10a195ab1b577918fdfa1f4a08b7b634f137be9) | `` gcc: tighten platform flags special-case for aarch64-darwin ``               |
| [`9c990545`](https://github.com/NixOS/nixpkgs/commit/9c990545234f5b08172f5878aaab09bf9114a407) | `` python310Packages.ansible-later: 3.2.2 -> 3.3.1 ``                           |
| [`8f218d6d`](https://github.com/NixOS/nixpkgs/commit/8f218d6d789c5283eb63d63c8889c5e216b11531) | `` python310Packages.cirq-google: disable problematic tests ``                  |
| [`cf6fb1bb`](https://github.com/NixOS/nixpkgs/commit/cf6fb1bbccbe74f4fc76e446d75ffa8f02d0e32d) | `` python310Packages.cirq-ionq: disable deprecated tests ``                     |
| [`24978ed7`](https://github.com/NixOS/nixpkgs/commit/24978ed771787bba7ec4356d4b661ae051dcb336) | `` python310Packages.pyquil: relax deps ``                                      |
| [`14e649ed`](https://github.com/NixOS/nixpkgs/commit/14e649ed6f9b53d83e6f8970859fea98d0455c00) | `` python310Packages.cirq-core: fix build ``                                    |
| [`d7d3821a`](https://github.com/NixOS/nixpkgs/commit/d7d3821ab83260e5b9d376b39fa139989c61c978) | `` tofi: fix cross ``                                                           |
| [`a7333e6b`](https://github.com/NixOS/nixpkgs/commit/a7333e6b435e6ae8ca28af8cd6de863215d43846) | `` tofi: unmark broken on aarch64 ``                                            |
| [`cd2cf0e6`](https://github.com/NixOS/nixpkgs/commit/cd2cf0e625b761d1072ca0db0bdbd940259a349a) | `` python310Packages.marshmallow-dataclass: 8.5.13 -> 8.5.14 ``                 |
| [`f7cb50b3`](https://github.com/NixOS/nixpkgs/commit/f7cb50b3cfd4c6c4be75f5e33172021be562a49b) | `` trash-cli: use installShellCompletion ``                                     |
| [`86346416`](https://github.com/NixOS/nixpkgs/commit/8634641676c76bc7245ce1dd18d34b42035aea74) | `` trash-cli: add shell completions ``                                          |
| [`a2991ad5`](https://github.com/NixOS/nixpkgs/commit/a2991ad5250d8b9822e9b9fbf87d60727a4d5308) | `` python310Packages.pydevccu: 0.1.5 -> 0.1.6 ``                                |
| [`53e5cca7`](https://github.com/NixOS/nixpkgs/commit/53e5cca730d5c8ad562328e166fe10526e647b48) | `` vimPlugins.vim-solarized8: init at 2023-02-25 ``                             |
| [`ea88f831`](https://github.com/NixOS/nixpkgs/commit/ea88f8313ea31b0e76cac6a396dab416dc93b014) | `` qscintilla: remove from libsForQt5 ``                                        |
| [`c6df64ab`](https://github.com/NixOS/nixpkgs/commit/c6df64ab73a3e1caecc0f207033bee81527971c7) | `` python310Packages.sentry-sdk: 1.20.0 -> 1.21.0 ``                            |
| [`45f11d89`](https://github.com/NixOS/nixpkgs/commit/45f11d894d4b09c3c98c134d67418991f46c88ac) | `` python310Packages.fountains: 2.0.0 -> 2.1.0 ``                               |
| [`a4875233`](https://github.com/NixOS/nixpkgs/commit/a487523390d8a0409c1ad920497137eb2770af2b) | `` python310Packages.pontos: 23.4.6 -> 23.4.7 ``                                |
| [`b18c84f2`](https://github.com/NixOS/nixpkgs/commit/b18c84f2a5361aa6d3e9e60b293eb4b3a41a877d) | `` python310Packages.bitlist: 1.0.1 -> 1.1.0 ``                                 |
| [`fc17b707`](https://github.com/NixOS/nixpkgs/commit/fc17b707cf999addd45c2c672c4b824b3044a6c2) | `` python310Packages.parts: 1.5.2 -> 1.6.0 ``                                   |
| [`f3013e9b`](https://github.com/NixOS/nixpkgs/commit/f3013e9b2ba9d46007ae2c7cdd9fdc235a32d3cc) | `` python310Packages.bc-detect-secrets: 1.4.21 -> 1.4.23 ``                     |
| [`53264e7d`](https://github.com/NixOS/nixpkgs/commit/53264e7daa7952967d1a7bd3ee194e93f336bacb) | `` kubecm: init at 0.22.1 ``                                                    |
| [`337a4cc4`](https://github.com/NixOS/nixpkgs/commit/337a4cc448551f1f47e973a484b3e5dab23f29a2) | `` python310Packages.pytibber: 0.27.1 -> 0.27.2 ``                              |
| [`28211c5c`](https://github.com/NixOS/nixpkgs/commit/28211c5c65c83de8f327e5f61e5dd4e73facb705) | `` python310Packages.uamqp: fix build on aarch64-darwin ``                      |
| [`13e9ef73`](https://github.com/NixOS/nixpkgs/commit/13e9ef736a8f4458172d324de0a784d4c6167e9a) | `` python310Packages.adlfs: 2023.1.0 -> 2023.4.0 ``                             |
| [`36302a30`](https://github.com/NixOS/nixpkgs/commit/36302a3056631dc66d73c7a6343950fdb1750e77) | `` root: fix build on aarch64-darwin ``                                         |
| [`26dd4a84`](https://github.com/NixOS/nixpkgs/commit/26dd4a84edb018d06936ebbe48b6af029138e796) | `` buildLuarocksPackage: fixes attributes being ignored ``                      |
| [`3d409345`](https://github.com/NixOS/nixpkgs/commit/3d409345416cda845407e3075f5eaf7a590d9db5) | `` rofi-wayland: fix cross ``                                                   |
| [`2e2d5d6f`](https://github.com/NixOS/nixpkgs/commit/2e2d5d6f1136dbce0a8b558a35b2bc4ddf3d9831) | `` river-tag-overlay: unmark broken on aarch64 ``                               |
| [`dbed5465`](https://github.com/NixOS/nixpkgs/commit/dbed54656c61498e30530bb00a098b9b272d9c90) | `` river-tag-overlay: fix cross ``                                              |
| [`36233d96`](https://github.com/NixOS/nixpkgs/commit/36233d967522af6e072cc1c45d1b9f9c8f531310) | `` hello-wayland: unstable-2023-03-16 -> unstable-2023-04-23 ``                 |
| [`6bda19fb`](https://github.com/NixOS/nixpkgs/commit/6bda19fb912049d6801b3402225a3ee6fdce6cef) | `` hello-wayland: add update script ``                                          |
| [`d5904d7e`](https://github.com/NixOS/nixpkgs/commit/d5904d7e6b57d82212be4db9745633fd93925f37) | `` squashfsTools: fix build on darwin ``                                        |
| [`8cf10a71`](https://github.com/NixOS/nixpkgs/commit/8cf10a715a194cee25e675623d47d1de7790e86f) | `` python310Packages.vertica-python: 1.3.1 -> 1.3.2 ``                          |
| [`1e07e548`](https://github.com/NixOS/nixpkgs/commit/1e07e5480d8fceac95be7eaaced4885d1859ed85) | `` digikam: 7.9.0 → 7.10.0 ``                                                   |
| [`dfcc29fe`](https://github.com/NixOS/nixpkgs/commit/dfcc29fe27efff078d2a05a1d579583c0ef2a4e4) | `` pkgsMusl.gtk4: fix build (#228560) ``                                        |