### PR TITLE
chore(flake/nur): `14e8647c` -> `b47c7b8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692429749,
-        "narHash": "sha256-T+tZl47TX+KNYirY7aSB3PpuIGD5aUjQau0IbNSEg9Y=",
+        "lastModified": 1692437027,
+        "narHash": "sha256-gWtVFoPw7HhbKGLp7vupVbCNAvNMQS5+2PujOt2QbRk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "14e8647ca23d46249663b4ce2aca76488d90416a",
+        "rev": "b47c7b8d313f9739a7fbb572413c959a362c244a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b47c7b8d`](https://github.com/nix-community/NUR/commit/b47c7b8d313f9739a7fbb572413c959a362c244a) | `` automatic update `` |
| [`9ab28397`](https://github.com/nix-community/NUR/commit/9ab28397631d67b5d2a8bbcfc3f04758511e271a) | `` automatic update `` |