### PR TITLE
chore(flake/lanzaboote): `bf82f823` -> `e7246c6b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -356,11 +356,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683560683,
-        "narHash": "sha256-XAygPMN5Xnk/W2c1aW0jyEa6lfMDZWlQgiNtmHXytPc=",
+        "lastModified": 1688466019,
+        "narHash": "sha256-VeM2akYrBYMsb4W/MmBo1zmaMfgbL4cH3Pu8PGyIwJ0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "006c75898cf814ef9497252b022e91c946ba8e17",
+        "rev": "8e8d955c22df93dbe24f19ea04f47a74adbdc5ec",
         "type": "github"
       },
       "original": {
@@ -549,11 +549,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689845416,
-        "narHash": "sha256-ERkXfeLjDlYliIK6aPZpnlWAhgXAj3t1ppXWJAtFRoA=",
+        "lastModified": 1689889377,
+        "narHash": "sha256-ChBawisTCY3Cl06CSG+QNC2ES+G0ASiOxtOVif9uP/0=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "bf82f823e185fce19a8fb50c336432d7ed95216f",
+        "rev": "e7246c6bce1733d373059e6342f67fd53f90c198",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                  |
| --------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`ec210ff4`](https://github.com/nix-community/lanzaboote/commit/ec210ff40d5337b0c8682cf3c866a2145133a4f8) | `` stub: fix typo ``     |
| [`2a109c01`](https://github.com/nix-community/lanzaboote/commit/2a109c0121122bfd7080c11cf37eedf06d877e78) | `` flake.lock: Update `` |