### PR TITLE
chore(flake/emacs-overlay): `c98175e1` -> `6bc1f87f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693420702,
-        "narHash": "sha256-iKj+ODIDk7lK2po9TYj9HA9QKNJoefwMiLCCan1MuFY=",
+        "lastModified": 1693450526,
+        "narHash": "sha256-N6wkYe52qT/Rh4ZdB+UmaM1SAMOMKAzjCcjIYqsTcUY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c98175e11975e29300e082bba2f63e12fd804127",
+        "rev": "6bc1f87faed1388fe83c295bc944bf7dfaafa8df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`6bc1f87f`](https://github.com/nix-community/emacs-overlay/commit/6bc1f87faed1388fe83c295bc944bf7dfaafa8df) | `` Updated repos/nongnu `` |
| [`7a565988`](https://github.com/nix-community/emacs-overlay/commit/7a565988476b5e20224425f9b3a322e97b1c3d28) | `` Updated repos/melpa ``  |
| [`b80c45ff`](https://github.com/nix-community/emacs-overlay/commit/b80c45ffae2b32fb976abf76b7d7d723790126f2) | `` Updated repos/emacs ``  |
| [`7b26a48e`](https://github.com/nix-community/emacs-overlay/commit/7b26a48eceda3bee6b3ec62b789f8d269eb42ddc) | `` Updated repos/elpa ``   |