### PR TITLE
chore(flake/nur): `e54f334e` -> `ed0e79e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691603114,
-        "narHash": "sha256-WVzZUW8C6QizJqBM5BvbZ6Dm69GVPQZgdxKRHlhtdyI=",
+        "lastModified": 1691609865,
+        "narHash": "sha256-3JCcyh9uFR0J8xiLKK8zUkVeeAyuJqlFdRNYKwNf+O0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e54f334e8c950e8288c3b405d4ff13bb6e2a6b9b",
+        "rev": "ed0e79e0b5592426dbb78516ec95001d7b515a84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ed0e79e0`](https://github.com/nix-community/NUR/commit/ed0e79e0b5592426dbb78516ec95001d7b515a84) | `` automatic update `` |