### PR TITLE
chore(flake/nur): `3551924f` -> `4328ae2a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682963119,
-        "narHash": "sha256-M9KJTCpzpCUsGc2GmKNRdS7EK07qSjnsJ3uC6FgLVRY=",
+        "lastModified": 1682966740,
+        "narHash": "sha256-M0LVTTb245sBT1NWsZ/BPVYrVoznPANu5YMC4GUBryY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3551924f9dcf5692b5d7fbd9e2e2c46bd6c62fb1",
+        "rev": "4328ae2ace77a156f0837f8343259f7c1020ab3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4328ae2a`](https://github.com/nix-community/NUR/commit/4328ae2ace77a156f0837f8343259f7c1020ab3d) | `` automatic update `` |