### PR TITLE
chore(flake/nur): `02a1ecd3` -> `71663dc4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684430965,
-        "narHash": "sha256-vt5B8GU8m8HoZmlyVosB/svd/s8hp71RPdhHsHq9qwI=",
+        "lastModified": 1684456647,
+        "narHash": "sha256-eddUgjaMYEzLdXojsJQH1Yy97ncJ5tP2ywrCEnUICl8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "02a1ecd351cd36a92d558dd85a15df2fc424cd1b",
+        "rev": "71663dc4f82c9ce47833ea3c261cb5e914763491",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`71663dc4`](https://github.com/nix-community/NUR/commit/71663dc4f82c9ce47833ea3c261cb5e914763491) | `` automatic update `` |
| [`8285b3ef`](https://github.com/nix-community/NUR/commit/8285b3eff24f16dd14784acecf7bce6af1d80622) | `` automatic update `` |
| [`075c51cd`](https://github.com/nix-community/NUR/commit/075c51cd2e813f166956d99099d7fcaf3cd3807d) | `` automatic update `` |
| [`f57952bb`](https://github.com/nix-community/NUR/commit/f57952bb76f63be90400b74eb149c75460c10bc0) | `` automatic update `` |
| [`2754f982`](https://github.com/nix-community/NUR/commit/2754f982ce12019969192fa083acb51c894f556f) | `` automatic update `` |
| [`e23f631e`](https://github.com/nix-community/NUR/commit/e23f631ecbff067f2fd13dc3127aa70443abc934) | `` automatic update `` |