### PR TITLE
chore(flake/nur): `e59d30a3` -> `ca68452b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684352760,
-        "narHash": "sha256-6HLYGHLyQfewP0d78k8n7dnnpj7z9TE2npg7VCacLd4=",
+        "lastModified": 1684360268,
+        "narHash": "sha256-fvQWCYVaoy46/dz5FEMV7/A4QFra3DQbUpo6A7YXhFU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e59d30a3687ef8b93473360bfcfa69ea012764bd",
+        "rev": "ca68452b8a9e9ca328e60308d87cd62aa0541c4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ca68452b`](https://github.com/nix-community/NUR/commit/ca68452b8a9e9ca328e60308d87cd62aa0541c4b) | `` automatic update `` |
| [`7ca1ac61`](https://github.com/nix-community/NUR/commit/7ca1ac61530a0bde59187b448e94f49a3136810c) | `` automatic update `` |
| [`511bbc99`](https://github.com/nix-community/NUR/commit/511bbc99cc48d1e3b03cbd501393325ca84ddc8a) | `` automatic update `` |