### PR TITLE
chore(flake/emacs-overlay): `357e0d33` -> `a44ec998`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689272190,
-        "narHash": "sha256-DQXppLXurv8DlIbYm37cd6ZZ7nNFHdtBbdU6jgUUTlE=",
+        "lastModified": 1689306175,
+        "narHash": "sha256-8A9V2m8SsHMmn2F7SAwsbwu5QVTRR9MkX9kF48T+Qsk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "357e0d33bb28c3e558eba0c7822590927040015d",
+        "rev": "a44ec998f6c8f04973f8e8630847157efec2bbfb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`a44ec998`](https://github.com/nix-community/emacs-overlay/commit/a44ec998f6c8f04973f8e8630847157efec2bbfb) | `` Updated repos/nongnu `` |
| [`d853845d`](https://github.com/nix-community/emacs-overlay/commit/d853845d96c5f209ae2a61357547909c1a788d3a) | `` Updated repos/melpa ``  |
| [`c557b749`](https://github.com/nix-community/emacs-overlay/commit/c557b749a6e7f7ae5af7b0b7829fddb91d7d5d43) | `` Updated repos/emacs ``  |
| [`0da2b0ca`](https://github.com/nix-community/emacs-overlay/commit/0da2b0caa2bb0e2b9749b8d3a5b602bb55a4d345) | `` Updated repos/elpa ``   |