### PR TITLE
chore(flake/nur): `d20910e4` -> `800a9c73`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685715344,
-        "narHash": "sha256-Om5RM1aZTjA9On6s59WYgHor27q0e0jWpY6YFy3V7Gc=",
+        "lastModified": 1685728700,
+        "narHash": "sha256-dc8fQoi39g0tUjsZ7rNOSoReTKIPBg293U11+5mx9OQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d20910e4325043886e32c8d459b727e1e5be079e",
+        "rev": "800a9c734c3488eb8f9847315d7e32492b80f6c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`800a9c73`](https://github.com/nix-community/NUR/commit/800a9c734c3488eb8f9847315d7e32492b80f6c6) | `` automatic update `` |
| [`86576c5c`](https://github.com/nix-community/NUR/commit/86576c5ca0bfbf828c57d8edabaf9c6fe01e0380) | `` automatic update `` |