### PR TITLE
chore(flake/nur): `0da294f4` -> `af03fbc5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693305898,
-        "narHash": "sha256-8R1PBgMEqDDttazM3wFsvebMe/HE8c2zNcNBxm7a50E=",
+        "lastModified": 1693313869,
+        "narHash": "sha256-gz72Ya7qOLUZ6PHJY7shAlJRTvrv7EG9bK3YJ6/EZ/0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0da294f40840d6360d5c4ea2f24bf2a27ad34caa",
+        "rev": "af03fbc52348a0bdb1c331e6a0a0f8661f192841",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`af03fbc5`](https://github.com/nix-community/NUR/commit/af03fbc52348a0bdb1c331e6a0a0f8661f192841) | `` automatic update `` |
| [`8b24f976`](https://github.com/nix-community/NUR/commit/8b24f976fe74f10ccb286063b0293d5ced1ffe64) | `` automatic update `` |