### PR TITLE
chore(flake/sops-nix): `fd2d857c` -> `2e77ca66`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -970,11 +970,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1683428115,
-        "narHash": "sha256-sxkM4upCCdsaWVpDWxYgQXooobex8QHbFkGj40Uf9uQ=",
+        "lastModified": 1683521893,
+        "narHash": "sha256-9447+MD2BD64w+12tXOIjacBhRk9NH36HAWrDo5QiUQ=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "fd2d857ce2450a3ba5700d1e95eb110070e0dbc3",
+        "rev": "2e77ca66d8362ebf4b3112489068ce9f38d5cb3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`b84b3177`](https://github.com/Mic92/sops-nix/commit/b84b3177a1031f70e5d5c20aa8c748dade477385) | `` fix makeSetupHook's also for older nixos release `` |
| [`bea992ff`](https://github.com/Mic92/sops-nix/commit/bea992ff5e70e31de4380cdbf068787371006d60) | `` fix makeSetupHook deprecations ``                   |