### PR TITLE
chore(flake/nur): `70667192` -> `c626b2de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684007134,
-        "narHash": "sha256-eQNgdw4kipTSqMfyC8OWTYyPp5iJZ3BjExnAKjg3Qjg=",
+        "lastModified": 1684015269,
+        "narHash": "sha256-dlQ+eBGLNJpZOjA1v8xnpjqw9FZNsA4kpUUMelC8vf8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "70667192d90f81313362cd3296c9c6ad29c2d431",
+        "rev": "c626b2debd22f7dcd4c622a97b0034f5677155f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c626b2de`](https://github.com/nix-community/NUR/commit/c626b2debd22f7dcd4c622a97b0034f5677155f4) | `` automatic update `` |
| [`a509c12d`](https://github.com/nix-community/NUR/commit/a509c12d36668e5fa470e2cdb5a35faaeb326aad) | `` automatic update `` |
| [`dc8ecefd`](https://github.com/nix-community/NUR/commit/dc8ecefda0ffbfde78ab83c1709bd3646de12d15) | `` automatic update `` |
| [`202be37d`](https://github.com/nix-community/NUR/commit/202be37de85dfe8be1874c5c3fe992cfb0874eb7) | `` automatic update `` |
| [`80b309fd`](https://github.com/nix-community/NUR/commit/80b309fdb0bc6d999830bc4d68c0dcce94afe56d) | `` automatic update `` |