### PR TITLE
chore(flake/emacs-overlay): `6fe1b6ed` -> `59216360`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683604309,
-        "narHash": "sha256-o+ii3SdNh7VITaEkL1+l8phiktwk5ADNIHAkC4iA12w=",
+        "lastModified": 1683623343,
+        "narHash": "sha256-ue6HW/Xybj45VvssNtcaxCVoFM5kU0hi+oyaVhia0dk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6fe1b6ed8880aa6631be652b9c7eac98bca7307f",
+        "rev": "592163607796fde463be9ef4a274199587fd0578",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`59216360`](https://github.com/nix-community/emacs-overlay/commit/592163607796fde463be9ef4a274199587fd0578) | `` Updated repos/melpa `` |