### PR TITLE
chore(flake/home-manager): `c24deeca` -> `b406b8d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -491,11 +491,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688409282,
-        "narHash": "sha256-nnVCN5QiZ5+DEc70PRQLEcxqlxtsmeBU1BnpsRPUJlA=",
+        "lastModified": 1688467264,
+        "narHash": "sha256-AUQP1WtmBb36bRc41p5ieTwq6Y8pgiKurbdrsPeP3fg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c24deeca64538dcbc589ed8da9146e4ca9eb85b7",
+        "rev": "b406b8d1bc90f6cd3e120d189b3e929f17ca4aea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`b406b8d1`](https://github.com/nix-community/home-manager/commit/b406b8d1bc90f6cd3e120d189b3e929f17ca4aea) | `` PULL_REQUEST_TEMPLATE.md: add maintainer cc section (#4193) ``   |
| [`4a26e210`](https://github.com/nix-community/home-manager/commit/4a26e21030a6ea9adbcc967812286bbe71fe45c5) | `` programs.khal ``                                                 |
| [`d895a774`](https://github.com/nix-community/home-manager/commit/d895a774489cacd10c0140d54c4d158a53dcde90) | `` vdirsyncer: synchronize metadata as well (#4167) ``              |
| [`3be2abb2`](https://github.com/nix-community/home-manager/commit/3be2abb2e6df41d9ddd5816032adf91691328225) | `` i18n: Use glibcLocales from NixOS if possible (#2333) (#4177) `` |