### PR TITLE
chore(flake/nur): `cf05d780` -> `1909bde2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683891949,
-        "narHash": "sha256-N4Wk31Y6hJpuKi1GZrZVcy3shca0kWu6EfPBwGX4NFk=",
+        "lastModified": 1683896271,
+        "narHash": "sha256-qF/GFquBc1D6zPmuzpaGC+LfwiM/SVwz6C0xNv+K/rE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cf05d780e93eea84791a667cc052044988230a23",
+        "rev": "1909bde2032156e9ff60e2deada4dd3c00b39e62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1909bde2`](https://github.com/nix-community/NUR/commit/1909bde2032156e9ff60e2deada4dd3c00b39e62) | `` automatic update `` |
| [`8f21fa3d`](https://github.com/nix-community/NUR/commit/8f21fa3d62e20eecbdfc446b1c06665aa048625a) | `` automatic update `` |
| [`053d84ca`](https://github.com/nix-community/NUR/commit/053d84ca1b63cd14f7a5eba1e058f64d7a4df660) | `` automatic update `` |