### PR TITLE
chore(flake/nur): `fe1fdaa9` -> `0cd39b26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -899,11 +899,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1688085933,
-        "narHash": "sha256-O1b/aPX1G3vlXV0CCrZtLcjEbRrfCq6lzBnuINBfKfk=",
+        "lastModified": 1688097397,
+        "narHash": "sha256-LyQWoOa5FpbudYDyQmJxQDeCXvrr9wRT/g6E8fvhFlk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fe1fdaa91395543bcae04091f0881ccf8d6a7927",
+        "rev": "0cd39b26dc7d80bb2f68b45771bb75cc635ad2dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0cd39b26`](https://github.com/nix-community/NUR/commit/0cd39b26dc7d80bb2f68b45771bb75cc635ad2dd) | `` automatic update `` |
| [`1bd65cd2`](https://github.com/nix-community/NUR/commit/1bd65cd2ad9c4660333ebab2d2e8c7d733e3e60c) | `` automatic update `` |