### PR TITLE
chore(flake/nur): `aecea8e2` -> `dcd922e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691102677,
-        "narHash": "sha256-EzE+gvY7mQl8UbcrQSmmF4nonBOLCmFYcPG+dqpfAH4=",
+        "lastModified": 1691109630,
+        "narHash": "sha256-NkltnE+ZMABNP7pJVj7ftu/58aTGa5PXxICLr8fjkI4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aecea8e204137ea0a66cd6bcdb3d0c677098207a",
+        "rev": "dcd922e7738fc027c73cd2cc110015d38fba9651",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dcd922e7`](https://github.com/nix-community/NUR/commit/dcd922e7738fc027c73cd2cc110015d38fba9651) | `` automatic update `` |