### PR TITLE
chore(flake/agenix-rekey): `787efa41` -> `317558ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,11 +33,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686617801,
-        "narHash": "sha256-fXNOCYjuFL4427jRW9C5xdc7KSJKhoFxXbBrxE3kibU=",
+        "lastModified": 1687090623,
+        "narHash": "sha256-LdlH20WGKY1ebO3YJ85gPgmMPlGJUP4JUdqM+k5MsZw=",
         "owner": "oddlama",
         "repo": "agenix-rekey",
-        "rev": "787efa41f1611403320517bbd41cd7cb7ebdf93d",
+        "rev": "317558abbec903324e6d38393e2e84b42c25f479",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                       |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`317558ab`](https://github.com/oddlama/agenix-rekey/commit/317558abbec903324e6d38393e2e84b42c25f479) | `` feat: also regenerate secrets if dependencies if any dependency changes `` |