### PR TITLE
chore(flake/nur): `d4f66561` -> `2aaadd09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684824758,
-        "narHash": "sha256-XsjaDug+5cUaUQ1xHgc2jhS1w0V4HBY8UfVgs+jpFgg=",
+        "lastModified": 1684838772,
+        "narHash": "sha256-YDzX4aq1EZ6+BsFZi3pXV77ccA8x2BR20tu2ZPrlObo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d4f6656104ef49b0eeb3c9dd6cb87773904375e7",
+        "rev": "2aaadd09c27233f4ddebc85ea51460c01dae2b3c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2aaadd09`](https://github.com/nix-community/NUR/commit/2aaadd09c27233f4ddebc85ea51460c01dae2b3c) | `` automatic update `` |