### PR TITLE
chore(flake/emacs-overlay): `6fe23f0a` -> `b16c71aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689930411,
-        "narHash": "sha256-vjKePHaTQ8feRw/YYVGRnzHutQ74FaTZrELJFiCSipE=",
+        "lastModified": 1689966529,
+        "narHash": "sha256-efLMcc7NsxpMTPW8i7ACUzigRKbKhHZDvBRKbzVxJEI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6fe23f0a4196b39afe00a4fd1629115b58947f6d",
+        "rev": "b16c71aaf1d246e58a5206361b70071e6ec65cf5",
         "type": "github"
       },
       "original": {
@@ -711,11 +711,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1689680872,
-        "narHash": "sha256-brNix2+ihJSzCiKwLafbyejrHJZUP0Fy6z5+xMOC27M=",
+        "lastModified": 1689885880,
+        "narHash": "sha256-2ikAcvHKkKh8J/eUrwMA+wy1poscC+oL1RkN1V3RmT8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "08700de174bc6235043cb4263b643b721d936bdb",
+        "rev": "fa793b06f56896b7d1909e4b69977c7bf842b2f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b16c71aa`](https://github.com/nix-community/emacs-overlay/commit/b16c71aaf1d246e58a5206361b70071e6ec65cf5) | `` Updated repos/melpa ``  |
| [`2b70559f`](https://github.com/nix-community/emacs-overlay/commit/2b70559ffe69d8dfaf8bbc8b794b37901b64481d) | `` Updated repos/emacs ``  |
| [`6e7e79e2`](https://github.com/nix-community/emacs-overlay/commit/6e7e79e24d37fca3b2f9f9a4e02ab65c45116f7c) | `` Updated repos/elpa ``   |
| [`22f9e2a1`](https://github.com/nix-community/emacs-overlay/commit/22f9e2a121f6a8ec6d631d1cc51db0ed7362eb6c) | `` Updated flake inputs `` |