### PR TITLE
chore(flake/nur): `77327e3f` -> `baaa8b5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683459935,
-        "narHash": "sha256-6SRjyBr39/cWmYusQOs9QtFzFH/0MH3R9+ynVZekAmI=",
+        "lastModified": 1683467831,
+        "narHash": "sha256-CQ2djbQCRH31KMrUq9LWw0CrWGhOTd5hX78AVFhV/Xo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "77327e3fa2b352aca843447be62fc9d596513b1c",
+        "rev": "baaa8b5a7847cb33d25655407864261802e6eaf8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                        |
| -------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`baaa8b5a`](https://github.com/nix-community/NUR/commit/baaa8b5a7847cb33d25655407864261802e6eaf8) | `` automatic update ``         |
| [`0e5a8c51`](https://github.com/nix-community/NUR/commit/0e5a8c51fb380f462d4393bc8d899e6173e8ef6a) | `` update slaier repository `` |
| [`24b7e88a`](https://github.com/nix-community/NUR/commit/24b7e88aa797c61667410e86baf04500f450076a) | `` automatic update ``         |