### PR TITLE
chore(flake/darwin): `2ad716c2` -> `d468d4e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -122,11 +122,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689188243,
-        "narHash": "sha256-v3EDlWWLBQ+LIRWZ03jd8bnvHLyNae6iaqd03rbYhwo=",
+        "lastModified": 1689260591,
+        "narHash": "sha256-d4lwp7mLOuXVOntmFm3nIR7Q1sCIw7wfpKB1dZVKtyw=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "2ad716c2786dabf8f458ae1e7d343775d3acc65c",
+        "rev": "d468d4e813bb3ebe91e8d82ffed2f21852fa8909",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                               |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`a86a6f8b`](https://github.com/LnL7/nix-darwin/commit/a86a6f8b71a816b505d0e8e4310e644a3f75fdfd) | `` workflows: use `nix-darwin` instead of `darwin` `` |