### PR TITLE
chore(flake/nur): `d0eed7dd` -> `0a379ed9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684155595,
-        "narHash": "sha256-vHan3Q3NFVpOY5+zDnaUAEMNjzZbm4Hrzk6KmrBgdvk=",
+        "lastModified": 1684158328,
+        "narHash": "sha256-MpM9czpyefAJWTbCiN/T/6bXH/EW+/GHhPo6ES9bGAA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d0eed7ddc9b8e97cae58f1575715753bea4c649a",
+        "rev": "0a379ed9a1a2be51f6c189a9daae26eef01c727b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0a379ed9`](https://github.com/nix-community/NUR/commit/0a379ed9a1a2be51f6c189a9daae26eef01c727b) | `` automatic update `` |