### PR TITLE
chore(flake/nur): `99e083f8` -> `c4826503`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683514194,
-        "narHash": "sha256-8SuO3/g6Nr3gTTzT3bUqqZwTJs8+dYfRZmdr54ajINw=",
+        "lastModified": 1683518121,
+        "narHash": "sha256-u8aBPSoBlWcVOVeosN6BlAL1qbpaWlqy71U3CzxAV9E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "99e083f8ddc3583efe520fd917e5a6ea2bf74c89",
+        "rev": "c48265035a51833b068d62f6f7f8f5347ea850e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c4826503`](https://github.com/nix-community/NUR/commit/c48265035a51833b068d62f6f7f8f5347ea850e2) | `` automatic update `` |
| [`1f0370ea`](https://github.com/nix-community/NUR/commit/1f0370ea9749c59c9b821bd3c5bd5c6d16d7bddd) | `` automatic update `` |
| [`1ab1d6dd`](https://github.com/nix-community/NUR/commit/1ab1d6dde5b446400fbb17e4ea40e738800afb76) | `` automatic update `` |