### PR TITLE
chore(flake/nur): `9dc24443` -> `d2ea2e9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693204461,
-        "narHash": "sha256-71fHHNQX6GXD1SNweClhOW2spFiaPUHZ53DVNCjxZJU=",
+        "lastModified": 1693208722,
+        "narHash": "sha256-cS/L8x70iA7qkrcSG37ew3czBeY6Fh4ocXVUgL7siUo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9dc24443927b8482e9456001c7774a2de8749117",
+        "rev": "d2ea2e9a11115dc8315a686b06d294e7e5b1ef29",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d2ea2e9a`](https://github.com/nix-community/NUR/commit/d2ea2e9a11115dc8315a686b06d294e7e5b1ef29) | `` automatic update `` |