### PR TITLE
chore(flake/nur): `1836bc3c` -> `07670d5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683470760,
-        "narHash": "sha256-Xe5L52haU8nTz6f2pM4j/J0YaWfaeZX9mtNSy7UQGUc=",
+        "lastModified": 1683477974,
+        "narHash": "sha256-MmRFD5qCZ9xJy27F79pzmm0x/nLQAZwnvgc0U+oS/pM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1836bc3c9f7f033a6abfbf6ac3dd36ee875f85ae",
+        "rev": "07670d5e996df305e79cb7e9becc24b91b1b4d9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`07670d5e`](https://github.com/nix-community/NUR/commit/07670d5e996df305e79cb7e9becc24b91b1b4d9f) | `` automatic update `` |