### PR TITLE
chore(flake/home-manager): `4fd794d3` -> `310c0063`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690846837,
-        "narHash": "sha256-ZZ8YPOEdZG0zz61U4sfUAx28oEdqLdtG1iWTTH/98uc=",
+        "lastModified": 1690846843,
+        "narHash": "sha256-sfguzocpi42+juoiUNLMtXws33DeEZkbEVTLtx/LKC8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4fd794d3df88735dcf9662155d77b08a2e2dde29",
+        "rev": "310c0063b2558e94ad8bc3c1f2ddead82e0872cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`310c0063`](https://github.com/nix-community/home-manager/commit/310c0063b2558e94ad8bc3c1f2ddead82e0872cd) | `` Update translation files ``                       |
| [`04da1b90`](https://github.com/nix-community/home-manager/commit/04da1b908be79dd88c4e2ef43363a4d5a1536df2) | `` Translate using Weblate (Chinese (Simplified)) `` |