### PR TITLE
chore(flake/nur): `839664ca` -> `daea9fd8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686103552,
-        "narHash": "sha256-/whMtbM3EA1/IFXNhqA+P3d/Nofe1LETwvF8SS4HQ/w=",
+        "lastModified": 1686107157,
+        "narHash": "sha256-qxvzgXOKcK2P+mprzWUyvipV2ZfQnngG5dHT8Mfw0io=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "839664cab8bf00e2f71b3a44ea1ba5b0e9c21089",
+        "rev": "daea9fd82d53fea9c5300c49b87f0b83f489ab35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`daea9fd8`](https://github.com/nix-community/NUR/commit/daea9fd82d53fea9c5300c49b87f0b83f489ab35) | `` automatic update `` |