### PR TITLE
chore(flake/nur): `53282b35` -> `70667192`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1683999475,
-        "narHash": "sha256-Xel665u27Q1M8BMhyYMhu1DDRVoJWQqFvQuUjqrZ384=",
+        "lastModified": 1684007134,
+        "narHash": "sha256-eQNgdw4kipTSqMfyC8OWTYyPp5iJZ3BjExnAKjg3Qjg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "53282b3582018485892ea408a2fab402c8632bb1",
+        "rev": "70667192d90f81313362cd3296c9c6ad29c2d431",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`70667192`](https://github.com/nix-community/NUR/commit/70667192d90f81313362cd3296c9c6ad29c2d431) | `` automatic update `` |