### PR TITLE
chore(flake/nur): `3ab8a848` -> `2c806e31`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692546305,
-        "narHash": "sha256-wkh3AW5dMoZzpoois0EjUa+4iLjDIapCnMHNj5RPSWM=",
+        "lastModified": 1692557088,
+        "narHash": "sha256-87rF4OQwZwsvU8xzHnsVc8k9S9o/FF6AnoNgUpBKdzI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3ab8a848ef9af7c63a4740b3f1906704bb1677cc",
+        "rev": "2c806e31783492bfb4c8d7e7cd64ef3e3cbb3d66",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2c806e31`](https://github.com/nix-community/NUR/commit/2c806e31783492bfb4c8d7e7cd64ef3e3cbb3d66) | `` automatic update `` |