### PR TITLE
chore(flake/home-manager): `58eb968c` -> `d1f04b0f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684824189,
-        "narHash": "sha256-k3nCkn5Qy67rCguuw6YkGuL6hOUNRKxQoKOjnapk5sU=",
+        "lastModified": 1685019994,
+        "narHash": "sha256-81o6SKZPALvib21hIOMx2lIhFSs0mRy0PfPvg0zsfTk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "58eb968c21d309a6c2b020ea8d64e25c38ceebba",
+        "rev": "d1f04b0f365a34896a37d9015637796537ec88a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                      |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`d1f04b0f`](https://github.com/nix-community/home-manager/commit/d1f04b0f365a34896a37d9015637796537ec88a3) | `` yt-dlp: generate config if settings or extraConfig are defined (#4018) `` |