### PR TITLE
chore(flake/nur): `69e9c568` -> `45356c0d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685522697,
-        "narHash": "sha256-yVS7/mPgL+3d0wDlH54NZJfwt9ovnTOWcFVec4lJiJA=",
+        "lastModified": 1685529925,
+        "narHash": "sha256-teNOP1OvsENdXUP6IUZpi7D+BTVAXAtVr5W40XMU4Zo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "69e9c5682694db8d15f4c0363eef3e806c54a5fb",
+        "rev": "45356c0da084835bac934013262e1e7510d82073",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`45356c0d`](https://github.com/nix-community/NUR/commit/45356c0da084835bac934013262e1e7510d82073) | `` automatic update `` |