### PR TITLE
chore(flake/emacs-overlay): `6ec2e6f0` -> `5f96a733`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1692269428,
-        "narHash": "sha256-7ZP9KzPwcChLLNQKgeImUHbXEytxaknwCp0nhqAT4/A=",
+        "lastModified": 1692296919,
+        "narHash": "sha256-Q8RDZ5RRUeF9GinZbWlLtaa/EGOSU8SyeUHhyauZ3G4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6ec2e6f01d41269eaa541b99d3612dae36b6e711",
+        "rev": "5f96a733098d90912cba5329bf2cc75849000c09",
         "type": "github"
       },
       "original": {
@@ -697,11 +697,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1692134936,
-        "narHash": "sha256-Z68O969cioC6I3k/AFBxsuEwpJwt4l9fzwuAMUhCCs0=",
+        "lastModified": 1692207601,
+        "narHash": "sha256-tfPGNKQcJT1cvT6ufqO/7ydYNL6mcJClvzbrzhKjB80=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bfd953b2c6de4f550f75461bcc5768b6f966be10",
+        "rev": "b30c68669df77d981ce4aefd6b9d378563f6fc4e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`5f96a733`](https://github.com/nix-community/emacs-overlay/commit/5f96a733098d90912cba5329bf2cc75849000c09) | `` Updated repos/melpa ``  |
| [`75a00122`](https://github.com/nix-community/emacs-overlay/commit/75a001220097148491348844c219e7addaa857e6) | `` Updated repos/emacs ``  |
| [`aea5646a`](https://github.com/nix-community/emacs-overlay/commit/aea5646af89a91328207a68bc9e1786be41ca9bc) | `` Updated repos/elpa ``   |
| [`6fb25eb0`](https://github.com/nix-community/emacs-overlay/commit/6fb25eb0280b719bd42b139e827c2deaa73726f7) | `` Updated flake inputs `` |