### PR TITLE
chore(flake/nur): `e74b8056` -> `005dbfac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692696219,
-        "narHash": "sha256-fAGjUYD8FWDXFubBpAX4HX72OoPr6jqzhAaFDzRR5k8=",
+        "lastModified": 1692698578,
+        "narHash": "sha256-sNiNKomooOWb19XXIcDcJoXmhlBAseYNfgV7UC1dO+0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e74b8056b4b406266ac6e05b7d3d0c37b0e5acb1",
+        "rev": "005dbfacdbf783079ea727d3fc4c09d715224cd2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`005dbfac`](https://github.com/nix-community/NUR/commit/005dbfacdbf783079ea727d3fc4c09d715224cd2) | `` automatic update `` |