### PR TITLE
chore(flake/nur): `25bb8ff9` -> `c2ade119`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692679183,
-        "narHash": "sha256-l78Oh/efL9X17N7sqvcBiO8d8MbQhil1ClGQtk6dzAs=",
+        "lastModified": 1692686760,
+        "narHash": "sha256-Jos0lAuo6E8f3CEHtMlkmanCLY4PVo3dyn5Y/5TUxVk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "25bb8ff9d81b13572af6212e5eef0bc44c5646b6",
+        "rev": "c2ade119d26d95bc84b0f48afa10c63894e1150e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c2ade119`](https://github.com/nix-community/NUR/commit/c2ade119d26d95bc84b0f48afa10c63894e1150e) | `` automatic update `` |
| [`442c095d`](https://github.com/nix-community/NUR/commit/442c095d0b69aeed83ecae36c1c8ab5a10248e89) | `` automatic update `` |