### PR TITLE
chore(flake/nur): `b8d20431` -> `7e3ec2e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682987843,
-        "narHash": "sha256-84MB1+yn4sbVcFiYPjUURXSVvFB9s1E5Dp4Fpk5LDj4=",
+        "lastModified": 1682998455,
+        "narHash": "sha256-0oBN9ClMsRqxWha7/Cj+dC8zbmmSeSuhcZBFIFt7rgw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b8d20431e5138798414d91ee86ea7ce8df02e97f",
+        "rev": "7e3ec2e5d189022d7ce4fd7ebe6ad0ef61ae442f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7e3ec2e5`](https://github.com/nix-community/NUR/commit/7e3ec2e5d189022d7ce4fd7ebe6ad0ef61ae442f) | `` automatic update `` |