### PR TITLE
chore(flake/dendrite-demo-pinecone): `2bac9fbc` -> `1a0b5990`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -151,11 +151,11 @@
     "dendrite": {
       "flake": false,
       "locked": {
-        "lastModified": 1686666521,
-        "narHash": "sha256-+rNBPJ7Fjgd5SoJLg4TVRmKXf7fMSQk8qgn7KCUIH58=",
+        "lastModified": 1689966508,
+        "narHash": "sha256-296IR+oXuYGL+YhzZnfhuoC2q/z3socFnCWOhxQR06c=",
         "owner": "matrix-org",
         "repo": "dendrite",
-        "rev": "7a2e325d1014d76188b47a011730a42443f3c174",
+        "rev": "a48c7d33a555250f867370d56798b7a730931bb8",
         "type": "github"
       },
       "original": {
@@ -173,11 +173,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1686750681,
-        "narHash": "sha256-FOTyBP6bsdJtHkpfHjApTcRBD80xbfy7bYMAWcg5wXI=",
+        "lastModified": 1690579141,
+        "narHash": "sha256-Y/vOkZ9Ei8DJdi54WqxuhJKyDbXolktkfq+wrE7q0Kc=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "2bac9fbce856d6cf5325761b533514e3ffe05ddc",
+        "rev": "1a0b5990ab14a0da68997118bfa52a96ccf319e8",
         "type": "github"
       },
       "original": {
@@ -389,11 +389,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -777,11 +777,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1686582075,
-        "narHash": "sha256-vtflsfKkHtF8IduxDNtbme4cojiqvlvjp5QNYhvoHXc=",
+        "lastModified": 1690083312,
+        "narHash": "sha256-I3egwgNXavad1eIjWu1kYyi0u73di/sMmlnQIuzQASk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7e63eed145566cca98158613f3700515b4009ce3",
+        "rev": "af8cd5ded7735ca1df1a1174864daab75feeb64a",
         "type": "github"
       },
       "original": {
@@ -914,11 +914,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1686668298,
-        "narHash": "sha256-AADh9NqHh6X2LOem4BvI7oCkMm+JPCSCE7iIw5nn0VA=",
+        "lastModified": 1689668210,
+        "narHash": "sha256-XAATwDkaUxH958yXLs1lcEOmU6pSEIkatY3qjqk8X0E=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "5b6b54d3f722aa95cbf4ddbe35390a0af8c0015a",
+        "rev": "eb433bff05b285258be76513add6f6c57b441775",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                         |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`1a0b5990`](https://github.com/bbigras/dendrite-demo-pinecone/commit/1a0b5990ab14a0da68997118bfa52a96ccf319e8) | `` flake: update ``                                             |
| [`4d0de35e`](https://github.com/bbigras/dendrite-demo-pinecone/commit/4d0de35e7f966878f6caed936d7356daa9833c9b) | `` flake.lock: Update ``                                        |
| [`0fc35449`](https://github.com/bbigras/dendrite-demo-pinecone/commit/0fc354491aaed98084455945da290a37489fdeec) | `` chore(deps): bump cachix/install-nix-action from 21 to 22 `` |