### PR TITLE
chore(flake/nur): `441fe437` -> `a4beb012`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692862783,
-        "narHash": "sha256-0HzSrSoYlkevDoIjKqfeP9PDXF7RI9ZRl5JyMGluGRM=",
+        "lastModified": 1692866761,
+        "narHash": "sha256-qQy6sYem+Md+pownqPk0MqWAR7A5JBeJtbSU7mZKPHQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "441fe437a432e1fa8b9b912506aae67c56d37acc",
+        "rev": "a4beb012b535aaf7e01ab320b30ed7034265e4c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a4beb012`](https://github.com/nix-community/NUR/commit/a4beb012b535aaf7e01ab320b30ed7034265e4c4) | `` automatic update `` |