### PR TITLE
chore(flake/emacs-overlay): `7951ca5a` -> `e8d273d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1690794717,
-        "narHash": "sha256-vP7bAm6x8wiKLv3FAnekIO6lP2xXOobYg1RtOV0f07Q=",
+        "lastModified": 1690828436,
+        "narHash": "sha256-svQ+15uuEZo9Xp+b472FAqv1jwJENjeM9aVT3UZoFLg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7951ca5a9227877296c49a7ab0ce8dd430c12be5",
+        "rev": "e8d273d9f31998c892fd16396b9b6c51566a64b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`e8d273d9`](https://github.com/nix-community/emacs-overlay/commit/e8d273d9f31998c892fd16396b9b6c51566a64b2) | `` Updated repos/melpa `` |
| [`5d370050`](https://github.com/nix-community/emacs-overlay/commit/5d3700503c012ce1495016cce9bcfe018a6493cb) | `` Updated repos/emacs `` |
| [`452f3afb`](https://github.com/nix-community/emacs-overlay/commit/452f3afbf3f4b59349691879640ac6f52f2b7be3) | `` Updated repos/elpa ``  |