### PR TITLE
chore(flake/nur): `29665bd0` -> `21d3404e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684467873,
-        "narHash": "sha256-G65echh0rSvlXc1jrBbdY/bJN+ZDnrycQHXec8/F9JI=",
+        "lastModified": 1684475701,
+        "narHash": "sha256-cCgQ7SWnRkR3ZbJK+I7lG+TwD/NRhgyx4Gn8wQmUw+Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "29665bd00fec8ad94a2ed09ee03b53c9d438ae67",
+        "rev": "21d3404e8bab755acbfeff2ffb6a61a102f744be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                      |
| -------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`21d3404e`](https://github.com/nix-community/NUR/commit/21d3404e8bab755acbfeff2ffb6a61a102f744be) | `` automatic update ``       |
| [`3bcfac30`](https://github.com/nix-community/NUR/commit/3bcfac30751584cfae9e63ac736628d6f75873fd) | `` automatic update ``       |
| [`94a7d9d9`](https://github.com/nix-community/NUR/commit/94a7d9d9635f3271acba3c0d3b68b2ee56695f8d) | `` automatic update ``       |
| [`59f56035`](https://github.com/nix-community/NUR/commit/59f56035b95cf8584fdb2108ba9508e4064821bf) | `` automatic update ``       |
| [`868fce50`](https://github.com/nix-community/NUR/commit/868fce50c669080c90cbf5d467a3a405df55552a) | `` automatic update ``       |
| [`1ceaf96b`](https://github.com/nix-community/NUR/commit/1ceaf96bcdd133baa9a132cf5d564a3620853bae) | `` add materus repository `` |