### PR TITLE
chore(flake/emacs-overlay): `38cedeb8` -> `42a2a718`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683137941,
-        "narHash": "sha256-dkKL3WpEebaZRBqWzCzmwFYwx/787f6sxvxPizbisk8=",
+        "lastModified": 1683170309,
+        "narHash": "sha256-+APLd91AIU491eFp4qf66jnRacFfSqhwW438LNJUlls=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "38cedeb83b1ecc5ead82e6fe943dc3473627f3f6",
+        "rev": "42a2a718bdcbe389e7ef284666d4aba09339a416",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`42a2a718`](https://github.com/nix-community/emacs-overlay/commit/42a2a718bdcbe389e7ef284666d4aba09339a416) | `` Updated repos/melpa `` |
| [`afb6411e`](https://github.com/nix-community/emacs-overlay/commit/afb6411ee8d3a8162ad8773162c031cb7c40383e) | `` Updated repos/emacs `` |