### PR TITLE
chore(flake/dendrite-demo-pinecone): `d3b315ba` -> `75029efb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1692151758,
-        "narHash": "sha256-6O0/JXPORvJ84DT60CkOl0Z+OCR5AVJttuFGd+/d04o=",
+        "lastModified": 1692169521,
+        "narHash": "sha256-NEyKoYmAxB2EykbyzYe7RBrGzizaW4rspiZYPCEpevc=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "d3b315bac269f25752e6faf999976714b9138e69",
+        "rev": "75029efb3dacc0a7eb8c4679f16528e3b7cdbdd2",
         "type": "github"
       },
       "original": {
@@ -796,11 +796,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1692100542,
-        "narHash": "sha256-H4f4BMl6cII32vg44RW8S/f0sel+6oJVsI1Eek9IwX4=",
+        "lastModified": 1692128808,
+        "narHash": "sha256-Di1Zm/P042NuwThMiZNrtmaAjd4Tm2qBOKHX7xUOfMk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "32e8028c1c6d16f8783fb226fe1ab5b5cd5603ed",
+        "rev": "4ed9856be002a730234a1a1ed9dcd9dd10cbdb40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                  |
| --------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`75029efb`](https://github.com/bbigras/dendrite-demo-pinecone/commit/75029efb3dacc0a7eb8c4679f16528e3b7cdbdd2) | `` flake.lock: Update `` |