### PR TITLE
chore(flake/emacs-overlay): `aa9011e2` -> `f55f6538`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -240,11 +240,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689507145,
-        "narHash": "sha256-2ojaMkso1b0StMq54HxQP/7CE6K69GwHCF4lc9qhLk0=",
+        "lastModified": 1689531473,
+        "narHash": "sha256-S6EmHgRQXiFF7C9KG6eJBkXPA+WRnk++42i2NeRIc98=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "aa9011e25ca971ee914cc8db9224d213b691e8b0",
+        "rev": "f55f65384775ddce98368b86bf76816d6d3c5901",
         "type": "github"
       },
       "original": {
@@ -712,11 +712,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1689326639,
-        "narHash": "sha256-79zi0t83Dcc2dE0NuYZ+2hqtKXZN1yWVq5mtx8D2d7Y=",
+        "lastModified": 1689431009,
+        "narHash": "sha256-hPgQCRWP5q/Xc4qOIP3c2krR9nQua78+t9EDiuey5nc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9fdfaeb7b96f05e869f838c73cde8d98c640c649",
+        "rev": "af8279f65fe71ce5a448408034a8c06e2b4b2c66",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`f55f6538`](https://github.com/nix-community/emacs-overlay/commit/f55f65384775ddce98368b86bf76816d6d3c5901) | `` Updated repos/melpa ``  |
| [`8019616c`](https://github.com/nix-community/emacs-overlay/commit/8019616cffc4478d7a05d6f16d427d0c90df2248) | `` Updated repos/emacs ``  |
| [`ffc222e8`](https://github.com/nix-community/emacs-overlay/commit/ffc222e84e4516c1c0920252124c42816ca67ee8) | `` Updated repos/elpa ``   |
| [`6c2bc4e1`](https://github.com/nix-community/emacs-overlay/commit/6c2bc4e1c1eb83d77060b0cc9fcbe7ff99da4e56) | `` Updated flake inputs `` |