### PR TITLE
chore(flake/nur): `2f14a3d2` -> `febb8404`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692737112,
-        "narHash": "sha256-DHOEzu+U+mAOr1aQIZ+AOETO4yR24IEk5pm6Am7yqL4=",
+        "lastModified": 1692744376,
+        "narHash": "sha256-/hctyIdpPbbt+4ZIUEFVlmu5l/G9v9BIz2vXi/C1aYw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2f14a3d24e9ddd7bf68bddc585708fc5342ddf33",
+        "rev": "febb84045d3be8f8e004c74c933983c032714aaa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`febb8404`](https://github.com/nix-community/NUR/commit/febb84045d3be8f8e004c74c933983c032714aaa) | `` automatic update `` |