### PR TITLE
chore(flake/emacs-overlay): `bd593adc` -> `fabfebd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684055074,
-        "narHash": "sha256-yD7MidZf6nlKvepMtcr3iCDc4oHjkjdtU//ywqJLnKs=",
+        "lastModified": 1684089827,
+        "narHash": "sha256-iER4w9aU/qLJVsmk8eU2aVS9yZ9dizvUWVY+j3OtX3U=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bd593adc4469b86260085d8ac3148c6d5a65a669",
+        "rev": "fabfebd7b94348ff179d630d192da5c62429a68d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`fabfebd7`](https://github.com/nix-community/emacs-overlay/commit/fabfebd7b94348ff179d630d192da5c62429a68d) | `` Updated repos/melpa `` |
| [`44c65a19`](https://github.com/nix-community/emacs-overlay/commit/44c65a19dbc861423eadb52995ef2f825435eabe) | `` Updated repos/emacs `` |
| [`40c99422`](https://github.com/nix-community/emacs-overlay/commit/40c99422b0a022ba8ae62ed40899c5089fd0885f) | `` Updated repos/elpa ``  |