### PR TITLE
chore(flake/nur): `a937194b` -> `397e1796`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691541814,
-        "narHash": "sha256-2dV40wKt5MgMhDeekR2SObHkgJKmVWqN5RV1JckrpC0=",
+        "lastModified": 1691545779,
+        "narHash": "sha256-cEr2J4piIuM+QQqGfnd5mIekj1eCJ4/6afasu9XcKsQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a937194b691c27b188f20f2233b4fee7a7b58c30",
+        "rev": "397e1796d0d4c86abfb3903a27ece5fb1b182cb1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`397e1796`](https://github.com/nix-community/NUR/commit/397e1796d0d4c86abfb3903a27ece5fb1b182cb1) | `` automatic update `` |