### PR TITLE
chore(flake/nur): `c24a7490` -> `222cc784`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686152698,
-        "narHash": "sha256-Nf8kz0eZddJpeHbixOvwx0ZY30iWu88RtBIGqtKXmwA=",
+        "lastModified": 1686156360,
+        "narHash": "sha256-Hiq9RgnjOQ12PewlX5HIU+eZv7sK0H7pYpYD621uohI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c24a74900e28bbd4e3b69f9e136edbc0ef7ac830",
+        "rev": "222cc78435a2a102896f9046b36cde8dfb4b60a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`222cc784`](https://github.com/nix-community/NUR/commit/222cc78435a2a102896f9046b36cde8dfb4b60a8) | `` automatic update `` |
| [`e1f8bce8`](https://github.com/nix-community/NUR/commit/e1f8bce8ff849c04bb5c94783705759a9cab29ba) | `` automatic update `` |