### PR TITLE
chore(flake/nur): `a5531907` -> `f6d937f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690933173,
-        "narHash": "sha256-g7a1q9g3+GlQ+1TXTcD++prXISJmyP4djh+hBDBtTDw=",
+        "lastModified": 1690936853,
+        "narHash": "sha256-AQCt0VQN3nMxv84/YcIYyVadfphM11vQldla80zBFo0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a55319073fc2fc46918fb3a4cfe6c127c3f8ad37",
+        "rev": "f6d937f279c396b174a29974127aac9c57f22cdb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f6d937f2`](https://github.com/nix-community/NUR/commit/f6d937f279c396b174a29974127aac9c57f22cdb) | `` automatic update `` |
| [`b33cfcce`](https://github.com/nix-community/NUR/commit/b33cfcce78c7e9d68cfc92c51e7b0609417bb194) | `` automatic update `` |