### PR TITLE
chore(flake/nur): `229d30de` -> `7fb3b9f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685475020,
-        "narHash": "sha256-8AD1C3UYR7LkXIbBlbyXMj+z/eQDzL8Xo0MK9JCPqoM=",
+        "lastModified": 1685479516,
+        "narHash": "sha256-Tey0EBrsfPXdqo5lIaHbw+KxC8X0ZBNB8DpEB1yp7Ms=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "229d30de7b33b28009312b561be3a8138e7c455e",
+        "rev": "7fb3b9f415a6db39041ace7bce51d5507092f0a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7fb3b9f4`](https://github.com/nix-community/NUR/commit/7fb3b9f415a6db39041ace7bce51d5507092f0a2) | `` automatic update `` |