### PR TITLE
chore(flake/nur): `d2ea2e9a` -> `83841b39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693208722,
-        "narHash": "sha256-cS/L8x70iA7qkrcSG37ew3czBeY6Fh4ocXVUgL7siUo=",
+        "lastModified": 1693216997,
+        "narHash": "sha256-0HAACkUYEBq75/Dfgwm4sx9wid/vSpz2Upch1ulwTMs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d2ea2e9a11115dc8315a686b06d294e7e5b1ef29",
+        "rev": "83841b398b0728c8c7cf3b83ddc56a929eae101f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`83841b39`](https://github.com/nix-community/NUR/commit/83841b398b0728c8c7cf3b83ddc56a929eae101f) | `` automatic update `` |
| [`581c1d60`](https://github.com/nix-community/NUR/commit/581c1d60229bfc493182034e04630aab75e99bcb) | `` automatic update `` |
| [`163073f9`](https://github.com/nix-community/NUR/commit/163073f997576ee8aef404671bee548f57c3b6a2) | `` automatic update `` |