### PR TITLE
chore(flake/nur): `d6835f55` -> `25bb8ff9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692675804,
-        "narHash": "sha256-C/qODD3TlQZSjgrX1X3Q2f8d2RdhSmSdz/KKSuBCf/s=",
+        "lastModified": 1692679183,
+        "narHash": "sha256-l78Oh/efL9X17N7sqvcBiO8d8MbQhil1ClGQtk6dzAs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d6835f55127eb1ba6d9b01b21a38c773e737031a",
+        "rev": "25bb8ff9d81b13572af6212e5eef0bc44c5646b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`25bb8ff9`](https://github.com/nix-community/NUR/commit/25bb8ff9d81b13572af6212e5eef0bc44c5646b6) | `` automatic update `` |
| [`49751da6`](https://github.com/nix-community/NUR/commit/49751da67efaab43309a59909cd9aec1a2b0010b) | `` automatic update `` |
| [`70abf88e`](https://github.com/nix-community/NUR/commit/70abf88ead7e209423e55f6227f7bdf81b074c71) | `` automatic update `` |