### PR TITLE
chore(flake/emacs-overlay): `0b6c10ab` -> `ff0f8af5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682846727,
-        "narHash": "sha256-efEp8ziqbj/tdd46qRpaSf7elgNJ48W3x5xLiWRDDAE=",
+        "lastModified": 1682871454,
+        "narHash": "sha256-NiozRbgHVHg5WXmcQVOABzKGTVgsLPE2k9VTudd+LoY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0b6c10ab19e79fd85c1bb3ea29c38eb5db464e0c",
+        "rev": "ff0f8af5d4f511adf3a3252d1c09bfdc1912e8c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                  |
| ------------------------------------------------------------------------------------------------------------ | ------------------------ |
| [`ff0f8af5`](https://github.com/nix-community/emacs-overlay/commit/ff0f8af5d4f511adf3a3252d1c09bfdc1912e8c6) | `` Updated repos/elpa `` |