### PR TITLE
chore(flake/nur): `a5e58000` -> `d0d2acf3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693033920,
-        "narHash": "sha256-ONcmF1qXQE+j12fMexcB4MwasaKiA0h5Y/KSW1wQqpg=",
+        "lastModified": 1693043931,
+        "narHash": "sha256-hIm1nwNJnzlwPNB+xSQEiWQRpsXeKtLbHcUz8uibv/o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a5e58000830921fb76350795adead98fba2b47ef",
+        "rev": "d0d2acf388e9a842bb94c7695fd3dc4298bba88a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d0d2acf3`](https://github.com/nix-community/NUR/commit/d0d2acf388e9a842bb94c7695fd3dc4298bba88a) | `` automatic update `` |
| [`365e1dfa`](https://github.com/nix-community/NUR/commit/365e1dfa1d32dd375f055b420264328b696881b3) | `` automatic update `` |
| [`dd450ce4`](https://github.com/nix-community/NUR/commit/dd450ce4bdc409eb754267a1bfdc310cc9442b5b) | `` automatic update `` |