### PR TITLE
chore(flake/nur): `793dfc2c` -> `71c5a740`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691009219,
-        "narHash": "sha256-8iFdgpp7sdOiqRTM9nXxyOQK+fvMv+92hUT0XZMX9mI=",
+        "lastModified": 1691012695,
+        "narHash": "sha256-hn9KSrnnhMhQfGIPXXiYPXP9Yk/qNsAlmlrK2pwO84s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "793dfc2c49b23916806c9e0450631e0fd59cda57",
+        "rev": "71c5a740795a69675156fda522844766bd382421",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`71c5a740`](https://github.com/nix-community/NUR/commit/71c5a740795a69675156fda522844766bd382421) | `` automatic update `` |
| [`029b2271`](https://github.com/nix-community/NUR/commit/029b22719cc8ab2587bee2bc31fef923f8176b74) | `` automatic update `` |