### PR TITLE
chore(flake/nur): `ce762dfb` -> `f2e47c42`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683153915,
-        "narHash": "sha256-uyzsFVEq3q5ExZ5fNCk96q9gUM0oVPzTfR8E5+NBlg0=",
+        "lastModified": 1683160589,
+        "narHash": "sha256-AFCY70GvoCgQFx0eFMAOmQXeUkErugTCKoskbBfaPw4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ce762dfb328b70a5f835c56686c78885560481c4",
+        "rev": "f2e47c4223ad609237b66e1ebcfd0b29a499d63f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f2e47c42`](https://github.com/nix-community/NUR/commit/f2e47c4223ad609237b66e1ebcfd0b29a499d63f) | `` automatic update `` |
| [`a3048dad`](https://github.com/nix-community/NUR/commit/a3048dad6547d06dca79a9ed0d1d4379a41c2b00) | `` automatic update `` |