### PR TITLE
chore(flake/nur): `6efd40dd` -> `f7379c7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692190449,
-        "narHash": "sha256-KqV0xzvXTJom6XDK+upuP8sUJgiVu8zpJzoTqsdmdow=",
+        "lastModified": 1692207363,
+        "narHash": "sha256-cpQNTMfLuZfuaQD7wRTYEcgWc1Pt3AiiYA0yAlpsrHI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6efd40dda5777f355fad166639683a40b8499a62",
+        "rev": "f7379c7d130d8175ff7bd2f2df3766d53d35d810",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f7379c7d`](https://github.com/nix-community/NUR/commit/f7379c7d130d8175ff7bd2f2df3766d53d35d810) | `` automatic update `` |
| [`729e6266`](https://github.com/nix-community/NUR/commit/729e626690444958a252178500c6ec24ebad4396) | `` automatic update `` |