### PR TITLE
chore(flake/home-manager): `bffc49ff` -> `57ed23cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685833925,
-        "narHash": "sha256-KCo8QT/DtM4pSTQDWFOhVP7MDzwi0wb2ZlxhgjEwXtM=",
+        "lastModified": 1685865037,
+        "narHash": "sha256-atwfu0IUL2f6oWFt3KG1uqPTj7DxUoYW7+KVOv+o5DY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bffc49ffb255f213d2f902043da37b3016450f4a",
+        "rev": "57ed23cd29e7b72518e19d2917e2b2880a94162c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                               |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`57ed23cd`](https://github.com/nix-community/home-manager/commit/57ed23cd29e7b72518e19d2917e2b2880a94162c) | `` flake.lock: Update ``              |
| [`221056c5`](https://github.com/nix-community/home-manager/commit/221056c59ffab1e513fcf8ccb1079a8d44848fa9) | `` tests: fix `getOutput` on stubs `` |