### PR TITLE
chore(flake/nur): `5ab75354` -> `c3ec6173`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692819933,
-        "narHash": "sha256-2XatQtHBpxSQghonAtf8SbsbR0l9UplXNIqr5RRlz5o=",
+        "lastModified": 1692828982,
+        "narHash": "sha256-SV+/ui0cHPIz6Q1xm6O1Fc260U/VBnLq1zQUOqWKZ90=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5ab7535434534d6f5ad8f13acee581146860d13b",
+        "rev": "c3ec6173589db5e6eb6510b8648da8e630daaa15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c3ec6173`](https://github.com/nix-community/NUR/commit/c3ec6173589db5e6eb6510b8648da8e630daaa15) | `` automatic update `` |