### PR TITLE
chore(flake/nur): `f1a2ba79` -> `c64100ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691158033,
-        "narHash": "sha256-fuBXCT5Itztw+WzOd8zYPMCnsASJqndNAoLlwc6lw7o=",
+        "lastModified": 1691169402,
+        "narHash": "sha256-Bz3IYBXv3CPFRTg9i9A/CtM8iDMd1ZoEqW0+mK2tNNQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f1a2ba7912d6d39dba9ef7084a3c5fa931db54f6",
+        "rev": "c64100ba2b7d6c2831712fc59d3168265f9d93eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c64100ba`](https://github.com/nix-community/NUR/commit/c64100ba2b7d6c2831712fc59d3168265f9d93eb) | `` automatic update `` |
| [`fbadec61`](https://github.com/nix-community/NUR/commit/fbadec61915e3df68a996da2e53af6c81134b837) | `` automatic update `` |
| [`85f1b761`](https://github.com/nix-community/NUR/commit/85f1b7613fa044b97dee3a4e8ca60a1d93aa3d72) | `` automatic update `` |
| [`63bce03d`](https://github.com/nix-community/NUR/commit/63bce03d7d7af5e8c8af4861001098dd07f36e92) | `` automatic update `` |