### PR TITLE
chore(flake/nur): `464d096d` -> `29665bd0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684461335,
-        "narHash": "sha256-DVNwGc/YW7PoN+qKWs1UQ9TcoRe71Iwew/m0GVSCrkc=",
+        "lastModified": 1684467873,
+        "narHash": "sha256-G65echh0rSvlXc1jrBbdY/bJN+ZDnrycQHXec8/F9JI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "464d096df788bc30c8414958b735bef74c2ba125",
+        "rev": "29665bd00fec8ad94a2ed09ee03b53c9d438ae67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`29665bd0`](https://github.com/nix-community/NUR/commit/29665bd00fec8ad94a2ed09ee03b53c9d438ae67) | `` automatic update `` |