### PR TITLE
chore(flake/nixpkgs): `b85ed9dc` -> `18324978`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -810,11 +810,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1692734709,
-        "narHash": "sha256-SCFnyHCyYjwEmgUsHDDuU0TsbVMKeU1vwkR+r7uS2Rg=",
+        "lastModified": 1692913444,
+        "narHash": "sha256-1SvMQm2DwofNxXVtNWWtIcTh7GctEVrS/Xel/mdc6iY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b85ed9dcbf187b909ef7964774f8847d554fab3b",
+        "rev": "18324978d632ffc55ef1d928e81630c620f4f447",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`e11b2c5a`](https://github.com/NixOS/nixpkgs/commit/e11b2c5a2101467b3014fb6f3b2c2ffabd5009db) | `` acpica-tools: add delroth to maintainers ``                                            |
| [`98f5022d`](https://github.com/NixOS/nixpkgs/commit/98f5022d678aac2b0c395694bf49c745ece6eacd) | `` pythonPackages.ansible,pythonPackages.ansible-core: add ansible-pylibssh dependency `` |
| [`aebb003f`](https://github.com/NixOS/nixpkgs/commit/aebb003f2f9b40823ea6da62dea6945f92c9722f) | `` pythonPackages.ansible-pylibssh: init at 1.1.0 ``                                      |
| [`eee87711`](https://github.com/NixOS/nixpkgs/commit/eee8771175004efc538c01923a12826233dbc0ea) | `` pythonPackages.expandvars: init at 0.11.0 ``                                           |
| [`d4889256`](https://github.com/NixOS/nixpkgs/commit/d4889256e34d126068718d3f54e4e96d01f0e1c3) | `` nix-index-unwrapped: 0.1.6 -> 0.1.7 ``                                                 |
| [`ea42333f`](https://github.com/NixOS/nixpkgs/commit/ea42333fce1ddcc88cf551345e320fa878b07ca5) | `` maintainers: add geluk ``                                                              |
| [`94da73ac`](https://github.com/NixOS/nixpkgs/commit/94da73acea4412937984467d9d9af42d353388e0) | `` tor: 0.4.7.14 -> 0.4.8.4 ``                                                            |
| [`17fa104a`](https://github.com/NixOS/nixpkgs/commit/17fa104ac7b1405f22c9ff370021027850e6129f) | `` python310Packages.gensim: 4.3.1 -> 4.3.2 ``                                            |
| [`fcf9eb1b`](https://github.com/NixOS/nixpkgs/commit/fcf9eb1b5172919314d62dbf0209825c7f9626f8) | `` cryptominisat: 5.11.11 -> 5.11.12 ``                                                   |
| [`df4f0605`](https://github.com/NixOS/nixpkgs/commit/df4f0605ce820d9fb57c52131bf2670d251cc594) | `` gerbv: 2.9.8 -> 2.10.0 ``                                                              |
| [`fddd11e0`](https://github.com/NixOS/nixpkgs/commit/fddd11e0022436309a5b225d11772f08d2001c91) | `` python310Packages.pdf2docx: init at 0.5.6 ``                                           |
| [`1810789d`](https://github.com/NixOS/nixpkgs/commit/1810789d1d8f415e53c41ac1a7af355741885cf8) | `` waybar: add experimentalPatches option ``                                              |
| [`63f858bd`](https://github.com/NixOS/nixpkgs/commit/63f858bdf8e7ec26b7cb2f73649c9b4afde924a9) | `` hddfancontrol: license and metadata tweaks (#251184) ``                                |
| [`d4c3be99`](https://github.com/NixOS/nixpkgs/commit/d4c3be990dcdc5a857268477da75f1f5fee8405c) | `` python310Packages.bentoml: 1.1.1 -> 1.1.3 ``                                           |
| [`d3ad6cd9`](https://github.com/NixOS/nixpkgs/commit/d3ad6cd986872d1f2bd5d3891c55b4cc3b7ff0bd) | `` python310Packages.cohere: 4.16.0 -> 4.21 ``                                            |
| [`2137e9dc`](https://github.com/NixOS/nixpkgs/commit/2137e9dcbcdc45d27400a53e05cd19b4782bb8fa) | `` python311Packages.aioairzone: update disabled ``                                       |
| [`7b7b6396`](https://github.com/NixOS/nixpkgs/commit/7b7b6396f3c622aba920abdfd3867d515b6e124d) | `` exploitdb: 2023-08-22 -> 2023-08-24 ``                                                 |
| [`045910a1`](https://github.com/NixOS/nixpkgs/commit/045910a1a3108d5648e18de00bb39cedc24979c9) | `` qemu-utils: copy from qemu_kvm, not qemu ``                                            |
| [`6d26e3e5`](https://github.com/NixOS/nixpkgs/commit/6d26e3e58f91740f4ce611e05d2e17fbb5ea75e7) | `` pylyzer: 0.0.40 -> 0.0.41 ``                                                           |
| [`42d69013`](https://github.com/NixOS/nixpkgs/commit/42d69013ec6390272265ac67e5abbd6f37ecba9c) | `` python3Packages.orange3: init at 3.35.0 ``                                             |
| [`da0c5289`](https://github.com/NixOS/nixpkgs/commit/da0c5289ccef4da6c7b558cd48c36e9f115c8ceb) | `` python3Packages.orange-widget-base: init at 4.21.0 ``                                  |
| [`bb83b8f7`](https://github.com/NixOS/nixpkgs/commit/bb83b8f7e1ab699f613247f5bd9788057159e73e) | `` python3Packages.orange-canvas-core: init at 0.1.31 ``                                  |
| [`6e14c963`](https://github.com/NixOS/nixpkgs/commit/6e14c963974ffd335e22926625db60b4a062fac1) | `` python3Packages.anyqt: init at 0.2.0 ``                                                |
| [`67effe01`](https://github.com/NixOS/nixpkgs/commit/67effe018b80e4eb028072def00d518b1ea3b66a) | `` python3Packages.opentsne: init at 1.0.0 ``                                             |
| [`0e3349d5`](https://github.com/NixOS/nixpkgs/commit/0e3349d5486c24809f883efef8571a046d399477) | `` python3Packages.qasync: init at 0.24.1 ``                                              |
| [`2132e272`](https://github.com/NixOS/nixpkgs/commit/2132e272405ded1f7285b5fdf7cae72d53259ff4) | `` python3Packages.serverfiles: init at 0.3.1 ``                                          |
| [`c7e99a32`](https://github.com/NixOS/nixpkgs/commit/c7e99a323ba83db715989f043585ea04733875de) | `` python3Packages.baycomp: init at 1.0.2 ``                                              |
| [`d1e0c78b`](https://github.com/NixOS/nixpkgs/commit/d1e0c78b08bafffd9197e99db56a3f8281a72c95) | `` fastfetch: 2.0.2 -> 2.0.3 ``                                                           |
| [`a90dcdd4`](https://github.com/NixOS/nixpkgs/commit/a90dcdd4a276dae1bd15ec39ff76f9d317e7459d) | `` agdsn-zsh-config: 0.6.0 -> 0.7.0 ``                                                    |
| [`4230be04`](https://github.com/NixOS/nixpkgs/commit/4230be04b63c7f04004d61ff65a7f35c430895ac) | `` galer: use sri hash ``                                                                 |
| [`94a93233`](https://github.com/NixOS/nixpkgs/commit/94a932337f30e7cdda484c6f6cc47cc9f8aaba96) | `` python310Packages.flask-script: rename from flask_script ``                            |
| [`255e674e`](https://github.com/NixOS/nixpkgs/commit/255e674e257fc85cc46655290f94a3e2b5529152) | `` python310Packages.flask-principal: rename from flask_principal ``                      |
| [`80a24251`](https://github.com/NixOS/nixpkgs/commit/80a24251656869c9df1f7fe625c25ed3a57e4c00) | `` python310Packages.flask-migrate: rename from flask_migrate ``                          |
| [`6733b198`](https://github.com/NixOS/nixpkgs/commit/6733b198a451a864c26d60bf24260f1ae81b0fb7) | `` python310Packages.flask-mail: rename from flask_mail ``                                |
| [`98e9789c`](https://github.com/NixOS/nixpkgs/commit/98e9789c2310b6795ff4e0981d1e75b4ef968f32) | `` python310Packages.flask-elastic: rename from flask_elastic ``                          |
| [`98a5f015`](https://github.com/NixOS/nixpkgs/commit/98a5f015e7ab22307d95fffca81c75a151665e9d) | `` python310Packages.flask-assets: rename from flask_assets ``                            |
| [`e3b1b7cf`](https://github.com/NixOS/nixpkgs/commit/e3b1b7cfd95d289e523e1e9a2cd99dc04cccbbbb) | `` electron_26: init at 26.1.0 ``                                                         |
| [`ee99cb5d`](https://github.com/NixOS/nixpkgs/commit/ee99cb5dc677439b2afd9a6cc4ca66e4603e1361) | `` electron_*: updates ``                                                                 |
| [`9af10fef`](https://github.com/NixOS/nixpkgs/commit/9af10fefd9b3a90a5a1403a6095e042a4f99998b) | `` ferretdb: 1.7.0 -> 1.8.0 (#251122) ``                                                  |
| [`bff4a352`](https://github.com/NixOS/nixpkgs/commit/bff4a3526bd871d868a487a008ae47eec8869b3f) | `` grafana: 10.0.3 -> 10.1.0 (#251138) ``                                                 |
| [`aa07a8c4`](https://github.com/NixOS/nixpkgs/commit/aa07a8c45c891f1e2a2604fe85b477ea45074248) | `` python311Packages.hahomematic: 2023.8.7 -> 2023.8.9 ``                                 |
| [`2216e648`](https://github.com/NixOS/nixpkgs/commit/2216e6483923724956d5a25fad5ca954a0a5aac2) | `` matrix-sliding-sync: 0.99.6 -> 0.99.7 ``                                               |
| [`7a79425c`](https://github.com/NixOS/nixpkgs/commit/7a79425cdc9e036260507ee675f153af2dcaa803) | `` python311Packages.hahomematic: 2023.8.6 -> 2023.8.7 ``                                 |
| [`57364435`](https://github.com/NixOS/nixpkgs/commit/57364435d10b1f8de473b50d2e5c0c901ca52086) | `` python311Packages.hahomematic: 2023.8.5 -> 2023.8.6 ``                                 |
| [`af74aead`](https://github.com/NixOS/nixpkgs/commit/af74aead0429b8fdba63d8ec6b499dce352720d7) | `` python311Packages.hahomematic: 2023.8.4 -> 2023.8.5 ``                                 |
| [`ae40138a`](https://github.com/NixOS/nixpkgs/commit/ae40138afaf12b2e6266a88487556a84ff451f85) | `` python311Packages.hahomematic: 2023.8.3 -> 2023.8.4 ``                                 |
| [`90f091fe`](https://github.com/NixOS/nixpkgs/commit/90f091fe703903b17ce15fe05e885342fe03a967) | `` python311Packages.hahomematic: enable tests ``                                         |
| [`ba66651b`](https://github.com/NixOS/nixpkgs/commit/ba66651bbde06997abdacc4c0513253863da7f9c) | `` python311Packages.hahomematic: 2023.8.2 -> 2023.8.3 ``                                 |
| [`cb2a99a2`](https://github.com/NixOS/nixpkgs/commit/cb2a99a21772dbc0582246be80a70d149aae755a) | `` python3.pkgs.detectron2: fix build ``                                                  |
| [`1387d157`](https://github.com/NixOS/nixpkgs/commit/1387d1573191dc3d2bf7f0b82d0868d789af308a) | `` python311Packages.reolink-aio: 0.7.7 -> 0.7.8 ``                                       |
| [`121ea4d3`](https://github.com/NixOS/nixpkgs/commit/121ea4d34b6802a9ea2122892a01b4195693cbd6) | `` python311Packages.pylitterbot: 2023.4.4 -> 2023.4.5 ``                                 |
| [`4d969c85`](https://github.com/NixOS/nixpkgs/commit/4d969c85842dea8465e803b1ad2da4b2aa71e3e8) | `` python311Packages.devolo-plc-api: 1.3.2 -> 1.4.0 ``                                    |
| [`510b8e62`](https://github.com/NixOS/nixpkgs/commit/510b8e62277dbd58c4cc1046d674871b620e19df) | `` retool: init at unstable-2023-08-24 ``                                                 |
| [`cf069398`](https://github.com/NixOS/nixpkgs/commit/cf069398ebbf04a52e9f9e4e82396a984bbb9fb4) | `` jftui: 0.6.2 -> 0.7.1 ``                                                               |
| [`4c95c9f3`](https://github.com/NixOS/nixpkgs/commit/4c95c9f31ebc6ef3d01b593c5c84ad9aa2150bda) | `` netmaker: also, add qjoly as maintainer ``                                             |
| [`40b403a6`](https://github.com/NixOS/nixpkgs/commit/40b403a6f7c92ad59b9e9a56ec942a2e6a08042b) | `` netmaker: 0.20.5 -> 0.20.6 ``                                                          |
| [`032324fd`](https://github.com/NixOS/nixpkgs/commit/032324fd20e3be4124ffefd00da5bd66b0550e8c) | `` txr: 289 -> 291 ``                                                                     |
| [`188e5aea`](https://github.com/NixOS/nixpkgs/commit/188e5aea141b32060e019267e55be154f95e642b) | `` SP800-90B_EntropyAssessment: init at 1.1.6 ``                                          |
| [`e0ef2f29`](https://github.com/NixOS/nixpkgs/commit/e0ef2f29f1f1c2879d83fb3b0a6f9c40ffc53612) | `` terragrunt: 0.48.6 -> 0.50.6 ``                                                        |
| [`4f5e435b`](https://github.com/NixOS/nixpkgs/commit/4f5e435b9308601890366625c361aac7254f4eee) | `` mujs: install shared lib ``                                                            |
| [`9aa91ec7`](https://github.com/NixOS/nixpkgs/commit/9aa91ec7b5d59595281a584e70ee5c19efbee0bb) | `` build-support/vm: fix makeImageTestScript ``                                           |
| [`1f49f87c`](https://github.com/NixOS/nixpkgs/commit/1f49f87ca8971bc2ee9e3fcc4645b163eef5a753) | `` narrowlink: init at 0.1.4 ``                                                           |
| [`6e980e64`](https://github.com/NixOS/nixpkgs/commit/6e980e645823095c83c12eea43691e7a407bd6b4) | `` qemu_kvm.tests: use finalPackage ``                                                    |
| [`fdcf1350`](https://github.com/NixOS/nixpkgs/commit/fdcf135074af83ff5e0d878d81aec44a00882a23) | `` linux_latest-libre: 19386 -> 19392 ``                                                  |
| [`d68e7563`](https://github.com/NixOS/nixpkgs/commit/d68e7563973506270c5775ca3a1cd835c174149c) | `` linux: 6.4.11 -> 6.4.12 ``                                                             |
| [`b6209350`](https://github.com/NixOS/nixpkgs/commit/b6209350d7c5a639ccfe816e7b2065c7e190cbaa) | `` linux: 6.1.46 -> 6.1.47 ``                                                             |
| [`2be777b4`](https://github.com/NixOS/nixpkgs/commit/2be777b47fa533d3ac07bf40c49a3eda014546da) | `` python3Packages.pyxlsb: init at 1.0.10 ``                                              |
| [`1025a76f`](https://github.com/NixOS/nixpkgs/commit/1025a76f07f206e880355bfe12d4c07578601cdf) | `` cloudflard: also, add qjoly as maintainer ``                                           |
| [`a2e77ba8`](https://github.com/NixOS/nixpkgs/commit/a2e77ba8ab0f87f2ffdefcbc212b15bc3d0090cc) | `` path-of-building.data: 2.31.2 -> 2.32.2 ``                                             |
| [`260a0522`](https://github.com/NixOS/nixpkgs/commit/260a0522acb073bbcdea4e8d4446edd41bb86173) | `` terraform: 1.5.5 -> 1.5.6 (#251089) ``                                                 |
| [`189923f3`](https://github.com/NixOS/nixpkgs/commit/189923f35110445cd133e221feded078698aa649) | `` marp-cli: init at 3.2.0 ``                                                             |
| [`69f44e2e`](https://github.com/NixOS/nixpkgs/commit/69f44e2e0e8426d3c1ebb31d4a9edf4d953bb29c) | `` cloudflared: 2023.7.3 -> 2023.8.0 ``                                                   |
| [`4428f3a7`](https://github.com/NixOS/nixpkgs/commit/4428f3a79a9319925a4111f1ee20b3147761e2ec) | `` Revert "nixos/security/wrappers: simplifications and a fix for #98863" ``              |
| [`162c8d3d`](https://github.com/NixOS/nixpkgs/commit/162c8d3d1d4b7999cc6d56474d3df556c64b0ba7) | `` cilium-cli: add qjoly as maintainer ``                                                 |
| [`790b344b`](https://github.com/NixOS/nixpkgs/commit/790b344b1012db677fa51618f9c360ffc589c990) | `` cilium-cli: 0.14.3 -> 0.15.6 ``                                                        |
| [`ab9cf80e`](https://github.com/NixOS/nixpkgs/commit/ab9cf80e428a8814cecb173efce840cc56b025eb) | `` mixxx: 2.3.5 -> 2.3.6 ``                                                               |
| [`109e0ee2`](https://github.com/NixOS/nixpkgs/commit/109e0ee2f4985e10c5fd5ffca09a47411c5b4d43) | `` maintainers: update McSinyx's contacts ``                                              |
| [`d3e240ff`](https://github.com/NixOS/nixpkgs/commit/d3e240ff0aae301ca21a6eba03da4483b59cea5b) | `` gajim: 1.8.0 → 1.8.1 ``                                                                |
| [`0b88c566`](https://github.com/NixOS/nixpkgs/commit/0b88c566c7caee655f82e5d36776d7dac3cff042) | `` pdm: 2.8.0 -> 2.8.2 ``                                                                 |
| [`0a728d35`](https://github.com/NixOS/nixpkgs/commit/0a728d35995bed82c253ab80aed2df1085a91b0f) | `` python310Packages.unearth: 0.9.2 -> 0.10.0 ``                                          |
| [`e9b86d7b`](https://github.com/NixOS/nixpkgs/commit/e9b86d7b8b0b68bcb4dcf6770ed2e85652b0594e) | `` terraform-providers.oci: 5.9.0 -> 5.10.0 ``                                            |
| [`cbe70b30`](https://github.com/NixOS/nixpkgs/commit/cbe70b30bc11dac7506518017c870606565180f8) | `` terraform-providers.datadog: 3.28.0 -> 3.29.0 ``                                       |
| [`694f5f80`](https://github.com/NixOS/nixpkgs/commit/694f5f80bcdc95a2a33b398463d5619ae97c389d) | `` terraform-providers.equinix: 1.14.7 -> 1.15.0 ``                                       |
| [`d99d2ff5`](https://github.com/NixOS/nixpkgs/commit/d99d2ff5e4baeb649f6c0c1f9b794e99ea64477b) | `` terraform-providers.acme: 2.16.1 -> 2.17.0 ``                                          |
| [`1d51cbfe`](https://github.com/NixOS/nixpkgs/commit/1d51cbfe21da58915feb55447f2c99342ceb344f) | `` terraform-providers.cloudflare: 4.12.0 -> 4.13.0 ``                                    |
| [`e53866a3`](https://github.com/NixOS/nixpkgs/commit/e53866a3205c2b7173cf55780c01ee79e1806ac7) | `` terraform-providers.buildkite: 0.25.0 -> 0.25.1 ``                                     |
| [`5e33767c`](https://github.com/NixOS/nixpkgs/commit/5e33767c8c460f233382cd008c3a9dbe207b9adc) | `` terraform-providers.aiven: 4.8.0 -> 4.8.2 ``                                           |
| [`95b000c6`](https://github.com/NixOS/nixpkgs/commit/95b000c69eef51519948b4609bb6e8c5b9148a01) | `` telegraf: 1.27.3 -> 1.27.4 ``                                                          |
| [`9b3fefd3`](https://github.com/NixOS/nixpkgs/commit/9b3fefd37d264c7a6f560a5d932aa267c1c11b71) | `` elpa-devel-packages: build xeft dynamic module ``                                      |
| [`6dd389dd`](https://github.com/NixOS/nixpkgs/commit/6dd389dd9f3ced16f8a436a10445297540dfca8b) | `` elpa-packages: build xeft dynamic module ``                                            |
| [`8bcdc0fd`](https://github.com/NixOS/nixpkgs/commit/8bcdc0fd78e524495cce47280be9b73e204164a2) | `` oh-my-posh: 18.3.3 -> 18.3.5 ``                                                        |
| [`a9bbb44b`](https://github.com/NixOS/nixpkgs/commit/a9bbb44bed8777c0333caf1d182bf9a17884d4c8) | `` python310Packages.mypy-protobuf: update disabled python version ``                     |
| [`a0e6434a`](https://github.com/NixOS/nixpkgs/commit/a0e6434a3f590a933a9d3756fe0d90ff2c6ab0f5) | `` hydra_unstable: 2023-07-17 -> 2023-08-23 ``                                            |
| [`c5008e9a`](https://github.com/NixOS/nixpkgs/commit/c5008e9a860da340ad925dd6ea2d0efcca7be93b) | `` geogebra6: fix web archive url and darwin hash ``                                      |
| [`583a0ef0`](https://github.com/NixOS/nixpkgs/commit/583a0ef0f7019159a97acc8c3e01496206f90dbb) | `` tbox: 1.7.3 -> 1.7.4 ``                                                                |
| [`50b3adf5`](https://github.com/NixOS/nixpkgs/commit/50b3adf58255d3a893bccb422502e7c14b42462e) | `` specr-transpile: 0.1.21 -> 0.1.22 ``                                                   |
| [`6f05b86f`](https://github.com/NixOS/nixpkgs/commit/6f05b86fe8ad44345baca44f3baae4f39f2580ee) | `` qmplay2: 23.06.17 -> 23.08.22 ``                                                       |
| [`e2689c1c`](https://github.com/NixOS/nixpkgs/commit/e2689c1c98c1d09faf1a2d2af4284d8409e462fc) | `` nixos/zram-generator: drop outdated comments ``                                        |
| [`c330720b`](https://github.com/NixOS/nixpkgs/commit/c330720b48deb5cfbffed661f83ba0a018d9ef36) | `` pkgs: add consideration for new packages (#250352) ``                                  |
| [`dfe898c8`](https://github.com/NixOS/nixpkgs/commit/dfe898c8014622334a2ad541f1837b5319905b34) | `` glfw-wayland-minecraft: init at unstable-2023-06-01 (#243950) ``                       |
| [`926f6913`](https://github.com/NixOS/nixpkgs/commit/926f69130efb4988a9bc19433a421e8b1a425809) | `` checkov: 2.4.6 -> 2.4.7 ``                                                             |
| [`8b28d3f3`](https://github.com/NixOS/nixpkgs/commit/8b28d3f373a9dcd4a44228cc000515c571fb3aca) | `` python311Packages.kombu: add optional-dependencies ``                                  |
| [`54244430`](https://github.com/NixOS/nixpkgs/commit/542444304f027de80efcfebcf4691b8ccfd2c463) | `` dpkg: fix glibc issue on darwin ``                                                     |
| [`d2b623aa`](https://github.com/NixOS/nixpkgs/commit/d2b623aa59eae214550efe00188c997a1927e408) | `` trufflehog: 3.52.1 -> 3.53.0 ``                                                        |
| [`556dac07`](https://github.com/NixOS/nixpkgs/commit/556dac0725917278c5c750f14048af00d89319e4) | `` bwa-mem2: init at version 2.2.1 ``                                                     |
| [`a471cfcb`](https://github.com/NixOS/nixpkgs/commit/a471cfcbe7800a926a3d62e0db5a88cceef03253) | `` python3Packages.alive-progress: init at 3.1.4 ``                                       |
| [`a74c5bbf`](https://github.com/NixOS/nixpkgs/commit/a74c5bbf0ad062c079d2d7a2e4593000d8f9f77e) | `` xmrig: disable fortify hardening ``                                                    |
| [`47844c9a`](https://github.com/NixOS/nixpkgs/commit/47844c9a2974a2c151099f347a68cdf902e12aa9) | `` pulsemixer: Set meta.mainProgram ``                                                    |
| [`0c17bb9a`](https://github.com/NixOS/nixpkgs/commit/0c17bb9a3ac159d2c030b3ba236a4eadf0f02ac0) | `` unzip: Set meta.mainProgram ``                                                         |
| [`74482c9d`](https://github.com/NixOS/nixpkgs/commit/74482c9d6a841a982748d216c40cf78ba1f3ef9c) | `` vlock: Set meta.mainProgram ``                                                         |
| [`6c8b8bc2`](https://github.com/NixOS/nixpkgs/commit/6c8b8bc2f1a24fd23d290dc26814c121d35fd367) | `` gcc: limit gcc12 isMips `--disable-libsanitizer` to abi=="gnu" ``                      |
| [`a04f6881`](https://github.com/NixOS/nixpkgs/commit/a04f68815c3820ace322496b2926d21c17379d6f) | `` grimshot: Set meta.mainProgram ``                                                      |
| [`a62c92ab`](https://github.com/NixOS/nixpkgs/commit/a62c92ab9b205c999427d64ac2de3171229d0207) | `` gcc12: disable libsanitizer for mips64 ``                                              |
| [`f2f6be53`](https://github.com/NixOS/nixpkgs/commit/f2f6be534736053f86b8a3da4c3db21e2fc5fca8) | `` python3Packages.about-time: init at 4.2.1 ``                                           |
| [`ac7ed741`](https://github.com/NixOS/nixpkgs/commit/ac7ed741a59d1d30e3589b5e6f8060175f3d8ed5) | `` matrix-commander: 6.0.1 -> 7.2.0 ``                                                    |
| [`09869b89`](https://github.com/NixOS/nixpkgs/commit/09869b89f1c971073b12a965912410632718d1b9) | `` python310Packages.rich-pixels: fix build ``                                            |
| [`2b10135a`](https://github.com/NixOS/nixpkgs/commit/2b10135a049acb3fa2bc7dbbb37ab41507068eb2) | `` browsr: unbreak ``                                                                     |
| [`3b89afc4`](https://github.com/NixOS/nixpkgs/commit/3b89afc47cec9597560a49aabf46ad2cda0537fe) | `` postgres-lsp: unstable-2023-08-08 -> unstable-2023-08-23 ``                            |
| [`8af0d023`](https://github.com/NixOS/nixpkgs/commit/8af0d023f6389cd1476016631827cf734ea84397) | `` qemu: 8.0.3 -> 8.0.4 ``                                                                |
| [`1075ea84`](https://github.com/NixOS/nixpkgs/commit/1075ea84c72ce8b2300f04dc9c3c20c31d9d3321) | `` libupnp: 1.14.17 -> 1.14.18 ``                                                         |
| [`7e326a75`](https://github.com/NixOS/nixpkgs/commit/7e326a755d5206d6970f493ca3d6ed0bd091d4f5) | `` opengrok: 1.12.12 -> 1.12.13 ``                                                        |
| [`e739ef80`](https://github.com/NixOS/nixpkgs/commit/e739ef80665a9758029383fdbda36d3085e58c2c) | `` nixos/twingate: avoid conflicts with resolved ``                                       |
| [`b1b67ca3`](https://github.com/NixOS/nixpkgs/commit/b1b67ca3f86dbf2537c19c2c511061d230c07aff) | `` drawio: 21.6.1 -> 21.6.8 ``                                                            |
| [`8477a773`](https://github.com/NixOS/nixpkgs/commit/8477a7737538959eabbb025141b4679c7b146fdd) | `` wamr: 1.2.2 -> 1.2.3 ``                                                                |
| [`f4b43fb6`](https://github.com/NixOS/nixpkgs/commit/f4b43fb6b401c5137b9606942df5f02095c486e3) | `` rust-analyzer-unwrapped: 2023-08-14 -> 2023-08-21 ``                                   |
| [`156005fe`](https://github.com/NixOS/nixpkgs/commit/156005fef48652c4f0c4e159977b3603637afc3e) | `` Remove hardeningDisable attribute ``                                                   |
| [`472364f9`](https://github.com/NixOS/nixpkgs/commit/472364f92d95427eb3914038e269916cf8d73a07) | `` appflowy: 0.2.6 -> 0.3.0 ``                                                            |
| [`ed2096f7`](https://github.com/NixOS/nixpkgs/commit/ed2096f765808a6dc559fff47274a639486936d6) | `` llama: remove ``                                                                       |
| [`2c0c1d18`](https://github.com/NixOS/nixpkgs/commit/2c0c1d18c4c9ae76cec81799771da54a64d976b9) | `` walk: init at 1.5.2 ``                                                                 |
| [`6b5011d9`](https://github.com/NixOS/nixpkgs/commit/6b5011d9d3e8f0fbb0597244804c8579a7e3e419) | `` tests.texlive.binaries: fix test for xpdfopen binaries (#250635) ``                    |
| [`72764dfe`](https://github.com/NixOS/nixpkgs/commit/72764dfe30b7ecabaa7b5738951359ccd66ce78f) | `` python310Packages.xformers: 0.0.20 -> 0.0.21 ``                                        |
| [`c642f34f`](https://github.com/NixOS/nixpkgs/commit/c642f34f7f2eaf4b72fee7d2b81877d2f8825c73) | `` litestream: 0.3.9 -> 0.3.11 ``                                                         |
| [`715edcff`](https://github.com/NixOS/nixpkgs/commit/715edcff6131ac34b549c0e16303b125c320f960) | `` partclone: 0.3.24 -> 0.3.25 ``                                                         |
| [`1c465c8d`](https://github.com/NixOS/nixpkgs/commit/1c465c8d54299fba20e2fcc19ef61ceeca9d4fe6) | `` python311Packages.zeroconf: 0.81.0 -> 0.82.1 ``                                        |
| [`9d322b89`](https://github.com/NixOS/nixpkgs/commit/9d322b896de80f5163a33730b2afe80c390cc2e8) | `` fastfetch: 2.0.1 -> 2.0.2 ``                                                           |
| [`1c40852d`](https://github.com/NixOS/nixpkgs/commit/1c40852d7dca836861b6d1ea1ea7a067f2b8f5cd) | `` doctl: 1.97.1 -> 1.98.0 ``                                                             |
| [`78832009`](https://github.com/NixOS/nixpkgs/commit/78832009a4b6a463d1a099e9da29b2c9c860c403) | `` firefox-devedition-bin-unwrapped: 117.0b5 -> 117.0b9 ``                                |
| [`1643ae98`](https://github.com/NixOS/nixpkgs/commit/1643ae98ba5c6748ca83e8ba51e179597d08fc65) | `` firefox-beta-bin-unwrapped: 117.0b5 -> 117.0b9 ``                                      |
| [`3d6f09ab`](https://github.com/NixOS/nixpkgs/commit/3d6f09ab6ce2d813974aa9a5ca97aca2de6c2ec6) | `` firefox-devedition-unwrapped: 117.0b5 -> 117.0b9 ``                                    |