### PR TITLE
chore(flake/nur): `948b8e3e` -> `f4da6bd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683110772,
-        "narHash": "sha256-3tNSq5FWu5wU2td5NzYBoA+J+kjFUKUO42j9LfK7pG4=",
+        "lastModified": 1683117267,
+        "narHash": "sha256-ixbO5/XAo3OxRcLXc48MFk2iouo2UxdJPAkQ6pndymU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "948b8e3ee6aa175f99ac00d56f318178651c3ccf",
+        "rev": "f4da6bd7b6934fc82080910e8fc43e2f417dedc7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f4da6bd7`](https://github.com/nix-community/NUR/commit/f4da6bd7b6934fc82080910e8fc43e2f417dedc7) | `` automatic update `` |