### PR TITLE
chore(flake/nur): `cc07f9da` -> `e5744da0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -906,11 +906,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691761568,
-        "narHash": "sha256-GtcvdrPM6rXUYe0SJLY1QGs6wzH5KstBW5Sc4Gpm0O0=",
+        "lastModified": 1691772986,
+        "narHash": "sha256-TNeFvuUc3wCDpYTQ7px3Ij6DS1gZhRQB+NQSdoNqsaQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cc07f9da1fae2bd10bc128b82c06864ee429180a",
+        "rev": "e5744da069f533438f51f05540d302e079616491",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e5744da0`](https://github.com/nix-community/NUR/commit/e5744da069f533438f51f05540d302e079616491) | `` automatic update `` |