### PR TITLE
chore(flake/emacs-overlay): `523d2a9d` -> `b0100f5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683796237,
-        "narHash": "sha256-8y4/p8yiHZt8llTBtpIfYx4gBLYfu6VaniKg36A3uRE=",
+        "lastModified": 1683828712,
+        "narHash": "sha256-frB0BacpjtmzDunFZwyRZSNlyOvcxpL0ohtQVvFtiA8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "523d2a9d5de18e423e031236fe5f725c8f837459",
+        "rev": "b0100f5fdc823be12bbcb31bcc5293fc74e04a56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`b0100f5f`](https://github.com/nix-community/emacs-overlay/commit/b0100f5fdc823be12bbcb31bcc5293fc74e04a56) | `` Updated repos/melpa `` |
| [`e1c896e1`](https://github.com/nix-community/emacs-overlay/commit/e1c896e1e9448a6e383bafb28251d90c33ed772d) | `` Updated repos/emacs `` |
| [`399fbe3b`](https://github.com/nix-community/emacs-overlay/commit/399fbe3bece5760eec63f0c3cae52ed84e9f6e28) | `` Updated repos/elpa ``  |