### PR TITLE
chore(flake/emacs-overlay): `bf8fea22` -> `6b676f9e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1690914454,
-        "narHash": "sha256-UfUEewyikRVJOi6E857US6dUyIqgvNPlB2XABghfCAc=",
+        "lastModified": 1690945468,
+        "narHash": "sha256-K5DXGQw0rE1MgJpH3dz9GqN7xz193arN//UpLKg5Hgg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bf8fea22b4d5a5c59837c11d4675d4aa3a312957",
+        "rev": "6b676f9e3b025a515b03295058c9af7e90ef2299",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`6b676f9e`](https://github.com/nix-community/emacs-overlay/commit/6b676f9e3b025a515b03295058c9af7e90ef2299) | `` Updated repos/melpa ``  |
| [`5ff1b929`](https://github.com/nix-community/emacs-overlay/commit/5ff1b929437f83edda31d58f724d7c04beec4b90) | `` Updated repos/emacs ``  |
| [`e5f2aff9`](https://github.com/nix-community/emacs-overlay/commit/e5f2aff9f7b83b1a654ed7d73a6b52591a60c98a) | `` Updated repos/elpa ``   |
| [`bbb1c3f2`](https://github.com/nix-community/emacs-overlay/commit/bbb1c3f284928d093fe78e46acf633558a02ebbc) | `` Updated flake inputs `` |