### PR TITLE
chore(flake/nur): `eca6c94e` -> `aa425393`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691239769,
-        "narHash": "sha256-K0tBYYrd8o0esQ1iPgPXHeoV4E8hRQaw0R0293uFqNE=",
+        "lastModified": 1691241365,
+        "narHash": "sha256-WhvikDtfbD3pdE4qE1MVBVYC7n/FQ2d7qUHd9qFO3b8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eca6c94e23fc4dfa8e1e3d5b73b696668b494682",
+        "rev": "aa425393126192c80658983811c48cd0f0d59736",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aa425393`](https://github.com/nix-community/NUR/commit/aa425393126192c80658983811c48cd0f0d59736) | `` automatic update `` |