### PR TITLE
chore(flake/nur): `e304a1e9` -> `c2c16ede`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684295137,
-        "narHash": "sha256-y/4MZfxwbee45jERnQ3ZaBt7EMwjF5ND57S8NoYEXRE=",
+        "lastModified": 1684300102,
+        "narHash": "sha256-M3AT2x7497S/HLwWzoVHE3SIh2zzq+hvA174iGhU7b8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e304a1e91a0896b0b987b94151c14826186178b8",
+        "rev": "c2c16edecfe057e142b786c0f98a3e627d896608",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c2c16ede`](https://github.com/nix-community/NUR/commit/c2c16edecfe057e142b786c0f98a3e627d896608) | `` automatic update `` |
| [`40a1416e`](https://github.com/nix-community/NUR/commit/40a1416ebad0f3d29914834002bd01f36477eb56) | `` automatic update `` |