### PR TITLE
chore(flake/nur): `4754814f` -> `d82a6cf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691465515,
-        "narHash": "sha256-u8X2eKlpFQOdAlxNykHURg29IKQ3qjM3nL4Dlp2XhmA=",
+        "lastModified": 1691473273,
+        "narHash": "sha256-amOzw5wXn3CiPcNYaexI+qyithmKY+V41VNyaHxQSbM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4754814f5c489c4a7f17f78927d34d9fa36efeac",
+        "rev": "d82a6cf5c74a7b78c62b46e103cf73035c670128",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d82a6cf5`](https://github.com/nix-community/NUR/commit/d82a6cf5c74a7b78c62b46e103cf73035c670128) | `` automatic update `` |