### PR TITLE
chore(flake/emacs-overlay): `7c239d6e` -> `8f28153c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693220267,
-        "narHash": "sha256-/F1GUutDzX2o+JhK9JpL4IfytXJ8Gw9ABhYvh2Rnnz8=",
+        "lastModified": 1693248998,
+        "narHash": "sha256-Ss1XVDlmSFxjgD5isLEjEK+UcLXjPscfKVSsgVBFPS0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7c239d6ec798caba895588ee98e42d6a3df318e0",
+        "rev": "8f28153cad22536fa6d5929bc87e9fafb3c11c68",
         "type": "github"
       },
       "original": {
@@ -732,11 +732,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1693087214,
-        "narHash": "sha256-Kn1SSqRfPpqcI1MDy82JXrPT1WI8c03TA2F0xu6kS+4=",
+        "lastModified": 1693183237,
+        "narHash": "sha256-c7OtyBkZ/vZE/WosBpRGRtkbWZjDHGJP7fg1FyB9Dsc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f155f0cf4ea43c4e3c8918d2d327d44777b6cad4",
+        "rev": "ea5234e7073d5f44728c499192544a84244bf35a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`8f28153c`](https://github.com/nix-community/emacs-overlay/commit/8f28153cad22536fa6d5929bc87e9fafb3c11c68) | `` Updated repos/melpa ``  |
| [`d92436b3`](https://github.com/nix-community/emacs-overlay/commit/d92436b3acb5e4c78497c47e388cf2644269ea13) | `` Updated repos/emacs ``  |
| [`f9dd2465`](https://github.com/nix-community/emacs-overlay/commit/f9dd2465af09d592cb5669dad1cd2e613c0485ea) | `` Updated repos/elpa ``   |
| [`ae330a78`](https://github.com/nix-community/emacs-overlay/commit/ae330a787488e1cef773c8fdc8f7b5eda3c4683b) | `` Updated flake inputs `` |