### PR TITLE
chore(flake/nur): `fd1bc1dd` -> `68008bb1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -906,11 +906,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691809080,
-        "narHash": "sha256-S6Mdys/1Acq3XZkJ+BhFeOC20qHKajEuCE8H8Hm1StY=",
+        "lastModified": 1691814736,
+        "narHash": "sha256-hk1PmKF/y3NP9/gaZoQ97ySmxifnhyG/TrWcewjAV98=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fd1bc1ddd96ade9e8e756f9053a8cb8a13763d73",
+        "rev": "68008bb1e456742f6f4cba73ecd94b0c197e5a61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`68008bb1`](https://github.com/nix-community/NUR/commit/68008bb1e456742f6f4cba73ecd94b0c197e5a61) | `` automatic update `` |
| [`d078a2f5`](https://github.com/nix-community/NUR/commit/d078a2f58b6ba14660d4c3f612e6facce83d8cc0) | `` automatic update `` |
| [`2e926880`](https://github.com/nix-community/NUR/commit/2e92688022163f4b0bc51e2a463c770a290bea89) | `` automatic update `` |
| [`0ec91950`](https://github.com/nix-community/NUR/commit/0ec919509ac21efae8a1df43b4f054a912cbe660) | `` automatic update `` |