### PR TITLE
chore(flake/nur): `45bc162d` -> `3551924f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682959472,
-        "narHash": "sha256-P1GJkkgqu05bMzBsKISBYwX0humHQlKVJSj4qr33/g8=",
+        "lastModified": 1682963119,
+        "narHash": "sha256-M9KJTCpzpCUsGc2GmKNRdS7EK07qSjnsJ3uC6FgLVRY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "45bc162dfc88273186ce57e06d30383956dfbe76",
+        "rev": "3551924f9dcf5692b5d7fbd9e2e2c46bd6c62fb1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3551924f`](https://github.com/nix-community/NUR/commit/3551924f9dcf5692b5d7fbd9e2e2c46bd6c62fb1) | `` automatic update `` |