### PR TITLE
chore(flake/emacs-overlay): `0b7aef5e` -> `21a51e88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1690682165,
-        "narHash": "sha256-COYPlrsBemZFmx5V5/eNK/QyKn/974K0SiEVR3/etlw=",
+        "lastModified": 1690710599,
+        "narHash": "sha256-m1/eEWE3PlcA9xBw8y1Zc9uYfa8zlgts/+MziOmXops=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0b7aef5e21dc3b525eca3c6fcc6d826f84dc8d03",
+        "rev": "21a51e882f77a0866e530f9b29d61b292237b97a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`21a51e88`](https://github.com/nix-community/emacs-overlay/commit/21a51e882f77a0866e530f9b29d61b292237b97a) | `` Updated repos/nongnu `` |
| [`20d88829`](https://github.com/nix-community/emacs-overlay/commit/20d888290e50bccfe62924dc20b3687e524c0a43) | `` Updated repos/melpa ``  |
| [`e8a2c8a1`](https://github.com/nix-community/emacs-overlay/commit/e8a2c8a1396670ff8bcfef925c9f3a393778d0ed) | `` Updated repos/emacs ``  |