### PR TITLE
chore(flake/nur): `e8917652` -> `22099c91`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693145932,
-        "narHash": "sha256-dJTmp7Ixb8EDqUfZ2+AT07G0IHUSflfVmYP/MAaN1rc=",
+        "lastModified": 1693155170,
+        "narHash": "sha256-ah5+0d3RSDDuYvI4lUU6AsTc/oUlTxXWpl9xA7Ujh74=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e8917652bdfaf514b762afe4c815f4c938699675",
+        "rev": "22099c917d6204437be4d7abe088b8e0a4ffa57d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`22099c91`](https://github.com/nix-community/NUR/commit/22099c917d6204437be4d7abe088b8e0a4ffa57d) | `` automatic update `` |