### PR TITLE
chore(flake/nur): `8ddf6bfa` -> `4fe04937`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683499454,
-        "narHash": "sha256-TF9I8pfGtShdP9WE/ar3bVRB6K6nkP7VYjw0TNNkzME=",
+        "lastModified": 1683507965,
+        "narHash": "sha256-GWkZCxH4ijhHqvZcWY131fB6ZVkOpWLi0Y0b2g0EIdw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8ddf6bfae5fc1a61f0f4d80e03e74a3dbcb8b941",
+        "rev": "4fe04937d778932edad38aad653a347b9aadcf10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4fe04937`](https://github.com/nix-community/NUR/commit/4fe04937d778932edad38aad653a347b9aadcf10) | `` automatic update `` |
| [`2f80269f`](https://github.com/nix-community/NUR/commit/2f80269fc7331b5d676316594b22f639bac0f08a) | `` automatic update `` |