### PR TITLE
chore(flake/nur): `b552d4fe` -> `c24a7490`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686148805,
-        "narHash": "sha256-r1sPTIlBxA+4KSLyMlZQXHou4LnFtevWTgtZJXLQ04M=",
+        "lastModified": 1686152698,
+        "narHash": "sha256-Nf8kz0eZddJpeHbixOvwx0ZY30iWu88RtBIGqtKXmwA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b552d4fe926df4ae56e19dd4e467768a7a36c05b",
+        "rev": "c24a74900e28bbd4e3b69f9e136edbc0ef7ac830",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c24a7490`](https://github.com/nix-community/NUR/commit/c24a74900e28bbd4e3b69f9e136edbc0ef7ac830) | `` automatic update `` |
| [`ffd588e7`](https://github.com/nix-community/NUR/commit/ffd588e7d2eb69cad03c254201417a0f21b47941) | `` automatic update `` |