### PR TITLE
chore(flake/nur): `d037aca2` -> `81685119`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692416605,
-        "narHash": "sha256-m+Q4BM88kMCoK9VwPPmd/lG95J/fOehP0yHomJdmOAM=",
+        "lastModified": 1692424446,
+        "narHash": "sha256-xOCUGjJ4sGplhRQUWuU02Z+WV1WHaxwnd0UpXarwhMs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d037aca2bd452e1068ee2a9f744434fa50d00c03",
+        "rev": "81685119a29b51417ed22fe94a5484ac28fffeed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`81685119`](https://github.com/nix-community/NUR/commit/81685119a29b51417ed22fe94a5484ac28fffeed) | `` automatic update `` |