### PR TITLE
chore(flake/nur): `010a9c3a` -> `97ec0149`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691067576,
-        "narHash": "sha256-xOdc3+I6EmJy6RwsTfIZrdNlK5DEZrhEBe73hV4jQHs=",
+        "lastModified": 1691086336,
+        "narHash": "sha256-0UxcHQ9eV0vUhihxIYfcnbNPFQkm70SZTPHhheloatg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "010a9c3aa0cc874b4a3e4365f2ece970adc667a4",
+        "rev": "97ec0149a45401efec1f846f561a2f77c5524e39",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`97ec0149`](https://github.com/nix-community/NUR/commit/97ec0149a45401efec1f846f561a2f77c5524e39) | `` automatic update `` |
| [`e70eac44`](https://github.com/nix-community/NUR/commit/e70eac4469043a0f91c709997b7f12616591a3fd) | `` automatic update `` |