### PR TITLE
chore(flake/nur): `c4e46e93` -> `62a6b052`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1684959207,
-        "narHash": "sha256-lROs3YxWZDGeEPrcv0AYEfyps+gSW01E/VoTkmHU768=",
+        "lastModified": 1685036682,
+        "narHash": "sha256-5I5YPerGz4w5+WYCz0d60ugsCI08ebV0XBeTWP59kZ4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c4e46e935ba827acf70979c5e02a8431cf14cc5a",
+        "rev": "62a6b05243204ba288548add6305191c3432ad68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`62a6b052`](https://github.com/nix-community/NUR/commit/62a6b05243204ba288548add6305191c3432ad68) | `` automatic update `` |
| [`ad44dc24`](https://github.com/nix-community/NUR/commit/ad44dc2454969e5cf481c22808b893cf4ef88fc3) | `` automatic update `` |