### PR TITLE
chore(flake/nur): `2c452052` -> `76c6c290`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686318396,
-        "narHash": "sha256-8d4k+IEI5Pd+bxXBUgNJvKz6blBtGyllCpPHuSlr8f8=",
+        "lastModified": 1686325526,
+        "narHash": "sha256-WasLskVCytYt/LoVNWqLiFYyi5LsRU489eRwWibWm4Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2c452052aa3f3e366eaee797bffb382e173c6ac0",
+        "rev": "76c6c290bf183142baf9fc103b964048adadf3be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`76c6c290`](https://github.com/nix-community/NUR/commit/76c6c290bf183142baf9fc103b964048adadf3be) | `` automatic update `` |