### PR TITLE
chore(flake/nur): `5f15b57e` -> `6c3d248a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685105961,
-        "narHash": "sha256-gvcy3gq5XBqlERy0GJWshkQUa75XPLHRIgPakpPsRFk=",
+        "lastModified": 1685108738,
+        "narHash": "sha256-FvNK9oXGGZF2pzMQVU/GV5WzS6rDSXCjKUVcKYkgE/k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5f15b57eeaa42ceef0926d4cfaa9f7572d9cfd43",
+        "rev": "6c3d248aeb6e6763ab897d98c1e17de950ea2ad5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6c3d248a`](https://github.com/nix-community/NUR/commit/6c3d248aeb6e6763ab897d98c1e17de950ea2ad5) | `` automatic update `` |