### PR TITLE
chore(flake/nixpkgs): `18324978` -> `5690c427`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -810,11 +810,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1692913444,
-        "narHash": "sha256-1SvMQm2DwofNxXVtNWWtIcTh7GctEVrS/Xel/mdc6iY=",
+        "lastModified": 1693003285,
+        "narHash": "sha256-5nm4yrEHKupjn62MibENtfqlP6pWcRTuSKrMiH9bLkc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "18324978d632ffc55ef1d928e81630c620f4f447",
+        "rev": "5690c4271f2998c304a45c91a0aeb8fb69feaea7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`dd495f42`](https://github.com/NixOS/nixpkgs/commit/dd495f4261ad6d4cb10353982655c2b3475bd2d1) | `` python3Packages.pytest-testinfra: 8.1.0 → 9.0.0 ``                                      |
| [`94bd8489`](https://github.com/NixOS/nixpkgs/commit/94bd8489e9e772614903855ee6be3966487c920c) | `` vimPlugins: resolve github repository redirects ``                                      |
| [`b6eae406`](https://github.com/NixOS/nixpkgs/commit/b6eae406a8b748be400bb71fbd45944fe7af132a) | `` vimPlugins: update ``                                                                   |
| [`6422a7b1`](https://github.com/NixOS/nixpkgs/commit/6422a7b1bb33c0edda9c0a4b735c1482525433f9) | `` python311Packages.canals: 0.2.2 -> 0.6.0 ``                                             |
| [`468cc6ff`](https://github.com/NixOS/nixpkgs/commit/468cc6ffd3044686ad54a9f25e14b3c106512900) | `` python311Packages.gspread: 5.9.0 -> 5.10.0 ``                                           |
| [`89190701`](https://github.com/NixOS/nixpkgs/commit/891907019f9d17a8a724bee0a1d5b3cc902d6001) | `` python311Packages.vsure: 2.6.5 -> 2.6.6 ``                                              |
| [`db9cffaa`](https://github.com/NixOS/nixpkgs/commit/db9cffaafd7c68001158521f08f1beaa7b3ebd4e) | `` python311Packages.jsonpath: 0.82 -> 0.82.2 ``                                           |
| [`d712f8e4`](https://github.com/NixOS/nixpkgs/commit/d712f8e4c2665fb6627b70d478290414622fdea8) | `` python311Packages.aioaseko: 0.0.2 -> 0.1.0 ``                                           |
| [`5a7c5d7e`](https://github.com/NixOS/nixpkgs/commit/5a7c5d7e81aa950c6fe09553035202026a62f297) | `` python311Packages.hahomematic: 2023.8.10 -> 2023.8.11 ``                                |
| [`487eb77b`](https://github.com/NixOS/nixpkgs/commit/487eb77b10cea299eea4b5b782bec262f0a1a4d7) | ``  python311Packages.mdformat: add changelog to meta ``                                   |
| [`3d37de3c`](https://github.com/NixOS/nixpkgs/commit/3d37de3cc9bc6009c1abc14bffcc543f27829701) | `` python311Packages.mdformat: 0.7.16 -> 0.7.17 ``                                         |
| [`29e72dc2`](https://github.com/NixOS/nixpkgs/commit/29e72dc26d53ea821cfa6fca50be570fdc97acc1) | `` metasploit: 6.3.30 -> 6.3.31 ``                                                         |
| [`19a689af`](https://github.com/NixOS/nixpkgs/commit/19a689af9e7dcfafd0a9c97fc91c4668f07355c1) | `` python311Packages.adax: disable on unsupported Python releases ``                       |
| [`2d4cda19`](https://github.com/NixOS/nixpkgs/commit/2d4cda191f481e43914997f0c767380cf089e9b1) | `` python311Packages.adax: add changelog to meta ``                                        |
| [`75213da3`](https://github.com/NixOS/nixpkgs/commit/75213da35d92ad30d6482414c9bb8a9cdfd6472c) | `` python311Packages.adax: 0.2.0 -> 0.3.0 ``                                               |
| [`3e025f13`](https://github.com/NixOS/nixpkgs/commit/3e025f13938264d3e9ba1ae443485100a674985a) | `` emacsWithPackages: add a note for EMACSNATIVELOADPATH ``                                |
| [`7f8cd3d8`](https://github.com/NixOS/nixpkgs/commit/7f8cd3d8f98524e5609788e4fdda16c3a2ea0bc7) | `` emacsWithPackages: remove redundant colons ``                                           |
| [`d3807843`](https://github.com/NixOS/nixpkgs/commit/d380784357e531122814f74fc0bbb64258231f60) | `` emacsWithPackages: fix logic of adding EMACSNATIVELOADPATH ``                           |
| [`0093ac71`](https://github.com/NixOS/nixpkgs/commit/0093ac7102134d379cd7429899efc91daf5f6fd6) | `` stm32cubemx: 6.8.1 -> 6.9.1 ``                                                          |
| [`437e88c9`](https://github.com/NixOS/nixpkgs/commit/437e88c91903f6fa4173da6cf42fe84638921e5e) | `` maintainers: add angaz ``                                                               |
| [`940264dc`](https://github.com/NixOS/nixpkgs/commit/940264dc4cc795db53976850bf90ce1bbd79f350) | `` lief, python3Packages.lief: add genericnerdyusername as maintainer ``                   |
| [`e05e67e5`](https://github.com/NixOS/nixpkgs/commit/e05e67e5d51cd14196ee12b80bd36eda50bff3b5) | `` lief, python3Packages.lief: 0.12.3 -> 0.13.2 ``                                         |
| [`77eb86d9`](https://github.com/NixOS/nixpkgs/commit/77eb86d962f8c2c4fc08e5e9d5b0a23df7056849) | `` smenu: 1.2.0 -> 1.3.0 ``                                                                |
| [`1974feb4`](https://github.com/NixOS/nixpkgs/commit/1974feb428f9231fb9d5eb1f7a34c15e12604e71) | `` getoptions: disable tests against yash ``                                               |
| [`cc515a6e`](https://github.com/NixOS/nixpkgs/commit/cc515a6e015f66291cd29ffd13cc5d45d8c7dde5) | `` genemichaels: init at 0.1.21 ``                                                         |
| [`32b62b08`](https://github.com/NixOS/nixpkgs/commit/32b62b08e9b9d15c78c09c63299141c9116460e0) | `` python311Packages.types-beautifulsoup4: init at 4.12.0.6 ``                             |
| [`019f208a`](https://github.com/NixOS/nixpkgs/commit/019f208adadf47e23c57e50d0de4c07d6f804369) | `` python311Packages.types-html5lib: init at 1.1.11.15 ``                                  |
| [`eadaccff`](https://github.com/NixOS/nixpkgs/commit/eadaccffc76ca7c6e3134375abb21de8cf550d2d) | `` clash-meta: 1.15.0 -> 1.15.1 ``                                                         |
| [`dafab32a`](https://github.com/NixOS/nixpkgs/commit/dafab32a63f15dd646f4e1fe684eddf21e13b19a) | `` k3sup: 0.12.14 -> 0.12.15 ``                                                            |
| [`23d4032e`](https://github.com/NixOS/nixpkgs/commit/23d4032e75be309e29810c471b822197adcad7ac) | `` netdata: 1.42.0 -> 1.42.1 ``                                                            |
| [`c7cf24c5`](https://github.com/NixOS/nixpkgs/commit/c7cf24c52782e1a6008504739397bd8704f104e4) | `` vimPlugins.nvim-treesitter: update grammars ``                                          |
| [`b4c1f7d7`](https://github.com/NixOS/nixpkgs/commit/b4c1f7d724f76450851758202cf4648356ef3037) | `` vimPlugins: update ``                                                                   |
| [`dc157dc2`](https://github.com/NixOS/nixpkgs/commit/dc157dc2ee575ae472e8566a59a03e4540f31f5b) | `` vimPlugins.nvim-treesitter-context: update URL ``                                       |
| [`d764a59f`](https://github.com/NixOS/nixpkgs/commit/d764a59fc79f57cdb1941e7cff9213066f611c3c) | `` vimPlugins.rainbow-delimiters-nvim: init at 2023-08-25 ``                               |
| [`473e7f03`](https://github.com/NixOS/nixpkgs/commit/473e7f0314c242521e2f8d1547813b26d6679ce8) | `` riffdiff: 2.25.0 -> 2.25.2 ``                                                           |
| [`fadfb841`](https://github.com/NixOS/nixpkgs/commit/fadfb84199c878e96a23512a6184372df38d7109) | `` grpc_cli: 1.56.2 -> 1.57.0 ``                                                           |
| [`cbac1a8c`](https://github.com/NixOS/nixpkgs/commit/cbac1a8ce5e947c53bf072c3933042254136affe) | `` traefik: 2.10.3 -> 2.10.4 ``                                                            |
| [`478d38ed`](https://github.com/NixOS/nixpkgs/commit/478d38edae75e0ff7f5f0f6482b3f1957a4c9e70) | `` nxpmicro-mfgtools: 1.5.11 -> 1.5.21 ``                                                  |
| [`0ebb3b6e`](https://github.com/NixOS/nixpkgs/commit/0ebb3b6ed84715de1ca6f31186d1c2117504d6a5) | `` nixos/netbox: add keycloakClientSecret option ``                                        |
| [`5bef6d0e`](https://github.com/NixOS/nixpkgs/commit/5bef6d0e051c45536dcc760152ea784767bdd80f) | `` gum: add meta.mainProgram ``                                                            |
| [`63ad6387`](https://github.com/NixOS/nixpkgs/commit/63ad63874330a6cb946837a545e207183411891a) | `` wl-screenrec: add meta.mainProgram ``                                                   |
| [`4ce973d7`](https://github.com/NixOS/nixpkgs/commit/4ce973d7bd73cd11ffc1201330fe92219eb93158) | `` eza: add meta.mainProgram ``                                                            |
| [`8415619e`](https://github.com/NixOS/nixpkgs/commit/8415619e42a0972706e213197a310d461234a5c1) | `` webcord: add meta.mainProgram ``                                                        |
| [`c8fac2d0`](https://github.com/NixOS/nixpkgs/commit/c8fac2d09d3b7ce639679c1bb35adbe5ed090097) | `` cargo-tally: 1.0.28 -> 1.0.29 ``                                                        |
| [`a7502f31`](https://github.com/NixOS/nixpkgs/commit/a7502f315b9bea13e42708016c7b3770ec6199d3) | `` diffoci: init at 0.1.1 ``                                                               |
| [`041756f8`](https://github.com/NixOS/nixpkgs/commit/041756f8c218ce72e35ef179caa4a53ceaf01978) | `` Revert "python3Packages.pillow & python3Packages.pillow-simd: Fix cross compilation" `` |
| [`5f139d8c`](https://github.com/NixOS/nixpkgs/commit/5f139d8cd67c3c432102d36dc71e876dd4035a09) | `` toot: Add pleroma to passthru.tests ``                                                  |
| [`3eeaa497`](https://github.com/NixOS/nixpkgs/commit/3eeaa497ed05288b7f41458526f435f7a74400a1) | `` path-of-building.data: 2.33.0 -> 2.33.1 ``                                              |
| [`fd05bbae`](https://github.com/NixOS/nixpkgs/commit/fd05bbaee84078935abb51ba2f1883da18c88efe) | `` fastfetch: 2.0.3 -> 2.0.4 ``                                                            |
| [`2404cc79`](https://github.com/NixOS/nixpkgs/commit/2404cc79999b1f738254d529c7d0d6543300e3db) | `` python311Packages.homeassistant-stubs: 2023.8.3 -> 2023.8.4 ``                          |
| [`e1b695a9`](https://github.com/NixOS/nixpkgs/commit/e1b695a96f5e04abb4a53cfc4ccb9360ebccba9d) | `` iqtree: 2.2.2.6 -> 2.2.2.7 ``                                                           |
| [`97f4754b`](https://github.com/NixOS/nixpkgs/commit/97f4754b11fa4efd50f2bb32d1455e964c8985e8) | `` slint-lsp: 1.1.0 -> 1.1.1 ``                                                            |
| [`2cf66b1a`](https://github.com/NixOS/nixpkgs/commit/2cf66b1ab660da197cb8a98d48f2112a6846b3af) | `` yarr: 2.3 -> 2.4 ``                                                                     |
| [`c5773735`](https://github.com/NixOS/nixpkgs/commit/c5773735aca77ab4a8071434839f6c00d14a34bb) | `` crosvm: 115.2 -> 116.1 ``                                                               |
| [`22716326`](https://github.com/NixOS/nixpkgs/commit/227163264272dda5110f9c4613e23ce62bc04019) | `` ugrep: 4.0.2 -> 4.0.3 ``                                                                |
| [`c787d7bb`](https://github.com/NixOS/nixpkgs/commit/c787d7bb9ab3ebf0b8e143a342e45327fbd6644e) | `` codux: 15.6.1 -> 15.9.0 ``                                                              |
| [`8203aec6`](https://github.com/NixOS/nixpkgs/commit/8203aec636fe63cbf35f451b775812d73461ba47) | `` exploitdb: 2023-08-24 -> 2023-08-25 ``                                                  |
| [`8dcdc002`](https://github.com/NixOS/nixpkgs/commit/8dcdc0029eb01a9fc01be27715dc631d361fb0c8) | `` nushellPlugins.query: 0.83.1 -> 0.84.0 ``                                               |
| [`b5a22a41`](https://github.com/NixOS/nixpkgs/commit/b5a22a41c5045389e35b29757b33b58ddf8c1800) | `` nushellPlugins.gstat: 0.83.1 -> 0.84.0 ``                                               |
| [`b4e06a16`](https://github.com/NixOS/nixpkgs/commit/b4e06a160cea4adfca324094fb153c9acf34af45) | `` nu_scripts: unstable-2023-07-29 -> unstable-2023-08-24 ``                               |
| [`11c58954`](https://github.com/NixOS/nixpkgs/commit/11c5895493dbbd2dbb275ea7db4b0ccc654bf497) | `` nushell: 0.83.1 -> 0.84.0 ``                                                            |
| [`d16f8e41`](https://github.com/NixOS/nixpkgs/commit/d16f8e410cc54a7887cdc5c6567b3354cd419908) | `` qownnotes: 23.8.0 -> 23.8.1 ``                                                          |
| [`5b5b66d0`](https://github.com/NixOS/nixpkgs/commit/5b5b66d04f98fd1ebed7e277999458bdf131c243) | `` micronaut: 4.0.3 -> 4.0.4 ``                                                            |
| [`26e8da26`](https://github.com/NixOS/nixpkgs/commit/26e8da26b4089966dce23f36741dd2be35fbeedc) | `` emacsPackages: update comment about package-directory-list ``                           |
| [`665651c7`](https://github.com/NixOS/nixpkgs/commit/665651c7366ba4a6efe6f549170ffddfc80ef688) | `` emacs: remove outdated doc about package initialization ``                              |
| [`71a87531`](https://github.com/NixOS/nixpkgs/commit/71a875313402e808cf7c32e82854276c5919d67e) | `` emacs: update doc about emacs.pkgs.withPackages ``                                      |
| [`0d3ba90f`](https://github.com/NixOS/nixpkgs/commit/0d3ba90f52a4af5109392269dd1aa5d1c8b5ecf2) | `` nixos/emacs: replace emacs with Emacs in the doc ``                                     |
| [`01de4f27`](https://github.com/NixOS/nixpkgs/commit/01de4f272001adb86e26d741780ae241f7c87ebe) | `` weaviate: 1.20.5 -> 1.21.0 ``                                                           |
| [`91498b49`](https://github.com/NixOS/nixpkgs/commit/91498b491ac6116af516864eec63f20d34807fc7) | `` python311Packages.exchangelib: 5.0.3 -> 5.1.0 ``                                        |
| [`dcf94dee`](https://github.com/NixOS/nixpkgs/commit/dcf94dee78fa79159e33bdb536c60f98a1ba32b6) | `` python311Packages.asyncsleepiq: 1.3.5 -> 1.3.6 ``                                       |
| [`88694cdb`](https://github.com/NixOS/nixpkgs/commit/88694cdb0edbd255d2ad17c7fb1b16089e149ab2) | `` python311Packages.coinmetrics-api-client: 2023.8.10.19 -> 2023.8.24.13 ``               |
| [`a3778201`](https://github.com/NixOS/nixpkgs/commit/a377820115cb84589e1dd2d9b73fc77f3a752690) | `` python311Packages.ical: 5.0.0 -> 5.0.1 ``                                               |
| [`c88e2d83`](https://github.com/NixOS/nixpkgs/commit/c88e2d8315ad25d5f65cce49f4af28421b42bd62) | `` python311Packages.hahomematic: 2023.8.9 -> 2023.8.10 ``                                 |
| [`0fba4aa9`](https://github.com/NixOS/nixpkgs/commit/0fba4aa9c36761c01ab1e6a72b42e9114b6bfdf0) | `` python311Packages.troposphere: migrate to unittestCheckHook ``                          |
| [`de9fdcfa`](https://github.com/NixOS/nixpkgs/commit/de9fdcfaa8862c9962ca98412896cbafaec4c44f) | `` monkeysAudio: 10.17 -> 10.19 ``                                                         |
| [`f47db52f`](https://github.com/NixOS/nixpkgs/commit/f47db52fd26b3d8921bd5b0f4a61c845dce56351) | `` python311Packages.pysnooz: relax events constraint ``                                   |
| [`0ca21291`](https://github.com/NixOS/nixpkgs/commit/0ca2129100e46af79cea42c34cc2bd66988cba0a) | `` weechatScripts.wee-slack: 2.9.1 -> 2.10.0 ``                                            |
| [`de5fe4bd`](https://github.com/NixOS/nixpkgs/commit/de5fe4bdb635d9616a3bdbc2fd924735443a6420) | `` python311Packages.pysnooz: add changelog to meta ``                                     |
| [`629c8da1`](https://github.com/NixOS/nixpkgs/commit/629c8da168da3f13ed01787ad5475b7eaaecfd4d) | `` python311Packages.strawberry-graphql: 0.185.1 -> 0.205.0 ``                             |
| [`183d3269`](https://github.com/NixOS/nixpkgs/commit/183d3269e8575f84c3cc7c6e928c5bc0c17df49c) | `` python311Packages.events: 0.4 -> 0.5 ``                                                 |
| [`2eba8d3e`](https://github.com/NixOS/nixpkgs/commit/2eba8d3e46c6a0dedd982ef9227b0689865ac087) | `` ast-grep: 0.11.0 -> 0.11.1 ``                                                           |
| [`06c2814a`](https://github.com/NixOS/nixpkgs/commit/06c2814ae891ce84956d75ebce73b9eea16552ca) | `` python311Packages.keyrings-cryptfile: 1.3.4 -> 1.3.9 ``                                 |
| [`8bcfd8b5`](https://github.com/NixOS/nixpkgs/commit/8bcfd8b5229407915cb944aa625ef09a6c629278) | `` cargo-public-api: 0.31.3 -> 0.32.0 ``                                                   |
| [`1db5ef68`](https://github.com/NixOS/nixpkgs/commit/1db5ef68695e0b9b85176ea8ce6ca862291c8e6b) | `` xml2: add install check ``                                                              |
| [`e2a2f3cc`](https://github.com/NixOS/nixpkgs/commit/e2a2f3cc9e4a51ac96ba671693139cf29f310dc7) | `` katriawm: 23.04 -> 23.06 ``                                                             |
| [`3d7fcb0a`](https://github.com/NixOS/nixpkgs/commit/3d7fcb0ae2494a8b8e8f2896a7d1aae1bd2d6106) | `` python310Packages.troposphere: 4.3.2 -> 4.4.1 ``                                        |
| [`2a365c82`](https://github.com/NixOS/nixpkgs/commit/2a365c82ed4fb8a73e415fca46bd7fac99df20cf) | `` gopacked: use sri hash ``                                                               |
| [`ae1d5f81`](https://github.com/NixOS/nixpkgs/commit/ae1d5f81fb420858acd9e601c03a91a83b50a176) | `` terraform-providers.talos: 0.3.0 -> 0.3.1 ``                                            |
| [`1a09cc09`](https://github.com/NixOS/nixpkgs/commit/1a09cc09e370ea192f40707c9607d5eeaa53e76c) | `` terraform-providers.signalfx: 8.1.0 -> 9.0.0 ``                                         |
| [`6e815f77`](https://github.com/NixOS/nixpkgs/commit/6e815f779220ec8f7f3794baa7a98a98b2166da3) | `` terraform-providers.pagerduty: 2.16.0 -> 2.16.1 ``                                      |
| [`64321bf4`](https://github.com/NixOS/nixpkgs/commit/64321bf4e6eb0a50f25d67bd62809e95b48f46e8) | `` terraform-providers.opentelekomcloud: 1.35.5 -> 1.35.6 ``                               |
| [`3631287d`](https://github.com/NixOS/nixpkgs/commit/3631287dfcef02dea2321034980e096eadad2a4f) | `` terraform-providers.ovh: 0.32.0 -> 0.33.0 ``                                            |
| [`87107faa`](https://github.com/NixOS/nixpkgs/commit/87107faa9298ef2f6db9e592ee42e9d55418f199) | `` terraform-providers.lxd: 1.10.1 -> 1.10.2 ``                                            |
| [`a7881461`](https://github.com/NixOS/nixpkgs/commit/a7881461c548b6452365ea03de45560a5f785bbe) | `` terraform-providers.helm: 2.10.1 -> 2.11.0 ``                                           |
| [`9f854d93`](https://github.com/NixOS/nixpkgs/commit/9f854d93664cea9eb4ca15e22e5f65a8b58db91d) | `` terraform-providers.aws: 5.13.1 -> 5.14.0 ``                                            |
| [`57030d9a`](https://github.com/NixOS/nixpkgs/commit/57030d9a45addc2939bce37aea81d89b6e821dc6) | `` terraform-providers.github: 5.33.0 -> 5.34.0 ``                                         |
| [`37280005`](https://github.com/NixOS/nixpkgs/commit/372800052a554a4e7609bd9558213c3881a2945b) | `` terraform-providers.buildkite: 0.25.1 -> 0.26.0 ``                                      |
| [`830d79a7`](https://github.com/NixOS/nixpkgs/commit/830d79a7c615447c6eab78d41887b0b8c5159148) | `` terraform-providers.azurerm: 3.70.0 -> 3.71.0 ``                                        |
| [`cd050a88`](https://github.com/NixOS/nixpkgs/commit/cd050a883c40ff70e3880e5b4b0667854e862343) | `` python310Packages.pyomo: 6.6.1 -> 6.6.2 ``                                              |
| [`afec397b`](https://github.com/NixOS/nixpkgs/commit/afec397bef443421ec993f3ca7e93b02935febef) | `` discord-ptb: 0.0.44 -> 0.0.45 ``                                                        |
| [`85217382`](https://github.com/NixOS/nixpkgs/commit/85217382d640022f7d2374b0da78d5f2b8b4521b) | `` pass: stop installing password-store.el ``                                              |
| [`dff06000`](https://github.com/NixOS/nixpkgs/commit/dff06000622c1f9d96f7dfb40757317b72fb9e03) | `` python310Packages.oci: 2.110.1 -> 2.110.2 ``                                            |
| [`19154f8b`](https://github.com/NixOS/nixpkgs/commit/19154f8b9effbad10db55b44cb773073352a7251) | `` azure-storage-azcopy: 10.20.0 -> 10.20.1 ``                                             |
| [`008ce73e`](https://github.com/NixOS/nixpkgs/commit/008ce73e1d7430d2113313f820a4f0993520b58e) | `` swtpm: 0.8.0 -> 0.8.1 ``                                                                |
| [`a1649f36`](https://github.com/NixOS/nixpkgs/commit/a1649f366d882f1522d079b05fdd134ad38e5bfe) | `` path-of-building.data: 2.32.2 -> 2.33.0 ``                                              |
| [`45adc10a`](https://github.com/NixOS/nixpkgs/commit/45adc10ae080be54f5e84b64069fda12dae6ed8d) | `` xfce.xfce4-appfinder: 4.18.0 -> 4.18.1 ``                                               |
| [`102c3c66`](https://github.com/NixOS/nixpkgs/commit/102c3c667eedec37773646750dd34bf9dffd0c0f) | `` pantheon.elementary-files: 6.4.1 -> 6.5.0 ``                                            |
| [`49f27ea2`](https://github.com/NixOS/nixpkgs/commit/49f27ea2ca246ac91dbb83139fa6b4e24cb37469) | `` jql: set meta.mainProgram ``                                                            |
| [`c67418a2`](https://github.com/NixOS/nixpkgs/commit/c67418a2c1039c75f58f1079dc298d6dc8fd262f) | `` jql: 7.0.2 -> 7.0.3 ``                                                                  |
| [`5a43ed11`](https://github.com/NixOS/nixpkgs/commit/5a43ed114f59dcbe2067321b68e1f38526b78602) | `` vial: cosmetic modifications ``                                                         |
| [`c18a848a`](https://github.com/NixOS/nixpkgs/commit/c18a848adb63b6135abd3c8c67b77b7a9d301123) | `` vial: 0.6 -> 0.7 ``                                                                     |
| [`878ebcb3`](https://github.com/NixOS/nixpkgs/commit/878ebcb3a809f1f0fc42eca71246efe5d2dbd2e1) | `` tg_owt: unstable-2023-05-01 → unstable-2023-08-15 ``                                    |