### PR TITLE
chore(flake/home-manager): `fa720861` -> `f714b170`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683796878,
-        "narHash": "sha256-8y2RossxrzY/RthUj8vikfwQDp25XkWNi0lw2oEYVbc=",
+        "lastModified": 1683806317,
+        "narHash": "sha256-uB1WeLj+GxjtyO7FXsLs/8+KMl3D4usMg09tBIoUj0Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fa720861b5b68536434360aa0ccf0a5fb9060a73",
+        "rev": "f714b170315770f5cb34107b17f2925f0aed7dd4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                           |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`f714b170`](https://github.com/nix-community/home-manager/commit/f714b170315770f5cb34107b17f2925f0aed7dd4) | `` emacs: extend startWithUserSession to start after graphical session (#3010) `` |