### PR TITLE
chore(flake/nur): `d1b5ecfc` -> `92cc0ab0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693550904,
-        "narHash": "sha256-Q/qed49+paxrSFAvhdH5x8wQrxdyWU0fEtvBMr2+A4U=",
+        "lastModified": 1693555295,
+        "narHash": "sha256-wmMYa7Wki1V53nkH50bUD9mmg5OMjgXG18BVadS1sgQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d1b5ecfcb32856285b7b25c070a29332d44bea85",
+        "rev": "92cc0ab078f0d82002caefbb9a8f38d198d03763",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`92cc0ab0`](https://github.com/nix-community/NUR/commit/92cc0ab078f0d82002caefbb9a8f38d198d03763) | `` automatic update `` |