### PR TITLE
chore(flake/nur): `4a0b2e81` -> `b0511c1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693424795,
-        "narHash": "sha256-7HBiRszliR7UjR9q4H4SXov6T7Tvoluuz/0M58jev0E=",
+        "lastModified": 1693432386,
+        "narHash": "sha256-dXJWkqm5bGshHR7q616VRqyTpqI5a7Gk9GjkX5PVZpA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4a0b2e813a93e5932fbedaafab47e9c404e0a812",
+        "rev": "b0511c1dfa8edd999d9265142390fcdd6fa48f3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b0511c1d`](https://github.com/nix-community/NUR/commit/b0511c1dfa8edd999d9265142390fcdd6fa48f3f) | `` automatic update `` |