### PR TITLE
chore(flake/emacs-overlay): `4aeae735` -> `d2dac086`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1690426938,
-        "narHash": "sha256-xPbfk6aNYPOGtPrIq/olZyY8HsKU0kUsgaNgH4XUTLc=",
+        "lastModified": 1690453210,
+        "narHash": "sha256-wSn+1ij5tD0MYlv9MVS5P8z8OVMwh6LxKKdTHKvh/Q4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4aeae735d19b2012108c41cbf9ff8dfc7895b97f",
+        "rev": "d2dac086c3bcaf686be6deb56368fcd426e5c434",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1690271650,
-        "narHash": "sha256-qwdsW8DBY1qH+9luliIH7VzgwvL+ZGI3LZWC0LTiDMI=",
+        "lastModified": 1690370995,
+        "narHash": "sha256-9z//23jGegLJrf3ITStLwVf715O39dq5u48Kr/XW14U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6dc93f0daec55ee2f441da385aaf143863e3d671",
+        "rev": "f3fbbc36b4e179a5985b9ab12624e9dfe7989341",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d2dac086`](https://github.com/nix-community/emacs-overlay/commit/d2dac086c3bcaf686be6deb56368fcd426e5c434) | `` Updated repos/nongnu `` |
| [`140bccd8`](https://github.com/nix-community/emacs-overlay/commit/140bccd893fda29984c3e7b188181a851b40c7c7) | `` Updated repos/melpa ``  |
| [`c41d0144`](https://github.com/nix-community/emacs-overlay/commit/c41d0144b56a67e74359abba5e5313e5512d2444) | `` Updated repos/emacs ``  |
| [`2837a959`](https://github.com/nix-community/emacs-overlay/commit/2837a959ae3d1b150e0969baef405e7cbe14935b) | `` Updated flake inputs `` |