### PR TITLE
chore(flake/nur): `15941d50` -> `8653d5b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684654960,
-        "narHash": "sha256-EMYhwqCHHmFZLNYesRb5f3hpA0zJymedIEp4KTjiHa8=",
+        "lastModified": 1684662910,
+        "narHash": "sha256-5CgDhxGxLS20ShGAA1dkyPfl8cN6PG5YWqueNKIChsw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "15941d503be28b16c132f29deb03566d896b52c7",
+        "rev": "8653d5b3293e04fe4bb56e6b0be5357a749ed7f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8653d5b3`](https://github.com/nix-community/NUR/commit/8653d5b3293e04fe4bb56e6b0be5357a749ed7f2) | `` automatic update `` |