### PR TITLE
chore(flake/nix-index-database): `669ca1f2` -> `7e83b70f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -660,11 +660,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685764721,
-        "narHash": "sha256-CIy1iwQTEKfZRrid4gBLA+r/LPGA9IUFo0lKJVyECGI=",
+        "lastModified": 1686574167,
+        "narHash": "sha256-hxE8z+S9E4Qw03D2VQRaJUmj9zep3FvhKz316JUZuPA=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "669ca1f2e2bc401abab6b837ae9c51503edc9b49",
+        "rev": "7e83b70f31f4483c07e6939166cb667ecb8d05d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`7e83b70f`](https://github.com/Mic92/nix-index-database/commit/7e83b70f31f4483c07e6939166cb667ecb8d05d5) | `` update packages.nix to release 2023-06-12-124826 `` |
| [`cd017305`](https://github.com/Mic92/nix-index-database/commit/cd017305c32fbaa80524414d2df42eb327dabe05) | `` drop i686-linux from ci ``                          |
| [`6bf1f559`](https://github.com/Mic92/nix-index-database/commit/6bf1f5593f768be3a6f3c86b256fa5e723b8155a) | `` enable swap to avoid oom ``                         |