### PR TITLE
chore(flake/nur): `aca5cab5` -> `507b38b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -886,11 +886,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686767133,
-        "narHash": "sha256-ks267AW9llOoU0CigBMuXAr6QiED+bqliqnGRCLrLHI=",
+        "lastModified": 1686771980,
+        "narHash": "sha256-VlxiiXEEe9g8wfB//d0B/JVvWytvKgVXoKMYgIvRskw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aca5cab53cc88e7f19c9fc6f6cf31a7a4b3a4325",
+        "rev": "507b38b1a5d39ff8b1e634b804fbdefa4eeb0c1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`507b38b1`](https://github.com/nix-community/NUR/commit/507b38b1a5d39ff8b1e634b804fbdefa4eeb0c1b) | `` automatic update `` |