### PR TITLE
chore(flake/emacs-overlay): `47c99763` -> `f88e77ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693479240,
-        "narHash": "sha256-jEQfzL3ZPiRr2B+J//VYlsvkQYWGznyvuaVPQcJvkL0=",
+        "lastModified": 1693505936,
+        "narHash": "sha256-9l8r/xpr6fo54XIpFSAh7exWDq7QYWMcnNmTnI7nNvM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "47c9976307a563c6c80250669e47c4b10a4801aa",
+        "rev": "f88e77ec11c9325e61bf06bb2eeed13f90ff2e42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`f88e77ec`](https://github.com/nix-community/emacs-overlay/commit/f88e77ec11c9325e61bf06bb2eeed13f90ff2e42) | `` Updated repos/melpa `` |
| [`2731b08f`](https://github.com/nix-community/emacs-overlay/commit/2731b08f4fd6e0ee026dbcdcf192a0f3c46cb230) | `` Updated repos/emacs `` |
| [`bd47f2c5`](https://github.com/nix-community/emacs-overlay/commit/bd47f2c5d8a26ab4fa5854e81b4741466768236b) | `` Updated repos/elpa ``  |