### PR TITLE
chore(flake/emacs-overlay): `8c3d5922` -> `cffb75cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -240,11 +240,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689618000,
-        "narHash": "sha256-y9hqlmkGfOBsHP5MJAl59yqW3ZaPF6Zy4HMAO7xTFc4=",
+        "lastModified": 1689652392,
+        "narHash": "sha256-G/yNhNw3sgVcuTRUmhNsGLqhpz+h79SGJ7DLRu/tLig=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8c3d5922afd522c2ad12c046242abcd2da4e700e",
+        "rev": "cffb75cf9e402be7e1a62fe4d67fe2d26713a3ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`cffb75cf`](https://github.com/nix-community/emacs-overlay/commit/cffb75cf9e402be7e1a62fe4d67fe2d26713a3ba) | `` Updated repos/melpa `` |
| [`210cb623`](https://github.com/nix-community/emacs-overlay/commit/210cb6239a8576800ff246166007b2939e96ff51) | `` Updated repos/emacs `` |
| [`7c2b8cdb`](https://github.com/nix-community/emacs-overlay/commit/7c2b8cdb9b156723e72fb82d3ea82ffa810af9ed) | `` Updated repos/elpa ``  |