### PR TITLE
chore(flake/emacs-overlay): `f4b61f88` -> `c82b1bb8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1692732917,
-        "narHash": "sha256-tcm4iO4akobo+/O8vb1kZV+qAOz6BFLZTCq1n8tSzxo=",
+        "lastModified": 1692762523,
+        "narHash": "sha256-O+PXo3f2fwQSkip7Sup0BUi6v292/zMScs8Ebq/euJw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f4b61f881ac07096f8e3b61a80e4062bca104e2a",
+        "rev": "c82b1bb82f4935d7b6d85d5ed8fe7cbade780c72",
         "type": "github"
       },
       "original": {
@@ -697,11 +697,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1692525914,
-        "narHash": "sha256-MUgZ9/9mE/EbEQA6JPdcQHkjoR5fgvaKhpy6UO67uEc=",
+        "lastModified": 1692698134,
+        "narHash": "sha256-YtMmZWR/dlTypOcwiZfZTMPr3tj9fwr05QTStfSyDSg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "475d5ae2c4cb87b904545bdb547af05681198fcc",
+        "rev": "a16f7eb56e88c8985fcc6eb81dabd6cade4e425a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c82b1bb8`](https://github.com/nix-community/emacs-overlay/commit/c82b1bb82f4935d7b6d85d5ed8fe7cbade780c72) | `` Updated repos/melpa ``  |
| [`31522ea2`](https://github.com/nix-community/emacs-overlay/commit/31522ea208a7a4f8bdeb97b3e45befd962c22d52) | `` Updated repos/emacs ``  |
| [`282a39f3`](https://github.com/nix-community/emacs-overlay/commit/282a39f33026b0a7a58b040ce69c439c9b3d2602) | `` Updated repos/elpa ``   |
| [`455454d3`](https://github.com/nix-community/emacs-overlay/commit/455454d3ae8350a8e969bae71d2d8200674d5bfd) | `` Updated flake inputs `` |