### PR TITLE
chore(flake/nur): `1498ad60` -> `336230a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -886,11 +886,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686874978,
-        "narHash": "sha256-6TUr5FmCR2kxSi2oTaJusFqetl+q87ZYP8HSNuG0EoE=",
+        "lastModified": 1686880757,
+        "narHash": "sha256-xYdhUYb2damS9PxhiD1Q3WkFCpTRwpTP6PZL72o4Pvk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1498ad60804148486caed17adf19264fa957e331",
+        "rev": "336230a182e401b84d2f4d77e66446cbbbfbf137",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`336230a1`](https://github.com/nix-community/NUR/commit/336230a182e401b84d2f4d77e66446cbbbfbf137) | `` automatic update `` |