### PR TITLE
chore(flake/nur): `b61718b1` -> `3c59cf3b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693262774,
-        "narHash": "sha256-bqYzG5QW5SpRukAfkYXukpJtgLuF8ihpxMPCQ3vHn38=",
+        "lastModified": 1693266198,
+        "narHash": "sha256-14NpmbESTwdgf4Us6R/WHiXabXqgHGqpalpQXo5ace4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b61718b151880dff3145b9960fd2a5dec403e7a7",
+        "rev": "3c59cf3bf37e2f620e6b16825f31082bfabc2028",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3c59cf3b`](https://github.com/nix-community/NUR/commit/3c59cf3bf37e2f620e6b16825f31082bfabc2028) | `` automatic update `` |
| [`bddc51e5`](https://github.com/nix-community/NUR/commit/bddc51e56088e40565182b461ed6acafad5c378d) | `` automatic update `` |
| [`dd7f1566`](https://github.com/nix-community/NUR/commit/dd7f156647055bfe00b42f9e644be426735bdd12) | `` automatic update `` |