### PR TITLE
chore(flake/nur): `6d6fdc38` -> `421d7c77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693378478,
-        "narHash": "sha256-Rp2JKS8BBE7W0ien9ByPq7xOu63KbxbNrR7X0DRZ7uY=",
+        "lastModified": 1693388682,
+        "narHash": "sha256-UuRcydM6Oq8dE/8auSiO78kioZFdn2eqR4Febis/2K8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6d6fdc38427b7da3a6d41ae1c0255b399ebb97f3",
+        "rev": "421d7c7768d8b90c7b58141e20c4e8172f9ee6d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`421d7c77`](https://github.com/nix-community/NUR/commit/421d7c7768d8b90c7b58141e20c4e8172f9ee6d1) | `` automatic update `` |
| [`a621881c`](https://github.com/nix-community/NUR/commit/a621881cb25cea8883f55c946c468d498a52e95d) | `` automatic update `` |