### PR TITLE
chore(flake/darwin): `43587cdb` -> `b06bab83`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -122,11 +122,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688145780,
-        "narHash": "sha256-dNUINvO7qM7fItWSeqL2nE/F3IHCGZEeERMkm1i4pP4=",
+        "lastModified": 1688307440,
+        "narHash": "sha256-7PTjbN+/+b799YN7Tk2SS5Vh8A0L3gBo8hmB7Y0VXug=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "43587cdb726f73b962f12028055520dbd1d7233f",
+        "rev": "b06bab83bdf285ea0ae3c8e145a081eb95959047",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                 |
| ------------------------------------------------------------------------------------------------ | --------------------------------------- |
| [`d2b70c61`](https://github.com/LnL7/nix-darwin/commit/d2b70c61bf5555df5f81bfa9b05c341cf68463b9) | `` tailscale: improve MagicDNS setup `` |