### PR TITLE
chore(flake/nur): `d82a6cf5` -> `7aea07b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691473273,
-        "narHash": "sha256-amOzw5wXn3CiPcNYaexI+qyithmKY+V41VNyaHxQSbM=",
+        "lastModified": 1691479396,
+        "narHash": "sha256-0vyhLJggW/cC00XKPe+urzTSxIDM9FGI1FwaJ60lLCk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d82a6cf5c74a7b78c62b46e103cf73035c670128",
+        "rev": "7aea07b38ae3da64172e25e983e76e99cd2f9cbd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7aea07b3`](https://github.com/nix-community/NUR/commit/7aea07b38ae3da64172e25e983e76e99cd2f9cbd) | `` automatic update `` |
| [`178bec36`](https://github.com/nix-community/NUR/commit/178bec36bd4379a1c3b3d2fa77ef1a6b9fcefebb) | `` automatic update `` |