### PR TITLE
chore(flake/home-manager): `b01eb1eb` -> `d9a97e8b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -528,11 +528,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686604884,
-        "narHash": "sha256-AkfxSmGGvNMtyXt1us9Lm8cMeIwqxpkSTeNeBQ00SL8=",
+        "lastModified": 1686647276,
+        "narHash": "sha256-ic82o42F9EDAMgHoMwrIG8UuRejI7sSYgc77bYnwLcA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b01eb1eb3b579c74e6a4189ef33cc3fa24c40613",
+        "rev": "d9a97e8b33227a6086538ac2d3d1960b03ed940c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`d9a97e8b`](https://github.com/nix-community/home-manager/commit/d9a97e8b33227a6086538ac2d3d1960b03ed940c) | `` calendars: add missing modules (#4087) ``      |
| [`8da11353`](https://github.com/nix-community/home-manager/commit/8da1135365829e77fb5b17cfa4587860f306147f) | `` aerc: improve module (#3150) ``                |
| [`cbbceb48`](https://github.com/nix-community/home-manager/commit/cbbceb4894acb9750388e0cf535aa7a5663b207c) | `` offlineimap: Add package option (#4021) ``     |
| [`d437f0d4`](https://github.com/nix-community/home-manager/commit/d437f0d4e0f72fe76688142e954a4a9b61ac9833) | `` specialisation: fix path ``                    |
| [`c8dafb18`](https://github.com/nix-community/home-manager/commit/c8dafb187b7b010bf279a7bf0842eaadf3e387a8) | `` specialisation: renamed from specialization `` |