### PR TITLE
chore(flake/home-manager): `3f3fa731` -> `983f8a1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683543852,
-        "narHash": "sha256-aS9qNcg9GwSYFLCWa3Lw+2nVPG11mmQ3B7Oka1hh04M=",
+        "lastModified": 1683651229,
+        "narHash": "sha256-HN0Mw8g1XQIrcdyzqT00YW0Uqi/V/BUUUAgvcK1pcSM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3f3fa731ad0f99741d4dc98e8e1287b45e30b452",
+        "rev": "983f8a1bb965b261492123cd8e2d07da46d4d50a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                     |
| ----------------------------------------------------------------------------------------------------------- | --------------------------- |
| [`983f8a1b`](https://github.com/nix-community/home-manager/commit/983f8a1bb965b261492123cd8e2d07da46d4d50a) | `` git-cliff: add module `` |