### PR TITLE
chore(flake/emacs-overlay): `027e735d` -> `519c98ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1692613011,
-        "narHash": "sha256-2CgHRwENvxO6j6eTnamIOmmFUKhlxDLNsA7gCJcL81Y=",
+        "lastModified": 1692643643,
+        "narHash": "sha256-znMUMwiNYZph8YZNA4x5F0bLpWRH2kNQDl8kcLTDLDY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "027e735d9a612a31b9adf54b9341086dadbeb7e7",
+        "rev": "519c98cef1aa5901568266146d085d230d92952f",
         "type": "github"
       },
       "original": {
@@ -697,11 +697,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1692414505,
-        "narHash": "sha256-sSTuyR9JYSxmUcYcj0Jvw1hIq1tz/Canw9mK0hEJvnE=",
+        "lastModified": 1692525914,
+        "narHash": "sha256-MUgZ9/9mE/EbEQA6JPdcQHkjoR5fgvaKhpy6UO67uEc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4cdad15f34e6321a2f789b99d42815b9142ac2ba",
+        "rev": "475d5ae2c4cb87b904545bdb547af05681198fcc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`519c98ce`](https://github.com/nix-community/emacs-overlay/commit/519c98cef1aa5901568266146d085d230d92952f) | `` Updated repos/melpa ``  |
| [`1facd6f1`](https://github.com/nix-community/emacs-overlay/commit/1facd6f1687e3699ac3cbf982508d94e237739c3) | `` Updated repos/emacs ``  |
| [`ba1b47e3`](https://github.com/nix-community/emacs-overlay/commit/ba1b47e3d19612e632e0973e3edaee93d12f9f09) | `` Updated repos/elpa ``   |
| [`0642592d`](https://github.com/nix-community/emacs-overlay/commit/0642592d60f705e0e27fcd96e26f965df4e573e0) | `` Updated flake inputs `` |