### PR TITLE
chore(flake/nur): `17a218d2` -> `2c452052`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686314097,
-        "narHash": "sha256-gti9KHLDijZtwUvoCyh2xGYc6zQMw4l5h9b7uKJfwVg=",
+        "lastModified": 1686318396,
+        "narHash": "sha256-8d4k+IEI5Pd+bxXBUgNJvKz6blBtGyllCpPHuSlr8f8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "17a218d22e68ab0eff74e1681d412a24165f187c",
+        "rev": "2c452052aa3f3e366eaee797bffb382e173c6ac0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2c452052`](https://github.com/nix-community/NUR/commit/2c452052aa3f3e366eaee797bffb382e173c6ac0) | `` automatic update `` |