### PR TITLE
chore(flake/nur): `b63dadd9` -> `bf72064b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -906,11 +906,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691659795,
-        "narHash": "sha256-2R9lD79VX+U0RZpssUOsw4ZavoEaixwHFWA0SLtn1y8=",
+        "lastModified": 1691682574,
+        "narHash": "sha256-JWnbpDPQz8LO3pMCIBotLeUOpiAcL27stMJkdUMF2lE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b63dadd998d04666efc875fcf0f6b05d22e6cad8",
+        "rev": "bf72064b29d70a81df3368b636c5df92825be1f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bf72064b`](https://github.com/nix-community/NUR/commit/bf72064b29d70a81df3368b636c5df92825be1f5) | `` automatic update `` |
| [`5f772683`](https://github.com/nix-community/NUR/commit/5f772683d0285de70a9e97706cc26a08ab91ae86) | `` automatic update `` |
| [`702c18ef`](https://github.com/nix-community/NUR/commit/702c18ef1676273ef2a4d99fdfef5e338241c70a) | `` automatic update `` |