### PR TITLE
chore(flake/nixpkgs): `963006aa` -> `e6e38991`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -718,11 +718,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1684215771,
-        "narHash": "sha256-fsum28z+g18yreNa1Y7MPo9dtps5h1VkHfZbYQ+YPbk=",
+        "lastModified": 1684305980,
+        "narHash": "sha256-vd4SKXX1KZfSX6n3eoguJw/vQ+sBL8XGdgfxjEgLpKc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "963006aab35e3e8ebbf6052b6bf4ea712fdd3c28",
+        "rev": "e6e389917a8c778be636e67a67ec958f511cc55d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                  |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`3c4aa21b`](https://github.com/NixOS/nixpkgs/commit/3c4aa21bee209a73f0045f9341b8b394037e61e6) | `` terraform-providers.google-beta: 4.65.0 -> 4.65.2 ``                                  |
| [`fbdd5de1`](https://github.com/NixOS/nixpkgs/commit/fbdd5de1f16b6cdd4ee3ea71d2d260bc887a5f48) | `` terraform-providers.google: 4.65.0 -> 4.65.2 ``                                       |
| [`36304516`](https://github.com/NixOS/nixpkgs/commit/36304516f4f9353a3e77494d9acd58cf0a3f16be) | `` terraform-providers.cloudflare: 4.5.0 -> 4.6.0 ``                                     |
| [`4a61453d`](https://github.com/NixOS/nixpkgs/commit/4a61453d0a0556abbc69a950189d7c4033ff5097) | `` maintainers: update jayeshbhoot ``                                                    |
| [`f8938533`](https://github.com/NixOS/nixpkgs/commit/f8938533601019766822ed0ca4e59bc10be49f81) | `` rymdport: 3.3.5 -> 3.3.6 ``                                                           |
| [`fbf754a3`](https://github.com/NixOS/nixpkgs/commit/fbf754a3a250d13e3f385d58ee8887db02db1200) | `` sqlcmd: 0.15.4 -> 1.0.0 ``                                                            |
| [`1e52e071`](https://github.com/NixOS/nixpkgs/commit/1e52e0711f2c999647bfb53fdbe2b660850cf43b) | `` rust-analyzer-unwrapped: 2023-05-01 -> 2023-05-15 ``                                  |
| [`3f2c8888`](https://github.com/NixOS/nixpkgs/commit/3f2c8888edda8da8ac8e538f4ec51bfbf64a87a0) | `` script-directory: init at 1.1.0 ``                                                    |
| [`7974082b`](https://github.com/NixOS/nixpkgs/commit/7974082b587b4d57a44553d8392174029816d129) | `` linuxPackages.nvidia_x11_vulkan_beta: 525.47.22 -> 525.47.24 ``                       |
| [`826e6991`](https://github.com/NixOS/nixpkgs/commit/826e69915ab0a0ba2d3ea934cde439ae2eecba07) | `` plexamp: 4.6.2 -> 4.7.4 ``                                                            |
| [`e8408498`](https://github.com/NixOS/nixpkgs/commit/e8408498f79c71d6bc25d2b430ca015cc4bbec30) | `` vlang: eliminate env.VFLAGS ``                                                        |
| [`11f614eb`](https://github.com/NixOS/nixpkgs/commit/11f614eb1359296ba0479b9df571511eb3bff40b) | `` ansible-lint: 6.16.0 -> 6.16.1 ``                                                     |
| [`72ffc999`](https://github.com/NixOS/nixpkgs/commit/72ffc9994d1f563e302c9b875fe669413f473086) | `` vscode: clean up generic expression now that everything is 1.78 ``                    |
| [`6d148248`](https://github.com/NixOS/nixpkgs/commit/6d148248b1327c66298bfbd690f34ecc54c8264f) | `` vscodium: 1.77.3.23102 -> 1.78.2.23132, drop armhf ``                                 |
| [`10304692`](https://github.com/NixOS/nixpkgs/commit/1030469295f031d89bc6f6ba854fab32f1190f81) | `` vscode: 1.78.0 -> 1.78.2 ``                                                           |
| [`0aee301a`](https://github.com/NixOS/nixpkgs/commit/0aee301acb415f305ac336083d14b2dc528a20be) | `` llvmPackages_rocm.llvm: build on big-parallel ``                                      |
| [`fedc294f`](https://github.com/NixOS/nixpkgs/commit/fedc294f603016efdcfe80d5cfad51aa70b6ea2c) | `` vlang: eliminate pkgsStatic ``                                                        |
| [`da6f0b6a`](https://github.com/NixOS/nixpkgs/commit/da6f0b6aabfbd52b8e07046c1fe62a4530f2fb75) | `` watchlog: 1.197.0 -> 1.213.0 ``                                                       |
| [`b1c83f9f`](https://github.com/NixOS/nixpkgs/commit/b1c83f9f0110e704e2bd7abf11dab911b639726b) | `` vlang: fix build on darwin ``                                                         |
| [`0e26e51b`](https://github.com/NixOS/nixpkgs/commit/0e26e51bdab0974364880fbe33f9087c6f76df22) | `` kubescape: 2.3.2 -> 2.3.3 ``                                                          |
| [`9b4fc47c`](https://github.com/NixOS/nixpkgs/commit/9b4fc47c6056a905c41beecc030fbd01cd420072) | `` icon-library: 0.0.11 -> 0.0.16 ``                                                     |
| [`407e142a`](https://github.com/NixOS/nixpkgs/commit/407e142a14c05b45cf9787ebcb9d118e304970cb) | `` time-decode: 4.2.0 -> 6.1.0 ``                                                        |
| [`cd5fb3d5`](https://github.com/NixOS/nixpkgs/commit/cd5fb3d5c07c41e993a06287f9dd28f2b2d84ab4) | `` python310Packages.pyatv: 0.10.3 -> 0.11.0 ``                                          |
| [`04cee1d6`](https://github.com/NixOS/nixpkgs/commit/04cee1d63113779d9ae19615be12e34431a525f3) | `` linux_testing: 6.4-rc1 -> 6.4-rc2 ``                                                  |
| [`42fca750`](https://github.com/NixOS/nixpkgs/commit/42fca750d46c36044a3eb5c04405d97132412cb4) | `` cpustat: 0.02.17 -> 0.02.19 ``                                                        |
| [`94141b78`](https://github.com/NixOS/nixpkgs/commit/94141b785f633d5355cd0d34c0591a511c5734c5) | `` pufferpanel: fix build on i686-linux ``                                               |
| [`3378e9f5`](https://github.com/NixOS/nixpkgs/commit/3378e9f58a9a5be0e9dfd8bd3b6b5a4fbf78da47) | `` wolf-shaper: 1.0.1 -> 1.0.2 ``                                                        |
| [`13f16955`](https://github.com/NixOS/nixpkgs/commit/13f16955e2938c6274217f703505ba1e41bf63e6) | `` python310Packages.dvc-data: 0.50.0 -> 0.51.0 ``                                       |
| [`acfadf48`](https://github.com/NixOS/nixpkgs/commit/acfadf488402d07b8b83f37e54338068bf9ea82a) | `` python310Packages.skl2onnx: 1.14.0 -> 1.14.1 ``                                       |
| [`ceffe4ef`](https://github.com/NixOS/nixpkgs/commit/ceffe4ef97e3bb3b32f2b47cb4ddeb7d1df45256) | `` python310Packages.inquirerpy: 0.3.3 -> 0.3.4 ``                                       |
| [`339670f1`](https://github.com/NixOS/nixpkgs/commit/339670f1dc2704f15f2fb9e70445fa29c7eed7cc) | `` temporal-cli: update tctl-next ``                                                     |
| [`48c9864e`](https://github.com/NixOS/nixpkgs/commit/48c9864e7d0990406300a0f57349bbf0c8b95b96) | `` cargo-zigbuild: 0.16.7 -> 0.16.8 ``                                                   |
| [`69ac7b4c`](https://github.com/NixOS/nixpkgs/commit/69ac7b4cc07fa619d1e9f1b87d168c9167b8a013) | `` abuild: 3.10.0 -> 3.11.0 ``                                                           |
| [`8f33b63c`](https://github.com/NixOS/nixpkgs/commit/8f33b63c2ddc0c4e24a76984d9987e5472442b5b) | `` python311Packages.azure-mgmt-network: 22.2.0 -> 23.0.1 ``                             |
| [`a8484588`](https://github.com/NixOS/nixpkgs/commit/a8484588035b979159ce29fb9f13336eca8f9a23) | `` ocamlPackages.ounit2: 2.2.6 -> 2.2.7 ``                                               |
| [`3fedce78`](https://github.com/NixOS/nixpkgs/commit/3fedce78b28a7966c8a27b7fe24245e389777e94) | `` python3Packages.publicsuffix2: restore original version number (#231610) ``           |
| [`a467a895`](https://github.com/NixOS/nixpkgs/commit/a467a895e92be418213d4b9458b6cceec6772a1a) | `` pt2-clone: 1.57 -> 1.58 ``                                                            |
| [`ade50c7c`](https://github.com/NixOS/nixpkgs/commit/ade50c7c36d5b6df337c3c4333bcfe02311f7ee8) | `` opentelemetry-collector{,-contrib}: move to cgo disabled and drop patch ``            |
| [`2c225b16`](https://github.com/NixOS/nixpkgs/commit/2c225b16dcaaa417830ffda3aa77e85e3541bb57) | `` docker-distribution: 2.8.1 -> 2.8.2 ``                                                |
| [`97530ed4`](https://github.com/NixOS/nixpkgs/commit/97530ed456f71b23d3f3f0b7b8cb38b14dae964b) | `` thonny: fix runtime error ``                                                          |
| [`f7191497`](https://github.com/NixOS/nixpkgs/commit/f7191497332e4ce52d25c3d4be06d264f5dfa817) | `` goredo: 1.21.0 -> 1.30.0 ``                                                           |
| [`dfde4bc7`](https://github.com/NixOS/nixpkgs/commit/dfde4bc764a29a395656d7de012f21c20125bfb8) | `` python311Packages.patator: specify license (#232170) ``                               |
| [`c6c6ba28`](https://github.com/NixOS/nixpkgs/commit/c6c6ba285c7934fb6c32bb2e14ee605af307433e) | `` webex: use libxcrypt-legacy, add tbb (#232008) ``                                     |
| [`d9223027`](https://github.com/NixOS/nixpkgs/commit/d922302771cff731915866d959d6ae64690f28e4) | `` vlang: improve darwin situation ``                                                    |
| [`854a19c5`](https://github.com/NixOS/nixpkgs/commit/854a19c596bccb363025d48c184ab99e2539128e) | `` goawk: 1.22.0 -> 1.23.0 ``                                                            |
| [`f594db64`](https://github.com/NixOS/nixpkgs/commit/f594db6447b0e17fd5a4adec81ada8cf2dc77f45) | `` mpvScripts.thumbfast: init at unstable-2023-05-12 ``                                  |
| [`0523727c`](https://github.com/NixOS/nixpkgs/commit/0523727c045edb706139502d6f614b3e79ce26fd) | `` snd: 23.2 -> 23.3 ``                                                                  |
| [`931b0f12`](https://github.com/NixOS/nixpkgs/commit/931b0f12efcddff8b75e730df7c96e31f3cf60f2) | `` metasploit: 6.3.15 -> 6.3.16 ``                                                       |
| [`e72d3d47`](https://github.com/NixOS/nixpkgs/commit/e72d3d47092dfc296226a9b82d93a60db7b1bfa7) | `` primesieve: 11.0 -> 11.1 ``                                                           |
| [`fe2c5697`](https://github.com/NixOS/nixpkgs/commit/fe2c56972e8c50c635c09ccf6fa825c79d8dfb86) | `` mgba: add `wrapGAppsHook` ``                                                          |
| [`9b342582`](https://github.com/NixOS/nixpkgs/commit/9b34258215a73aaef5b85b0350fa6060480847f4) | `` tts: 0.13.2 -> 0.13.3 ``                                                              |
| [`7c7baa0b`](https://github.com/NixOS/nixpkgs/commit/7c7baa0b781b7f0871d751d2138a334182038d0f) | `` python3.pkgs.bnnumerizer: init at 0.0.2 ``                                            |
| [`d4730d0c`](https://github.com/NixOS/nixpkgs/commit/d4730d0cd096a9b1280718853120cb25f63cfe49) | `` python3.pkgs.bangla: init at 0.0.2 ``                                                 |
| [`6abcef4a`](https://github.com/NixOS/nixpkgs/commit/6abcef4a82db26a8a3333cef8ba61fd9a9005fe3) | `` python3.pkgs.bnunicodenormalizer: init at 0.1.6 ``                                    |
| [`013bd5a8`](https://github.com/NixOS/nixpkgs/commit/013bd5a87d933ab6642f89f022612fb2f2183143) | `` qmk_hid: init at 0.1.5 ``                                                             |
| [`63f26166`](https://github.com/NixOS/nixpkgs/commit/63f26166c1b6fbc364ad06a103589d69fe6a357f) | `` chatty: 0.7.0 -> 0.7.2 ``                                                             |
| [`c19d8926`](https://github.com/NixOS/nixpkgs/commit/c19d8926fd680811822cafd3ae2a8e059d4253c1) | `` tinycc: fix static build ``                                                           |
| [`aa0d00f5`](https://github.com/NixOS/nixpkgs/commit/aa0d00f5475b772e93265f44062c90d7a0748401) | `` vlang: weekly.2022.20 -> weekly.2023.19 ``                                            |
| [`743362cd`](https://github.com/NixOS/nixpkgs/commit/743362cdded4e92f37d65ba6b0036c7a5b048d50) | `` gallia: relax argcomplete constraint ``                                               |
| [`034812e0`](https://github.com/NixOS/nixpkgs/commit/034812e0ae8763bfb4ac197bd5871cdcf1f50edc) | `` lisp-modules.facts: use backup url ``                                                 |
| [`619d5776`](https://github.com/NixOS/nixpkgs/commit/619d5776de578eefdec5e67308c8e908544be9e7) | `` yarn-lock-converter: init at 0.0.2 ``                                                 |
| [`191f7010`](https://github.com/NixOS/nixpkgs/commit/191f7010aa1b56226516b7cc930bf749f0b26c5a) | `` python311Packages.pegen: disable failing test on Python 3.11 ``                       |
| [`eed97cb5`](https://github.com/NixOS/nixpkgs/commit/eed97cb599c5ddf4c235e32d1d42e1b28e693ff3) | `` python311Packages.azure-mgmt-signalr: update disabled ``                              |
| [`1fffaf75`](https://github.com/NixOS/nixpkgs/commit/1fffaf757db02903de3b08572dcc2bbcb2082c67) | `` cpuid: 20230406 -> 20230505 ``                                                        |
| [`53065b9d`](https://github.com/NixOS/nixpkgs/commit/53065b9d8f17692f059844d39900ef29bb17e4fa) | `` poezio: modernize ``                                                                  |
| [`1a78ea35`](https://github.com/NixOS/nixpkgs/commit/1a78ea35ed67d33a79c338ee9771308c4a110e88) | `` miniaudio: 0.11.14 -> 0.11.16 ``                                                      |
| [`1db4eb46`](https://github.com/NixOS/nixpkgs/commit/1db4eb46ba47c2df8eb8436158e13eef565cb2a3) | `` python310Packages.vivisect: switch to pythonRelaxDepsHook ``                          |
| [`248f0054`](https://github.com/NixOS/nixpkgs/commit/248f00541dddec8c53aaf5b98c43e9bb713ca19d) | `` Revert "shadowsocks-v2ray-plugin: mark as broken" ``                                  |
| [`5610d2ec`](https://github.com/NixOS/nixpkgs/commit/5610d2ec67a4b54bfdf722cb3a2afd8342ee56fe) | `` swayrbar: Fix pulseaudio as optional dependency (default: disabled) ``                |
| [`872987d0`](https://github.com/NixOS/nixpkgs/commit/872987d040303394aef2fdba5ea5a3ee93e66e67) | `` beam/mixRelease: default stripDebug to false due frequent runtime errors (#232107) `` |
| [`73a67e80`](https://github.com/NixOS/nixpkgs/commit/73a67e809801222cc8b3f7b2f06ebd7cb4e7334d) | `` nova: 3.6.3 -> 3.6.4 ``                                                               |
| [`8b9ec101`](https://github.com/NixOS/nixpkgs/commit/8b9ec10173ec116e69c6ecd4fe82b23b429622f5) | `` coursera-dl: modernize ``                                                             |
| [`50b845c5`](https://github.com/NixOS/nixpkgs/commit/50b845c5a64af3cb42c37f3d75c3758cc96e1729) | `` nixos/wireguard: allow customizing peer unit name ``                                  |
| [`c4d619df`](https://github.com/NixOS/nixpkgs/commit/c4d619df1088ac269566b3219f8b965f281cc993) | `` python311Packages.azure-mgmt-signalr: 1.1.0 -> 1.2.0 ``                               |
| [`dced9a58`](https://github.com/NixOS/nixpkgs/commit/dced9a580ced8a42d6163e32250102436b2814e5) | `` python310Packages.gplaycli: enable tests ``                                           |
| [`3de24605`](https://github.com/NixOS/nixpkgs/commit/3de246057120fa703249de1e1aa7048bf066ef9b) | `` nerdfonts: 3.0.0 -> 3.0.1 ``                                                          |
| [`da46b2cc`](https://github.com/NixOS/nixpkgs/commit/da46b2cce087348f1fda8f0be0c91d09b8305faa) | `` python310Packages.requests-hawk: 1.1.1 -> 1.2.1 ``                                    |
| [`6e3bedf3`](https://github.com/NixOS/nixpkgs/commit/6e3bedf3aa57adf1c76147b3fec091b498a27451) | `` geoipupdate: 5.1.0 -> 5.1.1 ``                                                        |
| [`bd91922d`](https://github.com/NixOS/nixpkgs/commit/bd91922dbc5acbd0d6dbd1235c7c621e9d7fdb57) | `` maintainers/team-list: add bobby285271 to mate and xfce ``                            |
| [`fab6fc35`](https://github.com/NixOS/nixpkgs/commit/fab6fc35329b188c05d9b595ef4ae1895424ba5c) | `` ansible-later: Remove from python-modules ``                                          |
| [`e6a35faa`](https://github.com/NixOS/nixpkgs/commit/e6a35faa2739f8f0baaff2feffd5963b25813fe5) | `` python310Packages.pytest-testmon: 2.0.2 -> 2.0.6 ``                                   |
| [`b70ddf12`](https://github.com/NixOS/nixpkgs/commit/b70ddf1272bed0a6173ff87dd456f5da9da60cbc) | `` fdroidserver: 2.1.1 -> 2.2.1 ``                                                       |
| [`b59d345f`](https://github.com/NixOS/nixpkgs/commit/b59d345f0b74220ae404e6dac4d81704e7cc76f3) | `` fdroidserver: update meta ``                                                          |
| [`89b9c006`](https://github.com/NixOS/nixpkgs/commit/89b9c006ae81cf8b636f8e018df0fc04d6133142) | `` ckbcomp: 1.218 -> 1.220 ``                                                            |
| [`1e9a3598`](https://github.com/NixOS/nixpkgs/commit/1e9a35988fa9ade0965263751ecc83c5ec02d2e4) | `` linux-firmware: 20230310 -> 20230515 ``                                               |
| [`85d235bd`](https://github.com/NixOS/nixpkgs/commit/85d235bdca5a8ea1a1f1b915612dccf118f97b64) | `` spicetify-cli: 2.18.0 -> 2.18.1 ``                                                    |
| [`2b3468b8`](https://github.com/NixOS/nixpkgs/commit/2b3468b837260ad0aee9a62ae2ead7efa0086ed5) | `` mate.mate-themes: 3.22.23 -> 3.22.24 ``                                               |
| [`0e034404`](https://github.com/NixOS/nixpkgs/commit/0e03440448f3ceb36a873316c167bfe78a795634) | `` mate.mate-screensaver: 1.26.1 -> 1.26.2 ``                                            |
| [`b6db55eb`](https://github.com/NixOS/nixpkgs/commit/b6db55ebbe4a69afc27b16db8a07b5dcdc192533) | `` mate.mate-media: 1.26.0 -> 1.26.1 ``                                                  |
| [`4341067c`](https://github.com/NixOS/nixpkgs/commit/4341067c94e593d68c52a243c4d55532f837ebc0) | `` dokuwiki: 2023-04-04 -> 2023-04-04a ``                                                |
| [`190413d4`](https://github.com/NixOS/nixpkgs/commit/190413d491ef671825ac77da0bb4dd1da7824d15) | `` python311Packages.azure-mgmt-monitor: 6.0.0 -> 6.0.1 ``                               |
| [`a8004019`](https://github.com/NixOS/nixpkgs/commit/a8004019f0085b695075172091ffa7bc9c335812) | `` libspng: 0.7.3 -> 0.7.4 ``                                                            |
| [`9b7b37f4`](https://github.com/NixOS/nixpkgs/commit/9b7b37f4e2a77979a632806977540e3fd0f23dd8) | `` burpsuite: 2023.3.5 -> 2023.4.3 ``                                                    |
| [`afc0e875`](https://github.com/NixOS/nixpkgs/commit/afc0e8752728fe344bc3f34799d6dc87d914531f) | `` python310Packages.miniaudio: 1.56 -> 1.57 ``                                          |
| [`a3ba6bee`](https://github.com/NixOS/nixpkgs/commit/a3ba6beeba2cb5c9ce5fb61aedcf7db73a81d1fd) | `` python311Packages.glean-parser: 7.1.0 -> 7.2.1 ``                                     |
| [`5b2b3950`](https://github.com/NixOS/nixpkgs/commit/5b2b3950f06612421fcddc72e6812635224090d6) | `` minimal-bootstrap.mes: `replaceExt` -> `stripExt` ``                                  |
| [`e83d19d5`](https://github.com/NixOS/nixpkgs/commit/e83d19d547400edd5d87a55a4b76c2ef65a6c4c0) | `` ocamlPackages.uring: 0.5 → 0.6 ``                                                     |
| [`09531991`](https://github.com/NixOS/nixpkgs/commit/0953199148e0fc92a4401c348f680c78d6afcb69) | `` python310Packages.pyvmomi: 8.0.0.1.2 -> 8.0.1.0 ``                                    |
| [`1e7d8ddf`](https://github.com/NixOS/nixpkgs/commit/1e7d8ddff61f8bff7b59c3d9784881a153eed710) | `` cotp: 1.2.3 -> 1.2.4 ``                                                               |
| [`64e996fd`](https://github.com/NixOS/nixpkgs/commit/64e996fd1b1399778bfe11930230845d3008204e) | `` cdesktopenv: work around tcl8.6.13 error ``                                           |
| [`af692f81`](https://github.com/NixOS/nixpkgs/commit/af692f81e88b08eee22067c62cb5957c044692e5) | `` mongoc: 1.23.3 -> 1.23.4 ``                                                           |
| [`756fdfe6`](https://github.com/NixOS/nixpkgs/commit/756fdfe61bb366847a50d0adaede48dbc385c6a2) | `` leo-editor: 6.7.2 -> 6.7.3 ``                                                         |
| [`d4e3be78`](https://github.com/NixOS/nixpkgs/commit/d4e3be78de1daded6ba524a211ef3644f4faaf92) | `` mermerd: add version test ``                                                          |
| [`b03f1cef`](https://github.com/NixOS/nixpkgs/commit/b03f1ceff6ca1eff154f79134b123bc4315f772c) | `` mermerd: fix version command ``                                                       |
| [`1331b61d`](https://github.com/NixOS/nixpkgs/commit/1331b61d012bcc116007723f43cfc70f8bf87f71) | `` python311Packages.gspread: 5.8.0 -> 5.9.0 ``                                          |
| [`b9ebef05`](https://github.com/NixOS/nixpkgs/commit/b9ebef05289a7cfdd19eb1491121d43dc33ce980) | `` python310Packages.authcaptureproxy: 1.1.5 -> 1.2.0 ``                                 |
| [`5ed88860`](https://github.com/NixOS/nixpkgs/commit/5ed88860da980657fd2f59ed5b6b6d085642cc54) | `` talosctl: 1.4.1 -> 1.4.4 ``                                                           |
| [`37d15df3`](https://github.com/NixOS/nixpkgs/commit/37d15df311faed53845256453f2c82bc4bf692f4) | `` scala-cli: 1.0.0-RC1 -> 1.0.0-RC2 ``                                                  |
| [`683653d5`](https://github.com/NixOS/nixpkgs/commit/683653d5ef7eebac1d59dfb813985af7b7b95cdd) | `` nco: 5.1.5 -> 5.1.6 ``                                                                |
| [`7c8b1dbf`](https://github.com/NixOS/nixpkgs/commit/7c8b1dbf859ba0cbe8bf2026ac2f625911f94d6a) | `` secp256k1: 0.3.1 -> 0.3.2 ``                                                          |
| [`04821cd0`](https://github.com/NixOS/nixpkgs/commit/04821cd0d4ef9df0c202c7b85cee9f175c1051de) | `` ansible: 2.14.5 -> 2.15.0 ``                                                          |
| [`442fee47`](https://github.com/NixOS/nixpkgs/commit/442fee475fd23703a35d36d3f80f1ac6533f5def) | `` ansible_2_12: drop ``                                                                 |
| [`c5e98218`](https://github.com/NixOS/nixpkgs/commit/c5e98218c06fc22517e171a87df9d8373f14dc7e) | `` ansible_2_13: 2.13.6 -> 2.13.9 ``                                                     |
| [`0b11411d`](https://github.com/NixOS/nixpkgs/commit/0b11411de3658301099f0a4002a893b5d2012ddf) | `` ansible_2_14: 2.14.2 -> 2.14.5 ``                                                     |
| [`d0955a83`](https://github.com/NixOS/nixpkgs/commit/d0955a83cb5f76cb8cc4ef8b8efd1ba4feddcf5b) | `` python311Packages.coqpit: disable failing tests ``                                    |