### PR TITLE
chore(flake/nur): `474f1740` -> `01c05b60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684663871,
-        "narHash": "sha256-uuf/GCTGK+9IqLlPvFwxk1aXHXrJ+ZWhN33xiA8HXsM=",
+        "lastModified": 1684667092,
+        "narHash": "sha256-ZYxqlsgTCumT4AwNDRsu5oiPQ3LREr2R4xEuZ2H5K5Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "474f17401d8d47c1c4328d7c2985cb4f3691fff8",
+        "rev": "01c05b6010a4542867c2d85ac247e5bd36e2c937",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`01c05b60`](https://github.com/nix-community/NUR/commit/01c05b6010a4542867c2d85ac247e5bd36e2c937) | `` automatic update `` |