### PR TITLE
chore(flake/nur): `b7cb242a` -> `10e83ede`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683258264,
-        "narHash": "sha256-Mj+O3eYX0CxpZCq1BH8MxRFk6AVKWL3Oh7b3fVyqgKE=",
+        "lastModified": 1683265533,
+        "narHash": "sha256-dXgC28VT74nLUXwwDDW3d3tg3zh9Rchx0NfJ2XsswqM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b7cb242a628215c1611229efd3be6b082c67b92c",
+        "rev": "10e83ede8b514d24b8ea82e43be4e02d181a9678",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`10e83ede`](https://github.com/nix-community/NUR/commit/10e83ede8b514d24b8ea82e43be4e02d181a9678) | `` automatic update `` |
| [`7496586e`](https://github.com/nix-community/NUR/commit/7496586e9fde9c5ec9c34f314e3d13f11a4ee1a9) | `` automatic update `` |