### PR TITLE
chore(flake/nur): `6bdd89c5` -> `e3a3e360`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692237263,
-        "narHash": "sha256-B+P6HJyHm4xNVdFG3eEY2Uu0br7DVr1r3EYQPPnOo2U=",
+        "lastModified": 1692240376,
+        "narHash": "sha256-TqU0VmktB1D7+mMPKJ1kb8v0uxVHmWtZYVuR9J3UErs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6bdd89c5f8922468eab362e2206901e30b742259",
+        "rev": "e3a3e36038b66e6d736e9f286dae75fe0554911c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e3a3e360`](https://github.com/nix-community/NUR/commit/e3a3e36038b66e6d736e9f286dae75fe0554911c) | `` automatic update `` |