### PR TITLE
chore(flake/nur): `2404d4ac` -> `62c4d702`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685775575,
-        "narHash": "sha256-5d0oOSIgiUrjAGFg2nMMtDDlm+r+e/g2tpRGAPHiHeA=",
+        "lastModified": 1685776777,
+        "narHash": "sha256-ehEJa7N0+P242dNFSdbtglT1lS4IpW42O6AwYFhBZ/g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2404d4ac32e009dcddfb222b25537f3c276c0246",
+        "rev": "62c4d702f4c0b01095fdffb07090d9979a72a9fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`62c4d702`](https://github.com/nix-community/NUR/commit/62c4d702f4c0b01095fdffb07090d9979a72a9fd) | `` automatic update `` |