### PR TITLE
chore(flake/nur): `51e82ded` -> `12976f46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684321038,
-        "narHash": "sha256-YwM+DZswWeE2sqSfeI70WwLzXLfaCyITweD2KZnxsOk=",
+        "lastModified": 1684328344,
+        "narHash": "sha256-kkigG+7LBV7KxCh0iR6f0sWfu6/H1oZwvLyvlEgldXw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "51e82dedc8d185066b4118138f3a4bcfeb28fb08",
+        "rev": "12976f46a70a9d94ad8a79f2b63ade465a7d1ad5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`12976f46`](https://github.com/nix-community/NUR/commit/12976f46a70a9d94ad8a79f2b63ade465a7d1ad5) | `` automatic update `` |