### PR TITLE
chore(flake/emacs-overlay): `3c5a8694` -> `8fec2d96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1691463830,
-        "narHash": "sha256-IYsrzsYzR0hypA8X2aidszuc1OJqmS4Aiqi2uA04RrM=",
+        "lastModified": 1691492522,
+        "narHash": "sha256-LHe9QGeo5HYBPXuTvW26wyTAwWf/o3I9hpIZpAAx8gY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3c5a869494bbd768b832a4567ae93d1c1224571c",
+        "rev": "8fec2d96e94b620d62ee5dbf52bd757c2c45ec9f",
         "type": "github"
       },
       "original": {
@@ -749,11 +749,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1691328192,
-        "narHash": "sha256-w59N1zyDQ7SupfMJLFvtms/SIVbdryqlw5AS4+DiH+Y=",
+        "lastModified": 1691421349,
+        "narHash": "sha256-RRJyX0CUrs4uW4gMhd/X4rcDG8PTgaaCQM5rXEJOx6g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "61676e4dcfeeb058f255294bcb08ea7f3bc3ce56",
+        "rev": "011567f35433879aae5024fc6ec53f2a0568a6c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`8fec2d96`](https://github.com/nix-community/emacs-overlay/commit/8fec2d96e94b620d62ee5dbf52bd757c2c45ec9f) | `` Updated repos/nongnu `` |
| [`3e235f8b`](https://github.com/nix-community/emacs-overlay/commit/3e235f8b8edd2f262dde5e35d80299ad17877904) | `` Updated repos/melpa ``  |
| [`1abe5dbc`](https://github.com/nix-community/emacs-overlay/commit/1abe5dbc82f50aa9e45a6c8c7147910d74923d30) | `` Updated repos/emacs ``  |
| [`ad62842d`](https://github.com/nix-community/emacs-overlay/commit/ad62842dc77e9589bf15ba7f155edcecb6b212c4) | `` Updated flake inputs `` |