### PR TITLE
chore(flake/emacs-overlay): `42d29a68` -> `3372519e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1688293424,
-        "narHash": "sha256-GPAeV+CqU+NZyLmvWHWFV0hU0rw2qe++3qYeovqNN5k=",
+        "lastModified": 1688322111,
+        "narHash": "sha256-wwc+POUpjLYp14H6xhD8QpFax80Nyt8QJekzbvbUP3g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "42d29a68c6b16aeb4a92141a743e564fe8dbbfad",
+        "rev": "3372519e7d0a4fa74beaa60dc07f3fd2b34379d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`3372519e`](https://github.com/nix-community/emacs-overlay/commit/3372519e7d0a4fa74beaa60dc07f3fd2b34379d7) | `` Updated repos/melpa ``  |
| [`cbe60479`](https://github.com/nix-community/emacs-overlay/commit/cbe604798e93f7490a9a1fe5d3be5787485bac06) | `` Updated repos/emacs ``  |
| [`8a229b75`](https://github.com/nix-community/emacs-overlay/commit/8a229b756728fb3cecb2c6e4bd11045e1da42fb7) | `` Updated repos/elpa ``   |
| [`2659c275`](https://github.com/nix-community/emacs-overlay/commit/2659c275b75b029627cfa5daa51fdd55b46dd246) | `` Updated flake inputs `` |