### PR TITLE
chore(flake/emacs-overlay): `47a74774` -> `9ef499ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1692847667,
-        "narHash": "sha256-RGgKBRneWTrZW+auXE7fxwU9dK3pBC9njn3/xZfOMfc=",
+        "lastModified": 1692873315,
+        "narHash": "sha256-qph7eXfkuGg6LckiJIXXcyRmL01BUHjzFDjENyH6UDY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "47a747748b3a978425ad7eeec008ef7308e7a92a",
+        "rev": "9ef499ed35baf1e70f2a530462e9aeb505ad3da4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`9ef499ed`](https://github.com/nix-community/emacs-overlay/commit/9ef499ed35baf1e70f2a530462e9aeb505ad3da4) | `` Updated repos/nongnu `` |
| [`a4ba3330`](https://github.com/nix-community/emacs-overlay/commit/a4ba33301f3652eb28ed13fd635c4cf7127867c6) | `` Updated repos/melpa ``  |
| [`70621186`](https://github.com/nix-community/emacs-overlay/commit/7062118613938e63466438e8079ae54835d5dd8f) | `` Updated repos/emacs ``  |