### PR TITLE
chore(flake/nur): `b3274158` -> `45b3b859`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -886,11 +886,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686919402,
-        "narHash": "sha256-geLQRveBmGqzBq+5r/HezXVOdtn7k/HSVVH7LTDG+FM=",
+        "lastModified": 1686941099,
+        "narHash": "sha256-E5kjv3InO8FVUuDuGL3nM7riLvtZt1KDyKSgeEmPfXU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b327415826c65b9138817155bd6e7bc0feb17f33",
+        "rev": "45b3b859b65ad06581773b1e8cbde32db60b013c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`45b3b859`](https://github.com/nix-community/NUR/commit/45b3b859b65ad06581773b1e8cbde32db60b013c) | `` automatic update `` |
| [`c8ba0fe5`](https://github.com/nix-community/NUR/commit/c8ba0fe5c186ad12261469e8bec3630d1520b6f7) | `` automatic update `` |
| [`86ac1a7b`](https://github.com/nix-community/NUR/commit/86ac1a7b68ec32c5a5543123bc92d58b895a01a5) | `` automatic update `` |