### PR TITLE
chore(flake/nur): `2be99201` -> `963ad2d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691206772,
-        "narHash": "sha256-s1TPmpWxfcYg1CEJG59KfaM5GSwlnR7rx+rD8NFceV8=",
+        "lastModified": 1691214006,
+        "narHash": "sha256-kdfBd+Y0DTOOdgSA6h6iIn403xVj4bzLnXqb7+yM6lQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2be99201b3d07c256ef4b1851d1c86aded22cb89",
+        "rev": "963ad2d1bb0a8f59b2c23ab521d4dff2148aad16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`963ad2d1`](https://github.com/nix-community/NUR/commit/963ad2d1bb0a8f59b2c23ab521d4dff2148aad16) | `` automatic update `` |
| [`ec97a506`](https://github.com/nix-community/NUR/commit/ec97a5065dd69d99ea59cba66f55e0c6b3ccb7e5) | `` automatic update `` |