### PR TITLE
chore(flake/nur): `59bf0846` -> `e5841550`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686343483,
-        "narHash": "sha256-i7o8/1/8saCRNolXDjkaAldW7bwJxqbqiFDDxf5ZgSQ=",
+        "lastModified": 1686348012,
+        "narHash": "sha256-4vMc0mutNHQi/LFC/g+rcWBqqOcMS933LcsOLrIY3d4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "59bf0846591e7a020d22d027d4c37c654e67f35b",
+        "rev": "e58415500b4bd030dabdfbd49f68116e8c258ae2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e5841550`](https://github.com/nix-community/NUR/commit/e58415500b4bd030dabdfbd49f68116e8c258ae2) | `` automatic update `` |
| [`aa3eed54`](https://github.com/nix-community/NUR/commit/aa3eed5432264e47084272aa9f679ec8aaa795ea) | `` automatic update `` |