### PR TITLE
chore(flake/nur): `10e83ede` -> `4dfe38b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683265533,
-        "narHash": "sha256-dXgC28VT74nLUXwwDDW3d3tg3zh9Rchx0NfJ2XsswqM=",
+        "lastModified": 1683279897,
+        "narHash": "sha256-iVDg5FSmFwriLuuYF9r3Jmjy2SEnbgifelm6D6aPICo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "10e83ede8b514d24b8ea82e43be4e02d181a9678",
+        "rev": "4dfe38b74d52259176d8649e187488cb8c2614c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4dfe38b7`](https://github.com/nix-community/NUR/commit/4dfe38b74d52259176d8649e187488cb8c2614c8) | `` automatic update `` |
| [`6bde26f8`](https://github.com/nix-community/NUR/commit/6bde26f8a3b4c8e203232a7ff77678408f590dde) | `` automatic update `` |
| [`e86a3f04`](https://github.com/nix-community/NUR/commit/e86a3f0458a5db685782971f94e876292758b565) | `` automatic update `` |