### PR TITLE
chore(flake/home-manager): `669669fc` -> `6fc82e56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683276747,
-        "narHash": "sha256-T3st1VBg3wmhHyBQb0z12sTSGsQgiu3mxkS61nLO8Xs=",
+        "lastModified": 1683459775,
+        "narHash": "sha256-Ab1pIKOj7XRZbJAv4g9937ElhaZF7Pob3hqGTDKt5w8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "669669fcb403e3137dfe599bbcc26e60502c3543",
+        "rev": "6fc82e56971523acfe1a61dbcb20f4bb969b3990",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`6fc82e56`](https://github.com/nix-community/home-manager/commit/6fc82e56971523acfe1a61dbcb20f4bb969b3990) | `` i3status-rust: revert #3938 (#3957) ``                           |
| [`0b4ec666`](https://github.com/nix-community/home-manager/commit/0b4ec66640ad5a1aa912a2ae7643f9756e71b4a7) | `` dconf: Warn about strict typing of options ``                    |
| [`ea29b1a8`](https://github.com/nix-community/home-manager/commit/ea29b1a8d1e2717581f4db852ad6647fc03bd00d) | `` docs: Add GVariant cross-references ``                           |
| [`13d666dd`](https://github.com/nix-community/home-manager/commit/13d666dd68d18dd20760662b78e885559f90991d) | `` docs: Mention GVariant format strings ``                         |
| [`a0ddb8af`](https://github.com/nix-community/home-manager/commit/a0ddb8af40bee08737170b167e04ab608215d8de) | `` docs: Mention GVariant auto-coercion at the top ``               |
| [`cfa5c286`](https://github.com/nix-community/home-manager/commit/cfa5c2869b535e5e83dac6b04745f673c591e0d2) | `` docs: GVariant dictionaries are already supported ``             |
| [`81d5b220`](https://github.com/nix-community/home-manager/commit/81d5b220cde5860b529e87fdc3aae55718c24030) | `` docs: Fix broken GVariant docs link ``                           |
| [`3e906060`](https://github.com/nix-community/home-manager/commit/3e906060a88a6929c40b7170e73e7adf9e84a8a8) | `` docs: Add inline anchors for direct linking to GVariant types `` |
| [`c7529068`](https://github.com/nix-community/home-manager/commit/c7529068002983f4a0489ec625fe51dd1d4ec0c5) | `` flake.lock: Update ``                                            |
| [`a834ddf8`](https://github.com/nix-community/home-manager/commit/a834ddf88cb2eb4f77b7c0a2d6e2e8e0fb37c4e3) | `` flake: set source path in home-manager tool ``                   |