### PR TITLE
chore(flake/nur): `9c383599` -> `53282b35`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683993879,
-        "narHash": "sha256-Vkh3NwvtjFuDp7TzSYNaqm2bG2Mbu2lvFxjHfdJX10o=",
+        "lastModified": 1683999475,
+        "narHash": "sha256-Xel665u27Q1M8BMhyYMhu1DDRVoJWQqFvQuUjqrZ384=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9c38359908111a7338c585d986d6056618da5745",
+        "rev": "53282b3582018485892ea408a2fab402c8632bb1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`53282b35`](https://github.com/nix-community/NUR/commit/53282b3582018485892ea408a2fab402c8632bb1) | `` automatic update `` |