### PR TITLE
chore(flake/nur): `967227ad` -> `0930f769`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692402216,
-        "narHash": "sha256-d3NsjdcstbS/y3OM802MudZtOV8WaYps2EDbPMe68D0=",
+        "lastModified": 1692408692,
+        "narHash": "sha256-AsL5Dwohxu3NEhwyFxsJcNVFyfw4MLQuCaDRjevwHxI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "967227ad9a1835f91c745381d0d01d1fbb7f3d70",
+        "rev": "0930f7694a69c3683aae933b5c69c661af1529f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0930f769`](https://github.com/nix-community/NUR/commit/0930f7694a69c3683aae933b5c69c661af1529f4) | `` automatic update `` |