### PR TITLE
chore(flake/emacs-overlay): `a8d06a34` -> `8557a967`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1690308994,
-        "narHash": "sha256-Mq3SJzCtDdblx08kdNyjcAAdudMXEK8ep4AZMjdAdz8=",
+        "lastModified": 1690342477,
+        "narHash": "sha256-yUivW1rWlTvzicmKvJdtdDxfyuO7hA1wFSIyyBPRgcI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a8d06a3438ef4d32167ccb256c4b42441e841dc4",
+        "rev": "8557a967260b6f6fca567dcf6d1dee47aa71871f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`8557a967`](https://github.com/nix-community/emacs-overlay/commit/8557a967260b6f6fca567dcf6d1dee47aa71871f) | `` Updated repos/nongnu `` |
| [`53bee007`](https://github.com/nix-community/emacs-overlay/commit/53bee0073ec62b4549f4d8ded7acba6b4368f89a) | `` Updated repos/melpa ``  |
| [`708b54bb`](https://github.com/nix-community/emacs-overlay/commit/708b54bb60e8ffc4ebe4ecb67e6fe22553571d85) | `` Updated repos/emacs ``  |
| [`828ee154`](https://github.com/nix-community/emacs-overlay/commit/828ee154515dedd1e5ef6e753ce455b937bf7a8e) | `` Updated repos/elpa ``   |