### PR TITLE
chore(flake/nur): `813936f9` -> `c5f0de68`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684062022,
-        "narHash": "sha256-FZDjy+6popPDs/9HRKvtJpwlBqs+VPI6ZvrFWZrR+3g=",
+        "lastModified": 1684071888,
+        "narHash": "sha256-8m2c2Iar9Mimn+LMafA3trCeTdyfU3e9F8P/25ywkm0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "813936f9006b814e6888aee9a0b1da1fcfe00edc",
+        "rev": "c5f0de685909d66b643b688ad6fcbe538d419a2d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c5f0de68`](https://github.com/nix-community/NUR/commit/c5f0de685909d66b643b688ad6fcbe538d419a2d) | `` automatic update `` |