### PR TITLE
chore(flake/nur): `eef99211` -> `0da294f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693301659,
-        "narHash": "sha256-IeY46ZHJ3zZFcvO8UKVM4h9UF1B4XTVWtWL9SDb1Las=",
+        "lastModified": 1693305898,
+        "narHash": "sha256-8R1PBgMEqDDttazM3wFsvebMe/HE8c2zNcNBxm7a50E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eef992117754ddabc7015a2611213eabc926d2d2",
+        "rev": "0da294f40840d6360d5c4ea2f24bf2a27ad34caa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0da294f4`](https://github.com/nix-community/NUR/commit/0da294f40840d6360d5c4ea2f24bf2a27ad34caa) | `` automatic update `` |
| [`de6022bd`](https://github.com/nix-community/NUR/commit/de6022bde2d2ec9f9b4fdc879292e1c9d8933754) | `` automatic update `` |