### PR TITLE
chore(flake/emacs-overlay): `bea7c7ba` -> `39aaaf04`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683972856,
-        "narHash": "sha256-lLO4oizLHKd1yMFacaFe61Q2lQG/w7qB9i3T+qJN41c=",
+        "lastModified": 1684001897,
+        "narHash": "sha256-w/7Cgk5bCbSqiOBotZ98fS8k/J92rJl4X3rf5DVvLpM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bea7c7ba1c24ff791f2506e8af6e4eb88a414af5",
+        "rev": "39aaaf0465f7278b9f28358ff154ed26475620fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`39aaaf04`](https://github.com/nix-community/emacs-overlay/commit/39aaaf0465f7278b9f28358ff154ed26475620fe) | `` Updated repos/melpa `` |
| [`9a9271d9`](https://github.com/nix-community/emacs-overlay/commit/9a9271d9e599f96bf35039e9df3426b42c4b8e63) | `` Updated repos/emacs `` |