### PR TITLE
chore(flake/nur): `16edffdc` -> `a7e660b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684205381,
-        "narHash": "sha256-TtQgweQ6iKYarhQQacJ4L7lvsmR7ukmMYt8F7gfHXL4=",
+        "lastModified": 1684209344,
+        "narHash": "sha256-/dOjK+QDnvNRK5BIhEnr30FCAC2Cx04xPdgod/H/kHc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "16edffdc42f384a565a4278110ba40ce25a13a9d",
+        "rev": "a7e660b29003372023f73c24e16f0fdff3021df0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a7e660b2`](https://github.com/nix-community/NUR/commit/a7e660b29003372023f73c24e16f0fdff3021df0) | `` automatic update `` |
| [`d8ce2a52`](https://github.com/nix-community/NUR/commit/d8ce2a527e945cb6441cc66145294affb6557957) | `` automatic update `` |