### PR TITLE
chore(flake/nur): `ca68452b` -> `242abe0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684360268,
-        "narHash": "sha256-fvQWCYVaoy46/dz5FEMV7/A4QFra3DQbUpo6A7YXhFU=",
+        "lastModified": 1684374890,
+        "narHash": "sha256-N78W/NJC+nUJz6P5pTOYvAhpcDCRdi89wATeofJM5v0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ca68452b8a9e9ca328e60308d87cd62aa0541c4b",
+        "rev": "242abe0b6aae2cedd9e0b4f8a35ddbbf3a7394b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`242abe0b`](https://github.com/nix-community/NUR/commit/242abe0b6aae2cedd9e0b4f8a35ddbbf3a7394b8) | `` automatic update `` |