### PR TITLE
chore(flake/home-manager): `6a94c1a5` -> `bdb5bcad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -492,11 +492,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1692260837,
-        "narHash": "sha256-2FpkX1zl+7ni7djK7NeE1ZGupRUwZgjW+RPCSBgDf4k=",
+        "lastModified": 1692448348,
+        "narHash": "sha256-/Wy9Bzw59A5OD82S9dWHshg+wiSzJNh95hPXNhO5K7E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6a94c1a59737783c282c4031555a289c28b961e4",
+        "rev": "bdb5bcad01ff7332fdcf4b128211e81905113f84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`bdb5bcad`](https://github.com/nix-community/home-manager/commit/bdb5bcad01ff7332fdcf4b128211e81905113f84) | `` home-cursor: improve icon compatibility `` |