### PR TITLE
chore(flake/nur): `13219907` -> `6725852b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -899,11 +899,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1688031882,
-        "narHash": "sha256-ke1Bn/+ab9npzkjfVZYW7mD/4PG9paw6vqTZkmmxKl8=",
+        "lastModified": 1688039092,
+        "narHash": "sha256-LdSxF+4sScA7QIrIWc7dty+FDv1JURen6WXSScWFaV0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "132199078682629a45058264f0ae4567071dbd8d",
+        "rev": "6725852be8625409b9df80a3d816c1a7716335f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6725852b`](https://github.com/nix-community/NUR/commit/6725852be8625409b9df80a3d816c1a7716335f2) | `` automatic update `` |