### PR TITLE
chore(flake/nur): `fc8faf8b` -> `822187c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683920763,
-        "narHash": "sha256-NmnyRG0HydGPsvctPJXJlAnopimhTBkMem6Wf2nTAJw=",
+        "lastModified": 1683922718,
+        "narHash": "sha256-zgx95v9pStqxhW8KU/hPh5E98he1vj33RVRLuOzkFr4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc8faf8bd08a2c305b9dc1adfa672e6abb5a6c69",
+        "rev": "822187c46fa198c35b731b59717585efca3ef7be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`822187c4`](https://github.com/nix-community/NUR/commit/822187c46fa198c35b731b59717585efca3ef7be) | `` automatic update `` |