### PR TITLE
chore(flake/nur): `2193de09` -> `dc4dc6c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693508393,
-        "narHash": "sha256-FagQkHWoo91Lm0oT2wMPHqVIg6/RGeJg5M/sL2glg90=",
+        "lastModified": 1693525631,
+        "narHash": "sha256-82BOwU3cLKbuf5hld/hHtYc52bPhEcz8JuGFpvaun9A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2193de091ecd925af783069b8393a80cd6cc8a29",
+        "rev": "dc4dc6c7d7383bf147be51f1364f259d720f61f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dc4dc6c7`](https://github.com/nix-community/NUR/commit/dc4dc6c7d7383bf147be51f1364f259d720f61f6) | `` automatic update `` |
| [`9b88e738`](https://github.com/nix-community/NUR/commit/9b88e738576d738c3ee1d6668c794cf0e7159939) | `` automatic update `` |