### PR TITLE
chore(flake/nur): `12976f46` -> `da988644`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684328344,
-        "narHash": "sha256-kkigG+7LBV7KxCh0iR6f0sWfu6/H1oZwvLyvlEgldXw=",
+        "lastModified": 1684349153,
+        "narHash": "sha256-S/QRtvw5t3bQKjBX89eXsQJpEroPd9oUfhTO0eRBQI8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "12976f46a70a9d94ad8a79f2b63ade465a7d1ad5",
+        "rev": "da988644b16939cd2ccaa5ae2a17250066275361",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`da988644`](https://github.com/nix-community/NUR/commit/da988644b16939cd2ccaa5ae2a17250066275361) | `` automatic update `` |
| [`267982e6`](https://github.com/nix-community/NUR/commit/267982e6cb36a6d54f750c9f64666390dc62ef3e) | `` automatic update `` |
| [`efc10b36`](https://github.com/nix-community/NUR/commit/efc10b36b6d025af03f653b13b3917379ad3511a) | `` automatic update `` |