### PR TITLE
chore(flake/nur): `bf880432` -> `660bb727`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683521957,
-        "narHash": "sha256-HhnNl6EyxAwslMw3xx5VKIc2Bmq1kySj0bg2EKP9Y6c=",
+        "lastModified": 1683531130,
+        "narHash": "sha256-CyjNDiDD/LVA15TOCeBcpupHCB287kFNZuL1E8g4FRw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bf880432587831e8ccf0d7af62a57bb847398e42",
+        "rev": "660bb727072852d6600d5f9592aa06c1dbc1aaa1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`660bb727`](https://github.com/nix-community/NUR/commit/660bb727072852d6600d5f9592aa06c1dbc1aaa1) | `` automatic update `` |
| [`1d6de516`](https://github.com/nix-community/NUR/commit/1d6de516208e1ac37fe948bb3e63ba3278fd9bf9) | `` automatic update `` |
| [`5f507d23`](https://github.com/nix-community/NUR/commit/5f507d2371488fdd64c4e63cfd6b817f31691b24) | `` automatic update `` |