### PR TITLE
chore(flake/emacs-overlay): `55139469` -> `0da5effd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684314617,
-        "narHash": "sha256-V7LnO8F7LnlhpRiKqcQZ9kJcS416OWEMh957nByqG9o=",
+        "lastModified": 1684323447,
+        "narHash": "sha256-YUXVg2MlZJ6so1m9PeBrAtbiZO5bXiW7C6Lo74BMMbk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "551394696c8db0fa65cc3e49fa6a81bc733b7a8a",
+        "rev": "0da5effdc8bef9bbfb4938ccb8a21dd22f47760f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                  |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
| [`0da5effd`](https://github.com/nix-community/emacs-overlay/commit/0da5effdc8bef9bbfb4938ccb8a21dd22f47760f) | `` added missing 'pkgs.' at start of package name for example. (#324) `` |