### PR TITLE
chore(flake/emacs-overlay): `21a51e88` -> `5148f0e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1690710599,
-        "narHash": "sha256-m1/eEWE3PlcA9xBw8y1Zc9uYfa8zlgts/+MziOmXops=",
+        "lastModified": 1690742895,
+        "narHash": "sha256-h9xzTf2iaxF4VsiHo7sVdoTQYXlfxnWKOH7XxkneAEk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "21a51e882f77a0866e530f9b29d61b292237b97a",
+        "rev": "5148f0e35c9b884eec954113941c4292f60e55fa",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1690558459,
-        "narHash": "sha256-5W7y1l2cLYPkpJGNlAja7XW2X2o9rjf0O1mo9nxS9jQ=",
+        "lastModified": 1690630041,
+        "narHash": "sha256-gbnvqm5goS9DSKAqGFpq3398aOpwejmq4qWikqmQyRo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48e82fe1b1c863ee26a33ce9bd39621d2ada0a33",
+        "rev": "d57e8c535d4cbb07f441c30988ce52eec69db7a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`5148f0e3`](https://github.com/nix-community/emacs-overlay/commit/5148f0e35c9b884eec954113941c4292f60e55fa) | `` Updated repos/melpa ``  |
| [`b58e4f27`](https://github.com/nix-community/emacs-overlay/commit/b58e4f27c1fa582cc797de527c40f8d092abb1ed) | `` Updated repos/emacs ``  |
| [`138cfb06`](https://github.com/nix-community/emacs-overlay/commit/138cfb0636cc06e1e8a413a31245f84f1b8f8317) | `` Updated repos/elpa ``   |
| [`f353bff1`](https://github.com/nix-community/emacs-overlay/commit/f353bff1dadfbe229b61afd6da67baad97b437b4) | `` Updated flake inputs `` |