### PR TITLE
chore(flake/nur): `5fa8a47c` -> `52d30bbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692985530,
-        "narHash": "sha256-P3uk7vkyYoB9F/ArFGAPJn96XN62idEtmoeczRHfhDI=",
+        "lastModified": 1692989118,
+        "narHash": "sha256-kZbWXQYO29bsDvEBvg2p/dsSp6yGZnj2qMC62G0pgFI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5fa8a47c458e0f8b55a3a783d125f3e0017cac28",
+        "rev": "52d30bbc08936a5fd9552db356e404a373ef9652",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`52d30bbc`](https://github.com/nix-community/NUR/commit/52d30bbc08936a5fd9552db356e404a373ef9652) | `` automatic update `` |