### PR TITLE
chore(flake/nur): `c36f9cb7` -> `bd4e2d5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686296688,
-        "narHash": "sha256-UkjyiivHkQDnA1QqS0g9z9LV4YTW3PuMk3y3VRR28Mw=",
+        "lastModified": 1686311667,
+        "narHash": "sha256-KSaRjnosc+KpXbQf6aRe60Q9TNtgQrxexk0zov9eEag=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c36f9cb75e5a211c5544516724be3d672558ed7d",
+        "rev": "bd4e2d5eae3543a8bd6e6b0a333ea5d248640b77",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bd4e2d5e`](https://github.com/nix-community/NUR/commit/bd4e2d5eae3543a8bd6e6b0a333ea5d248640b77) | `` automatic update `` |
| [`c779f0f9`](https://github.com/nix-community/NUR/commit/c779f0f96adc3a00be2c22ad854e9931f1daad76) | `` automatic update `` |