### PR TITLE
chore(flake/emacs-overlay): `4acc71cd` -> `525aaf59`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1688145679,
-        "narHash": "sha256-JolyLHMqIQTjzDHONt54600eRQAjmEX4iwU615MMf1I=",
+        "lastModified": 1688181703,
+        "narHash": "sha256-MtIEWmuWfYjsfzosr7JPbN0vPY+U1HUIjARlNBDYNYg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4acc71cdae77ca29a3b9fe71297e08f3d82ead7e",
+        "rev": "525aaf59a6bc06b80a19c1158c307627e0eef1a7",
         "type": "github"
       },
       "original": {
@@ -756,11 +756,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1687829761,
-        "narHash": "sha256-QRe1Y8SS3M4GeC58F/6ajz6V0ZLUVWX3ZAMgov2N3/g=",
+        "lastModified": 1688109178,
+        "narHash": "sha256-BSdeYp331G4b1yc7GIRgAnfUyaktW2nl7k0C577Tttk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9790f3242da2152d5aa1976e3e4b8b414f4dd206",
+        "rev": "b72aa95f7f096382bff3aea5f8fde645bca07422",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`525aaf59`](https://github.com/nix-community/emacs-overlay/commit/525aaf59a6bc06b80a19c1158c307627e0eef1a7) | `` Updated repos/melpa ``  |
| [`009c85b7`](https://github.com/nix-community/emacs-overlay/commit/009c85b7f12d48dd7a534dfd6f4096c6dd577e55) | `` Updated repos/emacs ``  |
| [`0c1f7f44`](https://github.com/nix-community/emacs-overlay/commit/0c1f7f44130ef6bb31cebe0dbcbba158a31daaae) | `` Updated repos/elpa ``   |
| [`a4eefefb`](https://github.com/nix-community/emacs-overlay/commit/a4eefefbc172964c836521d3242dc27d5f02b18d) | `` Updated flake inputs `` |