### PR TITLE
chore(flake/emacs-overlay): `5faeffd3` -> `6fe1b6ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683571286,
-        "narHash": "sha256-W9pObaS2aKdHKghnTniTAPoMam1bqL6LACaIbzpP22A=",
+        "lastModified": 1683604309,
+        "narHash": "sha256-o+ii3SdNh7VITaEkL1+l8phiktwk5ADNIHAkC4iA12w=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5faeffd3d6d7f35348ef21f5245da783c7cd395f",
+        "rev": "6fe1b6ed8880aa6631be652b9c7eac98bca7307f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`6fe1b6ed`](https://github.com/nix-community/emacs-overlay/commit/6fe1b6ed8880aa6631be652b9c7eac98bca7307f) | `` Updated repos/nongnu `` |
| [`86884a77`](https://github.com/nix-community/emacs-overlay/commit/86884a7788f2bae2d8e61c666454d0f8e8cd6436) | `` Updated repos/melpa ``  |
| [`3e6b225d`](https://github.com/nix-community/emacs-overlay/commit/3e6b225de6dd5b0882575c78eb35832861926a01) | `` Updated repos/emacs ``  |