### PR TITLE
chore(flake/nur): `98294130` -> `08dea384`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684500955,
-        "narHash": "sha256-EJUdpm4lkMn+/HUl3NSHutK+jDLdOHvGBWgz8RlT6Ck=",
+        "lastModified": 1684508143,
+        "narHash": "sha256-WizPijYnuVW++2Uqw6KoeUnIG1mRWBD9znpjuDVu+8E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "98294130adb4c09ac5f66e83bf98d80b7853f1d3",
+        "rev": "08dea3848c4bde970cdccdbacd301b65d9b44ad9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`08dea384`](https://github.com/nix-community/NUR/commit/08dea3848c4bde970cdccdbacd301b65d9b44ad9) | `` automatic update `` |