### PR TITLE
chore(flake/nixpkgs): `5faab298` -> `5a8e9243`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -827,11 +827,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1691276849,
-        "narHash": "sha256-RNnrzxhW38SOFIF6TY/WaX7VB3PCkYFEeRE5YZU+wHw=",
+        "lastModified": 1691368598,
+        "narHash": "sha256-ia7li22keBBbj02tEdqjVeLtc7ZlSBuhUk+7XTUFr14=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5faab29808a2d72f4ee0c44c8e850e4e6ada972f",
+        "rev": "5a8e9243812ba528000995b294292d3b5e120947",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`5a8e9243`](https://github.com/NixOS/nixpkgs/commit/5a8e9243812ba528000995b294292d3b5e120947) | `` solana-cli: 1.14.17 -> 1.14.23 ``                                                            |
| [`0d9fe73c`](https://github.com/NixOS/nixpkgs/commit/0d9fe73c144f4a89c8a942b12292f8a030fbd7b9) | `` buildah-unwrapped: 1.31.0 -> 1.31.1 ``                                                       |
| [`efe95a15`](https://github.com/NixOS/nixpkgs/commit/efe95a157a5e5c0c4ac750b96dc8af115e0de487) | `` harmonia: 0.6.7 -> 0.7.0 ``                                                                  |
| [`4620966a`](https://github.com/NixOS/nixpkgs/commit/4620966adbe37ec8a2633841dc05e4f4436bf563) | `` nix-eval-jobs: 2.16.0 -> 2.17.0 ``                                                           |
| [`b59150e9`](https://github.com/NixOS/nixpkgs/commit/b59150e99ca3160375f67ae4e5a748c0c26dafaf) | `` nix-doc: 0.5.8 -> 0.5.9 ``                                                                   |
| [`2b08b1ab`](https://github.com/NixOS/nixpkgs/commit/2b08b1ab684883323d87c4ff538c80a9b4e261fd) | `` python311Packages.bimmer-connected: 0.13.8 -> 0.13.9 ``                                      |
| [`e25bd6ca`](https://github.com/NixOS/nixpkgs/commit/e25bd6ca099b84946d65b973925861ae65061bfc) | `` twitch-tui: 2.4.0 -> 2.4.1 ``                                                                |
| [`1ee7d95e`](https://github.com/NixOS/nixpkgs/commit/1ee7d95e0e4e03e41c3df76d40155f13d461fdba) | `` cargo-udeps: 0.1.40 -> 0.1.41 ``                                                             |
| [`9cf67bcb`](https://github.com/NixOS/nixpkgs/commit/9cf67bcb599ccbac5a0194e59cc674430ea4c911) | `` tuigreet: add main-program ``                                                                |
| [`4f0d455a`](https://github.com/NixOS/nixpkgs/commit/4f0d455a9002b4b9ae2400df09b7ea7971c27a0b) | `` docker: add main-program ``                                                                  |
| [`7a49ac26`](https://github.com/NixOS/nixpkgs/commit/7a49ac268403ce92086ed7ab8d81209032aa0a5f) | `` timelens: init at 0.1.1 ``                                                                   |
| [`f55cee06`](https://github.com/NixOS/nixpkgs/commit/f55cee06f252a89e8470d9864c8b32c298200c19) | `` gllsls: init at 0.4.1 ``                                                                     |
| [`46a57802`](https://github.com/NixOS/nixpkgs/commit/46a5780249fae84e2b4145d3caa19e34e1023712) | `` maintainers: add declan ``                                                                   |
| [`e6a26299`](https://github.com/NixOS/nixpkgs/commit/e6a2629950506a3df9491ea5b5cd41b326e90f1a) | `` calibre: 6.23.0 -> 6.24.0 ``                                                                 |
| [`179f4816`](https://github.com/NixOS/nixpkgs/commit/179f481687d038e638660d697b23b02c7367633f) | `` waybar: add hyprlandSupport feature flag ``                                                  |
| [`7d396389`](https://github.com/NixOS/nixpkgs/commit/7d396389914c42bde1843ba3c592b299af8e9347) | `` nix-update: 0.19.2 -> 0.19.3 ``                                                              |
| [`62d3dc70`](https://github.com/NixOS/nixpkgs/commit/62d3dc70267e6136d0f9fec70e79469f7dc20b18) | `` openfpgaloader: use ``finalAttrs` pattern ``                                                 |
| [`f32917de`](https://github.com/NixOS/nixpkgs/commit/f32917dec5dcfe782a25d07d68acb4a2957f8cf6) | `` balena-cli: fix source hashes for 16.7.6 ``                                                  |
| [`63cef72d`](https://github.com/NixOS/nixpkgs/commit/63cef72d95a7d7f1ed740388db1426dc5aa8eecb) | `` questdb: use `finalAttrs` pattern ``                                                         |
| [`c9f8bdaf`](https://github.com/NixOS/nixpkgs/commit/c9f8bdaf6c994ac5520ae0c1527a5ea687d61d55) | `` seatd: use `finalAttrs` pattern ``                                                           |
| [`bf76e795`](https://github.com/NixOS/nixpkgs/commit/bf76e795575c824d40f4095ba3ff49ac19f4584b) | `` reshape: refactor ``                                                                         |
| [`5925e79d`](https://github.com/NixOS/nixpkgs/commit/5925e79d83e015b30760c2b1085ad1e4eb83d370) | `` libfive: unstable-2022-05-19 -> unstable-2023-06-07 ``                                       |
| [`88599cef`](https://github.com/NixOS/nixpkgs/commit/88599cef17a1c58251e40e5ba1b2762470e8eba3) | `` supabase-cli: 1.82.4 -> 1.83.5 ``                                                            |
| [`6be6a06a`](https://github.com/NixOS/nixpkgs/commit/6be6a06acf18d16a0d85b3c9804879847208c8d0) | `` d2: fix version ldflag ``                                                                    |
| [`35550546`](https://github.com/NixOS/nixpkgs/commit/3555054614dfa8994557d45b495ebc461fccb7ce) | `` nixpkgs-review: 2.9.3 -> 2.10.0 ``                                                           |
| [`b3340fc5`](https://github.com/NixOS/nixpkgs/commit/b3340fc540ff4479da25680041ee8979c794b9fd) | `` mda-lv2: Update homepage URL ``                                                              |
| [`0d8d2377`](https://github.com/NixOS/nixpkgs/commit/0d8d2377478ba005b49e9fa6967fb79b1fc2e28b) | `` api-linter: 1.55.0 -> 1.55.2 ``                                                              |
| [`c2318dbd`](https://github.com/NixOS/nixpkgs/commit/c2318dbd60fc4892c90bff89b915934e424f4561) | `` gtree: 1.9.3 -> 1.9.4 ``                                                                     |
| [`43e580c6`](https://github.com/NixOS/nixpkgs/commit/43e580c6e498afe3cb0cbede5e770e1411e21576) | `` cargo-hack: 0.5.28 -> 0.5.29 ``                                                              |
| [`06058d99`](https://github.com/NixOS/nixpkgs/commit/06058d9998ecfb252fecc304081bcfa75bad0d34) | `` copilot-cli: 1.29.0 -> 1.29.1 ``                                                             |
| [`7d573d6a`](https://github.com/NixOS/nixpkgs/commit/7d573d6a905b15cc64159b6512b0a863be748048) | `` python310Packages.streamlit: add natsukium as maintainer ``                                  |
| [`3cb0c7d5`](https://github.com/NixOS/nixpkgs/commit/3cb0c7d55e591700d6175014fcac802515ab865a) | `` python310Packages.streamlit: clean up inputs ``                                              |
| [`4187eadf`](https://github.com/NixOS/nixpkgs/commit/4187eadf09424b1fd93fffbdea0f0667dc368ce0) | `` gimme-aws-creds: 2.7.0 -> 2.7.1 ``                                                           |
| [`6ac8ae0f`](https://github.com/NixOS/nixpkgs/commit/6ac8ae0fb0742bfe61f456d8e452e9e77a148995) | `` python310Packages.laspy: 2.4.1 -> 2.5.1 ``                                                   |
| [`0c5c1df1`](https://github.com/NixOS/nixpkgs/commit/0c5c1df1840d39e6e5ce7821155a26820073cfd1) | `` python310Packages.laspy: refactor ``                                                         |
| [`20a9422c`](https://github.com/NixOS/nixpkgs/commit/20a9422c03c7b983bfe5247a1886e997b296d3e2) | `` python310Packages.laszip: 0.2.1 -> 0.2.3 ``                                                  |
| [`24d17589`](https://github.com/NixOS/nixpkgs/commit/24d17589ebfa816042de98df37d6a1091f6b5b39) | `` python310Packages.streamlit: 1.24.0 -> 1.24.1 ``                                             |
| [`edc5d13e`](https://github.com/NixOS/nixpkgs/commit/edc5d13ef3d37c60b3a35b68463b5cd25f9f50e7) | `` streamlit: manage as python-modules ``                                                       |
| [`63ae6def`](https://github.com/NixOS/nixpkgs/commit/63ae6defdd3cf2e3338d2207f564f4fbdce55591) | `` clusterctl: remove maintainer ``                                                             |
| [`6a29380d`](https://github.com/NixOS/nixpkgs/commit/6a29380d9bf99ab67faab7395605a5fc69db9c00) | `` clusterctl: 1.4.4 -> 1.5.0 ``                                                                |
| [`f9a789bc`](https://github.com/NixOS/nixpkgs/commit/f9a789bc0555fd24295f6069d5aa525bdd8565e8) | `` tuba: 0.4.0 -> 0.4.1 ``                                                                      |
| [`4daae3ba`](https://github.com/NixOS/nixpkgs/commit/4daae3ba2f22c71fb024898a6eaa086e913fa983) | `` ddosify: 1.0.4 -> 1.0.5 ``                                                                   |
| [`a4afe034`](https://github.com/NixOS/nixpkgs/commit/a4afe0346a8a9638bc2322833cdac4296ff8596d) | `` wasmedge: 0.13.2 -> 0.13.3 ``                                                                |
| [`7d5c8290`](https://github.com/NixOS/nixpkgs/commit/7d5c829040358a7f56205b1f380b758100371c86) | `` diffsitter: 0.8.0 -> 0.8.1 ``                                                                |
| [`399c6c7b`](https://github.com/NixOS/nixpkgs/commit/399c6c7bfaf9841deddf9be5b136b63dd0c3bba6) | `` guile-fibers: fix cross ``                                                                   |
| [`47c09c23`](https://github.com/NixOS/nixpkgs/commit/47c09c231272e6ed88569304fabc2f3aea2f7003) | `` govc: 0.30.6 -> 0.30.7 ``                                                                    |
| [`d1c1e266`](https://github.com/NixOS/nixpkgs/commit/d1c1e2666e73be5053d5f5ef01c4c466cc780eb2) | `` liblinear: 2.46 -> 2.47 ``                                                                   |
| [`86cc23b6`](https://github.com/NixOS/nixpkgs/commit/86cc23b63d2b884fe14a783e3c23c89ca0c2459e) | `` seatd: 0.7.0 -> 0.8.0 ``                                                                     |
| [`124a6ef9`](https://github.com/NixOS/nixpkgs/commit/124a6ef9b085494fc643af3cfe497759ed6ddb54) | `` python310Packages.pygccxml: add format ``                                                    |
| [`2c50e349`](https://github.com/NixOS/nixpkgs/commit/2c50e3491eb15bcaf7108224c94b3691ac699f8a) | `` fetchrepoproject: fix a bug that was there since bef6bef0d2ce2ef7cfaa3e9f1eac2cdc793560c4 `` |
| [`231f561d`](https://github.com/NixOS/nixpkgs/commit/231f561d78adc9a0e9223255acc7b240aaf419ee) | `` heh: init at 0.4.1 ``                                                                        |
| [`a512a789`](https://github.com/NixOS/nixpkgs/commit/a512a78939523d2ce94ecbfa461ebbe5aecdfc07) | `` frink: 2023-05-22 -> 2023-07-31 ``                                                           |
| [`12a6a8be`](https://github.com/NixOS/nixpkgs/commit/12a6a8be22621378d70bfc2c897c5b6b29a3cdcf) | `` gnmic: 0.31.3 -> 0.31.7 ``                                                                   |
| [`cb820210`](https://github.com/NixOS/nixpkgs/commit/cb820210e8c0e70481590a009c96c48cb75969bd) | `` kid3: use `finalAttrs` pattern ``                                                            |
| [`78c41c98`](https://github.com/NixOS/nixpkgs/commit/78c41c986b1640d387788a1720ca5b2fe0d9590d) | `` praat: use `finalAttrs` pattern ``                                                           |
| [`acb33846`](https://github.com/NixOS/nixpkgs/commit/acb3384672df9420fe544630411d4fad8e21385b) | `` kid3: 3.9.3 -> 3.9.4 ``                                                                      |
| [`0d3898fd`](https://github.com/NixOS/nixpkgs/commit/0d3898fdf62b27bf58f982c7a8435422bbee7184) | `` mbedtls: run tests ``                                                                        |
| [`ce2c71c6`](https://github.com/NixOS/nixpkgs/commit/ce2c71c6b33489b3f9ca0737af6a935d809a35a2) | `` python310Packages.cattrs: 22.2.0 -> 23.1.2 ``                                                |
| [`29bbabc5`](https://github.com/NixOS/nixpkgs/commit/29bbabc5f55c5695415ae37670ab3bca28722d23) | `` python310Packages.cattrs: add meta.changelog ``                                              |
| [`7f565d9c`](https://github.com/NixOS/nixpkgs/commit/7f565d9c0dbf2097caddab114a0b162727bb39da) | `` praat: 6.3.10 -> 6.3.14 ``                                                                   |
| [`8720f814`](https://github.com/NixOS/nixpkgs/commit/8720f814e4534f044f6d13ebf621d7e93a03e466) | `` cargo-llvm-cov: 0.5.24 -> 0.5.25 ``                                                          |
| [`060c8f58`](https://github.com/NixOS/nixpkgs/commit/060c8f587503538cd860782ecd7f915def45fae5) | `` edk2: fix x86_64-darwin build ``                                                             |
| [`a35bcbf8`](https://github.com/NixOS/nixpkgs/commit/a35bcbf810d7076ca21e0c7e43eb81b5c89f0262) | `` kdiff3: 1.10.4 -> 1.10.5 ``                                                                  |
| [`3a1f5757`](https://github.com/NixOS/nixpkgs/commit/3a1f5757b9684c2636ffae30169f68eba08e2e0a) | `` mautrix-whatsapp: move defaults back to options. ``                                          |
| [`2195e53f`](https://github.com/NixOS/nixpkgs/commit/2195e53f3f250e412d07a58d2041633fb78ac89b) | `` openfpgaloader: 0.10.0 -> 0.11.0 ``                                                          |
| [`88582f8f`](https://github.com/NixOS/nixpkgs/commit/88582f8f9784cde5c175967af5b5ee4788561153) | `` scaleway-cli: 2.18.0 -> 2.19.0 ``                                                            |
| [`5514a157`](https://github.com/NixOS/nixpkgs/commit/5514a1578b40d4674c1adb2604fa8b64176ceea4) | `` ft2-clone: 1.68 -> 1.69 ``                                                                   |
| [`fed87528`](https://github.com/NixOS/nixpkgs/commit/fed87528f3f0206fa49b6348228aa11a60ee483c) | `` dolt: 1.8.4 -> 1.8.8 ``                                                                      |
| [`4e0fae36`](https://github.com/NixOS/nixpkgs/commit/4e0fae36b66da97dfbf2892360df4b8e7ec4c31c) | `` carla: 2.5.5 -> 2.5.6 ``                                                                     |
| [`1a18ac33`](https://github.com/NixOS/nixpkgs/commit/1a18ac33409ac30b3bb02be827d5a755aa2d1652) | `` opensnitch: 1.5.2 -> 1.6.1 ``                                                                |
| [`caa6270d`](https://github.com/NixOS/nixpkgs/commit/caa6270dfbce858a7c83e2b71b7b37da88104477) | `` opensnitch-ui: 1.5.2 -> 1.6.1 ``                                                             |
| [`d9b88ffc`](https://github.com/NixOS/nixpkgs/commit/d9b88ffcf124628116ef1b2c7a91ab161c64319c) | `` tile38: 1.31.0 -> 1.32.0 ``                                                                  |
| [`cc9aeeb5`](https://github.com/NixOS/nixpkgs/commit/cc9aeeb518c246f1afff9af986ac34900003eea8) | `` act: 0.2.48 -> 0.2.49 ``                                                                     |
| [`4c54c5ad`](https://github.com/NixOS/nixpkgs/commit/4c54c5ad2826862e6059220ad9afb4ae5ab51d8e) | `` go-containerregistry: 0.15.2 -> 0.16.1 ``                                                    |
| [`f306f561`](https://github.com/NixOS/nixpkgs/commit/f306f5611dc46da0ad1423dbc04678d003bc3343) | `` jumppad: 0.5.31 -> 0.5.35 ``                                                                 |
| [`2c2b3b1c`](https://github.com/NixOS/nixpkgs/commit/2c2b3b1c24ea87cff6bbaf7152e4c1b1d596cb95) | `` kubeswitch: 0.7.2 -> 0.8.0 ``                                                                |
| [`d2a10fe1`](https://github.com/NixOS/nixpkgs/commit/d2a10fe1b4140d254752037901e10d189876bc23) | `` obs-studio-plugins.advanced-scene-switcher: 1.22.1 -> 1.23.0 ``                              |
| [`be98d462`](https://github.com/NixOS/nixpkgs/commit/be98d462a1565460605c757aea82cc775bc1501f) | `` python3.pkgs.bitlist: audit and update dependencies ``                                       |
| [`8946d2e0`](https://github.com/NixOS/nixpkgs/commit/8946d2e0b58ac3fc9721b7f9e0a0e2a1eb7eee19) | `` questdb: 7.2.1 -> 7.3 ``                                                                     |
| [`4dd84755`](https://github.com/NixOS/nixpkgs/commit/4dd8475578701f419d35d5dc34d1d3a6f4b90818) | `` assemblyscript: 0.27.6 -> 0.27.8 ``                                                          |
| [`38723846`](https://github.com/NixOS/nixpkgs/commit/38723846e4f5919c66c232e5f9bc7ba35ffc45f9) | `` xmrig-proxy: 6.19.2 -> 6.20.0 ``                                                             |
| [`a2cd81f0`](https://github.com/NixOS/nixpkgs/commit/a2cd81f0def86f3d7c18c886c7c11be30ee65a09) | `` lazydocker: 0.21.0 -> 0.21.1 ``                                                              |
| [`75ca751b`](https://github.com/NixOS/nixpkgs/commit/75ca751b628e84f942e97b181156c4fa0ca389c3) | `` opentelemetry-collector: 0.81.0 -> 0.82.0 ``                                                 |
| [`e91d18e0`](https://github.com/NixOS/nixpkgs/commit/e91d18e0d17fba7c9b3e56027e60f389128770d2) | `` terraform-ls: 0.31.3 -> 0.31.4 ``                                                            |
| [`44e74879`](https://github.com/NixOS/nixpkgs/commit/44e748795c6445adfdd32b1af36a5267d5a9e74f) | `` lynis: 3.0.8 -> 3.0.9 ``                                                                     |
| [`a7babc4a`](https://github.com/NixOS/nixpkgs/commit/a7babc4a4adaf136e68e0ecb66a4a71bfc247b84) | `` pspg: 5.7.8 -> 5.8.0 ``                                                                      |
| [`5543a77d`](https://github.com/NixOS/nixpkgs/commit/5543a77d28f18b8b67466f54ec799cf9b8744438) | `` pscale: 0.150.0 -> 0.151.0 ``                                                                |
| [`c331a2c6`](https://github.com/NixOS/nixpkgs/commit/c331a2c641ab3a3adc7db5924fb3acf74c480fba) | `` vitess: 17.0.0 -> 17.0.1 ``                                                                  |
| [`c7643019`](https://github.com/NixOS/nixpkgs/commit/c7643019c4b6f1be1cfa51393443c9a73194bf09) | `` mdbook-katex: 0.5.5 -> 0.5.6 ``                                                              |
| [`541c5d8d`](https://github.com/NixOS/nixpkgs/commit/541c5d8de0013ba0fa8695e62800cf6ae1d02886) | `` python310Packages.txtai: init at 5.5.1 ``                                                    |
| [`14bb10f9`](https://github.com/NixOS/nixpkgs/commit/14bb10f98fb98fd8973657e86f364c0648b0c80e) | `` python310Packages.hydra-check: 1.3.4 -> 1.3.5 ``                                             |
| [`33602569`](https://github.com/NixOS/nixpkgs/commit/33602569e20d7d3ac217ee8618a8a0a37fa599a3) | `` python310Packages.trimesh: 3.22.5 -> 3.23.0 ``                                               |
| [`6421f070`](https://github.com/NixOS/nixpkgs/commit/6421f070e393e62e918a9330a41c9ac41f2bf914) | `` libgpiod: fix Python bindings ``                                                             |
| [`3b74f120`](https://github.com/NixOS/nixpkgs/commit/3b74f1205cf227872bbe7fd130ab752b1770d8b6) | `` zig_0_11: init ``                                                                            |
| [`36ca4639`](https://github.com/NixOS/nixpkgs/commit/36ca4639d76c02156464f87cf0778105d560b81d) | `` zig: introduce generic.nix to remove duplicate code ``                                       |
| [`27ffa910`](https://github.com/NixOS/nixpkgs/commit/27ffa910095a63add3d6a4b66c103ddf1b3f1142) | `` renderdoc: 1.27 -> 1.28 ``                                                                   |
| [`3e83bb9f`](https://github.com/NixOS/nixpkgs/commit/3e83bb9f4c78a61d266badb59bfe5963086658ef) | `` python310Packages.pygccxml: 2.2.1 -> 2.3.0 ``                                                |
| [`71812299`](https://github.com/NixOS/nixpkgs/commit/71812299fc8028855bfa2d9a906a70ac7c4335b2) | `` carapace: 0.25.3 -> 0.26.0 ``                                                                |
| [`251f7d47`](https://github.com/NixOS/nixpkgs/commit/251f7d47fd54313a03fbc4e2a59e90b715186d72) | `` Treewide: add meta.mainProgram for bupstash, fd, autossh and ssh-to-age ``                   |
| [`d47082aa`](https://github.com/NixOS/nixpkgs/commit/d47082aa9a33d295328f9160cdad9517baf2234b) | `` crystal: correct usage of darwin.apple_sdk_11_0 ``                                           |
| [`2c55562d`](https://github.com/NixOS/nixpkgs/commit/2c55562deb1082335a14eaf5c563f4a1defd692c) | `` bottom: 0.9.3 -> 0.9.4 ``                                                                    |
| [`c7a9f7c1`](https://github.com/NixOS/nixpkgs/commit/c7a9f7c13206594136a8bf3b9b8e44b189aab0fc) | `` nixos/nextcloud: improve documentation ``                                                    |
| [`cb0526cf`](https://github.com/NixOS/nixpkgs/commit/cb0526cfd0b42d4ee77a904236f656178eba8b97) | `` restish: 0.17.0 -> 0.18.0 ``                                                                 |
| [`59080851`](https://github.com/NixOS/nixpkgs/commit/59080851541a11bd013432060a64525692f3da88) | `` python311Packages.aiohomekit: 2.6.12 -> 2.6.13 ``                                            |
| [`e2b05273`](https://github.com/NixOS/nixpkgs/commit/e2b0527318834b3798be16ec98c1024d21de45e1) | `` gitea-actions-runner: 0.2.3 -> 0.2.5 ``                                                      |
| [`d7e921b2`](https://github.com/NixOS/nixpkgs/commit/d7e921b2d13670a04f5f3d102af8835b8ebd4637) | `` autocorrect: 2.6.2 -> 2.8.4 ``                                                               |
| [`f48570f2`](https://github.com/NixOS/nixpkgs/commit/f48570f223115a68c6a1e0ad4c16082a5dc53e84) | `` treewide: fixup ``                                                                           |
| [`2cceb70b`](https://github.com/NixOS/nixpkgs/commit/2cceb70b13f898e09e95412e04e757a7b46cae80) | `` guile: add effectiveVersion and site{Ccache,}Dir ``                                          |
| [`125ed68c`](https://github.com/NixOS/nixpkgs/commit/125ed68c42defdd6f25b901b52a4f0e343841138) | `` ryujinx: 1.1.968 -> 1.1.974 ``                                                               |
| [`8758657b`](https://github.com/NixOS/nixpkgs/commit/8758657bf138c176243282ae112965a7dd054e32) | `` esphome: 2023.7.0 -> 2023.7.1 ``                                                             |
| [`8872c6c1`](https://github.com/NixOS/nixpkgs/commit/8872c6c1dc2fa91d3d77c4a315996245a1301a1e) | `` adguardhome: 0.107.35 -> 0.107.36 ``                                                         |
| [`288d2ee5`](https://github.com/NixOS/nixpkgs/commit/288d2ee55d193c476bd62312f7ed5326835e442f) | `` mautrix-whatsapp: Move defaults to config section ``                                         |
| [`f597cc88`](https://github.com/NixOS/nixpkgs/commit/f597cc8859d07d303857e9721a068c0ec9690d27) | `` edgedb: 3.3.0 -> 3.4.0 ``                                                                    |
| [`8fcf05bc`](https://github.com/NixOS/nixpkgs/commit/8fcf05bc95442257fedba0a50c909ca714a12678) | `` prqlc: init at 0.9.3 ``                                                                      |
| [`4627e977`](https://github.com/NixOS/nixpkgs/commit/4627e977571633c27deff8a475aafc8baadcebac) | `` checkov: 2.3.318 -> 2.3.356 ``                                                               |
| [`f6063283`](https://github.com/NixOS/nixpkgs/commit/f6063283e12213db9bad23c0d7ff31e6d4539434) | `` python311Packages.millheater: 0.10.0 -> 0.11.0 ``                                            |
| [`4d47a405`](https://github.com/NixOS/nixpkgs/commit/4d47a405c4ecdf7e42207822e5d0eef03ecf71b1) | `` python310Packages.getjump: init at 2.4.0 ``                                                  |
| [`c956c8fc`](https://github.com/NixOS/nixpkgs/commit/c956c8fcbec2924a61d7f6e62bcaa12349a13243) | `` nixd: 1.2.0 -> 1.2.1 ``                                                                      |
| [`461d89ee`](https://github.com/NixOS/nixpkgs/commit/461d89eedee0ecc4c24a6ce4ce13a5052c90e2a3) | `` python310Packages.scrapy: 2.9.0 -> 2.10.0 ``                                                 |
| [`df66ed5c`](https://github.com/NixOS/nixpkgs/commit/df66ed5c3bcf76396552bd75adc24575b7dce5a5) | `` linkerd_edge: 23.7.2 -> 23.8.1 ``                                                            |
| [`12cb284a`](https://github.com/NixOS/nixpkgs/commit/12cb284a4493f75d96c9e94159ce2696d82cd23d) | ``   nixos/wyoming/faster-whisper: fix device option description ``                             |
| [`c21906ef`](https://github.com/NixOS/nixpkgs/commit/c21906efbd75522b29cb3b5365e8ed4299366b5a) | `` networkmanagerapplet: add meta.mainProgram ``                                                |
| [`063ed83c`](https://github.com/NixOS/nixpkgs/commit/063ed83c09d3a7c84155f963559a13dde8f8e9a9) | `` chromium: 115.0.5790.110 -> 115.0.5790.170 ``                                                |
| [`754c7b7c`](https://github.com/NixOS/nixpkgs/commit/754c7b7c0261225b9581cb7464394e1b52c92410) | `` vscode: 1.80.2 -> 1.81.0 ``                                                                  |
| [`48b67359`](https://github.com/NixOS/nixpkgs/commit/48b67359a3c1af6978f8e3537f2aaae16c71228a) | `` mbedtls: 3.4.0 -> 3.4.1 ``                                                                   |
| [`38642f3d`](https://github.com/NixOS/nixpkgs/commit/38642f3dce0fd419d6a822b367aba4d2af997698) | `` mbedtls_2: 2.28.3 -> 2.28.4 ``                                                               |
| [`cf4c0f09`](https://github.com/NixOS/nixpkgs/commit/cf4c0f090fe55e3018164a15d81dd0a374dfd43c) | `` python310Packages.laszip: refactor ``                                                        |
| [`32f3046e`](https://github.com/NixOS/nixpkgs/commit/32f3046ef509993b35f11c08e441982d6d434470) | `` LASzip: refactor ``                                                                          |
| [`8f67c489`](https://github.com/NixOS/nixpkgs/commit/8f67c489ba2b8c9523d4645e17c2c6ed0c546932) | `` LASzip: fix dylib name for darwin ``                                                         |
| [`4feab75f`](https://github.com/NixOS/nixpkgs/commit/4feab75fd378cbfebaba88d5d84676746993dbf1) | `` zigbee2mqtt: 1.32.1 -> 1.32.2 ``                                                             |
| [`4f268950`](https://github.com/NixOS/nixpkgs/commit/4f268950147ea09a84d04f5d57f01ee935675fd8) | `` metals: 0.11.12 -> 1.0.0 ``                                                                  |
| [`a71889c0`](https://github.com/NixOS/nixpkgs/commit/a71889c042b1e274671f5d84a19bf18e1516e816) | `` mautrix-whatsapp: Add release notes ``                                                       |
| [`01733304`](https://github.com/NixOS/nixpkgs/commit/01733304267d0840bccf34bd5a6a39c16448b0ed) | `` mautrix-whatsapp: Add postgres options to example ``                                         |
| [`b443a4d9`](https://github.com/NixOS/nixpkgs/commit/b443a4d9406b83ea7819e9ea4d9dedb8a17821c5) | `` mautrix-whatsapp: Apply suggestions ``                                                       |
| [`641d717a`](https://github.com/NixOS/nixpkgs/commit/641d717acedd9a468c762b77fa15b5d8a3728600) | `` nixos/mautrix-whatsapp: init module ``                                                       |
| [`af65a5c0`](https://github.com/NixOS/nixpkgs/commit/af65a5c0343498ab2a273dc69075a0d0dc881ecc) | `` noto-fonts: 23.7.1 -> 23.8.1 ``                                                              |
| [`076a0b1e`](https://github.com/NixOS/nixpkgs/commit/076a0b1eebe75d7acbe2fa319d7b470c51943999) | `` python3Packages.mpv: 1.0.1 -> 1.0.4 ``                                                       |
| [`bd0411d8`](https://github.com/NixOS/nixpkgs/commit/bd0411d80a138c6c422702b6def65c485c893a3e) | `` highlight: 4.6 -> 4.7 ``                                                                     |
| [`176f7e77`](https://github.com/NixOS/nixpkgs/commit/176f7e778f1ec77aabfde36bd2585415d936e8f0) | `` yutto: 2.0.0b24 -> 2.0.0b28 ``                                                               |