### PR TITLE
chore(flake/emacs-overlay): `ca955fac` -> `9ce6881c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683050962,
-        "narHash": "sha256-oQS3k66eZ77PE2dg5UaPn5QFc2v5U5KS3ufxWCG7QRc=",
+        "lastModified": 1683083220,
+        "narHash": "sha256-ne6NK9IyLREtDefOIfV9IqFBpyhzKfXo30iYA+dYl0E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ca955facdc9b29fde6dbd12823b7f4809fc5f18b",
+        "rev": "9ce6881c337289f24f1514cd052141c1552ddde1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`9ce6881c`](https://github.com/nix-community/emacs-overlay/commit/9ce6881c337289f24f1514cd052141c1552ddde1) | `` Updated repos/melpa `` |
| [`f5719229`](https://github.com/nix-community/emacs-overlay/commit/f57192297f370f8f01b1476023ca29caf032b20a) | `` Updated repos/emacs `` |