### PR TITLE
chore(flake/darwin): `0f9058e7` -> `6ed4eb54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -119,11 +119,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690100173,
-        "narHash": "sha256-v3DT7u5KlW1ZoulvFQPndbg0gVD0zKGkJmPqGsBVQ3I=",
+        "lastModified": 1690239084,
+        "narHash": "sha256-o5fN5XNwlNZbT4rS33VuFs+MLCinfEbc9hKNF0LRpVk=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "0f9058e739dbefc676dee557b4b627962268d556",
+        "rev": "6ed4eb544f3e4d8733e95dac2527123d9a6ea4f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                             |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
| [`a5b09580`](https://github.com/LnL7/nix-darwin/commit/a5b09580e2d0bbc52b338afe4f1f1d46178e6bbf) | `` Revert "eval-config: set `class`" ``             |
| [`c4a1a1c4`](https://github.com/LnL7/nix-darwin/commit/c4a1a1c458b70156f85b2529dc5113c21f832916) | `` eternal-terminal: change launchd agent config `` |
| [`6adc4c68`](https://github.com/LnL7/nix-darwin/commit/6adc4c680b6b6970004629e5496b191f9a315faa) | `` eternal-terminal: add module ``                  |
| [`72493746`](https://github.com/LnL7/nix-darwin/commit/724937461f2326bbe512c5d03b145ac8381624b4) | `` eval-config: set `class` ``                      |
| [`0d3ad9e7`](https://github.com/LnL7/nix-darwin/commit/0d3ad9e7ffca6d63ee1e7548b3ef88cb5ea7bc41) | `` documentation: use `eval-config.nix` ``          |