### PR TITLE
chore(flake/emacs-overlay): `7bc0bbb1` -> `86dd13ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693131922,
-        "narHash": "sha256-aAiybFVpKv1CKgv3tO+Y2Utvk5n7EICqIxq3pW4jjr0=",
+        "lastModified": 1693162271,
+        "narHash": "sha256-J4+BhrhNIFDeJMw0MQqB5PbARMDxcUADvh/5dId5Kaw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7bc0bbb1d4ff82629707a79bc4070372889c4b1b",
+        "rev": "86dd13ecf891934a28707d982aa490e701e72fc2",
         "type": "github"
       },
       "original": {
@@ -732,11 +732,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1692986144,
-        "narHash": "sha256-M4VFpy7Av9j+33HF5nIGm0k2+DXXW4qSSKdidIKg5jY=",
+        "lastModified": 1693087214,
+        "narHash": "sha256-Kn1SSqRfPpqcI1MDy82JXrPT1WI8c03TA2F0xu6kS+4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "74e5bdc5478ebbe7ba5849f0d765f92757bb9dbf",
+        "rev": "f155f0cf4ea43c4e3c8918d2d327d44777b6cad4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`86dd13ec`](https://github.com/nix-community/emacs-overlay/commit/86dd13ecf891934a28707d982aa490e701e72fc2) | `` Updated repos/melpa ``  |
| [`5fc3461e`](https://github.com/nix-community/emacs-overlay/commit/5fc3461e99f1e98eb94cc557ecdca3521cee2010) | `` Updated repos/emacs ``  |
| [`f47d41f2`](https://github.com/nix-community/emacs-overlay/commit/f47d41f2a4690a29c2d21fba89f07d0251daa3da) | `` Updated repos/elpa ``   |
| [`411bc3de`](https://github.com/nix-community/emacs-overlay/commit/411bc3de01ab32cdd6a7e1ff9fdebc8ea9741cfb) | `` Updated flake inputs `` |