### PR TITLE
chore(flake/attic): `171c89fb` -> `5f85e35a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1681335578,
-        "narHash": "sha256-yIZqE6WpkgAllsJ7IAbn8k6IRz/0CS/xp6IR+8yrEP8=",
+        "lastModified": 1683433501,
+        "narHash": "sha256-9L+OZeU3bcNZ55mhMINBxnqskbaEU0mhiZIMhkEtNl0=",
         "owner": "zhaofengli",
         "repo": "attic",
-        "rev": "171c89fbe0f099e8bf6e466a1a1a12578f703f0e",
+        "rev": "5f85e35a25085b75e1cbb6cc7291726fa4fab2ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                             |
| ------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`5f85e35a`](https://github.com/zhaofengli/attic/commit/5f85e35a25085b75e1cbb6cc7291726fa4fab2ed) | `` feat: Build & Push images as part of CI (#44) `` |