### PR TITLE
chore(flake/nur): `202456d4` -> `b0ca5d9f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692906366,
-        "narHash": "sha256-XQ5ZguOfoXRrRcHiWChKUwsuyf726XTKP360oDtePGM=",
+        "lastModified": 1692913330,
+        "narHash": "sha256-gy8P5r3Xm0pnzDvES/GQlNYjmIR//oYhIxV/EPiKZ9o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "202456d40f4700e2356f72e6ba57bb2a6ddc4921",
+        "rev": "b0ca5d9fcc0ddee367379d59574d25cb404a2b47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b0ca5d9f`](https://github.com/nix-community/NUR/commit/b0ca5d9fcc0ddee367379d59574d25cb404a2b47) | `` automatic update `` |