### PR TITLE
chore(flake/nur): `931c534a` -> `7cbb1be4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693241161,
-        "narHash": "sha256-MRJHIKBn2vhX6eslfyKj+H9nb2gj56k80OO8vE0Poy8=",
+        "lastModified": 1693259171,
+        "narHash": "sha256-mxANnn/Zk5CuUg20TMEqAnl6ttXs1FV1CAMw/JThA4g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "931c534a5d7ee0cf576c1e114cfef7d4f53212c8",
+        "rev": "7cbb1be43ec3251f14879837d870043fb7bb717c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7cbb1be4`](https://github.com/nix-community/NUR/commit/7cbb1be43ec3251f14879837d870043fb7bb717c) | `` automatic update `` |