### PR TITLE
chore(flake/nur): `d2fbebb4` -> `1554d212`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685436302,
-        "narHash": "sha256-0vP2Ut106A/FqHuWRpKDf8hoZns80p+m2wvHtf2k3kU=",
+        "lastModified": 1685443567,
+        "narHash": "sha256-2yFl7plxXLjCSg0rOVz1nl8Kw/oInuBnbAZnZp6EgFE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d2fbebb44f5c8cb1985a99ec74456f2ac13caa5c",
+        "rev": "1554d212c39d61c0b2d9116c43869dd027ebbf34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1554d212`](https://github.com/nix-community/NUR/commit/1554d212c39d61c0b2d9116c43869dd027ebbf34) | `` automatic update `` |