### PR TITLE
chore(flake/nur): `c34c9447` -> `73fcb38f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686003547,
-        "narHash": "sha256-N44LeU0txaahUhbGaN6SfYD1ArqlTU14zOf+7gJLiUQ=",
+        "lastModified": 1686009232,
+        "narHash": "sha256-sUiL7RO9NuqT3810mRjqLpVeeE7kvmv+ZYY70qchjaI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c34c944795f4031c6555e94936bf78512539d461",
+        "rev": "73fcb38fb64bcb15c61ca841577081fe9c5f810c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`73fcb38f`](https://github.com/nix-community/NUR/commit/73fcb38fb64bcb15c61ca841577081fe9c5f810c) | `` automatic update `` |