### PR TITLE
chore(flake/emacs-overlay): `4ba15d6f` -> `a0928a82`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1691144360,
-        "narHash": "sha256-DPaalQfXWXbyiuSqbk0dWKusniMWQSzAu0e36xU6rbA=",
+        "lastModified": 1691174294,
+        "narHash": "sha256-z1HCdhgjTcDPxB2Qee/qI47rhbG8r2tS4K2QvZ59T0Q=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4ba15d6f4310459e6da08dcd4d3df7f4d102bdf0",
+        "rev": "a0928a82ae68f4697f39c6e0ffcba763ea02a66b",
         "type": "github"
       },
       "original": {
@@ -749,11 +749,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1690927903,
-        "narHash": "sha256-D5gCaCROnjEKDOel//8TO/pOP87pAEtT0uT8X+0Bj/U=",
+        "lastModified": 1691065946,
+        "narHash": "sha256-IVSh42Q3oJwUjgLKMdzH5fMx+fk1z3V735gK1Izj1Zw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bd836ac5e5a7358dea73cb74a013ca32864ccb86",
+        "rev": "e9ca92b55bed47696cc7cc25d3f854a1e2e01f86",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`a0928a82`](https://github.com/nix-community/emacs-overlay/commit/a0928a82ae68f4697f39c6e0ffcba763ea02a66b) | `` Updated repos/melpa ``  |
| [`f19693dd`](https://github.com/nix-community/emacs-overlay/commit/f19693ddaf1fa3b500e2a8a672416f3bd9f43335) | `` Updated repos/emacs ``  |
| [`41a61172`](https://github.com/nix-community/emacs-overlay/commit/41a611728bafc86f6a4ab4cacbe5dfd93fe72dd2) | `` Updated repos/elpa ``   |
| [`d52a216c`](https://github.com/nix-community/emacs-overlay/commit/d52a216cbba5185e8d3b76b7877bfc8c3f62c018) | `` Updated flake inputs `` |