### PR TITLE
chore(flake/sops-nix): `0618c8f0` -> `c89ee064`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1035,11 +1035,11 @@
         "nixpkgs-stable": "nixpkgs-stable_5"
       },
       "locked": {
-        "lastModified": 1693105804,
-        "narHash": "sha256-nlqNjW7dfucUJQqRGuG08MKPOSME8fLOCx/bd9hiEPs=",
+        "lastModified": 1693263624,
+        "narHash": "sha256-GzmVIUKStC1HCzUb0YdGDPAewv4+KxCHKQZEZZDpApY=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "0618c8f0ed5255ad74ee08d1618841ff5af85c86",
+        "rev": "c89ee06488706b587a22085b1844bf9ca6ba5687",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                    |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`c89ee064`](https://github.com/Mic92/sops-nix/commit/c89ee06488706b587a22085b1844bf9ca6ba5687) | `` build(deps): bump DeterminateSystems/update-flake-lock from 19 to 20 `` |