### PR TITLE
chore(flake/emacs-overlay): `e8d273d9` -> `613eb3bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1690828436,
-        "narHash": "sha256-svQ+15uuEZo9Xp+b472FAqv1jwJENjeM9aVT3UZoFLg=",
+        "lastModified": 1690865132,
+        "narHash": "sha256-9sSe66mcbfCEzyOpcRDqBxojb18iQez/fKi2hUPs1dk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e8d273d9f31998c892fd16396b9b6c51566a64b2",
+        "rev": "613eb3bdb2a6579fd13895daf890470190d4bb9b",
         "type": "github"
       },
       "original": {
@@ -749,11 +749,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1690630041,
-        "narHash": "sha256-gbnvqm5goS9DSKAqGFpq3398aOpwejmq4qWikqmQyRo=",
+        "lastModified": 1690726002,
+        "narHash": "sha256-cACz6jCJZtsZHGCJAN4vMobxzH5s6FCOTZHMrh/Hu0M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d57e8c535d4cbb07f441c30988ce52eec69db7a8",
+        "rev": "391e8db1f06c3f74c2d313a73135515023af3993",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                               |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
| [`613eb3bd`](https://github.com/nix-community/emacs-overlay/commit/613eb3bdb2a6579fd13895daf890470190d4bb9b) | `` flake: Set herculesCI attribute `` |
| [`fa97a075`](https://github.com/nix-community/emacs-overlay/commit/fa97a0757899ea3b1415d5f376e2d9a4ab8526f8) | `` Updated repos/nongnu ``            |
| [`20a8571e`](https://github.com/nix-community/emacs-overlay/commit/20a8571ed6deae1ca09fdab67b58b74f1d515e70) | `` Updated repos/melpa ``             |
| [`1fb626ea`](https://github.com/nix-community/emacs-overlay/commit/1fb626ea36729268ffea467203e416643ae23a76) | `` Updated repos/emacs ``             |
| [`7258fadc`](https://github.com/nix-community/emacs-overlay/commit/7258fadcf56b3e0d25041b615b8c946538bd2c2a) | `` Updated repos/elpa ``              |
| [`021a6434`](https://github.com/nix-community/emacs-overlay/commit/021a6434c2dc98ced1ae6d9ee09f6bd70abd5ec8) | `` Updated flake inputs ``            |