### PR TITLE
chore(flake/attic): `4fedffe6` -> `4902d57f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1686620679,
-        "narHash": "sha256-Ck/r3f+W9mOn3cHn5ii/fogBiJtosFnDaOQveaJ0zVU=",
+        "lastModified": 1689457600,
+        "narHash": "sha256-1XLn2ZZMaqQx+Ys3eel5hQRkgUn3DeHcVb2JT8WYU0A=",
         "owner": "zhaofengli",
         "repo": "attic",
-        "rev": "4fedffe6a1020edfcfa7bef18d21321d4983b3a7",
+        "rev": "4902d57f5dae8ec660ee9ee14c45c2192f9fe8b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                        |
| ------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`b1e512e0`](https://github.com/zhaofengli/attic/commit/b1e512e0222e0150e78cda8bea4d43763cfdca63) | `` Open the default store, not `auto` (#71) `` |
| [`91d8bd5c`](https://github.com/zhaofengli/attic/commit/91d8bd5cdc2bfbc893c12d35b0c77b1f96e613af) | `` fix chunk deletion bug ``                   |