### PR TITLE
chore(flake/dendrite-demo-pinecone): `d4143f50` -> `047523b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -206,11 +206,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1693578867,
-        "narHash": "sha256-FWVDXUMFzut3fQk2BNyxf+8zkxycG7/cGC9c8x7rDhU=",
+        "lastModified": 1693613526,
+        "narHash": "sha256-CjJnmPxgfGj50FAAFLJy/Uoe3f8b/sNKVI5L2chr8sg=",
         "owner": "bbigras",
         "repo": "dendrite-demo-pinecone",
-        "rev": "d4143f50a70b56ae8ee2d6dce1dd759b7d5014fb",
+        "rev": "047523b516136088f0cbb592b7f43dc82913ef0e",
         "type": "github"
       },
       "original": {
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690933134,
-        "narHash": "sha256-ab989mN63fQZBFrkk4Q8bYxQCktuHmBIBqUG1jl6/FQ=",
+        "lastModified": 1693611461,
+        "narHash": "sha256-aPODl8vAgGQ0ZYFIRisxYG5MOGSkIczvu2Cd8Gb9+1Y=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "59cf3f1447cfc75087e7273b04b31e689a8599fb",
+        "rev": "7f53fdb7bdc5bb237da7fefef12d099e4fd611ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                  |
| --------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`047523b5`](https://github.com/bbigras/dendrite-demo-pinecone/commit/047523b516136088f0cbb592b7f43dc82913ef0e) | `` flake.lock: Update `` |