### PR TITLE
chore(flake/nur): `a502f836` -> `a54f47a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685126679,
-        "narHash": "sha256-cOZiSirGQ4gP7Q2Yoht/rtEaAZgsHum6xm3NjN82In0=",
+        "lastModified": 1685130348,
+        "narHash": "sha256-TgzyUxXLa/FRoxyIG4kmjRtqjMnjKNTNKueCmrXcitE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a502f8367bdd5fedb9eb19b70fec1513c3d0d1b5",
+        "rev": "a54f47a819594fae542dc40a5438149c93e8a631",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a54f47a8`](https://github.com/nix-community/NUR/commit/a54f47a819594fae542dc40a5438149c93e8a631) | `` automatic update `` |