### PR TITLE
chore(flake/nur): `ec82d277` -> `edc79b4c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -906,11 +906,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691783201,
-        "narHash": "sha256-D3AHYQQ0CLpv7/RiWOXU6RgkaNqcNv7WHrRs4sTQnpc=",
+        "lastModified": 1691790394,
+        "narHash": "sha256-82j2QCkKQQXBNylkwt02vXvx64ImloE55m01Ii3nuAQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ec82d27773bfa365331531df0e17bf88f7f2cff4",
+        "rev": "edc79b4ce205a2537fc18038b24ad0f2ae3df6d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`edc79b4c`](https://github.com/nix-community/NUR/commit/edc79b4ce205a2537fc18038b24ad0f2ae3df6d8) | `` automatic update `` |