### PR TITLE
chore(flake/nur): `17720986` -> `812c34e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683485645,
-        "narHash": "sha256-IuYrTIgpMbadMR38Dgo/nMvlVbcqLRbfPFyL4L0qiC8=",
+        "lastModified": 1683488756,
+        "narHash": "sha256-/wykqqb4SK2m26wHG/pysC/HoLQAWG6jcNGWMDQaopE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "17720986d359ac222bca383875f16c3ea41636a8",
+        "rev": "812c34e11a17372c8dbf6d95ac4d2620a3209b77",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`812c34e1`](https://github.com/nix-community/NUR/commit/812c34e11a17372c8dbf6d95ac4d2620a3209b77) | `` automatic update `` |