### PR TITLE
chore(flake/emacs-overlay): `07500c25` -> `d899f2d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1692383282,
-        "narHash": "sha256-c+Kg8f1ISz2YCMLg8tNyVYlyM7HJncs7V9xdDUuJFCg=",
+        "lastModified": 1692415698,
+        "narHash": "sha256-OFWVlHm1dgZizkoO6+Q+YaaXRV9E0Zneybjbvsp6EWE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "07500c2529eb8af81b1b26d82e3c3704520d8ffd",
+        "rev": "d899f2d3ad2d3587e6f9122298746f715db1c072",
         "type": "github"
       },
       "original": {
@@ -697,11 +697,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1692311310,
-        "narHash": "sha256-K3VAwgGl7BnoAbDp6qNoCiE2TRuF7j/3nUao57hfh6U=",
+        "lastModified": 1692339729,
+        "narHash": "sha256-TUK76/Pqm9qIDjEGd27Lz9EiBIvn5F70JWDmEQ4Y5DQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "53baed0863ff7df14b14444b779ddfaa80621f1a",
+        "rev": "ae521bd4e460b076a455dca8b13f4151489a725c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d899f2d3`](https://github.com/nix-community/emacs-overlay/commit/d899f2d3ad2d3587e6f9122298746f715db1c072) | `` Updated repos/nongnu `` |
| [`d5f2211b`](https://github.com/nix-community/emacs-overlay/commit/d5f2211b47ec2afa0050e705c571d421b8920b38) | `` Updated repos/melpa ``  |
| [`b0fd9132`](https://github.com/nix-community/emacs-overlay/commit/b0fd913206441b66a0bd98e4a04bad6cf6ff2e2d) | `` Updated repos/emacs ``  |
| [`915496a6`](https://github.com/nix-community/emacs-overlay/commit/915496a63319b872114dd421bad3fd35fe3e038b) | `` Updated repos/elpa ``   |
| [`2a71fbec`](https://github.com/nix-community/emacs-overlay/commit/2a71fbecb20078a1413b094c48d59af282177623) | `` Updated flake inputs `` |