### PR TITLE
chore(flake/nur): `eb2118cd` -> `1aa969c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683060374,
-        "narHash": "sha256-6yfeqytI9vCouLTAvFyqlNyRKnmD669Hfk7o00ilnGY=",
+        "lastModified": 1683067464,
+        "narHash": "sha256-vodCb2YbRhDQfE8d9nvfY4zwJJofII2FXwuU9MHJ7Wc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eb2118cd4558440844aa1dfff888005c174c4522",
+        "rev": "1aa969c5e57c76ec8b78e0d21fde0090317eb5a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1aa969c5`](https://github.com/nix-community/NUR/commit/1aa969c5e57c76ec8b78e0d21fde0090317eb5a1) | `` automatic update `` |