### PR TITLE
chore(flake/nur): `21731d0b` -> `8bc4ab14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692502961,
-        "narHash": "sha256-vBWqvGKiNZJEdXMntvUWTlLfGgYYlSQ5iUnvZI9pm44=",
+        "lastModified": 1692507644,
+        "narHash": "sha256-EMmr4HCZB47kGELXgQWhGFhyDTZ7A6IGjVDd3gSTukc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "21731d0bfce13b60bee36ee2d5397799e6a28096",
+        "rev": "8bc4ab14a9d7e3340d00b80f015e1d0acbe92c96",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8bc4ab14`](https://github.com/nix-community/NUR/commit/8bc4ab14a9d7e3340d00b80f015e1d0acbe92c96) | `` automatic update `` |