### PR TITLE
chore(flake/nur): `3a69dfc4` -> `a106fcc4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685412542,
-        "narHash": "sha256-yHHMC3Q7+To57iErEInguY8PjuLes7UdbRO4SPfr53E=",
+        "lastModified": 1685415160,
+        "narHash": "sha256-h9xOzZ/mW8h7FVvgzh1TUPe2IBLW1gMmCiqKB0AotzY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3a69dfc43a8856b6ef426d60146ed8d1541f7d90",
+        "rev": "a106fcc436dc5e40714c5bb6da519b41779037ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a106fcc4`](https://github.com/nix-community/NUR/commit/a106fcc436dc5e40714c5bb6da519b41779037ea) | `` automatic update `` |