### PR TITLE
chore(flake/nur): `878fbf20` -> `c6902178`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684790290,
-        "narHash": "sha256-k5HKYcQb56EtOpjNUIuM9Eun82x8w71vSXfDG+x6NdQ=",
+        "lastModified": 1684793770,
+        "narHash": "sha256-McAEK8yOdEpJySUm1mGs863Lg2Thx9j/9YLmtCCHiyY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "878fbf206e63c330eddd323af211aa6ab85b1cba",
+        "rev": "c69021782cabd6ebc8705f3b6c9587adc9cd4722",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c6902178`](https://github.com/nix-community/NUR/commit/c69021782cabd6ebc8705f3b6c9587adc9cd4722) | `` automatic update `` |