### PR TITLE
chore(flake/nur): `7172af86` -> `51ac9f17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685461889,
-        "narHash": "sha256-Y950dMivppS49/bzqJec/7q6tnpATuzctNkv4IGYr/8=",
+        "lastModified": 1685465159,
+        "narHash": "sha256-EQJaX8miP6W+lFha/CwaVt8GuW+MveFa6RAPF+qOa7s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7172af865620981e95bd010a0076a8dda30e1d52",
+        "rev": "51ac9f171ef089742c59e1d98ecef8a10386f294",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`51ac9f17`](https://github.com/nix-community/NUR/commit/51ac9f171ef089742c59e1d98ecef8a10386f294) | `` automatic update `` |
| [`df77e2f2`](https://github.com/nix-community/NUR/commit/df77e2f2e5a0849d43330abb18c3be185a971a0b) | `` automatic update `` |