### PR TITLE
chore(flake/darwin): `57094eaf` -> `b8c286c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -111,11 +111,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684773749,
-        "narHash": "sha256-Fq4Qt1TrstYJLxGAaEEFQ4fr3lpzwdv+nxHbsKCqGFw=",
+        "lastModified": 1684774948,
+        "narHash": "sha256-hJTaw4dYzcB+lsasKejnafq0CxPsVetn9RLXrcL+4jE=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "57094eaf5a2e7cce4ea6a7a8ac2820519c1ee25b",
+        "rev": "b8c286c82c6b47826a6c0377e7017052ad91353c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                               |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`9f93b195`](https://github.com/LnL7/nix-darwin/commit/9f93b195853a275668e013d330d7bdd59e6c4b49) | `` feat: support writing arrays to system defaults `` |