### PR TITLE
chore(flake/nur): `febb8404` -> `c261aa5d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692744376,
-        "narHash": "sha256-/hctyIdpPbbt+4ZIUEFVlmu5l/G9v9BIz2vXi/C1aYw=",
+        "lastModified": 1692749138,
+        "narHash": "sha256-M31jzDfF0dhbmA1zfXxeb55RlQY6qwPeoMQWtaVmD7o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "febb84045d3be8f8e004c74c933983c032714aaa",
+        "rev": "c261aa5dff5f678921aa01020267597409f0a630",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c261aa5d`](https://github.com/nix-community/NUR/commit/c261aa5dff5f678921aa01020267597409f0a630) | `` automatic update `` |