### PR TITLE
chore(flake/emacs-overlay): `6bc1f87f` -> `47c99763`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693450526,
-        "narHash": "sha256-N6wkYe52qT/Rh4ZdB+UmaM1SAMOMKAzjCcjIYqsTcUY=",
+        "lastModified": 1693479240,
+        "narHash": "sha256-jEQfzL3ZPiRr2B+J//VYlsvkQYWGznyvuaVPQcJvkL0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6bc1f87faed1388fe83c295bc944bf7dfaafa8df",
+        "rev": "47c9976307a563c6c80250669e47c4b10a4801aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`47c99763`](https://github.com/nix-community/emacs-overlay/commit/47c9976307a563c6c80250669e47c4b10a4801aa) | `` Updated repos/nongnu `` |
| [`ddde5514`](https://github.com/nix-community/emacs-overlay/commit/ddde5514d990a472dcc6b96c835a6beb5c4a2549) | `` Updated repos/melpa ``  |
| [`aeceeab4`](https://github.com/nix-community/emacs-overlay/commit/aeceeab4dc6c3e7f196e73979f1ebe758be0e296) | `` Updated repos/emacs ``  |