### PR TITLE
chore(flake/nur): `04668c9e` -> `3c932dd0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684611880,
-        "narHash": "sha256-ARovxjC5e89FuKjAdYehwyljYx3XGwQ8jX1GrShc+IQ=",
+        "lastModified": 1684612984,
+        "narHash": "sha256-XqWVrtHiY7r/NJMDS02i1kj3Q7BOU7BnfQfEd6v3ZIE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "04668c9e7fc85fe0242b7d21eecef085382cda81",
+        "rev": "3c932dd06b0a537b890e1fd3e31deceb1ac3dea3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3c932dd0`](https://github.com/nix-community/NUR/commit/3c932dd06b0a537b890e1fd3e31deceb1ac3dea3) | `` automatic update `` |