### PR TITLE
chore(flake/nur): `d8113384` -> `6aaa1715`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685140971,
-        "narHash": "sha256-qrEfovuVoREaQ2wtLmj51nftOzKzghqjl+lPqqwHdVQ=",
+        "lastModified": 1685177103,
+        "narHash": "sha256-aUnfIh9DRcAA0ICGImgCK+h5B5wodE+AJTcYH1HZ/7Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d81133849aba618b1330aa897bab1e2296bdbd23",
+        "rev": "6aaa1715b010a33432131eef3b70f64d286b9ed8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6aaa1715`](https://github.com/nix-community/NUR/commit/6aaa1715b010a33432131eef3b70f64d286b9ed8) | `` automatic update `` |
| [`d71033ac`](https://github.com/nix-community/NUR/commit/d71033acca2e80c8a2341a6dcd81fc9a677b1c4f) | `` automatic update `` |
| [`cbc0fb5c`](https://github.com/nix-community/NUR/commit/cbc0fb5c6412cc84de6a4fb33d6500217082c4c9) | `` automatic update `` |
| [`38b8931b`](https://github.com/nix-community/NUR/commit/38b8931baadb4c412b702f91a2993e325ca1e0da) | `` automatic update `` |