### PR TITLE
chore(flake/nur): `bdabaf34` -> `b3908294`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692348312,
-        "narHash": "sha256-VO63VlLj0HNZXDn+SwLquCvJcJUXFHUJw6Hvqi3aV78=",
+        "lastModified": 1692351902,
+        "narHash": "sha256-4/phpOglEZCpCsmieKnJUiq8llucyXgdL+75OvrclsU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bdabaf34ed295396f2b361e53f1700c3258558cd",
+        "rev": "b3908294b9dce49c091a5031965b647828bae932",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b3908294`](https://github.com/nix-community/NUR/commit/b3908294b9dce49c091a5031965b647828bae932) | `` automatic update `` |
| [`67e97830`](https://github.com/nix-community/NUR/commit/67e97830c1be4c06b4a3e4f98774a0dd77fbdb67) | `` automatic update `` |
| [`d01716f1`](https://github.com/nix-community/NUR/commit/d01716f1192fd485567e2cc3843ac24720bb9a4a) | `` automatic update `` |