### PR TITLE
chore(flake/nur): `d1085178` -> `0e5be7e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683074450,
-        "narHash": "sha256-Il4zmuZCwpnA+R7R3qC6K8/3QjT+HTaUgeeY46tFLJ0=",
+        "lastModified": 1683078751,
+        "narHash": "sha256-+8LLOXlbnYT0aGIFZilGbtWnx3yh3uJEL+VtF0Rm+/E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d10851789cd1320596be456b6e8e38a2aafb8da0",
+        "rev": "0e5be7e7b5c58abdf0200d343be13be6c48bbccb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0e5be7e7`](https://github.com/nix-community/NUR/commit/0e5be7e7b5c58abdf0200d343be13be6c48bbccb) | `` automatic update `` |