### PR TITLE
chore(flake/nur): `12503f38` -> `19d51b67`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -906,11 +906,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691725539,
-        "narHash": "sha256-7TvXi9pUaZXiGZW0eH+JMcbFfBPvDgx03UuaHhIBPoI=",
+        "lastModified": 1691740222,
+        "narHash": "sha256-HHVI2d0Q1K8zbg3TeHvx7RCPxZ4nv7BhfV8VaCGSTIs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "12503f38212124d5ce66bba48a5534ad6d61a1b9",
+        "rev": "19d51b6724e367663156df38b674f974133f50c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                 |
| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`19d51b67`](https://github.com/nix-community/NUR/commit/19d51b6724e367663156df38b674f974133f50c2) | `` automatic update ``                                  |
| [`8f36cb76`](https://github.com/nix-community/NUR/commit/8f36cb7623c15ed0c8e4c53695518069ee9075cc) | `` automatic update ``                                  |
| [`5c0439b7`](https://github.com/nix-community/NUR/commit/5c0439b786dd0d1c2e38dbd8a4e54747c875ab93) | `` automatic update ``                                  |
| [`895586de`](https://github.com/nix-community/NUR/commit/895586de92f803296b7c6a7599acb5f90ea4d9f4) | `` automatic update ``                                  |
| [`50ed27f2`](https://github.com/nix-community/NUR/commit/50ed27f2a8f565e5d76e7b4818050dd26fc1e7fc) | `` add caarlos0, charmbracelet, and goreleaser repos `` |