### PR TITLE
chore(flake/nur): `0e5be7e7` -> `55268255`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683078751,
-        "narHash": "sha256-+8LLOXlbnYT0aGIFZilGbtWnx3yh3uJEL+VtF0Rm+/E=",
+        "lastModified": 1683085468,
+        "narHash": "sha256-lZZCzx/KNs1TXe4gd2YBwjFAducL4vnlkZ5AC7oUESc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0e5be7e7b5c58abdf0200d343be13be6c48bbccb",
+        "rev": "552682556a5ffaf95abc2d392575a330ee6c9027",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`55268255`](https://github.com/nix-community/NUR/commit/552682556a5ffaf95abc2d392575a330ee6c9027) | `` automatic update `` |
| [`a8996f02`](https://github.com/nix-community/NUR/commit/a8996f02fa5dc7912df35c27cb98fa16255e6b4b) | `` automatic update `` |