### PR TITLE
chore(flake/nur): `7c15140f` -> `d3705230`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684773867,
-        "narHash": "sha256-6TxzJUnDCenS0uwGrbnLa2z5rqgz03pS2TzOWpxdD+A=",
+        "lastModified": 1684788300,
+        "narHash": "sha256-CUBJXwQ7wT6zNEeT1xD8bqM5oNCoMG++qrmTsIwmuQ8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7c15140f937797dd1bc376d59857cfe32ba4a50e",
+        "rev": "d37052305305e8d8d0be0e6b36de2639034a52a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d3705230`](https://github.com/nix-community/NUR/commit/d37052305305e8d8d0be0e6b36de2639034a52a8) | `` automatic update `` |
| [`74882351`](https://github.com/nix-community/NUR/commit/74882351557ccfccd5a95700479a3e2d4d7bc98c) | `` automatic update `` |