### PR TITLE
chore(flake/nur): `3a685236` -> `2c7307a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684852548,
-        "narHash": "sha256-N+uN5CXxzy/rqTMkkQWC40dt83hm56ce8PqVheybrDk=",
+        "lastModified": 1684856747,
+        "narHash": "sha256-sauDfmQDn1NFW2IdQ5aOcwcU5YTJ+OTN7VpqskVXrb0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3a68523694d2f0672d678e0d7b0c579c0081e6ac",
+        "rev": "2c7307a5423802a6da62ec3bc80ce44e1788dd5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2c7307a5`](https://github.com/nix-community/NUR/commit/2c7307a5423802a6da62ec3bc80ce44e1788dd5b) | `` automatic update `` |
| [`e0b8ec9e`](https://github.com/nix-community/NUR/commit/e0b8ec9e5d09d56ace53f1800f7711a1db976fea) | `` automatic update `` |