### PR TITLE
chore(flake/nur): `b08994b7` -> `23621ea7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685609174,
-        "narHash": "sha256-+PsT/Gj1/TUVESTT+ZRPRiMhZTPVPGy4PkG498Rl2KQ=",
+        "lastModified": 1685612768,
+        "narHash": "sha256-XD1LKFG1N/VpcqQ63lQd6LdPHPAl/XbbLa00p5hfMW4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b08994b750a957928e46844a170365f741391fd6",
+        "rev": "23621ea768b76cc7d98a1bd66f4bd90f049d9dda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`23621ea7`](https://github.com/nix-community/NUR/commit/23621ea768b76cc7d98a1bd66f4bd90f049d9dda) | `` automatic update `` |