### PR TITLE
chore(flake/home-manager): `c4f3a370` -> `27d89b49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682712853,
-        "narHash": "sha256-XWgurvKeJsCLOVZZyR2HlPt56mIjbSgoh/Mi6s5RQS4=",
+        "lastModified": 1682759296,
+        "narHash": "sha256-FgBfP1e+TnED0lT3L9G6KJ6j07xQElFMRdLIsmKQ0Ss=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c4f3a3707104999d5b6fe4c4e5c3833980a92513",
+        "rev": "27d89b49e3cd3c83b9609a6ff9173a9b8d2d9ad4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`27d89b49`](https://github.com/nix-community/home-manager/commit/27d89b49e3cd3c83b9609a6ff9173a9b8d2d9ad4) | `` zplug: Update the path of init.zsh (#3922) `` |