### PR TITLE
chore(flake/nixos-hardware): `81cd8867` -> `b3a8d308`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -593,11 +593,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1683965003,
-        "narHash": "sha256-DrzSdOnLv/yFBvS2FqmwBA2xIbN/Lny/WlxHyoLR9zE=",
+        "lastModified": 1684169129,
+        "narHash": "sha256-AEbTTVpaeRAf3vKvjQT6JiT6VAm1YZO8j3/P82gUNiQ=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "81cd886719e10d4822b2a6caa96e95d56cc915ef",
+        "rev": "b3a8d308a13390df35b198d4db36a654ec29e25a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`b3b91ca4`](https://github.com/NixOS/nixos-hardware/commit/b3b91ca4871dcbbcb9dbe016c6203736480edd6e) | `` samsung/np900x3c: drop deprecated synaptics `` |