### PR TITLE
chore(flake/home-manager): `0945875a` -> `b01eb1eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -528,11 +528,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686342731,
-        "narHash": "sha256-GwCwviXcc5nrewuFwtsrxys8srrZcI+m8hdIGOt+fHY=",
+        "lastModified": 1686604884,
+        "narHash": "sha256-AkfxSmGGvNMtyXt1us9Lm8cMeIwqxpkSTeNeBQ00SL8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0945875a2a20de314093b0f9d4d5448e9b4fdccb",
+        "rev": "b01eb1eb3b579c74e6a4189ef33cc3fa24c40613",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`b01eb1eb`](https://github.com/nix-community/home-manager/commit/b01eb1eb3b579c74e6a4189ef33cc3fa24c40613) | `` Add infrastructure for contacts and calendars (#4078) ``     |
| [`9e37a1b6`](https://github.com/nix-community/home-manager/commit/9e37a1b6f9507ed27080518ff4007988a50c957e) | `` programs.joshuto: add the joshuto file manager (#4004) ``    |
| [`b0cdae4e`](https://github.com/nix-community/home-manager/commit/b0cdae4e9baa188d69ba84aa1b7406b7bebe37f6) | `` browserpass: test on Darwin again (#4081) ``                 |
| [`0144ac41`](https://github.com/nix-community/home-manager/commit/0144ac418ef633bfc9dbd89b8c199ad3a617c59f) | `` sway: add support for XDG autostart using systemd (#3747) `` |