### PR TITLE
chore(flake/dendrite-demo-pinecone): `e0524f85` -> `86b7c410`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1691075097,
-        "narHash": "sha256-v4gxAy0Z7zpl0yK7GGrbaA6Bnvoqq4fgctePIripmrA=",
+        "lastModified": 1691081892,
+        "narHash": "sha256-+VqbD96bb8+I8nb6ZzoxPrCjdQvM1apmmYzB83p4OZ0=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "e0524f85657514e379433d7e0262e10c1bfe1d53",
+        "rev": "86b7c410eb9e4fe8762dee015cf4677d8831979a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                          |
| --------------------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`86b7c410`](https://github.com/bbigras/dendrite-demo-pinecone/commit/86b7c410eb9e4fe8762dee015cf4677d8831979a) | `` update-flakes: don't build `` |