### PR TITLE
chore(flake/nur): `3a984ad3` -> `5fa8a47c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692981341,
-        "narHash": "sha256-UVFFAz8GvY2jP/qT0dOVUekKRiRpl9RMlHJxAixMm1E=",
+        "lastModified": 1692985530,
+        "narHash": "sha256-P3uk7vkyYoB9F/ArFGAPJn96XN62idEtmoeczRHfhDI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3a984ad3b8d3ed478f474a0a0c786e1c2c7a95d3",
+        "rev": "5fa8a47c458e0f8b55a3a783d125f3e0017cac28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5fa8a47c`](https://github.com/nix-community/NUR/commit/5fa8a47c458e0f8b55a3a783d125f3e0017cac28) | `` automatic update `` |