### PR TITLE
chore(flake/nur): `6b707e0f` -> `f083000f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -886,11 +886,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686708010,
-        "narHash": "sha256-f5MKrMO0QajizAhPM/buBhxlZ2b2PzPPcdJd5tNSsqU=",
+        "lastModified": 1686714972,
+        "narHash": "sha256-Gl1F8O3JYKwwhF1BNfSL+kqIHsIbDqvcZAp7zZf/5Co=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6b707e0f7a4b7f92825e7cae1910145cad4fc3c2",
+        "rev": "f083000f41cf9c8c1ce7967af95fc3409028f37b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f083000f`](https://github.com/nix-community/NUR/commit/f083000f41cf9c8c1ce7967af95fc3409028f37b) | `` automatic update `` |
| [`b16089f6`](https://github.com/nix-community/NUR/commit/b16089f6b85ef849dd3f9d3f69a3bac548a6a40f) | `` automatic update `` |