### PR TITLE
chore(flake/emacs-overlay): `a296b6e6` -> `5fb607b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1688019553,
-        "narHash": "sha256-zoRQUZaBSDRx7CvxI+JlzqcishY0DgMRlzwI6i4IXg8=",
+        "lastModified": 1688033745,
+        "narHash": "sha256-5u9ysFHuBahdKFcBBz26VxZYw9GKLiDvQLJHDzjIQX8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a296b6e6d151351589f643b656f7c92188cabadb",
+        "rev": "5fb607b2ee0c37a9aa0570a53c11405b21883313",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`5fb607b2`](https://github.com/nix-community/emacs-overlay/commit/5fb607b2ee0c37a9aa0570a53c11405b21883313) | `` Updated repos/nongnu `` |
| [`2322e368`](https://github.com/nix-community/emacs-overlay/commit/2322e368874d6805d950dfef62583faa58959752) | `` Updated repos/melpa ``  |
| [`1d490eef`](https://github.com/nix-community/emacs-overlay/commit/1d490eef2c4fd8e5f151fcaa8c1fcf195f332a3e) | `` Updated repos/emacs ``  |