### PR TITLE
chore(flake/nur): `5e0ca996` -> `874d4a6c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684893396,
-        "narHash": "sha256-Tdmj7dvT/2v6fyomqFkeIKGWPkUmvos0vfpiV7Dfpbs=",
+        "lastModified": 1684897071,
+        "narHash": "sha256-Y6BQZfRa4/Fm3OBHHbEEWCuqKS059HTp8eByY+GiUZ8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5e0ca996264b2e5e2cfb924a11a384a3776d13ef",
+        "rev": "874d4a6c4480d9c1791b9b8dadbff5f639be798e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`874d4a6c`](https://github.com/nix-community/NUR/commit/874d4a6c4480d9c1791b9b8dadbff5f639be798e) | `` automatic update `` |