### PR TITLE
chore(flake/nur): `96e8fefc` -> `319664a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685331965,
-        "narHash": "sha256-EyRREtCfX9iBLjGFhSBSZUIeoNfpZnTzkvNHQFOoBTw=",
+        "lastModified": 1685335491,
+        "narHash": "sha256-HGapByNt3+POMmcB08KPGfHRY4fPbHrGWVO9R8tIoWc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "96e8fefc8c77e087b04ca71405aaf29ed820917a",
+        "rev": "319664a8c7980d69b39b3308735b4ee5b2c19943",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`319664a8`](https://github.com/nix-community/NUR/commit/319664a8c7980d69b39b3308735b4ee5b2c19943) | `` automatic update `` |
| [`84b6ff94`](https://github.com/nix-community/NUR/commit/84b6ff9446a6f09ec84affb3bb8337dcc204a9cf) | `` automatic update `` |