### PR TITLE
chore(flake/emacs-overlay): `3998784d` -> `d0a4bfcb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -240,11 +240,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689392924,
-        "narHash": "sha256-5dXqjjUNpW0Hkm8AcV+QKzjE1iGwZNbtyLYEVAgMHUs=",
+        "lastModified": 1689416235,
+        "narHash": "sha256-Q/sEiwBflAg5lefJJpiIO+fFyxx5rNxyXIAvansSqu8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3998784d02091a70316eecd435cc6e3e780ff63c",
+        "rev": "d0a4bfcb6c78b9f71ad096771be0c6029973734c",
         "type": "github"
       },
       "original": {
@@ -712,11 +712,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1689209875,
-        "narHash": "sha256-8AVcBV1DiszaZzHFd5iLc8HSLfxRAuqcU0QdfBEF3Ag=",
+        "lastModified": 1689326639,
+        "narHash": "sha256-79zi0t83Dcc2dE0NuYZ+2hqtKXZN1yWVq5mtx8D2d7Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fcc147b1e9358a8386b2c4368bd928e1f63a7df2",
+        "rev": "9fdfaeb7b96f05e869f838c73cde8d98c640c649",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d0a4bfcb`](https://github.com/nix-community/emacs-overlay/commit/d0a4bfcb6c78b9f71ad096771be0c6029973734c) | `` Updated repos/melpa ``  |
| [`449e672b`](https://github.com/nix-community/emacs-overlay/commit/449e672bc77bb3604d3970dc8ad2195efbbae080) | `` Updated repos/emacs ``  |
| [`09d1858b`](https://github.com/nix-community/emacs-overlay/commit/09d1858b06b85cdc105d7c58ccd5c1a70e1980fc) | `` Updated flake inputs `` |