### PR TITLE
chore(flake/nur): `dd2b073a` -> `86efb50c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686210105,
-        "narHash": "sha256-hA1NWUCfZHmZcUaLP7R8rDHp4ssZI1CbreGMol5vKqM=",
+        "lastModified": 1686213906,
+        "narHash": "sha256-/DawKeaRsY68K6r7E1fSg2e7SsRHBgzaZ21KcGdNDVk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd2b073a0d02c76e1b22d6f017675522464642fb",
+        "rev": "86efb50c53d78df2030f789f4c9b323b775c2fb6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`86efb50c`](https://github.com/nix-community/NUR/commit/86efb50c53d78df2030f789f4c9b323b775c2fb6) | `` automatic update `` |