### PR TITLE
chore(flake/home-manager): `69bdd6de` -> `2bbfc3a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686265146,
-        "narHash": "sha256-w5RtAG37rqcfqVWEQrJGUvZnUjt/BKdGvf+3XAw09ps=",
+        "lastModified": 1686265152,
+        "narHash": "sha256-ArdPMx2G2rWlnGlqfIV+efTKXcN7F3W0/b5XKYq7n8E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "69bdd6de50df2082901d94dbf70ecb762d8b636c",
+        "rev": "2bbfc3a78afb4ea60345a5660d8d4173da66c884",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`2bbfc3a7`](https://github.com/nix-community/home-manager/commit/2bbfc3a78afb4ea60345a5660d8d4173da66c884) | `` Translate using Weblate (Russian) ``              |
| [`7d07f8b6`](https://github.com/nix-community/home-manager/commit/7d07f8b6f9db338dffa9b11e047bf82efa4ad696) | `` Translate using Weblate (Chinese (Simplified)) `` |