### PR TITLE
chore(flake/pre-commit-hooks): `fb58866e` -> `48c59cec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -846,11 +846,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1682596858,
-        "narHash": "sha256-Hf9XVpqaGqe/4oDGr30W8HlsWvJXtMsEPHDqHZA6dDg=",
+        "lastModified": 1684176146,
+        "narHash": "sha256-jZcgFyyBvlP0MHoBI1X8A0liVMb/trS2fIDG00FmQNQ=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "fb58866e20af98779017134319b5663b8215d912",
+        "rev": "48c59cec0b8ca341cca96f759cb066333309c1fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                          |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`10a4aede`](https://github.com/cachix/pre-commit-hooks.nix/commit/10a4aedeb6b25fe39144dbcf36942b56a8c91e10) | `` Add custom hook example to hook option doc `` |