### PR TITLE
chore(flake/sops-nix): `4f0f113b` -> `1b7b3a32`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -975,11 +975,11 @@
         "nixpkgs-stable": "nixpkgs-stable_5"
       },
       "locked": {
-        "lastModified": 1692500916,
-        "narHash": "sha256-iKADqEOHmyi+LCJ5LzWcM2zH0DP3WHFETjX98blH0tE=",
+        "lastModified": 1692728678,
+        "narHash": "sha256-02MjG7Sb9k7eOi86CcC4GNWVOjT6gjmXFSqkRjZ8Xyk=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "4f0f113b7dbcb92edb9c901515fcab0b91c6def7",
+        "rev": "1b7b3a32d65dbcd69c217d7735fdf0a6b2184f45",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                     |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`1b7b3a32`](https://github.com/Mic92/sops-nix/commit/1b7b3a32d65dbcd69c217d7735fdf0a6b2184f45) | `` Update pkgs/sops-install-secrets/darwin.go ``            |
| [`fce0c8ce`](https://github.com/Mic92/sops-nix/commit/fce0c8ce93accbe126cbe6c0a2b9765a736a41f4) | `` fix: add missing argument for MountSecretFs on darwin `` |
| [`429007f7`](https://github.com/Mic92/sops-nix/commit/429007f7f3e948069a20fc48b7291eaddaae5dc8) | `` document templates ``                                    |