### PR TITLE
chore(flake/nur): `18334762` -> `060e161d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684554289,
-        "narHash": "sha256-cQaEqAp+f8gsurpvOT6K/P2X1WWy7V2R1WmSn/g2UBw=",
+        "lastModified": 1684568109,
+        "narHash": "sha256-CawOTyGZ/Sq4gilJhHI/C4uQvlXm/DCD7UKELTZGtIA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "18334762274fb5973f8907cf2d6d3ecf2a9544f9",
+        "rev": "060e161d67ccc3a590eb8e9c071382a2250d8c37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`060e161d`](https://github.com/nix-community/NUR/commit/060e161d67ccc3a590eb8e9c071382a2250d8c37) | `` automatic update `` |
| [`99d629e4`](https://github.com/nix-community/NUR/commit/99d629e44e1229f35e1291e69d597d449bddc1df) | `` automatic update `` |