### PR TITLE
chore(flake/nur): `35eb9f2b` -> `0b3f61b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692618332,
-        "narHash": "sha256-fPLECTsVHzGEOYvfy437UdbfAd9tCEgNRLR6iQLWR6g=",
+        "lastModified": 1692625595,
+        "narHash": "sha256-VxeOB4KxSGZuehFpri/zz3D7uMDs8yfERGmw7P+HPDg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "35eb9f2bce6dbd674ebdc338a3d512efb8fc252e",
+        "rev": "0b3f61b71e01138dc4d05dc073a4bf8461cb2bf6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0b3f61b7`](https://github.com/nix-community/NUR/commit/0b3f61b71e01138dc4d05dc073a4bf8461cb2bf6) | `` automatic update `` |