### PR TITLE
chore(flake/nur): `4e564643` -> `ed83c5e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685493828,
-        "narHash": "sha256-6b6DLa98W2njrzhm8uVqmjt8OkR9pkSBeLFsZE9Xjp8=",
+        "lastModified": 1685498693,
+        "narHash": "sha256-/WYXyMuIVjexBOU1jzSWlwpE9aQ8NOhbeJkkP1tCOPI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4e564643e3912370f406a47b6ad4ea8a59832984",
+        "rev": "ed83c5e5c59fdcee5fb517386864538d400955b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ed83c5e5`](https://github.com/nix-community/NUR/commit/ed83c5e5c59fdcee5fb517386864538d400955b3) | `` automatic update `` |