### PR TITLE
chore(flake/nur): `dfe0ed96` -> `c4e46e93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684958453,
-        "narHash": "sha256-FKW+moi2Xal8fYT/ErTnjzBoxR3IB+TX/NdZqZcF76s=",
+        "lastModified": 1684959207,
+        "narHash": "sha256-lROs3YxWZDGeEPrcv0AYEfyps+gSW01E/VoTkmHU768=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dfe0ed963b6daf392259fe1acc851c29ee3ef7fb",
+        "rev": "c4e46e935ba827acf70979c5e02a8431cf14cc5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c4e46e93`](https://github.com/nix-community/NUR/commit/c4e46e935ba827acf70979c5e02a8431cf14cc5a) | `` automatic update `` |
| [`2d0e5a78`](https://github.com/nix-community/NUR/commit/2d0e5a7832af66da5b5fde9fa445ffef264bae31) | `` automatic update `` |