### PR TITLE
chore(flake/combobulate): `e3370c97` -> `e37e24de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
     "combobulate": {
       "flake": false,
       "locked": {
-        "lastModified": 1690787588,
-        "narHash": "sha256-4KNlyftCuniP4DDXDBsDQmB1KReYz3xzRzkr/awx9eA=",
+        "lastModified": 1692027991,
+        "narHash": "sha256-CUv78OrkVPBxzJlk/px2yJPuLMv4tyJJGvgabjIWi1I=",
         "owner": "mickeynp",
         "repo": "combobulate",
-        "rev": "e3370c97bcd1eb9b5dcba03014b246948c6e7126",
+        "rev": "e37e24de1afa577a19974b6967a4837a2ae5cb98",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                 |
| ----------------------------------------------------------------------------------------------------- | ----------------------- |
| [`e37e24de`](https://github.com/mickeynp/combobulate/commit/e37e24de1afa577a19974b6967a4837a2ae5cb98) | `` Update README.rst `` |