### PR TITLE
chore(flake/nix-on-droid): `064e1b28` -> `2301e01d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -647,11 +647,11 @@
         "nmd": "nmd_2"
       },
       "locked": {
-        "lastModified": 1684353543,
-        "narHash": "sha256-0b85kcdeM1WgGZZn0L4fke39xcVpO99hidzcpqvNOcQ=",
+        "lastModified": 1688144254,
+        "narHash": "sha256-8KL1l/7eP2Zm1aJjdVaSOk0W5kTnJo9kcgW03gqWuiI=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "064e1b280e4711ecea0d7abbe885362cbf7b717a",
+        "rev": "2301e01d48c90b60751005317de7a84a51a87eb6",
         "type": "github"
       },
       "original": {
@@ -692,17 +692,17 @@
     },
     "nixpkgs-for-bootstrap": {
       "locked": {
-        "lastModified": 1669834992,
-        "narHash": "sha256-YnhZGHgb4C3Q7DSGisO/stc50jFb9F/MzHeKS4giotg=",
+        "lastModified": 1686921029,
+        "narHash": "sha256-J1bX9plPCFhTSh6E3TWn9XSxggBh/zDD4xigyaIQBy8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "596a8e828c5dfa504f91918d0fa4152db3ab5502",
+        "rev": "c7ff1b9b95620ce8728c0d7bd501c458e6da9e04",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "596a8e828c5dfa504f91918d0fa4152db3ab5502",
+        "rev": "c7ff1b9b95620ce8728c0d7bd501c458e6da9e04",
         "type": "github"
       }
     },


### PR DESCRIPTION
| Commit                                                                                                | Message                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`2301e01d`](https://github.com/t184256/nix-on-droid/commit/2301e01d48c90b60751005317de7a84a51a87eb6) | `` pkgs: update talloc and proot ``            |
| [`468bf944`](https://github.com/t184256/nix-on-droid/commit/468bf944df432851ee7f6a82be16abe00ea26bd6) | `` update nixpkgs version ``                   |
| [`f77ae621`](https://github.com/t184256/nix-on-droid/commit/f77ae62112b8717ea9a3071f145916112b50e9cc) | `` pkgs/nix-directory: update nix to 2.16.1 `` |
| [`c367bba3`](https://github.com/t184256/nix-on-droid/commit/c367bba3416f7d36e838e5d5ff18f7d0d3e3c5f9) | `` tests/fakedroid: update qemu to 7.2.0 ``    |
| [`f636824b`](https://github.com/t184256/nix-on-droid/commit/f636824b08269640da482b42f2df8ce4d937580d) | `` set stable version to 23.05 ``              |