### PR TITLE
chore(flake/nur): `a54f47a8` -> `45aee5ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685130348,
-        "narHash": "sha256-TgzyUxXLa/FRoxyIG4kmjRtqjMnjKNTNKueCmrXcitE=",
+        "lastModified": 1685138270,
+        "narHash": "sha256-Z7n3VLKoAMyzCdl1ppPATEVjV/sPtbsxwZHVoJC6rww=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a54f47a819594fae542dc40a5438149c93e8a631",
+        "rev": "45aee5ad278a32fc6426080007ab2300be0ad65a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`45aee5ad`](https://github.com/nix-community/NUR/commit/45aee5ad278a32fc6426080007ab2300be0ad65a) | `` automatic update `` |
| [`174bd805`](https://github.com/nix-community/NUR/commit/174bd80585bc86e75bbf16718decfb3eca16ac33) | `` automatic update `` |