### PR TITLE
chore(flake/nixpkgs): `fb942492` -> `9e1960bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -827,11 +827,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1690789960,
-        "narHash": "sha256-3K+2HuyGTiJUSZNJxXXvc0qj4xFx1FHC/ItYtEa7/Xs=",
+        "lastModified": 1690881714,
+        "narHash": "sha256-h/nXluEqdiQHs1oSgkOOWF+j8gcJMWhwnZ9PFabN6q0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fb942492b7accdee4e6d17f5447091c65897dde4",
+        "rev": "9e1960bc196baf6881340d53dccb203a951745a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                  |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`57304313`](https://github.com/NixOS/nixpkgs/commit/573043135592bb27f5b5e7214d7b8ce8f1493845) | `` phrase-cli: 2.8.2 -> 2.8.4 ``                                                         |
| [`9c13db21`](https://github.com/NixOS/nixpkgs/commit/9c13db213589ab77b57538b6c29c7480426a0b12) | `` python310Packages.subarulink: 0.7.6-1 -> 0.7.7 ``                                     |
| [`f6cc80e7`](https://github.com/NixOS/nixpkgs/commit/f6cc80e7932b0f3664cd7637fc43bda3ec5e7f04) | `` python311Packages.async-lru: 2.0.3 -> 2.0.4 ``                                        |
| [`2838d990`](https://github.com/NixOS/nixpkgs/commit/2838d990639de962915b9701b1b0e3bc85938265) | `` circt: refactor patch to substituteInPlace ``                                         |
| [`b5de13f7`](https://github.com/NixOS/nixpkgs/commit/b5de13f73a66e3b9e5378b2876394957b4207b95) | `` python310Packages.accelerate: 0.19.0 -> 0.21.0 ``                                     |
| [`0c388c5c`](https://github.com/NixOS/nixpkgs/commit/0c388c5c9d72e0479156b7cc2ad29476ad70d330) | `` v2ray-domain-list-community: 20230725085751 -> 20230730120627 ``                      |
| [`69a9c350`](https://github.com/NixOS/nixpkgs/commit/69a9c3509e4799f19921b36228607b960e409d5a) | `` dbip-country-lite: 2023-07 -> 2023-08 ``                                              |
| [`b13c0104`](https://github.com/NixOS/nixpkgs/commit/b13c0104a6e4758b47c447db64872753c330c7fc) | `` terraform-providers.tencentcloud: 1.81.17 -> 1.81.18 ``                               |
| [`b0b6752a`](https://github.com/NixOS/nixpkgs/commit/b0b6752ad4d30d6f0bbebaff37feac75a6905d18) | `` terraform-providers.yandex: 0.95.0 -> 0.96.1 ``                                       |
| [`24631ebe`](https://github.com/NixOS/nixpkgs/commit/24631ebe1f85a52312031169415964df2b6d2266) | `` terraform-providers.snowflake: 0.68.2 -> 0.69.0 ``                                    |
| [`b2e3b4f6`](https://github.com/NixOS/nixpkgs/commit/b2e3b4f6b844e3f27084dbc5a065a8e0a4c3a8bd) | `` terraform-providers.opennebula: 1.2.2 -> 1.3.0 ``                                     |
| [`10161f84`](https://github.com/NixOS/nixpkgs/commit/10161f84e3ea759816a53658ee39f6527af89c41) | `` terraform-providers.google-beta: 4.75.1 -> 4.76.0 ``                                  |
| [`615056cb`](https://github.com/NixOS/nixpkgs/commit/615056cba5fcc681a4253e97f3697e84e54a4fd8) | `` terraform-providers.huaweicloud: 1.52.1 -> 1.53.0 ``                                  |
| [`f9d80454`](https://github.com/NixOS/nixpkgs/commit/f9d8045440b2e11f9e989faaadc896cac638601e) | `` terraform-providers.google: 4.75.1 -> 4.76.0 ``                                       |
| [`c177cbaf`](https://github.com/NixOS/nixpkgs/commit/c177cbaf2e88305b4a40cd6cd1a23a692030cc59) | `` terraform-providers.alicloud: 1.208.0 -> 1.208.1 ``                                   |
| [`47528410`](https://github.com/NixOS/nixpkgs/commit/47528410f55973504a610c7a21ea2f52e80eef02) | `` terraform-providers.buildkite: 0.21.2 -> 0.22.0 ``                                    |
| [`891b97ca`](https://github.com/NixOS/nixpkgs/commit/891b97ca5c6524d1416e9e8a9fa3b7efd3062751) | `` offpunk: 1.9.2 -> 1.10 ``                                                             |
| [`444797ac`](https://github.com/NixOS/nixpkgs/commit/444797ac0240a84157d685ab9513bfc7bdd568ff) | `` circt: fix version info ``                                                            |
| [`43696083`](https://github.com/NixOS/nixpkgs/commit/436960830627e55d8e6c601be064ceda52ec6f6c) | `` circt: 1.45.0 -> 1.48.0 ``                                                            |
| [`9c5f0aac`](https://github.com/NixOS/nixpkgs/commit/9c5f0aacfa8f4dc1aa082e80359b617a2e7aa965) | `` allure: 2.23.0 -> 2.23.1 ``                                                           |
| [`97588fcd`](https://github.com/NixOS/nixpkgs/commit/97588fcdb27354c3226e658cda3c50588def21f1) | `` polaris: 0.13.5 -> 0.14.0 ``                                                          |
| [`14fe716c`](https://github.com/NixOS/nixpkgs/commit/14fe716c14b6b236e2d85a26de0cc11187407df6) | `` python310Packages.google-cloud-translate: 3.11.2 -> 3.11.3 ``                         |
| [`5ea94a7d`](https://github.com/NixOS/nixpkgs/commit/5ea94a7d2c3ff7c0222b39519e17b451c0e2d739) | `` grype: 0.64.2 -> 0.65.0 ``                                                            |
| [`6fce47d4`](https://github.com/NixOS/nixpkgs/commit/6fce47d4d1c7f4a5687c0f9a69b2b253944c4c6d) | `` prometheus-sachet: 0.3.1 -> 0.3.2 ``                                                  |
| [`c52ce848`](https://github.com/NixOS/nixpkgs/commit/c52ce848e88d9f32d4c863e67fd7d7333b1b42cf) | `` vscode-extensions.usernamehw.errorlens: 3.8.0 -> 3.12.0 ``                            |
| [`96d403ee`](https://github.com/NixOS/nixpkgs/commit/96d403ee2479f2070050353b94808209f1352edb) | `` pythia: 8.309 -> 8.310 (#246455) ``                                                   |
| [`019d9ec5`](https://github.com/NixOS/nixpkgs/commit/019d9ec5d9013ccc311e52a42870df6c8c402c7a) | `` aravis: 0.8.27 -> 0.8.28 ``                                                           |
| [`30e4b015`](https://github.com/NixOS/nixpkgs/commit/30e4b015dfce1b8111ebcb3277e8b6660c5f2f90) | `` bacon: 2.12.0 -> 2.12.1 ``                                                            |
| [`bafc87ee`](https://github.com/NixOS/nixpkgs/commit/bafc87ee1279f9f10690056df15066258b4f310b) | `` ast-grep: 0.9.2 -> 0.10.0 ``                                                          |
| [`80d4b035`](https://github.com/NixOS/nixpkgs/commit/80d4b03586abb6a8b5aba586ee185191efebde45) | `` assemblyscript: 0.27.5 -> 0.27.6 ``                                                   |
| [`65047c0c`](https://github.com/NixOS/nixpkgs/commit/65047c0c0f7a685bf1c88854311a1a624064b642) | `` libgpiod: drop outdated patch ``                                                      |
| [`bc5fd403`](https://github.com/NixOS/nixpkgs/commit/bc5fd40358eb13325c1f68c0e1f375f9cb147f9a) | `` libgpiod: fix src hash ``                                                             |
| [`f6ac56eb`](https://github.com/NixOS/nixpkgs/commit/f6ac56ebed3476362d4424c7b87519b68e96e509) | `` bazarr: 1.2.3 -> 1.2.4 ``                                                             |
| [`aeeda1c3`](https://github.com/NixOS/nixpkgs/commit/aeeda1c346453f037ab4d95bffd89b16eac225a1) | `` bearer: 1.16.0 -> 1.17.0 ``                                                           |
| [`7d4892c6`](https://github.com/NixOS/nixpkgs/commit/7d4892c6876d2ed772042c31471da64f97e488a4) | `` maintainers: remove mcbeth ``                                                         |
| [`01644616`](https://github.com/NixOS/nixpkgs/commit/0164461684445b87208aa73cf3f456e55e8cb832) | `` qrcodegen: refactor ``                                                                |
| [`e98bea13`](https://github.com/NixOS/nixpkgs/commit/e98bea13f9aa88cf06a3ad0a69d4739b6207e72d) | `` aliyun-cli: 3.0.169 -> 3.0.170 ``                                                     |
| [`bff917a3`](https://github.com/NixOS/nixpkgs/commit/bff917a3ed37b1f9e705b5c07210acd295691770) | `` AusweisApp2: 1.26.5 -> 1.26.7 ``                                                      |
| [`d78c7243`](https://github.com/NixOS/nixpkgs/commit/d78c7243b329d9fb74d8687e4c23c1150a094fca) | `` farge: fix dependencies & font issue ``                                               |
| [`65023ddb`](https://github.com/NixOS/nixpkgs/commit/65023ddb58d728bb998d9019e5aae773de9f636e) | `` maintainers.anselmschueler: add pgp key ``                                            |
| [`2107f93e`](https://github.com/NixOS/nixpkgs/commit/2107f93efce9e3495842672c59be97947ffbae07) | `` weechat: set mainProgram ``                                                           |
| [`9f51c70b`](https://github.com/NixOS/nixpkgs/commit/9f51c70b4f37cb70d918dfd566184f04c8bc7615) | `` maintainers: add justinlime ``                                                        |
| [`684f3c72`](https://github.com/NixOS/nixpkgs/commit/684f3c72b469c359dc5057c2468c4ebc5971c138) | `` skhd: use `finalAttrs` pattern ``                                                     |
| [`a8b50538`](https://github.com/NixOS/nixpkgs/commit/a8b5053805b3a9734000c20475d5eeb2eafb0fd1) | `` skhd: 0.3.5 -> 0.3.9 ``                                                               |
| [`062b7457`](https://github.com/NixOS/nixpkgs/commit/062b745704093f27ec938c8df6dc9c7f00ae8034) | `` sagoin: 0.2.2 -> 0.2.3 ``                                                             |
| [`925f72c6`](https://github.com/NixOS/nixpkgs/commit/925f72c696727156f4066729c29fbcee8d853cd2) | `` dune_3: 3.9.2 -> 3.10.0 ``                                                            |
| [`d32e0305`](https://github.com/NixOS/nixpkgs/commit/d32e030506c510069c1f594ba2a611deb56a65d9) | `` vscode-extensions.mkhl.direnv: 0.13.0 -> 0.14.0 ``                                    |
| [`57f4bdf4`](https://github.com/NixOS/nixpkgs/commit/57f4bdf484c4d5d64c3ea5576ebbc85dd635afc4) | `` git-cinnabar: use `finalAttrs` pattern ``                                             |
| [`78da6da2`](https://github.com/NixOS/nixpkgs/commit/78da6da249f1a3c608803d0049487bc898327633) | `` python311Packages.pywemo: 1.1.0 -> 1.2.0 ``                                           |
| [`e278cb21`](https://github.com/NixOS/nixpkgs/commit/e278cb21fd41386cd717f43b04283cd693be297d) | `` python311Packages.python-roborock: 0.30.2 -> 0.30.3 ``                                |
| [`e84e4e46`](https://github.com/NixOS/nixpkgs/commit/e84e4e46d5fbd3140c5a9a88ba8b2925f8643113) | `` tilt: 0.33.1 -> 0.33.3 ``                                                             |
| [`124f4800`](https://github.com/NixOS/nixpkgs/commit/124f4800ff86667bcf1ce3a5d1c587f7ebc41d98) | `` apkid: 2.1.4 -> 2.1.5 ``                                                              |
| [`eee1968d`](https://github.com/NixOS/nixpkgs/commit/eee1968d375560eea1c392132a7b2dfb34cbfc96) | `` vscode-extensions.dotenv.dotenv-vscode: init at 0.28.0 ``                             |
| [`3f525f2c`](https://github.com/NixOS/nixpkgs/commit/3f525f2cb90e972e0c0492ec1e429ffb8e3f16f6) | `` vscode-extensions.enkia.tokyo-night: init at 1.0.0 ``                                 |
| [`fb22f5b8`](https://github.com/NixOS/nixpkgs/commit/fb22f5b887f82604ed0536d268e655e4b3435eee) | `` vscode-extensions.unifiedjs.vscode-mdx: init at 1.4.0 ``                              |
| [`637af7a0`](https://github.com/NixOS/nixpkgs/commit/637af7a0fc7cd6b0ae3485feba896bb3eea0728e) | `` vscode-extensions.bierner.docs-view: init at 0.0.11 ``                                |
| [`869f62aa`](https://github.com/NixOS/nixpkgs/commit/869f62aa48fa76aa0909f80630c8517a7f09ff0a) | `` vscode-extensions.wmaurer.change-case: init at 1.0.0 ``                               |
| [`4e862547`](https://github.com/NixOS/nixpkgs/commit/4e862547cca09b1354dd8fb4a212f1568b62cbb0) | `` vscode-extensions.emroussel.atomize-atom-one-dark-theme: init at 2.0.2 ``             |
| [`c613ccf1`](https://github.com/NixOS/nixpkgs/commit/c613ccf1f878481762e7e5ff9a6b3d16f58ac3bd) | `` python310Packages.types-tabulate: 0.9.0.2 -> 0.9.0.3 ``                               |
| [`544eb3d6`](https://github.com/NixOS/nixpkgs/commit/544eb3d6faee05138c0c1c9299f7e5eaf751574b) | `` python311Packages.reolink-aio: 0.7.3 -> 0.7.6 ``                                      |
| [`30464bb5`](https://github.com/NixOS/nixpkgs/commit/30464bb5c54d8c706443f433db6777284b8a99d2) | `` treewide: fix mvnHash ``                                                              |
| [`e658ffa9`](https://github.com/NixOS/nixpkgs/commit/e658ffa994c2e356fb9387c02e5204df5e590a94) | `` treewide: cleanup maven packages ``                                                   |
| [`e0f32f89`](https://github.com/NixOS/nixpkgs/commit/e0f32f89449cbd52c8cf24050c10a5ff61f03510) | `` buildMavenPackage: inherit maven ``                                                   |
| [`bc65031e`](https://github.com/NixOS/nixpkgs/commit/bc65031eba8feef02db5e0f868c366cd966cbe12) | `` yuzu-ea: 3702 -> 3783, yuzu-mainline: 1475 -> 1513 ``                                 |
| [`d64cc4bd`](https://github.com/NixOS/nixpkgs/commit/d64cc4bd17f6a377cb7cedfe1f4da245d5a9d13a) | `` imagemagick: 7.1.1-14 -> 7.1.1-15 ``                                                  |
| [`516ca7d8`](https://github.com/NixOS/nixpkgs/commit/516ca7d8a332ae784d0f4c06d460aa61dd11b463) | `` notes: init at 2.2.0 ``                                                               |
| [`5f68deff`](https://github.com/NixOS/nixpkgs/commit/5f68deff215080ef3ecdf9a5b1a7bf866cfc70d8) | `` nerdctl: 1.4.0 -> 1.5.0 ``                                                            |
| [`3a9486d6`](https://github.com/NixOS/nixpkgs/commit/3a9486d67a42e67755364390059ab5b883fc3a68) | `` urn-timer: unstable-2023-07-01 -> unstable-2023-07-31 ``                              |
| [`2df128a4`](https://github.com/NixOS/nixpkgs/commit/2df128a4eff1681a9c9091fec5a72e5bfb7ab3dd) | `` python310Packages.graphene: 3.2.2 -> 3.3.0 ``                                         |
| [`26e8499f`](https://github.com/NixOS/nixpkgs/commit/26e8499f22ba8ba5005f6a573d2d4df453e56d33) | `` minify: 2.12.7 -> 2.12.8 ``                                                           |
| [`8ab3c9ed`](https://github.com/NixOS/nixpkgs/commit/8ab3c9edf8bb695d1004fd9a4c9f30043088386f) | `` process-compose: 0.51.4 -> 0.60.0 ``                                                  |
| [`458308d1`](https://github.com/NixOS/nixpkgs/commit/458308d15f23149c9466879847e4e36ce1396fc5) | `` maintainers: add koralowiec ``                                                        |
| [`946f7868`](https://github.com/NixOS/nixpkgs/commit/946f7868f04239d2285cb06ed3a0c9d04b0e534c) | `` kubectl-explore: init at 0.7.1 ``                                                     |
| [`02169286`](https://github.com/NixOS/nixpkgs/commit/021692865a0e1fbce7d32be7f289f2041299bd31) | `` matrix-synapse.plugins.matrix-synapse-s3-storage-provider: init at 1.2.1 (#229192) `` |
| [`89ed1546`](https://github.com/NixOS/nixpkgs/commit/89ed15464cdd0b21ed0bfd87f86be5e5256843fa) | `` libgudev: fix cross ``                                                                |
| [`63ac8333`](https://github.com/NixOS/nixpkgs/commit/63ac833319dd7e85aa400b8134b8966cff972ab1) | `` obsidian: 1.3.5 -> 1.3.7 ``                                                           |
| [`6a08fa52`](https://github.com/NixOS/nixpkgs/commit/6a08fa5215193c4ff599b2c5e37da0f42f0cb492) | `` juicity: 0.1.0 -> 0.1.1 ``                                                            |
| [`930080b0`](https://github.com/NixOS/nixpkgs/commit/930080b04eceda49805a9250dfc66169d8cb9bda) | `` python310Packages.aiopvpc: 4.2.1 -> 4.2.2 ``                                          |
| [`bb2fd1be`](https://github.com/NixOS/nixpkgs/commit/bb2fd1be106ae26671b4a5533199401ba3b9cbd0) | `` botan: fix cross compilation on aarch64 ``                                            |
| [`e75a8ae6`](https://github.com/NixOS/nixpkgs/commit/e75a8ae64834b45486c5b1e322b4b178ffc85f97) | `` karma: 0.114 -> 0.115 ``                                                              |
| [`b0e1416a`](https://github.com/NixOS/nixpkgs/commit/b0e1416a6b7fff4e3c4c837d1d7b0cf4910e63e3) | `` karma: use buildNpmPackage ``                                                         |
| [`0ccd0c3c`](https://github.com/NixOS/nixpkgs/commit/0ccd0c3c3e31e72592dc46e371ec77690795da78) | `` spectacle: backport a patch to fix region capture preview being misaligned ``         |
| [`21ad1050`](https://github.com/NixOS/nixpkgs/commit/21ad1050bf67f6a31acc38d41b7999e1a0bd0ca0) | `` gopls: 0.12.4 -> 0.13.0 (#246366) ``                                                  |
| [`022d53ed`](https://github.com/NixOS/nixpkgs/commit/022d53ede9c920f28e97e83794798e2dfa9c49dc) | `` python310Packages.ttstokenizer: init at 1.0.0 ``                                      |
| [`daa869b5`](https://github.com/NixOS/nixpkgs/commit/daa869b53b560ca9a0acfb9c6f26924466a15cdb) | `` tracker: fix cross using mesonEmulatorHook ``                                         |
| [`0cfbbe92`](https://github.com/NixOS/nixpkgs/commit/0cfbbe928a6b94d4d38b9341a8d3972f55462c2d) | `` python310Packages.mypy-boto3-s3: 1.28.12 -> 1.28.15.post1 ``                          |
| [`38a927f1`](https://github.com/NixOS/nixpkgs/commit/38a927f1fb7719ed13bc13a6a419a923297fda05) | `` nixdoc: 2.3.0 -> 2.4.0 ``                                                             |
| [`9520bdd0`](https://github.com/NixOS/nixpkgs/commit/9520bdd08839adb23d5750fb659871273e197038) | `` code-server: 4.15.0 -> 4.16.0 ``                                                      |
| [`9ea70cf7`](https://github.com/NixOS/nixpkgs/commit/9ea70cf76f37f31c63626ef47bdf5e3727633184) | `` backintime-common: add missing dependency 'packaging' ``                              |
| [`6dfbb7c8`](https://github.com/NixOS/nixpkgs/commit/6dfbb7c89f716038a2567d6eb6f7f86e52cc876f) | `` ocamlPackages.ptime: use `finalAttrs` pattern ``                                      |
| [`9d789710`](https://github.com/NixOS/nixpkgs/commit/9d78971007802fc8c4a30cb9e64645b624a6e4ab) | `` nixos/boot/initrd-network: add option to enable udhcpc (#240406) ``                   |
| [`70bd808e`](https://github.com/NixOS/nixpkgs/commit/70bd808e818e26175b4b82635e0ebaf523be3652) | `` mastodon: 4.1.5 -> 4.1.6 (#246348) ``                                                 |
| [`07c88c96`](https://github.com/NixOS/nixpkgs/commit/07c88c96579b2e51fa4055256ad5b7d149e3523e) | `` python310Packages.pyvista: 0.40.1 -> 0.41.1 ``                                        |
| [`819bb53c`](https://github.com/NixOS/nixpkgs/commit/819bb53c2c49065ece6bfc4eb5d97eff08f0eda4) | `` nvc: 1.10.0 -> 1.10.1 ``                                                              |
| [`a72614f0`](https://github.com/NixOS/nixpkgs/commit/a72614f09300b02e79bef0193fe2d0a579a5aa9e) | `` python310Packages.mwdblib: 4.4.0 -> 4.5.0 ``                                          |
| [`c1b8959e`](https://github.com/NixOS/nixpkgs/commit/c1b8959ecdf8dd3ad26ff7bd2498234a2bb9b06c) | `` rehex: 0.5.4 -> 0.60.1 ``                                                             |
| [`25dc50e6`](https://github.com/NixOS/nixpkgs/commit/25dc50e6df4818aea2001f604dc8d2e87d949f09) | `` python310Packages.azure-mgmt-network: 23.1.0 -> 24.0.0 ``                             |
| [`0445837c`](https://github.com/NixOS/nixpkgs/commit/0445837cc7aeb9ad73c51f20ba0b71295be367cc) | `` nixos/fish: fix cross build ``                                                        |
| [`403f35e9`](https://github.com/NixOS/nixpkgs/commit/403f35e92ff9bd82be6f23b82dcbeccb6e8f14d9) | `` proxysql: use `finalAttrs` pattern ``                                                 |
| [`31d4a4af`](https://github.com/NixOS/nixpkgs/commit/31d4a4af19f34cf1e3df9f6760396e3f133425fc) | `` nixos/bird: fix checkConfig with cross-compilation ``                                 |
| [`24e2bb4e`](https://github.com/NixOS/nixpkgs/commit/24e2bb4e8c09ff245162860f0201a1e1a3f68dc0) | `` amdgpu_top: 0.1.9 -> 0.1.11 ``                                                        |
| [`86a31e1e`](https://github.com/NixOS/nixpkgs/commit/86a31e1efa4418d18c0a7c1c7936b5b7511b493d) | `` init tesh at 0.3.0: TEstable SHell sessions in Markdown ``                            |
| [`72d4cb47`](https://github.com/NixOS/nixpkgs/commit/72d4cb47279ab49c6de2121f6c7a4fd7999e6d5b) | `` hugo: 0.115.4 -> 0.116.0 ``                                                           |
| [`b6adf477`](https://github.com/NixOS/nixpkgs/commit/b6adf477384bdb5f2237c0efaaab05be77021798) | `` python310Packages.azure-mgmt-authorization: 3.0.0 -> 4.0.0 ``                         |
| [`4b3d2bd4`](https://github.com/NixOS/nixpkgs/commit/4b3d2bd40e18fd326432decf70a92cb11af1c1f1) | `` maintainers: add knightpp ``                                                          |
| [`79e370f2`](https://github.com/NixOS/nixpkgs/commit/79e370f220bfa77cb6e818500876038ab00666a2) | `` espup: init at 0.4.1 ``                                                               |
| [`0b5456b3`](https://github.com/NixOS/nixpkgs/commit/0b5456b363efbe38e14b7481f990f8de535165a5) | `` firefox-unwrapped: 115.0.2 -> 115.0.3 (#246324) ``                                    |
| [`48d622fe`](https://github.com/NixOS/nixpkgs/commit/48d622fe551fb2a269a0260e35593b97432b31b6) | `` git-cinnabar: 0.6.1 -> 0.6.2 ``                                                       |
| [`07347b53`](https://github.com/NixOS/nixpkgs/commit/07347b5352cd1ba9f80930690638980600a503ee) | `` texstudio: qt5 -> qt6 ``                                                              |
| [`f66a1742`](https://github.com/NixOS/nixpkgs/commit/f66a17427221bbbb76bdd5ef8011030341c4a457) | `` texstudio: 4.5.2 -> 4.6.2 ``                                                          |
| [`e513d4f7`](https://github.com/NixOS/nixpkgs/commit/e513d4f71f7d2b06c60e54e9a3f31561eea1d636) | `` semgrep{,-core}: 1.27.0 -> 1.34.1 ``                                                  |
| [`bcb34716`](https://github.com/NixOS/nixpkgs/commit/bcb347160cb0b728048a4435d674b8fb28a51a31) | `` matrix-hookshot: 4.4.0 -> 4.4.1 ``                                                    |
| [`237fb148`](https://github.com/NixOS/nixpkgs/commit/237fb1483246285ce1ed60e6ab40d760a8f7af06) | `` matrix-appservice-slack: 2.1.1 -> 2.1.2 ``                                            |
| [`3b0560c6`](https://github.com/NixOS/nixpkgs/commit/3b0560c6d93c0be269c31b4910e1c6cff3df569e) | `` unifi-protect-backup: 0.9.1 -> 0.9.4 ``                                               |
| [`69bc2ad7`](https://github.com/NixOS/nixpkgs/commit/69bc2ad72fb743b7581a01c59e73a839a6d83c87) | `` matrix-appservice-irc: 0.38.0 -> 1.0.1 ``                                             |
| [`b4395db6`](https://github.com/NixOS/nixpkgs/commit/b4395db6756b2872fadbd8060d35a8a2e1f23f5b) | `` hmcl: init at 3.5.5 ``                                                                |
| [`27a2a7e5`](https://github.com/NixOS/nixpkgs/commit/27a2a7e519b8014130a4af846a92bd0668bd1c5b) | `` trino-cli: 418 -> 422 ``                                                              |
| [`8c028ce6`](https://github.com/NixOS/nixpkgs/commit/8c028ce6ff47689f444f77fc66baf8a898021381) | `` maintainers: add rs0vere ``                                                           |
| [`bf287a02`](https://github.com/NixOS/nixpkgs/commit/bf287a02caa56ce0c71e01723315894af2f062d0) | `` gnubg: add desktop item ``                                                            |
| [`45cbde5b`](https://github.com/NixOS/nixpkgs/commit/45cbde5b8d7f193faacb00828509dce5f26131eb) | `` gnubg: 1.06.002 -> 1.07.001 ``                                                        |
| [`fcc76889`](https://github.com/NixOS/nixpkgs/commit/fcc768897b8c42690aabd2f481ecf73138969cad) | `` vengi-tools: 0.0.24 -> 0.0.25 ``                                                      |
| [`ad796a73`](https://github.com/NixOS/nixpkgs/commit/ad796a732d0bc85fd0c68c33ca8f388cebbb021d) | `` keycloak-scim-user-storage-api: 20230412 -> 20230710 ``                               |
| [`956bdd6f`](https://github.com/NixOS/nixpkgs/commit/956bdd6f2268a0ba2fe9b95d6842b570bb36065f) | `` ogre_14: init at 14.0.1 ``                                                            |
| [`c1d8ad53`](https://github.com/NixOS/nixpkgs/commit/c1d8ad53ece0a509091529f1f89cc4c2ae67bc94) | `` sketchybar: use `finalAttrs` pattern ``                                               |
| [`f4105cf5`](https://github.com/NixOS/nixpkgs/commit/f4105cf5bad6553b2bf8f29bde724bee7e075ac9) | `` ghorg: 1.9.6 -> 1.9.7 ``                                                              |
| [`012ff4f8`](https://github.com/NixOS/nixpkgs/commit/012ff4f8b039d5f78a1b4e38a4b1c0261e5b1efd) | `` keycloak.plugins.keycloak-metrics-spi: build from source ``                           |
| [`dd1154c1`](https://github.com/NixOS/nixpkgs/commit/dd1154c11c5bda5e36cb132a3ef43f68e58afb68) | `` go-task: 3.27.1 -> 3.28.0 ``                                                          |
| [`0bd14a0c`](https://github.com/NixOS/nixpkgs/commit/0bd14a0cc02d2b5f9978c41c452662df8bc403fc) | `` d2: 0.5.1 -> 0.6.0 ``                                                                 |
| [`45a973d3`](https://github.com/NixOS/nixpkgs/commit/45a973d3f0e68dbf5cd4d267a097c5329dc9d850) | `` grcov: 0.8.18 -> 0.8.19 ``                                                            |
| [`7e54422b`](https://github.com/NixOS/nixpkgs/commit/7e54422bf9c323ce1aef3063dcd1108910b2b4c8) | `` ledger-live-desktop: 2.64.1 -> 2.64.2 ``                                              |
| [`d213d1e1`](https://github.com/NixOS/nixpkgs/commit/d213d1e173c657498d408a92fbdacef955d51e3b) | `` ocamlPackages.ptime: 1.0.0 -> 1.1.0 ``                                                |
| [`95c39466`](https://github.com/NixOS/nixpkgs/commit/95c3946692836205b2a5d26f6d06a6f1611034d4) | `` skhd: add khaneliman as maintainer ``                                                 |
| [`4986e8bf`](https://github.com/NixOS/nixpkgs/commit/4986e8bf74fe2ec62d4384c7508d98b3fbc2f5f0) | `` mame: 0.256 -> 0.257 ``                                                               |
| [`05277105`](https://github.com/NixOS/nixpkgs/commit/0527710541cd2eab6a43206ad4d72dc4e6a6787f) | `` sketchybar: 2.15.1 -> 2.15.2 ``                                                       |
| [`fb8f43e5`](https://github.com/NixOS/nixpkgs/commit/fb8f43e5bfdd76bb6140e3ab1dd72a479843def8) | `` sketchybar: add khaneliman as maintainer ``                                           |
| [`9f6754b7`](https://github.com/NixOS/nixpkgs/commit/9f6754b7ae4b30307133300e6975b9702f6763d3) | `` farge: init at 1.0.9 ``                                                               |
| [`42255e72`](https://github.com/NixOS/nixpkgs/commit/42255e72642f8ad144ed47a1373a423523a7fd50) | `` maintainers: add jtbx ``                                                              |
| [`c3591639`](https://github.com/NixOS/nixpkgs/commit/c3591639b0b3377158e5b0806041c943d53bbfa0) | `` grype: 0.64.0 -> 0.64.2 ``                                                            |
| [`0610720d`](https://github.com/NixOS/nixpkgs/commit/0610720dadffe0aa77a72fa7a92fb643f1ea8337) | `` apple_sdk_11_0: Add MediaRemote private framework ``                                  |
| [`ff10792a`](https://github.com/NixOS/nixpkgs/commit/ff10792ad121277cd09a0be73c22975066844eb8) | `` helmsman: 3.16.4 -> 3.17.0 ``                                                         |