### PR TITLE
chore(flake/nixos-hardware): `24f9162b` -> `87e3122b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -671,11 +671,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1690957133,
-        "narHash": "sha256-0Y4CiOIszhHDDXHFmvHUpmhUotKOIn0m3jpMlm6zUTE=",
+        "lastModified": 1691179816,
+        "narHash": "sha256-WSMwqzU70ZMRHv1CUAfHEEKJuB0c9c9r0F+lJehXfSI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "24f9162b26f0debd163f6d94752aa2acb9db395a",
+        "rev": "87e3122b67587492a617764f88c71991893fcf8a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`87e3122b`](https://github.com/NixOS/nixos-hardware/commit/87e3122b67587492a617764f88c71991893fcf8a) | `` starfive visionfive2: Increase mtd0 to fit spl ``   |
| [`e8159d4e`](https://github.com/NixOS/nixos-hardware/commit/e8159d4e3d271f60f89e349d820726856ce09f11) | `` starfive visionfive2: update kernel to 6.5.0-rc1 `` |
| [`258b9faf`](https://github.com/NixOS/nixos-hardware/commit/258b9faff07cb7676002c63793e6f7da2c522a96) | `` apple/t2: update to kernel 6.4.8 ``                 |
| [`b4f1105b`](https://github.com/NixOS/nixos-hardware/commit/b4f1105b9c894b255388629cb9b15c908f414e58) | `` Update default.nix: removing the fwupd line ``      |
| [`6dcf1381`](https://github.com/NixOS/nixos-hardware/commit/6dcf1381ec3a77901bbd8b014b8a0e29157f9688) | `` Adding Dell XPS 13 9333 ``                          |