### PR TITLE
chore(flake/nur): `68008bb1` -> `9ab0b143`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -906,11 +906,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691814736,
-        "narHash": "sha256-hk1PmKF/y3NP9/gaZoQ97ySmxifnhyG/TrWcewjAV98=",
+        "lastModified": 1691821487,
+        "narHash": "sha256-APUW8CFOxzRdeX7k2ZtJnFPYz1n1369ruunMJ14ULKs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "68008bb1e456742f6f4cba73ecd94b0c197e5a61",
+        "rev": "9ab0b1430048688a64456117b7ec72be8f2c27d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ab0b143`](https://github.com/nix-community/NUR/commit/9ab0b1430048688a64456117b7ec72be8f2c27d4) | `` automatic update `` |