### PR TITLE
chore(flake/nur): `e724514d` -> `5be0cbc9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684165476,
-        "narHash": "sha256-D0ek1aBXXscnKm5w9aCzBHejHeufD3XocmUphx0kCbI=",
+        "lastModified": 1684179875,
+        "narHash": "sha256-8Ffi8Mq3K0J4grULPn4Lwcobe6yYbvx0ybnhNfNR9WM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e724514d54b0a97e9a754815398ef79a397fd158",
+        "rev": "5be0cbc90f8ec78c828edeeeb6922ee639e9eef0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5be0cbc9`](https://github.com/nix-community/NUR/commit/5be0cbc90f8ec78c828edeeeb6922ee639e9eef0) | `` automatic update `` |
| [`5916c732`](https://github.com/nix-community/NUR/commit/5916c73277fe0ceda579432cdce0caa43e8b455e) | `` automatic update `` |
| [`cfea9b8b`](https://github.com/nix-community/NUR/commit/cfea9b8b368bc4b8ae59c8f686f29b902f905bb0) | `` automatic update `` |