### PR TITLE
chore(flake/nur): `81613fad` -> `b7cb242a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683252000,
-        "narHash": "sha256-B3ZA5fWV3coVUbCpbyUEkmC6CqTnXIqarhUcZV79cac=",
+        "lastModified": 1683258264,
+        "narHash": "sha256-Mj+O3eYX0CxpZCq1BH8MxRFk6AVKWL3Oh7b3fVyqgKE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "81613fadb39e86a0f888f8e0b9dd32e8e979db45",
+        "rev": "b7cb242a628215c1611229efd3be6b082c67b92c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b7cb242a`](https://github.com/nix-community/NUR/commit/b7cb242a628215c1611229efd3be6b082c67b92c) | `` automatic update `` |
| [`bea3b62b`](https://github.com/nix-community/NUR/commit/bea3b62b247b4b1b412a6ee7cc71d41ee67461d7) | `` automatic update `` |