### PR TITLE
chore(flake/nur): `873e4346` -> `407c930b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691257568,
-        "narHash": "sha256-dPJYYSbW7iG4M6daE8cpjHoGspEzYEl2D51UmAelvT0=",
+        "lastModified": 1691259378,
+        "narHash": "sha256-4mV3nJ1ldndtNAxtp5B+w9jfViHq+bnHeugvJxDlb04=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "873e434611c3b0d2d7a0da650b3856f9fe2a8800",
+        "rev": "407c930bb774984d2d9ca1907c15d977907b44df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`407c930b`](https://github.com/nix-community/NUR/commit/407c930bb774984d2d9ca1907c15d977907b44df) | `` automatic update `` |
| [`2d98768d`](https://github.com/nix-community/NUR/commit/2d98768ddc106fb37c9d6481472494419b4e4b8d) | `` automatic update `` |