### PR TITLE
chore(flake/nur): `bb6c4d19` -> `fd1bc1dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -906,11 +906,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691804189,
-        "narHash": "sha256-Q/KKUddYKLTKcEbeb65tSrln8fCyQRyXREQRPWGi57Q=",
+        "lastModified": 1691809080,
+        "narHash": "sha256-S6Mdys/1Acq3XZkJ+BhFeOC20qHKajEuCE8H8Hm1StY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bb6c4d19856446cfaa61e971f0875070b0579862",
+        "rev": "fd1bc1ddd96ade9e8e756f9053a8cb8a13763d73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fd1bc1dd`](https://github.com/nix-community/NUR/commit/fd1bc1ddd96ade9e8e756f9053a8cb8a13763d73) | `` automatic update `` |