### PR TITLE
chore(flake/nur): `69ca9fe4` -> `9b5b6235`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683086893,
-        "narHash": "sha256-DhMF9nlTpA9omc+rp3HX5XeiZeq0wKd8OtkU0tVYRbs=",
+        "lastModified": 1683106140,
+        "narHash": "sha256-kteCzvc9+6t46PTbTruP5r+FXqnJl/xoCfteV4CQmGE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "69ca9fe403403a7a6c2bcf81570e94b056fe46ec",
+        "rev": "9b5b623552610c800cfeb24a5b818de77f12e575",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9b5b6235`](https://github.com/nix-community/NUR/commit/9b5b623552610c800cfeb24a5b818de77f12e575) | `` automatic update `` |
| [`790887ec`](https://github.com/nix-community/NUR/commit/790887ec8812fcf92dc72c247daef57a1bf20758) | `` automatic update `` |