### PR TITLE
chore(flake/nixpkgs): `4f53efe3` -> `e6351928`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -718,11 +718,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1685564631,
-        "narHash": "sha256-8ywr3AkblY4++3lIVxmrWZFzac7+f32ZEhH/A8pNscI=",
+        "lastModified": 1685655444,
+        "narHash": "sha256-6EujQNAeaUkWvpEZZcVF8qSfQrNVWFNNGbUJxv/A5a8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4f53efe34b3a8877ac923b9350c874e3dcd5dc0a",
+        "rev": "e635192892f5abbc2289eaac3a73cdb249abaefd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`04147e05`](https://github.com/NixOS/nixpkgs/commit/04147e058dcdec8e04c1bcbfbeed7dd7366a20a9) | `` fetchurl: remove mirror kent.dl.sourceforge.net ``                       |
| [`7cb219d3`](https://github.com/NixOS/nixpkgs/commit/7cb219d309992c8ec62b1eb80be701ed486fd4f5) | `` yamlfix: 1.9.0 -> 1.10.0 ``                                              |
| [`99d37f54`](https://github.com/NixOS/nixpkgs/commit/99d37f54f002290eb32c5a06451d05572af8ee45) | `` nixos/sway: fix package option documentation ``                          |
| [`4b2df3e8`](https://github.com/NixOS/nixpkgs/commit/4b2df3e871aa5c039925d03498328350fcf11f03) | `` python310Packages.spsdk: 1.10.0 -> 1.10.1 ``                             |
| [`f96e1e36`](https://github.com/NixOS/nixpkgs/commit/f96e1e36e616e50dee03ce7e6430e0a2557cf7d2) | `` vscode-extensions.techtheawesome.rust-yew: init at 0.2.2 ``              |
| [`013acf23`](https://github.com/NixOS/nixpkgs/commit/013acf2396f451c73b6cd6b0148df21cbaa4c165) | `` lib/tests: Also run with nixVersions.minimum and nixVersions.unstable `` |
| [`0b6021ee`](https://github.com/NixOS/nixpkgs/commit/0b6021ee53eb4677e96f28a260db9157b4f19c7a) | `` lib/tests: Fix when run with Nix 2.3 ``                                  |
| [`de0c1124`](https://github.com/NixOS/nixpkgs/commit/de0c11241f8a2e72c2cd02b86fedaaeb30292e97) | `` lib/tests/filesystem.sh: Check success and failure separately ``         |
| [`29124b85`](https://github.com/NixOS/nixpkgs/commit/29124b85cf8cc60c25b6618e0f9f25ea46cb03d9) | `` nixVersions.minver: init ``                                              |
| [`b5d19d8a`](https://github.com/NixOS/nixpkgs/commit/b5d19d8a9e62453390b2613de5eb9fee41d32b78) | `` obsidian: 1.3.4 -> 1.3.5 ``                                              |
| [`72588581`](https://github.com/NixOS/nixpkgs/commit/72588581ee4e1cc76dfc074afe356f18da2f65f0) | `` atuin: remove xvfb-run for tests ``                                      |
| [`4930b230`](https://github.com/NixOS/nixpkgs/commit/4930b230cf550bbe975de770454204c9c7ce2190) | `` hurl: 3.0.0 -> 3.0.1 ``                                                  |
| [`88da0982`](https://github.com/NixOS/nixpkgs/commit/88da0982d10dc12ecebfdecdba197e17869311a5) | `` repgrep: init at 0.12.4 ``                                               |
| [`14fdabbb`](https://github.com/NixOS/nixpkgs/commit/14fdabbb7bf9fb2a666eb6832f4449e58a83e079) | `` lighttpd: 1.4.69 -> 1.4.71 ``                                            |
| [`825ad30f`](https://github.com/NixOS/nixpkgs/commit/825ad30f7065800760becd03bd2aeebc6434757f) | `` atuin: v14.0.1 -> v15.0.0. (#234826) ``                                  |
| [`7190fa8e`](https://github.com/NixOS/nixpkgs/commit/7190fa8e972b0d93ffacc56bee6f55ec982a7519) | `` brave: 1.51.118 -> 1.52.117 ``                                           |
| [`b1d30570`](https://github.com/NixOS/nixpkgs/commit/b1d3057032753ccf51bac45b145244f2cff9fc69) | `` calibre: 6.17.0 -> 6.19.1 ``                                             |
| [`e1ed1660`](https://github.com/NixOS/nixpkgs/commit/e1ed166090781ea737c2ee583aeea46c8428c88f) | `` podofo010: init at 0.10.0 ``                                             |
| [`ed99bd0f`](https://github.com/NixOS/nixpkgs/commit/ed99bd0fb94271721aea0c9816e162c00ef51c7f) | `` kanidm: 1.1.0-alpha.11 -> 1.1.0-alpha.12 ``                              |
| [`016baa1d`](https://github.com/NixOS/nixpkgs/commit/016baa1dbb3d447c78dafa1dbd5494b958ab35ec) | `` btcpayserver: 1.9.3 -> 1.10.0 ``                                         |
| [`a33bd9d8`](https://github.com/NixOS/nixpkgs/commit/a33bd9d8e4480ed805a984297ac8488ff4edfdaa) | `` nbxplorer: 2.3.63 -> 2.3.65 ``                                           |
| [`527b3365`](https://github.com/NixOS/nixpkgs/commit/527b3365883389f7abc6e3b8cc57490bb8772cfd) | `` tailscale-systray: init at 2022-10-19 ``                                 |
| [`44a331ac`](https://github.com/NixOS/nixpkgs/commit/44a331ac331e603684af642e8e89d4e6e21c9d98) | `` minizinc: enable gecode and cbc solvers by default ``                    |
| [`fc4ffe5a`](https://github.com/NixOS/nixpkgs/commit/fc4ffe5a7a07210c2b963f1d8a4abdcb6eb06428) | `` westonLite: disable JPEG and LCMS2 support ``                            |
| [`c214eb90`](https://github.com/NixOS/nixpkgs/commit/c214eb90a1586c6f99b281b700deda6b4b0a6a5a) | `` mockoon: init at 3.0.0 ``                                                |
| [`b856a7bb`](https://github.com/NixOS/nixpkgs/commit/b856a7bbbc8371d3f7eb171ee2eab9539dc5edaf) | `` papirus-icon-theme: 20230301 -> 20230601 ``                              |
| [`0ad766dd`](https://github.com/NixOS/nixpkgs/commit/0ad766dd2284fe686bef8631fcc3af2d0f672486) | `` dasel: 2.2.0 -> 2.3.3 ``                                                 |
| [`ceb97de9`](https://github.com/NixOS/nixpkgs/commit/ceb97de9b84965748c2401753a45322f46551bd0) | `` steampipe: 0.20.2 -> 0.20.5 ``                                           |
| [`095dfa20`](https://github.com/NixOS/nixpkgs/commit/095dfa20dcc28210040df91c11e7e11c5b0a6102) | `` php: use binary wrappers ``                                              |
| [`c3bf9ba6`](https://github.com/NixOS/nixpkgs/commit/c3bf9ba6afa492aeff1d13fe0abac110931a1e9e) | `` i3status-rust: 0.31.5 -> 0.31.6 ``                                       |
| [`ba15f99e`](https://github.com/NixOS/nixpkgs/commit/ba15f99e56af2a201ed8e32f97a6c7b6e4d1cf88) | `` inform6: 6.41-r4 -> 6.41-r5 ``                                           |
| [`2f4a5b9c`](https://github.com/NixOS/nixpkgs/commit/2f4a5b9ca29a8d540028c662a7e6ea24e1bcee91) | `` hugo: 0.112.5 -> 0.112.6 ``                                              |
| [`87dac23c`](https://github.com/NixOS/nixpkgs/commit/87dac23cb2c22c7bde97242806b6ee90d977e8fe) | `` haproxy: 2.7.8 -> 2.8.0 ``                                               |
| [`054c184c`](https://github.com/NixOS/nixpkgs/commit/054c184cab9d6a5fc9d663bcd4f0532d13c8e25d) | `` nixos/doc: drop a repeated paragraph ``                                  |
| [`c41c1927`](https://github.com/NixOS/nixpkgs/commit/c41c19276d2883a8957b097a210bdd06dbe7ddce) | `` nixos/doc: drop a repeated paragraph ``                                  |
| [`ad90e881`](https://github.com/NixOS/nixpkgs/commit/ad90e88108a40246a7defbc2b36b0ddb35803724) | `` nixos/doc: fix typo ``                                                   |
| [`4e80f808`](https://github.com/NixOS/nixpkgs/commit/4e80f80864db80ef05482325a379243c41f925fa) | `` lib.systems.doubles: add big-endian MIPS linux doubles ``                |
| [`94d9a6ce`](https://github.com/NixOS/nixpkgs/commit/94d9a6ce177b3a67fb6d583c66cc59522333318c) | `` lib.systems: remove mipsisa(32|64)r6 triples ``                          |
| [`51785558`](https://github.com/NixOS/nixpkgs/commit/51785558a349e77540d35574685a5f3122c0b733) | `` python310Packages.rq: 1.14.1 -> 1.15 ``                                  |
| [`1b7ba8a4`](https://github.com/NixOS/nixpkgs/commit/1b7ba8a45b8b690d6847b74205a2e0880f431390) | `` rauc: fix cross-compilation ``                                           |
| [`df1af73e`](https://github.com/NixOS/nixpkgs/commit/df1af73e283159516575cd799375f5ca3aba41d4) | `` python310Packages.pywebview: 4.0.2 -> 4.1 ``                             |
| [`3425365f`](https://github.com/NixOS/nixpkgs/commit/3425365f629311a91f9df28b64b19e02898599c3) | `` flyctl: 0.1.20 -> 0.1.23 ``                                              |
| [`64d92ed1`](https://github.com/NixOS/nixpkgs/commit/64d92ed1122698958a7fb14ae71fbb4afc3ff072) | `` qdrant: 1.1.3 -> 1.2.2 ``                                                |
| [`02a0d8c0`](https://github.com/NixOS/nixpkgs/commit/02a0d8c054cfeae028ef2f57bf668db368a22005) | `` mako: 1.7.1 -> 1.8.0 ``                                                  |
| [`15fe59e3`](https://github.com/NixOS/nixpkgs/commit/15fe59e369e773fc0724a56ba5c585a543b83dd7) | `` boulder: unpin go ``                                                     |
| [`dc073e71`](https://github.com/NixOS/nixpkgs/commit/dc073e7175b797125d7064c9269898e59b6f4f63) | `` mgmt: unpin go ``                                                        |
| [`f7000b91`](https://github.com/NixOS/nixpkgs/commit/f7000b91098c2a4fcec2b07681479d531440a06f) | `` enumer: unpin go ``                                                      |
| [`58a56fdc`](https://github.com/NixOS/nixpkgs/commit/58a56fdc15a93e73fcc096e53c355bcee27c3631) | `` python310Packages.lion-pytorch: 0.0.7 -> 0.1.2 ``                        |
| [`eb9f0de4`](https://github.com/NixOS/nixpkgs/commit/eb9f0de453a2711c4c1c48981e5cdb1ca859bc81) | `` datadog-agent: unpin go1.18 ``                                           |
| [`803787d9`](https://github.com/NixOS/nixpkgs/commit/803787d9dd32eae10857b28ee27ee5a984f7c2c7) | `` certsync: init at unstable-2023-04-14 ``                                 |
| [`995007b1`](https://github.com/NixOS/nixpkgs/commit/995007b146a8f39e7c2095b8f1d3f2a2a82f6396) | `` python310Packages.intensity-normalization: 2.2.3 -> 2.2.4 ``             |
| [`9c5ae002`](https://github.com/NixOS/nixpkgs/commit/9c5ae0023685def0f241cee57e01494c4947d6de) | `` qt6Packages.qxlsx: 1.4.5 -> 1.4.6 ``                                     |
| [`ff35c6cf`](https://github.com/NixOS/nixpkgs/commit/ff35c6cf96a55832221b53ec37559000664070cc) | `` subtitlr: init at 0.1.0 ``                                               |
| [`922d823d`](https://github.com/NixOS/nixpkgs/commit/922d823d0b5a8cc461b6bc5a751198da469b9daf) | `` v2ray: 5.6.0 -> 5.7.0 ``                                                 |
| [`ac7614ae`](https://github.com/NixOS/nixpkgs/commit/ac7614ae5b02790456e9908b4711953c66ecba07) | `` python310Packages.spacy-transformers: 1.2.3 -> 1.2.4 ``                  |
| [`3074443c`](https://github.com/NixOS/nixpkgs/commit/3074443cc918d12ef17227951b1c4e6b791fc5bc) | `` unifont_upper: 15.0.02 -> 15.0.04 ``                                     |
| [`9b089304`](https://github.com/NixOS/nixpkgs/commit/9b0893042e10a4b741089e0a14b5db784d03a500) | `` unifont: 15.0.02 -> 15.0.04 ``                                           |
| [`d7f6d76e`](https://github.com/NixOS/nixpkgs/commit/d7f6d76ec36f3548b11c13ba284e05a3f7112151) | `` spleen: 1.9.3 -> 2.0.0 ``                                                |
| [`e5e1b4b3`](https://github.com/NixOS/nixpkgs/commit/e5e1b4b3674a04db5b0c0a0ae59ddabb9eedcce7) | `` python311Packages.ipyvue: 1.9.0 -> 1.9.1 ``                              |
| [`3cbf9713`](https://github.com/NixOS/nixpkgs/commit/3cbf9713f9ecfaab3440791b6f127d4dd1923c39) | `` alephone: 1.6.1 -> 1.6.2 ``                                              |
| [`73f005f6`](https://github.com/NixOS/nixpkgs/commit/73f005f642626c8061ce8f1f24ff48d6b1838ac9) | `` unciv: 4.6.14-patch1 -> 4.6.15 ``                                        |
| [`7a3dc946`](https://github.com/NixOS/nixpkgs/commit/7a3dc9465aa3e0e33ec484c76a7c2835a491bd83) | `` python310Packages.awkward: 2.0.8 -> 2.2.1 (#235333) ``                   |
| [`08fc59f0`](https://github.com/NixOS/nixpkgs/commit/08fc59f09a457ce3fba5633236821a474bbad620) | `` cwm: fix cross compilation, enable strictDeps ``                         |
| [`b3584080`](https://github.com/NixOS/nixpkgs/commit/b3584080dbf09cf052e7f509378d7de72a6808cc) | `` Add willcohen to geospatial (#235213) ``                                 |
| [`691dadf4`](https://github.com/NixOS/nixpkgs/commit/691dadf46154dd4f28914f991853f5585fe39a54) | `` roxctl: 4.0.1 -> 4.0.2 ``                                                |
| [`65a360bf`](https://github.com/NixOS/nixpkgs/commit/65a360bfe0ff74b99a394dec098e49d4d20ec086) | `` vimPlugins.nvim-treesitter: update grammars ``                           |
| [`dfb2614c`](https://github.com/NixOS/nixpkgs/commit/dfb2614c6b7ca6b97f231fa551b298b81c8bc9ed) | `` vimPlugins: update ``                                                    |
| [`d71bd4a1`](https://github.com/NixOS/nixpkgs/commit/d71bd4a1688d3e91ce7e86d39f7411b11643a194) | `` vimPlugins.vim-julia-cell: init at 2020-08-04 ``                         |
| [`bf8f1005`](https://github.com/NixOS/nixpkgs/commit/bf8f100570f669a0b648ee496dc16addf515906f) | `` adguardian: init at 1.2.0 ``                                             |
| [`2c8203e4`](https://github.com/NixOS/nixpkgs/commit/2c8203e45ecb3fdc9b66f6a08a796c596707f77e) | `` konstraint: 0.28.0 -> 0.29.0 ``                                          |
| [`b47d2227`](https://github.com/NixOS/nixpkgs/commit/b47d2227565c6376ce11e52af3ccf6217dbbb972) | `` python310Packages.django-vite: 2.0.2 -> 2.1.0 ``                         |
| [`013daf43`](https://github.com/NixOS/nixpkgs/commit/013daf43576a87efdf75d9c5302aef57c8aeefdd) | `` terraform-providers.tencentcloud: 1.81.2 -> 1.81.4 ``                    |
| [`3a293497`](https://github.com/NixOS/nixpkgs/commit/3a2934976bf2e1cd6fbe751942421f9cedddb0f0) | `` terraform-providers.yandex: 0.91.0 -> 0.92.0 ``                          |
| [`a368a637`](https://github.com/NixOS/nixpkgs/commit/a368a6372f3d8ffc0a8b6cac6c3958ba811a5856) | `` terraform-providers.opennebula: 1.2.1 -> 1.2.2 ``                        |
| [`4ae46b7b`](https://github.com/NixOS/nixpkgs/commit/4ae46b7b1a78d079f1df93ade43ab916b98b0bf1) | `` terraform-providers.ns1: 2.0.2 -> 2.0.3 ``                               |
| [`e904ec50`](https://github.com/NixOS/nixpkgs/commit/e904ec50dbb4187ce42766b5a95b592bfceabc40) | `` terraform-providers.huaweicloud: 1.48.0 -> 1.49.0 ``                     |
| [`38e33aca`](https://github.com/NixOS/nixpkgs/commit/38e33aca94c262a35fe11c3ef658dfd1dd534ed1) | `` terraform-providers.cloudflare: 4.7.0 -> 4.7.1 ``                        |
| [`b9abe8e3`](https://github.com/NixOS/nixpkgs/commit/b9abe8e3217f23e99e34415ac6c3b89b12ad0d4c) | `` terraform-providers.buildkite: 0.17.1 -> 0.18.0 ``                       |
| [`536eb2a9`](https://github.com/NixOS/nixpkgs/commit/536eb2a9092f31e0cd14eff548899da4da390492) | `` terraform-providers.aci: 2.7.0 -> 2.8.0 ``                               |
| [`dbab5218`](https://github.com/NixOS/nixpkgs/commit/dbab52189b652f8f5ab1993ad30384c502cab18e) | `` rshim-user-space: 2.0.7 -> 2.0.8 ``                                      |
| [`ab39f645`](https://github.com/NixOS/nixpkgs/commit/ab39f64570ca0f396dd5655ec9b371ec5c33d684) | `` python311Packages.vispy: 0.12.2 -> 0.13.0 ``                             |
| [`8d4d822b`](https://github.com/NixOS/nixpkgs/commit/8d4d822bc0efa9de6eddc79cb0d82897a9baa750) | `` coqPackages.extructures: enable for Coq 8.17 ``                          |
| [`cba7a109`](https://github.com/NixOS/nixpkgs/commit/cba7a1095de129e0e5cfe46e0ce669282fc9d979) | `` coqPackages.deriving: 0.1.0 → 0.1.1 ``                                   |
| [`028ad55b`](https://github.com/NixOS/nixpkgs/commit/028ad55ba4b5d5ae225cb5b685b3bce84635b847) | `` python310Packages.looseversion: 1.1.2 -> 1.2.0 ``                        |
| [`b15b9898`](https://github.com/NixOS/nixpkgs/commit/b15b9898df23b0112de2f50e11cc538ec6b030bf) | `` xfce.xfce4-pulseaudio-plugin: 0.4.6 -> 0.4.7 ``                          |
| [`32147d38`](https://github.com/NixOS/nixpkgs/commit/32147d3893cd0b6a094e4090877450a3c857d9f0) | `` brook: 20230601 -> 20230606 ``                                           |
| [`41b3e5f0`](https://github.com/NixOS/nixpkgs/commit/41b3e5f0edc68c338a181b7f30655dcb13e2a314) | `` mdbook-katex: 0.5.2 -> 0.5.3 ``                                          |
| [`2bb67b84`](https://github.com/NixOS/nixpkgs/commit/2bb67b849762036461c3de48fb4fda24f6df5386) | `` SDL_compat: 1.2.60 -> 1.2.64 ``                                          |
| [`d901e95e`](https://github.com/NixOS/nixpkgs/commit/d901e95e4969bb390950e77df8289e5fae9c7d08) | `` babashka: 1.3.179 -> 1.3.180 ``                                          |
| [`4ec4f73b`](https://github.com/NixOS/nixpkgs/commit/4ec4f73bef22ea9ef4f9167242e072be9075df78) | `` netplan: 0.106 -> 0.106.1 ``                                             |
| [`e09b9632`](https://github.com/NixOS/nixpkgs/commit/e09b963272f5ba0abccd4a9c25ad0c07b5a4b2c9) | `` gnome.gnome-mahjongg: 3.38.3 → 3.40.0 ``                                 |
| [`44a6cd3d`](https://github.com/NixOS/nixpkgs/commit/44a6cd3d8c0a03c6218aad53ebe4a5137c84041e) | `` gdu: 5.23.0 -> 5.24.0 ``                                                 |
| [`fabe2064`](https://github.com/NixOS/nixpkgs/commit/fabe2064486b607c2516296ce6108549de0649c4) | `` byacc: 20230219 -> 20230521 ``                                           |
| [`f970e996`](https://github.com/NixOS/nixpkgs/commit/f970e996fcc4c032693883777be26f5120692607) | `` nixos/doc/manual: add release notes for util-linux on Darwin ``          |
| [`01680e9f`](https://github.com/NixOS/nixpkgs/commit/01680e9f066b6c72e374be99290a2cdd10194804) | `` reindeer: update passthru.updateScript to use upstream Cargo.lock ``     |
| [`2a11009e`](https://github.com/NixOS/nixpkgs/commit/2a11009ee75aec445c38a99a115806f84e26b53a) | `` python311Packages.netdata: add changelog to meta ``                      |
| [`67853d55`](https://github.com/NixOS/nixpkgs/commit/67853d55c89d7e891ba40bfdf1b74a6a87c13a9e) | `` python311Packages.netdata: 1.0.3 -> 1.1.0 ``                             |
| [`1cd86afa`](https://github.com/NixOS/nixpkgs/commit/1cd86afa2c129025cada1f197ab1c916d1472655) | `` shellhub-agent: 0.12.0 -> 0.12.1 ``                                      |
| [`2d3e77ef`](https://github.com/NixOS/nixpkgs/commit/2d3e77efa8c591c4018ff12edeef761072b018fe) | `` snagboot: replace fetchPypi with fetchFromGitHub ``                      |
| [`1f278bc4`](https://github.com/NixOS/nixpkgs/commit/1f278bc4559fafe0fb00d8a5d6d8f6150def71ba) | `` python311Packages.pyezviz: 0.2.0.15 -> 0.2.0.17 ``                       |
| [`e8bb343b`](https://github.com/NixOS/nixpkgs/commit/e8bb343be8558263ce8a8c8d4d2b2370e8b6d213) | `` python311Packages.aioairzone-cloud: 0.1.6 -> 0.1.7 ``                    |
| [`d7d098f4`](https://github.com/NixOS/nixpkgs/commit/d7d098f4eba754222960b1744f018b76731ea847) | `` checkov: 2.3.264 -> 2.3.267 ``                                           |
| [`7d00ba66`](https://github.com/NixOS/nixpkgs/commit/7d00ba66fd9b2912adad79d4d819b39adf955554) | `` python311Packages.zha-quirks: 0.0.99 -> 0.0.100 ``                       |
| [`7b1ad6d2`](https://github.com/NixOS/nixpkgs/commit/7b1ad6d2a4aa1d73c308abb0e32ee107847b09cf) | `` gerrit: 3.7.2 -> 3.8.0 ``                                                |
| [`6d4da8a9`](https://github.com/NixOS/nixpkgs/commit/6d4da8a9aa68d550e9c60ae75cac5adbbe8272d2) | `` cmocka: unmark as broken for static builds ``                            |
| [`2c6ae713`](https://github.com/NixOS/nixpkgs/commit/2c6ae7132ca558f1052da0eececed3cad191b883) | `` Release NixOS 23.05 ``                                                   |
| [`1275444a`](https://github.com/NixOS/nixpkgs/commit/1275444abb7d04308f62c93782bc60803e93790f) | `` prometheus-gitlab-ci-pipelines-exporter: 0.5.4 -> 0.5.5 ``               |
| [`a5a7bdb7`](https://github.com/NixOS/nixpkgs/commit/a5a7bdb793553a09da018d6a13e09c28db209fcb) | `` sq: 0.35.0 -> 0.36.2 ``                                                  |
| [`330fb83c`](https://github.com/NixOS/nixpkgs/commit/330fb83cd8363624945d7cf00e3000dbdc7fae01) | `` vscode-extensions.tailscale.vscode-tailscale: init at 0.4.0 ``           |
| [`91a87cb7`](https://github.com/NixOS/nixpkgs/commit/91a87cb7c75d48aa5db455cfd96c0811ef6a7b57) | `` python310Packages.types-pyopenssl: 23.0.0.4 -> 23.1.0.3 ``               |
| [`8890bf2a`](https://github.com/NixOS/nixpkgs/commit/8890bf2a730f24b945c003477fabe9a17bb86082) | `` Add vscode-extensions.RoweWilsonFrederiskHolme.wikitext ``               |
| [`1734b324`](https://github.com/NixOS/nixpkgs/commit/1734b3245dd3e29f1d0d18fdcf17d6bfe2904664) | `` codemov: unstable-2022-10-24 -> unstable-2023-05-28 ``                   |
| [`eb58d1e9`](https://github.com/NixOS/nixpkgs/commit/eb58d1e9287da37e81e5a0291ab4b6497b41f7f6) | `` intel-compute-runtime: 23.13.26032.30 -> 23.17.26241.15 ``               |
| [`ffbf6f27`](https://github.com/NixOS/nixpkgs/commit/ffbf6f27c97cd4ecb794c39fd183363be72c5a1f) | `` python3.pkgs.fetchPypi: deprecate in favor of top-level fetchPypi ``     |
| [`390c5dd0`](https://github.com/NixOS/nixpkgs/commit/390c5dd03639755677f37aad6a71da84b145a4a0) | `` signalbackup-tools: 20230528-1 -> 20230531 ``                            |
| [`4492a5f9`](https://github.com/NixOS/nixpkgs/commit/4492a5f972ca5d5552caa7d99141290b3d889f07) | `` waybar: 0.9.17 -> 0.9.18 ``                                              |
| [`daa321a0`](https://github.com/NixOS/nixpkgs/commit/daa321a065ac597bf442ef43e25c6755d7a7abf9) | `` slweb: 0.5.5 -> 0.5.6 ``                                                 |
| [`cf696bb1`](https://github.com/NixOS/nixpkgs/commit/cf696bb1d54322715445e88906ffac3db2e26b31) | `` dotacat: init at 0.3.0 ``                                                |
| [`1af797e5`](https://github.com/NixOS/nixpkgs/commit/1af797e5e53b50905a2129fb2d53465d871191e8) | `` cargo-modules: 0.8.0 -> 0.9.0 ``                                         |
| [`95b82210`](https://github.com/NixOS/nixpkgs/commit/95b82210876197d231f81c6be34320c56c04be31) | `` nixVersions.unstable: 2.15 -> 2.16 ``                                    |
| [`6964ee2b`](https://github.com/NixOS/nixpkgs/commit/6964ee2bea80cb60643a57a26c7107331686bb52) | `` nixVersions.nix_2_16: init at 2.16.0 ``                                  |
| [`94fdd2a4`](https://github.com/NixOS/nixpkgs/commit/94fdd2a40a0505ecaa1c3031f6608386bbebc495) | `` nixVersions: use hash instead of sha256 ``                               |
| [`97dd3d21`](https://github.com/NixOS/nixpkgs/commit/97dd3d21257aaa91c50cc681e83a1990cab77c6c) | `` python310Packages.dash: 2.9.3 -> 2.10.1 ``                               |
| [`6897f813`](https://github.com/NixOS/nixpkgs/commit/6897f813ea827aedd3d2fa247f147ea7c4ae4e4d) | `` grass: Be explicit about build-time tools and run-time dependencies ``   |
| [`01e8760d`](https://github.com/NixOS/nixpkgs/commit/01e8760db8813d7446c22c2a095ebd2fdf29479a) | `` grass: 8.2.0 -> 8.2.1. Fixes build failure. ``                           |
| [`318dc3de`](https://github.com/NixOS/nixpkgs/commit/318dc3de9deeb0c682ee8b39f14de0b0d2a771ac) | `` cinnamon.bulky: 2.7 -> 2.8 ``                                            |
| [`7c4e31bb`](https://github.com/NixOS/nixpkgs/commit/7c4e31bb4c5b366106ed338d69bf0ef5bad485c9) | `` igv: 2.16.0 -> 2.16.1 ``                                                 |
| [`536e245f`](https://github.com/NixOS/nixpkgs/commit/536e245f420b393f3b83b737c0eccbff3e29bef5) | `` rome: 12.1.0 -> 12.1.3 ``                                                |
| [`53141d5f`](https://github.com/NixOS/nixpkgs/commit/53141d5fd72376a1c0d9cc35262fe2b88bd110e7) | `` rome: add passthru.updateScript ``                                       |
| [`9afc4d4e`](https://github.com/NixOS/nixpkgs/commit/9afc4d4efb45ee0bb1089f68ac472bcaee8ec235) | `` pocketbase: 0.15.3 -> 0.16.3 ``                                          |
| [`47eda8e0`](https://github.com/NixOS/nixpkgs/commit/47eda8e00a28e5b09e7c1819f9a7fce5fee013e3) | `` isync: add optional support for XOAUTH2 authentication method ``         |