### PR TITLE
chore(flake/emacs-overlay): `b6a57652` -> `9855d7f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1690168024,
-        "narHash": "sha256-Z3fKrHSIUQdNK0jZaMS8dlbrn7l1QqZli3r8Z3LKcrU=",
+        "lastModified": 1690195528,
+        "narHash": "sha256-ZwJTXjvG9ssUypJfI/FZ3TWIbCksPJNfiqISm19Ro58=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b6a576523e6b1dd4310d1debf97ee91e521a8590",
+        "rev": "9855d7f268dffa9643f9bc3eaabb7957f4a3c476",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`9855d7f2`](https://github.com/nix-community/emacs-overlay/commit/9855d7f268dffa9643f9bc3eaabb7957f4a3c476) | `` Updated repos/melpa `` |
| [`9fcfdcaa`](https://github.com/nix-community/emacs-overlay/commit/9fcfdcaad14a411cd3eb97d046ba332cb4750af3) | `` Updated repos/emacs `` |