### PR TITLE
chore(flake/nur): `39b12dd9` -> `6b90cb96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1689254984,
-        "narHash": "sha256-Fgk7HPibWwmewsftq6PeFvJp2e62+V1L0YRkzlqGDfE=",
+        "lastModified": 1690199168,
+        "narHash": "sha256-8eo615fNLfpLGTtqjMapdyBLMUXBO8TSsSMZdW6nxvQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "39b12dd997d4d22c3ac243e76b94367577753f75",
+        "rev": "6b90cb969b8e9d063ff71688085bf8ffb23a2788",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                            |
| -------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`6b90cb96`](https://github.com/nix-community/NUR/commit/6b90cb969b8e9d063ff71688085bf8ffb23a2788) | `` automatic update ``             |
| [`c6391c99`](https://github.com/nix-community/NUR/commit/c6391c999ab63ab9f825384a97ac42a8fb3e069e) | `` automatic update ``             |
| [`497afc54`](https://github.com/nix-community/NUR/commit/497afc54e9e4cf177f53cd0854687765d65e6e38) | `` automatic update ``             |
| [`01bba910`](https://github.com/nix-community/NUR/commit/01bba9104c563fd253667fdd8c4f81b50be8b569) | `` automatic update ``             |
| [`1e1c0ae3`](https://github.com/nix-community/NUR/commit/1e1c0ae3f496c5688e16c9c704e62b5e9099bb6d) | `` automatic update ``             |
| [`458ae174`](https://github.com/nix-community/NUR/commit/458ae17477970b6fd9c1b71787c8c3c3c9f554c3) | `` add NotEvenANeko repository ``  |
| [`5c0ac383`](https://github.com/nix-community/NUR/commit/5c0ac38327eb0f1233153f6e9b97de157db16a5c) | `` mergify: fix merge condition `` |
| [`4e850b08`](https://github.com/nix-community/NUR/commit/4e850b08a4605f683054a9ca3a837d6ac10e27fa) | `` automatic update ``             |
| [`bacff85c`](https://github.com/nix-community/NUR/commit/bacff85c1ae4d0d56956c173e7a93abca3575cb5) | `` automatic update ``             |
| [`579379db`](https://github.com/nix-community/NUR/commit/579379db0340113dd07e863f0ad75d9438564a07) | `` automatic update ``             |
| [`fdf21e83`](https://github.com/nix-community/NUR/commit/fdf21e83fa7d86042cdf20ec5448fde3fc2bf31c) | `` automatic update ``             |
| [`80d8820d`](https://github.com/nix-community/NUR/commit/80d8820d711291e6cecf32f9c9852cc51762952f) | `` automatic update ``             |
| [`ed99ac4b`](https://github.com/nix-community/NUR/commit/ed99ac4b1132f418508c37f72dd23cf04f306393) | `` automatic update ``             |
| [`df9f5b8c`](https://github.com/nix-community/NUR/commit/df9f5b8c5779f5bfa08df742af507ba24e3acfe2) | `` automatic update ``             |
| [`b26251ca`](https://github.com/nix-community/NUR/commit/b26251cadc25d51bc8ead7c0e71e238d2ff2d9e7) | `` automatic update ``             |
| [`d94dbc61`](https://github.com/nix-community/NUR/commit/d94dbc61018142b7bb592c26647d2d690cf5ea55) | `` automatic update ``             |
| [`fff383fb`](https://github.com/nix-community/NUR/commit/fff383fbfd8f5bcd5a1c1c8e554857079b5436c1) | `` automatic update ``             |
| [`0a400015`](https://github.com/nix-community/NUR/commit/0a400015f0b97fad8047acc52ed273eb29fdb384) | `` automatic update ``             |
| [`7ee19b89`](https://github.com/nix-community/NUR/commit/7ee19b895aa4d57a61523cfed617447ba0a192a3) | `` automatic update ``             |
| [`b9125b39`](https://github.com/nix-community/NUR/commit/b9125b395f5a3dad36760625755f0546b771cc9c) | `` automatic update ``             |
| [`dd0c3142`](https://github.com/nix-community/NUR/commit/dd0c314217c07e3c4e84d288f8c4ec9119b109c3) | `` automatic update ``             |
| [`b76359f2`](https://github.com/nix-community/NUR/commit/b76359f2d7bc0a3f2b476bfc07c7e4b7e90c1059) | `` add mergify ``                  |
| [`261e1e0d`](https://github.com/nix-community/NUR/commit/261e1e0dbadd9113a71c8dd70e3ab04214cf59c8) | `` automatic update ``             |
| [`4a96bb70`](https://github.com/nix-community/NUR/commit/4a96bb70b86d0cc68168250cabb6088fff358a5f) | `` automatic update ``             |
| [`45801daf`](https://github.com/nix-community/NUR/commit/45801daffc232dedb329f24f76fb562b70d06314) | `` automatic update ``             |
| [`dfe1a805`](https://github.com/nix-community/NUR/commit/dfe1a80547eb6520739b6f1de7b1d3e2f2b5e14b) | `` automatic update ``             |
| [`5cca8929`](https://github.com/nix-community/NUR/commit/5cca8929bc6ed32ee5a99e7ed9fff5f87820519f) | `` automatic update ``             |
| [`ae0d950b`](https://github.com/nix-community/NUR/commit/ae0d950b961f2dc5b0865d4e6b9ad871bd3b7c1a) | `` automatic update ``             |
| [`8cb36739`](https://github.com/nix-community/NUR/commit/8cb367398fbd63c0ecd3f0e568738fdd9dd5240c) | `` automatic update ``             |
| [`34925aaf`](https://github.com/nix-community/NUR/commit/34925aaf24cca833cfe25daf42dee56634855050) | `` automatic update ``             |
| [`f8a67842`](https://github.com/nix-community/NUR/commit/f8a6784284480ec02eea3ff4c20ce64fd63e6d4e) | `` automatic update ``             |
| [`d500c83c`](https://github.com/nix-community/NUR/commit/d500c83cf9f635aad09f1c34316745b87f0fb525) | `` automatic update ``             |
| [`bd5b8524`](https://github.com/nix-community/NUR/commit/bd5b85248a456a96d0d61c2584bf0953ada385ec) | `` automatic update ``             |
| [`3d48fd67`](https://github.com/nix-community/NUR/commit/3d48fd67de78a87a974cba381604ac83c2017417) | `` automatic update ``             |
| [`ef346c78`](https://github.com/nix-community/NUR/commit/ef346c782a0c4c3a94c344af48fc0a266162867e) | `` automatic update ``             |
| [`1f30bcdd`](https://github.com/nix-community/NUR/commit/1f30bcdd39146a9d79897334350f9f5712f131e2) | `` automatic update ``             |
| [`baada31a`](https://github.com/nix-community/NUR/commit/baada31a28e1a19f71176afa8effb5db62f5a5fd) | `` automatic update ``             |
| [`e1b395b0`](https://github.com/nix-community/NUR/commit/e1b395b0556a71dfde403d1203628977d51f01f1) | `` automatic update ``             |
| [`7396733c`](https://github.com/nix-community/NUR/commit/7396733c1755ab9bd31ff79a1438d5ac805665ea) | `` automatic update ``             |
| [`6be732b1`](https://github.com/nix-community/NUR/commit/6be732b18451ea43ead4ea4f5b499ae909102351) | `` automatic update ``             |
| [`15a8d464`](https://github.com/nix-community/NUR/commit/15a8d4645c280e35c00a36303bb76eb697d38206) | `` automatic update ``             |
| [`9e4cf3f0`](https://github.com/nix-community/NUR/commit/9e4cf3f02b19550e6d3d587b5447fd76f087d087) | `` automatic update ``             |
| [`d614a0ae`](https://github.com/nix-community/NUR/commit/d614a0ae13e7065ce417752ffe40f7140bb2fec6) | `` Add iopq repo ``                |
| [`e2986014`](https://github.com/nix-community/NUR/commit/e2986014d7da46ea1cafb1e86aab6df59fe5a614) | `` automatic update ``             |
| [`157fba35`](https://github.com/nix-community/NUR/commit/157fba358eed162282487972422801cea9b62f4f) | `` automatic update ``             |
| [`8da0d3c3`](https://github.com/nix-community/NUR/commit/8da0d3c374a0fb1d2f600f7844d72df104e542f0) | `` automatic update ``             |
| [`850c52d6`](https://github.com/nix-community/NUR/commit/850c52d6dbd5832a549eb3ffd9363ea3c7427616) | `` automatic update ``             |
| [`25ef9aec`](https://github.com/nix-community/NUR/commit/25ef9aece8d9566fcb34f80ffe141c09c30344c3) | `` automatic update ``             |
| [`3077beb4`](https://github.com/nix-community/NUR/commit/3077beb4fd911f40408b4aa9e7e8b834994149c0) | `` automatic update ``             |
| [`00ff8d20`](https://github.com/nix-community/NUR/commit/00ff8d20ab20e03856e8805582b9ee5aaf82bff9) | `` automatic update ``             |
| [`07a01e32`](https://github.com/nix-community/NUR/commit/07a01e32c0f4f6faf90a254b65c9328445fb75e4) | `` automatic update ``             |
| [`696c789f`](https://github.com/nix-community/NUR/commit/696c789f917c8a9bf04d8b68dce1851132c12ebf) | `` automatic update ``             |
| [`37ed05c6`](https://github.com/nix-community/NUR/commit/37ed05c6953e388784580a9bd6405d5d845524db) | `` automatic update ``             |
| [`3d51c813`](https://github.com/nix-community/NUR/commit/3d51c81356bd84bfa7b5b2ccb11c36b58b9f5cde) | `` automatic update ``             |
| [`bf0251ab`](https://github.com/nix-community/NUR/commit/bf0251ab72f1f830f9e6801f1b7d7038155a8d22) | `` automatic update ``             |
| [`1c82e122`](https://github.com/nix-community/NUR/commit/1c82e122f10dda007765ed0d71e949fd5b55622a) | `` automatic update ``             |
| [`c91a96e2`](https://github.com/nix-community/NUR/commit/c91a96e29e8518c0c7098e954d34a0aa34a00406) | `` automatic update ``             |
| [`1985ae8a`](https://github.com/nix-community/NUR/commit/1985ae8a4843347ad8278a9fbc9368b3ed9fe34d) | `` automatic update ``             |
| [`876b9498`](https://github.com/nix-community/NUR/commit/876b9498f36a394fcf8472f62ecf6685585c0509) | `` automatic update ``             |
| [`56d1fa6e`](https://github.com/nix-community/NUR/commit/56d1fa6e3880ef28c4b1a4f9efcd9c0d6a7228a3) | `` Add JuniorIsAJitterbug repo ``  |
| [`5bf71ded`](https://github.com/nix-community/NUR/commit/5bf71ded2372cbf1df969164193523c09a36b92c) | `` automatic update ``             |
| [`da7302a6`](https://github.com/nix-community/NUR/commit/da7302a6394f375ec5d590cfa38521f75c5c413b) | `` automatic update ``             |
| [`9de4a0b9`](https://github.com/nix-community/NUR/commit/9de4a0b9da190ef91ca14d4f37d5bdce2bf1f3d4) | `` automatic update ``             |
| [`227aa387`](https://github.com/nix-community/NUR/commit/227aa387f9a8cb5df11387554381f7ff96caa843) | `` automatic update ``             |
| [`e0c6eb00`](https://github.com/nix-community/NUR/commit/e0c6eb006bd873445f5916d08dbce06c9d929b6c) | `` automatic update ``             |
| [`fdc0daf4`](https://github.com/nix-community/NUR/commit/fdc0daf456aafd346cbf766ad85fbd959300ce3e) | `` automatic update ``             |
| [`52abb3fa`](https://github.com/nix-community/NUR/commit/52abb3faa81d38783938b34614e2356a995763f4) | `` automatic update ``             |
| [`12f1e776`](https://github.com/nix-community/NUR/commit/12f1e7762ec34745631273ea87a194a0c69fe952) | `` automatic update ``             |
| [`7e12ad94`](https://github.com/nix-community/NUR/commit/7e12ad947cbb0241dbc613c116efa65b9400c280) | `` automatic update ``             |
| [`3f3d5620`](https://github.com/nix-community/NUR/commit/3f3d56201009dd96b8983214c68fe1fbdf43e3da) | `` automatic update ``             |
| [`082f9064`](https://github.com/nix-community/NUR/commit/082f9064d7c455d37fe7d4f7bb600c4055749ae6) | `` automatic update ``             |
| [`92d95e73`](https://github.com/nix-community/NUR/commit/92d95e73551541dbb91c23e5f65f7c0127252013) | `` automatic update ``             |
| [`5f9fd538`](https://github.com/nix-community/NUR/commit/5f9fd5382a59df474ad5593e413552e97b0effa0) | `` automatic update ``             |
| [`252418d7`](https://github.com/nix-community/NUR/commit/252418d7636c353620a882e050908428f71c5420) | `` automatic update ``             |
| [`778d2c59`](https://github.com/nix-community/NUR/commit/778d2c59c5138de2c896337b73852a27613ca9f1) | `` automatic update ``             |
| [`3722d5ca`](https://github.com/nix-community/NUR/commit/3722d5cae8067e65b7a64c2b326678fb2c670b39) | `` automatic update ``             |
| [`801ae070`](https://github.com/nix-community/NUR/commit/801ae070fb20519c6406e873f908393a67f31474) | `` automatic update ``             |
| [`0ed70c3f`](https://github.com/nix-community/NUR/commit/0ed70c3f437c9da3b809f2407cffa92c85f37135) | `` automatic update ``             |
| [`c7c63ed3`](https://github.com/nix-community/NUR/commit/c7c63ed3d4e826901e6d0b3d7e0859acb9670621) | `` automatic update ``             |
| [`37bf365f`](https://github.com/nix-community/NUR/commit/37bf365f9d23f12c73b962109a62b118d0e58d20) | `` automatic update ``             |
| [`2dee309c`](https://github.com/nix-community/NUR/commit/2dee309c5644fdc60ce7d0f96ae973a4e914ab3a) | `` automatic update ``             |
| [`de92354e`](https://github.com/nix-community/NUR/commit/de92354e1ada5b0b7f98726d0196f55f8fa0bd93) | `` automatic update ``             |
| [`acad1df6`](https://github.com/nix-community/NUR/commit/acad1df6e562ee5aad78a90ce1d4082536d9d727) | `` automatic update ``             |
| [`fe8c7551`](https://github.com/nix-community/NUR/commit/fe8c7551a9a0a52d27de176b0277fbb83d613d3f) | `` automatic update ``             |
| [`22bf13b0`](https://github.com/nix-community/NUR/commit/22bf13b0eea42af70679147824e761bf2f5782b4) | `` automatic update ``             |
| [`3604f906`](https://github.com/nix-community/NUR/commit/3604f906ee925321d0410f03914dcbbba1380c76) | `` automatic update ``             |
| [`e3661778`](https://github.com/nix-community/NUR/commit/e36617788c4b1ef2f47d33bfd732493b0a15e6c2) | `` automatic update ``             |
| [`49338787`](https://github.com/nix-community/NUR/commit/4933878701afc99357d1ceae43101906d1de007a) | `` automatic update ``             |
| [`9ddeca99`](https://github.com/nix-community/NUR/commit/9ddeca993af5c34698d1e9a5765021dff9d30a05) | `` automatic update ``             |
| [`d98419c1`](https://github.com/nix-community/NUR/commit/d98419c13076da506af00f86a2a8249da586657d) | `` automatic update ``             |
| [`87404f31`](https://github.com/nix-community/NUR/commit/87404f3175ca129e13838fc8a398b166d9f40ee0) | `` automatic update ``             |
| [`baec8ac3`](https://github.com/nix-community/NUR/commit/baec8ac347f0cb9e2f487017b04315377dbda9ca) | `` automatic update ``             |
| [`3a15e620`](https://github.com/nix-community/NUR/commit/3a15e62034564902f7e049bd5c964af16b9ebf24) | `` automatic update ``             |
| [`6873d2ef`](https://github.com/nix-community/NUR/commit/6873d2ef8623a4cc5d10ce356c10a7bd4602c46d) | `` automatic update ``             |
| [`27e3b2a7`](https://github.com/nix-community/NUR/commit/27e3b2a7ea5a4064cbc39e311e7d44ee6f1ce41b) | `` automatic update ``             |
| [`036c3e6a`](https://github.com/nix-community/NUR/commit/036c3e6a76cf1f2fe5f2c13dc31a4cf7bcf23315) | `` automatic update ``             |
| [`0efd461b`](https://github.com/nix-community/NUR/commit/0efd461b4456aced4d09d3d3c164340ad6bb28c6) | `` automatic update ``             |
| [`d983bcca`](https://github.com/nix-community/NUR/commit/d983bccadb90390b04e44dcde2dce4450eff0ef1) | `` automatic update ``             |
| [`a5313ff2`](https://github.com/nix-community/NUR/commit/a5313ff291bf10a5faf16b88cad969af3544d071) | `` automatic update ``             |
| [`553bfbdc`](https://github.com/nix-community/NUR/commit/553bfbdce2d7368c282bc69cce181d29b3d75e3d) | `` automatic update ``             |
| [`56daeaa9`](https://github.com/nix-community/NUR/commit/56daeaa9da76a35180ea92696100b1163c554bad) | `` automatic update ``             |
| [`94163e73`](https://github.com/nix-community/NUR/commit/94163e73e3d744a423abd5cd08417f19e01bd207) | `` automatic update ``             |
| [`4941a92f`](https://github.com/nix-community/NUR/commit/4941a92fea6e8cfb605c7a152d43742208f85e58) | `` automatic update ``             |
| [`05c6d9d0`](https://github.com/nix-community/NUR/commit/05c6d9d00750b03b56f7792e8f60ba67f78e869f) | `` automatic update ``             |
| [`4157031a`](https://github.com/nix-community/NUR/commit/4157031a9d12e8f1395f2ecaf63e94cbc5877dba) | `` automatic update ``             |
| [`30d058ee`](https://github.com/nix-community/NUR/commit/30d058ee68b02dc2abb6beacf0be5c9bdcfd2d98) | `` automatic update ``             |
| [`dfa4b333`](https://github.com/nix-community/NUR/commit/dfa4b3331ddc0b2deac8cc29d23671b2d3d92ad0) | `` automatic update ``             |
| [`d8cf8f51`](https://github.com/nix-community/NUR/commit/d8cf8f51fba71c1e673b6f6f6f15f58e1386fa41) | `` automatic update ``             |
| [`66655ae6`](https://github.com/nix-community/NUR/commit/66655ae652c48d102b066a12815c8104003ae189) | `` automatic update ``             |
| [`11f003cc`](https://github.com/nix-community/NUR/commit/11f003cc0a54c848e2ad6dabbc963911fe9e2984) | `` automatic update ``             |
| [`1bff5a1b`](https://github.com/nix-community/NUR/commit/1bff5a1b718e5004128bc1dbfa793258a0d40756) | `` automatic update ``             |
| [`0d25312a`](https://github.com/nix-community/NUR/commit/0d25312aaca446769c00d99c9910419dc11790c0) | `` automatic update ``             |
| [`da07aff9`](https://github.com/nix-community/NUR/commit/da07aff967347d45d8053869c61241f05cd1fd6e) | `` automatic update ``             |
| [`2095a2d9`](https://github.com/nix-community/NUR/commit/2095a2d9ade2f5cf424f89015a86478e971b9981) | `` automatic update ``             |
| [`bd63a1c8`](https://github.com/nix-community/NUR/commit/bd63a1c8a8e223c1de5727ac54c1338e82c40b44) | `` automatic update ``             |
| [`8b709b4c`](https://github.com/nix-community/NUR/commit/8b709b4ca62ded5938a5ac61a3d86fc2d119fb1a) | `` automatic update ``             |
| [`092ea744`](https://github.com/nix-community/NUR/commit/092ea7443f334c362cc5429612846f6193a7de11) | `` automatic update ``             |
| [`c37df3a1`](https://github.com/nix-community/NUR/commit/c37df3a1423ae99d95d6eb72bdb8cb5fac77b360) | `` automatic update ``             |
| [`4bc44ebe`](https://github.com/nix-community/NUR/commit/4bc44ebeae67b288983d0b47f589ab8ba23e2495) | `` automatic update ``             |
| [`2e762e11`](https://github.com/nix-community/NUR/commit/2e762e115c4a9df08ecf13f3641b98bd46cd4527) | `` automatic update ``             |
| [`af779ead`](https://github.com/nix-community/NUR/commit/af779eadbd165dd1229ecd0b6602847e99859fbd) | `` automatic update ``             |
| [`bfae11df`](https://github.com/nix-community/NUR/commit/bfae11dfbc37237f5e656e5b20fe70f1debc2e2b) | `` automatic update ``             |
| [`cd31d89a`](https://github.com/nix-community/NUR/commit/cd31d89a192ada1e054e0d19f68033e6de51adff) | `` automatic update ``             |
| [`34791109`](https://github.com/nix-community/NUR/commit/3479110917a73433c5ba3054a21d56cf4af0f79c) | `` automatic update ``             |
| [`145b27ee`](https://github.com/nix-community/NUR/commit/145b27eefbe178978b628c26b991658a8d5394af) | `` automatic update ``             |
| [`757f1d28`](https://github.com/nix-community/NUR/commit/757f1d284cdcddfa7e31fa8fba4ad34db5df31fb) | `` automatic update ``             |
| [`35169f9c`](https://github.com/nix-community/NUR/commit/35169f9cd6bcbcb704d293401e5c55c36e772e3f) | `` automatic update ``             |
| [`573dfe57`](https://github.com/nix-community/NUR/commit/573dfe57151068c86ab1b09716600075180adce6) | `` automatic update ``             |
| [`0c89ba37`](https://github.com/nix-community/NUR/commit/0c89ba379bdbcd48cf05f79372dc9918f9de0390) | `` automatic update ``             |
| [`83de34f8`](https://github.com/nix-community/NUR/commit/83de34f8463f43eb583bcd3b0ef8f2e1c88731e9) | `` automatic update ``             |
| [`4b6680be`](https://github.com/nix-community/NUR/commit/4b6680becbcdd5c7ce08e550a2953087ca9d7e03) | `` automatic update ``             |
| [`bbf6a9f8`](https://github.com/nix-community/NUR/commit/bbf6a9f8c735355277a4515adec28b73ed4608ee) | `` automatic update ``             |
| [`6c2a51bc`](https://github.com/nix-community/NUR/commit/6c2a51bcfb5b0fe8c6699cbeea83afb2490168e0) | `` automatic update ``             |
| [`19b23400`](https://github.com/nix-community/NUR/commit/19b2340044ffea8c875301316b8fc07dc34591ac) | `` automatic update ``             |
| [`ffab7d92`](https://github.com/nix-community/NUR/commit/ffab7d9245ca270f4599a77ddd366bdce38780f0) | `` automatic update ``             |
| [`029d2023`](https://github.com/nix-community/NUR/commit/029d2023eeceee09200a93a48ba1a60413e9b328) | `` automatic update ``             |
| [`12e5cc7a`](https://github.com/nix-community/NUR/commit/12e5cc7a04da9ef5ef3fbfb684f5c517c4837518) | `` automatic update ``             |
| [`46138202`](https://github.com/nix-community/NUR/commit/46138202326facdfd677a4caed8b86a480baec6e) | `` automatic update ``             |
| [`f66a9a45`](https://github.com/nix-community/NUR/commit/f66a9a45abfe71823a85bdba0d989aa1ad2d8266) | `` automatic update ``             |
| [`8271501d`](https://github.com/nix-community/NUR/commit/8271501da8fe76976d1ddba1619b45637273fa64) | `` automatic update ``             |
| [`4441b1fe`](https://github.com/nix-community/NUR/commit/4441b1fe0adb0a75f240be19e968513cd0a7fac6) | `` automatic update ``             |
| [`2352bf9c`](https://github.com/nix-community/NUR/commit/2352bf9c5e8c4d98112c9bb54d3e0efbb8cefd60) | `` automatic update ``             |
| [`d404103d`](https://github.com/nix-community/NUR/commit/d404103da11b84ade1ef9bceae90cfe4686e0e4e) | `` automatic update ``             |
| [`dd2e1ad6`](https://github.com/nix-community/NUR/commit/dd2e1ad6f691c11e73be864fbeb10893d9804a18) | `` automatic update ``             |
| [`3c9c787f`](https://github.com/nix-community/NUR/commit/3c9c787f3e8d65b815457412fec81e7224020c3b) | `` automatic update ``             |
| [`c78dd1c7`](https://github.com/nix-community/NUR/commit/c78dd1c71068a2fadd4a9dbe49f3e5472c52caae) | `` automatic update ``             |
| [`3ac04196`](https://github.com/nix-community/NUR/commit/3ac04196ff5b7ca61e3c32211242e5353587b03d) | `` automatic update ``             |
| [`43c17efd`](https://github.com/nix-community/NUR/commit/43c17efdacac6b287e7e9682a9b81e7f6c3aefb5) | `` automatic update ``             |
| [`543fd83b`](https://github.com/nix-community/NUR/commit/543fd83b04aee430edfa04ec0566562f14a726f7) | `` automatic update ``             |
| [`bf61aa6e`](https://github.com/nix-community/NUR/commit/bf61aa6eaa632d8ad4a79f1b623e8d18e5cea109) | `` automatic update ``             |
| [`f5252333`](https://github.com/nix-community/NUR/commit/f525233367a5f2da31703a886946c1ac0447b054) | `` automatic update ``             |
| [`d323bed9`](https://github.com/nix-community/NUR/commit/d323bed9eab87af4758220a8d019d9724980ffd5) | `` automatic update ``             |
| [`2b8ea80d`](https://github.com/nix-community/NUR/commit/2b8ea80d0844bf9b6e681bd8ca2bab9023a7804b) | `` automatic update ``             |
| [`6df22bf3`](https://github.com/nix-community/NUR/commit/6df22bf34973b592e15d2bb8ebe2c0663e1da8e4) | `` automatic update ``             |
| [`73cac06d`](https://github.com/nix-community/NUR/commit/73cac06db708bff06a0e2656edfe83e909c94eb0) | `` automatic update ``             |
| [`95825186`](https://github.com/nix-community/NUR/commit/958251865f23082222f24e47f511db536d2be1b7) | `` automatic update ``             |
| [`0b8d56bb`](https://github.com/nix-community/NUR/commit/0b8d56bbb4e1d8bf997e5c3e5d7d79b40c045816) | `` automatic update ``             |
| [`1ea58b3c`](https://github.com/nix-community/NUR/commit/1ea58b3c7c5689cb4941e30b41e21d8420bef6e0) | `` add humxc repository ``         |
| [`127d7917`](https://github.com/nix-community/NUR/commit/127d79170f199eb58cd768a9a14f21ae8590aa33) | `` automatic update ``             |
| [`f811d7c5`](https://github.com/nix-community/NUR/commit/f811d7c51c38df83a53012cd489d33ea4ebfbb45) | `` automatic update ``             |
| [`db4e975c`](https://github.com/nix-community/NUR/commit/db4e975c47c87e7719d1efe2465e3b8730b9fd58) | `` automatic update ``             |
| [`c4ac2ea9`](https://github.com/nix-community/NUR/commit/c4ac2ea99190785209eb1f377ef7e57036eff512) | `` automatic update ``             |
| [`1549f169`](https://github.com/nix-community/NUR/commit/1549f1693325a7a0b0bd03330bfe3e45d267200c) | `` automatic update ``             |
| [`3403b4e3`](https://github.com/nix-community/NUR/commit/3403b4e3c0886e8c2744fff2689ce0bf0009c805) | `` automatic update ``             |
| [`572feb8f`](https://github.com/nix-community/NUR/commit/572feb8f54b443ec523c3f74965cbb50058104a4) | `` automatic update ``             |
| [`9c9f4f33`](https://github.com/nix-community/NUR/commit/9c9f4f336d55914355a85d5cd9e945f785a28a15) | `` automatic update ``             |
| [`a014e830`](https://github.com/nix-community/NUR/commit/a014e830e99e9c2375d5c9fe8174e940be5e5b95) | `` automatic update ``             |
| [`3a6c93d0`](https://github.com/nix-community/NUR/commit/3a6c93d0643f65faf67e94fce5a2cbd381365969) | `` automatic update ``             |
| [`337d2425`](https://github.com/nix-community/NUR/commit/337d24259cd974990a23c1a88b169a5bf7880b1e) | `` automatic update ``             |
| [`af29a452`](https://github.com/nix-community/NUR/commit/af29a452c1e4fd99b3b9b07ca53135807be2bb01) | `` automatic update ``             |
| [`e63268c1`](https://github.com/nix-community/NUR/commit/e63268c11cc7324a004e50383dad8f8b26c85204) | `` automatic update ``             |
| [`d4b5e446`](https://github.com/nix-community/NUR/commit/d4b5e4464be84bf86f8f0eec4c9d5bb378656501) | `` automatic update ``             |
| [`df1c5050`](https://github.com/nix-community/NUR/commit/df1c50504631272f5bd703d756d9a36643b4fa56) | `` automatic update ``             |
| [`6f3ee62c`](https://github.com/nix-community/NUR/commit/6f3ee62c26497c489d1c10a36b5d73d7d4b31476) | `` automatic update ``             |
| [`420db9ad`](https://github.com/nix-community/NUR/commit/420db9ad7b6025c76ad8a084998f1244db7f7d95) | `` automatic update ``             |
| [`d6e00df8`](https://github.com/nix-community/NUR/commit/d6e00df82434f97f3c9bb9a6d4b2ccd5d591e00f) | `` automatic update ``             |
| [`265b38f9`](https://github.com/nix-community/NUR/commit/265b38f9b9a71613c47f13626e375363b0449165) | `` automatic update ``             |
| [`098f02af`](https://github.com/nix-community/NUR/commit/098f02af2a5e257230cc54cc8d49770cd07b4175) | `` automatic update ``             |
| [`b0442ec4`](https://github.com/nix-community/NUR/commit/b0442ec474d8ea412895d7026b708ee7f01c71bd) | `` automatic update ``             |
| [`4e3a7389`](https://github.com/nix-community/NUR/commit/4e3a7389db1343d9b37942b2955f86481976b9d6) | `` automatic update ``             |
| [`260e49ff`](https://github.com/nix-community/NUR/commit/260e49ff90729f719167658c67cfc0484cf61eb2) | `` automatic update ``             |
| [`35a136b9`](https://github.com/nix-community/NUR/commit/35a136b97a64ee17fa03c0f16b6815b5289f6045) | `` automatic update ``             |
| [`977e05ee`](https://github.com/nix-community/NUR/commit/977e05ee3fe72fa3d46d38d5dba30333437ee07c) | `` automatic update ``             |
| [`c0c36754`](https://github.com/nix-community/NUR/commit/c0c367546ec47b2354074be5f0c690a21d7c96da) | `` automatic update ``             |
| [`d24cae4b`](https://github.com/nix-community/NUR/commit/d24cae4bc1f69ec64b4c01c41208b7c09bb5a60e) | `` automatic update ``             |
| [`9b34b7a7`](https://github.com/nix-community/NUR/commit/9b34b7a7cc1038c92864b64cabac0e2c95a3e02b) | `` automatic update ``             |
| [`1518c3c6`](https://github.com/nix-community/NUR/commit/1518c3c66982981dcbfc3d508202b4e672b528ae) | `` automatic update ``             |
| [`94f72836`](https://github.com/nix-community/NUR/commit/94f72836fcc4678789b613abff8929cb9911f655) | `` automatic update ``             |
| [`3fce5664`](https://github.com/nix-community/NUR/commit/3fce56648d530c6083029eaa508b8b855313dce6) | `` automatic update ``             |
| [`5069c66f`](https://github.com/nix-community/NUR/commit/5069c66f5b619a10b3ee1dd70a725be6b67853d8) | `` automatic update ``             |
| [`bee3a6a5`](https://github.com/nix-community/NUR/commit/bee3a6a559df309d95efa57686f88142bbf7d8b6) | `` automatic update ``             |
| [`e7ec8929`](https://github.com/nix-community/NUR/commit/e7ec892929d337f69e601e0aa087b91d5b27fd50) | `` automatic update ``             |
| [`a5ec361c`](https://github.com/nix-community/NUR/commit/a5ec361c610f7ec0235af6cc5090ae99a7cb84ee) | `` automatic update ``             |
| [`dee4d145`](https://github.com/nix-community/NUR/commit/dee4d1450f47d3c07f08d68f58913fd10503b2a7) | `` automatic update ``             |
| [`9820ac64`](https://github.com/nix-community/NUR/commit/9820ac64192d452bc195038d39e6f715f5bdff93) | `` automatic update ``             |
| [`f056f658`](https://github.com/nix-community/NUR/commit/f056f658230c121d72bdbb6de0408fbd7e9ef97e) | `` automatic update ``             |
| [`22bba685`](https://github.com/nix-community/NUR/commit/22bba685176db632b260a23057dc3137cd279142) | `` automatic update ``             |
| [`f9148ad1`](https://github.com/nix-community/NUR/commit/f9148ad128b1b2bb051de90924be7b74f71b1678) | `` automatic update ``             |
| [`3278b5cc`](https://github.com/nix-community/NUR/commit/3278b5cc33529e7301c831e554687017ea240ab7) | `` automatic update ``             |
| [`cd738dc9`](https://github.com/nix-community/NUR/commit/cd738dc9fd70bfde0ccc3a2ffa7e7b0c27cae37d) | `` automatic update ``             |
| [`1839d2b9`](https://github.com/nix-community/NUR/commit/1839d2b991671f63666cdb0716875a2dd8ba4a46) | `` automatic update ``             |
| [`b31e3c01`](https://github.com/nix-community/NUR/commit/b31e3c01e8d6f9628eef600f14ca30979e868feb) | `` automatic update ``             |
| [`a5acf638`](https://github.com/nix-community/NUR/commit/a5acf638edd0fa9c221906b71407e590be971b30) | `` automatic update ``             |
| [`0831893f`](https://github.com/nix-community/NUR/commit/0831893fc0b729ae344c6b8ab4597ea10636cf27) | `` automatic update ``             |
| [`c9f8f70d`](https://github.com/nix-community/NUR/commit/c9f8f70dcd5249e5f4062fca9e874168b6c46195) | `` automatic update ``             |
| [`def45d08`](https://github.com/nix-community/NUR/commit/def45d084409a4814a6be822d98f74776f868683) | `` automatic update ``             |
| [`b09e0461`](https://github.com/nix-community/NUR/commit/b09e04613ea491c1b2d082efc372521ce336def9) | `` automatic update ``             |
| [`a88bdbd0`](https://github.com/nix-community/NUR/commit/a88bdbd04b5c1a16717557ce06b72efdd760916c) | `` automatic update ``             |
| [`b4f870e1`](https://github.com/nix-community/NUR/commit/b4f870e1e5ff02cba4ab8ad6544b26a90da683c1) | `` automatic update ``             |
| [`009e19f8`](https://github.com/nix-community/NUR/commit/009e19f805f96bb68afa7f31c6e278c09c3d6536) | `` automatic update ``             |
| [`e43a22f6`](https://github.com/nix-community/NUR/commit/e43a22f6fd5f15202962f40da32e5088cb18d799) | `` automatic update ``             |
| [`b7f37286`](https://github.com/nix-community/NUR/commit/b7f37286648498ef53c3838fb36178df6ef18460) | `` automatic update ``             |
| [`f3c6539d`](https://github.com/nix-community/NUR/commit/f3c6539d6faa92440a45ce7b1e2f1576ad5f66bf) | `` automatic update ``             |
| [`41a03f94`](https://github.com/nix-community/NUR/commit/41a03f94f2c9eaf6b836801c27c824c0556e6115) | `` automatic update ``             |
| [`1e39d432`](https://github.com/nix-community/NUR/commit/1e39d43293b5469141ae8878b9b5a582f0411f5e) | `` automatic update ``             |
| [`0e522f7a`](https://github.com/nix-community/NUR/commit/0e522f7ab79e679494ba0a5d5d4b6927a33497ee) | `` automatic update ``             |
| [`b628a183`](https://github.com/nix-community/NUR/commit/b628a183586e0de78a9250728eb4acee4fac1818) | `` automatic update ``             |
| [`cae34195`](https://github.com/nix-community/NUR/commit/cae34195effc7f9612ac2de6369fa389e61614bd) | `` automatic update ``             |