### PR TITLE
chore(flake/nixos-hardware): `7dc46304` -> `a2018d33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -593,11 +593,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1683009613,
-        "narHash": "sha256-jJh8JaoHOLlk7iFLgZk1PlxCCNA2KTKfOLMLCa9mduA=",
+        "lastModified": 1683267783,
+        "narHash": "sha256-Jmk0MUq25f0Za2OWvEEWJiL6QQ5zSNj0HgfkuCSrngA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "7dc46304675f4ff2d6be921ef60883efd31363c4",
+        "rev": "a2018d339145984d38757b51739a9c826fdb738f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`31f8d1c3`](https://github.com/NixOS/nixos-hardware/commit/31f8d1c36431153b98606e0b0c4427140ab8dc69) | `` Added Lenovo Thinkpad x390 ``                           |
| [`adab6fd8`](https://github.com/NixOS/nixos-hardware/commit/adab6fd8e96ee67f8b7afbf91a7e990694d76e52) | `` hardkernel/odroid-hc4: fix fancontrol on 5.15 kernel `` |