### PR TITLE
chore(flake/nur): `97ec0149` -> `2e58a312`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691086336,
-        "narHash": "sha256-0UxcHQ9eV0vUhihxIYfcnbNPFQkm70SZTPHhheloatg=",
+        "lastModified": 1691095520,
+        "narHash": "sha256-Vu72WREEfQbwHqxlv7AW3dTMFFlT1Pexkkju6Pb5v54=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "97ec0149a45401efec1f846f561a2f77c5524e39",
+        "rev": "2e58a3127d964b1add23f86ef6a51966d0717988",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2e58a312`](https://github.com/nix-community/NUR/commit/2e58a3127d964b1add23f86ef6a51966d0717988) | `` automatic update `` |
| [`28166de8`](https://github.com/nix-community/NUR/commit/28166de817c51e3b316d722b43bdb5f3c715ee38) | `` automatic update `` |