### PR TITLE
chore(flake/stylix): `0087f554` -> `0b8a92a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1007,11 +1007,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689347170,
-        "narHash": "sha256-3IO+37XkKKGILEFw60VeG7P+3za47SNXD3wIXzpNTlU=",
+        "lastModified": 1689527293,
+        "narHash": "sha256-XVFBwpLX1Kz0IFCg5Q75dioEje0TgXGh/9pqBhlF2fk=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "0087f554ffe5293a2db7444145b1c54ee338399f",
+        "rev": "0b8a92a4f88117cdbdb4b9863fc021b6a6f7c3cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                              |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`0b8a92a4`](https://github.com/danth/stylix/commit/0b8a92a4f88117cdbdb4b9863fc021b6a6f7c3cc) | `` Ignore failures in KDE activation script :bug: `` |