### PR TITLE
chore(flake/nur): `90352f1a` -> `dd3020b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690940749,
-        "narHash": "sha256-LsSrDAbHcCP005qU+fZakdLRSYW9jq5kJphQ3RJJV4A=",
+        "lastModified": 1690947759,
+        "narHash": "sha256-8DgfWDtHzmY+loIeroeGNY+TaNE+TcDujU7OcleyLNs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "90352f1aaca3426e93788517e8325afc211aa564",
+        "rev": "dd3020b8c19f300e732fd0edbaf718712cd16098",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dd3020b8`](https://github.com/nix-community/NUR/commit/dd3020b8c19f300e732fd0edbaf718712cd16098) | `` automatic update `` |
| [`12fdb073`](https://github.com/nix-community/NUR/commit/12fdb07394841081c13c18ff282d2e4f57315b2a) | `` automatic update `` |