### PR TITLE
chore(flake/nur): `87ad7ed7` -> `09a9a9e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693226061,
-        "narHash": "sha256-ALFSdfG/B8oCZkjOTts/ENC62+GSgcB3RcOf3bSq2ms=",
+        "lastModified": 1693230384,
+        "narHash": "sha256-rDbfW3VYmGdXYa1FNwC0BiyOtUZ3FmxM2RrgtbgU1CU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "87ad7ed7682963b4bb1d9a518499d7471f9326c2",
+        "rev": "09a9a9e83d751c38d6c57ff97786af37978f7a3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`09a9a9e8`](https://github.com/nix-community/NUR/commit/09a9a9e83d751c38d6c57ff97786af37978f7a3b) | `` automatic update `` |