### PR TITLE
chore(flake/nur): `739688b4` -> `e47f866e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690858374,
-        "narHash": "sha256-fFy/f0C07WOUgG1NhlkiongVXyjeQMIvLtDYBKsxNU4=",
+        "lastModified": 1690861488,
+        "narHash": "sha256-S6eQbhh/h5KYQne6Pac2ll9dDWsO86fh/rxeL7HZo4c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "739688b458893be8b99c1c27854024d8a2d129a8",
+        "rev": "e47f866eb7e02ec94fd108eb317bcc20769fae68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e47f866e`](https://github.com/nix-community/NUR/commit/e47f866eb7e02ec94fd108eb317bcc20769fae68) | `` automatic update `` |
| [`bb9d2982`](https://github.com/nix-community/NUR/commit/bb9d29824b883f06607c9140ec08f07501d1ff98) | `` automatic update `` |
| [`7874bf0d`](https://github.com/nix-community/NUR/commit/7874bf0d01d9c13031dcd6b9627996d81069eb54) | `` automatic update `` |