### PR TITLE
chore(flake/stylix): `5f7b55cc` -> `beb35709`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1055,11 +1055,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690905065,
-        "narHash": "sha256-7RP7PJlHlK7yTsKBwvzzin8TX0Iiu4YcRWCr633wApM=",
+        "lastModified": 1691942466,
+        "narHash": "sha256-bK6FFbsKtyLKJLwgHerWp/EMMoWqE0UJk0KEbgYICbY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "5f7b55cc690b5ca02d1dc19175cab2ccdd408811",
+        "rev": "beb35709c9a769a5f279d3177af778a15dcbda46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                            |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`beb35709`](https://github.com/danth/stylix/commit/beb35709c9a769a5f279d3177af778a15dcbda46) | `` Move extra CSS to the end of the file (#147) `` |