### PR TITLE
chore(flake/nur): `e566c492` -> `83d0742a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690264809,
-        "narHash": "sha256-F4ID6/bnH75P/mwz1TUA93p2ocdQ4xXcu1OZWqX3sL0=",
+        "lastModified": 1690274760,
+        "narHash": "sha256-N7wq2vRvih2PLh9rqrPja/2e8mBdQS58gD2QXbNl0oc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e566c49204f6e79ac0a9143a73820369a0e5ab8d",
+        "rev": "83d0742aead176901b2a895482f34d9422fcecd0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`83d0742a`](https://github.com/nix-community/NUR/commit/83d0742aead176901b2a895482f34d9422fcecd0) | `` automatic update `` |
| [`34b969aa`](https://github.com/nix-community/NUR/commit/34b969aa73fefb4fc2983422f94116a83061b751) | `` automatic update `` |
| [`6ca85925`](https://github.com/nix-community/NUR/commit/6ca8592589d36eca86a316390487c2fdc674ff4e) | `` automatic update `` |