### PR TITLE
chore(flake/emacs-overlay): `6c47e62b` -> `b6a57652`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1690049638,
-        "narHash": "sha256-A42LIS6x/tU3vbbOgJmLU3AEEDCSDD2iPyOJvzuoDQ8=",
+        "lastModified": 1690168024,
+        "narHash": "sha256-Z3fKrHSIUQdNK0jZaMS8dlbrn7l1QqZli3r8Z3LKcrU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6c47e62b612814daf38f830cd32187768b813fac",
+        "rev": "b6a576523e6b1dd4310d1debf97ee91e521a8590",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                   |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
| [`379d9c26`](https://github.com/nix-community/emacs-overlay/commit/379d9c260bd91845a334c58aeddf05e55868547c) | `` Updated repos/nongnu ``                |
| [`767f9cc8`](https://github.com/nix-community/emacs-overlay/commit/767f9cc84819396a2e62c15e6e5bbd07cd7bc725) | `` Updated repos/melpa ``                 |
| [`08ec70f2`](https://github.com/nix-community/emacs-overlay/commit/08ec70f27c8cbf8c5c04df947815f3a189da5df9) | `` Updated repos/elpa ``                  |
| [`deaebf8f`](https://github.com/nix-community/emacs-overlay/commit/deaebf8f0a2034eb5015e916df40c2ddf5629eb9) | `` nativeComp -> withNativeCompilation `` |
| [`02551988`](https://github.com/nix-community/emacs-overlay/commit/02551988a01ed9a1857f9c2b6b80854ba2bd0f06) | `` Updated repos/melpa ``                 |
| [`00bb40d9`](https://github.com/nix-community/emacs-overlay/commit/00bb40d978624cfb8a194f978a22c4c3059522e5) | `` Updated repos/emacs ``                 |
| [`478c8f35`](https://github.com/nix-community/emacs-overlay/commit/478c8f359adb4e021d8f45001af6dce5528afbbd) | `` Updated repos/elpa ``                  |
| [`d0d1e369`](https://github.com/nix-community/emacs-overlay/commit/d0d1e3695cb80db1d75cf03082658a98d5dedb44) | `` Updated repos/nongnu ``                |
| [`1a0dddeb`](https://github.com/nix-community/emacs-overlay/commit/1a0dddebbe6499e905b7638163ed543df79e6e87) | `` Updated repos/melpa ``                 |
| [`5f8b7d8f`](https://github.com/nix-community/emacs-overlay/commit/5f8b7d8f8f10894e536c23b0d6ed2f27751a7bd8) | `` Updated repos/emacs ``                 |
| [`f50142b8`](https://github.com/nix-community/emacs-overlay/commit/f50142b8483dfeb1f3725aae4064ffac20340cdb) | `` Updated repos/melpa ``                 |
| [`9d8c7399`](https://github.com/nix-community/emacs-overlay/commit/9d8c7399ba7560a70f13be28b61254a563186ca4) | `` Updated repos/emacs ``                 |
| [`b0037119`](https://github.com/nix-community/emacs-overlay/commit/b0037119c05675312e8ab3f0ec7f149005792f1b) | `` Updated repos/elpa ``                  |
| [`7054cf08`](https://github.com/nix-community/emacs-overlay/commit/7054cf08ed2a2f81589e94a4bf5bce48c1dd1109) | `` Updated flake inputs ``                |