### PR TITLE
chore(flake/nur): `86efb50c` -> `c7aae32a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686213906,
-        "narHash": "sha256-/DawKeaRsY68K6r7E1fSg2e7SsRHBgzaZ21KcGdNDVk=",
+        "lastModified": 1686221903,
+        "narHash": "sha256-LdHC6APb7E9yHvA06YKnbSW1JbLgNxIsF9Gt5S9MnxM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "86efb50c53d78df2030f789f4c9b323b775c2fb6",
+        "rev": "c7aae32a5ad724fda11d58219399955acbaf629d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                          |
| -------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`c7aae32a`](https://github.com/nix-community/NUR/commit/c7aae32a5ad724fda11d58219399955acbaf629d) | `` automatic update ``           |
| [`58ba577e`](https://github.com/nix-community/NUR/commit/58ba577eb8aa01a370bd5bc5d558c06b3b8c3637) | `` automatic update ``           |
| [`03bbccbe`](https://github.com/nix-community/NUR/commit/03bbccbebb917c10ea43a1e4b1ab62961d8a7979) | `` automatic update ``           |
| [`d6e77bb2`](https://github.com/nix-community/NUR/commit/d6e77bb28a8ccb2eb113e08abc9b70a91a9722d2) | `` automatic update ``           |
| [`b575b90f`](https://github.com/nix-community/NUR/commit/b575b90fb59d2b226d070931ca389b90f5c5c4d8) | `` add onemoresuza repository `` |