### PR TITLE
chore(flake/nur): `45356c0d` -> `1872f9d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685529925,
-        "narHash": "sha256-teNOP1OvsENdXUP6IUZpi7D+BTVAXAtVr5W40XMU4Zo=",
+        "lastModified": 1685535224,
+        "narHash": "sha256-r9PMTDYswNqPCcMGQv6SFvE7tKtp3kIfmyixT3CH/3E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "45356c0da084835bac934013262e1e7510d82073",
+        "rev": "1872f9d69d18d4afb3b5ff7771fa6bbacdabf03f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1872f9d6`](https://github.com/nix-community/NUR/commit/1872f9d69d18d4afb3b5ff7771fa6bbacdabf03f) | `` automatic update `` |