### PR TITLE
chore(flake/emacs-overlay): `b04a264d` -> `405d1e75`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682737663,
-        "narHash": "sha256-gXEP1Sy9LrQdD2y7sqQUumJvqiRWX3CJpEEJ9JOBUro=",
+        "lastModified": 1682788987,
+        "narHash": "sha256-DC6Ih040ndwT1cI5Bj2Y10J8BvxBW8abzHOoqhpJu8I=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b04a264d5f566ce27e1d62eeae3eabaaa8e942ef",
+        "rev": "405d1e75811d96bb177dabfe6d813e921866b014",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`405d1e75`](https://github.com/nix-community/emacs-overlay/commit/405d1e75811d96bb177dabfe6d813e921866b014) | `` Updated repos/emacs `` |
| [`038158de`](https://github.com/nix-community/emacs-overlay/commit/038158de4da32a280b1787d34c8f41a2a4cb6a5f) | `` Updated repos/elpa ``  |