### PR TITLE
chore(flake/nur): `0331a11d` -> `d4f66561`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684813549,
-        "narHash": "sha256-wxLhBPwq+WUOVOLT8l18+573B9S7EUr0o5eYLmlRdCA=",
+        "lastModified": 1684824758,
+        "narHash": "sha256-XsjaDug+5cUaUQ1xHgc2jhS1w0V4HBY8UfVgs+jpFgg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0331a11d944383f1173cf9d20d2975cf9bba40e3",
+        "rev": "d4f6656104ef49b0eeb3c9dd6cb87773904375e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d4f66561`](https://github.com/nix-community/NUR/commit/d4f6656104ef49b0eeb3c9dd6cb87773904375e7) | `` automatic update `` |
| [`532cfa78`](https://github.com/nix-community/NUR/commit/532cfa785cbd42f82d600de6c7adabc75f9cc1e9) | `` automatic update `` |
| [`34ed2bd0`](https://github.com/nix-community/NUR/commit/34ed2bd079b537453e90428f201f5221517cdd49) | `` automatic update `` |