### PR TITLE
chore(flake/emacs-overlay): `427290aa` -> `bf8fea22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1690886209,
-        "narHash": "sha256-Rtp3tsi6IaO4xQ8nDJCprMDeO1g/j1kNu7ByRv53vlU=",
+        "lastModified": 1690914454,
+        "narHash": "sha256-UfUEewyikRVJOi6E857US6dUyIqgvNPlB2XABghfCAc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "427290aa4ff074cfe31f3abd439bb9d1d24f6fc8",
+        "rev": "bf8fea22b4d5a5c59837c11d4675d4aa3a312957",
         "type": "github"
       },
       "original": {
@@ -749,11 +749,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1690726002,
-        "narHash": "sha256-cACz6jCJZtsZHGCJAN4vMobxzH5s6FCOTZHMrh/Hu0M=",
+        "lastModified": 1690835256,
+        "narHash": "sha256-SZy/Nvwbf6CorhEsvmjqgjoYNLnRfaKVZMfSnpUDPnc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "391e8db1f06c3f74c2d313a73135515023af3993",
+        "rev": "b7cde1c47b7316f6138a2b36ef6627f3d16d645c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`bf8fea22`](https://github.com/nix-community/emacs-overlay/commit/bf8fea22b4d5a5c59837c11d4675d4aa3a312957) | `` Updated repos/melpa ``  |
| [`f6e88d37`](https://github.com/nix-community/emacs-overlay/commit/f6e88d37f1fd7b378274534bbc51017896adda99) | `` Updated repos/emacs ``  |
| [`2fe6f1fa`](https://github.com/nix-community/emacs-overlay/commit/2fe6f1faa09356b52aa9ac2386fceb3083d5182e) | `` Updated repos/elpa ``   |
| [`ae1b93b1`](https://github.com/nix-community/emacs-overlay/commit/ae1b93b12f369bcdbd9020b82c834275cc1189f2) | `` Updated flake inputs `` |