### PR TITLE
chore(flake/nixos-hardware): `3006d286` -> `e4a21ddc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -593,11 +593,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1680876084,
-        "narHash": "sha256-eP9yxP0wc7XuVaODugh+ajgbFGaile2O1ihxiLxOuvU=",
+        "lastModified": 1682836095,
+        "narHash": "sha256-PdzpJhuXBz71AgWNWMMYLbB8GMMce6QguhQY/6HOOcc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3006d2860a6ed5e01b0c3e7ffb730e9b293116e2",
+        "rev": "e4a21ddcb45ee5f5c85a5d9e9698debf77fb98c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`0cfe2552`](https://github.com/NixOS/nixos-hardware/commit/0cfe255229e2f617377feaceb3e890d9cf884125) | `` starfive visionfive2: update kernel ``                |
| [`b0fd9625`](https://github.com/NixOS/nixos-hardware/commit/b0fd96252521a42c2c691c7eb0fffb958b6f49b4) | `` starfive visionfive2: update u-boot ``                |
| [`2ce2f3f9`](https://github.com/NixOS/nixos-hardware/commit/2ce2f3f9789a24f4ddd7f925b7b5f67ec8920e33) | `` starfive visionfive2: fix flake check ``              |
| [`16d6b81a`](https://github.com/NixOS/nixos-hardware/commit/16d6b81a4760d9a4991bcd99b6351e182059cdc5) | `` starfive visionfive2: Fix cross compilation ``        |
| [`f5298eb1`](https://github.com/NixOS/nixos-hardware/commit/f5298eb1d7be19f8651649cbdf16068b6ce7ad50) | `` starfive visionfive2: Fix kernel on nixos-unstable `` |
| [`4fb7708a`](https://github.com/NixOS/nixos-hardware/commit/4fb7708a20fc1f6ba5de3d3767efed34979c2f56) | `` starfive visionfive2: Update spl_tool ``              |
| [`7b2aec99`](https://github.com/NixOS/nixos-hardware/commit/7b2aec9939065fe56e424a47164906de721c9c84) | `` starfive visionfive2: Fix deviceTree name ``          |
| [`34f96de8`](https://github.com/NixOS/nixos-hardware/commit/34f96de8c9ad390d8717e3ca6260afd5f500de04) | `` starfive-visionfive2: add to README ``                |
| [`82ae8a31`](https://github.com/NixOS/nixos-hardware/commit/82ae8a31ae0ff64c0b6c603634f41a4472cce657) | `` starfive-visionfive2: Add README.md ``                |
| [`0cc12142`](https://github.com/NixOS/nixos-hardware/commit/0cc1214203def995d0863a389bbbe002c24a377f) | `` Init starfive visionfive 2 ``                         |