### PR TITLE
chore(flake/nur): `7e3ec2e5` -> `d889aaa9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1682998455,
-        "narHash": "sha256-0oBN9ClMsRqxWha7/Cj+dC8zbmmSeSuhcZBFIFt7rgw=",
+        "lastModified": 1683002478,
+        "narHash": "sha256-af6LDktTjh3S6jWS2luOla1EW8uic0nFamkLenSvdRM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7e3ec2e5d189022d7ce4fd7ebe6ad0ef61ae442f",
+        "rev": "d889aaa91f9185bce2017679380ee9b233bb1c5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d889aaa9`](https://github.com/nix-community/NUR/commit/d889aaa91f9185bce2017679380ee9b233bb1c5e) | `` automatic update `` |
| [`07d27872`](https://github.com/nix-community/NUR/commit/07d27872a13418ea318d3df1cf078102ade857ba) | `` automatic update `` |