### PR TITLE
chore(flake/nur): `a399b093` -> `c4572077`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684910683,
-        "narHash": "sha256-Y1ir9at2RHF3tVzx6oYZzNEwnNYvP15iotKTMoq55mk=",
+        "lastModified": 1684914349,
+        "narHash": "sha256-9Om1VdRkNf4XTf9pFRYE+84KlWHK2PKNkTrtviUhUow=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a399b093e7dfaed4f71730738db6f2ffe4ecb3bb",
+        "rev": "c4572077d85a2f1e8cbd5728298217d459f5302f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c4572077`](https://github.com/nix-community/NUR/commit/c4572077d85a2f1e8cbd5728298217d459f5302f) | `` automatic update `` |
| [`ea34abdc`](https://github.com/nix-community/NUR/commit/ea34abdcb1f8b49b19833aaae83864b07fbd25e9) | `` automatic update `` |