### PR TITLE
chore(flake/nur): `19d51b67` -> `3873acca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -906,11 +906,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691740222,
-        "narHash": "sha256-HHVI2d0Q1K8zbg3TeHvx7RCPxZ4nv7BhfV8VaCGSTIs=",
+        "lastModified": 1691743508,
+        "narHash": "sha256-jMaMPFI/Lr4LZGFWP2ymS+0qDryrv8hzGu1/zzezTNk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "19d51b6724e367663156df38b674f974133f50c2",
+        "rev": "3873accac1f8765f2a50148db4237edbf728de66",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3873acca`](https://github.com/nix-community/NUR/commit/3873accac1f8765f2a50148db4237edbf728de66) | `` automatic update `` |