### PR TITLE
chore(flake/emacs-overlay): `9ff7c99f` -> `42d29a68`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1688267954,
-        "narHash": "sha256-tkGDMcIPEaNJ0LkQ7L41vzmrl1nbDdDLxmIlGvdG3YU=",
+        "lastModified": 1688293424,
+        "narHash": "sha256-GPAeV+CqU+NZyLmvWHWFV0hU0rw2qe++3qYeovqNN5k=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9ff7c99ff19c08e15f5012990dbf83d0068d0646",
+        "rev": "42d29a68c6b16aeb4a92141a743e564fe8dbbfad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`42d29a68`](https://github.com/nix-community/emacs-overlay/commit/42d29a68c6b16aeb4a92141a743e564fe8dbbfad) | `` Updated repos/melpa ``  |
| [`5e277f09`](https://github.com/nix-community/emacs-overlay/commit/5e277f09508ec5633857d5a3a8ef0f67914a814f) | `` Updated repos/emacs ``  |
| [`21d3a568`](https://github.com/nix-community/emacs-overlay/commit/21d3a5680ab159782635ead834a406afa9186cf0) | `` Updated flake inputs `` |