### PR TITLE
chore(flake/emacs-overlay): `1f1b95c4` -> `21d40b52`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683396944,
-        "narHash": "sha256-4hDwgwijwsviqwSmtUEZHtrCAoMGLfNpGxtyd+33G/s=",
+        "lastModified": 1683429207,
+        "narHash": "sha256-P75AnuDwLX/JqL8QQTX/Zp+ASe2qnCCwBd32+QKa1Qo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1f1b95c4fca959fac6dad0e0a7156bd9f0b2071e",
+        "rev": "21d40b527260498eeb9aed8d2200e4f79d6b152c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`21d40b52`](https://github.com/nix-community/emacs-overlay/commit/21d40b527260498eeb9aed8d2200e4f79d6b152c) | `` Updated repos/nongnu `` |
| [`3b885f77`](https://github.com/nix-community/emacs-overlay/commit/3b885f77c366a83f021375bf7252185bc1c914d5) | `` Updated repos/melpa ``  |
| [`8522f60c`](https://github.com/nix-community/emacs-overlay/commit/8522f60ce0d7900ccb604b42e4c397e54d9387a6) | `` Updated repos/emacs ``  |
| [`0fdaa4ae`](https://github.com/nix-community/emacs-overlay/commit/0fdaa4ae06d2e9c534841d6b91c2d2aa99d9c2ac) | `` Updated repos/elpa ``   |