### PR TITLE
chore(flake/nur): `8d3942e6` -> `daba2fd2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690776551,
-        "narHash": "sha256-MREXs43UefPFfLr9T1dhbXV2s+qYtmz8jLKDOp2Jkis=",
+        "lastModified": 1690786134,
+        "narHash": "sha256-ZfzWtKapu48qmPMSIHObKl7UjzO5lU0GXi98TjeAraA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8d3942e6b9bf65529777633e3934e8d87c927957",
+        "rev": "daba2fd27a0a344a05df4c2a9472b637a3407008",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`daba2fd2`](https://github.com/nix-community/NUR/commit/daba2fd27a0a344a05df4c2a9472b637a3407008) | `` automatic update `` |
| [`293017f2`](https://github.com/nix-community/NUR/commit/293017f2ec31771e0ed05ba0f95b73425850a65e) | `` automatic update `` |
| [`61e89b5a`](https://github.com/nix-community/NUR/commit/61e89b5a2bb24ad4d2f312f2100d84e5a35cbeff) | `` automatic update `` |