### PR TITLE
chore(flake/pre-commit-hooks): `6881eb2a` -> `182af512`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -866,11 +866,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1686050334,
-        "narHash": "sha256-R0mczWjDzBpIvM3XXhO908X5e2CQqjyh/gFbwZk/7/Q=",
+        "lastModified": 1686213770,
+        "narHash": "sha256-Re6xXLEqQ/HRnThryumyGzEf3Uv0Pl4cuG50MrDofP8=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "6881eb2ae5d8a3516e34714e7a90d9d95914c4dc",
+        "rev": "182af51202998af5b64ddecaa7ff9be06425399b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`d64b4d64`](https://github.com/cachix/pre-commit-hooks.nix/commit/d64b4d64e56fd1fcabb71b97ab54c6dcc36da3a5) | `` Add pyupgrade `` |