### PR TITLE
chore(flake/nur): `c2c16ede` -> `51e82ded`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684300102,
-        "narHash": "sha256-M3AT2x7497S/HLwWzoVHE3SIh2zzq+hvA174iGhU7b8=",
+        "lastModified": 1684321038,
+        "narHash": "sha256-YwM+DZswWeE2sqSfeI70WwLzXLfaCyITweD2KZnxsOk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c2c16edecfe057e142b786c0f98a3e627d896608",
+        "rev": "51e82dedc8d185066b4118138f3a4bcfeb28fb08",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`51e82ded`](https://github.com/nix-community/NUR/commit/51e82dedc8d185066b4118138f3a4bcfeb28fb08) | `` automatic update `` |