### PR TITLE
chore(flake/darwin): `90ae979e` -> `43ce0868`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -122,11 +122,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688973178,
-        "narHash": "sha256-nsIzOjD3v5zuozWeUvifEQ778C8cLMqW5ga5cfrmxAA=",
+        "lastModified": 1689163348,
+        "narHash": "sha256-qL3FnBauu3PmYf0OZzv2cKtVyRg4ELVXPQl0AAYqlqs=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "90ae979e352d241a86b73f8c7193bf7f749f37e4",
+        "rev": "43ce086813c83184b88f67fc544af2050a3035ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                      |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
| [`8eb09d4d`](https://github.com/LnL7/nix-darwin/commit/8eb09d4d0b3d820934d9871c884e0423bc95ba89) | `` uninstaller: fix removing `/Applications/Nix Apps` ``     |
| [`63af129c`](https://github.com/LnL7/nix-darwin/commit/63af129cb56548edf8e620437443f8e8b57864f9) | `` etc: use `.before-nix-darwin` instead of `.orig` ``       |
| [`ac9a366a`](https://github.com/LnL7/nix-darwin/commit/ac9a366aed7e0d4cbad304aa97d1a3da70f27fa5) | `` uninstaller: remove `/Applications/Nix Apps` ``           |
| [`cad8954f`](https://github.com/LnL7/nix-darwin/commit/cad8954f75809eda533cfb01dc92de8d32f5332d) | `` etc: fail if we can't add a file ``                       |
| [`4b90ea84`](https://github.com/LnL7/nix-darwin/commit/4b90ea84e4e90aab2bcaec117ceddf83e02d6adf) | `` doc: store a copy of known files ``                       |
| [`78817270`](https://github.com/LnL7/nix-darwin/commit/7881727017b0320ac14e7d253efe027676e7fa10) | `` installer: match flaky installation logic ``              |
| [`22620845`](https://github.com/LnL7/nix-darwin/commit/22620845fee1cc16f4ea639509c50fd989ccc1ce) | `` readme: update with new flaky instructions ``             |
| [`5288a723`](https://github.com/LnL7/nix-darwin/commit/5288a723540fdb25e34364518115e2ef32ed19ad) | `` Allow flaky installation with `darwin-rebuild` ``         |
| [`f70f90c4`](https://github.com/LnL7/nix-darwin/commit/f70f90c42207ede0c3b21b785e2650beeecc161c) | `` flake: add `packages.darwin-{option,rebuild}` ``          |
| [`aeaafcc8`](https://github.com/LnL7/nix-darwin/commit/aeaafcc88a65c6ca18c1b699afbb53e6ff0b5ae2) | `` flake: add `packages.darwin-uninstaller` ``               |
| [`b70656af`](https://github.com/LnL7/nix-darwin/commit/b70656affa5e63efcf0a0a728c6f9a26911c7ef4) | `` Add system.systemBuilderCommands and systemBuilderArgs `` |
| [`591446ca`](https://github.com/LnL7/nix-darwin/commit/591446ca945402044ad109990491ed87c42ba37a) | `` nix: Remove readOnlyStore option as it has no effect ``   |
| [`4a7da05c`](https://github.com/LnL7/nix-darwin/commit/4a7da05c1ef53064d548742eddb1964cf4b3dda7) | `` Fix spelling ``                                           |