### PR TITLE
chore(flake/emacs-overlay): `f6a34676` -> `c13ae6eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1691722951,
-        "narHash": "sha256-V6ERc3gVbITjNDljQsfFRz/s68717aPjK+e94uZbLvQ=",
+        "lastModified": 1691751073,
+        "narHash": "sha256-9uQMoWUo72ut3zDLoJottEeydDcln+OVOunzKa9gucs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f6a346762491a4655c3b43da5f2f154b57237a44",
+        "rev": "c13ae6eb68176037cc5acb03288262b69f331b03",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`c13ae6eb`](https://github.com/nix-community/emacs-overlay/commit/c13ae6eb68176037cc5acb03288262b69f331b03) | `` Updated repos/melpa `` |
| [`ab287b58`](https://github.com/nix-community/emacs-overlay/commit/ab287b58200d6fb1961ed8ac1eed94dd78a46be9) | `` Updated repos/emacs `` |