### PR TITLE
chore(flake/nur): `9698007e` -> `0982ef72`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690890402,
-        "narHash": "sha256-+UC9m4g5iBZ8CRuR/OgVy1MUQfnmPisxy6XzBcu4BKE=",
+        "lastModified": 1690894712,
+        "narHash": "sha256-THgErV4TIWDtvgaMgkx3B2yAaqegokCwxuZ3Qq3hKjA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9698007ef8913af0ebd07a70ffc95e5861451af2",
+        "rev": "0982ef7216827190b6b9455925d5e347093af5ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0982ef72`](https://github.com/nix-community/NUR/commit/0982ef7216827190b6b9455925d5e347093af5ab) | `` automatic update `` |