### PR TITLE
chore(flake/nur): `a27b5b81` -> `397b2fb9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686049354,
-        "narHash": "sha256-yvMTBhMd+p2JzlxXFE/TFyVog+yzOL2MuLkmLsSXWe8=",
+        "lastModified": 1686062765,
+        "narHash": "sha256-ZaGCHjYbahpxz8fukVIwR/k/TlGASMCcLAW3Oe9/gEA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a27b5b81ea6dcf5a69df5a7921ad833c2ea48b33",
+        "rev": "397b2fb9fd76d9cf7ae68a242af10852d18ca1ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`397b2fb9`](https://github.com/nix-community/NUR/commit/397b2fb9fd76d9cf7ae68a242af10852d18ca1ba) | `` automatic update `` |
| [`19e89629`](https://github.com/nix-community/NUR/commit/19e896297d52b9d7c5d049ddfba79f3adc53a825) | `` automatic update `` |