### PR TITLE
chore(flake/nur): `e47f866e` -> `6fa0b49d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690861488,
-        "narHash": "sha256-S6eQbhh/h5KYQne6Pac2ll9dDWsO86fh/rxeL7HZo4c=",
+        "lastModified": 1690871766,
+        "narHash": "sha256-3Lu6IvWD8KZajnhLSFpHeVYfqDhkaD3RbQn4qht48no=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e47f866eb7e02ec94fd108eb317bcc20769fae68",
+        "rev": "6fa0b49d376000c13418f599c3565a4a38d2dfd4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6fa0b49d`](https://github.com/nix-community/NUR/commit/6fa0b49d376000c13418f599c3565a4a38d2dfd4) | `` automatic update `` |
| [`240eece3`](https://github.com/nix-community/NUR/commit/240eece3151d22e68a9d23fb1bfffd18f53010f2) | `` automatic update `` |
| [`18157f06`](https://github.com/nix-community/NUR/commit/18157f060b7ec27b53d17ae0808213b6ca094bf3) | `` automatic update `` |
| [`c9e993d2`](https://github.com/nix-community/NUR/commit/c9e993d2dd568ab2eb5590fb6e29b986a0df0917) | `` automatic update `` |
| [`a144f486`](https://github.com/nix-community/NUR/commit/a144f4863e3603d80fb4b93bed4ff9da2516e758) | `` automatic update `` |