### PR TITLE
chore(flake/emacs-ement): `ec31709c` -> `ee0eb6f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -230,11 +230,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1684942123,
-        "narHash": "sha256-1qXV2s0giE4PHZ+uHBRoSlehFNHTduTP3Sv59RPA1w0=",
+        "lastModified": 1684952890,
+        "narHash": "sha256-fyO5a5oH7q0WKdhLJ59Qyl1/Bmbv7LPMbnMiqynJ4GE=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "ec31709c3aef0a3abbab3052d93f5f6cda6394e1",
+        "rev": "ee0eb6f9a3f04eeb4220c2af94189a75abc86d5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                     |
| --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`817ed15a`](https://github.com/alphapapa/ement.el/commit/817ed15adb74356a3287c693f0dc299767096278) | `` Update changelog, formatting ``                          |
| [`cdd35a0e`](https://github.com/alphapapa/ement.el/commit/cdd35a0ee373990fa6a40eb44837a701cd6dd498) | `` Fix: avoid spurious indent in room membership changes `` |