### PR TITLE
chore(flake/nur): `fe879a65` -> `878654e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686023150,
-        "narHash": "sha256-SS8xDfkMeNgaXadE5LozdllYAzyTRpfJceaSD0al9eQ=",
+        "lastModified": 1686030115,
+        "narHash": "sha256-zv01tpM0aGOJMwPYZtWGxKhueQJwPys8/hvG6+JBeAg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fe879a6565e3125892297e4bd7cbad6620352a26",
+        "rev": "878654e3c67353ef27cc707271ec3fe3998a26ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`878654e3`](https://github.com/nix-community/NUR/commit/878654e3c67353ef27cc707271ec3fe3998a26ce) | `` automatic update `` |
| [`2f7e5fb3`](https://github.com/nix-community/NUR/commit/2f7e5fb3fd20e4c17ea5a1a5a2710ca600c937e5) | `` automatic update `` |