### PR TITLE
chore(flake/nur): `db91dccd` -> `d0eed7dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684150449,
-        "narHash": "sha256-/ki0VW+92/0fdLp9E5enH0CO/gYXEvpzWcJbY69hDi8=",
+        "lastModified": 1684155595,
+        "narHash": "sha256-vHan3Q3NFVpOY5+zDnaUAEMNjzZbm4Hrzk6KmrBgdvk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "db91dccd773ec0af7e62beb1ee20a5bb3faf66e2",
+        "rev": "d0eed7ddc9b8e97cae58f1575715753bea4c649a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d0eed7dd`](https://github.com/nix-community/NUR/commit/d0eed7ddc9b8e97cae58f1575715753bea4c649a) | `` automatic update `` |