### PR TITLE
chore(flake/nur): `80f93379` -> `01e21525`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692654323,
-        "narHash": "sha256-tsjrkrrcNkyRs4KnLGxoxsVuJqEY6JAgJsifkbN7O8M=",
+        "lastModified": 1692658471,
+        "narHash": "sha256-mClrvAg5GOfH2ovdxL/zPwlLXa3vC5NZkamtnAzEcwQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "80f93379b80f3129c3eb41c6c76c3f7434ebd4c6",
+        "rev": "01e21525f7706e0fb4751da6253765ada15f4df6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`01e21525`](https://github.com/nix-community/NUR/commit/01e21525f7706e0fb4751da6253765ada15f4df6) | `` automatic update `` |
| [`9c488bb8`](https://github.com/nix-community/NUR/commit/9c488bb8e4ea2926d5290472edbd4722500baca0) | `` automatic update `` |