### PR TITLE
chore(flake/emacs-overlay): `33a166b2` -> `027e735d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1692589297,
-        "narHash": "sha256-vTA/uuUvFpFrNSy4AMJS/zTxGwR2YgnOfXapgXLJ5bU=",
+        "lastModified": 1692613011,
+        "narHash": "sha256-2CgHRwENvxO6j6eTnamIOmmFUKhlxDLNsA7gCJcL81Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "33a166b214c841d6fa5874ccc925871b2394a7e3",
+        "rev": "027e735d9a612a31b9adf54b9341086dadbeb7e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`027e735d`](https://github.com/nix-community/emacs-overlay/commit/027e735d9a612a31b9adf54b9341086dadbeb7e7) | `` Updated repos/melpa `` |
| [`57d10a23`](https://github.com/nix-community/emacs-overlay/commit/57d10a230d77beb1d57df73d2257a63233de8956) | `` Updated repos/emacs `` |