### PR TITLE
chore(flake/nur): `56c33c04` -> `1512d9cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685657221,
-        "narHash": "sha256-SmKa44A5NZyYyoEqiBkBmYA9VaHhV3Oo/NuXGUrJox0=",
+        "lastModified": 1685666614,
+        "narHash": "sha256-qluwaaDt4aLH+ID/LrCGI+ZzopfoSE9njFMZmQcZotg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "56c33c0467d9758cd95385cfb3d8ffbd748c5730",
+        "rev": "1512d9cc8885ec8af295cefae8709a03ae51a913",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1512d9cc`](https://github.com/nix-community/NUR/commit/1512d9cc8885ec8af295cefae8709a03ae51a913) | `` automatic update `` |
| [`fb2109dd`](https://github.com/nix-community/NUR/commit/fb2109dd5a01b5fc869aec3d333dcd1eb46649ab) | `` automatic update `` |