### PR TITLE
chore(flake/deploy-rs): `6b0b6a1c` -> `64160276`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -214,11 +214,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683255183,
-        "narHash": "sha256-UUxpb5PMkFfP2JGoPMEUvKbxv+wCkTWy4uZs1MyyCes=",
+        "lastModified": 1683515103,
+        "narHash": "sha256-vWlnZ0twW+ekOC6JuAHDfupv+u4QNvWawG7+DaQJ4VA=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "6b0b6a1c2527e8b1ef370a308b6ef8903004ac47",
+        "rev": "64160276cd6569694131ed8864d4d35470a84ec3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                            |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`c17d71fa`](https://github.com/serokell/deploy-rs/commit/c17d71fadf9a124ad6dd6af91944dbc2f0a60496) | `` fixup! [#202] Provide '^out' suffix for deriver on newer nix `` |
| [`e3bc066b`](https://github.com/serokell/deploy-rs/commit/e3bc066bd8f2bcf8433616b7610ef59ba04b679e) | `` [#202] Provide '^out' suffix for deriver on newer nix ``        |