### PR TITLE
chore(flake/emacs-overlay): `7eda134a` -> `d09c2516`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -240,11 +240,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689564099,
-        "narHash": "sha256-Nu5m+sKcV/Hiy0ALNjIW3thZNdOTf3y1qyPLuQdVRZQ=",
+        "lastModified": 1689586058,
+        "narHash": "sha256-8dnEi6cm3XNcwwRbANGd1uJbB1FZOzsyf8JZp7NNXVs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7eda134a8c17ec036ce67a478428d4bac0594aaf",
+        "rev": "d09c2516f7370bbe5e474e4355a6362e1317e2f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d09c2516`](https://github.com/nix-community/emacs-overlay/commit/d09c2516f7370bbe5e474e4355a6362e1317e2f1) | `` Updated repos/nongnu `` |
| [`c118418a`](https://github.com/nix-community/emacs-overlay/commit/c118418a55e9e9ae6732beb91831947beeceed8b) | `` Updated repos/melpa ``  |
| [`63eed2ba`](https://github.com/nix-community/emacs-overlay/commit/63eed2ba81521e0846c30cfc742b5545ba9004c2) | `` Updated repos/emacs ``  |
| [`a205da87`](https://github.com/nix-community/emacs-overlay/commit/a205da878adef23aab68dd0f915a505c8571f7b2) | `` Updated flake inputs `` |