### PR TITLE
chore(flake/emacs-overlay): `95c844b1` -> `8c867d0f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684348799,
-        "narHash": "sha256-K/2G+BnHK3JdGnT/qkYWGljgy5kUeCZDSnBz4cLqb+c=",
+        "lastModified": 1684380272,
+        "narHash": "sha256-MGvFpMJPnyayGYzwy89PPRqRoHS/kjyEUn7OKCKySj0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "95c844b1985808df780acc1835a354fe3ff27282",
+        "rev": "8c867d0fbab638cdb4707feae3d2d2245315bd68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`8c867d0f`](https://github.com/nix-community/emacs-overlay/commit/8c867d0fbab638cdb4707feae3d2d2245315bd68) | `` Updated repos/melpa `` |
| [`5843c82e`](https://github.com/nix-community/emacs-overlay/commit/5843c82e182db1c246c0849a500c51991f62a83c) | `` Updated repos/emacs `` |
| [`743b7d89`](https://github.com/nix-community/emacs-overlay/commit/743b7d89b7525531458beb333aed29e1261bbd38) | `` Updated repos/elpa ``  |