### PR TITLE
chore(flake/nur): `0930f769` -> `d037aca2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692408692,
-        "narHash": "sha256-AsL5Dwohxu3NEhwyFxsJcNVFyfw4MLQuCaDRjevwHxI=",
+        "lastModified": 1692416605,
+        "narHash": "sha256-m+Q4BM88kMCoK9VwPPmd/lG95J/fOehP0yHomJdmOAM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0930f7694a69c3683aae933b5c69c661af1529f4",
+        "rev": "d037aca2bd452e1068ee2a9f744434fa50d00c03",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d037aca2`](https://github.com/nix-community/NUR/commit/d037aca2bd452e1068ee2a9f744434fa50d00c03) | `` automatic update `` |
| [`dcb2c436`](https://github.com/nix-community/NUR/commit/dcb2c4362d015a87e56bde175851b267f50c1a4a) | `` automatic update `` |
| [`1a0cec13`](https://github.com/nix-community/NUR/commit/1a0cec13595d58117b38e82a4315bcf27cd91c4d) | `` automatic update `` |