### PR TITLE
chore(flake/nur): `01e21525` -> `3f3fadff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692658471,
-        "narHash": "sha256-mClrvAg5GOfH2ovdxL/zPwlLXa3vC5NZkamtnAzEcwQ=",
+        "lastModified": 1692672389,
+        "narHash": "sha256-nUuV7oyCIzOrpTMT1QbISP35ap3khZL/koGiDVRCh3c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "01e21525f7706e0fb4751da6253765ada15f4df6",
+        "rev": "3f3fadffb6d37b6b297183d9b9872ae0998c701d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3f3fadff`](https://github.com/nix-community/NUR/commit/3f3fadffb6d37b6b297183d9b9872ae0998c701d) | `` automatic update `` |