### PR TITLE
chore(flake/pre-commit-hooks): `8d316204` -> `c8d18ba3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -948,11 +948,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1688569817,
-        "narHash": "sha256-arDXSfIcVwHCcpB8HAHtdsMMFyhcwYC0xZZ2HjYisbk=",
+        "lastModified": 1688596063,
+        "narHash": "sha256-9t7RxBiKWHygsqXtiNATTJt4lim/oSYZV3RG8OjDDng=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "8d316204b4b977202551d98ab51a7b8c9898afca",
+        "rev": "c8d18ba345730019c3faf412c96a045ade171895",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                              |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`658bf06b`](https://github.com/cachix/pre-commit-hooks.nix/commit/658bf06b1691f76803527ce0eda660620a03a161) | `` Only run `typos` against text files by default `` |