### PR TITLE
chore(flake/nur): `7bd2ca05` -> `80f93379`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692647167,
-        "narHash": "sha256-6frwQDtJoJTc8fPOko5sh7xdg766HItGbm7ebVdkEdU=",
+        "lastModified": 1692654323,
+        "narHash": "sha256-tsjrkrrcNkyRs4KnLGxoxsVuJqEY6JAgJsifkbN7O8M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7bd2ca0523961cc0436febef2002471cefc9ba67",
+        "rev": "80f93379b80f3129c3eb41c6c76c3f7434ebd4c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`80f93379`](https://github.com/nix-community/NUR/commit/80f93379b80f3129c3eb41c6c76c3f7434ebd4c6) | `` automatic update `` |
| [`5a3b5cdf`](https://github.com/nix-community/NUR/commit/5a3b5cdf33adcd210310d1cdcc27623e4abd3070) | `` automatic update `` |
| [`23cf83f1`](https://github.com/nix-community/NUR/commit/23cf83f10b2459f7a2ade144995a0d0d6343301d) | `` automatic update `` |