### PR TITLE
chore(flake/emacs-overlay): `613eb3bd` -> `427290aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1690865132,
-        "narHash": "sha256-9sSe66mcbfCEzyOpcRDqBxojb18iQez/fKi2hUPs1dk=",
+        "lastModified": 1690886209,
+        "narHash": "sha256-Rtp3tsi6IaO4xQ8nDJCprMDeO1g/j1kNu7ByRv53vlU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "613eb3bdb2a6579fd13895daf890470190d4bb9b",
+        "rev": "427290aa4ff074cfe31f3abd439bb9d1d24f6fc8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`427290aa`](https://github.com/nix-community/emacs-overlay/commit/427290aa4ff074cfe31f3abd439bb9d1d24f6fc8) | `` Updated repos/melpa `` |
| [`c2f27863`](https://github.com/nix-community/emacs-overlay/commit/c2f278632a1e768540797c7cf08a8ec5f6658396) | `` Updated repos/emacs `` |