### PR TITLE
chore(flake/attic): `5f85e35a` -> `b1fb790b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1683433501,
-        "narHash": "sha256-9L+OZeU3bcNZ55mhMINBxnqskbaEU0mhiZIMhkEtNl0=",
+        "lastModified": 1685309025,
+        "narHash": "sha256-pZxMM3AMP/ojwhrFD0A2ML4NOgehlBLGHseInnO5evc=",
         "owner": "zhaofengli",
         "repo": "attic",
-        "rev": "5f85e35a25085b75e1cbb6cc7291726fa4fab2ed",
+        "rev": "b1fb790b5f2afaaa1b2f7f18979b8318abe604bb",
         "type": "github"
       },
       "original": {
@@ -607,11 +607,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677852945,
-        "narHash": "sha256-liiVJjkBTuBTAkRW3hrI8MbPD2ImYzwUpa7kvteiKhM=",
+        "lastModified": 1685012353,
+        "narHash": "sha256-U3oOge4cHnav8OLGdRVhL45xoRj4Ppd+It6nPC9nNIU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f5ffd5787786dde3a8bf648c7a1b5f78c4e01abb",
+        "rev": "aeb75dba965e790de427b73315d5addf91a54955",
         "type": "github"
       },
       "original": {
@@ -639,16 +639,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1675327819,
-        "narHash": "sha256-Fd2BUNUsTO7wmoU1fbOC4HNkl370dYdkfKgWPretuj0=",
+        "lastModified": 1685004253,
+        "narHash": "sha256-AbVL1nN/TDicUQ5wXZ8xdLERxz/eJr7+o8lqkIOVuaE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21efc622b939884db3c92f49d638ca89f12f22f8",
+        "rev": "3e01645c40b92d29f3ae76344a6d654986a91a91",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }


### PR DESCRIPTION
| Commit                                                                                            | Message                                                    |
| ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`b1fb790b`](https://github.com/zhaofengli/attic/commit/b1fb790b5f2afaaa1b2f7f18979b8318abe604bb) | `` integration-tests: Strip tokens return from atticadm `` |
| [`a71582a9`](https://github.com/zhaofengli/attic/commit/a71582a9521cd925d5d97830ce353adf60e99d5b) | `` client/watch_store: Ignore sources when watching ``     |
| [`2d0aeefd`](https://github.com/zhaofengli/attic/commit/2d0aeefd2f5ac9d981883f5064c05d6482ac8ca6) | `` Trivial semver-incompatible upgrades ``                 |
| [`1b980a96`](https://github.com/zhaofengli/attic/commit/1b980a9640671c3c2996fc0e19cf374cdaa6b92b) | `` server: Upgrade async-compression ``                    |
| [`1a0116fe`](https://github.com/zhaofengli/attic/commit/1a0116fee8963c4186b7e4d9efd880df477a020e) | `` server: Upgrade aws-sdk-rust ``                         |
| [`6489d775`](https://github.com/zhaofengli/attic/commit/6489d775ae75a9f5453995802f2ebfe4ee309ffa) | `` Update deps ``                                          |
| [`b0fd8429`](https://github.com/zhaofengli/attic/commit/b0fd84299cf5b6b04b1c419c14ebecc64073ec53) | `` Update nixpkgs ``                                       |
| [`7115778c`](https://github.com/zhaofengli/attic/commit/7115778c8cad1b7b7151806df77de9f77a0ee6fd) | `` Cargo.lock: Update ``                                   |