### PR TITLE
chore(flake/darwin): `531c3de7` -> `0f9058e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -119,11 +119,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689825754,
-        "narHash": "sha256-u3W3WGO3BA63nb+CeNLBajbJ/sl8tDXBHKxxeTOCxfo=",
+        "lastModified": 1690100173,
+        "narHash": "sha256-v3DT7u5KlW1ZoulvFQPndbg0gVD0zKGkJmPqGsBVQ3I=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "531c3de7eccf95155828e0cd9f18c25e7f937777",
+        "rev": "0f9058e739dbefc676dee557b4b627962268d556",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                   |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------- |
| [`5fd8914d`](https://github.com/LnL7/nix-darwin/commit/5fd8914dac6ba43ea650fadec35344f20ce50544) | `` treewide: fix `mkEnableOption` docs `` |
| [`0dafe217`](https://github.com/LnL7/nix-darwin/commit/0dafe2170deb6a691255cecc212af4b1cdf8297b) | `` Add `darwin-version` command ``        |