### PR TITLE
chore(flake/nur): `86569578` -> `8b186ad7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684525565,
-        "narHash": "sha256-mkvY7B1GaiPt56oDG1qgqp5WfHKVIOaDuBej7TjrGoU=",
+        "lastModified": 1684527793,
+        "narHash": "sha256-OqbLip5qIN5NJa3mY41xaQWyynUUtggqBWlYt2aXv24=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "86569578d5298fedcd6ccc6b18ecde0f67a9d0c7",
+        "rev": "8b186ad7a99398036bbc01b7ea67fc03f69fc69e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8b186ad7`](https://github.com/nix-community/NUR/commit/8b186ad7a99398036bbc01b7ea67fc03f69fc69e) | `` automatic update `` |