### PR TITLE
chore(flake/nur): `612e4e11` -> `afd10d72`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690695647,
-        "narHash": "sha256-9l2fuu/8QnSDOAmyuvsYJsN1U63akWPxcK4W4V6vxr4=",
+        "lastModified": 1690703966,
+        "narHash": "sha256-e8bJdH+aj5fuV6pc99IknC1sik09N6ULlMihxY24J60=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "612e4e11ca96d2c205053a74ab3949c516a7e4ec",
+        "rev": "afd10d72a2f6b9b60ea0476b59fbd140eaf9ff7e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`afd10d72`](https://github.com/nix-community/NUR/commit/afd10d72a2f6b9b60ea0476b59fbd140eaf9ff7e) | `` automatic update `` |
| [`b98d4d27`](https://github.com/nix-community/NUR/commit/b98d4d27236cca739b83fd69ef8c1a2f1799e795) | `` automatic update `` |