### PR TITLE
chore(flake/nur): `07670d5e` -> `17720986`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683477974,
-        "narHash": "sha256-MmRFD5qCZ9xJy27F79pzmm0x/nLQAZwnvgc0U+oS/pM=",
+        "lastModified": 1683485645,
+        "narHash": "sha256-IuYrTIgpMbadMR38Dgo/nMvlVbcqLRbfPFyL4L0qiC8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "07670d5e996df305e79cb7e9becc24b91b1b4d9f",
+        "rev": "17720986d359ac222bca383875f16c3ea41636a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`17720986`](https://github.com/nix-community/NUR/commit/17720986d359ac222bca383875f16c3ea41636a8) | `` automatic update `` |
| [`a62bcc6c`](https://github.com/nix-community/NUR/commit/a62bcc6c30552ed94539d5722c9157c9b522b6c1) | `` automatic update `` |
| [`561b8ba4`](https://github.com/nix-community/NUR/commit/561b8ba4ea2ec3bde98525caa66b05e0980c5959) | `` automatic update `` |