### PR TITLE
chore(flake/nur): `242abe0b` -> `59fdba11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684374890,
-        "narHash": "sha256-N78W/NJC+nUJz6P5pTOYvAhpcDCRdi89wATeofJM5v0=",
+        "lastModified": 1684377680,
+        "narHash": "sha256-HNidsIv6QQ7SSIqewz1eg6ECVEFn5l9lD2d0YHDBYNI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "242abe0b6aae2cedd9e0b4f8a35ddbbf3a7394b8",
+        "rev": "59fdba11c1f5aa956054b6fd0aa6cecd5896cc06",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`59fdba11`](https://github.com/nix-community/NUR/commit/59fdba11c1f5aa956054b6fd0aa6cecd5896cc06) | `` automatic update `` |