### PR TITLE
chore(flake/impermanence): `ec1a8e70` -> `89253fb1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -509,11 +509,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1684144492,
-        "narHash": "sha256-5TBG9kZGdKrZGHdyjLA04ODSzhx1Bx/vwMxfRgWF+JU=",
+        "lastModified": 1684264534,
+        "narHash": "sha256-K0zr+ry3FwIo3rN2U/VWAkCJSgBslBisvfRIPwMbuCQ=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "ec1a8e70d61261f9ada30f4e450ea7230d9efb62",
+        "rev": "89253fb1518063556edd5e54509c30ac3089d5e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`6f4fc9d7`](https://github.com/nix-community/impermanence/commit/6f4fc9d70c3ec1bcf5fc5e2563e77621ad13eb1e) | `` Skip generating bind mounts if no bind mounts are configured. `` |