### PR TITLE
chore(flake/nur): `30fbc74e` -> `eb0430d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693608529,
-        "narHash": "sha256-U16cn2YYY97LSeXZCZeIEobW6ZJv2USN0jOGPuYN+D8=",
+        "lastModified": 1693620304,
+        "narHash": "sha256-uciMuPdngMBrjKtRowsNViB6wWRD13u39ihEqKWnKC0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "30fbc74eb68f62cb791c82b045e4b70dcea88720",
+        "rev": "eb0430d214b5f70fa5db5809b798274fffbee80c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eb0430d2`](https://github.com/nix-community/NUR/commit/eb0430d214b5f70fa5db5809b798274fffbee80c) | `` automatic update `` |
| [`8f90d0a9`](https://github.com/nix-community/NUR/commit/8f90d0a940625de42f1021378c5f6934795403c2) | `` automatic update `` |