### PR TITLE
chore(flake/nur): `94670037` -> `875deba7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -921,11 +921,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686357655,
-        "narHash": "sha256-K82UgASvAwRyt/K4K4AjidhXU6+PuDD/RB/NTtWo6hk=",
+        "lastModified": 1686634533,
+        "narHash": "sha256-YszZkcJfhQL3m2zBNT8hLpA+DNCcVxSHK2/3jNa9EMY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "94670037fe84717a161034b5f5d70836826d6ac7",
+        "rev": "875deba73f2360a885d1b81c3d88218bce4c1230",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                      |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`875deba7`](https://github.com/nix-community/NUR/commit/875deba73f2360a885d1b81c3d88218bce4c1230) | `` automatic update ``                       |
| [`94fef868`](https://github.com/nix-community/NUR/commit/94fef86877519157112e10809689b3ae9c2738c2) | `` automatic update ``                       |
| [`11dc864d`](https://github.com/nix-community/NUR/commit/11dc864ddc780c726f04ac32b1dd92c259ee1da0) | `` automatic update ``                       |
| [`f973cec0`](https://github.com/nix-community/NUR/commit/f973cec0cd5fd99923da6f35e38ea26eb0965d5f) | `` automatic update ``                       |
| [`8a56420f`](https://github.com/nix-community/NUR/commit/8a56420fd7b87827e272556909b7301420008db7) | `` automatic update ``                       |
| [`06ada973`](https://github.com/nix-community/NUR/commit/06ada9731059fffb363ee259c62db475380745e6) | `` automatic update ``                       |
| [`2fbf73d8`](https://github.com/nix-community/NUR/commit/2fbf73d8c8cd9c113508a4539a12007cb6c8df53) | `` automatic update ``                       |
| [`34a8bfdf`](https://github.com/nix-community/NUR/commit/34a8bfdf3f1cc701ecca0e0f3fa02717269a41c4) | `` automatic update ``                       |
| [`6c540d9a`](https://github.com/nix-community/NUR/commit/6c540d9af3c5df7b92c6621bd96ee4137be41e5d) | `` automatic update ``                       |
| [`a53e1f50`](https://github.com/nix-community/NUR/commit/a53e1f5030fd20c60e8e308b1ad479c707c3d369) | `` automatic update ``                       |
| [`b7cd60c7`](https://github.com/nix-community/NUR/commit/b7cd60c7b638706d99bda1568edc8acb675fa0a3) | `` automatic update ``                       |
| [`abcd99cc`](https://github.com/nix-community/NUR/commit/abcd99cc8e2d042ca48cf71c4fa16fa0e1c91d2f) | `` automatic update ``                       |
| [`6ad25ba8`](https://github.com/nix-community/NUR/commit/6ad25ba83c8ffa16a274980571f79d3e368a1940) | `` automatic update ``                       |
| [`31b3aaf9`](https://github.com/nix-community/NUR/commit/31b3aaf9110f1c0642fac00fc1cd4440700eda2d) | `` automatic update ``                       |
| [`d146b05e`](https://github.com/nix-community/NUR/commit/d146b05e972bcad19d5dd4369b589daa65f92dfb) | `` automatic update ``                       |
| [`61042561`](https://github.com/nix-community/NUR/commit/6104256148c9bd0be783d37af66dceee70686d61) | `` automatic update ``                       |
| [`d3e28dec`](https://github.com/nix-community/NUR/commit/d3e28dec6aba3f8a406b846445636ad4c242778a) | `` automatic update ``                       |
| [`565165b7`](https://github.com/nix-community/NUR/commit/565165b765982830f99b05959092f51491c7e8a6) | `` automatic update ``                       |
| [`3a8d0a9b`](https://github.com/nix-community/NUR/commit/3a8d0a9bc840311a7f860e6d9575b137c0830285) | `` automatic update ``                       |
| [`e182190d`](https://github.com/nix-community/NUR/commit/e182190dfbadc1e72615201404548a1a0b70f921) | `` automatic update ``                       |
| [`21af7dc4`](https://github.com/nix-community/NUR/commit/21af7dc45dff79795796161503fae6d9cc40f809) | `` automatic update ``                       |
| [`d5d81b26`](https://github.com/nix-community/NUR/commit/d5d81b26c82b80b05d5d64c442b79fb45428cb00) | `` automatic update ``                       |
| [`e63c8dab`](https://github.com/nix-community/NUR/commit/e63c8dab750c58bb81bdba54b38f0080ff7ce438) | `` automatic update ``                       |
| [`0d3c8efa`](https://github.com/nix-community/NUR/commit/0d3c8efa0533f8a868b20ecc7d9954ad6452b857) | `` automatic update ``                       |
| [`bf20fd39`](https://github.com/nix-community/NUR/commit/bf20fd39704e093378009777fa4f90041b4fe1cc) | `` automatic update ``                       |
| [`bf56b346`](https://github.com/nix-community/NUR/commit/bf56b346d4a27bdf0237e827cddba93e9658399b) | `` automatic update ``                       |
| [`8b9e7ff6`](https://github.com/nix-community/NUR/commit/8b9e7ff6ca87aba69fc900e2bd2f380ff36db90d) | `` automatic update ``                       |
| [`46c244ec`](https://github.com/nix-community/NUR/commit/46c244ec901161db0195ef690b4f8224c565dbbb) | `` automatic update ``                       |
| [`6d01650c`](https://github.com/nix-community/NUR/commit/6d01650cc8f2447218a07c99c2c5fc087f14d8ae) | `` automatic update ``                       |
| [`319c01a3`](https://github.com/nix-community/NUR/commit/319c01a37a91362597f3f28bdaf26bd2b1a27714) | `` automatic update ``                       |
| [`312e17aa`](https://github.com/nix-community/NUR/commit/312e17aac9f113c744ce745f8e2e33664b3d45d9) | `` automatic update ``                       |
| [`daf7100b`](https://github.com/nix-community/NUR/commit/daf7100b6147114c5f0a68583ba50e15d82e9788) | `` automatic update ``                       |
| [`f1edfc2d`](https://github.com/nix-community/NUR/commit/f1edfc2d404e81d3e621f2d36fb2b7af98bee091) | `` automatic update ``                       |
| [`416eb10d`](https://github.com/nix-community/NUR/commit/416eb10d0850d5041169b70e57df91206f7a613d) | `` automatic update ``                       |
| [`708f8138`](https://github.com/nix-community/NUR/commit/708f8138a900f80f574af6344cbfbd1ca698f2ac) | `` automatic update ``                       |
| [`0e444eaa`](https://github.com/nix-community/NUR/commit/0e444eaa99504941847393f336a4e7165bc6587c) | `` automatic update ``                       |
| [`5a8ae87e`](https://github.com/nix-community/NUR/commit/5a8ae87eec20478fd39f3e0d8da9bb051b6bcb1d) | `` automatic update ``                       |
| [`9435a766`](https://github.com/nix-community/NUR/commit/9435a76653e623f242523b810231091ed4e4b7b4) | `` automatic update ``                       |
| [`b1e02c20`](https://github.com/nix-community/NUR/commit/b1e02c200550fd3291d6e1db16fc397ceca81ea5) | `` automatic update ``                       |
| [`af1aa3ec`](https://github.com/nix-community/NUR/commit/af1aa3ecd7e9b00fe6dac001d54a1afc37833a4f) | `` automatic update ``                       |
| [`3f744f60`](https://github.com/nix-community/NUR/commit/3f744f60a7b924ae20f6c7d61db5a22070893c5d) | `` automatic update ``                       |
| [`8f6b0bb7`](https://github.com/nix-community/NUR/commit/8f6b0bb72aa15e35afe0b26f6d376ffc3ae56569) | `` automatic update ``                       |
| [`012d2d97`](https://github.com/nix-community/NUR/commit/012d2d97f09d2eaa36fb8d83947b2dd9c61cf470) | `` automatic update ``                       |
| [`67ddc568`](https://github.com/nix-community/NUR/commit/67ddc5685459f3161462d04c39b643e75c72f341) | `` automatic update ``                       |
| [`1f32a440`](https://github.com/nix-community/NUR/commit/1f32a4406f8aa6f63e57b03dd21664eb36ba200e) | `` automatic update ``                       |
| [`f98c2f1c`](https://github.com/nix-community/NUR/commit/f98c2f1c540867470df7c084351de02d62f8d208) | `` automatic update ``                       |
| [`eacb538d`](https://github.com/nix-community/NUR/commit/eacb538d43ac7a7707ecb0ede446fd503b945f78) | `` automatic update ``                       |
| [`1dd74ed8`](https://github.com/nix-community/NUR/commit/1dd74ed8fb466ade06a0290e59601a8224ac0e33) | `` automatic update ``                       |
| [`57ef994d`](https://github.com/nix-community/NUR/commit/57ef994d1b72a22dee57302400b462e2b10786c7) | `` automatic update ``                       |
| [`36065258`](https://github.com/nix-community/NUR/commit/3606525861d17e16cd9732e2f7b325e513d1b6f4) | `` automatic update ``                       |
| [`a9173a74`](https://github.com/nix-community/NUR/commit/a9173a74357e129d5a6dd43c8ba2637aad58c2a9) | `` automatic update ``                       |
| [`4bf801ba`](https://github.com/nix-community/NUR/commit/4bf801ba283395f1eedcb698f8aa4fcd6d847a98) | `` automatic update ``                       |
| [`4736a71c`](https://github.com/nix-community/NUR/commit/4736a71cd124fb04c0d486c73551ce9b9dcb97dc) | `` add Frankoslaw/nur-packages repository `` |
| [`8b7f428e`](https://github.com/nix-community/NUR/commit/8b7f428e311bfbc8c83c0e41f19c27f2a39e86b8) | `` automatic update ``                       |
| [`dab64617`](https://github.com/nix-community/NUR/commit/dab64617a2bc1d94418ce01ae8f8934ae7562123) | `` automatic update ``                       |
| [`58fcd707`](https://github.com/nix-community/NUR/commit/58fcd707f2882fd8c8e4d16a231ad3ea3d7c1ef3) | `` automatic update ``                       |
| [`90a61ce9`](https://github.com/nix-community/NUR/commit/90a61ce9985ef110249146e521dc57e236bcd2c8) | `` automatic update ``                       |
| [`cb14d840`](https://github.com/nix-community/NUR/commit/cb14d840a5ae86d7a6968df64803e710d63402a8) | `` automatic update ``                       |
| [`b1e22275`](https://github.com/nix-community/NUR/commit/b1e22275c88be32c631d7a3bc323eda924784e41) | `` automatic update ``                       |