### PR TITLE
chore(flake/nixpkgs): `100a1550` -> `6e287913`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -826,11 +826,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1691899779,
-        "narHash": "sha256-IBf4KVr/UQJlzrqB2/IHtlvmwsvyIVLPerSzCPU/6Xk=",
+        "lastModified": 1691990649,
+        "narHash": "sha256-gMbKOiX1HwClRP9lADaaV/lnZr93NEaOFe4ApDx/zd8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "100a1550b0e7a64b960c625b656f9229bdef5f87",
+        "rev": "6e287913f7b1ef537c97aa301b67c34ea46b640f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                  |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`6e287913`](https://github.com/NixOS/nixpkgs/commit/6e287913f7b1ef537c97aa301b67c34ea46b640f) | `` buck2: include prelude source in .prelude passthru ``                                 |
| [`e85b6933`](https://github.com/NixOS/nixpkgs/commit/e85b6933d543dc98a5f80525150ed048209f5e73) | `` buck2: minor tweaks ``                                                                |
| [`0ca8b2eb`](https://github.com/NixOS/nixpkgs/commit/0ca8b2ebeb09ab8e86a9c4219a1cf81282f836ed) | `` maintainers: change rs0vere's email ``                                                |
| [`8a22de0a`](https://github.com/NixOS/nixpkgs/commit/8a22de0a84861ff6be372009bffb5165967b1593) | `` rsbkb: 1.1 -> 1.2 ``                                                                  |
| [`f3c8f334`](https://github.com/NixOS/nixpkgs/commit/f3c8f334ebfe26c8a86a583470d2a06896acfcbd) | `` uwc: 1.0.4 -> 1.0.5 ``                                                                |
| [`df376149`](https://github.com/NixOS/nixpkgs/commit/df37614991669315b62da68add5574f2a85e53e0) | `` gomatrix: use sri hash ``                                                             |
| [`c26c7080`](https://github.com/NixOS/nixpkgs/commit/c26c708048cdafdffe8d3ca84b8f72b1037cb69f) | `` edge-runtime: 1.8.1 -> 1.10.0 ``                                                      |
| [`2a600eea`](https://github.com/NixOS/nixpkgs/commit/2a600eea3eedd2a1be81d4595e8259bb780bd865) | `` maintainers: remove kototama ``                                                       |
| [`6dfe7307`](https://github.com/NixOS/nixpkgs/commit/6dfe73079d0721261a3ba916729315424c6d7ce9) | `` uxn: mark as broken on Darwin ``                                                      |
| [`6ec3610c`](https://github.com/NixOS/nixpkgs/commit/6ec3610cd8926d89c42ce657c00425e5872d8855) | `` uxn: refactor ``                                                                      |
| [`dbc8e3a3`](https://github.com/NixOS/nixpkgs/commit/dbc8e3a3cfb7cd9a2b5e9df782043ac1a8f6a37f) | `` uxn: unstable-2023-07-30 -> unstable-2023-08-10 ``                                    |
| [`a262231c`](https://github.com/NixOS/nixpkgs/commit/a262231ccac4edfe56e64a16ff401fc0be9ca22b) | `` postgresqlPackages.pg_net: init at 0.7.2 ``                                           |
| [`c8129bd5`](https://github.com/NixOS/nixpkgs/commit/c8129bd5705825c59f77abe1aad095f42cbd0922) | `` python310Packages.traits: 6.4.1 -> 6.4.2 ``                                           |
| [`eed5548d`](https://github.com/NixOS/nixpkgs/commit/eed5548ddb036bf9d7c878b35f1d03246e481d11) | `` beets: add main program ``                                                            |
| [`7b0c7b91`](https://github.com/NixOS/nixpkgs/commit/7b0c7b911e38bcc8d043cdcbca18d078bce953a5) | `` mepo: 1.1.2 -> 1.2.0 ``                                                               |
| [`fe4594ec`](https://github.com/NixOS/nixpkgs/commit/fe4594ec3c2f5dbcccc48f479b55389dd05d2b51) | `` rustywind: 0.18.0 -> 0.19.0 ``                                                        |
| [`f915c568`](https://github.com/NixOS/nixpkgs/commit/f915c568160d0bd533476ed454baedc1bf2be432) | `` numix-icon-theme-circle: 23.07.21 -> 23.08.09 ``                                      |
| [`e69de7fe`](https://github.com/NixOS/nixpkgs/commit/e69de7fe01fc1b1d06025bbc7e83afaaad3dceba) | `` k6: 0.45.0 -> 0.45.1 ``                                                               |
| [`d0a131d8`](https://github.com/NixOS/nixpkgs/commit/d0a131d85c80a0f49698e5bae9a421d28a5dd03f) | `` minio-client: 2023-07-21T20-44-27Z -> 2023-08-08T17-23-59Z ``                         |
| [`2b8644f8`](https://github.com/NixOS/nixpkgs/commit/2b8644f8831d714e01f500b1e3d84a88d295f324) | `` pgmetrics: 1.15.0 -> 1.15.1 ``                                                        |
| [`eafc041a`](https://github.com/NixOS/nixpkgs/commit/eafc041a1944229e5e56d81bcd8cb4ee2397a842) | `` grub2: workaround parallel build failure by building .po files sequentially ``        |
| [`4f255e7f`](https://github.com/NixOS/nixpkgs/commit/4f255e7f10bdeb15d40cea35ea260b08bfbda62c) | `` colloid-gtk-theme: 2023.04.11 -> 2023-08-12 ``                                        |
| [`05ff3adc`](https://github.com/NixOS/nixpkgs/commit/05ff3adc4e933e7baf714caa00ae04dfda68b8bd) | `` ani-cli: 4.5 -> 4.6 ``                                                                |
| [`54f50455`](https://github.com/NixOS/nixpkgs/commit/54f5045571a3f728631b507668068f7f06cffa28) | `` nixos/zoneminder: replace lib.optional with lib.optionals to make module work ``      |
| [`bbf08eef`](https://github.com/NixOS/nixpkgs/commit/bbf08eef8e1a7d8f32615da7fe35be0339d4e09e) | `` chars: 0.6.0 -> 0.7.0 ``                                                              |
| [`b6a25074`](https://github.com/NixOS/nixpkgs/commit/b6a25074ae78bbb8ce10c7ea321871e69c43da16) | `` kubie: 0.21.1 -> 0.21.2 ``                                                            |
| [`7f58542d`](https://github.com/NixOS/nixpkgs/commit/7f58542d9afe1d055da5b72330afff4d664078a9) | `` kics: 1.7.4 -> 1.7.5 ``                                                               |
| [`50308ec7`](https://github.com/NixOS/nixpkgs/commit/50308ec793f2757df3eddcf06215d909b268e035) | `` lalrpop: set meta.mainProgram ``                                                      |
| [`6198e6be`](https://github.com/NixOS/nixpkgs/commit/6198e6be7f7f29ea0b1ee0482b7f56f904c271cb) | `` subfinder: add Misaka13514 to maintainers ``                                          |
| [`07f923ae`](https://github.com/NixOS/nixpkgs/commit/07f923ae3a22187bc81b55797adcaea0f5c14cdf) | `` subfinder: 2.6.1 -> 2.6.2 ``                                                          |
| [`0d483de0`](https://github.com/NixOS/nixpkgs/commit/0d483de08f2c5895c30bbc0f3895b3f0a8144745) | `` juicity: 0.1.2 -> 0.1.3 ``                                                            |
| [`7f466dbc`](https://github.com/NixOS/nixpkgs/commit/7f466dbc36f0a1a76631d073769d9cf47bc33635) | `` ssm-session-manager-plugin: 1.2.463.0 -> 1.2.497.0 ``                                 |
| [`cf9cf31d`](https://github.com/NixOS/nixpkgs/commit/cf9cf31d1039148fa6262d4572cde8155eb7d459) | `` python310Packages.dicom-numpy: 0.6.3 -> 0.6.5 ``                                      |
| [`777fb1fc`](https://github.com/NixOS/nixpkgs/commit/777fb1fc154e8ad23782186b4689e53adebf799d) | `` dart-sass: add tests ``                                                               |
| [`3d08a87b`](https://github.com/NixOS/nixpkgs/commit/3d08a87bde2c2935d9442a22f1cd35a20d6b993f) | `` dart-sass: 1.64.1 -> 1.65.1 ``                                                        |
| [`189daa5e`](https://github.com/NixOS/nixpkgs/commit/189daa5eb3288dd77e7d72805ed677d776705360) | `` python310Packages.chex: 0.1.6 -> 0.1.82; unbreak ``                                   |
| [`28ea69ef`](https://github.com/NixOS/nixpkgs/commit/28ea69efc32a521b82e83947b555b489e4694f9a) | `` ocamlPackages.ssl: 0.6.0 -> 0.7.0 ``                                                  |
| [`bd4b92f9`](https://github.com/NixOS/nixpkgs/commit/bd4b92f97360ec7f4599d167a0559180439297bc) | `` uthenticode: 1.0.9 -> 2.0.0 ``                                                        |
| [`8917a70f`](https://github.com/NixOS/nixpkgs/commit/8917a70fde55c1a86a5ed3f0873fc0432a9b4495) | `` wayshot: add meta.mainProgram ``                                                      |
| [`f6538bb8`](https://github.com/NixOS/nixpkgs/commit/f6538bb83af2ca47dbcf013bc0bad56f28b1f069) | `` eigenmath: set platforms ``                                                           |
| [`7c014dd1`](https://github.com/NixOS/nixpkgs/commit/7c014dd170c84bd7a4ec0236c54250ea4ff45e4d) | `` gotraceui: 0.2.0 -> 0.3.0 ``                                                          |
| [`6d2b1273`](https://github.com/NixOS/nixpkgs/commit/6d2b127349711f6a8cfa6488215bc83f8343eebe) | `` linuxPackages.nvidia_x11.settings: add mainProgram ``                                 |
| [`5ffd4ef3`](https://github.com/NixOS/nixpkgs/commit/5ffd4ef38261f35f3ca76ccfda1f3a5d5ae0be1b) | `` ocamlPackages.odoc: 2.2.0 -> 2.2.1 ``                                                 |
| [`d999615d`](https://github.com/NixOS/nixpkgs/commit/d999615d005cd77829dd75d8f69b2dc4a57b78bf) | `` dae: 0.2.3 -> 0.2.4 ``                                                                |
| [`c5f4a460`](https://github.com/NixOS/nixpkgs/commit/c5f4a460368cd1d43c41a72a2523f689ee29e398) | `` nixos/opensnitch: Add support for EPBF process monitor ``                             |
| [`33da3909`](https://github.com/NixOS/nixpkgs/commit/33da3909e7d6c9685199b4c5e7106a01981664a3) | `` kamilalisp: 0.2p -> 0.3.0.1 ``                                                        |
| [`5a5a16c3`](https://github.com/NixOS/nixpkgs/commit/5a5a16c3e073cf73f526febf3c86932f27b07242) | `` pico-sdk: fix homepage link points to pkg source ``                                   |
| [`70648bee`](https://github.com/NixOS/nixpkgs/commit/70648bee6e8896b641d86bfa9c5c26ded2c4b22c) | `` vault-ssh-plus: init at 0.7.0 ``                                                      |
| [`19cd58a6`](https://github.com/NixOS/nixpkgs/commit/19cd58a6ca6153a62139128e93876d5e6e703b62) | `` flutter37: fix skyNotice hash for version 1a65d409c7a1438a34d21b60bf30a6fd5db59314 `` |
| [`f0a34513`](https://github.com/NixOS/nixpkgs/commit/f0a3451322f130a516ebe861c45d6955a2a00ab1) | `` jc: add shell completions ``                                                          |
| [`0305a695`](https://github.com/NixOS/nixpkgs/commit/0305a6950d54b457c45ffca4850c2dd68aaea663) | `` unciv: 4.7.11 -> 4.7.13 ``                                                            |
| [`df8dcb51`](https://github.com/NixOS/nixpkgs/commit/df8dcb51b94b0e9f244281a9fd5912aa888e8ab5) | `` okteto: 2.18.0 -> 2.18.3 ``                                                           |
| [`41a2b273`](https://github.com/NixOS/nixpkgs/commit/41a2b273ab62bc6813be53e181262a8861aadcf8) | `` rmlint: 2.10.1 -> 2.10.2 ``                                                           |
| [`59dc8ca7`](https://github.com/NixOS/nixpkgs/commit/59dc8ca70e1e25af2490c01a58a2f8893c756427) | `` perlPackages.FinanceQuote: 1.57 -> 1.58 ``                                            |
| [`1bc43577`](https://github.com/NixOS/nixpkgs/commit/1bc43577f32c53bab984cbe9808a997125a7932b) | `` yubioath-flutter: add libnotify and libappindicator dependencies ``                   |
| [`f802e332`](https://github.com/NixOS/nixpkgs/commit/f802e332156140f5416a86ac92fd64a4e4f76842) | `` yubioath-flutter: update deps and deps hash ``                                        |
| [`895889ff`](https://github.com/NixOS/nixpkgs/commit/895889fffa4e6ab2be74ccdd01d0bc23615d6444) | `` yubioath-flutter.helper: relax all dependencies ``                                    |
| [`91f441cf`](https://github.com/NixOS/nixpkgs/commit/91f441cf77e4495bf26bb35c12ac91f350473bbc) | `` yubioath-flutter: Relax python deps in helper ``                                      |
| [`3a034cb6`](https://github.com/NixOS/nixpkgs/commit/3a034cb60a9cd9fc8711b0c6f89183ca5efa6c30) | `` yubioath-flutter: 6.1.0 -> 6.2.0 ``                                                   |
| [`8f5cb9e1`](https://github.com/NixOS/nixpkgs/commit/8f5cb9e132367b3390fd6e462ff23115c1013efc) | `` notesnook: update darwin hash ``                                                      |
| [`3907af83`](https://github.com/NixOS/nixpkgs/commit/3907af83872c48b8d26e92e0c52791679a8e28de) | `` fm: init at unstable-2023-07-25 ``                                                    |
| [`396095b8`](https://github.com/NixOS/nixpkgs/commit/396095b811054b4110c253db955b65a79e318eb1) | `` renpy: 8.1.0 -> 8.1.1 ``                                                              |
| [`07fec85b`](https://github.com/NixOS/nixpkgs/commit/07fec85bd90e66bb8f13cf19b00febf173743053) | `` owncloud-client: 4.1.0 -> 4.2.0 ``                                                    |
| [`4392a7e3`](https://github.com/NixOS/nixpkgs/commit/4392a7e3bcaf5d076f6d8c8cf1dcee56462c5e18) | `` pantheon.elementary-default-settings: Backport picture-uri-dark changes ``            |
| [`96e34513`](https://github.com/NixOS/nixpkgs/commit/96e34513904e42f401cc642cbcf5ab37571ccaf3) | `` fteqw: unstable-2022-08-09 -> unstable-2023-08-03 ``                                  |
| [`4022b273`](https://github.com/NixOS/nixpkgs/commit/4022b2733af68f5ab623f8a801fda4bd3f017726) | `` nixos/rustus: add user name to enable restoring of backups ``                         |
| [`38b2c039`](https://github.com/NixOS/nixpkgs/commit/38b2c039bd36e6769fb8ce9878ef9ddccdb80675) | `` gitea-actions-runner: restart on failure ``                                           |
| [`3d58bac7`](https://github.com/NixOS/nixpkgs/commit/3d58bac73be93af787e6642f64296617edec88a7) | `` services.gitea-actions-runner: make ExecStartPre extensible ``                        |
| [`7ad7e993`](https://github.com/NixOS/nixpkgs/commit/7ad7e99370e1a281f0edd307f70f50b577ce876a) | `` nixos/gitea-actions-runner: settings option to configure daemon ``                    |
| [`bce4ebfe`](https://github.com/NixOS/nixpkgs/commit/bce4ebfe2390d063ff86afaa2bc42dc5fadeecdf) | `` oneDNN: 3.2 -> 3.2.1 ``                                                               |
| [`b1f7d884`](https://github.com/NixOS/nixpkgs/commit/b1f7d88470fd0f8451dffda281359a3621bdcc3d) | `` nifi: 1.22.0 -> 1.23.0 ``                                                             |
| [`a4f5b7b8`](https://github.com/NixOS/nixpkgs/commit/a4f5b7b8ec8d038ac68cb627fcf016da8842107a) | `` cargo-bolero: 0.8.0 -> 0.9.0 ``                                                       |
| [`eea0f158`](https://github.com/NixOS/nixpkgs/commit/eea0f158cc6e3b8be04c47696d6ddb9e19eab0c3) | `` yacreader: 9.12.0 -> 9.13.1 ``                                                        |
| [`c3519508`](https://github.com/NixOS/nixpkgs/commit/c3519508e0c8808ded4e7600a7f51ff86ced38bc) | `` influxdb2-cli: specify meta.mainProgram to allow nix run ``                           |
| [`d8b50ae3`](https://github.com/NixOS/nixpkgs/commit/d8b50ae3197b0a12984e23321c59e67886706d97) | `` sabnbzd: 3.7.2 -> 4.0.3 (#248411) ``                                                  |
| [`0897afbf`](https://github.com/NixOS/nixpkgs/commit/0897afbf92f866e62489f4dde2afaca222e6c78b) | `` python311Packages.icalendar: 5.0.4 -> 5.0.7 ``                                        |
| [`35cb7461`](https://github.com/NixOS/nixpkgs/commit/35cb7461589d87d8e78eeb25ec3a759223d22d34) | `` mold: 2.0.0 -> 2.1.0 ``                                                               |
| [`4f9ae918`](https://github.com/NixOS/nixpkgs/commit/4f9ae918e3d8fb92cf1806c602d4d685ea54f573) | `` python311Packages.ibm-watson: remove postPatch section ``                             |
| [`c316383a`](https://github.com/NixOS/nixpkgs/commit/c316383a6ccfec77ff38b4b43821b57172f55ef9) | `` python311Packages.ibm-watson: add changelog to meta ``                                |
| [`f328790b`](https://github.com/NixOS/nixpkgs/commit/f328790bcf7362a0acb2a2245b1f4b97d65ffb69) | `` python311Packages.ibm-watson: 7.0.0 -> 7.0.1 ``                                       |
| [`9549e2aa`](https://github.com/NixOS/nixpkgs/commit/9549e2aa9ba87682b430ed58dad00049b7d9eaaf) | `` python311Packages.goocalendar: add pythonImportsCheck ``                              |
| [`9bea50a4`](https://github.com/NixOS/nixpkgs/commit/9bea50a421b71d36fc583ab816bd696b7d9016db) | `` python311Packages.goocalendar: normalize pname ``                                     |
| [`3f38bbf6`](https://github.com/NixOS/nixpkgs/commit/3f38bbf6ae2cf3bf99641e0ea585800966a3bf3b) | `` python311Packages.goocalendar: add format and update disabled ``                      |
| [`91074af2`](https://github.com/NixOS/nixpkgs/commit/91074af2ab139459d7c34bce1a82d399f049e8ab) | `` squeekboard: 1.21 -> 1.22 ``                                                          |
| [`63bc7f8f`](https://github.com/NixOS/nixpkgs/commit/63bc7f8f35b1d8515c1913ae15d62c80035aed27) | `` python311Packages.goocalendar: specifiy license ``                                    |
| [`c52a2261`](https://github.com/NixOS/nixpkgs/commit/c52a226159e8a8cc7a42a105fd79061f58aa39d4) | `` python311Packages.goocalendar: add changelog to meta ``                               |
| [`7301b48f`](https://github.com/NixOS/nixpkgs/commit/7301b48f7f7a085fe12834a269ff8aa8bd9fe152) | `` python311Packages.goocalendar: 0.7.2 -> 0.8.0 ``                                      |
| [`e737f504`](https://github.com/NixOS/nixpkgs/commit/e737f504155b06a1ac4c79b5d1bd9d14f754dc75) | `` python311Packages.google-api-python-client: 2.88.0 -> 2.96.0 ``                       |
| [`5fdc4649`](https://github.com/NixOS/nixpkgs/commit/5fdc46492ecd63c30600590ec013be7c4f88d45b) | `` liberation_ttf_v2: 2.1.0 -> 2.1.5 ``                                                  |
| [`37ee7a56`](https://github.com/NixOS/nixpkgs/commit/37ee7a563cb184bd8665884abfd911b5fc261dc2) | `` python311Packages.google-cloud-container: 2.28.0 -> 2.29.0 ``                         |
| [`afe5b9dd`](https://github.com/NixOS/nixpkgs/commit/afe5b9dd6cb902243b77211c632c4798cef30725) | `` python311Packages.google-cloud-bigtable: 2.20.0 -> 2.21.0 ``                          |
| [`07b51609`](https://github.com/NixOS/nixpkgs/commit/07b516098730b5946aac465d8829e32ed9707085) | `` python311Packages.aiomqtt: 1.0.0 -> 1.1.0 ``                                          |
| [`02c20a20`](https://github.com/NixOS/nixpkgs/commit/02c20a20d9f51761a3bacb67be916fd0cc2139f1) | `` python311Packages.mcstatus: 11.0.0 -> 11.0.1 ``                                       |
| [`70e9e2cd`](https://github.com/NixOS/nixpkgs/commit/70e9e2cd8132bb8b80ff82867f021ac76165010e) | `` plasma-pass: 1.2.0 -> 1.2.1 ``                                                        |
| [`b28fb7ac`](https://github.com/NixOS/nixpkgs/commit/b28fb7acb97b668ecbff88df75272ef06883d52d) | `` taskwarrior-tui: 0.23.7 -> 0.28.1 ``                                                  |
| [`75fbacb4`](https://github.com/NixOS/nixpkgs/commit/75fbacb4c1a59de121f46f77719a09c3f09aacb0) | `` metasploit: 6.3.28 -> 6.3.29 ``                                                       |
| [`883b0f8e`](https://github.com/NixOS/nixpkgs/commit/883b0f8eeed28b82a8c036731a6a7416685a04b6) | `` vimPlugins.fuzzy-nvim: fix by changing dependency ``                                  |
| [`7eb93b20`](https://github.com/NixOS/nixpkgs/commit/7eb93b20cc84abc3c845c89d88c62e3aabf9fcc8) | `` proxify: 0.0.11 -> 0.0.12 ``                                                          |
| [`67c24249`](https://github.com/NixOS/nixpkgs/commit/67c2424991ce41852e742109d35335c55894a5e1) | `` python3.pkgs.mpi4py: fix sandbox darwin build ``                                      |
| [`2ef98d2d`](https://github.com/NixOS/nixpkgs/commit/2ef98d2db92c652286a8d30cbabfd96698123fbc) | `` notesnook: 2.5.7 -> 2.6.1 ``                                                          |
| [`750fc50b`](https://github.com/NixOS/nixpkgs/commit/750fc50bfd132a44972aa15bb21937ae26303bc4) | `` meilisearch: 1.2.0 -> 1.3.1 ``                                                        |
| [`387551a4`](https://github.com/NixOS/nixpkgs/commit/387551a45b17aa77f068c788a4125d0d4c03a57e) | `` python311Packages.tplink-omada-client: 1.3.2 -> 1.3.3 ``                              |
| [`84d00f17`](https://github.com/NixOS/nixpkgs/commit/84d00f176e91be1ecdbedc076c55e24cb004792c) | `` exploitdb: 2023-08-11 -> 2023-08-12 ``                                                |
| [`50236223`](https://github.com/NixOS/nixpkgs/commit/502362234d218769ebe63986df09e28c9becc9f0) | `` go-mockery: 2.32.0 -> 2.32.4 ``                                                       |