### PR TITLE
chore(flake/nur): `14742b4e` -> `2404d4ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685771032,
-        "narHash": "sha256-G6gsuOFsOnM0czQ7wC900nmgQjja7H0laXURmcgdD1g=",
+        "lastModified": 1685775575,
+        "narHash": "sha256-5d0oOSIgiUrjAGFg2nMMtDDlm+r+e/g2tpRGAPHiHeA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "14742b4e16ea6a49e630997c0154b90b2f5d945d",
+        "rev": "2404d4ac32e009dcddfb222b25537f3c276c0246",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2404d4ac`](https://github.com/nix-community/NUR/commit/2404d4ac32e009dcddfb222b25537f3c276c0246) | `` automatic update `` |
| [`3731c53c`](https://github.com/nix-community/NUR/commit/3731c53c264e18f73c6a258a685f4331189b1a0b) | `` automatic update `` |