### PR TITLE
chore(flake/nur): `8034469d` -> `83e9b219`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -886,11 +886,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686839001,
-        "narHash": "sha256-RYyTnz4gjmoh5dcAT577rKh6Tm7esOtvr9f4xkt/zXg=",
+        "lastModified": 1686854693,
+        "narHash": "sha256-0SHF3+oRxFc41+Qm2lXqOEC6xqEdLt/nnGd6kffZmwA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8034469dea30dfe972d3c258958c019f62e63e4b",
+        "rev": "83e9b219e1b9e0844298d808e55d0253b8929b8e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`83e9b219`](https://github.com/nix-community/NUR/commit/83e9b219e1b9e0844298d808e55d0253b8929b8e) | `` automatic update `` |