### PR TITLE
chore(flake/nixpkgs): `e6ab4698` -> `fb942492`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -827,11 +827,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1690640159,
-        "narHash": "sha256-5DZUYnkeMOsVb/eqPYb9zns5YsnQXRJRC8Xx/nPMcno=",
+        "lastModified": 1690789960,
+        "narHash": "sha256-3K+2HuyGTiJUSZNJxXXvc0qj4xFx1FHC/ItYtEa7/Xs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e6ab46982debeab9831236869539a507f670a129",
+        "rev": "fb942492b7accdee4e6d17f5447091c65897dde4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`5ba1b5be`](https://github.com/NixOS/nixpkgs/commit/5ba1b5be5a22b2f955ee294d347ba8b76e172bc2) | `` nushellPlugins.query: 0.83.0 -> 0.83.1 ``                                           |
| [`f7a4a376`](https://github.com/NixOS/nixpkgs/commit/f7a4a3764f3675af8d7aec314a550546cd603f0c) | `` nushellPlugins.gstat: 0.83.0 -> 0.83.1 ``                                           |
| [`5becdd85`](https://github.com/NixOS/nixpkgs/commit/5becdd85fcee634edeba5e6feef3bd3ef23ac510) | `` nu_scripts: unstable-2023-07-24 -> unstable-2023-07-29 ``                           |
| [`c38219f1`](https://github.com/NixOS/nixpkgs/commit/c38219f1ced7f1d0d83606abea3a1576c0fc2ce0) | `` nushell: 0.83.0 -> 0.83.1 ``                                                        |
| [`a9e76af1`](https://github.com/NixOS/nixpkgs/commit/a9e76af1b9ef7a5e00690907cf00fa8c696eb76b) | `` kdocker: init at 5.4 ``                                                             |
| [`b0f41a7c`](https://github.com/NixOS/nixpkgs/commit/b0f41a7c3af0ffaccc68ee1c6bda54f75f7674b8) | `` scheherazade-new: 3.300 → 4.000 ``                                                  |
| [`6f3cf1c1`](https://github.com/NixOS/nixpkgs/commit/6f3cf1c1a8f6ba1915cd8619458abaf86f347946) | `` ocamlPackages.xenstore-tool: fix for OCaml ≥ 5.0 ``                                 |
| [`5bd5a258`](https://github.com/NixOS/nixpkgs/commit/5bd5a25808dc23a702d4aeb334555285d29cc2a6) | `` ocamlPackages.sosa: fix for OCaml ≥ 5.0 ``                                          |
| [`cba62cad`](https://github.com/NixOS/nixpkgs/commit/cba62cad7047d596b06551eca31feff4d44a892b) | `` ocamlPackages.rfc7748: fix for OCaml ≥ 5.0 ``                                       |
| [`2c38aefa`](https://github.com/NixOS/nixpkgs/commit/2c38aefa2b773a990f582e63aa9cf623783707b0) | `` vscode: Fix icon name ``                                                            |
| [`caaace49`](https://github.com/NixOS/nixpkgs/commit/caaace4918cff22ca9110152bcc41808d4005007) | `` python311Packages.tensorflow: mark as broken ``                                     |
| [`b7b9f11c`](https://github.com/NixOS/nixpkgs/commit/b7b9f11c8985628c7bd5d04b70b864b9ce99507f) | `` irrd: init at 4.3.0.post1 ``                                                        |
| [`f7b797b4`](https://github.com/NixOS/nixpkgs/commit/f7b797b4e73a70a4bf99d5732a3223472a94a0ca) | `` python3Packages.py-radix-sr: init at 1.0.0.post1 ``                                 |
| [`513dbe59`](https://github.com/NixOS/nixpkgs/commit/513dbe59bef4ab62d0ea1355f75cb1baf6c0e0b8) | `` python3Packages.coredis: init at 4.14.0 ``                                          |
| [`85bd250f`](https://github.com/NixOS/nixpkgs/commit/85bd250fffd410880a8fc02b253c82cbc614e2af) | `` pkgsMusl.systemdMinimal: fix build ``                                               |
| [`7efa5777`](https://github.com/NixOS/nixpkgs/commit/7efa5777e2924792bac419dd6d6960d924925c3c) | `` pkgsMusl.fmt: fix build (#246269) ``                                                |
| [`5b36914d`](https://github.com/NixOS/nixpkgs/commit/5b36914d210fda6d1a38f4468f7d79bfbcb8da4e) | `` lagrange: 1.16.5 -> 1.16.6 ``                                                       |
| [`3ba3da48`](https://github.com/NixOS/nixpkgs/commit/3ba3da482432a120a1bceb90484ce3b045ceb089) | `` hedgedoc: 1.9.8 -> 1.9.9 (#246259) ``                                               |
| [`38b99bf8`](https://github.com/NixOS/nixpkgs/commit/38b99bf8e26fc7291f7bad921a67ea616916bb81) | `` python310Packages.pipdeptree: 2.10.2 -> 2.12.0 ``                                   |
| [`b84613ef`](https://github.com/NixOS/nixpkgs/commit/b84613efb9e4fc7dc9012dcc5db842b5bbfe83ba) | `` linuxPackages.rtl8812au: unstable-2023-07-20 -> unstable-2023-07-22 ``              |
| [`d7a34b53`](https://github.com/NixOS/nixpkgs/commit/d7a34b5327b5d2f21f9ad8999087edab269843ae) | `` linuxPackages.rtl88x2bu: unstable-2023-07-20 -> unstable-2023-07-23 ``              |
| [`e21f3595`](https://github.com/NixOS/nixpkgs/commit/e21f35958ce715ed1aaefeb5e924cbf304bdef32) | `` heisenbridge: 1.14.3 -> 1.14.4 (#246249) ``                                         |
| [`739fc683`](https://github.com/NixOS/nixpkgs/commit/739fc683716f0aad596c19c4a7c1b4a18fce438c) | `` ksmbd-tools: 3.4.8 -> 3.4.9 ``                                                      |
| [`1f0c447a`](https://github.com/NixOS/nixpkgs/commit/1f0c447a93d6c64eddfae20669a0413972e80428) | `` pluto: 5.18.1 -> 5.18.2 ``                                                          |
| [`c1df21e5`](https://github.com/NixOS/nixpkgs/commit/c1df21e5b61f1bb45a6204fc9d592ecd20e3b6be) | `` alt-server: init at 0.0.5 ``                                                        |
| [`9165d5cb`](https://github.com/NixOS/nixpkgs/commit/9165d5cbe9ee86d49ce2f39647c5e61d6bc88893) | `` maintainers: add max-amb ``                                                         |
| [`785b7d40`](https://github.com/NixOS/nixpkgs/commit/785b7d40ebe51d40a583db630d4befe495284912) | `` gambit-unstable: 2020-09-20 -> 2023-07-30 ``                                        |
| [`d68f7974`](https://github.com/NixOS/nixpkgs/commit/d68f7974fa76c401829b3a0ba419db7450529bc9) | `` gambit: 4.9.3 -> 4.9.5 ``                                                           |
| [`413d0afd`](https://github.com/NixOS/nixpkgs/commit/413d0afd094a6ad82fa9a45eada60d42f15b338a) | `` wncast: 0.0.13 -> 0.1.1 ``                                                          |
| [`384a9eee`](https://github.com/NixOS/nixpkgs/commit/384a9eeee4ddccc42b98579efa58dbf9a19e4bed) | `` davinci-resolve: update payload request and URL of download ``                      |
| [`850c8282`](https://github.com/NixOS/nixpkgs/commit/850c828230fa6e5d8079594e1b1c823ae4cc6a6c) | `` uxn: unstable-2022-10-22 -> unstable-2023-07-26 ``                                  |
| [`8f8e2bc2`](https://github.com/NixOS/nixpkgs/commit/8f8e2bc2fd39a415ce620cdd869756462eba1e14) | `` xine-ui: split outputs ``                                                           |
| [`2d7e66bf`](https://github.com/NixOS/nixpkgs/commit/2d7e66bf829d2400b464f71e657850d94b2ce1a9) | `` xine-ui: 0.99.13 -> 0.99.14 ``                                                      |
| [`b6024f78`](https://github.com/NixOS/nixpkgs/commit/b6024f78a826fe0122a68d34edecd47a0b6ce198) | `` xine-lib: split outputs ``                                                          |
| [`484b606d`](https://github.com/NixOS/nixpkgs/commit/484b606d4ab1bb90d3a318f47052857557d0f6a6) | `` xine-lib: 1.2.11 -> 1.2.13 ``                                                       |
| [`ac0eb8ce`](https://github.com/NixOS/nixpkgs/commit/ac0eb8ced85765bc37e5d96423e5937d1d8157a9) | `` xine-ui, xine-lib: move to pkgs/xine ``                                             |
| [`6b377933`](https://github.com/NixOS/nixpkgs/commit/6b377933957214303480f482bcd0c54db4d19fe1) | `` twitterBootstrap: use `finalAttrs` pattern ``                                       |
| [`6c84ca2d`](https://github.com/NixOS/nixpkgs/commit/6c84ca2d811ad796a4184dc08fcf31e2002c27b2) | `` maintainers: add hexclover ``                                                       |
| [`15cadbb7`](https://github.com/NixOS/nixpkgs/commit/15cadbb7c036a9708adbc644c90a8492e65ab9ae) | `` aaaaxy: 1.4.33 -> 1.4.39 ``                                                         |
| [`088c1b39`](https://github.com/NixOS/nixpkgs/commit/088c1b399dca11290331665e7c07839ea9004443) | `` onionshare-gui: add .desktop, icon and appdata (#245914) ``                         |
| [`4909d886`](https://github.com/NixOS/nixpkgs/commit/4909d886c576747fff3d6b8859ca24d13fe7c149) | `` tickrs: 0.14.8 -> 0.14.9 ``                                                         |
| [`2ca7b3a4`](https://github.com/NixOS/nixpkgs/commit/2ca7b3a4aa0d5f8086ac611e7b12dacf378f5824) | `` dolt: 1.8.2 -> 1.8.4 ``                                                             |
| [`22c392b0`](https://github.com/NixOS/nixpkgs/commit/22c392b05ce9370e2a82b4502cda061908f91a71) | `` transifex-cli: 1.6.7 -> 1.6.9 ``                                                    |
| [`3e61801f`](https://github.com/NixOS/nixpkgs/commit/3e61801f5df74852465cd6f92c862eb6c3da761d) | `` linuxPackages.rtl88x2bu: remove myself from maintainers ``                          |
| [`03e8f7bb`](https://github.com/NixOS/nixpkgs/commit/03e8f7bba7d8df290193cbac76fd89d1246c1e95) | `` minikube: 1.30.1 -> 1.31.1 ``                                                       |
| [`335a0d1a`](https://github.com/NixOS/nixpkgs/commit/335a0d1a3213c10d25bc95f43b2bdc7debf163c7) | `` ast-grep: 0.9.1 -> 0.9.2 ``                                                         |
| [`ff9296f9`](https://github.com/NixOS/nixpkgs/commit/ff9296f93e39cfa2ec9b12268f2c280ab3c14b65) | `` nixos/gitlab: ensure service started again after dependency restarts (#245240) ``   |
| [`230def9f`](https://github.com/NixOS/nixpkgs/commit/230def9fe4fb0ab07562d11d9d0a14fc4f9bf697) | `` python310Packages.guidance: init at 0.0.64 ``                                       |
| [`5acfaa6f`](https://github.com/NixOS/nixpkgs/commit/5acfaa6f64afae20f101ba20241aca5521b6434a) | `` python310Packages.gptcache: init at 0.1.37 ``                                       |
| [`29a702df`](https://github.com/NixOS/nixpkgs/commit/29a702dfa6f8ff418ebc484a8e7411ea29a66e21) | `` python310Packages.opentelemetry-instrumentation: add natsukium as maintainer ``     |
| [`86200041`](https://github.com/NixOS/nixpkgs/commit/86200041e2aeb4f4e43c9413713295a907e3855e) | `` python310Packages.opentelemetry-instrumentation: refactor ``                        |
| [`35a8ff1d`](https://github.com/NixOS/nixpkgs/commit/35a8ff1d1d6e4e11529c07a9753f39ca4a0f1044) | `` python310Packages.opentelemetry-api: add natsukium as maintainer ``                 |
| [`db1ccedc`](https://github.com/NixOS/nixpkgs/commit/db1ccedc1299b2a39dc57fa2d5938116c9a04317) | `` python310Packages.opentelemetry-api: refactor ``                                    |
| [`a36659be`](https://github.com/NixOS/nixpkgs/commit/a36659be3b3ff7308d2dcd798b8cf49dcb2bf9d5) | `` memray: 1.8.1 -> 1.9.0 ``                                                           |
| [`d8985093`](https://github.com/NixOS/nixpkgs/commit/d898509390c66f4758ec3ff1985fef4c93c7adb6) | `` exploitdb: 2023-07-22 -> 2023-07-29 ``                                              |
| [`3084745e`](https://github.com/NixOS/nixpkgs/commit/3084745ef41566278da2159e9d18c224b0023b68) | `` amass: 4.0.4 -> 4.1.0 ``                                                            |
| [`a4797351`](https://github.com/NixOS/nixpkgs/commit/a4797351620f3bf45c234a886b8ef413cd3e8c36) | `` respond to pr feedback ``                                                           |
| [`db62d26e`](https://github.com/NixOS/nixpkgs/commit/db62d26e0eab2cd3b74f13c02f1bbfbcd8e303d0) | `` starship: 1.15.0 -> 1.16.0 ``                                                       |
| [`d780bdf3`](https://github.com/NixOS/nixpkgs/commit/d780bdf308c8f6900c5ec09eaeb650a1d15cd427) | `` Update nixos/modules/virtualisation/proxmox-image.nix ``                            |
| [`1fbc41b9`](https://github.com/NixOS/nixpkgs/commit/1fbc41b961e0adc59eec687f69a3c6f3b23b2607) | `` diffoscope: 245 -> 246 ``                                                           |
| [`a865d875`](https://github.com/NixOS/nixpkgs/commit/a865d875b8fb981b56b8d4ac533a1dcb700d1a4d) | `` spigot: 20210527 -> 20220606.eb585f8 ``                                             |
| [`6b13c622`](https://github.com/NixOS/nixpkgs/commit/6b13c6227c743496634603c919328d21be82bb14) | `` firefox-devedition-unwrapped: 116.0b3 -> 116.0b8 ``                                 |
| [`f318e5cd`](https://github.com/NixOS/nixpkgs/commit/f318e5cd59131665aeb7e02d007108bd8689ff08) | `` ttdl: 3.10.0 -> 4.0.0 ``                                                            |
| [`43d1c4d7`](https://github.com/NixOS/nixpkgs/commit/43d1c4d782a7a28c55f973ff063388c53f6fbd79) | `` nixos/gogs: fix deprecations for 0.13.0 ``                                          |
| [`7fae0116`](https://github.com/NixOS/nixpkgs/commit/7fae0116199ee909c0f877619edd91f9bd32d9a3) | `` linux_testing: 6.5-rc2 -> 6.5-rc3 ``                                                |
| [`aaeea6ae`](https://github.com/NixOS/nixpkgs/commit/aaeea6ae80391f5e0d77974c28a0ceece328119f) | `` firefox-beta-unwrapped: 116.0b3 -> 116.0b8 ``                                       |
| [`a0c846a0`](https://github.com/NixOS/nixpkgs/commit/a0c846a05ad76b7f36c6672988175984285f7849) | `` nixos/test-driver: format ``                                                        |
| [`d0d2424b`](https://github.com/NixOS/nixpkgs/commit/d0d2424bc04ff8af1cbdb4128735ac078b6c3e53) | `` to-html: init at 0.1.4 ``                                                           |
| [`f06933de`](https://github.com/NixOS/nixpkgs/commit/f06933def61c358004dd55263a9b88ee6c4f2397) | `` xdg-desktop-portal-gnome: 44.1 → 44.2 ``                                            |
| [`d02bcaf5`](https://github.com/NixOS/nixpkgs/commit/d02bcaf5f1c023b5f28156c60438f535c05979a9) | `` epiphany: 44.5 → 44.6 ``                                                            |
| [`d7f26a84`](https://github.com/NixOS/nixpkgs/commit/d7f26a8484ea5f59677ec1a99c1f11fbcf879a08) | `` gspell: 1.12.1 → 1.12.2 ``                                                          |
| [`71d9bb7c`](https://github.com/NixOS/nixpkgs/commit/71d9bb7cc68d320d10b72470ff425356aa18f456) | `` ccache: fix tests for cross compile targets ``                                      |
| [`f633f596`](https://github.com/NixOS/nixpkgs/commit/f633f5965a6dba7c2fe2c4e0b4b46b9a3b68cfac) | `` ruby_3_3: init at 3.3.0.preview1 ``                                                 |
| [`b8d4f020`](https://github.com/NixOS/nixpkgs/commit/b8d4f020e38a582f85d71671548774399ac00aa4) | `` tijolo: 0.7.3->0.7.4 ``                                                             |
| [`6f22451e`](https://github.com/NixOS/nixpkgs/commit/6f22451e6590751214018204f34b732bbc8efd8c) | `` python310Packages.smart-meter-texas: 0.5.1 -> 0.5.3 ``                              |
| [`ce0e84ad`](https://github.com/NixOS/nixpkgs/commit/ce0e84adb9272eff83af962cf034f997d990b858) | `` helmfile-wrapped: 0.155.0 -> 0.155.1 ``                                             |
| [`5359f316`](https://github.com/NixOS/nixpkgs/commit/5359f3161e7a02e34b6faf019d4408f6baecf392) | `` carapace: 0.25.1 -> 0.25.3 ``                                                       |
| [`354235fb`](https://github.com/NixOS/nixpkgs/commit/354235fbff7b55b34db4a3e8cf2801412b83acf2) | `` velero: 1.11.0 -> 1.11.1 ``                                                         |
| [`d1d134d4`](https://github.com/NixOS/nixpkgs/commit/d1d134d4ebad99931761af812e39f882c48db0fa) | `` base16384: 2.2.3 -> 2.2.4 ``                                                        |
| [`a8e308bf`](https://github.com/NixOS/nixpkgs/commit/a8e308bff1b34c00808eb1e8b0a194c5ade2cd0d) | `` syncthingtray: build as a shared library, small cleanup ``                          |
| [`8767f7a3`](https://github.com/NixOS/nixpkgs/commit/8767f7a362169ee96715b6953c6a78623d682636) | `` qtutilities: build as a shared library ``                                           |
| [`90c8630a`](https://github.com/NixOS/nixpkgs/commit/90c8630a9a361e712172eabf7a8c3c4786286831) | `` cpp-utilities: build as a shared library ``                                         |
| [`5b9886e2`](https://github.com/NixOS/nixpkgs/commit/5b9886e2c68f8a08693d499d7642fb70750a5398) | `` musescore: 4.1.0 -> 4.1.1 ``                                                        |
| [`4ef447b7`](https://github.com/NixOS/nixpkgs/commit/4ef447b7b2648e71b504f53587086805ce3bf286) | `` supabase-cli: 1.79.0 -> 1.82.4 ``                                                   |
| [`d6604d0c`](https://github.com/NixOS/nixpkgs/commit/d6604d0c8a808dbaf984ea7064037f52c1f5daf5) | `` twitterBootstrap: 5.3.0 -> 5.3.1 ``                                                 |
| [`4ccfdcad`](https://github.com/NixOS/nixpkgs/commit/4ccfdcadc27ad89488e885da2bc4f97b6e9dcd91) | `` twspace-crawler: 1.12.6 -> 1.12.7 ``                                                |
| [`5e7d57ac`](https://github.com/NixOS/nixpkgs/commit/5e7d57acec3bcd56f7345eacc680670bf075ea62) | `` shadowenv: 2.1.0 -> 2.1.1 ``                                                        |
| [`7e7165d9`](https://github.com/NixOS/nixpkgs/commit/7e7165d966b7a78ffe6691d588627811c669bfd3) | `` luau: 0.584 -> 0.588 ``                                                             |
| [`c63a98dd`](https://github.com/NixOS/nixpkgs/commit/c63a98dd41bb7fd6e7e32db4eb88fc0e84a81236) | `` python310Packages.myst-nb: fix compatibility with myst-parser 1.0 ``                |
| [`b5c14b30`](https://github.com/NixOS/nixpkgs/commit/b5c14b308306001af4e672b92e85a9e30aa64be8) | `` terraform-providers.minio: 1.17.0 -> 1.17.1 ``                                      |
| [`784fbc18`](https://github.com/NixOS/nixpkgs/commit/784fbc1811241c71ac0ab8a660959a91a3f43f48) | `` cargo-nextest: 0.9.54 -> 0.9.55 ``                                                  |
| [`14a259a9`](https://github.com/NixOS/nixpkgs/commit/14a259a91ef1489fd534d479316135a75f2985ad) | `` werf: 1.2.242 -> 1.2.248 ``                                                         |
| [`4dfdcda6`](https://github.com/NixOS/nixpkgs/commit/4dfdcda6a0e7a8af9b813d6271b52803ddf42559) | `` credhub-cli: 2.9.17 -> 2.9.18 ``                                                    |
| [`a8806a8a`](https://github.com/NixOS/nixpkgs/commit/a8806a8a5b5137afc75b44bf44306c761a7c95ff) | `` cadvisor: 0.46.0 -> unstable-2023-07-28 ``                                          |
| [`6ae8e133`](https://github.com/NixOS/nixpkgs/commit/6ae8e13396ead898761732ccff3ec5351d9fed2a) | `` nixos/matrix-appservice-irc: update syscall filter ``                               |
| [`77f921c3`](https://github.com/NixOS/nixpkgs/commit/77f921c37e679e133309ac9ba5ac44c9ebc54f66) | `` grpc-gateway: 2.16.0 -> 2.16.1 ``                                                   |
| [`f2794786`](https://github.com/NixOS/nixpkgs/commit/f2794786fdd79247e2d0b8d92fe670a45d1d7cca) | `` proxmox-image: add additionalDiskSpace parameter as input to make-disk-image.nix `` |
| [`b7929dd4`](https://github.com/NixOS/nixpkgs/commit/b7929dd4c8904136f0cd102589c3178b701834f3) | `` api-linter: 1.54.1 -> 1.55.0 ``                                                     |
| [`135b79b9`](https://github.com/NixOS/nixpkgs/commit/135b79b95463e62b1e1db9132b9dbaf79af2f13b) | `` solo2-cli: fix zsh completion ``                                                    |
| [`982d9a83`](https://github.com/NixOS/nixpkgs/commit/982d9a839c4316e8fc9fe48b37228a464a1d0c6d) | `` treesheets: unstable-2023-07-22 -> unstable-2023-07-28 ``                           |
| [`cb4c6f05`](https://github.com/NixOS/nixpkgs/commit/cb4c6f051510b42aae67d209eec0489698e0f7dd) | `` engage: install shell completions ``                                                |
| [`7f23f9fe`](https://github.com/NixOS/nixpkgs/commit/7f23f9fee227a66b3eeab931119175c04cd14bfa) | `` gst_all_1.gst-plugins-rs: make cargo-c temp fix work for cross ``                   |
| [`3d6d095d`](https://github.com/NixOS/nixpkgs/commit/3d6d095d8492c0031271882f815d11f88be549c5) | `` onionshare-gui: add patch to fix qrcode ``                                          |
| [`789d1d42`](https://github.com/NixOS/nixpkgs/commit/789d1d4248258ae4818b718387a05397192df29e) | `` stacer: init at 1.1.0 ``                                                            |
| [`88e78b6a`](https://github.com/NixOS/nixpkgs/commit/88e78b6a97fb08a35bd65903eab6ec18005472a7) | `` trealla: 2.21.33 -> 2.23.35 ``                                                      |
| [`dbac08be`](https://github.com/NixOS/nixpkgs/commit/dbac08beafa42478b526b99db06a57782bb3f4ff) | `` libcef: 114.2.13 -> 115.3.11 ``                                                     |
| [`703b264b`](https://github.com/NixOS/nixpkgs/commit/703b264b07251df3a8194ac93ad384e764846b97) | `` spectre-meltdown-checker: use `finalAttrs` pattern ``                               |
| [`50a7139f`](https://github.com/NixOS/nixpkgs/commit/50a7139fbd1acd4a3d4cfa695e694c529dd26f3a) | `` pmenu: use `finalAttrs` pattern ``                                                  |
| [`ad66cedc`](https://github.com/NixOS/nixpkgs/commit/ad66cedc57acb8b8bf1b23eb10e3694323e42635) | `` python310Packages.ppft: 1.7.6.6 -> 1.7.6.7 ``                                       |
| [`dd903200`](https://github.com/NixOS/nixpkgs/commit/dd90320024bb88eda95efc61ff9febc9ef7ba4b6) | `` cargo-guppy: unstable-2023-06-26 -> unstable-2023-07-29 ``                          |
| [`2010c1de`](https://github.com/NixOS/nixpkgs/commit/2010c1dea47d7a54a331c7e493d73e1393687e15) | `` cargo-hakari: 0.9.26 -> 0.9.27 ``                                                   |
| [`60d546a9`](https://github.com/NixOS/nixpkgs/commit/60d546a96d45bb9c0e5aa6479008fb934c257fb5) | `` envoy: 1.26.1 -> 1.26.3 ``                                                          |
| [`84d9a1e8`](https://github.com/NixOS/nixpkgs/commit/84d9a1e808d9a0a10f7485b496b3cbf25430cdaf) | `` nixos/test-driver: log what to do if backdoor service doesn't come oneline ``       |
| [`06e023e4`](https://github.com/NixOS/nixpkgs/commit/06e023e4cf8e21c69058c421b9e4bf57f2f96c18) | `` owmods-cli: init at 0.10.0 ``                                                       |
| [`1b78e939`](https://github.com/NixOS/nixpkgs/commit/1b78e939aa8ffe1aa7a15f8940fb5df2b74e6c20) | `` jami: apply CVE patch ``                                                            |
| [`bd35f53f`](https://github.com/NixOS/nixpkgs/commit/bd35f53fe2aae8afaae65904efcc82fbd6576d02) | `` python310Packages.imap-tools: 1.0.0 -> 1.1.0 ``                                     |