### PR TITLE
chore(flake/nur): `49a6f312` -> `8715d3b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693287301,
-        "narHash": "sha256-QHObvcH4cyl2K8aXeGbA9p/ItQpHZV8Ol+6L6Jcak+w=",
+        "lastModified": 1693290833,
+        "narHash": "sha256-pFYDR5S/t22kH1uaCpF5uny5iH0V7v/w7fDmjukntFs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "49a6f312bd04b5a02bf62dccafae257c015337d1",
+        "rev": "8715d3b7df518e7e9679aae12d4d33f76f93587d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8715d3b7`](https://github.com/nix-community/NUR/commit/8715d3b7df518e7e9679aae12d4d33f76f93587d) | `` automatic update `` |