### PR TITLE
chore(flake/nur): `c64100ba` -> `00a3f983`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691169402,
-        "narHash": "sha256-Bz3IYBXv3CPFRTg9i9A/CtM8iDMd1ZoEqW0+mK2tNNQ=",
+        "lastModified": 1691174764,
+        "narHash": "sha256-bgNL1f7mT0LRaV8S0G/Fv7DNYMbvbSVAP01Jkjn5aA4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c64100ba2b7d6c2831712fc59d3168265f9d93eb",
+        "rev": "00a3f983f3028a4bc4ad675070e7657a1b767957",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`00a3f983`](https://github.com/nix-community/NUR/commit/00a3f983f3028a4bc4ad675070e7657a1b767957) | `` automatic update `` |
| [`a7d51409`](https://github.com/nix-community/NUR/commit/a7d514097f274f8f9fff7790a578e84762c5ba26) | `` automatic update `` |