### PR TITLE
chore(flake/emacs-overlay): `525aaf59` -> `54c0d37e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1688181703,
-        "narHash": "sha256-MtIEWmuWfYjsfzosr7JPbN0vPY+U1HUIjARlNBDYNYg=",
+        "lastModified": 1688237303,
+        "narHash": "sha256-+mm3PAt+VWhX+0bn3l5dqOR2TfIdmuzTHuPLI5GyHfY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "525aaf59a6bc06b80a19c1158c307627e0eef1a7",
+        "rev": "54c0d37eb161dd90a6da788676143091e5108613",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`54c0d37e`](https://github.com/nix-community/emacs-overlay/commit/54c0d37eb161dd90a6da788676143091e5108613) | `` Updated repos/melpa `` |
| [`8c2bf1be`](https://github.com/nix-community/emacs-overlay/commit/8c2bf1be5a5f6467fa03eab7132ad6e6c40f2e60) | `` Updated repos/emacs `` |
| [`bc36053b`](https://github.com/nix-community/emacs-overlay/commit/bc36053b24c95ffcbd6fd679735ff18a2b6c6697) | `` Updated repos/elpa ``  |