### PR TITLE
chore(flake/home-manager): `0841242b` -> `44ba0184`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -504,11 +504,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689783520,
-        "narHash": "sha256-uZ4PA9MFsZbmjFsOoFRkCjckF4btTNc9UvvbNL/pX8c=",
+        "lastModified": 1689791618,
+        "narHash": "sha256-+GbknQxvqytQDecu8vyAAUipP7DZexdckBbByykVJW0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0841242b94638fcd010f7f64e56b7b1cad50c697",
+        "rev": "44ba0184376c1bf017b8f2646a6040fb66d9c3e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`44ba0184`](https://github.com/nix-community/home-manager/commit/44ba0184376c1bf017b8f2646a6040fb66d9c3e8) | `` jujutsu: update for Jujutsu 0.8.0 (#4250) `` |