### PR TITLE
chore(flake/emacs-overlay): `f55f6538` -> `7eda134a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -240,11 +240,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689531473,
-        "narHash": "sha256-S6EmHgRQXiFF7C9KG6eJBkXPA+WRnk++42i2NeRIc98=",
+        "lastModified": 1689564099,
+        "narHash": "sha256-Nu5m+sKcV/Hiy0ALNjIW3thZNdOTf3y1qyPLuQdVRZQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f55f65384775ddce98368b86bf76816d6d3c5901",
+        "rev": "7eda134a8c17ec036ce67a478428d4bac0594aaf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`7eda134a`](https://github.com/nix-community/emacs-overlay/commit/7eda134a8c17ec036ce67a478428d4bac0594aaf) | `` Updated repos/melpa `` |
| [`ccbe339b`](https://github.com/nix-community/emacs-overlay/commit/ccbe339bc261353a7e3cb93ce6bf5221535e3b39) | `` Updated repos/emacs `` |
| [`1cfcbae1`](https://github.com/nix-community/emacs-overlay/commit/1cfcbae16b09925e3cd089e877c5278d78fb2cea) | `` Updated repos/elpa ``  |