### PR TITLE
chore(flake/dendrite-demo-pinecone): `76fba359` -> `152b80ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1690844723,
-        "narHash": "sha256-0n1CNME4jVI154+9LfJb/DDoc7LoTlvaIjo7ChrmSMo=",
+        "lastModified": 1690852553,
+        "narHash": "sha256-wl0zoADrFo6HUiMPDsjOx4xz2JMIpBurYWJUvlHo73I=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "76fba359b65779e1ae1293e395361a89c887a4a7",
+        "rev": "152b80ae9953552f5e6d8ffc4afad34de0314d68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                         |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`152b80ae`](https://github.com/bbigras/dendrite-demo-pinecone/commit/152b80ae9953552f5e6d8ffc4afad34de0314d68) | `` chore(deps): bump cachix/install-nix-action from 20 to 22 `` |