### PR TITLE
chore(flake/nur): `04aaaa5e` -> `c7e56e73`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685860280,
-        "narHash": "sha256-iLF8HTXYP0wkqEm421RKXOkc86pU0BU1dw1GxCWCw9g=",
+        "lastModified": 1685862238,
+        "narHash": "sha256-HlcMK0cWdiZGCi+T02xbxaow0TvZV3qvFpeTvLEv5jI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "04aaaa5ef1c01116cf4ecebe539a4691b057f6b2",
+        "rev": "c7e56e7335a355919eb9b72050cf9e3c29007335",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c7e56e73`](https://github.com/nix-community/NUR/commit/c7e56e7335a355919eb9b72050cf9e3c29007335) | `` automatic update `` |