### PR TITLE
chore(flake/emacs-overlay): `9ce6881c` -> `8459a591`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683083220,
-        "narHash": "sha256-ne6NK9IyLREtDefOIfV9IqFBpyhzKfXo30iYA+dYl0E=",
+        "lastModified": 1683109148,
+        "narHash": "sha256-vQqbAQw5ASpUh7FWijlOIJaNGWBYy+gdIVXU1r6tTps=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9ce6881c337289f24f1514cd052141c1552ddde1",
+        "rev": "8459a591ac280c044465359d110d981bf46faa7b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`8459a591`](https://github.com/nix-community/emacs-overlay/commit/8459a591ac280c044465359d110d981bf46faa7b) | `` Updated repos/melpa `` |
| [`9eb99c31`](https://github.com/nix-community/emacs-overlay/commit/9eb99c310710d00bf76e310b7911444705305ac1) | `` Updated repos/emacs `` |