### PR TITLE
chore(flake/sops-nix): `3e016341` -> `876846cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -970,11 +970,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1685242617,
-        "narHash": "sha256-UBPXGfGwGMJm2Wj9kDj8+TMMK2PTouSM/TpiXYtaqtQ=",
+        "lastModified": 1685434555,
+        "narHash": "sha256-aZl0yeaYX3T2L3W3yXOd3S9OfpS+8YUOT2b1KwrSf6E=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "3e016341d4dca6ce7c62316f90e66341841a30f9",
+        "rev": "876846cde9762ae563f018c17993354875e2538e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                            |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`3de23722`](https://github.com/Mic92/sops-nix/commit/3de2372274c42d71b34a9c3e8b6cce62b4d7ac3f) | `` Bump cachix/install-nix-action from 20 to 21 `` |