### PR TITLE
chore(flake/nur): `b9c688b5` -> `e8456a8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -886,11 +886,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686647763,
-        "narHash": "sha256-0vsU7rgNx7GRrENtfJHb7oOV0I8ayHnsYzbc0cZtxPA=",
+        "lastModified": 1686682568,
+        "narHash": "sha256-/bOf6hi3QSg87pHMcazKeM04Z/efAigkxbPEAy7G22g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b9c688b5384d1210b1fb6e82c1c81a608476a961",
+        "rev": "e8456a8e514c651031e510822891649a9ac86bf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e8456a8e`](https://github.com/nix-community/NUR/commit/e8456a8e514c651031e510822891649a9ac86bf2) | `` automatic update `` |
| [`2e9dbbc2`](https://github.com/nix-community/NUR/commit/2e9dbbc26c44bd1008f93e63380396500c04d7c0) | `` automatic update `` |
| [`81654452`](https://github.com/nix-community/NUR/commit/816544525127d756c65ace72c602332c708e0473) | `` automatic update `` |
| [`052dfe5c`](https://github.com/nix-community/NUR/commit/052dfe5c3ecc78c24eaf615ab5e1a2f1a99718c3) | `` automatic update `` |