### PR TITLE
chore(flake/stylix): `7bcf3ce6` -> `0015e563`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1017,11 +1017,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686044491,
-        "narHash": "sha256-AX+iGW94aEXJDVog9oR7sejDbnEnK9JFqxuZ7luS2eI=",
+        "lastModified": 1686685523,
+        "narHash": "sha256-xE9y9IA6Vu1Qnhw+xf8wStUugt+WsWaGySj/OyDf7gM=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "7bcf3ce6c9e9225e87d4e3b0c2e7d27a39954c02",
+        "rev": "0015e56326ede9857a074ad2f442e7f86fc7b233",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                        |
| --------------------------------------------------------------------------------------------- | ------------------------------ |
| [`0015e563`](https://github.com/danth/stylix/commit/0015e56326ede9857a074ad2f442e7f86fc7b233) | `` Create style guide (#90) `` |