### PR TITLE
chore(flake/nur): `b0ca5d9f` -> `7b245e0e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692913330,
-        "narHash": "sha256-gy8P5r3Xm0pnzDvES/GQlNYjmIR//oYhIxV/EPiKZ9o=",
+        "lastModified": 1692919240,
+        "narHash": "sha256-uDRyV7PqwFGsSTi+fz9eod05akAc7Xlwut7szYQSZ6M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b0ca5d9fcc0ddee367379d59574d25cb404a2b47",
+        "rev": "7b245e0ed3f8230039eeb6c0c59dca22839609f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7b245e0e`](https://github.com/nix-community/NUR/commit/7b245e0ed3f8230039eeb6c0c59dca22839609f5) | `` automatic update `` |
| [`5a0fd7ad`](https://github.com/nix-community/NUR/commit/5a0fd7ade559b70892958425a131a78a296d5bbb) | `` automatic update `` |