### PR TITLE
chore(flake/emacs-overlay): `d0a4bfcb` -> `15734e5d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -240,11 +240,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689416235,
-        "narHash": "sha256-Q/sEiwBflAg5lefJJpiIO+fFyxx5rNxyXIAvansSqu8=",
+        "lastModified": 1689420866,
+        "narHash": "sha256-h45KShkuZwEnuHF87MNjydhW9zOAFa7uYbvmSCi2rKU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d0a4bfcb6c78b9f71ad096771be0c6029973734c",
+        "rev": "15734e5d482a558d434a831a3b058323d79ecb4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                           |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
| [`d068b271`](https://github.com/nix-community/emacs-overlay/commit/d068b271bdc9b604fb514aa7fabd4ae22a4ed0c3) | `` Remove ensure API breakage notice ``                           |
| [`0d890d28`](https://github.com/nix-community/emacs-overlay/commit/0d890d28b3489dd96c4fac8cd49bd360ab1f908c) | `` Add basic evaluation check to run on pull requests ``          |
| [`b93864f9`](https://github.com/nix-community/emacs-overlay/commit/b93864f99e0186c03f078c1d7bbc2bd0840011be) | `` flake: Filter out non derivation attributes from hydra jobs `` |