### PR TITLE
chore(flake/nixpkgs): `8ecc900b` -> `d680ded2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -775,11 +775,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1692356644,
-        "narHash": "sha256-AYkPFT+CbCVSBmh0WwIzPpwhEJ4Yy3A7JZvUkGJIg5o=",
+        "lastModified": 1692447944,
+        "narHash": "sha256-fkJGNjEmTPvqBs215EQU4r9ivecV5Qge5cF/QDLVn3U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8ecc900b2f695d74dea35a92f8a9f9b32c8ea33d",
+        "rev": "d680ded26da5cf104dd2735a51e88d2d8f487b4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`66ee5202`](https://github.com/NixOS/nixpkgs/commit/66ee520289a94519350a741924a52b41ae8237df) | `` grocy: replace @ma27 with @n0emis as maintainer ``                                       |
| [`ca499f69`](https://github.com/NixOS/nixpkgs/commit/ca499f6965b5db2aede9734706e288f4d6012fe8) | `` python.tests.tkinter: init ``                                                            |
| [`0b3d65e8`](https://github.com/NixOS/nixpkgs/commit/0b3d65e8306509dbe8481c868ee759434920ddb3) | `` python3.pkgs.pyprusalink: unpin setuptools dependency ``                                 |
| [`51653037`](https://github.com/NixOS/nixpkgs/commit/51653037ae186c40d8543863cbc67f0a67239941) | `` honk: update formatting ``                                                               |
| [`7e0f47ff`](https://github.com/NixOS/nixpkgs/commit/7e0f47ff118108eaf143341daebd8211799321b3) | `` honk: fix filename in `postPatch` ``                                                     |
| [`57486d0e`](https://github.com/NixOS/nixpkgs/commit/57486d0e5e214c5b4fdec24c9be9c41114b1739f) | `` honk: add `meta.changelog` attribute ``                                                  |
| [`41b5ccc7`](https://github.com/NixOS/nixpkgs/commit/41b5ccc774d1ea048cfde6cba03a26bb0e080425) | `` honk: add `meta.mainProgram` attribute ``                                                |
| [`a98ed181`](https://github.com/NixOS/nixpkgs/commit/a98ed1813ae6c324fa82a8f6382618dcf0c958ae) | `` honk: 0.9.91 -> 1.0.0 ``                                                                 |
| [`a12b1adf`](https://github.com/NixOS/nixpkgs/commit/a12b1adf5251006fb38298595536d92a5dd1a673) | `` python3.pkgs.compreffor: fix up build dependencies ``                                    |
| [`6b2935d6`](https://github.com/NixOS/nixpkgs/commit/6b2935d60ce62f70155635eb3df609ef969552d3) | `` python3.pkgs.cffsubr: fix up build dependencies ``                                       |
| [`beaf533e`](https://github.com/NixOS/nixpkgs/commit/beaf533eec01a0cc59cf897cc0d0e17e1b9334d0) | `` python3.pkgs.blosc2: add missing build dependencies ``                                   |
| [`da69b146`](https://github.com/NixOS/nixpkgs/commit/da69b1463edf03d3bfe2bc9be7a0fdb5486429a7) | `` butt: 0.1.37 -> 0.1.38 ``                                                                |
| [`b665cce5`](https://github.com/NixOS/nixpkgs/commit/b665cce576bbc497f2af922ef58b8b09a40ceeff) | `` python311Packages.pyswitchbot: 0.38.0 -> 0.39.0 ``                                       |
| [`24a53193`](https://github.com/NixOS/nixpkgs/commit/24a5319360430f337d6d17d0af934c8cfef4cd44) | `` nuclei: 2.9.10 -> 2.9.11 ``                                                              |
| [`00c34f9e`](https://github.com/NixOS/nixpkgs/commit/00c34f9e19ee9225d5fb523653d1247945e550d3) | `` clash-geoip: 20230712 -> 20230812 ``                                                     |
| [`53314495`](https://github.com/NixOS/nixpkgs/commit/53314495c582b3e3f7abf3b0851375b54c56dc41) | `` argocd-vault-plugin: 1.16.0 -> 1.16.1 ``                                                 |
| [`684d700c`](https://github.com/NixOS/nixpkgs/commit/684d700c12d7245ee810262a5338b95dd8a46b61) | `` faraday-agent-dispatcher: 2.4.0 -> 2.6.2 ``                                              |
| [`07b9eee1`](https://github.com/NixOS/nixpkgs/commit/07b9eee14bd772a3506ed9483cb2be40daddd18d) | `` python3.pkgs.pytenable: audit and propagate dependencies ``                              |
| [`7514dce2`](https://github.com/NixOS/nixpkgs/commit/7514dce297ed982b1173412a318de4d991d0e63d) | `` buttercup-desktop: 2.20.2 -> 2.20.3 ``                                                   |
| [`849c7557`](https://github.com/NixOS/nixpkgs/commit/849c75577d1379ab328703a8fdab70cf9f38fef8) | `` nixos/openarena: cleanup ``                                                              |
| [`758b6fa9`](https://github.com/NixOS/nixpkgs/commit/758b6fa94ba056a54b9cf0fd574232d987b93439) | `` openarena: compile from sources ``                                                       |
| [`ff078d1f`](https://github.com/NixOS/nixpkgs/commit/ff078d1f5826f32a9e106f95785ddbda7955abc0) | `` prometheus-bind-exporter: 0.6.1 -> 0.7.0 ``                                              |
| [`5fdff213`](https://github.com/NixOS/nixpkgs/commit/5fdff213c9ac02b2ad79f6c42de7deb77a6cd8ac) | `` nixos/quake3-server: add `package` config option ``                                      |
| [`dbcc734b`](https://github.com/NixOS/nixpkgs/commit/dbcc734bbd3bd1ef1f3cee11aa72452d498db745) | `` ioquake3: cleanup ``                                                                     |
| [`09661df6`](https://github.com/NixOS/nixpkgs/commit/09661df614c12577e1dbe3cc63c2aa8a5d034397) | `` terraform-providers.aws: 5.13.0 -> 5.13.1 ``                                             |
| [`b9fa0f61`](https://github.com/NixOS/nixpkgs/commit/b9fa0f61c8778cf6f7bb2014582371577a1297b6) | `` terraform-providers.utils: 1.10.0 -> 1.11.0 ``                                           |
| [`34ff03b0`](https://github.com/NixOS/nixpkgs/commit/34ff03b0f85848d363190eb369e76d455e3e6326) | `` terraform-providers.tencentcloud: 1.81.20 -> 1.81.21 ``                                  |
| [`ab559e6d`](https://github.com/NixOS/nixpkgs/commit/ab559e6d3dad8fde1bfbc9f142f775b1ff23c0d5) | `` terraform-providers.spotinst: 1.133.0 -> 1.134.0 ``                                      |
| [`03c35798`](https://github.com/NixOS/nixpkgs/commit/03c35798c64f6ceb37ee4d4d0c8629b84a02bb8d) | `` terraform-providers.okta: 4.2.0 -> 4.3.0 ``                                              |
| [`f3fbe47e`](https://github.com/NixOS/nixpkgs/commit/f3fbe47e188fb676a4fbf87fa5440437af7f3db7) | `` aliyun-cli: 3.0.170 -> 3.0.177 ``                                                        |
| [`6e1fe015`](https://github.com/NixOS/nixpkgs/commit/6e1fe01570b8eed68e5969ee6c5fc77159891ed0) | `` ddev: init at 1.22.1 ``                                                                  |
| [`374d4aab`](https://github.com/NixOS/nixpkgs/commit/374d4aabeb7841a716d58b92961ab0d8280572a0) | `` bazel-buildtools: 6.1.2 -> 6.3.2 ``                                                      |
| [`2076724c`](https://github.com/NixOS/nixpkgs/commit/2076724c51140ee67f070f0b5d03ecad129e70bf) | `` blobby: 1.1 -> 1.1.1 ``                                                                  |
| [`aea209b9`](https://github.com/NixOS/nixpkgs/commit/aea209b9ef70a635caab5c5db12be9e24610b462) | `` fzf-make: add sigmanificient as a maintainer ``                                          |
| [`fd0b5954`](https://github.com/NixOS/nixpkgs/commit/fd0b5954d192c1e3b98db42beff16717fa05c267) | `` fzf-make: init at 0.6.0 ``                                                               |
| [`adfbae87`](https://github.com/NixOS/nixpkgs/commit/adfbae87779c5752ed374042126758a647314a84) | `` k0sctl: 0.15.4 -> 0.15.5 ``                                                              |
| [`c66b43de`](https://github.com/NixOS/nixpkgs/commit/c66b43deecbb7fe89d4aa039ba0008ee1727cf00) | `` mommy: init at 1.2.3 ``                                                                  |
| [`e17a9b76`](https://github.com/NixOS/nixpkgs/commit/e17a9b76d749068078a5e5b6e16f1b8bd0b0912b) | `` python3Packages.sourmash: init at 4.8.3 ``                                               |
| [`35a0419f`](https://github.com/NixOS/nixpkgs/commit/35a0419f5ff6dd4d24acb9fffd45da45a00c0a11) | `` helmfile: 0.155.1 -> 0.156.0 ``                                                          |
| [`5a5401dc`](https://github.com/NixOS/nixpkgs/commit/5a5401dc95294e3c363919952df1da79d647f628) | `` elmPackages.elm-test: use buildNpmPackage ``                                             |
| [`1954c1d0`](https://github.com/NixOS/nixpkgs/commit/1954c1d0ffc99a0c836284fe0cf2469e0e5e8c72) | `` static-web-server: 2.20.2 -> 2.21.0 ``                                                   |
| [`e2ea79b2`](https://github.com/NixOS/nixpkgs/commit/e2ea79b261ea7a0307e3123a7af2af50703f1b2a) | `` netbird-ui: 0.22.4 -> 0.22.6 ``                                                          |
| [`c76f645c`](https://github.com/NixOS/nixpkgs/commit/c76f645c8c4bf75d859ad083a93fbdbc74d9db4a) | `` python3.pkgs.pytest-test-utils: add missing build dependencies ``                        |
| [`6a89fda4`](https://github.com/NixOS/nixpkgs/commit/6a89fda4def23b7886c84c468403333043bdc9e0) | `` anki: remove pip from anki-build-python ``                                               |
| [`06e57d36`](https://github.com/NixOS/nixpkgs/commit/06e57d36066be08c8a9f96f16f0dd2c97f3dafec) | `` jbang: 0.110.0 -> 0.110.1 ``                                                             |
| [`fb948705`](https://github.com/NixOS/nixpkgs/commit/fb94870539ed31ca8b9db1337bdb914d0970ad0d) | `` gobgp: 3.16.0 -> 3.17.0 ``                                                               |
| [`6cc020be`](https://github.com/NixOS/nixpkgs/commit/6cc020bedd96c16184cf5e0b3c90f8847bb1cd8f) | `` ip2unix: 2.2.0 -> 2.2.1 ``                                                               |
| [`5ca0b68a`](https://github.com/NixOS/nixpkgs/commit/5ca0b68afdf9910096ae9703e3bdbb021553c1ff) | `` prometheus-zfs-exporter: 2.2.8 -> 2.3.1 ``                                               |
| [`c141b8da`](https://github.com/NixOS/nixpkgs/commit/c141b8da62e03c0fa4b486af82051bd5987c73b0) | `` python311Packages.batchgenerators: 0.24 -> 0.25 ``                                       |
| [`f8827fc4`](https://github.com/NixOS/nixpkgs/commit/f8827fc4009131b81ef920e91ce5c988f17fdcd9) | `` python311Packages.awswrangler: equalize content ``                                       |
| [`1403486d`](https://github.com/NixOS/nixpkgs/commit/1403486d17ef0fbd698970b90df6c40c22b1d74a) | `` nixos/lxd-agent: init module from distrobuilder generator ``                             |
| [`799d0c89`](https://github.com/NixOS/nixpkgs/commit/799d0c89cd2b2f439ddcaf6f7884a9de81608326) | `` threatest: 1.2.1 -> 1.2.4 ``                                                             |
| [`5fc08598`](https://github.com/NixOS/nixpkgs/commit/5fc085988400e9723b81b5d13423bb8ed030334d) | `` osm2pgsql: 1.8.1 → 1.9.0 ``                                                              |
| [`aa25b89e`](https://github.com/NixOS/nixpkgs/commit/aa25b89e64de1c5c6d896e3559e374d0421099f7) | `` typos: 1.16.5 -> 1.16.6 ``                                                               |
| [`5f01945f`](https://github.com/NixOS/nixpkgs/commit/5f01945f7c26497f358ae2c8cb2fd994c05c7902) | `` dolibarr: 16.0.4 -> 16.0.5 ``                                                            |
| [`ce96c159`](https://github.com/NixOS/nixpkgs/commit/ce96c159c88e97573162d0bdb345103bf5595aea) | `` python311Packages.awswrangler: 3.2.1 -> 3.3.0 ``                                         |
| [`5e88e819`](https://github.com/NixOS/nixpkgs/commit/5e88e819a548a5a9c5e1069c39fdd3247eb3c84e) | `` your-editor: 1505 -> 1506 ``                                                             |
| [`84ed578b`](https://github.com/NixOS/nixpkgs/commit/84ed578b7626b688c3d200fbcb766eccd1a268b2) | `` python311Packages.mkdocstrings-python: 1.3.0 -> 1.4.0 ``                                 |
| [`d429fd69`](https://github.com/NixOS/nixpkgs/commit/d429fd69e10945242ea112fa491fc0926fbe5ea5) | `` python311Packages.griffe: 0.32.3 -> 0.33.0 ``                                            |
| [`238fcb92`](https://github.com/NixOS/nixpkgs/commit/238fcb9281daaa47d20d72ff6daa3a2b610acded) | `` wasm-tools: 1.0.38 -> 1.0.39 ``                                                          |
| [`03f6f069`](https://github.com/NixOS/nixpkgs/commit/03f6f069b3ebe978debca7a608421902e1e1ebdf) | `` gtkwave: 3.3.115 -> 3.3.117 ``                                                           |
| [`bcedfe83`](https://github.com/NixOS/nixpkgs/commit/bcedfe83e7288a9c0e3e09181037f0e61ce608d6) | `` gtkwave: add maintainer jleightcap ``                                                    |
| [`e10bda7a`](https://github.com/NixOS/nixpkgs/commit/e10bda7a5b9a2735761b7b49bae38982a6f465a7) | `` nwg-dock: 0.3.5 -> 0.3.6 ``                                                              |
| [`0fe7b28d`](https://github.com/NixOS/nixpkgs/commit/0fe7b28dcadfd09572b0f056f00b22c697518742) | `` gamescope: 3.12.0-beta10 -> 3.12.3 ``                                                    |
| [`48c11dfa`](https://github.com/NixOS/nixpkgs/commit/48c11dfa5174868eebf44a1de56559a198899722) | `` python311Packages.dbus-fast: 1.91.4 -> 1.92.0 ``                                         |
| [`ea322c26`](https://github.com/NixOS/nixpkgs/commit/ea322c26623899551d98c512e285e1ffe4b4fcac) | `` crosvm: 114.1 -> 115.2 ``                                                                |
| [`dabfd933`](https://github.com/NixOS/nixpkgs/commit/dabfd933589c73d011199fb619eb70d6c2b038e4) | `` crosvm: remove obsolete pkg-config hack ``                                               |
| [`4f7238cc`](https://github.com/NixOS/nixpkgs/commit/4f7238cca9a265b7c7c1f81532a800cf3a11c6b2) | `` cloud-hypervisor: 33.0 -> 34.0 ``                                                        |
| [`ea9af80d`](https://github.com/NixOS/nixpkgs/commit/ea9af80d5ffdf94ad254ab9d35b96fadeb680149) | `` linux_xanmod_latest: 6.4.10 -> 6.4.11 ``                                                 |
| [`0d164bfc`](https://github.com/NixOS/nixpkgs/commit/0d164bfc22e0c8a5f0e9c56cf96d92c2680bf075) | `` linux_xanmod: 6.1.45 -> 6.1.46 ``                                                        |
| [`c02f8330`](https://github.com/NixOS/nixpkgs/commit/c02f83305756e2ef4e957d8025f1cc747e84fc25) | `` python311Packages.m2crypto: 0.38.0 -> 0.39.0 ``                                          |
| [`39f8327e`](https://github.com/NixOS/nixpkgs/commit/39f8327e758fdd0f33558f4166694bf148eed6a6) | `` python311Packages.m2crypto: enable tests ``                                              |
| [`7585ef14`](https://github.com/NixOS/nixpkgs/commit/7585ef14b6becd44b3d73901d5d25ab1514809d8) | `` python311Packages.m2crypto: add format ``                                                |
| [`d37c7dc7`](https://github.com/NixOS/nixpkgs/commit/d37c7dc7446ec7098c21463b13ce4b33ae3944fb) | `` python311Packages.m2crypto: normalize pname ``                                           |
| [`fa32ad6b`](https://github.com/NixOS/nixpkgs/commit/fa32ad6b4589cee589a2632226e851c004a27a39) | `` python311Packages.m2crypto: add changelog to meta ``                                     |
| [`cee2cf0c`](https://github.com/NixOS/nixpkgs/commit/cee2cf0c426e48b329a26ac3014d7b61f698c444) | `` home-assistant: 2023.8.2 -> 2023.8.3 ``                                                  |
| [`c1322a76`](https://github.com/NixOS/nixpkgs/commit/c1322a76a2de0cfa5218c32bdc3d03690ec2834a) | `` ocamlPackages.sel init at 0.4.0 (#247479) ``                                             |
| [`bd555159`](https://github.com/NixOS/nixpkgs/commit/bd5551592ef0fc4c17951c43c19250ca6df43c6f) | `` zarf: 0.28.4 -> 0.29.0 ``                                                                |
| [`4a6d4374`](https://github.com/NixOS/nixpkgs/commit/4a6d4374382782d519f6d25c969ae7f2fda7d1d5) | `` python311Packages.opower: 0.0.26 -> 0.0.29 (#249818) ``                                  |
| [`ddb49e6b`](https://github.com/NixOS/nixpkgs/commit/ddb49e6ba69079705250af76a5c15f139ea6b651) | `` python311Packages.devito: disable failing tests ``                                       |
| [`6039decb`](https://github.com/NixOS/nixpkgs/commit/6039decbd1c40e31b25a71fefe23b007e9fc92d4) | `` waybar: 0.9.21 -> 0.9.22 ``                                                              |
| [`e2a47abb`](https://github.com/NixOS/nixpkgs/commit/e2a47abbc395c3f26416900ce7f23f84d5d43775) | `` ledit: 2.04 → 2.06 ``                                                                    |
| [`7db27210`](https://github.com/NixOS/nixpkgs/commit/7db272106173e16b07f42af61196d4e2cc439fd0) | `` nodePackages.s3http: drop ``                                                             |
| [`5c5d4c72`](https://github.com/NixOS/nixpkgs/commit/5c5d4c7282689c4e670d3068b58facc15c3e87ac) | `` oranda: 0.3.0 -> 0.3.1 ``                                                                |
| [`0e997fba`](https://github.com/NixOS/nixpkgs/commit/0e997fba257d1cac7badd04ac959c97e0b28cc1d) | `` ntfy-sh: 2.6.2 -> 2.7.0 ``                                                               |
| [`0a681238`](https://github.com/NixOS/nixpkgs/commit/0a68123804c8d8d2887e6572a1150cabd1b2c491) | `` borgbackup: use python3Packages instead of python3.pkgs to fix cross compilation ``      |
| [`8be6c852`](https://github.com/NixOS/nixpkgs/commit/8be6c852be8e6c2e1d6c0e48ea6e44ef2364e280) | `` sshuttle: clarify license, add changelog ``                                              |
| [`ec6b1599`](https://github.com/NixOS/nixpkgs/commit/ec6b1599901f58acce3784feccb690d46b72f29f) | `` sshuttle: build and install man page ``                                                  |
| [`81604694`](https://github.com/NixOS/nixpkgs/commit/81604694bd98d9623145653eb7b94e77c8826d95) | `` python311Packages.moderngl-window: mark as broken for Pillow > 10 ``                     |
| [`acc01be8`](https://github.com/NixOS/nixpkgs/commit/acc01be813a16b2eb920d379444ad27951c78417) | `` postgresql: fix musl patches ``                                                          |
| [`28363237`](https://github.com/NixOS/nixpkgs/commit/28363237c515dad8834523315b4c0d9f181f482b) | `` python311Packages.moderngl-window: add optional-dependencies ``                          |
| [`b140d4c3`](https://github.com/NixOS/nixpkgs/commit/b140d4c30cb77ef52caea03abfe283351d1c73bc) | `` python311Packages.moderngl-window: disable on unsupported Python releases ``             |
| [`4e07fbc1`](https://github.com/NixOS/nixpkgs/commit/4e07fbc1ffe53d41c0f6c3378198b87d4140fb38) | `` python311Packages.moderngl-window: update meta ``                                        |
| [`30bb5983`](https://github.com/NixOS/nixpkgs/commit/30bb59839ff26aa294378e3f5ecec811fbe90f4e) | `` ferdium: 6.4.0 -> 6.4.1 ``                                                               |
| [`f8d227be`](https://github.com/NixOS/nixpkgs/commit/f8d227bed3acd86af35a09da1427eead1cf30244) | `` tbls: 1.68.1 -> 1.68.2 ``                                                                |
| [`c9dc4c1e`](https://github.com/NixOS/nixpkgs/commit/c9dc4c1e1568ae6413b33d1a7e0551f968c286cd) | `` g4music: add gst-plugins-bad for m4a support ``                                          |
| [`db423551`](https://github.com/NixOS/nixpkgs/commit/db42355180ddb05346d790c22a3e9161b2cf0265) | `` anytype: 0.33.3 -> 0.34.3 ``                                                             |
| [`bccff6f3`](https://github.com/NixOS/nixpkgs/commit/bccff6f3ef29ef91701340cfabf6e6012802cbac) | `` caddy: 2.7.3 -> 2.7.4 ``                                                                 |
| [`d7c1a98e`](https://github.com/NixOS/nixpkgs/commit/d7c1a98e4b6593331f2f7f6941efd8a3dfbc2572) | `` python311Packages.langsmith: update repo details ``                                      |
| [`b8ad165f`](https://github.com/NixOS/nixpkgs/commit/b8ad165f38f0d829fb5c365377c04973c91a4bb2) | `` python310Packages.langchain: 0.0.263 -> 0.0.268 ``                                       |
| [`ea483ed6`](https://github.com/NixOS/nixpkgs/commit/ea483ed60ad3ffd58cda8adb48a0e92c965280ae) | `` memento: 1.1.0 -> 1.2.1 ``                                                               |
| [`b9fe2002`](https://github.com/NixOS/nixpkgs/commit/b9fe20025178d8f1111591cd6c397e3038fe3065) | `` go-tools: 2023.1.3 -> 2023.1.5 ``                                                        |
| [`bd6f9243`](https://github.com/NixOS/nixpkgs/commit/bd6f9243465075d88d9cd9f7e08f94545c9c3dd5) | `` a4term: 0.2.2 -> 0.2.3 ``                                                                |
| [`2c5088a6`](https://github.com/NixOS/nixpkgs/commit/2c5088a6d82c42a5426a2e462311c0ff4fa6994e) | `` python311Packages.langsmith: 0.0.14 -> 0.0.24 ``                                         |
| [`03e2460c`](https://github.com/NixOS/nixpkgs/commit/03e2460c9cfb2e39363030df05b08d019d8846b3) | `` python311Packages.langsmith: disable on unsupported Python releases ``                   |
| [`f3a2c3fc`](https://github.com/NixOS/nixpkgs/commit/f3a2c3fce8685ea4a4c62ea969aa2ee192d3f9a7) | `` python311Packages.langsmith: add changelog to meta ``                                    |
| [`2d9342b9`](https://github.com/NixOS/nixpkgs/commit/2d9342b9be782d7ea86a46a3615bf129f0897eee) | `` fixup bazel_6 buildBazelPackage references ``                                            |
| [`505c9718`](https://github.com/NixOS/nixpkgs/commit/505c9718cd465aad854b6131beb48cf20aa908ab) | `` python310Packages.oci: 2.110.0 -> 2.110.1 ``                                             |
| [`999a8951`](https://github.com/NixOS/nixpkgs/commit/999a8951e367f39c624696504a2056df941cfc5f) | `` neovide: 0.11.0 -> 0.11.1 ``                                                             |
| [`9263d4c5`](https://github.com/NixOS/nixpkgs/commit/9263d4c527e493990fcc4e464bd9a4659bdb94b0) | `` ruff-lsp: 0.0.35 -> 0.0.36 ``                                                            |
| [`3a729b2f`](https://github.com/NixOS/nixpkgs/commit/3a729b2f90e563de7b89acacd70cbd7ebb62d901) | `` python3Packages.ray: relax virtualenv dep ``                                             |
| [`3cf97b6e`](https://github.com/NixOS/nixpkgs/commit/3cf97b6ed5198247f97aa320dcf071e32b68c16d) | `` raycast: 1.55.2 -> 1.57.1 ``                                                             |
| [`c93147ce`](https://github.com/NixOS/nixpkgs/commit/c93147ce79fb839543715ac9b6fd5908f832974d) | `` jenkins: update meta.homepage ``                                                         |
| [`5dc98a85`](https://github.com/NixOS/nixpkgs/commit/5dc98a85eb4dd9d66f7d409272e9af553cda4bcf) | `` browsr: mark as broken ``                                                                |
| [`49b3bb7d`](https://github.com/NixOS/nixpkgs/commit/49b3bb7d5e325092697a5e900d2076e4dfee6a00) | `` gitlab-runner: 16.2.0 -> 16.2.1 ``                                                       |
| [`3e8fd876`](https://github.com/NixOS/nixpkgs/commit/3e8fd8766392c960ca4c96d1239356f7295055d3) | `` python310Packages.experiment-utilities: 0.3.4 -> 0.3.5 ``                                |
| [`a31444b1`](https://github.com/NixOS/nixpkgs/commit/a31444b1b844ca829338ca7b47e961fcd36ddacf) | `` nyxt: 3.5.0 -> 3.6.0 ``                                                                  |
| [`1a29b529`](https://github.com/NixOS/nixpkgs/commit/1a29b529763fd1e7da5f2e1311f34f05552de2d5) | `` mermerd: 0.8.1 -> 0.9.0 ``                                                               |
| [`a4c6594d`](https://github.com/NixOS/nixpkgs/commit/a4c6594dcda14ca9fd0b1e795023b8942a6dc22d) | `` nixos/influxdb2: do not load passwordFile and tokenFile when provisioning is disabled `` |
| [`a3d19722`](https://github.com/NixOS/nixpkgs/commit/a3d19722edbe921e563edef8f89dcddabe299d6e) | `` python311Packages.hcloud: 1.27.2 -> 1.28.0 ``                                            |
| [`5f10cd99`](https://github.com/NixOS/nixpkgs/commit/5f10cd992271ed152070f4dd62354dfcd3dd4ae1) | `` wiki-tui: 0.8.0 -> 0.8.2 ``                                                              |
| [`473e81ed`](https://github.com/NixOS/nixpkgs/commit/473e81ede4ddb08a3b1c07085d8a1bc402467580) | `` emacs: better glib-networking detection ``                                               |
| [`f0113d65`](https://github.com/NixOS/nixpkgs/commit/f0113d650de0c9399d1237ce9cedf742b2f66e3f) | `` gci: 0.10.1 -> 0.11.0 ``                                                                 |
| [`93699027`](https://github.com/NixOS/nixpkgs/commit/936990271ef9923ccec2dd85fd6b890ab875b41f) | `` nmap-formatter: 2.1.0 -> 2.1.1 ``                                                        |
| [`28693fb1`](https://github.com/NixOS/nixpkgs/commit/28693fb1c3f8ace1b8fdcc23218d9b3d29955ad1) | `` buildNpmPackage: symlink manpages to the correct output directory ``                     |
| [`b54a28bd`](https://github.com/NixOS/nixpkgs/commit/b54a28bd4d7c53fb99726d1950cdd74e6975fece) | `` python311Packages.jq: add changelog to meta ``                                           |
| [`7e9c39e5`](https://github.com/NixOS/nixpkgs/commit/7e9c39e51cb90185c7cedc44c3ecbeea75b6f405) | `` python311Packages.jq: 1.3.0 -> 1.4.1 ``                                                  |
| [`9a038452`](https://github.com/NixOS/nixpkgs/commit/9a038452ced93cc89844ae61b7460420c78d4b90) | `` python310Packages.k-diffusion: disable on unsupported Python releases ``                 |
| [`f8905acb`](https://github.com/NixOS/nixpkgs/commit/f8905acb281f8a649fb54768716fb3788c534e10) | `` python310Packages.k-diffusion: 0.0.14 -> 0.0.16 ``                                       |
| [`5b885645`](https://github.com/NixOS/nixpkgs/commit/5b8856450e9eb198f38a4f148da7a85c5d8fd80b) | `` ddcutil: 1.4.1 -> 1.4.2 ``                                                               |
| [`fe8acaa8`](https://github.com/NixOS/nixpkgs/commit/fe8acaa8327e07b9128c8f0af40735c58413bfe8) | `` lbreakout2: fix runtime issues ``                                                        |
| [`e8b74b41`](https://github.com/NixOS/nixpkgs/commit/e8b74b418eba9d596d0dd45b4f0fb5567f40942e) | `` python3.pkgs.vdirsyncer: add missing build dependencies ``                               |
| [`df40e12f`](https://github.com/NixOS/nixpkgs/commit/df40e12f2dd0ff467e742e7f674d944821d95a98) | `` python310Packages.jaxtyping: 0.2.20 -> 0.2.21 ``                                         |
| [`937db53f`](https://github.com/NixOS/nixpkgs/commit/937db53f2a40db2caa5a1117e23cb2aea5afb547) | `` libreswan: 4.11 -> 4.12 ``                                                               |
| [`628f3761`](https://github.com/NixOS/nixpkgs/commit/628f376143ab6356522d47f387addf6dd133009f) | `` packer: 1.9.2 -> 1.9.3 ``                                                                |
| [`0e0b2fb5`](https://github.com/NixOS/nixpkgs/commit/0e0b2fb549c02a48c29c3ad72a3b1e59db0a23ed) | `` mate.libmateweather: fix cross compilation, set strictDeps ``                            |
| [`c8b2c359`](https://github.com/NixOS/nixpkgs/commit/c8b2c3592c1a8dd2cc9d578e9624e3660ef34088) | `` python3.pkgs.correctionlib: clean up / fix up build dependencies ``                      |
| [`982923c3`](https://github.com/NixOS/nixpkgs/commit/982923c3e58b2a4eb1b3ffb8f1bd03b209bdf678) | `` python3.pkgs.python-swiftclient: patch out duplicate script ``                           |
| [`6208a372`](https://github.com/NixOS/nixpkgs/commit/6208a37211d3abac4b922b4e9d3f01d0e3c0d74f) | `` oranda: 0.2.0 -> 0.3.0 ``                                                                |
| [`e8c2411e`](https://github.com/NixOS/nixpkgs/commit/e8c2411e8232fb984f47794b2630ee5abacf6216) | `` tailwindcss: set meta.mainProgram ``                                                     |
| [`109f0941`](https://github.com/NixOS/nixpkgs/commit/109f09412752c7108c1bb954ab0cd8921e723094) | `` postgresqlPackages.timescaledb: 2.11.1 -> 2.11.2 ``                                      |