### PR TITLE
chore(flake/home-manager): `44d1a854` -> `7a0e9a67`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -491,11 +491,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688168945,
-        "narHash": "sha256-AfBdMc2JU54YKaOAvCR0t3dWQIA1bLKb9vGnaZJUh0E=",
+        "lastModified": 1688218897,
+        "narHash": "sha256-qIBOgrUoQjWzbzC/SOQDGQHnyNkFPGnV3FWOgGKYNGY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "44d1a8542ac92f0ce75d970090216245043a2709",
+        "rev": "7a0e9a67824aa05f972459aefc2caafe6fdc0f88",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`7a0e9a67`](https://github.com/nix-community/home-manager/commit/7a0e9a67824aa05f972459aefc2caafe6fdc0f88) | `` chromium: fix `commandLineArgs` to use the user specified package (#4175) `` |