### PR TITLE
chore(flake/nur): `0543456a` -> `3c18a83e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684122329,
-        "narHash": "sha256-vRMQZiU3/9q4uu+c5cupVbXdVS6aQ9UzVHjVJOLhTG4=",
+        "lastModified": 1684123833,
+        "narHash": "sha256-YhoqB665ZQrCXNUMzKXlPbUM0C22VR/E+t+OHnpVt7M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0543456ab4af4928af9801f65941373b9596e65b",
+        "rev": "3c18a83e875962de17f83b817b6c66e1d7590620",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3c18a83e`](https://github.com/nix-community/NUR/commit/3c18a83e875962de17f83b817b6c66e1d7590620) | `` automatic update `` |