### PR TITLE
chore(flake/home-manager): `96078e4a` -> `3876cc61`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685573046,
-        "narHash": "sha256-IktTf92Fl1yU8qI2s0MRx3//k6NDmFuqZrGHKJV8i4M=",
+        "lastModified": 1685573051,
+        "narHash": "sha256-zrpbdQVJFpNVFK3SlA6mE0le8qnKjUjcuY4OzL+wSHw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "96078e4a939b5e5fec1cfd83a11b3df7146a58ff",
+        "rev": "3876cc613ac3983078964ffb5a0c01d00028139e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                   |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`3876cc61`](https://github.com/nix-community/home-manager/commit/3876cc613ac3983078964ffb5a0c01d00028139e) | `` Translate using Weblate (Ukrainian) `` |
| [`04f6c292`](https://github.com/nix-community/home-manager/commit/04f6c2925b2e625504cd5a6ee758d320596f6394) | `` Translate using Weblate (Persian) ``   |
| [`efed2ccd`](https://github.com/nix-community/home-manager/commit/efed2ccd9f7fbdae1f355b245bed7864dee96317) | `` Translate using Weblate (Spanish) ``   |
| [`4d8fedfd`](https://github.com/nix-community/home-manager/commit/4d8fedfd29f05657dcdd8cdc437c31b4dba7ee6b) | `` Translate using Weblate (Swedish) ``   |
| [`76a816a8`](https://github.com/nix-community/home-manager/commit/76a816a89685448127e28b00f14d2e813f23a9f9) | `` Update translation files ``            |