### PR TITLE
chore(flake/nixos-hardware): `f61352cf` -> `430a56dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -670,11 +670,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1691730710,
-        "narHash": "sha256-q/UBet5RdX8CBjOIpI2Y8EB8DXYr9cb7WuNGTP9HKf8=",
+        "lastModified": 1691871742,
+        "narHash": "sha256-6yDNjfbAMpwzWL4y75fxs6beXHRANfYX8BNSPjYehck=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f61352cf8066ddd3dfe9058e62184bae7382672d",
+        "rev": "430a56dd16fe583a812b2df44dca002acab2f4f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                              |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`430a56dd`](https://github.com/NixOS/nixos-hardware/commit/430a56dd16fe583a812b2df44dca002acab2f4f6) | `` raspberry-pi/4: fix modesetting on 6.1 kernels `` |
| [`33052d5c`](https://github.com/NixOS/nixos-hardware/commit/33052d5cad540300eade03d72e74dc8389e34afb) | `` apple/t2: update to kernel 6.4.9 ``               |
| [`ca062b3e`](https://github.com/NixOS/nixos-hardware/commit/ca062b3e6c324b1a00098d67360a6e13b0fed805) | `` star64: remove unused flake input from README ``  |