### PR TITLE
chore(flake/nur): `b3908294` -> `5723f966`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692351902,
-        "narHash": "sha256-4/phpOglEZCpCsmieKnJUiq8llucyXgdL+75OvrclsU=",
+        "lastModified": 1692376909,
+        "narHash": "sha256-fcwKrjaYBixuTP+fcxScag0ELfE3xunAbjcEsyPpb2o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b3908294b9dce49c091a5031965b647828bae932",
+        "rev": "5723f9666abf2a45d0972db5dd1f9a5b0ac90f1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                            |
| -------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`5723f966`](https://github.com/nix-community/NUR/commit/5723f9666abf2a45d0972db5dd1f9a5b0ac90f1a) | `` automatic update ``             |
| [`266f7569`](https://github.com/nix-community/NUR/commit/266f756943e71988a81fa8f40f0db36641c1e866) | `` automatic update ``             |
| [`9b792afb`](https://github.com/nix-community/NUR/commit/9b792afb9597936d82e2bf16357cbbc67ae47f30) | `` add tehplague/NUR repository `` |