### PR TITLE
chore(flake/nixos-hardware): `96e5a0a0` -> `24f9162b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -671,11 +671,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1690704397,
-        "narHash": "sha256-sgIWjcz0e+x87xlKg324VtHgH55J5rIuFF0ZWRDvQoE=",
+        "lastModified": 1690957133,
+        "narHash": "sha256-0Y4CiOIszhHDDXHFmvHUpmhUotKOIn0m3jpMlm6zUTE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "96e5a0a0e8568c998135ea05575a9ed2c87f5492",
+        "rev": "24f9162b26f0debd163f6d94752aa2acb9db395a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`24f9162b`](https://github.com/NixOS/nixos-hardware/commit/24f9162b26f0debd163f6d94752aa2acb9db395a) | `` framework: Clarify 13th Gen Intel Core support ``       |
| [`35382904`](https://github.com/NixOS/nixos-hardware/commit/353829048c3a7c3a99346fe6686672330b1109b1) | `` microsoft-surface: update default kernel to 6.1.18 ``   |
| [`af694376`](https://github.com/NixOS/nixos-hardware/commit/af694376e2f20e6ab40bf814cad24590bed0aa9d) | `` p14s: Add common/{cpu,gpu}/amd to imports ``            |
| [`9910c698`](https://github.com/NixOS/nixos-hardware/commit/9910c6985687cf1c365bc10c95c5bacdaed81e3f) | `` GPD-P3: Remove S2 sleep kernel param, use S3 instead `` |