### PR TITLE
chore(flake/nur): `800a9c73` -> `98d779dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685728700,
-        "narHash": "sha256-dc8fQoi39g0tUjsZ7rNOSoReTKIPBg293U11+5mx9OQ=",
+        "lastModified": 1685735114,
+        "narHash": "sha256-BiT/XSlD+lV5vaugdcAg7r47imT9PUJiSHnOsj7qRF4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "800a9c734c3488eb8f9847315d7e32492b80f6c6",
+        "rev": "98d779ddf824703826b17ab01ca0e2ab0ad66bf6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`98d779dd`](https://github.com/nix-community/NUR/commit/98d779ddf824703826b17ab01ca0e2ab0ad66bf6) | `` automatic update `` |
| [`f83f4772`](https://github.com/nix-community/NUR/commit/f83f477273b90f1604d4d591b4f905c5c877713e) | `` automatic update `` |