### PR TITLE
chore(flake/nur): `c7aae32a` -> `22f50b84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686221903,
-        "narHash": "sha256-LdHC6APb7E9yHvA06YKnbSW1JbLgNxIsF9Gt5S9MnxM=",
+        "lastModified": 1686222498,
+        "narHash": "sha256-9oBA9OjS9UMYFNLHDEIHUU69gFPt4XkR0hjVVKks0fQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c7aae32a5ad724fda11d58219399955acbaf629d",
+        "rev": "22f50b848822fabed3c75cc12c8e38472df306c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`22f50b84`](https://github.com/nix-community/NUR/commit/22f50b848822fabed3c75cc12c8e38472df306c7) | `` automatic update `` |