### PR TITLE
chore(flake/emacs-overlay): `2747f52c` -> `bb06a68d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -240,11 +240,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689675388,
-        "narHash": "sha256-75fSXZO9t3ydkS2T8SNdmfeDpwUyomp/wKCf0fL7ojE=",
+        "lastModified": 1689700121,
+        "narHash": "sha256-YoKqbhyIQUCF7hGQNABMvcSfc9IgIFyxa6ZRInD5W+Q=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2747f52c2c919ec72f8e422626a852134a403f53",
+        "rev": "bb06a68dba7b316472dab0a7255a3ea21be45812",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`bb06a68d`](https://github.com/nix-community/emacs-overlay/commit/bb06a68dba7b316472dab0a7255a3ea21be45812) | `` Updated repos/melpa `` |
| [`162c3ea5`](https://github.com/nix-community/emacs-overlay/commit/162c3ea5aab7f324adc33dacfa3f87510050cba2) | `` Updated repos/elpa ``  |