### PR TITLE
chore(flake/emacs-overlay): `22c986c6` -> `2e1e8922`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1690367022,
-        "narHash": "sha256-758guvqQf4NlmzYB/SlHK4APc/II6qO7XXyTTI80vcg=",
+        "lastModified": 1690397761,
+        "narHash": "sha256-ASb0X6WAKAVUZIZOB28KSfGz7FNhuf4MWd9bxaFW7iI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "22c986c6ed401dcdbc5fdbfe7e0cf551a35b58dc",
+        "rev": "2e1e89226ae423cd0b1d33986f8ef1389548fecb",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1690148897,
-        "narHash": "sha256-l/j/AX1d2K79EWslwgWR2+htkzCbtjKZsS5NbWXnhz4=",
+        "lastModified": 1690271650,
+        "narHash": "sha256-qwdsW8DBY1qH+9luliIH7VzgwvL+ZGI3LZWC0LTiDMI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ac1acba43b2f9db073943ff5ed883ce7e8a40a2c",
+        "rev": "6dc93f0daec55ee2f441da385aaf143863e3d671",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`2e1e8922`](https://github.com/nix-community/emacs-overlay/commit/2e1e89226ae423cd0b1d33986f8ef1389548fecb) | `` Updated repos/melpa ``  |
| [`90593b42`](https://github.com/nix-community/emacs-overlay/commit/90593b4284e396ff68fdcb8b19ee4e7c4f9b88ad) | `` Updated repos/emacs ``  |
| [`8dce1412`](https://github.com/nix-community/emacs-overlay/commit/8dce1412af0b2f40e61819f3a1abe29c3eb2f73b) | `` Updated repos/elpa ``   |
| [`72e4bb8b`](https://github.com/nix-community/emacs-overlay/commit/72e4bb8b43760b8fe90d76940b67bec53c04cd53) | `` Updated flake inputs `` |