### PR TITLE
chore(flake/nur): `0e325961` -> `a5311a04`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684101117,
-        "narHash": "sha256-HoIz8IhukrhwxWH4U/WChp/r0rTTK+gU1Vrl6mM57cU=",
+        "lastModified": 1684104319,
+        "narHash": "sha256-bpkJS6fn8TZFZWqOzFJZKEBVYwqVPjjAuYdrq6pkd9I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0e32596111a0199b5550d14454f22fea833afbab",
+        "rev": "a5311a048417e217989ed6e40584483bbbf31666",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a5311a04`](https://github.com/nix-community/NUR/commit/a5311a048417e217989ed6e40584483bbbf31666) | `` automatic update `` |
| [`7184a38f`](https://github.com/nix-community/NUR/commit/7184a38f724521d10a760030928013264ef7e203) | `` automatic update `` |