### PR TITLE
chore(flake/nur): `c08219c0` -> `3388470f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683333309,
-        "narHash": "sha256-tLXPuzvpvzDYWIoA69CssG4e+AU53Pgzx6gIbTd5LKg=",
+        "lastModified": 1683343930,
+        "narHash": "sha256-DZXh8C99E8CArLCYqOV9SknBU9rbYYZzFaY2uREnWyU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c08219c085d267b990aa65b7451be1463d8b74b3",
+        "rev": "3388470f553e9b86efdc3eb0da373b781206d1e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3388470f`](https://github.com/nix-community/NUR/commit/3388470f553e9b86efdc3eb0da373b781206d1e9) | `` automatic update `` |