### PR TITLE
chore(flake/nur): `319664a8` -> `01b895a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685335491,
-        "narHash": "sha256-HGapByNt3+POMmcB08KPGfHRY4fPbHrGWVO9R8tIoWc=",
+        "lastModified": 1685339143,
+        "narHash": "sha256-a7ZOduDqSnS9OOHZL2T2ec0TDNUzpauK7w+rfjo3ZJE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "319664a8c7980d69b39b3308735b4ee5b2c19943",
+        "rev": "01b895a5305f5d2ac161b3c5f1b213ad133e327e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`01b895a5`](https://github.com/nix-community/NUR/commit/01b895a5305f5d2ac161b3c5f1b213ad133e327e) | `` automatic update `` |
| [`b0d4bf1f`](https://github.com/nix-community/NUR/commit/b0d4bf1faa65900dcafee9319f012c95999a68da) | `` automatic update `` |
| [`170e6cb1`](https://github.com/nix-community/NUR/commit/170e6cb1a8f9de58a8709e3feac217dbd461efbe) | `` automatic update `` |