### PR TITLE
chore(flake/nur): `4cc5a5f4` -> `fc016f71`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -906,11 +906,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691707585,
-        "narHash": "sha256-qidGV8I0c8QJEwXAeaPl5eCYeb1GRNi5HszYOpfgcG8=",
+        "lastModified": 1691714012,
+        "narHash": "sha256-rDiyzag2uLpxp573vn6dJqzAtX0Sqby3AZPgRvjDjE8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4cc5a5f4ee5749ec456f53e786bd6ed769e5ed9d",
+        "rev": "fc016f7120ce8be8daecbdff4aaa668744eeadd3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fc016f71`](https://github.com/nix-community/NUR/commit/fc016f7120ce8be8daecbdff4aaa668744eeadd3) | `` automatic update `` |