### PR TITLE
chore(flake/emacs-overlay): `c46f414d` -> `50bd6119`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1692155730,
-        "narHash": "sha256-F4kHCKuUpK3PfTdjqtfuz9o4bq2x9EYPL+sZQ0ik96A=",
+        "lastModified": 1692181692,
+        "narHash": "sha256-wpLsGJb2zEUpQ5SqZSeMCDMg8nqlsw9/bP9IcpDyMds=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c46f414d642a1bbadb9d1f783ec895374cf9997a",
+        "rev": "50bd61195c8f9ddbaa862a2fcf4f40f82769a5ba",
         "type": "github"
       },
       "original": {
@@ -748,11 +748,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1692025715,
-        "narHash": "sha256-tsRiiopGT7HA8d/cuk5xYBRXgdnnvD+JhUGUe3x7vmY=",
+        "lastModified": 1692134936,
+        "narHash": "sha256-Z68O969cioC6I3k/AFBxsuEwpJwt4l9fzwuAMUhCCs0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "09a137528c3aea3780720d19f99cd706f52c3823",
+        "rev": "bfd953b2c6de4f550f75461bcc5768b6f966be10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`50bd6119`](https://github.com/nix-community/emacs-overlay/commit/50bd61195c8f9ddbaa862a2fcf4f40f82769a5ba) | `` Updated repos/nongnu `` |
| [`70a19b59`](https://github.com/nix-community/emacs-overlay/commit/70a19b59cc994aa5f5abe1da9eb920ca483c32fb) | `` Updated repos/melpa ``  |
| [`5a919b71`](https://github.com/nix-community/emacs-overlay/commit/5a919b715801423ee4d0ea16d5f61fb059f36f42) | `` Updated repos/emacs ``  |
| [`314ea6e0`](https://github.com/nix-community/emacs-overlay/commit/314ea6e0c500c52886d7d375229716e34995e643) | `` Updated flake inputs `` |