### PR TITLE
chore(flake/nur): `28f99ac9` -> `03ae96da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -899,11 +899,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1688067912,
-        "narHash": "sha256-ESAdklSSgufQaLA8k1s8r0PVAXQqHRzkVM3NUajv8SY=",
+        "lastModified": 1688071500,
+        "narHash": "sha256-My4uDG8zpOB2gX8aGp3M1K82ogykGxeF58qTsfGK1pU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "28f99ac948e740a2e0f096c1846daa9d4e791ea2",
+        "rev": "03ae96da0b00c4069901e3f81aaa111d14d07cb4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`03ae96da`](https://github.com/nix-community/NUR/commit/03ae96da0b00c4069901e3f81aaa111d14d07cb4) | `` automatic update `` |