### PR TITLE
chore(flake/nur): `5a308968` -> `4d77f55f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690954772,
-        "narHash": "sha256-PSJbIi4wZHrbpGpenMsu2maEAY9VzO4zGypVR30QC9M=",
+        "lastModified": 1690960973,
+        "narHash": "sha256-8uBIS3fFCKHccV6iyAzg1cNdWydtE4NLADH62F9Z4Oo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5a308968ec012d9f83abfd1356471efc629cdf28",
+        "rev": "4d77f55fc328f46db035ed01dbdad8319954fd73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4d77f55f`](https://github.com/nix-community/NUR/commit/4d77f55fc328f46db035ed01dbdad8319954fd73) | `` automatic update `` |
| [`117d2d94`](https://github.com/nix-community/NUR/commit/117d2d948abd6081ff31753ddf5484e71d6674ca) | `` automatic update `` |
| [`44026986`](https://github.com/nix-community/NUR/commit/4402698663cd3b6af28045114db97a1187da36bf) | `` automatic update `` |