### PR TITLE
chore(flake/nur): `9d84eb2a` -> `be1e9795`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692708992,
-        "narHash": "sha256-VVhVI7gVc/TBcZxbOlDTqBIU/nj3CfsXDxgP1fTjHvU=",
+        "lastModified": 1692711986,
+        "narHash": "sha256-GftpxVWBY0Ro66N29pBKPLSm9Sm35MkO8DcgM6uXclc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9d84eb2ae0075c371033a5834022ca0fba9b2385",
+        "rev": "be1e9795afae8698e4f3919a71006c58415b2d2b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`be1e9795`](https://github.com/nix-community/NUR/commit/be1e9795afae8698e4f3919a71006c58415b2d2b) | `` automatic update `` |