### PR TITLE
chore(flake/nur): `1554d212` -> `c7550977`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685443567,
-        "narHash": "sha256-2yFl7plxXLjCSg0rOVz1nl8Kw/oInuBnbAZnZp6EgFE=",
+        "lastModified": 1685451673,
+        "narHash": "sha256-XtGCDdSTgdZPV3+vDOX1DUwe1oNL46hhKuEKZNV6ydE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1554d212c39d61c0b2d9116c43869dd027ebbf34",
+        "rev": "c7550977321eb69ebfbed1d47e09bbfc7fb552a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c7550977`](https://github.com/nix-community/NUR/commit/c7550977321eb69ebfbed1d47e09bbfc7fb552a3) | `` automatic update `` |