### PR TITLE
chore(flake/emacs-overlay): `eba67dfe` -> `5f4523e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -240,11 +240,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689740988,
-        "narHash": "sha256-54wKfYFWnLmGE5Cyqjo2sGGnTe2AZaT0YUoMaXc3cec=",
+        "lastModified": 1689761825,
+        "narHash": "sha256-YyvenI6Rfxg5Rpf3ttRFRw4n3sv3JHbtTpCnf26ukqs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "eba67dfe6c63f4baab70bec7dc4e9ec9a80f2c4a",
+        "rev": "5f4523e4c97618ad9383eaf594411808ef098656",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`5f4523e4`](https://github.com/nix-community/emacs-overlay/commit/5f4523e4c97618ad9383eaf594411808ef098656) | `` Updated repos/melpa `` |
| [`cea09a24`](https://github.com/nix-community/emacs-overlay/commit/cea09a24ced2a2fa136ec907d07c8df555b5557a) | `` Updated repos/emacs `` |