### PR TITLE
chore(flake/nur): `c1e9b399` -> `a5e58000`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693027022,
-        "narHash": "sha256-zIEhbR9aDHL6n522zJ9b5Yx7LYzSPShAcf6iF8iKyxA=",
+        "lastModified": 1693033920,
+        "narHash": "sha256-ONcmF1qXQE+j12fMexcB4MwasaKiA0h5Y/KSW1wQqpg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c1e9b3996c4f5023db1efddc73719480a40edc16",
+        "rev": "a5e58000830921fb76350795adead98fba2b47ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a5e58000`](https://github.com/nix-community/NUR/commit/a5e58000830921fb76350795adead98fba2b47ef) | `` automatic update `` |