### PR TITLE
chore(flake/emacs-overlay): `8fd061df` -> `ff4dba89`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1692096417,
-        "narHash": "sha256-Q42fSPnvqPJ2OLU/WL4BDCxZLyUnvLJgmKU9GQrcT1I=",
+        "lastModified": 1692125006,
+        "narHash": "sha256-D3UuE9aiKBFmNuzRfZLmNUlwujXDFeD8/ZSSaNwAuAs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8fd061dfb95bfc1823f9ac6718680b59b4f22895",
+        "rev": "ff4dba8979ddc3bfa40867d4f256cc7f0e635d75",
         "type": "github"
       },
       "original": {
@@ -748,11 +748,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1691950488,
-        "narHash": "sha256-iUNEeudc4dGjx+HsHccnGiuZUVE/nhjXuQ1DVCsHIUY=",
+        "lastModified": 1692025715,
+        "narHash": "sha256-tsRiiopGT7HA8d/cuk5xYBRXgdnnvD+JhUGUe3x7vmY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "720e61ed8de116eec48d6baea1d54469b536b985",
+        "rev": "09a137528c3aea3780720d19f99cd706f52c3823",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ff4dba89`](https://github.com/nix-community/emacs-overlay/commit/ff4dba8979ddc3bfa40867d4f256cc7f0e635d75) | `` Updated repos/melpa ``  |
| [`7c9dd63b`](https://github.com/nix-community/emacs-overlay/commit/7c9dd63bc22eb3f841ac3ecab9d2ab0113adce0b) | `` Updated repos/emacs ``  |
| [`937799af`](https://github.com/nix-community/emacs-overlay/commit/937799af65bd725807dc5172829807900605c9ca) | `` Updated repos/elpa ``   |
| [`4c2006bf`](https://github.com/nix-community/emacs-overlay/commit/4c2006bf7ed2d62d14d7ebc0d8a1a728bd281bcc) | `` Updated flake inputs `` |