### PR TITLE
chore(flake/emacs-overlay): `388758cb` -> `3d790419`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1688381365,
-        "narHash": "sha256-vtgPuxArGyYNHTnjX7l7PYsFmgGm1S/pkVxJvCZJFDQ=",
+        "lastModified": 1688410373,
+        "narHash": "sha256-TYh1O1a59BY1mX7w25nAwC2hHPdsmtTcwUwD1U9dUKA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "388758cbdd4fb1fa3c24543a5f19e9f0f570c3eb",
+        "rev": "3d790419f80b908cca53e256556d3dd1332ec052",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`3d790419`](https://github.com/nix-community/emacs-overlay/commit/3d790419f80b908cca53e256556d3dd1332ec052) | `` Updated repos/melpa `` |
| [`4a2791f0`](https://github.com/nix-community/emacs-overlay/commit/4a2791f0041034dcf525aa8aa71a623624a38bcc) | `` Updated repos/emacs `` |