### PR TITLE
chore(flake/nur): `7022b887` -> `2dda5b64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690904771,
-        "narHash": "sha256-CE3z+fD1RBxDhjPS1O6/6veTehCKpi4o3pjjl0sfsGo=",
+        "lastModified": 1690919193,
+        "narHash": "sha256-Vb3iT3g+XphFczMKYlpff7uwVul6clh8kjS1VFsOcqw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7022b8873656b25b057d6e8ff542e990acd16247",
+        "rev": "2dda5b64cb5682ba4cdd33045adfd875a5b08e67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2dda5b64`](https://github.com/nix-community/NUR/commit/2dda5b64cb5682ba4cdd33045adfd875a5b08e67) | `` automatic update `` |
| [`23cc2f27`](https://github.com/nix-community/NUR/commit/23cc2f271009ca00ef891b9b9adef0a6274e211c) | `` automatic update `` |
| [`6580069c`](https://github.com/nix-community/NUR/commit/6580069cef5a8826972840430b4c595d1cd44621) | `` automatic update `` |
| [`c0e1ffe4`](https://github.com/nix-community/NUR/commit/c0e1ffe4edd797f72da42c2f04bad774286de2f7) | `` automatic update `` |