### PR TITLE
chore(flake/nur): `defe8f89` -> `e54f334e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691595928,
-        "narHash": "sha256-rWfRj69KUA/EN7OR4rj333EYC+I7bUzMXQdW4HLuO04=",
+        "lastModified": 1691603114,
+        "narHash": "sha256-WVzZUW8C6QizJqBM5BvbZ6Dm69GVPQZgdxKRHlhtdyI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "defe8f8923e585e730280628b9c206fda05053f3",
+        "rev": "e54f334e8c950e8288c3b405d4ff13bb6e2a6b9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e54f334e`](https://github.com/nix-community/NUR/commit/e54f334e8c950e8288c3b405d4ff13bb6e2a6b9b) | `` automatic update `` |