### PR TITLE
chore(flake/pre-commit-hooks): `eb433bff` -> `2ddd4dbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -936,11 +936,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1689668210,
-        "narHash": "sha256-XAATwDkaUxH958yXLs1lcEOmU6pSEIkatY3qjqk8X0E=",
+        "lastModified": 1690452200,
+        "narHash": "sha256-Sx0/TOPXrvtsPLbymNAwxF5Gkc6ldnKZ9Yknzh6IfkY=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "eb433bff05b285258be76513add6f6c57b441775",
+        "rev": "2ddd4dbc39a9448d04f274800cbcc84bbe6058ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                         |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------- |
| [`901814db`](https://github.com/cachix/pre-commit-hooks.nix/commit/901814db4e3a6988aa082f59cfab3375f926a90e) | `` Fix typo in code comment ``  |
| [`de701a97`](https://github.com/cachix/pre-commit-hooks.nix/commit/de701a97a0271ebda5d1cae76db08937e56206ca) | `` Add rome ``                  |
| [`bef27b95`](https://github.com/cachix/pre-commit-hooks.nix/commit/bef27b950c966263fea3a9822f9ed24e739c7b1f) | `` Add mkdocs-linkcheck hook `` |