### PR TITLE
chore(flake/nur): `0f4a8873` -> `ab9b4594`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683319528,
-        "narHash": "sha256-5sHLy/lzcUZG/0okPWCv74gfjN07PR3PiCu29SdUcGU=",
+        "lastModified": 1683326739,
+        "narHash": "sha256-Jwyb+x/DmCwgNsyczrb0anrB7HobVzQvDZf7KFgc6Vw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0f4a887323828e19052addec3b8c3163b36b76a5",
+        "rev": "ab9b459472e72eced8f593d5c3368643d5c29ad6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ab9b4594`](https://github.com/nix-community/NUR/commit/ab9b459472e72eced8f593d5c3368643d5c29ad6) | `` automatic update `` |