### PR TITLE
chore(flake/nur): `31a07089` -> `8e97f671`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -899,11 +899,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1687960224,
-        "narHash": "sha256-IK1Shpb/GdrI+OcO4u7SJn6FKB/JoIahgEcoOJXOtNg=",
+        "lastModified": 1687976849,
+        "narHash": "sha256-lTGZD86jTX1HklcofWaGL5M5dsTsJNpmYGR2/i1w+aA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "31a0708975489c991df5a1d31f2d4e4382d7bb2b",
+        "rev": "8e97f671d347a539bc9f152011e77236508f7a31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8e97f671`](https://github.com/nix-community/NUR/commit/8e97f671d347a539bc9f152011e77236508f7a31) | `` automatic update `` |