### PR TITLE
chore(flake/nur): `bad097b7` -> `b9e8229a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684629675,
-        "narHash": "sha256-gODBzU7+dpF2EDvSfTACPPoHb6fZf3755c2hfvcJGr8=",
+        "lastModified": 1684640733,
+        "narHash": "sha256-Cx03qMJfcXd41489ZCfweqFx7PosmVolTyM+GR8nnmQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bad097b7d052e6b273954ca714ca294e6c196b78",
+        "rev": "b9e8229ae043807b95213eaa1e4b3c8f747f7531",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b9e8229a`](https://github.com/nix-community/NUR/commit/b9e8229ae043807b95213eaa1e4b3c8f747f7531) | `` automatic update `` |
| [`fa8473da`](https://github.com/nix-community/NUR/commit/fa8473dabd0e87324a4954bddbab125058e31e30) | `` automatic update `` |
| [`13fe0f4f`](https://github.com/nix-community/NUR/commit/13fe0f4fdf48cd8026e20b2bc77ff10ccfc6b9d1) | `` automatic update `` |