### PR TITLE
chore(flake/emacs-overlay): `aae3c605` -> `7a4b5bbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1692010894,
-        "narHash": "sha256-5c4rEUfB/o3uWHk0OXY2gWE0R6p4reQPczNvUj3U/3Q=",
+        "lastModified": 1692037570,
+        "narHash": "sha256-bvj/wfLLFTc8cWAwhN8tgShiy8ekPWt1+gWlEH7W4zY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "aae3c60518d98de6780f08cd99ed84016474089f",
+        "rev": "7a4b5bbc06182e2f704630cd77a614ab0d9c2f2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`7a4b5bbc`](https://github.com/nix-community/emacs-overlay/commit/7a4b5bbc06182e2f704630cd77a614ab0d9c2f2e) | `` Updated repos/melpa `` |
| [`7caa1491`](https://github.com/nix-community/emacs-overlay/commit/7caa1491ddf4422185709cd2501d0bfdd21758d2) | `` Updated repos/emacs `` |
| [`c888ee96`](https://github.com/nix-community/emacs-overlay/commit/c888ee96354322919f12ad8771ac4eddf0d50d11) | `` Updated repos/elpa ``  |