### PR TITLE
chore(flake/home-manager): `86dd48d7` -> `15043a65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1691039228,
-        "narHash": "sha256-iPNZJ1LvfUf1Y456ewC0DXgf99TNssG8OLObOyqxO6M=",
+        "lastModified": 1691143977,
+        "narHash": "sha256-zXHmmghQdDLecVxFedRxSny4FtVH9lig1/BKObsHwfg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "86dd48d70a2e2c17e84e747ba4faa92453e68d4a",
+        "rev": "15043a65915bcc16ad207d65b202659e4988066b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`15043a65`](https://github.com/nix-community/home-manager/commit/15043a65915bcc16ad207d65b202659e4988066b) | `` zsh: Add `zsh.history.ignoreAllDups` config option (#4248) `` |
| [`a4f45087`](https://github.com/nix-community/home-manager/commit/a4f450879119a2a000264bd5ac90b186e1147617) | `` jujutsu: fix zsh completion (#4305) ``                        |