### PR TITLE
chore(flake/nur): `5e4ea83c` -> `dc91b6f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683401891,
-        "narHash": "sha256-6NprhPP1LsCFBXnQSTO073YknpW/l10gkhrgUdqHSQA=",
+        "lastModified": 1683407259,
+        "narHash": "sha256-GmeE6mQ0WPxyto3kCW3HvnYyrBDeBNBtw+Rqg94e5pY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5e4ea83c7afd24f3902a3ce70e2468f34257614e",
+        "rev": "dc91b6f918cc38f3cd4fff987be969bfc514ce4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dc91b6f9`](https://github.com/nix-community/NUR/commit/dc91b6f918cc38f3cd4fff987be969bfc514ce4f) | `` automatic update `` |
| [`1851b114`](https://github.com/nix-community/NUR/commit/1851b114004251c9df3df9e67abbbb3e83f3b57b) | `` automatic update `` |