### PR TITLE
chore(flake/nur): `4c58adf6` -> `442e080a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693057602,
-        "narHash": "sha256-EGNBYNeEO9pcF8e8QSt+SyJf4goBpC1E7D69hFJ3r70=",
+        "lastModified": 1693064739,
+        "narHash": "sha256-dlN3+INmfQ8uU4MT0vaBWwYrp0uwzaPJwplv3JVWbSQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4c58adf6f6d01ee9392343f578f8c701aa0373b5",
+        "rev": "442e080ad15c06941ea592692aa3f3f6fc225975",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`442e080a`](https://github.com/nix-community/NUR/commit/442e080ad15c06941ea592692aa3f3f6fc225975) | `` automatic update `` |