### PR TITLE
chore(flake/nur): `05ac30c2` -> `027f8cb1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693540099,
-        "narHash": "sha256-HuYjS1wcdtU6rXr39XSiMSdwLdrlVs59C5q665da1BE=",
+        "lastModified": 1693546898,
+        "narHash": "sha256-2yEeuYhCe2SnqW9WYigkDXD5wfDbRvkrhYQrp2WepjI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "05ac30c259a806d17cf9d9cfa337860144ab419e",
+        "rev": "027f8cb120a1e92b31667d0d9185cf01d5a3f60e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`027f8cb1`](https://github.com/nix-community/NUR/commit/027f8cb120a1e92b31667d0d9185cf01d5a3f60e) | `` automatic update `` |
| [`adf56dbb`](https://github.com/nix-community/NUR/commit/adf56dbb167375295afa89e27ce03194a1c5e734) | `` automatic update `` |
| [`897beda4`](https://github.com/nix-community/NUR/commit/897beda4234c30e764d1a5dd2a32932cf4b9ba53) | `` automatic update `` |