### PR TITLE
chore(flake/nur): `27fb77d5` -> `f37ffc34`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692251097,
-        "narHash": "sha256-U8DwZx4TvyhgYtqn7a2Z1swb/OX7ZGdXkRp01b/9YQw=",
+        "lastModified": 1692261396,
+        "narHash": "sha256-Zk24PncyzCJC8ceVVmtxwIzNEDOgdRv/UHgMTiky/Fg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "27fb77d59cee6a1210e7451b5771a40a2dbd05c6",
+        "rev": "f37ffc34f3baebdde20b74b4779679b083abe933",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f37ffc34`](https://github.com/nix-community/NUR/commit/f37ffc34f3baebdde20b74b4779679b083abe933) | `` automatic update `` |
| [`3af804ae`](https://github.com/nix-community/NUR/commit/3af804ae643adc5723ef7d3097dce8eab25c2803) | `` automatic update `` |