### PR TITLE
chore(flake/nur): `b475ae0d` -> `1c14e580`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -886,11 +886,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686887115,
-        "narHash": "sha256-Wt+XOLfqdlDVCz8i+sYanN1wd79uQmGZqwPgKgb62iI=",
+        "lastModified": 1686894171,
+        "narHash": "sha256-QyEdSgyOdSGM3kS6N/r+0i47VbeZI41OZik37ipkQBs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b475ae0d9816ddc5365e6fde58c546b9d793165e",
+        "rev": "1c14e580cdf9e778d76a15ff13d6d302da628a30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1c14e580`](https://github.com/nix-community/NUR/commit/1c14e580cdf9e778d76a15ff13d6d302da628a30) | `` automatic update `` |
| [`ecc758e6`](https://github.com/nix-community/NUR/commit/ecc758e68e90828690d621862ef4a3072e4982c6) | `` automatic update `` |