### PR TITLE
chore(flake/nur): `5b411423` -> `b163f960`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690313182,
-        "narHash": "sha256-1m1Focmo7lV2M1mHRL78ylioByaVGTA7e1w3gGFiKnw=",
+        "lastModified": 1690689826,
+        "narHash": "sha256-CzdetEeUlFhBBqvGYl/R07AkvWFTTRr7MmY26RErY8g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5b4114232231badd5092b77e0fde64bf8c8a6c3a",
+        "rev": "b163f9605d8360a88e61f09bb5a65bb3747573e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                       |
| -------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`b163f960`](https://github.com/nix-community/NUR/commit/b163f9605d8360a88e61f09bb5a65bb3747573e3) | `` automatic update ``        |
| [`8a3e064a`](https://github.com/nix-community/NUR/commit/8a3e064a36585628a256a1be9ced9a0924b0d82d) | `` automatic update ``        |
| [`ee48bdc3`](https://github.com/nix-community/NUR/commit/ee48bdc3562b66364ed42e64104fc990930f6094) | `` automatic update ``        |
| [`e731d694`](https://github.com/nix-community/NUR/commit/e731d694c01b2e17ebb7edfb26442d0124b795a4) | `` automatic update ``        |
| [`36a54ee4`](https://github.com/nix-community/NUR/commit/36a54ee4dea992172f1c83df36f8cf2f66f90598) | `` automatic update ``        |
| [`dd3944c3`](https://github.com/nix-community/NUR/commit/dd3944c37b1bff6e81d31f980f1b1c99ffb772dc) | `` automatic update ``        |
| [`511f665c`](https://github.com/nix-community/NUR/commit/511f665c5202be46bf0de8075852b5b6173ad7bc) | `` automatic update ``        |
| [`50bd3986`](https://github.com/nix-community/NUR/commit/50bd39861f3cc496e16ac6613f4f781574f418ac) | `` automatic update ``        |
| [`5103ef56`](https://github.com/nix-community/NUR/commit/5103ef56b10c6b2da37549bf39e563e94c8331ec) | `` automatic update ``        |
| [`e56bf68f`](https://github.com/nix-community/NUR/commit/e56bf68f763dc5b74dca63bdb5f7fd4fc49134b5) | `` automatic update ``        |
| [`8720cbb6`](https://github.com/nix-community/NUR/commit/8720cbb6189c998d2d5303bb294be5e586bd7143) | `` automatic update ``        |
| [`7759596e`](https://github.com/nix-community/NUR/commit/7759596e1d3c97b00a1231f856154b7ce7271dbf) | `` automatic update ``        |
| [`3442c209`](https://github.com/nix-community/NUR/commit/3442c209edb518ddd02c38489f3b56b23b91bbf5) | `` automatic update ``        |
| [`5ea61799`](https://github.com/nix-community/NUR/commit/5ea61799d2b7c71ab36df41aed32f952c7081265) | `` automatic update ``        |
| [`85b46fd8`](https://github.com/nix-community/NUR/commit/85b46fd88a3b597276602151454ac3be6ae689cc) | `` automatic update ``        |
| [`01d8c3ef`](https://github.com/nix-community/NUR/commit/01d8c3efa2fff6c10a80245185873b5eab4b40d8) | `` automatic update ``        |
| [`34e03dc5`](https://github.com/nix-community/NUR/commit/34e03dc5f1745f8d8d2e5416863a06eea1b66aed) | `` automatic update ``        |
| [`6f196e4c`](https://github.com/nix-community/NUR/commit/6f196e4cef160981c51459beb770e25e3937ef62) | `` automatic update ``        |
| [`b30e32d8`](https://github.com/nix-community/NUR/commit/b30e32d83e47d7313967a67375f66c6e1b7402fc) | `` automatic update ``        |
| [`766b1090`](https://github.com/nix-community/NUR/commit/766b1090f41371d94356b7fc188d1ee87f640bcd) | `` automatic update ``        |
| [`a0a4a0f1`](https://github.com/nix-community/NUR/commit/a0a4a0f1cf40c5e2821a6fc981ec746e540559d3) | `` automatic update ``        |
| [`d6945b9b`](https://github.com/nix-community/NUR/commit/d6945b9ba30cc36b6e5cfa89ad9d7fe052aaaa20) | `` automatic update ``        |
| [`521c6c9c`](https://github.com/nix-community/NUR/commit/521c6c9c383c129dce88a296c1a61c6c1f0d2b4d) | `` automatic update ``        |
| [`49fa9484`](https://github.com/nix-community/NUR/commit/49fa94849d9b0478203a05d8291dc192cbc69c7b) | `` automatic update ``        |
| [`c7fd6c10`](https://github.com/nix-community/NUR/commit/c7fd6c107945e7bb4f98fcd8292c9737cc9aaad9) | `` automatic update ``        |
| [`f5efdbdc`](https://github.com/nix-community/NUR/commit/f5efdbdc726b67d691c2a606e02956b7bb8896d2) | `` automatic update ``        |
| [`f32f4c8a`](https://github.com/nix-community/NUR/commit/f32f4c8a0451782bcdfba97e9f4ce524ee57b71a) | `` automatic update ``        |
| [`03f02d6f`](https://github.com/nix-community/NUR/commit/03f02d6f7b5c284fe6ed12f86debb21429ca124c) | `` automatic update ``        |
| [`f3f6c905`](https://github.com/nix-community/NUR/commit/f3f6c905ccf6d1e823eeade12f3c94c2ffb7b532) | `` automatic update ``        |
| [`4b571e41`](https://github.com/nix-community/NUR/commit/4b571e4114deb396b4e72c33ab816ef724993f6f) | `` automatic update ``        |
| [`c905da94`](https://github.com/nix-community/NUR/commit/c905da94cc744f6f10e965ad4c1ea0b4d7121afb) | `` automatic update ``        |
| [`91203bd9`](https://github.com/nix-community/NUR/commit/91203bd91b0737ae75c92986478fad89eda09743) | `` automatic update ``        |
| [`411d7b6e`](https://github.com/nix-community/NUR/commit/411d7b6eb7ecfe112928107c04b38ca72c830f4f) | `` automatic update ``        |
| [`b5499d9f`](https://github.com/nix-community/NUR/commit/b5499d9fbcc911be1c90da86b64e5de5ad2a7e4e) | `` automatic update ``        |
| [`710ef3ea`](https://github.com/nix-community/NUR/commit/710ef3ea263266aec846ba045cf38c10033534a3) | `` automatic update ``        |
| [`60ba0e8f`](https://github.com/nix-community/NUR/commit/60ba0e8fc9b41f36934f7a47f7e5f54fe16bb252) | `` automatic update ``        |
| [`edc9f726`](https://github.com/nix-community/NUR/commit/edc9f72616689562b3e40413380ad69fe13dfe6e) | `` automatic update ``        |
| [`0067f833`](https://github.com/nix-community/NUR/commit/0067f8335088a91c31c5bd0eb4d52511ff5865b8) | `` automatic update ``        |
| [`61cce890`](https://github.com/nix-community/NUR/commit/61cce8900a1940642e433fec9c5624269a919246) | `` automatic update ``        |
| [`0f85a8d7`](https://github.com/nix-community/NUR/commit/0f85a8d74414f8634d2b5382e837fc964ecf9264) | `` automatic update ``        |
| [`e5381dfa`](https://github.com/nix-community/NUR/commit/e5381dfacea6a370383d95ade73bccc99460eb78) | `` automatic update ``        |
| [`2a17986f`](https://github.com/nix-community/NUR/commit/2a17986f307a668b107cf4865a22883c242bae66) | `` automatic update ``        |
| [`096bc7fd`](https://github.com/nix-community/NUR/commit/096bc7fdda4684f8675399013e02fea36fed47d4) | `` automatic update ``        |
| [`2168d5ff`](https://github.com/nix-community/NUR/commit/2168d5fff432bb7ee332984712ee32e66ecce651) | `` automatic update ``        |
| [`6fd81396`](https://github.com/nix-community/NUR/commit/6fd81396eaadf28ec7a06acc16daa716f414839e) | `` automatic update ``        |
| [`f753002f`](https://github.com/nix-community/NUR/commit/f753002fca6244e2776f4c87778e3313db2a9f19) | `` automatic update ``        |
| [`d86c92c7`](https://github.com/nix-community/NUR/commit/d86c92c7c536f0f260885958eef6581ef029358c) | `` automatic update ``        |
| [`51564e80`](https://github.com/nix-community/NUR/commit/51564e807346daf15f4d897bc6f9b4fbd75229a6) | `` automatic update ``        |
| [`6390bb4f`](https://github.com/nix-community/NUR/commit/6390bb4fe4c7a77247ae733290ab611c69834281) | `` automatic update ``        |
| [`546cf409`](https://github.com/nix-community/NUR/commit/546cf40922c4df15bc8470b7ef60773ae282f6ec) | `` automatic update ``        |
| [`20be898a`](https://github.com/nix-community/NUR/commit/20be898a199491b26c2cee506b94e97c566ac8c6) | `` automatic update ``        |
| [`b2e272a4`](https://github.com/nix-community/NUR/commit/b2e272a4f5ae9ea2db4f81ae5d070c4bd9b022fa) | `` automatic update ``        |
| [`506e4873`](https://github.com/nix-community/NUR/commit/506e4873c745561736a0e8b9487e4dba0d8f7e97) | `` automatic update ``        |
| [`64148346`](https://github.com/nix-community/NUR/commit/641483462d1562db8f10d57188ef6f8d44b2c281) | `` automatic update ``        |
| [`f27f8fd7`](https://github.com/nix-community/NUR/commit/f27f8fd79fd44e2496e3c9f6574cf941c3d9e442) | `` automatic update ``        |
| [`605f0e79`](https://github.com/nix-community/NUR/commit/605f0e79745c29828f8e4138b4ce5893a9b32387) | `` automatic update ``        |
| [`ff280033`](https://github.com/nix-community/NUR/commit/ff280033708f22ca0aae57104cbb7fd352654fd1) | `` automatic update ``        |
| [`86f90816`](https://github.com/nix-community/NUR/commit/86f9081644a67a1a18f1f428ef9c3e2837abe79e) | `` automatic update ``        |
| [`539f1e75`](https://github.com/nix-community/NUR/commit/539f1e757a633e070c0e6fc4bb839612e4b06a66) | `` automatic update ``        |
| [`570743d3`](https://github.com/nix-community/NUR/commit/570743d3fd1c1aa5e23b211e377359ce54f31bae) | `` automatic update ``        |
| [`3354a399`](https://github.com/nix-community/NUR/commit/3354a3995e1f844e2e091de45a8a394337b3c831) | `` automatic update ``        |
| [`84fde758`](https://github.com/nix-community/NUR/commit/84fde7582154dfc017abaac68b2a9bec3159c2d3) | `` automatic update ``        |
| [`e9c12561`](https://github.com/nix-community/NUR/commit/e9c12561a118c90c5154c5661bc240c17121bd6f) | `` automatic update ``        |
| [`1d50c8b9`](https://github.com/nix-community/NUR/commit/1d50c8b9b075ddd3efac2c893abcb4650bfeec1a) | `` automatic update ``        |
| [`7eeada2e`](https://github.com/nix-community/NUR/commit/7eeada2e17e74f7b11dff68a3547fbbfd4b9f958) | `` automatic update ``        |
| [`d4872f6d`](https://github.com/nix-community/NUR/commit/d4872f6d5a43f04ed19f780e5d918ac3786e163c) | `` automatic update ``        |
| [`ef9e9148`](https://github.com/nix-community/NUR/commit/ef9e9148b115692712da285525b2cc0eed4dde07) | `` automatic update ``        |
| [`2482c3ad`](https://github.com/nix-community/NUR/commit/2482c3adcabcb4ae1846ecd2bf7e8e9a4ba138a7) | `` automatic update ``        |
| [`d80b4cff`](https://github.com/nix-community/NUR/commit/d80b4cffaf14990c51c6f9e783a48d1282840722) | `` Add gbytedev repository `` |
| [`8fc6179d`](https://github.com/nix-community/NUR/commit/8fc6179dc380b2ca3e6e8e2bfe1394baae77d5b5) | `` automatic update ``        |
| [`275b7b98`](https://github.com/nix-community/NUR/commit/275b7b98bb228386cbfe64802d98e12a715a9441) | `` automatic update ``        |
| [`f6615ee2`](https://github.com/nix-community/NUR/commit/f6615ee2431517d26b9e2c79895553a1f420eb6b) | `` automatic update ``        |
| [`a3424f88`](https://github.com/nix-community/NUR/commit/a3424f886aad15adfe4257755316cf847db73de4) | `` automatic update ``        |
| [`665429df`](https://github.com/nix-community/NUR/commit/665429df9f26e2851318a183f764c110b16683cb) | `` automatic update ``        |