### PR TITLE
chore(flake/nixos-hardware): `87e3122b` -> `5426a950`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -671,11 +671,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1691179816,
-        "narHash": "sha256-WSMwqzU70ZMRHv1CUAfHEEKJuB0c9c9r0F+lJehXfSI=",
+        "lastModified": 1691305349,
+        "narHash": "sha256-0Pig7jnmuRH3c5dOTVTOvTLwo2CRzYTyvJRQ82HWRSo=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "87e3122b67587492a617764f88c71991893fcf8a",
+        "rev": "5426a95071d0b9782b3209b3995cde1f5689616e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`5426a950`](https://github.com/NixOS/nixos-hardware/commit/5426a95071d0b9782b3209b3995cde1f5689616e) | `` inspiron 14 5420: more tlp info in README `` |
| [`a5a696f2`](https://github.com/NixOS/nixos-hardware/commit/a5a696f281b5ecc8a56396491df00f6f0b9786db) | `` inspiron 14 5420: add to flake.nix ``        |
| [`a75e04b2`](https://github.com/NixOS/nixos-hardware/commit/a75e04b2599136dc41606f7aab7ab41c2de718f9) | `` inspiron 14 5420: remove TLP ``              |
| [`ae712596`](https://github.com/NixOS/nixos-hardware/commit/ae712596242bd537d491528ba5a863595952689b) | `` inspiron 14 5420: initial ``                 |