### PR TITLE
chore(flake/nur): `d0d942fd` -> `14e8647c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692428127,
-        "narHash": "sha256-zZZ4wyu+MPeWmd5atg48xEbszCDzfNYVjqH8F6N+wIk=",
+        "lastModified": 1692429749,
+        "narHash": "sha256-T+tZl47TX+KNYirY7aSB3PpuIGD5aUjQau0IbNSEg9Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d0d942fd46d9f41fe8cad4400acd64edb04dca97",
+        "rev": "14e8647ca23d46249663b4ce2aca76488d90416a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`14e8647c`](https://github.com/nix-community/NUR/commit/14e8647ca23d46249663b4ce2aca76488d90416a) | `` automatic update `` |