### PR TITLE
chore(flake/emacs-overlay): `54567ac5` -> `44bffe24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1688494665,
-        "narHash": "sha256-wXIBz6NVB1/d+H/nz+6XOrtn5s2jdFEJWuFP1qoHIjY=",
+        "lastModified": 1688527822,
+        "narHash": "sha256-6hHi5yqZN3sxY2OdzGORhbjMpgejsqs4WFyOAyCOagU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "54567ac566cd6bfa2607fbe155f9e009ce72306a",
+        "rev": "44bffe245cd8ce2281cf0a60021a4dccb6e78148",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`44bffe24`](https://github.com/nix-community/emacs-overlay/commit/44bffe245cd8ce2281cf0a60021a4dccb6e78148) | `` Updated repos/melpa `` |
| [`38426b19`](https://github.com/nix-community/emacs-overlay/commit/38426b1997b4cd62929efa081ccd9e019d63656a) | `` Updated repos/emacs `` |
| [`8d653d51`](https://github.com/nix-community/emacs-overlay/commit/8d653d517603879aea30e8a3ef5b0d9fe5f28b4c) | `` Updated repos/elpa ``  |