### PR TITLE
chore(flake/nur): `f51fd412` -> `bb6771b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683128519,
-        "narHash": "sha256-p8dIEyBP/s5Xu2Jqm76dsy5NfXx9tunLQwumbYrKGKk=",
+        "lastModified": 1683138362,
+        "narHash": "sha256-e/H70nFp5YyVt43LnQj3jghSB1WSvGIAfzkbCH/bz4A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f51fd41299fa4d7f5228e1a4ffb7f7157d1301cc",
+        "rev": "bb6771b32975fd6196770856f02bdc52eed05c8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bb6771b3`](https://github.com/nix-community/NUR/commit/bb6771b32975fd6196770856f02bdc52eed05c8b) | `` automatic update `` |