### PR TITLE
chore(flake/emacs-overlay): `fcc338ec` -> `9a738849`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1692527503,
-        "narHash": "sha256-8TS2jQou1oRSrbp3Hh3Ldby1/lMs921kQpXcNe71TIA=",
+        "lastModified": 1692555851,
+        "narHash": "sha256-OcCzFUTiYsP1K/vlhV7U0ae8Ine/vTG8XaQll0AeqGw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fcc338ec334ec93adb816d5ebaeef6f34093f2b8",
+        "rev": "9a7388497abed4a4c0fffd938fab35f1168ce8c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`9a738849`](https://github.com/nix-community/emacs-overlay/commit/9a7388497abed4a4c0fffd938fab35f1168ce8c9) | `` Updated repos/melpa `` |
| [`5b261137`](https://github.com/nix-community/emacs-overlay/commit/5b26113704e83faa837e3cd0f9b38cde438bbebe) | `` Updated repos/emacs `` |
| [`45a20b7f`](https://github.com/nix-community/emacs-overlay/commit/45a20b7f3888b8e2b71f95b0b5705833aa0296aa) | `` Updated repos/elpa ``  |