### PR TITLE
chore(flake/nur): `4ba6ab75` -> `e304a1e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684288445,
-        "narHash": "sha256-jfzax/EQLC+8NZQoTbtzXffOH9QECQBYpj8T6FZdzqg=",
+        "lastModified": 1684295137,
+        "narHash": "sha256-y/4MZfxwbee45jERnQ3ZaBt7EMwjF5ND57S8NoYEXRE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ba6ab756c2ee4428f95d9b1232300a33c818097",
+        "rev": "e304a1e91a0896b0b987b94151c14826186178b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e304a1e9`](https://github.com/nix-community/NUR/commit/e304a1e91a0896b0b987b94151c14826186178b8) | `` automatic update `` |