### PR TITLE
chore(flake/nur): `b2adbf01` -> `96363e35`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686076172,
-        "narHash": "sha256-FA0RCy8AkxWCfhdCfTNjHG2IMM14HZ50IUIkVbJRVF0=",
+        "lastModified": 1686080678,
+        "narHash": "sha256-qTJIx9oCQAVTObEWp8mv7X5MoJAM2sicTgmx17jUal8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b2adbf0149922d8503a89bccf099ffdc22907d51",
+        "rev": "96363e3543a5067af6db7ac585bfeb9f74900e4e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`96363e35`](https://github.com/nix-community/NUR/commit/96363e3543a5067af6db7ac585bfeb9f74900e4e) | `` automatic update `` |