### PR TITLE
chore(flake/emacs-overlay): `54c0d37e` -> `9ff7c99f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1688237303,
-        "narHash": "sha256-+mm3PAt+VWhX+0bn3l5dqOR2TfIdmuzTHuPLI5GyHfY=",
+        "lastModified": 1688267954,
+        "narHash": "sha256-tkGDMcIPEaNJ0LkQ7L41vzmrl1nbDdDLxmIlGvdG3YU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "54c0d37eb161dd90a6da788676143091e5108613",
+        "rev": "9ff7c99ff19c08e15f5012990dbf83d0068d0646",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`9ff7c99f`](https://github.com/nix-community/emacs-overlay/commit/9ff7c99ff19c08e15f5012990dbf83d0068d0646) | `` Updated repos/melpa `` |
| [`dc15eed1`](https://github.com/nix-community/emacs-overlay/commit/dc15eed1ec726f00cb41bdaa3c7a3b38e9cc54b6) | `` Updated repos/emacs `` |
| [`48424827`](https://github.com/nix-community/emacs-overlay/commit/48424827aa80414955fe2f161c94b884c5073a31) | `` Updated repos/elpa ``  |