### PR TITLE
chore(flake/emacs-overlay): `2e1e8922` -> `4aeae735`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1690397761,
-        "narHash": "sha256-ASb0X6WAKAVUZIZOB28KSfGz7FNhuf4MWd9bxaFW7iI=",
+        "lastModified": 1690426938,
+        "narHash": "sha256-xPbfk6aNYPOGtPrIq/olZyY8HsKU0kUsgaNgH4XUTLc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2e1e89226ae423cd0b1d33986f8ef1389548fecb",
+        "rev": "4aeae735d19b2012108c41cbf9ff8dfc7895b97f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4aeae735`](https://github.com/nix-community/emacs-overlay/commit/4aeae735d19b2012108c41cbf9ff8dfc7895b97f) | `` Updated repos/melpa ``  |
| [`271ef8ab`](https://github.com/nix-community/emacs-overlay/commit/271ef8ab2d9ee4cd4c0930de5076c3836568359e) | `` Updated repos/emacs ``  |
| [`4a838e63`](https://github.com/nix-community/emacs-overlay/commit/4a838e63177bd354c23d4440ddaeb574a477d09e) | `` Updated repos/elpa ``   |
| [`eb07b0b3`](https://github.com/nix-community/emacs-overlay/commit/eb07b0b3eb0130c2f06535ed425a26d939efd346) | `` Updated flake inputs `` |