### PR TITLE
chore(flake/home-manager): `2bbfc3a7` -> `9b8ba302`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686265152,
-        "narHash": "sha256-ArdPMx2G2rWlnGlqfIV+efTKXcN7F3W0/b5XKYq7n8E=",
+        "lastModified": 1686304640,
+        "narHash": "sha256-x4+ueGW2Q+aPAmS1+5rmotS7e0WH2LTqIwJqExsF4+s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2bbfc3a78afb4ea60345a5660d8d4173da66c884",
+        "rev": "9b8ba302ff38fe25b4a30c7dcafeb26d0ef37f9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`9b8ba302`](https://github.com/nix-community/home-manager/commit/9b8ba302ff38fe25b4a30c7dcafeb26d0ef37f9d) | `` Clean up deprecated lib functions (#4068) `` |