### PR TITLE
chore(flake/nur): `454a2251` -> `7140e90a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685343537,
-        "narHash": "sha256-AqAv6spSOhrkStU67cnjFxnFolT3NZNuoMYT9mWnOFY=",
+        "lastModified": 1685344244,
+        "narHash": "sha256-FJF5OQuoGc7FEfxFZ0eiTWrNQlaBOUfBITRjTjmxWbs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "454a225133a706874fa2c78276a2551fe56436df",
+        "rev": "7140e90a7bb16c7f5af94ad20173813371602c4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7140e90a`](https://github.com/nix-community/NUR/commit/7140e90a7bb16c7f5af94ad20173813371602c4b) | `` automatic update `` |