### PR TITLE
chore(flake/nur): `22099c91` -> `6ac8f964`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693155170,
-        "narHash": "sha256-ah5+0d3RSDDuYvI4lUU6AsTc/oUlTxXWpl9xA7Ujh74=",
+        "lastModified": 1693158398,
+        "narHash": "sha256-LwvEtGfUWZKhFdaoz359xoHOY2G7lokS4Pc2mDHmvfs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "22099c917d6204437be4d7abe088b8e0a4ffa57d",
+        "rev": "6ac8f964958f9596b69a9ac876de054e8afe50aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6ac8f964`](https://github.com/nix-community/NUR/commit/6ac8f964958f9596b69a9ac876de054e8afe50aa) | `` automatic update `` |