### PR TITLE
chore(flake/sops-nix): `4ead5280` -> `cfe47aff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -980,11 +980,11 @@
         "nixpkgs-stable": "nixpkgs-stable_5"
       },
       "locked": {
-        "lastModified": 1689404092,
-        "narHash": "sha256-skumlIqwdu09UrQuFRhgfKwOm9FSaIzDDI0VL99Ihi8=",
+        "lastModified": 1689405598,
+        "narHash": "sha256-80fuO3FiXgJmUDQgB7sc2lq8Qe/oSkqDNwx9N/fCtBs=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "4ead52809041d90bdbd203cc6db81fa93075ad4f",
+        "rev": "cfe47aff8660fd760b1db89613a3205c2c4ba7b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                     |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`8cbe746c`](https://github.com/Mic92/sops-nix/commit/8cbe746c18c966c54f4633a20cb155cbdd452458) | `` ci/update-vendor-hash: fix pushing from detached head `` |
| [`53597ddc`](https://github.com/Mic92/sops-nix/commit/53597ddcfd050f1eb5b8314183518789e1f8a91f) | `` ci/update-vendor-hash: push to write github ref ``       |
| [`b472c585`](https://github.com/Mic92/sops-nix/commit/b472c58559e8c9fbae7fce15838c7981e87a80d2) | `` ci/update-vendor-hash: checkout pr itself ``             |
| [`a69e3ca7`](https://github.com/Mic92/sops-nix/commit/a69e3ca7dc378e520a5863269e2e186d954c7eed) | `` drop git commit from update-vendor-hash.sh ``            |