### PR TITLE
chore(flake/nur): `407c930b` -> `d88f9769`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691259378,
-        "narHash": "sha256-4mV3nJ1ldndtNAxtp5B+w9jfViHq+bnHeugvJxDlb04=",
+        "lastModified": 1691460734,
+        "narHash": "sha256-Zp85w+ZpZrnG2SXTRq2505J47Sg8K8mT0K2vYXxPTAI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "407c930bb774984d2d9ca1907c15d977907b44df",
+        "rev": "d88f976982b963ad831c42ec198887732d985d0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                            |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`d88f9769`](https://github.com/nix-community/NUR/commit/d88f976982b963ad831c42ec198887732d985d0e) | `` automatic update ``                             |
| [`c42cb337`](https://github.com/nix-community/NUR/commit/c42cb337cde2c82282deab1a8d6df4c4d9059429) | `` automatic update ``                             |
| [`65298de3`](https://github.com/nix-community/NUR/commit/65298de3dc925fb37b688fa899cb8b16d89ce604) | `` automatic update ``                             |
| [`95865b36`](https://github.com/nix-community/NUR/commit/95865b3619f01d8263d306fa79ef8a67c6430fe6) | `` automatic update ``                             |
| [`cbdfc717`](https://github.com/nix-community/NUR/commit/cbdfc7175761f2ca87e8e770adb6c44bc2b321b3) | `` automatic update ``                             |
| [`33fc23d3`](https://github.com/nix-community/NUR/commit/33fc23d321725093266f69e0f948a27adf02c0b8) | `` automatic update ``                             |
| [`7038553b`](https://github.com/nix-community/NUR/commit/7038553b4660dbac2a11f24ceb9f7282b1ece316) | `` automatic update ``                             |
| [`d65caa8f`](https://github.com/nix-community/NUR/commit/d65caa8fd24d5f585c306fa19f3d9fa49f1c9ad4) | `` automatic update ``                             |
| [`687ed97c`](https://github.com/nix-community/NUR/commit/687ed97c4379e9ad1346fc673e3e0fc88210de14) | `` automatic update ``                             |
| [`d3ce928d`](https://github.com/nix-community/NUR/commit/d3ce928dde33f44204ba1908deda09f87ed63010) | `` automatic update ``                             |
| [`7c49ab3b`](https://github.com/nix-community/NUR/commit/7c49ab3b6ab71130b3bf45c2f206a31ce39f1cf9) | `` automatic update ``                             |
| [`d49dcd35`](https://github.com/nix-community/NUR/commit/d49dcd35ba0040853ede7ab3d8b85af7b3853765) | `` automatic update ``                             |
| [`9f44224a`](https://github.com/nix-community/NUR/commit/9f44224a80a2828f1cbb93f31e1a7f441fe20d5a) | `` automatic update ``                             |
| [`dc79e86c`](https://github.com/nix-community/NUR/commit/dc79e86c214aa89f8d63b942ce0cec4727f7a51f) | `` automatic update ``                             |
| [`1a0055e7`](https://github.com/nix-community/NUR/commit/1a0055e7993d9b28e026325a7e8b0038fa758a94) | `` automatic update ``                             |
| [`be09ab2e`](https://github.com/nix-community/NUR/commit/be09ab2ed0a59f4ac65aa33249a32690b7790d34) | `` automatic update ``                             |
| [`7f2b3e5b`](https://github.com/nix-community/NUR/commit/7f2b3e5b691f7822eead52b0f81111510d8000ee) | `` automatic update ``                             |
| [`4c6f954b`](https://github.com/nix-community/NUR/commit/4c6f954bda6db80ccacc7029ba5541519cbee9ee) | `` automatic update ``                             |
| [`3cc9bd56`](https://github.com/nix-community/NUR/commit/3cc9bd56c4cadc9c36b020231a7391bd4650d826) | `` automatic update ``                             |
| [`da4cafcc`](https://github.com/nix-community/NUR/commit/da4cafcc14ccde3e813cc3c4b1c3ba712d31947d) | `` automatic update ``                             |
| [`fa672967`](https://github.com/nix-community/NUR/commit/fa672967c4a9816cd7ef84b8c3606afb6cbadf25) | `` automatic update ``                             |
| [`99c5ceff`](https://github.com/nix-community/NUR/commit/99c5ceff45111c306e47812970dc1c1edb666f28) | `` automatic update ``                             |
| [`b82d17f7`](https://github.com/nix-community/NUR/commit/b82d17f73ec62b9e549b2b012e856a484921d548) | `` automatic update ``                             |
| [`4f23301a`](https://github.com/nix-community/NUR/commit/4f23301a19746efa5c7033f0e4eaefe2e901df7e) | `` automatic update ``                             |
| [`8a9c9c46`](https://github.com/nix-community/NUR/commit/8a9c9c465f88f8277f24bb88f2e695b9b59c4e76) | `` automatic update ``                             |
| [`24ab182c`](https://github.com/nix-community/NUR/commit/24ab182c746d436e4e1089e46f20d32efff1f588) | `` automatic update ``                             |
| [`9f1d0f20`](https://github.com/nix-community/NUR/commit/9f1d0f208821c3e75d280e858e8744e6b8fa06ae) | `` automatic update ``                             |
| [`579296f4`](https://github.com/nix-community/NUR/commit/579296f4ec7ce0bd49c706407273cd12afec9d54) | `` automatic update ``                             |
| [`9a4295d6`](https://github.com/nix-community/NUR/commit/9a4295d6d57ec1760c0ad1d24dbaa927e9b783df) | `` automatic update ``                             |
| [`22f87b0e`](https://github.com/nix-community/NUR/commit/22f87b0eebca4878cabfdd634d4505b2a07447b9) | `` automatic update ``                             |
| [`cd1ffa79`](https://github.com/nix-community/NUR/commit/cd1ffa7927aa148158b0b19779316129e1cb7fb3) | `` automatic update ``                             |
| [`d7c34298`](https://github.com/nix-community/NUR/commit/d7c34298304cb60339278038cd0b28f33b2f69ed) | `` automatic update ``                             |
| [`f9dfd533`](https://github.com/nix-community/NUR/commit/f9dfd533fdfca640c52ce5ba9ad4829be760e3ed) | `` automatic update ``                             |
| [`6720fea2`](https://github.com/nix-community/NUR/commit/6720fea26d333f3ff13495dcefe5e390aa25dba6) | `` automatic update ``                             |
| [`9ce7b351`](https://github.com/nix-community/NUR/commit/9ce7b351a3fb6ffd2ab2270d68545ac37781af5e) | `` automatic update ``                             |
| [`4af1e9a1`](https://github.com/nix-community/NUR/commit/4af1e9a14ee2a94552f03ae9f50fbfed58dc4a7c) | `` automatic update ``                             |
| [`d6ee9668`](https://github.com/nix-community/NUR/commit/d6ee96683419614266a8b5ca24209fd23ec4fe46) | `` automatic update ``                             |
| [`d8db2ba5`](https://github.com/nix-community/NUR/commit/d8db2ba5c97665fe7ccbb8e307155b77b0c9e72f) | `` automatic update ``                             |
| [`084e6b03`](https://github.com/nix-community/NUR/commit/084e6b0386621f4228ab81818a915c7aaabd29b6) | `` automatic update ``                             |
| [`3253d1e1`](https://github.com/nix-community/NUR/commit/3253d1e1a391277820a98ba62e815ac4629fe8ad) | `` automatic update ``                             |
| [`534e0780`](https://github.com/nix-community/NUR/commit/534e078006ca501fff053eaa3998e8e62031438e) | `` automatic update ``                             |
| [`1206d045`](https://github.com/nix-community/NUR/commit/1206d0453af7c8a2eea035481c8b826d94aca9f9) | `` automatic update ``                             |
| [`6dbc5000`](https://github.com/nix-community/NUR/commit/6dbc50004e9998d907b906570c264854e6675b8c) | `` automatic update ``                             |
| [`589b8348`](https://github.com/nix-community/NUR/commit/589b83487ef5a3bf39a154c59bacded3d60fdd69) | `` automatic update ``                             |
| [`01a0cc52`](https://github.com/nix-community/NUR/commit/01a0cc52dd70ccd45d2db15fb178fb8a79ea0548) | `` automatic update ``                             |
| [`cf2f5d8a`](https://github.com/nix-community/NUR/commit/cf2f5d8ad452795e5aca290c95eedc829d3da7ec) | `` automatic update ``                             |
| [`a3e677ad`](https://github.com/nix-community/NUR/commit/a3e677ad9f2ece0d8d3192be134e1516d1e5ec63) | `` automatic update ``                             |
| [`47f9a674`](https://github.com/nix-community/NUR/commit/47f9a674c3f823ce136cfb87fafaf8c6fb4c72e5) | `` automatic update ``                             |
| [`16915d0d`](https://github.com/nix-community/NUR/commit/16915d0d3dcce6857e2ce3c2e800e005aeccbf27) | `` automatic update ``                             |
| [`dcb1bbf5`](https://github.com/nix-community/NUR/commit/dcb1bbf571d2c3972a85058a398925c51db7655a) | `` automatic update ``                             |
| [`132e3a98`](https://github.com/nix-community/NUR/commit/132e3a981f794e455948773832db65b5bed80925) | `` automatic update ``                             |
| [`f5882fcd`](https://github.com/nix-community/NUR/commit/f5882fcd4589fbea298c4b50fa0e1fed80d15282) | `` automatic update ``                             |
| [`58c9645a`](https://github.com/nix-community/NUR/commit/58c9645acabb7dc10b615b3c5791148b0540647b) | `` automatic update ``                             |
| [`7e2ce83a`](https://github.com/nix-community/NUR/commit/7e2ce83acb53d27ce6c100b97a86e3d55e9ee091) | `` automatic update ``                             |
| [`f45ea62f`](https://github.com/nix-community/NUR/commit/f45ea62f23e1d672f3126dd1cced1b435395b2e4) | `` automatic update ``                             |
| [`088e2ab2`](https://github.com/nix-community/NUR/commit/088e2ab2c6d123a1c9be63b9ba62343f5dea38cb) | `` automatic update ``                             |
| [`9c810333`](https://github.com/nix-community/NUR/commit/9c8103334605fa3f503ef830c618d293093bdfc4) | `` automatic update ``                             |
| [`fdefa81c`](https://github.com/nix-community/NUR/commit/fdefa81c297ef514bcc53ebdd650356c46eebb00) | `` automatic update ``                             |
| [`168b720d`](https://github.com/nix-community/NUR/commit/168b720dbea80c257d07dea56087be3f9b17be94) | `` automatic update ``                             |
| [`1971f035`](https://github.com/nix-community/NUR/commit/1971f0356c40d5c6993814fa0c1cef58190d0089) | `` Show how to use modules on NixOS with flakes `` |