### PR TITLE
chore(flake/nur): `ed79623f` -> `10e756d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691628138,
-        "narHash": "sha256-ATcCz2e4Y6yOd8FA86wmp7MU+gkpKfCTrloA1AnQu7w=",
+        "lastModified": 1691641937,
+        "narHash": "sha256-maXxCvV0mdjuLmMXFQC/7O1k7BBJzUfXRUgAWhLjR28=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed79623fae98f0f681c9a2bd126586bf935e4ff1",
+        "rev": "10e756d614d58014be8068ecca9d2520fa6b4292",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`10e756d6`](https://github.com/nix-community/NUR/commit/10e756d614d58014be8068ecca9d2520fa6b4292) | `` automatic update `` |
| [`d0ef46c7`](https://github.com/nix-community/NUR/commit/d0ef46c748ba941882a5cf7b256723c0f5303007) | `` automatic update `` |