### PR TITLE
chore(flake/nur): `87415d80` -> `de817406`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685975983,
-        "narHash": "sha256-dR+jx1vDpcyuGWNKjtrkIyknQBLPs+4Yja08kZYKUfk=",
+        "lastModified": 1685980073,
+        "narHash": "sha256-7BkreZ2cH488dR1XPcdlALj+2g+NvrZdG9ZhwRt0YFI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "87415d8029c9abe57c5277d12acb96255534363b",
+        "rev": "de817406e39c1f9be28fde1d62c1f1f0c91acb09",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`de817406`](https://github.com/nix-community/NUR/commit/de817406e39c1f9be28fde1d62c1f1f0c91acb09) | `` automatic update `` |