### PR TITLE
chore(flake/nur): `0f5e1c13` -> `66e36daa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684800172,
-        "narHash": "sha256-d/08irI+7JBfu5AqsjTVTWapsQczroKimaRCfXISkLM=",
+        "lastModified": 1684803634,
+        "narHash": "sha256-YlpFJzQ+8fsqfinAhZz8GhcPYSGZsIT7e/p2CIAvMDM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0f5e1c13508689ad982dee19eff8e18ccf3c0e10",
+        "rev": "66e36daae22e6b88ed23dc1aa6ee70f258a54276",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`66e36daa`](https://github.com/nix-community/NUR/commit/66e36daae22e6b88ed23dc1aa6ee70f258a54276) | `` automatic update `` |
| [`acac1be2`](https://github.com/nix-community/NUR/commit/acac1be21a068002af642982803900dab614ab07) | `` automatic update `` |
| [`7359e1f4`](https://github.com/nix-community/NUR/commit/7359e1f4f15e0c3f256d291cf5b2622ebb5cc70d) | `` automatic update `` |
| [`20fba2d2`](https://github.com/nix-community/NUR/commit/20fba2d28860dfbc033d3bddf6af9344270939af) | `` automatic update `` |