### PR TITLE
chore(flake/emacs-overlay): `f438072a` -> `859e27b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684405120,
-        "narHash": "sha256-xuX0JLkVDl6lmnd6SZvhVeFXDtVbyEyyerp1ZDoDJQk=",
+        "lastModified": 1684435384,
+        "narHash": "sha256-MrH+NpnQqCx1bobTAp5b1TW/SvY/cO+L0EkbTL/d4IA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f438072ac6d2a0271a0ac5ad566d9612a9b35bb9",
+        "rev": "859e27b4dccdfee45ea258510bbfcceaa527a85e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`859e27b4`](https://github.com/nix-community/emacs-overlay/commit/859e27b4dccdfee45ea258510bbfcceaa527a85e) | `` Updated repos/melpa `` |
| [`d63827ee`](https://github.com/nix-community/emacs-overlay/commit/d63827ee414eb99d8791d1db0d95c2a0521af843) | `` Updated repos/emacs `` |
| [`2b2674b8`](https://github.com/nix-community/emacs-overlay/commit/2b2674b88fbb73b028dd21a7394c9dde30f80bb4) | `` Updated repos/elpa ``  |