### PR TITLE
chore(flake/nur): `10e756d6` -> `b45bf70d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -907,11 +907,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691641937,
-        "narHash": "sha256-maXxCvV0mdjuLmMXFQC/7O1k7BBJzUfXRUgAWhLjR28=",
+        "lastModified": 1691649780,
+        "narHash": "sha256-qnfMKEHfr0gVuTHqXiGXKNx21tHCOSIbWG+KdeyMUvs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "10e756d614d58014be8068ecca9d2520fa6b4292",
+        "rev": "b45bf70d09a6c16b0e0328ed8077d31de1d04b82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b45bf70d`](https://github.com/nix-community/NUR/commit/b45bf70d09a6c16b0e0328ed8077d31de1d04b82) | `` automatic update `` |
| [`621503b4`](https://github.com/nix-community/NUR/commit/621503b4a5548c897fa4f7fbf4787502496016c8) | `` automatic update `` |