### PR TITLE
chore(flake/home-manager): `607d8fad` -> `28614ed7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -497,11 +497,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685885003,
-        "narHash": "sha256-+OB0EvZBfGvnlTGg6mtyUCqkMnUp9DkmRUU4d7BZBVE=",
+        "lastModified": 1685999310,
+        "narHash": "sha256-gaRMZhc7z4KeU/xS3IWv3kC+WhVcAXOLXXGKLe5zn1Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "607d8fad96436b134424b9935166a7cd0884003e",
+        "rev": "28614ed7a1e3ace824c122237bdc0e5e0b62c5c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`28614ed7`](https://github.com/nix-community/home-manager/commit/28614ed7a1e3ace824c122237bdc0e5e0b62c5c3) | `` lib: add functions to create DAGs from lists ``       |
| [`79e03fbe`](https://github.com/nix-community/home-manager/commit/79e03fbe24dde6fe10662723870400d87a9cb40d) | `` lib: remove listOrDagOf type ``                       |
| [`24d590cc`](https://github.com/nix-community/home-manager/commit/24d590cc32ca9c685668c3e5a67e57327613d32f) | `` wezterm: add integrations for Bash and Zsh (#3934) `` |