### PR TITLE
chore(flake/emacs-overlay): `9b3881d1` -> `e4959460`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1692674849,
-        "narHash": "sha256-t9BqUFWaqXbusQtJkLlNu236m1y27ZCZr/6FQIx7arE=",
+        "lastModified": 1692700056,
+        "narHash": "sha256-KWk7tPc4VHqtcV0Q89SD4aELFppGKNJs0F8amJEb8Yc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9b3881d181a32137f97514cbf43cc51bafcef283",
+        "rev": "e4959460ea8e7d122baab8fd967bc604df928bec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`e4959460`](https://github.com/nix-community/emacs-overlay/commit/e4959460ea8e7d122baab8fd967bc604df928bec) | `` Updated repos/melpa `` |
| [`9a622ba9`](https://github.com/nix-community/emacs-overlay/commit/9a622ba9efa7b6680a41d1ca1129cebe5602d6dd) | `` Updated repos/emacs `` |