### PR TITLE
chore(flake/nur): `62ae3ced` -> `2a747f55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684721811,
-        "narHash": "sha256-1ImmmAEiDOnNqdIqmzYZcAhDeghM3AsqtyYSKGeUQPc=",
+        "lastModified": 1684727156,
+        "narHash": "sha256-xTGhZXU1P/Io41a2Z+lIP9lVDpgRX5faNdbenP0Q8Eg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "62ae3ced6672e0dde3c788a01f41e0d3f6242810",
+        "rev": "2a747f55bcff9519a4c65cab32f401b053cf53ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2a747f55`](https://github.com/nix-community/NUR/commit/2a747f55bcff9519a4c65cab32f401b053cf53ba) | `` automatic update `` |