### PR TITLE
chore(flake/nur): `1f97e9ce` -> `82edcf1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -915,11 +915,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1687931422,
-        "narHash": "sha256-9FMTRy/fclkGfP2c0q4GW1RTC29IZty7HTajbB1TS1g=",
+        "lastModified": 1687952700,
+        "narHash": "sha256-GpPnHSrFFFZ/RgWEcs3gIDzM1HMnPUg73vgymCbVv2o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1f97e9ce2f1f38db9d1267c214dd859190dca01d",
+        "rev": "82edcf1bca8214ecc3cb472826aa5854314359d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`82edcf1b`](https://github.com/nix-community/NUR/commit/82edcf1bca8214ecc3cb472826aa5854314359d5) | `` automatic update `` |
| [`be72fce6`](https://github.com/nix-community/NUR/commit/be72fce6957d77a122f552e97c52680ddb08cbd5) | `` automatic update `` |
| [`24d948d1`](https://github.com/nix-community/NUR/commit/24d948d12d1cbcee77c83248a79b3df6b4962cd4) | `` automatic update `` |