### PR TITLE
chore(flake/nur): `de817406` -> `79c58f8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1685980073,
-        "narHash": "sha256-7BkreZ2cH488dR1XPcdlALj+2g+NvrZdG9ZhwRt0YFI=",
+        "lastModified": 1685994311,
+        "narHash": "sha256-Jun6nq/l8VIbD4YKHyvfEK/Z46UwzgEZJj4CFKloocI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "de817406e39c1f9be28fde1d62c1f1f0c91acb09",
+        "rev": "79c58f8e4cfd78a798eddbd2496e181f2a482e90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`79c58f8e`](https://github.com/nix-community/NUR/commit/79c58f8e4cfd78a798eddbd2496e181f2a482e90) | `` automatic update `` |