### PR TITLE
chore(flake/pre-commit-hooks): `ebb43bda` -> `3139c4d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -953,11 +953,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1691093055,
-        "narHash": "sha256-sjNWYpDHc6vx+/M0WbBZKltR0Avh2S43UiDbmYtfHt0=",
+        "lastModified": 1691256628,
+        "narHash": "sha256-M0YXHemR3zbyhM7PvJa5lzGhWVf6kM/fpZ4cWe/VIhI=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ebb43bdacd1af8954d04869c77bc3b61fde515e4",
+        "rev": "3139c4d1f7732cab89f06492bdd4677b877e3785",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                        |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------ |
| [`2b9608f3`](https://github.com/cachix/pre-commit-hooks.nix/commit/2b9608f3c679ca55b2d0083aa8d6672783e2c068) | `` Expose always_run option `` |