### PR TITLE
chore(flake/nur): `66ca423d` -> `8d3942e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690768489,
-        "narHash": "sha256-ONM2ATLKJsBkgwV+vgzj7girp6R7HzNapJaTEifpkuo=",
+        "lastModified": 1690776551,
+        "narHash": "sha256-MREXs43UefPFfLr9T1dhbXV2s+qYtmz8jLKDOp2Jkis=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "66ca423d699932db984f8b56f9b430644b18ad60",
+        "rev": "8d3942e6b9bf65529777633e3934e8d87c927957",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8d3942e6`](https://github.com/nix-community/NUR/commit/8d3942e6b9bf65529777633e3934e8d87c927957) | `` automatic update `` |
| [`f17ab648`](https://github.com/nix-community/NUR/commit/f17ab648180d2d0b6bf58b67dd472f27f4dfdb0e) | `` automatic update `` |
| [`e94e1d6c`](https://github.com/nix-community/NUR/commit/e94e1d6c5b4868a506a4b0a0def72fb66b383429) | `` automatic update `` |