### PR TITLE
chore(flake/nur): `a5311a04` -> `b2fd13e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684104319,
-        "narHash": "sha256-bpkJS6fn8TZFZWqOzFJZKEBVYwqVPjjAuYdrq6pkd9I=",
+        "lastModified": 1684105873,
+        "narHash": "sha256-x/tGZz+YYfLzfkZFFqoSShc02ferrDhRebxqJ1kWE3U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a5311a048417e217989ed6e40584483bbbf31666",
+        "rev": "b2fd13e23eb71e2a210d98729e68aa1e69bb8348",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b2fd13e2`](https://github.com/nix-community/NUR/commit/b2fd13e23eb71e2a210d98729e68aa1e69bb8348) | `` automatic update `` |