### PR TITLE
chore(flake/nur): `0f81f016` -> `486ded78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693082793,
-        "narHash": "sha256-di/x+vrMYmjSHabbiuPi6EZ0m6HoPXOVtA7ugU3rVZM=",
+        "lastModified": 1693118524,
+        "narHash": "sha256-tVTrvqyLBJ3pOFPoY3FqjEOLOt+s7hsaDqkgzmY8twc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0f81f016eecec153a26099beb25b0c8bac87bd23",
+        "rev": "486ded782d41aa7a84631a3faba95ffadfded8ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`486ded78`](https://github.com/nix-community/NUR/commit/486ded782d41aa7a84631a3faba95ffadfded8ae) | `` automatic update `` |
| [`9eb1587d`](https://github.com/nix-community/NUR/commit/9eb1587db52b0c30e986ab6c0faf74de77041714) | `` automatic update `` |
| [`beb0da3b`](https://github.com/nix-community/NUR/commit/beb0da3b5eaebb07f1fc9d1f62e10f802123e3ce) | `` automatic update `` |