### PR TITLE
chore(flake/nur): `0f1674ef` -> `8aa62918`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684255481,
-        "narHash": "sha256-rMiMTtzjLQJMOpCZQZw8MbiXBij1OY0Tomme2nZLHcA=",
+        "lastModified": 1684266264,
+        "narHash": "sha256-jSeFCelij48A12NZiUOhTAa6RUhZcXiiXMnWvtbiXPY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0f1674ef409a05716eeaeef0bd28204c9dbacf66",
+        "rev": "8aa62918f0580ff1c34a9e00e0baabb403595100",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8aa62918`](https://github.com/nix-community/NUR/commit/8aa62918f0580ff1c34a9e00e0baabb403595100) | `` automatic update `` |
| [`d1a1418d`](https://github.com/nix-community/NUR/commit/d1a1418d6b7821be7aeba964f2dd55b1563338b2) | `` automatic update `` |