### PR TITLE
chore(flake/nur): `7c926433` -> `c1e9b399`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693021060,
-        "narHash": "sha256-/I+ziECG1s49DQ3MzImP43k2NYhqZ6mSYGZAvhASM40=",
+        "lastModified": 1693027022,
+        "narHash": "sha256-zIEhbR9aDHL6n522zJ9b5Yx7LYzSPShAcf6iF8iKyxA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7c92643336b7a6f4289db7b11e23cf453080709b",
+        "rev": "c1e9b3996c4f5023db1efddc73719480a40edc16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c1e9b399`](https://github.com/nix-community/NUR/commit/c1e9b3996c4f5023db1efddc73719480a40edc16) | `` automatic update `` |