### PR TITLE
chore(flake/nixpkgs): `caac0eb6` -> `42c25608`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -775,11 +775,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1692174805,
-        "narHash": "sha256-xmNPFDi/AUMIxwgOH/IVom55Dks34u1g7sFKKebxUm0=",
+        "lastModified": 1692264070,
+        "narHash": "sha256-WepAkIL2UcHOj7JJiaFS/vxrA9lklQHv8p+xGL+7oQ0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "caac0eb6bdcad0b32cb2522e03e4002c8975c62e",
+        "rev": "42c25608aa2ad4e5d3716d8d63c606063513ba33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`8fc24972`](https://github.com/NixOS/nixpkgs/commit/8fc24972c51a2ab5fb55fcdebc6c5fa8d06c8888) | `` ocamlPackages.domain-local-await: 0.2.1 → 1.0.0 ``                           |
| [`b1981b02`](https://github.com/NixOS/nixpkgs/commit/b1981b02e183fb376a45932c9a901ea22d4bf77a) | `` arm-trusted-firmware.armTrustedFirmwareTools: remove CC_FOR_BUILD ``         |
| [`994fcd68`](https://github.com/NixOS/nixpkgs/commit/994fcd68b932702219ca08859eb7288d317d3606) | `` arm-trusted-firmware: tell Makefile abt arm-embedded's targetPrefix ``       |
| [`2fa04224`](https://github.com/NixOS/nixpkgs/commit/2fa0422405f12e7c1ecccc5e7e873cdf46ffea78) | `` arm-trusted-firmware: set HOSTCC to CC_FOR_BUILD ``                          |
| [`703e7bd4`](https://github.com/NixOS/nixpkgs/commit/703e7bd4328c9d8d2f171fdcde6e14c4cb7a1626) | `` haskellPackages.data-tree-print: relax upper bound on base ``                |
| [`2a93f443`](https://github.com/NixOS/nixpkgs/commit/2a93f44336daee33f28bb82bcb0d55e743d35c13) | `` haskellPackages.czipwith: relax upper bound on base and t-h ``               |
| [`bac83374`](https://github.com/NixOS/nixpkgs/commit/bac83374f17960eedb6c45ad8a1b1b9ec88f3fea) | `` haskellPackages.butcher: relax upper bound on base ``                        |
| [`c24a2882`](https://github.com/NixOS/nixpkgs/commit/c24a28822ea1cb41a79a0cce9f7fb7f429ecb382) | `` haskell.packages.ghc8107.ghc-lib: downgrade to 9.2.* ``                      |
| [`29eb909f`](https://github.com/NixOS/nixpkgs/commit/29eb909fe2f1d8802420b33f8222af2139600c61) | `` python310Packages.datetime: update changelog ``                              |
| [`8ed8155a`](https://github.com/NixOS/nixpkgs/commit/8ed8155ab17c68d9b58b144f5d70179f14dc3e92) | `` kubescape: 2.3.6 -> 2.9.0 ``                                                 |
| [`0ece843b`](https://github.com/NixOS/nixpkgs/commit/0ece843bf8aa21e492b262326d1409c89658749c) | `` commix: 3.7 -> 3.8 ``                                                        |
| [`c26cfbe7`](https://github.com/NixOS/nixpkgs/commit/c26cfbe784e86b1cda6d97d42fa510433583a711) | `` open-pdf-sign: use `finalAttrs` pattern ``                                   |
| [`95a15fd4`](https://github.com/NixOS/nixpkgs/commit/95a15fd40025f73b285900a30778c1fdadd8e34b) | `` checkov: 2.3.366 -> 2.4.1 ``                                                 |
| [`1ad6dccd`](https://github.com/NixOS/nixpkgs/commit/1ad6dccd2da92ec532589365d7a2fc6cb3f11a5d) | `` yamlfix: 1.11.0 -> 1.13.0 ``                                                 |
| [`53234774`](https://github.com/NixOS/nixpkgs/commit/532347744e271daacf9c461a98d4f0686d839261) | `` python3.pkgs.sanic: fix tests running on one CPU ``                          |
| [`b9cfaf77`](https://github.com/NixOS/nixpkgs/commit/b9cfaf77f8da58e9ed978a19001c5735ad9fb7fc) | `` tgt: 1.0.86 -> 1.0.87 ``                                                     |
| [`2540f5c0`](https://github.com/NixOS/nixpkgs/commit/2540f5c05c4223228b58700b5690486658c719bb) | `` terraform-providers.oci: 5.8.0 -> 5.9.0 ``                                   |
| [`3f410ddc`](https://github.com/NixOS/nixpkgs/commit/3f410ddcf650369a64bf11d5d1db1c538eca15dc) | `` terraform-providers.yandex: 0.96.1 -> 0.97.0 ``                              |
| [`057d2bd7`](https://github.com/NixOS/nixpkgs/commit/057d2bd7dd8b831c2c326030dede795205f11463) | `` terraform-providers.kubernetes: 2.22.0 -> 2.23.0 ``                          |
| [`eea82945`](https://github.com/NixOS/nixpkgs/commit/eea82945f9e60bd77f022d395dcca1429daaf308) | `` terraform-providers.linode: 2.5.2 -> 2.6.0 ``                                |
| [`9325eefb`](https://github.com/NixOS/nixpkgs/commit/9325eefbdc3ab7810deff4bce53cc25a381d4aea) | `` nixos/budgie: Add Magpie to services.udev.packages ``                        |
| [`dc01c463`](https://github.com/NixOS/nixpkgs/commit/dc01c463b6cfee923253656cd9e4b07286f180ac) | `` budgie.budgie-gsettings-overrides: Remove unused Mutter ``                   |
| [`748f36da`](https://github.com/NixOS/nixpkgs/commit/748f36da3061782c8ddadc98a0f1b7f8e8b48f20) | `` budgie.budgie-control-center: Replace Mutter with Magpie ``                  |
| [`f0da6992`](https://github.com/NixOS/nixpkgs/commit/f0da6992b9dc006021bd0fd1ea65bf98aaf3a435) | `` budgie.budgie-desktop: Replace Mutter with Magpie ``                         |
| [`16e347c8`](https://github.com/NixOS/nixpkgs/commit/16e347c83d42899c8f890fb5b0534eb5c368317c) | `` budgie.magpie: init at 0.9.2 ``                                              |
| [`d3257078`](https://github.com/NixOS/nixpkgs/commit/d3257078d8b345b2be04630897a2e308e0487463) | `` python310Packages.drf-spectacular: 0.26.3 -> 0.26.4 ``                       |
| [`af9400ec`](https://github.com/NixOS/nixpkgs/commit/af9400ec258987f28711850ea6f2eda079adc685) | `` open-pdf-sign: 0.1.5 -> 0.1.6 ``                                             |
| [`8a811970`](https://github.com/NixOS/nixpkgs/commit/8a81197021a16a50a54a4aa185161f96d23073d5) | `` bearer: 1.17.0 -> 1.19.1 ``                                                  |
| [`dfde1120`](https://github.com/NixOS/nixpkgs/commit/dfde1120b3633de70194898976734fdcd15d4177) | `` hetzner-kube: use sri hash ``                                                |
| [`a7a20d01`](https://github.com/NixOS/nixpkgs/commit/a7a20d0109c597dde914a42a3c64ce770458c9df) | `` picom-next: add meta.maintainers correctly ``                                |
| [`65a5e1df`](https://github.com/NixOS/nixpkgs/commit/65a5e1df068f16bd391faa64c65ff97d0b0705d9) | `` circt: 1.50.0 -> 1.51.0 ``                                                   |
| [`f2b53029`](https://github.com/NixOS/nixpkgs/commit/f2b530294f34dfb52a0fdc1fb5a01ea908abb388) | `` .github/labeler.yml: add zig label ``                                        |
| [`eb3493f8`](https://github.com/NixOS/nixpkgs/commit/eb3493f84cbd07f56325ae3ea0032a9e34eb9e13) | `` cargo-make: 0.36.12 -> 0.36.13 ``                                            |
| [`c41b8d09`](https://github.com/NixOS/nixpkgs/commit/c41b8d090d817f817d9de129b87484a688ec27a3) | `` linux/hardened/patches/6.4: 6.4.7-hardened1 -> 6.4.10-hardened1 ``           |
| [`e9b4fa1c`](https://github.com/NixOS/nixpkgs/commit/e9b4fa1c380d0657e316229e5145ae4f0f246839) | `` linux/hardened/patches/6.1: 6.1.42-hardened1 -> 6.1.45-hardened1 ``          |
| [`9e4a1cf2`](https://github.com/NixOS/nixpkgs/commit/9e4a1cf233ab6457bb73a6616b7c3ce9f219845c) | `` haskell.packages.ghc94.ghc-tags: pin to matching version 1.6 ``              |
| [`6946af61`](https://github.com/NixOS/nixpkgs/commit/6946af616ccedb4182093cc4d2b63b5fa2645aef) | `` linux/hardened/patches/5.4: 5.4.251-hardened1 -> 5.4.253-hardened1 ``        |
| [`36aa1b20`](https://github.com/NixOS/nixpkgs/commit/36aa1b207ce8630d131c745bc1a327955b2f7e91) | `` linux/hardened/patches/5.15: 5.15.123-hardened1 -> 5.15.126-hardened1 ``     |
| [`808af668`](https://github.com/NixOS/nixpkgs/commit/808af668639a4f111214770d1992e84061339de6) | `` linux/hardened/patches/5.10: 5.10.188-hardened1 -> 5.10.190-hardened1 ``     |
| [`0d7e1948`](https://github.com/NixOS/nixpkgs/commit/0d7e1948cbc05a4070f3087dfc4e38a5f34aafcb) | `` linux/hardened/patches/4.19: 4.19.289-hardened1 -> 4.19.291-hardened1 ``     |
| [`fcfd921f`](https://github.com/NixOS/nixpkgs/commit/fcfd921fd65c9e21a7cb4ca1470df88ca2563eb2) | `` linux/hardened/patches/4.14: 4.14.320-hardened1 -> 4.14.322-hardened1 ``     |
| [`154f9ca3`](https://github.com/NixOS/nixpkgs/commit/154f9ca398b5fa1fb684fb4b6576cd1c74486d84) | `` linux_latest-libre: 19337 -> 19386 ``                                        |
| [`9ab06d3c`](https://github.com/NixOS/nixpkgs/commit/9ab06d3cde443930d170c0101dd836615d6bb2af) | `` python310Packages.datetime: 5.1 -> 5.2 ``                                    |
| [`1541cb8c`](https://github.com/NixOS/nixpkgs/commit/1541cb8cdd91fe141ea7c325120f0b5287719788) | `` linux: 6.4.10 -> 6.4.11 ``                                                   |
| [`148ff04e`](https://github.com/NixOS/nixpkgs/commit/148ff04e56e139e8bbbe4718836b2aea8b49c15e) | `` linux: 6.1.45 -> 6.1.46 ``                                                   |
| [`62cee8e2`](https://github.com/NixOS/nixpkgs/commit/62cee8e21a1ff573535d03dac86e80d60644492f) | `` linux: 5.4.253 -> 5.4.254 ``                                                 |
| [`96577750`](https://github.com/NixOS/nixpkgs/commit/965777503c337695d0871e62b790b723092d89f7) | `` linux: 5.15.126 -> 5.15.127 ``                                               |
| [`8c93ca75`](https://github.com/NixOS/nixpkgs/commit/8c93ca7597fcffa6806efa39f4902d39e7db185f) | `` python310Packages.boschshcpy: 0.2.60 -> 0.2.65 ``                            |
| [`6f0af277`](https://github.com/NixOS/nixpkgs/commit/6f0af2778d9b30aa4583dd2fad86e34b68e08d68) | `` linux: 5.10.190 -> 5.10.191 ``                                               |
| [`feee70e0`](https://github.com/NixOS/nixpkgs/commit/feee70e06aa5a929fac29f10827e3c7bd62608bc) | `` linux: 4.19.291 -> 4.19.292 ``                                               |
| [`6e2765b8`](https://github.com/NixOS/nixpkgs/commit/6e2765b803f42def927fc0c169020a3596587f6a) | `` linux: 4.14.322 -> 4.14.323 ``                                               |
| [`7b3adc85`](https://github.com/NixOS/nixpkgs/commit/7b3adc85bfb0af3d4a1fda4a54e202211fbf71a7) | `` python310Packages.aioesphomeapi: 16.0.0 -> 16.0.1 ``                         |
| [`dc0009d9`](https://github.com/NixOS/nixpkgs/commit/dc0009d9fc7e8f86e0461539cf6684d3664b4254) | `` python310Packages.meraki: 1.34.0 -> 1.36.0 ``                                |
| [`a06675df`](https://github.com/NixOS/nixpkgs/commit/a06675df221319506efb363272648b2ab56fb858) | `` python311Packages.jupyterhub: allow tests with require executable ``         |
| [`190e3457`](https://github.com/NixOS/nixpkgs/commit/190e3457d1790a286f5b0dabc17a68057dc98b7b) | `` python311Packages.oracledb: 1.3.2 -> 1.4.0 ``                                |
| [`9817d601`](https://github.com/NixOS/nixpkgs/commit/9817d601094f65d2ffbd72225d45fc3c5ccec8ab) | `` python310Packages.oauthenticator: 16.0.4 -> 16.0.5 ``                        |
| [`2f29aa92`](https://github.com/NixOS/nixpkgs/commit/2f29aa92b52306055c7e99c2c8a765466618b74d) | `` python311Packages.odp-amsterdam: 5.1.1 -> 5.2.0 ``                           |
| [`5f30e783`](https://github.com/NixOS/nixpkgs/commit/5f30e78315e509fa8cab552973f4fffea0730d35) | `` python310Packages.nbxmpp: update inputs ``                                   |
| [`dc8c0037`](https://github.com/NixOS/nixpkgs/commit/dc8c0037642220239b4a7be14b3fb943d14c0c3f) | `` python310Packages.nbxmpp: 4.3.1 -> 4.3.2 ``                                  |
| [`5a747c08`](https://github.com/NixOS/nixpkgs/commit/5a747c08443daff0a2626ad73d98f67a9b5adc74) | `` python310Packages.msgspec: 0.18.0 -> 0.18.1 ``                               |
| [`ea0c453f`](https://github.com/NixOS/nixpkgs/commit/ea0c453fea3949b82f89475b6b10cddd77831564) | `` python311Packages.json-tricks: update disabled ``                            |
| [`d2514e1a`](https://github.com/NixOS/nixpkgs/commit/d2514e1a8e2f833f36fced192ccd0fad2d92fe29) | `` python311Packages.json-tricks: add format ``                                 |
| [`681b500b`](https://github.com/NixOS/nixpkgs/commit/681b500b6faaccf5a0b685ce226295d89bafbd6a) | `` python311Packages.json-tricks: 3.15.5 -> 3.17.2 ``                           |
| [`5310ce9e`](https://github.com/NixOS/nixpkgs/commit/5310ce9ed558cd7ab99546a1423cc04a9d1500b3) | `` python311Packages.emoji: 2.7.0 -> 2.8.0 ``                                   |
| [`b043af98`](https://github.com/NixOS/nixpkgs/commit/b043af988c84066221cbbe5a9e2e9278221f472d) | `` peazip: init at 9.9.0 ``                                                     |
| [`d6efaa98`](https://github.com/NixOS/nixpkgs/commit/d6efaa989d355aa77e172ccd1132975cbe4797a6) | `` python311Packages.discordpy: 2.3.1 -> 2.3.2 ``                               |
| [`e3c6e2fb`](https://github.com/NixOS/nixpkgs/commit/e3c6e2fbd13832613354f162aec4815b87b781a1) | `` python311Packages.deezer-python: 6.0.0 -> 6.1.0 ``                           |
| [`9049df5a`](https://github.com/NixOS/nixpkgs/commit/9049df5a042d6496c7aaa41ced282f3798127eef) | `` treewide: add meta.mainProgram (#249601) ``                                  |
| [`d095f4d2`](https://github.com/NixOS/nixpkgs/commit/d095f4d2b20f5987653d76a718806fbfd9c8a455) | `` remnote: 1.12.3 -> 1.12.9 ``                                                 |
| [`66469836`](https://github.com/NixOS/nixpkgs/commit/66469836beed072969f0e9f77036260020ee85d3) | `` Fix Lemmy Caddy config static path handling ``                               |
| [`30280ee4`](https://github.com/NixOS/nixpkgs/commit/30280ee41155d069ca8bea6a679c957fb46a1fa2) | `` woodpecker-*: add 'meta.changelog' ``                                        |
| [`42f60308`](https://github.com/NixOS/nixpkgs/commit/42f60308934f21ee7c84259b314173993592a068) | `` woodpecker-*: 1.0.1 -> 1.0.2 ``                                              |
| [`d16b0690`](https://github.com/NixOS/nixpkgs/commit/d16b0690f8f73e2b085136591cab912d51fe944b) | `` libiio: disable Python for static builds ``                                  |
| [`8a9eb199`](https://github.com/NixOS/nixpkgs/commit/8a9eb199071f671ae5f9d87e6b5d804145654a7b) | `` mdbook-emojicodes: 0.1.3.1 -> 0.2.2 ``                                       |
| [`d28fdbe9`](https://github.com/NixOS/nixpkgs/commit/d28fdbe9742c680ec410bd70bf2962b90a374d36) | `` veilid: init at 0.1.7 ``                                                     |
| [`75f0aff8`](https://github.com/NixOS/nixpkgs/commit/75f0aff870517d34baf8a3af1ef90dfff63e9129) | `` unison: M5b -> M5c ``                                                        |
| [`575338ab`](https://github.com/NixOS/nixpkgs/commit/575338ab87286e2da22eecc6d906b31536b88108) | `` dmarc-metrics-exporter: 0.9.1 -> 0.9.4 ``                                    |
| [`777cd5d5`](https://github.com/NixOS/nixpkgs/commit/777cd5d56642b9ab27883e61ab7baf77705c9328) | `` python3.pkgs.xsdata: 23.7 -> 23.8 ``                                         |
| [`fd4b0d9e`](https://github.com/NixOS/nixpkgs/commit/fd4b0d9e5c669816a1ec34b2b2c822a772f6560a) | `` cargo-component: unstable-2023-08-03 -> unstable-2023-08-16 ``               |
| [`72573db3`](https://github.com/NixOS/nixpkgs/commit/72573db36b51713115046b1831873b9da583017c) | `` haskellPackages: mark builds failing on hydra as broken ``                   |
| [`517c188a`](https://github.com/NixOS/nixpkgs/commit/517c188a2c872b3196b26ff672b3b5875311678c) | `` gns3-server,gns3-gui: 2.2.35.1 -> 2.2.42 ``                                  |
| [`67a16a0e`](https://github.com/NixOS/nixpkgs/commit/67a16a0e60e7a82e0fcaacac3e8391b2262a1c08) | `` python311Packages.truststore: init at 0.7.0 ``                               |
| [`9c0cf2ea`](https://github.com/NixOS/nixpkgs/commit/9c0cf2eacf51cb593f59234317e7084f73923549) | `` phpExtensions.ddtrace: fix `pname` ``                                        |
| [`5bbfcd32`](https://github.com/NixOS/nixpkgs/commit/5bbfcd3267821e4329b48ec82493afbb55a61a9e) | `` okteto: 2.18.3 -> 2.19.0 ``                                                  |
| [`af13ed44`](https://github.com/NixOS/nixpkgs/commit/af13ed448331981a9deb30c8019c52e0e5cc1233) | `` documenso: init at 0.9 ``                                                    |
| [`ba96b6bd`](https://github.com/NixOS/nixpkgs/commit/ba96b6bdaaa276fbb6d0007a7b196017ac169077) | `` nixosTests.budgie: Re-add checks for budgie-wm ``                            |
| [`ee21e353`](https://github.com/NixOS/nixpkgs/commit/ee21e353947367e3fdb4c2e47cf9ead8a07eb8b0) | `` haskellPackages.nix-graph: relax bound on algebraic-graphs ``                |
| [`703fd72a`](https://github.com/NixOS/nixpkgs/commit/703fd72aabe72ae318040c3ac416f614f6af6869) | `` haskellPackages.nix-deploy: lift upper bounds on text/turtle ``              |
| [`556e723a`](https://github.com/NixOS/nixpkgs/commit/556e723ae19e1d82f56fd49ac0d871673ed37522) | `` haskellPackages.glualint: work around missing test data ``                   |
| [`cfebc50c`](https://github.com/NixOS/nixpkgs/commit/cfebc50c3b19d39ea98857d822b08840e39bda05) | `` crypto-tracker: init at 0.1.8 ``                                             |
| [`421ab83d`](https://github.com/NixOS/nixpkgs/commit/421ab83db634ed79b2bedc9484422141fa34aa21) | `` nco: minor refactoring and format using `nixpkgs-fmt` ``                     |
| [`d86dc7c0`](https://github.com/NixOS/nixpkgs/commit/d86dc7c016a95e9d6f2133db317ba505371b0a88) | `` nixosTests.pantheon: Ensure the test fails when gala coredumps ``            |
| [`691bc196`](https://github.com/NixOS/nixpkgs/commit/691bc1965e80f92f8dea1ce4b5e5ac71262f9534) | `` nco: use `finalAttrs` pattern ``                                             |
| [`ba1c676c`](https://github.com/NixOS/nixpkgs/commit/ba1c676cf49b666b6a9ebe3d8f6b3aee315868c9) | `` sdrangel: use `finalAttrs` pattern ``                                        |
| [`91c7524f`](https://github.com/NixOS/nixpkgs/commit/91c7524fd295c4ce24d0d4cbd2ca0b88865fd2a9) | `` lispModules_new.sdl2-{image,mixer,ttf}: add native libs ``                   |
| [`34812e87`](https://github.com/NixOS/nixpkgs/commit/34812e87d13234a4a59a1722493be96c972127b6) | `` eww: add support for svg icons ``                                            |
| [`d7e10997`](https://github.com/NixOS/nixpkgs/commit/d7e1099787d5121c080335b1b23704862f1a8739) | `` cargo-shuttle: 0.23.0 -> 0.24.0 ``                                           |
| [`5cfd2d03`](https://github.com/NixOS/nixpkgs/commit/5cfd2d03aa84c972ef37cd8ed112b27c5c322d5e) | `` fflinuxprint: init at 1.1.3-4 ``                                             |
| [`9a6ea9af`](https://github.com/NixOS/nixpkgs/commit/9a6ea9af2801e009346c970b7182257e0de546b5) | `` api-linter: 1.55.2 -> 1.56.0 ``                                              |
| [`7c2f3db2`](https://github.com/NixOS/nixpkgs/commit/7c2f3db2141142b5ab014848dc905f53879bfb49) | `` ssh-to-pgp: 1.0.4 -> 1.1.0 ``                                                |
| [`228a8d90`](https://github.com/NixOS/nixpkgs/commit/228a8d907a82edc008a9c587ee76e14f1c7735a2) | `` komga: 1.3.0 -> 1.3.1 ``                                                     |
| [`14767f46`](https://github.com/NixOS/nixpkgs/commit/14767f46f348917d39184e15c5a742df5a5029cf) | `` difftastic: 0.49.0 -> 0.50.0 ``                                              |
| [`7f9b04a9`](https://github.com/NixOS/nixpkgs/commit/7f9b04a90e1aece6abd19732bdc9f4b652b3384e) | `` virtualbox: install UnattendedTemplates ``                                   |
| [`1422b80e`](https://github.com/NixOS/nixpkgs/commit/1422b80e213967d68a0772defb4c7b9aee97de03) | `` haskell.packages.ghc8107.hspec_2_7_10: correct hspec-meta version ``         |
| [`821b63e6`](https://github.com/NixOS/nixpkgs/commit/821b63e6f016bcbc3fb0d0608bf3707f1153c972) | `` haskellPackages.nixfmt: relax upper bounds ``                                |
| [`f17751d0`](https://github.com/NixOS/nixpkgs/commit/f17751d00d0d5ef35c957c4a83822a57dae87910) | `` phpExtensions.vld: init at 0.18.0 ``                                         |
| [`b4d718f1`](https://github.com/NixOS/nixpkgs/commit/b4d718f14a00c5cad817406f08052a52c2fef4ed) | `` nixos/influxdb2: add initial setup automation and nixos tests ``             |
| [`bf6c1577`](https://github.com/NixOS/nixpkgs/commit/bf6c1577a9032e76c0f1527a82b8a444a7bb80be) | `` libxisf: 0.2.8 -> 0.2.9 ``                                                   |
| [`4222fe5b`](https://github.com/NixOS/nixpkgs/commit/4222fe5bcf0bcaf1663dbf5f185a3455d6983e55) | `` osu-lazer: 2023.811.0 -> 2023.815.0 ``                                       |
| [`23cb71d3`](https://github.com/NixOS/nixpkgs/commit/23cb71d312bad7745d4aa08db0c7f0c9ed82fae3) | `` osu-lazer-bin: 2023.811.0 -> 2023.815.0 ``                                   |
| [`76286641`](https://github.com/NixOS/nixpkgs/commit/762866412d3dee9248865b020d91f2629ff5e61d) | `` witness: 0.1.13 -> 0.1.14 ``                                                 |
| [`0a732d2a`](https://github.com/NixOS/nixpkgs/commit/0a732d2adf679b654775013252bb8c91ff608d1a) | `` nixos/oauth2_proxy: service after network.target -> network-online.target `` |
| [`6daee558`](https://github.com/NixOS/nixpkgs/commit/6daee5585d43a47fe111adacfbc2330798aa8f66) | `` pdf-sign: init at unstable-2022-08-08 ``                                     |
| [`31c3909e`](https://github.com/NixOS/nixpkgs/commit/31c3909ef9012e97a895578e479aa546b8a3cc7a) | `` matrix-alertmanager: 0.5.0 -> 0.7.2 ``                                       |