### PR TITLE
chore(flake/nur): `b9e8229a` -> `279c0062`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684640733,
-        "narHash": "sha256-Cx03qMJfcXd41489ZCfweqFx7PosmVolTyM+GR8nnmQ=",
+        "lastModified": 1684647356,
+        "narHash": "sha256-9yyhw6lmzk5JQskT3FLwsOK426Jl4dZPL849E5HkjVk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b9e8229ae043807b95213eaa1e4b3c8f747f7531",
+        "rev": "279c00628c655363c6a728128bafbd50c1aa34a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`279c0062`](https://github.com/nix-community/NUR/commit/279c00628c655363c6a728128bafbd50c1aa34a9) | `` automatic update `` |
| [`fd963ed0`](https://github.com/nix-community/NUR/commit/fd963ed0646db69bed35ab721e4f928ec727abc5) | `` automatic update `` |