### PR TITLE
chore(flake/nur): `e3e76e6f` -> `db91dccd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684132416,
-        "narHash": "sha256-o0NSL/e4uFSC38wRXFWhgGKaDcr2baG2pvE2uWlVkkI=",
+        "lastModified": 1684150449,
+        "narHash": "sha256-/ki0VW+92/0fdLp9E5enH0CO/gYXEvpzWcJbY69hDi8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e3e76e6f738839784188d6509216b9d9b9098f84",
+        "rev": "db91dccd773ec0af7e62beb1ee20a5bb3faf66e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`db91dccd`](https://github.com/nix-community/NUR/commit/db91dccd773ec0af7e62beb1ee20a5bb3faf66e2) | `` automatic update `` |
| [`4cc60a88`](https://github.com/nix-community/NUR/commit/4cc60a887561c23d5e5c0970bd14800e55aefa6a) | `` automatic update `` |