### PR TITLE
chore(flake/emacs-overlay): `3862b237` -> `6c47e62b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1690020840,
-        "narHash": "sha256-JSzBByEy0vzB5qGog+pPxZWg5/hG7Uhr74eMeML6MkM=",
+        "lastModified": 1690049638,
+        "narHash": "sha256-A42LIS6x/tU3vbbOgJmLU3AEEDCSDD2iPyOJvzuoDQ8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3862b237a56b02ddd88c9dcfc74c9ee3d3f936a5",
+        "rev": "6c47e62b612814daf38f830cd32187768b813fac",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1689885880,
-        "narHash": "sha256-2ikAcvHKkKh8J/eUrwMA+wy1poscC+oL1RkN1V3RmT8=",
+        "lastModified": 1689956312,
+        "narHash": "sha256-NV9yamMhE5jgz+ZSM2IgXeYqOvmGIbIIJ+AFIhfD7Ek=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fa793b06f56896b7d1909e4b69977c7bf842b2f0",
+        "rev": "6da4bc6cb07cba1b8e53d139cbf1d2fb8061d967",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`6c47e62b`](https://github.com/nix-community/emacs-overlay/commit/6c47e62b612814daf38f830cd32187768b813fac) | `` Updated repos/melpa ``  |
| [`c6a21136`](https://github.com/nix-community/emacs-overlay/commit/c6a21136003a8d377a50079c1e785886d96ab8b0) | `` Updated repos/emacs ``  |
| [`c83c2687`](https://github.com/nix-community/emacs-overlay/commit/c83c26878cdcf43cc02a6838a232545b1b6203b7) | `` Updated repos/elpa ``   |
| [`cefe6528`](https://github.com/nix-community/emacs-overlay/commit/cefe6528106f9df427cc415a7ba47e31a4dc55ef) | `` Updated flake inputs `` |