### PR TITLE
chore(flake/nur): `c5baf349` -> `2fb3e7c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686271593,
-        "narHash": "sha256-AWyIlgrjWQ/JqdaCfeV0nyw2uX/x7JkOdn+WHhBRd/c=",
+        "lastModified": 1686282365,
+        "narHash": "sha256-HPjyeDRg+IfOKC0MvTnnMnp1vJ90i0oA9E/nLmg2eBA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c5baf3494e79f35e0b0cbab53eed994d29796ce2",
+        "rev": "2fb3e7c80c8cdd3af958b0067c628176e8c66764",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2fb3e7c8`](https://github.com/nix-community/NUR/commit/2fb3e7c80c8cdd3af958b0067c628176e8c66764) | `` automatic update `` |
| [`8a57b975`](https://github.com/nix-community/NUR/commit/8a57b975bfb98363e7a01e52b74d6c861413a4fc) | `` automatic update `` |