### PR TITLE
chore(flake/nur): `6ff6f607` -> `18334762`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684550831,
-        "narHash": "sha256-JPtlnuVoRmie03s4oTQbnXHHWVZfTYm+10d1qhtq+mo=",
+        "lastModified": 1684554289,
+        "narHash": "sha256-cQaEqAp+f8gsurpvOT6K/P2X1WWy7V2R1WmSn/g2UBw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6ff6f607bf62ba1a25a57bb1c6b085b2d49cda54",
+        "rev": "18334762274fb5973f8907cf2d6d3ecf2a9544f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`18334762`](https://github.com/nix-community/NUR/commit/18334762274fb5973f8907cf2d6d3ecf2a9544f9) | `` automatic update `` |