### PR TITLE
chore(flake/nur): `4543a5dc` -> `82a4da5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684218745,
-        "narHash": "sha256-UvP4puWuP+FD7/mxzd9UZZxeeggS5si3EyYMa6oZRR8=",
+        "lastModified": 1684233954,
+        "narHash": "sha256-MWu767sddr9S0gTVMjuM19E4EEunVhW0KP+NIv/zQoc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4543a5dcb060e40588ba753f773793e34e7e9489",
+        "rev": "82a4da5ad1373a7b5728343b139085689e4c4006",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`82a4da5a`](https://github.com/nix-community/NUR/commit/82a4da5ad1373a7b5728343b139085689e4c4006) | `` automatic update `` |