### PR TITLE
chore(flake/nur): `2e2c4bd0` -> `e8707508`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684382937,
-        "narHash": "sha256-QY0GrYIPkGlJYEYtr5DhjUf2y7n2pL34R9vxhrXgs8c=",
+        "lastModified": 1684392987,
+        "narHash": "sha256-fBmogilTj+VcqtEtUqDn53xWwx+ZAX3aydZjN1v7yrI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2e2c4bd074fe6ff588a95ed83d1602f41cdca63b",
+        "rev": "e870750871812ea1500910aa10b0926a0df1b14b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e8707508`](https://github.com/nix-community/NUR/commit/e870750871812ea1500910aa10b0926a0df1b14b) | `` automatic update `` |
| [`9a3234de`](https://github.com/nix-community/NUR/commit/9a3234de5d9fdb8733553c7e14b67dcdc08be2bd) | `` automatic update `` |