### PR TITLE
chore(flake/home-manager): `89d10f8a` -> `c85d9137`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -491,11 +491,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688220547,
-        "narHash": "sha256-cNKKLPaEOxd6t22Mt3tHGubyylbKGdoi2A3QkMTKes0=",
+        "lastModified": 1688302761,
+        "narHash": "sha256-YIYKeX3YfoAIg9DTe6cl1ga87rDCNDZugdGuqsvEN30=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "89d10f8adce369a80e046c2fd56d1e7b7507bb5b",
+        "rev": "c85d9137db45a1c9c161f4718b13cc3bd4cbd173",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                   |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`c85d9137`](https://github.com/nix-community/home-manager/commit/c85d9137db45a1c9c161f4718b13cc3bd4cbd173) | `` ci: autolabel calendars PRs (#4165) `` |
| [`53c75ac2`](https://github.com/nix-community/home-manager/commit/53c75ac2e6de7eb6f4837a0f1abf55abe013afad) | `` flake.lock: Update (#4161) ``          |