### PR TITLE
chore(flake/nixos-hardware): `817e297f` -> `fe0ea731`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -654,11 +654,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1692952286,
-        "narHash": "sha256-TsrtPv3+Q1KR0avZxpiJH+b6fX/R/hEQVHbjl1ebotY=",
+        "lastModified": 1693588489,
+        "narHash": "sha256-hUGiONyurfBxmTtRUttdlkdq+ml16L1MiKKAS1047OE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "817e297fc3352fadc15f2c5306909aa9192d7d97",
+        "rev": "fe0ea731b84b10143fc68cd557368ac70f0fb65c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                   |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`ba8a6e06`](https://github.com/NixOS/nixos-hardware/commit/ba8a6e0612d2c973d0029945d2bff94d37bb060e) | `` star64: linux: 5.15.115 -> 5.15.128 `` |