### PR TITLE
chore(flake/nur): `14abb19f` -> `9462f49b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693070594,
-        "narHash": "sha256-jDeOjYc54UrMazr4ooLXdOpQJGJ+IP7A/epV9Wg9KcU=",
+        "lastModified": 1693079179,
+        "narHash": "sha256-93UBO7bljJmQlC3SUVllnF8+3XwsC4oH60F7e2aWEb0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "14abb19f7444b2fc5c2549e2307c310d1331f7cd",
+        "rev": "9462f49b22771a5df041bf8e3445f65f161c6779",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9462f49b`](https://github.com/nix-community/NUR/commit/9462f49b22771a5df041bf8e3445f65f161c6779) | `` automatic update `` |