### PR TITLE
chore(flake/nur): `f4da6bd7` -> `bf213c6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683117267,
-        "narHash": "sha256-ixbO5/XAo3OxRcLXc48MFk2iouo2UxdJPAkQ6pndymU=",
+        "lastModified": 1683123657,
+        "narHash": "sha256-/RRubLn+P61uwruoELBD/xZtwdyjgLUH0YosbiV67lc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f4da6bd7b6934fc82080910e8fc43e2f417dedc7",
+        "rev": "bf213c6f18981ae52cc11d5fc07f8e94c9f5755e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bf213c6f`](https://github.com/nix-community/NUR/commit/bf213c6f18981ae52cc11d5fc07f8e94c9f5755e) | `` automatic update `` |