### PR TITLE
chore(flake/nur): `9cbd3904` -> `4e564643`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685486797,
-        "narHash": "sha256-iU+55mgzlha8yn490TMz2K+c/+lG7YzKAjNQ0wztcGs=",
+        "lastModified": 1685493828,
+        "narHash": "sha256-6b6DLa98W2njrzhm8uVqmjt8OkR9pkSBeLFsZE9Xjp8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9cbd3904a60b2e22fc7c7387d6694b1ce8a37bbe",
+        "rev": "4e564643e3912370f406a47b6ad4ea8a59832984",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4e564643`](https://github.com/nix-community/NUR/commit/4e564643e3912370f406a47b6ad4ea8a59832984) | `` automatic update `` |