### PR TITLE
chore(flake/nur): `c2cd67b2` -> `3c58e841`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685652397,
-        "narHash": "sha256-81h+NYjKsi0whOCUqOMEzpCQyJDpez2rK1rbh8VXFhE=",
+        "lastModified": 1685655936,
+        "narHash": "sha256-KkOQZQK0upEq+O2JDWeceeo0ulRh6UV1/wBxtD9ef9k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c2cd67b25c0975e162eeb7e04bcd11fcff735151",
+        "rev": "3c58e841ac19ae929e68c5ae11c6b2c92996a618",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3c58e841`](https://github.com/nix-community/NUR/commit/3c58e841ac19ae929e68c5ae11c6b2c92996a618) | `` automatic update `` |