### PR TITLE
chore(flake/emacs-overlay): `e9e67599` -> `0b6c10ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682822669,
-        "narHash": "sha256-Nbi12MqbtiItv2iwv5UAT5H5lOpESKYZoRan3PW75TY=",
+        "lastModified": 1682846727,
+        "narHash": "sha256-efEp8ziqbj/tdd46qRpaSf7elgNJ48W3x5xLiWRDDAE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e9e67599cda6f57f37178fd33ccff86cc2c2d6c4",
+        "rev": "0b6c10ab19e79fd85c1bb3ea29c38eb5db464e0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`0b6c10ab`](https://github.com/nix-community/emacs-overlay/commit/0b6c10ab19e79fd85c1bb3ea29c38eb5db464e0c) | `` Updated repos/emacs `` |