### PR TITLE
chore(flake/emacs-overlay): `b16c71aa` -> `3fd7df8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689966529,
-        "narHash": "sha256-efLMcc7NsxpMTPW8i7ACUzigRKbKhHZDvBRKbzVxJEI=",
+        "lastModified": 1689991196,
+        "narHash": "sha256-TL3GRuNeUD28ngzGUYumpFoSmOf7+2/eo+i3mY4cESQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b16c71aaf1d246e58a5206361b70071e6ec65cf5",
+        "rev": "3fd7df8e48255363c9460e8284f5ec92a3cc4403",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`3fd7df8e`](https://github.com/nix-community/emacs-overlay/commit/3fd7df8e48255363c9460e8284f5ec92a3cc4403) | `` Updated repos/nongnu `` |
| [`ec2afcdc`](https://github.com/nix-community/emacs-overlay/commit/ec2afcdc4b4284246f66264777c4670e52d0d505) | `` Updated repos/melpa ``  |
| [`47eb4910`](https://github.com/nix-community/emacs-overlay/commit/47eb49104f31c11c985dbce1aa6fd4b41f337554) | `` Updated repos/emacs ``  |
| [`7bb17e59`](https://github.com/nix-community/emacs-overlay/commit/7bb17e59c1efa639e5900a2ca44307cec4e78f7d) | `` Updated repos/elpa ``   |
| [`bd864742`](https://github.com/nix-community/emacs-overlay/commit/bd86474205eed43f75539a154edbf7670007a4d8) | `` Updated flake inputs `` |