### PR TITLE
chore(flake/nur): `2f01e066` -> `b6185ff5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692387968,
-        "narHash": "sha256-dwchyl0FFRHebbfCL5u9+v9J7Z64j9ZKwUftSZQdX3Q=",
+        "lastModified": 1692391460,
+        "narHash": "sha256-8+17i2eFIdAJ9zZShFCtm7CPTXrrGGPfAGvd/yzKxNM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2f01e066317ebc684424e40863725dce1d99df22",
+        "rev": "b6185ff5f42311bf686571981ca48486a3f9c430",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b6185ff5`](https://github.com/nix-community/NUR/commit/b6185ff5f42311bf686571981ca48486a3f9c430) | `` automatic update `` |
| [`338ce7b2`](https://github.com/nix-community/NUR/commit/338ce7b2a0f8ae6b084295d09042b8b58a3aed5e) | `` automatic update `` |