### PR TITLE
chore(flake/emacs-overlay): `e0902043` -> `ea185dc2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683221311,
-        "narHash": "sha256-UuiPrML5Acp1lyH88IQUnNSKLfTLDQ3KxciTuQXGWmM=",
+        "lastModified": 1683255279,
+        "narHash": "sha256-KlWoELN3mQ5bBcYQiqPvPHm7cQ0NLcsJG3GwnHTr/UE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e0902043a891c61adcca88b7697ce322022a2663",
+        "rev": "ea185dc25842517a953ffa3669dc5c42a3537461",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ea185dc2`](https://github.com/nix-community/emacs-overlay/commit/ea185dc25842517a953ffa3669dc5c42a3537461) | `` Updated repos/nongnu `` |
| [`24984a17`](https://github.com/nix-community/emacs-overlay/commit/24984a172baa197143d5983e9ab1b0e4cff72b30) | `` Updated repos/melpa ``  |
| [`6531e307`](https://github.com/nix-community/emacs-overlay/commit/6531e30704d09a017096945087cf8cfbdda0ce8a) | `` Updated repos/emacs ``  |