### PR TITLE
chore(flake/home-manager): `4542db60` -> `8c731978`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690887397,
-        "narHash": "sha256-ckasuN7MgAiDgLkUo1IdEq8FEKymcUWKzmY6/R9KOOo=",
+        "lastModified": 1690910850,
+        "narHash": "sha256-diLPKIDpR9zubqGl0wPFKMNPV9QpT/eNkqUN2dSt19o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4542db605602898fe0c431e19f01e1af2865dae8",
+        "rev": "8c731978f0916b9a904d67a0e53744ceff47882c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`8c731978`](https://github.com/nix-community/home-manager/commit/8c731978f0916b9a904d67a0e53744ceff47882c) | `` nushell: deprecation of let-env (#4292) `` |