### PR TITLE
chore(flake/nixos-hardware): `2a807ad6` -> `429f232f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -666,11 +666,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1686452266,
-        "narHash": "sha256-zLKiX0iu6jZFeZDpR1gE6fNyMr8eiM8GLnj9SoUCjFs=",
+        "lastModified": 1686838567,
+        "narHash": "sha256-aqKCUD126dRlVSKV6vWuDCitfjFrZlkwNuvj5LtjRRU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "2a807ad6e8dc458db08588b78cc3c0f0ec4ff321",
+        "rev": "429f232fe1dc398c5afea19a51aad6931ee0fb89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                       |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`2ed58e3f`](https://github.com/NixOS/nixos-hardware/commit/2ed58e3fa29abb411dd921f15f820c4be1456bc4) | `` Removed extra overlay for kernel ``        |
| [`ba8b9209`](https://github.com/NixOS/nixos-hardware/commit/ba8b9209ce99b572b971678cb7f0341c2f20f518) | `` Add Microchip Icicle-kit board support. `` |