### PR TITLE
chore(flake/nur): `50ae70c2` -> `86ca1fa1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685580651,
-        "narHash": "sha256-xLWEpyxD1Jp2GOUmdYgdx2Bb2b2tcRhvf8MSNxdmTv0=",
+        "lastModified": 1685590488,
+        "narHash": "sha256-eZ4Tr97NluZTH05fb+8zCswfueIdeIJKb8DivP1ZAjs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "50ae70c264e1dbcdd4fe97ea9d8938329b0306c4",
+        "rev": "86ca1fa148b273488423249d74672636fa15ea5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`86ca1fa1`](https://github.com/nix-community/NUR/commit/86ca1fa148b273488423249d74672636fa15ea5a) | `` automatic update `` |
| [`7dce3ec7`](https://github.com/nix-community/NUR/commit/7dce3ec721ea33606ddde8737a4318d6abf763dc) | `` automatic update `` |