### PR TITLE
chore(flake/nixos-hardware): `a2018d33` -> `51559e69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -593,11 +593,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1683267783,
-        "narHash": "sha256-Jmk0MUq25f0Za2OWvEEWJiL6QQ5zSNj0HgfkuCSrngA=",
+        "lastModified": 1683269598,
+        "narHash": "sha256-KNsb+nBbB1Fmxd07dt4E0KXMT4YeKJB7gQaA6Xfk+mo=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "a2018d339145984d38757b51739a9c826fdb738f",
+        "rev": "51559e691f1493a26f94f1df1aaf516bb507e78b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`db08b1f1`](https://github.com/NixOS/nixos-hardware/commit/db08b1f13fe125d3dfeac89745ea3f362442eede) | `` tests: fix conflicts with profiles using grub `` |
| [`d626c3f8`](https://github.com/NixOS/nixos-hardware/commit/d626c3f873e20e56f59bea88430f83328a355933) | `` add missing nxp boards ``                        |