### PR TITLE
chore(flake/nur): `62c4d702` -> `b489b530`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685776777,
-        "narHash": "sha256-ehEJa7N0+P242dNFSdbtglT1lS4IpW42O6AwYFhBZ/g=",
+        "lastModified": 1685792665,
+        "narHash": "sha256-cAicgkTAX9EVNOmJwt+SRRfvYzb47uEt7pRV57w6/yo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "62c4d702f4c0b01095fdffb07090d9979a72a9fd",
+        "rev": "b489b530f22ef9fc761eb9800df702b1cc438b55",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b489b530`](https://github.com/nix-community/NUR/commit/b489b530f22ef9fc761eb9800df702b1cc438b55) | `` automatic update `` |
| [`eec5e7de`](https://github.com/nix-community/NUR/commit/eec5e7defd8ea2013dab8622e38d9e7b5d176bb7) | `` automatic update `` |
| [`626b603b`](https://github.com/nix-community/NUR/commit/626b603b70802f0bb780a8bdaf0eda31c3d8f616) | `` automatic update `` |