### PR TITLE
chore(flake/pre-commit-hooks): `3139c4d1` -> `e5588ddf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -953,11 +953,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1691256628,
-        "narHash": "sha256-M0YXHemR3zbyhM7PvJa5lzGhWVf6kM/fpZ4cWe/VIhI=",
+        "lastModified": 1691397944,
+        "narHash": "sha256-4fa4bX3kPYKpEssgrFRxRCPVXczidArDeSWaUMSzQAU=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "3139c4d1f7732cab89f06492bdd4677b877e3785",
+        "rev": "e5588ddffd4c3578547a86ef40ec9a6fbdae2986",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                        |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
| [`2175ea0a`](https://github.com/cachix/pre-commit-hooks.nix/commit/2175ea0a00a8f2033bff9487d3f54a9186b84a33) | `` Fix settings for hook `mkdocs-linkcheck` `` |