### PR TITLE
chore(flake/nur): `1eeefaf7` -> `5a6b7ceb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684899919,
-        "narHash": "sha256-VQpj2P2MMW/eiN5yhdrHsMuanKEen/aarXZZJgLm5Ms=",
+        "lastModified": 1684905575,
+        "narHash": "sha256-Y3L98l5VNE/2l/iarhcC1onzZE1yyXnisNLbHCYM8fY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1eeefaf753be9bfec5aafaac98c3485947b1cd53",
+        "rev": "5a6b7ceb6dfe46452b2a595e247d5ac6cfe8c684",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5a6b7ceb`](https://github.com/nix-community/NUR/commit/5a6b7ceb6dfe46452b2a595e247d5ac6cfe8c684) | `` automatic update `` |