### PR TITLE
chore(flake/nur): `9a7a1a3b` -> `781c5c24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683536301,
-        "narHash": "sha256-OZtcIqafASXDvgmh6Kx7Bw+WPJwhP6T2EB8yfFKhEDc=",
+        "lastModified": 1683823518,
+        "narHash": "sha256-u9YSqMFfVy3tIlq2W/Yi2bFN8ZZF2g4IlGnKIrM7vrk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9a7a1a3bb8a8687258cc24c95ea5454bbe1da0ea",
+        "rev": "781c5c24892d4038cf711d4762d67b1f48498319",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`781c5c24`](https://github.com/nix-community/NUR/commit/781c5c24892d4038cf711d4762d67b1f48498319) | `` automatic update `` |
| [`1b388bb0`](https://github.com/nix-community/NUR/commit/1b388bb0c2052916b93dbbae0e49af552980644e) | `` automatic update `` |
| [`1ede06df`](https://github.com/nix-community/NUR/commit/1ede06df8d8c8748a75ba3e0a3e321a6e2ff6610) | `` automatic update `` |
| [`dfd9b849`](https://github.com/nix-community/NUR/commit/dfd9b849697c4357ea62e45ef0a54ef42052ac35) | `` automatic update `` |
| [`3b9fad6a`](https://github.com/nix-community/NUR/commit/3b9fad6aeb323eef6e249ca7b0eda828b7a33c57) | `` automatic update `` |
| [`697b5941`](https://github.com/nix-community/NUR/commit/697b5941fc03e8bcd394eac5f6b267a92525ad9a) | `` automatic update `` |
| [`c1a45cf7`](https://github.com/nix-community/NUR/commit/c1a45cf78910e7076f0c80d3266b155b027715dd) | `` automatic update `` |
| [`e3b12740`](https://github.com/nix-community/NUR/commit/e3b127400a226fe2d44d69653f13a36475f5271d) | `` automatic update `` |
| [`520c6983`](https://github.com/nix-community/NUR/commit/520c698344969cb1e3842c69eec050c73b84b94d) | `` automatic update `` |
| [`401751f8`](https://github.com/nix-community/NUR/commit/401751f8fc436d4eafad24e52b4a791c9ab1ae8a) | `` automatic update `` |
| [`7f75d908`](https://github.com/nix-community/NUR/commit/7f75d9082c87b4a2db366c3c74479a6bbde5c936) | `` automatic update `` |
| [`3dfdf808`](https://github.com/nix-community/NUR/commit/3dfdf8084da69cee45996842542cff5d9ad9e505) | `` automatic update `` |
| [`cbc8c861`](https://github.com/nix-community/NUR/commit/cbc8c861d43f95a4d84d5e2109ea463fd4a356b4) | `` automatic update `` |
| [`d7f8ec81`](https://github.com/nix-community/NUR/commit/d7f8ec81c2994aeb1f79bf2c5bb2e93b85ea448f) | `` automatic update `` |
| [`dee85744`](https://github.com/nix-community/NUR/commit/dee857442dcfacad2ed6463da6a34c7b1d0e0cb3) | `` automatic update `` |
| [`8698f6ad`](https://github.com/nix-community/NUR/commit/8698f6ad862ab581f609819ca585703198b0aca5) | `` automatic update `` |
| [`b9cebc59`](https://github.com/nix-community/NUR/commit/b9cebc592900981485fdb0e35bd6a0bba794fae3) | `` automatic update `` |
| [`1c904623`](https://github.com/nix-community/NUR/commit/1c904623667c801c5216a5f9af72866060684a41) | `` automatic update `` |
| [`bb36ff69`](https://github.com/nix-community/NUR/commit/bb36ff69d08607c36101bd7c97a1f64d0171408c) | `` automatic update `` |
| [`a85e9649`](https://github.com/nix-community/NUR/commit/a85e964927973a6074c2d514459f7c46d02f09a4) | `` automatic update `` |
| [`90bd994a`](https://github.com/nix-community/NUR/commit/90bd994aa63eec114837e282cbb614c20ca349dd) | `` automatic update `` |
| [`c524842d`](https://github.com/nix-community/NUR/commit/c524842d10fe65f19e0bb544b39d805e0b5d6d8e) | `` automatic update `` |
| [`763d79a9`](https://github.com/nix-community/NUR/commit/763d79a96172b5e5b7ef48c2e00055520b4c811a) | `` automatic update `` |
| [`c1cde3c9`](https://github.com/nix-community/NUR/commit/c1cde3c99b92f0c34f629c7b1bceccb5b4aacb61) | `` automatic update `` |
| [`ca56df9f`](https://github.com/nix-community/NUR/commit/ca56df9f70823e6e75e3223cc0c91c5529e5d048) | `` automatic update `` |
| [`a23d12c4`](https://github.com/nix-community/NUR/commit/a23d12c427ff118e2fb3e54943baacc717ca0a0b) | `` automatic update `` |
| [`da1aa676`](https://github.com/nix-community/NUR/commit/da1aa676d21a334c160cb819921a55e92c61561d) | `` automatic update `` |
| [`998b2869`](https://github.com/nix-community/NUR/commit/998b28692e0c6be6fe094482a38ce128187179f8) | `` automatic update `` |
| [`3595a6da`](https://github.com/nix-community/NUR/commit/3595a6dad0c0a279a4e721c0dd1649b2e202072f) | `` automatic update `` |
| [`e9cb8005`](https://github.com/nix-community/NUR/commit/e9cb8005d3822264e03c8cb85fb35bf1c695bdd4) | `` automatic update `` |
| [`5374d09a`](https://github.com/nix-community/NUR/commit/5374d09ae8e4e1f599a3f6de4e56e06a80263e49) | `` automatic update `` |
| [`8020e4b8`](https://github.com/nix-community/NUR/commit/8020e4b8c9da9e2abba9a060dcdf0e5d1f6cacc5) | `` automatic update `` |
| [`b2b9928c`](https://github.com/nix-community/NUR/commit/b2b9928cb4e3ae65af2a738ff5168ac2ab6d5d2f) | `` automatic update `` |
| [`96374255`](https://github.com/nix-community/NUR/commit/96374255643a5caeae96e4634ad64244e0f284a0) | `` automatic update `` |
| [`303ebe67`](https://github.com/nix-community/NUR/commit/303ebe67298dfece9e7494124f03aaa1be2af85e) | `` automatic update `` |
| [`f4763e71`](https://github.com/nix-community/NUR/commit/f4763e719874c053b53e31314c86379cb268dc7a) | `` automatic update `` |
| [`da616963`](https://github.com/nix-community/NUR/commit/da61696348d0b55240f637cc8ce35f9f9bdf2f0b) | `` automatic update `` |
| [`f6db8b0b`](https://github.com/nix-community/NUR/commit/f6db8b0ba8ac8a60df02771a1bf56b0f7c3c33e6) | `` automatic update `` |
| [`70966c10`](https://github.com/nix-community/NUR/commit/70966c103bf04371d77cd25f2d1d3fa5af113200) | `` automatic update `` |
| [`efebc011`](https://github.com/nix-community/NUR/commit/efebc01180c448d55c6f5ca19bb4264cbfd0d876) | `` automatic update `` |
| [`88259348`](https://github.com/nix-community/NUR/commit/882593486efed5ddde038c5a0ae77fcd39798dd7) | `` automatic update `` |
| [`51292519`](https://github.com/nix-community/NUR/commit/51292519f21890e73813a9663fff93d4b583e461) | `` automatic update `` |
| [`12a0364c`](https://github.com/nix-community/NUR/commit/12a0364c918c0aebcbd80cad8864324d77e8848f) | `` automatic update `` |
| [`036980ad`](https://github.com/nix-community/NUR/commit/036980adfe8f0798b6a4420aaed580c2926efdfb) | `` automatic update `` |
| [`bd5bd8fd`](https://github.com/nix-community/NUR/commit/bd5bd8fd3b1d1e862bf412b570c1143cd2ab1cb4) | `` automatic update `` |
| [`d2b4061a`](https://github.com/nix-community/NUR/commit/d2b4061a60934718566c5003cccc38be2aefdd68) | `` automatic update `` |
| [`a4342da3`](https://github.com/nix-community/NUR/commit/a4342da373f5a3d1eae4b912bed88ec42b1a0766) | `` automatic update `` |
| [`7388cd20`](https://github.com/nix-community/NUR/commit/7388cd20e402d45cdff23b84cf1559fa1da007c2) | `` automatic update `` |
| [`5cb22ced`](https://github.com/nix-community/NUR/commit/5cb22cedf008a141db248c165e82aa8ef258f864) | `` automatic update `` |
| [`d9ec38ad`](https://github.com/nix-community/NUR/commit/d9ec38ad6ef405f03355ee3c10ecb2fa488b8268) | `` automatic update `` |
| [`06e52912`](https://github.com/nix-community/NUR/commit/06e52912d61f635766d56d389022e81d53834e5e) | `` automatic update `` |
| [`4b5d6b76`](https://github.com/nix-community/NUR/commit/4b5d6b762e3cf61231cbc51d404835d4de46702b) | `` automatic update `` |
| [`f1ca96d7`](https://github.com/nix-community/NUR/commit/f1ca96d74020cf2a8d0b5480ba5fdcfa17e3bb5f) | `` automatic update `` |
| [`9236f04e`](https://github.com/nix-community/NUR/commit/9236f04e96a88efee66ccefec007003510552e7c) | `` automatic update `` |
| [`c7a57ebb`](https://github.com/nix-community/NUR/commit/c7a57ebbd3a6ec7d203070f54eaf8ea0bb455f42) | `` automatic update `` |
| [`09fd995f`](https://github.com/nix-community/NUR/commit/09fd995f1a77803ca3cb23ca865b9232ea95100f) | `` automatic update `` |
| [`1f628b89`](https://github.com/nix-community/NUR/commit/1f628b89c63822513f5df50de77d67a32b52c1c5) | `` automatic update `` |
| [`0f94a162`](https://github.com/nix-community/NUR/commit/0f94a162c73f870b142c15f7a5892df6f65db470) | `` automatic update `` |
| [`16d9417d`](https://github.com/nix-community/NUR/commit/16d9417d415e2134e1d29dbf542461a5e3ff96f4) | `` automatic update `` |
| [`4b983bcd`](https://github.com/nix-community/NUR/commit/4b983bcd9d4115d03a5f0e6804190e0923d0a068) | `` automatic update `` |
| [`5cf67d47`](https://github.com/nix-community/NUR/commit/5cf67d4752ae998cb413e5217f236be568087766) | `` automatic update `` |
| [`3238e0da`](https://github.com/nix-community/NUR/commit/3238e0da76548bc2f9536636d94aba9038294ad4) | `` automatic update `` |
| [`522ec7be`](https://github.com/nix-community/NUR/commit/522ec7bef8d5f2ef6007d208b36fefd5061ceb83) | `` automatic update `` |
| [`96a7e302`](https://github.com/nix-community/NUR/commit/96a7e3028eafc336b7ad141df51999dd89790a86) | `` automatic update `` |
| [`05982955`](https://github.com/nix-community/NUR/commit/059829557a6387556c1739dbbb5f88832a1ce467) | `` automatic update `` |