### PR TITLE
chore(flake/emacs-overlay): `32282591` -> `d4d8903c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693565656,
-        "narHash": "sha256-ydbVFKWAFV8R0Dcy+LDlb9+rPwvzB+jwUfg1o46n0xA=",
+        "lastModified": 1693592973,
+        "narHash": "sha256-FeYujg/eg/eC/80WX+XBlBn0QohUdeKl8UjaJ6STdoY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "32282591ce0496c2a38b593b8bc01aff2ba7c14b",
+        "rev": "d4d8903c024b763ea40db264dd531085651f09e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d4d8903c`](https://github.com/nix-community/emacs-overlay/commit/d4d8903c024b763ea40db264dd531085651f09e3) | `` Updated repos/melpa ``  |
| [`e787c5f2`](https://github.com/nix-community/emacs-overlay/commit/e787c5f2d958dd8feeaaad8a9fc55cf74432f958) | `` Updated repos/emacs ``  |
| [`02703a16`](https://github.com/nix-community/emacs-overlay/commit/02703a16e4843001d247c46001e6e0e3208a7880) | `` Updated repos/elpa ``   |
| [`272e7390`](https://github.com/nix-community/emacs-overlay/commit/272e7390a3417f235616146786c89d025d37fd51) | `` Updated flake inputs `` |