### PR TITLE
chore(flake/nur): `da715545` -> `af936114`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685943732,
-        "narHash": "sha256-P1GnG0MSh2zxhvIc4Lp5+KoH0DGWZNsTCHnckiYE4p4=",
+        "lastModified": 1685953686,
+        "narHash": "sha256-/X+bjVqwCgM34wakAhmFp47QbA89jQa/FLSNl9aDH9o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "da715545fdb4dadeb2c19ab14b9967b9470fe923",
+        "rev": "af936114a4cd8a128b23ded64db2a1090defb876",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`af936114`](https://github.com/nix-community/NUR/commit/af936114a4cd8a128b23ded64db2a1090defb876) | `` automatic update `` |