### PR TITLE
chore(flake/nur): `2e3b7571` -> `86bceed8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683211490,
-        "narHash": "sha256-iG5fjod5PvlNeDc1qLnVehg7mj1FUiSJxSmW8NUgCkY=",
+        "lastModified": 1683229489,
+        "narHash": "sha256-nYo+WbU2Cz3rJVVTyngN0jMeobhL2r7Kbs9QjaheTGo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2e3b75718d66135b437166862a0e10a391832339",
+        "rev": "86bceed8878e4419aac37ad913fb1cec0818c3f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`86bceed8`](https://github.com/nix-community/NUR/commit/86bceed8878e4419aac37ad913fb1cec0818c3f6) | `` automatic update `` |
| [`be4d9f13`](https://github.com/nix-community/NUR/commit/be4d9f13946e4969632f20d735eac722ad582029) | `` automatic update `` |
| [`7d87e759`](https://github.com/nix-community/NUR/commit/7d87e759974e12539915985e2eeed7641113e4da) | `` automatic update `` |
| [`7e8650cf`](https://github.com/nix-community/NUR/commit/7e8650cf100a41b938d4557823b0c3ab409200e5) | `` automatic update `` |