### PR TITLE
chore(flake/nur): `92f4536e` -> `fe1fdaa9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -899,11 +899,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1688082333,
-        "narHash": "sha256-NpeC75cB62cgEIynCkmaymcmKdeA9IuhhNiEm7qlL/k=",
+        "lastModified": 1688085933,
+        "narHash": "sha256-O1b/aPX1G3vlXV0CCrZtLcjEbRrfCq6lzBnuINBfKfk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "92f4536e0b969ace98bef0cb83aff1212ade0e6b",
+        "rev": "fe1fdaa91395543bcae04091f0881ccf8d6a7927",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fe1fdaa9`](https://github.com/nix-community/NUR/commit/fe1fdaa91395543bcae04091f0881ccf8d6a7927) | `` automatic update `` |
| [`e3ceaaa5`](https://github.com/nix-community/NUR/commit/e3ceaaa5e5f74e5edc6d1bad52cfa73f225a7415) | `` automatic update `` |