### PR TITLE
chore(flake/nur): `03ae96da` -> `92f4536e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -899,11 +899,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1688071500,
-        "narHash": "sha256-My4uDG8zpOB2gX8aGp3M1K82ogykGxeF58qTsfGK1pU=",
+        "lastModified": 1688082333,
+        "narHash": "sha256-NpeC75cB62cgEIynCkmaymcmKdeA9IuhhNiEm7qlL/k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "03ae96da0b00c4069901e3f81aaa111d14d07cb4",
+        "rev": "92f4536e0b969ace98bef0cb83aff1212ade0e6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`92f4536e`](https://github.com/nix-community/NUR/commit/92f4536e0b969ace98bef0cb83aff1212ade0e6b) | `` automatic update `` |