### PR TITLE
chore(flake/emacs-overlay): `859e27b4` -> `201c7544`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -250,14 +250,15 @@
         ],
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1684435384,
-        "narHash": "sha256-MrH+NpnQqCx1bobTAp5b1TW/SvY/cO+L0EkbTL/d4IA=",
+        "lastModified": 1686018145,
+        "narHash": "sha256-4otkca8zBBSCKrj7J5KpimzWJRw2ijIM6Y3eieUabCc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "859e27b4dccdfee45ea258510bbfcceaa527a85e",
+        "rev": "201c7544f6842430e8cc872658bdf8a91de20503",
         "type": "github"
       },
       "original": {
@@ -674,6 +675,22 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
+        "lastModified": 1685883127,
+        "narHash": "sha256-zPDaPNrAtBnO24rNqjHLINHsqTdRbgWy1c/TL3EdwlM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d4a9ff82fc18723219b60c66fb2ccb0734c460eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_4": {
+      "locked": {
         "lastModified": 1685801374,
         "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
         "owner": "NixOS",
@@ -688,7 +705,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable_4": {
+    "nixpkgs-stable_5": {
       "locked": {
         "lastModified": 1685758009,
         "narHash": "sha256-IT4Z5WGhafrq+xbDTyuKrRPRQ1f+kVOtE+4JU1CHFeo=",
@@ -846,7 +863,7 @@
         "flake-utils": "flake-utils_4",
         "gitignore": "gitignore_2",
         "nixpkgs": "nixpkgs_4",
-        "nixpkgs-stable": "nixpkgs-stable_3"
+        "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
         "lastModified": 1685970613,
@@ -970,7 +987,7 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "nixpkgs-stable": "nixpkgs-stable_4"
+        "nixpkgs-stable": "nixpkgs-stable_5"
       },
       "locked": {
         "lastModified": 1685848844,


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                                           |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
| [`201c7544`](https://github.com/nix-community/emacs-overlay/commit/201c7544f6842430e8cc872658bdf8a91de20503) | `` Updated repos/melpa ``                                                                         |
| [`1c17cd17`](https://github.com/nix-community/emacs-overlay/commit/1c17cd17b6d9d11bd9ff06c27e7a5397f4cd52fb) | `` Updated repos/elpa ``                                                                          |
| [`d0ed6edc`](https://github.com/nix-community/emacs-overlay/commit/d0ed6edc7561f7a5518bd51f501e0cc6f9aa3023) | `` Updated repos/melpa ``                                                                         |
| [`dee4fca6`](https://github.com/nix-community/emacs-overlay/commit/dee4fca68840d5a428f106099ede217f463626d4) | `` Updated repos/emacs ``                                                                         |
| [`5c6bfc6d`](https://github.com/nix-community/emacs-overlay/commit/5c6bfc6d5a6a99d22f1949efddf06df468c87762) | `` Updated flake inputs ``                                                                        |
| [`ec3643e9`](https://github.com/nix-community/emacs-overlay/commit/ec3643e9cf2e09e9a328ae53de7c602b05c07b61) | `` Account for upstream renaming ``                                                               |
| [`9bfa1758`](https://github.com/nix-community/emacs-overlay/commit/9bfa175833e5775d57f470f30b5404b04a7250be) | `` Updated repos/melpa ``                                                                         |
| [`378276bc`](https://github.com/nix-community/emacs-overlay/commit/378276bcf9df3c3b8dea6d34085578b7b5c7dd8f) | `` Updated repos/emacs ``                                                                         |
| [`22678cd2`](https://github.com/nix-community/emacs-overlay/commit/22678cd26cd886c9f29775b2102981b66b6d0a42) | `` Updated repos/melpa ``                                                                         |
| [`3054f859`](https://github.com/nix-community/emacs-overlay/commit/3054f85921ad6e1f1015a51206255c71c012fb42) | `` Updated repos/emacs ``                                                                         |
| [`2e674f0d`](https://github.com/nix-community/emacs-overlay/commit/2e674f0d41cfcb62e1e7b1469841ac0e454b3af5) | `` Updated repos/elpa ``                                                                          |
| [`e214ae80`](https://github.com/nix-community/emacs-overlay/commit/e214ae80f69bb2c8642b4b98190e49321d3b7c72) | `` Updated repos/melpa ``                                                                         |
| [`daf30816`](https://github.com/nix-community/emacs-overlay/commit/daf30816d3159e7dc6dae227bfe4dfe9ecef5f83) | `` Updated repos/emacs ``                                                                         |
| [`f5ef413b`](https://github.com/nix-community/emacs-overlay/commit/f5ef413b70a689a476f7858236dc7f449eaa94db) | `` Updated flake inputs ``                                                                        |
| [`70db1748`](https://github.com/nix-community/emacs-overlay/commit/70db17480e76d556cc5363c1ba22cd591c83fa76) | `` Updated repos/melpa ``                                                                         |
| [`9bc16d78`](https://github.com/nix-community/emacs-overlay/commit/9bc16d788b9b09e986b2fba5a76fe44d35010d52) | `` Updated repos/melpa ``                                                                         |
| [`232c9fc5`](https://github.com/nix-community/emacs-overlay/commit/232c9fc5221652a8f353a3fa0dfd6c09a4401389) | `` Updated repos/emacs ``                                                                         |
| [`63810837`](https://github.com/nix-community/emacs-overlay/commit/638108373002d5eab0249aa68b43941bee4e204e) | `` Updated flake inputs ``                                                                        |
| [`074dc30c`](https://github.com/nix-community/emacs-overlay/commit/074dc30cec64604d650fffcb90631f63900d76d9) | `` Updated repos/melpa ``                                                                         |
| [`2ec68d6f`](https://github.com/nix-community/emacs-overlay/commit/2ec68d6fd08db49d27ff2080c81a3012b11e8a57) | `` Updated repos/emacs ``                                                                         |
| [`92e2053f`](https://github.com/nix-community/emacs-overlay/commit/92e2053fd614bc0402754c5ed09fddd88560fbce) | `` Updated repos/elpa ``                                                                          |
| [`fbbf354b`](https://github.com/nix-community/emacs-overlay/commit/fbbf354bceb8d42d1e0eef8116b66e9947c84017) | `` Updated repos/melpa ``                                                                         |
| [`f39fec6a`](https://github.com/nix-community/emacs-overlay/commit/f39fec6afdc6a9e6fd7f9f44c9a2337171d7d331) | `` Updated repos/emacs ``                                                                         |
| [`7951eca6`](https://github.com/nix-community/emacs-overlay/commit/7951eca672c2b9e62919e70be3d2a3e13d7f87e4) | `` Updated repos/melpa ``                                                                         |
| [`3749415e`](https://github.com/nix-community/emacs-overlay/commit/3749415ec47d66e50e8005df7a02e165b60b7e1f) | `` Updated repos/elpa ``                                                                          |
| [`f49b868d`](https://github.com/nix-community/emacs-overlay/commit/f49b868da65b360332fc404662959d81c489906e) | `` Updated repos/emacs ``                                                                         |
| [`901768d7`](https://github.com/nix-community/emacs-overlay/commit/901768d7ab98e8081f994cd98d93a07f6b5078ec) | `` Updated repos/elpa ``                                                                          |
| [`081f0448`](https://github.com/nix-community/emacs-overlay/commit/081f04481f512a63988d4cbea5f91aa810e2ecdb) | `` Updated flake inputs ``                                                                        |
| [`0e320163`](https://github.com/nix-community/emacs-overlay/commit/0e320163bcf62a4db3666d366f6752562c2aa409) | `` Updated repos/nongnu ``                                                                        |
| [`d2e5053c`](https://github.com/nix-community/emacs-overlay/commit/d2e5053c646c6f283553b46eab5723aee4fecfd2) | `` Updated repos/melpa ``                                                                         |
| [`52c35b7d`](https://github.com/nix-community/emacs-overlay/commit/52c35b7dce1db6d87dc3258e1a1c6e8cd2be4c1a) | `` Updated repos/emacs ``                                                                         |
| [`3bc2a725`](https://github.com/nix-community/emacs-overlay/commit/3bc2a725ff3a5a3ede8ad7268a40b27454746dc2) | `` Updated repos/elpa ``                                                                          |
| [`409f7606`](https://github.com/nix-community/emacs-overlay/commit/409f76066f48da486adf838e4adf0280546f44ad) | `` Updated flake inputs ``                                                                        |
| [`669d6397`](https://github.com/nix-community/emacs-overlay/commit/669d63975489ace6915437e04546edf300f7a847) | `` Updated repos/melpa ``                                                                         |
| [`3fa0953d`](https://github.com/nix-community/emacs-overlay/commit/3fa0953df78d93754c611f368a8807e30ad5b9c1) | `` Updated repos/emacs ``                                                                         |
| [`737fe5a5`](https://github.com/nix-community/emacs-overlay/commit/737fe5a55365f51bc3d47ffb0534a45cf0697c89) | `` Remove exwm repo ``                                                                            |
| [`dbb2bb4f`](https://github.com/nix-community/emacs-overlay/commit/dbb2bb4f40a27e2bba0bee5fe6f97e832a4583c6) | `` Updated repos/melpa ``                                                                         |
| [`848c2a86`](https://github.com/nix-community/emacs-overlay/commit/848c2a86028488eff1683a30ed3ff2c70e772ea3) | `` Updated repos/emacs ``                                                                         |
| [`fe9ad516`](https://github.com/nix-community/emacs-overlay/commit/fe9ad516f6404f8ce5fffd3955a29418eb82347f) | `` flake.nix: Fixup typos in hydraJobs ``                                                         |
| [`88d3f72d`](https://github.com/nix-community/emacs-overlay/commit/88d3f72dcc3d4b87499c54c2c66074d94890721e) | `` Fix indentation ``                                                                             |
| [`fdf09998`](https://github.com/nix-community/emacs-overlay/commit/fdf09998a0484722757cfd5672a8b745bec982bb) | `` Align with nixpkgs attribute syntax since https://github.com/NixOS/nixpkgs/pull/233301 ``      |
| [`9a0f8dec`](https://github.com/nix-community/emacs-overlay/commit/9a0f8decb5be3cd0020888426cc4a3bc1fc5d67d) | `` Updated repos/melpa ``                                                                         |
| [`a3467378`](https://github.com/nix-community/emacs-overlay/commit/a34673785802f2355a8be1870da45defad5b9ff4) | `` Updated repos/emacs ``                                                                         |
| [`8a84e2bf`](https://github.com/nix-community/emacs-overlay/commit/8a84e2bfae1f6d5bd5c2e08e8f0a6d235aee4d71) | `` flake.nix: Only expose hydraJobs on x86_64-linux ``                                            |
| [`908711c0`](https://github.com/nix-community/emacs-overlay/commit/908711c0c6eb1160ea0cbaf3187200674609d661) | `` github actions: Set cachix auth token ``                                                       |
| [`ea1a1424`](https://github.com/nix-community/emacs-overlay/commit/ea1a14245ed6817ee3f44627444d1f9d1794004d) | `` Remove hydra jobset files ``                                                                   |
| [`7d59cba4`](https://github.com/nix-community/emacs-overlay/commit/7d59cba4540fe4dac590475afbec3b3786dd6530) | `` Move hydra jobsets to flake.nix ``                                                             |
| [`6ec96835`](https://github.com/nix-community/emacs-overlay/commit/6ec96835d9328bcb245d81c5997eea2ec6144fea) | `` Updated repos/melpa ``                                                                         |
| [`4bd64d30`](https://github.com/nix-community/emacs-overlay/commit/4bd64d30e696a9dd2e459c16b8ea1122dd5b9d64) | `` Updated repos/emacs ``                                                                         |
| [`d0fc4dae`](https://github.com/nix-community/emacs-overlay/commit/d0fc4dae0e0248453324e8d05733163a6a2f102e) | `` Updated repos/melpa ``                                                                         |
| [`ad1bee73`](https://github.com/nix-community/emacs-overlay/commit/ad1bee73d84d38ba67ca949720d08ad82d08af7f) | `` Updated repos/emacs ``                                                                         |
| [`030b0280`](https://github.com/nix-community/emacs-overlay/commit/030b0280030dd18024ef97d7618c9126ac8ea50d) | `` Update inputs ``                                                                               |
| [`2143986e`](https://github.com/nix-community/emacs-overlay/commit/2143986e6283433634dc0f661b665b3351b808af) | `` Clarify to-do ``                                                                               |
| [`e20a3891`](https://github.com/nix-community/emacs-overlay/commit/e20a3891139758fd04ef1905c19e3e1fcc744179) | `` Account for nixpkgs checkouts lacking withTreeSitter attribute ``                              |
| [`f3de842d`](https://github.com/nix-community/emacs-overlay/commit/f3de842d61a82311589af736888c0bd52e300615) | `` Updated repos/nongnu ``                                                                        |
| [`8d024852`](https://github.com/nix-community/emacs-overlay/commit/8d0248521591916db73447016588fae5b9594f66) | `` Updated repos/melpa ``                                                                         |
| [`cbe51a02`](https://github.com/nix-community/emacs-overlay/commit/cbe51a02085cd9c9ccfb992f0c6b899835c2344c) | `` Updated repos/emacs ``                                                                         |
| [`9bdb618f`](https://github.com/nix-community/emacs-overlay/commit/9bdb618fa89c631fa1ea58cb1a2134fa1e839a80) | `` Updated repos/elpa ``                                                                          |
| [`936f581f`](https://github.com/nix-community/emacs-overlay/commit/936f581fed5296053cb6098063fa706dec7fc13f) | `` Make emacsLsp overridable ``                                                                   |
| [`77c0c823`](https://github.com/nix-community/emacs-overlay/commit/77c0c82383520020990fb0fe12592fcfaf5a4d3a) | `` Account for upstream refactor ``                                                               |
| [`509a7ef0`](https://github.com/nix-community/emacs-overlay/commit/509a7ef0ea8d63fac38a09f68fde3f4fe8678c92) | `` Remove tree-sitter stuff ``                                                                    |
| [`a7dd3403`](https://github.com/nix-community/emacs-overlay/commit/a7dd340354f3bd500019428ba5928b36d6e76f1b) | `` Updated repos/melpa ``                                                                         |
| [`e2e5f216`](https://github.com/nix-community/emacs-overlay/commit/e2e5f216161dd40d8d6e60b7db22a05bef7c5188) | `` Updated repos/emacs ``                                                                         |
| [`bb1c627b`](https://github.com/nix-community/emacs-overlay/commit/bb1c627bf3d413f4518d52830c4b87701d9caab7) | `` Updated repos/elpa ``                                                                          |
| [`7735f53e`](https://github.com/nix-community/emacs-overlay/commit/7735f53ef8f28d80ca5339e486e29177ed7c8297) | `` Updated repos/melpa ``                                                                         |
| [`41823560`](https://github.com/nix-community/emacs-overlay/commit/4182356068ac0ead0d0e3cf994f2b09d2b8ac6b3) | `` Updated repos/emacs ``                                                                         |
| [`04f25058`](https://github.com/nix-community/emacs-overlay/commit/04f25058fbe3ae1aadd435aba49b66493e939f83) | `` Updated repos/melpa ``                                                                         |
| [`3ed7dbbb`](https://github.com/nix-community/emacs-overlay/commit/3ed7dbbbfaf8014175bc25d3f88702e4e522d9d6) | `` Updated repos/melpa ``                                                                         |
| [`26f860f7`](https://github.com/nix-community/emacs-overlay/commit/26f860f7016359c128ec9523ae763afdf5415755) | `` Updated repos/emacs ``                                                                         |
| [`0c1a3b4d`](https://github.com/nix-community/emacs-overlay/commit/0c1a3b4d76ceb3898afbe083f6b75ff132a00e54) | `` Updated repos/melpa ``                                                                         |
| [`b03abde2`](https://github.com/nix-community/emacs-overlay/commit/b03abde24c0f40d83a907dc56a3c57857b4916e7) | `` Updated repos/emacs ``                                                                         |
| [`7e8059be`](https://github.com/nix-community/emacs-overlay/commit/7e8059be4e368c5162b242a26fc1d809f455231a) | `` Update inputs ``                                                                               |
| [`f6f7f8ef`](https://github.com/nix-community/emacs-overlay/commit/f6f7f8ef79ab84f6585a7d6ee7b8cb65719f4f1f) | `` Revert "Work around https://lists.gnu.org/archive/html/bug-gnu-emacs/2023-05/msg01512.html" `` |
| [`77269bb9`](https://github.com/nix-community/emacs-overlay/commit/77269bb9a0c99fdc5f356eac10b41172775194fc) | `` Updated repos/melpa ``                                                                         |
| [`8b10f751`](https://github.com/nix-community/emacs-overlay/commit/8b10f751e48ae0e48b3f037a352c7447dc7d1afe) | `` Updated repos/melpa ``                                                                         |
| [`6ec9045f`](https://github.com/nix-community/emacs-overlay/commit/6ec9045f8b81b187d0628a8986ca47e163f90285) | `` Updated repos/melpa ``                                                                         |
| [`8ae5e04b`](https://github.com/nix-community/emacs-overlay/commit/8ae5e04ba2f5366fea35d20682af009e4f790298) | `` Updated repos/nongnu ``                                                                        |
| [`5a3f2fe5`](https://github.com/nix-community/emacs-overlay/commit/5a3f2fe5101a01edeadac40210518e9cfbbaaef7) | `` Updated repos/melpa ``                                                                         |
| [`23dfd9c7`](https://github.com/nix-community/emacs-overlay/commit/23dfd9c7e508ab17b3171c8c37551479ce845c2c) | `` Updated repos/melpa ``                                                                         |
| [`12a1b383`](https://github.com/nix-community/emacs-overlay/commit/12a1b383b9e8fa630321742729daf3901f1a8558) | `` Updated repos/emacs ``                                                                         |
| [`1058bda4`](https://github.com/nix-community/emacs-overlay/commit/1058bda4a06d3951cefbe79aaf92168cfacf1c4a) | `` Updated repos/nongnu ``                                                                        |
| [`c7ca2818`](https://github.com/nix-community/emacs-overlay/commit/c7ca2818d7562c62f4c7f5e55d59979144e3f078) | `` Updated repos/melpa ``                                                                         |
| [`5eda5719`](https://github.com/nix-community/emacs-overlay/commit/5eda5719cc4366ddcab47e109b52ce13690d9e0c) | `` Updated repos/emacs ``                                                                         |
| [`095e709a`](https://github.com/nix-community/emacs-overlay/commit/095e709a3b488538c5bd05399803a73c05db8d8b) | `` Updated repos/melpa ``                                                                         |
| [`95692612`](https://github.com/nix-community/emacs-overlay/commit/956926122e62ea2ce0875ca48f781e5cc4bfea13) | `` Updated repos/emacs ``                                                                         |
| [`72c88808`](https://github.com/nix-community/emacs-overlay/commit/72c888082acc0a75cc8a76c9b15603f1044b168c) | `` Updated repos/melpa ``                                                                         |
| [`30d50ec9`](https://github.com/nix-community/emacs-overlay/commit/30d50ec907edd37cafd215a922e97a0d58af4994) | `` Updated repos/melpa ``                                                                         |
| [`7fba168f`](https://github.com/nix-community/emacs-overlay/commit/7fba168f4473eb769715f5ef8cc08c1c3bc50431) | `` Updated repos/melpa ``                                                                         |
| [`dd907639`](https://github.com/nix-community/emacs-overlay/commit/dd907639163218e99839668ca416c1fb1a762825) | `` Updated repos/emacs ``                                                                         |
| [`e7cd4e40`](https://github.com/nix-community/emacs-overlay/commit/e7cd4e4053af9872840f04e7a36c5f11aa81648b) | `` Work around https://lists.gnu.org/archive/html/bug-gnu-emacs/2023-05/msg01512.html ``          |
| [`9a691c70`](https://github.com/nix-community/emacs-overlay/commit/9a691c7088459182b7dd37b7acdb21f805c81a7e) | `` Work around #318 ``                                                                            |
| [`24e553ce`](https://github.com/nix-community/emacs-overlay/commit/24e553ce39c07dcfdb56375190e1ec92f1df0317) | `` Updated repos/melpa ``                                                                         |
| [`3dedbf67`](https://github.com/nix-community/emacs-overlay/commit/3dedbf675c93de8941778a12676cc8fd39c27d3f) | `` Updated repos/nongnu ``                                                                        |
| [`e790cd00`](https://github.com/nix-community/emacs-overlay/commit/e790cd0042a4ad62419bbe411cd013d8d1549cea) | `` Updated repos/melpa ``                                                                         |
| [`e4b7303a`](https://github.com/nix-community/emacs-overlay/commit/e4b7303ac641902d7f5e541071fea537d723871a) | `` Updated repos/emacs ``                                                                         |
| [`8f327ba7`](https://github.com/nix-community/emacs-overlay/commit/8f327ba75dc95080ffab59a4f68b2c73b52d3cb3) | `` Updated repos/melpa ``                                                                         |
| [`1fb7acff`](https://github.com/nix-community/emacs-overlay/commit/1fb7acff3753a86c973a25d7f1c06cd574a3716d) | `` Updated repos/emacs ``                                                                         |
| [`960aa61f`](https://github.com/nix-community/emacs-overlay/commit/960aa61f1c9c62ecb210e52f2859413fae5699a4) | `` Updated repos/elpa ``                                                                          |
| [`3c1b5e0b`](https://github.com/nix-community/emacs-overlay/commit/3c1b5e0bb800541b1f5d41cf23fdd2394858d507) | `` Updated repos/melpa ``                                                                         |
| [`e0c0b3f0`](https://github.com/nix-community/emacs-overlay/commit/e0c0b3f09829e333326a10a051a0836b27b1e08d) | `` Updated repos/melpa ``                                                                         |
| [`6384b7e2`](https://github.com/nix-community/emacs-overlay/commit/6384b7e26999e59a9a27c78c11bad677766edab1) | `` Updated repos/melpa ``                                                                         |
| [`d4fbab64`](https://github.com/nix-community/emacs-overlay/commit/d4fbab64e7423db3e9c391d382d65ed9019fe762) | `` Updated repos/melpa ``                                                                         |
| [`2806dea6`](https://github.com/nix-community/emacs-overlay/commit/2806dea6457fed28013169a05a6dcf9c722d5465) | `` Updated repos/melpa ``                                                                         |
| [`082c2c37`](https://github.com/nix-community/emacs-overlay/commit/082c2c3775c7fba9642e02106cc19dee1f997e54) | `` Updated repos/emacs ``                                                                         |
| [`27d44f3b`](https://github.com/nix-community/emacs-overlay/commit/27d44f3be97f9a3e21e076052af0532719b59c91) | `` Updated repos/melpa ``                                                                         |
| [`40b39715`](https://github.com/nix-community/emacs-overlay/commit/40b3971545145dbff2a0e811ea297c9b346c3ddf) | `` Updated repos/emacs ``                                                                         |
| [`93fa3515`](https://github.com/nix-community/emacs-overlay/commit/93fa3515c250d0a92adb993c6adf3edd73f259b2) | `` Updated repos/elpa ``                                                                          |
| [`37d3fd88`](https://github.com/nix-community/emacs-overlay/commit/37d3fd88e6e7c7dd3b5b659cf3cf18f0d81a55c9) | `` Updated repos/melpa ``                                                                         |
| [`e1aa2803`](https://github.com/nix-community/emacs-overlay/commit/e1aa280376d294408cc97b068aa98b5f7bf0c9ec) | `` Updated repos/emacs ``                                                                         |
| [`4f65398a`](https://github.com/nix-community/emacs-overlay/commit/4f65398a9b2739e61db17ddbc1642117f1a5c1ca) | `` Updated repos/melpa ``                                                                         |
| [`9a0b3d89`](https://github.com/nix-community/emacs-overlay/commit/9a0b3d89865cd20ebbfbdc8573a8e7eed70ab205) | `` Updated repos/melpa ``                                                                         |
| [`c3f786d5`](https://github.com/nix-community/emacs-overlay/commit/c3f786d5c27e7c9337ec28299d360b4d99d01cf3) | `` Updated repos/emacs ``                                                                         |
| [`af00099e`](https://github.com/nix-community/emacs-overlay/commit/af00099ef2272d442b90dc888ecd2a1543748144) | `` Updated repos/elpa ``                                                                          |
| [`fd44d0d5`](https://github.com/nix-community/emacs-overlay/commit/fd44d0d55374c24bf92aa59b4131a5cada358bb6) | `` Updated repos/melpa ``                                                                         |
| [`25cbd5b0`](https://github.com/nix-community/emacs-overlay/commit/25cbd5b0f32cab75356a0a8e73aa2913529db36a) | `` Updated repos/nongnu ``                                                                        |
| [`925b7805`](https://github.com/nix-community/emacs-overlay/commit/925b78051c9c8d2a5908483927046a8802377c5a) | `` Updated repos/melpa ``                                                                         |
| [`d8223443`](https://github.com/nix-community/emacs-overlay/commit/d8223443e229d973f1ba287d18df8431bf5bc9c6) | `` Updated repos/emacs ``                                                                         |
| [`b4d748b3`](https://github.com/nix-community/emacs-overlay/commit/b4d748b3b06fece127426314c1e42e238da9c4e7) | `` Updated repos/melpa ``                                                                         |
| [`54a099d3`](https://github.com/nix-community/emacs-overlay/commit/54a099d3c0c09d2117539075951ce4d0eac67312) | `` Updated repos/emacs ``                                                                         |
| [`a506541e`](https://github.com/nix-community/emacs-overlay/commit/a506541e0dcd1b2bf0c4268d88dfc62fb6a50f4e) | `` Updated repos/elpa ``                                                                          |
| [`0bd4cb5e`](https://github.com/nix-community/emacs-overlay/commit/0bd4cb5ef11985ad1eb6f6ad7e24d0cd86e91dd5) | `` Updated repos/melpa ``                                                                         |
| [`18bfb00e`](https://github.com/nix-community/emacs-overlay/commit/18bfb00ee5e6fed0ad873bc2702ebf6131a7a4a3) | `` Updated repos/melpa ``                                                                         |
| [`deeb9232`](https://github.com/nix-community/emacs-overlay/commit/deeb9232d4545b989cb0ec025db5eacaaa0ed400) | `` Updated repos/melpa ``                                                                         |
| [`3901afec`](https://github.com/nix-community/emacs-overlay/commit/3901afec03ce67ecb377eac43c401cfb29508584) | `` Updated repos/elpa ``                                                                          |
| [`bbf5f5da`](https://github.com/nix-community/emacs-overlay/commit/bbf5f5da6bd4c6e002dd766b8c337a0c40f7c467) | `` Updated repos/nongnu ``                                                                        |
| [`b17ab0c8`](https://github.com/nix-community/emacs-overlay/commit/b17ab0c887c0332ea0006f7522da58833084b4e3) | `` Updated repos/melpa ``                                                                         |
| [`9d1c3a8f`](https://github.com/nix-community/emacs-overlay/commit/9d1c3a8f981b7f95b2d7d92b0b18b5796e49a3c4) | `` Updated repos/emacs ``                                                                         |
| [`34e7e913`](https://github.com/nix-community/emacs-overlay/commit/34e7e913bb78cbb10a1fac073b55eaacb10c1f7c) | `` Updated repos/nongnu ``                                                                        |
| [`fa8e1c5a`](https://github.com/nix-community/emacs-overlay/commit/fa8e1c5a787356fe12a56d915f23fd93660ba2e9) | `` Updated repos/melpa ``                                                                         |
| [`1d37ae5b`](https://github.com/nix-community/emacs-overlay/commit/1d37ae5b3815f1723c9cf24096414b1ea44bd2e5) | `` Updated repos/elpa ``                                                                          |