### PR TITLE
chore(flake/emacs-overlay): `bb06a68d` -> `eba67dfe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -240,11 +240,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689700121,
-        "narHash": "sha256-YoKqbhyIQUCF7hGQNABMvcSfc9IgIFyxa6ZRInD5W+Q=",
+        "lastModified": 1689740988,
+        "narHash": "sha256-54wKfYFWnLmGE5Cyqjo2sGGnTe2AZaT0YUoMaXc3cec=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bb06a68dba7b316472dab0a7255a3ea21be45812",
+        "rev": "eba67dfe6c63f4baab70bec7dc4e9ec9a80f2c4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`eba67dfe`](https://github.com/nix-community/emacs-overlay/commit/eba67dfe6c63f4baab70bec7dc4e9ec9a80f2c4a) | `` Updated repos/melpa `` |
| [`c6dda944`](https://github.com/nix-community/emacs-overlay/commit/c6dda94449f4840a088216eff16d3d6a24f8c44e) | `` Updated repos/emacs `` |
| [`46336f09`](https://github.com/nix-community/emacs-overlay/commit/46336f09b2e019238097b11d8f412ef260bb8715) | `` Updated repos/elpa ``  |