### PR TITLE
chore(flake/emacs-overlay): `9ef499ed` -> `7c78afad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1692873315,
-        "narHash": "sha256-qph7eXfkuGg6LckiJIXXcyRmL01BUHjzFDjENyH6UDY=",
+        "lastModified": 1692897118,
+        "narHash": "sha256-Hb4JTX23oFZzNpsCRnMZriTpPfQa8//BbPR03a5E1HU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9ef499ed35baf1e70f2a530462e9aeb505ad3da4",
+        "rev": "7c78afad4565bcb49b3c848c6f1fb28f0cb361d7",
         "type": "github"
       },
       "original": {
@@ -697,11 +697,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1692698134,
-        "narHash": "sha256-YtMmZWR/dlTypOcwiZfZTMPr3tj9fwr05QTStfSyDSg=",
+        "lastModified": 1692794066,
+        "narHash": "sha256-H0aG8r16dj0x/Wz6wQhQxc9V7AsObOiHPaKxQgH6Y08=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a16f7eb56e88c8985fcc6eb81dabd6cade4e425a",
+        "rev": "fc944919f743bb22379dddf18dcb72db6cff84aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`7c78afad`](https://github.com/nix-community/emacs-overlay/commit/7c78afad4565bcb49b3c848c6f1fb28f0cb361d7) | `` Updated repos/melpa ``  |
| [`fc653f96`](https://github.com/nix-community/emacs-overlay/commit/fc653f96dd8bee1ed21fade86b185d60a6c3bc6c) | `` Updated repos/elpa ``   |
| [`685873c1`](https://github.com/nix-community/emacs-overlay/commit/685873c16190c520a4550bd98c2773cbc0f09f54) | `` Updated flake inputs `` |