### PR TITLE
chore(flake/nur): `6812a24b` -> `4754814f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691463372,
-        "narHash": "sha256-n6BwlPdALIvkdRMTE5qBzEIo0gcYwJUBF+QYqMfAokU=",
+        "lastModified": 1691465515,
+        "narHash": "sha256-u8X2eKlpFQOdAlxNykHURg29IKQ3qjM3nL4Dlp2XhmA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6812a24b58c38e7f786ad81f0ecc6119ab05495c",
+        "rev": "4754814f5c489c4a7f17f78927d34d9fa36efeac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4754814f`](https://github.com/nix-community/NUR/commit/4754814f5c489c4a7f17f78927d34d9fa36efeac) | `` automatic update `` |