### PR TITLE
chore(flake/emacs-overlay): `3372519e` -> `f443f77e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1688322111,
-        "narHash": "sha256-wwc+POUpjLYp14H6xhD8QpFax80Nyt8QJekzbvbUP3g=",
+        "lastModified": 1688354933,
+        "narHash": "sha256-E3/o+Qs59YGoLgo/TsLM34wt0GcxpNmNxrX9vVWeznw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3372519e7d0a4fa74beaa60dc07f3fd2b34379d7",
+        "rev": "f443f77e16da5b244761ae7d5c45064418c9df7b",
         "type": "github"
       },
       "original": {
@@ -756,11 +756,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1688109178,
-        "narHash": "sha256-BSdeYp331G4b1yc7GIRgAnfUyaktW2nl7k0C577Tttk=",
+        "lastModified": 1688177999,
+        "narHash": "sha256-JZ5nk90Ym79b4J593xYb0mI79QxU0efJLuCU3sXDalQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b72aa95f7f096382bff3aea5f8fde645bca07422",
+        "rev": "0de86059128947b2438995450f2c2ca08cc783d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`f443f77e`](https://github.com/nix-community/emacs-overlay/commit/f443f77e16da5b244761ae7d5c45064418c9df7b) | `` Updated repos/melpa ``  |
| [`f1d42619`](https://github.com/nix-community/emacs-overlay/commit/f1d42619627cb573d23ae41131115de72866c3ba) | `` Updated repos/emacs ``  |
| [`1a2047ac`](https://github.com/nix-community/emacs-overlay/commit/1a2047ac2aa3770b9634d8fe3f0191dfa6f448f9) | `` Updated repos/elpa ``   |
| [`53e153e2`](https://github.com/nix-community/emacs-overlay/commit/53e153e2c46e21ccb49155da2f448d428f47d0be) | `` Updated flake inputs `` |