### PR TITLE
chore(flake/nur): `8cc49d21` -> `eef99211`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693294762,
-        "narHash": "sha256-s4XR8RZ3qYNl63UN1yvN4HniAWuo3tqVlkJm/29QU4A=",
+        "lastModified": 1693301659,
+        "narHash": "sha256-IeY46ZHJ3zZFcvO8UKVM4h9UF1B4XTVWtWL9SDb1Las=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8cc49d212c8d11049a8460905d4a41b09a7fadd4",
+        "rev": "eef992117754ddabc7015a2611213eabc926d2d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eef99211`](https://github.com/nix-community/NUR/commit/eef992117754ddabc7015a2611213eabc926d2d2) | `` automatic update `` |