### PR TITLE
chore(flake/nur): `ff57e2e8` -> `4ba6ab75`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684284049,
-        "narHash": "sha256-oHdnBC9J2wOSEpPDvPcYoOQImVSu4zp79gDQ2AJZnWI=",
+        "lastModified": 1684288445,
+        "narHash": "sha256-jfzax/EQLC+8NZQoTbtzXffOH9QECQBYpj8T6FZdzqg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ff57e2e8f24dbeffbac5ffebd88ee5f9035d5a6c",
+        "rev": "4ba6ab756c2ee4428f95d9b1232300a33c818097",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4ba6ab75`](https://github.com/nix-community/NUR/commit/4ba6ab756c2ee4428f95d9b1232300a33c818097) | `` automatic update `` |