### PR TITLE
chore(flake/nur): `6f1156df` -> `b3274158`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -886,11 +886,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686905117,
-        "narHash": "sha256-GwmaC8bvfChyvwBhKJsun86lWBvVh+1ql5I8uIRAZRA=",
+        "lastModified": 1686919402,
+        "narHash": "sha256-geLQRveBmGqzBq+5r/HezXVOdtn7k/HSVVH7LTDG+FM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6f1156df74875c31b154b584867a0c57196cdb9b",
+        "rev": "b327415826c65b9138817155bd6e7bc0feb17f33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b3274158`](https://github.com/nix-community/NUR/commit/b327415826c65b9138817155bd6e7bc0feb17f33) | `` automatic update `` |