### PR TITLE
chore(flake/emacs-overlay): `f42cc216` -> `2c48f3c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1687944496,
-        "narHash": "sha256-/m+L9hXVcqtF9djetgRkKEaC3BiSEN0XHoWmV00piMg=",
+        "lastModified": 1687978115,
+        "narHash": "sha256-On8GM5BTZpBNnPn/F8h98nv0S4j+FfYfwMNT5ItR3ng=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f42cc216ad19b81c18657671b8681f1b005804b3",
+        "rev": "2c48f3c8cc381ce8ec207b3ee2c435a8aa594a65",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`2c48f3c8`](https://github.com/nix-community/emacs-overlay/commit/2c48f3c8cc381ce8ec207b3ee2c435a8aa594a65) | `` Updated repos/melpa ``  |
| [`bc8e79b6`](https://github.com/nix-community/emacs-overlay/commit/bc8e79b656845439ef72346d3bf7333109bedd15) | `` Updated repos/emacs ``  |
| [`e9697464`](https://github.com/nix-community/emacs-overlay/commit/e96974648f0927d7b0fd8214fad9d5903d394634) | `` Updated repos/elpa ``   |
| [`529bc705`](https://github.com/nix-community/emacs-overlay/commit/529bc70504f88852421264f6adfcf2f627c4b75d) | `` Updated flake inputs `` |