### PR TITLE
chore(flake/nur): `2c8cb59b` -> `02a1ecd3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684416496,
-        "narHash": "sha256-t1vPAJqbHaelwKBNEVNIYp434eLCtkBEXIR8s4ggl8I=",
+        "lastModified": 1684430965,
+        "narHash": "sha256-vt5B8GU8m8HoZmlyVosB/svd/s8hp71RPdhHsHq9qwI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2c8cb59b2703bd68c177c1085221eda9e2fe7db9",
+        "rev": "02a1ecd351cd36a92d558dd85a15df2fc424cd1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`02a1ecd3`](https://github.com/nix-community/NUR/commit/02a1ecd351cd36a92d558dd85a15df2fc424cd1b) | `` automatic update `` |