### PR TITLE
chore(flake/emacs-overlay): `f0f67575` -> `05f4c43b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1688581790,
-        "narHash": "sha256-SupqhKSnz4t0hvQu24q/tfExuXEhy5saZUmoegGiaDs=",
+        "lastModified": 1688614126,
+        "narHash": "sha256-aq8Mg2mJ3hyLRTv5vYSNwdMSPwOkpvNBihYZRt5ORWI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f0f675751b0ddfff1edf44013064b5f5f52f9493",
+        "rev": "05f4c43b163391ac984cfbe2b4787350ee565b3e",
         "type": "github"
       },
       "original": {
@@ -756,11 +756,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1688482527,
-        "narHash": "sha256-9zd0YC2gfsRvVJENZsVs1R5LBj5/t127JlCLggn/970=",
+        "lastModified": 1688566749,
+        "narHash": "sha256-3Og5xbNk1qncLWl2zrrL/k80UqRI/nEGPEbzz306Izk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c7a18f89ef1dc423f57f3de9bd5d9355550a5d15",
+        "rev": "c99004f75fd28cc10b9d2e01f51a412d768269c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`05f4c43b`](https://github.com/nix-community/emacs-overlay/commit/05f4c43b163391ac984cfbe2b4787350ee565b3e) | `` Updated repos/melpa ``  |
| [`158b659a`](https://github.com/nix-community/emacs-overlay/commit/158b659aa7aaf3768f6fb66e291efedd0d4c14f2) | `` Updated repos/emacs ``  |
| [`68584a6a`](https://github.com/nix-community/emacs-overlay/commit/68584a6a829040d50249c66e78e3afced8d78d11) | `` Updated repos/elpa ``   |
| [`558fb879`](https://github.com/nix-community/emacs-overlay/commit/558fb8793b51294e1e51a0534810991253d08565) | `` Updated flake inputs `` |