### PR TITLE
chore(flake/nur): `0ce74374` -> `b56f4edc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -886,11 +886,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686973429,
-        "narHash": "sha256-JyPXn9Bl+XDtN+QK87QejWdNyIoeBygfJpOwuLjpZtI=",
+        "lastModified": 1686975066,
+        "narHash": "sha256-GU3ymcXMdGl1TOSJgcYH4tNK4o7gzk3v8hgHoJERzQY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0ce7437439c7e2a730e1b5a128f86c8b2f22401b",
+        "rev": "b56f4edc61a0c4b982d12268242ef78b7334ccc4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b56f4edc`](https://github.com/nix-community/NUR/commit/b56f4edc61a0c4b982d12268242ef78b7334ccc4) | `` automatic update `` |