### PR TITLE
chore(flake/nur): `cf0ea18a` -> `59bf0846`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686335420,
-        "narHash": "sha256-cXa50qlC/0f6Qt6TkvYkJCzFL6IvYY2ap1Pe4RkITE0=",
+        "lastModified": 1686343483,
+        "narHash": "sha256-i7o8/1/8saCRNolXDjkaAldW7bwJxqbqiFDDxf5ZgSQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cf0ea18ae83fe63ef80128862b8666892e617597",
+        "rev": "59bf0846591e7a020d22d027d4c37c654e67f35b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`59bf0846`](https://github.com/nix-community/NUR/commit/59bf0846591e7a020d22d027d4c37c654e67f35b) | `` automatic update `` |
| [`7ea92f44`](https://github.com/nix-community/NUR/commit/7ea92f442e4f455cc99b6bf8061be48f7f3a7c66) | `` automatic update `` |
| [`f49bda93`](https://github.com/nix-community/NUR/commit/f49bda9309763a40d0b98c5b311fb8749f30e264) | `` automatic update `` |