### PR TITLE
chore(flake/emacs-ement): `3a01d427` -> `abedcf0d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -215,11 +215,11 @@
     "emacs-ement": {
       "flake": false,
       "locked": {
-        "lastModified": 1691997933,
-        "narHash": "sha256-YpKUxGm2n7075z7ib/PUMSpIGqV/geNYbkF8gtvka/w=",
+        "lastModified": 1692152386,
+        "narHash": "sha256-/lpvK4kl36I4QijIIA6lLWP2j0rv1enbhQBBuljgLyc=",
         "owner": "alphapapa",
         "repo": "ement.el",
-        "rev": "3a01d427ddf73b927ad718a15bda12fbb9cb4c5a",
+        "rev": "abedcf0d21aa8b1f79e9ef4c275b54b01faf247b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                    |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`abedcf0d`](https://github.com/alphapapa/ement.el/commit/abedcf0d21aa8b1f79e9ef4c275b54b01faf247b) | `` Meta: Enable testing with Emacs 29.1 `` |
| [`837991d2`](https://github.com/alphapapa/ement.el/commit/837991d265ffa9a0004bc8f2fdd866a48cf3ea44) | `` Tidy: Lint warnings on CI ``            |
| [`63e22bab`](https://github.com/alphapapa/ement.el/commit/63e22bab0f34efefc82b732c52414871912d77df) | `` Meta: Install ispell for CI ``          |