### PR TITLE
chore(flake/nur): `98d779dd` -> `f062b976`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685735114,
-        "narHash": "sha256-BiT/XSlD+lV5vaugdcAg7r47imT9PUJiSHnOsj7qRF4=",
+        "lastModified": 1685738778,
+        "narHash": "sha256-pGkXrAqolHPOjzBSt4nLK+GX6sgBrDCED/AWjgs9ikA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "98d779ddf824703826b17ab01ca0e2ab0ad66bf6",
+        "rev": "f062b9767861fee15e19bc76ec0cb4c637ad8a09",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f062b976`](https://github.com/nix-community/NUR/commit/f062b9767861fee15e19bc76ec0cb4c637ad8a09) | `` automatic update `` |