### PR TITLE
chore(flake/home-manager): `2f84579a` -> `0841242b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -504,11 +504,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689495092,
-        "narHash": "sha256-yZu2j5FpLZEPhJQQutMCPTxa1VMigLPabLYvLTq6ASM=",
+        "lastModified": 1689783520,
+        "narHash": "sha256-uZ4PA9MFsZbmjFsOoFRkCjckF4btTNc9UvvbNL/pX8c=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f84579a70b8c74e5ebb37299a0c3ba279f09382",
+        "rev": "0841242b94638fcd010f7f64e56b7b1cad50c697",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`0841242b`](https://github.com/nix-community/home-manager/commit/0841242b94638fcd010f7f64e56b7b1cad50c697) | `` ripgrep: don't set env. variable if no config (#4254) `` |
| [`8c350c20`](https://github.com/nix-community/home-manager/commit/8c350c2069ac3eed6344fa62e3249afa0ce2728c) | `` docs: update for Markdown migration ``                   |
| [`9f9e277b`](https://github.com/nix-community/home-manager/commit/9f9e277b60a6e6915ad3a129e06861044b50fdf2) | `` treewide: remove now-redundant `lib.mdDoc` calls ``      |
| [`7398af11`](https://github.com/nix-community/home-manager/commit/7398af11b88bc905caaf2596b34ac4e8b6c6449d) | `` docs: clean up after Markdown migration ``               |
| [`60e42285`](https://github.com/nix-community/home-manager/commit/60e4228504f65aca821965e8cf7f4d1449d57c38) | `` flake: remove temporary nixpkgs pin ``                   |
| [`36a53d9f`](https://github.com/nix-community/home-manager/commit/36a53d9f26f2ec2530263250e808262bc78fc3be) | `` treewide: convert all option docs to Markdown ``         |
| [`c1d8d2a3`](https://github.com/nix-community/home-manager/commit/c1d8d2a3d1cc7b5ee5849d486140c15e7d82d336) | `` treewide: adjust some DocBook for conversion ``          |
| [`b5a65b91`](https://github.com/nix-community/home-manager/commit/b5a65b91fb0244a7e71e1bc75e666a8b2f78ce7c) | `` treewide: `mkAliasOption` -> `mkAliasOptionMD` ``        |
| [`e04de5b3`](https://github.com/nix-community/home-manager/commit/e04de5b308ffe8def2bd5c463a426286222b5e82) | `` treewide: `mkPackageOption` -> `mkPackageOptionMD` ``    |
| [`71df5071`](https://github.com/nix-community/home-manager/commit/71df507159dde0f7f5ac6874a813c486786ec0e7) | `` treewide: convert options with tables to Markdown ``     |
| [`21c700d1`](https://github.com/nix-community/home-manager/commit/21c700d14bd7e406aba86f70bb7da13df78a68e8) | `` treewide: convert options with lists to Markdown ``      |
| [`9e4a73c2`](https://github.com/nix-community/home-manager/commit/9e4a73c25e9b6348392fd7c17e88dc78a25475a1) | `` treewide: convert custom `enable` docs to Markdown ``    |
| [`3222c99a`](https://github.com/nix-community/home-manager/commit/3222c99a916f4019ecf1bc6d3c59f08294857b2e) | `` treewide: convert parameterized docs to Markdown ``      |
| [`3228f92b`](https://github.com/nix-community/home-manager/commit/3228f92b9087775869a3cbfb0669a2eb6540452a) | `` treewide: manually convert some docs to Markdown ``      |
| [`e2a1cb50`](https://github.com/nix-community/home-manager/commit/e2a1cb50d8c1da9df3f98ae5f6459f4e1dd867d6) | `` treewide: fix `mkEnableOption` arguments ``              |
| [`11b09b10`](https://github.com/nix-community/home-manager/commit/11b09b10e4404b3247ea6f56fb2248102e8e33d8) | `` treewide: add missing option descriptions ``             |
| [`59b93365`](https://github.com/nix-community/home-manager/commit/59b933653ab2ba7b7976cbb8b4b134a7363edf6f) | `` docs: use `nixosOptionsDoc` ``                           |
| [`82c157f2`](https://github.com/nix-community/home-manager/commit/82c157f255c28fb2ff7e37b81ec584cc286fab9a) | `` flake: temporarily pin nixpkgs version ``                |
| [`23ad3d2b`](https://github.com/nix-community/home-manager/commit/23ad3d2b5398402967bbc566fae3f15cb1a1be27) | `` version: add `isReleaseBranch` ``                        |
| [`1add3c3a`](https://github.com/nix-community/home-manager/commit/1add3c3a99ce2c2486cf524c2b42677787916a9e) | `` manual: add test ``                                      |