### PR TITLE
chore(flake/nur): `e3a3e360` -> `58477247`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692240376,
-        "narHash": "sha256-TqU0VmktB1D7+mMPKJ1kb8v0uxVHmWtZYVuR9J3UErs=",
+        "lastModified": 1692243839,
+        "narHash": "sha256-LxlTxXuMZsGjaGa9V/ZKotwJp6sg+6cooQyqOQSXbAw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e3a3e36038b66e6d736e9f286dae75fe0554911c",
+        "rev": "584772472b7551d9329ea6316f508d9eb336c469",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`58477247`](https://github.com/nix-community/NUR/commit/584772472b7551d9329ea6316f508d9eb336c469) | `` automatic update `` |
| [`67b3727c`](https://github.com/nix-community/NUR/commit/67b3727c578da23c7bd74f47a96ee31c304d324f) | `` automatic update `` |