### PR TITLE
chore(flake/nur): `8bc4ab14` -> `6a11e174`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692507644,
-        "narHash": "sha256-EMmr4HCZB47kGELXgQWhGFhyDTZ7A6IGjVDd3gSTukc=",
+        "lastModified": 1692518211,
+        "narHash": "sha256-7gyJ9lOH87Tn5zfMYfiMNgJON5pqME0JtJXJwq9nKV4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8bc4ab14a9d7e3340d00b80f015e1d0acbe92c96",
+        "rev": "6a11e17484e90c1255dc89693322710be86b71ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6a11e174`](https://github.com/nix-community/NUR/commit/6a11e17484e90c1255dc89693322710be86b71ad) | `` automatic update `` |
| [`b961170a`](https://github.com/nix-community/NUR/commit/b961170a1cc54baad1058155a27ccfc82467653b) | `` automatic update `` |
| [`e378bfd5`](https://github.com/nix-community/NUR/commit/e378bfd52aa6fe5b06275c6a9d470e7d29acfacd) | `` automatic update `` |
| [`6faccb50`](https://github.com/nix-community/NUR/commit/6faccb5078d63f34e6ee5d3207ccc71d232090ff) | `` automatic update `` |