### PR TITLE
chore(flake/nur): `696742d0` -> `8ddf6bfa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683496751,
-        "narHash": "sha256-G1sAE7AnQcTwJXdrfORLf6O8nwelhdPsZDhysMD+YtM=",
+        "lastModified": 1683499454,
+        "narHash": "sha256-TF9I8pfGtShdP9WE/ar3bVRB6K6nkP7VYjw0TNNkzME=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "696742d0ca1d0ffcf50823652a25666f4cc81474",
+        "rev": "8ddf6bfae5fc1a61f0f4d80e03e74a3dbcb8b941",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8ddf6bfa`](https://github.com/nix-community/NUR/commit/8ddf6bfae5fc1a61f0f4d80e03e74a3dbcb8b941) | `` automatic update `` |