### PR TITLE
chore(flake/nur): `83e9b219` -> `b3d13e35`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -886,11 +886,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686854693,
-        "narHash": "sha256-0SHF3+oRxFc41+Qm2lXqOEC6xqEdLt/nnGd6kffZmwA=",
+        "lastModified": 1686858300,
+        "narHash": "sha256-puBTBN6pJXAZ7oI2MHHyj+GCnipqZwTF9PvGtouBXKA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "83e9b219e1b9e0844298d808e55d0253b8929b8e",
+        "rev": "b3d13e358b2ec4caf73562492128a483b84970da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b3d13e35`](https://github.com/nix-community/NUR/commit/b3d13e358b2ec4caf73562492128a483b84970da) | `` automatic update `` |