### PR TITLE
chore(flake/nur): `9ac2afa7` -> `f22b681b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685375181,
-        "narHash": "sha256-K2PBVb6PZ9eq7dgNf+Qn+tK9AbekgH8M3tgwUXTfDdg=",
+        "lastModified": 1685378776,
+        "narHash": "sha256-+9x4+PgqkmbIHb4aClvrusnk2aXEUllWUO2HeGPJXes=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ac2afa79c6cfbde61326aaf9ba0e84aa9505ae7",
+        "rev": "f22b681bdef16c8e5d385e55efdc82efc63369a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f22b681b`](https://github.com/nix-community/NUR/commit/f22b681bdef16c8e5d385e55efdc82efc63369a2) | `` automatic update `` |
| [`56cfebe7`](https://github.com/nix-community/NUR/commit/56cfebe75c58d1f83705b1d5001af7da6ec837cb) | `` automatic update `` |