### PR TITLE
chore(flake/nur): `2aaadd09` -> `08683b44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684838772,
-        "narHash": "sha256-YDzX4aq1EZ6+BsFZi3pXV77ccA8x2BR20tu2ZPrlObo=",
+        "lastModified": 1684846653,
+        "narHash": "sha256-kedtrV1IHoiRjFsb7P3f44n44bgzZN8evP1EVyXmsB8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2aaadd09c27233f4ddebc85ea51460c01dae2b3c",
+        "rev": "08683b44189f6d5e67531d3383563f8357903cdb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                           |
| -------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`08683b44`](https://github.com/nix-community/NUR/commit/08683b44189f6d5e67531d3383563f8357903cdb) | `` automatic update ``            |
| [`c9154e54`](https://github.com/nix-community/NUR/commit/c9154e547291becded9c37a280bc75d1a9d97b4a) | `` automatic update ``            |
| [`463cb21e`](https://github.com/nix-community/NUR/commit/463cb21e8cad969a6b44de48e72dd71f0a470b5a) | `` automatic update ``            |
| [`9aecee3e`](https://github.com/nix-community/NUR/commit/9aecee3edd72ea7f784655c55c81d799e422d0f5) | `` add ataraxiasjel repository `` |