### PR TITLE
chore(flake/nur): `26a9d4a3` -> `823806a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684692007,
-        "narHash": "sha256-/9gfY6dkCue0kKe7pNT4ElOax9lIgIF1mV144MCzuhQ=",
+        "lastModified": 1684694687,
+        "narHash": "sha256-pGPk6ruaPDx/lhwygzGynnMKVdsLwdocAx1zNgFb788=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "26a9d4a327e388cff1b21c8448607563eaa8076f",
+        "rev": "823806a28f2e67e6ab25e134ad4fe43a1673e9a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`823806a2`](https://github.com/nix-community/NUR/commit/823806a28f2e67e6ab25e134ad4fe43a1673e9a6) | `` automatic update `` |
| [`466d62c8`](https://github.com/nix-community/NUR/commit/466d62c84ff9482f3d877803799ef88b866bd017) | `` automatic update `` |