### PR TITLE
chore(flake/nur): `5c4311a3` -> `37f30106`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692452704,
-        "narHash": "sha256-4Xwazlo18u8oBANtN0KBsIt1Bj7yCKSJ3Qj6xfSy1ew=",
+        "lastModified": 1692455181,
+        "narHash": "sha256-XL4dXONV2sxtmYiIy9nGkAsI8L57SPbzrzSZp4yk+m4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5c4311a3f4bb08b3a1519315f4d3435895851fb4",
+        "rev": "37f30106cbd37398a53973fdc78a9fed152fc28b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`37f30106`](https://github.com/nix-community/NUR/commit/37f30106cbd37398a53973fdc78a9fed152fc28b) | `` automatic update `` |