### PR TITLE
chore(flake/emacs-overlay): `86d5bb75` -> `123ac69d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693075642,
-        "narHash": "sha256-6Lqd+CVQfCnfyikufsCDCpPLWkgIiv7JRoAPStlWueo=",
+        "lastModified": 1693105704,
+        "narHash": "sha256-j1SSgP2K1iv9G7dc3yX2ulsB4mV3K231L8xNmuDS8WM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "86d5bb75f9e60b85c4b627948f4f5a5236905f28",
+        "rev": "123ac69d1d430562dd1a266a2f50296eaac7d65d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`123ac69d`](https://github.com/nix-community/emacs-overlay/commit/123ac69d1d430562dd1a266a2f50296eaac7d65d) | `` Updated repos/melpa `` |
| [`f075bfef`](https://github.com/nix-community/emacs-overlay/commit/f075bfefa5c09bce7f519e2608c38cd67c484a9d) | `` Updated repos/emacs `` |
| [`43015739`](https://github.com/nix-community/emacs-overlay/commit/430157395e34c8d7df9fd576e49345aca4aec635) | `` Updated repos/elpa ``  |