### PR TITLE
chore(flake/home-manager): `70c8bd08` -> `eec22729`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683892466,
-        "narHash": "sha256-/zN3pQ4xoyolJoxrtn9oLU4JMjG5+c5K7BeLxZ7BR8o=",
+        "lastModified": 1683929392,
+        "narHash": "sha256-qJddrb/bgS58AXAv25iv5xJ+69G5g7FAYCWec1lLnW0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "70c8bd08e6c186e5c628a4e5af6f7ad67cd344b8",
+        "rev": "eec22729990ddf53d1e45e74624ddf667cdbe11b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                               |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`eec22729`](https://github.com/nix-community/home-manager/commit/eec22729990ddf53d1e45e74624ddf667cdbe11b) | `` tests: various minor cleanups ``   |
| [`19c509a6`](https://github.com/nix-community/home-manager/commit/19c509a6fa945212e478e5522149117162217bc5) | `` emacs: minor fixes ``              |
| [`1eac5feb`](https://github.com/nix-community/home-manager/commit/1eac5febc412b3aa6acc29c705e99d425f180b62) | `` translate-shell: add news entry `` |
| [`caa47705`](https://github.com/nix-community/home-manager/commit/caa47705f791b43feb63f612f2fd13d08275675c) | `` beets: minor fixes ``              |
| [`8345a316`](https://github.com/nix-community/home-manager/commit/8345a3166dd482f98e37b502e30dc56a16da4853) | `` kitty: minor fixes ``              |