### PR TITLE
chore(flake/nur): `afd10d72` -> `930eb01e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690703966,
-        "narHash": "sha256-e8bJdH+aj5fuV6pc99IknC1sik09N6ULlMihxY24J60=",
+        "lastModified": 1690705896,
+        "narHash": "sha256-JqMHkApL84JZKRscvNn4Hc7VldPdL8XBjFYuZn4WPnY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "afd10d72a2f6b9b60ea0476b59fbd140eaf9ff7e",
+        "rev": "930eb01e0974035501c66a1c7104e7d7e2152e90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`930eb01e`](https://github.com/nix-community/NUR/commit/930eb01e0974035501c66a1c7104e7d7e2152e90) | `` automatic update `` |