### PR TITLE
chore(flake/nix-on-droid): `dd86937e` -> `064e1b28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -578,11 +578,11 @@
         "nmd": "nmd_2"
       },
       "locked": {
-        "lastModified": 1684254218,
-        "narHash": "sha256-qn7uLzBrbAFpT9eSzBCHsnLlYfcqQHlnzkygBNq6qQo=",
+        "lastModified": 1684353543,
+        "narHash": "sha256-0b85kcdeM1WgGZZn0L4fke39xcVpO99hidzcpqvNOcQ=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "dd86937ef79f631af6f8f5b2b203b0b840549c2c",
+        "rev": "064e1b280e4711ecea0d7abbe885362cbf7b717a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                             |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`064e1b28`](https://github.com/t184256/nix-on-droid/commit/064e1b280e4711ecea0d7abbe885362cbf7b717a) | `` ci: regularly run all actions `` |
| [`109abda3`](https://github.com/t184256/nix-on-droid/commit/109abda38121caf677b0816f517475ac4bcb592d) | `` ci: update github actions ``     |