### PR TITLE
chore(flake/nur): `ab9b4594` -> `c8235601`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683326739,
-        "narHash": "sha256-Jwyb+x/DmCwgNsyczrb0anrB7HobVzQvDZf7KFgc6Vw=",
+        "lastModified": 1683330335,
+        "narHash": "sha256-IunYfxuutivKideTDYoyK8pDQG8aNTv8wrpcIRx4z1g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ab9b459472e72eced8f593d5c3368643d5c29ad6",
+        "rev": "c8235601459998f5e703bff0125d33986d49d489",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c8235601`](https://github.com/nix-community/NUR/commit/c8235601459998f5e703bff0125d33986d49d489) | `` automatic update `` |