### PR TITLE
chore(flake/nur): `8b94b37c` -> `995dd743`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693121506,
-        "narHash": "sha256-uACr/q8kCzgfLQ4w7TMB2XAPqid7Q4MryLXJrg9/W00=",
+        "lastModified": 1693128245,
+        "narHash": "sha256-bQ40UOOuKrDBucfDiEW30MYc8LODFGZzk8tnXgofr3c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8b94b37cf004acc1a7b7970b1e60f9b24f70b519",
+        "rev": "995dd743eaa0862b24ae805778319ceacdc9a70b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`995dd743`](https://github.com/nix-community/NUR/commit/995dd743eaa0862b24ae805778319ceacdc9a70b) | `` automatic update `` |
| [`3b89307c`](https://github.com/nix-community/NUR/commit/3b89307ca62b66d549b238230861b79611acd2a3) | `` automatic update `` |