### PR TITLE
chore(flake/emacs-overlay): `2c48f3c8` -> `4654df7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1687978115,
-        "narHash": "sha256-On8GM5BTZpBNnPn/F8h98nv0S4j+FfYfwMNT5ItR3ng=",
+        "lastModified": 1688010489,
+        "narHash": "sha256-XwznzVLLFXD5OTIM8LFV0dg1LiMosbDM3vh+c5+pXfA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2c48f3c8cc381ce8ec207b3ee2c435a8aa594a65",
+        "rev": "4654df7d1ca4379989fc0a1e28896d51d345f428",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`4654df7d`](https://github.com/nix-community/emacs-overlay/commit/4654df7d1ca4379989fc0a1e28896d51d345f428) | `` Updated repos/melpa `` |
| [`f403a159`](https://github.com/nix-community/emacs-overlay/commit/f403a15947d42eeb5888ce5935cb4c3fdf2f92f0) | `` Updated repos/emacs `` |
| [`5554b776`](https://github.com/nix-community/emacs-overlay/commit/5554b77606dd4fe283d8b4a5f5969657d16411b4) | `` Updated repos/elpa ``  |