### PR TITLE
chore(flake/emacs-overlay): `984950c6` -> `e018e015`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1688440625,
-        "narHash": "sha256-zMmCsbHplBCiZvWLBzlioTqLLyYlPzOa1c89Wmy+BOE=",
+        "lastModified": 1688462538,
+        "narHash": "sha256-H1OFqmnD5XiD+wRxYf/2lnRu65c+GbiKt4Msdfuj8Jc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "984950c68da3892237f66c1bf5051116214b25c9",
+        "rev": "e018e01518119131c1358d523aa1f6f37349ed9f",
         "type": "github"
       },
       "original": {
@@ -756,11 +756,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1688177999,
-        "narHash": "sha256-JZ5nk90Ym79b4J593xYb0mI79QxU0efJLuCU3sXDalQ=",
+        "lastModified": 1688389917,
+        "narHash": "sha256-RKiK1QeommEsjQ8fLgxt4831x9O6n2gD7wAhVZTrr8M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0de86059128947b2438995450f2c2ca08cc783d5",
+        "rev": "aed4b19d312525ae7ca9bceb4e1efe3357d0e2eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`e018e015`](https://github.com/nix-community/emacs-overlay/commit/e018e01518119131c1358d523aa1f6f37349ed9f) | `` Updated repos/melpa ``  |
| [`e5d2edd9`](https://github.com/nix-community/emacs-overlay/commit/e5d2edd98d6f8c58ec756991d4aeac6542040c26) | `` Updated flake inputs `` |