### PR TITLE
chore(flake/nur): `edc79b4c` -> `cd4eed0c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -906,11 +906,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691790394,
-        "narHash": "sha256-82j2QCkKQQXBNylkwt02vXvx64ImloE55m01Ii3nuAQ=",
+        "lastModified": 1691793966,
+        "narHash": "sha256-EJYmglkdlbtblj1gkYU613rjw+1cS9aRTCQly288bmE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "edc79b4ce205a2537fc18038b24ad0f2ae3df6d8",
+        "rev": "cd4eed0c1d5297783a8d8f8d1fd37e5411964344",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cd4eed0c`](https://github.com/nix-community/NUR/commit/cd4eed0c1d5297783a8d8f8d1fd37e5411964344) | `` automatic update `` |