### PR TITLE
chore(flake/nur): `dedd7de8` -> `0a03fb4c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692333807,
-        "narHash": "sha256-vWrP83xJ1E5Sg5Dp2OTwowZtQqCyYsirHCBWn4QXgmo=",
+        "lastModified": 1692339853,
+        "narHash": "sha256-/DGzJsMfqctIj2uoG0GqaiUf4qHkAqqMGJil59LRV0E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dedd7de8a2b1fc29e1a92948a285c8819175431e",
+        "rev": "0a03fb4c921d61a02709db585d210b6a0005163e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0a03fb4c`](https://github.com/nix-community/NUR/commit/0a03fb4c921d61a02709db585d210b6a0005163e) | `` automatic update `` |