### PR TITLE
chore(flake/nur): `63e7a76a` -> `2a1413b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686086857,
-        "narHash": "sha256-FR3kJathheBl3BJqmVGTwR+XG2Nad0QnkJNWZrucj5Q=",
+        "lastModified": 1686092333,
+        "narHash": "sha256-vROOvZB5ybsIzWmxNn96BjQnJ7XKToVYBaY5IQxGjHM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "63e7a76a62cc7d4321c0e5beaa100062710ec3a5",
+        "rev": "2a1413b4526363c77248d11b746a4761bd8692d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2a1413b4`](https://github.com/nix-community/NUR/commit/2a1413b4526363c77248d11b746a4761bd8692d7) | `` automatic update `` |