### PR TITLE
chore(flake/nur): `4328ae2a` -> `69486543`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682966740,
-        "narHash": "sha256-M0LVTTb245sBT1NWsZ/BPVYrVoznPANu5YMC4GUBryY=",
+        "lastModified": 1682970362,
+        "narHash": "sha256-SrivGIhZr8rl136UpPlMY6oYAMDvI1RMcrto1YqilwI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4328ae2ace77a156f0837f8343259f7c1020ab3d",
+        "rev": "694865435f5f375eb5d86e33096d9e527f297bc3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`69486543`](https://github.com/nix-community/NUR/commit/694865435f5f375eb5d86e33096d9e527f297bc3) | `` automatic update `` |