### PR TITLE
chore(flake/nur): `92fbf4ae` -> `86569578`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684520274,
-        "narHash": "sha256-nU8KdFu+m+5fMB0CPRsw55tKnChw1NyjlL/DAgdNfhY=",
+        "lastModified": 1684525565,
+        "narHash": "sha256-mkvY7B1GaiPt56oDG1qgqp5WfHKVIOaDuBej7TjrGoU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "92fbf4aee64772f86e9ff5816ae738e355435743",
+        "rev": "86569578d5298fedcd6ccc6b18ecde0f67a9d0c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`86569578`](https://github.com/nix-community/NUR/commit/86569578d5298fedcd6ccc6b18ecde0f67a9d0c7) | `` automatic update `` |