### PR TITLE
chore(flake/nur): `069b0b52` -> `56b00207`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693475171,
-        "narHash": "sha256-kaxICPWe1GNrvvMCi30w4+k0edJQaj0LQHQHqv8B+VA=",
+        "lastModified": 1693478746,
+        "narHash": "sha256-zxHznBa9tkpkKyBiQCnae9jG/4zhyD6Oqw9XCaJV4GY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "069b0b52616886ece17110d763e2256aeae851c7",
+        "rev": "56b00207a96984f78eb379c2cb9300e110becec3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`56b00207`](https://github.com/nix-community/NUR/commit/56b00207a96984f78eb379c2cb9300e110becec3) | `` automatic update `` |