### PR TITLE
chore(flake/nur): `b3d13e35` -> `1498ad60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -886,11 +886,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686858300,
-        "narHash": "sha256-puBTBN6pJXAZ7oI2MHHyj+GCnipqZwTF9PvGtouBXKA=",
+        "lastModified": 1686874978,
+        "narHash": "sha256-6TUr5FmCR2kxSi2oTaJusFqetl+q87ZYP8HSNuG0EoE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b3d13e358b2ec4caf73562492128a483b84970da",
+        "rev": "1498ad60804148486caed17adf19264fa957e331",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1498ad60`](https://github.com/nix-community/NUR/commit/1498ad60804148486caed17adf19264fa957e331) | `` automatic update `` |
| [`ff5efcd0`](https://github.com/nix-community/NUR/commit/ff5efcd0da72d0cd7e30c89fb5b57a70153f68b3) | `` automatic update `` |
| [`64f08c7f`](https://github.com/nix-community/NUR/commit/64f08c7f765fee382613f6c7f4daa0bfb4f48a20) | `` automatic update `` |