### PR TITLE
chore(flake/nur): `8b7f0f7b` -> `b756c932`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683013403,
-        "narHash": "sha256-YdA0OiXwWSiN/dj+OsBFlqFoVzH+Cz3Dm1Gbx7Nd8Eg=",
+        "lastModified": 1683024330,
+        "narHash": "sha256-kr+R14eLcnk7BSjl9H2V42jdejIU+VP+t2dnDQLCQ3o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8b7f0f7b8b15dc64458e3b63ccc891d572da0629",
+        "rev": "b756c9324c1b76ad842e5e8a40fce0e4802924f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b756c932`](https://github.com/nix-community/NUR/commit/b756c9324c1b76ad842e5e8a40fce0e4802924f8) | `` automatic update `` |