### PR TITLE
chore(flake/nur): `68be119f` -> `cb557a26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692524698,
-        "narHash": "sha256-32Yv1SkYsk20IWK4VYtbfJBSWEEIxudf/ucjIJnHuyw=",
+        "lastModified": 1692539091,
+        "narHash": "sha256-ID0Bd0l4q+SCYmOHJwL13IfxuihnfxnU68YsLbIokQY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "68be119f022374c9deb1b54ff7e5c0af8ca4de5d",
+        "rev": "cb557a26c223ab09568890d28c5f51ac4a7c418c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cb557a26`](https://github.com/nix-community/NUR/commit/cb557a26c223ab09568890d28c5f51ac4a7c418c) | `` automatic update `` |