### PR TITLE
chore(flake/nur): `82f3aa5c` -> `1975224e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685061478,
-        "narHash": "sha256-fNCFmOOfTmtWCV4WEoAnwwyjjB4NRAzucTKdt0w5zvg=",
+        "lastModified": 1685079564,
+        "narHash": "sha256-I41o1LR9rVnLUjd9R3IF1uxZItC9dF59OzJ0KJ+3fBg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "82f3aa5c5a85a9f2a1e72eaf0eec30c8ab8fdf2c",
+        "rev": "1975224eaef5d3f3b912ea9ade018e7e3c156dd1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1975224e`](https://github.com/nix-community/NUR/commit/1975224eaef5d3f3b912ea9ade018e7e3c156dd1) | `` automatic update `` |