### PR TITLE
chore(flake/nur): `7845b412` -> `7bd2ca05`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692640722,
-        "narHash": "sha256-0Gc0ToGpPG+CRVxP+RYbC7LRBFCKDjaxLJBDJ4wbN5I=",
+        "lastModified": 1692647167,
+        "narHash": "sha256-6frwQDtJoJTc8fPOko5sh7xdg766HItGbm7ebVdkEdU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7845b4123108cb2943ec031e1dab8982030444f3",
+        "rev": "7bd2ca0523961cc0436febef2002471cefc9ba67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7bd2ca05`](https://github.com/nix-community/NUR/commit/7bd2ca0523961cc0436febef2002471cefc9ba67) | `` automatic update `` |
| [`c79a8b54`](https://github.com/nix-community/NUR/commit/c79a8b5405807c516cda5308fa0599832085e9ae) | `` automatic update `` |