### PR TITLE
chore(flake/nur): `d912ff9c` -> `d22e6372`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692870244,
-        "narHash": "sha256-t28pPT4p+hKaXD1OiOMbEkkU4bw3cqb5EKoXVr7HgrU=",
+        "lastModified": 1692874010,
+        "narHash": "sha256-k4P5ZqMNsBxCP22TOBOHZwpI3DoXfCmtCV3QSP4sAKQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d912ff9c2368676a5a0585c600d7eee4e475133e",
+        "rev": "d22e6372e3346ec9b5484003ed269a1526514219",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d22e6372`](https://github.com/nix-community/NUR/commit/d22e6372e3346ec9b5484003ed269a1526514219) | `` automatic update `` |