### PR TITLE
chore(flake/nur): `10c20b70` -> `903f4ec7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693489557,
-        "narHash": "sha256-0AO1D/w3EBz1UMnxi9LJEHdFO02Hidy06YqkxHaNvRg=",
+        "lastModified": 1693492797,
+        "narHash": "sha256-OJ3SlDXRbF5bUK4p9FPgVAV5AoKZBbDyiEO5prWZKuE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "10c20b70fc4d97beacdd67cb5b153a2f47364aba",
+        "rev": "903f4ec7c3f2b1401b68dbe830bc56e65d335759",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`903f4ec7`](https://github.com/nix-community/NUR/commit/903f4ec7c3f2b1401b68dbe830bc56e65d335759) | `` automatic update `` |