### PR TITLE
chore(flake/nur): `1dc48cf3` -> `3a984ad3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692974449,
-        "narHash": "sha256-R2DKGdOtcse8Ck+lJq0EHsKrOcQ60Krbn7ai0KttL4k=",
+        "lastModified": 1692981341,
+        "narHash": "sha256-UVFFAz8GvY2jP/qT0dOVUekKRiRpl9RMlHJxAixMm1E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1dc48cf3da10cd19767a1133239b6937627c1d60",
+        "rev": "3a984ad3b8d3ed478f474a0a0c786e1c2c7a95d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3a984ad3`](https://github.com/nix-community/NUR/commit/3a984ad3b8d3ed478f474a0a0c786e1c2c7a95d3) | `` automatic update `` |