### PR TITLE
chore(flake/nur): `c8d57189` -> `d416a5d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691120585,
-        "narHash": "sha256-uIopcV3i1p8Pki1M+3NSPZH5a0OMIIn9i0PHIgxL76c=",
+        "lastModified": 1691127947,
+        "narHash": "sha256-SfiMhbne7Hk1lphbKC9v7L+s5QaZISIYlXoyYwDjvdI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c8d57189fda5d8fe6a6f9a075c5357d92dec23e7",
+        "rev": "d416a5d22f979ba32c754b45f5e6cf03aef6bdc3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d416a5d2`](https://github.com/nix-community/NUR/commit/d416a5d22f979ba32c754b45f5e6cf03aef6bdc3) | `` automatic update `` |
| [`fe509e7a`](https://github.com/nix-community/NUR/commit/fe509e7af971a39149a9c676e5bbb90d1a4f0681) | `` automatic update `` |
| [`461faa2c`](https://github.com/nix-community/NUR/commit/461faa2c286a6c3884689a5dcf41dfa18c66cef8) | `` automatic update `` |