### PR TITLE
chore(flake/nur): `32345bd7` -> `4c58adf6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693054425,
-        "narHash": "sha256-Opl37bc6iXkCJIfXP2yCCK8TlgUzNhCTYs0GQMBlXeI=",
+        "lastModified": 1693057602,
+        "narHash": "sha256-EGNBYNeEO9pcF8e8QSt+SyJf4goBpC1E7D69hFJ3r70=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "32345bd790fe2c69236de00bb8d854d8296bad9c",
+        "rev": "4c58adf6f6d01ee9392343f578f8c701aa0373b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4c58adf6`](https://github.com/nix-community/NUR/commit/4c58adf6f6d01ee9392343f578f8c701aa0373b5) | `` automatic update `` |