### PR TITLE
chore(flake/nur): `344e45e1` -> `15941d50`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684651570,
-        "narHash": "sha256-lYWfTJMgpCU5jKazJxXoZErd4b0laKl530b9OM4dW8U=",
+        "lastModified": 1684654960,
+        "narHash": "sha256-EMYhwqCHHmFZLNYesRb5f3hpA0zJymedIEp4KTjiHa8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "344e45e1c85110869f941c0e7fd6bccd852652ff",
+        "rev": "15941d503be28b16c132f29deb03566d896b52c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`15941d50`](https://github.com/nix-community/NUR/commit/15941d503be28b16c132f29deb03566d896b52c7) | `` automatic update `` |
| [`6c45d071`](https://github.com/nix-community/NUR/commit/6c45d0712862cb42d85dff0ab3accdc8a7c1f908) | `` automatic update `` |
| [`a32e3e24`](https://github.com/nix-community/NUR/commit/a32e3e24fec94840edf29e48195011cd4842576c) | `` automatic update `` |
| [`f4491cdc`](https://github.com/nix-community/NUR/commit/f4491cdc34befb81f0c7e05ddc1955db91599da8) | `` automatic update `` |