### PR TITLE
chore(flake/nur): `daea9fd8` -> `c744db1e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686107157,
-        "narHash": "sha256-qxvzgXOKcK2P+mprzWUyvipV2ZfQnngG5dHT8Mfw0io=",
+        "lastModified": 1686110130,
+        "narHash": "sha256-LnXPo/L9HDvl1/aBa7WS3Eep9MF1e6PblYP+xu/N9yQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "daea9fd82d53fea9c5300c49b87f0b83f489ab35",
+        "rev": "c744db1ef30132896eb98f86fc2b543a1ea28ad7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c744db1e`](https://github.com/nix-community/NUR/commit/c744db1ef30132896eb98f86fc2b543a1ea28ad7) | `` automatic update `` |