### PR TITLE
chore(flake/nur): `b6cded28` -> `7b1b1de0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -906,11 +906,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691690619,
-        "narHash": "sha256-0g391Xbut7AC9D7xhIc94rYEADeRCA09vzxOyB+nAAo=",
+        "lastModified": 1691696815,
+        "narHash": "sha256-X66k1DjbKcIBJi0z3qNN9kCWerG/BdbDc58W5HfB99M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b6cded28b383076b9fc89862f98427223bb200ef",
+        "rev": "7b1b1de0592bd9cae88137bd9d74c0eeadbd0b79",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7b1b1de0`](https://github.com/nix-community/NUR/commit/7b1b1de0592bd9cae88137bd9d74c0eeadbd0b79) | `` automatic update `` |