### PR TITLE
chore(flake/emacs-overlay): `a160e897` -> `5faeffd3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683537168,
-        "narHash": "sha256-lVon2uTdnH9vgQA0NfhF+FIZ/YaRrZqIHZwUAfxx2Oo=",
+        "lastModified": 1683571286,
+        "narHash": "sha256-W9pObaS2aKdHKghnTniTAPoMam1bqL6LACaIbzpP22A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a160e897d1f9f3b0fedf191a79d8ab99a09bcfd6",
+        "rev": "5faeffd3d6d7f35348ef21f5245da783c7cd395f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`5faeffd3`](https://github.com/nix-community/emacs-overlay/commit/5faeffd3d6d7f35348ef21f5245da783c7cd395f) | `` Updated repos/melpa `` |
| [`4fcd9f9f`](https://github.com/nix-community/emacs-overlay/commit/4fcd9f9f582537d6b0ac6332eb22dd543a58212e) | `` Updated repos/emacs `` |
| [`5aa2545f`](https://github.com/nix-community/emacs-overlay/commit/5aa2545f47e7da23b17653f26905d306587753ff) | `` Updated repos/elpa ``  |