### PR TITLE
chore(flake/nur): `95ef79d0` -> `1f0419f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684403108,
-        "narHash": "sha256-vExZx+sBTqM7rHP6Tt9JA2bhjGcrxwIDiGpJamk2yi8=",
+        "lastModified": 1684406329,
+        "narHash": "sha256-LoqdMB2tLhsJdFtTKNiFllbwk/IXxtgg2jC5rnyHodM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "95ef79d0d41f42fd33695ce0bc8e284cd80b0967",
+        "rev": "1f0419f2b7b43fe624ad0b2a107fe5b3cdc0ec3c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1f0419f2`](https://github.com/nix-community/NUR/commit/1f0419f2b7b43fe624ad0b2a107fe5b3cdc0ec3c) | `` automatic update `` |
| [`acc3694c`](https://github.com/nix-community/NUR/commit/acc3694c5c1c740a12d147a1eb8ff8edbcca22d1) | `` automatic update `` |