### PR TITLE
chore(flake/nur): `8e97f671` -> `a4f6a6ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -899,11 +899,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1687976849,
-        "narHash": "sha256-lTGZD86jTX1HklcofWaGL5M5dsTsJNpmYGR2/i1w+aA=",
+        "lastModified": 1687985211,
+        "narHash": "sha256-H84kfD7kzEBsoKLyqGsO2N2IUqsuuaeYtEAMdHMyJ1o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8e97f671d347a539bc9f152011e77236508f7a31",
+        "rev": "a4f6a6ad8a9e30785c2dac98a373fb668807fa47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a4f6a6ad`](https://github.com/nix-community/NUR/commit/a4f6a6ad8a9e30785c2dac98a373fb668807fa47) | `` automatic update `` |
| [`8e1c2d64`](https://github.com/nix-community/NUR/commit/8e1c2d64c0671c0b8e242d61c602118371cb5711) | `` automatic update `` |