### PR TITLE
chore(flake/nur): `99e85056` -> `9dc24443`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693194972,
-        "narHash": "sha256-7xEczeMBAP5n7jFLu4F5orvUNIG7+lwLo5bmZNsPMXM=",
+        "lastModified": 1693204461,
+        "narHash": "sha256-71fHHNQX6GXD1SNweClhOW2spFiaPUHZ53DVNCjxZJU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "99e850565cf29ce0a6a6798b0c479eb5b68a7600",
+        "rev": "9dc24443927b8482e9456001c7774a2de8749117",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9dc24443`](https://github.com/nix-community/NUR/commit/9dc24443927b8482e9456001c7774a2de8749117) | `` automatic update `` |