### PR TITLE
chore(flake/home-manager): `88067b9b` -> `da6874e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1691998809,
-        "narHash": "sha256-GcvMrPYgDYPJ3iXozhpxN3Sp33dy0ZXJFKfAwh8aaf4=",
+        "lastModified": 1691998815,
+        "narHash": "sha256-HuFgb+W1Dvd0mjjudpTf0hVg/YKKiMRpX14t7dJeTm8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "88067b9b148ed86f81d80d13e49f0f848dbd96e0",
+        "rev": "da6874e8bb82204323b94154585a1471c739f73e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`da6874e8`](https://github.com/nix-community/home-manager/commit/da6874e8bb82204323b94154585a1471c739f73e) | `` Translate using Weblate (Romanian) ``            |
| [`d08812fe`](https://github.com/nix-community/home-manager/commit/d08812fe1a850b5948b2101cb4adcb6f8c4faa94) | `` Translate using Weblate (Portuguese (Brazil)) `` |