### PR TITLE
chore(flake/nur): `7529d24e` -> `0f37e482`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691033576,
-        "narHash": "sha256-x+nMJvWoHDo/ldTHDTtxHcaqZScOfx71kgsgT8xeMUE=",
+        "lastModified": 1691035585,
+        "narHash": "sha256-RQKPFh18tSVYXTp+f8c7WvcdxKFlJ/SMt4BFhA+cb/w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7529d24ebbf6f94d4b211214df0da6e669dc54d0",
+        "rev": "0f37e482b73c4dcf720eedb6fbcee6890392a6eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0f37e482`](https://github.com/nix-community/NUR/commit/0f37e482b73c4dcf720eedb6fbcee6890392a6eb) | `` automatic update `` |