### PR TITLE
chore(flake/nur): `351509ba` -> `e7bf6b74`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685313956,
-        "narHash": "sha256-jnnEkvuFxdrpdJuLdWpqS3aTsICOFIgZm6AXW2nY51A=",
+        "lastModified": 1685320818,
+        "narHash": "sha256-QRLfYOJuL/1lwPHmelTbvCK6EDQeWcKZfGF0QSbsJ5c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "351509baa5c0d25a6cb30be460f3ec822aadf97c",
+        "rev": "e7bf6b743fc8b1aea39b926a5b4ca657270d393b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e7bf6b74`](https://github.com/nix-community/NUR/commit/e7bf6b743fc8b1aea39b926a5b4ca657270d393b) | `` automatic update `` |
| [`3fb6b929`](https://github.com/nix-community/NUR/commit/3fb6b929aacdd41503539577a59f0e7d086b48c8) | `` automatic update `` |