### PR TITLE
chore(flake/nur): `59fdba11` -> `4501c6a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684377680,
-        "narHash": "sha256-HNidsIv6QQ7SSIqewz1eg6ECVEFn5l9lD2d0YHDBYNI=",
+        "lastModified": 1684381490,
+        "narHash": "sha256-qmDXGCBcetXsda8xz3wan8LP04xMSDB5YQcbBgW8/Uo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "59fdba11c1f5aa956054b6fd0aa6cecd5896cc06",
+        "rev": "4501c6a0a32699f77914a76ce6ae79264d6d9b56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4501c6a0`](https://github.com/nix-community/NUR/commit/4501c6a0a32699f77914a76ce6ae79264d6d9b56) | `` automatic update `` |