### PR TITLE
chore(flake/emacs-overlay): `2a762092` -> `76e16043`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693279912,
-        "narHash": "sha256-CSUWr0r4/C13hzbMHYUARDVGfyQoqp2lrWhiG6k/pmo=",
+        "lastModified": 1693304662,
+        "narHash": "sha256-IOORzGsr+aetrf1fpppID0VT/NjxiUNzXJq1oEjvgRY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2a762092db6b66e7e0fb32f380d6260a00b14ff9",
+        "rev": "76e1604362f675c6b9ee37bd9feca2b87730a987",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`76e16043`](https://github.com/nix-community/emacs-overlay/commit/76e1604362f675c6b9ee37bd9feca2b87730a987) | `` Updated repos/melpa `` |
| [`9e1f0784`](https://github.com/nix-community/emacs-overlay/commit/9e1f078407e6142aa4a305111c88544ff37f4346) | `` Updated repos/emacs `` |