### PR TITLE
chore(flake/emacs-overlay): `44bffe24` -> `c084710d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1688527822,
-        "narHash": "sha256-6hHi5yqZN3sxY2OdzGORhbjMpgejsqs4WFyOAyCOagU=",
+        "lastModified": 1688552915,
+        "narHash": "sha256-eMG8RA9lO7YVWpZ2/+IPSnfyt9Zr03UVEc+l6gHz3WQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "44bffe245cd8ce2281cf0a60021a4dccb6e78148",
+        "rev": "c084710df62bb9f681e52452a0cf518d1bfcedec",
         "type": "github"
       },
       "original": {
@@ -756,11 +756,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1688389917,
-        "narHash": "sha256-RKiK1QeommEsjQ8fLgxt4831x9O6n2gD7wAhVZTrr8M=",
+        "lastModified": 1688482527,
+        "narHash": "sha256-9zd0YC2gfsRvVJENZsVs1R5LBj5/t127JlCLggn/970=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aed4b19d312525ae7ca9bceb4e1efe3357d0e2eb",
+        "rev": "c7a18f89ef1dc423f57f3de9bd5d9355550a5d15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c084710d`](https://github.com/nix-community/emacs-overlay/commit/c084710df62bb9f681e52452a0cf518d1bfcedec) | `` Updated repos/melpa ``  |
| [`be1374aa`](https://github.com/nix-community/emacs-overlay/commit/be1374aad75cb15de580de541a4bc9ddb318f524) | `` Updated repos/emacs ``  |
| [`fcac8e09`](https://github.com/nix-community/emacs-overlay/commit/fcac8e09c6a7b5fb4272f33021351823e74719a2) | `` Updated flake inputs `` |