### PR TITLE
chore(flake/nur): `17adbe15` -> `94670037`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686349691,
-        "narHash": "sha256-IjxxBHkOsuBVgAHyI3mEPE6yREZR5gh2L8gtxOGAcKg=",
+        "lastModified": 1686357655,
+        "narHash": "sha256-K82UgASvAwRyt/K4K4AjidhXU6+PuDD/RB/NTtWo6hk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "17adbe15cc3ae64e3f20ab8707c930994140bfd2",
+        "rev": "94670037fe84717a161034b5f5d70836826d6ac7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`94670037`](https://github.com/nix-community/NUR/commit/94670037fe84717a161034b5f5d70836826d6ac7) | `` automatic update `` |