### PR TITLE
chore(flake/nur): `59874cc9` -> `839664ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686095819,
-        "narHash": "sha256-Z8Gas0gxUAiIQmFjaX41C74+NK5gVk424xsYEesMZQE=",
+        "lastModified": 1686103552,
+        "narHash": "sha256-/whMtbM3EA1/IFXNhqA+P3d/Nofe1LETwvF8SS4HQ/w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "59874cc9831e3891765e33d54ae9c0917f9de810",
+        "rev": "839664cab8bf00e2f71b3a44ea1ba5b0e9c21089",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`839664ca`](https://github.com/nix-community/NUR/commit/839664cab8bf00e2f71b3a44ea1ba5b0e9c21089) | `` automatic update `` |
| [`0762e39c`](https://github.com/nix-community/NUR/commit/0762e39cfb9d9d25dbd475553d81b01c7e6b41d3) | `` automatic update `` |