### PR TITLE
chore(flake/nur): `739a0b82` -> `908a95d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685385907,
-        "narHash": "sha256-ePJkyFpasjnry4nbSUT/YZd0gr9vRYu268nE+bN+2ts=",
+        "lastModified": 1685389579,
+        "narHash": "sha256-LdkQAw5hjg/MWJ8Mmh68JTDiU1XfyxmApRO4YeZWLIc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "739a0b82844d3219521868e452c08f4ba4d88c84",
+        "rev": "908a95d4b0623affeb55c81a687da0dcd6ebf5a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`908a95d4`](https://github.com/nix-community/NUR/commit/908a95d4b0623affeb55c81a687da0dcd6ebf5a0) | `` automatic update `` |