### PR TITLE
chore(flake/nur): `4ea745ff` -> `77327e3f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683456847,
-        "narHash": "sha256-slmPspW4A0+sLDYAADnrMshn5Z3OI/XxU6qXULuve00=",
+        "lastModified": 1683459935,
+        "narHash": "sha256-6SRjyBr39/cWmYusQOs9QtFzFH/0MH3R9+ynVZekAmI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ea745ffb0f4b64d59fa82e564ff6458ecb62f11",
+        "rev": "77327e3fa2b352aca843447be62fc9d596513b1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`77327e3f`](https://github.com/nix-community/NUR/commit/77327e3fa2b352aca843447be62fc9d596513b1c) | `` automatic update `` |
| [`ba0994a2`](https://github.com/nix-community/NUR/commit/ba0994a226a51a5b7834baf1ec8418e1b55af84e) | `` automatic update `` |