### PR TITLE
chore(flake/nur): `fe21bcf2` -> `39f65107`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685673671,
-        "narHash": "sha256-1utPjZjNj3Dt9rM5+hLhsNRI9xgGDw1GfhL3rm11F3s=",
+        "lastModified": 1685677080,
+        "narHash": "sha256-SUJ5Nkor/bdVvnzyHTwTQNX9cbf3aV704GMd2Y3EfLE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fe21bcf231dabb2fdb173f5367c5801390555a8f",
+        "rev": "39f65107109253e2924273bd4de761621c889e51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`39f65107`](https://github.com/nix-community/NUR/commit/39f65107109253e2924273bd4de761621c889e51) | `` automatic update `` |