### PR TITLE
chore(flake/emacs-overlay): `15734e5d` -> `084807d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -240,11 +240,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689420866,
-        "narHash": "sha256-h45KShkuZwEnuHF87MNjydhW9zOAFa7uYbvmSCi2rKU=",
+        "lastModified": 1689446852,
+        "narHash": "sha256-ExvyCJ5DYUNRh6KtK+XOuT8DpDcQesa49QqPnPimKS4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "15734e5d482a558d434a831a3b058323d79ecb4a",
+        "rev": "084807d7ac3ce106e3dee92c5b012c8362f0395d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`084807d7`](https://github.com/nix-community/emacs-overlay/commit/084807d7ac3ce106e3dee92c5b012c8362f0395d) | `` Updated repos/melpa `` |
| [`50d8ac56`](https://github.com/nix-community/emacs-overlay/commit/50d8ac56af9357c11844c492e63a60f76e946b7c) | `` Updated repos/emacs `` |
| [`0f4fd73a`](https://github.com/nix-community/emacs-overlay/commit/0f4fd73a5f7dcd180ae6c7bcfa7285f830d9d8e1) | `` Updated repos/elpa ``  |