### PR TITLE
chore(flake/nur): `21d3404e` -> `07863a7c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684475701,
-        "narHash": "sha256-cCgQ7SWnRkR3ZbJK+I7lG+TwD/NRhgyx4Gn8wQmUw+Q=",
+        "lastModified": 1684490043,
+        "narHash": "sha256-HKSh+oOHhpoNOLYiHVO+TCO6Zg7LXsFv227/Y3fRmbI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "21d3404e8bab755acbfeff2ffb6a61a102f744be",
+        "rev": "07863a7c644844578fc15bddb9e249db05ad582e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`07863a7c`](https://github.com/nix-community/NUR/commit/07863a7c644844578fc15bddb9e249db05ad582e) | `` automatic update `` |
| [`b036ff69`](https://github.com/nix-community/NUR/commit/b036ff699f8f266201727b63c45e5a90e1d29b1a) | `` automatic update `` |