### PR TITLE
chore(flake/nur): `80f090da` -> `a937194b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691534786,
-        "narHash": "sha256-/fuQIw/tlrjnxzVfgV+KyKMSHTzDe2CSimxhwTnHvxM=",
+        "lastModified": 1691541814,
+        "narHash": "sha256-2dV40wKt5MgMhDeekR2SObHkgJKmVWqN5RV1JckrpC0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "80f090dafcb948ae0ab77541aaa51b2d2c716e51",
+        "rev": "a937194b691c27b188f20f2233b4fee7a7b58c30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a937194b`](https://github.com/nix-community/NUR/commit/a937194b691c27b188f20f2233b4fee7a7b58c30) | `` automatic update `` |