### PR TITLE
chore(flake/attic): `b1fb790b` -> `4fedffe6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -55,11 +55,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1685309025,
-        "narHash": "sha256-pZxMM3AMP/ojwhrFD0A2ML4NOgehlBLGHseInnO5evc=",
+        "lastModified": 1686620679,
+        "narHash": "sha256-Ck/r3f+W9mOn3cHn5ii/fogBiJtosFnDaOQveaJ0zVU=",
         "owner": "zhaofengli",
         "repo": "attic",
-        "rev": "b1fb790b5f2afaaa1b2f7f18979b8318abe604bb",
+        "rev": "4fedffe6a1020edfcfa7bef18d21321d4983b3a7",
         "type": "github"
       },
       "original": {
@@ -715,11 +715,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685012353,
-        "narHash": "sha256-U3oOge4cHnav8OLGdRVhL45xoRj4Ppd+It6nPC9nNIU=",
+        "lastModified": 1686519857,
+        "narHash": "sha256-VkBhuq67aXXiCoEmicziuDLUPPjeOTLQoj6OeVai5zM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aeb75dba965e790de427b73315d5addf91a54955",
+        "rev": "6b1b72c0f887a478a5aac355674ff6df0fc44f44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                                                            |
| ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`4fedffe6`](https://github.com/zhaofengli/attic/commit/4fedffe6a1020edfcfa7bef18d21321d4983b3a7) | `` attic: Build binding with C++20 ``                                              |
| [`564b4be0`](https://github.com/zhaofengli/attic/commit/564b4be0f90ae5f9a524521e17a8b5ff0327f43a) | `` Update sea-orm to 0.11.3 ``                                                     |
| [`ebb13b6e`](https://github.com/zhaofengli/attic/commit/ebb13b6e6f89e3f15680ca03936948c2cf909eaf) | `` Update nixpkgs ``                                                               |
| [`71a5580d`](https://github.com/zhaofengli/attic/commit/71a5580d17aa3ced0a446c5974dd9ca2f012f909) | `` Work around https://github.com/NixOS/nix/pull/8484 ``                           |
| [`5ca98fba`](https://github.com/zhaofengli/attic/commit/5ca98fbaa8adca2fe69fd12bb537dc10a7f75d42) | `` Drop bindgen and specialize hash handling ``                                    |
| [`552120a6`](https://github.com/zhaofengli/attic/commit/552120a68a79f086492b3f663421153c1e672c53) | `` fix: writing config does not truncate (#55) ``                                  |
| [`2568e6df`](https://github.com/zhaofengli/attic/commit/2568e6df7a24f5187a3ca21e640c13fb74ec07a6) | `` crane.nix: Suppress warning of missing version attribute in Cargo.toml (#53) `` |