### PR TITLE
chore(flake/nur): `f1d72bc7` -> `16edffdc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684194379,
-        "narHash": "sha256-8+Ka2AjXZ+er4s9JEq2Z5SpSYFgQuIiDtl5SheXbJCo=",
+        "lastModified": 1684205381,
+        "narHash": "sha256-TtQgweQ6iKYarhQQacJ4L7lvsmR7ukmMYt8F7gfHXL4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f1d72bc75d3b9777639323ef7dc662133c20d3a4",
+        "rev": "16edffdc42f384a565a4278110ba40ce25a13a9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`16edffdc`](https://github.com/nix-community/NUR/commit/16edffdc42f384a565a4278110ba40ce25a13a9d) | `` automatic update `` |