### PR TITLE
chore(flake/nur): `e4eec8ee` -> `a2b0d6b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683358363,
-        "narHash": "sha256-VXEyJAmzEYWiem0aZ8WkkqAoOrdN3W68PQZgp7NcLa0=",
+        "lastModified": 1683387910,
+        "narHash": "sha256-Z/DdH139kmJ/3DxTvBCsSvY//ktYqE93JBol+P2FmLo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e4eec8eeb1185788f97991bc0dfe4b30cf593d2f",
+        "rev": "a2b0d6b90795358fcf7c9b6e1f0b710c4120f411",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a2b0d6b9`](https://github.com/nix-community/NUR/commit/a2b0d6b90795358fcf7c9b6e1f0b710c4120f411) | `` automatic update `` |