### PR TITLE
chore(flake/emacs-overlay): `9a146838` -> `300460e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693018432,
-        "narHash": "sha256-D81bAOCYeH00lmhZg38YmKk8PeIqI54T/VPo/g0oJ6w=",
+        "lastModified": 1693045018,
+        "narHash": "sha256-l1TuQfxR3jBwQGToxdVqu5sBxp+eoypQqWXywbBGP+4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9a14683828917fe3f6f278eabe4782cf3b1970e1",
+        "rev": "300460e827e39285f98a1c105bdc6601ded8ccf8",
         "type": "github"
       },
       "original": {
@@ -732,11 +732,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1692794066,
-        "narHash": "sha256-H0aG8r16dj0x/Wz6wQhQxc9V7AsObOiHPaKxQgH6Y08=",
+        "lastModified": 1692896067,
+        "narHash": "sha256-jZ5j5RVhDltTidVnxvCEztTVLBMxx/WRUoz8orMPUWw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fc944919f743bb22379dddf18dcb72db6cff84aa",
+        "rev": "7419e94880e41304e67184718eb4270461cf15c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`300460e8`](https://github.com/nix-community/emacs-overlay/commit/300460e827e39285f98a1c105bdc6601ded8ccf8) | `` Updated repos/nongnu `` |
| [`7792d7ed`](https://github.com/nix-community/emacs-overlay/commit/7792d7ed901e9535ea9683764a6e991573b3a184) | `` Updated repos/melpa ``  |
| [`27745f15`](https://github.com/nix-community/emacs-overlay/commit/27745f1541a12350bd5875dfadfe821b405b85a1) | `` Updated repos/emacs ``  |
| [`c7945db5`](https://github.com/nix-community/emacs-overlay/commit/c7945db5a0e0e9699b2284970cf5a01d6fd0cdf1) | `` Updated flake inputs `` |