### PR TITLE
chore(flake/nur): `8009360e` -> `48fce8d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692881861,
-        "narHash": "sha256-8yWfUWEHpbshP0UWC0pExQgaQwP02lUQlxPVJDLw3uQ=",
+        "lastModified": 1692895597,
+        "narHash": "sha256-DqrtJx1N69km/PqtBb0OVubu7ORtmvQJILSNlVwfMgU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8009360e1aea4d302ec22f9149bc5687dd938f25",
+        "rev": "48fce8d1a2576b92d067e7ffd05d60c12ab6eaa0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`48fce8d1`](https://github.com/nix-community/NUR/commit/48fce8d1a2576b92d067e7ffd05d60c12ab6eaa0) | `` automatic update `` |