### PR TITLE
chore(flake/nix-index-database): `22fa44b7` -> `c1e6fc40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -613,11 +613,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689479461,
-        "narHash": "sha256-Ak+PTYdmfOQEmcOsOEnrwqdP0HP20PLraRwpjSAzSeE=",
+        "lastModified": 1690083300,
+        "narHash": "sha256-xnUtWO/5TuuHkIpmzMXGvHJqS06FSVADnAZ4bvqO4Zo=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "22fa44b7f14684d184733fb26a628f3878ff7aaf",
+        "rev": "c1e6fc40dd5c0d16940bc012421268b94e404b0b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`c1e6fc40`](https://github.com/nix-community/nix-index-database/commit/c1e6fc40dd5c0d16940bc012421268b94e404b0b) | `` update packages.nix to release 2023-07-23-033400 `` |
| [`8de10d21`](https://github.com/nix-community/nix-index-database/commit/8de10d210a672af5d62af39cd2a60a80d09f34fa) | `` flake.lock: Update ``                               |