### PR TITLE
chore(flake/emacs-overlay): `01c076bb` -> `5bb02950`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1690483432,
-        "narHash": "sha256-o4/IGadFvyT68byD+NglNK+zykMMjglXdsCSL63OJLc=",
+        "lastModified": 1690510160,
+        "narHash": "sha256-M9UKxr0veST9JNINMXo0bOAQkLOoWRoaIC+H7/fxkdQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "01c076bb6f9fd34630f4c87cfab18ea4e85ef819",
+        "rev": "5bb029505a7cc53054e6b66a75c98f68857b0928",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`5bb02950`](https://github.com/nix-community/emacs-overlay/commit/5bb029505a7cc53054e6b66a75c98f68857b0928) | `` Updated repos/melpa `` |
| [`aa4147fb`](https://github.com/nix-community/emacs-overlay/commit/aa4147fb5fba763697588e992385b46066728c2f) | `` Updated repos/emacs `` |
| [`6f2b8e6b`](https://github.com/nix-community/emacs-overlay/commit/6f2b8e6bc177a65f73cbcd15a6932a8dcd90b89e) | `` Updated repos/elpa ``  |