### PR TITLE
chore(flake/nur): `1faabc69` -> `840de0c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685402758,
-        "narHash": "sha256-IZWiOlVrVQlVQM13cy97oOibYbapB/a+rey3ignrbWk=",
+        "lastModified": 1685407271,
+        "narHash": "sha256-8e9NOm0twooinxHGN81l7r7mSJJvmFXRWEvNClJ8ueQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1faabc69e7400bf8e5a3dce3545d5db6da2ad307",
+        "rev": "840de0c8ee94c92dabfe20c2e400105ba95e7ad9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`840de0c8`](https://github.com/nix-community/NUR/commit/840de0c8ee94c92dabfe20c2e400105ba95e7ad9) | `` automatic update `` |