### PR TITLE
chore(flake/nixpkgs): `a999c1cc` -> `3efb0f6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -810,11 +810,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1693158576,
-        "narHash": "sha256-aRTTXkYvhXosGx535iAFUaoFboUrZSYb1Ooih/auGp0=",
+        "lastModified": 1693250523,
+        "narHash": "sha256-y3up5gXMTbnCsXrNEB5j+7TVantDLUYyQLu/ueiXuyg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a999c1cc0c9eb2095729d5aa03e0d8f7ed256780",
+        "rev": "3efb0f6f404ec8dae31bdb1a9b17705ce0d6986e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`bd194f33`](https://github.com/NixOS/nixpkgs/commit/bd194f336c1e69842255803199118f3d19b97bf7) | `` pgbadger: 11.5 -> 12.2 ``                                                               |
| [`14aa0299`](https://github.com/NixOS/nixpkgs/commit/14aa0299977f7bfe84a4969526f4df138d30d543) | `` python311Packages.homematicip: 1.0.14 -> 1.0.15 ``                                      |
| [`49add44e`](https://github.com/NixOS/nixpkgs/commit/49add44e4dd93514339ff2d732596b441be31a09) | `` openssh: add withPAM parameter ``                                                       |
| [`e1854055`](https://github.com/NixOS/nixpkgs/commit/e1854055c8e66a345e089ed95509ae3392dbbe04) | `` colord-kde: fix missing buildInput ``                                                   |
| [`2cc480a3`](https://github.com/NixOS/nixpkgs/commit/2cc480a38fa0f56b4fe92dd1681cb34cb6f7f17d) | `` vnote: 3.16.0 -> 3.17.0 ``                                                              |
| [`7d4ea94d`](https://github.com/NixOS/nixpkgs/commit/7d4ea94d02670f7028168a00cd11d621048201c2) | `` emacs: keep the default first writable native-comp-eln-load-path dir ``                 |
| [`2d324ed8`](https://github.com/NixOS/nixpkgs/commit/2d324ed8f96721b74c3a232ffd4bf5af1497405b) | `` emacs: fix the detection of native compilation for Emacs 29 ``                          |
| [`6505082e`](https://github.com/NixOS/nixpkgs/commit/6505082e724da1906003aa17ae9fc9e550e86ef6) | `` emacsWithPackages: load compiled site-start.el of $emacs if possible ``                 |
| [`1506ab49`](https://github.com/NixOS/nixpkgs/commit/1506ab49e39cb208774ac49c480b77e9edb4dea7) | `` emacs: correct the order of profiles and their sub dirs in load-path ``                 |
| [`e8f6a5ce`](https://github.com/NixOS/nixpkgs/commit/e8f6a5ce341d3db1cb4c707eb58b3162f93353a3) | `` emacsWithPackages: do not symlink $emacs/share/emacs ``                                 |
| [`f5fbea97`](https://github.com/NixOS/nixpkgs/commit/f5fbea9761033a847ce91508471ed57f3ae67e95) | `` emacsWithPackages: do not add the wrapper path twice ``                                 |
| [`94eeeb87`](https://github.com/NixOS/nixpkgs/commit/94eeeb87851a71c7471fe289cd15e71f610c85b5) | `` path-of-building.data: 2.33.3 -> 2.33.5 ``                                              |
| [`df02fcb7`](https://github.com/NixOS/nixpkgs/commit/df02fcb79b4cae3652640ca66c2d1dfd0c6a4486) | `` cc-wrapper: don't use fortify-headers for non-gcc compilers ``                          |
| [`0944e191`](https://github.com/NixOS/nixpkgs/commit/0944e19139ab43427f5e70c2667667056368edfd) | `` betterbird: 102.12.0-bb37 → 102.14.0-bb39 ``                                            |
| [`fc0e6da3`](https://github.com/NixOS/nixpkgs/commit/fc0e6da3781a8eabf960339dffff849d6c3cf508) | `` obs-studio-plugins.obs-freeze-filter: init at 0.3.3 ``                                  |
| [`3f9b7920`](https://github.com/NixOS/nixpkgs/commit/3f9b79207b9f28c81939b1d306c76154ce6e4f47) | `` python310Packages.approvaltests: 8.4.1 -> 9.0.0 ``                                      |
| [`6d448972`](https://github.com/NixOS/nixpkgs/commit/6d448972067003903b9a28b4d2055f3493c9a54d) | `` azure-cli: add msrest to specific overrides ``                                          |
| [`c31fa5cf`](https://github.com/NixOS/nixpkgs/commit/c31fa5cf89f4edbdf0b27973fc222f7ffd489b1d) | `` azure-cli: add missing azure-mgmt-appcontainers dependency ``                           |
| [`da686a62`](https://github.com/NixOS/nixpkgs/commit/da686a62dc742ef1dc022c2f480b374a93dba622) | `` style: format azure-cli/python-packages.nix ``                                          |
| [`1b8869eb`](https://github.com/NixOS/nixpkgs/commit/1b8869eb7fb3f2d80efd1455a839f7b683ebd9ea) | `` linux/hardened/patches/6.4: 6.4.11-hardened1 -> 6.4.12-hardened1 ``                     |
| [`1125d5fc`](https://github.com/NixOS/nixpkgs/commit/1125d5fcd2130e8ceb6776bbb288013847b2f686) | `` linux/hardened/patches/6.1: 6.1.46-hardened1 -> 6.1.47-hardened1 ``                     |
| [`be50d8c3`](https://github.com/NixOS/nixpkgs/commit/be50d8c358e62e2fb74a41b840c2d561358c42ac) | `` linux_latest-libre: 19392 -> 19397 ``                                                   |
| [`385cbd7f`](https://github.com/NixOS/nixpkgs/commit/385cbd7fc4a7d0bc6d1d7b574a0b755e670ea171) | `` linux: 6.1.47 -> 6.1.49 ``                                                              |
| [`e1338219`](https://github.com/NixOS/nixpkgs/commit/e133821958541ff50e07b5bfa25e4179d5ce0816) | `` linux: 5.15.127 -> 5.15.128 ``                                                          |
| [`238eca32`](https://github.com/NixOS/nixpkgs/commit/238eca32de1c32ad6b6fe7f739726eceba533329) | `` linux: 5.10.191 -> 5.10.192 ``                                                          |
| [`4e4d4ed5`](https://github.com/NixOS/nixpkgs/commit/4e4d4ed5c75439889e37af0b5696f67d8e138366) | `` linux_6_5: init ``                                                                      |
| [`e45b9d1b`](https://github.com/NixOS/nixpkgs/commit/e45b9d1b8c27121b6faa5e82f3a04b1045f09e61) | `` citron: init at 0.15.0 ``                                                               |
| [`9f9e0cc5`](https://github.com/NixOS/nixpkgs/commit/9f9e0cc5cc2fcb4dca56c9b2b011804b8af8c1f4) | `` maintainers: add vuimuich ``                                                            |
| [`4bb3ee6b`](https://github.com/NixOS/nixpkgs/commit/4bb3ee6bc6c089fc3eb9f585e4c0c8a765065bed) | `` zellij: 0.37.2 -> 0.38.0 ``                                                             |
| [`838fea9a`](https://github.com/NixOS/nixpkgs/commit/838fea9a55a7ef7a7916f996433501100c37662b) | `` pdfcpu: 0.4.1 -> 0.5.0 ``                                                               |
| [`26a8c648`](https://github.com/NixOS/nixpkgs/commit/26a8c648570bf235b302085b6e54f96451849db8) | `` ugrep: 4.0.4 -> 4.0.5 ``                                                                |
| [`dd7e988e`](https://github.com/NixOS/nixpkgs/commit/dd7e988ed495637568507c1ab80c3177b8b19f32) | `` eza: v0.10.8 -> v0.10.9 ``                                                              |
| [`f7b59782`](https://github.com/NixOS/nixpkgs/commit/f7b5978272e32ffc7895530ed6b7e26d8c81c849) | `` osc: 1.0.0b1 -> 1.3.0 ``                                                                |
| [`dbdd3d43`](https://github.com/NixOS/nixpkgs/commit/dbdd3d434f13423b3afa2ac5a40eedb5bb3d793e) | `` python310Packages.mkdocs-minify: 0.6.3 -> 0.7.1 ``                                      |
| [`c467dd64`](https://github.com/NixOS/nixpkgs/commit/c467dd643a64ffdbc59c347769d013959985ae0f) | `` python310Packages.djangorestframework-simplejwt: add optional-dependencies ``           |
| [`35d24bae`](https://github.com/NixOS/nixpkgs/commit/35d24bae405a23484cdd012e95e2e90441bd1352) | `` hcloud: replace sha256 with hash ``                                                     |
| [`b516af56`](https://github.com/NixOS/nixpkgs/commit/b516af56c13c1d97e8bef2aaed78aaf035d7bc2c) | `` python310Packages.djangorestframework-simplejwt: add changelog to meta ``               |
| [`ab2a9efb`](https://github.com/NixOS/nixpkgs/commit/ab2a9efb9918bf6f0bad6cd60664a6b50ab7d057) | `` skopeo: 1.13.2 -> 1.13.3 ``                                                             |
| [`35f2adf1`](https://github.com/NixOS/nixpkgs/commit/35f2adf1caf7933900bda7e1f3216db4f1d33b39) | `` fetchMavenDeps: add missing pre/post runHooks ``                                        |
| [`830612d1`](https://github.com/NixOS/nixpkgs/commit/830612d1092173d91b135b2e911934863a205683) | `` global-platform-pro: 18.09.14 -> 20.01.23 ``                                            |
| [`1ffac91a`](https://github.com/NixOS/nixpkgs/commit/1ffac91a875571d4c43711a4663f79de41f1e793) | `` pantheon.switchboard-plug-applications: 7.0.0 -> 7.0.1 ``                               |
| [`e18671d4`](https://github.com/NixOS/nixpkgs/commit/e18671d41f11b3d6447ecf6f2620fa4590efc89a) | `` python311Packages.unstructured-api-tools: 0.10.10 -> 0.10.11 ``                         |
| [`2ae7493c`](https://github.com/NixOS/nixpkgs/commit/2ae7493cb6fe1e5d3f3c10a24a7de2ec4213f770) | `` coqPackages.hierarchy-builder: 1.4.0 → 1.5.0 ``                                         |
| [`409d682a`](https://github.com/NixOS/nixpkgs/commit/409d682a57d75bd303b35bdb95b933291674f338) | `` coqPackages_8_14.coq-elpi: fix by using old camlp5 ``                                   |
| [`b499f97c`](https://github.com/NixOS/nixpkgs/commit/b499f97cf52cf0ca5e8a2c80a9a1f83e2edc6af0) | `` terraform-providers.ucloud: 1.36.1 -> 1.37.0 ``                                         |
| [`196a8438`](https://github.com/NixOS/nixpkgs/commit/196a8438ee8afb9974e2ab71757d49b25cb8892e) | `` python310Packages.djangorestframework-simplejwt: 5.2.2 -> 5.3.0 ``                      |
| [`cd23dfab`](https://github.com/NixOS/nixpkgs/commit/cd23dfabf74219f1d8ab2f56e25ba16302db3c41) | `` python310Packages.textual: 0.33.0 -> 0.35.1 ``                                          |
| [`df280cdf`](https://github.com/NixOS/nixpkgs/commit/df280cdf95c318aa5a18a1a1e51ef315f5fc6092) | `` shotman: 0.4.3 -> 0.4.5 ``                                                              |
| [`d92e50c6`](https://github.com/NixOS/nixpkgs/commit/d92e50c6a3a5bb9c3271f416a684a1720c480fba) | `` jwx: 2.0.11 -> 2.0.12 ``                                                                |
| [`21c0a31d`](https://github.com/NixOS/nixpkgs/commit/21c0a31d648a3db6f2d42b9b824a35afaf034c31) | `` hcloud: 1.36.0 -> 1.37.0 ``                                                             |
| [`41c8568b`](https://github.com/NixOS/nixpkgs/commit/41c8568b3ae2f066582c65b21f3134b2333bed94) | `` web-eid-app: 2.3.1 -> 2.4.0 ``                                                          |
| [`d25e1e76`](https://github.com/NixOS/nixpkgs/commit/d25e1e766a69eb18d033e7171291de98ce1b63ac) | `` talosctl: 1.4.7 -> 1.5.0 ``                                                             |
| [`97357247`](https://github.com/NixOS/nixpkgs/commit/97357247c9e9b6cb0a2a91eda07ebdbb5ce60439) | `` mympd: 11.0.3 -> 11.0.4 ``                                                              |
| [`f938e1ac`](https://github.com/NixOS/nixpkgs/commit/f938e1ac056804e432c01a8cb0873de90d4d7c70) | `` ssl-proxy: init at 0.2.7 ``                                                             |
| [`9b625903`](https://github.com/NixOS/nixpkgs/commit/9b625903671ae8fb10ffa25a52b759e6892549c9) | `` libnl-tiny: unstable-2022-12-13 -> unstable-2023-07-27 ``                               |
| [`54a92c8b`](https://github.com/NixOS/nixpkgs/commit/54a92c8bca5646e378b44e0245f09744597baffc) | `` ustream-ssl: unstable-2022-12-08- -> unstable-2023-02-25 ``                             |
| [`3a8aa079`](https://github.com/NixOS/nixpkgs/commit/3a8aa079a51aea40912a9454d789a0f2ee35d7bc) | `` uci: unstable-2021-04-14 -> unstable-2023-08-10 ``                                      |
| [`0ff1e969`](https://github.com/NixOS/nixpkgs/commit/0ff1e969adeaee0716a9212145ecfeea4ab8e745) | `` ubus: unstable-2021-02-15 -> unstable-2023-06-05 ``                                     |
| [`0f14ca4c`](https://github.com/NixOS/nixpkgs/commit/0f14ca4cefcce1a0d50050ae3ceec27fb578e7e4) | `` libubox: unstable-2023-01-03 -> unstable-2023-05-23 ``                                  |
| [`39df712e`](https://github.com/NixOS/nixpkgs/commit/39df712ed59e768aead663f9064d231b0bf179e7) | `` uclient: unstable-2022-02-24 -> unstable-2023-04-13 ``                                  |
| [`369e18f1`](https://github.com/NixOS/nixpkgs/commit/369e18f1c78c6f7b5b67b177430a2c347eae5375) | `` networking/nftables: ensure deletions ``                                                |
| [`7c6847bf`](https://github.com/NixOS/nixpkgs/commit/7c6847bfc92561333a6dca89dc887de4dee98379) | `` winePackages: add reckenrode as a maintainer ``                                         |
| [`6658b3fc`](https://github.com/NixOS/nixpkgs/commit/6658b3fcf185f6b9eef7ab1923711c35023407b2) | `` networking/nftables: make ruleset+rulesetFile non-exclusive ``                          |
| [`a1dd69d7`](https://github.com/NixOS/nixpkgs/commit/a1dd69d7615feb8d3f6ddc63351849f279344395) | `` networking/nftables: enable flushRuleset by default if rulset{,File} used ``            |
| [`55213b54`](https://github.com/NixOS/nixpkgs/commit/55213b54f0ebb96250021a8788e36126174ca8a7) | `` nixos/nftables: save deletions to file and run them afterwards ``                       |
| [`5f300ad7`](https://github.com/NixOS/nixpkgs/commit/5f300ad70cbbb7192f5a86795c37ed99d70ab545) | `` networking/nftables: only delete our tables if flushRuleset is set to false ``          |
| [`d5a08266`](https://github.com/NixOS/nixpkgs/commit/d5a08266866f91efd7d27ccde9f89469b09047a2) | `` networking/nftables: remove no longer relevant conflict warnings ``                     |
| [`dc3f8728`](https://github.com/NixOS/nixpkgs/commit/dc3f8728b949550d10ffe6a165cd2a1d5b9f7a97) | `` release-notes: add networking.nftables.tables news ``                                   |
| [`7e427c35`](https://github.com/NixOS/nixpkgs/commit/7e427c3595baa4e729a091c59b2e1b3e6d22f19c) | `` clac: 0.3.3 -> 0.3.3-unstable-2021-09-06 ``                                             |
| [`cd3af259`](https://github.com/NixOS/nixpkgs/commit/cd3af25932425e1b1acfaad9c9ee85694fe70ae6) | `` networking/nftables: enable flushing ruleset for older versions ``                      |
| [`311d2fa9`](https://github.com/NixOS/nixpkgs/commit/311d2fa994565ab412681b9ab8cbb12054ab265a) | `` *: migrate to using nftables.tables instead of ruleset directly ``                      |
| [`048ef0d4`](https://github.com/NixOS/nixpkgs/commit/048ef0d45573d89195d69bdb5045aa50fa94d6a0) | `` networking/nftables: add .tables property and disable ruleset flushing by default ``    |
| [`e0b74ead`](https://github.com/NixOS/nixpkgs/commit/e0b74ead2d458e286d359639db9971a8682682c1) | `` odoo15: remove updatescript ``                                                          |
| [`b0ace70d`](https://github.com/NixOS/nixpkgs/commit/b0ace70d46d40acf77c88ccc77ca311ebdf96089) | `` odoo: use fetchzip ``                                                                   |
| [`9fa3a8b6`](https://github.com/NixOS/nixpkgs/commit/9fa3a8b6296ad4cebdabc8be4880337bd78e0bed) | `` odoo15: 15.0.20230317->15.020230816 fix broken fetcher ``                               |
| [`48de6493`](https://github.com/NixOS/nixpkgs/commit/48de649336a552051afdcc42b007c84cb24dd1b1) | `` nixos/modules/honk: init ``                                                             |
| [`07075b3f`](https://github.com/NixOS/nixpkgs/commit/07075b3ff92caf585121637ea673aa9e2b4d733b) | `` fishPlugins.pure: 4.1.1 -> 4.7.0 ``                                                     |
| [`ecae7dc2`](https://github.com/NixOS/nixpkgs/commit/ecae7dc206a68d5d2517765f2b4ade25fb3aba7a) | `` python3Packages.pyssim: unbreak after recent pillow bump ``                             |
| [`871b2828`](https://github.com/NixOS/nixpkgs/commit/871b2828fd108fdd0af48269312f5079d5e0e6b1) | `` python311Packages.bimmer-connected: 0.13.10 -> 0.14.0 ``                                |
| [`524abda8`](https://github.com/NixOS/nixpkgs/commit/524abda807b279c9768be0b9e687983b1871d3e8) | `` python311Packages.python-engineio: 4.5.1 -> 4.6.1 ``                                    |
| [`ad972123`](https://github.com/NixOS/nixpkgs/commit/ad97212346a23bd1c1a47f8c34429bb55ea9b5c2) | `` wl-clipboard: 2.2.0 -> 2.2.1 ``                                                         |
| [`e0c075a8`](https://github.com/NixOS/nixpkgs/commit/e0c075a8bf652e05131efe30a6013d4aaf95cbad) | `` awsbck: 0.3.3 -> 0.3.4 ``                                                               |
| [`3aed80b2`](https://github.com/NixOS/nixpkgs/commit/3aed80b2c3349c64b354ead0803961723de66d23) | `` nixpkgs-review: 2.10.0 -> 2.10.1 ``                                                     |
| [`1c37010b`](https://github.com/NixOS/nixpkgs/commit/1c37010b1e5dfd2e22e3de5fa03e68918283e9e4) | `` listmonk: modify the 1.20 Go support patch ``                                           |
| [`c0856cfa`](https://github.com/NixOS/nixpkgs/commit/c0856cfabc477763c9c65784d4d98b5f485b53af) | `` soapui: fix runtime error on darwin ``                                                  |
| [`1de3e4dd`](https://github.com/NixOS/nixpkgs/commit/1de3e4ddeddeb86c027b4e93acf3a81347d0d186) | `` neocmakelsp: 0.6.1 -> 0.6.3 ``                                                          |
| [`2da80dbf`](https://github.com/NixOS/nixpkgs/commit/2da80dbfbacf47ba1a9070c4855d68e5d52a339f) | `` openarena: fix make flags, cleanup ``                                                   |
| [`6eef340c`](https://github.com/NixOS/nixpkgs/commit/6eef340c21c947a6efede5256af88ef2e9d9a8fa) | `` pineapple-pictures: 0.7.1 -> 0.7.2 ``                                                   |
| [`5d655946`](https://github.com/NixOS/nixpkgs/commit/5d65594677a51435b78d771504d4eadabdff21a5) | `` textplots: 0.8.0 -> 0.8.1 ``                                                            |
| [`c9de78a3`](https://github.com/NixOS/nixpkgs/commit/c9de78a33019f77e66cca95ee3b14f46b3a4450a) | `` pantheon.wingpanel-indicator-power: 6.2.0 -> 6.2.1 ``                                   |
| [`af9e1b2f`](https://github.com/NixOS/nixpkgs/commit/af9e1b2fa6143a27b0e09ac3533f559f10db0f64) | `` nomino: 1.3.1 -> 1.3.2 ``                                                               |
| [`a56c246a`](https://github.com/NixOS/nixpkgs/commit/a56c246ae830204e29631abe60b8bd6341fcd56d) | `` leptosfmt: 0.1.12 -> 0.1.13 ``                                                          |
| [`d17bee53`](https://github.com/NixOS/nixpkgs/commit/d17bee53b69fbbc7dbd39a2622a55005ad3206e0) | `` coursier: 2.1.5 -> 2.1.6 ``                                                             |
| [`097a680f`](https://github.com/NixOS/nixpkgs/commit/097a680f8da86c20a2c53960b365317a3662172a) | `` python3Packages.pywebm: no longer maintained ``                                         |
| [`41032ee3`](https://github.com/NixOS/nixpkgs/commit/41032ee3681e20d38b444ac9f790ccc712be49f5) | `` python311Packages.msgspec: 0.18.1 -> 0.18.2 ``                                          |
| [`7f42717c`](https://github.com/NixOS/nixpkgs/commit/7f42717cf995965e255100488924cb598d78c205) | `` checkov: 2.4.10 -> 2.4.12 ``                                                            |
| [`0a89a794`](https://github.com/NixOS/nixpkgs/commit/0a89a79460a854e936a07e8bd5cec7e7dbb810f6) | `` haproxy: 2.8.1 -> 2.8.2 ``                                                              |
| [`6f74163d`](https://github.com/NixOS/nixpkgs/commit/6f74163d4a5887b5079e246601a7e4b71209033e) | `` chromiumBeta: 116.0.5845.50 -> 117.0.5938.22 ``                                         |
| [`7ce7e093`](https://github.com/NixOS/nixpkgs/commit/7ce7e093e850face3bfa81bb177c90aa3be3c2c7) | `` chromiumDev: 117.0.5897.3 -> 118.0.5966.0 ``                                            |
| [`ed9c38b3`](https://github.com/NixOS/nixpkgs/commit/ed9c38b3fa956d50c835b8f95d14f735c985508b) | `` chromium: Fix the chromedriver version ``                                               |
| [`babce2f2`](https://github.com/NixOS/nixpkgs/commit/babce2f26a756aac6017b15a06af8cfb30219875) | `` texlive: factor out tlpdb overrides ``                                                  |
| [`e7011961`](https://github.com/NixOS/nixpkgs/commit/e7011961344285c3f5e9828ef6dd79f899901dc0) | `` ssh-to-age: 1.1.4 -> 1.1.5 ``                                                           |
| [`9155fec9`](https://github.com/NixOS/nixpkgs/commit/9155fec96b3f4c24f7742b5fd1015257e9458cef) | `` texlive.combine: explicitly list params ``                                              |
| [`a424dacb`](https://github.com/NixOS/nixpkgs/commit/a424dacb8a50f08bef9dbe7eeaa309d8f8880d9a) | `` texlive: move combinePkgs from default.nix to combine.nix ``                            |
| [`ba986f8b`](https://github.com/NixOS/nixpkgs/commit/ba986f8b34ff94b08bb494ad3025073c65f21519) | `` python310Packages.ipfshttpclient: switch to pyproject build and mark darwin unbroken `` |
| [`af82b6ae`](https://github.com/NixOS/nixpkgs/commit/af82b6ae7477c1ee0fbd6c16f3957d4985e08e66) | `` go-mockery: 2.32.4 -> 2.33.0 ``                                                         |
| [`f0872999`](https://github.com/NixOS/nixpkgs/commit/f08729990a9440aabd6aae817d90e61c208b2baa) | `` kdash: 0.4.0 -> 0.4.2 ``                                                                |
| [`f27b81b4`](https://github.com/NixOS/nixpkgs/commit/f27b81b421dfff8028fa991c659dff04ced78292) | `` liquibase: 4.23.0 -> 4.23.1 ``                                                          |
| [`27393315`](https://github.com/NixOS/nixpkgs/commit/27393315bff2ceb0cb5b8404dbfabd0b48dfad41) | `` cargo-udeps: 0.1.41 -> 0.1.42 ``                                                        |
| [`bdf47492`](https://github.com/NixOS/nixpkgs/commit/bdf47492d43d88844db5bd758150bb493aa22ff1) | `` wine64Packages.unstable: Darwin compatibility fixes ``                                  |
| [`cd2ae27e`](https://github.com/NixOS/nixpkgs/commit/cd2ae27e0a061c90cc7b07e68b8dc3716975fd73) | `` frp: 0.51.2 -> 0.51.3 ``                                                                |
| [`8c02d4d4`](https://github.com/NixOS/nixpkgs/commit/8c02d4d44d317aedc1110dbe56634786ab8d2fbc) | `` python310Packages.curtsies: add changelog to meta ``                                    |
| [`bf9f6f5c`](https://github.com/NixOS/nixpkgs/commit/bf9f6f5c72630155c904e2fa73b70335be638bee) | `` python310Packages.numpyro: 0.12.1 -> 0.13.0 ``                                          |
| [`79af5861`](https://github.com/NixOS/nixpkgs/commit/79af586173707171f6a3edcca2c7b0f8bccbb5d8) | `` dnsperf: 2.13.0 -> 2.13.1 ``                                                            |
| [`7619eb3b`](https://github.com/NixOS/nixpkgs/commit/7619eb3b44297b75239d8b7b3f1885d359f705ce) | `` sqldef: 0.12.7 -> 0.16.4 ``                                                             |
| [`48853167`](https://github.com/NixOS/nixpkgs/commit/48853167e4ab52cedfed1ecc441d4288cd47198a) | `` freetds: 1.3.19 -> 1.3.20 ``                                                            |
| [`a2028f60`](https://github.com/NixOS/nixpkgs/commit/a2028f60339895b0e305801fe7a7cbfc59dbb309) | `` flexget: 3.9.4 -> 3.9.5 ``                                                              |
| [`bd5d4259`](https://github.com/NixOS/nixpkgs/commit/bd5d4259312a014576400aae54d7084adb98a666) | `` python310Packages.curtsies: 0.4.1 -> 0.4.2 ``                                           |
| [`fd904b85`](https://github.com/NixOS/nixpkgs/commit/fd904b8558594f5c13fb5a3a8e022e7d7d12e72f) | `` v2ray-domain-list-community: 20230815132423 -> 20230825070717 ``                        |
| [`c8aef93d`](https://github.com/NixOS/nixpkgs/commit/c8aef93daea3d1f5e7edd2399a80da3b507e87a6) | `` maintainers: add pschmitt ``                                                            |
| [`8823a5ba`](https://github.com/NixOS/nixpkgs/commit/8823a5ba0d6d1a3b05cb9b409c349436b9fa267a) | `` invidious: unstable-2023-08-07 -> unstable-2023-08-25 ``                                |
| [`c41a8609`](https://github.com/NixOS/nixpkgs/commit/c41a8609ed078126c9554a22db5adb88600bae52) | `` vimPlugins.nvim-treesitter: update grammars ``                                          |
| [`be3af7fe`](https://github.com/NixOS/nixpkgs/commit/be3af7fed08534debeade1e696d64bc352d465b6) | `` vimPlugins: update ``                                                                   |
| [`991afce3`](https://github.com/NixOS/nixpkgs/commit/991afce31d372a5cc4a0e052719604ffcf9d4e23) | `` freetds: 1.3.18 -> 1.3.19 ``                                                            |
| [`e96a0b3c`](https://github.com/NixOS/nixpkgs/commit/e96a0b3c8bf728e9d711765450a3769223a67e40) | `` insync: fix bwrap namespaces ``                                                         |
| [`94e6e837`](https://github.com/NixOS/nixpkgs/commit/94e6e837f4146e0373e071ad5b5a1d0c796b83f4) | `` google-guest-oslogin: 20230808.00 -> 20230821.01 ``                                     |
| [`7c31a275`](https://github.com/NixOS/nixpkgs/commit/7c31a275321d81f33e289da29aa4367be416d18c) | `` python310Packages.oldest-supported-numpy: fix numpy dependency ``                       |
| [`ee533072`](https://github.com/NixOS/nixpkgs/commit/ee5330729205f78878c775c72e84e5edbf9dab76) | `` ntpd-rs: init at 0.3.7 ``                                                               |
| [`0f361174`](https://github.com/NixOS/nixpkgs/commit/0f3611743aa1d4ba189d74716e5044460a435a1b) | `` wine64Packages.unstable: 8.13 -> 8.14 ``                                                |
| [`a2a7149a`](https://github.com/NixOS/nixpkgs/commit/a2a7149af1660801d69b417a8494411e81cd895a) | `` mavproxy: 1.8.62 -> 1.8.66 ``                                                           |
| [`c40323b9`](https://github.com/NixOS/nixpkgs/commit/c40323b934742284d0ca237fe3c09e5979be251e) | `` fishPlugins.fzf-fish: 9.9 -> 10.0 ``                                                    |
| [`cf8bd451`](https://github.com/NixOS/nixpkgs/commit/cf8bd45123420cf14d5012783f01fd90a42040b2) | `` fishPlugins.fzf-fish: add meta.changelog ``                                             |
| [`84b273f8`](https://github.com/NixOS/nixpkgs/commit/84b273f885fbcd470f5f82ab3300b20e0bf86f3e) | `` playwright: 1.34.3 > 1.37.0 ``                                                          |
| [`dc51f3f0`](https://github.com/NixOS/nixpkgs/commit/dc51f3f01a18d48d63f72a498c5c21c64b9af7c3) | `` krane: 3.1.0 -> 3.3.0 ``                                                                |
| [`7b0326e4`](https://github.com/NixOS/nixpkgs/commit/7b0326e46f92961b9d1d757b923b0481f12fac2d) | `` fwupd: 1.9.3 -> 1.9.4 ``                                                                |
| [`d3ac8de0`](https://github.com/NixOS/nixpkgs/commit/d3ac8de01e1fdcab7e7aa3da90478ae727520d90) | `` maintainers: add rvdp ``                                                                |
| [`57118402`](https://github.com/NixOS/nixpkgs/commit/5711840226e354fd299561e44a73abecdc7946bd) | `` python311Packages.aiounifi: 54 -> 55 ``                                                 |
| [`11c2f309`](https://github.com/NixOS/nixpkgs/commit/11c2f3098865e2298632ee5330bd7dadcf2418fa) | `` pymavlink: 2.4.39 -> 2.4.40 ``                                                          |
| [`eb831f75`](https://github.com/NixOS/nixpkgs/commit/eb831f759bc2c98ef84a0a97c60e5ab0b73f309c) | `` nixos/stc: Improve mount unit handling ``                                               |
| [`8e53e1ba`](https://github.com/NixOS/nixpkgs/commit/8e53e1bae7f3df96627501966ec3ce3970523864) | `` spotify-player: make build options configurable ``                                      |
| [`0482394f`](https://github.com/NixOS/nixpkgs/commit/0482394fe0eb4d3eba91bded8e1d9dbef1bb7c64) | `` ragnarwm: init at 1.3.1 ``                                                              |
| [`fcef652d`](https://github.com/NixOS/nixpkgs/commit/fcef652da8210d753f85acaf0afb569be4cc40e4) | `` honk: add `passthru.tests` ``                                                           |
| [`bff13ed2`](https://github.com/NixOS/nixpkgs/commit/bff13ed20e3061fbef3dba8d6a7ca9411be9c4e3) | `` libcap: add some key reverse-dependencies to passthru.tests ``                          |
| [`8b84d90d`](https://github.com/NixOS/nixpkgs/commit/8b84d90d84c6369dc6625ff620af2fd28b2edcfe) | `` python3.pkgs.gobject-stubs: Disable the check phase ``                                  |
| [`3c500a0c`](https://github.com/NixOS/nixpkgs/commit/3c500a0cc8290c547151daf95a701509f2860f36) | `` python3.pkgs.gobject-stubs: Use lgpl21Plus license ``                                   |