### PR TITLE
chore(flake/nur): `3388470f` -> `0b7eca0e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683343930,
-        "narHash": "sha256-DZXh8C99E8CArLCYqOV9SknBU9rbYYZzFaY2uREnWyU=",
+        "lastModified": 1683346230,
+        "narHash": "sha256-y1zqWlxCAco/1MEkG4+kJDAf1fEDYryM5RppqUrPZtQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3388470f553e9b86efdc3eb0da373b781206d1e9",
+        "rev": "0b7eca0e97a57c05f10dd40b0294e3d25f3c1b5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0b7eca0e`](https://github.com/nix-community/NUR/commit/0b7eca0e97a57c05f10dd40b0294e3d25f3c1b5d) | `` automatic update `` |