### PR TITLE
chore(flake/nur): `df6bad47` -> `5c4311a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692449585,
-        "narHash": "sha256-ql8/rzamUz/BanH4hj/gsuTolpHq82QDlEcnM46PUHA=",
+        "lastModified": 1692452704,
+        "narHash": "sha256-4Xwazlo18u8oBANtN0KBsIt1Bj7yCKSJ3Qj6xfSy1ew=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "df6bad471bb01297acb97a9374e935c9d4d4e85c",
+        "rev": "5c4311a3f4bb08b3a1519315f4d3435895851fb4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5c4311a3`](https://github.com/nix-community/NUR/commit/5c4311a3f4bb08b3a1519315f4d3435895851fb4) | `` automatic update `` |