### PR TITLE
chore(flake/nur): `39e2e8bd` -> `793dfc2c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1690997491,
-        "narHash": "sha256-0OZAL/F9VsSrHAVGMZnyyrow69KGEVIRD+6OQ0EthT4=",
+        "lastModified": 1691009219,
+        "narHash": "sha256-8iFdgpp7sdOiqRTM9nXxyOQK+fvMv+92hUT0XZMX9mI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "39e2e8bd482b478fbc5ec99b1458fabe4c2e26c6",
+        "rev": "793dfc2c49b23916806c9e0450631e0fd59cda57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`793dfc2c`](https://github.com/nix-community/NUR/commit/793dfc2c49b23916806c9e0450631e0fd59cda57) | `` automatic update `` |
| [`469d81b8`](https://github.com/nix-community/NUR/commit/469d81b8f357d8e01e52f3a5a0e8b82b16839b04) | `` automatic update `` |