### PR TITLE
chore(flake/nur): `6e4e6322` -> `e4eec8ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683351737,
-        "narHash": "sha256-Tlmg23Jm2PzshbGWLevwgbhFUGZiUBF6HCvBW6pENRc=",
+        "lastModified": 1683358363,
+        "narHash": "sha256-VXEyJAmzEYWiem0aZ8WkkqAoOrdN3W68PQZgp7NcLa0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6e4e63223f2a2a04c408f524525ef72fed61fcba",
+        "rev": "e4eec8eeb1185788f97991bc0dfe4b30cf593d2f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e4eec8ee`](https://github.com/nix-community/NUR/commit/e4eec8eeb1185788f97991bc0dfe4b30cf593d2f) | `` automatic update `` |