### PR TITLE
chore(flake/nur): `c469c299` -> `98079ce8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685205422,
-        "narHash": "sha256-LaxEP1d1I+gGFZiJcNOk2wHaloxOuwf0ZKFd0kPeB28=",
+        "lastModified": 1685211399,
+        "narHash": "sha256-5NQVl/80PoNi6CXufaifaDGYlOHyicujodhj8n6Duu0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c469c2991971d13c39c5a221c61408475aa53b1a",
+        "rev": "98079ce8a11b052ec6a325a4e9c98412dd1ae40b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`98079ce8`](https://github.com/nix-community/NUR/commit/98079ce8a11b052ec6a325a4e9c98412dd1ae40b) | `` automatic update `` |