### PR TITLE
chore(flake/nur): `e7bf6b74` -> `96e8fefc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685320818,
-        "narHash": "sha256-QRLfYOJuL/1lwPHmelTbvCK6EDQeWcKZfGF0QSbsJ5c=",
+        "lastModified": 1685331965,
+        "narHash": "sha256-EyRREtCfX9iBLjGFhSBSZUIeoNfpZnTzkvNHQFOoBTw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e7bf6b743fc8b1aea39b926a5b4ca657270d393b",
+        "rev": "96e8fefc8c77e087b04ca71405aaf29ed820917a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`96e8fefc`](https://github.com/nix-community/NUR/commit/96e8fefc8c77e087b04ca71405aaf29ed820917a) | `` automatic update `` |