### PR TITLE
chore(flake/nur): `4cd2bac3` -> `dedd7de8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692330166,
-        "narHash": "sha256-dgxA0pcaqUCtnVNXsZKdQclRGDAvyIzes3WD/oix+aA=",
+        "lastModified": 1692333807,
+        "narHash": "sha256-vWrP83xJ1E5Sg5Dp2OTwowZtQqCyYsirHCBWn4QXgmo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4cd2bac3ca49bcfa4b8df82cd9ae0eba6c58e842",
+        "rev": "dedd7de8a2b1fc29e1a92948a285c8819175431e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dedd7de8`](https://github.com/nix-community/NUR/commit/dedd7de8a2b1fc29e1a92948a285c8819175431e) | `` automatic update `` |