### PR TITLE
chore(flake/nur): `82edcf1b` -> `31a07089`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -915,11 +915,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1687952700,
-        "narHash": "sha256-GpPnHSrFFFZ/RgWEcs3gIDzM1HMnPUg73vgymCbVv2o=",
+        "lastModified": 1687960224,
+        "narHash": "sha256-IK1Shpb/GdrI+OcO4u7SJn6FKB/JoIahgEcoOJXOtNg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "82edcf1bca8214ecc3cb472826aa5854314359d5",
+        "rev": "31a0708975489c991df5a1d31f2d4e4382d7bb2b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`31a07089`](https://github.com/nix-community/NUR/commit/31a0708975489c991df5a1d31f2d4e4382d7bb2b) | `` automatic update `` |