### PR TITLE
chore(flake/nur): `e2fb0c3c` -> `a34b0604`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693363527,
-        "narHash": "sha256-mYjKFknS4wYQM0pWjBJBH8zymfUTnCVh7BPVq0r112M=",
+        "lastModified": 1693366596,
+        "narHash": "sha256-aMLcUl2c3mtISXSlfknQeIWrhu6YX3COo+4DCeWi/Gk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e2fb0c3c94858f0784aa085cff06854b579ffdd0",
+        "rev": "a34b0604fcb65b9dae9582ebbc4dd8e248b017d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a34b0604`](https://github.com/nix-community/NUR/commit/a34b0604fcb65b9dae9582ebbc4dd8e248b017d9) | `` automatic update `` |
| [`e2ecebc4`](https://github.com/nix-community/NUR/commit/e2ecebc4a947923c727f0921f1084f38de3f8ef4) | `` automatic update `` |