### PR TITLE
chore(flake/nur): `56e7a231` -> `647437d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693352676,
-        "narHash": "sha256-Z+tKfiaAW6TeCjUQNJUbbxjv3z+XxAdqDDnSdeGkchc=",
+        "lastModified": 1693360664,
+        "narHash": "sha256-+R1/X+sIfPHn+vRxaobCZbYmsA2Z4GdR8VR80IiMa64=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "56e7a231c63e0575079cbd3ec909bc4d1ede133e",
+        "rev": "647437d403c6193cc6051af671342e3713edf36e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`647437d4`](https://github.com/nix-community/NUR/commit/647437d403c6193cc6051af671342e3713edf36e) | `` automatic update `` |
| [`1f08b22d`](https://github.com/nix-community/NUR/commit/1f08b22d84ee2858369b969b655b7958d263fac3) | `` automatic update `` |