### PR TITLE
chore(flake/emacs-overlay): `9279ce71` -> `def0e546`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1691921730,
-        "narHash": "sha256-2vTR0Vq2VRQt7+4todEdOJRGIU/qyPdVCXJgbosz3Aw=",
+        "lastModified": 1691950993,
+        "narHash": "sha256-7GvvoIRkigRbACvqyRQB3tFrccSWnpEH0ZkmzgLKCR0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9279ce7180483c5ec9e6da74b87000a49a4942c0",
+        "rev": "def0e546482c60a2cb17a282e39466b0daa02e54",
         "type": "github"
       },
       "original": {
@@ -748,11 +748,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1691693223,
-        "narHash": "sha256-9t8ZY1XNAsWqxAJmXgg+GXqF5chORMVnBT6PSHaRV3I=",
+        "lastModified": 1691831739,
+        "narHash": "sha256-6e12VCvA7jOjhzJ1adLiUV1GTPXGBcCfhggsDwiuNB4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "18784aac1013da9b442adf29b6c7c228518b5d3f",
+        "rev": "3fe694c4156b84dac12627685c7ae592a71e2206",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`def0e546`](https://github.com/nix-community/emacs-overlay/commit/def0e546482c60a2cb17a282e39466b0daa02e54) | `` Updated repos/melpa ``  |
| [`5cf81db8`](https://github.com/nix-community/emacs-overlay/commit/5cf81db89a78ae2d35d7adc306b6062e7e837fde) | `` Updated repos/emacs ``  |
| [`4ac9e3fa`](https://github.com/nix-community/emacs-overlay/commit/4ac9e3fa0db0e3e3595d4e11573431ef24e82e84) | `` Updated repos/elpa ``   |
| [`e9a73ce4`](https://github.com/nix-community/emacs-overlay/commit/e9a73ce4aaa5192d242342bc2f974434ea25e957) | `` Updated flake inputs `` |