### PR TITLE
chore(flake/nur): `1909bde2` -> `8fcb6b87`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683896271,
-        "narHash": "sha256-qF/GFquBc1D6zPmuzpaGC+LfwiM/SVwz6C0xNv+K/rE=",
+        "lastModified": 1683903555,
+        "narHash": "sha256-O121Bt3PsV5pDWrQPfhGADH5NnjhLURIGJmsRn7O4J4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1909bde2032156e9ff60e2deada4dd3c00b39e62",
+        "rev": "8fcb6b87cb31fd7383026832fdcacee2c6b637ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8fcb6b87`](https://github.com/nix-community/NUR/commit/8fcb6b87cb31fd7383026832fdcacee2c6b637ea) | `` automatic update `` |
| [`20f4083a`](https://github.com/nix-community/NUR/commit/20f4083a90c20cef58f6a53fbc0b1354fec12490) | `` automatic update `` |