### PR TITLE
chore(flake/nur): `17d36c83` -> `33b4841f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693133146,
-        "narHash": "sha256-bZ9zC0GS3PQ91batGx0F6qPkFXHCuBPFhltD2SZejsM=",
+        "lastModified": 1693136796,
+        "narHash": "sha256-JXSewQ7qKBN4D8MMpnAarASnSAravfbETEwxDDi8on8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "17d36c83e208873232bfd5f5d78b37d90ff1958a",
+        "rev": "33b4841fe111b93d6a67e0585f6d60b4621e0ae7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`33b4841f`](https://github.com/nix-community/NUR/commit/33b4841fe111b93d6a67e0585f6d60b4621e0ae7) | `` automatic update `` |