### PR TITLE
chore(flake/nur): `08683b44` -> `3a685236`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684846653,
-        "narHash": "sha256-kedtrV1IHoiRjFsb7P3f44n44bgzZN8evP1EVyXmsB8=",
+        "lastModified": 1684852548,
+        "narHash": "sha256-N+uN5CXxzy/rqTMkkQWC40dt83hm56ce8PqVheybrDk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "08683b44189f6d5e67531d3383563f8357903cdb",
+        "rev": "3a68523694d2f0672d678e0d7b0c579c0081e6ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3a685236`](https://github.com/nix-community/NUR/commit/3a68523694d2f0672d678e0d7b0c579c0081e6ac) | `` automatic update `` |
| [`e50d7404`](https://github.com/nix-community/NUR/commit/e50d740418558485f838eecd3d42f1019eb3a7d1) | `` automatic update `` |