### PR TITLE
chore(flake/home-manager): `8c731978` -> `484a1c94`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690910850,
-        "narHash": "sha256-diLPKIDpR9zubqGl0wPFKMNPV9QpT/eNkqUN2dSt19o=",
+        "lastModified": 1690970947,
+        "narHash": "sha256-7vOE9NFsNhe3+cpgGZ9ZLuSIzE+b8oNutezmr8tI60w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8c731978f0916b9a904d67a0e53744ceff47882c",
+        "rev": "484a1c94424d296b15af3e6858f08b576b842ec2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`484a1c94`](https://github.com/nix-community/home-manager/commit/484a1c94424d296b15af3e6858f08b576b842ec2) | `` network-manager-applet: remove `--sm-disable` flag `` |
| [`a146ab6a`](https://github.com/nix-community/home-manager/commit/a146ab6a61c20b97b8343c7c77870a4a3f645b1c) | `` himalaya: update a link to ticket ``                  |