### PR TITLE
chore(flake/nur): `b489b530` -> `e94d128e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685792665,
-        "narHash": "sha256-cAicgkTAX9EVNOmJwt+SRRfvYzb47uEt7pRV57w6/yo=",
+        "lastModified": 1685797051,
+        "narHash": "sha256-v0swF5EanugbMJyXJc8jUGw7u0llQ8Zrm7pt9GH87yM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b489b530f22ef9fc761eb9800df702b1cc438b55",
+        "rev": "e94d128e63936f8959ed7aa9ecbb2b8fca65a3d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e94d128e`](https://github.com/nix-community/NUR/commit/e94d128e63936f8959ed7aa9ecbb2b8fca65a3d0) | `` automatic update `` |
| [`b0d0d8de`](https://github.com/nix-community/NUR/commit/b0d0d8de0f260a3f09d0fd7a8c2caf1983f0e3ec) | `` automatic update `` |