### PR TITLE
chore(flake/nur): `ed094632` -> `dfe7215d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690247650,
-        "narHash": "sha256-xasDfDeXnR9PgUhOEzjn1NrvAcqloEgoNFUcQjv20Wg=",
+        "lastModified": 1690256022,
+        "narHash": "sha256-FX5NYsb0USqeZ+4waR6lNRfc+t6t62+Z5yceZS/nOXA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed0946320360d3a08404d93077c0847c176d4da0",
+        "rev": "dfe7215da7b7193294db277dec788d1de369359c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dfe7215d`](https://github.com/nix-community/NUR/commit/dfe7215da7b7193294db277dec788d1de369359c) | `` automatic update `` |
| [`0fd75f31`](https://github.com/nix-community/NUR/commit/0fd75f315e88d6e8e573a7a5bad05f07cdd87679) | `` automatic update `` |
| [`e4f157a2`](https://github.com/nix-community/NUR/commit/e4f157a2ad85472089b7ed806c491b8414890113) | `` automatic update `` |