### PR TITLE
chore(flake/nur): `871016f1` -> `58413428`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692833558,
-        "narHash": "sha256-g01TW0aKbR5jK8vgWQqFnRywM3fLLlNMNA7u0aYx7t8=",
+        "lastModified": 1692845181,
+        "narHash": "sha256-5RzZkedC3JxI55Mtd+GXRp8cKH4wGY3grX/n1nI9qp0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "871016f113a1db351fc6f65ffcec79069df27a9f",
+        "rev": "58413428754fe2ac45ca90afec1d26d14b86a670",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`58413428`](https://github.com/nix-community/NUR/commit/58413428754fe2ac45ca90afec1d26d14b86a670) | `` automatic update `` |