### PR TITLE
chore(flake/nur): `82a50f1f` -> `92fbf4ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684518420,
-        "narHash": "sha256-sHIjPaduyAqmLHy1P+x2Z/HcJaQKpJoTu/cV1hM9XPQ=",
+        "lastModified": 1684520274,
+        "narHash": "sha256-nU8KdFu+m+5fMB0CPRsw55tKnChw1NyjlL/DAgdNfhY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "82a50f1f93458732cdb75e469d2d52237f90b9ab",
+        "rev": "92fbf4aee64772f86e9ff5816ae738e355435743",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`92fbf4ae`](https://github.com/nix-community/NUR/commit/92fbf4aee64772f86e9ff5816ae738e355435743) | `` automatic update `` |