### PR TITLE
chore(flake/home-manager): `90e62f96` -> `43ec65ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -525,11 +525,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693162067,
-        "narHash": "sha256-4o6rj/cFGvAV2o3V3nABPSQg73d7mvpq7wQd4jDr+MQ=",
+        "lastModified": 1693170594,
+        "narHash": "sha256-7B8iugyTt26vVsYnXkLIack32r5uh//iZiSw+I1xiJU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "90e62f96c775162580091085831f89b49dba2ee3",
+        "rev": "43ec65ad553dab80a8f619e6e3e888002772ce58",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`43ec65ad`](https://github.com/nix-community/home-manager/commit/43ec65ad553dab80a8f619e6e3e888002772ce58) | `` Translate using Weblate (Danish) ``     |
| [`455cc8cf`](https://github.com/nix-community/home-manager/commit/455cc8cf1c768a1d85c30ea102c574cc77663101) | `` offlineimap: cleanup unused bindings `` |
| [`0962772e`](https://github.com/nix-community/home-manager/commit/0962772e0bc4631394b694df27331e9a3a5a5028) | `` antidote: cleanup unused bindings ``    |
| [`35cbed7a`](https://github.com/nix-community/home-manager/commit/35cbed7ac74035279cecb7c037fe96f7afb3e746) | `` aerc: cleanup unused bindings ``        |