### PR TITLE
chore(flake/nur): `1a4a3778` -> `ff2a014d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683930891,
-        "narHash": "sha256-LMtTt3XXqRIIJf1Rfyg21ZwKaP3BzIcsSa11FR7usnk=",
+        "lastModified": 1683946044,
+        "narHash": "sha256-23K45lAT63YN1quyxaIGS+sLqjuvgpXUOUuLW3CBCCk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1a4a37780572902eb66b6a52236d59778007648e",
+        "rev": "ff2a014db7026ae20be955a7ac2a3acae59b8964",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ff2a014d`](https://github.com/nix-community/NUR/commit/ff2a014db7026ae20be955a7ac2a3acae59b8964) | `` automatic update `` |