### PR TITLE
chore(flake/nur): `cb557a26` -> `3ab8a848`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692539091,
-        "narHash": "sha256-ID0Bd0l4q+SCYmOHJwL13IfxuihnfxnU68YsLbIokQY=",
+        "lastModified": 1692546305,
+        "narHash": "sha256-wkh3AW5dMoZzpoois0EjUa+4iLjDIapCnMHNj5RPSWM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cb557a26c223ab09568890d28c5f51ac4a7c418c",
+        "rev": "3ab8a848ef9af7c63a4740b3f1906704bb1677cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3ab8a848`](https://github.com/nix-community/NUR/commit/3ab8a848ef9af7c63a4740b3f1906704bb1677cc) | `` automatic update `` |
| [`ab900d85`](https://github.com/nix-community/NUR/commit/ab900d857a7a1ff98afa20221cb0866172e1a2cd) | `` automatic update `` |