### PR TITLE
chore(flake/nur): `b7fcbcbb` -> `07670466`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692275917,
-        "narHash": "sha256-PcUYd0Si3tFsxnT57IfiLy/s5VCPXuUoFK+SvQ7kexI=",
+        "lastModified": 1692302443,
+        "narHash": "sha256-oMqr6bQkUdspYWb2tkPQESII0TjACXjAnDPfVqWdbRQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b7fcbcbbdbf2bbbda6965cbcc8f85542c314167c",
+        "rev": "076704663f6451c0ff38eb0f74d8a78e7ebb300c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`07670466`](https://github.com/nix-community/NUR/commit/076704663f6451c0ff38eb0f74d8a78e7ebb300c) | `` automatic update `` |
| [`3f1e7f35`](https://github.com/nix-community/NUR/commit/3f1e7f350a193c26e17021dda5aa05a41241f941) | `` automatic update `` |