### PR TITLE
chore(flake/nur): `ae1d1edd` -> `1c4128d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692949103,
-        "narHash": "sha256-kxHsJo/1MN6sdBCcFQu3J0Dtjpb54cRBBEByK5DXG5s=",
+        "lastModified": 1692955245,
+        "narHash": "sha256-Eu0DomPN0xs+6Mu/PWB6QeDPEijMlbG9SsPhbdoFYqs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ae1d1eddea079e549d2cb3b408090879feb17dec",
+        "rev": "1c4128d1a0358e38fc3bc5deefd943c0a3003d04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1c4128d1`](https://github.com/nix-community/NUR/commit/1c4128d1a0358e38fc3bc5deefd943c0a3003d04) | `` automatic update `` |