### PR TITLE
chore(flake/nur): `ff2a014d` -> `2d85d878`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683946044,
-        "narHash": "sha256-23K45lAT63YN1quyxaIGS+sLqjuvgpXUOUuLW3CBCCk=",
+        "lastModified": 1683962403,
+        "narHash": "sha256-wJaQhKet22vmyxA3bPGNUGSmWElqMzCPKEnf8IzIYDQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ff2a014db7026ae20be955a7ac2a3acae59b8964",
+        "rev": "2d85d8781e4fa1e793c92763733b6b131e5aabbb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2d85d878`](https://github.com/nix-community/NUR/commit/2d85d8781e4fa1e793c92763733b6b131e5aabbb) | `` automatic update `` |
| [`46d6805b`](https://github.com/nix-community/NUR/commit/46d6805b3d36700b07187e3dad0897dc5fcc508c) | `` automatic update `` |