### PR TITLE
chore(flake/nur): `cd2b5afc` -> `0f4a8873`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683305135,
-        "narHash": "sha256-ovnkM6b/2pqGGMOLgaBS/Pe6t3cw5R5Eys0nOt+7FRA=",
+        "lastModified": 1683319528,
+        "narHash": "sha256-5sHLy/lzcUZG/0okPWCv74gfjN07PR3PiCu29SdUcGU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cd2b5afc272a338ea506adc78b5b6a7a4445ceed",
+        "rev": "0f4a887323828e19052addec3b8c3163b36b76a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0f4a8873`](https://github.com/nix-community/NUR/commit/0f4a887323828e19052addec3b8c3163b36b76a5) | `` automatic update `` |