### PR TITLE
chore(flake/nur): `89a0c73b` -> `1faabc69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685399230,
-        "narHash": "sha256-7M4ctf5wZ/Ghm40FR8cVWRqoI5Y47/+bFdiRCFzF8ck=",
+        "lastModified": 1685402758,
+        "narHash": "sha256-IZWiOlVrVQlVQM13cy97oOibYbapB/a+rey3ignrbWk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "89a0c73be42ff8bf7d81ce9f90e451569ccff187",
+        "rev": "1faabc69e7400bf8e5a3dce3545d5db6da2ad307",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1faabc69`](https://github.com/nix-community/NUR/commit/1faabc69e7400bf8e5a3dce3545d5db6da2ad307) | `` automatic update `` |