### PR TITLE
chore(flake/nur): `4501c6a0` -> `2e2c4bd0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684381490,
-        "narHash": "sha256-qmDXGCBcetXsda8xz3wan8LP04xMSDB5YQcbBgW8/Uo=",
+        "lastModified": 1684382937,
+        "narHash": "sha256-QY0GrYIPkGlJYEYtr5DhjUf2y7n2pL34R9vxhrXgs8c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4501c6a0a32699f77914a76ce6ae79264d6d9b56",
+        "rev": "2e2c4bd074fe6ff588a95ed83d1602f41cdca63b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2e2c4bd0`](https://github.com/nix-community/NUR/commit/2e2c4bd074fe6ff588a95ed83d1602f41cdca63b) | `` automatic update `` |