### PR TITLE
chore(flake/emacs-overlay): `0be36058` -> `f6a34676`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1691692395,
-        "narHash": "sha256-ftsi1lM5Hq0d0ClgRziqVI3eToyzMKpmYvhxdsSYTiI=",
+        "lastModified": 1691722951,
+        "narHash": "sha256-V6ERc3gVbITjNDljQsfFRz/s68717aPjK+e94uZbLvQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0be36058b192ac18229ec023d7f642555165ed7a",
+        "rev": "f6a346762491a4655c3b43da5f2f154b57237a44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`f6a34676`](https://github.com/nix-community/emacs-overlay/commit/f6a346762491a4655c3b43da5f2f154b57237a44) | `` Updated repos/melpa ``  |
| [`01045b21`](https://github.com/nix-community/emacs-overlay/commit/01045b21c08a322789d9aaaf7892c1bdaf38ea66) | `` Updated repos/emacs ``  |
| [`c2b37676`](https://github.com/nix-community/emacs-overlay/commit/c2b376768b1ec58cd6b28bca3dfbd7998bd7f26a) | `` Updated repos/elpa ``   |
| [`ee24a9ba`](https://github.com/nix-community/emacs-overlay/commit/ee24a9baa6e24d45639c33cb592146d0036462ac) | `` Updated flake inputs `` |