### PR TITLE
chore(flake/nur): `89f42901` -> `dd22fdec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693565297,
-        "narHash": "sha256-vsLSVlmvKWAROf/GVnH1BGeKqR2U2YyqvF7dnMpaj+M=",
+        "lastModified": 1693577091,
+        "narHash": "sha256-2f63QZib9qKskqTWs6f0Mu0HKWVE9iRJUaCokKCnMls=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "89f429014bf6d1df56df530a780909ac7cad1c95",
+        "rev": "dd22fdec18a5b2c1403b40ca2122db1a0c000f6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dd22fdec`](https://github.com/nix-community/NUR/commit/dd22fdec18a5b2c1403b40ca2122db1a0c000f6b) | `` automatic update `` |