### PR TITLE
chore(flake/pre-commit-hooks): `5843cf06` -> `522fd47a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -948,11 +948,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1688056373,
-        "narHash": "sha256-2+SDlNRTKsgo3LBRiMUcoEUb6sDViRNQhzJquZ4koOI=",
+        "lastModified": 1688137124,
+        "narHash": "sha256-ramG4s/+A5+t/QG2MplTNPP/lmBWDtbW6ilpwb9sKVo=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "5843cf069272d92b60c3ed9e55b7a8989c01d4c7",
+        "rev": "522fd47af79b66cdd04b92618e65c7a11504650a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                          |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`31522e85`](https://github.com/cachix/pre-commit-hooks.nix/commit/31522e851a65b5bafe9292395d61e12a37c0597c) | `` Get rid of the runtime dependency in OCaml `` |
| [`ed3d3d1f`](https://github.com/cachix/pre-commit-hooks.nix/commit/ed3d3d1fc1febb4e9e9cf041cc7af01d8f2afbf0) | `` Add a hook for `headache` ``                  |