### PR TITLE
chore(flake/nur): `efb0edbd` -> `1d4f9183`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686195973,
-        "narHash": "sha256-9Lc+ylQsCfYermsP3yw3mAYP1mTABBldw7YY30H4uKw=",
+        "lastModified": 1686203102,
+        "narHash": "sha256-pTDlrXulN/C1AoVZGLveo6zBso9rtEXQsHOsn+0Z4EU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "efb0edbd3e16f1023733b8b910b582dbb5cc7704",
+        "rev": "1d4f91838bd518224f079c531be86a7b77161015",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1d4f9183`](https://github.com/nix-community/NUR/commit/1d4f91838bd518224f079c531be86a7b77161015) | `` automatic update `` |
| [`ac87f967`](https://github.com/nix-community/NUR/commit/ac87f96747c202384ad2c5a41ee8101e98c178a4) | `` automatic update `` |