### PR TITLE
chore(flake/home-manager): `010c2698` -> `fa720861`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683762874,
-        "narHash": "sha256-EC7EDhzz/HjKppcaJFePlCOZqfVg8fooO/aWWUxwAJU=",
+        "lastModified": 1683796878,
+        "narHash": "sha256-8y2RossxrzY/RthUj8vikfwQDp25XkWNi0lw2oEYVbc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "010c26987729d6a2e0e19da6df7c3f0465ae03b3",
+        "rev": "fa720861b5b68536434360aa0ccf0a5fb9060a73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`fa720861`](https://github.com/nix-community/home-manager/commit/fa720861b5b68536434360aa0ccf0a5fb9060a73) | `` translate-shell: add module (#3659) ``              |
| [`b365342a`](https://github.com/nix-community/home-manager/commit/b365342adb36fd659a1472dced6f55b706c15162) | `` ledger: add structural `settings` option (#3661) `` |