### PR TITLE
chore(flake/nur): `00a3f983` -> `e2c6f6f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691174764,
-        "narHash": "sha256-bgNL1f7mT0LRaV8S0G/Fv7DNYMbvbSVAP01Jkjn5aA4=",
+        "lastModified": 1691178333,
+        "narHash": "sha256-vSRBbvFMv79AZkb0IxKz7qU7Hiy3JDRpMNG8lMpgCdI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "00a3f983f3028a4bc4ad675070e7657a1b767957",
+        "rev": "e2c6f6f75cd712159314f08d1b4e3490a7073826",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e2c6f6f7`](https://github.com/nix-community/NUR/commit/e2c6f6f75cd712159314f08d1b4e3490a7073826) | `` automatic update `` |