### PR TITLE
chore(flake/nur): `2c7307a5` -> `5e232b89`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684856747,
-        "narHash": "sha256-sauDfmQDn1NFW2IdQ5aOcwcU5YTJ+OTN7VpqskVXrb0=",
+        "lastModified": 1684860191,
+        "narHash": "sha256-MLI6OznRdPRA4FhYZFRgfIWI4shLE2IwJr0PWE3dEp8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2c7307a5423802a6da62ec3bc80ce44e1788dd5b",
+        "rev": "5e232b89063f2358136f6e558b90baf412547952",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5e232b89`](https://github.com/nix-community/NUR/commit/5e232b89063f2358136f6e558b90baf412547952) | `` automatic update `` |