### PR TITLE
chore(flake/nur): `fc016f71` -> `2048ae97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -906,11 +906,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691714012,
-        "narHash": "sha256-rDiyzag2uLpxp573vn6dJqzAtX0Sqby3AZPgRvjDjE8=",
+        "lastModified": 1691717694,
+        "narHash": "sha256-bJH9g1TBj+JAQoQuVajvD/XPVC73TMeIS0cNUozMKVM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc016f7120ce8be8daecbdff4aaa668744eeadd3",
+        "rev": "2048ae97aab2489755faebd306ae8716f721937d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2048ae97`](https://github.com/nix-community/NUR/commit/2048ae97aab2489755faebd306ae8716f721937d) | `` automatic update `` |