### PR TITLE
chore(flake/nur): `65020354` -> `16d0b773`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682923190,
-        "narHash": "sha256-c/VngL/4eku/EhXX9cfw+MC5GoikKR17ZSbFJRbxGl8=",
+        "lastModified": 1682934611,
+        "narHash": "sha256-MjV/vTx8Bv5gVDNQSMftguWs5Zm36t+Dj7X2/UR04+A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "65020354709d1b5d88327a0bd170e0a95872c6b2",
+        "rev": "16d0b773b30f5f0d0887ce8db6f68c0385616b69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`16d0b773`](https://github.com/nix-community/NUR/commit/16d0b773b30f5f0d0887ce8db6f68c0385616b69) | `` automatic update `` |
| [`edd2d797`](https://github.com/nix-community/NUR/commit/edd2d79713004e9bac3f2586637424a6ab8ba1d2) | `` automatic update `` |