### PR TITLE
chore(flake/nur): `c2ade119` -> `39fc2500`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692686760,
-        "narHash": "sha256-Jos0lAuo6E8f3CEHtMlkmanCLY4PVo3dyn5Y/5TUxVk=",
+        "lastModified": 1692693974,
+        "narHash": "sha256-0QLUkE2H78hXyXZbaYs7jK3D/cFMWKY3kYOv+S/kX5g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c2ade119d26d95bc84b0f48afa10c63894e1150e",
+        "rev": "39fc2500bc078faa463150a3ee0ccdd228faeb5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`39fc2500`](https://github.com/nix-community/NUR/commit/39fc2500bc078faa463150a3ee0ccdd228faeb5b) | `` automatic update `` |