### PR TITLE
chore(flake/nur): `bab9eecd` -> `a9b5b5f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685223913,
-        "narHash": "sha256-Wqbi/6iLW7ivR8fpQ+ZEkMNGfzEYyUNtbivIVXJTbtA=",
+        "lastModified": 1685225422,
+        "narHash": "sha256-gZnlv+PXIWOKQ1nzdq7eLvtpxLI4uGtTLrbSsGb8dyw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bab9eecd1d6afd6b8513e14b3653c167c887589a",
+        "rev": "a9b5b5f574aa416e46b14d5b87fd56be17cf864b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a9b5b5f5`](https://github.com/nix-community/NUR/commit/a9b5b5f574aa416e46b14d5b87fd56be17cf864b) | `` automatic update `` |