### PR TITLE
chore(flake/nur): `b1729b90` -> `ee3497fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683841550,
-        "narHash": "sha256-nhZMbft7H1i0odTuar68kzTS1zlQpl7nBKEBOZehaOQ=",
+        "lastModified": 1683884754,
+        "narHash": "sha256-o3JF2SZJIwnz2YXwS0tb+CZqfXTABZDTdCjOG6fahIA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b1729b9029f4a4f8b9cd08a2f84f6fc09e5cf2a3",
+        "rev": "ee3497fa69c9c48ec7e4c0ffc1610ea543497633",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ee3497fa`](https://github.com/nix-community/NUR/commit/ee3497fa69c9c48ec7e4c0ffc1610ea543497633) | `` automatic update `` |
| [`6f8d15ef`](https://github.com/nix-community/NUR/commit/6f8d15ef7a6de53c8b01828113262af48ea0fbcd) | `` automatic update `` |
| [`cfffb407`](https://github.com/nix-community/NUR/commit/cfffb4071e1d27c9666ba0486e84b9d3e7571289) | `` automatic update `` |