### PR TITLE
chore(flake/nur): `c3ec6173` -> `871016f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692828982,
-        "narHash": "sha256-SV+/ui0cHPIz6Q1xm6O1Fc260U/VBnLq1zQUOqWKZ90=",
+        "lastModified": 1692833558,
+        "narHash": "sha256-g01TW0aKbR5jK8vgWQqFnRywM3fLLlNMNA7u0aYx7t8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c3ec6173589db5e6eb6510b8648da8e630daaa15",
+        "rev": "871016f113a1db351fc6f65ffcec79069df27a9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`871016f1`](https://github.com/nix-community/NUR/commit/871016f113a1db351fc6f65ffcec79069df27a9f) | `` automatic update `` |
| [`ed5b906e`](https://github.com/nix-community/NUR/commit/ed5b906e52f9faa22664e6ec521d16eb178f43bd) | `` automatic update `` |
| [`576e4d9e`](https://github.com/nix-community/NUR/commit/576e4d9e0339231cefb805398e60ca9d71dbaead) | `` automatic update `` |