### PR TITLE
chore(flake/nur): `eae65a90` -> `a27b5b81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686049193,
-        "narHash": "sha256-mQcfqYckDSson/gE2yUx9u4NnD/shCUKVfAy+P1u3u4=",
+        "lastModified": 1686049354,
+        "narHash": "sha256-yvMTBhMd+p2JzlxXFE/TFyVog+yzOL2MuLkmLsSXWe8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eae65a902dd89b49685fb994c37690c2a2bfc16e",
+        "rev": "a27b5b81ea6dcf5a69df5a7921ad833c2ea48b33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a27b5b81`](https://github.com/nix-community/NUR/commit/a27b5b81ea6dcf5a69df5a7921ad833c2ea48b33) | `` automatic update `` |