### PR TITLE
chore(flake/emacs-overlay): `8c867d0f` -> `f438072a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684380272,
-        "narHash": "sha256-MGvFpMJPnyayGYzwy89PPRqRoHS/kjyEUn7OKCKySj0=",
+        "lastModified": 1684405120,
+        "narHash": "sha256-xuX0JLkVDl6lmnd6SZvhVeFXDtVbyEyyerp1ZDoDJQk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8c867d0fbab638cdb4707feae3d2d2245315bd68",
+        "rev": "f438072ac6d2a0271a0ac5ad566d9612a9b35bb9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`f438072a`](https://github.com/nix-community/emacs-overlay/commit/f438072ac6d2a0271a0ac5ad566d9612a9b35bb9) | `` Updated repos/melpa `` |
| [`8fc1eaa8`](https://github.com/nix-community/emacs-overlay/commit/8fc1eaa840ea7cdf601c7bb3479b6418ebb06d35) | `` Updated repos/emacs `` |