### PR TITLE
chore(flake/nur): `d1635a95` -> `04668c9e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684596696,
-        "narHash": "sha256-xkiqdXR2ekQx7kvFBMXXY0gV4AIMm+ihtCf6CKOA5cM=",
+        "lastModified": 1684611880,
+        "narHash": "sha256-ARovxjC5e89FuKjAdYehwyljYx3XGwQ8jX1GrShc+IQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d1635a9543afe0e213e4cbc37154487cab884b84",
+        "rev": "04668c9e7fc85fe0242b7d21eecef085382cda81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                   |
| -------------------------------------------------------------------------------------------------- | ------------------------- |
| [`04668c9e`](https://github.com/nix-community/NUR/commit/04668c9e7fc85fe0242b7d21eecef085382cda81) | `` automatic update ``    |
| [`aa675f91`](https://github.com/nix-community/NUR/commit/aa675f91f587c28b486a7d3162520539617ffa84) | `` add bd-g repository `` |