### PR TITLE
chore(flake/nur): `6c3d248a` -> `4a2a9583`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685108738,
-        "narHash": "sha256-FvNK9oXGGZF2pzMQVU/GV5WzS6rDSXCjKUVcKYkgE/k=",
+        "lastModified": 1685121851,
+        "narHash": "sha256-tPvAxqsM4VkPoO4QyqQxTYecv1ormqhZ+JmsUC/PUEA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6c3d248aeb6e6763ab897d98c1e17de950ea2ad5",
+        "rev": "4a2a958322444e3c3156b3442872f34b38db2ac8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4a2a9583`](https://github.com/nix-community/NUR/commit/4a2a958322444e3c3156b3442872f34b38db2ac8) | `` automatic update `` |