### PR TITLE
chore(flake/pre-commit-hooks): `87589fa4` -> `eb433bff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -791,11 +791,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1685866647,
-        "narHash": "sha256-4jKguNHY/edLYImB+uL8jKPL/vpfOvMmSlLAGfxSrnY=",
+        "lastModified": 1689261696,
+        "narHash": "sha256-LzfUtFs9MQRvIoQ3MfgSuipBVMXslMPH/vZ+nM40LkA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a53a3bec10deef6e1cc1caba5bc60f53b959b1e8",
+        "rev": "df1eee2aa65052a18121ed4971081576b25d6b5c",
         "type": "github"
       },
       "original": {
@@ -904,11 +904,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1689553106,
-        "narHash": "sha256-RFFf6BbpqQB0l1ehAbgri9g9MGZkAY9UdiNotD9fG8Y=",
+        "lastModified": 1689668210,
+        "narHash": "sha256-XAATwDkaUxH958yXLs1lcEOmU6pSEIkatY3qjqk8X0E=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "87589fa438dd6d5b8c7c1c6ab2ad69e4663bb51f",
+        "rev": "eb433bff05b285258be76513add6f6c57b441775",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                          |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`f189105d`](https://github.com/cachix/pre-commit-hooks.nix/commit/f189105d2acf08f7719a4fe18cc347613fceedf3) | `` Handle package missing from stable channel `` |
| [`af02198e`](https://github.com/cachix/pre-commit-hooks.nix/commit/af02198e564aba9d4b4f3cf4683c66daf21bcb1d) | `` Add pre-commit-hook-ensure-sops ``            |