### PR TITLE
chore(flake/darwin): `b06bab83` -> `90ae979e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -122,11 +122,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688307440,
-        "narHash": "sha256-7PTjbN+/+b799YN7Tk2SS5Vh8A0L3gBo8hmB7Y0VXug=",
+        "lastModified": 1688973178,
+        "narHash": "sha256-nsIzOjD3v5zuozWeUvifEQ778C8cLMqW5ga5cfrmxAA=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "b06bab83bdf285ea0ae3c8e145a081eb95959047",
+        "rev": "90ae979e352d241a86b73f8c7193bf7f749f37e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                  |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
| [`8364529f`](https://github.com/LnL7/nix-darwin/commit/8364529fc49f35294c2fcc23f7caa0becd6e5cdf) | `` fix zsh eating output without new line ending ``      |
| [`f9724c45`](https://github.com/LnL7/nix-darwin/commit/f9724c4543035d6190c00168ebfa93f0b2e927d0) | `` eval-config: rationalize handling of Nixpkgs ``       |
| [`51ba5e61`](https://github.com/LnL7/nix-darwin/commit/51ba5e614acf1c94d519e6047814219082827faa) | `` version: rewrite Git revision logic ``                |
| [`72b7e866`](https://github.com/LnL7/nix-darwin/commit/72b7e8668c24950b8300ffe3d135dad1ae72a4f5) | `` version: default Git revision options to `null` ``    |
| [`d9e825f1`](https://github.com/LnL7/nix-darwin/commit/d9e825f121784a7628ae177a04cb80709043e0fe) | `` linux-builder: fix evaluation errors ``               |
| [`e25eeff1`](https://github.com/LnL7/nix-darwin/commit/e25eeff158ceb415079e38f6e78a470c5664fa2f) | `` nixpkgs: rebase module on latest NixOS ``             |
| [`2d20e861`](https://github.com/LnL7/nix-darwin/commit/2d20e861112955cd2d102d0a0abf36d265001a5d) | `` documentation: use feature test for docs generator `` |
| [`d2b01ab4`](https://github.com/LnL7/nix-darwin/commit/d2b01ab455cb3fcae531fecc5fd23947dd102065) | `` nix/linux-builder: init ``                            |