### PR TITLE
chore(flake/nur): `b6cfdb64` -> `c3677b05`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -886,11 +886,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686685543,
-        "narHash": "sha256-84fmoTO7yBn2GYG7vWM/wCV7yS3Z0PYdnWj1cOvvwLI=",
+        "lastModified": 1686696247,
+        "narHash": "sha256-gZL5rk1iySrvKbdw8NU5BaSDWuWA5O7ZWw+j+vxXjc4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b6cfdb6488f02ea5bcecf4bea2cbed8f134c5481",
+        "rev": "c3677b051af4921de6e184749035d08859e4ed62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c3677b05`](https://github.com/nix-community/NUR/commit/c3677b051af4921de6e184749035d08859e4ed62) | `` automatic update `` |