### PR TITLE
chore(flake/nur): `c8a1624b` -> `7a572830`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684878188,
-        "narHash": "sha256-U/SiJ6CMbXX4rnK2CnwNGXP3TSfoydAzm7L2g3qHeRQ=",
+        "lastModified": 1684882903,
+        "narHash": "sha256-Q9aG7ojai9Gffnt2IKohagnRRQgcpM8ytLBbM89vhDA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c8a1624b2947db227994cd3ba1455a895e676c05",
+        "rev": "7a5728300e796c6cbc01b08b4084cfd21a2fdbd9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7a572830`](https://github.com/nix-community/NUR/commit/7a5728300e796c6cbc01b08b4084cfd21a2fdbd9) | `` automatic update `` |
| [`92d0a546`](https://github.com/nix-community/NUR/commit/92d0a546053aa02e47ee0c4ce7cb0ed4d68e7b16) | `` automatic update `` |