### PR TITLE
chore(flake/nur): `e38f56ea` -> `a5531907`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690926309,
-        "narHash": "sha256-o7iKYSiQ4UAYBeOVShm/bF0wIU27Hgo5IzzgcqC0U0U=",
+        "lastModified": 1690933173,
+        "narHash": "sha256-g7a1q9g3+GlQ+1TXTcD++prXISJmyP4djh+hBDBtTDw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e38f56eaa66b6b16cf0285489a00625cc03be607",
+        "rev": "a55319073fc2fc46918fb3a4cfe6c127c3f8ad37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a5531907`](https://github.com/nix-community/NUR/commit/a55319073fc2fc46918fb3a4cfe6c127c3f8ad37) | `` automatic update `` |