### PR TITLE
chore(flake/nur): `18436a20` -> `21731d0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692488764,
-        "narHash": "sha256-SCtwgqxLUCHf4gT83ab/46eqcw2ocm5FZanysSF9Bg4=",
+        "lastModified": 1692502961,
+        "narHash": "sha256-vBWqvGKiNZJEdXMntvUWTlLfGgYYlSQ5iUnvZI9pm44=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "18436a20915d6cc569d7fb13807a07ae5de10661",
+        "rev": "21731d0bfce13b60bee36ee2d5397799e6a28096",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`21731d0b`](https://github.com/nix-community/NUR/commit/21731d0bfce13b60bee36ee2d5397799e6a28096) | `` automatic update `` |
| [`a6a60450`](https://github.com/nix-community/NUR/commit/a6a60450e6d2d1e43e8feadc7c9a965cdf55158c) | `` automatic update `` |
| [`69d89062`](https://github.com/nix-community/NUR/commit/69d89062e9c59e33fb97087e9ac2621ced02ba75) | `` automatic update `` |