### PR TITLE
chore(flake/sops-nix): `88b964df` -> `4ead5280`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -744,11 +744,11 @@
     },
     "nixpkgs-stable_5": {
       "locked": {
-        "lastModified": 1688868408,
-        "narHash": "sha256-RR9N5XTAxSBhK8MCvLq9uxfdkd7etC//seVXldy0k48=",
+        "lastModified": 1689398528,
+        "narHash": "sha256-qVn/doWn20axR+KvmAAGexv0A5RVzcBbd5HfNMAMeVI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "510d721ce097150ae3b80f84b04b13b039186571",
+        "rev": "3dc2bc15956db2ff2316af45eefd45803fc1372b",
         "type": "github"
       },
       "original": {
@@ -980,11 +980,11 @@
         "nixpkgs-stable": "nixpkgs-stable_5"
       },
       "locked": {
-        "lastModified": 1689149796,
-        "narHash": "sha256-3FCUdayBHcxk6BZOxEIfa5UxbXNQzTc/VlN7ociI2Dw=",
+        "lastModified": 1689404092,
+        "narHash": "sha256-skumlIqwdu09UrQuFRhgfKwOm9FSaIzDDI0VL99Ihi8=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "88b964df6981e4844c07be8c192aa6bdca768a10",
+        "rev": "4ead52809041d90bdbd203cc6db81fa93075ad4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                |
| ----------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`f77dd7df`](https://github.com/Mic92/sops-nix/commit/f77dd7df8f8b647d2ba0294808fa175d8c980d14) | `` ci/dependabot: set email ``         |
| [`3c851dbb`](https://github.com/Mic92/sops-nix/commit/3c851dbbeacf2c5dd694ece5e8e201d54255eb2f) | `` add scripts to update vendorHash `` |
| [`62a7c95c`](https://github.com/Mic92/sops-nix/commit/62a7c95c8c6284a54ad152e451bc633ac85ddca8) | `` vendorHash: make it overridable ``  |
| [`5fc5cdda`](https://github.com/Mic92/sops-nix/commit/5fc5cddafd5b68f3706570dcf59d84fd3f4584d3) | `` flake.lock: Update ``               |