### PR TITLE
chore(flake/nur): `44ed42e7` -> `441fe437`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692847861,
-        "narHash": "sha256-gfx3GCaprNMxgJ6Il5TWMJdw51GAL4pv5fQvVS+tWw4=",
+        "lastModified": 1692862783,
+        "narHash": "sha256-0HzSrSoYlkevDoIjKqfeP9PDXF7RI9ZRl5JyMGluGRM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "44ed42e74f04bf18ae35beeec0d529ba6e06c1bb",
+        "rev": "441fe437a432e1fa8b9b912506aae67c56d37acc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`441fe437`](https://github.com/nix-community/NUR/commit/441fe437a432e1fa8b9b912506aae67c56d37acc) | `` automatic update `` |
| [`1fe635b9`](https://github.com/nix-community/NUR/commit/1fe635b9486f5b42a3a9c7940d7e5b3b92d6daf8) | `` automatic update `` |