### PR TITLE
chore(flake/nur): `ab80a73c` -> `8e579a7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685821464,
-        "narHash": "sha256-iBuRbM8WisvqpYZt21wzWEejlIaeIPeGOh69/g1A0mo=",
+        "lastModified": 1685828760,
+        "narHash": "sha256-iZ/M6FjmWgtSvbEbRTG0Rnuw6fv3T/r1CEoYhE7A+sc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ab80a73c8ae7860d15cabb887917c0c3bfc05575",
+        "rev": "8e579a7df40a858552e1918a3716be05c4b6e50c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8e579a7d`](https://github.com/nix-community/NUR/commit/8e579a7df40a858552e1918a3716be05c4b6e50c) | `` automatic update `` |
| [`c65c45f0`](https://github.com/nix-community/NUR/commit/c65c45f0033ae5a6eacab94a831e54270d3a1c5f) | `` automatic update `` |