### PR TITLE
chore(flake/nur): `f4faba8a` -> `4ea745ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683444851,
-        "narHash": "sha256-EUK0AzZ2ykvSbVC05kxIwOOyaf4q/2eZKTO2ylRa3z4=",
+        "lastModified": 1683456847,
+        "narHash": "sha256-slmPspW4A0+sLDYAADnrMshn5Z3OI/XxU6qXULuve00=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f4faba8ad29afdc8e759a592289f4583116276d6",
+        "rev": "4ea745ffb0f4b64d59fa82e564ff6458ecb62f11",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4ea745ff`](https://github.com/nix-community/NUR/commit/4ea745ffb0f4b64d59fa82e564ff6458ecb62f11) | `` automatic update `` |
| [`b92534f4`](https://github.com/nix-community/NUR/commit/b92534f4ef54d883cd6f38a498044851872814c8) | `` automatic update `` |