### PR TITLE
chore(flake/nixpkgs): `dfdbcc42` -> `8acef304`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -775,11 +775,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1689373857,
-        "narHash": "sha256-mtBksyvhhT98Zsm9tYHuMKuLwUKDwv+BGTl6K5nOGhY=",
+        "lastModified": 1689444953,
+        "narHash": "sha256-0o56bfb2LC38wrinPdCGLDScd77LVcr7CrH1zK7qvDg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dfdbcc428f365071f0ca3888f6ec8c25c3792885",
+        "rev": "8acef304efe70152463a6399f73e636bcc363813",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`e16a75d3`](https://github.com/NixOS/nixpkgs/commit/e16a75d3be094fe120724e49b53adf64e684ef2c) | `` redis: use system jemalloc (#243398) ``                                        |
| [`e123d6f4`](https://github.com/NixOS/nixpkgs/commit/e123d6f4c40ba6eb6de6df38a17ca81e849c60d2) | `` spicedb: 1.22.2 -> 1.23.0 ``                                                   |
| [`27406971`](https://github.com/NixOS/nixpkgs/commit/27406971272524c301612b27eb670fe694fbd906) | `` python310Packages.pydeps: 1.12.10 -> 1.12.12 ``                                |
| [`e6c5017b`](https://github.com/NixOS/nixpkgs/commit/e6c5017b25b10668a83998fd693330cc3b952b08) | `` firefox-beta-bin-unwrapped: 116.0b2 -> 116.0b5 ``                              |
| [`ff8d08cc`](https://github.com/NixOS/nixpkgs/commit/ff8d08cc60eb652ef261b180ce3707b2ff5579c5) | `` python310Packages.hcloud: 1.24.0 -> 1.25.0 ``                                  |
| [`22732725`](https://github.com/NixOS/nixpkgs/commit/227327259226b49de7f54dabe89398af28255cce) | `` python310Packages.dm-haiku: 0.0.9 -> 0.0.10 ``                                 |
| [`61bb4823`](https://github.com/NixOS/nixpkgs/commit/61bb4823feedc78539fef19698ab52209f57be54) | `` python310Packages.clize: 5.0.0 -> 5.0.2 ``                                     |
| [`1319cc35`](https://github.com/NixOS/nixpkgs/commit/1319cc3520efd82596415411c15b254f0d22ec82) | `` python310Packages.diff-cover: 7.6.0 -> 7.7.0 ``                                |
| [`fc2f254a`](https://github.com/NixOS/nixpkgs/commit/fc2f254a1bb147e26625fc19f81de9f83f446fdf) | `` terraformer: 0.8.22 -> 0.8.24 ``                                               |
| [`c74628ad`](https://github.com/NixOS/nixpkgs/commit/c74628adfa68c73a3ba79accb5138db6bc24b8b7) | `` opera: 100.0.4815.21 -> 100.0.4815.47 ``                                       |
| [`8eda7130`](https://github.com/NixOS/nixpkgs/commit/8eda713040d71d0b3c19b0dbeb9a21fc2bdb84b6) | `` mmctl: 7.10.3 -> 7.10.4 ``                                                     |
| [`13360954`](https://github.com/NixOS/nixpkgs/commit/133609542150dac01ac0d8ae64e88031873a1e66) | `` amf-headers: 1.4.29 -> 1.4.30 ``                                               |
| [`77daf4da`](https://github.com/NixOS/nixpkgs/commit/77daf4daeebda76aff951006e368c7c2822a858c) | `` conftest: 0.44.0 -> 0.44.1 ``                                                  |
| [`07b4156a`](https://github.com/NixOS/nixpkgs/commit/07b4156af448b846d7b1cbfe3f5bcf34b0a6b5b7) | `` bazel-gazelle: 0.31.1 -> 0.32.0 ``                                             |
| [`14cba544`](https://github.com/NixOS/nixpkgs/commit/14cba54488a0cfd5d40e855588176b96682c34d8) | `` python310Packages.metakernel: 0.29.4 -> 0.29.5 ``                              |
| [`2d3bf200`](https://github.com/NixOS/nixpkgs/commit/2d3bf20086bf1b8d15f60c92f34d6e4b8565f07a) | `` nixos/keyd: add support for multi-file configuration ``                        |
| [`45ad1240`](https://github.com/NixOS/nixpkgs/commit/45ad1240e800b6420105a4cb98fbb7c14e1941fc) | `` lemmy-server: 0.18.1 -> 0.18.2 ``                                              |
| [`ced78b33`](https://github.com/NixOS/nixpkgs/commit/ced78b33391473d6ba97756ea8f50e6498368cd1) | `` lemmy-{server,ui}: Use tag to get latest release for both server and ui ``     |
| [`e989daa6`](https://github.com/NixOS/nixpkgs/commit/e989daa65f2dd9827d56bee6a14a1965471f0597) | `` shadowfox: fix build ``                                                        |
| [`7d804177`](https://github.com/NixOS/nixpkgs/commit/7d80417710a9077b9142b479b02d07200d71d9db) | `` wuzz: unbreak ``                                                               |
| [`1c807356`](https://github.com/NixOS/nixpkgs/commit/1c807356b6c603887be693b4afdbe1e85bef8e27) | `` hubble: unbreak on aarch64-linux ``                                            |
| [`9d4dab5d`](https://github.com/NixOS/nixpkgs/commit/9d4dab5df84d0ee1d973d563415d9bf6de8563bd) | `` doggo: unpin go ``                                                             |
| [`50f20488`](https://github.com/NixOS/nixpkgs/commit/50f2048830d02405244af838abbda1628543fc5b) | `` terraform-providers.postgresql: 1.19.0 -> 1.20.0 ``                            |
| [`ea1a65bd`](https://github.com/NixOS/nixpkgs/commit/ea1a65bd342b59f1aa3ea08f88c9f60691197e2f) | `` terraform-providers.huaweicloud: 1.51.0 -> 1.52.0 ``                           |
| [`77c1ece6`](https://github.com/NixOS/nixpkgs/commit/77c1ece6083693f575e11df9c0ab18b3bc7c6213) | `` terraform-providers.github: 5.30.1 -> 5.31.0 ``                                |
| [`d641aa33`](https://github.com/NixOS/nixpkgs/commit/d641aa3314f243856d0e6242cbcb8ae7dc5031d3) | `` terraform-providers.grafana: 2.0.0 -> 2.1.0 ``                                 |
| [`394a1d26`](https://github.com/NixOS/nixpkgs/commit/394a1d260b4f3103bce4dad0cbe81ac97c94ee46) | `` terraform-providers.cloudfoundry: 0.50.8 -> 0.51.2 ``                          |
| [`c04e9ece`](https://github.com/NixOS/nixpkgs/commit/c04e9ece46e38d5cb5802f3fa3bd955267b58402) | `` terraform-providers.brightbox: 3.4.2 -> 3.4.3 ``                               |
| [`06cb588e`](https://github.com/NixOS/nixpkgs/commit/06cb588ed78d3f3a8dd677d2833d46b3a997673b) | `` terraform-providers.bigip: 1.18.0 -> 1.18.1 ``                                 |
| [`4a8ac857`](https://github.com/NixOS/nixpkgs/commit/4a8ac8577cb8ddfa7db0bb9e5ca5bb8409b597cf) | `` terraform-providers.bitbucket: 2.34.0 -> 2.35.0 ``                             |
| [`ff369049`](https://github.com/NixOS/nixpkgs/commit/ff3690490fadcd46b555407fa4ffadf2bf7d8ac4) | `` alfis: 0.8.3 -> 0.8.4 ``                                                       |
| [`36a0dfc4`](https://github.com/NixOS/nixpkgs/commit/36a0dfc4c502265f4945f0e9dae7c326dd8270f5) | `` python310Packages.pytest-testmon: 2.0.9 -> 2.0.12 ``                           |
| [`adf22d21`](https://github.com/NixOS/nixpkgs/commit/adf22d21c9d428f42f90e66c187e25708bbd519e) | `` fulcrum: pin older rocksdb ``                                                  |
| [`b2051317`](https://github.com/NixOS/nixpkgs/commit/b2051317a88ee1820f44975fee7cf500219c563e) | `` surrealdb: pin older rocksdb ``                                                |
| [`8f47d38a`](https://github.com/NixOS/nixpkgs/commit/8f47d38ac860f39b8c76d65bb21ae7af2f8e025b) | `` rocksdb_7_10: init at 7.10.2 ``                                                |
| [`7dbbfb67`](https://github.com/NixOS/nixpkgs/commit/7dbbfb676434a42a3c48fe3ea413b9f57cd2c6af) | `` rocksdb_lite: remove ``                                                        |
| [`933c4517`](https://github.com/NixOS/nixpkgs/commit/933c4517220c3d816055c57c8825b0bce9f3f897) | `` rocksdb: 7.10.2 -> 8.3.2 ``                                                    |
| [`604c2608`](https://github.com/NixOS/nixpkgs/commit/604c2608b42b2eee7fee70d883e4feaacc8611d1) | `` tuxedo-keyboard: set it as broken for kernel <= 5.4 ``                         |
| [`42be0b1b`](https://github.com/NixOS/nixpkgs/commit/42be0b1bfedbc7f0201fee944174c8844adc31f8) | `` chafa: fixup build with libwebp-1.3.1 ``                                       |
| [`88e87869`](https://github.com/NixOS/nixpkgs/commit/88e87869c0c2b37b1df1441c5fc8d1c76d6486a9) | `` swayimg: patch build with libwebp-1.3.1 ``                                     |
| [`336ba443`](https://github.com/NixOS/nixpkgs/commit/336ba443ef1f4615fd0944f804030a7a0452573b) | `` python310Packages.flake8-bugbear: 23.6.5 -> 23.7.10 ``                         |
| [`3e583687`](https://github.com/NixOS/nixpkgs/commit/3e583687e0ae939b635a09884b42d9d0474af728) | `` python310Packages.dvc-data: 2.3.3 -> 2.5.0 ``                                  |
| [`17157597`](https://github.com/NixOS/nixpkgs/commit/1715759771a737ec8e5275aed25bff6e7920a03e) | `` python310Packages.globus-sdk: 3.22.0 -> 3.23.0 ``                              |
| [`dfd30dea`](https://github.com/NixOS/nixpkgs/commit/dfd30dea6f4a3451ac86a1dcc8e2ad25da23617a) | `` netdata-go-plugins: 0.53.2 -> 0.54.0 ``                                        |
| [`05313029`](https://github.com/NixOS/nixpkgs/commit/053130292caa8bbe9246845bd38a9aa8d012613b) | `` restic-rest-server: 0.12.0 -> 0.12.1 ``                                        |
| [`bbd16e79`](https://github.com/NixOS/nixpkgs/commit/bbd16e798cdb7bb1bfdbae1c293f688813e19de8) | `` python3Packages.dissect-target: disable failing tests ``                       |
| [`162039a2`](https://github.com/NixOS/nixpkgs/commit/162039a2336d88affd2542cb67f82672078ae029) | `` nixos/swraid: Add missing mkRenamedOption ``                                   |
| [`03f4e727`](https://github.com/NixOS/nixpkgs/commit/03f4e727c53322064592b1af75df946a65f2f26c) | `` python310Packages.plantuml-markdown: 3.9.1 -> 3.9.2 ``                         |
| [`5829ef37`](https://github.com/NixOS/nixpkgs/commit/5829ef37cc07aa3c7da58654a7f7f2e8bc2012ea) | `` calibre: 6.22.0 -> 6.23.0 ``                                                   |
| [`351417c6`](https://github.com/NixOS/nixpkgs/commit/351417c686d73ea36aa9c8e6a7ce4219f86d6d57) | `` libxmp: 4.5.0 -> 4.6.0 ``                                                      |
| [`a0892e08`](https://github.com/NixOS/nixpkgs/commit/a0892e08588058ab1cc3e1911ae7178806a623c4) | `` deno: 1.35.0 -> 1.35.1 ``                                                      |
| [`70ae1f4f`](https://github.com/NixOS/nixpkgs/commit/70ae1f4f8b2ac2a1a2775c73a3ddbb83274f6d38) | `` httplz: 1.12.6 -> 1.13.0 ``                                                    |
| [`c5240d97`](https://github.com/NixOS/nixpkgs/commit/c5240d9775abf5ae48cc792048ef6966c719aeae) | `` asterisk: update the update script version regex ``                            |
| [`85331ccd`](https://github.com/NixOS/nixpkgs/commit/85331ccd98261180fc9de5388ef180e87f0380e2) | `` doc/../haskell.section.md: Make a bit clearer and more beginner friendly ``    |
| [`81b354ce`](https://github.com/NixOS/nixpkgs/commit/81b354ceb05728eee931e95183f3b9d0fce77306) | `` keybase: fix build on x86_64-darwin ``                                         |
| [`7764e287`](https://github.com/NixOS/nixpkgs/commit/7764e28784180311051541497bc19a7ec890dbda) | `` python310Packages.xformers: init at 0.0.20 ``                                  |
| [`3d19582e`](https://github.com/NixOS/nixpkgs/commit/3d19582ebe18c4b9a710d30ce666ce44d403cae2) | `` python310Packages.pyre-extensions: init at 0.0.30 ``                           |
| [`0c38ea41`](https://github.com/NixOS/nixpkgs/commit/0c38ea41406316d4562170e98630b3d7a5c01bc1) | `` nodehun: init at 3.0.2 ``                                                      |
| [`0563baa0`](https://github.com/NixOS/nixpkgs/commit/0563baa02ed2f4f232299d4b0dc4d87a2ad38130) | `` gopatch: 0.2.0 -> 0.3.0 ``                                                     |
| [`7e9f41c2`](https://github.com/NixOS/nixpkgs/commit/7e9f41c295c2fae84fa0d40efacf1bfa933220d2) | `` scrcpy: 2.1 -> 2.1.1 ``                                                        |
| [`ee38adc8`](https://github.com/NixOS/nixpkgs/commit/ee38adc8e2fa43ab2f8553cf47205ff750c81abf) | `` keepalived: use `ints.between` ``                                              |
| [`8a6d5acb`](https://github.com/NixOS/nixpkgs/commit/8a6d5acb5f021ac5ee314a4f5954fb9f48ed3855) | `` cytoscape: Dependency openjdk11 -> openjdk17 ``                                |
| [`80a75c8a`](https://github.com/NixOS/nixpkgs/commit/80a75c8ad2cb7b458f1b1017eb44ca95542b07e4) | `` tfupdate: 0.7.1 -> 0.7.2 ``                                                    |
| [`48cbc7ae`](https://github.com/NixOS/nixpkgs/commit/48cbc7ae740e3cfb0a7fbf809048f68cb8805316) | `` phpExtensions.msgpack: 2.2.0RC2 -> 2.2.0 ``                                    |
| [`19ac5194`](https://github.com/NixOS/nixpkgs/commit/19ac5194268c876a4a58aa37b2e96e7010e8b6b9) | `` grafana-dash-n-grab: 0.4.3 -> 0.4.5 ``                                         |
| [`2376ec39`](https://github.com/NixOS/nixpkgs/commit/2376ec3971b4081dac65fa7d4675b3ba3d8fee6a) | `` typos: 1.16.0 -> 1.16.1 ``                                                     |
| [`ec7dea44`](https://github.com/NixOS/nixpkgs/commit/ec7dea44bf0e6086cd62f0d90ef7d9e0789d7127) | `` cl-gtk4.webkit2: mark as broken ``                                             |
| [`acd0161b`](https://github.com/NixOS/nixpkgs/commit/acd0161ba27062a0e72b2faf81662ef36dde1827) | `` sbcl.pkgs: use Quicklisp versions of tar and tar-file ``                       |
| [`0d84933b`](https://github.com/NixOS/nixpkgs/commit/0d84933bfe2fec2a5de540c07287ab69428409da) | `` sbcl.pkgs: update to Quicklisp dist from June 2023 ``                          |
| [`2a9010bf`](https://github.com/NixOS/nixpkgs/commit/2a9010bfb42d4f9d4ad082fde409e39255f174a9) | `` betterbird: inherit from correct thunderbird ``                                |
| [`a347027a`](https://github.com/NixOS/nixpkgs/commit/a347027ace06cabc55e56df57e07ab3ba18e41ce) | `` python310Packages.yfinance: 0.2.22 -> 0.2.24 ``                                |
| [`bb219736`](https://github.com/NixOS/nixpkgs/commit/bb219736e42a0311fcd959a6f639ea53ce1d62ec) | `` stdenvBootstrapTools: in darwin, only run install_name_tool on Mach-O files `` |
| [`6454fb1b`](https://github.com/NixOS/nixpkgs/commit/6454fb1bc0b5884d0c11c98a8a99735ef5a0cae8) | `` haskell.compiler.ghc962: fix build on Darwin after stdenv rework merge ``      |
| [`67442c13`](https://github.com/NixOS/nixpkgs/commit/67442c1394f2a09027f01c1c82e1f88ca0f5c1ea) | `` critcmp: 0.1.7 -> 0.1.8 ``                                                     |
| [`3d37f6e0`](https://github.com/NixOS/nixpkgs/commit/3d37f6e0c162b2351fc52405dd2f0231335fa073) | `` popsicle: 1.3.1 -> 1.3.2 ``                                                    |
| [`c44f64c5`](https://github.com/NixOS/nixpkgs/commit/c44f64c508359d4c6da418a565d356df04147893) | `` complgen: unstable-2023-07-05 -> unstable-2023-07-10 ``                        |
| [`f6793ae4`](https://github.com/NixOS/nixpkgs/commit/f6793ae4af293302840c75e192b83905193efb28) | `` egglog: unstable-2023-06-26 -> unstable-2023-07-11 ``                          |
| [`4ffb691f`](https://github.com/NixOS/nixpkgs/commit/4ffb691f8f6abeb9dedee64489f1cfc4ee88a672) | `` cargo-local-registry: 0.2.3 -> 0.2.5 ``                                        |
| [`6d157073`](https://github.com/NixOS/nixpkgs/commit/6d157073cf3caebeeeb0964749cfee085c8d655e) | `` piston-cli: use Python 3.10 ``                                                 |
| [`01fc7c52`](https://github.com/NixOS/nixpkgs/commit/01fc7c527c3a07a0b464e48e9b0ce6e61fef005f) | `` piston-cli: fix build ``                                                       |
| [`776af907`](https://github.com/NixOS/nixpkgs/commit/776af907f086e0b76ea2ecd8f9f8d86be83d0f83) | `` bisq-desktop: 1.9.10 -> 1.9.12 ``                                              |
| [`2289a489`](https://github.com/NixOS/nixpkgs/commit/2289a489c2d0ba213692b388e643c7b3fb8aaeeb) | `` asterisk: use latest python for update script ``                               |
| [`7aba3238`](https://github.com/NixOS/nixpkgs/commit/7aba3238803ae8c6d65b26b7fc2df69790f888cc) | `` mandelbulber: 2.29 -> 2.30 ``                                                  |
| [`9228255e`](https://github.com/NixOS/nixpkgs/commit/9228255e4a08889e3e82ae8bd679f697c8ad7516) | `` ibus-libpinyin: add linsui as maintainer ``                                    |
| [`8a3a06a7`](https://github.com/NixOS/nixpkgs/commit/8a3a06a757f68fc4354d4db3a10e5b0a9e1dc666) | `` ibus-libpinyin: 2.13.1 -> 2.15.3 ``                                            |
| [`65395e50`](https://github.com/NixOS/nixpkgs/commit/65395e50750f0779d14aa95320d28b25a232ff90) | `` vscode: 1.80.0 -> 1.80.1 ``                                                    |
| [`dff3296a`](https://github.com/NixOS/nixpkgs/commit/dff3296a1b0188321b2fabe66bb87492b33497b4) | `` pods: 1.2.2 -> 1.2.3 ``                                                        |
| [`7f832df5`](https://github.com/NixOS/nixpkgs/commit/7f832df5ef996f934a3a7192b701b7544674df9b) | `` gql: 0.3.0 -> 0.4.0 ``                                                         |
| [`c66a01a1`](https://github.com/NixOS/nixpkgs/commit/c66a01a1af1e0ba9cf50711ef114ce103ca18141) | `` libpinyin: 2.6.2 -> 2.8.1 ``                                                   |
| [`917bb930`](https://github.com/NixOS/nixpkgs/commit/917bb930786538a314f7e9602f9aa46c3d85340b) | `` nixos/klipper: add enableKlipperFlash option ``                                |
| [`c84d0c72`](https://github.com/NixOS/nixpkgs/commit/c84d0c72e372a303b41c9c3bfd3c12b81b498e8b) | `` dbcsr: 2.5.0 -> 2.6.0 ``                                                       |
| [`e98b2ab2`](https://github.com/NixOS/nixpkgs/commit/e98b2ab23396d288ecd0c6077580b21ed1845f87) | `` qownnotes: 23.7.1 -> 23.7.2 ``                                                 |
| [`1c015108`](https://github.com/NixOS/nixpkgs/commit/1c015108ad1521b468200fc196bf8ec27c09d277) | `` lightwalletd: 0.4.13 -> 0.4.15 ``                                              |
| [`87ab6231`](https://github.com/NixOS/nixpkgs/commit/87ab62310ed5ea8fb8dfef68ddfaba2ebd743a94) | `` kubernetes-polaris: 8.2.4 -> 8.3.0 ``                                          |
| [`aad14589`](https://github.com/NixOS/nixpkgs/commit/aad1458981045216fa19e30859087a132ccb9d11) | `` python310Packages.wasmer: remove unused rec ``                                 |
| [`af947b57`](https://github.com/NixOS/nixpkgs/commit/af947b57a87ddba37f107de0339b7276ae9260af) | `` python310Packages.uvicorn: remove unused rec ``                                |
| [`91ae0efe`](https://github.com/NixOS/nixpkgs/commit/91ae0efefd244b4fd5aea8f3f730bd6112508a23) | `` python310Packages.setuptools-scm: remove unused rec, use inherit ``            |
| [`09cb8467`](https://github.com/NixOS/nixpkgs/commit/09cb8467e6aeb47fe06007379e82031482ba3261) | `` python310Packages.pytest-asyncio: remove unused rec ``                         |
| [`5cfde706`](https://github.com/NixOS/nixpkgs/commit/5cfde70626511d645cb8e701a82d75d881c0b87c) | `` python310Packages.optax: remove unused input, rec ``                           |
| [`b42f5443`](https://github.com/NixOS/nixpkgs/commit/b42f54435eda8496d47fc41ad9e84eab85ea1182) | `` python310Packages.flit-core: remove unused rec ``                              |
| [`9c6a7f93`](https://github.com/NixOS/nixpkgs/commit/9c6a7f93e24b87a625f9e0d34a8fd1ee3137b86f) | `` python310Packages.dm-haiku: remove unused input, rec ``                        |
| [`e052d608`](https://github.com/NixOS/nixpkgs/commit/e052d608cbd3f5e5ac1b6eeed2cf7e20dcfa5d1d) | `` python310Packages.stestr: fix passthru.tests ``                                |
| [`f5dd8142`](https://github.com/NixOS/nixpkgs/commit/f5dd81423af44759701f1c0dde4b9735ccc8da27) | `` python310Packages.python-manilaclient: fix passthru.tests ``                   |
| [`aecf7364`](https://github.com/NixOS/nixpkgs/commit/aecf7364ccfaf3d2dbca3418e9a5ecd20b8ac4a1) | `` python310Packages.pbr: fix passthru.tests ``                                   |
| [`b9d0814f`](https://github.com/NixOS/nixpkgs/commit/b9d0814f509b7e5c41622279848dd7697890821a) | `` python310Packages.oslotest: fix passthru.tests ``                              |
| [`36340bf6`](https://github.com/NixOS/nixpkgs/commit/36340bf60124ee415a123e15f09b197118452677) | `` python310Packages.oslo-config: fix passthru.tests ``                           |
| [`f8ca471e`](https://github.com/NixOS/nixpkgs/commit/f8ca471ef65ca5234fa527eeea966680bd22b8b6) | `` python310Packages.os-service-types: fix passthru.tests ``                      |
| [`a2a2f483`](https://github.com/NixOS/nixpkgs/commit/a2a2f4838e822ced5af9439ed5dc20772ddc0e5a) | `` python310Packages.openstacksdk: fix passthru.tests ``                          |
| [`d4166c31`](https://github.com/NixOS/nixpkgs/commit/d4166c312f1097b67b35bab18f6f8f4d6399e374) | `` python310Packages.ipykernel: fix passthru.tests ``                             |
| [`7261c52f`](https://github.com/NixOS/nixpkgs/commit/7261c52fedfef95079c401f86d36cfbc4cbbc85c) | `` chromium: supply Rust compiler for M115+ ``                                    |
| [`f22fdf5d`](https://github.com/NixOS/nixpkgs/commit/f22fdf5d72e99e6ac5dd69992fd89acf0fa82ec3) | `` python310Packages.debtcollector: fix passthru.tests ``                         |
| [`15640652`](https://github.com/NixOS/nixpkgs/commit/15640652bf2903019885d336493e975a5fa24f2f) | `` python310Packages.cliff: fix passthru.tests ``                                 |
| [`b6e04d64`](https://github.com/NixOS/nixpkgs/commit/b6e04d64867d603556e87a5b7ba7f86fd685829d) | `` mongodb-tools: 100.7.0 -> 100.7.3 ``                                           |
| [`9a4e9412`](https://github.com/NixOS/nixpkgs/commit/9a4e94126264a81c3d6b6a7e08f27e6e78a67d80) | `` grafana: 10.0.1 -> 10.0.2 ``                                                   |
| [`c834c87b`](https://github.com/NixOS/nixpkgs/commit/c834c87be4fefdc72a6403be68a36029b2438b74) | `` jaeles: add changelog to meta ``                                               |
| [`95864211`](https://github.com/NixOS/nixpkgs/commit/95864211d262796d7adfc9f8b8aaabfbd7b04950) | `` python311Packages.qcodes: 0.38.1 -> 0.39.0 ``                                  |
| [`370ad60d`](https://github.com/NixOS/nixpkgs/commit/370ad60d07856b687a72de73118467a4131501ee) | `` listenbrainz-mpd: 2.1.0 -> 2.2.0 ``                                            |
| [`28ee142c`](https://github.com/NixOS/nixpkgs/commit/28ee142c7d07ec4b6b837a0e029e25af9cdab0b7) | `` xorg.xeyes: 1.2.0 -> 1.3.0 ``                                                  |
| [`c61151ef`](https://github.com/NixOS/nixpkgs/commit/c61151ef06bb89045bf0194926a7f44d65d6c8b8) | `` ocamlPackages.mirage-crypto: 0.11.0 -> 0.11.1 ``                               |
| [`c7a2d494`](https://github.com/NixOS/nixpkgs/commit/c7a2d49497cf5ad088f14f8e65ef7bd181395e36) | `` python310Packages.stripe: 5.4.0 -> 5.5.0 ``                                    |
| [`4bb75693`](https://github.com/NixOS/nixpkgs/commit/4bb75693711a53b7a25cf9c27f35146fa0666280) | `` python310Packages.python-manilaclient: 4.4.0 -> 4.5.0 ``                       |
| [`94a47f1d`](https://github.com/NixOS/nixpkgs/commit/94a47f1d6df73ca6aa361a06db0b6c36f1e85f3f) | `` python310Packages.imbalanced-learn: 0.10.1 -> 0.11.0 ``                        |
| [`2a3d3107`](https://github.com/NixOS/nixpkgs/commit/2a3d3107090ef1e54773925ff6f109c820b2a6f0) | `` asterisk: apply patch for pjsip CVE-2023-27585 ``                              |
| [`8a2273b0`](https://github.com/NixOS/nixpkgs/commit/8a2273b058a4d62097fd54b96d8c385696726893) | `` buf: 1.23.1 -> 1.24.0 ``                                                       |
| [`81c163df`](https://github.com/NixOS/nixpkgs/commit/81c163dfce58e4b7c7e0689803f882b189cf1bc3) | `` python311Packages.phonenumbers: 8.13.13 -> 8.13.16 ``                          |
| [`3afd8e03`](https://github.com/NixOS/nixpkgs/commit/3afd8e03e5858ad60355174c1939dee1d6cee9db) | `` pdfhummus: 4.5.6 -> 4.5.8 ``                                                   |
| [`7cc85d2d`](https://github.com/NixOS/nixpkgs/commit/7cc85d2d7cc14c960abdc7e7264406ee3bbd0fb6) | `` python310Packages.pypresence: 4.2.1 -> 4.3.0 ``                                |
| [`dc190f96`](https://github.com/NixOS/nixpkgs/commit/dc190f969f1138f3053037340880eadb7f130846) | `` pdfhummus: init at 4.5.6 ``                                                    |
| [`ee4f1fe1`](https://github.com/NixOS/nixpkgs/commit/ee4f1fe1d861610682e1d2c821043118b15ff225) | `` build2: use lld from llvm 16 to link on darwin ``                              |
| [`a64d41c1`](https://github.com/NixOS/nixpkgs/commit/a64d41c1008c0ae9fa18e695b916c54fdf4ec4d4) | `` rbdoom-3-bfg: disable fortify3 hardening flag ``                               |