### PR TITLE
chore(flake/nur): `f7f54482` -> `f1a2ba79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691145978,
-        "narHash": "sha256-AfzxUMLtcFVqlsgn0odeYDzK6F1ILQYo4Ro78c9yyRc=",
+        "lastModified": 1691158033,
+        "narHash": "sha256-fuBXCT5Itztw+WzOd8zYPMCnsASJqndNAoLlwc6lw7o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f7f54482b8cb013d0298f732f3aa4258ab2f72c8",
+        "rev": "f1a2ba7912d6d39dba9ef7084a3c5fa931db54f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f1a2ba79`](https://github.com/nix-community/NUR/commit/f1a2ba7912d6d39dba9ef7084a3c5fa931db54f6) | `` automatic update `` |
| [`ceb09b49`](https://github.com/nix-community/NUR/commit/ceb09b49fc8c221edbf08dc4436411c7ac5e9bc5) | `` automatic update `` |
| [`9ac2fa1a`](https://github.com/nix-community/NUR/commit/9ac2fa1a6bf4654d84d9c703849ac1eb4a00d0e2) | `` automatic update `` |