### PR TITLE
chore(flake/darwin): `efd35d99` -> `1c1dd8b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -119,11 +119,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690247892,
-        "narHash": "sha256-WMGc1yq1cqRd+kzjWgbvHxckJIe8VQfiZ5RfR8tgABw=",
+        "lastModified": 1690329015,
+        "narHash": "sha256-cyRYHECh8JQL0HPW2LBEPtfmJ6oHZ6SrKgFvUXoUCAw=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "efd35d99ce412335c478dff9da9a4256bbd39757",
+        "rev": "1c1dd8b0703feda8e7f1e7753088ae8307df5993",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                          |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`7ff10017`](https://github.com/LnL7/nix-darwin/commit/7ff10017ed1636d23a1ad838611fe7339c9a499f) | `` chore: apply CR suggestions ``                |
| [`56f56c80`](https://github.com/LnL7/nix-darwin/commit/56f56c80ef15178c0f6c4dc5b72338c95f0f0076) | `` sketchybar: init ``                           |
| [`640331df`](https://github.com/LnL7/nix-darwin/commit/640331dfba943068a20f7519fff619e7e9f375ba) | `` docs: add magnification values range ``       |
| [`8c1c48c8`](https://github.com/LnL7/nix-darwin/commit/8c1c48c87ae1685710da0dd2b6e85f558b5cdef1) | `` feat: add dock icon magnification settings `` |