### PR TITLE
chore(flake/darwin): `379d42fa` -> `9520a6e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -111,11 +111,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682773107,
-        "narHash": "sha256-+h94XeJnG3uk5imJlBi/1lVmcfCbxHpwZp5u7n3Krwg=",
+        "lastModified": 1683719734,
+        "narHash": "sha256-+PVRapPi3KK4dL93zHr+BZaWES/GseroTetW2Ua1Bls=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "379d42fad6bc5c28f79d5f7ff2fa5f1c90cb7bf8",
+        "rev": "9520a6e48393d4bfefe1cd47b726b7c10a3b9b6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                              |
| ------------------------------------------------------------------------------------------------ | ------------------------------------ |
| [`da2c0a74`](https://github.com/LnL7/nix-darwin/commit/da2c0a74ca7aa2472cf2bc819ce8af53530b3bd8) | `` buildkite-agent: update module `` |