### PR TITLE
chore(flake/nur): `592debe6` -> `56e7a231`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693345500,
-        "narHash": "sha256-eJ+nxmXxd8g+mlQWBOTdb05eAEUNXheWwKkcwkWD/po=",
+        "lastModified": 1693352676,
+        "narHash": "sha256-Z+tKfiaAW6TeCjUQNJUbbxjv3z+XxAdqDDnSdeGkchc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "592debe60d9b8d4ce4dda1f92c2e3a0675e5dac9",
+        "rev": "56e7a231c63e0575079cbd3ec909bc4d1ede133e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`56e7a231`](https://github.com/nix-community/NUR/commit/56e7a231c63e0575079cbd3ec909bc4d1ede133e) | `` automatic update `` |