### PR TITLE
chore(flake/nur): `d9ac1e57` -> `c46affe7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685686294,
-        "narHash": "sha256-nAJsX7jHsVktl2dd1OIHhWIsqV35lugxLZw9X8zo46w=",
+        "lastModified": 1685692640,
+        "narHash": "sha256-ZkGXTCdLgHjVLpPHDSL00CvrRvBwgTpvB7G5Sh62PzA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d9ac1e5718f819dac7db1660d94b2dff1e198456",
+        "rev": "c46affe773da5aeec4193b9929e0d64badd51c85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                       |
| -------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`b6b34981`](https://github.com/nix-community/NUR/commit/b6b3498150e323b908f109c4aefc639854f8857c) | `` automatic update ``        |
| [`a9eeb495`](https://github.com/nix-community/NUR/commit/a9eeb495d9f034566fda8e3fdb1f614bc7607d71) | `` Add 'detegr' repository `` |