### PR TITLE
chore(flake/nur): `c744db1e` -> `b53d8f8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686110130,
-        "narHash": "sha256-LnXPo/L9HDvl1/aBa7WS3Eep9MF1e6PblYP+xu/N9yQ=",
+        "lastModified": 1686123941,
+        "narHash": "sha256-PohqzWeF5dILUV/Gc6yIxvp/4ou3cPMfKj2fF/WI3+E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c744db1ef30132896eb98f86fc2b543a1ea28ad7",
+        "rev": "b53d8f8e684ecfad2a730b8c86b1449ef415dd91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b53d8f8e`](https://github.com/nix-community/NUR/commit/b53d8f8e684ecfad2a730b8c86b1449ef415dd91) | `` automatic update `` |
| [`e8905970`](https://github.com/nix-community/NUR/commit/e8905970744ad1a992bff885ac82e45c41f4b14e) | `` automatic update `` |
| [`9fa0698e`](https://github.com/nix-community/NUR/commit/9fa0698ec12a7b685b9978691d3b5ed505611f72) | `` automatic update `` |
| [`67bb263f`](https://github.com/nix-community/NUR/commit/67bb263fe047e5e548f5698e316ce0ea5d3e8aef) | `` automatic update `` |