### PR TITLE
chore(flake/nur): `20b75553` -> `14d6aa10`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692560722,
-        "narHash": "sha256-WiDiephenR7hjkDqZe2reo6JhyOlUmpQenwfQeU1ivI=",
+        "lastModified": 1692585190,
+        "narHash": "sha256-aCaG7Xqp2q3E88zP64OsFEBPjNJpvxByGlxbJmJfNkc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "20b75553a905eff5c9e86f07d38bdacb96dc56da",
+        "rev": "14d6aa107f5fedcb63b61f12a573ac612d20ad3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`14d6aa10`](https://github.com/nix-community/NUR/commit/14d6aa107f5fedcb63b61f12a573ac612d20ad3e) | `` automatic update `` |