### PR TITLE
chore(flake/emacs-overlay): `adefd0c1` -> `338da822`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684234701,
-        "narHash": "sha256-UrA8YP81IjGlYaBXyIF+fM9eP1LuOXOnqgMXUaz63rY=",
+        "lastModified": 1684260652,
+        "narHash": "sha256-WHlAnZ4lnuI1s9IaHTGyZP/QLDbvjosDvbcHLF4Wrmc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "adefd0c1974731350a6ec6b960178bb9fa970942",
+        "rev": "338da822b1506c26c18e6fced9527a8de4f08665",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`338da822`](https://github.com/nix-community/emacs-overlay/commit/338da822b1506c26c18e6fced9527a8de4f08665) | `` Updated repos/melpa `` |
| [`dde451de`](https://github.com/nix-community/emacs-overlay/commit/dde451ded0f4fd7d8812f1537ac29aee2692bea1) | `` Updated repos/emacs `` |
| [`aad7bd32`](https://github.com/nix-community/emacs-overlay/commit/aad7bd32496f49d5cc05b7929752886bbdb264ca) | `` Updated repos/elpa ``  |