### PR TITLE
chore(flake/nur): `4fe04937` -> `fa655578`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683507965,
-        "narHash": "sha256-GWkZCxH4ijhHqvZcWY131fB6ZVkOpWLi0Y0b2g0EIdw=",
+        "lastModified": 1683511499,
+        "narHash": "sha256-V7qoA0TO5DL4f9deRll9D030KTfnh2Zx7k6ggJIVh+I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4fe04937d778932edad38aad653a347b9aadcf10",
+        "rev": "fa655578e3ac3183f37ac46b7066333cf4561cfb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fa655578`](https://github.com/nix-community/NUR/commit/fa655578e3ac3183f37ac46b7066333cf4561cfb) | `` automatic update `` |
| [`95cbf079`](https://github.com/nix-community/NUR/commit/95cbf07956e59881c832408227595466cf30f43a) | `` automatic update `` |