### PR TITLE
chore(flake/nur): `822187c4` -> `1a4a3778`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683922718,
-        "narHash": "sha256-zgx95v9pStqxhW8KU/hPh5E98he1vj33RVRLuOzkFr4=",
+        "lastModified": 1683930891,
+        "narHash": "sha256-LMtTt3XXqRIIJf1Rfyg21ZwKaP3BzIcsSa11FR7usnk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "822187c46fa198c35b731b59717585efca3ef7be",
+        "rev": "1a4a37780572902eb66b6a52236d59778007648e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1a4a3778`](https://github.com/nix-community/NUR/commit/1a4a37780572902eb66b6a52236d59778007648e) | `` automatic update `` |