### PR TITLE
chore(flake/nur): `70eb5181` -> `f7b89777`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686070388,
-        "narHash": "sha256-4k0N7owmwK8wY2mhebPRULFS2r0WcP0MB6mpelY7f7o=",
+        "lastModified": 1686073525,
+        "narHash": "sha256-CasBCbPGC/qieXIYMOsb27qTJa5f2dqxl1up2LEenso=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "70eb5181d97da233e3bfc0f659f20cc9e8e94722",
+        "rev": "f7b89777c77c063e0b366073d83693a66a81270f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f7b89777`](https://github.com/nix-community/NUR/commit/f7b89777c77c063e0b366073d83693a66a81270f) | `` automatic update `` |