### PR TITLE
chore(flake/emacs-overlay): `21d40b52` -> `c25f4cb9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683429207,
-        "narHash": "sha256-P75AnuDwLX/JqL8QQTX/Zp+ASe2qnCCwBd32+QKa1Qo=",
+        "lastModified": 1683451029,
+        "narHash": "sha256-6YnyESt6RZMiI7WOezBd6rvxQkUVV30BhbYJiOEuDIE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "21d40b527260498eeb9aed8d2200e4f79d6b152c",
+        "rev": "c25f4cb97b6efaac40971e73fe8ad94450ad81ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c25f4cb9`](https://github.com/nix-community/emacs-overlay/commit/c25f4cb97b6efaac40971e73fe8ad94450ad81ad) | `` Updated repos/nongnu `` |
| [`3326dd49`](https://github.com/nix-community/emacs-overlay/commit/3326dd49b853982b7c397510c0817ad2835e4dfc) | `` Updated repos/melpa ``  |