### PR TITLE
chore(flake/nur): `3ac6bef0` -> `f050fc28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692992794,
-        "narHash": "sha256-P8cSCvHnXVWbqNCop+hk0rznOX2pCfT1GlF1ahUMGHY=",
+        "lastModified": 1692996347,
+        "narHash": "sha256-0gMI45VgTgQBonFr/utWkUyDJ7Tt+TA0pbqJXMIFU0g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3ac6bef0eb97c326b1093ad54bbb51271353181f",
+        "rev": "f050fc284b58af8989b996f2e17950e55bae1332",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f050fc28`](https://github.com/nix-community/NUR/commit/f050fc284b58af8989b996f2e17950e55bae1332) | `` automatic update `` |