### PR TITLE
chore(flake/nur): `a47bbb0c` -> `b567ce95`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690735560,
-        "narHash": "sha256-HbC25rudp0t0TuXqg74Vaz+u3ikzT0LmU4jy6fKeoa4=",
+        "lastModified": 1690747541,
+        "narHash": "sha256-f5mR+n/J//ZJPzewz0wafFAXJxagRk5vgE/KTLmpTKI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a47bbb0ce02fdb3df6a11f7c2cbed946abb515ce",
+        "rev": "b567ce95e58961efca66d85498eeb1f087d85e2a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b567ce95`](https://github.com/nix-community/NUR/commit/b567ce95e58961efca66d85498eeb1f087d85e2a) | `` automatic update `` |
| [`a8678caf`](https://github.com/nix-community/NUR/commit/a8678cafe9170de768ad8f3053ad4264c639b366) | `` automatic update `` |