### PR TITLE
chore(flake/emacs-overlay): `e4959460` -> `f4b61f88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1692700056,
-        "narHash": "sha256-KWk7tPc4VHqtcV0Q89SD4aELFppGKNJs0F8amJEb8Yc=",
+        "lastModified": 1692732917,
+        "narHash": "sha256-tcm4iO4akobo+/O8vb1kZV+qAOz6BFLZTCq1n8tSzxo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e4959460ea8e7d122baab8fd967bc604df928bec",
+        "rev": "f4b61f881ac07096f8e3b61a80e4062bca104e2a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`f4b61f88`](https://github.com/nix-community/emacs-overlay/commit/f4b61f881ac07096f8e3b61a80e4062bca104e2a) | `` Updated repos/melpa ``  |
| [`c1c7cd68`](https://github.com/nix-community/emacs-overlay/commit/c1c7cd68cd957e2f86446364155dfa834970b1f2) | `` Updated repos/emacs ``  |
| [`63059600`](https://github.com/nix-community/emacs-overlay/commit/63059600f244d80c0a196e002314898a2549c634) | `` Updated repos/elpa ``   |
| [`d75d6345`](https://github.com/nix-community/emacs-overlay/commit/d75d6345f5256b6cdb42e3c7a3b116980db769a5) | `` Updated flake inputs `` |