### PR TITLE
chore(flake/nixpkgs): `dd498255` -> `7409480d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -718,11 +718,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1685836261,
-        "narHash": "sha256-rpxEPGeW4JZJcH58SQApJUtJ7w78VPtkF6Cut/Pq6Kg=",
+        "lastModified": 1685931219,
+        "narHash": "sha256-8EWeOZ6LKQfgAjB/USffUSELPRjw88A+xTcXnOUvO5M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dd4982554e18b936790da07c4ea2db7c7600f283",
+        "rev": "7409480d5c8584a1a83c422530419efe4afb0d19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`2e5b4636`](https://github.com/NixOS/nixpkgs/commit/2e5b4636ffebf5fa32bb9680e16a6b75afb93ee9) | `` berglas: 1.0.2 -> 1.0.3 ``                                                |
| [`03c65919`](https://github.com/NixOS/nixpkgs/commit/03c659190515317c5164ae6239a9556b6c1ac12a) | `` zincsearch: 0.3.5 -> 0.4.5, rename from zinc (#218017) ``                 |
| [`b1efae4a`](https://github.com/NixOS/nixpkgs/commit/b1efae4a9edc0402c1611e86696bc92b33ce75cd) | `` python3Packages.oca-port: init at 0.13 (#224626) ``                       |
| [`df9d3da7`](https://github.com/NixOS/nixpkgs/commit/df9d3da7525a5e381316761f8187954a26325ae0) | `` golangci-lint: 1.53.1 -> 1.53.2 ``                                        |
| [`dbd3bea0`](https://github.com/NixOS/nixpkgs/commit/dbd3bea0874d4ad9e55c9b747579a8e90f00be86) | `` hash-slinger: 3.2 -> 3.3 ``                                               |
| [`1fca3245`](https://github.com/NixOS/nixpkgs/commit/1fca3245e7857c0f1294b581488e742fa5bf19f2) | `` livebook: init at 0.9.2 ``                                                |
| [`d9ab7b1b`](https://github.com/NixOS/nixpkgs/commit/d9ab7b1b652dc0dce8af8e89d2a3671dde7d623f) | `` blink: init at 1.0.0 ``                                                   |
| [`00497646`](https://github.com/NixOS/nixpkgs/commit/004976464fe9baeac38331d9ea21d7aacb33c988) | `` shopware-cli: 0.1.74 -> 0.1.78 ``                                         |
| [`d8d3bcc7`](https://github.com/NixOS/nixpkgs/commit/d8d3bcc73cb635b4e46432327fc69364b8fccd71) | `` air: 1.43.0 -> 1.44.0 ``                                                  |
| [`8ba006e0`](https://github.com/NixOS/nixpkgs/commit/8ba006e05708c4235aaff7e03fac3a37f16ad5d6) | `` pforth: 1.28.0 -> 2.0.1 ``                                                |
| [`783f7e4d`](https://github.com/NixOS/nixpkgs/commit/783f7e4d7c4b50da23602c14f2daee4a89ce11a3) | `` ttyper: 1.2.0 -> 1.2.1 ``                                                 |
| [`31e745a3`](https://github.com/NixOS/nixpkgs/commit/31e745a3a55d5321d4c5ec29c02792ad90e965d2) | `` boxxy: 0.7.1 -> 0.7.2 ``                                                  |
| [`fe02c5ee`](https://github.com/NixOS/nixpkgs/commit/fe02c5ee1a172552f2a0548e131df20d9ab9602e) | `` isync: Disable the XOAUTH2 support by default as it caused regressions `` |
| [`ac379b0a`](https://github.com/NixOS/nixpkgs/commit/ac379b0ac519f0ac3f07228f8be2f0d205ad9d97) | `` rshijack: 0.4.0 -> 0.5.0 ``                                               |
| [`714cc104`](https://github.com/NixOS/nixpkgs/commit/714cc1046a940eda8dd9583e8e2d6d1aab7f481b) | `` resholve: fix tests after #232713 ``                                      |
| [`ffcdc5bb`](https://github.com/NixOS/nixpkgs/commit/ffcdc5bb81746fdd93e54f79bdbca355bb6a5f32) | `` obs-studio-plugins.obs-vkcapture: 1.3.2 -> 1.3.3 ``                       |
| [`8aa5842e`](https://github.com/NixOS/nixpkgs/commit/8aa5842eac92e07b20402981d9e1d319011f6b49) | `` pylyzer: 0.0.30 -> 0.0.31 ``                                              |
| [`158d19fa`](https://github.com/NixOS/nixpkgs/commit/158d19fa808b65fed9fa8294c22056f689b59e4f) | `` mmark: fix version ``                                                     |
| [`3102d771`](https://github.com/NixOS/nixpkgs/commit/3102d7713e086b4e77b8cb3c4af89d4ad827f8d6) | `` okteto: 2.16.2 -> 2.16.3 ``                                               |
| [`b4a2d679`](https://github.com/NixOS/nixpkgs/commit/b4a2d6796437b1c108f86e28743988670f2afb86) | `` mpvScripts.thumbfast: change license ``                                   |
| [`abc86bc4`](https://github.com/NixOS/nixpkgs/commit/abc86bc4ed54fc850a55962e3c23e74a03f478d5) | `` mpvScripts.thumbfast: unstable-2023-05-12 -> unstable-2023-06-04 ``       |
| [`d465aaf7`](https://github.com/NixOS/nixpkgs/commit/d465aaf7c662cb6bdb7d745d9b75292c28c31c0b) | `` rl-2305: mention nerdfonts update ``                                      |
| [`1f1c63f9`](https://github.com/NixOS/nixpkgs/commit/1f1c63f98d8ee047e4e6bfe045ad233c73402f5b) | `` openimageio: 2.4.11.1 -> 2.4.12.0 ``                                      |
| [`3bb9d9c7`](https://github.com/NixOS/nixpkgs/commit/3bb9d9c76f8d21e8a3e67cc858f2cfbdf51dca71) | `` codevis: 0.8.3 -> 0.8.4 ``                                                |
| [`745089a9`](https://github.com/NixOS/nixpkgs/commit/745089a9e025986dc58ce666c4dd11cbe0cb68ee) | `` mmark: 2.2.31 -> 2.2.32 ``                                                |
| [`82f8be70`](https://github.com/NixOS/nixpkgs/commit/82f8be70cdec4550f2032c85023f4d71d5739dfd) | `` playwright: 1.32.1 -> 1.34.3 ``                                           |
| [`21ed9b18`](https://github.com/NixOS/nixpkgs/commit/21ed9b18f0021623ebb3eedc55a9a2972429ad1c) | `` gabutdm: 2.1.5 -> 2.1.6 ``                                                |
| [`139013bc`](https://github.com/NixOS/nixpkgs/commit/139013bc42943ebfeecafcdb7cd424f0262bbeac) | `` maintainers: remove WeebSorceress ``                                      |
| [`4bffe265`](https://github.com/NixOS/nixpkgs/commit/4bffe265372dc372bcb2f9540bacb9c3e6429ad4) | `` maintainers: remove gordias ``                                            |
| [`3788de53`](https://github.com/NixOS/nixpkgs/commit/3788de53f963ee6f0c8815dd47e7eca2b72edc92) | `` maintainers: update a few changed GitHub usernames ``                     |
| [`756e89e6`](https://github.com/NixOS/nixpkgs/commit/756e89e6ef61ea52691ee53be9e567f51f124c42) | `` maintainers/fix-maintainers.pl: ignore case ``                            |
| [`28b153b4`](https://github.com/NixOS/nixpkgs/commit/28b153b4b8efcecede19ba4b55494704dddcbc8f) | `` raven-reader: 1.0.78 -> 1.0.80 ``                                         |
| [`6672ae61`](https://github.com/NixOS/nixpkgs/commit/6672ae61c1e054c679e9659f7cead4b56fa60b42) | `` hyperfine: 0.17.0 -> 1.17.0 ``                                            |
| [`2bcd410b`](https://github.com/NixOS/nixpkgs/commit/2bcd410b7563bc3e90faceeb336cd4b37788b1f9) | `` capnproto-rust: init at 0.17.1 ``                                         |
| [`1b4bcd4d`](https://github.com/NixOS/nixpkgs/commit/1b4bcd4d8abb4b58abfe67d4c376b44d9aae6c21) | `` jetty: 11.0.14 -> 11.0.15 ``                                              |
| [`b6ed3b8f`](https://github.com/NixOS/nixpkgs/commit/b6ed3b8f402893df91a8e21ce993520301c2f076) | `` nixos/public-inbox: explicit a few more freeform settings ``              |
| [`50301d73`](https://github.com/NixOS/nixpkgs/commit/50301d73e9250276693e19e96013bd25799331b9) | `` public-inbox: 1.8.0 -> 1.9.0 ``                                           |
| [`4fdd015c`](https://github.com/NixOS/nixpkgs/commit/4fdd015c769c72adf92f85df7b0db427e6b17f6d) | `` public-inbox: fix InlineC ``                                              |
| [`5e777d59`](https://github.com/NixOS/nixpkgs/commit/5e777d5991260838691c2b5d148fd6bd6c9eb512) | `` realvnc-vnc-viewer: 7.1.0 -> 7.5.0 ``                                     |
| [`fca9bc36`](https://github.com/NixOS/nixpkgs/commit/fca9bc364ab130ddf72c0dd9ec2fbf0ef98a9f5a) | `` python311Packages.frigidaire: 0.18.12 -> 0.18.13 ``                       |
| [`7c0f98bb`](https://github.com/NixOS/nixpkgs/commit/7c0f98bba54d2ae4aa3941c5dffb4f7061e75cb5) | `` maintainers: fix formatting/indentation ``                                |
| [`00b378b1`](https://github.com/NixOS/nixpkgs/commit/00b378b10beb4dc80b8dce17c3db01ef39a5d2cd) | `` python311Packages.pydelijn: 1.0.0 -> 1.1.0 ``                             |
| [`4537beec`](https://github.com/NixOS/nixpkgs/commit/4537beecf33f594d248728e3d5f71945652b75f2) | `` python310Packages.plumbum: 1.8.1 -> 1.8.2 ``                              |
| [`d79f0203`](https://github.com/NixOS/nixpkgs/commit/d79f020366d56fff14c10a07c34bcceb7c6c70e0) | `` thanos: fix build go1.20 and unpin go ``                                  |
| [`408b28e9`](https://github.com/NixOS/nixpkgs/commit/408b28e98840a97d6b67d3d91cf1a09123e1b420) | `` libsForQt5: Add description and home page for kde integrations ``         |
| [`be3252f3`](https://github.com/NixOS/nixpkgs/commit/be3252f3a06e67697f052303f6775897d88dfb16) | `` cobalt: 0.18.4 -> 0.18.5 ``                                               |
| [`acc3c4e3`](https://github.com/NixOS/nixpkgs/commit/acc3c4e38bed135e803dcc1ee5f462ec385f1f8f) | `` kluctl: fix binary name ``                                                |
| [`7bb81043`](https://github.com/NixOS/nixpkgs/commit/7bb810431b6b9d03f5415331c4024caa2693c4f5) | `` python310Packages.reqif: add changelog to meta ``                         |
| [`142dadf1`](https://github.com/NixOS/nixpkgs/commit/142dadf17457080aa9717f9f054a98b11ac4bb88) | `` python310Packages.mizani: 0.9.1 -> 0.9.2 ``                               |
| [`d85fecf2`](https://github.com/NixOS/nixpkgs/commit/d85fecf2e17a7e3b25c102c1ea8a89e2f970e692) | `` python311Packages.aiosmtplib: 2.0.1 -> 2.0.2 ``                           |
| [`640627ba`](https://github.com/NixOS/nixpkgs/commit/640627bae85de92f9fae5b30611b6b6120f045b5) | `` dos2unix: 7.4.4 -> 7.5.0 ``                                               |
| [`b6bbf837`](https://github.com/NixOS/nixpkgs/commit/b6bbf837d8c543b10ea6445cbaf5318c06c0c9b8) | `` gopls: 0.12.0 -> 0.12.2 ``                                                |
| [`e635ba6b`](https://github.com/NixOS/nixpkgs/commit/e635ba6b59ead3792dbb6910df58418e17f25a73) | `` python310Packages.python-nomad: disable on unsupported Python releases `` |
| [`85d2314e`](https://github.com/NixOS/nixpkgs/commit/85d2314e206410b4a8b4b4770d47bbe0d74f6f45) | `` python310Packages.python-nomad: add changelog to meta ``                  |
| [`82707746`](https://github.com/NixOS/nixpkgs/commit/82707746d3accd1cc8cfe3e0861fe950939c49c4) | `` python310Packages.reqif: 0.0.27 -> 0.0.35 ``                              |
| [`f32e9394`](https://github.com/NixOS/nixpkgs/commit/f32e93944fff59680d361ffa1416e8480c226e15) | `` cista: 0.13 -> 0.14 ``                                                    |
| [`b6176bfb`](https://github.com/NixOS/nixpkgs/commit/b6176bfba2eaf85b53e7b73dd1e1ea2b0dcb243a) | `` yoshimi: 2.2.3 -> 2.3.0 ``                                                |
| [`87012bce`](https://github.com/NixOS/nixpkgs/commit/87012bced87907cf9a61ff0fb8a8789786809686) | `` dae: 0.1.9patch1 -> 0.1.10 ``                                             |
| [`adff278e`](https://github.com/NixOS/nixpkgs/commit/adff278e5913079ac5c97d3b2adfa1e7b3d83b70) | `` mob: 4.4.2 -> 4.4.3 ``                                                    |
| [`2de0ec33`](https://github.com/NixOS/nixpkgs/commit/2de0ec338cf8d6ea256704951c178bc4f6512267) | `` python310Packages.pyomo: 6.5.0 -> 6.6.1 ``                                |
| [`a40d9917`](https://github.com/NixOS/nixpkgs/commit/a40d991777bd44401babd84b6866c28290381364) | `` clash-meta: 1.14.4 -> 1.14.5 ``                                           |
| [`a1daf9bd`](https://github.com/NixOS/nixpkgs/commit/a1daf9bdf6b36d1f14eb782f5ff560b1527b1db5) | `` python310Packages.python-nomad: 1.5.0 -> 2.0.0 ``                         |
| [`ef81932c`](https://github.com/NixOS/nixpkgs/commit/ef81932c2603cfe7bc35117021069a8106f95206) | `` uncover: 1.0.4 -> 1.0.5 ``                                                |
| [`d49ed98f`](https://github.com/NixOS/nixpkgs/commit/d49ed98fd7e1d58fb656c0123860480eaa1c148b) | `` exploitdb: 2023-06-01 -> 2023-06-03 ``                                    |
| [`626bf2b5`](https://github.com/NixOS/nixpkgs/commit/626bf2b598ff87d53343a701566baea688569495) | `` epilys-bb: init at unstable-2020-12-04 ``                                 |
| [`0f85ec3a`](https://github.com/NixOS/nixpkgs/commit/0f85ec3a2115bc74d6759ed201dc2a0a87490e86) | `` dbmate: 2.3.0 -> 2.4.0 ``                                                 |
| [`063696f8`](https://github.com/NixOS/nixpkgs/commit/063696f828b053d053f3add8417b96b76a5fc98f) | `` python310Packages.pyopencl: use pyproject format ``                       |
| [`71adbbc7`](https://github.com/NixOS/nixpkgs/commit/71adbbc7f370b6dc0f62253943f6946e745fa81d) | `` millet: 0.10.0 -> 0.10.1 ``                                               |
| [`962968af`](https://github.com/NixOS/nixpkgs/commit/962968afce31c094a24094434f01f45b9fd5878d) | `` devbox: 0.5.3 -> 0.5.4 ``                                                 |
| [`1f231abe`](https://github.com/NixOS/nixpkgs/commit/1f231abe57afe462b11a18aa72db1f2141c19d65) | `` fastp: 0.23.3 -> 0.23.4 ``                                                |
| [`c4c24047`](https://github.com/NixOS/nixpkgs/commit/c4c24047160217bb6a874b55e2ff4edeeaf6a000) | `` devbox: 0.5.2 -> 0.5.3 ``                                                 |
| [`11c4eb08`](https://github.com/NixOS/nixpkgs/commit/11c4eb0873a62618487c6f06f09ad4ac3f49cfaa) | `` granted: 0.11.1 -> 0.13.0 ``                                              |
| [`50d66bcb`](https://github.com/NixOS/nixpkgs/commit/50d66bcba638b527a02a4aee21fb91e6f5f1eb67) | `` nixos/gitlab: Fix config reference for registry (#235639) ``              |
| [`a1bc1cbf`](https://github.com/NixOS/nixpkgs/commit/a1bc1cbf8e5a7bc966143bb425e109531cc522ca) | `` act: 0.2.45 -> 0.2.46 ``                                                  |
| [`93a55a32`](https://github.com/NixOS/nixpkgs/commit/93a55a32ab29064132855e0e62b554fdef1fe528) | `` ooniprobe-cli: 3.17.2 -> 3.17.3 ``                                        |
| [`4cf5e410`](https://github.com/NixOS/nixpkgs/commit/4cf5e410a44a74431c0fac618f6a698f7a43ba74) | `` python310Packages.snakeviz: 2.1.2 -> 2.2.0 ``                             |
| [`db7534df`](https://github.com/NixOS/nixpkgs/commit/db7534df5fb9b7dfd3404ec26d977997ff2cc1a0) | `` python310Packages.python-ecobee-api: 0.2.16 -> 0.2.17 ``                  |
| [`feb0d41b`](https://github.com/NixOS/nixpkgs/commit/feb0d41b6b6bee68fda1e762fbaddd30b1ba0018) | `` python310Packages.nestedtext: 3.5 -> 3.6 ``                               |
| [`97995f5e`](https://github.com/NixOS/nixpkgs/commit/97995f5e8640c986aad90ad88fbff71a4bf8a9e6) | `` python310Packages.azure-mgmt-core: 1.3.2 -> 1.4.0 ``                      |
| [`63e829fe`](https://github.com/NixOS/nixpkgs/commit/63e829fe273e138348d551ba7f02469714b799a4) | `` lilypond-unstable: 2.25.4 -> 2.25.5 ``                                    |
| [`60ffe8e9`](https://github.com/NixOS/nixpkgs/commit/60ffe8e9033f13de41cda046cb7b3f2ae34bfe34) | `` python310Packages.sentry-sdk: 1.24.0 -> 1.25.0 ``                         |
| [`2fb4a0a0`](https://github.com/NixOS/nixpkgs/commit/2fb4a0a0d253c8bc8642ab058ac175bf42521a2d) | ``  python310Packages.azure-mgmt-compute: update disabled ``                 |
| [`ea7b4a52`](https://github.com/NixOS/nixpkgs/commit/ea7b4a528767ce9d1dce48de4d56e8e3485c4df0) | `` python310Packages.pyopencl: 2022.3.1 -> 2023.1 ``                         |
| [`01e460d6`](https://github.com/NixOS/nixpkgs/commit/01e460d69ecaad102de4aa47370a249d0add3d7d) | `` perlPackages.HashSharedMem: fix build on aarch64-linux ``                 |
| [`df0136b8`](https://github.com/NixOS/nixpkgs/commit/df0136b8e085022de88c9fe77d5084c03a808d35) | `` vivaldi: 6.0.2979.18 -> 6.0.2979.22 ``                                    |
| [`abf8128a`](https://github.com/NixOS/nixpkgs/commit/abf8128af390574c11a13101d402c8ba8731175d) | `` handbrake: fix build ``                                                   |
| [`37111dc0`](https://github.com/NixOS/nixpkgs/commit/37111dc014417c8a45347ce46bfbc63d30be74eb) | `` envfs: 1.0.0 -> 1.0.1 ``                                                  |
| [`2390ba5f`](https://github.com/NixOS/nixpkgs/commit/2390ba5fac490dfd687420423dd91fd22e6a095c) | `` wxsqlite3: 4.9.3 -> 4.9.4 ``                                              |
| [`af49f985`](https://github.com/NixOS/nixpkgs/commit/af49f98525a529c0803e130023215f9d0ef620fb) | `` re-flex: 3.3.3 -> 3.3.4 ``                                                |
| [`489e8c83`](https://github.com/NixOS/nixpkgs/commit/489e8c837eb02bc3b8aee210955f16d5e7fc3349) | `` ginkgo: 2.9.5 -> 2.9.7 ``                                                 |
| [`344c56d5`](https://github.com/NixOS/nixpkgs/commit/344c56d53208b21fe3d9293c4e4ef332d79341c2) | `` pachyderm: 2.6.0 -> 2.6.1 ``                                              |
| [`73a15c9f`](https://github.com/NixOS/nixpkgs/commit/73a15c9f147a5aac572f5ba6ff7fc478430a70f6) | `` python310Packages.azure-mgmt-compute: 29.1.0 -> 30.0.0 ``                 |
| [`3e24038f`](https://github.com/NixOS/nixpkgs/commit/3e24038fba7edfa12dd42d13f3167a3304b5841a) | `` chromiumDev: 115.0.5790.3 -> 116.0.5803.2 ``                              |
| [`8d83062b`](https://github.com/NixOS/nixpkgs/commit/8d83062b048c05a30a86dffa4a746a575cfd0349) | `` chromiumBeta: 114.0.5735.45 -> 115.0.5790.13 ``                           |
| [`41436add`](https://github.com/NixOS/nixpkgs/commit/41436adde4048bc8603b0b40346463d2ea9fe740) | `` v2ray-geoip: build from source with dbip-country-lite ``                  |
| [`252b6122`](https://github.com/NixOS/nixpkgs/commit/252b6122a6a6eaa398a0a9857a5714db2e224329) | `` python311Packages.google-auth: 2.18.1 -> 2.19.1 ``                        |
| [`0cb5680d`](https://github.com/NixOS/nixpkgs/commit/0cb5680d95f0d4ad5ccac87a5c4b67c18e5edb6e) | `` python311Packages.google-cloud-bigquery-storage: 2.19.1 -> 2.20.0 ``      |
| [`d58b0b11`](https://github.com/NixOS/nixpkgs/commit/d58b0b11887f92037e0004c04572805f965f8efb) | `` python311Packages.google-cloud-bigquery: 3.10.0 -> 3.11.0 ``              |
| [`126871f5`](https://github.com/NixOS/nixpkgs/commit/126871f5e80ea6b60a3c6ae87b88788da81cf0c1) | `` python311Packages.google-cloud-container: 2.21.0 -> 2.22.0 ``             |
| [`29f154fc`](https://github.com/NixOS/nixpkgs/commit/29f154fcc2cfe516c61332a2980483c4b50d0d89) | `` python311Packages.google-cloud-datacatalog: 3.12.0 -> 3.13.0 ``           |
| [`be0ba20f`](https://github.com/NixOS/nixpkgs/commit/be0ba20fa61554594143dc90c8c767ab56fc354c) | `` python311Packages.google-cloud-language: 2.9.1 -> 2.10.0 ``               |
| [`2dc1cf40`](https://github.com/NixOS/nixpkgs/commit/2dc1cf4057083f3828dba181fa116e21f7d1c4e2) | `` python311Packages.google-cloud-spanner: 3.35.0 -> 3.35.1 ``               |
| [`eb78c31c`](https://github.com/NixOS/nixpkgs/commit/eb78c31c65597b728b21f504a44b573213a1172c) | `` python311Packages.google-cloud-speech: 2.19.0 -> 2.20.0 ``                |
| [`2d2e4649`](https://github.com/NixOS/nixpkgs/commit/2d2e46498108ba26ebdd22b79ef06337c43d90de) | `` python311Packages.google-cloud-videointelligence: 2.11.1 -> 2.11.2 ``     |
| [`d9e0b59a`](https://github.com/NixOS/nixpkgs/commit/d9e0b59a64450f59ba6fff229b5c71da91739fec) | `` python311Packages.google-cloud-vision: 3.4.1 -> 3.4.2 ``                  |
| [`bb1da66f`](https://github.com/NixOS/nixpkgs/commit/bb1da66f9d802aab670f9df5f5f98460c064b255) | `` eludris: init at 0.3.3 ``                                                 |
| [`30d8b2af`](https://github.com/NixOS/nixpkgs/commit/30d8b2afa8158a7e8d8515c530e33e4291e88b17) | `` maintainers: add ooliver1 ``                                              |
| [`497e42c1`](https://github.com/NixOS/nixpkgs/commit/497e42c14be9d4726fad98b28f8337d541d67411) | `` urbit: 2.6 -> 2.8 ``                                                      |
| [`5319c6b5`](https://github.com/NixOS/nixpkgs/commit/5319c6b53bccc2f58e10a11424d8700ce0071926) | `` stellar-core: 19.10.0 -> 19.11.0 ``                                       |
| [`c3ce5917`](https://github.com/NixOS/nixpkgs/commit/c3ce591722bc3c88f0cbeda08507882f71c4a517) | `` angelscript: 2.36.0 -> 2.36.1 ``                                          |
| [`7921cbe1`](https://github.com/NixOS/nixpkgs/commit/7921cbe15b495ee5f8bb08b955fb870908d57a5b) | `` volta: init at 1.1.1 ``                                                   |
| [`4ba66ea3`](https://github.com/NixOS/nixpkgs/commit/4ba66ea33ed7dd0eff6c90ebb12e455b833911c5) | `` python311Packages.python-gvm: 23.5.0 -> 23.5.1 ``                         |
| [`33d8777a`](https://github.com/NixOS/nixpkgs/commit/33d8777af9d151a722b24da45d63e003309f46e8) | `` diamond: 2.1.6 -> 2.1.7 ``                                                |
| [`64f062ec`](https://github.com/NixOS/nixpkgs/commit/64f062ec3f6f65706854b2c21134c1f7bd1b0e19) | `` php82Extensions.blackfire: 1.86.8 -> 1.87.2 ``                            |
| [`e23960a3`](https://github.com/NixOS/nixpkgs/commit/e23960a38d58aab21123fe3bbe043f7be5abfb06) | `` blackfire: 2.15.0 -> 2.16.1 ``                                            |
| [`9783bd46`](https://github.com/NixOS/nixpkgs/commit/9783bd46c9c307afb29ff51d6f126b66ba6f0644) | `` opera: 98.0.4759.39 -> 99.0.4788.31 ``                                    |
| [`7672a0e6`](https://github.com/NixOS/nixpkgs/commit/7672a0e67306e717e23d5f9b4aef08a0f853278c) | `` kluctl: 2.19.4 -> 2.20.2 ``                                               |
| [`4288b3aa`](https://github.com/NixOS/nixpkgs/commit/4288b3aa4dc793221455a7c39ba23a68a4ddd1bb) | `` karmor: 0.13.1 -> 0.13.2 ``                                               |
| [`4bda0f0b`](https://github.com/NixOS/nixpkgs/commit/4bda0f0beb23fce2b1c3cfad7c0a7fe6306256a0) | `` whatsapp-for-linux: 1.6.2 -> 1.6.3 ``                                     |
| [`0190867e`](https://github.com/NixOS/nixpkgs/commit/0190867eeca7923123e75ea3c8a248c493ab3fb8) | `` changedetection-io: unpin apprise dependency ``                           |
| [`6c19ea9e`](https://github.com/NixOS/nixpkgs/commit/6c19ea9ed870498a27f517280566e85ab897fc66) | `` flexget: 3.7.2 -> 3.7.4 ``                                                |
| [`7756df7b`](https://github.com/NixOS/nixpkgs/commit/7756df7b572ebe012cf4d331e6ebc0c55e4810d4) | `` mcfly: 0.8.0 -> 0.8.1 ``                                                  |
| [`22a7f0ce`](https://github.com/NixOS/nixpkgs/commit/22a7f0cea1e279801f8ab62cd9d5484b66ede958) | `` python310Packages.apprise: 1.3.0 -> 1.4.0 ``                              |
| [`bfbcd4c9`](https://github.com/NixOS/nixpkgs/commit/bfbcd4c912bfefe37faacd422d6d68a68890d860) | `` imgproxy: 3.17.0 -> 3.18.0 ``                                             |
| [`4e42d830`](https://github.com/NixOS/nixpkgs/commit/4e42d8309a36da655f8af21b016cdf696d3bbe97) | `` cloudlog: 2.4.2 -> 2.4.3 ``                                               |
| [`faad480c`](https://github.com/NixOS/nixpkgs/commit/faad480c76fbbc225853296cfe0f3ac5b2c31064) | `` hyperrogue: 12.1o -> 12.1q ``                                             |
| [`fb814704`](https://github.com/NixOS/nixpkgs/commit/fb8147045b58f3059c7165139b35916b467fba5c) | `` pulumi: 3.60.1 -> 3.69.0 ``                                               |
| [`bfe156cc`](https://github.com/NixOS/nixpkgs/commit/bfe156cc0b3d6364a5872d1aa21cabf7e7d5c5ab) | `` matrix-hookshot: 4.0.0 -> 4.1.0 ``                                        |
| [`8ac4225a`](https://github.com/NixOS/nixpkgs/commit/8ac4225a0e0c966b943172da11c0d952c0fa9eca) | `` rPackages.rvg: add dependency ``                                          |
| [`cc0171f7`](https://github.com/NixOS/nixpkgs/commit/cc0171f7b6cddc15c09f506ad71e0a8e636c9530) | `` pgbouncer: 1.19.0 -> 1.19.1 ``                                            |
| [`157a06a9`](https://github.com/NixOS/nixpkgs/commit/157a06a92d335857c1374adb83be23e547e96b76) | `` swaysome: 1.1.5 -> 2.0.0 ``                                               |
| [`2ab198f2`](https://github.com/NixOS/nixpkgs/commit/2ab198f21781b5eabf79a7641270caac982055a9) | `` electron_25-bin: init 25.0.1 ``                                           |
| [`ada8fb64`](https://github.com/NixOS/nixpkgs/commit/ada8fb64b87842fbfdd3698d99bea34dc849f3ee) | `` electron_24-bin: 24.2.0 -> 24.4.1 ``                                      |
| [`84f38d0d`](https://github.com/NixOS/nixpkgs/commit/84f38d0de6ad4edc39ea0418beb103e3cc2841cb) | `` electron_23-bin: 23.3.1 -> 22.3.5 ``                                      |