### PR TITLE
chore(flake/emacs-overlay): `332d0cfc` -> `707daad5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1691551050,
-        "narHash": "sha256-OlNJ6YTdAA4yEPHwucRRXe3px7fpbL8QJmVxSZ+Cn5w=",
+        "lastModified": 1691580895,
+        "narHash": "sha256-Iht82/rMZw926WygP59CZnlsk9nSjUck/AH6pu5+ZN4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "332d0cfcd041400033eb4c440e7d32b94f193bd1",
+        "rev": "707daad5fa2bc37a405d4be86dd503876cd9135a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`707daad5`](https://github.com/nix-community/emacs-overlay/commit/707daad5fa2bc37a405d4be86dd503876cd9135a) | `` Updated repos/melpa ``  |
| [`8294a4dd`](https://github.com/nix-community/emacs-overlay/commit/8294a4dd5749494485acc2059d69e1e607e91d73) | `` Updated repos/emacs ``  |
| [`f5e773b9`](https://github.com/nix-community/emacs-overlay/commit/f5e773b94fde8fb8bc968dd6ea7dbd4f34767d6c) | `` Updated flake inputs `` |