### PR TITLE
chore(flake/nur): `2c806e31` -> `20b75553`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692557088,
-        "narHash": "sha256-87rF4OQwZwsvU8xzHnsVc8k9S9o/FF6AnoNgUpBKdzI=",
+        "lastModified": 1692560722,
+        "narHash": "sha256-WiDiephenR7hjkDqZe2reo6JhyOlUmpQenwfQeU1ivI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2c806e31783492bfb4c8d7e7cd64ef3e3cbb3d66",
+        "rev": "20b75553a905eff5c9e86f07d38bdacb96dc56da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`20b75553`](https://github.com/nix-community/NUR/commit/20b75553a905eff5c9e86f07d38bdacb96dc56da) | `` automatic update `` |