### PR TITLE
chore(flake/emacs-overlay): `7ad10dd0` -> `2a52d78c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1690568535,
-        "narHash": "sha256-V8nsU/3pWjw9C+JH3Xn0aPWgXU9/ztHB00C2aBT2ag8=",
+        "lastModified": 1690655028,
+        "narHash": "sha256-6ApYk2XOiyDFKDus5Ysmiw591AgxJpxK4/5rWtRWYfU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7ad10dd0d14aa95e7644a9177978b40c69a1363e",
+        "rev": "2a52d78c85ee0608938670c7db79ffaba6f7b31d",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1690470004,
-        "narHash": "sha256-l57RmPhPz9r1LGDg/0v8bYgJO8R+GGTQZtkIxE7negU=",
+        "lastModified": 1690558459,
+        "narHash": "sha256-5W7y1l2cLYPkpJGNlAja7XW2X2o9rjf0O1mo9nxS9jQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9462344318b376e157c94fa60c20a25b913b2381",
+        "rev": "48e82fe1b1c863ee26a33ce9bd39621d2ada0a33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`2a52d78c`](https://github.com/nix-community/emacs-overlay/commit/2a52d78c85ee0608938670c7db79ffaba6f7b31d) | `` Updated repos/melpa ``  |
| [`d4a78ddc`](https://github.com/nix-community/emacs-overlay/commit/d4a78ddc335535921d0fa00f35825addc3acf00f) | `` Updated repos/emacs ``  |
| [`b0e60539`](https://github.com/nix-community/emacs-overlay/commit/b0e605397802b33321333165948b156b1faa60b7) | `` Updated repos/melpa ``  |
| [`4a6297cf`](https://github.com/nix-community/emacs-overlay/commit/4a6297cfd174c32aa311fe8a5b131ce7c4423411) | `` Updated flake inputs `` |
| [`e9982c6d`](https://github.com/nix-community/emacs-overlay/commit/e9982c6dd9ef4d47aed955013820cd15104be6df) | `` Updated repos/melpa ``  |
| [`c4d8c3db`](https://github.com/nix-community/emacs-overlay/commit/c4d8c3db4c075a6842f82fce718c66bc65cb6dfe) | `` Updated repos/emacs ``  |
| [`d767de73`](https://github.com/nix-community/emacs-overlay/commit/d767de73ba1e3b9fe58719d520b9ef7c8bff4cf0) | `` Updated repos/elpa ``   |
| [`19bd8a49`](https://github.com/nix-community/emacs-overlay/commit/19bd8a49b5a456efeb0f49a312a29239143c06a4) | `` Updated flake inputs `` |