### PR TITLE
chore(flake/nur): `1c14e580` -> `c0573bc2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -886,11 +886,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686894171,
-        "narHash": "sha256-QyEdSgyOdSGM3kS6N/r+0i47VbeZI41OZik37ipkQBs=",
+        "lastModified": 1686900194,
+        "narHash": "sha256-3WOh2uosgLY74G1mrseC8CIyRPkXCa5dHR3B3n9VPNs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1c14e580cdf9e778d76a15ff13d6d302da628a30",
+        "rev": "c0573bc27f896dc06b488961e88fec7a997ab7df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c0573bc2`](https://github.com/nix-community/NUR/commit/c0573bc27f896dc06b488961e88fec7a997ab7df) | `` automatic update `` |