### PR TITLE
chore(flake/combobulate): `427fca4e` -> `e3370c97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
     "combobulate": {
       "flake": false,
       "locked": {
-        "lastModified": 1690449422,
-        "narHash": "sha256-raWdeKvqgVEY4mngu7lpb7LHLvIIllYesDNKnre9IMA=",
+        "lastModified": 1690787588,
+        "narHash": "sha256-4KNlyftCuniP4DDXDBsDQmB1KReYz3xzRzkr/awx9eA=",
         "owner": "mickeynp",
         "repo": "combobulate",
-        "rev": "427fca4eba7fad8f9146735a3777aa1b8d4cb3fc",
+        "rev": "e3370c97bcd1eb9b5dcba03014b246948c6e7126",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                           |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`e3370c97`](https://github.com/mickeynp/combobulate/commit/e3370c97bcd1eb9b5dcba03014b246948c6e7126) | `` Add all the rules as an experiment to python's default navigation node list `` |
| [`b7820019`](https://github.com/mickeynp/combobulate/commit/b78200190c2c9d43bccbfc0f64d3ed8f0d7f2eac) | `` Improve specificity of Python's default navigation nodes ``                    |
| [`9b1c6239`](https://github.com/mickeynp/combobulate/commit/9b1c623926c9cae87bf0226351c5b76efe85cb20) | `` Fix breakpoint() highlighter ``                                                |