### PR TITLE
chore(flake/nur): `af039bb4` -> `7845b412`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692633435,
-        "narHash": "sha256-T6vN5degfaj35Q2esd28xaZOlKawvMjqdSYVT+5K/WY=",
+        "lastModified": 1692640722,
+        "narHash": "sha256-0Gc0ToGpPG+CRVxP+RYbC7LRBFCKDjaxLJBDJ4wbN5I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "af039bb4ed63f19c244a126c90211028d1d377ef",
+        "rev": "7845b4123108cb2943ec031e1dab8982030444f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7845b412`](https://github.com/nix-community/NUR/commit/7845b4123108cb2943ec031e1dab8982030444f3) | `` automatic update `` |
| [`fba581a5`](https://github.com/nix-community/NUR/commit/fba581a5bac0606553b968a6b685d562328d2de7) | `` automatic update `` |