### PR TITLE
chore(flake/nur): `19bdb817` -> `a7302ec5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692754580,
-        "narHash": "sha256-lCBKYNmO0FdWkdK+yu1YxlPNnhQ4YVL53jX/Dy2yHQ0=",
+        "lastModified": 1692762987,
+        "narHash": "sha256-Z+Kp7Q/VNurVRd8spMTwhISN1pT63ga+xdrZiVLKisg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "19bdb81702a30b1abc53646223a188442a0f72f2",
+        "rev": "a7302ec5410626e179d29d545f576efce631d8d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a7302ec5`](https://github.com/nix-community/NUR/commit/a7302ec5410626e179d29d545f576efce631d8d5) | `` automatic update `` |
| [`62f48500`](https://github.com/nix-community/NUR/commit/62f48500e560d2db23ef314e26cfb1b55b7593ec) | `` automatic update `` |
| [`397c9f16`](https://github.com/nix-community/NUR/commit/397c9f16f7cded7eb629498ff8ecbc4896570525) | `` automatic update `` |