### PR TITLE
chore(flake/emacs-overlay): `c45a4e9a` -> `32282591`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693537717,
-        "narHash": "sha256-zjEppddHHy5kEyRHN+8xd7hLXXcjtbCajsyD5BdxSX8=",
+        "lastModified": 1693565656,
+        "narHash": "sha256-ydbVFKWAFV8R0Dcy+LDlb9+rPwvzB+jwUfg1o46n0xA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c45a4e9a687936dade94b60f423ee1699d8e8ac8",
+        "rev": "32282591ce0496c2a38b593b8bc01aff2ba7c14b",
         "type": "github"
       },
       "original": {
@@ -732,11 +732,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1693341273,
-        "narHash": "sha256-wrsPjsIx2767909MPGhSIOmkpGELM9eufqLQOPxmZQg=",
+        "lastModified": 1693428224,
+        "narHash": "sha256-FWUUlhYqkGEySUD0blTADRiDQ7fw+H1ikivfu88uy+w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2ab91c8d65c00fd22a441c69bbf1bc9b420d5ea1",
+        "rev": "841889913dfd06a70ffb39f603e29e46f45f0c1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`32282591`](https://github.com/nix-community/emacs-overlay/commit/32282591ce0496c2a38b593b8bc01aff2ba7c14b) | `` Updated repos/melpa ``  |
| [`f3f7544d`](https://github.com/nix-community/emacs-overlay/commit/f3f7544db1a2a5c0a1e65539b6d6e03caf93a616) | `` Updated repos/emacs ``  |
| [`00eb85ea`](https://github.com/nix-community/emacs-overlay/commit/00eb85ea0fa4133a9e94164df3e5c2f872cdc3f6) | `` Updated flake inputs `` |