### PR TITLE
chore(flake/nur): `a4beb012` -> `d912ff9c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692866761,
-        "narHash": "sha256-qQy6sYem+Md+pownqPk0MqWAR7A5JBeJtbSU7mZKPHQ=",
+        "lastModified": 1692870244,
+        "narHash": "sha256-t28pPT4p+hKaXD1OiOMbEkkU4bw3cqb5EKoXVr7HgrU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a4beb012b535aaf7e01ab320b30ed7034265e4c4",
+        "rev": "d912ff9c2368676a5a0585c600d7eee4e475133e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d912ff9c`](https://github.com/nix-community/NUR/commit/d912ff9c2368676a5a0585c600d7eee4e475133e) | `` automatic update `` |