### PR TITLE
chore(flake/nur): `8705c279` -> `94771c09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692305109,
-        "narHash": "sha256-oebxcvtunfVPJ5OKCBbWtkjrHjxNoU5zceChf/uYm+s=",
+        "lastModified": 1692322884,
+        "narHash": "sha256-fKicmOIp346VehbPYlr8xvQM/UEdgnw+5me4NxxdZTE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8705c2795b2809c195c275289338049203802ab2",
+        "rev": "94771c098e8448fb6b0b6d95b030698db326c13e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`94771c09`](https://github.com/nix-community/NUR/commit/94771c098e8448fb6b0b6d95b030698db326c13e) | `` automatic update `` |
| [`8bbe1f8e`](https://github.com/nix-community/NUR/commit/8bbe1f8eea89925d7e38906c6e7ebfc214b75aed) | `` automatic update `` |