### PR TITLE
chore(flake/lanzaboote): `85420159` -> `bf82f823`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -549,11 +549,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689842110,
-        "narHash": "sha256-4+5IQ+893ZgI9pY1DPw0/Wkzq+/6WdShnes7lTNn4dU=",
+        "lastModified": 1689845416,
+        "narHash": "sha256-ERkXfeLjDlYliIK6aPZpnlWAhgXAj3t1ppXWJAtFRoA=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "85420159e7d37b960f11c3aa64324b34db70d10b",
+        "rev": "bf82f823e185fce19a8fb50c336432d7ed95216f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                                          |
| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`aa2cb467`](https://github.com/nix-community/lanzaboote/commit/aa2cb467da1bf9507cc8c0106572e00963c901bc) | `` docs: suggest to use 0.3.0 tagged release of lanzaboote rather than master `` |