### PR TITLE
chore(flake/nur): `3b9157cd` -> `65020354`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682914315,
-        "narHash": "sha256-eKOPnLa9VlMdMGfN2M8ctj5A/tfHCxROqKwr/kDzhBE=",
+        "lastModified": 1682923190,
+        "narHash": "sha256-c/VngL/4eku/EhXX9cfw+MC5GoikKR17ZSbFJRbxGl8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3b9157cdffafef7c911a29a643d181d427ad7315",
+        "rev": "65020354709d1b5d88327a0bd170e0a95872c6b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                               |
| -------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`f34c0dfe`](https://github.com/nix-community/NUR/commit/f34c0dfe5698d57a9d1390009226e5ed448e8a86) | `` nur/index: fix meta no longer beeing available ``  |
| [`0189fdc3`](https://github.com/nix-community/NUR/commit/0189fdc31d58183da3c5282a5a0ac6dd6af8b9a5) | `` automatic update ``                                |
| [`022e6afb`](https://github.com/nix-community/NUR/commit/022e6afbf603d18fcf17ae69ff0a0525fed19d4d) | `` re-order imports using ruff ``                     |
| [`8222cf13`](https://github.com/nix-community/NUR/commit/8222cf135b6e8605298f0e726bb01fa7f125ece3) | `` update python ci tooling (add ruff, drop flake8 `` |
| [`466559a0`](https://github.com/nix-community/NUR/commit/466559a0c75902453fc54861382db39bcecf4ca8) | `` nur: print OK if eval worked ``                    |
| [`f8a1c2f3`](https://github.com/nix-community/NUR/commit/f8a1c2f3cfcfa54af85de145367b1e0108c96b8a) | `` nur: add eval command for local testing ``         |
| [`6d46ca7b`](https://github.com/nix-community/NUR/commit/6d46ca7b4b43d0d12bad03257f177dc9dc4658d2) | `` ci/flake.lock: Update ``                           |