### PR TITLE
chore(flake/nur): `7b1b1de0` -> `4cc5a5f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -906,11 +906,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691696815,
-        "narHash": "sha256-X66k1DjbKcIBJi0z3qNN9kCWerG/BdbDc58W5HfB99M=",
+        "lastModified": 1691707585,
+        "narHash": "sha256-qidGV8I0c8QJEwXAeaPl5eCYeb1GRNi5HszYOpfgcG8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7b1b1de0592bd9cae88137bd9d74c0eeadbd0b79",
+        "rev": "4cc5a5f4ee5749ec456f53e786bd6ed769e5ed9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4cc5a5f4`](https://github.com/nix-community/NUR/commit/4cc5a5f4ee5749ec456f53e786bd6ed769e5ed9d) | `` automatic update `` |