### PR TITLE
chore(flake/nur): `8e866b32` -> `5e934ff2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685245522,
-        "narHash": "sha256-EyNXSUgeKebGevlS9I6cSvhhHyBytvkYTBFl1OxwST4=",
+        "lastModified": 1685263548,
+        "narHash": "sha256-qljNXIQePMRWr0yhQP16C/rBPSjzqcF38Y2ad4/KnXQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8e866b325a4347a77bd1578dbc0f3f624892b7f4",
+        "rev": "5e934ff2c9502937ebd39cff1aeebe7e60126c45",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5e934ff2`](https://github.com/nix-community/NUR/commit/5e934ff2c9502937ebd39cff1aeebe7e60126c45) | `` automatic update `` |
| [`fd140f82`](https://github.com/nix-community/NUR/commit/fd140f82c2fb3056af9e443f4d1125af4cbc226d) | `` automatic update `` |
| [`56056b7e`](https://github.com/nix-community/NUR/commit/56056b7eab6da803c9fefcebed4ce4b47df64820) | `` automatic update `` |
| [`0acdb6e5`](https://github.com/nix-community/NUR/commit/0acdb6e520d81b727a35a5de3ace061318d84e3e) | `` automatic update `` |
| [`831b6ac6`](https://github.com/nix-community/NUR/commit/831b6ac64e047bdc23015dc29b7ef79acad61083) | `` automatic update `` |
| [`7f968b1e`](https://github.com/nix-community/NUR/commit/7f968b1e38101f3acc89cc7971f2662990391536) | `` automatic update `` |