### PR TITLE
chore(flake/nur): `c987eac4` -> `4974a8c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691559855,
-        "narHash": "sha256-UkXcNHsasO0sr8W8X8wGeM1bBuLC5tHEueryGSLaE+E=",
+        "lastModified": 1691570799,
+        "narHash": "sha256-pi+yPruJFZidG4S/kmzwfeR0ODwKjmXZtXcpthA0nN4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c987eac4f579d9e989d5a0cde93d688592bda990",
+        "rev": "4974a8c07200dc12cb1ca6ec3390567a4adb4e9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4974a8c0`](https://github.com/nix-community/NUR/commit/4974a8c07200dc12cb1ca6ec3390567a4adb4e9f) | `` automatic update `` |