### PR TITLE
chore(flake/emacs-overlay): `5f4523e4` -> `38b18086`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689761825,
-        "narHash": "sha256-YyvenI6Rfxg5Rpf3ttRFRw4n3sv3JHbtTpCnf26ukqs=",
+        "lastModified": 1689792138,
+        "narHash": "sha256-+S0L6MAqP2aQxG0UcWpzXwL/ap0bbq7qg2Rjh22H0Zs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5f4523e4c97618ad9383eaf594411808ef098656",
+        "rev": "38b180866b9ab9b9fcf68ed98e97bb33e9579da2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`38b18086`](https://github.com/nix-community/emacs-overlay/commit/38b180866b9ab9b9fcf68ed98e97bb33e9579da2) | `` Updated repos/melpa `` |
| [`8cdf1abd`](https://github.com/nix-community/emacs-overlay/commit/8cdf1abd1a1d9edb3e5a77bb5328709064f94183) | `` Updated repos/emacs `` |
| [`77d29448`](https://github.com/nix-community/emacs-overlay/commit/77d29448dfbed86b0493ebd6d5345db91100c31f) | `` Updated repos/elpa ``  |