### PR TITLE
chore(flake/nur): `6ac8f964` -> `fc760cc6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693158398,
-        "narHash": "sha256-LwvEtGfUWZKhFdaoz359xoHOY2G7lokS4Pc2mDHmvfs=",
+        "lastModified": 1693168249,
+        "narHash": "sha256-iXkE1JlIi2KLzVGLwshS9j1hnu9mppzwT76WJgaYGqA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6ac8f964958f9596b69a9ac876de054e8afe50aa",
+        "rev": "fc760cc63eae03bfd16f47843151f7920becb71f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fc760cc6`](https://github.com/nix-community/NUR/commit/fc760cc63eae03bfd16f47843151f7920becb71f) | `` automatic update `` |
| [`3051fa58`](https://github.com/nix-community/NUR/commit/3051fa58a7465cbd89c19e214bb0a1ef59439a50) | `` automatic update `` |
| [`2e28c787`](https://github.com/nix-community/NUR/commit/2e28c7879e0ace2e7e7a4f6796a2ba7cfa7bf010) | `` automatic update `` |
| [`21ed65f8`](https://github.com/nix-community/NUR/commit/21ed65f844f4605841a6ce759e14864e9c634498) | `` automatic update `` |
| [`5b6c7a58`](https://github.com/nix-community/NUR/commit/5b6c7a58af0d12c256c8499cfb2df6eab8efc61d) | `` automatic update `` |