### PR TITLE
chore(flake/nur): `854b3790` -> `7ed08091`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693176358,
-        "narHash": "sha256-Su8FA5siaU8lotg8j9cbRqfFgSh01Ao+TFwNOM737IY=",
+        "lastModified": 1693186217,
+        "narHash": "sha256-5g0CnX04/VKzBxWwQzok4iFSoqAVUanCq0a5OGQ2a5o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "854b37902d9432ed96ad0ad432bb006ddc7d65cc",
+        "rev": "7ed080915addbd80d0ed5c1fd0f026d19323b1e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7ed08091`](https://github.com/nix-community/NUR/commit/7ed080915addbd80d0ed5c1fd0f026d19323b1e8) | `` automatic update `` |
| [`74d541c4`](https://github.com/nix-community/NUR/commit/74d541c48e1ddd069dc0e83b8f8bbfa6d153bb5e) | `` automatic update `` |