### PR TITLE
chore(flake/nur): `840de0c8` -> `3a69dfc4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685407271,
-        "narHash": "sha256-8e9NOm0twooinxHGN81l7r7mSJJvmFXRWEvNClJ8ueQ=",
+        "lastModified": 1685412542,
+        "narHash": "sha256-yHHMC3Q7+To57iErEInguY8PjuLes7UdbRO4SPfr53E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "840de0c8ee94c92dabfe20c2e400105ba95e7ad9",
+        "rev": "3a69dfc43a8856b6ef426d60146ed8d1541f7d90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3a69dfc4`](https://github.com/nix-community/NUR/commit/3a69dfc43a8856b6ef426d60146ed8d1541f7d90) | `` automatic update `` |
| [`100e9cfe`](https://github.com/nix-community/NUR/commit/100e9cfea09b779f9be70449d998d0707873b5a3) | `` automatic update `` |
| [`bb71f4fb`](https://github.com/nix-community/NUR/commit/bb71f4fbae4cce6897a6ccfb103cb5ee09299b27) | `` automatic update `` |