### PR TITLE
chore(flake/nur): `55268255` -> `69ca9fe4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683085468,
-        "narHash": "sha256-lZZCzx/KNs1TXe4gd2YBwjFAducL4vnlkZ5AC7oUESc=",
+        "lastModified": 1683086893,
+        "narHash": "sha256-DhMF9nlTpA9omc+rp3HX5XeiZeq0wKd8OtkU0tVYRbs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "552682556a5ffaf95abc2d392575a330ee6c9027",
+        "rev": "69ca9fe403403a7a6c2bcf81570e94b056fe46ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`69ca9fe4`](https://github.com/nix-community/NUR/commit/69ca9fe403403a7a6c2bcf81570e94b056fe46ec) | `` automatic update `` |