### PR TITLE
chore(flake/nur): `7a957bd6` -> `0543456a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684119703,
-        "narHash": "sha256-uC7PKOigHeZqGJtFzAg5xJWeO46wLarSgGDbATWahKQ=",
+        "lastModified": 1684122329,
+        "narHash": "sha256-vRMQZiU3/9q4uu+c5cupVbXdVS6aQ9UzVHjVJOLhTG4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7a957bd6ecde8280b3b512b4746a6bf38d45945d",
+        "rev": "0543456ab4af4928af9801f65941373b9596e65b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0543456a`](https://github.com/nix-community/NUR/commit/0543456ab4af4928af9801f65941373b9596e65b) | `` automatic update `` |