### PR TITLE
chore(flake/nur): `2305adfd` -> `f4faba8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683432572,
-        "narHash": "sha256-GPi990XR/OvHghGj2nZaxp/7m4LxTjlYuD77FsGjCrQ=",
+        "lastModified": 1683444851,
+        "narHash": "sha256-EUK0AzZ2ykvSbVC05kxIwOOyaf4q/2eZKTO2ylRa3z4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2305adfd63c885defb4d8c81e1e813d1a7e83331",
+        "rev": "f4faba8ad29afdc8e759a592289f4583116276d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f4faba8a`](https://github.com/nix-community/NUR/commit/f4faba8ad29afdc8e759a592289f4583116276d6) | `` automatic update `` |
| [`5124ebc8`](https://github.com/nix-community/NUR/commit/5124ebc82d8eb1c54eac3f6d16c34b0e0213456e) | `` automatic update `` |