### PR TITLE
chore(flake/emacs-overlay): `8459a591` -> `38cedeb8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683109148,
-        "narHash": "sha256-vQqbAQw5ASpUh7FWijlOIJaNGWBYy+gdIVXU1r6tTps=",
+        "lastModified": 1683137941,
+        "narHash": "sha256-dkKL3WpEebaZRBqWzCzmwFYwx/787f6sxvxPizbisk8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8459a591ac280c044465359d110d981bf46faa7b",
+        "rev": "38cedeb83b1ecc5ead82e6fe943dc3473627f3f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`38cedeb8`](https://github.com/nix-community/emacs-overlay/commit/38cedeb83b1ecc5ead82e6fe943dc3473627f3f6) | `` Updated repos/melpa `` |
| [`66321c1f`](https://github.com/nix-community/emacs-overlay/commit/66321c1feed738c78bae6462fbbf18379fea2678) | `` Updated repos/emacs `` |