### PR TITLE
chore(flake/nur): `dd3020b8` -> `5a308968`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690947759,
-        "narHash": "sha256-8DgfWDtHzmY+loIeroeGNY+TaNE+TcDujU7OcleyLNs=",
+        "lastModified": 1690954772,
+        "narHash": "sha256-PSJbIi4wZHrbpGpenMsu2maEAY9VzO4zGypVR30QC9M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd3020b8c19f300e732fd0edbaf718712cd16098",
+        "rev": "5a308968ec012d9f83abfd1356471efc629cdf28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5a308968`](https://github.com/nix-community/NUR/commit/5a308968ec012d9f83abfd1356471efc629cdf28) | `` automatic update `` |
| [`47ab15ab`](https://github.com/nix-community/NUR/commit/47ab15ab517b11af88a7a661a2e42d073225f8af) | `` automatic update `` |
| [`3e3bc425`](https://github.com/nix-community/NUR/commit/3e3bc42500aac64f38513d7749aefbac323ef3b1) | `` automatic update `` |