### PR TITLE
chore(flake/home-manager): `6fc82e56` -> `3f3fa731`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683459775,
-        "narHash": "sha256-Ab1pIKOj7XRZbJAv4g9937ElhaZF7Pob3hqGTDKt5w8=",
+        "lastModified": 1683543852,
+        "narHash": "sha256-aS9qNcg9GwSYFLCWa3Lw+2nVPG11mmQ3B7Oka1hh04M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6fc82e56971523acfe1a61dbcb20f4bb969b3990",
+        "rev": "3f3fa731ad0f99741d4dc98e8e1287b45e30b452",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`3f3fa731`](https://github.com/nix-community/home-manager/commit/3f3fa731ad0f99741d4dc98e8e1287b45e30b452) | `` gnome-keyring: fix pass-secret-service assertion (#3963) `` |
| [`78ceec68`](https://github.com/nix-community/home-manager/commit/78ceec68f29ed56d6118617e9f0f588bf164067f) | `` xsession: cleanup systemd variables (#3636) ``              |
| [`e34fbe18`](https://github.com/nix-community/home-manager/commit/e34fbe18011483d1aac6f44cd2f03c0c89196812) | `` pass-secret-service: Add dbus file, assert (#3953) ``       |
| [`d12ca778`](https://github.com/nix-community/home-manager/commit/d12ca77844a08b8b44edae0d66be0922544c2172) | `` atuin: Replace dead link in documentation (#3962) ``        |
| [`de8ba413`](https://github.com/nix-community/home-manager/commit/de8ba413c578b68ef602c4f4c5909d9636a5bf92) | `` home-environment: honor use-xdg-base-directories ``         |
| [`01730248`](https://github.com/nix-community/home-manager/commit/017302483c2c4372e7a680f390d7bb861335d849) | `` xfconf: fix type order (#3961) ``                           |