### PR TITLE
chore(flake/nur): `2a1413b4` -> `59874cc9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686092333,
-        "narHash": "sha256-vROOvZB5ybsIzWmxNn96BjQnJ7XKToVYBaY5IQxGjHM=",
+        "lastModified": 1686095819,
+        "narHash": "sha256-Z8Gas0gxUAiIQmFjaX41C74+NK5gVk424xsYEesMZQE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2a1413b4526363c77248d11b746a4761bd8692d7",
+        "rev": "59874cc9831e3891765e33d54ae9c0917f9de810",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`59874cc9`](https://github.com/nix-community/NUR/commit/59874cc9831e3891765e33d54ae9c0917f9de810) | `` automatic update `` |
| [`2ace3683`](https://github.com/nix-community/NUR/commit/2ace36833f73b70e61bc19b8f420fe235dd43efe) | `` automatic update `` |