### PR TITLE
chore(flake/nur): `7a572830` -> `5e0ca996`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684882903,
-        "narHash": "sha256-Q9aG7ojai9Gffnt2IKohagnRRQgcpM8ytLBbM89vhDA=",
+        "lastModified": 1684893396,
+        "narHash": "sha256-Tdmj7dvT/2v6fyomqFkeIKGWPkUmvos0vfpiV7Dfpbs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7a5728300e796c6cbc01b08b4084cfd21a2fdbd9",
+        "rev": "5e0ca996264b2e5e2cfb924a11a384a3776d13ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5e0ca996`](https://github.com/nix-community/NUR/commit/5e0ca996264b2e5e2cfb924a11a384a3776d13ef) | `` automatic update `` |