### PR TITLE
chore(flake/nur): `7ed08091` -> `99e85056`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693186217,
-        "narHash": "sha256-5g0CnX04/VKzBxWwQzok4iFSoqAVUanCq0a5OGQ2a5o=",
+        "lastModified": 1693194972,
+        "narHash": "sha256-7xEczeMBAP5n7jFLu4F5orvUNIG7+lwLo5bmZNsPMXM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7ed080915addbd80d0ed5c1fd0f026d19323b1e8",
+        "rev": "99e850565cf29ce0a6a6798b0c479eb5b68a7600",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`99e85056`](https://github.com/nix-community/NUR/commit/99e850565cf29ce0a6a6798b0c479eb5b68a7600) | `` automatic update `` |
| [`a8e269c9`](https://github.com/nix-community/NUR/commit/a8e269c90c15e47466a160ecca192ceded9735ce) | `` automatic update `` |
| [`2a1e9c48`](https://github.com/nix-community/NUR/commit/2a1e9c48c362452dd086bb2e37cc9df21aab71d4) | `` automatic update `` |