### PR TITLE
chore(flake/nur): `d889aaa9` -> `89f00535`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683002478,
-        "narHash": "sha256-af6LDktTjh3S6jWS2luOla1EW8uic0nFamkLenSvdRM=",
+        "lastModified": 1683007082,
+        "narHash": "sha256-VkIXnMkKaKGlUo9B2V+/mVRLjUwpoGxkazvuJ0DDJ4o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d889aaa91f9185bce2017679380ee9b233bb1c5e",
+        "rev": "89f00535a138b73a23d5a00c0bef6818b462873d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`89f00535`](https://github.com/nix-community/NUR/commit/89f00535a138b73a23d5a00c0bef6818b462873d) | `` automatic update `` |
| [`2136dd6c`](https://github.com/nix-community/NUR/commit/2136dd6c374ea9a723333d7f1b282b34277003fb) | `` automatic update `` |