### PR TITLE
chore(flake/nixpkgs): `d680ded2` -> `91a22f76`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -775,11 +775,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1692447944,
-        "narHash": "sha256-fkJGNjEmTPvqBs215EQU4r9ivecV5Qge5cF/QDLVn3U=",
+        "lastModified": 1692638711,
+        "narHash": "sha256-J0LgSFgJVGCC1+j5R2QndadWI1oumusg6hCtYAzLID4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d680ded26da5cf104dd2735a51e88d2d8f487b4d",
+        "rev": "91a22f76cd1716f9d0149e8a5c68424bb691de15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
| [`53d7ae9d`](https://github.com/NixOS/nixpkgs/commit/53d7ae9de93fd8a30b9c5d5db035d6f7edfe9487) | `` budgie.budgie-desktop: 10.7.2 -> 10.8 ``                                                                                          |
| [`6d2033e2`](https://github.com/NixOS/nixpkgs/commit/6d2033e2b997b9cccbad098ff7b54fbc54c4d9f0) | `` just.setupHook: init ``                                                                                                           |
| [`9cac0ea1`](https://github.com/NixOS/nixpkgs/commit/9cac0ea125d5e245c098cc55e2ee6554c3566e9b) | `` python310Packages.mkdocstrings-python: update disabled ``                                                                         |
| [`f3d36186`](https://github.com/NixOS/nixpkgs/commit/f3d361869a34d6ca4cc600292477a210966ab907) | `` gopls: 0.13.1 -> 0.13.2 (#250537) ``                                                                                              |
| [`b16b6cc6`](https://github.com/NixOS/nixpkgs/commit/b16b6cc6f2fcaa178ddff686e3eba46645bfb903) | `` grails: 5.3.3 -> 6.0.0 ``                                                                                                         |
| [`7526787a`](https://github.com/NixOS/nixpkgs/commit/7526787a4ee52531998b04c32be158b1741052ca) | `` bind: disable tests on i686 ``                                                                                                    |
| [`1a2b257d`](https://github.com/NixOS/nixpkgs/commit/1a2b257d748b8add1d6274696c8b39d12789873a) | `` screen: 4.9.0 -> 4.9.1 ``                                                                                                         |
| [`d032f104`](https://github.com/NixOS/nixpkgs/commit/d032f1043e1a9dc053e457167b8324a7ac118449) | `` python310Packages.mkdocstrings-python: 1.4.0 -> 1.5.0 ``                                                                          |
| [`6d71fd1c`](https://github.com/NixOS/nixpkgs/commit/6d71fd1c0ba026fb1b271be05fb0a10df76beadc) | `` Add optional Hyprland dependencies ``                                                                                             |
| [`5086aba8`](https://github.com/NixOS/nixpkgs/commit/5086aba85ee884a179b29abbbfea2b212d0d3cd4) | `` buildkite-agent-metrics: 5.2.1 -> 5.7.0 ``                                                                                        |
| [`49ca8fb4`](https://github.com/NixOS/nixpkgs/commit/49ca8fb4ee9717fbfe6f80eb8f61cf105aa5b563) | `` texlive.bin.xpdfopen: init (#250388) ``                                                                                           |
| [`e134c208`](https://github.com/NixOS/nixpkgs/commit/e134c208ae80bba0ccc2311519e6ccabf4c0c91c) | `` texlive.bin.xetex: add teckit_compile to output (#250390) ``                                                                      |
| [`13e4891d`](https://github.com/NixOS/nixpkgs/commit/13e4891d6d2b04dc87282118694104b6c5f19dd6) | `` nixpkgs manual: doc python: render manual notes as admonitions ``                                                                 |
| [`69d965cb`](https://github.com/NixOS/nixpkgs/commit/69d965cb9ed0b90b8f9acf38597375741eaa4c75) | `` n8n: 1.1.1 -> 1.3.1 ``                                                                                                            |
| [`8f3e6dca`](https://github.com/NixOS/nixpkgs/commit/8f3e6dca010f69fc324a8ead6eb1fc4bf9a6ab62) | `` golangci-lint: 1.54.1 -> 1.54.2 ``                                                                                                |
| [`d687c828`](https://github.com/NixOS/nixpkgs/commit/d687c82885fd22b4bb2df59161847b0a5f57394e) | `` zfsUnstable: 2.1.12 → 2.1.13-unstable-2023-08-02 ``                                                                               |
| [`9182fed8`](https://github.com/NixOS/nixpkgs/commit/9182fed84cbc8215fc479c9d89d677dce107a9ba) | `` zig-shell-completions: init at unstable-2023-08-17 ``                                                                             |
| [`86b19901`](https://github.com/NixOS/nixpkgs/commit/86b19901adb386585984ef4573172ee356b0cfe0) | `` python311Packages.aliyun-python-sdk-config: 2.2.10 -> 2.2.11 ``                                                                   |
| [`0eef983d`](https://github.com/NixOS/nixpkgs/commit/0eef983d340a795f5314f5a446dcf6d4aafa6fd5) | `` ddnet: 17.1.1 -> 17.2.1 ``                                                                                                        |
| [`89004b7c`](https://github.com/NixOS/nixpkgs/commit/89004b7cf2b15171d01987cdf451fdf18effd4d5) | `` libz: init at unstable-2018-03-31 ``                                                                                              |
| [`d939536b`](https://github.com/NixOS/nixpkgs/commit/d939536baa6dc0b83d3d267e952a15b2dd65ff65) | `` rc: enable lineEditingLibrary ``                                                                                                  |
| [`96fab0a9`](https://github.com/NixOS/nixpkgs/commit/96fab0a9fd9571ada2d615f3d0b87a474cde631a) | `` python311Packages.yalexs: 1.5.2 -> 1.7.0 ``                                                                                       |
| [`801d81ed`](https://github.com/NixOS/nixpkgs/commit/801d81ede825df7846f8e1097d9a90dae602fda5) | `` tmux-sessionizer: 0.2.1 -> 0.2.3 ``                                                                                               |
| [`d56d4dcc`](https://github.com/NixOS/nixpkgs/commit/d56d4dccecac2026215d4aa6f40923679bb33eb5) | `` python3Packages.ibis-framework: remove failing dask and polars tests ``                                                           |
| [`96d73070`](https://github.com/NixOS/nixpkgs/commit/96d730707f62ef6e8e39f2d5e706bec3f80293e1) | `` python3Packages.clickhouse-connect: remove extra comment characters ``                                                            |
| [`1bcbedf4`](https://github.com/NixOS/nixpkgs/commit/1bcbedf4606966238ef84410417bf37c3e6bfab7) | `` python3Packges.ibis-framework: remove unnecessary `set -eo pipefail` ``                                                           |
| [`3d283d42`](https://github.com/NixOS/nixpkgs/commit/3d283d42a27e63b358d463f7fb5b820d4603126f) | `` python3Packages.clickhouse-connect: use `disabledTestPaths` instead of `pytestFlagsArray` for disabling whole test directories `` |
| [`f234ec95`](https://github.com/NixOS/nixpkgs/commit/f234ec95871aa413e5bd4db367a8e730c9e2525b) | `` python3Packages.sqlglot: 17.8.0 -> 17.14.2 ``                                                                                     |
| [`04146ce1`](https://github.com/NixOS/nixpkgs/commit/04146ce1c40f6a7941d484113935a448a0a8c922) | `` python3Packages.ibis-framework: 5.1.0 -> 6.0.0 ``                                                                                 |
| [`ad533469`](https://github.com/NixOS/nixpkgs/commit/ad53346987a5488ee3cbb3356aac2280296b6c7b) | `` python3Packages.sqlglot: 16.3.1 -> 17.8.0 ``                                                                                      |
| [`eaf3b3de`](https://github.com/NixOS/nixpkgs/commit/eaf3b3deb32769a5c61b3ffc38b7cd2ab6e6f4f9) | `` python3Packages.clickhouse-connect: init at 0.6.8 ``                                                                              |
| [`1415759a`](https://github.com/NixOS/nixpkgs/commit/1415759ada33e32b27a8ddf8bb71d37b21f06120) | `` python311Packages.aioqsw: 0.3.2 -> 0.3.3 ``                                                                                       |
| [`e179ccdb`](https://github.com/NixOS/nixpkgs/commit/e179ccdb5555247277863a6ba533d5ea5f114b54) | `` python311Packages.opower: 0.0.29 -> 0.0.31 ``                                                                                     |
| [`90a233cf`](https://github.com/NixOS/nixpkgs/commit/90a233cf3a564ef404f1b44ff3c7af838bdd984d) | `` python311Packages.griffe: 0.33.0 -> 0.34.0 ``                                                                                     |
| [`8bc5ba46`](https://github.com/NixOS/nixpkgs/commit/8bc5ba46ba506afb93901466a0e02c0486665913) | `` wpsoffice: 11.1.0.11698 -> 11.1.0.11704 ``                                                                                        |
| [`0bf9bcd9`](https://github.com/NixOS/nixpkgs/commit/0bf9bcd95eaf7d8b9196f52d68be7e0b3f3bc766) | `` snarkos: 2.1.4 -> 2.1.6 ``                                                                                                        |
| [`2d7ce9a2`](https://github.com/NixOS/nixpkgs/commit/2d7ce9a27aeaf9953f4d1e4ec7d9f5a935d8ffed) | `` qtcreator: 11.0.1 -> 11.0.2 ``                                                                                                    |
| [`1b0ed9f8`](https://github.com/NixOS/nixpkgs/commit/1b0ed9f81b357f0ac7e383bb26014b441f7edfb1) | `` gcc: patches: fix patch name ``                                                                                                   |
| [`c9afaec4`](https://github.com/NixOS/nixpkgs/commit/c9afaec459c918145c602f8f92d3e9ee22c1bcfd) | `` nimPackages.db_connector: package broken out of standard library ``                                                               |
| [`62dba544`](https://github.com/NixOS/nixpkgs/commit/62dba54481387e524422db58d9e212511fe92dbb) | `` nimPackages.smtp: package broken out of standard library ``                                                                       |
| [`ed353dc7`](https://github.com/NixOS/nixpkgs/commit/ed353dc72116731a20aefeb303f55a0b906c3e0b) | `` mosdepth: build with Nim-2 ``                                                                                                     |
| [`9025a583`](https://github.com/NixOS/nixpkgs/commit/9025a583b1f3e2cf328a02b3f2ac88d187ce047b) | `` nimPackages.hts: 0.3.4 -> 0.3.23, rename from hts-nim ``                                                                          |
| [`714fb068`](https://github.com/NixOS/nixpkgs/commit/714fb0684e9e65852857420b42f722529d358839) | `` nitter: build with Nim-2 ``                                                                                                       |
| [`063b8706`](https://github.com/NixOS/nixpkgs/commit/063b8706631cf726102a34d6dbb1c060e7fc5c3b) | `` nimPackages.syndicate: 20230530 -> 20230801 ``                                                                                    |
| [`13223196`](https://github.com/NixOS/nixpkgs/commit/132231963c98484fa5acc3121f9018e0c9cba0f7) | `` nimPackages.pixie: disable tests ``                                                                                               |
| [`27974e05`](https://github.com/NixOS/nixpkgs/commit/27974e05e215ee08fdf9c67c56a36c5dbe69394c) | `` nimPackages.vmath: use legacy memory-management ``                                                                                |
| [`2d369b5f`](https://github.com/NixOS/nixpkgs/commit/2d369b5f108cb8ac52874ec64eeedd3e9e8b61bc) | `` nimPackages.npeg: disable threads ``                                                                                              |
| [`9ae4174b`](https://github.com/NixOS/nixpkgs/commit/9ae4174b9ad6be8cddc7b8e2068b8d283b040b76) | `` nimPackages.astpatternmatching: update ``                                                                                         |
| [`4b332175`](https://github.com/NixOS/nixpkgs/commit/4b3321751b4918f866f2d1b0eafa5e3b75569710) | `` nimPackages.flatty: disable tests ``                                                                                              |
| [`e1d9fa5e`](https://github.com/NixOS/nixpkgs/commit/e1d9fa5ebedf08e4785dc02382e0332725357d71) | `` nimPackages.chroma: 0.2.5 -> 0.2.7 ``                                                                                             |
| [`12cf9186`](https://github.com/NixOS/nixpkgs/commit/12cf91863a18d37d27d59698d86d6f5554749c72) | `` nimPackages.nimsimd: 1.0.0 -> 1.2.5 ``                                                                                            |
| [`0e5fcd67`](https://github.com/NixOS/nixpkgs/commit/0e5fcd671f41ffa1c27dba03144242ea39086eb0) | `` nimPackages.sdl2: 2.0.4 -> 2.0.5 ``                                                                                               |
| [`b9c26088`](https://github.com/NixOS/nixpkgs/commit/b9c260884b61c0e52e94c5b3565041f58e7091d6) | `` buildNimPackage: use nimFlags in checkPhase ``                                                                                    |
| [`380a34d0`](https://github.com/NixOS/nixpkgs/commit/380a34d03cd7cda2844483fb2d2c382b588aefaa) | `` nim2: init 2.0.0 ``                                                                                                               |
| [`ba83b25a`](https://github.com/NixOS/nixpkgs/commit/ba83b25a50edbf38a84da60d831115ca2b405876) | `` freetube: 0.18.0 -> 0.19.0 ``                                                                                                     |
| [`f4ef1153`](https://github.com/NixOS/nixpkgs/commit/f4ef1153c6a2f02a468faaf5c3fb5877070f90d5) | `` git-bars: init at 2023-08-08 ``                                                                                                   |
| [`cbc976a9`](https://github.com/NixOS/nixpkgs/commit/cbc976a97c3372e1eec5db021db994b85e098d12) | `` fix: install go.env in go_1_21 ``                                                                                                 |
| [`8221d5f4`](https://github.com/NixOS/nixpkgs/commit/8221d5f4e75e5ccf1b5cb98d90cfdea115e2cdfc) | `` gcc: resolve merge conflict from staging ``                                                                                       |
| [`8f225b51`](https://github.com/NixOS/nixpkgs/commit/8f225b515fb2e2f30d71c063428189fdf190c6c0) | `` gcc: match weird whack-a-mole per-version hash algorithm ``                                                                       |
| [`de363654`](https://github.com/NixOS/nixpkgs/commit/de36365466722008d066061ca78b272a3e8da073) | `` gcc: clean up version conditions ``                                                                                               |
| [`74dce901`](https://github.com/NixOS/nixpkgs/commit/74dce901aae2dd82d6ce69fb85b88ea884795200) | `` gcc: update gccFun for deduplicated gcc expressions ``                                                                            |
| [`30171782`](https://github.com/NixOS/nixpkgs/commit/30171782b773f1a7522aff989929660633a03706) | `` gcc: move version-map out of all-packages.nix, into pkgs/ ``                                                                      |
| [`911452cc`](https://github.com/NixOS/nixpkgs/commit/911452ccbdea2285872936c5594a66cc5af7d4a5) | `` gcc: move patches attribute into patches/ subdirectory ``                                                                         |
| [`95475034`](https://github.com/NixOS/nixpkgs/commit/95475034d5d510c77086dd0e702d4c8a37e016aa) | `` gcc: if atLeast 4.8, use deduplicated version ``                                                                                  |
| [`beeb48d1`](https://github.com/NixOS/nixpkgs/commit/beeb48d17a18f34f95ef8bec2f8cc31c956b5cd9) | `` gcc: if atLeast 4.9, use deduplicated version ``                                                                                  |
| [`920df10a`](https://github.com/NixOS/nixpkgs/commit/920df10ab7fced6d1f5a0f3a32870fe0d3761e98) | `` gcc: if atLeast 6, use deduplicated version ``                                                                                    |
| [`33f7f2c5`](https://github.com/NixOS/nixpkgs/commit/33f7f2c5aa13eb64d1b762dc42d248a30eb0e0e3) | `` gcc: if atLeast 7, use deduplicated version ``                                                                                    |
| [`e7afebbc`](https://github.com/NixOS/nixpkgs/commit/e7afebbc4ca7048a6f96c360fae5065e3e82297c) | `` gcc: if atLeast 8, use deduplicated version ``                                                                                    |
| [`4116fc3e`](https://github.com/NixOS/nixpkgs/commit/4116fc3e6f72807a1f2cc07f9c2250cf0e3d2c98) | `` gcc: if atLeast 9, use deduplicated version ``                                                                                    |
| [`10ee71f5`](https://github.com/NixOS/nixpkgs/commit/10ee71f582c2820737f5586c92f16d64dfe4ad28) | `` gcc: if atLeast 10, use deduplicated version ``                                                                                   |
| [`72fe0428`](https://github.com/NixOS/nixpkgs/commit/72fe04286e8f4f60a21d384788e59dbe94764434) | `` gcc: if atLeast 11, use deduplicated version ``                                                                                   |
| [`e9ece66a`](https://github.com/NixOS/nixpkgs/commit/e9ece66a8032e2432a1f240d3bce5c9940a95233) | `` gcc: if atLeast 12, use deduplicated version ``                                                                                   |
| [`93d63aaa`](https://github.com/NixOS/nixpkgs/commit/93d63aaa0558fde20f3fedc2e0d74b91a2bc0999) | `` gcc: if atLeast 13, use deduplicated version ``                                                                                   |
| [`9dc98729`](https://github.com/NixOS/nixpkgs/commit/9dc98729220e051863e3351965c9f81a78cf86a2) | `` gcc: default.nix: parameterize by version ``                                                                                      |
| [`57a2dfe6`](https://github.com/NixOS/nixpkgs/commit/57a2dfe6469cdf6635c28eb6f41db1a013ac99e9) | `` gcc: default.nix: replace ../ with ./ ``                                                                                          |
| [`671b761d`](https://github.com/NixOS/nixpkgs/commit/671b761d05acb95983437582390a492079c1e0cb) | `` gcc: cp ./13/default.nix ./default.nix ``                                                                                         |
| [`bb5ee1fe`](https://github.com/NixOS/nixpkgs/commit/bb5ee1fe60d560cf12a83bb668e8763c777cd920) | `` default-gcc-version: init ``                                                                                                      |
| [`6698fd45`](https://github.com/NixOS/nixpkgs/commit/6698fd456eed52fdf91e5fd48b6d6cef478ff3ff) | `` ocamlPackages.qcheck-stm: init at 0.2 ``                                                                                          |
| [`991356c8`](https://github.com/NixOS/nixpkgs/commit/991356c8074eedea2ee40879188b9a8a622b3b4b) | `` ocamlPackages.qcheck-lin: init at 0.2 ``                                                                                          |
| [`aa47da4c`](https://github.com/NixOS/nixpkgs/commit/aa47da4c2c37d2889c85885c401c805bf4fb9844) | `` ocamlPackages.qcheck-multicoretests-util: init at 0.2 ``                                                                          |
| [`8ca5a5a7`](https://github.com/NixOS/nixpkgs/commit/8ca5a5a7687c76d13ae3a4b2769778ed09acf574) | `` ocamlPackages.uring: 0.6 → 0.7 (#250313) ``                                                                                       |
| [`c6d28294`](https://github.com/NixOS/nixpkgs/commit/c6d282948bdb9d5ab80c52d6209c246d76629941) | `` llhttp: 9.0.0 -> 9.0.1 ``                                                                                                         |
| [`d9cde8f9`](https://github.com/NixOS/nixpkgs/commit/d9cde8f9fc9ee2bd05a159bb71b5696e39b069e6) | `` bearer: 1.19.1 -> 1.19.2 ``                                                                                                       |
| [`d0c4b57e`](https://github.com/NixOS/nixpkgs/commit/d0c4b57e1f49b4d649b378108de1f0ac8bb9e35d) | `` gobgpd: 3.16.0 -> 3.17.0 ``                                                                                                       |
| [`a1d02bae`](https://github.com/NixOS/nixpkgs/commit/a1d02bae32ce388e4ce29bfaabb045a9f70c8d07) | `` round: use sri hash ``                                                                                                            |
| [`c70cc9e1`](https://github.com/NixOS/nixpkgs/commit/c70cc9e18f73b2d3be82e4ae997aa715256ce45e) | `` mdbook-i18n-helpers: 0.1.0 -> 0.2.0 ``                                                                                            |
| [`8bcca535`](https://github.com/NixOS/nixpkgs/commit/8bcca535055a7eda125f2e62cf75a09cdc4bbb20) | `` skopeo: 1.13.1 -> 1.13.2 ``                                                                                                       |
| [`5a14ee34`](https://github.com/NixOS/nixpkgs/commit/5a14ee3432fc4352b82af87b985c96e685c49fbc) | `` flannel: 0.22.0 -> 0.22.2 ``                                                                                                      |
| [`f232a997`](https://github.com/NixOS/nixpkgs/commit/f232a99788e2ea9f699c635f10ac17619fb1019e) | `` famistudio: 4.1.1 -> 4.1.2 ``                                                                                                     |
| [`b525275e`](https://github.com/NixOS/nixpkgs/commit/b525275e1e523fc85ac82a136b99b494bb869955) | `` ytt: 0.45.3 -> 0.45.4 ``                                                                                                          |
| [`796dee5c`](https://github.com/NixOS/nixpkgs/commit/796dee5cc349f2109878d9c5ded705276635ea34) | `` terraform-providers.tailscale: 0.13.7 -> 0.13.9 ``                                                                                |
| [`e2e76267`](https://github.com/NixOS/nixpkgs/commit/e2e76267f8b7da8ade9d8f266c40950c969c4166) | `` cloudfox: 1.11.3 -> 1.12.0 ``                                                                                                     |
| [`b9132cec`](https://github.com/NixOS/nixpkgs/commit/b9132cec873a05be8a3e959fb2aaa2080c1f38c6) | `` immer: init at 0.8.0 ``                                                                                                           |
| [`980b0a92`](https://github.com/NixOS/nixpkgs/commit/980b0a9206491e5425dfa89e8083029fe15f70ad) | `` python3.pkgs.pysim: init at unstable-2023-08-11 ``                                                                                |
| [`ba1d1a86`](https://github.com/NixOS/nixpkgs/commit/ba1d1a863bfbf487a064e198d41f9968137c7307) | `` python3.pkgs.smpp_pdu: init at unstable-2022-09-02 ``                                                                             |
| [`51ff54b5`](https://github.com/NixOS/nixpkgs/commit/51ff54b5cc9b26ce2b57d8c0cc1e7a7d6e0922ce) | `` python3.pkgs.gsm0338: init at 1.1.0 ``                                                                                            |
| [`6d1c5dd1`](https://github.com/NixOS/nixpkgs/commit/6d1c5dd1dc19b7eaed2b43d8bf2f709daba8e012) | `` pytlv: init at 0.71 ``                                                                                                            |
| [`d0aa935f`](https://github.com/NixOS/nixpkgs/commit/d0aa935f90dfeb36c016455b900ce4e38e2cdaca) | `` immich-cli: use buildNpmPackage ``                                                                                                |
| [`8ed712ec`](https://github.com/NixOS/nixpkgs/commit/8ed712ec90468c931713e5ec60bd9e6678daf8a8) | `` go_1_21: 1.21rc4 -> 1.21.0 ``                                                                                                     |
| [`2836fd6f`](https://github.com/NixOS/nixpkgs/commit/2836fd6fce609d0fb1b01a9cb75500750a6ea5f3) | `` etlegacy: reformat files ``                                                                                                       |
| [`bc586df9`](https://github.com/NixOS/nixpkgs/commit/bc586df93d44ce2a672e2afb3ea60f67a62ddf39) | `` etlegacy: add `meta.longDescription` ``                                                                                           |
| [`d998c261`](https://github.com/NixOS/nixpkgs/commit/d998c261ccb6abd400bcd837025e73fb45bda11f) | `` etlegacy: replace `writeScriptBin` with `writeShellApplication` ``                                                                |
| [`349819e6`](https://github.com/NixOS/nixpkgs/commit/349819e61fa21d81dbc3c7bc8962d80cc97eb373) | `` cargo-component: unstable-2023-08-16 -> unstable-2023-08-19 ``                                                                    |
| [`1e3e6852`](https://github.com/NixOS/nixpkgs/commit/1e3e6852ba78df39aba0e433698072311bb29dfd) | `` complgen: unstable-2023-08-07 -> unstable-2023-08-17 ``                                                                           |
| [`890e954c`](https://github.com/NixOS/nixpkgs/commit/890e954c169a756a68b5068ed56b6e64dfe9a18a) | `` qovery-cli: 0.63.0 -> 0.65.1 ``                                                                                                   |
| [`936d4b5f`](https://github.com/NixOS/nixpkgs/commit/936d4b5fa321b08aee75e4bd5c1cb1a36020d79b) | `` configurable-http-proxy: use buildNpmPackage ``                                                                                   |
| [`781822bc`](https://github.com/NixOS/nixpkgs/commit/781822bc8f0f30be361504a0d3a92faacce7cebf) | `` hnswlib: add patch for CVE-2023-37365 ``                                                                                          |
| [`806ef309`](https://github.com/NixOS/nixpkgs/commit/806ef309c5af7442359e0073832755fc86074913) | `` expr: 1.14.0 -> 1.14.1 ``                                                                                                         |
| [`5691969e`](https://github.com/NixOS/nixpkgs/commit/5691969ebdab5b0c82500832dc2edb3999dece11) | `` mympd: Reenable strictoverflow hardening flag ``                                                                                  |
| [`12fe23d2`](https://github.com/NixOS/nixpkgs/commit/12fe23d257ab439cad84efa47d64af83a925bc9a) | `` mympd: Disable tests explicitly ``                                                                                                |
| [`e88fa156`](https://github.com/NixOS/nixpkgs/commit/e88fa156882c8cac42b0ddafb4dc7b056e9c409e) | `` mympd: Remove enabled by default lua support ``                                                                                   |
| [`6a5928fb`](https://github.com/NixOS/nixpkgs/commit/6a5928fb0d3320fdafe6ab8a1ab342e78d503f39) | `` vimPlugins.hardtime-nvim: init at 2023-08-20 ``                                                                                   |
| [`8bd00717`](https://github.com/NixOS/nixpkgs/commit/8bd00717e817f74e751768463635d83cfc9a27ad) | `` pdf-sign: use makeBinPath instead of patching ``                                                                                  |
| [`a9d662cc`](https://github.com/NixOS/nixpkgs/commit/a9d662ccde3497c1a69a8ffe083ca6de4783ce66) | `` rwedid: init at 0.3.2 ``                                                                                                          |
| [`4b695e64`](https://github.com/NixOS/nixpkgs/commit/4b695e64f7cf7f1c5ca66148f540c1ee0c7fe5df) | `` mympd: 10.3.3 -> 11.0.3 ``                                                                                                        |
| [`352ec7d7`](https://github.com/NixOS/nixpkgs/commit/352ec7d71443806b13ab7c1ff9570d86e7866d0c) | `` typstfmt: unstable-2023-08-06 -> unstable-2023-08-15 ``                                                                           |
| [`9fece688`](https://github.com/NixOS/nixpkgs/commit/9fece688bcf6c502f09127ff74c5e9f7366ad044) | `` egglog: unstable-2023-08-09 -> unstable-2023-08-19 ``                                                                             |
| [`852db6a4`](https://github.com/NixOS/nixpkgs/commit/852db6a45b11f451fd40c1d4bb188a455dff9b4b) | `` containerlab: 0.43.0 -> 0.44.0 ``                                                                                                 |
| [`7cd096db`](https://github.com/NixOS/nixpkgs/commit/7cd096dbc5a582543fc6f7a4c25f5d527153dc14) | `` textual-paint: init at 0.1.0 ``                                                                                                   |
| [`9914997a`](https://github.com/NixOS/nixpkgs/commit/9914997ab6c286b0b115adda284ad32c4dec0d23) | `` zellij: add meta.mainProgram ``                                                                                                   |
| [`4acb1154`](https://github.com/NixOS/nixpkgs/commit/4acb1154a55540555d3212bfccd8dc4a5c0e5ef9) | `` python310Packages.stransi: init at 0.3.0 ``                                                                                       |
| [`4eed7453`](https://github.com/NixOS/nixpkgs/commit/4eed74534362195ee11935d8fa4c983d320cc24a) | `` python310Packages.ochre: init at 0.4.0 ``                                                                                         |
| [`d121cf41`](https://github.com/NixOS/nixpkgs/commit/d121cf41354d58a2f814cc807d922ff8ceea6f0c) | `` libtensorflow: mark as broken and vulnerable ``                                                                                   |
| [`c9cc3a2e`](https://github.com/NixOS/nixpkgs/commit/c9cc3a2e3eb4661b49176e0c62afd097793c9626) | `` qutebrowser: use pyqt6-webengine ``                                                                                               |
| [`95497182`](https://github.com/NixOS/nixpkgs/commit/95497182636482c26a422fabe13d8b5702336b52) | `` openocd-rp2040: init at version v0.12.0 ``                                                                                        |
| [`b0b03e7f`](https://github.com/NixOS/nixpkgs/commit/b0b03e7f67935bc3a48a23fa3a56532cb7b1d767) | `` ruff-lsp: 0.0.36 -> 0.0.37 ``                                                                                                     |
| [`a69d70d6`](https://github.com/NixOS/nixpkgs/commit/a69d70d6bc4de0dca2139091f217d4ad9bbde45f) | `` texlive: refactor package builder in separate expression ``                                                                       |
| [`23d90eb8`](https://github.com/NixOS/nixpkgs/commit/23d90eb88c778f97e7e40201759f4ff5e214b41d) | `` inferno: 0.11.15 -> 0.11.16 ``                                                                                                    |
| [`b5188683`](https://github.com/NixOS/nixpkgs/commit/b518868334095f4e7a8b331443545d427836407a) | `` texlive: group fixed hashes into one attribute set per package ``                                                                 |
| [`fc6e07f1`](https://github.com/NixOS/nixpkgs/commit/fc6e07f1fd804dcc4e4e3cdf7ded4a76c3da7f86) | `` python311Packages.pem: 21.2.0 -> 23.1.0 ``                                                                                        |