### PR TITLE
chore(flake/nur): `39f65107` -> `fe103413`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685677080,
-        "narHash": "sha256-SUJ5Nkor/bdVvnzyHTwTQNX9cbf3aV704GMd2Y3EfLE=",
+        "lastModified": 1685684786,
+        "narHash": "sha256-/lvVSST+RXp16EL1PPphGhJ9kMEw6tWhwLg2ta26lDw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "39f65107109253e2924273bd4de761621c889e51",
+        "rev": "fe1034139db25a203ca86c66ef83339d6d5ab448",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fe103413`](https://github.com/nix-community/NUR/commit/fe1034139db25a203ca86c66ef83339d6d5ab448) | `` automatic update `` |
| [`aff5a893`](https://github.com/nix-community/NUR/commit/aff5a893d93197d0f196c78d08ee4782fb303385) | `` automatic update `` |