### PR TITLE
chore(flake/nur): `9462f49b` -> `0f81f016`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693079179,
-        "narHash": "sha256-93UBO7bljJmQlC3SUVllnF8+3XwsC4oH60F7e2aWEb0=",
+        "lastModified": 1693082793,
+        "narHash": "sha256-di/x+vrMYmjSHabbiuPi6EZ0m6HoPXOVtA7ugU3rVZM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9462f49b22771a5df041bf8e3445f65f161c6779",
+        "rev": "0f81f016eecec153a26099beb25b0c8bac87bd23",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0f81f016`](https://github.com/nix-community/NUR/commit/0f81f016eecec153a26099beb25b0c8bac87bd23) | `` automatic update `` |