### PR TITLE
chore(flake/nur): `5ca9f268` -> `f7529257`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684698381,
-        "narHash": "sha256-dL6D9EMSKukbpnGg8Uq97nvIh0V+o8yAfW3IT2tZSls=",
+        "lastModified": 1684701889,
+        "narHash": "sha256-x92NQyqCeWhVf2YB7kVEAiUSuAxlbi3fk/XcOcBvlKI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5ca9f268e43743c5a669eefe80ca095897c46625",
+        "rev": "f75292571f7f6e59051c92570a9051d0e9486c4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f7529257`](https://github.com/nix-community/NUR/commit/f75292571f7f6e59051c92570a9051d0e9486c4b) | `` automatic update `` |