### PR TITLE
chore(flake/dendrite-demo-pinecone): `152b80ae` -> `8d9e5f7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1690852553,
-        "narHash": "sha256-wl0zoADrFo6HUiMPDsjOx4xz2JMIpBurYWJUvlHo73I=",
+        "lastModified": 1690930834,
+        "narHash": "sha256-z1HxsWFK+MH5rgzHruSZ8GmYaRJqO+bLw0eBRW90g70=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "152b80ae9953552f5e6d8ffc4afad34de0314d68",
+        "rev": "8d9e5f7d4d277a6ba70a662b6fb49341bd79264c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                           |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`8d9e5f7d`](https://github.com/bbigras/dendrite-demo-pinecone/commit/8d9e5f7d4d277a6ba70a662b6fb49341bd79264c) | `` test fix PR with auto-merge `` |