### PR TITLE
chore(flake/nur): `e1977f10` -> `5e01d906`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685925733,
-        "narHash": "sha256-WOngD/006iiUTeKAGH9XJpe2RQZRx1Iyw9WAM7FF3Bw=",
+        "lastModified": 1685936744,
+        "narHash": "sha256-UTWAvj28NpPsT0e2eHi4/n9zyeSJuVUxuDzRSt2vhw8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e1977f103d4128465a70c7859ab14a6530818c51",
+        "rev": "5e01d906c9464d6f6deb741b1d8b6cbe69532f01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5e01d906`](https://github.com/nix-community/NUR/commit/5e01d906c9464d6f6deb741b1d8b6cbe69532f01) | `` automatic update `` |