### PR TITLE
chore(flake/nur): `83841b39` -> `87ad7ed7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693216997,
-        "narHash": "sha256-0HAACkUYEBq75/Dfgwm4sx9wid/vSpz2Upch1ulwTMs=",
+        "lastModified": 1693226061,
+        "narHash": "sha256-ALFSdfG/B8oCZkjOTts/ENC62+GSgcB3RcOf3bSq2ms=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "83841b398b0728c8c7cf3b83ddc56a929eae101f",
+        "rev": "87ad7ed7682963b4bb1d9a518499d7471f9326c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`87ad7ed7`](https://github.com/nix-community/NUR/commit/87ad7ed7682963b4bb1d9a518499d7471f9326c2) | `` automatic update `` |
| [`2b7bf47f`](https://github.com/nix-community/NUR/commit/2b7bf47f6acc86fe425422c14ea3eee4196a2313) | `` automatic update `` |