### PR TITLE
chore(flake/stylix): `d3092bed` -> `d14076e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -50,22 +50,20 @@
     },
     "base16": {
       "inputs": {
-        "nixpkgs": [
-          "stylix",
-          "nixpkgs"
-        ]
+        "fromYaml": "fromYaml"
       },
       "locked": {
-        "lastModified": 1658847131,
-        "narHash": "sha256-X6Mml7cT0YR3WCD5fkUhpRVV5ZPcwdcDsND8r8xMqTE=",
+        "lastModified": 1687651793,
+        "narHash": "sha256-AjV/f/grsR4y6t0aUviXxjeLAEYmpE/4XE08IIPhHag=",
         "owner": "SenchoPens",
         "repo": "base16.nix",
-        "rev": "6b404cda2e04ca3cf5ca7b877af9c469e1386acb",
+        "rev": "f493d8a8a6b4c1d814790e2189f26d4bcf433185",
         "type": "github"
       },
       "original": {
         "owner": "SenchoPens",
         "repo": "base16.nix",
+        "rev": "f493d8a8a6b4c1d814790e2189f26d4bcf433185",
         "type": "github"
       }
     },
@@ -438,6 +436,22 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "fromYaml": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1685846909,
+        "narHash": "sha256-ibxtG018Qq2Qjxir4Hai3Gr1hOOa+ad4V0EbFaHOj9Y=",
+        "owner": "SenchoPens",
+        "repo": "fromYaml",
+        "rev": "706176e156923d963ead81fe6bfba041f057cc65",
+        "type": "github"
+      },
+      "original": {
+        "owner": "SenchoPens",
+        "repo": "fromYaml",
         "type": "github"
       }
     },
@@ -993,11 +1007,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689278525,
-        "narHash": "sha256-zCvkIBZGj4eDuzMhv8m5bqo5QXTJpQF8oYYpqhBLU6E=",
+        "lastModified": 1689335408,
+        "narHash": "sha256-Tnwpf0LyUL64DxaTQU6iMSPvmZWJKUSgNXm17ctAtNI=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "d3092bed023406359d06ea9a6d1f8bd7bf93d447",
+        "rev": "d14076e46f31c932e2a2998df0fb8ebff9d28a71",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                              |
| --------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`d14076e4`](https://github.com/danth/stylix/commit/d14076e46f31c932e2a2998df0fb8ebff9d28a71) | `` Update flake inputs :arrow_up: `` |