### PR TITLE
chore(flake/emacs-overlay): `a72132a5` -> `47a74774`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1692817463,
-        "narHash": "sha256-zdjxmnsWoVhorIqpcWI5ZokNi08shcOvBN6ypDqAv9Y=",
+        "lastModified": 1692847667,
+        "narHash": "sha256-RGgKBRneWTrZW+auXE7fxwU9dK3pBC9njn3/xZfOMfc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a72132a55c96f2f97e076f041dbfb158c2e937a6",
+        "rev": "47a747748b3a978425ad7eeec008ef7308e7a92a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`47a74774`](https://github.com/nix-community/emacs-overlay/commit/47a747748b3a978425ad7eeec008ef7308e7a92a) | `` Updated repos/nongnu `` |
| [`4d3f7851`](https://github.com/nix-community/emacs-overlay/commit/4d3f7851b9524c2de0bd3631108471ddad8b0d10) | `` Updated repos/melpa ``  |
| [`89a902eb`](https://github.com/nix-community/emacs-overlay/commit/89a902eb586fc601688af59d9d27cf0b6d8ebc94) | `` Updated repos/emacs ``  |
| [`7e873877`](https://github.com/nix-community/emacs-overlay/commit/7e873877291f82909048021c6e7bb8877d6d775d) | `` Updated repos/elpa ``   |
| [`48c23895`](https://github.com/nix-community/emacs-overlay/commit/48c238951118c836eeb34ebf9d33dbb68df80a63) | `` Updated flake inputs `` |