### PR TITLE
chore(flake/nur): `6aaa1715` -> `a12748ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685177103,
-        "narHash": "sha256-aUnfIh9DRcAA0ICGImgCK+h5B5wodE+AJTcYH1HZ/7Y=",
+        "lastModified": 1685184367,
+        "narHash": "sha256-KmjyDFswZPPdhg3PpF75iGNjDkedLq1gs8KgDjFsots=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6aaa1715b010a33432131eef3b70f64d286b9ed8",
+        "rev": "a12748eeefa2f672f27c2ad45be844dddefac098",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a12748ee`](https://github.com/nix-community/NUR/commit/a12748eeefa2f672f27c2ad45be844dddefac098) | `` automatic update `` |
| [`f9709bc9`](https://github.com/nix-community/NUR/commit/f9709bc9023eec5581bd0d52eef4aca723e72494) | `` automatic update `` |
| [`9b49c3a2`](https://github.com/nix-community/NUR/commit/9b49c3a2db4606aea7cfc809bad87c29755a9768) | `` automatic update `` |