### PR TITLE
chore(flake/nixpkgs): `18036c0b` -> `5faab298`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -827,11 +827,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1691186842,
-        "narHash": "sha256-wxBVCvZUwq+XS4N4t9NqsHV4E64cPVqQ2fdDISpjcw0=",
+        "lastModified": 1691276849,
+        "narHash": "sha256-RNnrzxhW38SOFIF6TY/WaX7VB3PCkYFEeRE5YZU+wHw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "18036c0be90f4e308ae3ebcab0e14aae0336fe42",
+        "rev": "5faab29808a2d72f4ee0c44c8e850e4e6ada972f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`148e69a4`](https://github.com/NixOS/nixpkgs/commit/148e69a477594c6b40061124dd39b5ab704d0b97) | `` viking: enable on darwin (#247225) ``                           |
| [`54e6327e`](https://github.com/NixOS/nixpkgs/commit/54e6327e288a41c1ead755480d288e9712eb66b2) | `` lens: 6.3.0 -> 6.5.2 (#242911) ``                               |
| [`7cbd6c6b`](https://github.com/NixOS/nixpkgs/commit/7cbd6c6bccf3cf8dbeea61c8a949d690666e4ffa) | `` remnote: 1.8.52 -> 1.12.3 (#247342) ``                          |
| [`1be476a0`](https://github.com/NixOS/nixpkgs/commit/1be476a0c24d455a0b09437f2a8fbc528ab31885) | `` grafana-image-renderer: 3.7.1 -> 3.7.2 (#246517) ``             |
| [`85d4248a`](https://github.com/NixOS/nixpkgs/commit/85d4248a4f5aa6bc55dd2cea8131bb68b2d43804) | `` treewide: fix some comments (#247365) ``                        |
| [`d7768d14`](https://github.com/NixOS/nixpkgs/commit/d7768d14f6d37d62603e4a38e88c61cd7a5f38f6) | `` doomrunner: 1.8.0 -> 1.8.1 ``                                   |
| [`9696c45d`](https://github.com/NixOS/nixpkgs/commit/9696c45d779a3cea8e9655f1b67858e8ee9d7876) | `` nwg-dock-hyprland: 0.1.3 -> 0.1.4 ``                            |
| [`3d9a6399`](https://github.com/NixOS/nixpkgs/commit/3d9a6399a1a90c8f811285672e03b19f250bad4b) | `` nixos/paperless: set default thumbnail font ``                  |
| [`540a2054`](https://github.com/NixOS/nixpkgs/commit/540a20546a1bd40622b678d8f603d2503f1d5bd8) | `` nixos/paperless: add test for plaintext document ``             |
| [`f2131916`](https://github.com/NixOS/nixpkgs/commit/f2131916bda21ef4f9d6087da0b307d38a0e4ec1) | `` jotdown: 0.3.0 -> 0.3.1 ``                                      |
| [`d1a225bb`](https://github.com/NixOS/nixpkgs/commit/d1a225bb72756ce005abe823ccfb4267291ee955) | `` iosevka-bin: 25.1.1 -> 26.0.1 ``                                |
| [`30cbe813`](https://github.com/NixOS/nixpkgs/commit/30cbe813b949f26484366304f5a0104e20330c8e) | `` cargo-tally: 1.0.27 -> 1.0.28 ``                                |
| [`a9a13325`](https://github.com/NixOS/nixpkgs/commit/a9a13325960fbdae99faca5b55071d7817843fc6) | `` cargo-expand: 1.0.62 -> 1.0.64 ``                               |
| [`8eacf1f7`](https://github.com/NixOS/nixpkgs/commit/8eacf1f7d8ef0b6baf4f2724b65d6d4d4abc82c3) | `` python310Packages.psycopg: 3.1.9 -> 3.1.10 ``                   |
| [`2ee10898`](https://github.com/NixOS/nixpkgs/commit/2ee1089884f6301a8fe787a6ff3329749b4d39d4) | `` lefthook: add mainProgram name ``                               |
| [`2cda04d0`](https://github.com/NixOS/nixpkgs/commit/2cda04d0c5ccb7bcf636a026b1c81fe55004a126) | `` jing-trang: copy resolver.jar to output ``                      |
| [`b881156c`](https://github.com/NixOS/nixpkgs/commit/b881156cec7b253079f23d182ae5c01c217f302b) | `` scenebuilder: 19.0.0 -> 20.0.0 ``                               |
| [`e08e100b`](https://github.com/NixOS/nixpkgs/commit/e08e100b0c6a6651c3235d1520c53280142d9d5f) | `` home-manager: fix bug in which home-manager.nix is not found `` |
| [`b7729de7`](https://github.com/NixOS/nixpkgs/commit/b7729de7b1d82d5a4324c6c60a80c37f8a2dffb4) | `` juicity: 0.1.1 -> 0.1.2 ``                                      |
| [`6c5c0bbc`](https://github.com/NixOS/nixpkgs/commit/6c5c0bbcda9197dfe56baf192e5fd1ce8ac31c4a) | `` rare-regex: 0.3.2 -> 0.3.3 ``                                   |
| [`ae742829`](https://github.com/NixOS/nixpkgs/commit/ae7428291813535fca0d5e419190199837ed9ce1) | `` slibGuile: 3b5 -> 3b7 ``                                        |
| [`e8efb589`](https://github.com/NixOS/nixpkgs/commit/e8efb5899c1d78868473fa0f3be1b6cbdf13ae72) | `` python310Packages.sqlmap: 1.7.7 -> 1.7.8 ``                     |
| [`2ba6d553`](https://github.com/NixOS/nixpkgs/commit/2ba6d5536f51d897dd5da0638a3d8d2df8dce3ef) | `` felix-fm: 2.6.0 -> 2.7.0 ``                                     |
| [`b109c7f1`](https://github.com/NixOS/nixpkgs/commit/b109c7f1ff287283c70c31f6d0836ffc73deecb9) | `` telegraf: 1.27.2 -> 1.27.3 ``                                   |
| [`a7221aa8`](https://github.com/NixOS/nixpkgs/commit/a7221aa8aa2029ccdaedb0af416e2d64e453b63f) | `` cargo-public-api: 0.31.2 -> 0.31.3 ``                           |
| [`8d6b40e8`](https://github.com/NixOS/nixpkgs/commit/8d6b40e898dccce04795d9ddc25fd9fc825899fa) | `` pdfhummus: 4.5.9 -> 4.5.10 ``                                   |
| [`f5a31501`](https://github.com/NixOS/nixpkgs/commit/f5a31501018b12e791cf5cbe6325591daae1d0de) | `` _389-ds-base: 2.4.2 -> 2.4.3 ``                                 |
| [`763ed867`](https://github.com/NixOS/nixpkgs/commit/763ed867f1817c8604019734e32c6143edc33136) | `` rc: unstable-2021-08-03 -> unstable-2023-06-14 ``               |
| [`631b5b9c`](https://github.com/NixOS/nixpkgs/commit/631b5b9cc6b2227c2a589dceb7856b29a55ea1c4) | `` colorstorm: init at 2.0.0 ``                                    |
| [`29b89132`](https://github.com/NixOS/nixpkgs/commit/29b89132fb4fa7a21785478cd5c83fe343b00a01) | `` ncdu: use zigHook ``                                            |
| [`d695b7ef`](https://github.com/NixOS/nixpkgs/commit/d695b7ef5b3fbd6d56630d58d819d54f1dcc8dfe) | `` linuxwave: use zigHook ``                                       |
| [`393a9367`](https://github.com/NixOS/nixpkgs/commit/393a936719234557d2cfbec0b6016c800600687d) | `` zf: disable tests ``                                            |
| [`fe310a18`](https://github.com/NixOS/nixpkgs/commit/fe310a185539159f1de46c0728fcceaa65c37f90) | `` zf: use zigHook ``                                              |
| [`a3ccdee0`](https://github.com/NixOS/nixpkgs/commit/a3ccdee063a090aaa5da8290007e2cc31946f798) | `` zls: use zigHook ``                                             |
| [`5c68e0e7`](https://github.com/NixOS/nixpkgs/commit/5c68e0e7e1f1736e507b1ceefae4132221298323) | `` waylock: use zigHook ``                                         |
| [`6d87dc71`](https://github.com/NixOS/nixpkgs/commit/6d87dc71369d2730b360423138011752f7e29848) | `` rivercarro: use zigHook ``                                      |
| [`299723c8`](https://github.com/NixOS/nixpkgs/commit/299723c8756b80b7d511776fa53ad25a74afe5e5) | `` river: split man output ``                                      |
| [`c4867cc7`](https://github.com/NixOS/nixpkgs/commit/c4867cc7947bdf72034c4b4e1dc8c79fca5d339b) | `` river: use zigHook ``                                           |
| [`ba1c193d`](https://github.com/NixOS/nixpkgs/commit/ba1c193d28fe009594f93be3424b18f4e846c776) | `` mepo: use zigHook ``                                            |
| [`a34e8fe1`](https://github.com/NixOS/nixpkgs/commit/a34e8fe1617420b9df728834fe2a6b0f1b32417a) | `` findup: use zigHook ``                                          |
| [`30567662`](https://github.com/NixOS/nixpkgs/commit/30567662bbfabdcb5fe4e0e62ab45999fcf0d5ae) | `` clipbuzz: use zigHook ``                                        |
| [`dd8d813a`](https://github.com/NixOS/nixpkgs/commit/dd8d813a73e1a7c4a2a34de3d209c282caf8904e) | `` blackshades: use zigHook ``                                     |
| [`a63c9818`](https://github.com/NixOS/nixpkgs/commit/a63c9818ba93175ab46a9ed6c63e2777e9bd3ea9) | `` scdoc: set `meta.mainProgram` ``                                |
| [`6576a7b6`](https://github.com/NixOS/nixpkgs/commit/6576a7b6e6d2db21eb83010395881c565fffe8d6) | `` scdoc: refactor ``                                              |
| [`dfde395b`](https://github.com/NixOS/nixpkgs/commit/dfde395b2af558cdad66aaa4b8439e03026873be) | `` cinnamon.xreader: Backport meson 1.2 fix ``                     |
| [`0ba388c9`](https://github.com/NixOS/nixpkgs/commit/0ba388c9676bdbfd62bc5bc59055bc3e197365e7) | `` picard: 2.8.5 -> 2.9 ``                                         |
| [`17235965`](https://github.com/NixOS/nixpkgs/commit/1723596522d6730e45c4e72219c715357a7222bf) | `` vsce: 2.19.0 -> 2.20.1 ``                                       |
| [`83f9448e`](https://github.com/NixOS/nixpkgs/commit/83f9448e6439fe26e10b7f28edddde254191515b) | `` numcpp: init at 2.11.0 ``                                       |
| [`2ddb1453`](https://github.com/NixOS/nixpkgs/commit/2ddb1453e6fadb7ac10d3c9996a9f3f7356deb76) | `` nixos/nextcloud: make php settings additive ``                  |
| [`d02a90fd`](https://github.com/NixOS/nixpkgs/commit/d02a90fd173f4076412432fd3ef8fadacd7b1945) | `` scenic-view: use a jdk with bundled openjfx ``                  |
| [`f2bdee43`](https://github.com/NixOS/nixpkgs/commit/f2bdee4337d37a58e4ede5c37894f1d905abf6f1) | `` scenebuilder: 15.0.1 -> 19.0.0 ``                               |
| [`fe1e7622`](https://github.com/NixOS/nixpkgs/commit/fe1e7622fd7bbb7a3c0c2ef3989640127dd6c7b9) | `` ser2net: 4.3.13 -> 4.4.0 ``                                     |
| [`b6c51121`](https://github.com/NixOS/nixpkgs/commit/b6c51121520fefb7e5696099ad59e5080b3f13d0) | `` nixos/ntopng: seperate interface config with newlines ``        |
| [`1eb6175b`](https://github.com/NixOS/nixpkgs/commit/1eb6175b0db1ae8a3f03404a426c6db2c44a098a) | `` domination: 1.2.8 -> 1.2.9 ``                                   |
| [`5d8e3208`](https://github.com/NixOS/nixpkgs/commit/5d8e320833d2ef2df013c5c45e9521364cffa1e2) | `` jc: set meta.mainProgram ``                                     |
| [`6a921d61`](https://github.com/NixOS/nixpkgs/commit/6a921d61b2a5af99de7afe7a76b2c1eed15e6d61) | `` python3.pkgs.deploykit: 1.0.2 -> 1.1.0 ``                       |
| [`b44786fc`](https://github.com/NixOS/nixpkgs/commit/b44786fcdf519fd08d91bd9d8734deb9615ceea3) | `` jackett: 0.21.547 -> 0.21.584 ``                                |
| [`7a6cde4e`](https://github.com/NixOS/nixpkgs/commit/7a6cde4e51ba374aacaaa9265f758f020f6feb3f) | `` gvm-libs: 22.6.3 -> 22.7.0 ``                                   |
| [`e3c771f8`](https://github.com/NixOS/nixpkgs/commit/e3c771f877eec37cc5991399ad4da05a53903dd1) | `` lazygit: 0.39.4 -> 0.40.0 ``                                    |
| [`66709f3a`](https://github.com/NixOS/nixpkgs/commit/66709f3ae180ba4cef6ce4c53ac886c697aeac6d) | `` python311Packages.python-velbus: 2.1.9 -> 2.1.12 ``             |
| [`9e742472`](https://github.com/NixOS/nixpkgs/commit/9e742472affe53ce0ba02cf0dbbf9ecb69c75a78) | `` python3.pkgs.clr-loader: add build dependencies ``              |
| [`809db2e8`](https://github.com/NixOS/nixpkgs/commit/809db2e8e5a7c240f1e19e0fc616b5f8b573a970) | `` python3.pkgs.clr-loader: normalize pname ``                     |
| [`fe99af51`](https://github.com/NixOS/nixpkgs/commit/fe99af5109cd38e1ef16112c7c3e6b7b82e184d5) | `` gex: 0.6.0 -> 0.6.1 ``                                          |
| [`5f54224e`](https://github.com/NixOS/nixpkgs/commit/5f54224ed0416592697de154376c9651c9cf98c0) | `` klipper: unstable-2023-06-29 -> unstable-2023-08-01 ``          |
| [`d7fcdbc1`](https://github.com/NixOS/nixpkgs/commit/d7fcdbc1dea2895b5c947ca2361a56143bebf303) | `` profanity: 0.13.1 → 0.14.0 ``                                   |
| [`67fd84ef`](https://github.com/NixOS/nixpkgs/commit/67fd84ef6244c211aaeaa5074900e8d985d5edfe) | `` libstrophe: 0.12.2 → 0.12.3 ``                                  |
| [`b5e3917c`](https://github.com/NixOS/nixpkgs/commit/b5e3917c8531dd401845ffe50a51c0d1ed74f49b) | `` grype: 0.65.0 -> 0.65.1 ``                                      |
| [`6838ebcb`](https://github.com/NixOS/nixpkgs/commit/6838ebcb45dd1c40977de5ca3cf9f711e91c46ee) | `` python311Packages.cdcs: 0.2.1 -> 0.2.2 ``                       |
| [`dcbd242f`](https://github.com/NixOS/nixpkgs/commit/dcbd242fe7365a3d04edf972b4ce0de87896534a) | `` python310Packages.azure-mgmt-keyvault: 10.2.2 -> 10.2.3 ``      |
| [`797b2949`](https://github.com/NixOS/nixpkgs/commit/797b2949381b83e538b0b75e9d9ef23023a402ea) | `` esbuild: 0.18.17 -> 0.18.18 ``                                  |
| [`73a81887`](https://github.com/NixOS/nixpkgs/commit/73a818872b9c0dbf567860820b073b2d1f2cc78b) | `` libpg_query: 15-4.2.2 -> 15-4.2.3 ``                            |
| [`48b692f5`](https://github.com/NixOS/nixpkgs/commit/48b692f51abedad028695f24a188dcc658c512fb) | `` python310Packages.pglast: 5.2 -> 5.3 ``                         |
| [`8993f513`](https://github.com/NixOS/nixpkgs/commit/8993f513be5f2b2db0a063bdc3ee5192321e2101) | `` terraform-providers.tencentcloud: 1.81.18 -> 1.81.19 ``         |
| [`7cd29251`](https://github.com/NixOS/nixpkgs/commit/7cd29251eac3f3ac87b00e8911ccfadc102ef0a0) | `` terraform-providers.wavefront: 4.2.0 -> 5.0.0 ``                |
| [`ac149115`](https://github.com/NixOS/nixpkgs/commit/ac149115d553a95e26798e5f350b14774e208c50) | `` terraform-providers.talos: 0.2.0 -> 0.2.1 ``                    |
| [`eb9f8ccf`](https://github.com/NixOS/nixpkgs/commit/eb9f8ccf14e757cfe38099064cb4a58f7477cf53) | `` terraform-providers.mongodbatlas: 1.10.2 -> 1.11.0 ``           |
| [`2b35626a`](https://github.com/NixOS/nixpkgs/commit/2b35626a48f546df6ced64389f191380ccee4ea6) | `` terraform-providers.minio: 1.17.1 -> 1.17.2 ``                  |
| [`7aa5327a`](https://github.com/NixOS/nixpkgs/commit/7aa5327a7b201ee3281065dba680e50e65efc571) | `` terraform-providers.fastly: 5.2.2 -> 5.3.0 ``                   |
| [`ca4f1641`](https://github.com/NixOS/nixpkgs/commit/ca4f164129a4422ce57c478831e9811b2bfce1c9) | `` terraform-providers.buildkite: 0.22.0 -> 0.23.0 ``              |
| [`1c59e0da`](https://github.com/NixOS/nixpkgs/commit/1c59e0daedfc754017929134c75e7e001557f205) | `` terraform-providers.baiducloud: 1.19.9 -> 1.19.10 ``            |
| [`5b49f80c`](https://github.com/NixOS/nixpkgs/commit/5b49f80c780376032c9e31b689aaac09bc3f3809) | `` terraform-providers.aci: 2.10.0 -> 2.10.1 ``                    |
| [`732e3f69`](https://github.com/NixOS/nixpkgs/commit/732e3f692b2e3abc410542cc9563baf557f7e33f) | `` timoni: 0.11.0 -> 0.11.1 ``                                     |
| [`d59a43bd`](https://github.com/NixOS/nixpkgs/commit/d59a43bdb3dcef174d8a3e7081909609cdad102d) | `` vintagestory: 1.18.6 -> 1.18.7 ``                               |
| [`d886e44d`](https://github.com/NixOS/nixpkgs/commit/d886e44d9b086da2374f25932ac0b1f6724b7dbe) | `` statix: add meta.mainProgram ``                                 |
| [`f40cb1d8`](https://github.com/NixOS/nixpkgs/commit/f40cb1d86b6f3e715ea05e059b8c9ebda302c6e5) | `` pgbackrest: add meta.mainProgram ``                             |
| [`35ec1b0a`](https://github.com/NixOS/nixpkgs/commit/35ec1b0ae431d743d73609248cf4e31e977487c8) | `` ruff: add meta.mainProgram ``                                   |
| [`088060ab`](https://github.com/NixOS/nixpkgs/commit/088060ab698babc0c469fb420d6f3b5dc72d6dc6) | `` hclfmt: add meta.mainProgram ``                                 |
| [`44c0f1c8`](https://github.com/NixOS/nixpkgs/commit/44c0f1c89bf1bcf8cfac6996f212cf38edd31ac4) | `` deadnix: add meta.mainProgram ``                                |
| [`f645dc11`](https://github.com/NixOS/nixpkgs/commit/f645dc112b7d00edd4899af09729926050bb2a43) | `` python3.pkgs.black: add meta.mainProgram ``                     |
| [`a7704231`](https://github.com/NixOS/nixpkgs/commit/a7704231f498282c7aba6a9ebbd2bb048dd4a218) | `` nodePackages.prettier: add meta.mainProgram ``                  |
| [`f19f7236`](https://github.com/NixOS/nixpkgs/commit/f19f7236bd09811e4eb9a30e1b7df458513b8164) | `` python310Packages.flask-talisman: 1.0.0 -> 1.1.0 ``             |
| [`efdf4e9d`](https://github.com/NixOS/nixpkgs/commit/efdf4e9d1f05d6587230d1b71fab1e5000bed22a) | `` swift: use stdenv libc++ on Darwin ``                           |
| [`6cd2ab27`](https://github.com/NixOS/nixpkgs/commit/6cd2ab27ce129b32777000c63961be0dd202b929) | `` python3.pkgs.ax: add and move some build dependencies ``        |
| [`92fceb3c`](https://github.com/NixOS/nixpkgs/commit/92fceb3cc29fe818d5d1c4d71de5c095818a9434) | `` ctranslate2: 3.17.1 -> 3.18.0 ``                                |
| [`7deb1525`](https://github.com/NixOS/nixpkgs/commit/7deb15252c5bfe0fd6ee156b4c9640f0a1732bf3) | `` deno: 1.35.2 -> 1.36.0 ``                                       |
| [`491d7a11`](https://github.com/NixOS/nixpkgs/commit/491d7a111f37c063bba71f525cc26c94833508ec) | `` webcat: unstable-2021-09-06 -> 0.2.0 ``                         |
| [`875d14e6`](https://github.com/NixOS/nixpkgs/commit/875d14e695f62c1cbcc91c571f62898e5e68d885) | `` plistwatch: unstable-2020-12-22 -> unstable-2023-06-22 ``       |
| [`8e49af0f`](https://github.com/NixOS/nixpkgs/commit/8e49af0f3e7c305cd969d3571310b6d434832ace) | `` hueadm: use buildNpmPackage ``                                  |
| [`71f45b41`](https://github.com/NixOS/nixpkgs/commit/71f45b41b0cfdafd869e2ac0f9c2a4286cd4efbf) | `` node-packages/remove-attr.py: also remove from overrides.nix `` |
| [`8b75ef3a`](https://github.com/NixOS/nixpkgs/commit/8b75ef3a6897f3eed71b9b423cf5f04a63ba9216) | `` castnow: use buildNpmPackage ``                                 |
| [`e0245ba6`](https://github.com/NixOS/nixpkgs/commit/e0245ba6bb8fec572dcac0c3974c751e0038342e) | `` antennas: use buildNpmPackage ``                                |
| [`2f707365`](https://github.com/NixOS/nixpkgs/commit/2f707365e2ae839eecd8b4bbabea59ea19336765) | `` gromacs: update meta ``                                         |
| [`ac6127bd`](https://github.com/NixOS/nixpkgs/commit/ac6127bd6aada0ec58afb286532308fbb015c2f0) | `` infracost: 0.10.26 -> 0.10.27 ``                                |
| [`0e267f84`](https://github.com/NixOS/nixpkgs/commit/0e267f84e0fc6fb21431b9d23dc0c87d968b46b1) | `` guile-sdl: 0.5.2 -> 0.6.1 ``                                    |
| [`02d604cd`](https://github.com/NixOS/nixpkgs/commit/02d604cd68caa10bafbf9bc45a82b40d8d2a2e45) | `` treewide: add meta.mainProgram ``                               |
| [`47253abc`](https://github.com/NixOS/nixpkgs/commit/47253abc9fb9a004aaa718312cc4552674c3f92b) | `` vimPlugins.cmp-async-path: init at 2023-01-16 ``                |
| [`44fbeaed`](https://github.com/NixOS/nixpkgs/commit/44fbeaed37e6e1e7994fe94b430f6ea92b437110) | `` thunderbirdPackages.thunderbird-102: 102.13.0 -> 102.14.0 ``    |
| [`27b6d3ad`](https://github.com/NixOS/nixpkgs/commit/27b6d3ade02e6da153a79534940c80839ccb4e87) | `` rtz: 0.4.2 -> 0.5.3 ``                                          |
| [`27b7e86e`](https://github.com/NixOS/nixpkgs/commit/27b7e86eeffc45a8addb87c0b59388ed78758e1c) | `` altserver: cleanup ``                                           |
| [`3f8cf9b1`](https://github.com/NixOS/nixpkgs/commit/3f8cf9b158bebc00480a660d04810c9516955c86) | `` altserver-linux: rename from alt-server / AltServer-Linux ``    |
| [`575fd9d0`](https://github.com/NixOS/nixpkgs/commit/575fd9d0ccf03afe43882fbbc2d8470c3405fa33) | `` thunderbird-unwrapped-bin: 115.0 -> 115.1.0 ``                  |
| [`fa10cfa9`](https://github.com/NixOS/nixpkgs/commit/fa10cfa9bf8905d11cba0a6676580e6759167be5) | `` firefox-beta-bin-unwrapped: 117.0b2 -> 117.0b3 ``               |
| [`09f3da0e`](https://github.com/NixOS/nixpkgs/commit/09f3da0e65d62d07edec3a7b7032c1b03a634322) | `` firefox-devedition-bin-unwrapped: 117.0b2 -> 117.0b3 ``         |
| [`988f381d`](https://github.com/NixOS/nixpkgs/commit/988f381d89c8a5b45ff4f0c2d12dc742754bc5da) | `` thunderbird-unwrapped: 115.0.1 -> 115.1.0 ``                    |
| [`10e59781`](https://github.com/NixOS/nixpkgs/commit/10e59781be483fff778556440eae484a97fb960b) | `` firefox-devedition-unwrapped: 116.0b8 -> 117.0b3 ``             |
| [`2b01c7cc`](https://github.com/NixOS/nixpkgs/commit/2b01c7cc7462f359a7b8afd01f7f6f594b547763) | `` firefox-beta-unwrapped: 116.0b8 -> 117.0b3 ``                   |
| [`df004587`](https://github.com/NixOS/nixpkgs/commit/df0045875d313053aff64ddf9e5aa2ab5bc397d8) | `` firefox-bin-unwrapped: 116.0 -> 116.0.1 ``                      |
| [`bc5eb668`](https://github.com/NixOS/nixpkgs/commit/bc5eb668144aa6ee7188887557a1f0cc9e749d80) | `` firefox-unwrapped: 116.0 -> 116.0.1 ``                          |
| [`19ddd665`](https://github.com/NixOS/nixpkgs/commit/19ddd665f3e07b1b9d78cd8da6081fd0a128dc55) | `` rust-script: 0.30.0 -> 0.31.0 ``                                |
| [`98422c29`](https://github.com/NixOS/nixpkgs/commit/98422c29fdaf296f6f4ca02d9e88554a34d80af6) | `` lektor: add meta.mainProgram ``                                 |
| [`161bf188`](https://github.com/NixOS/nixpkgs/commit/161bf188f699612cc1c0d45e250d7cad6cc74105) | `` python310Packages.mat2: add meta.mainProgram ``                 |
| [`e5dce04f`](https://github.com/NixOS/nixpkgs/commit/e5dce04f63d45f22366aa2b089265fa648fb3788) | `` mrkd: add meta.mainProgram ``                                   |
| [`5d6cf036`](https://github.com/NixOS/nixpkgs/commit/5d6cf03646a5db61cfd50cde0bc5a3ebf735634b) | `` nodePackages.karma: turn into alias ``                          |