### PR TITLE
chore(flake/nur): `a4f6a6ad` -> `64b73fb2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -899,11 +899,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1687985211,
-        "narHash": "sha256-H84kfD7kzEBsoKLyqGsO2N2IUqsuuaeYtEAMdHMyJ1o=",
+        "lastModified": 1687988783,
+        "narHash": "sha256-3Km9CxPgdSv6sH8nun+5GmnoJdDpt/L2fQld2nAobbk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a4f6a6ad8a9e30785c2dac98a373fb668807fa47",
+        "rev": "64b73fb2ebc1c8bd79a4343fe40ca8f83b2c7879",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`64b73fb2`](https://github.com/nix-community/NUR/commit/64b73fb2ebc1c8bd79a4343fe40ca8f83b2c7879) | `` automatic update `` |