### PR TITLE
chore(flake/nur): `5723f966` -> `2f01e066`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692376909,
-        "narHash": "sha256-fcwKrjaYBixuTP+fcxScag0ELfE3xunAbjcEsyPpb2o=",
+        "lastModified": 1692387968,
+        "narHash": "sha256-dwchyl0FFRHebbfCL5u9+v9J7Z64j9ZKwUftSZQdX3Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5723f9666abf2a45d0972db5dd1f9a5b0ac90f1a",
+        "rev": "2f01e066317ebc684424e40863725dce1d99df22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2f01e066`](https://github.com/nix-community/NUR/commit/2f01e066317ebc684424e40863725dce1d99df22) | `` automatic update `` |