### PR TITLE
chore(flake/nur): `5a6b7ceb` -> `a399b093`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684905575,
-        "narHash": "sha256-Y3L98l5VNE/2l/iarhcC1onzZE1yyXnisNLbHCYM8fY=",
+        "lastModified": 1684910683,
+        "narHash": "sha256-Y1ir9at2RHF3tVzx6oYZzNEwnNYvP15iotKTMoq55mk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5a6b7ceb6dfe46452b2a595e247d5ac6cfe8c684",
+        "rev": "a399b093e7dfaed4f71730738db6f2ffe4ecb3bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a399b093`](https://github.com/nix-community/NUR/commit/a399b093e7dfaed4f71730738db6f2ffe4ecb3bb) | `` automatic update `` |
| [`b902461d`](https://github.com/nix-community/NUR/commit/b902461d22a080d160b5c853a92670e9f0dbacf0) | `` automatic update `` |