### PR TITLE
chore(flake/home-manager): `18791781` -> `b84767a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1692081771,
-        "narHash": "sha256-LWhyDz3gi1RzTcW6e6iwfs4VuDWFajOexBKygNIqvQM=",
+        "lastModified": 1692120418,
+        "narHash": "sha256-xAT8tLCz6v2sqwA5nduJYjmQEYI3h079Zr1Y+M2lk0Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "18791781ea86cbec6bce8bcb847444b9c73b8b3b",
+        "rev": "b84767a145e04d07ef699d266161cda605f48b11",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                |
| ----------------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b84767a1`](https://github.com/nix-community/home-manager/commit/b84767a145e04d07ef699d266161cda605f48b11) | `` xplr: add module `` |