### PR TITLE
chore(flake/nur): `2991da74` -> `25a7110b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693273114,
-        "narHash": "sha256-QHXEPXKdbTEZZwJBM5QpYxJk/KpKpmlekqdpyVyhI78=",
+        "lastModified": 1693280503,
+        "narHash": "sha256-Zev55BQ3Rrsz2KcGHNS43WKkJ71tZvUcUUsGy0+vKPo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2991da74fd8d0d16c4accd8b1c8880ef6a0adb9d",
+        "rev": "25a7110bc1a78c114e9f885d34eff9cc1b32fba8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`25a7110b`](https://github.com/nix-community/NUR/commit/25a7110bc1a78c114e9f885d34eff9cc1b32fba8) | `` automatic update `` |
| [`0be9c6c1`](https://github.com/nix-community/NUR/commit/0be9c6c1983ac605affe5fca18c71ddb9c64ed39) | `` automatic update `` |