### PR TITLE
chore(flake/nixpkgs): `8353344d` -> `caac0eb6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -775,11 +775,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1692084312,
-        "narHash": "sha256-Za++qKVK6ovjNL9poQZtLKRM/re663pxzbJ+9M4Pgwg=",
+        "lastModified": 1692174805,
+        "narHash": "sha256-xmNPFDi/AUMIxwgOH/IVom55Dks34u1g7sFKKebxUm0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8353344d3236d3fda429bb471c1ee008857d3b7c",
+        "rev": "caac0eb6bdcad0b32cb2522e03e4002c8975c62e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
| [`7c450c93`](https://github.com/NixOS/nixpkgs/commit/7c450c934eab73639011a06f2d27a6667f755a8c) | `` python310Packages.vega: 3.6.0 -> 4.0.0 ``                                                                  |
| [`a887febd`](https://github.com/NixOS/nixpkgs/commit/a887febd06b5045a80b415394a03058b26257a90) | `` python310Packages.ipytablewidgets: init at 0.3.1 ``                                                        |
| [`83b9200f`](https://github.com/NixOS/nixpkgs/commit/83b9200f6dfd2dd570459124270f881ac16a18f8) | `` python310Packages.altair: 5.0.1 -> unstable-2023-08-12 ``                                                  |
| [`b1661036`](https://github.com/NixOS/nixpkgs/commit/b16610365ec743c57716aa115b876417f61dfb0f) | `` python310Packages.anywidget: init at 0.6.3 ``                                                              |
| [`9306ad33`](https://github.com/NixOS/nixpkgs/commit/9306ad337f65cc0771b600446153651c5eafe65e) | `` ocamlPackages.ocaml-lsp: 1.14.2 -> 1.16.2 ``                                                               |
| [`7217de61`](https://github.com/NixOS/nixpkgs/commit/7217de617e3ece3fe205d713aae02ea34aae53df) | `` terraform-providers.huaweicloud: 1.53.0 -> 1.54.0 ``                                                       |
| [`cd3ebd88`](https://github.com/NixOS/nixpkgs/commit/cd3ebd88ec37327c8ba2fb4b51bf047b37be5273) | `` terraform-providers.google-beta: 4.77.0 -> 4.78.0 ``                                                       |
| [`5012d342`](https://github.com/NixOS/nixpkgs/commit/5012d34294eee3a98c6861d86792a860470cbb1f) | `` terraform-providers.google: 4.77.0 -> 4.78.0 ``                                                            |
| [`16555a26`](https://github.com/NixOS/nixpkgs/commit/16555a26a9c637ef35c646ef51298c493d511820) | `` terraform-providers.dexidp: 0.2.1 -> 0.3.0 ``                                                              |
| [`f893ddad`](https://github.com/NixOS/nixpkgs/commit/f893ddad8812db9410288b67ce75a297f16f366d) | `` python3.pkgs.doc8: fix build dependency constraints ``                                                     |
| [`60c86fec`](https://github.com/NixOS/nixpkgs/commit/60c86fec0b9b3c26930f1689721742e599d24a55) | `` supabase-cli: 1.83.5 -> 1.86.1 ``                                                                          |
| [`9654988f`](https://github.com/NixOS/nixpkgs/commit/9654988f35bdcb08444fbb79293bc60359756eee) | `` tilt: 0.33.3 -> 0.33.4 ``                                                                                  |
| [`6b9d2e72`](https://github.com/NixOS/nixpkgs/commit/6b9d2e7252f3f57c27edbf277c94e382d0002d73) | `` syncthingtray: 1.4.4 -> 1.4.5 ``                                                                           |
| [`d308a20c`](https://github.com/NixOS/nixpkgs/commit/d308a20c2a8d4019bf490afcfac365f6c5c6d8c5) | `` python310Packages.flask-marshmallow: 0.14.0 -> 0.15.0 ``                                                   |
| [`79ce5286`](https://github.com/NixOS/nixpkgs/commit/79ce52869decf895295baf2dc086ebfbec439ea0) | `` python310Packages.flask-marshmallow: rename from flask_marshmallow ``                                      |
| [`8ba91230`](https://github.com/NixOS/nixpkgs/commit/8ba91230a0da929172cf003e7b04efd6dd61b314) | `` pulumi-bin: 3.76.0 -> 3.78.1 ``                                                                            |
| [`ebc8dfbb`](https://github.com/NixOS/nixpkgs/commit/ebc8dfbb9d53af283139eeea996767ae3fc1aa21) | `` chatgpt-retrieval-plugin: mark broken ``                                                                   |
| [`528a0cb8`](https://github.com/NixOS/nixpkgs/commit/528a0cb8dde67d39f8a9751167c60bed4c42eda2) | `` click: 0.4.2 -> 0.6.2 ``                                                                                   |
| [`e64c4226`](https://github.com/NixOS/nixpkgs/commit/e64c4226b19d117230352b666bb70aea0bd28d99) | `` woodpecker-plugin-git: 2.1.0 -> 2.1.1 ``                                                                   |
| [`9f3f0d09`](https://github.com/NixOS/nixpkgs/commit/9f3f0d0922cc4d767bdba1c4f118fbf3085c8aaf) | `` typst-lsp: 0.9.2 -> 0.9.3 ``                                                                               |
| [`afd4607c`](https://github.com/NixOS/nixpkgs/commit/afd4607cf467aaaca99468584256d6d1345c6290) | `` apparency: init at 1.5.1 ``                                                                                |
| [`e98111e2`](https://github.com/NixOS/nixpkgs/commit/e98111e2c048b1dcf3db1b95cfe2a9fd4d27b500) | `` python310Packages.pykeepass: 4.0.3 -> 4.0.5 ``                                                             |
| [`19921bdb`](https://github.com/NixOS/nixpkgs/commit/19921bdb760b4a85252746f694d7917312ca42e8) | `` clojure: 1.11.1.1356 -> 1.11.1.1386 ``                                                                     |
| [`820d55bb`](https://github.com/NixOS/nixpkgs/commit/820d55bb16b96b94e719096733158cd2c5d5dc57) | `` helix: fix UB in diff gutter ``                                                                            |
| [`6ce9a794`](https://github.com/NixOS/nixpkgs/commit/6ce9a79489c3f12fb01e211421463e49bdca7553) | `` python310Packages.upcloud-api: 2.0.1 -> 2.5.0 ``                                                           |
| [`414110e5`](https://github.com/NixOS/nixpkgs/commit/414110e5eab40ceda7669df6466538308383ba8e) | `` typst-lsp: 0.9.1 -> 0.9.2 ``                                                                               |
| [`cfad3719`](https://github.com/NixOS/nixpkgs/commit/cfad3719d10b3b353b46cf4ab8bb5e4ec3bbb801) | `` python311Packages.azure-eventhub: 5.11.3 -> 5.11.4 ``                                                      |
| [`7719f2a0`](https://github.com/NixOS/nixpkgs/commit/7719f2a0483376973960c4701835c9101fa6ab04) | `` python311Packages.google-cloud-language: 2.10.1 -> 2.11.0 ``                                               |
| [`6f46c37d`](https://github.com/NixOS/nixpkgs/commit/6f46c37d92fd95d6979cb0daeaaa8d6023f4a77e) | `` nixosTests.agate: switch to using gemget ``                                                                |
| [`a9461554`](https://github.com/NixOS/nixpkgs/commit/a946155493d06e5effb8fd3682eb3ba19ee75a3c) | `` sqlfluff: 2.2.1 -> 2.3.0 ``                                                                                |
| [`c682e07c`](https://github.com/NixOS/nixpkgs/commit/c682e07c132d641750d1fd67d42e64d0b45a1c48) | `` python311Packages.bimmer-connected: 0.13.9 -> 0.13.10 ``                                                   |
| [`46f6ed1c`](https://github.com/NixOS/nixpkgs/commit/46f6ed1c2cb5218ea463bdaa4f2429fff3af1f4d) | `` python311Packages.python-otbr-api: 2.4.0 -> 2.5.0 ``                                                       |
| [`8edfe0f3`](https://github.com/NixOS/nixpkgs/commit/8edfe0f3da435f8e159a86293f8f29e3e45d853c) | `` python311Packages.todoist-api-python: 2.1.1 -> 2.1.3 ``                                                    |
| [`8e6928f7`](https://github.com/NixOS/nixpkgs/commit/8e6928f71777719dce667802e4d1ab621857c9b0) | `` checkov: 2.3.365 -> 2.3.366 ``                                                                             |
| [`2055b0a5`](https://github.com/NixOS/nixpkgs/commit/2055b0a59fbe523c5831cfa82e972612554dd3a0) | `` python311Packages.dbus-fast: 1.90.1 -> 1.91.2 ``                                                           |
| [`e4c18943`](https://github.com/NixOS/nixpkgs/commit/e4c189435c89d0a7b5bc141c7f0c93b25a5178bc) | `` debianutils: refactor ``                                                                                   |
| [`c88a504b`](https://github.com/NixOS/nixpkgs/commit/c88a504bb9169d3bc06914b417914c804cb71ae9) | `` debianutils: 5.7 -> 5.8 ``                                                                                 |
| [`a93ab55b`](https://github.com/NixOS/nixpkgs/commit/a93ab55b415e8c50f01cb6c9ebd705c458409d57) | `` gdal: make armadillo and netcdf optional ``                                                                |
| [`55f76104`](https://github.com/NixOS/nixpkgs/commit/55f76104aae2015a07a2877fc26bad1c683c6082) | `` gdalMinimal: make poppler, arrow, and HDF optional ``                                                      |
| [`5a093929`](https://github.com/NixOS/nixpkgs/commit/5a093929cf139b016ea24a461c6dc1987abdada3) | `` gdalMinimal: make database support optional ``                                                             |
| [`a62a25c2`](https://github.com/NixOS/nixpkgs/commit/a62a25c2922f14728e0a7c82b509de45fd2b5f5d) | `` gdalMinimal: make libheif optional ``                                                                      |
| [`0570c3fd`](https://github.com/NixOS/nixpkgs/commit/0570c3fdf64849f2bc5d127cb5d3c2f070ff3254) | `` gdal: introduce 'useMinimalFeatures' flag to reduce closure size ``                                        |
| [`65cbebcb`](https://github.com/NixOS/nixpkgs/commit/65cbebcb81ce2e076e70f599bf5cd8f55cf1f8f0) | `` nix-plugins: 11.0.0 -> 12.0.0 ``                                                                           |
| [`d7fa28d7`](https://github.com/NixOS/nixpkgs/commit/d7fa28d7110e3e927fe87c7c1e4fdf709490f419) | `` agate: 3.3.0 → 3.3.1 ``                                                                                    |
| [`d4e8dc21`](https://github.com/NixOS/nixpkgs/commit/d4e8dc2122e3cf9820c8b7dfd2e454eb724d75d4) | `` kubergrunt: 0.12.0 -> 0.12.1 ``                                                                            |
| [`574d11f2`](https://github.com/NixOS/nixpkgs/commit/574d11f231f4e7b6953178eef2c1bf247da1268c) | `` path-of-building: 2.31.0 -> 2.31.1 ``                                                                      |
| [`9504c91c`](https://github.com/NixOS/nixpkgs/commit/9504c91c02ef50356b2b23ae460a28f96b51a67b) | `` cudatext: 1.196.0 -> 1.197.0 ``                                                                            |
| [`54f4ca5d`](https://github.com/NixOS/nixpkgs/commit/54f4ca5de4b713cf6b856159f0c6b52360d4b84a) | `` keymapper: 2.6.2 -> 2.7.0 ``                                                                               |
| [`80dcf0e3`](https://github.com/NixOS/nixpkgs/commit/80dcf0e37bd2e8f168e32149f24183f48c5e68d6) | `` zef: 0.18.2 -> 0.18.3 ``                                                                                   |
| [`95a20b3f`](https://github.com/NixOS/nixpkgs/commit/95a20b3f39beb94be92b88611c4ec5bd57a6afd1) | `` u2ps: init at 1.2 ``                                                                                       |
| [`81735358`](https://github.com/NixOS/nixpkgs/commit/817353588ebdbd7a50352d802fe370789c3a6b9b) | `` g4music: init at 3.2 ``                                                                                    |
| [`f082a112`](https://github.com/NixOS/nixpkgs/commit/f082a11226a69d65d5d4cbc546c1135bef134d6a) | `` mdbook-admonish: 1.10.1 -> 1.10.2 ``                                                                       |
| [`d539ceee`](https://github.com/NixOS/nixpkgs/commit/d539ceee9c2e54dd398d95a0ec1c7517caf3ba14) | `` hyprland: unstable-2023-08-08 -> unstable-2023-08-15 ``                                                    |
| [`a66786ec`](https://github.com/NixOS/nixpkgs/commit/a66786ecba1381b70221c2ba3529c52d23e1de77) | `` opensearch: minor cleanup and reformat ``                                                                  |
| [`fa5cfd04`](https://github.com/NixOS/nixpkgs/commit/fa5cfd04d0712d9a46784bd5a7bb2f3b69a5799e) | `` openhantek6022: 3.3.2.2 -> 3.3.3 ``                                                                        |
| [`f0590235`](https://github.com/NixOS/nixpkgs/commit/f0590235639927d26dee3f64573bcd34e1d77450) | `` opensearch: use `finalAttrs` pattern ``                                                                    |
| [`4fdeb05e`](https://github.com/NixOS/nixpkgs/commit/4fdeb05ef8aa6fe4f2275e9a85c5f9ec85aa8f82) | `` kyverno: 1.10.2 -> 1.10.3 ``                                                                               |
| [`63c1fb20`](https://github.com/NixOS/nixpkgs/commit/63c1fb205837723f4c9f1a646e4434a6632d59d3) | `` python310Packages.ipympl: unbreak ``                                                                       |
| [`ea19faf9`](https://github.com/NixOS/nixpkgs/commit/ea19faf90550dad3875a05d57bf2e4726f6eeab1) | `` buildah-unwrapped: 1.31.1 -> 1.31.2 ``                                                                     |
| [`052cec59`](https://github.com/NixOS/nixpkgs/commit/052cec5965e24909302080c31102d82508fc5de4) | `` riffdiff: 2.23.4 -> 2.25.0 ``                                                                              |
| [`11c867b6`](https://github.com/NixOS/nixpkgs/commit/11c867b605042deb15415397993ad081ed9966d6) | `` metal-cli: 0.15.0 -> 0.16.0 ``                                                                             |
| [`d7442304`](https://github.com/NixOS/nixpkgs/commit/d744230467cd0daa25ca1b025b16993477559e8c) | `` btcpayserver: 1.11.1 -> 1.11.2 ``                                                                          |
| [`dd3e1cc8`](https://github.com/NixOS/nixpkgs/commit/dd3e1cc80eb457137089fabf88b2b99009b4bfca) | `` matrix-synapse: 1.89.0 -> 1.90.0 ``                                                                        |
| [`c9f973ff`](https://github.com/NixOS/nixpkgs/commit/c9f973ff7e61faa5509cd293d21dbd7a3dfe9cc2) | `` git-codereview: 1.4.0 -> 1.5.0 ``                                                                          |
| [`739ef72b`](https://github.com/NixOS/nixpkgs/commit/739ef72bff7214112b8c1f211b4a9e3062639167) | `` python311Packages.pytest-raises: disable failing tests ``                                                  |
| [`1a3e4eb2`](https://github.com/NixOS/nixpkgs/commit/1a3e4eb238f3c6c5c5a5c23e6af4c77730e554c1) | `` firefox-bin-unwrapped: 116.0.1 -> 116.0.2 ``                                                               |
| [`b8cf6b8f`](https://github.com/NixOS/nixpkgs/commit/b8cf6b8f1c59ce28f9ed62d32aed6d847d921d5b) | `` firefox-unwrapped: 116.0.1 -> 116.0.2 ``                                                                   |
| [`2b42b842`](https://github.com/NixOS/nixpkgs/commit/2b42b842edcdb0772a4e1566f6bf3e5abf154617) | `` nixos/prometheus-exporters: fix smartctl test ``                                                           |
| [`1f77e1b9`](https://github.com/NixOS/nixpkgs/commit/1f77e1b946e35e83d2db4812686a0dc78e565691) | `` ripdrag: 0.4.1 -> 0.4.2 ``                                                                                 |
| [`23386a59`](https://github.com/NixOS/nixpkgs/commit/23386a593e757970419091aa7157e0c43b9b6a23) | `` portfolio: 0.65.0 -> 0.65.1 ``                                                                             |
| [`68f38d46`](https://github.com/NixOS/nixpkgs/commit/68f38d4634b17281f03a18b5ea7e9be15561eeff) | `` emacsPackages.consult-gh: init at 20230706.438 ``                                                          |
| [`e270bfe9`](https://github.com/NixOS/nixpkgs/commit/e270bfe9147aa4cb7e1526abfd93645403641db2) | `` emacsPackages.power-mode: remove ``                                                                        |
| [`3c723251`](https://github.com/NixOS/nixpkgs/commit/3c7232510686adcf66f5f416e7f35a0c9d35e042) | `` teams-for-linux: Remove wayland patch ``                                                                   |
| [`1d6d2576`](https://github.com/NixOS/nixpkgs/commit/1d6d2576e50b8ddc8916dfc9c76a62c5aaf7fa07) | `` viceroy: 0.6.1 -> 0.7.0 ``                                                                                 |
| [`e26528b4`](https://github.com/NixOS/nixpkgs/commit/e26528b4ba172af1ade0acc43d0bc7b44dcfb1df) | `` python310Packages.pylint-venv: add changelog to meta ``                                                    |
| [`f7a451fd`](https://github.com/NixOS/nixpkgs/commit/f7a451fdfb5b5b0fe057627eb7f87ebeaa0a4dac) | `` python311Packages.nomadnet: 0.3.5 -> 0.3.6 ``                                                              |
| [`1c7b5188`](https://github.com/NixOS/nixpkgs/commit/1c7b51880b3e7884aff5302aaa4dd521be1fdccd) | `` python311Packages.lxmf: 0.3.1 -> 0.3.2 ``                                                                  |
| [`fcd76c39`](https://github.com/NixOS/nixpkgs/commit/fcd76c3953e1ef2025a508fb7f2c3b464c0f522e) | `` python311Packages.rns: 0.5.6 -> 0.5.7 ``                                                                   |
| [`0f35a0e3`](https://github.com/NixOS/nixpkgs/commit/0f35a0e354ea3f2c4e6057228bb397b68637d018) | `` teams-for-linux: 1.2.8 -> 1.3.2 ``                                                                         |
| [`90da2c12`](https://github.com/NixOS/nixpkgs/commit/90da2c1223475ff186967c7ace807678ff0d5870) | `` nixos/haproxy: allow to specify haproxy package ``                                                         |
| [`02fc87d9`](https://github.com/NixOS/nixpkgs/commit/02fc87d9639ee7d37afea9bfb1c1ec1e9379ece3) | `` python310Packages.casbin: 1.23.0 -> 1.23.1 ``                                                              |
| [`40002b0d`](https://github.com/NixOS/nixpkgs/commit/40002b0d4d5e113a69e8c80994dfbed4250bb5ba) | `` git-vanity-hash: 2020-02-26-unstable -> 1.0.0 ``                                                           |
| [`f8a17e42`](https://github.com/NixOS/nixpkgs/commit/f8a17e4200d3e79ef1e21d802af6eb4979c3e6b6) | `` mailman/python: remove obsolete almebic override, add explanation why this empty overlay should be kept `` |
| [`6d005720`](https://github.com/NixOS/nixpkgs/commit/6d00572038cd2ad1c1a0b92dceca1ee6da981b09) | `` tf-summarize: use sri hash ``                                                                              |
| [`a2316e26`](https://github.com/NixOS/nixpkgs/commit/a2316e268ddb4dfaacd32094f200762830422c55) | `` wmenu: 0.1.2 -> 0.1.4 ``                                                                                   |
| [`c8cd773e`](https://github.com/NixOS/nixpkgs/commit/c8cd773e729b016e5ab0f6196007f66a88c18d69) | `` appgate-sdp: 6.2.0 -> 6.2.1 ``                                                                             |
| [`b11a3687`](https://github.com/NixOS/nixpkgs/commit/b11a36879f87250c59ac35108f3524a3b0e0dc86) | `` prometheus-smartctl-exporter: 0.9.1 -> 0.10.0 ``                                                           |
| [`78188e2b`](https://github.com/NixOS/nixpkgs/commit/78188e2b616849d4e226c1d81fd0fa2af6196fe9) | `` geos: update meta attrs ``                                                                                 |
| [`0f02f25e`](https://github.com/NixOS/nixpkgs/commit/0f02f25eeca33be990ef866e58cb8949f168bdee) | `` python310Packages.pylint-venv: 3.0.1 -> 3.0.2 ``                                                           |
| [`cc34e8af`](https://github.com/NixOS/nixpkgs/commit/cc34e8af5712b881424feefbe22ab96870577f46) | `` kubectl-klock: init at 0.3.1 ``                                                                            |
| [`03865edf`](https://github.com/NixOS/nixpkgs/commit/03865edfeee0e1d3d542bd1330ed429716a13cf2) | `` maintainers: add scm2342 ``                                                                                |
| [`a46e69e5`](https://github.com/NixOS/nixpkgs/commit/a46e69e5afc2ee72dd603c100bcb4c0d5d8031e9) | `` forgejo-actions-runner: 2.3.0 -> 2.4.0 ``                                                                  |
| [`9e39dea6`](https://github.com/NixOS/nixpkgs/commit/9e39dea660a80fb99e72cb87faeac1752fc6dad9) | `` python311Packages.fakeredis: 2.17.0 -> 2.18.0 ``                                                           |
| [`4c9ae26c`](https://github.com/NixOS/nixpkgs/commit/4c9ae26c42f1583730ae377d00b4564d50fcd094) | `` python311Packages.txtai: 5.5.1 -> 6.0.0 ``                                                                 |
| [`1a3b7f61`](https://github.com/NixOS/nixpkgs/commit/1a3b7f61b254290c9a7f8faa8a38e255a4c9b53c) | `` nixos/invidious: generate hmac_key automatically ``                                                        |
| [`794044e7`](https://github.com/NixOS/nixpkgs/commit/794044e79d09a6e370a10ae0268e5f7e0a002ec5) | `` python311Packages.dissect: 3.8 -> 3.8.1 ``                                                                 |
| [`e655d3ba`](https://github.com/NixOS/nixpkgs/commit/e655d3baf910343399e4509a9cf56df50c9ddc6e) | `` python311Packages.dissect-target: 3.11 -> 3.11.1 ``                                                        |
| [`08f98015`](https://github.com/NixOS/nixpkgs/commit/08f9801576bb09ef476a1e2aa45a8f0678987ca7) | `` python311Packages.detectron2: add patch for Pillow>10 support ``                                           |
| [`786318d7`](https://github.com/NixOS/nixpkgs/commit/786318d798eff3da0a077e0b0874e6db5eb4833d) | `` buck2: more cosmetic refactorings; NFC ``                                                                  |
| [`9412d184`](https://github.com/NixOS/nixpkgs/commit/9412d184a9a11104582ab3b2ee7cb6b56d929463) | `` buck2: propagate name for fetchurl ``                                                                      |
| [`39dd6ba1`](https://github.com/NixOS/nixpkgs/commit/39dd6ba1a3d89ef42e72f2c59c26c85bd684e139) | `` buck2: unstable-2023-08-01 -> unstable-2023-08-15 ``                                                       |
| [`6a2f23de`](https://github.com/NixOS/nixpkgs/commit/6a2f23dec73b29eaa290f9694dba118cc7dc9d20) | `` reindeer: unstable-2023-07-14 -> unstable-2023-08-14 ``                                                    |
| [`ef77d0d2`](https://github.com/NixOS/nixpkgs/commit/ef77d0d273ccca115b05cff12840476b4a60f486) | `` python311Packages.pdfplumber: remove coverage and lint parts ``                                            |
| [`655a04a8`](https://github.com/NixOS/nixpkgs/commit/655a04a8fa43507f1642be4732926b2d1cec5128) | `` nixos/kanidm: add package option ``                                                                        |
| [`ff004506`](https://github.com/NixOS/nixpkgs/commit/ff00450695507b343be5f59c2b2057d1e8803103) | `` python311Packages.pandas-stubs: 1.5.3.230321 -> 2.0.3.230814 ``                                            |
| [`58c66339`](https://github.com/NixOS/nixpkgs/commit/58c6633940a51b9e58eb651c825a396cc18b9599) | `` terraform-providers.pagerduty: 2.15.2 -> 2.15.3 ``                                                         |
| [`963f2962`](https://github.com/NixOS/nixpkgs/commit/963f2962cb444d41332addd8d91d96e1f601dff8) | `` terraform-providers.okta: 4.1.0 -> 4.2.0 ``                                                                |
| [`77175475`](https://github.com/NixOS/nixpkgs/commit/77175475ff21e53fb0cab3c7434e954255d7de09) | `` terraform-providers.newrelic: 3.26.0 -> 3.26.1 ``                                                          |
| [`aa5a5b43`](https://github.com/NixOS/nixpkgs/commit/aa5a5b433eda77053cf9d121ed051c8daf7c0981) | `` terraform-providers.hcloud: 1.42.0 -> 1.42.1 ``                                                            |
| [`af1a2828`](https://github.com/NixOS/nixpkgs/commit/af1a2828fea6e05c55c3d19fdae893a63a49eca9) | `` terraform-providers.heroku: 5.2.5 -> 5.2.6 ``                                                              |
| [`d7e9196f`](https://github.com/NixOS/nixpkgs/commit/d7e9196f8cf48680286a3153b9864777f47281d3) | `` terraform-providers.cloudfoundry: 0.51.2 -> 0.51.3 ``                                                      |
| [`73fa5aca`](https://github.com/NixOS/nixpkgs/commit/73fa5aca3ff613c75751318dbffcdcc9953f8f57) | `` terraform-providers.buildkite: 0.23.0 -> 0.24.0 ``                                                         |
| [`b08975e3`](https://github.com/NixOS/nixpkgs/commit/b08975e36bec7195551e20692a41482b0b6b3dc3) | `` python311Packages.rokuecp: 0.18.0 -> 0.18.1 ``                                                             |
| [`aefb8068`](https://github.com/NixOS/nixpkgs/commit/aefb8068bdd14e48b72719792c370ffd0a6f6d03) | `` python311Packages.pyipp: 0.14.2 -> 0.14.3 ``                                                               |
| [`a9a29b70`](https://github.com/NixOS/nixpkgs/commit/a9a29b70590d95761044fb976b8135c9087ee24b) | `` lib/meta.nix: recommend use of getExe' in getExe warning ``                                                |
| [`7e596a31`](https://github.com/NixOS/nixpkgs/commit/7e596a31910034f4ad3ce37a035749d1dea589dc) | `` cargo-llvm-cov: 0.5.26 -> 0.5.27 ``                                                                        |
| [`1c537fc7`](https://github.com/NixOS/nixpkgs/commit/1c537fc7a8a1fd87e960b48331fb8e55d9ca8afa) | `` python311Packages.nsz: add format ``                                                                       |
| [`f8c4fe4d`](https://github.com/NixOS/nixpkgs/commit/f8c4fe4df3a45837d14aeff8604de70aa32782ad) | `` python311Packages.nsz: add changelog to meta ``                                                            |
| [`d9224842`](https://github.com/NixOS/nixpkgs/commit/d92248422a7caea4ca0c0d68f5b4b71c18ab7ec3) | `` python310Packages.pysigma-backend-elasticsearch: 1.0.4 -> 1.0.5 ``                                         |
| [`cc5b04d9`](https://github.com/NixOS/nixpkgs/commit/cc5b04d9d2bbdd4bd760b7f81b6c2a3d6c3cc507) | `` python311Packages.nsz: 4.3.0 -> 4.4.0 ``                                                                   |