### PR TITLE
chore(flake/nixpkgs): `e74e6844` -> `dfdbcc42`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -775,11 +775,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1689282004,
-        "narHash": "sha256-VNhuyb10c9SV+3hZOlxwJwzEGytZ31gN9w4nPCnNvdI=",
+        "lastModified": 1689373857,
+        "narHash": "sha256-mtBksyvhhT98Zsm9tYHuMKuLwUKDwv+BGTl6K5nOGhY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e74e68449c385db82de3170288a28cd0f608544f",
+        "rev": "dfdbcc428f365071f0ca3888f6ec8c25c3792885",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`dfdbcc42`](https://github.com/NixOS/nixpkgs/commit/dfdbcc428f365071f0ca3888f6ec8c25c3792885) | `` 9pfs: 2015-09-18 -> 0.3 (#241801) ``                                          |
| [`c48d319a`](https://github.com/NixOS/nixpkgs/commit/c48d319ac6d676bf56cf29c2362e61e705e43d77) | `` jenkins: 2.401.1 -> 2.401.2 ``                                                |
| [`d1a9aa51`](https://github.com/NixOS/nixpkgs/commit/d1a9aa51f7159ea548d687801f34f99735311c83) | `` grails: 5.3.2 -> 5.3.3 ``                                                     |
| [`f448f095`](https://github.com/NixOS/nixpkgs/commit/f448f0959c70879c8950094f42652a5888947ee8) | `` bun: 0.6.13 -> 0.6.14 ``                                                      |
| [`996c9544`](https://github.com/NixOS/nixpkgs/commit/996c95449c0819c512197f72f274727f6fb06473) | `` dolt: 1.7.4 -> 1.7.5 ``                                                       |
| [`8980fdd9`](https://github.com/NixOS/nixpkgs/commit/8980fdd9b57b2b43592058cbda2e866148e14ab5) | `` nixos/cgit: fix \v and \f in regexEscape ``                                   |
| [`e7ec942d`](https://github.com/NixOS/nixpkgs/commit/e7ec942dea0ee69c24e46a8b70bc4c3993eef634) | `` fsuae-launcher: fix find executable ``                                        |
| [`91153952`](https://github.com/NixOS/nixpkgs/commit/9115395261bf5b8d38d1075bba03744601084361) | `` brave: add kerberos authentication ``                                         |
| [`4fae5e76`](https://github.com/NixOS/nixpkgs/commit/4fae5e769a2f5ddd313e9bf27de791a2f6a9f941) | `` buck2: add passthru.tests ``                                                  |
| [`1fa18909`](https://github.com/NixOS/nixpkgs/commit/1fa18909cab5f385f54b450ac2b3e72f324fd60e) | `` python3Packages.python3-application 3.0.4 -> 3.0.6 ``                         |
| [`07919ff7`](https://github.com/NixOS/nixpkgs/commit/07919ff7215444b0087832a6665cac14daf5d9d6) | `` doq: init at 0.9.1 ``                                                         |
| [`88c4aa0c`](https://github.com/NixOS/nixpkgs/commit/88c4aa0c1e364a1e6593ace8c46c997754fa70ca) | `` reindeer: unstable-2023-06-20 -> unstable-2023-07-14 ``                       |
| [`f3a1c560`](https://github.com/NixOS/nixpkgs/commit/f3a1c560c60c980ab605a2c42cbaa8ab8a14cbe7) | `` vscode-extensions.mgt19937.typst-preview: 0.6.0 -> 0.6.1 ``                   |
| [`aae4350c`](https://github.com/NixOS/nixpkgs/commit/aae4350c5bedcc3ef1a312b378b5febc65fc9328) | `` openipmi: use Python 3.10 ``                                                  |
| [`aa23f045`](https://github.com/NixOS/nixpkgs/commit/aa23f04560b8e15d69095c1b0bba0e4aed1c24c6) | `` sumokoin: don't override boost ``                                             |
| [`639dfdec`](https://github.com/NixOS/nixpkgs/commit/639dfdecd031c4deff056f2964536c1bdb9cd1f4) | `` vertcoin: don't override boost ``                                             |
| [`230170ee`](https://github.com/NixOS/nixpkgs/commit/230170eecabc4f249dcea111cb9ea29c0510a12f) | `` monero-gui: don't override boost ``                                           |
| [`5aefc56f`](https://github.com/NixOS/nixpkgs/commit/5aefc56fb85cca599a79467587a5acdce2779a39) | `` groestlcoin: don't override boost ``                                          |
| [`5c6057d9`](https://github.com/NixOS/nixpkgs/commit/5c6057d946bdf351ae86466ac0810702c78008a4) | `` dogecoin: don't override boost ``                                             |
| [`43021050`](https://github.com/NixOS/nixpkgs/commit/430210502a1a963f197a15a867bea65b03bab8bb) | `` bitcoind-abc: don't override boost ``                                         |
| [`da4f87c0`](https://github.com/NixOS/nixpkgs/commit/da4f87c04df48a9fcc649214d28f7a5d39d3ec88) | `` bitcoind-knots: don't override boost ``                                       |
| [`cef4da0b`](https://github.com/NixOS/nixpkgs/commit/cef4da0bd832977025725a895ea07e09a08174e0) | `` bitcoin: don't override boost ``                                              |
| [`ff0e55ff`](https://github.com/NixOS/nixpkgs/commit/ff0e55ff2267ea973a7bcd4a92c99c73513e65fc) | `` vimPlugins.cmp-beancount: init at 2022-11-27 ``                               |
| [`6ead38d5`](https://github.com/NixOS/nixpkgs/commit/6ead38d5c536c793d3cc3da23c81d5d155ee7cce) | `` bosh-cli: 7.2.4 -> 7.3.0 ``                                                   |
| [`b5f28477`](https://github.com/NixOS/nixpkgs/commit/b5f28477aa938cb6099ea6c6444b528caa221037) | `` nixos/prowlarr: make use of 'lib.getExe' ``                                   |
| [`5b5b04c5`](https://github.com/NixOS/nixpkgs/commit/5b5b04c560b11183d24457eeb1e1cfe9532f7cd5) | `` ansible-language-server: 1.1.0 -> 1.2.0 ``                                    |
| [`b17ee5fe`](https://github.com/NixOS/nixpkgs/commit/b17ee5fe402aec3c64c09723bb7ed46d7f3863b2) | `` prowlarr: add 'meta.mainProgram' ``                                           |
| [`9d8053e2`](https://github.com/NixOS/nixpkgs/commit/9d8053e2bb508de621247a0aeb1a480ba7339c1f) | `` otpclient: 3.1.8 -> 3.1.9 ``                                                  |
| [`824bc780`](https://github.com/NixOS/nixpkgs/commit/824bc780b268308eeb0f9e59c8df8d4b9e9305a8) | `` tango: init at 1.1.0 ``                                                       |
| [`5a9f33ef`](https://github.com/NixOS/nixpkgs/commit/5a9f33efbfe544f03225fc6779c5c920f9095571) | `` fnm: 1.34.0 -> 1.35.0 ``                                                      |
| [`974afd4a`](https://github.com/NixOS/nixpkgs/commit/974afd4a60a38ef72043ba3438c82f98e6cf3da9) | `` django-cacheops: mark broken on darwin ``                                     |
| [`1f8e1307`](https://github.com/NixOS/nixpkgs/commit/1f8e1307f74d4c119fe08496f469ec847d721597) | `` python3.pkgs.django-cacheops: update, fix build, refactor to run all tests `` |
| [`89c65139`](https://github.com/NixOS/nixpkgs/commit/89c65139211957aee5b8fcc39887bfe4c7a4bd28) | `` python3.pkgs.before-after: init at 1.0.1 ``                                   |
| [`971ef1a8`](https://github.com/NixOS/nixpkgs/commit/971ef1a8e011a865583c4d2fa7d2ee618e0cbc95) | `` pforth: allow cross-compile ``                                                |
| [`e4db1840`](https://github.com/NixOS/nixpkgs/commit/e4db1840dcf3c73085ad72a4ef13fbbe788f5a20) | `` mold: patch an upstream bug in --strip-debug ``                               |
| [`0f1222fa`](https://github.com/NixOS/nixpkgs/commit/0f1222faf7fc84aae54777c9334aca4e9ddcc558) | `` cairo-lang: 2.0.1 -> 2.0.2 ``                                                 |
| [`c033b637`](https://github.com/NixOS/nixpkgs/commit/c033b637a367240a2cd84282ec0f7f1857ec6359) | `` raylib: 4.2.0 -> 4.5.0 ``                                                     |
| [`b093cb4c`](https://github.com/NixOS/nixpkgs/commit/b093cb4cd8a971ab77993f77152fac31e5ccdf2f) | `` go-ethereum: remove adisbladis as maintainer ``                               |
| [`d70459bd`](https://github.com/NixOS/nixpkgs/commit/d70459bd36d7c64c73b3898d55e7831bc4253278) | `` python3Packages.semaphore-bot: init at 0.16.0 ``                              |
| [`f6f0ccd6`](https://github.com/NixOS/nixpkgs/commit/f6f0ccd6c9b4aab06997354dd423bca9efc489db) | `` lib.systems.bluefield2: init ``                                               |
| [`9a064200`](https://github.com/NixOS/nixpkgs/commit/9a064200068f2b8549fa07acd56d6f26b58ff7d6) | `` go-ethereum: 1.11.6 -> 1.12.0 ``                                              |
| [`fb99b395`](https://github.com/NixOS/nixpkgs/commit/fb99b39503bf201ee2a2955920258117b5b75226) | `` python310Packages.xarray-einstats: 0.5.1 -> 0.6.0 ``                          |
| [`40cf4a3b`](https://github.com/NixOS/nixpkgs/commit/40cf4a3b18d32cd36cc15e13f5557782f178b060) | `` terraform-providers.yandex: 0.94.0 -> 0.95.0 ``                               |
| [`6b48a31e`](https://github.com/NixOS/nixpkgs/commit/6b48a31e43fafdbf3995d99e853cbe450a80119e) | `` terraform-providers.scaleway: 2.23.0 -> 2.24.0 ``                             |
| [`5d07e594`](https://github.com/NixOS/nixpkgs/commit/5d07e594c4cc2e47356c7ac9f20ddbdd4593b2ee) | `` terraform-providers.opentelekomcloud: 1.35.2 -> 1.35.3 ``                     |
| [`f35bebb3`](https://github.com/NixOS/nixpkgs/commit/f35bebb301822c98cd3d69eba270d53d8782cc88) | `` terraform-providers.opsgenie: 0.6.27 -> 0.6.28 ``                             |
| [`32f90202`](https://github.com/NixOS/nixpkgs/commit/32f902021b71e444f71334de9d6d14382c460681) | `` terraform-providers.mongodbatlas: 1.10.0 -> 1.10.1 ``                         |
| [`fe03c327`](https://github.com/NixOS/nixpkgs/commit/fe03c327fd591e9d4231eb52c1b7bc3c826546d2) | `` terraform-providers.google-beta: 4.73.0 -> 4.73.1 ``                          |
| [`b354b2c4`](https://github.com/NixOS/nixpkgs/commit/b354b2c492aad2baf773c0665c2ed4b026af6dfb) | `` terraform-providers.lxd: 1.10.0 -> 1.10.1 ``                                  |
| [`103b432d`](https://github.com/NixOS/nixpkgs/commit/103b432d8e569b9e70b40a6745d1175d60e8fc3d) | `` terraform-providers.aws: 5.7.0 -> 5.8.0 ``                                    |
| [`20cc1bd3`](https://github.com/NixOS/nixpkgs/commit/20cc1bd39cdc74715b7b5edd94afe083f3182883) | `` terraform-providers.google: 4.73.0 -> 4.73.1 ``                               |
| [`5e2daa49`](https://github.com/NixOS/nixpkgs/commit/5e2daa491c90e28e1831258434b9e62443fbae3c) | `` terraform-providers.buildkite: 0.19.2 -> 0.20.0 ``                            |
| [`3c65e305`](https://github.com/NixOS/nixpkgs/commit/3c65e305f31c84a52f34066ecd201e351760f849) | `` terraform-providers.azurerm: 3.64.0 -> 3.65.0 ``                              |
| [`80ce0991`](https://github.com/NixOS/nixpkgs/commit/80ce0991a8d3daeef44241334381f2909f80961c) | `` terraform-providers.azuread: 2.39.0 -> 2.40.0 ``                              |
| [`a086370d`](https://github.com/NixOS/nixpkgs/commit/a086370d9d0aacd006a5f30ee77d91f9e9cbfbee) | `` terraform-providers.aiven: 4.6.0 -> 4.7.0 ``                                  |
| [`03c4db6f`](https://github.com/NixOS/nixpkgs/commit/03c4db6f96db675df3958a4dccd9dd4fdffb3c28) | `` python311Packages.google-cloud-pubsub: 2.17.1 -> 2.18.0 ``                    |
| [`1df733d8`](https://github.com/NixOS/nixpkgs/commit/1df733d83081fe79c109b066c90badece6b8d8b1) | `` gemrb: 0.9.1.1 -> 0.9.2 ``                                                    |
| [`f6901b61`](https://github.com/NixOS/nixpkgs/commit/f6901b6171d81827dbf6c439094c6c72ef8dcba9) | `` python311Packages.androidtvremote2: 0.0.10 -> 0.0.11 ``                       |
| [`82873ae2`](https://github.com/NixOS/nixpkgs/commit/82873ae29e73ddcf4e0ed7e98103a502ef85bad2) | `` python311Packages.devolo-plc-api: 1.3.1 -> 1.3.2 ``                           |
| [`dda15a62`](https://github.com/NixOS/nixpkgs/commit/dda15a62256013c1b4aa5aac3cc29b5fa876bce2) | `` python311Packages.metar: 1.10.0 -> 1.11.0 ``                                  |
| [`956cf5dd`](https://github.com/NixOS/nixpkgs/commit/956cf5dd028031621ea315e523a848ffd7e55f37) | `` python311Packages.mypy-boto3-s3: 1.28.0 -> 1.28.3 ``                          |
| [`50984aa3`](https://github.com/NixOS/nixpkgs/commit/50984aa3017f02fdba92d0353bb7bbb58a626a37) | `` python311Packages.opower: 0.0.13 -> 0.0.14 ``                                 |
| [`b422c3de`](https://github.com/NixOS/nixpkgs/commit/b422c3de45f56a49abc7965708cd0cb6a8810148) | `` python311Packages.yalexs-ble: 2.1.18 -> 2.2.0 ``                              |
| [`10314c8f`](https://github.com/NixOS/nixpkgs/commit/10314c8fc05d5748fea73d8c33096d9417978d4b) | `` python310Packages.azure-containerregistry: 1.1.0 -> 1.2.0 ``                  |
| [`bec99c5a`](https://github.com/NixOS/nixpkgs/commit/bec99c5ae490d47b817c8b0c81246ad045a797d0) | `` femtolisp: init at 2023-07-12 ``                                              |
| [`e8a6acb8`](https://github.com/NixOS/nixpkgs/commit/e8a6acb8d475a99f485c31f00e8bf0a64c9663de) | `` pdns-recursor: 4.8.4 -> 4.9.0 ``                                              |
| [`cb697b86`](https://github.com/NixOS/nixpkgs/commit/cb697b86b1513dc02b6441d0f63dcb5437f4d243) | `` edge-runtime: init at 1.6.7 ``                                                |
| [`c625352b`](https://github.com/NixOS/nixpkgs/commit/c625352b5326f9b52d20b2a6c6d9bd1c5aa6bfe3) | `` python310Packages.argilla: 1.8.0 -> 1.12.0 ``                                 |
| [`239ae48d`](https://github.com/NixOS/nixpkgs/commit/239ae48dd354e202cd82666848a1ae6779007ede) | `` python310Packages.brotli-asgi: init at 1.4.0 ``                               |
| [`e457874b`](https://github.com/NixOS/nixpkgs/commit/e457874b992d95543cbeb04c7f0ff5091e2a4467) | `` python310Packages.rstcheck: disable failing darwin tests ``                   |
| [`1e6d25ef`](https://github.com/NixOS/nixpkgs/commit/1e6d25efaf0b1b510e5e823209fe268fcc9842fd) | `` python310Packages.rstcheck-core: disable failing darwin tests ``              |
| [`0cac0b03`](https://github.com/NixOS/nixpkgs/commit/0cac0b03f79e4291a7770a7a009bbb4c9ad15050) | `` honeytrap: unstable-2020-12-10 -> unstable-2021-12-20 ``                      |
| [`84d052b7`](https://github.com/NixOS/nixpkgs/commit/84d052b76c418de215b00353446357f4919bfb34) | `` oauth2c: 1.9.0 -> 1.10.0 ``                                                   |
| [`3f13f26e`](https://github.com/NixOS/nixpkgs/commit/3f13f26e937ebf78bb4a091d221d609ae71eaef7) | `` numix-icon-theme-circle: 23.06.21 -> 23.07.08 ``                              |
| [`c7501c10`](https://github.com/NixOS/nixpkgs/commit/c7501c10414229b8cb7e895e233dd3f98cfff83c) | `` cnspec: 8.17.0 -> 8.18.0 ``                                                   |
| [`82fc0c6e`](https://github.com/NixOS/nixpkgs/commit/82fc0c6e96d98857323ded85505461b5e8a0c365) | `` pritunl-client: refactor, add service and electron app ``                     |
| [`395fa502`](https://github.com/NixOS/nixpkgs/commit/395fa502763eb34e295de0d1d7e2853d4ba6bdf6) | `` oh-my-posh: 17.6.0 -> 17.9.0 ``                                               |
| [`078d8d5e`](https://github.com/NixOS/nixpkgs/commit/078d8d5efe27b28d918b9a240accc6509b470869) | `` txr: mark as broken on Apple Intel ``                                         |
| [`8983401a`](https://github.com/NixOS/nixpkgs/commit/8983401a0faf77fc5fe27c5b246bab5334f1839d) | `` txr: 288 -> 289 ``                                                            |
| [`f3783908`](https://github.com/NixOS/nixpkgs/commit/f3783908dd381e5abc2a34daffcb8b4d816562e4) | `` johnny-reborn: init at unstable-2020-12-06 ``                                 |
| [`ab155b06`](https://github.com/NixOS/nixpkgs/commit/ab155b06badf00218717af1dbd98380d3b4b42bb) | `` iosevka: 24.1.4 -> 25.0.1 ``                                                  |
| [`37a0e4b8`](https://github.com/NixOS/nixpkgs/commit/37a0e4b844c4c1c6f35b326e9537b45e1ebfe99d) | `` python311Packages.jaraco-net: disable tests on Python 3.11 ``                 |
| [`718f1207`](https://github.com/NixOS/nixpkgs/commit/718f12075484042c3d314669fa7fd81da45bbc3b) | `` home-assistant: 2023.7.1 -> 2023.7.2 ``                                       |
| [`02b05fb7`](https://github.com/NixOS/nixpkgs/commit/02b05fb704dfcadcac85e754c79c90e9a338359f) | `` python310Packages.zigpy: 0.56.1 -> 0.56.2 ``                                  |
| [`68ab7ff2`](https://github.com/NixOS/nixpkgs/commit/68ab7ff2ef96e242bd5f671b3baa3e33c4a4e749) | `` python310Packages.python-crontab: 2.7.1 -> 3.0.0 ``                           |
| [`5a67e7be`](https://github.com/NixOS/nixpkgs/commit/5a67e7be68d6d59a57a3befec252329a492d126e) | `` mpvScripts.youtube-quality: replace with mpvScripts.quality-menu v4.1.0 ``    |
| [`7a6c9231`](https://github.com/NixOS/nixpkgs/commit/7a6c92317438abc10285b333707f220b3aac4200) | `` tui-journal: 0.2.0 -> 0.3.0 ``                                                |
| [`45590adc`](https://github.com/NixOS/nixpkgs/commit/45590adc026030d831a667f3fc17e6a6aea7ef97) | `` cargo-temp: 0.2.17 -> 0.2.18 ``                                               |
| [`ec05aa83`](https://github.com/NixOS/nixpkgs/commit/ec05aa83bc52853435dfdb8480a087929e3bb17b) | `` komorebi: init at 2.2.1 ``                                                    |
| [`775f683a`](https://github.com/NixOS/nixpkgs/commit/775f683a5a08ea58d012b034e48b651d70b1d8a4) | `` nixos-option: fix expression position calculation ``                          |
| [`9cc181f5`](https://github.com/NixOS/nixpkgs/commit/9cc181f5c624c883518b7a5a681b87eba19b561c) | `` nixos/nexus: add jvm package option ``                                        |
| [`26003af2`](https://github.com/NixOS/nixpkgs/commit/26003af2ece60329b25dc6c9872bf11cb0afb1d3) | `` vbam: 2.1.5 -> 2.1.6 ``                                                       |
| [`74eeef20`](https://github.com/NixOS/nixpkgs/commit/74eeef204344583ab7471bdd81fc41ad1847f773) | `` minesweep-rs: 6.0.13 -> 6.0.14 ``                                             |
| [`7bf2cecc`](https://github.com/NixOS/nixpkgs/commit/7bf2ceccf62ba2cca04fa051c28ee15572224057) | `` kubecm: 0.24.1 -> 0.25.0 ``                                                   |
| [`473b3887`](https://github.com/NixOS/nixpkgs/commit/473b3887ef8b87878d5b97c158ba2f63b8479821) | `` aaaaxy: 1.4.18 -> 1.4.33 ``                                                   |
| [`19134850`](https://github.com/NixOS/nixpkgs/commit/1913485046884d4be5355ac1d02b5b5845e94422) | `` standardnotes: 3.162.8 -> 3.165.9 ``                                          |
| [`dd47be7e`](https://github.com/NixOS/nixpkgs/commit/dd47be7ec8f22070dd44739c3edbd01c2d287d9e) | `` jetbrains.*: replace `jbr` directory instead of removing ``                   |
| [`dd4054b9`](https://github.com/NixOS/nixpkgs/commit/dd4054b93dd7653483e3f446ef1269bfe96b643a) | `` jetbrains.clion: remove redundant wrapper ``                                  |
| [`4619083f`](https://github.com/NixOS/nixpkgs/commit/4619083f80018aa02ebe30c7542200c787d23338) | `` python310Packages.pydaikin: 2.9.1 -> 2.10.5 ``                                |
| [`1aea47f6`](https://github.com/NixOS/nixpkgs/commit/1aea47f67865a0e786dd114107627dc714941046) | `` qrcode: unstable-2016-08-04 -> unstable-2022-01-10 ``                         |
| [`9c57ba66`](https://github.com/NixOS/nixpkgs/commit/9c57ba6631253b2e5828492a36798f5c2f309d89) | `` vrc-get: 1.1.1 -> 1.1.2 ``                                                    |
| [`a542c2ef`](https://github.com/NixOS/nixpkgs/commit/a542c2ef4d48c3692edfba8bacbff39e36e7ad82) | `` awsbck: 0.3.2 -> 0.3.3 ``                                                     |
| [`2d3a5a99`](https://github.com/NixOS/nixpkgs/commit/2d3a5a99e10808bd03f7fdacc5d4a5cbfe71ed54) | `` jackett: 0.21.456 -> 0.21.462 ``                                              |
| [`16745af6`](https://github.com/NixOS/nixpkgs/commit/16745af614230e092f853caf08ef02da84c48179) | `` matrix-sliding-sync: 0.99.3 -> 0.99.4 ``                                      |
| [`526df213`](https://github.com/NixOS/nixpkgs/commit/526df2136c3a4107f97a280d1f8146e0a6ba3d88) | `` coqPackages.autosubst: 1.7 -> 1.8 ``                                          |
| [`2bfb14fd`](https://github.com/NixOS/nixpkgs/commit/2bfb14fdd13b7d951d2a1553b40061a22d0a89bb) | `` moon: 1.9.2 -> 1.10.0 ``                                                      |
| [`29f743d6`](https://github.com/NixOS/nixpkgs/commit/29f743d6bee13b31c2cb2400abd7227c53489980) | `` orbiton: 2.62.5 -> 2.62.6 ``                                                  |
| [`296e58b8`](https://github.com/NixOS/nixpkgs/commit/296e58b815f70413c3969b5fa33d3f4e86c75f54) | `` python3Packages.datrie: set format ``                                         |
| [`2f3dc413`](https://github.com/NixOS/nixpkgs/commit/2f3dc4132f85da49a2a4852c7770522457abda01) | `` python3Packages.caldav: move tzlocal and pytz to propagatedBuildInputs ``     |
| [`f94b38be`](https://github.com/NixOS/nixpkgs/commit/f94b38be98b9b9df4a964b019257d511f65b0c13) | `` tests/homepage-dashboard: add tests for homepage ``                           |
| [`3de6be09`](https://github.com/NixOS/nixpkgs/commit/3de6be09518a97066b358da98b153a421aae8d24) | `` nixos/homepage-dashboard: init ``                                             |
| [`b1cf2cb3`](https://github.com/NixOS/nixpkgs/commit/b1cf2cb35928d994ebb13d2f8faa6440e2ef18a1) | `` homepage-dashboard: init at 0.6.21 ``                                         |
| [`c7b6f807`](https://github.com/NixOS/nixpkgs/commit/c7b6f8071d9569993e510dc4de06997885816ab0) | `` melange: init at 0.4.0 ``                                                     |
| [`41083ee4`](https://github.com/NixOS/nixpkgs/commit/41083ee4cf5970ad247858f00823c13117f1dd44) | `` python3Packages.ducc0: 0.30.0 -> 0.31.0 ``                                    |
| [`3a3ab6bc`](https://github.com/NixOS/nixpkgs/commit/3a3ab6bcbdb2b09e2cd33b58aff94cb1b0a569d1) | `` jotta-cli: 0.15.80533 -> 0.15.84961 ``                                        |
| [`2868e85d`](https://github.com/NixOS/nixpkgs/commit/2868e85d93d6a60fdfd64031bcaf82f313553b80) | `` maintainers: add josephst ``                                                  |
| [`26f2e892`](https://github.com/NixOS/nixpkgs/commit/26f2e8922c52b753abf8b2bfcd53c90eba0f9173) | `` recyclarr: init at 5.1.0 ``                                                   |
| [`083a4cf6`](https://github.com/NixOS/nixpkgs/commit/083a4cf6d552fbe50269c5093c4651ec940a754e) | `` python311Packages.dsmr-parser: 1.2.3 -> 1.2.4 ``                              |
| [`fd29c6c5`](https://github.com/NixOS/nixpkgs/commit/fd29c6c5fe78cdf4c95f1872f118120fe69fcd21) | `` python311Packages.pysmartthings: 0.7.7 -> 0.7.8 ``                            |
| [`ba4dab06`](https://github.com/NixOS/nixpkgs/commit/ba4dab06a0a05adbb4f2e963493c3518007d5409) | `` ryujinx: 1.1.958 -> 1.1.960 ``                                                |
| [`a52f9770`](https://github.com/NixOS/nixpkgs/commit/a52f9770b0af4f5d9676849524e1dd1e4fd6f2e1) | `` python311Packages.praw: 7.7.0 -> 7.7.1 ``                                     |
| [`cc59ede2`](https://github.com/NixOS/nixpkgs/commit/cc59ede27254be108512895b601777c376cba791) | `` nixos/tests/peering-manager: fix 'nodes.machine.config' eval warning ``       |
| [`59342315`](https://github.com/NixOS/nixpkgs/commit/593423154249c41cf725b3ebfea3e21abdcc4620) | `` nixos/peering-manager: remove global 'with lib;' ``                           |
| [`041e9a8e`](https://github.com/NixOS/nixpkgs/commit/041e9a8e7a0087da7f357967f39eaff230a17c61) | `` nixos/peering-manager: add meta section ``                                    |
| [`16113947`](https://github.com/NixOS/nixpkgs/commit/1611394719fccb25163f1934d3ba93fb6cbcece7) | `` peering-manager: add meta section ``                                          |
| [`dd73f358`](https://github.com/NixOS/nixpkgs/commit/dd73f358ab30754f52b97aed9f023ae5ef70c077) | `` xq-xml: init at 1.2.1 ``                                                      |
| [`b853c706`](https://github.com/NixOS/nixpkgs/commit/b853c706613e4c9b9e80b306e5ddc1882d7780ad) | `` nixos/prowlarr: add package option ``                                         |
| [`853be697`](https://github.com/NixOS/nixpkgs/commit/853be697f59f64c342269e81e34ca375e8b3e7aa) | `` komikku: 1.21.1 -> 1.22.0 ``                                                  |
| [`b78c63bc`](https://github.com/NixOS/nixpkgs/commit/b78c63bc9a34db6a0c0bee167b1fb86f1b1bbd5b) | `` conntrack-tools: fixup systemd support ``                                     |
| [`f9e1d0bd`](https://github.com/NixOS/nixpkgs/commit/f9e1d0bd66f92807506303ebc0609ff7ab513c93) | `` xmake: 2.7.9 -> 2.8.1 ``                                                      |
| [`0927c081`](https://github.com/NixOS/nixpkgs/commit/0927c0815c48e8f949ee208a3ce2cc1f35468919) | `` tandoor-recipes: 1.4.12 -> 1.5.4 ``                                           |
| [`df366a59`](https://github.com/NixOS/nixpkgs/commit/df366a59420d880ed9d8146d7749c09976354d3b) | `` millet: 0.12.5 -> 0.12.6 ``                                                   |
| [`cb6c8e35`](https://github.com/NixOS/nixpkgs/commit/cb6c8e3526fc08b76c72eb942ac94747d8b7d191) | `` plik,plikd: 1.3.6 -> 1.3.7 ``                                                 |
| [`96b23c36`](https://github.com/NixOS/nixpkgs/commit/96b23c36e8b074d3060af0060067324fd1a01cb1) | `` openafs: 1.8.9 → 1.8.10 ``                                                    |
| [`04a44df5`](https://github.com/NixOS/nixpkgs/commit/04a44df55752b5e8376ec5d2f3c329891a573cb1) | `` openasar: unstable-2023-05-01 -> unstable-2023-07-07 ``                       |
| [`71fe1c7d`](https://github.com/NixOS/nixpkgs/commit/71fe1c7d00c4685189856b1a1c5cfefa5409f637) | `` obs-studio-plugins.obs-vkcapture: 1.3.3 -> 1.4.1 ``                           |
| [`08f19df3`](https://github.com/NixOS/nixpkgs/commit/08f19df3e79d822bac929bb64a764763ca23804c) | `` gex: add piturnah as maintainer ``                                            |
| [`a74251a0`](https://github.com/NixOS/nixpkgs/commit/a74251a00abaddd8f83fdb28edea526df739eaba) | `` maintainers: add piturnah ``                                                  |