### PR TITLE
chore(flake/nixos-hardware): `44bc0250` -> `d4ea64f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -620,11 +620,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1689060619,
+        "lastModified": 1689320556,
         "narHash": "sha256-vODUkZLWFVCvo1KPK3dC2CbXjxa9antEn5ozwlcTr48=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "44bc025007e5fcc10dbc3d9f96dcbf06fc0e8c1c",
+        "rev": "d4ea64f2063820120c05f6ba93ee02e6d4671d6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`d4ea64f2`](https://github.com/NixOS/nixos-hardware/commit/d4ea64f2063820120c05f6ba93ee02e6d4671d6b) | `` Revert "framework: switch to power-profiles-daemon" `` |
| [`bc2ab72b`](https://github.com/NixOS/nixos-hardware/commit/bc2ab72beca298aa6074eaee0a612d3dd08d5073) | `` framework: switch to power-profiles-daemon ``          |