### PR TITLE
chore(flake/emacs-plz): `4114e23d` -> `271d0aa8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
     "emacs-plz": {
       "flake": false,
       "locked": {
-        "lastModified": 1685464789,
-        "narHash": "sha256-HHNuETBMjdwsTdinXpMcnnlEEPHUVE8H5nIPcqfJcAY=",
+        "lastModified": 1686749837,
+        "narHash": "sha256-VWPbSLSNTPIoVOw6hRR1HvgPOEQxHLJumLOvsJ3SFoo=",
         "owner": "alphapapa",
         "repo": "plz.el",
-        "rev": "4114e23d88626a34c1189d48a63442f26472554d",
+        "rev": "271d0aa8e7d6b0575135a94fcb64af125e23323d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                   |
| ------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`271d0aa8`](https://github.com/alphapapa/plz.el/commit/271d0aa8e7d6b0575135a94fcb64af125e23323d) | `` Release: v0.6 ``                       |
| [`ecad562b`](https://github.com/alphapapa/plz.el/commit/ecad562bbdafca20ae9a2e4ce4067f660a8770ac) | `` Docs: (make-plz-queue :finally) ``     |
| [`bc6e745f`](https://github.com/alphapapa/plz.el/commit/bc6e745f523f6ddb187160953698b726530efb93) | `` Tidy: (plz-queue) Docstring ``         |
| [`da143a66`](https://github.com/alphapapa/plz.el/commit/da143a66dc41df709c2712b156d0704899a3a688) | `` Docs: Minor correction to changelog `` |