### PR TITLE
chore(flake/nur): `507b38b1` -> `259a335f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -886,11 +886,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686771980,
-        "narHash": "sha256-VlxiiXEEe9g8wfB//d0B/JVvWytvKgVXoKMYgIvRskw=",
+        "lastModified": 1686780750,
+        "narHash": "sha256-9A7I1pYYQSFWZjsq9d+Ut2lgpt99MyjeRMe5EslhYBw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "507b38b1a5d39ff8b1e634b804fbdefa4eeb0c1b",
+        "rev": "259a335fb00be9a08a080a29112b117377aaa459",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`259a335f`](https://github.com/nix-community/NUR/commit/259a335fb00be9a08a080a29112b117377aaa459) | `` automatic update `` |
| [`610d9329`](https://github.com/nix-community/NUR/commit/610d9329369fb576d65fdf152c3246b8d4f44543) | `` automatic update `` |
| [`6fdd2181`](https://github.com/nix-community/NUR/commit/6fdd218158c7546aa8f1f763e6fb4c5ab8aae5cb) | `` automatic update `` |