### PR TITLE
chore(flake/nur): `660bb727` -> `9a7a1a3b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683531130,
-        "narHash": "sha256-CyjNDiDD/LVA15TOCeBcpupHCB287kFNZuL1E8g4FRw=",
+        "lastModified": 1683536301,
+        "narHash": "sha256-OZtcIqafASXDvgmh6Kx7Bw+WPJwhP6T2EB8yfFKhEDc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "660bb727072852d6600d5f9592aa06c1dbc1aaa1",
+        "rev": "9a7a1a3bb8a8687258cc24c95ea5454bbe1da0ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9a7a1a3b`](https://github.com/nix-community/NUR/commit/9a7a1a3bb8a8687258cc24c95ea5454bbe1da0ea) | `` automatic update `` |
| [`9618a8fb`](https://github.com/nix-community/NUR/commit/9618a8fb589becf19233ce1fc801ea5923349222) | `` automatic update `` |