### PR TITLE
chore(flake/nur): `80554df8` -> `b3b850a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682750715,
-        "narHash": "sha256-gEIxWYyAbPGqBcEz4VqxQMdIkkqz1vmGwdGFxcSfu4c=",
+        "lastModified": 1682751794,
+        "narHash": "sha256-+lo+jlBp5Np2UId6CfAQZdG/yLJLZhtoluMj1NkBlDU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "80554df8fee42170e3f92e5a937a6ab0e771883f",
+        "rev": "b3b850a6da43a794e7fab9566b529ca43e22458a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b3b850a6`](https://github.com/nix-community/NUR/commit/b3b850a6da43a794e7fab9566b529ca43e22458a) | `` automatic update `` |