### PR TITLE
chore(flake/emacs-overlay): `0971dc25` -> `29b43ef2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1690968511,
-        "narHash": "sha256-AZlh4bORyIk7qQ+8vnWMvYeIQu9kOBRHx7xzJBXhvHQ=",
+        "lastModified": 1691001053,
+        "narHash": "sha256-WJGXivQn/vEPQ96HwDBf6VcXgnKLQ3R2W5Xhv7kkIBg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0971dc25fd34b0afbd8a91a8e19b1561eaa58078",
+        "rev": "29b43ef219428e5941f07099c4a85f8fb795e6ae",
         "type": "github"
       },
       "original": {
@@ -749,11 +749,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1690835256,
-        "narHash": "sha256-SZy/Nvwbf6CorhEsvmjqgjoYNLnRfaKVZMfSnpUDPnc=",
+        "lastModified": 1690927903,
+        "narHash": "sha256-D5gCaCROnjEKDOel//8TO/pOP87pAEtT0uT8X+0Bj/U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b7cde1c47b7316f6138a2b36ef6627f3d16d645c",
+        "rev": "bd836ac5e5a7358dea73cb74a013ca32864ccb86",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`29b43ef2`](https://github.com/nix-community/emacs-overlay/commit/29b43ef219428e5941f07099c4a85f8fb795e6ae) | `` Updated repos/melpa ``  |
| [`faa9a5c9`](https://github.com/nix-community/emacs-overlay/commit/faa9a5c9943bfe416447b7b894054662cf91fff3) | `` Updated repos/emacs ``  |
| [`8effa416`](https://github.com/nix-community/emacs-overlay/commit/8effa4160894429f46797a733f046f6774802886) | `` Updated repos/elpa ``   |
| [`79a2ebe2`](https://github.com/nix-community/emacs-overlay/commit/79a2ebe26dd8e1f8e9c322702bdaef215a7e5290) | `` Updated flake inputs `` |