### PR TITLE
chore(flake/home-manager): `93849977` -> `6702b22b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683960530,
-        "narHash": "sha256-hasZQSnM0nZkt8wlc0qKZIJ0Vn2EuJo8cOhxhLPkQH4=",
+        "lastModified": 1683989410,
+        "narHash": "sha256-puF/QsIkp4ch0sf6M5mNzbdZtYcq2MJHcKre9wJ3ZYo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "938499771727f2a53a19eb178f16fc42ff53a9f8",
+        "rev": "6702b22b9805bc1879715d4111e3764cd4237aed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                          |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`6702b22b`](https://github.com/nix-community/home-manager/commit/6702b22b9805bc1879715d4111e3764cd4237aed) | `` ssh: install an ssh client `` |
| [`e0026e16`](https://github.com/nix-community/home-manager/commit/e0026e16a5beff80f641e4edca318e654baa5a9b) | `` fuzzel: add module ``         |