### PR TITLE
chore(flake/emacs-overlay): `8fec2d96` -> `18e68ce4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1691492522,
-        "narHash": "sha256-LHe9QGeo5HYBPXuTvW26wyTAwWf/o3I9hpIZpAAx8gY=",
+        "lastModified": 1691521295,
+        "narHash": "sha256-/htjiqFwv8cuLlVPJC8mnIahBqUNBn6iEVn3dRJqWQE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8fec2d96e94b620d62ee5dbf52bd757c2c45ec9f",
+        "rev": "18e68ce41210cd4a00653f349285f9097c542fc4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`18e68ce4`](https://github.com/nix-community/emacs-overlay/commit/18e68ce41210cd4a00653f349285f9097c542fc4) | `` Updated repos/melpa `` |
| [`2fe48690`](https://github.com/nix-community/emacs-overlay/commit/2fe486906f25d97fd162e6c3d0d65b9f5efb00ff) | `` Updated repos/emacs `` |
| [`f2f9c764`](https://github.com/nix-community/emacs-overlay/commit/f2f9c764ee69c0e1a8675557dd0ed9a6f0854ea0) | `` Updated repos/elpa ``  |