### PR TITLE
chore(flake/nur): `ee3497fa` -> `cf05d780`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683884754,
-        "narHash": "sha256-o3JF2SZJIwnz2YXwS0tb+CZqfXTABZDTdCjOG6fahIA=",
+        "lastModified": 1683891949,
+        "narHash": "sha256-N4Wk31Y6hJpuKi1GZrZVcy3shca0kWu6EfPBwGX4NFk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ee3497fa69c9c48ec7e4c0ffc1610ea543497633",
+        "rev": "cf05d780e93eea84791a667cc052044988230a23",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cf05d780`](https://github.com/nix-community/NUR/commit/cf05d780e93eea84791a667cc052044988230a23) | `` automatic update `` |