### PR TITLE
chore(flake/nur): `e94d128e` -> `36455953`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685797051,
-        "narHash": "sha256-v0swF5EanugbMJyXJc8jUGw7u0llQ8Zrm7pt9GH87yM=",
+        "lastModified": 1685803539,
+        "narHash": "sha256-S/yHjHu4xrcuT9VyVPKWGPjOSYyY8hG9//1X6F8urpI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e94d128e63936f8959ed7aa9ecbb2b8fca65a3d0",
+        "rev": "364559535aae66fbc459d5190b0feb264a619d06",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`36455953`](https://github.com/nix-community/NUR/commit/364559535aae66fbc459d5190b0feb264a619d06) | `` automatic update `` |
| [`8f9d02fa`](https://github.com/nix-community/NUR/commit/8f9d02faeceaaf4e3a589d08df4c6a56b37a9de1) | `` automatic update `` |