### PR TITLE
chore(flake/nur): `6c4059e9` -> `28f99ac9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -899,11 +899,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1688063168,
-        "narHash": "sha256-rVHm/K4ExdWKBGt03bpKKQWFmm8qxt+/AtA2VZOIkyI=",
+        "lastModified": 1688067912,
+        "narHash": "sha256-ESAdklSSgufQaLA8k1s8r0PVAXQqHRzkVM3NUajv8SY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6c4059e93d16dac3e238a04ff5b925fcc83b0811",
+        "rev": "28f99ac948e740a2e0f096c1846daa9d4e791ea2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`28f99ac9`](https://github.com/nix-community/NUR/commit/28f99ac948e740a2e0f096c1846daa9d4e791ea2) | `` automatic update `` |