### PR TITLE
chore(flake/agenix): `db5637d1` -> `0d8c5325`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,11 +13,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684153753,
-        "narHash": "sha256-PVbWt3qrjYAK+T5KplFcO+h7aZWfEj1UtyoKlvcDxh0=",
+        "lastModified": 1689334118,
+        "narHash": "sha256-djk5AZv1yU84xlKFaVHqFWvH73U7kIRstXwUAnDJPsk=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "db5637d10f797bb251b94ef9040b237f4702cde3",
+        "rev": "0d8c5325fc81daf00532e3e26c6752f7bcde1143",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`6e8a48c2`](https://github.com/ryantm/agenix/commit/6e8a48c2dca4fd8bd6a002dda1da1645753ef006) | `` doc: fix nixos option format in descriptions ``     |
| [`0d949607`](https://github.com/ryantm/agenix/commit/0d94960783efdcaaee800b22f03c861b8c575d3f) | `` doc: fix defaultText by adding literalExpression `` |