### PR TITLE
chore(flake/nur): `8b186ad7` -> `6b5b5d10`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684527793,
-        "narHash": "sha256-OqbLip5qIN5NJa3mY41xaQWyynUUtggqBWlYt2aXv24=",
+        "lastModified": 1684542972,
+        "narHash": "sha256-U1VenHULSNWxQlb0oEQqNlmeIq0GK173nCDKGGCLqr8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8b186ad7a99398036bbc01b7ea67fc03f69fc69e",
+        "rev": "6b5b5d10a4cb21bcbe10a310f9cc442b20df0450",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6b5b5d10`](https://github.com/nix-community/NUR/commit/6b5b5d10a4cb21bcbe10a310f9cc442b20df0450) | `` automatic update `` |