### PR TITLE
chore(flake/nur): `19049935` -> `696742d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683491359,
-        "narHash": "sha256-dRTrRMzuBMq1HULYNzmNfiWzyvltNeh125UEH+NeV2o=",
+        "lastModified": 1683496751,
+        "narHash": "sha256-G1sAE7AnQcTwJXdrfORLf6O8nwelhdPsZDhysMD+YtM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "19049935c55197e9634eb99610c0aaf9542fa5a0",
+        "rev": "696742d0ca1d0ffcf50823652a25666f4cc81474",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`696742d0`](https://github.com/nix-community/NUR/commit/696742d0ca1d0ffcf50823652a25666f4cc81474) | `` automatic update `` |
| [`7fb82718`](https://github.com/nix-community/NUR/commit/7fb82718368eaf8b2a7cb1aac937738860aff7a4) | `` automatic update `` |