### PR TITLE
chore(flake/nur): `f9abe21b` -> `327abea0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684863931,
-        "narHash": "sha256-zrUkicOLh1FQ/KCWNl4LeZ3jnZHjcOQlD39qiAwOIm0=",
+        "lastModified": 1684865259,
+        "narHash": "sha256-yDikDcVDp+/m2xKn0NZEU8bM5qxR0VkrvGvnlbeDLnc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f9abe21b2f7465171ad2735f6c8925ac07eaaf29",
+        "rev": "327abea0f5972b1bb6aedfbe193dc761d16c416d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`327abea0`](https://github.com/nix-community/NUR/commit/327abea0f5972b1bb6aedfbe193dc761d16c416d) | `` automatic update `` |