### PR TITLE
chore(flake/nur): `327abea0` -> `c8a1624b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684865259,
-        "narHash": "sha256-yDikDcVDp+/m2xKn0NZEU8bM5qxR0VkrvGvnlbeDLnc=",
+        "lastModified": 1684878188,
+        "narHash": "sha256-U/SiJ6CMbXX4rnK2CnwNGXP3TSfoydAzm7L2g3qHeRQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "327abea0f5972b1bb6aedfbe193dc761d16c416d",
+        "rev": "c8a1624b2947db227994cd3ba1455a895e676c05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c8a1624b`](https://github.com/nix-community/NUR/commit/c8a1624b2947db227994cd3ba1455a895e676c05) | `` automatic update `` |
| [`537cc6a7`](https://github.com/nix-community/NUR/commit/537cc6a7782128876882b84b3f2c5b73e013390b) | `` automatic update `` |
| [`45a37571`](https://github.com/nix-community/NUR/commit/45a37571851369d948215b7cb1f082f65c9bf869) | `` automatic update `` |