### PR TITLE
chore(flake/emacs-overlay): `300460e8` -> `86d5bb75`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693045018,
-        "narHash": "sha256-l1TuQfxR3jBwQGToxdVqu5sBxp+eoypQqWXywbBGP+4=",
+        "lastModified": 1693075642,
+        "narHash": "sha256-6Lqd+CVQfCnfyikufsCDCpPLWkgIiv7JRoAPStlWueo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "300460e827e39285f98a1c105bdc6601ded8ccf8",
+        "rev": "86d5bb75f9e60b85c4b627948f4f5a5236905f28",
         "type": "github"
       },
       "original": {
@@ -732,11 +732,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1692896067,
-        "narHash": "sha256-jZ5j5RVhDltTidVnxvCEztTVLBMxx/WRUoz8orMPUWw=",
+        "lastModified": 1692986144,
+        "narHash": "sha256-M4VFpy7Av9j+33HF5nIGm0k2+DXXW4qSSKdidIKg5jY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7419e94880e41304e67184718eb4270461cf15c7",
+        "rev": "74e5bdc5478ebbe7ba5849f0d765f92757bb9dbf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`86d5bb75`](https://github.com/nix-community/emacs-overlay/commit/86d5bb75f9e60b85c4b627948f4f5a5236905f28) | `` Updated repos/nongnu `` |
| [`40b61b86`](https://github.com/nix-community/emacs-overlay/commit/40b61b865a1fcd7d470456e594fe08ded7dbbe55) | `` Updated repos/melpa ``  |
| [`707b73f1`](https://github.com/nix-community/emacs-overlay/commit/707b73f19bef0e17e607778cd3749e9d4a5e7007) | `` Updated repos/emacs ``  |
| [`345e2621`](https://github.com/nix-community/emacs-overlay/commit/345e2621e1cea385d545bc0697a0341ce26deab1) | `` Updated repos/elpa ``   |
| [`89eaefa7`](https://github.com/nix-community/emacs-overlay/commit/89eaefa707ffefe658797348bb0cff90ad655d84) | `` Updated flake inputs `` |