### PR TITLE
chore(flake/emacs-overlay): `3fbcace5` -> `357e0d33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689245342,
-        "narHash": "sha256-pRFDRHpa654j8TkVrQBcRf6c6/VQXt6TCLbBPwkphJs=",
+        "lastModified": 1689272190,
+        "narHash": "sha256-DQXppLXurv8DlIbYm37cd6ZZ7nNFHdtBbdU6jgUUTlE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3fbcace5b46e8b75d45314914f0ac58cc680ab81",
+        "rev": "357e0d33bb28c3e558eba0c7822590927040015d",
         "type": "github"
       },
       "original": {
@@ -698,11 +698,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1689137672,
-        "narHash": "sha256-QZoHxr0a73x6rQcAo5CiwYpysHbSnk7lAR8/16um7mM=",
+        "lastModified": 1689209875,
+        "narHash": "sha256-8AVcBV1DiszaZzHFd5iLc8HSLfxRAuqcU0QdfBEF3Ag=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "98da3dd0de6660d4abed7bb74e748694bd803413",
+        "rev": "fcc147b1e9358a8386b2c4368bd928e1f63a7df2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`357e0d33`](https://github.com/nix-community/emacs-overlay/commit/357e0d33bb28c3e558eba0c7822590927040015d) | `` Updated repos/melpa ``  |
| [`199d73b3`](https://github.com/nix-community/emacs-overlay/commit/199d73b373b3d49866b4dde9aee97ebd9f8b276a) | `` Updated repos/emacs ``  |
| [`fa643a8a`](https://github.com/nix-community/emacs-overlay/commit/fa643a8a136b6d24172d4a3f012df07d9baf584d) | `` Updated repos/elpa ``   |
| [`0910889d`](https://github.com/nix-community/emacs-overlay/commit/0910889d8b47ee43ae58329d18fe6706f85d899c) | `` Updated flake inputs `` |