### PR TITLE
chore(flake/nur): `181689b2` -> `351509ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685310285,
-        "narHash": "sha256-P+vu1FDfz+HeomusYtMnHj6uMxGSJLehGqjRoiHJ52Y=",
+        "lastModified": 1685313956,
+        "narHash": "sha256-jnnEkvuFxdrpdJuLdWpqS3aTsICOFIgZm6AXW2nY51A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "181689b2275c94566378ab18a20bb1972920bc41",
+        "rev": "351509baa5c0d25a6cb30be460f3ec822aadf97c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`351509ba`](https://github.com/nix-community/NUR/commit/351509baa5c0d25a6cb30be460f3ec822aadf97c) | `` automatic update `` |