### PR TITLE
chore(flake/nur): `b47c7b8d` -> `c2eb6273`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692437027,
-        "narHash": "sha256-gWtVFoPw7HhbKGLp7vupVbCNAvNMQS5+2PujOt2QbRk=",
+        "lastModified": 1692446373,
+        "narHash": "sha256-/XrcXEPVPD6O6TYL3K8GOTNMu6PrieFvFbpq8NDvfss=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b47c7b8d313f9739a7fbb572413c959a362c244a",
+        "rev": "c2eb627394f363f0494d07321c2c06a6a5a31686",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c2eb6273`](https://github.com/nix-community/NUR/commit/c2eb627394f363f0494d07321c2c06a6a5a31686) | `` automatic update `` |
| [`bc9f27c4`](https://github.com/nix-community/NUR/commit/bc9f27c4623b04d9ac027b05df13555fac5b847b) | `` automatic update `` |