### PR TITLE
chore(flake/nur): `5e01d906` -> `da715545`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685936744,
-        "narHash": "sha256-UTWAvj28NpPsT0e2eHi4/n9zyeSJuVUxuDzRSt2vhw8=",
+        "lastModified": 1685943732,
+        "narHash": "sha256-P1GnG0MSh2zxhvIc4Lp5+KoH0DGWZNsTCHnckiYE4p4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5e01d906c9464d6f6deb741b1d8b6cbe69532f01",
+        "rev": "da715545fdb4dadeb2c19ab14b9967b9470fe923",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`da715545`](https://github.com/nix-community/NUR/commit/da715545fdb4dadeb2c19ab14b9967b9470fe923) | `` automatic update `` |