### PR TITLE
chore(flake/nur): `58413428` -> `44ed42e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692845181,
-        "narHash": "sha256-5RzZkedC3JxI55Mtd+GXRp8cKH4wGY3grX/n1nI9qp0=",
+        "lastModified": 1692847861,
+        "narHash": "sha256-gfx3GCaprNMxgJ6Il5TWMJdw51GAL4pv5fQvVS+tWw4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "58413428754fe2ac45ca90afec1d26d14b86a670",
+        "rev": "44ed42e74f04bf18ae35beeec0d529ba6e06c1bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`44ed42e7`](https://github.com/nix-community/NUR/commit/44ed42e74f04bf18ae35beeec0d529ba6e06c1bb) | `` automatic update `` |