### PR TITLE
chore(flake/nur): `c5f0de68` -> `a04e5e31`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684071888,
-        "narHash": "sha256-8m2c2Iar9Mimn+LMafA3trCeTdyfU3e9F8P/25ywkm0=",
+        "lastModified": 1684078972,
+        "narHash": "sha256-HfzRAo1bgQInTLXSb2EkaKUv8vlWP2jzgWH8qdxNFCA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c5f0de685909d66b643b688ad6fcbe538d419a2d",
+        "rev": "a04e5e31112cf7307e1c63cfd7278a5e322ac689",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a04e5e31`](https://github.com/nix-community/NUR/commit/a04e5e31112cf7307e1c63cfd7278a5e322ac689) | `` automatic update `` |