### PR TITLE
chore(flake/nur): `0a379ed9` -> `e724514d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684158328,
-        "narHash": "sha256-MpM9czpyefAJWTbCiN/T/6bXH/EW+/GHhPo6ES9bGAA=",
+        "lastModified": 1684165476,
+        "narHash": "sha256-D0ek1aBXXscnKm5w9aCzBHejHeufD3XocmUphx0kCbI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0a379ed9a1a2be51f6c189a9daae26eef01c727b",
+        "rev": "e724514d54b0a97e9a754815398ef79a397fd158",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e724514d`](https://github.com/nix-community/NUR/commit/e724514d54b0a97e9a754815398ef79a397fd158) | `` automatic update `` |