### PR TITLE
chore(flake/nur): `07863a7c` -> `98294130`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684490043,
-        "narHash": "sha256-HKSh+oOHhpoNOLYiHVO+TCO6Zg7LXsFv227/Y3fRmbI=",
+        "lastModified": 1684500955,
+        "narHash": "sha256-EJUdpm4lkMn+/HUl3NSHutK+jDLdOHvGBWgz8RlT6Ck=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "07863a7c644844578fc15bddb9e249db05ad582e",
+        "rev": "98294130adb4c09ac5f66e83bf98d80b7853f1d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`98294130`](https://github.com/nix-community/NUR/commit/98294130adb4c09ac5f66e83bf98d80b7853f1d3) | `` automatic update `` |