### PR TITLE
chore(flake/nur): `3f3fadff` -> `d6835f55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692672389,
-        "narHash": "sha256-nUuV7oyCIzOrpTMT1QbISP35ap3khZL/koGiDVRCh3c=",
+        "lastModified": 1692675804,
+        "narHash": "sha256-C/qODD3TlQZSjgrX1X3Q2f8d2RdhSmSdz/KKSuBCf/s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3f3fadffb6d37b6b297183d9b9872ae0998c701d",
+        "rev": "d6835f55127eb1ba6d9b01b21a38c773e737031a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d6835f55`](https://github.com/nix-community/NUR/commit/d6835f55127eb1ba6d9b01b21a38c773e737031a) | `` automatic update `` |
| [`af3f7455`](https://github.com/nix-community/NUR/commit/af3f74559b48903779500c5606a1a394e4109a2a) | `` automatic update `` |
| [`505e7c4f`](https://github.com/nix-community/NUR/commit/505e7c4f9b3d153f3e981efb4a3a3eee7ad9e92e) | `` automatic update `` |