### PR TITLE
chore(flake/nur): `035eea7a` -> `ee2675ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692968297,
-        "narHash": "sha256-yviIutZrzDKX2WY01sIABlfnph/V7FAd90CztJsxqRk=",
+        "lastModified": 1692971158,
+        "narHash": "sha256-1dZ9WJaPs1lCnRRctDgKwOXIn/t+UaiwxwcVksFXwzQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "035eea7add252967a8b6ca241e60c80739cee37b",
+        "rev": "ee2675bab6f3120ada6671204e9eca40da2fb180",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ee2675ba`](https://github.com/nix-community/NUR/commit/ee2675bab6f3120ada6671204e9eca40da2fb180) | `` automatic update `` |
| [`745f4907`](https://github.com/nix-community/NUR/commit/745f49070cb043644c95ab6513dfca429c4ae959) | `` automatic update `` |