### PR TITLE
chore(flake/nur): `baaa8b5a` -> `1836bc3c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683467831,
-        "narHash": "sha256-CQ2djbQCRH31KMrUq9LWw0CrWGhOTd5hX78AVFhV/Xo=",
+        "lastModified": 1683470760,
+        "narHash": "sha256-Xe5L52haU8nTz6f2pM4j/J0YaWfaeZX9mtNSy7UQGUc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "baaa8b5a7847cb33d25655407864261802e6eaf8",
+        "rev": "1836bc3c9f7f033a6abfbf6ac3dd36ee875f85ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1836bc3c`](https://github.com/nix-community/NUR/commit/1836bc3c9f7f033a6abfbf6ac3dd36ee875f85ae) | `` automatic update `` |
| [`821aa449`](https://github.com/nix-community/NUR/commit/821aa4496d0c6f4aa1d256da0ef2f48f60e1f5ea) | `` automatic update `` |