### PR TITLE
chore(flake/nur): `9ab0b143` -> `6efd40dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -906,11 +906,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1691821487,
-        "narHash": "sha256-APUW8CFOxzRdeX7k2ZtJnFPYz1n1369ruunMJ14ULKs=",
+        "lastModified": 1692190449,
+        "narHash": "sha256-KqV0xzvXTJom6XDK+upuP8sUJgiVu8zpJzoTqsdmdow=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ab0b1430048688a64456117b7ec72be8f2c27d4",
+        "rev": "6efd40dda5777f355fad166639683a40b8499a62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6efd40dd`](https://github.com/nix-community/NUR/commit/6efd40dda5777f355fad166639683a40b8499a62) | `` automatic update `` |
| [`984f5ff3`](https://github.com/nix-community/NUR/commit/984f5ff368a482de53d735ef9407f97302e16183) | `` automatic update `` |
| [`204dc2bf`](https://github.com/nix-community/NUR/commit/204dc2bf0eb03a607902876dec266516c44c4bfa) | `` automatic update `` |
| [`c132ebe6`](https://github.com/nix-community/NUR/commit/c132ebe65276784c18392715fb4db91020ab9f70) | `` automatic update `` |
| [`5ef4c0eb`](https://github.com/nix-community/NUR/commit/5ef4c0ebbae0130421868096a2541c8e618773b7) | `` automatic update `` |
| [`3dcd375e`](https://github.com/nix-community/NUR/commit/3dcd375e7fdb3c52a3fcf7e8c51e5de12cf52331) | `` automatic update `` |
| [`6c13efa9`](https://github.com/nix-community/NUR/commit/6c13efa973fc6f84a799fdcc55281a6d66cc25c4) | `` automatic update `` |
| [`c5c598b8`](https://github.com/nix-community/NUR/commit/c5c598b867ef45acc5312441fe8f1c0dca6ee901) | `` automatic update `` |
| [`7b4f79a6`](https://github.com/nix-community/NUR/commit/7b4f79a689a71db71236a0eae0c767c3b6b4d46a) | `` automatic update `` |
| [`5e81a262`](https://github.com/nix-community/NUR/commit/5e81a2624310e493084c12a21c0eec4ffd01e7cf) | `` automatic update `` |
| [`5509aed4`](https://github.com/nix-community/NUR/commit/5509aed48a83066e86238529fa9834b58cf7fcc2) | `` automatic update `` |
| [`878e51bd`](https://github.com/nix-community/NUR/commit/878e51bdfacb7153f3fa9f92b7925a54b0291c36) | `` automatic update `` |
| [`35938f04`](https://github.com/nix-community/NUR/commit/35938f04a498c9047e1936795a1e5d76c078b605) | `` automatic update `` |
| [`3e6fe09c`](https://github.com/nix-community/NUR/commit/3e6fe09cf6ec3402a7bd17e1ad2d0f40e6b1a9a8) | `` automatic update `` |
| [`e160259f`](https://github.com/nix-community/NUR/commit/e160259fdca39773787056333c54081fc4cec55d) | `` automatic update `` |
| [`3cfe3387`](https://github.com/nix-community/NUR/commit/3cfe3387a517fd68129eae715bed3952b06b159e) | `` automatic update `` |
| [`e03123dc`](https://github.com/nix-community/NUR/commit/e03123dcb115520f01c8d1b2cd5cfd98788052c5) | `` automatic update `` |
| [`721d7924`](https://github.com/nix-community/NUR/commit/721d7924b4e3c08fb08bb1039056713d17d4e9d0) | `` automatic update `` |
| [`471a397f`](https://github.com/nix-community/NUR/commit/471a397f147bdd9b9145b21408c1a5a12b126937) | `` automatic update `` |
| [`9ad63a47`](https://github.com/nix-community/NUR/commit/9ad63a47caa9ca553e442429db880cd39e5cd224) | `` automatic update `` |
| [`7cb353e4`](https://github.com/nix-community/NUR/commit/7cb353e4ddd9c3059b1dd36acea60354202c8447) | `` automatic update `` |
| [`2c2760b9`](https://github.com/nix-community/NUR/commit/2c2760b9a95840b360f49b61ec8bf34bf61dc781) | `` automatic update `` |
| [`a074a201`](https://github.com/nix-community/NUR/commit/a074a201713e5f3e2628aa45523570e107ac730d) | `` automatic update `` |
| [`3f616d2e`](https://github.com/nix-community/NUR/commit/3f616d2ecea6822dd8fdebd2b1297635da53240d) | `` automatic update `` |
| [`0fe703eb`](https://github.com/nix-community/NUR/commit/0fe703eb360c0b8ddf11d5019097f4d83f1bccd1) | `` automatic update `` |
| [`559ea2f0`](https://github.com/nix-community/NUR/commit/559ea2f0aaf452b9b7634d8ef97db17b78e939f7) | `` automatic update `` |
| [`35238b35`](https://github.com/nix-community/NUR/commit/35238b35a9f3cf9f63bf825dd9f4484b2c3db1ba) | `` automatic update `` |
| [`88b2a487`](https://github.com/nix-community/NUR/commit/88b2a487216b9d56f18cfdea936a8eb3612e3066) | `` automatic update `` |
| [`f0b8a1a1`](https://github.com/nix-community/NUR/commit/f0b8a1a1a579242f6ebe7fb54bb1dfc5cd38e58a) | `` automatic update `` |
| [`93a4de67`](https://github.com/nix-community/NUR/commit/93a4de674370cce89d584065bb1dd3ad1077b6a1) | `` automatic update `` |
| [`8bcad495`](https://github.com/nix-community/NUR/commit/8bcad495b8ee90577303ce016c84f655f079b4a3) | `` automatic update `` |
| [`bad78144`](https://github.com/nix-community/NUR/commit/bad78144969d3c0bb7f0cc6e3e203ba8b316bb04) | `` automatic update `` |
| [`a347a451`](https://github.com/nix-community/NUR/commit/a347a45196b1ea8a1e88a3d3a1dd74d829373b60) | `` automatic update `` |
| [`da7e5638`](https://github.com/nix-community/NUR/commit/da7e5638244583765c45647b05e2decbdcd16299) | `` automatic update `` |
| [`c3193925`](https://github.com/nix-community/NUR/commit/c319392513879af6eb1895d66c0094ff3d94bb3e) | `` automatic update `` |
| [`039f61b8`](https://github.com/nix-community/NUR/commit/039f61b857a30e83b03471ab5d7f69fbc9ef58cb) | `` automatic update `` |
| [`f3f54c4f`](https://github.com/nix-community/NUR/commit/f3f54c4f66c717b28fe267f73dc8cd238bfbd6fc) | `` automatic update `` |
| [`170d8d1a`](https://github.com/nix-community/NUR/commit/170d8d1a92ce8900de957330b04829c075f73980) | `` automatic update `` |
| [`5022df4c`](https://github.com/nix-community/NUR/commit/5022df4ca91c84817f0a35f2778c7981ea0baf3f) | `` automatic update `` |
| [`7e8b36a6`](https://github.com/nix-community/NUR/commit/7e8b36a6dc47dd832e94f24b254bfa75cb9202b8) | `` automatic update `` |
| [`5f8b357a`](https://github.com/nix-community/NUR/commit/5f8b357ac63561f33a8f5e3c372d64b92e6776f9) | `` automatic update `` |
| [`829d1d3b`](https://github.com/nix-community/NUR/commit/829d1d3b570abf580a8008873a3a0bb7be49962a) | `` automatic update `` |
| [`99b259ba`](https://github.com/nix-community/NUR/commit/99b259bad4deebd9dd365acfef1aecd617aec0e1) | `` automatic update `` |
| [`63589c71`](https://github.com/nix-community/NUR/commit/63589c7143fc9d3fd6178de8f020a48c9f2e7649) | `` automatic update `` |
| [`721a29a6`](https://github.com/nix-community/NUR/commit/721a29a607f5b95b3ceeb51400d7867bfcf31a7a) | `` automatic update `` |
| [`4bc121d0`](https://github.com/nix-community/NUR/commit/4bc121d0ca014ac4f4586b0fecf85fdb2e5144a0) | `` automatic update `` |
| [`2ba2c24c`](https://github.com/nix-community/NUR/commit/2ba2c24ca845753a7c8a62f5e372b68a7e39b78e) | `` automatic update `` |
| [`8483732e`](https://github.com/nix-community/NUR/commit/8483732ef9fd3764d61f59e6c295ea63d90ce690) | `` automatic update `` |
| [`5ec189f1`](https://github.com/nix-community/NUR/commit/5ec189f17d078713cb91b7a53a649aa31fe7400c) | `` automatic update `` |
| [`18516e0a`](https://github.com/nix-community/NUR/commit/18516e0a16a4fa8308e6db67d0fe70d9acd9b6ea) | `` automatic update `` |
| [`df4aa95a`](https://github.com/nix-community/NUR/commit/df4aa95a54629afe449fdb1c7dbbcba4412feca8) | `` automatic update `` |
| [`8dcc15db`](https://github.com/nix-community/NUR/commit/8dcc15dbdbc04634d9c0d686b14a7004d4dbfc94) | `` automatic update `` |
| [`79caddaa`](https://github.com/nix-community/NUR/commit/79caddaa08a511b8b294f7e4407d50765b4d6504) | `` automatic update `` |
| [`b86422ad`](https://github.com/nix-community/NUR/commit/b86422ad7caecc64380317d4768185a4c2edd57f) | `` automatic update `` |
| [`5098f0d8`](https://github.com/nix-community/NUR/commit/5098f0d81ac0e7cf2b432b1d9e584c1c0e92e4bf) | `` automatic update `` |
| [`907659eb`](https://github.com/nix-community/NUR/commit/907659ebd3aff565fff46f0154e0fad327f3d4ae) | `` automatic update `` |
| [`46308a85`](https://github.com/nix-community/NUR/commit/46308a855f48890fa463cc6fe830a4c6fcf976ba) | `` automatic update `` |
| [`9b8ab0f8`](https://github.com/nix-community/NUR/commit/9b8ab0f8c9026945d1e2b52e74e5f50728c2bbb7) | `` automatic update `` |
| [`f886a894`](https://github.com/nix-community/NUR/commit/f886a894bcd5a236f1e23c9e180ed07d873b0c67) | `` automatic update `` |
| [`7fa4c4af`](https://github.com/nix-community/NUR/commit/7fa4c4af46396ebbe5b2b08f8c3e68aaf22d31b7) | `` automatic update `` |
| [`4d740222`](https://github.com/nix-community/NUR/commit/4d74022229820366567ee0138b6314665f8c4ef4) | `` automatic update `` |
| [`b370859c`](https://github.com/nix-community/NUR/commit/b370859ced1a6a10070d2b2d215b6339a8560870) | `` automatic update `` |
| [`3dc7b15f`](https://github.com/nix-community/NUR/commit/3dc7b15f63b2b86a5bcb756f8558086c9c1b0cd8) | `` automatic update `` |
| [`5dfe5c73`](https://github.com/nix-community/NUR/commit/5dfe5c73ab292b60d34c49b21a400e5f851fad66) | `` automatic update `` |
| [`96b6f3a1`](https://github.com/nix-community/NUR/commit/96b6f3a14372425116936b58eb9bfb907fdf2b47) | `` automatic update `` |
| [`2c4b3332`](https://github.com/nix-community/NUR/commit/2c4b333223ede55e1b2ca7d3f306113a2c693bd4) | `` automatic update `` |
| [`0baf0070`](https://github.com/nix-community/NUR/commit/0baf00701fa85cd7ded76a5e5e0ef1f331449ce3) | `` automatic update `` |
| [`8611793e`](https://github.com/nix-community/NUR/commit/8611793ee714b3d9f766d61632464320948a1efc) | `` automatic update `` |
| [`121b4158`](https://github.com/nix-community/NUR/commit/121b41588a67bfd0539443c6a1895ef34e4b7536) | `` automatic update `` |
| [`c8fd67dc`](https://github.com/nix-community/NUR/commit/c8fd67dcbe555378765a3775a8ae811f721c7f05) | `` automatic update `` |
| [`a142ad30`](https://github.com/nix-community/NUR/commit/a142ad30a2f32e54686299c3999c998989a7befe) | `` automatic update `` |
| [`51ddbd39`](https://github.com/nix-community/NUR/commit/51ddbd397d07ab4e924be2f8ddf7401fbcf9c42e) | `` automatic update `` |
| [`8c884a03`](https://github.com/nix-community/NUR/commit/8c884a03eda0af9f813fba1e52cd98faeb058def) | `` automatic update `` |
| [`768b5280`](https://github.com/nix-community/NUR/commit/768b52804065d3fdbf78ccff4728eb12800a951b) | `` automatic update `` |
| [`766a8e8c`](https://github.com/nix-community/NUR/commit/766a8e8ce7a3646659c16f5d8d1368dfd4133c04) | `` automatic update `` |
| [`fe48fefb`](https://github.com/nix-community/NUR/commit/fe48fefbf13a75562599c1ab43871eb5c4274e1a) | `` automatic update `` |
| [`fa8f0f1d`](https://github.com/nix-community/NUR/commit/fa8f0f1d8fc736ecf5d0ded1d3e79dc97ad11465) | `` automatic update `` |
| [`c656cf68`](https://github.com/nix-community/NUR/commit/c656cf68fbc0f52ec2f43c1c4bd48192bf673cd3) | `` automatic update `` |
| [`69b7c3d7`](https://github.com/nix-community/NUR/commit/69b7c3d740f597386ba33ee66ab9e761dbfeeb77) | `` automatic update `` |
| [`789012e8`](https://github.com/nix-community/NUR/commit/789012e8c82cf28f02e1e66b2ab1d159c375537e) | `` automatic update `` |
| [`cd674121`](https://github.com/nix-community/NUR/commit/cd674121a570e0fd4619bfda5779be1c5530c7f4) | `` automatic update `` |
| [`417a0ec4`](https://github.com/nix-community/NUR/commit/417a0ec442414092dd524bdd280dd1383b496844) | `` automatic update `` |
| [`10724072`](https://github.com/nix-community/NUR/commit/107240729dc0fdd4afa1728aaa03d1df0d70a2e8) | `` automatic update `` |
| [`ff00e6e7`](https://github.com/nix-community/NUR/commit/ff00e6e780190721bff7dc6234cdf9e83b49ff0c) | `` automatic update `` |
| [`7a15e643`](https://github.com/nix-community/NUR/commit/7a15e6437acaac90ff7e58682fecffe2b6524726) | `` automatic update `` |
| [`6df059b9`](https://github.com/nix-community/NUR/commit/6df059b93475f40e5f6fe50428cf09a3ac66038e) | `` automatic update `` |
| [`547d87b5`](https://github.com/nix-community/NUR/commit/547d87b5b94944edb52c94684b6ed4fd31f0e092) | `` automatic update `` |
| [`7cbd1d28`](https://github.com/nix-community/NUR/commit/7cbd1d283f92dec001351cd59366f1053f7a6897) | `` automatic update `` |
| [`ff843350`](https://github.com/nix-community/NUR/commit/ff84335046f81ce5317ad83063c85c448c5439e0) | `` automatic update `` |
| [`93fd3971`](https://github.com/nix-community/NUR/commit/93fd3971deda2516b227a1bff71551c4eeb79f00) | `` automatic update `` |
| [`6db6e69d`](https://github.com/nix-community/NUR/commit/6db6e69da41fa46c5b798c567eefa4900b7e95c5) | `` automatic update `` |
| [`1419d984`](https://github.com/nix-community/NUR/commit/1419d984f3f8b22570ffa3f1133e0746b012205e) | `` automatic update `` |
| [`d8d1a487`](https://github.com/nix-community/NUR/commit/d8d1a487e82052ac7ba76c11cc332a6a90bd3f97) | `` automatic update `` |
| [`892ced40`](https://github.com/nix-community/NUR/commit/892ced401e457c150de968ff77e970f0b3f97487) | `` automatic update `` |
| [`99b2e733`](https://github.com/nix-community/NUR/commit/99b2e7331835917a1121dfb597a5d1ca3b14d5d0) | `` automatic update `` |
| [`57266975`](https://github.com/nix-community/NUR/commit/572669752a151190d13a7ee8bd8f18b172e7c4f9) | `` automatic update `` |