### PR TITLE
chore(flake/nur): `5a44df48` -> `b08994b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685605504,
-        "narHash": "sha256-f9iQyC6T/2c0ImcioDBu0EFokue0J9yzK/5vAyQpLa8=",
+        "lastModified": 1685609174,
+        "narHash": "sha256-+PsT/Gj1/TUVESTT+ZRPRiMhZTPVPGy4PkG498Rl2KQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5a44df48cf78c3914b1d8171b90cdc8e7ee8fbe6",
+        "rev": "b08994b750a957928e46844a170365f741391fd6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b08994b7`](https://github.com/nix-community/NUR/commit/b08994b750a957928e46844a170365f741391fd6) | `` automatic update `` |
| [`163f86af`](https://github.com/nix-community/NUR/commit/163f86afd4639c0f7acf18f73c104c9106a78442) | `` automatic update `` |
| [`ee0a0683`](https://github.com/nix-community/NUR/commit/ee0a06834c32152db5ef525b0a673f7cb4fe6857) | `` automatic update `` |