### PR TITLE
chore(flake/emacs-overlay): `07173e89` -> `9279ce71`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1691895415,
-        "narHash": "sha256-cHI5Nt0mhy7v1jtqX4F5jCv8IbUeUnUWANJqnMNnhu0=",
+        "lastModified": 1691921730,
+        "narHash": "sha256-2vTR0Vq2VRQt7+4todEdOJRGIU/qyPdVCXJgbosz3Aw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "07173e89a668ea643fbb6415440cc5ff566b8ea1",
+        "rev": "9279ce7180483c5ec9e6da74b87000a49a4942c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`9279ce71`](https://github.com/nix-community/emacs-overlay/commit/9279ce7180483c5ec9e6da74b87000a49a4942c0) | `` Updated repos/melpa `` |
| [`440dc53a`](https://github.com/nix-community/emacs-overlay/commit/440dc53a517ebffce82c551d4b6740d02e1c4e12) | `` Updated repos/emacs `` |