### PR TITLE
chore(flake/nur): `903f4ec7` -> `867565db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693492797,
-        "narHash": "sha256-OJ3SlDXRbF5bUK4p9FPgVAV5AoKZBbDyiEO5prWZKuE=",
+        "lastModified": 1693496837,
+        "narHash": "sha256-O46iCkmsmUEJCehSTtXQ3/f3VuRChVDEFKr1NKzN+hY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "903f4ec7c3f2b1401b68dbe830bc56e65d335759",
+        "rev": "867565db752f3193b856e43c74dc7422ab273ebd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`867565db`](https://github.com/nix-community/NUR/commit/867565db752f3193b856e43c74dc7422ab273ebd) | `` automatic update `` |