### PR TITLE
chore(flake/emacs-overlay): `fabfebd7` -> `f4a8c7d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684089827,
-        "narHash": "sha256-iER4w9aU/qLJVsmk8eU2aVS9yZ9dizvUWVY+j3OtX3U=",
+        "lastModified": 1684116144,
+        "narHash": "sha256-A3O3S15+g5Xqr2vdcnb9oGynuJsB1sW0ZsSS4TehJmE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fabfebd7b94348ff179d630d192da5c62429a68d",
+        "rev": "f4a8c7d56584b087ae1eff81f4419029ab42fa69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`f4a8c7d5`](https://github.com/nix-community/emacs-overlay/commit/f4a8c7d56584b087ae1eff81f4419029ab42fa69) | `` Updated repos/nongnu `` |
| [`977b854e`](https://github.com/nix-community/emacs-overlay/commit/977b854eac3fb6802d7adcab15a242ffe82c9301) | `` Updated repos/melpa ``  |
| [`0cd24f74`](https://github.com/nix-community/emacs-overlay/commit/0cd24f74d6d5ec9a881af1c149aefc4503261825) | `` Updated repos/elpa ``   |