### PR TITLE
chore(flake/nur): `411aca08` -> `728cd1f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692598479,
-        "narHash": "sha256-8bLYtaBVAt0BTVExy0AvajRkeWoHNz0BxfgQMtsUF5M=",
+        "lastModified": 1692601307,
+        "narHash": "sha256-+LQYdb78YRkkoCuJc9xV2qdMyEVlkdfEHqQKwfDc0VI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "411aca0839e7db69f8c5b6822a761a3839f792df",
+        "rev": "728cd1f35f4cc3a0e76a017f0f1d5b8137fc9d5c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`728cd1f3`](https://github.com/nix-community/NUR/commit/728cd1f35f4cc3a0e76a017f0f1d5b8137fc9d5c) | `` automatic update `` |