### PR TITLE
chore(flake/nur): `55680dae` -> `6bdd89c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692220584,
-        "narHash": "sha256-kgNOn2xvwtzgA3CC/xQ6Dg5vq7GZL+xMV95ESIFem4c=",
+        "lastModified": 1692237263,
+        "narHash": "sha256-B+P6HJyHm4xNVdFG3eEY2Uu0br7DVr1r3EYQPPnOo2U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "55680dae5e3f05f08c3b34a7aa7ca4901fe1d77b",
+        "rev": "6bdd89c5f8922468eab362e2206901e30b742259",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6bdd89c5`](https://github.com/nix-community/NUR/commit/6bdd89c5f8922468eab362e2206901e30b742259) | `` automatic update `` |
| [`2e4eadba`](https://github.com/nix-community/NUR/commit/2e4eadba5f662a4d013e388bf3c9621744a3ff5c) | `` automatic update `` |
| [`42eed8e2`](https://github.com/nix-community/NUR/commit/42eed8e2f96cd562fe2d1b8c8f239c3f6578a1e7) | `` automatic update `` |
| [`17749cb9`](https://github.com/nix-community/NUR/commit/17749cb9cd6f0c9a85a958a7d0bee66f33092d66) | `` automatic update `` |