### PR TITLE
chore(flake/nur): `8e50ef5a` -> `48fb17ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682797522,
-        "narHash": "sha256-Bxcihc9Li1jUdsTu9ZLgOFqvOaV9ljONwPqU1n250p8=",
+        "lastModified": 1682815231,
+        "narHash": "sha256-IAnkIb1xy2I0DSMngm1Bkjs38UmkHOnOkXcQZEEPd2w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8e50ef5a62e678cb98f1df3e53b7fbd79200578c",
+        "rev": "48fb17ad29652f5bb876f5c78be36e9b8a35127a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`48fb17ad`](https://github.com/nix-community/NUR/commit/48fb17ad29652f5bb876f5c78be36e9b8a35127a) | `` automatic update `` |