### PR TITLE
chore(flake/nur): `6caf1df8` -> `5f15b57e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685082753,
-        "narHash": "sha256-T/EZZ12KLCV+DmTSOAZElNqIv37EGsXsrYsppSYakKY=",
+        "lastModified": 1685105961,
+        "narHash": "sha256-gvcy3gq5XBqlERy0GJWshkQUa75XPLHRIgPakpPsRFk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6caf1df8f14553fa9295412c13776fb83e56bd4f",
+        "rev": "5f15b57eeaa42ceef0926d4cfaa9f7572d9cfd43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5f15b57e`](https://github.com/nix-community/NUR/commit/5f15b57eeaa42ceef0926d4cfaa9f7572d9cfd43) | `` automatic update `` |