### PR TITLE
chore(flake/emacs-overlay): `e4cc7646` -> `adefd0c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684174178,
-        "narHash": "sha256-uK05ToTuh5BP3U+wOOTfOAcJKy1q3KTjilzmr9ig1WQ=",
+        "lastModified": 1684234701,
+        "narHash": "sha256-UrA8YP81IjGlYaBXyIF+fM9eP1LuOXOnqgMXUaz63rY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e4cc7646293b591244f9e1cacdab53170084846b",
+        "rev": "adefd0c1974731350a6ec6b960178bb9fa970942",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`adefd0c1`](https://github.com/nix-community/emacs-overlay/commit/adefd0c1974731350a6ec6b960178bb9fa970942) | `` Updated repos/melpa ``  |
| [`920411b5`](https://github.com/nix-community/emacs-overlay/commit/920411b53cefe79eed0a462df11278df8306e1de) | `` Updated repos/emacs ``  |
| [`f8824fa1`](https://github.com/nix-community/emacs-overlay/commit/f8824fa1a882d07921d229c35d7076428e9d9075) | `` Updated repos/nongnu `` |
| [`2086d4d6`](https://github.com/nix-community/emacs-overlay/commit/2086d4d64e443bd81df254d037885b44254df75f) | `` Updated repos/melpa ``  |
| [`67fd0f86`](https://github.com/nix-community/emacs-overlay/commit/67fd0f86c7be58f14ec840b9823d5c8d60912eb4) | `` Updated repos/emacs ``  |