### PR TITLE
chore(flake/nur): `1afcf4b3` -> `58ff5464`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690277832,
-        "narHash": "sha256-bNYl/Uvx8ZR4GKg1Z5L2NZ1cefvt1Ic++5PyWEt+Rkw=",
+        "lastModified": 1690287667,
+        "narHash": "sha256-IDhGfygPFOT591psrpyQTFZetTEi+1BKzIAstb+3qxc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1afcf4b34ad147e5874cb01a7b8ca0c9f2828efb",
+        "rev": "58ff5464f35bf1ab2f9e811e48fdd8dbf3800bfe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`58ff5464`](https://github.com/nix-community/NUR/commit/58ff5464f35bf1ab2f9e811e48fdd8dbf3800bfe) | `` automatic update `` |