### PR TITLE
chore(flake/home-manager): `1e5d741e` -> `000df987`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686305101,
-        "narHash": "sha256-xCgeI+uTKay3Ab3tMdP9m9flIJbFkRMKwRAmg5PQhJQ=",
+        "lastModified": 1686339152,
+        "narHash": "sha256-qb2mdIwZvK1vNhj5zxnx1iw28pn3Zt0F7SRpSXkOo5k=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1e5d741ea3f3290d7ac06a02ded24bfdc7aadb37",
+        "rev": "000df987957b459b4e3de9e8977f95028e627424",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`000df987`](https://github.com/nix-community/home-manager/commit/000df987957b459b4e3de9e8977f95028e627424) | `` flake.lock: Update ``                           |
| [`e7fdcb40`](https://github.com/nix-community/home-manager/commit/e7fdcb40b2ddb79ed0b166e9694b361581c3dddb) | `` joshuto: add the joshuto file manager ``        |
| [`301b3648`](https://github.com/nix-community/home-manager/commit/301b3648927c050b224daa90cb4a99e4329456f2) | `` maintainers: add rasmus-kirk as a maintainer `` |