### PR TITLE
chore(flake/emacs-overlay): `18db5f94` -> `12332e7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693335035,
-        "narHash": "sha256-xm6moVv0Pm6aDw+u3eDPj3Iovew3Bxm9wUUHQ9pl6E0=",
+        "lastModified": 1693369114,
+        "narHash": "sha256-joI3EwD/6ODIpaxfAln+JbJsRTyYtZr3dRPmGPYVWXo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "18db5f949c4a8d2c8a04e446092414fcd65e6bcd",
+        "rev": "12332e7a2a2f3899dcca76c752464ca87215dd53",
         "type": "github"
       },
       "original": {
@@ -732,11 +732,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1693183237,
-        "narHash": "sha256-c7OtyBkZ/vZE/WosBpRGRtkbWZjDHGJP7fg1FyB9Dsc=",
+        "lastModified": 1693231525,
+        "narHash": "sha256-Zmh8m0HHcgGBDth6jdJPmc4UAAP0L4jQmqIztywF1Iw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ea5234e7073d5f44728c499192544a84244bf35a",
+        "rev": "c540061ac8d72d6e6d99345bd2d590c82b2f58c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`12332e7a`](https://github.com/nix-community/emacs-overlay/commit/12332e7a2a2f3899dcca76c752464ca87215dd53) | `` Updated repos/nongnu `` |
| [`f6c7aac8`](https://github.com/nix-community/emacs-overlay/commit/f6c7aac869b4972803fbdbfe7c903d37155104e6) | `` Updated repos/melpa ``  |
| [`dec98e66`](https://github.com/nix-community/emacs-overlay/commit/dec98e663c16a50ba8be243e64f5305971cd970c) | `` Updated repos/emacs ``  |
| [`0c5f0637`](https://github.com/nix-community/emacs-overlay/commit/0c5f0637c05833da636a5bb3d65dcaa2914e0d6b) | `` Updated repos/elpa ``   |
| [`475accbc`](https://github.com/nix-community/emacs-overlay/commit/475accbc73dd220d4d575b3723d1d74d10a63b4d) | `` Updated flake inputs `` |