### PR TITLE
chore(flake/home-manager): `75b24cc5` -> `194086df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686724286,
-        "narHash": "sha256-TREhlFfPlaOisADxKotzVqHpHwQE1JLeDBqgw7ke5PM=",
+        "lastModified": 1686777974,
+        "narHash": "sha256-ih/KlrOMutdcnG33bZN/wS1cpwE3h1UEYmo1nEA6gFo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "75b24cc557d4947ab46691142863e5a5db5c3f78",
+        "rev": "194086df82d235919c1f8da68c4af2490d4675f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`194086df`](https://github.com/nix-community/home-manager/commit/194086df82d235919c1f8da68c4af2490d4675f9) | `` git-credential-oauth: add module ``          |
| [`32376992`](https://github.com/nix-community/home-manager/commit/32376992f7ef4d7ae76dda690de5b23725fd8300) | `` qt: add "kde" to qt.platformTheme (#4085) `` |