### PR TITLE
chore(flake/nur): `908a95d4` -> `89a0c73b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685389579,
-        "narHash": "sha256-LdkQAw5hjg/MWJ8Mmh68JTDiU1XfyxmApRO4YeZWLIc=",
+        "lastModified": 1685399230,
+        "narHash": "sha256-7M4ctf5wZ/Ghm40FR8cVWRqoI5Y47/+bFdiRCFzF8ck=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "908a95d4b0623affeb55c81a687da0dcd6ebf5a0",
+        "rev": "89a0c73be42ff8bf7d81ce9f90e451569ccff187",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`89a0c73b`](https://github.com/nix-community/NUR/commit/89a0c73be42ff8bf7d81ce9f90e451569ccff187) | `` automatic update `` |
| [`21000e80`](https://github.com/nix-community/NUR/commit/21000e80bfda7b76c5a7b1b1458af0f3466ef4cc) | `` automatic update `` |
| [`c5bd9d59`](https://github.com/nix-community/NUR/commit/c5bd9d59aaac357d3762e924c59f7968c7e2efd4) | `` automatic update `` |
| [`996c7df5`](https://github.com/nix-community/NUR/commit/996c7df54e749d0eeeb44977d583c35a28d7a8e3) | `` automatic update `` |
| [`7b4f7012`](https://github.com/nix-community/NUR/commit/7b4f70126cb59f7a91336834958e0dc6a959480f) | `` automatic update `` |
| [`95d747cb`](https://github.com/nix-community/NUR/commit/95d747cb6ed34f05bc6a9f9b96eec454484764be) | `` automatic update `` |