### PR TITLE
chore(flake/nur): `b4bd481a` -> `13219907`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -899,11 +899,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1688020633,
-        "narHash": "sha256-xkRt7wIvg0urJ07Ad0OiLAASl5iBc54Xjl/VEMbaHmQ=",
+        "lastModified": 1688031882,
+        "narHash": "sha256-ke1Bn/+ab9npzkjfVZYW7mD/4PG9paw6vqTZkmmxKl8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b4bd481a5db25ae103d9ac69a1cca6aa2073edc8",
+        "rev": "132199078682629a45058264f0ae4567071dbd8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`13219907`](https://github.com/nix-community/NUR/commit/132199078682629a45058264f0ae4567071dbd8d) | `` automatic update `` |
| [`fee73837`](https://github.com/nix-community/NUR/commit/fee73837636df9092dbd72241f6b9ad281850056) | `` automatic update `` |