### PR TITLE
chore(flake/nur): `08dea384` -> `04f69805`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684508143,
-        "narHash": "sha256-WizPijYnuVW++2Uqw6KoeUnIG1mRWBD9znpjuDVu+8E=",
+        "lastModified": 1684511173,
+        "narHash": "sha256-y1oPHgNegnhYHu4noKKxQ3L7RJXaeohiOShXI+b3Epw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "08dea3848c4bde970cdccdbacd301b65d9b44ad9",
+        "rev": "04f6980544fdf078f2512839b5a5d315599aaf31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`04f69805`](https://github.com/nix-community/NUR/commit/04f6980544fdf078f2512839b5a5d315599aaf31) | `` automatic update `` |
| [`60138c94`](https://github.com/nix-community/NUR/commit/60138c94026e674cd5f92c7ffec5efd7fb57d113) | `` automatic update `` |