### PR TITLE
chore(flake/nur): `8653d5b3` -> `474f1740`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684662910,
-        "narHash": "sha256-5CgDhxGxLS20ShGAA1dkyPfl8cN6PG5YWqueNKIChsw=",
+        "lastModified": 1684663871,
+        "narHash": "sha256-uuf/GCTGK+9IqLlPvFwxk1aXHXrJ+ZWhN33xiA8HXsM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8653d5b3293e04fe4bb56e6b0be5357a749ed7f2",
+        "rev": "474f17401d8d47c1c4328d7c2985cb4f3691fff8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`474f1740`](https://github.com/nix-community/NUR/commit/474f17401d8d47c1c4328d7c2985cb4f3691fff8) | `` automatic update `` |
| [`7f299025`](https://github.com/nix-community/NUR/commit/7f2990250bd4ed354729be6beca7768043a59ef6) | `` automatic update `` |