### PR TITLE
chore(flake/nur): `771b2b90` -> `eb2118cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683042307,
-        "narHash": "sha256-NzMhWnwDoPbJznqjb7Wa6e/OoMBou8WCNYpimPx2eK0=",
+        "lastModified": 1683060374,
+        "narHash": "sha256-6yfeqytI9vCouLTAvFyqlNyRKnmD669Hfk7o00ilnGY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "771b2b9028b19dfd3e7e1ac0173b35b03cd47053",
+        "rev": "eb2118cd4558440844aa1dfff888005c174c4522",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eb2118cd`](https://github.com/nix-community/NUR/commit/eb2118cd4558440844aa1dfff888005c174c4522) | `` automatic update `` |
| [`2fc32d04`](https://github.com/nix-community/NUR/commit/2fc32d04f3a201b972011f37fbc88ed7acc72582) | `` automatic update `` |