### PR TITLE
chore(flake/nur): `33b4841f` -> `eb8125b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693136796,
-        "narHash": "sha256-JXSewQ7qKBN4D8MMpnAarASnSAravfbETEwxDDi8on8=",
+        "lastModified": 1693140791,
+        "narHash": "sha256-m6wtYw53Xey7STzhxh1J8mN5lnJqLZr3xad9RB8n3Kk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "33b4841fe111b93d6a67e0585f6d60b4621e0ae7",
+        "rev": "eb8125b81a94fb211af0e508d1de6c5ac285a8c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eb8125b8`](https://github.com/nix-community/NUR/commit/eb8125b81a94fb211af0e508d1de6c5ac285a8c7) | `` automatic update `` |