### PR TITLE
chore(flake/pre-commit-hooks): `42587d34` -> `f6a6863a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -948,11 +948,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1688386108,
-        "narHash": "sha256-Vffto9QaVonzYAcPlAzd0soqWYpPpKk60dfNLSIXcFA=",
+        "lastModified": 1688473851,
+        "narHash": "sha256-j+ViA3lh4uQGIDqB6TjM4+wijX2M5mfNb6MVJVekpAs=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "42587d3414d1747999a5f71e92a83cf6547b62da",
+        "rev": "f6a6863a3bcb61e846a9e4777b90ee365607a925",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                   |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
| [`f41c6e84`](https://github.com/cachix/pre-commit-hooks.nix/commit/f41c6e84f3a31d7415a293765d29244902bcf99d) | `` Revert "bump fourmolu, 0.9 -> 0.12" `` |