### PR TITLE
chore(flake/nur): `95e05399` -> `9ac2afa7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685367958,
-        "narHash": "sha256-7KqC9OKOfQPkwLVh8E+rAOPQ/yEzw82GcUYS4/V9v6g=",
+        "lastModified": 1685375181,
+        "narHash": "sha256-K2PBVb6PZ9eq7dgNf+Qn+tK9AbekgH8M3tgwUXTfDdg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "95e05399f4527fdde06cd151780324fb4f05ac9e",
+        "rev": "9ac2afa79c6cfbde61326aaf9ba0e84aa9505ae7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ac2afa7`](https://github.com/nix-community/NUR/commit/9ac2afa79c6cfbde61326aaf9ba0e84aa9505ae7) | `` automatic update `` |
| [`629ecf74`](https://github.com/nix-community/NUR/commit/629ecf74c7832ec5ae0b67b36094e0dda9a11d0c) | `` automatic update `` |
| [`e8f26cff`](https://github.com/nix-community/NUR/commit/e8f26cff032640f7b40b3455941eb2436c377368) | `` automatic update `` |