### PR TITLE
chore(flake/stylix): `2524c8ae` -> `cdf7e2de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -993,11 +993,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689207262,
-        "narHash": "sha256-sr7/oPidjRbXzEkhciGZyj7aoPpHyZf51SEs9FU8U04=",
+        "lastModified": 1689274123,
+        "narHash": "sha256-c/1WJqoyOufbDBH9Gm2psFt6R52uoIXLNlg7moaiXSE=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "2524c8ae027e4101b9a476c0b13fe05d3c8bdeb9",
+        "rev": "cdf7e2ded1149a24f1b38bbdcf7c6c20d6165571",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                        |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`cdf7e2de`](https://github.com/danth/stylix/commit/cdf7e2ded1149a24f1b38bbdcf7c6c20d6165571) | `` Support transparency in Helix :sparkles: `` |
| [`952ba1c7`](https://github.com/danth/stylix/commit/952ba1c7567c97b984368c1b92d1e01b6e092465) | `` Add support for Fuzzel :sparkles: ``        |