### PR TITLE
chore(flake/emacs-overlay): `e46cf9e0` -> `07173e89`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1691865829,
-        "narHash": "sha256-5ceau8KBj7WpvfN/QHA0q+lZC3HjNK4CJ7O8c9m8THU=",
+        "lastModified": 1691895415,
+        "narHash": "sha256-cHI5Nt0mhy7v1jtqX4F5jCv8IbUeUnUWANJqnMNnhu0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e46cf9e07a3a6c4f065ace50976bf0f915c02d97",
+        "rev": "07173e89a668ea643fbb6415440cc5ff566b8ea1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`07173e89`](https://github.com/nix-community/emacs-overlay/commit/07173e89a668ea643fbb6415440cc5ff566b8ea1) | `` Updated repos/nongnu `` |
| [`b311f6d4`](https://github.com/nix-community/emacs-overlay/commit/b311f6d4da9e75d75770f3cce2525eaea9c5ecbc) | `` Updated repos/melpa ``  |
| [`f6250def`](https://github.com/nix-community/emacs-overlay/commit/f6250def7c2d1282535b6a310bd1d8290721a99e) | `` Updated repos/emacs ``  |
| [`5e622602`](https://github.com/nix-community/emacs-overlay/commit/5e622602038a97ae8955103e5d44c9dddb81eb1b) | `` Updated repos/elpa ``   |