### PR TITLE
chore(flake/nur): `a2b0d6b9` -> `957195ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683387910,
-        "narHash": "sha256-Z/DdH139kmJ/3DxTvBCsSvY//ktYqE93JBol+P2FmLo=",
+        "lastModified": 1683390790,
+        "narHash": "sha256-NPzezpsOeNKMN0nye8VJfvychOKJg3/rKAMGhpb8J/w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a2b0d6b90795358fcf7c9b6e1f0b710c4120f411",
+        "rev": "957195eab78edbec9e4d8ed55980be4078adf225",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`957195ea`](https://github.com/nix-community/NUR/commit/957195eab78edbec9e4d8ed55980be4078adf225) | `` automatic update `` |