### PR TITLE
chore(flake/nur): `b45bf70d` -> `bbb14c75`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -906,11 +906,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691649780,
-        "narHash": "sha256-qnfMKEHfr0gVuTHqXiGXKNx21tHCOSIbWG+KdeyMUvs=",
+        "lastModified": 1691653357,
+        "narHash": "sha256-WXbL4QyOrtxkRmQLD4rmk4o1VzSPT5RoTedq/OM95JY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b45bf70d09a6c16b0e0328ed8077d31de1d04b82",
+        "rev": "bbb14c7521967ffbeb0a492a1bd209e0369be648",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bbb14c75`](https://github.com/nix-community/NUR/commit/bbb14c7521967ffbeb0a492a1bd209e0369be648) | `` automatic update `` |
| [`e73c44e4`](https://github.com/nix-community/NUR/commit/e73c44e4b24987d6d3c6ed0f89eb1bfcd126a44c) | `` automatic update `` |