### PR TITLE
chore(flake/nur): `a34b0604` -> `34db7a89`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693366596,
-        "narHash": "sha256-aMLcUl2c3mtISXSlfknQeIWrhu6YX3COo+4DCeWi/Gk=",
+        "lastModified": 1693369935,
+        "narHash": "sha256-GLMxos8UBK2cz6tbj7eUasNt99xRDh1yxiqN3wWY8Vs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a34b0604fcb65b9dae9582ebbc4dd8e248b017d9",
+        "rev": "34db7a8974aa46c8726815dc18a2cfe6ab3bcbe4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`34db7a89`](https://github.com/nix-community/NUR/commit/34db7a8974aa46c8726815dc18a2cfe6ab3bcbe4) | `` automatic update `` |
| [`7a36da6b`](https://github.com/nix-community/NUR/commit/7a36da6bf7d94b34451b96bf5cbc43502f6e7aa3) | `` automatic update `` |