### PR TITLE
chore(flake/nur): `66e36daa` -> `0331a11d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684803634,
-        "narHash": "sha256-YlpFJzQ+8fsqfinAhZz8GhcPYSGZsIT7e/p2CIAvMDM=",
+        "lastModified": 1684813549,
+        "narHash": "sha256-wxLhBPwq+WUOVOLT8l18+573B9S7EUr0o5eYLmlRdCA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "66e36daae22e6b88ed23dc1aa6ee70f258a54276",
+        "rev": "0331a11d944383f1173cf9d20d2975cf9bba40e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0331a11d`](https://github.com/nix-community/NUR/commit/0331a11d944383f1173cf9d20d2975cf9bba40e3) | `` automatic update `` |