### PR TITLE
chore(flake/nur): `f7529257` -> `62ae3ced`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684701889,
-        "narHash": "sha256-x92NQyqCeWhVf2YB7kVEAiUSuAxlbi3fk/XcOcBvlKI=",
+        "lastModified": 1684721811,
+        "narHash": "sha256-1ImmmAEiDOnNqdIqmzYZcAhDeghM3AsqtyYSKGeUQPc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f75292571f7f6e59051c92570a9051d0e9486c4b",
+        "rev": "62ae3ced6672e0dde3c788a01f41e0d3f6242810",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`62ae3ced`](https://github.com/nix-community/NUR/commit/62ae3ced6672e0dde3c788a01f41e0d3f6242810) | `` automatic update `` |