### PR TITLE
chore(flake/home-manager): `f8c5fd75` -> `90e62f96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -525,11 +525,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693125758,
-        "narHash": "sha256-7u591OQ1nzQ/IRMDBix8Ox1q+u3OyPQHs2HDZnR89qk=",
+        "lastModified": 1693162067,
+        "narHash": "sha256-4o6rj/cFGvAV2o3V3nABPSQg73d7mvpq7wQd4jDr+MQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f8c5fd75092448ac134d7fb823556b37d3c821f5",
+        "rev": "90e62f96c775162580091085831f89b49dba2ee3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`90e62f96`](https://github.com/nix-community/home-manager/commit/90e62f96c775162580091085831f89b49dba2ee3) | `` programs.yazi: add module (#4373) `` |