### PR TITLE
chore(flake/nur): `6ae794b7` -> `dfe0ed96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684954702,
-        "narHash": "sha256-wFF3RRgTSXEDxtJ5sMKV+PVEY1T7oAsVddO6MMtxXoE=",
+        "lastModified": 1684958453,
+        "narHash": "sha256-FKW+moi2Xal8fYT/ErTnjzBoxR3IB+TX/NdZqZcF76s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6ae794b74ffe18ad52d7c09f697e370192952e1a",
+        "rev": "dfe0ed963b6daf392259fe1acc851c29ee3ef7fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dfe0ed96`](https://github.com/nix-community/NUR/commit/dfe0ed963b6daf392259fe1acc851c29ee3ef7fb) | `` automatic update `` |
| [`3110337c`](https://github.com/nix-community/NUR/commit/3110337cd390c63c3af9c78e65387456fab2d5ef) | `` automatic update `` |
| [`7cce2f75`](https://github.com/nix-community/NUR/commit/7cce2f75f59b9663351f7d56374f650ec20e1974) | `` automatic update `` |