### PR TITLE
chore(flake/nur): `dbc0efd9` -> `70eb5181`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686066280,
-        "narHash": "sha256-vCCR8DTih/qXf384sbdI6qxcTjOb/pYtmBoyErfO8R8=",
+        "lastModified": 1686070388,
+        "narHash": "sha256-4k0N7owmwK8wY2mhebPRULFS2r0WcP0MB6mpelY7f7o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dbc0efd962f5dfd6389f682f86028a57064225ef",
+        "rev": "70eb5181d97da233e3bfc0f659f20cc9e8e94722",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`70eb5181`](https://github.com/nix-community/NUR/commit/70eb5181d97da233e3bfc0f659f20cc9e8e94722) | `` automatic update `` |