### PR TITLE
chore(flake/nur): `2fb3e7c8` -> `8692a69c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686282365,
-        "narHash": "sha256-HPjyeDRg+IfOKC0MvTnnMnp1vJ90i0oA9E/nLmg2eBA=",
+        "lastModified": 1686289365,
+        "narHash": "sha256-NhFI5JgL4e2EW8rNnJ5B8lBf0awZ3DtMqnhGuv5A8kc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2fb3e7c80c8cdd3af958b0067c628176e8c66764",
+        "rev": "8692a69c88fecbe83659ca4c82f87dbb1a37d5d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8692a69c`](https://github.com/nix-community/NUR/commit/8692a69c88fecbe83659ca4c82f87dbb1a37d5d6) | `` automatic update `` |
| [`eee1977d`](https://github.com/nix-community/NUR/commit/eee1977dd321197d23fbe376fe30dbe5e0a4535b) | `` automatic update `` |