### PR TITLE
chore(flake/nur): `fa655578` -> `99e083f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683511499,
-        "narHash": "sha256-V7qoA0TO5DL4f9deRll9D030KTfnh2Zx7k6ggJIVh+I=",
+        "lastModified": 1683514194,
+        "narHash": "sha256-8SuO3/g6Nr3gTTzT3bUqqZwTJs8+dYfRZmdr54ajINw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fa655578e3ac3183f37ac46b7066333cf4561cfb",
+        "rev": "99e083f8ddc3583efe520fd917e5a6ea2bf74c89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`99e083f8`](https://github.com/nix-community/NUR/commit/99e083f8ddc3583efe520fd917e5a6ea2bf74c89) | `` automatic update `` |
| [`0d34235b`](https://github.com/nix-community/NUR/commit/0d34235b1ca33376f107aed158529c21b10e5aec) | `` automatic update `` |