### PR TITLE
chore(flake/nix-on-droid): `b00cb5e7` -> `dd86937e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -578,11 +578,11 @@
         "nmd": "nmd_2"
       },
       "locked": {
-        "lastModified": 1670198918,
-        "narHash": "sha256-oNlUhAM0/a3pDdCMmBWA+CLrDAIYJqAAMyrDp8fNSM4=",
+        "lastModified": 1684254218,
+        "narHash": "sha256-qn7uLzBrbAFpT9eSzBCHsnLlYfcqQHlnzkygBNq6qQo=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "b00cb5e7e2a47d85a019119069b153cda4002d0a",
+        "rev": "dd86937ef79f631af6f8f5b2b203b0b840549c2c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`dd86937e`](https://github.com/t184256/nix-on-droid/commit/dd86937ef79f631af6f8f5b2b203b0b840549c2c) | `` CHANGELOG: add `environment.extraOutputsToInstall` option ``  |
| [`02c3b2d2`](https://github.com/t184256/nix-on-droid/commit/02c3b2d260007c7b2c7c2ae2c28e55d3174ffa70) | `` modules/environment/path: add extraOutputsToInstall option `` |