### PR TITLE
chore(flake/emacs-overlay): `3fd7df8e` -> `3862b237`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1689991196,
-        "narHash": "sha256-TL3GRuNeUD28ngzGUYumpFoSmOf7+2/eo+i3mY4cESQ=",
+        "lastModified": 1690020840,
+        "narHash": "sha256-JSzBByEy0vzB5qGog+pPxZWg5/hG7Uhr74eMeML6MkM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3fd7df8e48255363c9460e8284f5ec92a3cc4403",
+        "rev": "3862b237a56b02ddd88c9dcfc74c9ee3d3f936a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`3862b237`](https://github.com/nix-community/emacs-overlay/commit/3862b237a56b02ddd88c9dcfc74c9ee3d3f936a5) | `` Updated repos/nongnu `` |
| [`2a7ada9c`](https://github.com/nix-community/emacs-overlay/commit/2a7ada9c1d9e5772ae0244ab73f8ea377fb88b21) | `` Updated repos/melpa ``  |
| [`31fe8df6`](https://github.com/nix-community/emacs-overlay/commit/31fe8df61a64c1278cf89de6b41988211e85fa8f) | `` Updated repos/emacs ``  |