### PR TITLE
chore(flake/nur): `3baea5d9` -> `55680dae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692215167,
-        "narHash": "sha256-pfunFzYlVlW3iwGdAFiVdSldM9P7Xe15Rlill1SYP1E=",
+        "lastModified": 1692220584,
+        "narHash": "sha256-kgNOn2xvwtzgA3CC/xQ6Dg5vq7GZL+xMV95ESIFem4c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3baea5d923e52a1f1bed2ae40821ba92626c380d",
+        "rev": "55680dae5e3f05f08c3b34a7aa7ca4901fe1d77b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`55680dae`](https://github.com/nix-community/NUR/commit/55680dae5e3f05f08c3b34a7aa7ca4901fe1d77b) | `` automatic update `` |