### PR TITLE
chore(flake/emacs-overlay): `4c3cb10e` -> `aa9011e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -240,11 +240,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689480175,
-        "narHash": "sha256-esfvClbx/gs/8gC2ZLeZQNyzmeaWDsUUS5djlmOWnQc=",
+        "lastModified": 1689507145,
+        "narHash": "sha256-2ojaMkso1b0StMq54HxQP/7CE6K69GwHCF4lc9qhLk0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4c3cb10e40504e91e3619b770030c675d6278302",
+        "rev": "aa9011e25ca971ee914cc8db9224d213b691e8b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`aa9011e2`](https://github.com/nix-community/emacs-overlay/commit/aa9011e25ca971ee914cc8db9224d213b691e8b0) | `` Updated repos/melpa ``  |
| [`1cd1cde1`](https://github.com/nix-community/emacs-overlay/commit/1cd1cde19875bc7a4ec06bcbf1a7b74b1e5fe1bc) | `` Updated repos/emacs ``  |
| [`5aedb85a`](https://github.com/nix-community/emacs-overlay/commit/5aedb85aedecf6eab465862b3d41fb91cc9df6be) | `` Updated flake inputs `` |