### PR TITLE
chore(flake/home-manager): `8d243f7d` -> `f58889c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -504,11 +504,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690476848,
-        "narHash": "sha256-PSmzyuEbMxEn2uwwLYUN2l1psoJXb7jm/kfHD12Sq0k=",
+        "lastModified": 1690652600,
+        "narHash": "sha256-Dy09g7mezToVwtFPyY25fAx1hzqNXv73/QmY5/qyR44=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8d243f7da13d6ee32f722a3f1afeced150b6d4da",
+        "rev": "f58889c07efa8e1328fdf93dc1796ec2a5c47f38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`f58889c0`](https://github.com/nix-community/home-manager/commit/f58889c07efa8e1328fdf93dc1796ec2a5c47f38) | `` gnome-terminal: add assertion on profile names ``         |
| [`5c232267`](https://github.com/nix-community/home-manager/commit/5c23226768abd3402636f4d3c65aea8450997102) | `` hyprland: use `toKeyValue`'s `indent` argument (#4274) `` |