### PR TITLE
chore(flake/pre-commit-hooks): `96eabec5` -> `df448ffc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -846,11 +846,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1684195081,
-        "narHash": "sha256-IKnQUSBhQTChFERxW2AzuauVpY1HRgeVzAjNMAA4B6I=",
+        "lastModified": 1684763926,
+        "narHash": "sha256-1pSTzogoCmZc7JB3VrFFgFoj5lNXIIWwkVReFVMHDT8=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "96eabec58248ed8f4b0ad59e7ce9398018684fdc",
+        "rev": "df448ffc5d244f52261d05894c5a96af7f3758a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message               |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`0224eb71`](https://github.com/cachix/pre-commit-hooks.nix/commit/0224eb71a2f2db7f7e77574b72f901b283bc41be) | `` typos: Fix typo `` |