### PR TITLE
chore(flake/emacs-overlay): `50bd6119` -> `6d79e2ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1692181692,
-        "narHash": "sha256-wpLsGJb2zEUpQ5SqZSeMCDMg8nqlsw9/bP9IcpDyMds=",
+        "lastModified": 1692241775,
+        "narHash": "sha256-N3rZafCMt/A6k1T9+pmPsvr/WQxNlClYlbUT0Mj+ibs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "50bd61195c8f9ddbaa862a2fcf4f40f82769a5ba",
+        "rev": "6d79e2ce84fc36425e4ce8ebb46585707848748d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`6d79e2ce`](https://github.com/nix-community/emacs-overlay/commit/6d79e2ce84fc36425e4ce8ebb46585707848748d) | `` Updated repos/melpa ``  |
| [`ddb0bcdc`](https://github.com/nix-community/emacs-overlay/commit/ddb0bcdc29fc51dca95ebb25001a079edff5e3f4) | `` Updated repos/emacs ``  |
| [`3406ae23`](https://github.com/nix-community/emacs-overlay/commit/3406ae23eaeae6de11131f9f3e9e710320f886eb) | `` Updated repos/elpa ``   |
| [`1cfe12c0`](https://github.com/nix-community/emacs-overlay/commit/1cfe12c02506a1a03697244c4ba1fa910bf1286e) | `` Updated flake inputs `` |
| [`37514671`](https://github.com/nix-community/emacs-overlay/commit/3751467118141bafb77a277a6f2626332ab33154) | `` Updated repos/melpa ``  |
| [`362c72b8`](https://github.com/nix-community/emacs-overlay/commit/362c72b86b625b141f3a763e6e9aab6e3290c7e1) | `` Updated repos/emacs ``  |
| [`c91ccadc`](https://github.com/nix-community/emacs-overlay/commit/c91ccadc2acf61f0d8277b532a83b3d4f9c4e3ca) | `` Updated repos/elpa ``   |