### PR TITLE
chore(flake/nur): `b0511c1d` -> `6127104b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693432386,
-        "narHash": "sha256-dXJWkqm5bGshHR7q616VRqyTpqI5a7Gk9GjkX5PVZpA=",
+        "lastModified": 1693439170,
+        "narHash": "sha256-HQu0MH0W2azXm9T9iVPbisUuzCbcS8AXZMzxqQQh3QI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b0511c1dfa8edd999d9265142390fcdd6fa48f3f",
+        "rev": "6127104b9f7397d09bd47b8737d4aa10fb25826f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6127104b`](https://github.com/nix-community/NUR/commit/6127104b9f7397d09bd47b8737d4aa10fb25826f) | `` automatic update `` |