### PR TITLE
chore(flake/nur): `abcc8109` -> `5a13b336`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690227905,
-        "narHash": "sha256-A7zB8LZwbju7xdohnbA2OtNmzWCuEbgihtUQocTLmSk=",
+        "lastModified": 1690242283,
+        "narHash": "sha256-LYXk0tazlShqNL7DT0ftIeducQoK3erQIWsFTIh9bvI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "abcc8109912fcaf0ff8dc247e118e203db0ef664",
+        "rev": "5a13b3364abcd3770996c85deeabbd9ed759a964",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5a13b336`](https://github.com/nix-community/NUR/commit/5a13b3364abcd3770996c85deeabbd9ed759a964) | `` automatic update `` |
| [`ecc8a7d1`](https://github.com/nix-community/NUR/commit/ecc8a7d1d28784c6743f6edc57f62dfb9f5b2faf) | `` automatic update `` |