### PR TITLE
chore(flake/nur): `8715d3b7` -> `8cc49d21`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693290833,
-        "narHash": "sha256-pFYDR5S/t22kH1uaCpF5uny5iH0V7v/w7fDmjukntFs=",
+        "lastModified": 1693294762,
+        "narHash": "sha256-s4XR8RZ3qYNl63UN1yvN4HniAWuo3tqVlkJm/29QU4A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8715d3b7df518e7e9679aae12d4d33f76f93587d",
+        "rev": "8cc49d212c8d11049a8460905d4a41b09a7fadd4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8cc49d21`](https://github.com/nix-community/NUR/commit/8cc49d212c8d11049a8460905d4a41b09a7fadd4) | `` automatic update `` |
| [`755dbcb2`](https://github.com/nix-community/NUR/commit/755dbcb205510781dc156bdb99ddc5062908feeb) | `` automatic update `` |