### PR TITLE
chore(flake/nixpkgs): `3e313808` -> `897876e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -718,11 +718,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1683286087,
-        "narHash": "sha256-xseOd7W7xwF5GOF2RW8qhjmVGrKoBz+caBlreaNzoeI=",
+        "lastModified": 1683408522,
+        "narHash": "sha256-9kcPh6Uxo17a3kK3XCHhcWiV1Yu1kYj22RHiymUhMkU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e313808bd2e0a0669430787fb22e43b2f4bf8bf",
+        "rev": "897876e4c484f1e8f92009fd11b7d988a121a4e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                  |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
| [`81f51312`](https://github.com/NixOS/nixpkgs/commit/81f5131292ebf17115c2367fe02e15ff3b59738a) | `` yatas: 1.3.3 -> 1.5.1 ``                                                                              |
| [`56749016`](https://github.com/NixOS/nixpkgs/commit/567490160158d4ffe870a62ae8ed58c271279a67) | `` Revert "nixos/qemu-vm: fix diskless VMs" ``                                                           |
| [`dd6726df`](https://github.com/NixOS/nixpkgs/commit/dd6726df6cc90532300cdac87ad229cc30d9e8ad) | `` realesrgan-ncnn-vulkan: drop redundant libgcc dependency ``                                           |
| [`89abc99d`](https://github.com/NixOS/nixpkgs/commit/89abc99d5b6351b2984c6126ef3bda7929905cb9) | `` python310Packages.polars: 0.15.13 -> 0.17.11 ``                                                       |
| [`4fdd191d`](https://github.com/NixOS/nixpkgs/commit/4fdd191d657239832938a58cf008f4f3f1e28f05) | `` verilog-12.0: installCheckPhase on supported arch ``                                                  |
| [`16b3b0c5`](https://github.com/NixOS/nixpkgs/commit/16b3b0c53b1ee8936739f8c588544e7fcec3fc60) | `` nixos/tests/kavita: init ``                                                                           |
| [`e2854d33`](https://github.com/NixOS/nixpkgs/commit/e2854d332d34310763b60ade9d86bcedfac99e5c) | `` nixos/kavita: init ``                                                                                 |
| [`76de0ec7`](https://github.com/NixOS/nixpkgs/commit/76de0ec7503baca369fb7714075eb2dba05c7a93) | `` kavita: init at 0.7.1.4 ``                                                                            |
| [`ff573fb2`](https://github.com/NixOS/nixpkgs/commit/ff573fb2adc8fb9baa67308843c04e2f8f4d0db4) | `` tandoor-recipes: frontend: 'nodejs_16' -> 'nodejs' ``                                                 |
| [`03ad8569`](https://github.com/NixOS/nixpkgs/commit/03ad8569fd648be154c4258d8d3c02ee7e28bed6) | `` verilog-12.0: temp disable regression test suite ``                                                   |
| [`eab660d9`](https://github.com/NixOS/nixpkgs/commit/eab660d91e5d7a2796bc6e4b94b5939ed593db29) | `` lib.modules: configurationClass -> class ``                                                           |
| [`89491bef`](https://github.com/NixOS/nixpkgs/commit/89491bef8dc72496812d94c32b5fdd962cbbe1f6) | `` lib.modules: in evalModules return move _module.class -> configurationClass ``                        |
| [`4c7aa7d8`](https://github.com/NixOS/nixpkgs/commit/4c7aa7d831aa691a7331967a4a839b1088a48493) | `` doc/module-system: `_module` is not internal ``                                                       |
| [`fd88c794`](https://github.com/NixOS/nixpkgs/commit/fd88c79418bbb26758a89d111f136abdc8825acd) | `` lib.modules: Change class declaration in module to _class ``                                          |
| [`7459c024`](https://github.com/NixOS/nixpkgs/commit/7459c024950282da952d43762ad93ff30995cc6a) | `` lib/tests/modules.sh: Add submodule + class tests ``                                                  |
| [`80547851`](https://github.com/NixOS/nixpkgs/commit/8054785157119ea12e526481924d6676427904bb) | `` lib/modules: Move class out of specialArgs ``                                                         |
| [`8f02e95a`](https://github.com/NixOS/nixpkgs/commit/8f02e95aff2b9cb94470ec379e2a3f55858cb03d) | `` module-system.chapter.md: Elaborate on extendModules performance ``                                   |
| [`5fac3930`](https://github.com/NixOS/nixpkgs/commit/5fac39307dc75586d93e69920c4b837e277f0c85) | `` module-system.chapter.md: Add mental model to `type` and `extendModules` ``                           |
| [`73f584c3`](https://github.com/NixOS/nixpkgs/commit/73f584c3cc20015bfd1c4c72ebc6240897c10e48) | `` lib/modules.nix: Deduplicate documentation ``                                                         |
| [`03a465f0`](https://github.com/NixOS/nixpkgs/commit/03a465f0489ce35c86606dd5ef7dffa877c91dde) | `` fixup! doc: Add Module System chapter start ``                                                        |
| [`ee1e14be`](https://github.com/NixOS/nixpkgs/commit/ee1e14be0c8789745986698950e32f5946a7d272) | `` doc: Add Module System chapter start ``                                                               |
| [`79703eef`](https://github.com/NixOS/nixpkgs/commit/79703eef083d70046873dbb86f08e2ff08f58197) | `` nixos,nixpkgs: Add module classes ``                                                                  |
| [`84b1b017`](https://github.com/NixOS/nixpkgs/commit/84b1b017026bb1d0a37a8d3ef553f073225b4e8d) | `` lib/modules: Only interpret class declaration in non-shorthand mode ``                                |
| [`1f4a58ef`](https://github.com/NixOS/nixpkgs/commit/1f4a58ef038184eaf4757e96ec1f09b08a01c8ab) | `` lib/modules.nix: Refactor: extract applyModuleArgs ``                                                 |
| [`06ca7866`](https://github.com/NixOS/nixpkgs/commit/06ca78663c912eb62075ad4aea1f24c7f35cb0c3) | `` lib/modules.nix: Refactor: evaluate applyModuleArgsIfFunction in attrs case ``                        |
| [`439f6790`](https://github.com/NixOS/nixpkgs/commit/439f6790bd6e133c125935a8a2007227f671a360) | `` lib/modules.nix: Restore old collectModules interface ``                                              |
| [`9714487f`](https://github.com/NixOS/nixpkgs/commit/9714487f743d0ac9aec50a5513cb89a97932d4a6) | `` lib/modules: Explain that a configuration can't be loaded as a module ``                              |
| [`2e689d58`](https://github.com/NixOS/nixpkgs/commit/2e689d58cbbe6b7047bb132dc79097016e606dd0) | `` lib/modules: Improve error when a configuration is imported ``                                        |
| [`58f385f6`](https://github.com/NixOS/nixpkgs/commit/58f385f68005a6fed7b526ee2c19fef11d87038c) | `` lib/modules: Check against importing things with a _type ``                                           |
| [`b8ff2807`](https://github.com/NixOS/nixpkgs/commit/b8ff2807a29861236a7ac3ed01c4565ba725e1b1) | `` lib/modules: Add class concept to check imports ``                                                    |
| [`3633bf98`](https://github.com/NixOS/nixpkgs/commit/3633bf98be70af326056ebc87a9adedd0e8a24c7) | `` lib/modules.nix: Make some functions private ``                                                       |
| [`078a4801`](https://github.com/NixOS/nixpkgs/commit/078a4801bf01345267e1a7a6bd14c0a628af5598) | `` python3Packages.nikola: enable on darwin ``                                                           |
| [`fe152793`](https://github.com/NixOS/nixpkgs/commit/fe1527939038ac964df2028e6b90c35121db9955) | `` lib/modules.nix: Use explicit exports ``                                                              |
| [`e7e64233`](https://github.com/NixOS/nixpkgs/commit/e7e64233c9078f03de13a6d8750c1daaa673a0c2) | `` lib/tests/modules.sh: Unload implicit modules ``                                                      |
| [`5c5a360e`](https://github.com/NixOS/nixpkgs/commit/5c5a360e0884a2de7fb33d0fc57705dd34b9400e) | `` python3Packages.yapsy: use pytest and enable darwin ``                                                |
| [`91158208`](https://github.com/NixOS/nixpkgs/commit/91158208e405f8cd0ec42fd5a35c0169254b02c9) | `` nodePackages.aliases: add missing date comments ``                                                    |
| [`60737bc2`](https://github.com/NixOS/nixpkgs/commit/60737bc2d10325f71b0cbe3ff829265bc5c81c6b) | `` nodePackages.manta: convert to buildNpmPackage ``                                                     |
| [`7048a87e`](https://github.com/NixOS/nixpkgs/commit/7048a87e3cad9d4e9705df692d50143d2e9b2271) | `` nodePackages.triton: convert to buildNpmPackage ``                                                    |
| [`519582d8`](https://github.com/NixOS/nixpkgs/commit/519582d8102088264a34cd6c8142fc2136daafb2) | `` kubescape: 2.3.0 -> 2.3.1 ``                                                                          |
| [`c9581eaf`](https://github.com/NixOS/nixpkgs/commit/c9581eaf4377aca74cd56dceb104edcc77c16429) | `` dnsrecon: 1.1.3 -> 1.1.4 ``                                                                           |
| [`4c713a5e`](https://github.com/NixOS/nixpkgs/commit/4c713a5e90bc9c503a8d81b25c8252dd2c3e5d81) | `` texlab: 5.5.0 -> 5.5.1 ``                                                                             |
| [`dc6fdb6a`](https://github.com/NixOS/nixpkgs/commit/dc6fdb6af3b385bc050915e29fd495f4a5770a1c) | `` i3status-rust: 0.31.1 -> 0.31.2 ``                                                                    |
| [`ca169a29`](https://github.com/NixOS/nixpkgs/commit/ca169a299d5e693da0df6c9e23750d462efb974e) | `` _1password-gui: 8.10.5-10.BETA -> 8.10.6-20.BETA ``                                                   |
| [`ee18e6dd`](https://github.com/NixOS/nixpkgs/commit/ee18e6dd4bc786eed020a3a3bcfd926d0955ffe5) | `` furtherance: 1.6.0 -> 1.7.0 ``                                                                        |
| [`32fc1cea`](https://github.com/NixOS/nixpkgs/commit/32fc1ceac6f57165c1c0bb933d8a0fb475b90d91) | `` qucs-s: 0.0.22 -> 1.0.2 (#223378) ``                                                                  |
| [`4a1e9009`](https://github.com/NixOS/nixpkgs/commit/4a1e9009ad1fdba628c27e068ba1c5176afe0557) | `` anki-bin: add new dependencies ``                                                                     |
| [`18a9f60c`](https://github.com/NixOS/nixpkgs/commit/18a9f60cc420c4fdbb4fc9453a7038e3681c4c23) | `` insomnia: 2022.7.5 -> 2023.2.0 ``                                                                     |
| [`1f5554c2`](https://github.com/NixOS/nixpkgs/commit/1f5554c2273894e20244c7d538b687ba9a7b254b) | `` imaginer: init at 0.1.3 (#230079) ``                                                                  |
| [`00000001`](https://github.com/NixOS/nixpkgs/commit/00000001b4f4a57961f35ba1e0db5a4806a38ba2) | `` treewide: switch builtins.fromJSON(builtins.readFile ./file.json) to lib.importJSON ./file.json #2 `` |
| [`c59c3930`](https://github.com/NixOS/nixpkgs/commit/c59c3930135bc32d4247d577becc05075b140def) | `` segyio: removing unused input ``                                                                      |
| [`dd4c9eec`](https://github.com/NixOS/nixpkgs/commit/dd4c9eec90fdbe392f55b8698560818ebb10b3a3) | `` git: fix installCheck on darwin ``                                                                    |
| [`5d907dda`](https://github.com/NixOS/nixpkgs/commit/5d907dda7cd4617a6faf4f6c02483b226cbc28f3) | `` antora: repackage using buildNpmPackage ``                                                            |
| [`5dbd09e0`](https://github.com/NixOS/nixpkgs/commit/5dbd09e0fabea16d3a1bd7db547bb757fe34ebe8) | `` vaultwarden.webvault: Use default nodejs version ``                                                   |
| [`406a26c1`](https://github.com/NixOS/nixpkgs/commit/406a26c10dc5505dbf5e48bce07560e558d623ec) | `` wireshark: build with QT 6 ``                                                                         |
| [`e195435f`](https://github.com/NixOS/nixpkgs/commit/e195435fa64a0429595dfcad1e90cafdbb86cb64) | `` xc: 0.4.0 -> 0.4.1 ``                                                                                 |
| [`1d5d9105`](https://github.com/NixOS/nixpkgs/commit/1d5d9105a9699e2fef7a775f014b73606e25717e) | `` xc: fix version, add figsoda as a maintainer ``                                                       |
| [`c84344c0`](https://github.com/NixOS/nixpkgs/commit/c84344c0e17c66e4404c1499a9736331945708db) | `` brev-cli: 0.6.222 -> 0.6.224 ``                                                                       |
| [`96503103`](https://github.com/NixOS/nixpkgs/commit/96503103487d34ff5653782d61abe6c9506ebc97) | `` nixos/tandoor-recipes: disable debug toolbar ``                                                       |
| [`ca57e022`](https://github.com/NixOS/nixpkgs/commit/ca57e0223839d21d5fbc1111561e3efe62167756) | `` tandoor-recipes: 1.4.4 -> 1.4.9 ``                                                                    |
| [`a2633f93`](https://github.com/NixOS/nixpkgs/commit/a2633f9302206a44d8cb1ffd3d4ba52d301c1712) | `` python3Packages.recipe-scrapers: 14.32.1 -> 14.36.1 ``                                                |
| [`f9b6ab7e`](https://github.com/NixOS/nixpkgs/commit/f9b6ab7e8837d3266e959235f08833fa54377f7b) | `` python3Packages.django-js-reverse: 2022-09-16 -> 0.10.1-b1 ``                                         |
| [`79a0d9c5`](https://github.com/NixOS/nixpkgs/commit/79a0d9c570999d47199e11568b9ed76b12d0a02d) | `` cargo-careful: 0.3.3 -> 0.3.4 ``                                                                      |
| [`db2f37df`](https://github.com/NixOS/nixpkgs/commit/db2f37dfb24e34e0355db671f49f5cb6822901af) | `` cargo-tally: 1.0.25 -> 1.0.26 ``                                                                      |
| [`d8787b0f`](https://github.com/NixOS/nixpkgs/commit/d8787b0f38bff3308cdb9637299e67f524b04e77) | `` opengrok: 1.12.3 -> 1.12.4 ``                                                                         |
| [`d32489bf`](https://github.com/NixOS/nixpkgs/commit/d32489bf23e71f9a1d99fc15a197217d311f87f8) | `` kube-router: 1.5.3 -> 1.5.4 ``                                                                        |
| [`bcfcffdb`](https://github.com/NixOS/nixpkgs/commit/bcfcffdb15b5253e17e114bec1cde65f6a35da68) | `` emptty: 0.9.1 -> 0.10.0 ``                                                                            |
| [`e81a4ff2`](https://github.com/NixOS/nixpkgs/commit/e81a4ff2956a843cd90f0d6cdbba2783d8d9c690) | `` nootka: use getDev to access .dev attributes ``                                                       |
| [`dfef829c`](https://github.com/NixOS/nixpkgs/commit/dfef829c3bd18db82ab7e743a8f0f72f742c644d) | `` papi: 7.0.0 -> 7.0.1 ``                                                                               |
| [`7ef62c21`](https://github.com/NixOS/nixpkgs/commit/7ef62c21323aeaa746443687832b59fdc567e8f6) | `` gnuastro: 0.19 -> 0.20 ``                                                                             |
| [`2bab481e`](https://github.com/NixOS/nixpkgs/commit/2bab481ebd98fb99688bc389f09a5036462186a8) | `` python311Packages.publicsuffixlist: 0.10.0.20230429 -> 0.10.0.20230506 ``                             |
| [`e7f2aff5`](https://github.com/NixOS/nixpkgs/commit/e7f2aff58116a39044532b29744184f6d9d2d2d7) | `` xlibinput_calibrator: init at 0.11 ``                                                                 |
| [`71176121`](https://github.com/NixOS/nixpkgs/commit/711761216f79ed13dc5350bcea2be73ec8530e33) | `` python311Packages.mypy-boto3-s3: 1.26.116 -> 1.26.127 ``                                              |
| [`78d0412f`](https://github.com/NixOS/nixpkgs/commit/78d0412ffc582e54b6e3cc38211207ffc9ef4f65) | `` python310Packages.aeppl: 0.1.3 -> 0.1.4 ``                                                            |
| [`7af8cd7d`](https://github.com/NixOS/nixpkgs/commit/7af8cd7db11cdcd1ddd2cf13066c1d4ec4b3dd1c) | `` cloud-nuke: add changelog to meta ``                                                                  |
| [`23d3831a`](https://github.com/NixOS/nixpkgs/commit/23d3831a1edf2f6cb61de2b42a018baf22cac543) | `` python311Packages.transmission-rpc: 4.2.0 -> 4.2.1 ``                                                 |
| [`e5ded5a6`](https://github.com/NixOS/nixpkgs/commit/e5ded5a653c4896ddde4a2f11a97251166efc4ad) | `` vopono: 0.10.5 -> 0.10.6 ``                                                                           |
| [`53b9fb74`](https://github.com/NixOS/nixpkgs/commit/53b9fb7421e32cd11995e5e47074815b130f56e5) | `` svlint: 0.7.1 -> 0.7.2 ``                                                                             |
| [`b03fc254`](https://github.com/NixOS/nixpkgs/commit/b03fc2548c6bffdaa0ff2b6edad2195d04a98ae0) | `` faudio: 23.04 -> 23.05 ``                                                                             |
| [`793a45b8`](https://github.com/NixOS/nixpkgs/commit/793a45b8a758597fc774028849efa56c26792dba) | `` sqlfluff: 2.0.7 -> 2.1.0 ``                                                                           |
| [`d666dc51`](https://github.com/NixOS/nixpkgs/commit/d666dc51f7879711883525349b2c302b609a833e) | `` pscale: 0.140.0 -> 0.142.0 ``                                                                         |
| [`c6410d50`](https://github.com/NixOS/nixpkgs/commit/c6410d50e8b9fe645bdeb69ea8b6abb46500cca7) | `` xc: 0.3.0 -> 0.4.0 ``                                                                                 |
| [`6d51f116`](https://github.com/NixOS/nixpkgs/commit/6d51f116b02e1f131f3c8fc09fd219fe6b59b6e6) | `` noaa-apt: 1.3.1 -> 1.4.0 ``                                                                           |
| [`ec7e6d25`](https://github.com/NixOS/nixpkgs/commit/ec7e6d2538724e2179c8ace24b4efdcc772e004d) | `` v2ray-geoip: 202304270044 -> 202305040042 ``                                                          |
| [`5d924595`](https://github.com/NixOS/nixpkgs/commit/5d924595d0d456c85b806f4c6f7fcf31a047396a) | `` cloud-nuke: 0.29.7 -> 0.30.0 ``                                                                       |
| [`78081a31`](https://github.com/NixOS/nixpkgs/commit/78081a31e1022771ccdf14327e7f725e419821b7) | `` grub4dos: mark broken ``                                                                              |
| [`b458ef90`](https://github.com/NixOS/nixpkgs/commit/b458ef900f96ba60f91035d53eabf90340b6e773) | `` grive2: pull gcc-12 upstream fix ``                                                                   |
| [`2a9a75da`](https://github.com/NixOS/nixpkgs/commit/2a9a75da14eae8c1cc77c4c2902a496372718609) | `` nest-cli: repackage using buildNpmPackage ``                                                          |
| [`c74c4e4b`](https://github.com/NixOS/nixpkgs/commit/c74c4e4b49193f9a24609abdd54e3492362ace61) | `` doppler: 3.56.0 -> 3.58.0 ``                                                                          |
| [`b7028fd6`](https://github.com/NixOS/nixpkgs/commit/b7028fd6dc038055f2edf7ea5c41c5be413ddced) | `` noto-fonts-cjk: use typeface and version to generate git rev ``                                       |
| [`20e14364`](https://github.com/NixOS/nixpkgs/commit/20e14364e25a020ed342f94d971e396bd222dcda) | `` exploitdb: 2023-05-03 -> 2023-05-06 ``                                                                |
| [`41f05cdc`](https://github.com/NixOS/nixpkgs/commit/41f05cdc0348aa28835316a7a2219ba455b9b1a3) | `` python311Packages.boschshcpy: 0.2.56 -> 0.2.57 ``                                                     |
| [`e98366c1`](https://github.com/NixOS/nixpkgs/commit/e98366c1555a99086272001a3147705ce71399c1) | `` balena-cli: 15.2.2 -> 15.2.3; closes #230076 ``                                                       |
| [`dbfe3ff4`](https://github.com/NixOS/nixpkgs/commit/dbfe3ff44d76ebfc1c5fee77402acc382ddc261d) | `` oxigraph: 0.3.14 -> 0.3.16 ``                                                                         |
| [`64a14473`](https://github.com/NixOS/nixpkgs/commit/64a144731d68244a26261de8ffafc73d5c60c684) | `` hound: 0.7.0 -> 0.7.1 ``                                                                              |
| [`4c588954`](https://github.com/NixOS/nixpkgs/commit/4c5889547919e6328faa9063505accf7c9d7a1b6) | `` zulip: 5.9.5 → 5.10.0 ``                                                                              |
| [`3d326fbf`](https://github.com/NixOS/nixpkgs/commit/3d326fbf4e89ec5a1263b636b7185cd87fc76bd3) | `` web-eid-app: 2.3.0 -> 2.3.1 ``                                                                        |
| [`17bb54d4`](https://github.com/NixOS/nixpkgs/commit/17bb54d46f73e947877958a36fe063211e512c9f) | `` kubecm: 0.22.1 -> 0.23.0 ``                                                                           |
| [`daf34dc6`](https://github.com/NixOS/nixpkgs/commit/daf34dc6e28bfe1c272dfe0d8f80afccfa1f11e0) | `` netmaker: 0.18.7 -> 0.19.0 ``                                                                         |
| [`fb383b5f`](https://github.com/NixOS/nixpkgs/commit/fb383b5f9e0fa4fba9072e1f90917ac5b754b6da) | `` wtwitch: 2.6.1 -> 2.6.2 ``                                                                            |
| [`28ec8676`](https://github.com/NixOS/nixpkgs/commit/28ec86766b67de58caf87283813d26650324a360) | `` devbox: 0.4.8 -> 0.4.9 ``                                                                             |
| [`4b29851a`](https://github.com/NixOS/nixpkgs/commit/4b29851a3b2ec131ddc204d88898df5a6354fcf9) | `` vieb: 9.7.0 -> 9.7.1 ``                                                                               |
| [`a3927314`](https://github.com/NixOS/nixpkgs/commit/a3927314fa4e834a07cc899fa6675e7fb18d2c43) | `` lazygit: 0.38.1 -> 0.38.2 ``                                                                          |
| [`0c572ffe`](https://github.com/NixOS/nixpkgs/commit/0c572ffe4c914a5f9d79f2bd3835ba9e9b32fa3b) | `` flannel: 0.21.4 -> 0.21.5 ``                                                                          |
| [`20724f54`](https://github.com/NixOS/nixpkgs/commit/20724f5476bfff9394eab58b608dc2e330ae7cea) | `` treesheets: unstable-2023-05-03 -> unstable-2023-05-04 ``                                             |
| [`93c3d127`](https://github.com/NixOS/nixpkgs/commit/93c3d1274fa5909242aa824ae10dc99295b84ee1) | `` butt: init at 0.1.37 ``                                                                               |
| [`1c8efee8`](https://github.com/NixOS/nixpkgs/commit/1c8efee8e3d5c10233af675c4e4975066a17d000) | `` gobgp: 3.13.0 -> 3.14.0 ``                                                                            |
| [`cf12cc9d`](https://github.com/NixOS/nixpkgs/commit/cf12cc9d6ab115a2c5824b7b70b5f461054570e2) | `` noto-fonts-cjk-serif: 2.000 -> 2.001 ``                                                               |
| [`efb0a5d6`](https://github.com/NixOS/nixpkgs/commit/efb0a5d69bc626eadd016ddb6ab764dfda19da1a) | `` noto-fonts-cjk-sans: use official release version ``                                                  |
| [`25814765`](https://github.com/NixOS/nixpkgs/commit/25814765f320f18522ed7d6d8f2c18806b854825) | `` fldigi: 4.1.25 -> 4.1.26 ``                                                                           |
| [`35b1a3fd`](https://github.com/NixOS/nixpkgs/commit/35b1a3fd56dfdbac7fd1d6b4e32592bb1a190550) | `` mate.engrampa: 1.26.0 -> 1.26.1 ``                                                                    |
| [`51c106fa`](https://github.com/NixOS/nixpkgs/commit/51c106faf8c04991bd5d9005e7ade765d345985c) | `` deno: 1.33.1 -> 1.33.2 ``                                                                             |
| [`b98d3465`](https://github.com/NixOS/nixpkgs/commit/b98d346539bddbdd7d46f1c0736e21ec1d308510) | `` mate.marco: 1.26.1 -> 1.26.2 ``                                                                       |
| [`f149f3fe`](https://github.com/NixOS/nixpkgs/commit/f149f3fe0b0dc1e054d9ac8e6716725d479ddb1a) | `` hostctl: 1.1.3 -> 1.1.4 ``                                                                            |
| [`d008cd93`](https://github.com/NixOS/nixpkgs/commit/d008cd935be56146ed946bf58da29ec0584f1f9f) | `` dsdcc: 1.9.3 -> 1.9.4 ``                                                                              |
| [`720dc7c2`](https://github.com/NixOS/nixpkgs/commit/720dc7c27d9731618f100ee84af75cfc43fc2225) | `` libgcc: 11.3.0 -> 12.2.0 ``                                                                           |
| [`5f64875e`](https://github.com/NixOS/nixpkgs/commit/5f64875eced45367a7995316e8e680d00716cdc6) | `` cloudflared: 2023.4.2 -> 2023.5.0 ``                                                                  |
| [`0cbf682e`](https://github.com/NixOS/nixpkgs/commit/0cbf682e6dde395bc2a330d3bf0093e3b14a54fd) | `` httplib: 0.12.2 -> 0.12.3 ``                                                                          |
| [`caf436a5`](https://github.com/NixOS/nixpkgs/commit/caf436a52b25164b71e0d48b671127ac2e2a5b75) | `` ocamlPackages.buildDunePackage: deprecate useDune2 ``                                                 |
| [`e1a67232`](https://github.com/NixOS/nixpkgs/commit/e1a67232bb0f699eedf7231be76f5af140b0bcb1) | `` lxgw-wenkai: 1.250 -> 1.300 ``                                                                        |
| [`a9549f19`](https://github.com/NixOS/nixpkgs/commit/a9549f1987259e093c1ec01fdd50af5c7333cf37) | `` sentry-native: 0.6.1 -> 0.6.2 ``                                                                      |
| [`8607b058`](https://github.com/NixOS/nixpkgs/commit/8607b0587c465414ee716810cdfa8662a0ef2d9b) | `` terraform-providers.vsphere: 2.3.1 -> 2.4.0 ``                                                        |
| [`4fe03b0f`](https://github.com/NixOS/nixpkgs/commit/4fe03b0f60fb2c4d358d7f300a6f60f91cfe530a) | `` terraform-providers.minio: 1.14.0 -> 1.15.0 ``                                                        |
| [`8e04372a`](https://github.com/NixOS/nixpkgs/commit/8e04372a7d895706388a85bd69752c5384379283) | `` terraform-providers.aws: 4.66.0 -> 4.66.1 ``                                                          |
| [`ce108bd5`](https://github.com/NixOS/nixpkgs/commit/ce108bd58319b9c2b3e9fb0200788f3ca4c8538f) | `` terraform-providers.github: 5.24.0 -> 5.25.0 ``                                                       |