### PR TITLE
chore(flake/nur): `4911acd5` -> `53bdfe0d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -886,11 +886,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686800770,
-        "narHash": "sha256-rXbiagsrkz8rX0hujDEPU6UQNbdBwyjO2PjjF3Y+jo8=",
+        "lastModified": 1686807758,
+        "narHash": "sha256-0Kg2VqEZzrwZubTrtj+fu77F/IftkDH6ZESwe4ZXkfw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4911acd51405873163bb28f4621cb8051964730e",
+        "rev": "53bdfe0d57ba919516d99906d18db3a6f96b53f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`53bdfe0d`](https://github.com/nix-community/NUR/commit/53bdfe0d57ba919516d99906d18db3a6f96b53f2) | `` automatic update `` |
| [`cb119bb6`](https://github.com/nix-community/NUR/commit/cb119bb6ceee849d1a79f77f7d62302f4e83deb3) | `` automatic update `` |
| [`198346a4`](https://github.com/nix-community/NUR/commit/198346a481bb74d964305e35b3a9f8e1284ee609) | `` automatic update `` |