### PR TITLE
chore(flake/emacs-ement): `5be1e070` -> `726d17b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -230,11 +230,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1682661960,
-        "narHash": "sha256-7EdRyYlkFnO4YlBhCBNpNBftwPbgYf14nRMYmzLkh8s=",
+        "lastModified": 1684039993,
+        "narHash": "sha256-diZigopj8p21tBKSiBtUMgCxHyFxioYScLNNepke4+U=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "5be1e0700288fea0762b4fc9311e0b05d6c78cc0",
+        "rev": "726d17b082e1276e8ace5b2d75c95bc1405e5f44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                                   |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`726d17b0`](https://github.com/alphapapa/ement.el/commit/726d17b082e1276e8ace5b2d75c95bc1405e5f44) | `` Docs: Explain mentions and completion ``                               |
| [`cb95f5e0`](https://github.com/alphapapa/ement.el/commit/cb95f5e0e84c351758d757033257f21dd03f3b62) | `` Fix: (ement-room-init-compose-buffer) Enable member/room completion `` |
| [`1bad0569`](https://github.com/alphapapa/ement.el/commit/1bad05695cb7d84a8789d75104f889e1b56dab1a) | `` Change: Improve completion by looking for prefixes ``                  |
| [`4d46aa06`](https://github.com/alphapapa/ement.el/commit/4d46aa0659e138073ff7db9e25b243630f92cb45) | `` Change: (ement-room--member-names-and-ids) Use timeline not EWOC ``    |
| [`c0b922bc`](https://github.com/alphapapa/ement.el/commit/c0b922bcc5d3c11b60d283caf28356c251fe885b) | `` Fix: (ement-room-list) When no rooms are joined ``                     |
| [`6bd10917`](https://github.com/alphapapa/ement.el/commit/6bd1091757bce5feedb337d01b88ab0aa3bc6124) | `` Fix: (-defevent "m.room.avatar") Warn for unreadable images ``         |