### PR TITLE
chore(flake/emacs-overlay): `2a52d78c` -> `0b7aef5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1690655028,
-        "narHash": "sha256-6ApYk2XOiyDFKDus5Ysmiw591AgxJpxK4/5rWtRWYfU=",
+        "lastModified": 1690682165,
+        "narHash": "sha256-COYPlrsBemZFmx5V5/eNK/QyKn/974K0SiEVR3/etlw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2a52d78c85ee0608938670c7db79ffaba6f7b31d",
+        "rev": "0b7aef5e21dc3b525eca3c6fcc6d826f84dc8d03",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`0b7aef5e`](https://github.com/nix-community/emacs-overlay/commit/0b7aef5e21dc3b525eca3c6fcc6d826f84dc8d03) | `` Updated repos/melpa `` |
| [`16cc5e0d`](https://github.com/nix-community/emacs-overlay/commit/16cc5e0dbb4e93f81263d7e744622d3fd9de7033) | `` Updated repos/emacs `` |
| [`a96a41c0`](https://github.com/nix-community/emacs-overlay/commit/a96a41c04acde4a11ab86d00b420059b32353b09) | `` Updated repos/elpa ``  |