### PR TITLE
chore(flake/nur): `0b7eca0e` -> `6e4e6322`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683346230,
-        "narHash": "sha256-y1zqWlxCAco/1MEkG4+kJDAf1fEDYryM5RppqUrPZtQ=",
+        "lastModified": 1683351737,
+        "narHash": "sha256-Tlmg23Jm2PzshbGWLevwgbhFUGZiUBF6HCvBW6pENRc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0b7eca0e97a57c05f10dd40b0294e3d25f3c1b5d",
+        "rev": "6e4e63223f2a2a04c408f524525ef72fed61fcba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6e4e6322`](https://github.com/nix-community/NUR/commit/6e4e63223f2a2a04c408f524525ef72fed61fcba) | `` automatic update `` |