### PR TITLE
chore(flake/nur): `095e41a8` -> `d5f0bf40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685353153,
-        "narHash": "sha256-Hp69HYqQe2vAsUBxSxJ7BlDUDxMsVqDNbKMzq+ooYkM=",
+        "lastModified": 1685363668,
+        "narHash": "sha256-5yGREhUJ9XGVOavrfDzEFYuU9TXi0sUPJlC0YzCcRnU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "095e41a80dbb895ace4dab43b18d9503f00e574a",
+        "rev": "d5f0bf403e66522865af44a04abbf0c6eb280323",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d5f0bf40`](https://github.com/nix-community/NUR/commit/d5f0bf403e66522865af44a04abbf0c6eb280323) | `` automatic update `` |
| [`a39f0855`](https://github.com/nix-community/NUR/commit/a39f0855c61c03919bed5c9bc9d949ca0a4497ce) | `` automatic update `` |
| [`a6d951fa`](https://github.com/nix-community/NUR/commit/a6d951fa54a016ad538eee1dfad4e9520dca16c8) | `` automatic update `` |