### PR TITLE
chore(flake/home-manager): `f714b170` -> `6be87366`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683806317,
-        "narHash": "sha256-uB1WeLj+GxjtyO7FXsLs/8+KMl3D4usMg09tBIoUj0Q=",
+        "lastModified": 1683807760,
+        "narHash": "sha256-lwsyGtQ78entSG49qK0d5v+r4TP0qppVvzS0e17ap7k=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f714b170315770f5cb34107b17f2925f0aed7dd4",
+        "rev": "6be873663e5b16ded72f9b17b984f64be02437f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`6be87366`](https://github.com/nix-community/home-manager/commit/6be873663e5b16ded72f9b17b984f64be02437f0) | `` ssh: add setEnv option (#3935) ``                   |
| [`2f6a917a`](https://github.com/nix-community/home-manager/commit/2f6a917ade976325093dc60abe17cc72bdf3b76e) | `` i3-sway: fix indentation of `bar` blocks (#3978) `` |
| [`d9917765`](https://github.com/nix-community/home-manager/commit/d991776527b641b029a5916597a1261e2f3b4235) | `` taskwarrior: add package option (#3768) ``          |
| [`622fa737`](https://github.com/nix-community/home-manager/commit/622fa73725caa1f11ae184e70b406b207875ef9d) | `` beets: add mpdIntegration (#3755) ``                |