### PR TITLE
chore(flake/nur): `48e0d035` -> `181689b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685306730,
-        "narHash": "sha256-MkSgoaYE42zl119lLmtJjb4mOepN9vXLznDce+s0urg=",
+        "lastModified": 1685310285,
+        "narHash": "sha256-P+vu1FDfz+HeomusYtMnHj6uMxGSJLehGqjRoiHJ52Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "48e0d03517585f6d0e21285f64c30616fab524ec",
+        "rev": "181689b2275c94566378ab18a20bb1972920bc41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`181689b2`](https://github.com/nix-community/NUR/commit/181689b2275c94566378ab18a20bb1972920bc41) | `` automatic update `` |