### PR TITLE
chore(flake/emacs-overlay): `86113db3` -> `3998784d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -240,11 +240,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689355940,
-        "narHash": "sha256-AaAyHi5QnnYYg/m+7cIsb27BgFRRrzCU/H3O26mI9UQ=",
+        "lastModified": 1689392924,
+        "narHash": "sha256-5dXqjjUNpW0Hkm8AcV+QKzjE1iGwZNbtyLYEVAgMHUs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "86113db3e974e154772474017b26a90254d0aa81",
+        "rev": "3998784d02091a70316eecd435cc6e3e780ff63c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`3998784d`](https://github.com/nix-community/emacs-overlay/commit/3998784d02091a70316eecd435cc6e3e780ff63c) | `` Updated repos/melpa ``  |
| [`46220779`](https://github.com/nix-community/emacs-overlay/commit/46220779ac91f721f355e6e233c1d5a4dd49cb27) | `` Updated repos/emacs ``  |
| [`c77ac9ff`](https://github.com/nix-community/emacs-overlay/commit/c77ac9fff722a633e9aa5badc89dc99d245aa5d5) | `` Updated repos/elpa ``   |
| [`0068408b`](https://github.com/nix-community/emacs-overlay/commit/0068408b4cc5698d6b4b55700359a3d85fe84540) | `` Updated flake inputs `` |