### PR TITLE
chore(flake/nur): `b74d9605` -> `5e4ea83c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683397542,
-        "narHash": "sha256-CQRQDvsuMT2Z4JNPM1LHrNOx0tzDJZVyPdT81r79dt8=",
+        "lastModified": 1683401891,
+        "narHash": "sha256-6NprhPP1LsCFBXnQSTO073YknpW/l10gkhrgUdqHSQA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b74d96056e5d7977c566c79dcfdd7786fd0f068a",
+        "rev": "5e4ea83c7afd24f3902a3ce70e2468f34257614e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5e4ea83c`](https://github.com/nix-community/NUR/commit/5e4ea83c7afd24f3902a3ce70e2468f34257614e) | `` automatic update `` |