### PR TITLE
chore(flake/nur): `25a7110b` -> `49a6f312`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693280503,
-        "narHash": "sha256-Zev55BQ3Rrsz2KcGHNS43WKkJ71tZvUcUUsGy0+vKPo=",
+        "lastModified": 1693287301,
+        "narHash": "sha256-QHObvcH4cyl2K8aXeGbA9p/ItQpHZV8Ol+6L6Jcak+w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "25a7110bc1a78c114e9f885d34eff9cc1b32fba8",
+        "rev": "49a6f312bd04b5a02bf62dccafae257c015337d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`49a6f312`](https://github.com/nix-community/NUR/commit/49a6f312bd04b5a02bf62dccafae257c015337d1) | `` automatic update `` |
| [`8e5dd87b`](https://github.com/nix-community/NUR/commit/8e5dd87bcc444b083facc97921457b1060efadae) | `` automatic update `` |