### PR TITLE
chore(flake/emacs-overlay): `b0100f5f` -> `12024c92`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683828712,
-        "narHash": "sha256-frB0BacpjtmzDunFZwyRZSNlyOvcxpL0ohtQVvFtiA8=",
+        "lastModified": 1683861030,
+        "narHash": "sha256-Z55ww/23CriTp12nKabfoz2o9hEw3k9JYhV3Ysd6c9Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b0100f5fdc823be12bbcb31bcc5293fc74e04a56",
+        "rev": "12024c92a6af3f4c3f96ee8b6a4f7d271fa2507e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`12024c92`](https://github.com/nix-community/emacs-overlay/commit/12024c92a6af3f4c3f96ee8b6a4f7d271fa2507e) | `` Updated repos/melpa `` |
| [`5a6b94af`](https://github.com/nix-community/emacs-overlay/commit/5a6b94af408be55d38fa1b8e70d611eff0238b0c) | `` Updated repos/emacs `` |
| [`96b86966`](https://github.com/nix-community/emacs-overlay/commit/96b869664b0ac95ca663bf8193997349d85d6710) | `` Updated repos/elpa ``  |