### PR TITLE
chore(flake/nur): `dfe7215d` -> `e566c492`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690256022,
-        "narHash": "sha256-FX5NYsb0USqeZ+4waR6lNRfc+t6t62+Z5yceZS/nOXA=",
+        "lastModified": 1690264809,
+        "narHash": "sha256-F4ID6/bnH75P/mwz1TUA93p2ocdQ4xXcu1OZWqX3sL0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dfe7215da7b7193294db277dec788d1de369359c",
+        "rev": "e566c49204f6e79ac0a9143a73820369a0e5ab8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e566c492`](https://github.com/nix-community/NUR/commit/e566c49204f6e79ac0a9143a73820369a0e5ab8d) | `` automatic update `` |
| [`438f9d47`](https://github.com/nix-community/NUR/commit/438f9d478507bb1f47755767771226e73389e56b) | `` automatic update `` |
| [`8404c023`](https://github.com/nix-community/NUR/commit/8404c023bc3e9f11659645cfcb2728c29c38982c) | `` automatic update `` |
| [`26150daa`](https://github.com/nix-community/NUR/commit/26150daa39f99178d6403545c19f6c22aee30b6a) | `` automatic update `` |