### PR TITLE
chore(flake/dendrite-demo-pinecone): `47a8af23` -> `b484945b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -206,11 +206,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1693035275,
-        "narHash": "sha256-RmY9DRilKzBGiRA15k6jGmTzcc7P2d1L4soKQe4wsf4=",
+        "lastModified": 1693065903,
+        "narHash": "sha256-ipZ1Gc7yEeVeO7INo52U6EWgsd+egqw/9NGaVmNLpes=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "47a8af23ffdf4e33a96606e5ffc6c9c79abd551e",
+        "rev": "b484945b9bc532b1bbe4ee016140051a53909022",
         "type": "github"
       },
       "original": {
@@ -780,11 +780,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1692934111,
-        "narHash": "sha256-9EEE59v/esKNMR5zKbLRV9NoRPYvERw5jHQOnfr47bk=",
+        "lastModified": 1693028636,
+        "narHash": "sha256-WOG42JO/yyvgYK3jQktDEy2qtZI7R+s3Lo4Y9gBr6XM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1e44a037bbf4fcaba041436e65e87be88f3f495b",
+        "rev": "e61ea96d43505ba0d2c066134eb9d67cadfddce7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                  |
| --------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`b484945b`](https://github.com/bbigras/dendrite-demo-pinecone/commit/b484945b9bc532b1bbe4ee016140051a53909022) | `` flake.lock: Update `` |