### PR TITLE
chore(flake/nur): `1ae3a000` -> `add486fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683196661,
-        "narHash": "sha256-qbi+rFdYjOkaRy7/1ZMdHVUbtHGicuuM3AuKFVm67+4=",
+        "lastModified": 1683202836,
+        "narHash": "sha256-nJzTO2qn77b3AfCtV/J97hL/UiOzxRcS/6CfuSuvHS8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1ae3a000239353faed18a42a89f8781550be2b27",
+        "rev": "add486fbd0f36ee2bfc77cb2f6e1124d38dba04b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`add486fb`](https://github.com/nix-community/NUR/commit/add486fbd0f36ee2bfc77cb2f6e1124d38dba04b) | `` automatic update `` |
| [`839dc1c1`](https://github.com/nix-community/NUR/commit/839dc1c1a3a7b12663cc24f42096b3036efa925d) | `` automatic update `` |