### PR TITLE
chore(flake/nur): `7dec8c3e` -> `66ca423d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690760868,
-        "narHash": "sha256-qBi5XUX/+jglQ1Myp+VFNO9L0KGLAjfCXhexOix7VH8=",
+        "lastModified": 1690768489,
+        "narHash": "sha256-ONM2ATLKJsBkgwV+vgzj7girp6R7HzNapJaTEifpkuo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7dec8c3ee7a3e9d28714538a55a3b197f95169b8",
+        "rev": "66ca423d699932db984f8b56f9b430644b18ad60",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`66ca423d`](https://github.com/nix-community/NUR/commit/66ca423d699932db984f8b56f9b430644b18ad60) | `` automatic update `` |
| [`49aad672`](https://github.com/nix-community/NUR/commit/49aad6729b25b1343c483a0348a9601bc6f92e35) | `` automatic update `` |