### PR TITLE
chore(flake/nur): `7b245e0e` -> `02a685ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692919240,
-        "narHash": "sha256-uDRyV7PqwFGsSTi+fz9eod05akAc7Xlwut7szYQSZ6M=",
+        "lastModified": 1692934286,
+        "narHash": "sha256-ZQO49V8Mbmy1gla4VSjZlMMv2WfdamHdI4iZVia0JQg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7b245e0ed3f8230039eeb6c0c59dca22839609f5",
+        "rev": "02a685ac66a8af463fc36e744cbe391d0552769c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`02a685ac`](https://github.com/nix-community/NUR/commit/02a685ac66a8af463fc36e744cbe391d0552769c) | `` automatic update `` |