### PR TITLE
chore(flake/nixos-hardware): `b3a8d308` -> `71ce8537`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -593,11 +593,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1684169129,
-        "narHash": "sha256-AEbTTVpaeRAf3vKvjQT6JiT6VAm1YZO8j3/P82gUNiQ=",
+        "lastModified": 1684169666,
+        "narHash": "sha256-N5jrykeSxLVgvm3Dd3hZ38/XwM/jU+dltqlXgrGlYxk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b3a8d308a13390df35b198d4db36a654ec29e25a",
+        "rev": "71ce85372a614d418d5e303dd5702a79d1545c04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                               |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`bbacfd60`](https://github.com/NixOS/nixos-hardware/commit/bbacfd60126930faee6801c44bcda186151a22d6) | `` PR review comment ``                                                               |
| [`2c2d2240`](https://github.com/NixOS/nixos-hardware/commit/2c2d22409f4082ab8891fe118f7ec041e83175d4) | `` Add HP Elitebook 845g9 ``                                                          |
| [`c256df33`](https://github.com/NixOS/nixos-hardware/commit/c256df331235ce369fdd49c00989fdaa95942934) | `` cpu/amd/pstate: change the pstate mode to active ``                                |
| [`5febaab6`](https://github.com/NixOS/nixos-hardware/commit/5febaab6bd0e119a3f6223aa219e614c02593d06) | `` raspberry-pi."4": fix build error with poe-hat, because of incompatibility with `` |
| [`aa85ea33`](https://github.com/NixOS/nixos-hardware/commit/aa85ea337b275c3aeb6ce8b4fe5ff621a2842502) | `` raspberry-pi."4": fix compatible string ``                                         |
| [`40a9f0ed`](https://github.com/NixOS/nixos-hardware/commit/40a9f0ed77b720db44b49c6dbc049d0920952d91) | `` raspberry-pi."4": add assertion and update some source comments ``                 |
| [`1ffd9949`](https://github.com/NixOS/nixos-hardware/commit/1ffd9949eef6ae6db3bde1ccd1565605dff12932) | `` raspberry-pi."4": update poe hat overlay to work with newer kernel ``              |