### PR TITLE
chore(flake/dendrite-demo-pinecone): `1c36613b` -> `146bd708`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1692412517,
-        "narHash": "sha256-el/txEVpNWrSKfWPngTE9LU1dsfGuy6LBM+/a8o3rbc=",
+        "lastModified": 1692419685,
+        "narHash": "sha256-MkYaWoblmc3bRvz+fJ0nGN8m3QhTT5nPgGP8BoPUWCg=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "1c36613bffb75d638506499242f4b1b5c23f67b2",
+        "rev": "146bd70834665e9ebdcb34dca603c09cb22a6f2c",
         "type": "github"
       },
       "original": {
@@ -745,11 +745,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1692372666,
-        "narHash": "sha256-JyoI70xpi2irk2JW5KL2w4DrkKmr6EiPztYw6+dqnho=",
+        "lastModified": 1692404241,
+        "narHash": "sha256-TRZlFHtrQI6Kh8RFqnjBF2uNNi/c66ldB4WuIcrwMzg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da5b3c7f1029781ee3c0d971db3f259cf46d205d",
+        "rev": "2f9286912cb215969ece465147badf6d07aa43fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                  |
| --------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`146bd708`](https://github.com/bbigras/dendrite-demo-pinecone/commit/146bd70834665e9ebdcb34dca603c09cb22a6f2c) | `` flake.lock: Update `` |