### PR TITLE
chore(flake/nur): `c261aa5d` -> `19bdb817`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692749138,
-        "narHash": "sha256-M31jzDfF0dhbmA1zfXxeb55RlQY6qwPeoMQWtaVmD7o=",
+        "lastModified": 1692754580,
+        "narHash": "sha256-lCBKYNmO0FdWkdK+yu1YxlPNnhQ4YVL53jX/Dy2yHQ0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c261aa5dff5f678921aa01020267597409f0a630",
+        "rev": "19bdb81702a30b1abc53646223a188442a0f72f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`19bdb817`](https://github.com/nix-community/NUR/commit/19bdb81702a30b1abc53646223a188442a0f72f2) | `` automatic update `` |
| [`3c2c2ff5`](https://github.com/nix-community/NUR/commit/3c2c2ff588c4d22ecc40b6395dc13b357adb53b2) | `` automatic update `` |