### PR TITLE
chore(flake/nur): `9ad5ff80` -> `afd3a724`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693450549,
-        "narHash": "sha256-if25of4tu+xIhFWjK2BpOZXarc2LFJvnKuHrgaGiyrw=",
+        "lastModified": 1693453101,
+        "narHash": "sha256-WVPkLB5dFyVWOJ/YZWsEnORSp6Hgx6IHxAMC31J8+a8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ad5ff80f5808a9f0f3809dcd60b379df0c2b208",
+        "rev": "afd3a72440aeebb88d5560eeebd9c49963549e1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`afd3a724`](https://github.com/nix-community/NUR/commit/afd3a72440aeebb88d5560eeebd9c49963549e1c) | `` automatic update `` |
| [`286e9f53`](https://github.com/nix-community/NUR/commit/286e9f533380142cf0f27d9e3ba50c13fd584deb) | `` automatic update `` |