### PR TITLE
chore(flake/nur): `486ded78` -> `8b94b37c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693118524,
-        "narHash": "sha256-tVTrvqyLBJ3pOFPoY3FqjEOLOt+s7hsaDqkgzmY8twc=",
+        "lastModified": 1693121506,
+        "narHash": "sha256-uACr/q8kCzgfLQ4w7TMB2XAPqid7Q4MryLXJrg9/W00=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "486ded782d41aa7a84631a3faba95ffadfded8ae",
+        "rev": "8b94b37cf004acc1a7b7970b1e60f9b24f70b519",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8b94b37c`](https://github.com/nix-community/NUR/commit/8b94b37cf004acc1a7b7970b1e60f9b24f70b519) | `` automatic update `` |