### PR TITLE
chore(flake/nur): `fbe426e8` -> `14742b4e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685763978,
-        "narHash": "sha256-/e30TuiNxvEyrMkJ19wZhCf6wE7IUfBgD86gScz9xJQ=",
+        "lastModified": 1685771032,
+        "narHash": "sha256-G6gsuOFsOnM0czQ7wC900nmgQjja7H0laXURmcgdD1g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fbe426e87bbd5ebc177aee014ee7245167b0715c",
+        "rev": "14742b4e16ea6a49e630997c0154b90b2f5d945d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`14742b4e`](https://github.com/nix-community/NUR/commit/14742b4e16ea6a49e630997c0154b90b2f5d945d) | `` automatic update `` |
| [`03054d5b`](https://github.com/nix-community/NUR/commit/03054d5b41ba1c5f08d42a0c382cbc692941d7fe) | `` automatic update `` |
| [`53d668a5`](https://github.com/nix-community/NUR/commit/53d668a52f956483ca5b1f021536980a135ecf60) | `` automatic update `` |