### PR TITLE
chore(flake/emacs-overlay): `fe4fff6e` -> `e6b5351e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683683512,
-        "narHash": "sha256-ALZECBLOKm/gwUbJ3C0IFOTBfP2bBLBOiyAj5lNbTa8=",
+        "lastModified": 1683709557,
+        "narHash": "sha256-mkxj1co9dNK/hIKEo1J9PCtK20CqL2TN6VhOd8Wi1qQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fe4fff6e1f1df516e26a46053be025220812c8c7",
+        "rev": "e6b5351ef8059316e5114626f473dd15994318db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`e6b5351e`](https://github.com/nix-community/emacs-overlay/commit/e6b5351ef8059316e5114626f473dd15994318db) | `` Updated repos/melpa `` |