### PR TITLE
chore(flake/nur): `e69e123d` -> `30fbc74e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693597738,
-        "narHash": "sha256-4QMuDc1gDGzQHf5GvI9nSt/ESYVQ931N31ZNbRrom14=",
+        "lastModified": 1693608529,
+        "narHash": "sha256-U16cn2YYY97LSeXZCZeIEobW6ZJv2USN0jOGPuYN+D8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e69e123d01d7d8d0df53fe523ca542cd19dce29d",
+        "rev": "30fbc74eb68f62cb791c82b045e4b70dcea88720",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`30fbc74e`](https://github.com/nix-community/NUR/commit/30fbc74eb68f62cb791c82b045e4b70dcea88720) | `` automatic update `` |