### PR TITLE
chore(flake/emacs-overlay): `f92eaef4` -> `d9bbf2be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1692327983,
-        "narHash": "sha256-erfp98KitK+0xjoRGkfZ5M2wCifW4TOtoxAte4Jo9QI=",
+        "lastModified": 1692350627,
+        "narHash": "sha256-XOAotqHkhbO+0FUv56xp+qyNkdFBe/hvqaX5uD+3Tt8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f92eaef404ab814e458a9e56f08b0508e0ef73ad",
+        "rev": "d9bbf2beb40509ce619314e07a19b3dbe3e72899",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d9bbf2be`](https://github.com/nix-community/emacs-overlay/commit/d9bbf2beb40509ce619314e07a19b3dbe3e72899) | `` Updated repos/nongnu `` |
| [`886a3eaf`](https://github.com/nix-community/emacs-overlay/commit/886a3eaf0ba319c69c4b2326a250e1e1b55ea20c) | `` Updated repos/melpa ``  |
| [`be3d29b7`](https://github.com/nix-community/emacs-overlay/commit/be3d29b73101cf618b2a078df2e75f2200daf103) | `` Updated repos/emacs ``  |