### PR TITLE
chore(flake/nur): `daba2fd2` -> `be5da9d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690786134,
-        "narHash": "sha256-ZfzWtKapu48qmPMSIHObKl7UjzO5lU0GXi98TjeAraA=",
+        "lastModified": 1690800315,
+        "narHash": "sha256-INfR+05lqKazclxjSQ1kKkHRMro4QqtNn6YKsQ5wcQU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "daba2fd27a0a344a05df4c2a9472b637a3407008",
+        "rev": "be5da9d6384bc92fff5c298338b88eb1f5b7a28d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`be5da9d6`](https://github.com/nix-community/NUR/commit/be5da9d6384bc92fff5c298338b88eb1f5b7a28d) | `` automatic update `` |
| [`403907ff`](https://github.com/nix-community/NUR/commit/403907ff6b47ac7501ddf69841407d2954afa7b4) | `` automatic update `` |
| [`fb278246`](https://github.com/nix-community/NUR/commit/fb2782461a3c004778e430b49795e4cf195baeb1) | `` automatic update `` |
| [`d8572f88`](https://github.com/nix-community/NUR/commit/d8572f88d5703c4ceaeef586cba28b2946e1180b) | `` automatic update `` |
| [`826bb21d`](https://github.com/nix-community/NUR/commit/826bb21d32d195467a70b9b0c5827bc3f961e90f) | `` automatic update `` |