### PR TITLE
chore(flake/combobulate): `582f896c` -> `427fca4e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
     "combobulate": {
       "flake": false,
       "locked": {
-        "lastModified": 1687195931,
-        "narHash": "sha256-VtQwSho7IkeLivukWVto+GqpF2JClCuAyYvUlqBs4KE=",
+        "lastModified": 1690449422,
+        "narHash": "sha256-raWdeKvqgVEY4mngu7lpb7LHLvIIllYesDNKnre9IMA=",
         "owner": "mickeynp",
         "repo": "combobulate",
-        "rev": "582f896c73bd35654dc179155cfb9c7719098847",
+        "rev": "427fca4eba7fad8f9146735a3777aa1b8d4cb3fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`427fca4e`](https://github.com/mickeynp/combobulate/commit/427fca4eba7fad8f9146735a3777aa1b8d4cb3fc) | `` Add support for query building, highlighting, and searching `` |