### PR TITLE
chore(flake/nur): `14d6aa10` -> `cfd0e003`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692585190,
-        "narHash": "sha256-aCaG7Xqp2q3E88zP64OsFEBPjNJpvxByGlxbJmJfNkc=",
+        "lastModified": 1692593943,
+        "narHash": "sha256-BRXweNvz0Ao2oKDIRCT8+bxdfbn1BUlrgblr78tr2dU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "14d6aa107f5fedcb63b61f12a573ac612d20ad3e",
+        "rev": "cfd0e00302148439768f0d073a2fa62092443021",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cfd0e003`](https://github.com/nix-community/NUR/commit/cfd0e00302148439768f0d073a2fa62092443021) | `` automatic update `` |
| [`60e054af`](https://github.com/nix-community/NUR/commit/60e054af1488c2f3520aeac0f24f3967b7705916) | `` automatic update `` |