### PR TITLE
chore(flake/nur): `c6902178` -> `0f5e1c13`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684793770,
-        "narHash": "sha256-McAEK8yOdEpJySUm1mGs863Lg2Thx9j/9YLmtCCHiyY=",
+        "lastModified": 1684800172,
+        "narHash": "sha256-d/08irI+7JBfu5AqsjTVTWapsQczroKimaRCfXISkLM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c69021782cabd6ebc8705f3b6c9587adc9cd4722",
+        "rev": "0f5e1c13508689ad982dee19eff8e18ccf3c0e10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0f5e1c13`](https://github.com/nix-community/NUR/commit/0f5e1c13508689ad982dee19eff8e18ccf3c0e10) | `` automatic update `` |
| [`c3f4eee3`](https://github.com/nix-community/NUR/commit/c3f4eee3a6941c902506aefcae86febf1e05a2fe) | `` automatic update `` |