### PR TITLE
chore(flake/darwin): `e3c554fe` -> `829041cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -119,11 +119,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1691240627,
-        "narHash": "sha256-a3U6TdnxP8a06ZAJSkuBq7m4ge4lIjuXnrAvhO5ohO4=",
+        "lastModified": 1691275315,
+        "narHash": "sha256-9WN0IA0vNZSNxKHpy/bYvPnCw4VH/nr5iBv7c+7KUts=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "e3c554fe50aa64f9f0a43c7a5448a64173223da8",
+        "rev": "829041cf10c4f6751a53c0a11ca2fd22ff0918d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                               |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`9d539267`](https://github.com/LnL7/nix-darwin/commit/9d53926782b6c857ebdf9682137068f9cbcdb5d5) | `` tests: fix uses of `!` ``                          |
| [`e2187d63`](https://github.com/LnL7/nix-darwin/commit/e2187d633ca8e156e8810af29da39692a30c37d1) | `` fish: simplify `babelfishTranslate` ``             |
| [`e65825ca`](https://github.com/LnL7/nix-darwin/commit/e65825ca9ef935a3219c5a3e81a42b747e04e58b) | `` fish: add default for `babelfishPackage` ``        |
| [`75c2925c`](https://github.com/LnL7/nix-darwin/commit/75c2925c57e7c33c769a2d28758d3ef20aafb46f) | `` release: give test derivations meaningful names `` |