### PR TITLE
chore(flake/nixpkgs): `66aedfd0` -> `18036c0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -827,11 +827,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1691006197,
-        "narHash": "sha256-DbtxVWPt+ZP5W0Usg7jAyTomIM//c3Jtfa59Ht7AV8s=",
+        "lastModified": 1691186842,
+        "narHash": "sha256-wxBVCvZUwq+XS4N4t9NqsHV4E64cPVqQ2fdDISpjcw0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "66aedfd010204949cb225cf749be08cb13ce1813",
+        "rev": "18036c0be90f4e308ae3ebcab0e14aae0336fe42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`25bbc404`](https://github.com/NixOS/nixpkgs/commit/25bbc404a1c3ef99435ced65f949d4731621ad26) | `` flood: fix mainProgram merge issue ``                                     |
| [`ffbd4117`](https://github.com/NixOS/nixpkgs/commit/ffbd41175460f5d870fac5cfef58d73f770684c9) | `` home-assistant: 2023.8.0 -> 2023.8.1 ``                                   |
| [`6f82a3d2`](https://github.com/NixOS/nixpkgs/commit/6f82a3d2d6ee0e942c3a636fb236304209a585f8) | `` python311Packages.zigpy-znp: 0.11.3 -> 0.11.4 ``                          |
| [`62c5f723`](https://github.com/NixOS/nixpkgs/commit/62c5f723fb36461a168ccd5f28ab73dea717b9a1) | `` python311Packages.aiounifi: 50 -> 51 ``                                   |
| [`afa51689`](https://github.com/NixOS/nixpkgs/commit/afa51689b5ea45806ec75d93ed5ac2504f444730) | `` python311Packages.google-cloud-securitycenter: 1.23.1 -> 1.23.2 ``        |
| [`a63de787`](https://github.com/NixOS/nixpkgs/commit/a63de787af79f8da1bebf81975495a3051e5bf0b) | `` python311Packages.add-trailing-comma: 3.0.0 -> 3.0.1 ``                   |
| [`09a194a8`](https://github.com/NixOS/nixpkgs/commit/09a194a811317606c4bbba0be9c5dd250ac6042d) | `` python311Packages.aiounifi: 50 -> 51 ``                                   |
| [`1998f9aa`](https://github.com/NixOS/nixpkgs/commit/1998f9aa9b5e18df7d2de6b2754292b0297fa1e7) | `` treewide: add meta.mainPRogram to networking ``                           |
| [`9565bdbc`](https://github.com/NixOS/nixpkgs/commit/9565bdbcd411e40c3d1476b0f609eb6358c6895f) | `` python311Packages.bc-detect-secrets: 1.4.29 -> 1.4.30 ``                  |
| [`9591244e`](https://github.com/NixOS/nixpkgs/commit/9591244e00f3a164a96b60585e687d46c565876f) | `` safeeyes: 2.1.5 -> 2.1.6 ``                                               |
| [`f61284a1`](https://github.com/NixOS/nixpkgs/commit/f61284a19f2b302f9a99ded9fb563ebf4e9b1aed) | `` treewide: add meta.mainProgram to misc ``                                 |
| [`f16c0ae9`](https://github.com/NixOS/nixpkgs/commit/f16c0ae9d4a9cc89b42e1dbb4894246e77f4dfac) | `` python311Packages.karton-yaramatcher: 1.2.0 -> 1.3.0 ``                   |
| [`fa28015d`](https://github.com/NixOS/nixpkgs/commit/fa28015dedbf6b3d5b60e41fde79f56a8a1e4ba4) | `` python311Packages.karton-core: 5.1.0 -> 5.2.0 ``                          |
| [`e1501b7c`](https://github.com/NixOS/nixpkgs/commit/e1501b7cad5ecbdd43a88bf908f9dce24c5c46de) | `` python311Packages.sentry-sdk: 1.28.1 -> 1.29.2 ``                         |
| [`cdb0daef`](https://github.com/NixOS/nixpkgs/commit/cdb0daeff9c7ef93cf32ef69114a9088a5628e3c) | `` xbindkeys: unpin guile_2_2 ``                                             |
| [`919f5e13`](https://github.com/NixOS/nixpkgs/commit/919f5e1376d56b8dc4b27b381c09230250fd30b6) | `` treewide: add meta.mainProgram to file-managers ``                        |
| [`9d258bd1`](https://github.com/NixOS/nixpkgs/commit/9d258bd17d8b4ec6d6e0b5b2dbc7cdb8db73e497) | `` loudmouth: fix build on x86_64-darwin ``                                  |
| [`02969a2f`](https://github.com/NixOS/nixpkgs/commit/02969a2f59334bc2ebd07ece87aed95f93608e45) | `` sqlfluff: 2.1.2 -> 2.2.0 ``                                               |
| [`e5764e82`](https://github.com/NixOS/nixpkgs/commit/e5764e8204fe82ca992be5379627fb93ccc20064) | `` treewide: add meta.mainProgram to emulators ``                            |
| [`2b8a2792`](https://github.com/NixOS/nixpkgs/commit/2b8a2792c05dd54f9f38bd26e494956be74fdd76) | `` wayfire: use finalAttrs pattern and set meta.mainProgram ``               |
| [`0ca93ef0`](https://github.com/NixOS/nixpkgs/commit/0ca93ef0e61a521ba7968b7560dd2ec4412644e3) | `` rtorrent: 0.9.8+date=2021-08-07 -> 0.9.8+date=2022-06-20 ``               |
| [`d2c1acdb`](https://github.com/NixOS/nixpkgs/commit/d2c1acdbfdb6b5c0832b026ab08432aa0c5abb5d) | `` python311Packages.mypy-boto3-builder: 7.17.1 -> 7.17.2 ``                 |
| [`7666648e`](https://github.com/NixOS/nixpkgs/commit/7666648eb014953ffbe8bcbd6ab628c489463bd3) | `` neocmakelsp: 0.5.18 -> 0.6.1 ``                                           |
| [`d4e52e45`](https://github.com/NixOS/nixpkgs/commit/d4e52e45647f8d4e176856f62e04a3e8a69e1dcc) | `` beluga: fix hash ``                                                       |
| [`d787798f`](https://github.com/NixOS/nixpkgs/commit/d787798f1c69104b91f6dd8ebdaafa4be66adbda) | `` pass.withExtensions: add meta.mainProgram ``                              |
| [`61c0ecea`](https://github.com/NixOS/nixpkgs/commit/61c0ecea5b98249bc234466bc0e0ae778af72a45) | `` treewide: update mainProgram docs ``                                      |
| [`0611984a`](https://github.com/NixOS/nixpkgs/commit/0611984ad3eb2b9ead0f36388bb4a9c301c9764a) | `` python311Packages.faraday-agent-parameters-types: 1.3.0 -> 1.3.1 ``       |
| [`23aeaac3`](https://github.com/NixOS/nixpkgs/commit/23aeaac3d4fb5031a5b2badac4e01627fbc584f9) | `` python311Packages.zeep: expose optionals and clean up ``                  |
| [`c39c0479`](https://github.com/NixOS/nixpkgs/commit/c39c0479dd5f26660750af9bd4c22256aca7db0a) | `` geda: 1.8.2-20130925 -> 1.10.2 ``                                         |
| [`98bdc5f6`](https://github.com/NixOS/nixpkgs/commit/98bdc5f654ce2963f851c20d12adc7152c11a3e8) | `` maintainers: add alejandrosame ``                                         |
| [`f4c58373`](https://github.com/NixOS/nixpkgs/commit/f4c5837306d0f7860679e30831ee2328eb500fc0) | `` python311Packages.publicsuffixlist: 0.10.0.20230730 -> 0.10.0.20230804 `` |
| [`58920127`](https://github.com/NixOS/nixpkgs/commit/58920127ca39e4b4218d73b4f38821bfdd6878b8) | `` treewide: add meta.mainProgram to editors ``                              |
| [`3debecb5`](https://github.com/NixOS/nixpkgs/commit/3debecb54690ff26e6c53ee1edf7af1598f03885) | `` flips: unstable-2021-10-28 -> unstable-2023-03-15 ``                      |
| [`f991c6ec`](https://github.com/NixOS/nixpkgs/commit/f991c6ec4a2d5aabe43e9ec0acbe66ae19d4e61d) | `` libmatheval: unpin guile_2_0 ``                                           |
| [`491a3d73`](https://github.com/NixOS/nixpkgs/commit/491a3d732fa31b3ca38af680a00d2118ffa7a954) | `` ocamlPackages.{trace,trace-tef}: init at 0.2 ``                           |
| [`14651559`](https://github.com/NixOS/nixpkgs/commit/14651559b58066e572dbdc84fecb4a82dbd213bd) | `` hol_light: 2019-10-06 → 2023-07-21 ``                                     |
| [`2bb1eb77`](https://github.com/NixOS/nixpkgs/commit/2bb1eb77893627c3890800e12beca74cc1a246fb) | `` python311Packages.qcs-api-client: 0.21.5 -> 0.21.6 ``                     |
| [`c692da7f`](https://github.com/NixOS/nixpkgs/commit/c692da7f8376da5bf7560be21e443ca9c9c58d66) | `` python311Packages.gitignore-parser: 0.1.4 -> 0.1.5 ``                     |
| [`96d623af`](https://github.com/NixOS/nixpkgs/commit/96d623afd6f28bc2fed4f1527621189a924301d1) | `` memray: 1.9.0 -> 1.9.1 ``                                                 |
| [`bd707a57`](https://github.com/NixOS/nixpkgs/commit/bd707a574d53cbecf8aec28971505bfe62f4b648) | `` python311Packages.confection: 0.1.0 -> 0.1.1 ``                           |
| [`e3d54e3e`](https://github.com/NixOS/nixpkgs/commit/e3d54e3ed1c3e6a8224754669bb4f1563f478e4f) | `` trufflehog: 3.45.3 -> 3.46.3 ``                                           |
| [`bfcce824`](https://github.com/NixOS/nixpkgs/commit/bfcce8245b3f18f7b8f3f50a4d4574d34eecb116) | `` pgrok: 1.3.3 -> 1.3.4 ``                                                  |
| [`ef8105b8`](https://github.com/NixOS/nixpkgs/commit/ef8105b8e158d79d42e9817e9ae4ac123ce1dad0) | `` treewide: add meta.mainProgram to audio ``                                |
| [`ea1c770d`](https://github.com/NixOS/nixpkgs/commit/ea1c770d877ba20700ea11921defa41a79163ccd) | `` gnome.rygel: 0.42.3 → 0.42.4 ``                                           |
| [`8419104c`](https://github.com/NixOS/nixpkgs/commit/8419104ce96809c4bce7af58d5b8e0a653286df2) | `` gwrap: pin guile_2_2 instead ``                                           |
| [`37c34fa0`](https://github.com/NixOS/nixpkgs/commit/37c34fa0ba4b0d86d32ee9fc5e93a8f4324276fb) | `` guile-xcb: 1.3 -> unstable-2017-05-29 ``                                  |
| [`0d6c907b`](https://github.com/NixOS/nixpkgs/commit/0d6c907ba898701e06a7383f8b151a18c5936d30) | `` treewide: add meta.mainProgram to graphics ``                             |
| [`12c62ed6`](https://github.com/NixOS/nixpkgs/commit/12c62ed61634f498cfce9074f9051b833a7f05f0) | `` gupnp-tools: 0.12.0 → 0.12.1 ``                                           |
| [`37f3ebe4`](https://github.com/NixOS/nixpkgs/commit/37f3ebe498315da84c50cfa6f5e64df46a9d0b87) | `` freetalk: 4.1 -> 4.2 ``                                                   |
| [`e17f117a`](https://github.com/NixOS/nixpkgs/commit/e17f117a71b44fa272a75b6a3d77873b9b40ce80) | `` denemo: pin guile_2_2 instead ``                                          |
| [`d26b1b2d`](https://github.com/NixOS/nixpkgs/commit/d26b1b2d4a5c0845f3aee6af86123a2c280c473a) | `` treewide: add meta.mainProgram to instant-messengers ``                   |
| [`0f06670c`](https://github.com/NixOS/nixpkgs/commit/0f06670c7720a7f7898bae80143dc6eaebb9b624) | `` nerdfonts: Add missing fonts ``                                           |
| [`eca1f7bd`](https://github.com/NixOS/nixpkgs/commit/eca1f7bd56ed4a3760288d5aaf5c1aa54b38a53f) | `` vdrPlugins.nopacity: initial 1.1.14 ``                                    |
| [`ff202698`](https://github.com/NixOS/nixpkgs/commit/ff2026987f5e57ddfb6e449f88abc901c939789a) | `` craftos-pc: 2.7.4 -> 2.7.5 ``                                             |
| [`bcef1ed4`](https://github.com/NixOS/nixpkgs/commit/bcef1ed4d41b59019ea39087bff3ddfde33ea608) | `` viceroy: 0.6.0 -> 0.6.1 ``                                                |
| [`a323ed3d`](https://github.com/NixOS/nixpkgs/commit/a323ed3d15a0542dfa7e240da3dbb5f38ed83855) | `` gnome.gnome-software: 44.3 → 44.4 ``                                      |
| [`d6a8f303`](https://github.com/NixOS/nixpkgs/commit/d6a8f303ef33f10d469ae5f4c2168b3e2e64dc0f) | `` python3Packages.moderngl-window: 2.4.2 -> 2.4.4 ``                        |
| [`cc32deeb`](https://github.com/NixOS/nixpkgs/commit/cc32deeb91b124c356a6700cb4e14c2bc771b943) | `` python311Packages.pyatv: disable failing test on darwin ``                |
| [`0c0249df`](https://github.com/NixOS/nixpkgs/commit/0c0249dfeedf29449da2e856f509b948a460283a) | `` python311Packages.zigpy: 0.56.2 -> 0.56.4 ``                              |
| [`99b8966c`](https://github.com/NixOS/nixpkgs/commit/99b8966c8dcaf704dae48747e1edd5812ac4ada0) | `` python311Packages.opower: 0.0.18 -> 0.0.20 ``                             |
| [`286679f3`](https://github.com/NixOS/nixpkgs/commit/286679f3022e0585d1b832940796732d640e0f6d) | `` python311Packages.pyatv: 0.13.2 -> 0.13.3 ``                              |
| [`cf49c299`](https://github.com/NixOS/nixpkgs/commit/cf49c29935855481150594cf629b65ecde1a15ba) | `` swww: add shell completions and man pages ``                              |
| [`c0b21633`](https://github.com/NixOS/nixpkgs/commit/c0b216333a0d300e2d6d9dde2e3ef5f28cdc4918) | `` python311Packages.zeroconf: 0.72.0 -> 0.74.0 ``                           |
| [`ccd89a89`](https://github.com/NixOS/nixpkgs/commit/ccd89a89bafd1c08ce5bde18b5c88358f331aa66) | `` home-assistant.intents: 2023.7.25 -> 2023.8.2 ``                          |
| [`c84f5d49`](https://github.com/NixOS/nixpkgs/commit/c84f5d49e885d99b6361246e56aee14c014a99bb) | `` python311Packages.python-roborock: 0.31.1 -> 0.32.0 ``                    |
| [`94f0f914`](https://github.com/NixOS/nixpkgs/commit/94f0f914c65a4b01329e4c31cc12206922d8e0d9) | `` python311Packages.dbus-fast: 1.88.0 -> 1.90.1 ``                          |
| [`c0c91c26`](https://github.com/NixOS/nixpkgs/commit/c0c91c26094361385df0ad57daa388ddba8fb0fc) | `` wlogout: set mainProgram ``                                               |
| [`afc9a33e`](https://github.com/NixOS/nixpkgs/commit/afc9a33ec8150b5b0fa2a505b1c2e8a09ad28ea1) | `` gtklock: set mainProgram ``                                               |
| [`112c8c3b`](https://github.com/NixOS/nixpkgs/commit/112c8c3b11b318d3ee666567bb25c784b1197cf9) | `` brightnessctl: set mainProgram ``                                         |
| [`48912917`](https://github.com/NixOS/nixpkgs/commit/48912917aa1d2d8f2c5586656b39af28d27eb5a1) | `` mpc-cli: set mainProgram ``                                               |
| [`e60ea019`](https://github.com/NixOS/nixpkgs/commit/e60ea01959e2386723a4784abd04fe9747100377) | `` jq: set mainProgram ``                                                    |
| [`5bd8a5ef`](https://github.com/NixOS/nixpkgs/commit/5bd8a5ef2db5f2fe02cdfca2259a29bdc195896d) | `` kea: add more tests to passthru ``                                        |
| [`b9599a59`](https://github.com/NixOS/nixpkgs/commit/b9599a594424b141243745acfda7db971d92f2e2) | `` caprine-bin: 2.55.5 -> 2.58.0 ``                                          |
| [`1690adc4`](https://github.com/NixOS/nixpkgs/commit/1690adc424829313c5c4323770a313466f5d6ee5) | `` nixos/tests/networking/caseSensitiveRenaming: fix bash syntax ``          |
| [`799a6997`](https://github.com/NixOS/nixpkgs/commit/799a69971efd215e611b0e6c70b2575fef2f9dd2) | `` nixos/tests/networking: dhcpd -> kea ``                                   |
| [`4ce78b49`](https://github.com/NixOS/nixpkgs/commit/4ce78b49b9f8a8604da54d545a847e938ad58ff4) | `` prettierd: set meta.mainProgram ``                                        |
| [`47bed4fe`](https://github.com/NixOS/nixpkgs/commit/47bed4fe00ce4cf753dc5fc053ada62ce49e0804) | `` netease-cloud-music-gtk: restrict platforms ``                            |
| [`21d348b2`](https://github.com/NixOS/nixpkgs/commit/21d348b2eb1c135a487480c8ea4165e0ce9e8c53) | `` skribilo: disable pie charts on darwin ``                                 |
| [`feac9edf`](https://github.com/NixOS/nixpkgs/commit/feac9edf6a4fc5f95f87fb88012e78e91ca55460) | `` treewide: add meta.mainProgram ``                                         |
| [`9672b13a`](https://github.com/NixOS/nixpkgs/commit/9672b13a43c8c060fab7563fc9bc9bd44702401e) | `` mya: init at 1.0.0 ``                                                     |
| [`a5c7cb94`](https://github.com/NixOS/nixpkgs/commit/a5c7cb94a52c5657c463867e819c1da14ba29032) | `` guile-lib: skip check on darwin ``                                        |
| [`fb730878`](https://github.com/NixOS/nixpkgs/commit/fb73087890e4214861c95ba64e0f511961497ff8) | `` guile-git: skip check on darwin ``                                        |
| [`baa886b5`](https://github.com/NixOS/nixpkgs/commit/baa886b5f97acb2c0b73d5fc3c5ea645288fdf92) | `` guile-sdl: pin guile_2_2 ``                                               |
| [`a07806b9`](https://github.com/NixOS/nixpkgs/commit/a07806b9dce8e190c540fd3897d5d112c45b42cd) | `` guile-ncurses: 1.7 -> 3.1 ``                                              |
| [`207166a6`](https://github.com/NixOS/nixpkgs/commit/207166a65d5af1dccae4b9b60c0195ab2d06d729) | `` flood: 4.7.0 -> unstable-2023-06-03 ``                                    |
| [`2385e73c`](https://github.com/NixOS/nixpkgs/commit/2385e73cca73dbf0f853080e959834526aef7a8a) | `` flood: repackage using buildNpmPackage ``                                 |
| [`4f530892`](https://github.com/NixOS/nixpkgs/commit/4f5308922f99987cabb1821b675da86948af00b4) | `` treewide: add meta.mainProgram ``                                         |
| [`98edae65`](https://github.com/NixOS/nixpkgs/commit/98edae65c0cd947649b64788192b693028498c77) | `` guile-commonmark: 0.1.2 -> unstable-2020-04-30 ``                         |
| [`1a25a201`](https://github.com/NixOS/nixpkgs/commit/1a25a201039bd0ee388f29b32525fbbeece69c57) | `` guile: default to guile_3_0 ``                                            |
| [`e4b9770b`](https://github.com/NixOS/nixpkgs/commit/e4b9770b1ad369effd531cbe802d2200a0d4558c) | `` xbindkeys: pin guile_2_2 ``                                               |
| [`977c3976`](https://github.com/NixOS/nixpkgs/commit/977c397643daea45ebfb34d1e8394994bcf67c18) | `` mailutils: pin guile_2_2 ``                                               |
| [`6eccbaa3`](https://github.com/NixOS/nixpkgs/commit/6eccbaa3b1efc1c72fc2fabf2fcab6f162731668) | `` lilypond: pin guile_2_2 ``                                                |
| [`56376d41`](https://github.com/NixOS/nixpkgs/commit/56376d412bd1da83d366a0937137a041c29ef4db) | `` junkie: pin guile_2_2 ``                                                  |
| [`d59d36a2`](https://github.com/NixOS/nixpkgs/commit/d59d36a24b5eb274fa4e5e4d6cd50640e5b18ff3) | `` autogen: pin guile_2_2 ``                                                 |
| [`74e9b9cd`](https://github.com/NixOS/nixpkgs/commit/74e9b9cd498824105d65c08faf084a157fad9817) | `` openvi: 7.3.22 -> 7.4.23 ``                                               |
| [`95cd1bb6`](https://github.com/NixOS/nixpkgs/commit/95cd1bb632c498436e713bfa1f021bd9d006e21b) | `` tor-browser-bundle-bin: 12.5.1 -> 12.5.2 ``                               |
| [`140b6662`](https://github.com/NixOS/nixpkgs/commit/140b6662aac0fb52c7f71b05d4cee997a292e844) | `` php83: 8.3.0beta2 -> 8.3.0beta3 ``                                        |
| [`3ebfba5f`](https://github.com/NixOS/nixpkgs/commit/3ebfba5f605d0ebe6d5962e7530524c3c23aa790) | `` zoxide: 0.9.1 -> 0.9.2 ``                                                 |
| [`0c66bba4`](https://github.com/NixOS/nixpkgs/commit/0c66bba4554ce3e1943716f3943a55fd5ea880a3) | `` php81: 8.1.21 -> 8.1.22 ``                                                |
| [`cf086d9a`](https://github.com/NixOS/nixpkgs/commit/cf086d9ae6960e376d3370343cde8fa3ad3a2617) | `` safeeyes: Add passthru.tests.version ``                                   |
| [`a546cb6b`](https://github.com/NixOS/nixpkgs/commit/a546cb6b3e2626cb3c6ea6462dce3af6ab3923e0) | `` gleam: 0.30.2 -> 0.30.5 ``                                                |
| [`2ff8d8b2`](https://github.com/NixOS/nixpkgs/commit/2ff8d8b24fee303b6b9888d7b4f91d42053a592b) | `` gleam: add nix-update-script ``                                           |
| [`f05e7e02`](https://github.com/NixOS/nixpkgs/commit/f05e7e02a34dab4b5c162f07c4d3469aa07db896) | `` python310Packages.edk2-pytool-library: 0.15.3 -> 0.15.4 ``                |
| [`9f57ea05`](https://github.com/NixOS/nixpkgs/commit/9f57ea05a1b3f121cd06edbee273a90560100f22) | `` terraform-providers.rancher2: 3.1.0 -> 3.1.1 ``                           |
| [`4eddf22d`](https://github.com/NixOS/nixpkgs/commit/4eddf22d9ecf33af68ebe8da3f1b160f2fb2cf5b) | `` terraform-providers.aws: 5.10.0 -> 5.11.0 ``                              |
| [`96041239`](https://github.com/NixOS/nixpkgs/commit/960412394309829b73a93b7b6f8d44704f9b5e55) | `` terraform-providers.launchdarkly: 2.13.3 -> 2.13.4 ``                     |
| [`ce02f752`](https://github.com/NixOS/nixpkgs/commit/ce02f7520be63e1391068ee74005c6b351631ed4) | `` terraform-providers.checkly: 1.6.7 -> 1.6.8 ``                            |
| [`c074b249`](https://github.com/NixOS/nixpkgs/commit/c074b2497f55e4e318ccf79df8699e2431ab3b24) | `` terraform-providers.azurerm: 3.67.0 -> 3.68.0 ``                          |
| [`3ea80c9c`](https://github.com/NixOS/nixpkgs/commit/3ea80c9c2c26ff0740fd29b30f04766dbca179de) | `` srt-to-vtt-cl: fix macOS builds ``                                        |
| [`8a4f0c28`](https://github.com/NixOS/nixpkgs/commit/8a4f0c286ed074a0848541a5ff0a08d7e35819a7) | `` netease-cloud-music-gtk: 2.0.3 -> 2.2.0 ``                                |
| [`5377971c`](https://github.com/NixOS/nixpkgs/commit/5377971c39b5389932a05e8e02dfe6b42847d47a) | `` qtcreator: 11.0.0 -> 11.0.1 ``                                            |
| [`51606bc8`](https://github.com/NixOS/nixpkgs/commit/51606bc8c11c96cdbc2cfd1e85031a5b7357dd47) | `` lemmy: 0.18.2 -> 0.18.3 ``                                                |
| [`577b5231`](https://github.com/NixOS/nixpkgs/commit/577b523196858ecb6e152820e373afa00a42671f) | `` plexamp: 4.8.1 -> 4.8.2 ``                                                |
| [`540ff38c`](https://github.com/NixOS/nixpkgs/commit/540ff38c9cb4cd26ea7e6d1c358906caa487cd2a) | `` python310Packages.gssapi: support cross compilation ``                    |
| [`d44cf611`](https://github.com/NixOS/nixpkgs/commit/d44cf611fb7e67eab2c07edf738e0da0e3834c61) | `` gitignore: Add symlinks produced by `:bl` in repl ``                      |
| [`1ef3e3ec`](https://github.com/NixOS/nixpkgs/commit/1ef3e3ec59c5cb558ba34a1bf37b832d1ab23dac) | `` expressvpn: 3.25.0.13 -> 3.52.0.2 ``                                      |
| [`0c2cc0ee`](https://github.com/NixOS/nixpkgs/commit/0c2cc0eeb972d1fbd49dbb78950700db6df2d947) | `` vimPlugins.telescope-sg: init at 2023-08-02 ``                            |
| [`7079aa85`](https://github.com/NixOS/nixpkgs/commit/7079aa85667b29f0ff476133c2ae7335d1f46477) | `` wasmserve: init at 1.0.0 ``                                               |
| [`4d87592b`](https://github.com/NixOS/nixpkgs/commit/4d87592bf55afcbcd74d15616950013b2291ad9f) | `` brave: 1.56.9 -> 1.56.20 ``                                               |
| [`a13c8651`](https://github.com/NixOS/nixpkgs/commit/a13c86515a340c564eab98c4c175f0f510dd311b) | `` maintainers: add ludovicopiero ``                                         |
| [`a882b4a3`](https://github.com/NixOS/nixpkgs/commit/a882b4a3f7516542c001c78445f46f68fb47e7ce) | `` mailspring: 1.10.8 -> 1.11.0 ``                                           |
| [`d813fcfe`](https://github.com/NixOS/nixpkgs/commit/d813fcfeff0a7d3866e5eebcfd67d5ec01848118) | `` treewide: mark packages broken on darwin ``                               |
| [`8bde0406`](https://github.com/NixOS/nixpkgs/commit/8bde04060ae8baf4103ba25f5d8a50a13051b2c9) | `` doctest: fix build with clang 16 ``                                       |