### PR TITLE
chore(flake/nur): `e2c6f6f7` -> `f69327fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691178333,
-        "narHash": "sha256-vSRBbvFMv79AZkb0IxKz7qU7Hiy3JDRpMNG8lMpgCdI=",
+        "lastModified": 1691189083,
+        "narHash": "sha256-NZclZz5CS73KnsEV0m7fBO5eqiJPYfJJbpbTwu3PZeM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e2c6f6f75cd712159314f08d1b4e3490a7073826",
+        "rev": "f69327fecbc536fc8fa155ee28f422a7841494eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f69327fe`](https://github.com/nix-community/NUR/commit/f69327fecbc536fc8fa155ee28f422a7841494eb) | `` automatic update `` |
| [`cb0da6f8`](https://github.com/nix-community/NUR/commit/cb0da6f8750e49ef6b52aa6f9211965a35e289e7) | `` automatic update `` |