### PR TITLE
chore(flake/nur): `6fa0b49d` -> `9698007e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690871766,
-        "narHash": "sha256-3Lu6IvWD8KZajnhLSFpHeVYfqDhkaD3RbQn4qht48no=",
+        "lastModified": 1690890402,
+        "narHash": "sha256-+UC9m4g5iBZ8CRuR/OgVy1MUQfnmPisxy6XzBcu4BKE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6fa0b49d376000c13418f599c3565a4a38d2dfd4",
+        "rev": "9698007ef8913af0ebd07a70ffc95e5861451af2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9698007e`](https://github.com/nix-community/NUR/commit/9698007ef8913af0ebd07a70ffc95e5861451af2) | `` automatic update `` |
| [`00563603`](https://github.com/nix-community/NUR/commit/005636034ab29c6c8ab31784d8359ea6ca9477f0) | `` automatic update `` |
| [`920806cf`](https://github.com/nix-community/NUR/commit/920806cfb6d5298851f60140808f99f794d56642) | `` automatic update `` |