### PR TITLE
chore(flake/nur): `fc760cc6` -> `854b3790`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693168249,
-        "narHash": "sha256-iXkE1JlIi2KLzVGLwshS9j1hnu9mppzwT76WJgaYGqA=",
+        "lastModified": 1693176358,
+        "narHash": "sha256-Su8FA5siaU8lotg8j9cbRqfFgSh01Ao+TFwNOM737IY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc760cc63eae03bfd16f47843151f7920becb71f",
+        "rev": "854b37902d9432ed96ad0ad432bb006ddc7d65cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`854b3790`](https://github.com/nix-community/NUR/commit/854b37902d9432ed96ad0ad432bb006ddc7d65cc) | `` automatic update `` |
| [`98db672b`](https://github.com/nix-community/NUR/commit/98db672b50d34c08c9ca310714846e45beb0bac3) | `` automatic update `` |
| [`5cce7e33`](https://github.com/nix-community/NUR/commit/5cce7e33406d5722f957af631ef4f37a493b88e0) | `` automatic update `` |
| [`9d1281c1`](https://github.com/nix-community/NUR/commit/9d1281c16628658a8864510a7aa63168db99477b) | `` automatic update `` |
| [`bdb8f2ea`](https://github.com/nix-community/NUR/commit/bdb8f2ea0449f4948c0aac90d68ac391f03ed1a1) | `` automatic update `` |
| [`2716d3bd`](https://github.com/nix-community/NUR/commit/2716d3bd6fb64d4fdbd944e0024ac6d39aa160ee) | `` automatic update `` |
| [`2c6e0e27`](https://github.com/nix-community/NUR/commit/2c6e0e272d3d17ac5f501f12c753365b71223f43) | `` automatic update `` |
| [`d4285a64`](https://github.com/nix-community/NUR/commit/d4285a64b50e13188f58895a98e3304aeb567236) | `` automatic update `` |