### PR TITLE
chore(flake/nixos-hardware): `4cc688ee` -> `e4b34b90`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -597,11 +597,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1684899633,
-        "narHash": "sha256-NtwerXX8UFsoNy6k+DukJMriWtEjQtMU/Urbff2O2Dg=",
+        "lastModified": 1686217350,
+        "narHash": "sha256-Nb9b3m/GEK8jyFsYfUkXGsqj6rH05GgJ2QWcNNbK7dw=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "4cc688ee711159b9bcb5a367be44007934e1a49d",
+        "rev": "e4b34b90f27696ec3965fa15dcbacc351293dc67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`cacf82c2`](https://github.com/NixOS/nixos-hardware/commit/cacf82c2b13d9bebe9b37df508385207a35001fb) | `` starfive visionfive2: u-boot: update to SDK version v3.0.4 `` |
| [`468a7a10`](https://github.com/NixOS/nixos-hardware/commit/468a7a108108908c7a35d6549f1e1f0236a9448a) | `` lenovo-thinkpad-x1-6th-gen: swap throttled with thermald ``   |
| [`61509d05`](https://github.com/NixOS/nixos-hardware/commit/61509d052c2c4444d66c5671ab5c3597e051eb1d) | `` build(deps): bump cachix/install-nix-action from 20 to 21 ``  |
| [`d569ff4f`](https://github.com/NixOS/nixos-hardware/commit/d569ff4fcf611a0205c7b5ffd6cf652f430b4d72) | `` Framework 12th gen: add keys workaround ``                    |