### PR TITLE
chore(flake/nur): `6b90cb96` -> `abcc8109`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690199168,
-        "narHash": "sha256-8eo615fNLfpLGTtqjMapdyBLMUXBO8TSsSMZdW6nxvQ=",
+        "lastModified": 1690227905,
+        "narHash": "sha256-A7zB8LZwbju7xdohnbA2OtNmzWCuEbgihtUQocTLmSk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6b90cb969b8e9d063ff71688085bf8ffb23a2788",
+        "rev": "abcc8109912fcaf0ff8dc247e118e203db0ef664",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`abcc8109`](https://github.com/nix-community/NUR/commit/abcc8109912fcaf0ff8dc247e118e203db0ef664) | `` automatic update `` |
| [`fac04f83`](https://github.com/nix-community/NUR/commit/fac04f836e05e9c1c3f731c533c0685aa76931dd) | `` automatic update `` |