### PR TITLE
chore(flake/nur): `be1e9795` -> `74d31ccf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692711986,
-        "narHash": "sha256-GftpxVWBY0Ro66N29pBKPLSm9Sm35MkO8DcgM6uXclc=",
+        "lastModified": 1692715046,
+        "narHash": "sha256-DhsvkMMKGkDI80xNqL5m27MejD+onrbVfKfi091xjJA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "be1e9795afae8698e4f3919a71006c58415b2d2b",
+        "rev": "74d31ccf483309693e562231fa05afec5c5f4096",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`74d31ccf`](https://github.com/nix-community/NUR/commit/74d31ccf483309693e562231fa05afec5c5f4096) | `` automatic update `` |
| [`93305cd0`](https://github.com/nix-community/NUR/commit/93305cd05cc6454ae520e2eb815ca5851243ab3d) | `` automatic update `` |