### PR TITLE
chore(flake/emacs-overlay): `5fb607b2` -> `e6568d59`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1688033745,
-        "narHash": "sha256-5u9ysFHuBahdKFcBBz26VxZYw9GKLiDvQLJHDzjIQX8=",
+        "lastModified": 1688095315,
+        "narHash": "sha256-R+AWXZ0u9Rnmtsjo902vcYjZxWQc+lKJ5dfKCF8UpfY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5fb607b2ee0c37a9aa0570a53c11405b21883313",
+        "rev": "e6568d59ffa7ed3aa95d47f1218891c3934693a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`e6568d59`](https://github.com/nix-community/emacs-overlay/commit/e6568d59ffa7ed3aa95d47f1218891c3934693a9) | `` Updated repos/melpa `` |
| [`0b1b05f3`](https://github.com/nix-community/emacs-overlay/commit/0b1b05f33d0eff54471137dc3163334a9d1d6965) | `` Updated repos/emacs `` |
| [`dc24fd4c`](https://github.com/nix-community/emacs-overlay/commit/dc24fd4cfd2d36d6bc984c99948f46a71ea42ac7) | `` Updated repos/elpa ``  |