### PR TITLE
chore(flake/nur): `82a30341` -> `9053acaf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683183829,
-        "narHash": "sha256-Ta7qCL+mWSBt3851GYtbJpuAcCfNvNxD+MqfK+Yj4RU=",
+        "lastModified": 1683190321,
+        "narHash": "sha256-yeqpcLr1MMOtniMdG8CtQr85YLibXLLydlvefm+X2HE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "82a30341dc98d46808ea11ba932e95856e53452c",
+        "rev": "9053acaf1b3ba50c2e3c95db757d21aa3954660e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                        |
| -------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`9053acaf`](https://github.com/nix-community/NUR/commit/9053acaf1b3ba50c2e3c95db757d21aa3954660e) | `` automatic update ``         |
| [`edcdc8ea`](https://github.com/nix-community/NUR/commit/edcdc8ea7cf58946cc61f1a3424fdde8047cf399) | `` automatic update ``         |
| [`2d3aab65`](https://github.com/nix-community/NUR/commit/2d3aab65aa50e87e12a2aa50a6049bda3e76aaef) | `` add colinsane repository `` |