### PR TITLE
chore(flake/nur): `7386ab0e` -> `247f2c4f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691505961,
-        "narHash": "sha256-v06ojpyioZlKjErPpA5DfIre988eLwj4eOH0hvVnv+o=",
+        "lastModified": 1691507639,
+        "narHash": "sha256-Y3AUKXgVRZGmfzxre++whg7UuBJGYx080xuvZpeD/Jc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7386ab0e95b2d109b7999ba709550dc0e882b6c5",
+        "rev": "247f2c4fb0d2a9e7b57b0b2f8c90f94046dfb53d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`247f2c4f`](https://github.com/nix-community/NUR/commit/247f2c4fb0d2a9e7b57b0b2f8c90f94046dfb53d) | `` automatic update `` |