### PR TITLE
chore(flake/nur): `71c5a740` -> `4d3327ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691012695,
-        "narHash": "sha256-hn9KSrnnhMhQfGIPXXiYPXP9Yk/qNsAlmlrK2pwO84s=",
+        "lastModified": 1691028750,
+        "narHash": "sha256-Zn/8Se/w2J2RKiHo6HmyZyL2aqtm1QQ25HcZ3dRQUOc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "71c5a740795a69675156fda522844766bd382421",
+        "rev": "4d3327ce31b793c36898dbc995ba7e2aa9fcf28d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4d3327ce`](https://github.com/nix-community/NUR/commit/4d3327ce31b793c36898dbc995ba7e2aa9fcf28d) | `` automatic update `` |
| [`426d4489`](https://github.com/nix-community/NUR/commit/426d44898d1731c9a5536f8290e152d00486f617) | `` automatic update `` |