### PR TITLE
chore(flake/nur): `f76648b3` -> `a2299ea2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684088542,
-        "narHash": "sha256-PxwapaqL0GxTkRd+JnhD+tySAjNgHmzODPr6l1YDzmM=",
+        "lastModified": 1684091957,
+        "narHash": "sha256-bU7FzB1mdlPxuEgG8QoZxqWsPXGF38RF0i1h5UYYkBg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f76648b3aa8167656080e17a01e976635724a675",
+        "rev": "a2299ea2c2470deecb300fd333e93cfe5e4a4391",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a2299ea2`](https://github.com/nix-community/NUR/commit/a2299ea2c2470deecb300fd333e93cfe5e4a4391) | `` automatic update `` |