### PR TITLE
chore(flake/nur): `005dbfac` -> `9d84eb2a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692698578,
-        "narHash": "sha256-sNiNKomooOWb19XXIcDcJoXmhlBAseYNfgV7UC1dO+0=",
+        "lastModified": 1692708992,
+        "narHash": "sha256-VVhVI7gVc/TBcZxbOlDTqBIU/nj3CfsXDxgP1fTjHvU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "005dbfacdbf783079ea727d3fc4c09d715224cd2",
+        "rev": "9d84eb2ae0075c371033a5834022ca0fba9b2385",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9d84eb2a`](https://github.com/nix-community/NUR/commit/9d84eb2ae0075c371033a5834022ca0fba9b2385) | `` automatic update `` |
| [`7a757695`](https://github.com/nix-community/NUR/commit/7a757695a6a53afdbd0fa728e3c6a062be28510a) | `` automatic update `` |