### PR TITLE
chore(flake/emacs-ement): `60e9a50b` -> `dbe2212c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -215,11 +215,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1688820892,
-        "narHash": "sha256-QtGjOdjDWmnEmXDqmgSdBU/gvLrbj5SoBfzrM0gZwMI=",
+        "lastModified": 1691897457,
+        "narHash": "sha256-s9w06NIaDZFkVgqi7T7oLAkeI0XU4Fek2v21gUdS6Cs=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "60e9a50b8a230c00d92f639ba25040944bcda9ab",
+        "rev": "dbe2212cbad7e95a667e283df41c5e4897cfe440",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`dbe2212c`](https://github.com/alphapapa/ement.el/commit/dbe2212cbad7e95a667e283df41c5e4897cfe440) | `` Fix: (ement-room-list-next-unread) Infinite loop `` |