### PR TITLE
chore(flake/impermanence): `89253fb1` -> `e3a7acd1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1684264534,
-        "narHash": "sha256-K0zr+ry3FwIo3rN2U/VWAkCJSgBslBisvfRIPwMbuCQ=",
+        "lastModified": 1690797372,
+        "narHash": "sha256-GImz19e33SeVcIvBB7NnhbJSbTpFFmNtWLh7Z85Y188=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "89253fb1518063556edd5e54509c30ac3089d5e6",
+        "rev": "e3a7acd113903269a1b5c8b527e84ce7ee859851",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`e985164a`](https://github.com/nix-community/impermanence/commit/e985164ad5b17f4be8a2d3177b96b75a622a943a) | `` nixos: Introduce `persistentStoragePath` option `` |