### PR TITLE
chore(flake/nur): `ed83c5e5` -> `90fbc75e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685498693,
-        "narHash": "sha256-/WYXyMuIVjexBOU1jzSWlwpE9aQ8NOhbeJkkP1tCOPI=",
+        "lastModified": 1685501578,
+        "narHash": "sha256-PdohObEAlSPfzwJfi0EwrxsQX2yAzcRgY1ntDw8l82w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed83c5e5c59fdcee5fb517386864538d400955b3",
+        "rev": "90fbc75ebade34e5e881cd88def6aee2008609a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`90fbc75e`](https://github.com/nix-community/NUR/commit/90fbc75ebade34e5e881cd88def6aee2008609a6) | `` automatic update `` |