### PR TITLE
chore(flake/nur): `1a370a03` -> `7bbba03e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682898338,
-        "narHash": "sha256-wJXiIQ71Tu8YY8p8Pa9QeugyHnIZUy4vywLB7zahGnc=",
+        "lastModified": 1682901603,
+        "narHash": "sha256-LXUkup9za/GyIg+xjWlmtUS/nuhgVJQR9vjeBmfJ+JQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1a370a0375726be55b68b09f4d57fa7569fefc71",
+        "rev": "7bbba03ebfe1163a1cbfae3358abd307709751ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7bbba03e`](https://github.com/nix-community/NUR/commit/7bbba03ebfe1163a1cbfae3358abd307709751ba) | `` automatic update `` |