### PR TITLE
chore(flake/emacs-overlay): `39aaaf04` -> `023d9770`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684001897,
-        "narHash": "sha256-w/7Cgk5bCbSqiOBotZ98fS8k/J92rJl4X3rf5DVvLpM=",
+        "lastModified": 1684030369,
+        "narHash": "sha256-95WdJ6L3/ox72X5cJMuuQEeadf/RmWp8R1Sq0sZTYnc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "39aaaf0465f7278b9f28358ff154ed26475620fe",
+        "rev": "023d9770e37b6af1856b4ac506dd5cb9ce7db01d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`023d9770`](https://github.com/nix-community/emacs-overlay/commit/023d9770e37b6af1856b4ac506dd5cb9ce7db01d) | `` Updated repos/nongnu `` |
| [`c6cf3fb5`](https://github.com/nix-community/emacs-overlay/commit/c6cf3fb55c42a1344ef578121956a5440873c40e) | `` Updated repos/melpa ``  |
| [`3fc9857c`](https://github.com/nix-community/emacs-overlay/commit/3fc9857cccad4eafd02cf4e060dc71e73359a643) | `` Updated repos/elpa ``   |