### PR TITLE
chore(flake/nur): `b2fd13e2` -> `43f890fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684105873,
-        "narHash": "sha256-x/tGZz+YYfLzfkZFFqoSShc02ferrDhRebxqJ1kWE3U=",
+        "lastModified": 1684111175,
+        "narHash": "sha256-0IY1JO3nFm2ojN5X9aKCJEp+SLBA2bviQH7IkjZjGAw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b2fd13e23eb71e2a210d98729e68aa1e69bb8348",
+        "rev": "43f890fc852ca752aa9ca8b1c77c73c3df08f143",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`43f890fc`](https://github.com/nix-community/NUR/commit/43f890fc852ca752aa9ca8b1c77c73c3df08f143) | `` automatic update `` |
| [`b619a11b`](https://github.com/nix-community/NUR/commit/b619a11b96ef47e1d176e1bfbe3681b7538ed980) | `` automatic update `` |