### PR TITLE
chore(flake/nur): `76c6c290` -> `cf0ea18a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686325526,
-        "narHash": "sha256-WasLskVCytYt/LoVNWqLiFYyi5LsRU489eRwWibWm4Y=",
+        "lastModified": 1686335420,
+        "narHash": "sha256-cXa50qlC/0f6Qt6TkvYkJCzFL6IvYY2ap1Pe4RkITE0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "76c6c290bf183142baf9fc103b964048adadf3be",
+        "rev": "cf0ea18ae83fe63ef80128862b8666892e617597",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cf0ea18a`](https://github.com/nix-community/NUR/commit/cf0ea18ae83fe63ef80128862b8666892e617597) | `` automatic update `` |