### PR TITLE
chore(flake/emacs-overlay): `f4a8c7d5` -> `e4cc7646`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684116144,
-        "narHash": "sha256-A3O3S15+g5Xqr2vdcnb9oGynuJsB1sW0ZsSS4TehJmE=",
+        "lastModified": 1684174178,
+        "narHash": "sha256-uK05ToTuh5BP3U+wOOTfOAcJKy1q3KTjilzmr9ig1WQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f4a8c7d56584b087ae1eff81f4419029ab42fa69",
+        "rev": "e4cc7646293b591244f9e1cacdab53170084846b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`e4cc7646`](https://github.com/nix-community/emacs-overlay/commit/e4cc7646293b591244f9e1cacdab53170084846b) | `` Updated repos/melpa `` |
| [`4a6aaa0c`](https://github.com/nix-community/emacs-overlay/commit/4a6aaa0c97057dc7a2ba82a9e16d5524f84f004f) | `` Updated repos/emacs `` |
| [`9b41f829`](https://github.com/nix-community/emacs-overlay/commit/9b41f8296a3898bdb87b9d091f9df540a982b242) | `` Updated repos/melpa `` |
| [`edfd74f3`](https://github.com/nix-community/emacs-overlay/commit/edfd74f3705815b93cc4fb7759376f4f2e101334) | `` Updated repos/emacs `` |