### PR TITLE
chore(flake/nur): `dbc2ec5e` -> `fe879a65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686012200,
-        "narHash": "sha256-A9TWJjEP8P//lOrEawDZRyMWAU7G7uxlzS82n6/B4fo=",
+        "lastModified": 1686023150,
+        "narHash": "sha256-SS8xDfkMeNgaXadE5LozdllYAzyTRpfJceaSD0al9eQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dbc2ec5eed49f4ed2f5b5f6ea55aa817d509ae3a",
+        "rev": "fe879a6565e3125892297e4bd7cbad6620352a26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fe879a65`](https://github.com/nix-community/NUR/commit/fe879a6565e3125892297e4bd7cbad6620352a26) | `` automatic update `` |
| [`c0aefe85`](https://github.com/nix-community/NUR/commit/c0aefe85d0f7431d3768e6c6decee330d336ff61) | `` automatic update `` |