### PR TITLE
chore(flake/nur): `afb80708` -> `974a48a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691130598,
-        "narHash": "sha256-JxH1goZGV8RfnLk5ectArk9lkgMDAOmNgOih/zKaRTQ=",
+        "lastModified": 1691134299,
+        "narHash": "sha256-bsehJJrWOUZq6j5+1fW49gtwb7rJMYLmgU6rkqiE67o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "afb80708bf3ae53ceb37f32c03f47815fb9b18e5",
+        "rev": "974a48a5b5a6615a3d7f13b2b6e872b81c70a43e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`974a48a5`](https://github.com/nix-community/NUR/commit/974a48a5b5a6615a3d7f13b2b6e872b81c70a43e) | `` automatic update `` |
| [`60be52ca`](https://github.com/nix-community/NUR/commit/60be52ca4a6861968e175b9733ef19cc4de430cb) | `` automatic update `` |