### PR TITLE
chore(flake/home-manager): `b84767a1` -> `75cfe974`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1692120418,
-        "narHash": "sha256-xAT8tLCz6v2sqwA5nduJYjmQEYI3h079Zr1Y+M2lk0Q=",
+        "lastModified": 1692131549,
+        "narHash": "sha256-MFjI8NL63/6HjMZpvJgnB/Pgg2dht22t45jOYtipZig=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b84767a145e04d07ef699d266161cda605f48b11",
+        "rev": "75cfe974e2ca05a61b66768674032b4c079e55d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`75cfe974`](https://github.com/nix-community/home-manager/commit/75cfe974e2ca05a61b66768674032b4c079e55d4) | `` Translate using Weblate (German) `` |