### PR TITLE
chore(flake/emacs-overlay): `7a4b5bbc` -> `a86f50ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1692037570,
-        "narHash": "sha256-bvj/wfLLFTc8cWAwhN8tgShiy8ekPWt1+gWlEH7W4zY=",
+        "lastModified": 1692070756,
+        "narHash": "sha256-Vc9pNaxLiI4/JKJ/YvxJ5CkyYiF/OgJ9dXrziCgZXLg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7a4b5bbc06182e2f704630cd77a614ab0d9c2f2e",
+        "rev": "a86f50bad1a801e8e5a179244a5c0c63d2ae6ec8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`a86f50ba`](https://github.com/nix-community/emacs-overlay/commit/a86f50bad1a801e8e5a179244a5c0c63d2ae6ec8) | `` Updated repos/nongnu `` |
| [`cd7b1c80`](https://github.com/nix-community/emacs-overlay/commit/cd7b1c80be8ebec768f610b4fa2cb14dee342f1c) | `` Updated repos/melpa ``  |
| [`ddc08d21`](https://github.com/nix-community/emacs-overlay/commit/ddc08d21a8cc2daf8837a83b98c8944a22f3e319) | `` Updated repos/emacs ``  |
| [`e7963040`](https://github.com/nix-community/emacs-overlay/commit/e79630407bb906f27ca80a3875d271e08ed347d0) | `` Updated repos/elpa ``   |
| [`46af608d`](https://github.com/nix-community/emacs-overlay/commit/46af608d0a06238e97221969eff4ad4e42ed5c99) | `` Updated flake inputs `` |