### PR TITLE
chore(flake/nur): `f944f5be` -> `86e99304`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693319998,
-        "narHash": "sha256-GjdunTxfEcvWn7N6RrDLE+X35M/nJfmZdK2Cq2Lvk/0=",
+        "lastModified": 1693334687,
+        "narHash": "sha256-2P6hLkiP/R1YjWRm7ky7HIonvKRGPEntRDugzp2qYJg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f944f5befe39d7cf27cd0b41960ace172f9241b3",
+        "rev": "86e9930437f3982ef58ea92d34689241617a4746",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`86e99304`](https://github.com/nix-community/NUR/commit/86e9930437f3982ef58ea92d34689241617a4746) | `` automatic update `` |