### PR TITLE
chore(flake/nixpkgs): `2a9d660f` -> `e6ab4698`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -807,11 +807,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1690548937,
-        "narHash": "sha256-x3ZOPGLvtC0/+iFAg9Kvqm/8hTAIkGjc634SqtgaXTA=",
+        "lastModified": 1690640159,
+        "narHash": "sha256-5DZUYnkeMOsVb/eqPYb9zns5YsnQXRJRC8Xx/nPMcno=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2a9d660ff0f7ffde9d73be328ee6e6f10ef66b28",
+        "rev": "e6ab46982debeab9831236869539a507f670a129",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`e6ab4698`](https://github.com/NixOS/nixpkgs/commit/e6ab46982debeab9831236869539a507f670a129) | `` rpcs3: 0.0.27-14840-842edbcbe -> 0.0.28-15372-38a5313ed ``                       |
| [`00bb7e7c`](https://github.com/NixOS/nixpkgs/commit/00bb7e7c4d4b51a9f3b47993472c42cfbcfeb516) | `` feishin: init at 0.2.0 ``                                                        |
| [`a45519d0`](https://github.com/NixOS/nixpkgs/commit/a45519d09c2067c226eef65491f0433d1761a6a1) | `` p4c: use `finalAttrs` pattern ``                                                 |
| [`f6438e19`](https://github.com/NixOS/nixpkgs/commit/f6438e19e5a8127fdbe056d0c4aef4ffac9ac8cd) | `` fluent-bit: use `finalAttrs` pattern ``                                          |
| [`2670961a`](https://github.com/NixOS/nixpkgs/commit/2670961a5485a9f73f43165e6e8a2496c932dfec) | `` mantiscoresearch: use `finalAttrs` pattern ``                                    |
| [`e682ab6c`](https://github.com/NixOS/nixpkgs/commit/e682ab6c2e55bed0a94b3288717157b35adc390c) | `` ludusavi: 0.19.0 -> 0.20.0 ``                                                    |
| [`7866fdab`](https://github.com/NixOS/nixpkgs/commit/7866fdab140ab9f228c640336ae8d7544e0806a2) | `` uxplay: use `finalAttrs` pattern ``                                              |
| [`d6eb5cf1`](https://github.com/NixOS/nixpkgs/commit/d6eb5cf163cd890d0b34b78418fbb85b7a2fde17) | `` python311Packages.django-stubs: 4.2.0 -> 4.2.3 ``                                |
| [`ad172611`](https://github.com/NixOS/nixpkgs/commit/ad172611e8a3fe6be86bfa5868ce21e4718c3cff) | `` subfinder: 2.6.0 -> 2.6.1 ``                                                     |
| [`8e7efbd5`](https://github.com/NixOS/nixpkgs/commit/8e7efbd50eb90db81fab9b0033f190a89899bc8c) | `` maintainers/teams: add jupyter team ``                                           |
| [`971443c8`](https://github.com/NixOS/nixpkgs/commit/971443c80ec2abf8654f79222c68ed35fd4391b4) | `` vscodium: 1.80.1.23194 -> 1.80.2.23209 ``                                        |
| [`dfcd6a0c`](https://github.com/NixOS/nixpkgs/commit/dfcd6a0c0df2560686ee20a69110424ea8be5d24) | `` rdma-core: use `finalAttrs` pattern ``                                           |
| [`2a2aa957`](https://github.com/NixOS/nixpkgs/commit/2a2aa957d9649fcb0a841905927dff66cc2c570c) | `` juicity: init at 0.1.0 ``                                                        |
| [`db60e7eb`](https://github.com/NixOS/nixpkgs/commit/db60e7eb1ac30665e5d80e68dbc0afb78aab37bd) | `` codespelunker: 1.2.0 -> 1.3.0 ``                                                 |
| [`9eac873c`](https://github.com/NixOS/nixpkgs/commit/9eac873ced548fb2da5fbc73fef62ce5cf44025e) | `` wishlist: 0.12.0 -> 0.13.0 ``                                                    |
| [`050df834`](https://github.com/NixOS/nixpkgs/commit/050df834e824aae6bba2a1fdbf352d56293bcff4) | `` argocd: 2.7.8 -> 2.7.9 ``                                                        |
| [`ab3dd1f6`](https://github.com/NixOS/nixpkgs/commit/ab3dd1f606de66b6c2bf41c138b9dbd4a48047b9) | `` fluent-bit: 2.1.7 -> 2.1.8 ``                                                    |
| [`0b4560b9`](https://github.com/NixOS/nixpkgs/commit/0b4560b9ff598c32eea6d276fbb2cc9217b5cc33) | `` fastly: 10.2.3 -> 10.2.4 ``                                                      |
| [`87eff167`](https://github.com/NixOS/nixpkgs/commit/87eff1671d9ff79b1fd4bca1035375cc3f88c2d9) | `` uxplay: 1.65 -> 1.65.3 ``                                                        |
| [`958cc373`](https://github.com/NixOS/nixpkgs/commit/958cc373f5bb99674f3a4a21255c8186c6a33836) | `` p4c: 1.2.4.0 -> 1.2.4.1 ``                                                       |
| [`9a6290bf`](https://github.com/NixOS/nixpkgs/commit/9a6290bf9b601c518f6284187a0380e19ac1dc42) | `` cfitsio: fix Darwin builds ``                                                    |
| [`debd3291`](https://github.com/NixOS/nixpkgs/commit/debd3291efa318f416e670d589c426c371e8edef) | `` terraform-providers.argocd: 6.0.0 -> 6.0.1 ``                                    |
| [`3641464f`](https://github.com/NixOS/nixpkgs/commit/3641464f1c32bb566cc195696e73d1e784a2657d) | `` edge-runtime: 1.6.7 -> 1.7.2 ``                                                  |
| [`04e39a18`](https://github.com/NixOS/nixpkgs/commit/04e39a18916ad96b226943822c85b2969210ae10) | `` pscale: 0.147.0 -> 0.150.0 ``                                                    |
| [`ba4db6dd`](https://github.com/NixOS/nixpkgs/commit/ba4db6dd766d965383c74e082816932188a60c15) | `` license-cli: 3.0.0 -> 3.1.0 ``                                                   |
| [`a175a8e3`](https://github.com/NixOS/nixpkgs/commit/a175a8e33c38b65ce1b98f52af65078b713d05ed) | `` melody: 0.18.1 -> 0.19.0 ``                                                      |
| [`f1468a99`](https://github.com/NixOS/nixpkgs/commit/f1468a99463b4e94ff049263e3fda6efd10fe21d) | `` blender: Build with Draco support (#245535) ``                                   |
| [`e9276060`](https://github.com/NixOS/nixpkgs/commit/e92760602e10d8e819613a22a36ea469d78a7118) | `` fcitx5-qt: fix gui plugin ``                                                     |
| [`a428fcf7`](https://github.com/NixOS/nixpkgs/commit/a428fcf79fecafba3804ac06fc9cf0003cc910af) | `` rdma-core: 46.0 -> 46.1 ``                                                       |
| [`2c7ab46e`](https://github.com/NixOS/nixpkgs/commit/2c7ab46ea685fbac379160c9913968cfee7685c4) | `` efm-langserver: 0.0.44 -> 0.0.46 ``                                              |
| [`0abed5ec`](https://github.com/NixOS/nixpkgs/commit/0abed5ec8a0ed7457447ed963b72a452195ca214) | `` vals: 0.25.0 -> 0.26.1 ``                                                        |
| [`7535dce4`](https://github.com/NixOS/nixpkgs/commit/7535dce48c6d47db958a0fe7b65739b7fc50440a) | `` kubernetes-metrics-server: 0.6.3 -> 0.6.4 ``                                     |
| [`5dbff844`](https://github.com/NixOS/nixpkgs/commit/5dbff84445feb756a122c75bbb1de4c2f070e57b) | `` proxify: 0.0.9 -> 0.0.10 ``                                                      |
| [`bd4cdb0b`](https://github.com/NixOS/nixpkgs/commit/bd4cdb0b3568f4c1dd64a92466c840b20dc0f4fa) | `` lefthook: 1.4.6 -> 1.4.7 ``                                                      |
| [`b2f61e8b`](https://github.com/NixOS/nixpkgs/commit/b2f61e8ba04b5630f80e45faaee69355791e054d) | `` killport: 0.9.0 -> 0.9.1 ``                                                      |
| [`788ecd08`](https://github.com/NixOS/nixpkgs/commit/788ecd08fea1071ca214d53f1e47c8adff4fed69) | `` circleci-cli: 0.1.27660 -> 0.1.28084 ``                                          |
| [`c8940225`](https://github.com/NixOS/nixpkgs/commit/c894022569b5896854a19f4306ca971cd002951d) | `` sundials: 6.5.1 -> 6.6.0 ``                                                      |
| [`0f80873a`](https://github.com/NixOS/nixpkgs/commit/0f80873aa4d67417c3ea2657d273d358d85712ca) | `` lftp: use openssl instead of gnutls ``                                           |
| [`797c3cad`](https://github.com/NixOS/nixpkgs/commit/797c3cad71eb40741f9b789651eeff52a078fefd) | `` libzim: 8.2.0 -> 8.2.1 ``                                                        |
| [`174cbb96`](https://github.com/NixOS/nixpkgs/commit/174cbb964f6b518d3318fa86187b244fb519b80a) | `` kapp: 0.57.1 -> 0.58.0 ``                                                        |
| [`40b2830c`](https://github.com/NixOS/nixpkgs/commit/40b2830c490f1f76f847930f1f9867b5b06fd596) | `` mysql-workbench: 8.0.33 -> 8.0.34 ``                                             |
| [`4e90ab6c`](https://github.com/NixOS/nixpkgs/commit/4e90ab6cca0795346b4fbe4ac639ce9cbb72bfb6) | `` release-notes: add new services wayfire ``                                       |
| [`231b831b`](https://github.com/NixOS/nixpkgs/commit/231b831b5f77c685478c0cde35c2549b150f88f7) | `` aliases.nix: add wayfireApplications-unwrapped and wcm ``                        |
| [`e847a274`](https://github.com/NixOS/nixpkgs/commit/e847a2742aa1f9a189f58c41f66c5959ac5a2ef5) | `` psitop: 1.0.0 -> 1.1.3 ``                                                        |
| [`19a2f8df`](https://github.com/NixOS/nixpkgs/commit/19a2f8dfb87c55a2825ac4e37e6db3a1574477ca) | `` linuxPackages.nvidia_x11_vulkan_beta: 525.47.34 -> 525.47.35 ``                  |
| [`a0b8caf3`](https://github.com/NixOS/nixpkgs/commit/a0b8caf3bc21878b22411aaca1979ce60eeebace) | `` Revert "lib.customisation: uncurry makeScopeWithSplicing" ``                     |
| [`2dbda331`](https://github.com/NixOS/nixpkgs/commit/2dbda3314fb7bef997d93ce641e9a82752072485) | `` nixos/tailscale: add extraUpFlags option ``                                      |
| [`ffabc8c6`](https://github.com/NixOS/nixpkgs/commit/ffabc8c65820ff71f4de8b4e4ecd09a94c38100f) | `` fetchfirefoxaddon: fix passing md5 to fetchurl ``                                |
| [`e54f8b11`](https://github.com/NixOS/nixpkgs/commit/e54f8b11a1a1e12000a5e303fbe663bc22248ec9) | `` python311Packages.python-homewizard-energy: 2.0.1 -> 2.0.2 ``                    |
| [`dd28ccaf`](https://github.com/NixOS/nixpkgs/commit/dd28ccaf96ca269f021691dc4d8a402c672acf9a) | `` python311Packages.pyschlage: 2023.6.0 -> 2023.7.0 ``                             |
| [`4798f154`](https://github.com/NixOS/nixpkgs/commit/4798f154e44d0304d3f17a3c5f937d2ee99a30ec) | `` python311Packages.losant-rest: 1.17.5 -> 1.18.0 ``                               |
| [`a9161749`](https://github.com/NixOS/nixpkgs/commit/a916174941d4301dca9bcdebb8f6ec8319fd34ae) | `` python3Packages.types-pillow: 9.5.0.4 -> 10.0.0.2 ``                             |
| [`c2d1d8b7`](https://github.com/NixOS/nixpkgs/commit/c2d1d8b7519b540d3f592b2ea40dd867ceb35d4b) | `` gcc: deduplicate top-level expressions ``                                        |
| [`b7682220`](https://github.com/NixOS/nixpkgs/commit/b76822209adcf26e074dc743cefe6ede70c6f01c) | `` tpm2-tools: rework argv0 parsing ``                                              |
| [`0092231e`](https://github.com/NixOS/nixpkgs/commit/0092231e840431525cd583c7069e4e53e89fd14b) | `` bind: 9.18.16 -> 9.18.17 ``                                                      |
| [`51e2937f`](https://github.com/NixOS/nixpkgs/commit/51e2937f85501c839aed9fe9275f7ef67782c900) | `` cargo-deny: 0.13.9 -> 0.14.0 ``                                                  |
| [`e68f7930`](https://github.com/NixOS/nixpkgs/commit/e68f7930414dd6a67330edeadf4800a4853ac5ce) | `` nixos/tests/gitea: Test actions runner registration ``                           |
| [`60ed7ba7`](https://github.com/NixOS/nixpkgs/commit/60ed7ba7d71cdb9c049b9462c984de9daf759cd4) | `` qt5ct: 1.5 -> 1.7 ``                                                             |
| [`8821dc95`](https://github.com/NixOS/nixpkgs/commit/8821dc9535bcb4daf3a334429df91324594130e7) | `` maintainers: teams.deshaw: update members ``                                     |
| [`9c6274d5`](https://github.com/NixOS/nixpkgs/commit/9c6274d5fbb0df562e542459494b30bcffa25ae1) | `` maintainers: add de11n ``                                                        |
| [`b8c90382`](https://github.com/NixOS/nixpkgs/commit/b8c903826b042c1a38accf1b995f687717209c20) | `` maintainers: add invokes-su ``                                                   |
| [`b94abe0b`](https://github.com/NixOS/nixpkgs/commit/b94abe0b543f5d55c7d2580e05fd98a4db811493) | `` airbuddy: 2.7 -> 2.7.1 ``                                                        |
| [`96850c1a`](https://github.com/NixOS/nixpkgs/commit/96850c1aaff8e4995bf3acae074e447c52e26f1e) | `` hnswlib: init at 0.7.0 ``                                                        |
| [`4e356caa`](https://github.com/NixOS/nixpkgs/commit/4e356caa4ef1eb78d44bed16dba77ac13cd1abe2) | `` iptsd: 1.3.0 -> 1.3.1 ``                                                         |
| [`71302e5c`](https://github.com/NixOS/nixpkgs/commit/71302e5c147ae5fa5c9ba798d6ffd78fa02403df) | `` cage: 0.1.4 ->0.1.5 ``                                                           |
| [`7fdbac65`](https://github.com/NixOS/nixpkgs/commit/7fdbac6563c1b1f41c90fae7d9e71b358e34d298) | `` python310Packages.backports_weakref: remove ``                                   |
| [`3fe70ce0`](https://github.com/NixOS/nixpkgs/commit/3fe70ce0024a9e567e3404f3129c48968656991a) | `` pgcat: init at 1.1.0 ``                                                          |
| [`0e1093ec`](https://github.com/NixOS/nixpkgs/commit/0e1093ec31221740831cd46dc716bffdd3b011a5) | `` python310Packages.backports_unittest-mock: remove ``                             |
| [`1b8e164a`](https://github.com/NixOS/nixpkgs/commit/1b8e164a0693ecf4963cdfd4c8f2f362aca0ecd3) | `` python310Packages.backports_tempfile: remove ``                                  |
| [`b9b3be8e`](https://github.com/NixOS/nixpkgs/commit/b9b3be8e099f188b64af96742e4e78e025ff8794) | `` python310Packages.backports_functools_lru_cache: remove ``                       |
| [`3716ef19`](https://github.com/NixOS/nixpkgs/commit/3716ef19d837998c35cc102c80ad800d26517d7e) | `` lib.makeScopeWithSplicing: provide default for keep,extra ``                     |
| [`20e6ef62`](https://github.com/NixOS/nixpkgs/commit/20e6ef62a7de5ea4d066bc9cb61cb52f932408d4) | `` python311Packages.riscv-isac: 0.17.0 -> 0.18.0 ``                                |
| [`561a8461`](https://github.com/NixOS/nixpkgs/commit/561a8461e50af247fb70ca5811633249923c19a5) | `` python310Packages.backports_csv: remove ``                                       |
| [`f383ce36`](https://github.com/NixOS/nixpkgs/commit/f383ce3623b60cf8297a530d59981ae41b128411) | `` foot: Pull patch to fix under Mir ``                                             |
| [`c7ac8bcc`](https://github.com/NixOS/nixpkgs/commit/c7ac8bcc04a61ea638daf95ebc27ef15ab6be112) | `` linux_xanmod_latest: 6.4.4 -> 6.4.7 ``                                           |
| [`cbf2d325`](https://github.com/NixOS/nixpkgs/commit/cbf2d325b4812fb3e18349867a50a192ef34b3d1) | `` linux_xanmod: 6.1.39 -> 6.1.42 ``                                                |
| [`0fa6394c`](https://github.com/NixOS/nixpkgs/commit/0fa6394cbbebf30c1acb76a00c87c1a5f59ea53c) | `` telegram-cli: remove ``                                                          |
| [`74cf9a8f`](https://github.com/NixOS/nixpkgs/commit/74cf9a8f98f896716cf7dba88244b4820ecc605c) | `` kbt: 1.1.0 -> 1.2.1 ``                                                           |
| [`45e394f5`](https://github.com/NixOS/nixpkgs/commit/45e394f5aa95cb8aada1dd29e73214e8f798e358) | `` doomrunner: 1.7.3 -> 1.8.0 ``                                                    |
| [`f8f83ebe`](https://github.com/NixOS/nixpkgs/commit/f8f83ebe64fe1226f68730cad8acbde2aba79160) | `` cfitsio: 4.2.0 -> 4.3.0 ``                                                       |
| [`59524a3c`](https://github.com/NixOS/nixpkgs/commit/59524a3c6065e1a8d218fa6e60abb54178dbadba) | `` bitwig-studio: 5.0 -> 5.0.4 ``                                                   |
| [`4c26a41a`](https://github.com/NixOS/nixpkgs/commit/4c26a41a99d20f271598b55041c49192aa489363) | `` python3Packages.librespot: init at 0.0.9 ``                                      |
| [`68528671`](https://github.com/NixOS/nixpkgs/commit/6852867140a119f20299b950266d5d567fec38de) | `` python3Packages.music-tag: init at 0.4.3 ``                                      |
| [`446c03f5`](https://github.com/NixOS/nixpkgs/commit/446c03f5d80ec8207c8ca59d031d2876d7fdc5c1) | `` onthespot: init at 0.5 ``                                                        |
| [`c69d372a`](https://github.com/NixOS/nixpkgs/commit/c69d372a1ff95187a609665c3097d5f78c76bffa) | `` cnspec: 8.19.0 -> 8.20.0 ``                                                      |
| [`adf434ca`](https://github.com/NixOS/nixpkgs/commit/adf434ca17631e8edcdb3e24d453bce75eaa03dc) | `` multiviewer-for-f1: 1.24.1 -> 1.24.2 ``                                          |
| [`bab27b64`](https://github.com/NixOS/nixpkgs/commit/bab27b6419f73f8758538c93ba36786b7d386699) | `` python311Packages.aiohomekit: 2.6.11 -> 2.6.12 ``                                |
| [`ecbebc9e`](https://github.com/NixOS/nixpkgs/commit/ecbebc9e226d09144176396b4bc501bdac3b9900) | `` bazel_6: fix typo on comments ``                                                 |
| [`de1e10bc`](https://github.com/NixOS/nixpkgs/commit/de1e10bc783412637600c9bf148384c781b500f6) | `` zsh-history-substring-search: 1.0.2 -> 1.1.0 ``                                  |
| [`d694d3b0`](https://github.com/NixOS/nixpkgs/commit/d694d3b0a9c970d274b1db79bc557be20737509b) | `` vault: 1.14.0 -> 1.14.1 ``                                                       |
| [`5c1dca7e`](https://github.com/NixOS/nixpkgs/commit/5c1dca7edfd00142cf7cf7341355965b9b124bcf) | `` clojupyter: 0.3.3 -> 0.3.6 ``                                                    |
| [`79a63f28`](https://github.com/NixOS/nixpkgs/commit/79a63f2841fc4fd5d11780dbe2de2da8f19062a6) | `` woodpecker-*: 0.15.8 -> 0.15.11 ``                                               |
| [`79ab9bde`](https://github.com/NixOS/nixpkgs/commit/79ab9bde456965fe2cd76c43e51fa08af448e1b0) | `` stalwart-mail: 0.3.1 -> 0.3.2 ``                                                 |
| [`4ffc1c82`](https://github.com/NixOS/nixpkgs/commit/4ffc1c82c6abb61aebf1a452020a4d41201e89e7) | `` zfs: 'want', don't 'require', systemd-udev-settle ``                             |
| [`58902390`](https://github.com/NixOS/nixpkgs/commit/589023909328df90e2ddcd6d5ad977ca78c62ccb) | `` coqPackages.coquelicot: 3.3.1 → 3.4.0 ``                                         |
| [`16d5bc34`](https://github.com/NixOS/nixpkgs/commit/16d5bc3418d43b5cd7522b6fd3fa8de007abeed0) | `` coqPackages.interval: 4.7.0 → 4.8.0 ``                                           |
| [`d24242d8`](https://github.com/NixOS/nixpkgs/commit/d24242d841466a405716dcf8a2baaa48fd837664) | `` k3s: 1.27.3+k3s1 -> 1.27.4+k3s1 ``                                               |
| [`cb13669b`](https://github.com/NixOS/nixpkgs/commit/cb13669b0049e795c3421987fe9367d82a0525b1) | `` lib.customisation: uncurry makeScopeWithSplicing ``                              |
| [`739d918f`](https://github.com/NixOS/nixpkgs/commit/739d918f4e336af7537cc033f2411d622236059b) | `` python311Packages.sopel: fix build ``                                            |
| [`0da71c3f`](https://github.com/NixOS/nixpkgs/commit/0da71c3f163913f706710cb237b86c6bb40aeddd) | `` python310Packages.zope-component: 5.1.0 -> 6.0 ``                                |
| [`6295ab5b`](https://github.com/NixOS/nixpkgs/commit/6295ab5b29a62b4d62eaa0221fcbb3e458f0fe0b) | `` python310Packages.zope-component: refactor ``                                    |
| [`39ea250b`](https://github.com/NixOS/nixpkgs/commit/39ea250bb65e4d3313985fc9c0084191c99f2340) | `` python310Packages.zope-component: rename from zope_component ``                  |
| [`36d3be17`](https://github.com/NixOS/nixpkgs/commit/36d3be170748e4bd5acca2ee7a991465ceba5bc1) | `` ovmf: add adamcstephens as maintainer ``                                         |
| [`8d08370a`](https://github.com/NixOS/nixpkgs/commit/8d08370a41610b092bdae0892b48a2b077e5c92c) | `` ovmf: add support for 4MB flash image ``                                         |
| [`0ea638da`](https://github.com/NixOS/nixpkgs/commit/0ea638dac5eb4cc82e1e46acadbddadf6495a291) | `` texlive: fix build with clang 16 ``                                              |
| [`0c33a7cd`](https://github.com/NixOS/nixpkgs/commit/0c33a7cd3e774ed4fa20d78fdc20e05c08ea0b22) | `` freetype: pkgsCross.mingwW64.pkg-config doesn't build ``                         |
| [`75d8c49c`](https://github.com/NixOS/nixpkgs/commit/75d8c49cd6ff6279f4152221c72bde8a35144fc2) | `` pgadmin4: 7.4 -> 7.5 ``                                                          |
| [`dd005d7f`](https://github.com/NixOS/nixpkgs/commit/dd005d7fadcc721002619fc715ca7002885650d4) | `` nss_latest: 3.91 -> 3.92 ``                                                      |
| [`300b0624`](https://github.com/NixOS/nixpkgs/commit/300b0624994e5a29287c090b9c16a67e501220d7) | `` python310Packages.google-cloud-container: 2.27.0 -> 2.28.0 ``                    |
| [`cbdaab0f`](https://github.com/NixOS/nixpkgs/commit/cbdaab0f172114d15e489ca18e6f5c4f727115ab) | `` nixos/nginx: remove unnecessary acme locations to allow double proxied setups `` |
| [`1d64486b`](https://github.com/NixOS/nixpkgs/commit/1d64486ba73822f4186149bfabfa404f9789f89e) | `` nixos/tests/jenkins: fix deprecation warning ``                                  |
| [`c731a289`](https://github.com/NixOS/nixpkgs/commit/c731a289ac786059df0592371577f57dbcb98ccb) | `` jenkins: 2.401.2 -> 2.401.3 ``                                                   |
| [`89f2d205`](https://github.com/NixOS/nixpkgs/commit/89f2d20589f5704979dba75bdc4d9172f4ad7ae4) | `` pynitrokey: 0.4.38 -> 0.4.39 ``                                                  |
| [`5aa3fc52`](https://github.com/NixOS/nixpkgs/commit/5aa3fc52e2b4b37bdeb2b1e90e4516de2dc1dd21) | `` gradle: 8.0.1 -> 8.2.1 ``                                                        |
| [`e9875315`](https://github.com/NixOS/nixpkgs/commit/e987531533df5e774cd8d17d7865e86a698c59ee) | `` ungoogled-chromium: 115.0.5790.102 -> 115.0.5790.110 ``                          |
| [`6a299931`](https://github.com/NixOS/nixpkgs/commit/6a2999310e4f5d4bfdec15d1aed54f98096fba9d) | `` xfce.xfce4-power-manager: use fixed path for helpers ``                          |
| [`bcc3da34`](https://github.com/NixOS/nixpkgs/commit/bcc3da34b4ff306c8327263b0280b3a4bbc82cd7) | `` vscode: fix GPU acceleration not working ``                                      |
| [`1086eb85`](https://github.com/NixOS/nixpkgs/commit/1086eb857456e0e3e32392816fdd4cf94d0843bf) | `` python310Packages.hist: add changelog to meta ``                                 |
| [`6885368e`](https://github.com/NixOS/nixpkgs/commit/6885368ed8204a88539a90d890eda875101d8c82) | `` python310Packages.dtlssocket: 0.1.15 -> 0.1.16 ``                                |
| [`c5f924dc`](https://github.com/NixOS/nixpkgs/commit/c5f924dcc2e2a4dc087620ba58a2515d4841e008) | `` polaris-web: 55 -> 67 ``                                                         |
| [`025b63b1`](https://github.com/NixOS/nixpkgs/commit/025b63b129a40683aa24ac9576746d5551709652) | `` polaris-web: use buildNpmPackage ``                                              |
| [`f08ff4aa`](https://github.com/NixOS/nixpkgs/commit/f08ff4aa4d896449c2f55d7cdcccc0a5c7cb334a) | `` tailscale: 1.46.0 -> 1.46.1 ``                                                   |
| [`cd68dbf4`](https://github.com/NixOS/nixpkgs/commit/cd68dbf4c1a0f9308a46a6ceb6de43423547fdac) | `` jfsw: init at stable-20211225 ``                                                 |
| [`77ec700f`](https://github.com/NixOS/nixpkgs/commit/77ec700f57eebfc9959fd9f219bd9a28ead3ccf7) | `` python310Packages.hist: 2.6.3 -> 2.7.1 ``                                        |
| [`1a357a92`](https://github.com/NixOS/nixpkgs/commit/1a357a921e2ee77fa329bd5ee0a5296991e62811) | `` fx-cast-bridge: adopt buildNpmPackage ``                                         |
| [`ad5505f0`](https://github.com/NixOS/nixpkgs/commit/ad5505f0b24a3a66a02924c19d6cfdbe0ed79212) | `` fx_cast_bridge: rename to fx-cast-bridge ``                                      |
| [`67b7d291`](https://github.com/NixOS/nixpkgs/commit/67b7d2918dcce93129f885423d298a58273f78fa) | `` fx_cast_bridge: add pedrohlc to maintainers ``                                   |
| [`bf7ee226`](https://github.com/NixOS/nixpkgs/commit/bf7ee2269c158f08149b0063cfe4254306af9ca4) | `` fx_cast_bridge: remove kevincox from maintainers ``                              |
| [`08e3fb95`](https://github.com/NixOS/nixpkgs/commit/08e3fb954683f87e88bde4871c401c07d29bc25e) | `` xfsprogs: 6.3.0 -> 6.4.0 ``                                                      |
| [`b90555ef`](https://github.com/NixOS/nixpkgs/commit/b90555efe6e509b5e0589a8d50716916e34a1afd) | `` rtfm: init at 0.2.2 ``                                                           |
| [`0ac2ba76`](https://github.com/NixOS/nixpkgs/commit/0ac2ba763f586e432b26f52e97c06ea869a01523) | `` nixos/hostapd: fix regression after refactoring to RFC42. ``                     |
| [`3c342d47`](https://github.com/NixOS/nixpkgs/commit/3c342d47850bee40e729925f99d401a126081d65) | `` polkadot: 0.9.43 -> 1.0.0 ``                                                     |
| [`a0839b51`](https://github.com/NixOS/nixpkgs/commit/a0839b51017c93a099723c1787635b7f03eba93b) | `` drawterm: use fetchFrom9Front ``                                                 |
| [`a978e48e`](https://github.com/NixOS/nixpkgs/commit/a978e48e52011048325b0b0f8380d6100fc1f44a) | `` rc-9front: use fetchFrom9Front ``                                                |
| [`5dde2776`](https://github.com/NixOS/nixpkgs/commit/5dde2776d32b9f6ea206a13df2d5db1bc3710ad9) | `` unstableGitUpdater: add deepClone argument for non shallow clones ``             |