### PR TITLE
chore(flake/emacs-overlay): `0da5effd` -> `95c844b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684323447,
-        "narHash": "sha256-YUXVg2MlZJ6so1m9PeBrAtbiZO5bXiW7C6Lo74BMMbk=",
+        "lastModified": 1684348799,
+        "narHash": "sha256-K/2G+BnHK3JdGnT/qkYWGljgy5kUeCZDSnBz4cLqb+c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0da5effdc8bef9bbfb4938ccb8a21dd22f47760f",
+        "rev": "95c844b1985808df780acc1835a354fe3ff27282",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`95c844b1`](https://github.com/nix-community/emacs-overlay/commit/95c844b1985808df780acc1835a354fe3ff27282) | `` Updated repos/melpa `` |
| [`434e9c63`](https://github.com/nix-community/emacs-overlay/commit/434e9c63d4cedb9b8bcbd75ebdef00268e135459) | `` Updated repos/emacs `` |