### PR TITLE
chore(flake/nur): `05300ded` -> `7172af86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685455734,
-        "narHash": "sha256-9V5M0aQgSt6q8umGgtJKiDKWEu8ISm7ROKHFSEjO2D4=",
+        "lastModified": 1685461889,
+        "narHash": "sha256-Y950dMivppS49/bzqJec/7q6tnpATuzctNkv4IGYr/8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "05300deda528ba5964fbdb327279901368525265",
+        "rev": "7172af865620981e95bd010a0076a8dda30e1d52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7172af86`](https://github.com/nix-community/NUR/commit/7172af865620981e95bd010a0076a8dda30e1d52) | `` automatic update `` |
| [`8bd279f8`](https://github.com/nix-community/NUR/commit/8bd279f8ad70fcb45c1a7539a3f93eaf70760c05) | `` automatic update `` |