### PR TITLE
chore(flake/nur): `027f8cb1` -> `d1b5ecfc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693546898,
-        "narHash": "sha256-2yEeuYhCe2SnqW9WYigkDXD5wfDbRvkrhYQrp2WepjI=",
+        "lastModified": 1693550904,
+        "narHash": "sha256-Q/qed49+paxrSFAvhdH5x8wQrxdyWU0fEtvBMr2+A4U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "027f8cb120a1e92b31667d0d9185cf01d5a3f60e",
+        "rev": "d1b5ecfcb32856285b7b25c070a29332d44bea85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d1b5ecfc`](https://github.com/nix-community/NUR/commit/d1b5ecfcb32856285b7b25c070a29332d44bea85) | `` automatic update `` |