### PR TITLE
chore(flake/nur): `247f2c4f` -> `b614442b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691507639,
-        "narHash": "sha256-Y3AUKXgVRZGmfzxre++whg7UuBJGYx080xuvZpeD/Jc=",
+        "lastModified": 1691520309,
+        "narHash": "sha256-8qEIkhdIDelAaiqS+gXlIEGom8XxOlG8IxJu6SJ9xm8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "247f2c4fb0d2a9e7b57b0b2f8c90f94046dfb53d",
+        "rev": "b614442b73fa8a13727d219ef8b495f22d1af6ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b614442b`](https://github.com/nix-community/NUR/commit/b614442b73fa8a13727d219ef8b495f22d1af6ba) | `` automatic update `` |