### PR TITLE
chore(flake/nur): `8aa62918` -> `ff57e2e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684266264,
-        "narHash": "sha256-jSeFCelij48A12NZiUOhTAa6RUhZcXiiXMnWvtbiXPY=",
+        "lastModified": 1684284049,
+        "narHash": "sha256-oHdnBC9J2wOSEpPDvPcYoOQImVSu4zp79gDQ2AJZnWI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8aa62918f0580ff1c34a9e00e0baabb403595100",
+        "rev": "ff57e2e8f24dbeffbac5ffebd88ee5f9035d5a6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ff57e2e8`](https://github.com/nix-community/NUR/commit/ff57e2e8f24dbeffbac5ffebd88ee5f9035d5a6c) | `` automatic update `` |