### PR TITLE
chore(flake/nur): `5fff8d00` -> `bab9eecd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685220371,
-        "narHash": "sha256-rqmMECCCjWlBWhoO+KTP/xnSeNkLg0wqFFTfyYqtW3Q=",
+        "lastModified": 1685223913,
+        "narHash": "sha256-Wqbi/6iLW7ivR8fpQ+ZEkMNGfzEYyUNtbivIVXJTbtA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5fff8d00f1463c02505a0b4fd3ea228f6c6ae33b",
+        "rev": "bab9eecd1d6afd6b8513e14b3653c167c887589a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bab9eecd`](https://github.com/nix-community/NUR/commit/bab9eecd1d6afd6b8513e14b3653c167c887589a) | `` automatic update `` |