### PR TITLE
chore(flake/emacs-overlay): `c243dcc7` -> `fe2035cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689844330,
-        "narHash": "sha256-7KPk/0IA8sPdNBbH/vJQayijcGpzwnlR/e0EX99m9qM=",
+        "lastModified": 1689877766,
+        "narHash": "sha256-IsPJIX7wmdC8m+dDhdoFELv/lX24gqelcsCHVmyyluM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c243dcc7ea5fa3f1ccc781e8d7867e62e2525c06",
+        "rev": "fe2035cc0ddf11231d440a59268ccb4e778d3c94",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`fe2035cc`](https://github.com/nix-community/emacs-overlay/commit/fe2035cc0ddf11231d440a59268ccb4e778d3c94) | `` Updated repos/melpa `` |
| [`e567076d`](https://github.com/nix-community/emacs-overlay/commit/e567076d50f800ebad3f336391b43a0c55ef8858) | `` Updated repos/emacs `` |
| [`2fa82eb3`](https://github.com/nix-community/emacs-overlay/commit/2fa82eb31d3130b5ee0c227350a0ee8c0d1eec2a) | `` Updated repos/elpa ``  |