### PR TITLE
chore(flake/nur): `a2299ea2` -> `0e325961`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684091957,
-        "narHash": "sha256-bU7FzB1mdlPxuEgG8QoZxqWsPXGF38RF0i1h5UYYkBg=",
+        "lastModified": 1684101117,
+        "narHash": "sha256-HoIz8IhukrhwxWH4U/WChp/r0rTTK+gU1Vrl6mM57cU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a2299ea2c2470deecb300fd333e93cfe5e4a4391",
+        "rev": "0e32596111a0199b5550d14454f22fea833afbab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0e325961`](https://github.com/nix-community/NUR/commit/0e32596111a0199b5550d14454f22fea833afbab) | `` automatic update `` |
| [`e445037a`](https://github.com/nix-community/NUR/commit/e445037a3a8304302ce43bf38cb1cca507578ad5) | `` automatic update `` |
| [`b96df775`](https://github.com/nix-community/NUR/commit/b96df77574a915d5f425cfebd2cd7c6c017cb382) | `` automatic update `` |
| [`96430f34`](https://github.com/nix-community/NUR/commit/96430f34758eb89c91abc635167d90db8fa8a275) | `` automatic update `` |