### PR TITLE
chore(flake/nur): `2e66cece` -> `b7fcbcbb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692265451,
-        "narHash": "sha256-NHGBpfn6TruoYHqxyMl4GUar61UBd5vR5v2UIllNWa8=",
+        "lastModified": 1692275917,
+        "narHash": "sha256-PcUYd0Si3tFsxnT57IfiLy/s5VCPXuUoFK+SvQ7kexI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2e66ceced497f2c127fc965b132f1940e4fef488",
+        "rev": "b7fcbcbbdbf2bbbda6965cbcc8f85542c314167c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b7fcbcbb`](https://github.com/nix-community/NUR/commit/b7fcbcbbdbf2bbbda6965cbcc8f85542c314167c) | `` automatic update `` |
| [`9fc16fb3`](https://github.com/nix-community/NUR/commit/9fc16fb3797cf0726dba9b4dfe64cbdbaa25c310) | `` automatic update `` |
| [`25788863`](https://github.com/nix-community/NUR/commit/257888634aaed0c53697089552abb94a3a771913) | `` automatic update `` |