### PR TITLE
chore(flake/nur): `057866f4` -> `069b0b52`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693471520,
-        "narHash": "sha256-8Mb5TTLPhDak3GIZwo3nvvO3ocsEj8yCQmPqzsQwXv4=",
+        "lastModified": 1693475171,
+        "narHash": "sha256-kaxICPWe1GNrvvMCi30w4+k0edJQaj0LQHQHqv8B+VA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "057866f47f5a09db91feb72623db1c4661a881b6",
+        "rev": "069b0b52616886ece17110d763e2256aeae851c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`069b0b52`](https://github.com/nix-community/NUR/commit/069b0b52616886ece17110d763e2256aeae851c7) | `` automatic update `` |
| [`3dfb1bfc`](https://github.com/nix-community/NUR/commit/3dfb1bfcd1801a102a46f2b9567cbdf2dc83ac3f) | `` automatic update `` |
| [`926f91ba`](https://github.com/nix-community/NUR/commit/926f91ba6d506a3d617e7a6c44b26218142b1b18) | `` automatic update `` |
| [`2a1eb435`](https://github.com/nix-community/NUR/commit/2a1eb43598424a03c2c21cfdf91e4d43af72b7a7) | `` automatic update `` |