### PR TITLE
chore(flake/stylix): `cdf7e2de` -> `d3092bed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -993,11 +993,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689274123,
-        "narHash": "sha256-c/1WJqoyOufbDBH9Gm2psFt6R52uoIXLNlg7moaiXSE=",
+        "lastModified": 1689278525,
+        "narHash": "sha256-zCvkIBZGj4eDuzMhv8m5bqo5QXTJpQF8oYYpqhBLU6E=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "cdf7e2ded1149a24f1b38bbdcf7c6c20d6165571",
+        "rev": "d3092bed023406359d06ea9a6d1f8bd7bf93d447",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                               |
| --------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`d3092bed`](https://github.com/danth/stylix/commit/d3092bed023406359d06ea9a6d1f8bd7bf93d447) | `` Set fonts for Fuzzel :sparkles: `` |