### PR TITLE
chore(flake/nur): `69bc80a2` -> `6c4059e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -899,11 +899,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1688049654,
-        "narHash": "sha256-4ANk70Wrwbj5WkHNCsBJZlU84P8I7z1IXOHdAvOXbM0=",
+        "lastModified": 1688063168,
+        "narHash": "sha256-rVHm/K4ExdWKBGt03bpKKQWFmm8qxt+/AtA2VZOIkyI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "69bc80a2beb3657d238774cd0faff1291fa8414b",
+        "rev": "6c4059e93d16dac3e238a04ff5b925fcc83b0811",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6c4059e9`](https://github.com/nix-community/NUR/commit/6c4059e93d16dac3e238a04ff5b925fcc83b0811) | `` automatic update `` |
| [`1873e371`](https://github.com/nix-community/NUR/commit/1873e371aca0c0932e5bb2506295c80f36e9fff9) | `` automatic update `` |
| [`126934c1`](https://github.com/nix-community/NUR/commit/126934c1d4fa462b47abccbc305b233d917a0e5d) | `` automatic update `` |
| [`0b899611`](https://github.com/nix-community/NUR/commit/0b8996114b3497777d074cebda192fdc20a6d9dd) | `` automatic update `` |