### PR TITLE
chore(flake/nur): `f69327fe` -> `c5f43622`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691189083,
-        "narHash": "sha256-NZclZz5CS73KnsEV0m7fBO5eqiJPYfJJbpbTwu3PZeM=",
+        "lastModified": 1691200052,
+        "narHash": "sha256-H97vtqcBdDchzODvhe+OOJCDAOPRaLDfugs+lqg5N8s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f69327fecbc536fc8fa155ee28f422a7841494eb",
+        "rev": "c5f4362299b53a329748d0e95ade7abd4ec44162",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c5f43622`](https://github.com/nix-community/NUR/commit/c5f4362299b53a329748d0e95ade7abd4ec44162) | `` automatic update `` |