### PR TITLE
chore(flake/nur): `31da946b` -> `80554df8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682739583,
-        "narHash": "sha256-ZMj7KzCAjp5e3iUOjgDBoY8gSbcMAEdhr0I9eOC/Bn8=",
+        "lastModified": 1682750715,
+        "narHash": "sha256-gEIxWYyAbPGqBcEz4VqxQMdIkkqz1vmGwdGFxcSfu4c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "31da946bd4de2657adb9ec9baab975b1a7fa9c3d",
+        "rev": "80554df8fee42170e3f92e5a937a6ab0e771883f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`80554df8`](https://github.com/nix-community/NUR/commit/80554df8fee42170e3f92e5a937a6ab0e771883f) | `` automatic update `` |
| [`a386be1c`](https://github.com/nix-community/NUR/commit/a386be1c94e5f0712e0b0b810d9730beb891254e) | `` automatic update `` |