### PR TITLE
chore(flake/nur): `87373217` -> `e69e123d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693594033,
-        "narHash": "sha256-qYybqmJHfVeEPOww1xQf4lDqfhbDlEivwvRVZFxsSXI=",
+        "lastModified": 1693597738,
+        "narHash": "sha256-4QMuDc1gDGzQHf5GvI9nSt/ESYVQ931N31ZNbRrom14=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "873732175a124cf0ad631ec6dec5a6e3f8da45cd",
+        "rev": "e69e123d01d7d8d0df53fe523ca542cd19dce29d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e69e123d`](https://github.com/nix-community/NUR/commit/e69e123d01d7d8d0df53fe523ca542cd19dce29d) | `` automatic update `` |