### PR TITLE
chore(flake/nur): `620e8c7b` -> `739688b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690832783,
-        "narHash": "sha256-CkT0zgnbaB8MrVka5lN93gcgK7RSJXxImebZA7Ezvl0=",
+        "lastModified": 1690858374,
+        "narHash": "sha256-fFy/f0C07WOUgG1NhlkiongVXyjeQMIvLtDYBKsxNU4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "620e8c7b96e2e050645d4d31fd2585800f18e26a",
+        "rev": "739688b458893be8b99c1c27854024d8a2d129a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`739688b4`](https://github.com/nix-community/NUR/commit/739688b458893be8b99c1c27854024d8a2d129a8) | `` automatic update `` |
| [`daa14ca4`](https://github.com/nix-community/NUR/commit/daa14ca40ccfbab15ae19dec16fda365663c25dc) | `` automatic update `` |
| [`8d0d16d3`](https://github.com/nix-community/NUR/commit/8d0d16d334c39ae68306384c1476aa89c53ce3a4) | `` automatic update `` |
| [`74455ac7`](https://github.com/nix-community/NUR/commit/74455ac700d824d2d0e2e35f620efb6936060d11) | `` automatic update `` |