### PR TITLE
chore(flake/nur): `3c59cf3b` -> `2991da74`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693266198,
-        "narHash": "sha256-14NpmbESTwdgf4Us6R/WHiXabXqgHGqpalpQXo5ace4=",
+        "lastModified": 1693273114,
+        "narHash": "sha256-QHXEPXKdbTEZZwJBM5QpYxJk/KpKpmlekqdpyVyhI78=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3c59cf3bf37e2f620e6b16825f31082bfabc2028",
+        "rev": "2991da74fd8d0d16c4accd8b1c8880ef6a0adb9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2991da74`](https://github.com/nix-community/NUR/commit/2991da74fd8d0d16c4accd8b1c8880ef6a0adb9d) | `` automatic update `` |