### PR TITLE
chore(flake/nur): `03e6b2da` -> `873e4346`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691253315,
-        "narHash": "sha256-SauLRghYgrnMnLX15VkjHnNVpY4SKf4L8+iOj5EGvcY=",
+        "lastModified": 1691257568,
+        "narHash": "sha256-dPJYYSbW7iG4M6daE8cpjHoGspEzYEl2D51UmAelvT0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "03e6b2daf6d9313126be05c26b3e3d654650b406",
+        "rev": "873e434611c3b0d2d7a0da650b3856f9fe2a8800",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`873e4346`](https://github.com/nix-community/NUR/commit/873e434611c3b0d2d7a0da650b3856f9fe2a8800) | `` automatic update `` |
| [`de6076ac`](https://github.com/nix-community/NUR/commit/de6076aceb1d09ac21f0dbe3c1d5a97648ebd255) | `` automatic update `` |