### PR TITLE
chore(flake/home-manager): `b7d814c5` -> `59659243`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684189380,
-        "narHash": "sha256-GUp9OkZynocyppLur1VX8oAjtXGue0oKRHbsksOMUm0=",
+        "lastModified": 1684321175,
+        "narHash": "sha256-V4EbM+jK7pvjKBaj0dgAiW9ultzDE27Nz5fRyu/ceMk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b7d814c5744dca7e70b3dc2638f06568dce96ca6",
+        "rev": "59659243cd4ababda605e79b4a9c2e6d83e24c86",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`59659243`](https://github.com/nix-community/home-manager/commit/59659243cd4ababda605e79b4a9c2e6d83e24c86) | `` PR_TEMPLATE: Note nix3 test method in checklist (#3972) `` |
| [`e14e7970`](https://github.com/nix-community/home-manager/commit/e14e797041e393abd1ffab597d299a72d3b582e5) | `` neomutt: add missing stub in test (#3996) ``               |