### PR TITLE
chore(flake/lanzaboote): `c758cdad` -> `bfc88266`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -549,11 +549,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687124707,
-        "narHash": "sha256-BEC2y7zwDI/Saeupr9rijLvwb0OoqTD9vntlcyciyrM=",
+        "lastModified": 1689796182,
+        "narHash": "sha256-DTmddEfj/SK6G8nFMPtszj2vQTq00UQKjvP0dYzv568=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "c758cdad465e0c8174db57dc493f51a89f0e3372",
+        "rev": "bfc88266639ffed2b61e8045ea71f4e02f713179",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                                               |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`434ee97a`](https://github.com/nix-community/lanzaboote/commit/434ee97ab3131923d036a05e37c764f497e81c82) | `` flake: offer nix-community cache as a suggested substituter ``                     |
| [`d4131e0c`](https://github.com/nix-community/lanzaboote/commit/d4131e0c6586a4ee8197dc1986e5e0784e14d833) | `` docs: suggest to track released versions rather than master for the flake setup `` |