### PR TITLE
chore(flake/emacs-overlay): `86dd13ec` -> `78ec4983`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693162271,
-        "narHash": "sha256-J4+BhrhNIFDeJMw0MQqB5PbARMDxcUADvh/5dId5Kaw=",
+        "lastModified": 1693193430,
+        "narHash": "sha256-6qsW+c7CTlrOkY3PuZksNgNVrRSqUhlA/Uzq7Kb/3IY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "86dd13ecf891934a28707d982aa490e701e72fc2",
+        "rev": "78ec4983ba820b37fc2e7c998ead39be6bec7f6d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`78ec4983`](https://github.com/nix-community/emacs-overlay/commit/78ec4983ba820b37fc2e7c998ead39be6bec7f6d) | `` Updated repos/nongnu `` |
| [`69e073c0`](https://github.com/nix-community/emacs-overlay/commit/69e073c0f5065828632ca0b7446acc242e1123e3) | `` Updated repos/melpa ``  |
| [`82e36542`](https://github.com/nix-community/emacs-overlay/commit/82e36542ec58b2f274cd3565165764ad8251a298) | `` Updated repos/emacs ``  |
| [`83584628`](https://github.com/nix-community/emacs-overlay/commit/835846287dc6243245f2adfa0d1c6874bc920761) | `` Updated repos/elpa ``   |
| [`e281a007`](https://github.com/nix-community/emacs-overlay/commit/e281a007be5be8d34ecdf8d04854885d1efe98d1) | `` Updated flake inputs `` |