### PR TITLE
chore(flake/nur): `c4826503` -> `bf880432`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683518121,
-        "narHash": "sha256-u8aBPSoBlWcVOVeosN6BlAL1qbpaWlqy71U3CzxAV9E=",
+        "lastModified": 1683521957,
+        "narHash": "sha256-HhnNl6EyxAwslMw3xx5VKIc2Bmq1kySj0bg2EKP9Y6c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c48265035a51833b068d62f6f7f8f5347ea850e2",
+        "rev": "bf880432587831e8ccf0d7af62a57bb847398e42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bf880432`](https://github.com/nix-community/NUR/commit/bf880432587831e8ccf0d7af62a57bb847398e42) | `` automatic update `` |
| [`5c326de1`](https://github.com/nix-community/NUR/commit/5c326de18cb35f6e3841d8d4535472b9e5373fc4) | `` automatic update `` |
| [`19f3456d`](https://github.com/nix-community/NUR/commit/19f3456dc6296a72223d1d3e9ab3154d9dae1b4f) | `` automatic update `` |