### PR TITLE
chore(flake/emacs-overlay): `99757bed` -> `86113db3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -240,11 +240,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689329938,
-        "narHash": "sha256-zFtCJw/+iQ2IQ1J/ZzzCoCfkmdb6aw/hXVOFXtt2Brw=",
+        "lastModified": 1689355940,
+        "narHash": "sha256-AaAyHi5QnnYYg/m+7cIsb27BgFRRrzCU/H3O26mI9UQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "99757bed9044e2a778077c8254e22358be331186",
+        "rev": "86113db3e974e154772474017b26a90254d0aa81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`86113db3`](https://github.com/nix-community/emacs-overlay/commit/86113db3e974e154772474017b26a90254d0aa81) | `` Updated repos/melpa `` |
| [`bcd4795c`](https://github.com/nix-community/emacs-overlay/commit/bcd4795c623699df243b709160b6bbf228ae1a69) | `` Updated repos/emacs `` |
| [`d4900389`](https://github.com/nix-community/emacs-overlay/commit/d490038959ac10964e1c54c0e093c40ff00a1ced) | `` Updated repos/elpa ``  |