### PR TITLE
chore(flake/nur): `afd3a724` -> `4b212a81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693453101,
-        "narHash": "sha256-WVPkLB5dFyVWOJ/YZWsEnORSp6Hgx6IHxAMC31J8+a8=",
+        "lastModified": 1693454949,
+        "narHash": "sha256-2I4p5bPpDclmI1bUT9VJ2Difwed9DrhaZhWIu4qARjM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "afd3a72440aeebb88d5560eeebd9c49963549e1c",
+        "rev": "4b212a81d9cb311f3f52dcc8b38df47f55da0057",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4b212a81`](https://github.com/nix-community/NUR/commit/4b212a81d9cb311f3f52dcc8b38df47f55da0057) | `` automatic update `` |