### PR TITLE
chore(flake/nur): `dc4dc6c7` -> `05ac30c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693525631,
-        "narHash": "sha256-82BOwU3cLKbuf5hld/hHtYc52bPhEcz8JuGFpvaun9A=",
+        "lastModified": 1693540099,
+        "narHash": "sha256-HuYjS1wcdtU6rXr39XSiMSdwLdrlVs59C5q665da1BE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dc4dc6c7d7383bf147be51f1364f259d720f61f6",
+        "rev": "05ac30c259a806d17cf9d9cfa337860144ab419e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`05ac30c2`](https://github.com/nix-community/NUR/commit/05ac30c259a806d17cf9d9cfa337860144ab419e) | `` automatic update `` |
| [`dcfc3093`](https://github.com/nix-community/NUR/commit/dcfc309316f0f5cc713749ec83b759ecb3b8af5a) | `` automatic update `` |
| [`4c82c68a`](https://github.com/nix-community/NUR/commit/4c82c68a43dcc4314a247a2baac956ef9349d451) | `` automatic update `` |