### PR TITLE
chore(flake/emacs-overlay): `3d790419` -> `984950c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1688410373,
-        "narHash": "sha256-TYh1O1a59BY1mX7w25nAwC2hHPdsmtTcwUwD1U9dUKA=",
+        "lastModified": 1688440625,
+        "narHash": "sha256-zMmCsbHplBCiZvWLBzlioTqLLyYlPzOa1c89Wmy+BOE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3d790419f80b908cca53e256556d3dd1332ec052",
+        "rev": "984950c68da3892237f66c1bf5051116214b25c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`984950c6`](https://github.com/nix-community/emacs-overlay/commit/984950c68da3892237f66c1bf5051116214b25c9) | `` Updated repos/nongnu `` |
| [`324b98c5`](https://github.com/nix-community/emacs-overlay/commit/324b98c5cccb731ccb6f2b4e3e45a8c6d199c4bf) | `` Updated repos/melpa ``  |
| [`d4f72b53`](https://github.com/nix-community/emacs-overlay/commit/d4f72b539c1123294d53fbea2d8c88053e36d6a8) | `` Updated repos/emacs ``  |
| [`c9f31918`](https://github.com/nix-community/emacs-overlay/commit/c9f3191845c0a681a6c624e25fd267d7b50bcbbd) | `` Updated repos/elpa ``   |