### PR TITLE
chore(flake/emacs-overlay): `016a781c` -> `55139469`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684293023,
-        "narHash": "sha256-scsN8CvQ8ObD09verWq6e8u4FUMYrZh0uhYl2F1OOC4=",
+        "lastModified": 1684314617,
+        "narHash": "sha256-V7LnO8F7LnlhpRiKqcQZ9kJcS416OWEMh957nByqG9o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "016a781cc93d3c7f7005b6ba12f667e9861056e0",
+        "rev": "551394696c8db0fa65cc3e49fa6a81bc733b7a8a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`55139469`](https://github.com/nix-community/emacs-overlay/commit/551394696c8db0fa65cc3e49fa6a81bc733b7a8a) | `` Updated repos/melpa `` |