### PR TITLE
chore(flake/nur): `7cbb1be4` -> `b61718b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693259171,
-        "narHash": "sha256-mxANnn/Zk5CuUg20TMEqAnl6ttXs1FV1CAMw/JThA4g=",
+        "lastModified": 1693262774,
+        "narHash": "sha256-bqYzG5QW5SpRukAfkYXukpJtgLuF8ihpxMPCQ3vHn38=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7cbb1be43ec3251f14879837d870043fb7bb717c",
+        "rev": "b61718b151880dff3145b9960fd2a5dec403e7a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b61718b1`](https://github.com/nix-community/NUR/commit/b61718b151880dff3145b9960fd2a5dec403e7a7) | `` automatic update `` |
| [`df054192`](https://github.com/nix-community/NUR/commit/df054192d16ad831d239d27b0f06c0b0ac4f7bba) | `` automatic update `` |
| [`81ad8a74`](https://github.com/nix-community/NUR/commit/81ad8a74cfe92b00412a6de4f999a9b1a55d159b) | `` automatic update `` |
| [`99757f6a`](https://github.com/nix-community/NUR/commit/99757f6adc33fe4cae0586ebeec086d9fb3606cc) | `` automatic update `` |