### PR TITLE
chore(flake/nur): `a18bb266` -> `057866f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693467993,
-        "narHash": "sha256-3t42EiMFxyLEdL+yWciEOCKIORBLag3Kbc8pK+npcYo=",
+        "lastModified": 1693471520,
+        "narHash": "sha256-8Mb5TTLPhDak3GIZwo3nvvO3ocsEj8yCQmPqzsQwXv4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a18bb2664e2597598810dc45a17f70741254ea25",
+        "rev": "057866f47f5a09db91feb72623db1c4661a881b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`057866f4`](https://github.com/nix-community/NUR/commit/057866f47f5a09db91feb72623db1c4661a881b6) | `` automatic update `` |