### PR TITLE
chore(flake/nixpkgs): `e1080230` -> `4e37b4e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -718,11 +718,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1685168767,
-        "narHash": "sha256-wQgnxz0PdqbyKKpsWl/RU8T8QhJQcHfeC6lh1xRUTfk=",
+        "lastModified": 1685290091,
+        "narHash": "sha256-GGQYNZ7POoqPTtXgPOLUuSiHkOKFRWYpCoWUOSeSRoU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e10802309bf9ae351eb27002c85cfdeb1be3b262",
+        "rev": "4e37b4e55b60fb7d43d2b62deb51032a489bcbe8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`919e2249`](https://github.com/NixOS/nixpkgs/commit/919e224951a6d6749961594926a8dd4a75077335) | `` CODEOWNERS: add raitobezarius as a ZFS code owner ``                               |
| [`d7d44eb8`](https://github.com/NixOS/nixpkgs/commit/d7d44eb80840bbb8e338baf39c0708d3fe3be699) | `` rtl-sdr: fix version in librtlsdr.pc ``                                            |
| [`7f7f9c1e`](https://github.com/NixOS/nixpkgs/commit/7f7f9c1e44ac0a65523cc6d2d5cb4bfab8f98c4d) | `` done: init at 0.1.7 ``                                                             |
| [`958a28e4`](https://github.com/NixOS/nixpkgs/commit/958a28e4be9ae86c24817122a2eeb4c787af674e) | `` ppsspp-{sdl,sdl-wayland,qt}: Install desktop icons ``                              |
| [`68e77505`](https://github.com/NixOS/nixpkgs/commit/68e77505aebf81d27266e96285012b193b542f31) | `` openbugs: init at 3.2.3 ``                                                         |
| [`8f3559b7`](https://github.com/NixOS/nixpkgs/commit/8f3559b77d6558ed46846b6731a13e4160dfac62) | `` maintainers: add andresnav ``                                                      |
| [`30c04c42`](https://github.com/NixOS/nixpkgs/commit/30c04c42532c11b85c4bc24e91b2110705458669) | `` cvs-fast-export: 1.59 -> 1.60 ``                                                   |
| [`bbefb9b2`](https://github.com/NixOS/nixpkgs/commit/bbefb9b2a3ebe3bb1a5629df72e442eb806422a6) | `` flashmq: init at 1.4.5 ``                                                          |
| [`507ff392`](https://github.com/NixOS/nixpkgs/commit/507ff392516c1885e55cb9a5c42b1966932d503b) | `` nixos/test-driver: fix formatting ``                                               |
| [`4d83d2c5`](https://github.com/NixOS/nixpkgs/commit/4d83d2c5b099bcc46a332f8f4079ed03efa76a49) | `` python3Packages.hidapi: 0.13.1 -> 0.14.0 ``                                        |
| [`b4b45ee6`](https://github.com/NixOS/nixpkgs/commit/b4b45ee6d2aa15441f80d96883c10d91b1e08a5d) | `` Revert "nixos/lib/test-driver: enable EFI variable reads at runtime" ``            |
| [`99ceee18`](https://github.com/NixOS/nixpkgs/commit/99ceee1883d05f423d48fd0ef9a9dd339d665054) | `` bibclean: 3.06 -> 3.07 ``                                                          |
| [`86c8d96f`](https://github.com/NixOS/nixpkgs/commit/86c8d96f774c02c2c8dabc49a3584417cb825fc7) | `` netdata: add changelog to meta ``                                                  |
| [`b56c79d1`](https://github.com/NixOS/nixpkgs/commit/b56c79d1cb985b025e726e2681a11371ed5bd3bf) | `` netdata: 1.39.0 -> 1.39.1 ``                                                       |
| [`8292a0f4`](https://github.com/NixOS/nixpkgs/commit/8292a0f4a52647cdda4d37b12d5b40895ecdf08b) | `` iaito: 5.8.4 -> 5.8.6 ``                                                           |
| [`82082e93`](https://github.com/NixOS/nixpkgs/commit/82082e931fd7199c929fb7901aac05e54cd1e18c) | `` vtm: avoid using an alias ``                                                       |
| [`f79e7db9`](https://github.com/NixOS/nixpkgs/commit/f79e7db9bebc3fd730d111cf874125b78bc12a4f) | `` rain: 1.3.3 -> 1.4.0 ``                                                            |
| [`6d577e2e`](https://github.com/NixOS/nixpkgs/commit/6d577e2e88febbe980ebee0cd2d8f72edde8e60f) | `` python310Packages.simple-salesforce: 1.12.3 -> 1.12.4 ``                           |
| [`10fef5f9`](https://github.com/NixOS/nixpkgs/commit/10fef5f96567fcc3636603af99b2625138c7ca94) | `` osqp: 0.6.2 -> 0.6.3 ``                                                            |
| [`88de6494`](https://github.com/NixOS/nixpkgs/commit/88de6494acb1e2543473708cdc827d1e23aeff4c) | `` argocd: 2.7.2 -> 2.7.3 ``                                                          |
| [`b3976105`](https://github.com/NixOS/nixpkgs/commit/b3976105fb887b10cf89b09ae645d39f01e1a532) | `` sqlfluff: 2.1.0 -> 2.1.1 ``                                                        |
| [`62d34777`](https://github.com/NixOS/nixpkgs/commit/62d347770a26663db3332d3a04c5084f6a71dd9d) | `` nimPackages.eris: wontfix darwin ``                                                |
| [`e2ccc3dd`](https://github.com/NixOS/nixpkgs/commit/e2ccc3dd9f4da160bacf7da8d294b353678d2ce8) | `` cjdns: mark broken for aarch64 ``                                                  |
| [`d1b441d8`](https://github.com/NixOS/nixpkgs/commit/d1b441d8c44d2dd6627b23cc20084175157f5670) | `` cargo-chef: 0.1.59 -> 0.1.61 ``                                                    |
| [`b1b01a39`](https://github.com/NixOS/nixpkgs/commit/b1b01a39432c0754863f626dad5225c7997e726c) | `` sqlitecpp: 3.2.1 -> 3.3.0 ``                                                       |
| [`bebbc418`](https://github.com/NixOS/nixpkgs/commit/bebbc418d4f91a6eef197dff2f8bf869ec50fafe) | `` seqtk: 1.3 -> 1.4 ``                                                               |
| [`0820f018`](https://github.com/NixOS/nixpkgs/commit/0820f01874cb3be7a2ebf0c339f3c33e1f5e34ba) | `` pscale: 0.144.0 -> 0.145.0 ``                                                      |
| [`83127f00`](https://github.com/NixOS/nixpkgs/commit/83127f00cbadbca82d97f69f37be865e3bb3a9d1) | `` pylyzer: 0.0.27 -> 0.0.28 ``                                                       |
| [`db508e06`](https://github.com/NixOS/nixpkgs/commit/db508e06a1ee858582ab201b7c5ec819713b06d1) | `` treewide: add meta.mainProgram and changelog urls (#204317) ``                     |
| [`ae004253`](https://github.com/NixOS/nixpkgs/commit/ae0042535dfeeee7fb61b4a2f5281ea9af159337) | `` exploitdb: 2023-05-25 -> 2023-05-27 ``                                             |
| [`e5d80d7b`](https://github.com/NixOS/nixpkgs/commit/e5d80d7b08e61c87d39f6770ac61700221d3990a) | `` heimer: 4.1.0 -> 4.2.0 ``                                                          |
| [`b83997c2`](https://github.com/NixOS/nixpkgs/commit/b83997c2f6d61e656f23696c17b691616e571ecb) | `` v2ray-geoip: 202305180042 -> 202305250042 ``                                       |
| [`1926f40f`](https://github.com/NixOS/nixpkgs/commit/1926f40f723de79e0cb6d583007d27757677524f) | `` nexttrace: 1.1.3 -> 1.1.5 ``                                                       |
| [`22781dbf`](https://github.com/NixOS/nixpkgs/commit/22781dbf83b235f0bfc293fe37bbb611fb2fe809) | `` rbspy: add an update script ``                                                     |
| [`41bb263d`](https://github.com/NixOS/nixpkgs/commit/41bb263d28f1a3a3c4dbc6ce21d462cebd94ac71) | `` thelounge: fix build ``                                                            |
| [`f9138c5a`](https://github.com/NixOS/nixpkgs/commit/f9138c5ad63c9c5d1a6266d0b37ee85ef4f6ff05) | `` npmHooks.npmInstallHook: allow disabling `npm prune` invocation ``                 |
| [`91b4efa4`](https://github.com/NixOS/nixpkgs/commit/91b4efa44db76adaf1efbe678f665468679565ca) | `` allure: 2.22.0 -> 2.22.1 ``                                                        |
| [`a007ccb0`](https://github.com/NixOS/nixpkgs/commit/a007ccb08d56b129d4d69b0882604324a5ad84b9) | `` telegraf: 1.26.2 -> 1.26.3 ``                                                      |
| [`499a53a3`](https://github.com/NixOS/nixpkgs/commit/499a53a3f8e6c84f0a3253b97cac74fbdfa605e9) | `` gnome.gnome-remote-desktop: 44.1 → 44.2 ``                                         |
| [`5a6e2e3a`](https://github.com/NixOS/nixpkgs/commit/5a6e2e3a25ea917ecd9d7d92ee4ebb94100b6dc9) | `` terraform-providers.argocd: 5.3.0 -> 5.4.0 ``                                      |
| [`c450225f`](https://github.com/NixOS/nixpkgs/commit/c450225f02bc07ecefb960bd95b7802b71d12c3c) | `` brev-cli: 0.6.227 -> 0.6.229 ``                                                    |
| [`cfab797e`](https://github.com/NixOS/nixpkgs/commit/cfab797e9dd3c11729c2b6ce5805f06109fa22b0) | `` gnome.gnome-software: 44.1 → 44.2 ``                                               |
| [`24ad88ae`](https://github.com/NixOS/nixpkgs/commit/24ad88ae8244753defff917c96525d028c52eb11) | `` gnome.gnome-maps: 44.1 → 44.2 ``                                                   |
| [`f1b49e4d`](https://github.com/NixOS/nixpkgs/commit/f1b49e4d944ec23c57db3ff12194a0db4e4b7255) | `` libad9361: 0.2 -> 0.3 ``                                                           |
| [`5b6c851f`](https://github.com/NixOS/nixpkgs/commit/5b6c851f4e620cf1960afcedd037b8f3f4f39acc) | `` vimPlugins.nvim-treesitter: update grammars ``                                     |
| [`ff4d7a86`](https://github.com/NixOS/nixpkgs/commit/ff4d7a86872eae0ee127c33e46da1ba0b9b46145) | `` vimPlugins: resolve github repository redirects ``                                 |
| [`e8c5027c`](https://github.com/NixOS/nixpkgs/commit/e8c5027c5d6c617fc4f27a972db83357d200b361) | `` vimPlugins: update ``                                                              |
| [`46544468`](https://github.com/NixOS/nixpkgs/commit/46544468c7fc97fc61c4e0e0e0a12f9f3a69d36c) | `` vimPlugins.other-nvim: init at 2022-11-15 ``                                       |
| [`5ddcb975`](https://github.com/NixOS/nixpkgs/commit/5ddcb975a76b29710f9f40063290d64c563775fb) | `` nixpacks: 1.7.0 -> 1.9.0 ``                                                        |
| [`25d8d799`](https://github.com/NixOS/nixpkgs/commit/25d8d799897485ce61f7a191f4c50ba0e1e6c4ec) | `` hidapi: 0.13.1 -> 0.14.0 ``                                                        |
| [`d9f29f0e`](https://github.com/NixOS/nixpkgs/commit/d9f29f0ea55446e730bb2cade00fab053f6b2432) | `` remote-touchpad: 1.4.1 -> 1.4.2 ``                                                 |
| [`cd70115c`](https://github.com/NixOS/nixpkgs/commit/cd70115c44d06463db78c5442e1893b1a2debc50) | `` python310Packages.ibm-watson: 6.1.0 -> 7.0.0 ``                                    |
| [`ddb2e1f8`](https://github.com/NixOS/nixpkgs/commit/ddb2e1f8e5ca65b30c791aa41eeac2cd22fc8a09) | `` python311Packages.bqplot: 0.12.36 -> 0.12.39 ``                                    |
| [`cd51ed22`](https://github.com/NixOS/nixpkgs/commit/cd51ed22014e814710e9f0a53f2d246f1ec3e3e3) | `` podman: 4.5.0 -> 4.5.1 ``                                                          |
| [`2079f4dc`](https://github.com/NixOS/nixpkgs/commit/2079f4dcd207606379fc4a819280d92b4a33ee78) | `` ctlptl: 0.8.18 -> 0.8.19 ``                                                        |
| [`93ce263f`](https://github.com/NixOS/nixpkgs/commit/93ce263f091744ca156bb63ceef806908bdafb21) | `` civo: 1.0.54 -> 1.0.55 ``                                                          |
| [`f4c9a049`](https://github.com/NixOS/nixpkgs/commit/f4c9a049cee3979635a939d6c9cbdca176eb5ce2) | `` cotp: 1.2.4 -> 1.2.5 ``                                                            |
| [`5fa7642c`](https://github.com/NixOS/nixpkgs/commit/5fa7642c6cfe82e3828c11347d7b6d6f30077165) | `` go-task: add version test ``                                                       |
| [`c68cb4ce`](https://github.com/NixOS/nixpkgs/commit/c68cb4ce9bb887f349caa2a1178c3d356c5ded77) | `` go-task: fix version ``                                                            |
| [`b328f153`](https://github.com/NixOS/nixpkgs/commit/b328f1538294527ff8871155c5bfcf1e5d6a9e21) | `` kubeclarity: 2.18.0 -> 2.18.1 ``                                                   |
| [`9d7330f3`](https://github.com/NixOS/nixpkgs/commit/9d7330f338374b493e6f859474811cb708da62dc) | `` oh-my-posh: 16.7.0 -> 16.8.0 ``                                                    |
| [`83a615f6`](https://github.com/NixOS/nixpkgs/commit/83a615f695688887f0a77803c48736898188115a) | `` bore: fix build on darwin ``                                                       |
| [`140c84f7`](https://github.com/NixOS/nixpkgs/commit/140c84f79471e59a72755aff134d56a087acce45) | `` go-task: 3.24.0 -> 3.25.0 ``                                                       |
| [`f79a9b18`](https://github.com/NixOS/nixpkgs/commit/f79a9b183d3a30d36e7b4b3eeadcff1476aac480) | `` sequoia: migrate to bindgenHook ``                                                 |
| [`4be6648c`](https://github.com/NixOS/nixpkgs/commit/4be6648c935298adb01ccb88632204f81c182aeb) | `` mmctl: 7.10.0 -> 7.10.2 ``                                                         |
| [`bfcd5e6b`](https://github.com/NixOS/nixpkgs/commit/bfcd5e6bb14888b7c2623e3fed16af5be1f72116) | `` exfatprogs: 1.2.0 -> 1.2.1 ``                                                      |
| [`8b573d01`](https://github.com/NixOS/nixpkgs/commit/8b573d01baf907e7dadbdc58da1acf85e5f0efc2) | `` encpipe: init at 0.5 ``                                                            |
| [`93e6e971`](https://github.com/NixOS/nixpkgs/commit/93e6e9719459ad6aabc91dd68c4c81efa6adcf33) | `` victoriametrics: add upstream patches ``                                           |
| [`0b899d40`](https://github.com/NixOS/nixpkgs/commit/0b899d4084e4c4e473f5c9acc90a9e3a3e827eee) | `` oculante: 0.6.63 -> 0.6.64 ``                                                      |
| [`1ea22600`](https://github.com/NixOS/nixpkgs/commit/1ea2260060de2f9139f5e32f38f5134beabcb0ce) | `` fleng: init at 14 ``                                                               |
| [`570d4efc`](https://github.com/NixOS/nixpkgs/commit/570d4efc7cddbfb01d5f08c71695b2485c13c67f) | `` libwacom: disable tests on risc-v ``                                               |
| [`d1104e21`](https://github.com/NixOS/nixpkgs/commit/d1104e2109a87447ec2faebd41f42638d6505ce0) | `` nixos/test-driver: add `timeout` option for `wait_for_console_text` (variant 2) `` |
| [`ed332229`](https://github.com/NixOS/nixpkgs/commit/ed33222971ee19b52fd515265b14c158ada87d18) | `` etcd_3_3: mark vulnerable to CVE-2023-32082 ``                                     |
| [`85f15277`](https://github.com/NixOS/nixpkgs/commit/85f15277d05368bc35bf47779866d8c16e0cee94) | `` etcd: switch to etcd_3_5 ``                                                        |
| [`a24848c4`](https://github.com/NixOS/nixpkgs/commit/a24848c470968a9ae449afd26acfd4e7d1435ef9) | `` nixos/etcd: allow to choose the package ``                                         |
| [`e66453b8`](https://github.com/NixOS/nixpkgs/commit/e66453b831fc760361e694468f267bb408a142af) | `` rustdesk: migrate to bindgenHook ``                                                |
| [`406de94b`](https://github.com/NixOS/nixpkgs/commit/406de94b416e7944ff981d6913ce578fd4aa3508) | `` nixos/test-driver: add `timeout` option for `wait_for_console_text` ``             |
| [`1a89cfae`](https://github.com/NixOS/nixpkgs/commit/1a89cfae1f0fa83238ffdabf4f06dd435bd45108) | `` buildGoModule: simplify go-module attribute structure without rebuild ``           |
| [`48c59620`](https://github.com/NixOS/nixpkgs/commit/48c59620485b184b132f911823ece6fa0108eb97) | `` doc/language-frameworks/go.section.md: fix spelling ``                             |
| [`02914c3d`](https://github.com/NixOS/nixpkgs/commit/02914c3d0b95c70e977e07d8231d98fc2aa5ed32) | `` uniffi-bindgen: remove ``                                                          |
| [`fe1bb502`](https://github.com/NixOS/nixpkgs/commit/fe1bb502a32f194a969bd33d6e75008567f2db9a) | `` vector: migrate to bindgenHook ``                                                  |
| [`6656d69d`](https://github.com/NixOS/nixpkgs/commit/6656d69d7db55c282f1690d69271df1eec1fe744) | `` rust-code-analysis: 0.0.23 -> 0.0.25 ``                                            |
| [`b6f5b5de`](https://github.com/NixOS/nixpkgs/commit/b6f5b5de65eaa3afb9fe8625d3f736843ee8e600) | `` grass-sass: 0.12.3 -> 0.12.4 ``                                                    |
| [`76a9874e`](https://github.com/NixOS/nixpkgs/commit/76a9874ec19dfabc5bf27d07ec897f53f0a1a0e0) | `` proximity-sort: 1.2.0 -> 1.3.0 ``                                                  |
| [`9f7a5205`](https://github.com/NixOS/nixpkgs/commit/9f7a5205a9bc1b3b47d749bf78d8d4984e762250) | `` cargo-show-asm: set meta.mainProgram ``                                            |
| [`03b352a9`](https://github.com/NixOS/nixpkgs/commit/03b352a9317c6904da36b97bb9ab598470b8439a) | `` cargo-show-asm: 0.2.0 -> 0.2.18 ``                                                 |
| [`ea332796`](https://github.com/NixOS/nixpkgs/commit/ea332796f2bd6c571cd5c2aae044c298e0fea24f) | `` frogmouth: 0.5.0 -> 0.6.0 ``                                                       |
| [`8f73830d`](https://github.com/NixOS/nixpkgs/commit/8f73830dbe9e1a0f42a9a00437b3f2bc06864008) | `` wasmtime: 9.0.1 -> 9.0.2 ``                                                        |
| [`f1aee66f`](https://github.com/NixOS/nixpkgs/commit/f1aee66f92e2ec3293a83b47defc35176771fe99) | `` nixos/lib/test-driver: enable EFI variable reads at runtime ``                     |
| [`79de7130`](https://github.com/NixOS/nixpkgs/commit/79de71304886a5c8fb028eef7336c8f4c985e3d5) | `` plantuml-server: 1.2023.7 -> 1.2023.8 ``                                           |
| [`ef6f3a5c`](https://github.com/NixOS/nixpkgs/commit/ef6f3a5c9f3a113990c2ac2fc1e4f40aa1503334) | `` edk2: 202211 -> 202302 ``                                                          |
| [`3df66996`](https://github.com/NixOS/nixpkgs/commit/3df669965184571f861e5e1e8a7c315198b83e31) | `` procs: migrate to bindgenHook ``                                                   |
| [`dfa694f9`](https://github.com/NixOS/nixpkgs/commit/dfa694f915aa63c00d02bb5f8425726853ad9751) | `` rpm-ostree: 2023.3 -> 2023.4 ``                                                    |
| [`263dafd9`](https://github.com/NixOS/nixpkgs/commit/263dafd91f33e6b6115f1ea619a87162de3317a3) | `` system76-keyboard-configurator: 1.3.2 -> 1.3.3 ``                                  |
| [`2c9bea0e`](https://github.com/NixOS/nixpkgs/commit/2c9bea0eaadaf8e3c17afac89ae53154e37016da) | `` sharpsat-td: patch with updated version of mpreal/mpfrc++ ``                       |
| [`cbf3c2f6`](https://github.com/NixOS/nixpkgs/commit/cbf3c2f6f57122f2dfbdad65d611faaedf15e97a) | `` nats-server: 2.9.16 -> 2.9.17 ``                                                   |
| [`e074386f`](https://github.com/NixOS/nixpkgs/commit/e074386f98446165cbc0cc0565bfc1745d558a31) | `` fdroidcl: init at 0.7.0 ``                                                         |
| [`7a3065da`](https://github.com/NixOS/nixpkgs/commit/7a3065da25eac14f216a411d1c5cdf0890aefc8e) | `` python311Packages.dominate: 2.7.0 -> 2.8.0 ``                                      |
| [`7997e72c`](https://github.com/NixOS/nixpkgs/commit/7997e72cd9e80ba973cb8350451e0cfd0fe20d8f) | `` mdbook-katex: 0.5.0 -> 0.5.1 ``                                                    |
| [`6d6a709a`](https://github.com/NixOS/nixpkgs/commit/6d6a709a50dbf40654a6aa53b5fa679e167e27b4) | `` mdbook-katex: remove unused dependencies ``                                        |
| [`874d79d4`](https://github.com/NixOS/nixpkgs/commit/874d79d4757d399f8e5dc0c5b98720f9e8ac13d1) | `` lxd: 5.13 -> 5.14 ``                                                               |
| [`7db6adad`](https://github.com/NixOS/nixpkgs/commit/7db6adad1f66df38464092dd5b03f9a1a1b40ea7) | `` go-musicfox: 4.0.6 -> 4.1.1 ``                                                     |
| [`22731f49`](https://github.com/NixOS/nixpkgs/commit/22731f497dffb5df9d11d133abfb749b7950a3f1) | `` maintainers: add name-snrl ``                                                      |
| [`ac7c0ee7`](https://github.com/NixOS/nixpkgs/commit/ac7c0ee7e1ad86e8dc85c8c83be069c9443edcd2) | `` languagetool-rust: init at 2.1.1 ``                                                |
| [`3aa92e37`](https://github.com/NixOS/nixpkgs/commit/3aa92e371dfd106e94cf6f3e6069a0dd01b8ef7f) | `` grpc_cli: 1.54.1 -> 1.55.0 ``                                                      |
| [`2f384f9c`](https://github.com/NixOS/nixpkgs/commit/2f384f9c6679060438f806439ed078df15727fc2) | `` mdbook-katex: 0.4.2 -> 0.5.0 ``                                                    |
| [`e21b39b6`](https://github.com/NixOS/nixpkgs/commit/e21b39b6a7a729c50ae7e298ca9f8a10749f6bca) | `` cargo-spellcheck: migrate to bindgenHook ``                                        |
| [`e4eb2805`](https://github.com/NixOS/nixpkgs/commit/e4eb28051b68f5764c6f59ec7a6e040ce6ea71ef) | `` enchant: 2.3.4 -> 2.5.0 ``                                                         |
| [`9190b108`](https://github.com/NixOS/nixpkgs/commit/9190b1088daa2b69c3d89aafd6b4cb25ffb191d1) | `` zsh-autocomplete: 23.05.02 -> 23.05.24 ``                                          |
| [`2e290f56`](https://github.com/NixOS/nixpkgs/commit/2e290f56769b404784e4019776e167becbebbc6e) | `` influxdb2: migrate to bindgenHook ``                                               |
| [`26d5c72c`](https://github.com/NixOS/nixpkgs/commit/26d5c72cac6bba4985e324fd527b9a29d5aa9e3d) | `` influxdb: migrate to bindgenHook ``                                                |
| [`d915eb8a`](https://github.com/NixOS/nixpkgs/commit/d915eb8adfee81f3d68ec22e2e5b8572cbbed844) | `` linuxPackages.ena: 2.8.3 -> 2.8.6 and fix build against Linux 6.3 ``               |
| [`55a96327`](https://github.com/NixOS/nixpkgs/commit/55a963275353f246551cbe3cb622ec30b0030833) | `` metabase: 0.46.2 -> 0.46.4 ``                                                      |
| [`fca068a5`](https://github.com/NixOS/nixpkgs/commit/fca068a55862456224bedee8ff2f780b0028c6f8) | `` nixos/tests/legit: init ``                                                         |
| [`77520d39`](https://github.com/NixOS/nixpkgs/commit/77520d39ce72daed1f7bdf0d337c3c2a3249fece) | `` nixos/legit: init ``                                                               |
| [`3e5995d7`](https://github.com/NixOS/nixpkgs/commit/3e5995d7eadf679331e46c5902d2f57249ee6780) | `` legit: init at 0.2.1 ``                                                            |
| [`ee58ad84`](https://github.com/NixOS/nixpkgs/commit/ee58ad840b53e536dd893d809b23b51dadccf002) | `` gnome-decoder: migrate to bindgenHook ``                                           |
| [`09d10227`](https://github.com/NixOS/nixpkgs/commit/09d102278285e4a8917cb94de4d578243b57f2d3) | `` nixos/qemu-vm: fix 32-bits assert for memorySize ``                                |
| [`6abae5cb`](https://github.com/NixOS/nixpkgs/commit/6abae5cbb5950b973b115b99bcb7f8ac2b47a482) | `` xwayland: set meta.mainProgram ``                                                  |
| [`e33c2a5e`](https://github.com/NixOS/nixpkgs/commit/e33c2a5e4cbd1de00f4e4530e43f8be29200369f) | `` nixos/test-driver: add missing spaces to warning ``                                |
| [`bb26b9d6`](https://github.com/NixOS/nixpkgs/commit/bb26b9d60677e992a7bf29a98b398ead55e0bbe8) | `` qmarkdowntextedit: unstable-2022-08-24 -> unstable-2023-04-02 ``                   |
| [`5dd0190d`](https://github.com/NixOS/nixpkgs/commit/5dd0190da9b5aecb5238c1bea1ebaa77f15c6a45) | `` python310Packages.johnnycanencrypt: migrate to bindgenHook ``                      |
| [`e1a0a7aa`](https://github.com/NixOS/nixpkgs/commit/e1a0a7aa7610f0a4f11d1444cf77d06d7bf24cd9) | `` prometheus: skip tests on 32-bit platforms ``                                      |
| [`90bca32e`](https://github.com/NixOS/nixpkgs/commit/90bca32e902e96e786e4524b1f233783bbd8a0a2) | `` scli: fix version ``                                                               |