### PR TITLE
chore(flake/nur): `a04e5e31` -> `f76648b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684078972,
-        "narHash": "sha256-HfzRAo1bgQInTLXSb2EkaKUv8vlWP2jzgWH8qdxNFCA=",
+        "lastModified": 1684088542,
+        "narHash": "sha256-PxwapaqL0GxTkRd+JnhD+tySAjNgHmzODPr6l1YDzmM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a04e5e31112cf7307e1c63cfd7278a5e322ac689",
+        "rev": "f76648b3aa8167656080e17a01e976635724a675",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f76648b3`](https://github.com/nix-community/NUR/commit/f76648b3aa8167656080e17a01e976635724a675) | `` automatic update `` |
| [`e2d2a621`](https://github.com/nix-community/NUR/commit/e2d2a6218b28c7791ac3f482e47f76217202bb0e) | `` automatic update `` |