### PR TITLE
chore(flake/emacs-overlay): `fc1f1e0d` -> `bea7c7ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683943026,
-        "narHash": "sha256-G/kxYiRLWBBysS0vkyvm84AFSKCqdp2C42PfYsVZKYk=",
+        "lastModified": 1683972856,
+        "narHash": "sha256-lLO4oizLHKd1yMFacaFe61Q2lQG/w7qB9i3T+qJN41c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fc1f1e0d1a4132939df71ad63b7be0e726fc1844",
+        "rev": "bea7c7ba1c24ff791f2506e8af6e4eb88a414af5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`bea7c7ba`](https://github.com/nix-community/emacs-overlay/commit/bea7c7ba1c24ff791f2506e8af6e4eb88a414af5) | `` Updated repos/melpa `` |
| [`ecbd0cc0`](https://github.com/nix-community/emacs-overlay/commit/ecbd0cc016443a5492338993c9f5f5da3da03d5e) | `` Updated repos/emacs `` |