### PR TITLE
chore(flake/emacs-overlay): `084807d7` -> `4c3cb10e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -240,11 +240,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689446852,
-        "narHash": "sha256-ExvyCJ5DYUNRh6KtK+XOuT8DpDcQesa49QqPnPimKS4=",
+        "lastModified": 1689480175,
+        "narHash": "sha256-esfvClbx/gs/8gC2ZLeZQNyzmeaWDsUUS5djlmOWnQc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "084807d7ac3ce106e3dee92c5b012c8362f0395d",
+        "rev": "4c3cb10e40504e91e3619b770030c675d6278302",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4c3cb10e`](https://github.com/nix-community/emacs-overlay/commit/4c3cb10e40504e91e3619b770030c675d6278302) | `` Updated repos/nongnu `` |
| [`f34553f0`](https://github.com/nix-community/emacs-overlay/commit/f34553f0f5cc85b6edd571198867d904f8c089e1) | `` Updated repos/melpa ``  |
| [`aa03a306`](https://github.com/nix-community/emacs-overlay/commit/aa03a306dce0dd9edd5eb7085db0bd5092160a0e) | `` Updated repos/emacs ``  |
| [`c0b857fe`](https://github.com/nix-community/emacs-overlay/commit/c0b857fe888c2b6d3b4bee2cc9b13bab344e59be) | `` Updated repos/elpa ``   |
| [`d1e53169`](https://github.com/nix-community/emacs-overlay/commit/d1e53169c807b4cc38eb3c46271855152590962f) | `` Updated flake inputs `` |