### PR TITLE
chore(flake/nur): `bf213c6f` -> `f51fd412`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683123657,
-        "narHash": "sha256-/RRubLn+P61uwruoELBD/xZtwdyjgLUH0YosbiV67lc=",
+        "lastModified": 1683128519,
+        "narHash": "sha256-p8dIEyBP/s5Xu2Jqm76dsy5NfXx9tunLQwumbYrKGKk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bf213c6f18981ae52cc11d5fc07f8e94c9f5755e",
+        "rev": "f51fd41299fa4d7f5228e1a4ffb7f7157d1301cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f51fd412`](https://github.com/nix-community/NUR/commit/f51fd41299fa4d7f5228e1a4ffb7f7157d1301cc) | `` automatic update `` |