### PR TITLE
chore(flake/emacs-overlay): `25fc3974` -> `6fe23f0a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689909040,
-        "narHash": "sha256-OnJOL8USBe8LGmuEsHVbxh9jatASSeVYaSRVagJ9HqM=",
+        "lastModified": 1689930411,
+        "narHash": "sha256-vjKePHaTQ8feRw/YYVGRnzHutQ74FaTZrELJFiCSipE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "25fc3974fba5589fcf61d258a309ea23e9763ccf",
+        "rev": "6fe23f0a4196b39afe00a4fd1629115b58947f6d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`6fe23f0a`](https://github.com/nix-community/emacs-overlay/commit/6fe23f0a4196b39afe00a4fd1629115b58947f6d) | `` Updated repos/melpa ``  |
| [`00401900`](https://github.com/nix-community/emacs-overlay/commit/004019000fefc2021744b0e6481ba95db5400024) | `` Updated flake inputs `` |