### PR TITLE
chore(flake/nur): `397e1796` -> `d7598391`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691545779,
-        "narHash": "sha256-cEr2J4piIuM+QQqGfnd5mIekj1eCJ4/6afasu9XcKsQ=",
+        "lastModified": 1691549202,
+        "narHash": "sha256-RaJIiCP+jCgWP8GsQKFhds63u8PAtMlWRMDir+7Qgmk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "397e1796d0d4c86abfb3903a27ece5fb1b182cb1",
+        "rev": "d7598391de529dfe07604a31cf6992e3d495ed03",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d7598391`](https://github.com/nix-community/NUR/commit/d7598391de529dfe07604a31cf6992e3d495ed03) | `` automatic update `` |