### PR TITLE
chore(flake/nur): `28934e7a` -> `7386ab0e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691498565,
-        "narHash": "sha256-WRlPL2/ijhI/reXlP//XpxDu0x9PJTR2aksP0TBSgsw=",
+        "lastModified": 1691505961,
+        "narHash": "sha256-v06ojpyioZlKjErPpA5DfIre988eLwj4eOH0hvVnv+o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "28934e7a1acd70af1c15d377a05d3fd3bb2348a3",
+        "rev": "7386ab0e95b2d109b7999ba709550dc0e882b6c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7386ab0e`](https://github.com/nix-community/NUR/commit/7386ab0e95b2d109b7999ba709550dc0e882b6c5) | `` automatic update `` |