### PR TITLE
chore(flake/emacs-plz): `d4be5b2c` -> `e8ac29bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -258,11 +258,11 @@
     "emacs-plz": {
       "flake": false,
       "locked": {
-        "lastModified": 1688024815,
-        "narHash": "sha256-CVPaKkCcSmkruFg0VCIY2tbSOIt4PFLTnR9nyvUnRBg=",
+        "lastModified": 1688036423,
+        "narHash": "sha256-MZ4pasG5IR9ByD0vEUx0s+DYhMkH6vJbQATqDnMBH6k=",
         "owner": "alphapapa",
         "repo": "plz.el",
-        "rev": "d4be5b2c293c585ff79ffd5bc1a86fa441b23137",
+        "rev": "e8ac29bfb40e21a7681d264ca478b8c70bb9e26e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                                       |
| ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`e8ac29bf`](https://github.com/alphapapa/plz.el/commit/e8ac29bfb40e21a7681d264ca478b8c70bb9e26e) | `` Docs: Tidy ``                                              |
| [`4f106c43`](https://github.com/alphapapa/plz.el/commit/4f106c434799f46f9ae82989077c99113853f881) | `` Docs: Update plz docstring ``                              |
| [`9f83a74e`](https://github.com/alphapapa/plz.el/commit/9f83a74eef0d19df3753d73af736eceac206c61b) | `` Fix: For ":as 'buffer" result type ``                      |
| [`63e4b226`](https://github.com/alphapapa/plz.el/commit/63e4b2260c8aff4dfc1a9998c0feeee62d18a28f) | `` Fix: (plz) Use with-local-quit for synchronous requests `` |