### PR TITLE
chore(flake/emacs-overlay): `93c4fa53` -> `c243dcc7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689819191,
-        "narHash": "sha256-fK0rxxzhF+KohEBUhOdZbIwmazEEpFDSnrbSrT9Lrqs=",
+        "lastModified": 1689844330,
+        "narHash": "sha256-7KPk/0IA8sPdNBbH/vJQayijcGpzwnlR/e0EX99m9qM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "93c4fa53dcc26ea00672995deba057f59850d76a",
+        "rev": "c243dcc7ea5fa3f1ccc781e8d7867e62e2525c06",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c243dcc7`](https://github.com/nix-community/emacs-overlay/commit/c243dcc7ea5fa3f1ccc781e8d7867e62e2525c06) | `` Updated repos/nongnu `` |
| [`574432d3`](https://github.com/nix-community/emacs-overlay/commit/574432d3110d18214826653a7cd497d1575d77fa) | `` Updated repos/melpa ``  |