### PR TITLE
chore(flake/nur): `647437d4` -> `e2fb0c3c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693360664,
-        "narHash": "sha256-+R1/X+sIfPHn+vRxaobCZbYmsA2Z4GdR8VR80IiMa64=",
+        "lastModified": 1693363527,
+        "narHash": "sha256-mYjKFknS4wYQM0pWjBJBH8zymfUTnCVh7BPVq0r112M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "647437d403c6193cc6051af671342e3713edf36e",
+        "rev": "e2fb0c3c94858f0784aa085cff06854b579ffdd0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e2fb0c3c`](https://github.com/nix-community/NUR/commit/e2fb0c3c94858f0784aa085cff06854b579ffdd0) | `` automatic update `` |
| [`42f73e1d`](https://github.com/nix-community/NUR/commit/42f73e1d6c560b281f572ab847d4ffc6a2663d92) | `` automatic update `` |