### PR TITLE
chore(flake/nur): `d5f0bf40` -> `95e05399`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685363668,
-        "narHash": "sha256-5yGREhUJ9XGVOavrfDzEFYuU9TXi0sUPJlC0YzCcRnU=",
+        "lastModified": 1685367958,
+        "narHash": "sha256-7KqC9OKOfQPkwLVh8E+rAOPQ/yEzw82GcUYS4/V9v6g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d5f0bf403e66522865af44a04abbf0c6eb280323",
+        "rev": "95e05399f4527fdde06cd151780324fb4f05ac9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`95e05399`](https://github.com/nix-community/NUR/commit/95e05399f4527fdde06cd151780324fb4f05ac9e) | `` automatic update `` |