### PR TITLE
chore(flake/emacs-overlay): `180dc7cb` -> `4ba15d6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1691119623,
-        "narHash": "sha256-zL2Lh+tni8YfRHJl1d2btxk5gl6mlOrp/NoDu9ftBRw=",
+        "lastModified": 1691144360,
+        "narHash": "sha256-DPaalQfXWXbyiuSqbk0dWKusniMWQSzAu0e36xU6rbA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "180dc7cbf6af0cae6ce6c404e9dd5ea3b3790733",
+        "rev": "4ba15d6f4310459e6da08dcd4d3df7f4d102bdf0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4ba15d6f`](https://github.com/nix-community/emacs-overlay/commit/4ba15d6f4310459e6da08dcd4d3df7f4d102bdf0) | `` Updated repos/nongnu `` |
| [`60b5b4a4`](https://github.com/nix-community/emacs-overlay/commit/60b5b4a490b2af46e274b55cdad93d3d004b6445) | `` Updated repos/melpa ``  |
| [`30870d42`](https://github.com/nix-community/emacs-overlay/commit/30870d421125f4dfdc9074084547456e53ded022) | `` Updated repos/emacs ``  |