### PR TITLE
chore(flake/nur): `58477247` -> `27fb77d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692243839,
-        "narHash": "sha256-LxlTxXuMZsGjaGa9V/ZKotwJp6sg+6cooQyqOQSXbAw=",
+        "lastModified": 1692251097,
+        "narHash": "sha256-U8DwZx4TvyhgYtqn7a2Z1swb/OX7ZGdXkRp01b/9YQw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "584772472b7551d9329ea6316f508d9eb336c469",
+        "rev": "27fb77d59cee6a1210e7451b5771a40a2dbd05c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`27fb77d5`](https://github.com/nix-community/NUR/commit/27fb77d59cee6a1210e7451b5771a40a2dbd05c6) | `` automatic update `` |