### PR TITLE
chore(flake/nur): `2e58a312` -> `aecea8e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691095520,
-        "narHash": "sha256-Vu72WREEfQbwHqxlv7AW3dTMFFlT1Pexkkju6Pb5v54=",
+        "lastModified": 1691102677,
+        "narHash": "sha256-EzE+gvY7mQl8UbcrQSmmF4nonBOLCmFYcPG+dqpfAH4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2e58a3127d964b1add23f86ef6a51966d0717988",
+        "rev": "aecea8e204137ea0a66cd6bcdb3d0c677098207a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aecea8e2`](https://github.com/nix-community/NUR/commit/aecea8e204137ea0a66cd6bcdb3d0c677098207a) | `` automatic update `` |