### PR TITLE
chore(flake/nur): `4a2a9583` -> `a502f836`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685121851,
-        "narHash": "sha256-tPvAxqsM4VkPoO4QyqQxTYecv1ormqhZ+JmsUC/PUEA=",
+        "lastModified": 1685126679,
+        "narHash": "sha256-cOZiSirGQ4gP7Q2Yoht/rtEaAZgsHum6xm3NjN82In0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4a2a958322444e3c3156b3442872f34b38db2ac8",
+        "rev": "a502f8367bdd5fedb9eb19b70fec1513c3d0d1b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a502f836`](https://github.com/nix-community/NUR/commit/a502f8367bdd5fedb9eb19b70fec1513c3d0d1b5) | `` automatic update `` |