### PR TITLE
chore(flake/nur): `369d7cba` -> `95ef79d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684393705,
-        "narHash": "sha256-w5xLzA7UKW9zaJSQ8s3eSV72AQwBrODJcHcdwM2curI=",
+        "lastModified": 1684403108,
+        "narHash": "sha256-vExZx+sBTqM7rHP6Tt9JA2bhjGcrxwIDiGpJamk2yi8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "369d7cbaccdc84b26bd40b33050c5d56ab1cfcff",
+        "rev": "95ef79d0d41f42fd33695ce0bc8e284cd80b0967",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`95ef79d0`](https://github.com/nix-community/NUR/commit/95ef79d0d41f42fd33695ce0bc8e284cd80b0967) | `` automatic update `` |
| [`c27cba47`](https://github.com/nix-community/NUR/commit/c27cba4712f8eb426f8e2e7e2842cef89e672872) | `` automatic update `` |