### PR TITLE
chore(flake/nur): `d0d2acf3` -> `32345bd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693043931,
-        "narHash": "sha256-hIm1nwNJnzlwPNB+xSQEiWQRpsXeKtLbHcUz8uibv/o=",
+        "lastModified": 1693054425,
+        "narHash": "sha256-Opl37bc6iXkCJIfXP2yCCK8TlgUzNhCTYs0GQMBlXeI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d0d2acf388e9a842bb94c7695fd3dc4298bba88a",
+        "rev": "32345bd790fe2c69236de00bb8d854d8296bad9c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`32345bd7`](https://github.com/nix-community/NUR/commit/32345bd790fe2c69236de00bb8d854d8296bad9c) | `` automatic update `` |