### PR TITLE
chore(flake/nur): `6b5b5d10` -> `6ff6f607`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684542972,
-        "narHash": "sha256-U1VenHULSNWxQlb0oEQqNlmeIq0GK173nCDKGGCLqr8=",
+        "lastModified": 1684550831,
+        "narHash": "sha256-JPtlnuVoRmie03s4oTQbnXHHWVZfTYm+10d1qhtq+mo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6b5b5d10a4cb21bcbe10a310f9cc442b20df0450",
+        "rev": "6ff6f607bf62ba1a25a57bb1c6b085b2d49cda54",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6ff6f607`](https://github.com/nix-community/NUR/commit/6ff6f607bf62ba1a25a57bb1c6b085b2d49cda54) | `` automatic update `` |