### PR TITLE
chore(flake/sops-nix): `c89ee064` -> `d9c5dc41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1035,11 +1035,11 @@
         "nixpkgs-stable": "nixpkgs-stable_5"
       },
       "locked": {
-        "lastModified": 1693263624,
-        "narHash": "sha256-GzmVIUKStC1HCzUb0YdGDPAewv4+KxCHKQZEZZDpApY=",
+        "lastModified": 1693404499,
+        "narHash": "sha256-cx/7yvM/AP+o/3wPJmA9W9F+WHemJk5t+Xcr+Qwkqhg=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c89ee06488706b587a22085b1844bf9ca6ba5687",
+        "rev": "d9c5dc41c4b1f74c77f0dbffd0f3a4ebde447b7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                           |
| ----------------------------------------------------------------------------------------------- | --------------------------------- |
| [`d9c5dc41`](https://github.com/Mic92/sops-nix/commit/d9c5dc41c4b1f74c77f0dbffd0f3a4ebde447b7a) | `` fix: systemd unit file ``      |
| [`7593c278`](https://github.com/Mic92/sops-nix/commit/7593c2783d0f55da1d046212c5ef7706797a207a) | `` mergify: switch to buildbot `` |
| [`66df6576`](https://github.com/Mic92/sops-nix/commit/66df6576f68809f45f4ac73bcf707ae18bdcdac7) | `` templates: improve docs ``     |