### PR TITLE
chore(flake/nur): `a106fcc4` -> `35ffbfb6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685415160,
-        "narHash": "sha256-h9xOzZ/mW8h7FVvgzh1TUPe2IBLW1gMmCiqKB0AotzY=",
+        "lastModified": 1685418270,
+        "narHash": "sha256-jHx7khewFE1SsjqmOsaGGBlxcnbyqZsOcMKBMv6+XbM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a106fcc436dc5e40714c5bb6da519b41779037ea",
+        "rev": "35ffbfb64407da748820b2497a4ae1ab8d5c6dd3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`35ffbfb6`](https://github.com/nix-community/NUR/commit/35ffbfb64407da748820b2497a4ae1ab8d5c6dd3) | `` automatic update `` |
| [`38b0e54a`](https://github.com/nix-community/NUR/commit/38b0e54a74d86c987dfdc80da43a0d2804742a88) | `` automatic update `` |