### PR TITLE
chore(flake/nur): `e3974178` -> `9ad5ff80`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693445909,
-        "narHash": "sha256-9y9UPhCyAqV/tjDRfb+QmS9NjSgjnqC4Z+MoSWBJyC0=",
+        "lastModified": 1693450549,
+        "narHash": "sha256-if25of4tu+xIhFWjK2BpOZXarc2LFJvnKuHrgaGiyrw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e3974178bb290ad23e868ff12ecbfff794068ddc",
+        "rev": "9ad5ff80f5808a9f0f3809dcd60b379df0c2b208",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ad5ff80`](https://github.com/nix-community/NUR/commit/9ad5ff80f5808a9f0f3809dcd60b379df0c2b208) | `` automatic update `` |