### PR TITLE
chore(flake/emacs-overlay): `05a15119` -> `a72132a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1692787545,
-        "narHash": "sha256-07MW3+hYXARr2oJHnvHJ+Af3UizRYQOfquemYSOa5Aw=",
+        "lastModified": 1692817463,
+        "narHash": "sha256-zdjxmnsWoVhorIqpcWI5ZokNi08shcOvBN6ypDqAv9Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "05a1511966eeb5218d55f921146abff21aad1684",
+        "rev": "a72132a55c96f2f97e076f041dbfb158c2e937a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`a72132a5`](https://github.com/nix-community/emacs-overlay/commit/a72132a55c96f2f97e076f041dbfb158c2e937a6) | `` Updated repos/melpa ``  |
| [`206f7382`](https://github.com/nix-community/emacs-overlay/commit/206f738286d6a6de92d50c6f4558b96596ae3712) | `` Updated repos/emacs ``  |
| [`8e2d4169`](https://github.com/nix-community/emacs-overlay/commit/8e2d4169af63f9ba2ecb3ea1bded1e2cca9c1d41) | `` Updated repos/elpa ``   |
| [`c2b22168`](https://github.com/nix-community/emacs-overlay/commit/c2b22168439f3416dc0af6e34d90ac559fd8671e) | `` Updated flake inputs `` |