### PR TITLE
chore(flake/nur): `c674da8b` -> `6e3d1f27`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -899,11 +899,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1687999575,
-        "narHash": "sha256-/2Xc6jp2kDAeQzXtchg4WqVArhQtUXFYkcmDLac7WgA=",
+        "lastModified": 1688010356,
+        "narHash": "sha256-DPwPu6wEESqs0MCRtj45jONs9TA8Cnxu5as9eXFcSUk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c674da8b2a994d7d9f366e71a4790de4c0caf2ac",
+        "rev": "6e3d1f27deaaa2ce9e4fdcea8e7fcddf5992f3ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6e3d1f27`](https://github.com/nix-community/NUR/commit/6e3d1f27deaaa2ce9e4fdcea8e7fcddf5992f3ee) | `` automatic update `` |