### PR TITLE
chore(flake/emacs-ement): `4a8519b8` -> `ec31709c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -230,11 +230,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1684939864,
-        "narHash": "sha256-dyzCCLsMksv+0ldJ884KFGewL5NiPPh6OFmS4bTqVQk=",
+        "lastModified": 1684942123,
+        "narHash": "sha256-1qXV2s0giE4PHZ+uHBRoSlehFNHTduTP3Sv59RPA1w0=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "4a8519b85cb63e62cd28e5fca8786e5140ea43ad",
+        "rev": "ec31709c3aef0a3abbab3052d93f5f6cda6394e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                       |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`ec31709c`](https://github.com/alphapapa/ement.el/commit/ec31709c3aef0a3abbab3052d93f5f6cda6394e1) | `` Fix: Customization group for two faces ``                  |
| [`94547e90`](https://github.com/alphapapa/ement.el/commit/94547e906d14b88064537b6a3f8c93c7432004bd) | `` Fix: (ement-room--pp-thing) Timestamp with date headers `` |