### PR TITLE
chore(flake/nur): `a7e660b2` -> `8447351b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684209344,
-        "narHash": "sha256-/dOjK+QDnvNRK5BIhEnr30FCAC2Cx04xPdgod/H/kHc=",
+        "lastModified": 1684211281,
+        "narHash": "sha256-IaGa3IreU6S5qq4oXkHCLYqTBiMaAhAntkFOoufICJo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a7e660b29003372023f73c24e16f0fdff3021df0",
+        "rev": "8447351b8bec92aed948665bc631270ec153f321",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8447351b`](https://github.com/nix-community/NUR/commit/8447351b8bec92aed948665bc631270ec153f321) | `` automatic update `` |
| [`7c0e1b3f`](https://github.com/nix-community/NUR/commit/7c0e1b3fd43ab77fa89ea443a1a97a74897409e6) | `` automatic update `` |