### PR TITLE
chore(flake/emacs-overlay): `f8da8193` -> `2948ffc1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683743828,
-        "narHash": "sha256-Pq5VCVxmN/7dZg0U8QyQRSHfuiZjkD6PIpOdqo2y6pU=",
+        "lastModified": 1683771025,
+        "narHash": "sha256-Mjd5rbDa+y2dAUdgZPZh1/Y3IqbEE+5tYkDaUvMluoY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f8da819375f9e8e41a22bfb2b299750c942b90d7",
+        "rev": "2948ffc1d2d9ca9bcb22297234dadd369633e87b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`2948ffc1`](https://github.com/nix-community/emacs-overlay/commit/2948ffc1d2d9ca9bcb22297234dadd369633e87b) | `` Updated repos/melpa `` |
| [`d21ddf4a`](https://github.com/nix-community/emacs-overlay/commit/d21ddf4ac8afb13bd55440191a404d03b847edd3) | `` Updated repos/elpa ``  |