### PR TITLE
chore(flake/nur): `c626b2de` -> `f3b31a6e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684015269,
-        "narHash": "sha256-dlQ+eBGLNJpZOjA1v8xnpjqw9FZNsA4kpUUMelC8vf8=",
+        "lastModified": 1684042604,
+        "narHash": "sha256-kKaNKeDtMLOcsTf8XnOT0/rYvvcqTQNGiIr5rO9PcgQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c626b2debd22f7dcd4c622a97b0034f5677155f4",
+        "rev": "f3b31a6e1a397412d4c3afe5b508674cbfce2cee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f3b31a6e`](https://github.com/nix-community/NUR/commit/f3b31a6e1a397412d4c3afe5b508674cbfce2cee) | `` automatic update `` |
| [`888c71c4`](https://github.com/nix-community/NUR/commit/888c71c450486f883d6f174fa1b4a916682f2b8d) | `` automatic update `` |
| [`00abd63a`](https://github.com/nix-community/NUR/commit/00abd63a5a5f8c639d9ea28876f1b0575c99c224) | `` automatic update `` |
| [`4b2224ad`](https://github.com/nix-community/NUR/commit/4b2224ade23064f36744184b40cb4914aee65db6) | `` automatic update `` |
| [`a255d569`](https://github.com/nix-community/NUR/commit/a255d56955f84199d200777a16654f063eb3f8b4) | `` automatic update `` |