### PR TITLE
chore(flake/pre-commit-hooks): `f6a6863a` -> `8d316204`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -948,11 +948,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1688473851,
-        "narHash": "sha256-j+ViA3lh4uQGIDqB6TjM4+wijX2M5mfNb6MVJVekpAs=",
+        "lastModified": 1688569817,
+        "narHash": "sha256-arDXSfIcVwHCcpB8HAHtdsMMFyhcwYC0xZZ2HjYisbk=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "f6a6863a3bcb61e846a9e4777b90ee365607a925",
+        "rev": "8d316204b4b977202551d98ab51a7b8c9898afca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                       |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------- |
| [`57b845f5`](https://github.com/cachix/pre-commit-hooks.nix/commit/57b845f5f8f31ac0c48f449d17c9caa1c2f07291) | `` Do not print "hooks up to date" message `` |