### PR TITLE
chore(flake/nur): `57e82297` -> `920f1974`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682879890,
-        "narHash": "sha256-gnNDKsgsLX0dxumLDTuFylSRVvscErxRa0425gUk5Xk=",
+        "lastModified": 1682887580,
+        "narHash": "sha256-EjIGXbW+ZOq329YdvwJuY8GASeQ2bwnAvDNabqPUAGA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "57e8229760e718f670cd7b359b509246e6d734ab",
+        "rev": "920f197481e30dd68180e63b4ea18ac16d6cefea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`920f1974`](https://github.com/nix-community/NUR/commit/920f197481e30dd68180e63b4ea18ac16d6cefea) | `` automatic update `` |
| [`5c80b6a1`](https://github.com/nix-community/NUR/commit/5c80b6a1dec92e39e106e0db4a0f7e1ac3768d02) | `` automatic update `` |