### PR TITLE
chore(flake/nur): `ee152836` -> `313425ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685641588,
-        "narHash": "sha256-sl849BihOXclON5Ek5owalZBvhzN/XrQI0svC/vypwU=",
+        "lastModified": 1685643901,
+        "narHash": "sha256-3zkK8nno/fnL3PSMYKtY0uhPdCyM1xVd5ES3ciZqDWU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ee152836daaafab492aaa5b9ee2e6f7d2cad34b6",
+        "rev": "313425ecb994550f7b5c585f1c75a6f9c27fcf7e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`313425ec`](https://github.com/nix-community/NUR/commit/313425ecb994550f7b5c585f1c75a6f9c27fcf7e) | `` automatic update `` |