### PR TITLE
chore(flake/emacs-overlay): `a86f50ba` -> `8fd061df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1692070756,
-        "narHash": "sha256-Vc9pNaxLiI4/JKJ/YvxJ5CkyYiF/OgJ9dXrziCgZXLg=",
+        "lastModified": 1692096417,
+        "narHash": "sha256-Q42fSPnvqPJ2OLU/WL4BDCxZLyUnvLJgmKU9GQrcT1I=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a86f50bad1a801e8e5a179244a5c0c63d2ae6ec8",
+        "rev": "8fd061dfb95bfc1823f9ac6718680b59b4f22895",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`8fd061df`](https://github.com/nix-community/emacs-overlay/commit/8fd061dfb95bfc1823f9ac6718680b59b4f22895) | `` Updated repos/melpa `` |
| [`fa3b5f73`](https://github.com/nix-community/emacs-overlay/commit/fa3b5f732f136689349911fe5480722eb76a1770) | `` Updated repos/emacs `` |