### PR TITLE
chore(flake/emacs-overlay): `5f96a733` -> `f92eaef4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1692296919,
-        "narHash": "sha256-Q8RDZ5RRUeF9GinZbWlLtaa/EGOSU8SyeUHhyauZ3G4=",
+        "lastModified": 1692327983,
+        "narHash": "sha256-erfp98KitK+0xjoRGkfZ5M2wCifW4TOtoxAte4Jo9QI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5f96a733098d90912cba5329bf2cc75849000c09",
+        "rev": "f92eaef404ab814e458a9e56f08b0508e0ef73ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`f92eaef4`](https://github.com/nix-community/emacs-overlay/commit/f92eaef404ab814e458a9e56f08b0508e0ef73ad) | `` Updated repos/melpa `` |
| [`d5defcfc`](https://github.com/nix-community/emacs-overlay/commit/d5defcfcd38fee261926ddc3e3eb9e69ecdf5df0) | `` Updated repos/emacs `` |
| [`02537af0`](https://github.com/nix-community/emacs-overlay/commit/02537af062e360bf2ebbfe156f4c65dadee5e9e1) | `` Updated repos/elpa ``  |