### PR TITLE
chore(flake/stylix): `5c829554` -> `c29f2e6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1039,11 +1039,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690463825,
-        "narHash": "sha256-LILKFcKNVxYcYmzCB2+Gswyob5XrPJAF1YBExFR2yak=",
+        "lastModified": 1690620628,
+        "narHash": "sha256-cJKeQUeBbP5oC4ahfLOaZZxs7/LjANeSZZbgEEQbxuY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "5c829554280f3139ddbfce8561d7430efbf2abfb",
+        "rev": "c29f2e6f9d0326a690d0c2376712e9134ad8f5c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                  |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`c29f2e6f`](https://github.com/danth/stylix/commit/c29f2e6f9d0326a690d0c2376712e9134ad8f5c8) | `` Add trick with dynamic wallpaper generation (#135) `` |
| [`2719a57e`](https://github.com/danth/stylix/commit/2719a57e2bcadf441175bef1e7c3f593a978e56f) | `` Use renamed NixOS option for fonts (#134) ``          |