### PR TITLE
chore(flake/nur): `b163f960` -> `612e4e11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690689826,
-        "narHash": "sha256-CzdetEeUlFhBBqvGYl/R07AkvWFTTRr7MmY26RErY8g=",
+        "lastModified": 1690695647,
+        "narHash": "sha256-9l2fuu/8QnSDOAmyuvsYJsN1U63akWPxcK4W4V6vxr4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b163f9605d8360a88e61f09bb5a65bb3747573e3",
+        "rev": "612e4e11ca96d2c205053a74ab3949c516a7e4ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`612e4e11`](https://github.com/nix-community/NUR/commit/612e4e11ca96d2c205053a74ab3949c516a7e4ec) | `` automatic update `` |
| [`61d05404`](https://github.com/nix-community/NUR/commit/61d05404fc49d3b0a36d23562fe60f028f98adff) | `` automatic update `` |