### PR TITLE
chore(flake/emacs-overlay): `ca555235` -> `4acc71cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1688117142,
-        "narHash": "sha256-Udga1I5P+qe/dHk6oUdLmdpFCNpsKiCoPuI6xeAnbz8=",
+        "lastModified": 1688145679,
+        "narHash": "sha256-JolyLHMqIQTjzDHONt54600eRQAjmEX4iwU615MMf1I=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ca5552354228a4c10cfdc4aaa7dd22b784ee6dea",
+        "rev": "4acc71cdae77ca29a3b9fe71297e08f3d82ead7e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4acc71cd`](https://github.com/nix-community/emacs-overlay/commit/4acc71cdae77ca29a3b9fe71297e08f3d82ead7e) | `` Updated repos/melpa ``  |
| [`486a4c51`](https://github.com/nix-community/emacs-overlay/commit/486a4c51c483700f5d8fd686d164b9a4f06efe2c) | `` Updated repos/elpa ``   |
| [`87f01c66`](https://github.com/nix-community/emacs-overlay/commit/87f01c66cdd396c011569573990a893654b28db4) | `` Updated flake inputs `` |