### PR TITLE
chore(flake/nur): `812c34e1` -> `19049935`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683488756,
-        "narHash": "sha256-/wykqqb4SK2m26wHG/pysC/HoLQAWG6jcNGWMDQaopE=",
+        "lastModified": 1683491359,
+        "narHash": "sha256-dRTrRMzuBMq1HULYNzmNfiWzyvltNeh125UEH+NeV2o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "812c34e11a17372c8dbf6d95ac4d2620a3209b77",
+        "rev": "19049935c55197e9634eb99610c0aaf9542fa5a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`19049935`](https://github.com/nix-community/NUR/commit/19049935c55197e9634eb99610c0aaf9542fa5a0) | `` automatic update `` |