### PR TITLE
chore(flake/nur): `b567ce95` -> `7dec8c3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690747541,
-        "narHash": "sha256-f5mR+n/J//ZJPzewz0wafFAXJxagRk5vgE/KTLmpTKI=",
+        "lastModified": 1690760868,
+        "narHash": "sha256-qBi5XUX/+jglQ1Myp+VFNO9L0KGLAjfCXhexOix7VH8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b567ce95e58961efca66d85498eeb1f087d85e2a",
+        "rev": "7dec8c3ee7a3e9d28714538a55a3b197f95169b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7dec8c3e`](https://github.com/nix-community/NUR/commit/7dec8c3ee7a3e9d28714538a55a3b197f95169b8) | `` automatic update `` |