### PR TITLE
chore(flake/nur): `7fb3b9f4` -> `9cbd3904`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685479516,
-        "narHash": "sha256-Tey0EBrsfPXdqo5lIaHbw+KxC8X0ZBNB8DpEB1yp7Ms=",
+        "lastModified": 1685486797,
+        "narHash": "sha256-iU+55mgzlha8yn490TMz2K+c/+lG7YzKAjNQ0wztcGs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7fb3b9f415a6db39041ace7bce51d5507092f0a2",
+        "rev": "9cbd3904a60b2e22fc7c7387d6694b1ce8a37bbe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9cbd3904`](https://github.com/nix-community/NUR/commit/9cbd3904a60b2e22fc7c7387d6694b1ce8a37bbe) | `` automatic update `` |