### PR TITLE
chore(flake/nix-index-database): `219067a5` -> `669ca1f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683638468,
-        "narHash": "sha256-tQEaGZfZ2Hpw+XIVEHaJ8FaF1yNQyMDDhUyIQ7LTIEg=",
+        "lastModified": 1685764721,
+        "narHash": "sha256-CIy1iwQTEKfZRrid4gBLA+r/LPGA9IUFo0lKJVyECGI=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "219067a5e3cf4b9581c8b4fcfc59ecd5af953d07",
+        "rev": "669ca1f2e2bc401abab6b837ae9c51503edc9b49",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                            |
| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`e171cb06`](https://github.com/Mic92/nix-index-database/commit/e171cb06e7f77cc506e0712dd0a67530de1c80e3) | `` disable i686-linux again ``                     |
| [`eafda9c7`](https://github.com/Mic92/nix-index-database/commit/eafda9c78822602053b815d666424e115f70416e) | `` Bump cachix/install-nix-action from 20 to 21 `` |