### PR TITLE
chore(flake/nur): `2048ae97` -> `12503f38`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -906,11 +906,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691717694,
-        "narHash": "sha256-bJH9g1TBj+JAQoQuVajvD/XPVC73TMeIS0cNUozMKVM=",
+        "lastModified": 1691725539,
+        "narHash": "sha256-7TvXi9pUaZXiGZW0eH+JMcbFfBPvDgx03UuaHhIBPoI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2048ae97aab2489755faebd306ae8716f721937d",
+        "rev": "12503f38212124d5ce66bba48a5534ad6d61a1b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`12503f38`](https://github.com/nix-community/NUR/commit/12503f38212124d5ce66bba48a5534ad6d61a1b9) | `` automatic update `` |
| [`981e2d88`](https://github.com/nix-community/NUR/commit/981e2d8856aaaf31ce32d4f5661f664fcbb1e9fd) | `` automatic update `` |