### PR TITLE
chore(flake/nur): `9692cabb` -> `ae1d1edd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692940757,
-        "narHash": "sha256-QrYzsspcs/WM1TdKqPQ2/ghBxfCu917eBqaQuIYbBZ8=",
+        "lastModified": 1692949103,
+        "narHash": "sha256-kxHsJo/1MN6sdBCcFQu3J0Dtjpb54cRBBEByK5DXG5s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9692cabb293aa1862b12d8e0e754fd28112e6d1b",
+        "rev": "ae1d1eddea079e549d2cb3b408090879feb17dec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                           |
| -------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`ae1d1edd`](https://github.com/nix-community/NUR/commit/ae1d1eddea079e549d2cb3b408090879feb17dec) | `` automatic update ``            |
| [`eafe37ad`](https://github.com/nix-community/NUR/commit/eafe37adafdb2364028c57a1fa0960a1d86841e8) | `` automatic update ``            |
| [`4a20255b`](https://github.com/nix-community/NUR/commit/4a20255b7f9a3c2e58ac7ad135f5aee0b8fab4ed) | `` add dcsunset repository ``     |
| [`16902fd6`](https://github.com/nix-community/NUR/commit/16902fd65f824d08194133c8b5556b1bba2d3b76) | `` add weirdpkgs repository ``    |
| [`6d6301a2`](https://github.com/nix-community/NUR/commit/6d6301a238d294c7f8b054f1f5886a9c22e29f65) | `` automatic update ``            |
| [`7e70c816`](https://github.com/nix-community/NUR/commit/7e70c8168ea7672be0911dd626f76e8e1b2d5ed9) | `` automatic update ``            |
| [`162be7bb`](https://github.com/nix-community/NUR/commit/162be7bb70a833c5c1642c43c443cbc9f3bfcff2) | `` add SuperKenVery repository `` |
| [`b60058af`](https://github.com/nix-community/NUR/commit/b60058afe50607a440d067903b2ea775bc942a15) | `` milahu: enable submodules ``   |