### PR TITLE
chore(flake/nur): `48fce8d1` -> `202456d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692895597,
-        "narHash": "sha256-DqrtJx1N69km/PqtBb0OVubu7ORtmvQJILSNlVwfMgU=",
+        "lastModified": 1692906366,
+        "narHash": "sha256-XQ5ZguOfoXRrRcHiWChKUwsuyf726XTKP360oDtePGM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "48fce8d1a2576b92d067e7ffd05d60c12ab6eaa0",
+        "rev": "202456d40f4700e2356f72e6ba57bb2a6ddc4921",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`202456d4`](https://github.com/nix-community/NUR/commit/202456d40f4700e2356f72e6ba57bb2a6ddc4921) | `` automatic update `` |