### PR TITLE
chore(flake/nur): `d3e35c12` -> `739a0b82`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685382426,
-        "narHash": "sha256-9vEyx0VUm8Y4IDmWmVG/50MYB4a2WAfVTK2xVYziQcI=",
+        "lastModified": 1685385907,
+        "narHash": "sha256-ePJkyFpasjnry4nbSUT/YZd0gr9vRYu268nE+bN+2ts=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d3e35c1288790378cb1558a72485fa00663334b1",
+        "rev": "739a0b82844d3219521868e452c08f4ba4d88c84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`739a0b82`](https://github.com/nix-community/NUR/commit/739a0b82844d3219521868e452c08f4ba4d88c84) | `` automatic update `` |
| [`77781091`](https://github.com/nix-community/NUR/commit/77781091f8bbe6d03dc1ad7214b4b3649941ff09) | `` automatic update `` |
| [`17db6147`](https://github.com/nix-community/NUR/commit/17db6147d4f6cf1577466000f4726b8d87fdc007) | `` automatic update `` |