### PR TITLE
chore(flake/nur): `5694f7ec` -> `b1d68818`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685278508,
-        "narHash": "sha256-HbcZqPJvQsm3uhDci2FHF9mCyhMt9LqtvnLm4Qb6iVc=",
+        "lastModified": 1685299559,
+        "narHash": "sha256-PBi0xbf+sc8WzNx3XUZpUSJ5tdHo1fvICHbVLqVoMvU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5694f7ec1f41aecb0ac8374d6f6028a3dea51ee3",
+        "rev": "b1d6881849b467d812ef450f4031b3343812f8e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b1d68818`](https://github.com/nix-community/NUR/commit/b1d6881849b467d812ef450f4031b3343812f8e6) | `` automatic update `` |