### PR TITLE
chore(flake/nixpkgs): `e7f38be3` -> `3e52e76b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -810,11 +810,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1693377291,
-        "narHash": "sha256-vYGY9bnqEeIncNarDZYhm6KdLKgXMS+HA2mTRaWEc80=",
+        "lastModified": 1693471703,
+        "narHash": "sha256-0l03ZBL8P1P6z8MaSDS/MvuU8E75rVxe5eE1N6gxeTo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e7f38be3775bab9659575f192ece011c033655f0",
+        "rev": "3e52e76b70d5508f3cec70b882a29199f4d1ee85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`d7c9dc08`](https://github.com/NixOS/nixpkgs/commit/d7c9dc08d9d9a817dd8611886b1ff2b2f958c812) | `` python311Packages.pyinsteon: update disabled ``                          |
| [`7a34883b`](https://github.com/NixOS/nixpkgs/commit/7a34883bfbb272d9149cfab413e75de9dedb7906) | `` python311Packages.pyinsteon: add changelog to meta ``                    |
| [`9c9d9f7f`](https://github.com/NixOS/nixpkgs/commit/9c9d9f7f2075eec3e1934d28ec9a3b5f94db39bd) | `` python311Packages.pyinsteon: 1.4.3 -> 1.5.0 ``                           |
| [`3277291c`](https://github.com/NixOS/nixpkgs/commit/3277291c5d1999bcde122ef6f163caea57a3a3ee) | `` python310Packages.google-re2: update disabled ``                         |
| [`fa309425`](https://github.com/NixOS/nixpkgs/commit/fa309425fa73944b92a08c3736ad469f2778d302) | `` python311Packages.aiobiketrax: 1.1.0 -> 1.1.1 ``                         |
| [`5c4c1312`](https://github.com/NixOS/nixpkgs/commit/5c4c1312902e56776d249a3d99ea23183a34c8c9) | `` sigma-cli: 0.7.2 -> 0.7.7 ``                                             |
| [`ed562c5d`](https://github.com/NixOS/nixpkgs/commit/ed562c5d4747ad9fda362d2b6bae8fbd9d9ef5d9) | `` python311Packages.pysigma-pipeline-sysmon: 1.0.2 -> 1.0.3 ``             |
| [`153f0fd8`](https://github.com/NixOS/nixpkgs/commit/153f0fd87f0bee2d7e26c1fcc067aa62f3f5df26) | `` python311Packages.pysigma-backend-splunk: 1.0.2 -> 1.0.3 ``              |
| [`76e826d0`](https://github.com/NixOS/nixpkgs/commit/76e826d0b17ad44be3b90f3ea94605959787cffd) | `` python311Packages.pysigma-backend-opensearch: 1.0.0 -> 1.0.1 ``          |
| [`a7a14b73`](https://github.com/NixOS/nixpkgs/commit/a7a14b73e4d747d6434a465647be565aa7961695) | `` python311Packages.pysigma: 0.9.11 -> 0.10.4 ``                           |
| [`d80cc09b`](https://github.com/NixOS/nixpkgs/commit/d80cc09bfae2112deca15d313805e9b73b3634c8) | `` python311Packages.pysigma-pipeline-crowdstrike: 1.0.0 -> 1.0.1 ``        |
| [`7d8b3508`](https://github.com/NixOS/nixpkgs/commit/7d8b350857b8e0e66663911a57ff9b4188be37d4) | `` python311Packages.pysigma-pipeline-windows: 1.1.0 -> 1.1.1 ``            |
| [`86e6a0b7`](https://github.com/NixOS/nixpkgs/commit/86e6a0b7cc2ecb14f7dd940062482fb12132f02b) | `` python311Packages.pysnooz: 0.8.5 -> 0.8.6 ``                             |
| [`6fe604d6`](https://github.com/NixOS/nixpkgs/commit/6fe604d65b337f1a8baadccb75c4b590f7e2b8fb) | `` python310Packages.pytado: add format ``                                  |
| [`3cb349b4`](https://github.com/NixOS/nixpkgs/commit/3cb349b4068c7c845c0a8ec722c622f9ffc97b70) | `` python310Packages.pytado: update meta ``                                 |
| [`85fe456b`](https://github.com/NixOS/nixpkgs/commit/85fe456b00e927c48b6f685bff0cd405dbe53eeb) | `` python310Packages.pytado: remove stale comment ``                        |
| [`95f83b9f`](https://github.com/NixOS/nixpkgs/commit/95f83b9fd74b79d61df53c9b67fb46d514b58ca9) | `` python310Packages.google-re2: 1.0 -> 1.1 ``                              |
| [`003c0092`](https://github.com/NixOS/nixpkgs/commit/003c00925a39cd82a8f9658dc9570bf25b8f13dd) | `` liferea: 1.15.1 -> 1.15.2 ``                                             |
| [`7732a57c`](https://github.com/NixOS/nixpkgs/commit/7732a57c8704e846ebc2ad8b58aed2745e8fcbda) | `` gitui: 0.23.0 -> 0.24.1 ``                                               |
| [`86c0091f`](https://github.com/NixOS/nixpkgs/commit/86c0091f1c1c62ead7f4ceb5ddcb0f9300f1f07d) | `` gitui: add mfrw as maintainer ``                                         |
| [`cd6cdb00`](https://github.com/NixOS/nixpkgs/commit/cd6cdb001bb3bb2058324a4612952044628b6e31) | `` python310Packages.pytado: 0.16.0 -> 0.17.2 ``                            |
| [`9ee705f6`](https://github.com/NixOS/nixpkgs/commit/9ee705f63c7129765c49afaf8ac45d374fe9ad25) | `` python311Packages.botocore-stubs: 1.31.37 -> 1.31.38 ``                  |
| [`5f1d3357`](https://github.com/NixOS/nixpkgs/commit/5f1d335782bbe70a9ea681ebde469df9672079c9) | `` python311Packages.manifest-ml: add pythonImportsCheck ``                 |
| [`023ed237`](https://github.com/NixOS/nixpkgs/commit/023ed237f5b2ddd29785329dea5c5010429eca13) | `` python311Packages.manifest-ml: disable time-sensitve test ``             |
| [`3810cb56`](https://github.com/NixOS/nixpkgs/commit/3810cb56813c74cd526147d52aa004bfdd83dde7) | `` python311Packages.datasets: update disabled ``                           |
| [`9b4d043b`](https://github.com/NixOS/nixpkgs/commit/9b4d043ba2c3c7770bb23ea8ba7858c2a93906a6) | `` ocamlPackages.janestreet: 0.15 -> 0.16 (#247022) ``                      |
| [`a86b37a5`](https://github.com/NixOS/nixpkgs/commit/a86b37a5695bc385ae52b97e9b152b49066435a7) | `` mu: 1.10.6 -> 1.10.7 ``                                                  |
| [`20f321c8`](https://github.com/NixOS/nixpkgs/commit/20f321c847295367305364c78c0b002a79eee82d) | `` go-jet: 2.10.0 -> 2.10.1 ``                                              |
| [`dfe66fc6`](https://github.com/NixOS/nixpkgs/commit/dfe66fc6dfff137140ca32d8d628f1292d5fa172) | `` terraform-providers.vault: 3.19.0 -> 3.20.0 ``                           |
| [`3d56af83`](https://github.com/NixOS/nixpkgs/commit/3d56af83f36b12bbca210ecf369dd8b06813716d) | `` terraform-providers.oci: 5.10.0 -> 5.11.0 ``                             |
| [`cc72803f`](https://github.com/NixOS/nixpkgs/commit/cc72803f18e0053cb8c12d44085a12e59f4de70d) | `` terraform-providers.pagerduty: 2.16.1 -> 2.16.2 ``                       |
| [`4c3c0281`](https://github.com/NixOS/nixpkgs/commit/4c3c02816912b279cf6521d29a23dff50fd717a1) | `` terraform-providers.launchdarkly: 2.15.0 -> 2.15.1 ``                    |
| [`a2c49504`](https://github.com/NixOS/nixpkgs/commit/a2c4950424131566737e0287ffa06055b2643127) | `` terraform-providers.baiducloud: 1.19.14 -> 1.19.15 ``                    |
| [`ac635405`](https://github.com/NixOS/nixpkgs/commit/ac635405a648b15bc99021a94eb618fa42ef508f) | `` joker: 1.2.0 -> 1.3.0 ``                                                 |
| [`9a4cab8f`](https://github.com/NixOS/nixpkgs/commit/9a4cab8f974ab199354752cb53017800da8054b1) | `` vkd3d: 1.7.1 -> 1.8 ``                                                   |
| [`b18eba2d`](https://github.com/NixOS/nixpkgs/commit/b18eba2da85fc134270eb62ba48d371cd8522340) | `` python310Packages.optimum: 1.11.1 -> 1.12.0 ``                           |
| [`4810bb10`](https://github.com/NixOS/nixpkgs/commit/4810bb105ebb2295dac27f0c3f1fd9d1a2833176) | `` python3Packages.pycardano: init at 0.9.0 ``                              |
| [`35e66ea4`](https://github.com/NixOS/nixpkgs/commit/35e66ea4f690fd54b78d01e2ded2d32e7c04e5c8) | `` python3Packages.cose: init at 1.0.1 ``                                   |
| [`0042d1a5`](https://github.com/NixOS/nixpkgs/commit/0042d1a5995776402522377de809613aa1b3fe04) | `` python3Packages.blockfrost-python: init at 0.5.3 ``                      |
| [`0ced6748`](https://github.com/NixOS/nixpkgs/commit/0ced6748c91ff1913315fb7f7c46ec963d4a8bee) | `` jmol: 16.1.33 -> 16.1.35 ``                                              |
| [`bd502cad`](https://github.com/NixOS/nixpkgs/commit/bd502cad2c9bb41481c641fcb4c935c2bdcb9483) | `` docker-compose: 2.20.3 -> 2.21.0 ``                                      |
| [`cfbc8f99`](https://github.com/NixOS/nixpkgs/commit/cfbc8f99bc1d80d04af38064abbdead3a3e7e075) | `` blocky: 0.21 -> 0.22 ``                                                  |
| [`70a503b3`](https://github.com/NixOS/nixpkgs/commit/70a503b3af0bce53eb9882c35de6b9ceb626a0a9) | `` air: 1.44.0 -> 1.45.0 ``                                                 |
| [`c736c29f`](https://github.com/NixOS/nixpkgs/commit/c736c29f0b3eab0c20d2fcb0a69479808ff99535) | `` python311Packages.clarifai: 9.5.2 -> 9.7.1 ``                            |
| [`78734454`](https://github.com/NixOS/nixpkgs/commit/78734454e4777d193c80ed40a17da2b4af18b073) | `` hyprnome: init at 0.1.0 ``                                               |
| [`bbb8c464`](https://github.com/NixOS/nixpkgs/commit/bbb8c464705ad13e199159ccfe11cea6b70eff75) | `` sqlc: update source repository ``                                        |
| [`d970db15`](https://github.com/NixOS/nixpkgs/commit/d970db15e3107933579cca94ec740238c5fce949) | `` vimPlugins.sg-nvim: fix cargoHash ``                                     |
| [`b308d146`](https://github.com/NixOS/nixpkgs/commit/b308d14631607208b0f78635e4794907e4bd5df7) | `` hugin: add patch for exiv2 0.28 ``                                       |
| [`5ab5c5d6`](https://github.com/NixOS/nixpkgs/commit/5ab5c5d6c7c4ee56359d307f4339f5169bac0fe7) | `` golly: 4.1 -> 4.2 ``                                                     |
| [`fbb9e796`](https://github.com/NixOS/nixpkgs/commit/fbb9e796fa0eb830981067600a6a93e9e5b1c418) | `` python310Packages.torchio: 0.18.90 -> 0.19.1 ``                          |
| [`52cc7e92`](https://github.com/NixOS/nixpkgs/commit/52cc7e923a4594be5007a54efa5783c50a5c9c8a) | `` python311Packages.datasets: 2.12.0 -> 2.14.4 ``                          |
| [`151b3a4e`](https://github.com/NixOS/nixpkgs/commit/151b3a4e48efc3afb5d4676fa470897fe8e3417c) | `` python311Packages.datadiff: 2.1.0 -> 2.2.0 ``                            |
| [`7ee83818`](https://github.com/NixOS/nixpkgs/commit/7ee83818d71bdefb4c3a270a353e9705d474b5fd) | `` python311Packages.add-trailing-comma: 3.0.1 -> 3.1.0 ``                  |
| [`ce472c7f`](https://github.com/NixOS/nixpkgs/commit/ce472c7f307a72ede764ddcea79ea5fd47e7a1d0) | `` python311Packages.restrictedpython: 6.1 -> 6.2 ``                        |
| [`91f9bce0`](https://github.com/NixOS/nixpkgs/commit/91f9bce07e3664362f2127fdbbfd316729090a5e) | `` sqlfluff: 2.3.0 -> 2.3.1 ``                                              |
| [`de905160`](https://github.com/NixOS/nixpkgs/commit/de90516073f4e73295daec5af1dd0921ab596aa5) | `` textplots: 0.8.1 -> 0.8.2 ``                                             |
| [`7bf7c404`](https://github.com/NixOS/nixpkgs/commit/7bf7c4049a38847d4bd27be28380b34802ed5bb1) | `` prismlauncher: include udev as a runtime dependency ``                   |
| [`e2979cb3`](https://github.com/NixOS/nixpkgs/commit/e2979cb3ab6e908b0dc69dedc7c6b15e9d02496a) | `` trufflehog: 3.54.0 -> 3.54.1 ``                                          |
| [`128ebf86`](https://github.com/NixOS/nixpkgs/commit/128ebf865db05982f0803538e9da84b8f453cae8) | `` python311Packages.aioredis: fetch patch for python 3.11 compatibility `` |
| [`c0578b81`](https://github.com/NixOS/nixpkgs/commit/c0578b8128ace1397baac37bb4aa3433162290fb) | `` flare-signal: 0.9.1 -> 0.10.0 ``                                         |
| [`68e06a30`](https://github.com/NixOS/nixpkgs/commit/68e06a303a13979701e99a556bc131a25e6e01c1) | `` virt-manager: fix build on darwin ``                                     |
| [`9e7b9ff8`](https://github.com/NixOS/nixpkgs/commit/9e7b9ff8b5c00f4d9667d00dec7d9e1e836b6a79) | `` element-{desktop,web}: 1.11.38 -> 1.11.40 ``                             |
| [`54ea524b`](https://github.com/NixOS/nixpkgs/commit/54ea524b68c4ccc154aac1166c129fba55b35327) | `` qovery-cli: 0.66.1 -> 0.67.1 ``                                          |
| [`a2bc0428`](https://github.com/NixOS/nixpkgs/commit/a2bc042851dd1d757ef33ef2e7db6031ae1ec4b0) | `` tgpt: 1.7.2 -> 1.7.4 ``                                                  |
| [`8eb1802f`](https://github.com/NixOS/nixpkgs/commit/8eb1802f905f6f8c9e20dea877fec0a1839aa9aa) | `` checkov: 2.4.14 -> 2.4.18 ``                                             |
| [`da07ab78`](https://github.com/NixOS/nixpkgs/commit/da07ab78a5bb5fa35805daba42a47d141a513f13) | `` python311Packages.types-awscrt: 0.19.0 -> 0.19.1 ``                      |
| [`41049dea`](https://github.com/NixOS/nixpkgs/commit/41049dea026f2c2567ab4594214569960f42f41b) | `` python311Packages.regenmaschine: 2023.06.0 -> 2023.08.0 ``               |
| [`85f98d23`](https://github.com/NixOS/nixpkgs/commit/85f98d23040ad923f64deac2fb3d3bec57d70070) | `` python311Packages.pyweatherflowrest: 1.0.9 -> 1.0.10 ``                  |
| [`957edbf9`](https://github.com/NixOS/nixpkgs/commit/957edbf9ba80eaeb2f083f0c42ce7c3e4f9b9219) | `` python311Packages.python-roborock: 0.32.3 -> 0.32.4 ``                   |
| [`6b6abb25`](https://github.com/NixOS/nixpkgs/commit/6b6abb25a53ed25d34765405a9726564b18382ea) | `` python311Packages.pyoutbreaksnearme: 2022.10.0 -> 2023.08.0 ``           |
| [`530c204b`](https://github.com/NixOS/nixpkgs/commit/530c204bd199149e632e4e042a416f2894cfad7a) | `` python311Packages.app-model: 0.2.0 -> 0.2.1 ``                           |
| [`c1d863f5`](https://github.com/NixOS/nixpkgs/commit/c1d863f5855d94ff926f7cd4ea9c189e0ae66cf4) | `` python311Packages.aioambient: 2023.04.0 -> 2023.08.0 ``                  |
| [`1a2bf3b9`](https://github.com/NixOS/nixpkgs/commit/1a2bf3b9e643845c0bd201a3a58295fdf0df0ce5) | `` python311Packages.aioguardian: 2022.10.0 -> 2023.08.0 ``                 |
| [`39ab966b`](https://github.com/NixOS/nixpkgs/commit/39ab966bc4575ab703336dfa5e444a6da5dfae14) | `` python310Packages.pex: 2.1.144 -> 2.1.145 ``                             |
| [`9345e48b`](https://github.com/NixOS/nixpkgs/commit/9345e48bb40ff5d4036edd5c291c46e18196cfea) | `` privoxy: fix types.string -> types.str ``                                |
| [`0f64b0a6`](https://github.com/NixOS/nixpkgs/commit/0f64b0a6d8e9a1c1ecb80d8198c1f81e8f36e7b6) | `` ospd-openvas: 22.5.4 -> 22.6.0 ``                                        |
| [`c2b2e074`](https://github.com/NixOS/nixpkgs/commit/c2b2e07435c67ab1b9cadba6a02b98a2403ad91e) | `` python311Packages.notus-scanner: 22.6.0 -> 22.6.0 ``                     |
| [`7fb30725`](https://github.com/NixOS/nixpkgs/commit/7fb307255774108e1d029a30d139ee907ecd0538) | `` python311Packages.aiolifx-themes: 0.4.5 -> 0.4.7 ``                      |
| [`803dee58`](https://github.com/NixOS/nixpkgs/commit/803dee581de1e6e37edb2a74da2f6e63961bd235) | `` python311Packages.cookies: fetch patch to fix python 3.11 build ``       |
| [`b7aec84e`](https://github.com/NixOS/nixpkgs/commit/b7aec84ef0cf1cff7fb314ea3a4930112b66fb1a) | `` simdjson: 3.2.2 -> 3.2.3 ``                                              |
| [`87201d37`](https://github.com/NixOS/nixpkgs/commit/87201d37f3b7ebffbbda3adf303733801adc5e7e) | `` python310Packages.scikit-fuzzy: fix tests for numpy 1.25 ``              |
| [`ee577cc8`](https://github.com/NixOS/nixpkgs/commit/ee577cc88b7bff051b2b65c225578fd6759d13b0) | `` python310Packages.universal-pathlib: 0.1.2 -> 0.1.3 ``                   |
| [`660c4e86`](https://github.com/NixOS/nixpkgs/commit/660c4e86f6e9a9866579e6305bfade709cddea25) | `` python311Packages.mypy-boto3-s3: 1.28.27 -> 1.28.36 ``                   |
| [`2659b66c`](https://github.com/NixOS/nixpkgs/commit/2659b66c9c5139eebffc2032b1491b1b7a1a0134) | `` python311Packages.mypy-boto3-builder: 7.18.0 -> 7.18.2 ``                |
| [`addbdb1c`](https://github.com/NixOS/nixpkgs/commit/addbdb1cbbfba0936eb22bd4d68bee899ace7c8b) | `` simplotask: 1.11.3 -> 1.11.4 ``                                          |
| [`5681d9ec`](https://github.com/NixOS/nixpkgs/commit/5681d9ecbc071083418efda57d8c6c4b2fb1c568) | `` yx: init at 1.0.0 ``                                                     |
| [`d2b743f2`](https://github.com/NixOS/nixpkgs/commit/d2b743f2287135122f5c6a242363e23f1a935a97) | `` typos: 1.16.8 -> 1.16.9 ``                                               |
| [`8dd35e19`](https://github.com/NixOS/nixpkgs/commit/8dd35e19f62c50c0dca52a00661fcda7ebaa0799) | `` python310Packages.pdf2docx: add pip as a build dependency ``             |
| [`2a106ba0`](https://github.com/NixOS/nixpkgs/commit/2a106ba0acef8fd9a2a135802e3fc2589ad6af4e) | `` httplz: 1.13.1 -> 1.13.2 ``                                              |
| [`2c06749d`](https://github.com/NixOS/nixpkgs/commit/2c06749d99ce8f3554def6ff7bf0aa3cd3472a8e) | `` maintainers: add twz123 ``                                               |
| [`d6a9856b`](https://github.com/NixOS/nixpkgs/commit/d6a9856b3bae7a77c2db59d6bd2ef36ee908652f) | `` xfce.xfce4-whiskermenu-plugin: 2.7.3 -> 2.8.0 ``                         |
| [`1c89afa0`](https://github.com/NixOS/nixpkgs/commit/1c89afa06e6789e4449cb9eb2a5d6967cffc58d5) | `` ipscan: add alias for common name ``                                     |
| [`e0192b62`](https://github.com/NixOS/nixpkgs/commit/e0192b625cf591f12831f2a3752349c8ed8ac775) | `` ipscan: refactor meta and add totoroot as maintainer ``                  |
| [`23618ec1`](https://github.com/NixOS/nixpkgs/commit/23618ec15bb033a9f81dfeab604f9270087973fa) | `` ipscan: 3.9.0 -> 3.9.1 ``                                                |
| [`2a4d3201`](https://github.com/NixOS/nixpkgs/commit/2a4d3201287ad8397116f422c4a1ef9184e7aec3) | `` gojq: add mainProgram to meta ``                                         |
| [`1f6f0bec`](https://github.com/NixOS/nixpkgs/commit/1f6f0bec63bd25ef87563d528568eb9368199752) | `` home-assistant: update component-packages ``                             |
| [`d9211532`](https://github.com/NixOS/nixpkgs/commit/d921153291e1a76c5a361b59e34d2e9f5ee6afb6) | `` ipscan: fix broken package (core dump) ``                                |
| [`c8dc93df`](https://github.com/NixOS/nixpkgs/commit/c8dc93df2bb379e3df791c6cdec9dbe26e622741) | `` python311Packages.pydrawise: init at 2023.8.0 ``                         |
| [`7e72ee73`](https://github.com/NixOS/nixpkgs/commit/7e72ee73d5f13af349ddc0be9bc8841a38e7db2e) | `` python311Packages.apischema: init at 0.18.0 ``                           |
| [`3acf9561`](https://github.com/NixOS/nixpkgs/commit/3acf95613d3b5bd3b1a562ae6720e74015d93af2) | `` python311Packages.zeroconf: 0.87.0 -> 0.88.0 ``                          |
| [`68649b7e`](https://github.com/NixOS/nixpkgs/commit/68649b7e99092bea5eca207d771bdad0e832a96c) | `` python311Packages.zeroconf: 0.86.0 -> 0.87.0 ``                          |
| [`2ae65624`](https://github.com/NixOS/nixpkgs/commit/2ae65624f0ceac2d413cffc893274d20a2e23e9d) | `` python311Packages.zeroconf: 0.85.0 -> 0.86.0 ``                          |
| [`78ef8ca6`](https://github.com/NixOS/nixpkgs/commit/78ef8ca6babd736ba85e3fee15369f8e69d1ea4c) | `` python311Packages.zeroconf: 0.84.0 -> 0.85.0 ``                          |
| [`8068ee76`](https://github.com/NixOS/nixpkgs/commit/8068ee76a29236a75409ad7fa7ee3226eb777b43) | `` b4: 0.12.2 -> 0.12.3 ``                                                  |
| [`eb9930dd`](https://github.com/NixOS/nixpkgs/commit/eb9930ddfefaec7e6a18c7a01a7bbe835f464758) | `` python311Packages.pyduotecno: 2023.8.3 -> 2023.8.4 ``                    |
| [`1613250c`](https://github.com/NixOS/nixpkgs/commit/1613250c2c600dcc9ebf61f1578898b64eccc4eb) | `` python311Packages.pydaikin: 2.11.0 -> 2.11.1 ``                          |
| [`065fcbf6`](https://github.com/NixOS/nixpkgs/commit/065fcbf6fff18c042c5e52a4e936e7366ef57ac2) | `` python310Packages.casbin: 1.24.0 -> 1.25.0 ``                            |
| [`fad0b9e9`](https://github.com/NixOS/nixpkgs/commit/fad0b9e9567cb75fb5f1d34ae166a480fce5714f) | `` pantheon.elementary-iconbrowser: 2.1.1 -> 2.2.0 ``                       |
| [`481c4657`](https://github.com/NixOS/nixpkgs/commit/481c4657d50e22ae2f917a49371cb5c01453e377) | `` goreleaser: 1.19.2 -> 1.20.0 ``                                          |
| [`3ca4544f`](https://github.com/NixOS/nixpkgs/commit/3ca4544f7c55f74d4d6e5118d4fccccefd7c50c2) | `` python310Packages.gumath: patch tests to work with numpy 1.25 ``         |
| [`53bbb203`](https://github.com/NixOS/nixpkgs/commit/53bbb203e013e8fbbcddd9f205e73674475f129a) | `` postgresql12Packages.repmgr: fix build ``                                |
| [`da8681f4`](https://github.com/NixOS/nixpkgs/commit/da8681f4d1882c43de9e570b5580f7196adb4358) | `` dnscontrol: 4.2.0 -> 4.3.0 ``                                            |
| [`2918447a`](https://github.com/NixOS/nixpkgs/commit/2918447a9cfe522834f0bef35ed0d1629e3753c2) | `` Revert "nimdow: 0.7.36->0.7.37" ``                                       |
| [`59da896b`](https://github.com/NixOS/nixpkgs/commit/59da896b0913102d0ee1007ff17fdd2db485d7f4) | `` djvulibre: fix duplicate patches ``                                      |
| [`d81bfd82`](https://github.com/NixOS/nixpkgs/commit/d81bfd82ff1626249c91eb87d2f02e387083fc93) | `` molecule: 6.0.1 -> 6.0.2 ``                                              |
| [`a18c546e`](https://github.com/NixOS/nixpkgs/commit/a18c546e284f49cf1b5186134d637ce94fbca2f6) | `` onlyoffice-documentserver: 7.4.0 -> 7.4.1 ``                             |
| [`fae0b99e`](https://github.com/NixOS/nixpkgs/commit/fae0b99edcd0d59d929c9711ab0df2f2d8d90a3d) | `` crudini: 0.9.3 -> 0.9.4 ``                                               |