### PR TITLE
chore(flake/nur): `336230a1` -> `b202bb7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -886,11 +886,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686880757,
-        "narHash": "sha256-xYdhUYb2damS9PxhiD1Q3WkFCpTRwpTP6PZL72o4Pvk=",
+        "lastModified": 1686884148,
+        "narHash": "sha256-IlQMLXVT0TkSUS5R32cKThlPSuF5OsrrzQRkOwF3mGE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "336230a182e401b84d2f4d77e66446cbbbfbf137",
+        "rev": "b202bb7af54f5b399df6d14ec5aa0914106a0bee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b202bb7a`](https://github.com/nix-community/NUR/commit/b202bb7af54f5b399df6d14ec5aa0914106a0bee) | `` automatic update `` |