### PR TITLE
chore(flake/nixos-hardware): `e4b34b90` -> `2a807ad6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -701,11 +701,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1686217350,
-        "narHash": "sha256-Nb9b3m/GEK8jyFsYfUkXGsqj6rH05GgJ2QWcNNbK7dw=",
+        "lastModified": 1686452266,
+        "narHash": "sha256-zLKiX0iu6jZFeZDpR1gE6fNyMr8eiM8GLnj9SoUCjFs=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e4b34b90f27696ec3965fa15dcbacc351293dc67",
+        "rev": "2a807ad6e8dc458db08588b78cc3c0f0ec4ff321",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`a2ca907b`](https://github.com/NixOS/nixos-hardware/commit/a2ca907b42e713fa3c5416fac4f2dd161cfa48d5) | `` lenovo-thinkpad-x1-nano-gen1: init ``                |
| [`cc942923`](https://github.com/NixOS/nixos-hardware/commit/cc942923915d500c83822b72edef50b6c649ab35) | `` starfive visionfive2: Add firmware update script. `` |
| [`54cc1a6c`](https://github.com/NixOS/nixos-hardware/commit/54cc1a6c79dd2cdb7698816cb2d40e257f2939d3) | `` hp.14-df0023: init ``                                |