### PR TITLE
chore(flake/nur): `4d3327ce` -> `7529d24e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691028750,
-        "narHash": "sha256-Zn/8Se/w2J2RKiHo6HmyZyL2aqtm1QQ25HcZ3dRQUOc=",
+        "lastModified": 1691033576,
+        "narHash": "sha256-x+nMJvWoHDo/ldTHDTtxHcaqZScOfx71kgsgT8xeMUE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4d3327ce31b793c36898dbc995ba7e2aa9fcf28d",
+        "rev": "7529d24ebbf6f94d4b211214df0da6e669dc54d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7529d24e`](https://github.com/nix-community/NUR/commit/7529d24ebbf6f94d4b211214df0da6e669dc54d0) | `` automatic update `` |
| [`2b8ea710`](https://github.com/nix-community/NUR/commit/2b8ea71007ffb8cd20efb98220d73a6468a73c0d) | `` automatic update `` |