### PR TITLE
chore(flake/nur): `d22e6372` -> `8009360e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692874010,
-        "narHash": "sha256-k4P5ZqMNsBxCP22TOBOHZwpI3DoXfCmtCV3QSP4sAKQ=",
+        "lastModified": 1692881861,
+        "narHash": "sha256-8yWfUWEHpbshP0UWC0pExQgaQwP02lUQlxPVJDLw3uQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d22e6372e3346ec9b5484003ed269a1526514219",
+        "rev": "8009360e1aea4d302ec22f9149bc5687dd938f25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8009360e`](https://github.com/nix-community/NUR/commit/8009360e1aea4d302ec22f9149bc5687dd938f25) | `` automatic update `` |
| [`a85c4c98`](https://github.com/nix-community/NUR/commit/a85c4c9804acb573fd7c3fcc74ca187a8da53c85) | `` automatic update `` |