### PR TITLE
chore(flake/sops-nix): `c36df4fe` -> `5f5d9a3c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -780,11 +780,11 @@
     },
     "nixpkgs-stable_5": {
       "locked": {
-        "lastModified": 1690066826,
-        "narHash": "sha256-6L2qb+Zc0BFkh72OS9uuX637gniOjzU6qCDBpjB2LGY=",
+        "lastModified": 1691280485,
+        "narHash": "sha256-/8Ct9092OC1TTNzHgbcE9ejQdS2QxZYGqrWXEwUxdtQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ce45b591975d070044ca24e3003c830d26fea1c8",
+        "rev": "240472b7e47a641e9e7675f58b64d3626ca7824d",
         "type": "github"
       },
       "original": {
@@ -1028,11 +1028,11 @@
         "nixpkgs-stable": "nixpkgs-stable_5"
       },
       "locked": {
-        "lastModified": 1690199016,
-        "narHash": "sha256-yTLL72q6aqGmzHq+C3rDp3rIjno7EJZkFLof6Ika7cE=",
+        "lastModified": 1691830846,
+        "narHash": "sha256-ffR5maL8R4gsoF43YZRSBVzB7qYxzG+Ssjjktg80Wy4=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c36df4fe4bf4bb87759b1891cab21e7a05219500",
+        "rev": "5f5d9a3c8bc247eb574823b9f16a79e054dafe73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                        |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`5f5d9a3c`](https://github.com/Mic92/sops-nix/commit/5f5d9a3c8bc247eb574823b9f16a79e054dafe73) | `` update vendorHash ``                                                        |
| [`7c93670b`](https://github.com/Mic92/sops-nix/commit/7c93670b8226699ef075bb0e943a80b05b4e2852) | `` build(deps): bump golang.org/x/crypto from 0.11.0 to 0.12.0 ``              |
| [`339a5594`](https://github.com/Mic92/sops-nix/commit/339a5594021a3c1bd1fb3adfd967820eceb71a95) | `` Add configuration option to use tmpfs in place of ramfs (#355) ``           |
| [`1c673ba1`](https://github.com/Mic92/sops-nix/commit/1c673ba1053ad3e421fe043702237497bda0c621) | `` flake.lock: Update ``                                                       |
| [`dca9e50f`](https://github.com/Mic92/sops-nix/commit/dca9e50fe3906ba9911cf6525d27dcf11488d2dd) | `` modules/sops/templates: isCoercibleToString -> isConvertibleWithToString `` |