### PR TITLE
chore(flake/emacs-overlay): `def0e546` -> `ee309584`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1691950993,
-        "narHash": "sha256-7GvvoIRkigRbACvqyRQB3tFrccSWnpEH0ZkmzgLKCR0=",
+        "lastModified": 1691981580,
+        "narHash": "sha256-QcSKbWlF6HyX9dVZjMaOyFfnVqzI2cVAqkp3m3Sx+wo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "def0e546482c60a2cb17a282e39466b0daa02e54",
+        "rev": "ee309584c89d9603338c77cfa931944fbafac6b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ee309584`](https://github.com/nix-community/emacs-overlay/commit/ee309584c89d9603338c77cfa931944fbafac6b4) | `` Updated repos/melpa ``  |
| [`418701a2`](https://github.com/nix-community/emacs-overlay/commit/418701a2fae2964d667c6ab96a465d1e3116ffa0) | `` Updated repos/emacs ``  |
| [`aab422e8`](https://github.com/nix-community/emacs-overlay/commit/aab422e8a7806336add8b7b7e7f4552780427a45) | `` Updated repos/elpa ``   |
| [`b95d1097`](https://github.com/nix-community/emacs-overlay/commit/b95d109790f4f9214a5ffbbfb528043dffc26f88) | `` Updated flake inputs `` |