### PR TITLE
chore(flake/pre-commit-hooks): `fcbf4705` -> `52bf4046`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -953,11 +953,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1690743255,
-        "narHash": "sha256-dsJzQsyJGWCym1+LMyj2rbYmvjYmzeOrk7ypPrSFOPo=",
+        "lastModified": 1691073619,
+        "narHash": "sha256-18/EyL9QuzwaA1iJZm0Qp6Lk7sh4YftfWIa2Is3UOSE=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "fcbf4705d98398d084e6cb1c826a0b90a91d22d7",
+        "rev": "52bf404674068e7f1ad8ee08bb95648be5a4fb19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                           |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------- |
| [`b97cc1fb`](https://github.com/cachix/pre-commit-hooks.nix/commit/b97cc1fbb51e72a0fc0489586264de333da3e020) | `` Fix typo ``                    |
| [`b9ce83aa`](https://github.com/cachix/pre-commit-hooks.nix/commit/b9ce83aa6b383407f9cb58f6eb5d1854f8ef4cd9) | `` Add options to 'typos' hook `` |