### PR TITLE
chore(flake/nur): `45aee5ad` -> `d8113384`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685138270,
-        "narHash": "sha256-Z7n3VLKoAMyzCdl1ppPATEVjV/sPtbsxwZHVoJC6rww=",
+        "lastModified": 1685140971,
+        "narHash": "sha256-qrEfovuVoREaQ2wtLmj51nftOzKzghqjl+lPqqwHdVQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "45aee5ad278a32fc6426080007ab2300be0ad65a",
+        "rev": "d81133849aba618b1330aa897bab1e2296bdbd23",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d8113384`](https://github.com/nix-community/NUR/commit/d81133849aba618b1330aa897bab1e2296bdbd23) | `` automatic update `` |