### PR TITLE
chore(flake/deploy-rs): `64160276` -> `c8018991`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -214,11 +214,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683515103,
-        "narHash": "sha256-vWlnZ0twW+ekOC6JuAHDfupv+u4QNvWawG7+DaQJ4VA=",
+        "lastModified": 1683779844,
+        "narHash": "sha256-sIeOU0GsCeQEn5TpqE/jFRN4EGsPsjqVRsPdrzIDABM=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "64160276cd6569694131ed8864d4d35470a84ec3",
+        "rev": "c80189917086e43d49eece2bd86f56813500a0eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                         |
| --------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`03b02d20`](https://github.com/serokell/deploy-rs/commit/03b02d2097c1e7eb142e086bdc1fa20252246c03) | `` Make it possible to not rebuild deploy-rs `` |