### PR TITLE
chore(flake/emacs-overlay): `8f28153c` -> `2a762092`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693248998,
-        "narHash": "sha256-Ss1XVDlmSFxjgD5isLEjEK+UcLXjPscfKVSsgVBFPS0=",
+        "lastModified": 1693279912,
+        "narHash": "sha256-CSUWr0r4/C13hzbMHYUARDVGfyQoqp2lrWhiG6k/pmo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8f28153cad22536fa6d5929bc87e9fafb3c11c68",
+        "rev": "2a762092db6b66e7e0fb32f380d6260a00b14ff9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`2a762092`](https://github.com/nix-community/emacs-overlay/commit/2a762092db6b66e7e0fb32f380d6260a00b14ff9) | `` Updated repos/nongnu `` |
| [`1f2b5c46`](https://github.com/nix-community/emacs-overlay/commit/1f2b5c46f23ef9c9ae1de301e0cb6a2022c11913) | `` Updated repos/melpa ``  |
| [`c94cfe46`](https://github.com/nix-community/emacs-overlay/commit/c94cfe46a40e449ca0eb8b917e4e99a6cd29095d) | `` Updated repos/emacs ``  |
| [`f16ba939`](https://github.com/nix-community/emacs-overlay/commit/f16ba939fdda877edbe0bcb3d0e594b546a2c829) | `` Updated repos/elpa ``   |