### PR TITLE
chore(flake/nur): `648bbd6c` -> `f51b6a74`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693003564,
-        "narHash": "sha256-m0ZzmncMfSI/MLL2MeoaOFk2SuK1sFdI4NuzfhHRlQw=",
+        "lastModified": 1693017771,
+        "narHash": "sha256-4otLa9lH+4Pozb/VBlsZdPRMapC9EIu+t0TwwrQ4i4Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "648bbd6c24e7609b5511e6e6ed1df706d8b398a2",
+        "rev": "f51b6a74adebb3c895850d841600ed614be2961b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f51b6a74`](https://github.com/nix-community/NUR/commit/f51b6a74adebb3c895850d841600ed614be2961b) | `` automatic update `` |