### PR TITLE
chore(flake/pre-commit-hooks): `8e2c1a5a` -> `ca2fdbf3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -846,11 +846,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1685355253,
-        "narHash": "sha256-cQdHhcE630f1VTg4IP18sJqyYhjPchHyqRBJ9THj/hY=",
+        "lastModified": 1685361114,
+        "narHash": "sha256-4RjrlSb+OO+e1nzTExKW58o3WRwVGpXwj97iCta8aj4=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "8e2c1a5a62b698224c6f745599a9ec6b74283881",
+        "rev": "ca2fdbf3edda2a38140184da6381d49f8206eaf4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                             |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
| [`da695773`](https://github.com/cachix/pre-commit-hooks.nix/commit/da695773e5d7a7da7c4c6c3ec3f14d00a7a36803) | `` nil: Fix hook only failing if last file fails `` |