### PR TITLE
chore(flake/nur): `b9b4c6c6` -> `c012d74e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685752884,
-        "narHash": "sha256-2OvX7nU9OI+/5Trsdnf7Z0qzWca0601fLmfKUCOzM9Y=",
+        "lastModified": 1685761206,
+        "narHash": "sha256-tVUEgmyg/seo07ynvHM2ufuTLNLmr9DgnFgbLtZ4PdM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b9b4c6c683b344fe0990c18f22f20530d8cf5e81",
+        "rev": "c012d74eb6cd05275781b64ec078c79d5d96a255",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c012d74e`](https://github.com/nix-community/NUR/commit/c012d74eb6cd05275781b64ec078c79d5d96a255) | `` automatic update `` |