### PR TITLE
chore(flake/nixpkgs): `2de8efef` -> `e74e6844`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -775,11 +775,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1689192006,
-        "narHash": "sha256-QM0f0d8oPphOTYJebsHioR9+FzJcy1QNIzREyubB91U=",
+        "lastModified": 1689282004,
+        "narHash": "sha256-VNhuyb10c9SV+3hZOlxwJwzEGytZ31gN9w4nPCnNvdI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2de8efefb6ce7f5e4e75bdf57376a96555986841",
+        "rev": "e74e68449c385db82de3170288a28cd0f608544f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`304ccf24`](https://github.com/NixOS/nixpkgs/commit/304ccf2486da4113c02002aa5bac6187f43c8d80) | `` hamsket: init at 0.6.5 ``                                                                      |
| [`f2dfcaea`](https://github.com/NixOS/nixpkgs/commit/f2dfcaea3b8ee300c3c73c5ae57445813baa836f) | `` maintainers: add nova-madeline ``                                                              |
| [`4a6f4b54`](https://github.com/NixOS/nixpkgs/commit/4a6f4b549b6e5297776673c22be1361c858e2bc0) | `` gdal: 3.6.4 -> 3.7.0 (#239458) ``                                                              |
| [`2733706d`](https://github.com/NixOS/nixpkgs/commit/2733706dd8c2316f9d5679edf20cb6e91cf852e9) | `` ameba: patch to build against crystal 1.9 ``                                                   |
| [`b619d1b2`](https://github.com/NixOS/nixpkgs/commit/b619d1b2387f9b7de723cf66919623fe4b7a818c) | `` metasploit: 6.3.23 -> 6.3.25 ``                                                                |
| [`0774c17a`](https://github.com/NixOS/nixpkgs/commit/0774c17a2f62d5fee4454928756d5821cecae1cf) | `` hugo: 0.115.0 -> 0.115.3 ``                                                                    |
| [`1f0b0a20`](https://github.com/NixOS/nixpkgs/commit/1f0b0a20967e26bad9cfb2fe9b2934957e95c455) | `` python311Packages.denonavr: 0.11.2 -> 0.11.3 ``                                                |
| [`2af881f1`](https://github.com/NixOS/nixpkgs/commit/2af881f117bcf427fe4af98935af2f793a1e4627) | `` python311Packages.pyunifiprotect: 4.10.4 -> 4.10.5 ``                                          |
| [`d7ea9f90`](https://github.com/NixOS/nixpkgs/commit/d7ea9f90caeb61b84e1bc4cc329f87c71dac1243) | `` openxr-loader: 1.0.27 -> 1.0.28 ``                                                             |
| [`34692813`](https://github.com/NixOS/nixpkgs/commit/34692813e8145074722a284aa13b6c3ed4892694) | `` libayatana-common: init at 0.9.8 ``                                                            |
| [`35ec55c8`](https://github.com/NixOS/nixpkgs/commit/35ec55c81382ed0744782ec0b09d1908fd281b17) | `` tunnelx: init at 2023-07-nix ``                                                                |
| [`bb77dc67`](https://github.com/NixOS/nixpkgs/commit/bb77dc6715ef381c9ed6ca333d48c0e291dc8a80) | `` jetbrains: update IDEs & plugins ``                                                            |
| [`72fa91b9`](https://github.com/NixOS/nixpkgs/commit/72fa91b9db07714a71bede2df1d1f447c6b65ea8) | `` openscad-lsp: init at 1.2.5 ``                                                                 |
| [`a72b8145`](https://github.com/NixOS/nixpkgs/commit/a72b814577bd4c7e588fb190260ca953ec8bf586) | `` prettierd: add darwin to supported platforms ``                                                |
| [`239cb251`](https://github.com/NixOS/nixpkgs/commit/239cb25136b19b7c92f832466a6a6f161d3b961e) | `` govulncheck: 0.2.0 -> 1.0.0 ``                                                                 |
| [`df1eee2a`](https://github.com/NixOS/nixpkgs/commit/df1eee2aa65052a18121ed4971081576b25d6b5c) | `` nixos: show which files are related to "not applying GID/UID change" ``                        |
| [`7cec88e5`](https://github.com/NixOS/nixpkgs/commit/7cec88e50f4cea409c13c05eed63ae6f9cd7839b) | `` delly: enable openmp ``                                                                        |
| [`ae95c0d5`](https://github.com/NixOS/nixpkgs/commit/ae95c0d5a57143feb3aaac76aa694b906288c05d) | `` delly: refactor ``                                                                             |
| [`1bee79f9`](https://github.com/NixOS/nixpkgs/commit/1bee79f9f7c4a66ac144944f72a02c2e14bd931b) | `` nixos/swap: make sure all kernel modules are loaded before creating swap devices. (#239163) `` |
| [`8e083bb9`](https://github.com/NixOS/nixpkgs/commit/8e083bb9650cd1be3917e2e99a348e9ac6b51a19) | `` maintainers: add c-h-johnson ``                                                                |
| [`b2c1b176`](https://github.com/NixOS/nixpkgs/commit/b2c1b176d902477a623f3e7b99e2cf8900b0ea06) | `` nixos/nullmailer: allow users in the nullmailer group to send mails ``                         |
| [`61be2ca1`](https://github.com/NixOS/nixpkgs/commit/61be2ca18aa99609194a4589983a4f3747e38033) | `` delly: enable darwin support ``                                                                |
| [`315d1001`](https://github.com/NixOS/nixpkgs/commit/315d1001133a8bd8d0f998a497f8bc4b8eb15012) | `` boost17x, boost18x: remove aliases ``                                                          |
| [`f1ec4348`](https://github.com/NixOS/nixpkgs/commit/f1ec43484888381b64ae3d0874621103d1d37bb5) | `` pkgs/tools/misc: remove dead code ``                                                           |
| [`9d6cd347`](https://github.com/NixOS/nixpkgs/commit/9d6cd34766b6144db476cc3a94fd41d6a714122c) | `` esdm: init at 0.6.0 ``                                                                         |
| [`4d06b437`](https://github.com/NixOS/nixpkgs/commit/4d06b4373c62596f7bfad6cc037ebe3cf52e6d65) | `` add thillux to maintainer list ``                                                              |
| [`e3db2a39`](https://github.com/NixOS/nixpkgs/commit/e3db2a39c2c8982edc16a19650f578f2cd223748) | `` add orichter as maintainer ``                                                                  |
| [`9154d24a`](https://github.com/NixOS/nixpkgs/commit/9154d24a2ef605474ca70b11006f4755d614f4bc) | `` cargo-temp: 0.2.16 -> 0.2.17 ``                                                                |
| [`302bd003`](https://github.com/NixOS/nixpkgs/commit/302bd003d0e00f3f39be6f3dd54413f36cb81702) | `` jql: 7.0.0 -> 7.0.1 ``                                                                         |
| [`57071b60`](https://github.com/NixOS/nixpkgs/commit/57071b60fee67313a8ab1b9b44210a0491fafb94) | `` cups: add xdg-open as dependency package as substitution does not work ``                      |
| [`75d49ecf`](https://github.com/NixOS/nixpkgs/commit/75d49ecfa9dd55024c56d504601dd4d17b474028) | `` emacsPackages.ebuild-mode: 1.64 -> 1.65 ``                                                     |
| [`6b8186f4`](https://github.com/NixOS/nixpkgs/commit/6b8186f4050d61f774bb4a6c61fcd72c1a07069a) | `` nextcloud24: remove unused patch ``                                                            |
| [`bb3afd3b`](https://github.com/NixOS/nixpkgs/commit/bb3afd3b3a2ac8dbcf7a4e6c9cf8a084aadf7d03) | `` python310Packages.transformers: add myself as maintainer ``                                    |
| [`85ff2d1a`](https://github.com/NixOS/nixpkgs/commit/85ff2d1a26931af55a228d0da0aff0b1c31d23b2) | `` python310Packages.transformers: 4.28.1 -> 4.30.2 ``                                            |
| [`99ff4316`](https://github.com/NixOS/nixpkgs/commit/99ff431682691bba1ed8bd5b6fdaa56b78456ddc) | `` lefthook: 1.4.3 -> 1.4.4 ``                                                                    |
| [`a74f5842`](https://github.com/NixOS/nixpkgs/commit/a74f58421669087c1420d52b732b519af9430747) | `` python310Packages.griffe: 0.31.0 -> 0.32.0 ``                                                  |
| [`112dc821`](https://github.com/NixOS/nixpkgs/commit/112dc82132bb1a70241685c63efedbd642ea8003) | `` mawk: 1.3.4-20230203 -> 1.3.4-20230525 ``                                                      |
| [`3cf59a3c`](https://github.com/NixOS/nixpkgs/commit/3cf59a3c25bf923e054913aa5bbdec3c2f6710f7) | `` gleam: 0.29.0 -> 0.30.0 ``                                                                     |
| [`a8efd663`](https://github.com/NixOS/nixpkgs/commit/a8efd663ed7482a435ebd5518d4415829bba2a14) | `` rng-tools: increase initialization robustness together with jitterentropy-3.4.1 ``             |
| [`030b2f24`](https://github.com/NixOS/nixpkgs/commit/030b2f2457d4d7941b1dfb2c30858b1ad206e53f) | `` cri-tools: 1.27.0 -> 1.27.1 ``                                                                 |
| [`1547a6c4`](https://github.com/NixOS/nixpkgs/commit/1547a6c4a802ea04ec4f17a046c9403482de4f34) | `` jitterentropy: disable upstream install strip ``                                               |
| [`f60a3a00`](https://github.com/NixOS/nixpkgs/commit/f60a3a000440cd28dad8575675e3064fb9e44520) | `` jitterentropy: 3.3.1 -> 3.4.1 ``                                                               |
| [`b412ff87`](https://github.com/NixOS/nixpkgs/commit/b412ff87116b930e54da8cac218282d73c1fd309) | `` uhk-agent: 2.1.2 -> 3.0.0 ``                                                                   |
| [`b91d403b`](https://github.com/NixOS/nixpkgs/commit/b91d403b324e799993283c8e571fc88747543bef) | `` pdfarranger: 1.9.2 -> 1.10.0 ``                                                                |
| [`1128a666`](https://github.com/NixOS/nixpkgs/commit/1128a6668a27668a7d2799ebdc9e31e3ea3f727f) | `` terraform: 1.5.2 -> 1.5.3 (#243204) ``                                                         |
| [`eaeb62a8`](https://github.com/NixOS/nixpkgs/commit/eaeb62a83a6dad9e4eb4e5451f67e970ec7fbcdc) | `` turbo: 1.8.8 -> 1.10.7 ``                                                                      |
| [`b6ce42c9`](https://github.com/NixOS/nixpkgs/commit/b6ce42c92816b6b23a220e1f208301cc67ef1044) | `` Revert "irrd: init at 4.2.6 (#210565)" (#242957) ``                                            |
| [`989e727d`](https://github.com/NixOS/nixpkgs/commit/989e727d9cbcf39fc367f1f4a1660f745fa1edbd) | `` python310Packages.pyserial-asyncio: enable on darwin ``                                        |
| [`060a3909`](https://github.com/NixOS/nixpkgs/commit/060a39096f18f634a190ae6ccfbebd77cbd787bc) | `` master_me: init at 1.2.0 ``                                                                    |
| [`a0741696`](https://github.com/NixOS/nixpkgs/commit/a0741696289966df4b4d938c5fb1792b2dd698a5) | `` cypress: update checksum ``                                                                    |
| [`847f0520`](https://github.com/NixOS/nixpkgs/commit/847f05202c60219201c46ea9794c26a09d043c5c) | `` bolliedelayxt.lv2: init at unstable-2017-11-02 ``                                              |
| [`c7b8e3d1`](https://github.com/NixOS/nixpkgs/commit/c7b8e3d1aeec79a0526f41276b8b24f57276a6bd) | `` ipcalc: set platforms ``                                                                       |
| [`714867a8`](https://github.com/NixOS/nixpkgs/commit/714867a88e406f54fdf8de7d2358c468c8637edb) | `` wezterm: 20230408-112425-69ae8472 -> 20230712-072601-f4abf8fd ``                               |
| [`7dc3a8a6`](https://github.com/NixOS/nixpkgs/commit/7dc3a8a6baa1c5a90b4be876c6637c5b6d624580) | `` etcd_3_4: 3.4.26 -> 3.4.27 ``                                                                  |
| [`7b619248`](https://github.com/NixOS/nixpkgs/commit/7b6192486b9a99a5ca6e9c6464d0d47af216df30) | `` terraform-providers.kubernetes: 2.21.1 -> 2.22.0 ``                                            |
| [`e5c6b9ae`](https://github.com/NixOS/nixpkgs/commit/e5c6b9aef360fd682350c061eaea4e67d3249dbe) | `` terraform-providers.vault: 3.17.0 -> 3.18.0 ``                                                 |
| [`17f18d54`](https://github.com/NixOS/nixpkgs/commit/17f18d54ba1b13d77100ff383103e1a6bec5fde6) | `` terraform-providers.tencentcloud: 1.81.13 -> 1.81.14 ``                                        |
| [`06f5d7dc`](https://github.com/NixOS/nixpkgs/commit/06f5d7dc9ed154ae0c71ff83bc87485bee6df04a) | `` terraform-providers.oci: 5.3.0 -> 5.4.0 ``                                                     |
| [`242f2656`](https://github.com/NixOS/nixpkgs/commit/242f2656714c48e11b28428b4dfc02fdccbe091a) | `` terraform-providers.pagerduty: 2.15.0 -> 2.15.1 ``                                             |
| [`2add3e02`](https://github.com/NixOS/nixpkgs/commit/2add3e02613eb286347af15262f0ee848876560b) | `` terraform-providers.ns1: 2.0.3 -> 2.0.4 ``                                                     |
| [`c92113ae`](https://github.com/NixOS/nixpkgs/commit/c92113aee809bb5d6304f91c5dc1a4bd77b5114a) | `` terraform-providers.newrelic: 3.25.1 -> 3.25.2 ``                                              |
| [`89982554`](https://github.com/NixOS/nixpkgs/commit/89982554cddd86e9dc6e4477f9415b9bad1ad34b) | `` terraform-providers.minio: 1.15.3 -> 1.16.0 ``                                                 |
| [`ab290749`](https://github.com/NixOS/nixpkgs/commit/ab29074976eab5eca691a13e0ff4bde62bb4f519) | `` terraform-providers.brightbox: 3.4.1 -> 3.4.2 ``                                               |
| [`4f49d9a5`](https://github.com/NixOS/nixpkgs/commit/4f49d9a5676317389c015fbb4eae15addbe65970) | `` terraform-providers.baiducloud: 1.19.8 -> 1.19.9 ``                                            |
| [`9f7d40f8`](https://github.com/NixOS/nixpkgs/commit/9f7d40f8ad7486a356d5f2a9e272050dfff02a2b) | `` terraform-providers.akamai: 5.0.0 -> 5.0.1 ``                                                  |
| [`8b8ebd4c`](https://github.com/NixOS/nixpkgs/commit/8b8ebd4cededb0e414d8c25660f48d9ce4093a0e) | `` doctl: 1.96.1 -> 1.97.0 ``                                                                     |
| [`502293e4`](https://github.com/NixOS/nixpkgs/commit/502293e4d83fec2d11d25bb2191b2d5b575615ee) | `` chart-testing: 3.8.0 -> 3.9.0 ``                                                               |
| [`c88c434c`](https://github.com/NixOS/nixpkgs/commit/c88c434c3428ec9f725139f3ffe8a48b2128af3c) | `` nixos/lemmy: Move pictrs url from pictrs_url to pictrs.url ``                                  |
| [`2bc5b801`](https://github.com/NixOS/nixpkgs/commit/2bc5b801824abf3734abadd2cb8ffc57896db913) | `` lemmy-ui: Set NODE_ENV to run server in production mode ``                                     |
| [`12c4e539`](https://github.com/NixOS/nixpkgs/commit/12c4e53900051e233c1806d8d52c6208eb3067c8) | `` scalafmt: 3.7.8 -> 3.7.9 ``                                                                    |
| [`6b2ead2d`](https://github.com/NixOS/nixpkgs/commit/6b2ead2d4b0ba210384f7c4a41004a9f58d1e986) | `` pachyderm: 2.6.4 -> 2.6.5 ``                                                                   |
| [`e481f126`](https://github.com/NixOS/nixpkgs/commit/e481f1267246467c66bf8899bd0b77ad9ba92cc0) | `` buck2: init at unstable-2023-07-11 ``                                                          |
| [`094e70df`](https://github.com/NixOS/nixpkgs/commit/094e70df9a9c0ceae496a78369c7078c53c3d5b8) | `` jackett: 0.21.455 -> 0.21.456 ``                                                               |
| [`bcc899ac`](https://github.com/NixOS/nixpkgs/commit/bcc899acda781ab3bc8bab3e6b36b2a6814341c2) | `` python310Packages.uptime-kuma-api: 1.0.1 -> 1.1.0 ``                                           |
| [`a4103f63`](https://github.com/NixOS/nixpkgs/commit/a4103f6371ba5002e79169af4084043e5a59f7ca) | `` ocenaudio: 3.12.2 -> 3.12.4 ``                                                                 |
| [`c14fb905`](https://github.com/NixOS/nixpkgs/commit/c14fb9056569df2526c50080bb1367dae7c63bcb) | `` lune: init at version 0.7.4 ``                                                                 |
| [`4a67411b`](https://github.com/NixOS/nixpkgs/commit/4a67411b612e2a3adfd3e9e3b3322d69ef36337e) | `` ipcalc: 1.0.2 -> 1.0.3 ``                                                                      |
| [`133ce96b`](https://github.com/NixOS/nixpkgs/commit/133ce96b4a2b47ea2951106e7cb55d0e50a79458) | `` bacula: 13.0.2 -> 13.0.3 ``                                                                    |
| [`431d5ccd`](https://github.com/NixOS/nixpkgs/commit/431d5ccdf53b23d1be373fd524d6cc12b8de1721) | `` sbt-extras: 2023-06-07 -> 2023-07-11 ``                                                        |
| [`75759fc1`](https://github.com/NixOS/nixpkgs/commit/75759fc11261a83096d3b7620a0637c20ad13262) | `` python310Packages.pipdeptree: 2.9.3 -> 2.9.5 ``                                                |
| [`8fc3dc8e`](https://github.com/NixOS/nixpkgs/commit/8fc3dc8ee817b7596e282b30b5809eb66cc1b683) | `` frigate: 0.12.0 -> 0.12.1 ``                                                                   |
| [`ab687c5a`](https://github.com/NixOS/nixpkgs/commit/ab687c5a30919c544a1e760c1bd56d0b658a0804) | `` openvino: 2022.3.0 -> 2023.0.0 ``                                                              |
| [`277cfaf3`](https://github.com/NixOS/nixpkgs/commit/277cfaf3287bb541a0b12fd00927ccb4a1fee583) | `` edwood: init at 0.3.1 ``                                                                       |
| [`fe857949`](https://github.com/NixOS/nixpkgs/commit/fe8579492b9c1a6baf62475ac42a1f82faecc1fa) | `` thunderbirdPackages.thunderbird-115: patch icu for issues with non-compliant VTIMEZONE ``      |
| [`79463da2`](https://github.com/NixOS/nixpkgs/commit/79463da2b71307a56df445848c49b5616552642d) | `` trealla: mark as broken on Apple Intel ``                                                      |
| [`f7d71db7`](https://github.com/NixOS/nixpkgs/commit/f7d71db720b2a0047e92a6f6be1add325bda5dc1) | `` trealla: circumvent valgrind brokenness ``                                                     |
| [`c1a92af3`](https://github.com/NixOS/nixpkgs/commit/c1a92af32523ff936a96f678a57bf060bee1dc36) | `` trealla: 2.8.6 -> 2.21.33 ``                                                                   |
| [`4e24f15f`](https://github.com/NixOS/nixpkgs/commit/4e24f15f9660618ce57307e3a10c9d41ec763982) | `` flmsg: 4.0.20 -> 4.0.22 ``                                                                     |
| [`d8115cda`](https://github.com/NixOS/nixpkgs/commit/d8115cdaecdd8d5b259c6cf102be7019f18b99f0) | `` difftastic: 0.47.0 -> 0.48.0 ``                                                                |
| [`6310ed0d`](https://github.com/NixOS/nixpkgs/commit/6310ed0dbb753e217f78d83c07e01e53792892bf) | `` runme: 1.4.0 -> 1.4.1 ``                                                                       |
| [`f8d47941`](https://github.com/NixOS/nixpkgs/commit/f8d47941a0d09c25444db02a29d8e96cc818662c) | `` go2rtc: 1.5.0 -> 1.6.0 ``                                                                      |
| [`f2120bc2`](https://github.com/NixOS/nixpkgs/commit/f2120bc2bb208d258b453274ca532bc082e6281c) | `` digikam: 8.0.0 -> 8.1.0 ``                                                                     |
| [`bb925cf7`](https://github.com/NixOS/nixpkgs/commit/bb925cf7e7a744cd5a62c739a405a44a219a3dba) | `` grpc_cli: 1.56.0 -> 1.56.1 ``                                                                  |
| [`53fb1757`](https://github.com/NixOS/nixpkgs/commit/53fb175766088d8f3c9053ab884d45264c13f76f) | `` fits-cloudctl: 0.11.10 -> 0.11.11 ``                                                           |
| [`e2b310a9`](https://github.com/NixOS/nixpkgs/commit/e2b310a9ca3e4f84e9cd2a5e8b1d5b9538cc46d2) | `` jfrog-cli: 2.40.0 -> 2.42.1 ``                                                                 |
| [`392e1ab3`](https://github.com/NixOS/nixpkgs/commit/392e1ab3237633e65827a1ac1bdde02526b42224) | `` python310Packages.async-lru: 2.0.2 -> 2.0.3 ``                                                 |
| [`7959a16c`](https://github.com/NixOS/nixpkgs/commit/7959a16c193defad974203063eeda635a42e569b) | `` nixos-option: use C++20 ``                                                                     |
| [`a27c5b52`](https://github.com/NixOS/nixpkgs/commit/a27c5b52b208f9124bc7eb6fe6ed32c2fd28e021) | `` python310Packages.approvaltests: 8.2.5 -> 8.3.1 ``                                             |
| [`20338eb8`](https://github.com/NixOS/nixpkgs/commit/20338eb8c17ac0b5b4c13c224252f84db83500ef) | `` clash-meta: clean obsoleted code ``                                                            |
| [`c54ad50a`](https://github.com/NixOS/nixpkgs/commit/c54ad50af9d6119fdba07b51e735a5ca6eb73b13) | `` python310Packages.gaphas: 3.11.2 -> 3.11.3 ``                                                  |
| [`27114a2c`](https://github.com/NixOS/nixpkgs/commit/27114a2c4ebf6f487acad34eb7803a069b0e4b7c) | `` felix-fm: 2.4.1 -> 2.5.0 ``                                                                    |
| [`5975c5a8`](https://github.com/NixOS/nixpkgs/commit/5975c5a8a73a8441030426634e20524418060751) | `` crystal: 1.8 -> 1.9 ``                                                                         |
| [`87508551`](https://github.com/NixOS/nixpkgs/commit/87508551d9d9b927ef3eee6745c1ef0b7d5011dc) | `` cypress: 12.16.0 -> 12.17.1 ``                                                                 |
| [`d5d080a2`](https://github.com/NixOS/nixpkgs/commit/d5d080a27f1f2fc9686f595c698d039575ff6a93) | `` python3Packages.pynvim-pp: unstable-2023-07-05 -> unstable-2023-07-09 ``                       |
| [`00ae8331`](https://github.com/NixOS/nixpkgs/commit/00ae83314299592887b167d6c3a36ee8d63c6a1d) | `` python3Packages.std2: unstable-2023-07-05 -> unstable-2023-07-09 ``                            |
| [`e2b56b13`](https://github.com/NixOS/nixpkgs/commit/e2b56b13b99bead70b23af7b575412bb0e41e7c9) | `` python310Packages.python-glanceclient: 4.3.0 -> 4.4.0 ``                                       |
| [`6fa9f01d`](https://github.com/NixOS/nixpkgs/commit/6fa9f01dfae5179d8397bb316780e4ca303e22e8) | `` jetbrains.plugins: update ``                                                                   |
| [`c5884349`](https://github.com/NixOS/nixpkgs/commit/c5884349c6bbd097cad26512c5beeb2c7411fb1f) | `` vscode-extensions.gleam.gleam: init at 2.3.0 ``                                                |
| [`3e543013`](https://github.com/NixOS/nixpkgs/commit/3e543013a5f4f14a6c16d71cd47a3e28701d80f4) | `` vintagestory: 1.18.5 -> 1.18.6 ``                                                              |
| [`59bcad89`](https://github.com/NixOS/nixpkgs/commit/59bcad89a1e1cb38b437fafbbdb643749a584e56) | `` nix-update: 0.18.0 -> 0.19.0 ``                                                                |
| [`633b9d6b`](https://github.com/NixOS/nixpkgs/commit/633b9d6bcf08f97bba63782e06bf3e905ddb278d) | `` python310Packages.cpyparsing: 2.4.7.1.2.1 -> 2.4.7.2.1.1 ``                                    |
| [`a2a5ea13`](https://github.com/NixOS/nixpkgs/commit/a2a5ea13c79173b25a4d209152de343253e065e7) | `` weechat: 4.0.1 -> 4.0.2 ``                                                                     |
| [`6fdf20b6`](https://github.com/NixOS/nixpkgs/commit/6fdf20b642025bace7a68454d81e3fb86689d04e) | `` ruff: 0.0.277 -> 0.0.278 ``                                                                    |
| [`84b777d9`](https://github.com/NixOS/nixpkgs/commit/84b777d9c18ac8fdfeb445c0a66d2e21248fddd7) | `` kyverno: 1.10.0 -> 1.10.1 ``                                                                   |
| [`f97ce0a9`](https://github.com/NixOS/nixpkgs/commit/f97ce0a9a807a4894ded0cc02d286eebd3a6f0eb) | `` pkgs/tools/security: remove dead code ``                                                       |
| [`d99fd3da`](https://github.com/NixOS/nixpkgs/commit/d99fd3da4a11806bcbf8d08b09e0908e51f63eb6) | `` fluxcd: 2.0.0 -> 2.0.1 ``                                                                      |
| [`05c850e6`](https://github.com/NixOS/nixpkgs/commit/05c850e6c36d2387fbc22aa770cbcf3583bd08c2) | `` jetbrains: 2023.1.3 -> 2023.1.4 ``                                                             |
| [`5962759f`](https://github.com/NixOS/nixpkgs/commit/5962759f75777de6ef231389361ac94daa5b7f93) | `` nixd: 1.1.0 -> 1.2.0 ``                                                                        |
| [`710613e5`](https://github.com/NixOS/nixpkgs/commit/710613e53936e3c740a4907a52f2ef10723f0a92) | `` qownnotes: 23.6.6 -> 23.7.1 ``                                                                 |
| [`9bab4d1f`](https://github.com/NixOS/nixpkgs/commit/9bab4d1fc9abdd81373bbfa4b5a8c5b891e1fc40) | `` odo: 3.11.0 -> 3.12.0 ``                                                                       |
| [`d5f8edee`](https://github.com/NixOS/nixpkgs/commit/d5f8edee62e4eeeb26a5eee9b656bb6095caf820) | `` python310Packages.findpython: 0.2.5 -> 0.3.0 ``                                                |
| [`f946b1f3`](https://github.com/NixOS/nixpkgs/commit/f946b1f36ee461168a03aae14839e5e640ce8bc2) | `` chamber: 2.13.1 -> 2.13.2 ``                                                                   |
| [`74a17210`](https://github.com/NixOS/nixpkgs/commit/74a17210816fd5ca0b08741d8d20db30dfa5b88b) | `` python311Packages.angr: 9.2.58 -> 9.2.59 ``                                                    |
| [`6ec941be`](https://github.com/NixOS/nixpkgs/commit/6ec941be105d69f2763cf6198e2a424998456cc2) | `` python311Packages.cle: 9.2.58 -> 9.2.59 ``                                                     |
| [`04c828f2`](https://github.com/NixOS/nixpkgs/commit/04c828f215fb8c3c2c5ef03524cb32297e558169) | `` python311Packages.claripy: 9.2.58 -> 9.2.59 ``                                                 |
| [`7bd0f4d0`](https://github.com/NixOS/nixpkgs/commit/7bd0f4d0539103287e47fff6063a4d2796248d50) | `` python311Packages.pyvex: 9.2.58 -> 9.2.59 ``                                                   |
| [`e7e84769`](https://github.com/NixOS/nixpkgs/commit/e7e847696fc0d7e9b1ada3b90a4b47f162811b18) | `` python311Packages.ailment: 9.2.58 -> 9.2.59 ``                                                 |
| [`4737e888`](https://github.com/NixOS/nixpkgs/commit/4737e88887544b13ae4f14d389e9772b6b548cb0) | `` python311Packages.archinfo: 9.2.58 -> 9.2.59 ``                                                |
| [`5ae99a1c`](https://github.com/NixOS/nixpkgs/commit/5ae99a1c60f09397024ddf21be32be67fc1724c8) | `` python310Packages.pytapo: 3.1.13 -> 3.1.18 ``                                                  |
| [`d47584da`](https://github.com/NixOS/nixpkgs/commit/d47584da4da48ba046af33489041dce3377bfbfc) | `` python311Packages.aliyun-python-sdk-iot: 8.53.0 -> 8.54.0 ``                                   |
| [`63b455e0`](https://github.com/NixOS/nixpkgs/commit/63b455e0921a3813164be6dd0069a695ee7a9a03) | `` python311Packages.oracledb: 1.3.1 -> 1.3.2 ``                                                  |
| [`a2b7d875`](https://github.com/NixOS/nixpkgs/commit/a2b7d875387e245300e3e4f8e6691f18cdcf9aa1) | `` ferdium: 6.3.0 -> 6.4.0 ``                                                                     |
| [`83a8e075`](https://github.com/NixOS/nixpkgs/commit/83a8e0753cc95246b2d24e65c50732df5ccc6da2) | `` python310Packages.kneed: 0.8.3 -> 0.8.5 ``                                                     |
| [`b8fa959a`](https://github.com/NixOS/nixpkgs/commit/b8fa959a62f5a465113fe962aaa62184f8647c61) | `` blackfire: 2.16.2 -> 2.17.0 ``                                                                 |
| [`8a99e2a7`](https://github.com/NixOS/nixpkgs/commit/8a99e2a7d12197e0fe3655096c078ac9f90eceea) | `` ocamlPackages.bitstring: 4.1.0 -> 4.1.1 ``                                                     |
| [`75a46589`](https://github.com/NixOS/nixpkgs/commit/75a465890e56439f27b54f5cbfaf307fbf4d9eff) | `` maintainer-list.nix: replace @vikanezrimaya's PGP keys ``                                      |
| [`5ecef292`](https://github.com/NixOS/nixpkgs/commit/5ecef29242fbf2cae6e9eb0d0e0dbc2f25466b77) | `` age-plugin-tpm: unstable-2023-05-02 -> 0.1.0 ``                                                |
| [`988661b6`](https://github.com/NixOS/nixpkgs/commit/988661b6a742313ac884e5f474d5c3f893b34e63) | `` librewolf: 115.0.1-1 -> 115.0.2-2 ``                                                           |
| [`207fb761`](https://github.com/NixOS/nixpkgs/commit/207fb761aebdff0a995384f6b1b3c654e94c768c) | `` wasm-tools: 1.0.35 -> 1.0.36 ``                                                                |