### PR TITLE
chore(flake/nur): `36455953` -> `78147959`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685803539,
-        "narHash": "sha256-S/yHjHu4xrcuT9VyVPKWGPjOSYyY8hG9//1X6F8urpI=",
+        "lastModified": 1685810707,
+        "narHash": "sha256-5PrZFSsCT53aR+4ZjpPvXK9ZXwakuU33BX97q2T3BoY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "364559535aae66fbc459d5190b0feb264a619d06",
+        "rev": "7814795910cc42a67ce45588d03e6517c3dc3596",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`78147959`](https://github.com/nix-community/NUR/commit/7814795910cc42a67ce45588d03e6517c3dc3596) | `` automatic update `` |