### PR TITLE
chore(flake/nur): `43b9f76b` -> `ed9ed85e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685814329,
-        "narHash": "sha256-hAUtD2REDwvQCEPxrC8OvxwDd8GdLphjMP10qUl55wE=",
+        "lastModified": 1685816726,
+        "narHash": "sha256-9eeLfcsZ6oVdAy0MA3smlQp5ryWxvxj2sGzGEuCODQs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "43b9f76bfec5bfb1d33a3d2d2404ac348c8c3584",
+        "rev": "ed9ed85eb898c2810e7e01a29fc6a38dbbece311",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ed9ed85e`](https://github.com/nix-community/NUR/commit/ed9ed85eb898c2810e7e01a29fc6a38dbbece311) | `` automatic update `` |