### PR TITLE
chore(flake/emacs-overlay): `fe2035cc` -> `25fc3974`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689877766,
-        "narHash": "sha256-IsPJIX7wmdC8m+dDhdoFELv/lX24gqelcsCHVmyyluM=",
+        "lastModified": 1689909040,
+        "narHash": "sha256-OnJOL8USBe8LGmuEsHVbxh9jatASSeVYaSRVagJ9HqM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fe2035cc0ddf11231d440a59268ccb4e778d3c94",
+        "rev": "25fc3974fba5589fcf61d258a309ea23e9763ccf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`25fc3974`](https://github.com/nix-community/emacs-overlay/commit/25fc3974fba5589fcf61d258a309ea23e9763ccf) | `` Updated repos/nongnu `` |
| [`6027193b`](https://github.com/nix-community/emacs-overlay/commit/6027193b125cea9983d69bfb7261b7417869d1b2) | `` Updated repos/melpa ``  |
| [`1f2ada6e`](https://github.com/nix-community/emacs-overlay/commit/1f2ada6e32cdc7274c2384c9dc57a76e65626301) | `` Updated repos/emacs ``  |
| [`4f67a6b0`](https://github.com/nix-community/emacs-overlay/commit/4f67a6b09dec90a167e6263f0487fc7f5334bb91) | `` Updated repos/elpa ``   |