### PR TITLE
chore(flake/nur): `4cf1868f` -> `87415d80`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685965552,
-        "narHash": "sha256-HrbSXErQSxB2suQ6zXn5e3V3N8oK4DKpag+NRqTKqJM=",
+        "lastModified": 1685975983,
+        "narHash": "sha256-dR+jx1vDpcyuGWNKjtrkIyknQBLPs+4Yja08kZYKUfk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4cf1868fd5b16df653be023f8b72a0eb0b0cb3cc",
+        "rev": "87415d8029c9abe57c5277d12acb96255534363b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`87415d80`](https://github.com/nix-community/NUR/commit/87415d8029c9abe57c5277d12acb96255534363b) | `` automatic update `` |
| [`c3f9f28b`](https://github.com/nix-community/NUR/commit/c3f9f28bd9e73c179aa00b3fe4b887c9c1b19155) | `` automatic update `` |
| [`70ef5760`](https://github.com/nix-community/NUR/commit/70ef57602b3cc69c23d69361b92896720bf200ec) | `` automatic update `` |
| [`ce6023f1`](https://github.com/nix-community/NUR/commit/ce6023f158d82d9ff562bde900242dae506fbe32) | `` automatic update `` |