### PR TITLE
chore(flake/emacs-overlay): `caf71437` -> `9815e71d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1690224796,
-        "narHash": "sha256-C99/kRecS8B6YxykXwaWYJHt9Lftd5Tcx/5CnJPOOEY=",
+        "lastModified": 1690250820,
+        "narHash": "sha256-1EgvKQJ/rT23kY9SW5t+1vVMt5PqYsR1459TS87ulzg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "caf71437399bd01b2053c124f3a01240514cfc05",
+        "rev": "9815e71dd833db0b076072df6f7ea46737854470",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`9815e71d`](https://github.com/nix-community/emacs-overlay/commit/9815e71dd833db0b076072df6f7ea46737854470) | `` Updated repos/nongnu `` |
| [`70e79125`](https://github.com/nix-community/emacs-overlay/commit/70e79125be41c75fa57e0564be866bb0dc8407ed) | `` Updated repos/melpa ``  |
| [`866a2434`](https://github.com/nix-community/emacs-overlay/commit/866a243457f36c075a092a85a58281d8c3d3c791) | `` Updated repos/elpa ``   |