### PR TITLE
chore(flake/darwin): `25ae710b` -> `43587cdb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -122,11 +122,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687691275,
-        "narHash": "sha256-VVywT8ubStvDPF5TscDBokT3T0l3zsOzCW056noh5zc=",
+        "lastModified": 1688145780,
+        "narHash": "sha256-dNUINvO7qM7fItWSeqL2nE/F3IHCGZEeERMkm1i4pP4=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "25ae710ba3cd448c5d5678788d37f3d149378bc0",
+        "rev": "43587cdb726f73b962f12028055520dbd1d7233f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                       |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
| [`89ec258c`](https://github.com/LnL7/nix-darwin/commit/89ec258c7cac6d83f673ae5e4ce170bfc2c1f615) | `` documentation: Link to nixpkgs master if rev is unknown `` |
| [`d207fa60`](https://github.com/LnL7/nix-darwin/commit/d207fa609121341fe214b70b24fd4b12ae1e8737) | `` default.nix: Use nixpkgs.rev if it is set ``               |
| [`9af7fe60`](https://github.com/LnL7/nix-darwin/commit/9af7fe60b6a4ab990a95478a89f1bdd1c7517510) | `` feat(darwin-rebuild): support --refresh ``                 |