### PR TITLE
chore(flake/nur): `28cf464f` -> `608ca2c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685850359,
-        "narHash": "sha256-rEC4MexNgRKHGAIObKbmhzBxgp6W5tyX82U6hYN5GUQ=",
+        "lastModified": 1685857465,
+        "narHash": "sha256-G7SvdVL3kV9yYGFIa9ZHM+sVU1k9bSCn3dt+CEWLm+E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "28cf464f43639b2052ac4f3f0dcf8a0cc3aee404",
+        "rev": "608ca2c4a22aefecc81fd0508b8f24a1d4452e12",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`608ca2c4`](https://github.com/nix-community/NUR/commit/608ca2c4a22aefecc81fd0508b8f24a1d4452e12) | `` automatic update `` |
| [`11b0c120`](https://github.com/nix-community/NUR/commit/11b0c120d87fbc2362d361ace438144fb44c8900) | `` automatic update `` |