### PR TITLE
chore(flake/nur): `f37ffc34` -> `2e66cece`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692261396,
-        "narHash": "sha256-Zk24PncyzCJC8ceVVmtxwIzNEDOgdRv/UHgMTiky/Fg=",
+        "lastModified": 1692265451,
+        "narHash": "sha256-NHGBpfn6TruoYHqxyMl4GUar61UBd5vR5v2UIllNWa8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f37ffc34f3baebdde20b74b4779679b083abe933",
+        "rev": "2e66ceced497f2c127fc965b132f1940e4fef488",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2e66cece`](https://github.com/nix-community/NUR/commit/2e66ceced497f2c127fc965b132f1940e4fef488) | `` automatic update `` |
| [`cde5b68f`](https://github.com/nix-community/NUR/commit/cde5b68ff36a1e25912d29aae11e0467bb49916c) | `` automatic update `` |