### PR TITLE
chore(flake/deploy-rs): `c2ea4e64` -> `6b0b6a1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -214,11 +214,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682063650,
-        "narHash": "sha256-VaDHh2z6xlnTHaONlNVHP7qEMcK5rZ8Js3sT6mKb2XY=",
+        "lastModified": 1683255183,
+        "narHash": "sha256-UUxpb5PMkFfP2JGoPMEUvKbxv+wCkTWy4uZs1MyyCes=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "c2ea4e642dc50fd44b537e9860ec95867af30d39",
+        "rev": "6b0b6a1c2527e8b1ef370a308b6ef8903004ac47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                                  |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`784e9ee2`](https://github.com/serokell/deploy-rs/commit/784e9ee24d977c99dcb5ba5aef81dae48cb899fb) | `` [Chore] Handle 'temp_path' as an actual 'Path' instead of 'String' `` |