### PR TITLE
chore(flake/nur): `34db7a89` -> `6d6fdc38`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693369935,
-        "narHash": "sha256-GLMxos8UBK2cz6tbj7eUasNt99xRDh1yxiqN3wWY8Vs=",
+        "lastModified": 1693378478,
+        "narHash": "sha256-Rp2JKS8BBE7W0ien9ByPq7xOu63KbxbNrR7X0DRZ7uY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "34db7a8974aa46c8726815dc18a2cfe6ab3bcbe4",
+        "rev": "6d6fdc38427b7da3a6d41ae1c0255b399ebb97f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6d6fdc38`](https://github.com/nix-community/NUR/commit/6d6fdc38427b7da3a6d41ae1c0255b399ebb97f3) | `` automatic update `` |
| [`c2fba03b`](https://github.com/nix-community/NUR/commit/c2fba03bdf5d758018d747c44f2bbb5bd4014156) | `` automatic update `` |
| [`7cd54502`](https://github.com/nix-community/NUR/commit/7cd54502ab67c8311a1b1b0722a7aa56da575556) | `` automatic update `` |