### PR TITLE
chore(flake/nur): `b202bb7a` -> `b475ae0d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -886,11 +886,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686884148,
-        "narHash": "sha256-IlQMLXVT0TkSUS5R32cKThlPSuF5OsrrzQRkOwF3mGE=",
+        "lastModified": 1686887115,
+        "narHash": "sha256-Wt+XOLfqdlDVCz8i+sYanN1wd79uQmGZqwPgKgb62iI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b202bb7af54f5b399df6d14ec5aa0914106a0bee",
+        "rev": "b475ae0d9816ddc5365e6fde58c546b9d793165e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b475ae0d`](https://github.com/nix-community/NUR/commit/b475ae0d9816ddc5365e6fde58c546b9d793165e) | `` automatic update `` |