### PR TITLE
chore(flake/emacs-overlay): `f88e77ec` -> `c45a4e9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693505936,
-        "narHash": "sha256-9l8r/xpr6fo54XIpFSAh7exWDq7QYWMcnNmTnI7nNvM=",
+        "lastModified": 1693537717,
+        "narHash": "sha256-zjEppddHHy5kEyRHN+8xd7hLXXcjtbCajsyD5BdxSX8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f88e77ec11c9325e61bf06bb2eeed13f90ff2e42",
+        "rev": "c45a4e9a687936dade94b60f423ee1699d8e8ac8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`c45a4e9a`](https://github.com/nix-community/emacs-overlay/commit/c45a4e9a687936dade94b60f423ee1699d8e8ac8) | `` Updated repos/melpa `` |
| [`1bab7021`](https://github.com/nix-community/emacs-overlay/commit/1bab70211bbeaf58048865111501ecf6d870561b) | `` Updated repos/emacs `` |
| [`fa03b902`](https://github.com/nix-community/emacs-overlay/commit/fa03b90235a301e0758251653cecf0274474c738) | `` Updated repos/elpa ``  |