### PR TITLE
chore(flake/agenix-rekey): `6ee1548c` -> `787efa41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,11 +33,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686354959,
-        "narHash": "sha256-eL06GIQowJ6GnXvjaHkpzZoTosaIyXQNJ/jXiI2nhdU=",
+        "lastModified": 1686617801,
+        "narHash": "sha256-fXNOCYjuFL4427jRW9C5xdc7KSJKhoFxXbBrxE3kibU=",
         "owner": "oddlama",
         "repo": "agenix-rekey",
-        "rev": "6ee1548ca52afd17748c36c4c2829bcf832d7b43",
+        "rev": "787efa41f1611403320517bbd41cd7cb7ebdf93d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                    |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`787efa41`](https://github.com/oddlama/agenix-rekey/commit/787efa41f1611403320517bbd41cd7cb7ebdf93d) | `` fix: remove unnecessary dependency on resulting derivations ``                          |
| [`cd77cb3b`](https://github.com/oddlama/agenix-rekey/commit/cd77cb3bd43ece5b5fb1517d4b32338ac3cc5798) | `` fix: correctly determine host parameter for generator scripts ``                        |
| [`4c01269e`](https://github.com/oddlama/agenix-rekey/commit/4c01269e9177e71f536dfe95a0cf21bedc58f797) | `` feat: add --dummy rekeying mode and --show-out-paths to target resulting derivations `` |