### PR TITLE
chore(flake/emacs-overlay): `78ec4983` -> `7c239d6e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693193430,
-        "narHash": "sha256-6qsW+c7CTlrOkY3PuZksNgNVrRSqUhlA/Uzq7Kb/3IY=",
+        "lastModified": 1693220267,
+        "narHash": "sha256-/F1GUutDzX2o+JhK9JpL4IfytXJ8Gw9ABhYvh2Rnnz8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "78ec4983ba820b37fc2e7c998ead39be6bec7f6d",
+        "rev": "7c239d6ec798caba895588ee98e42d6a3df318e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`7c239d6e`](https://github.com/nix-community/emacs-overlay/commit/7c239d6ec798caba895588ee98e42d6a3df318e0) | `` Updated repos/melpa `` |
| [`bf25f35e`](https://github.com/nix-community/emacs-overlay/commit/bf25f35e7266b21ba6db1865080a05463ad87ffd) | `` Updated repos/emacs `` |