### PR TITLE
chore(flake/emacs-overlay): `e018e015` -> `54567ac5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1688462538,
-        "narHash": "sha256-H1OFqmnD5XiD+wRxYf/2lnRu65c+GbiKt4Msdfuj8Jc=",
+        "lastModified": 1688494665,
+        "narHash": "sha256-wXIBz6NVB1/d+H/nz+6XOrtn5s2jdFEJWuFP1qoHIjY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e018e01518119131c1358d523aa1f6f37349ed9f",
+        "rev": "54567ac566cd6bfa2607fbe155f9e009ce72306a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`54567ac5`](https://github.com/nix-community/emacs-overlay/commit/54567ac566cd6bfa2607fbe155f9e009ce72306a) | `` Updated repos/melpa ``  |
| [`37c8498a`](https://github.com/nix-community/emacs-overlay/commit/37c8498a09fb9cce79844076524be8bc3e0a1676) | `` Updated repos/emacs ``  |
| [`50211263`](https://github.com/nix-community/emacs-overlay/commit/502112634ab6ad399e7377726d2afe751f88f47b) | `` Updated repos/elpa ``   |
| [`6c137eb3`](https://github.com/nix-community/emacs-overlay/commit/6c137eb3b7783c0ea9fa4cb1f6058671b470d412) | `` Updated flake inputs `` |