### PR TITLE
chore(flake/nur): `60e8cf76` -> `2f14a3d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692723596,
-        "narHash": "sha256-84gyqKFZ0h9s8nib7kzA0sTwhZJAAt/m6fjNAf3PKvU=",
+        "lastModified": 1692737112,
+        "narHash": "sha256-DHOEzu+U+mAOr1aQIZ+AOETO4yR24IEk5pm6Am7yqL4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "60e8cf766f0421c6ee46cb821ac05c426dc2b18f",
+        "rev": "2f14a3d24e9ddd7bf68bddc585708fc5342ddf33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2f14a3d2`](https://github.com/nix-community/NUR/commit/2f14a3d24e9ddd7bf68bddc585708fc5342ddf33) | `` automatic update `` |
| [`da3b62d5`](https://github.com/nix-community/NUR/commit/da3b62d5ce962eef3c24b56ed9ac50bd2e32daba) | `` automatic update `` |