### PR TITLE
chore(flake/nur): `cd2e7849` -> `d983ee59`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692788777,
-        "narHash": "sha256-UpNj3pGGxjiFJjI8osih14oT/cdQU7WlB6jqxHdykls=",
+        "lastModified": 1692801604,
+        "narHash": "sha256-VaPOZVn9VCnxkxz53CSYmSGUA8IiGs2Y+/RIp7nslNY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cd2e7849222af80ea088d494cadac97658fb8fff",
+        "rev": "d983ee59bbff24f6a3f9fc40dc4fbff82031a66d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d983ee59`](https://github.com/nix-community/NUR/commit/d983ee59bbff24f6a3f9fc40dc4fbff82031a66d) | `` automatic update `` |
| [`1310bdaf`](https://github.com/nix-community/NUR/commit/1310bdaffb6b9765d53af37b8e8e836b557f253a) | `` automatic update `` |