### PR TITLE
chore(flake/nur): `39fc2500` -> `e74b8056`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692693974,
-        "narHash": "sha256-0QLUkE2H78hXyXZbaYs7jK3D/cFMWKY3kYOv+S/kX5g=",
+        "lastModified": 1692696219,
+        "narHash": "sha256-fAGjUYD8FWDXFubBpAX4HX72OoPr6jqzhAaFDzRR5k8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "39fc2500bc078faa463150a3ee0ccdd228faeb5b",
+        "rev": "e74b8056b4b406266ac6e05b7d3d0c37b0e5acb1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e74b8056`](https://github.com/nix-community/NUR/commit/e74b8056b4b406266ac6e05b7d3d0c37b0e5acb1) | `` automatic update `` |