### PR TITLE
chore(flake/nur): `4b212a81` -> `a18bb266`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693454949,
-        "narHash": "sha256-2I4p5bPpDclmI1bUT9VJ2Difwed9DrhaZhWIu4qARjM=",
+        "lastModified": 1693467993,
+        "narHash": "sha256-3t42EiMFxyLEdL+yWciEOCKIORBLag3Kbc8pK+npcYo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4b212a81d9cb311f3f52dcc8b38df47f55da0057",
+        "rev": "a18bb2664e2597598810dc45a17f70741254ea25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a18bb266`](https://github.com/nix-community/NUR/commit/a18bb2664e2597598810dc45a17f70741254ea25) | `` automatic update `` |