### PR TITLE
chore(flake/emacs-ement): `03d411a1` -> `995f0721`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -230,11 +230,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1685429036,
-        "narHash": "sha256-Oi4ekGgt4GQf0fzQ7ldRMbTQysOLZ3LYYF3tq/Bjk+g=",
+        "lastModified": 1685550581,
+        "narHash": "sha256-Hj9PDTmebGpGDeiXAS7zqD5FUuAI1trKRhfUPmpd/Rs=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "03d411a1778179dd1b68b404059e84508a2c1fd8",
+        "rev": "995f07219cfb2758dd97d48e7521514e4c67f72c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                             |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`995f0721`](https://github.com/alphapapa/ement.el/commit/995f07219cfb2758dd97d48e7521514e4c67f72c) | `` Docs: Update changelog ``                                        |
| [`4d28436a`](https://github.com/alphapapa/ement.el/commit/4d28436af023becd8b7b244d8f2853118a937821) | `` Fix: (ement--hostname-uri) Don't assume JSON has needed value `` |