### PR TITLE
chore(flake/nur): `8a452b26` -> `ee152836`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685634370,
-        "narHash": "sha256-67u3TcrWn7LHCAEZK1VajMJoQ4ehc0DsR1HsIHVTjD8=",
+        "lastModified": 1685641588,
+        "narHash": "sha256-sl849BihOXclON5Ek5owalZBvhzN/XrQI0svC/vypwU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8a452b269f57f38d9fdfb019946fedfa6fe6947c",
+        "rev": "ee152836daaafab492aaa5b9ee2e6f7d2cad34b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ee152836`](https://github.com/nix-community/NUR/commit/ee152836daaafab492aaa5b9ee2e6f7d2cad34b6) | `` automatic update `` |