### PR TITLE
chore(flake/attic): `f4cf5704` -> `b43d1208`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1691972610,
-        "narHash": "sha256-01X6GZ7nGZIvqzjM7zfnRemNXwgx5kneMldbTqRnPTU=",
+        "lastModified": 1692225040,
+        "narHash": "sha256-jbQNvkgWGioiC6S39dZVyn6us8p/DlEvm5hQKEYkzDU=",
         "owner": "zhaofengli",
         "repo": "attic",
-        "rev": "f4cf5704d64303ad11cc6918fbc6ab3cab6ca333",
+        "rev": "b43d12082e34bceb26038bdad0438fd68804cfcd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                                 |
| ------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`b43d1208`](https://github.com/zhaofengli/attic/commit/b43d12082e34bceb26038bdad0438fd68804cfcd) | `` nixos: use configured user in admin wrapper (#79) `` |