### PR TITLE
chore(flake/nur): `874d4a6c` -> `1eeefaf7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684897071,
-        "narHash": "sha256-Y6BQZfRa4/Fm3OBHHbEEWCuqKS059HTp8eByY+GiUZ8=",
+        "lastModified": 1684899919,
+        "narHash": "sha256-VQpj2P2MMW/eiN5yhdrHsMuanKEen/aarXZZJgLm5Ms=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "874d4a6c4480d9c1791b9b8dadbff5f639be798e",
+        "rev": "1eeefaf753be9bfec5aafaac98c3485947b1cd53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1eeefaf7`](https://github.com/nix-community/NUR/commit/1eeefaf753be9bfec5aafaac98c3485947b1cd53) | `` automatic update `` |