### PR TITLE
chore(flake/emacs-overlay): `d4d8903c` -> `0cfbf704`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693592973,
-        "narHash": "sha256-FeYujg/eg/eC/80WX+XBlBn0QohUdeKl8UjaJ6STdoY=",
+        "lastModified": 1693625609,
+        "narHash": "sha256-KQMDLH/l7/yobW0VZCdDmcwDDPCkClkKQ+yUmB7Ua38=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d4d8903c024b763ea40db264dd531085651f09e3",
+        "rev": "0cfbf7042022ba9e823e9d5dfb5fb6385ceba45a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`0cfbf704`](https://github.com/nix-community/emacs-overlay/commit/0cfbf7042022ba9e823e9d5dfb5fb6385ceba45a) | `` Updated repos/nongnu `` |
| [`3d321ff0`](https://github.com/nix-community/emacs-overlay/commit/3d321ff0fc591165423b20a33942d71f513200b1) | `` Updated repos/melpa ``  |
| [`4b109795`](https://github.com/nix-community/emacs-overlay/commit/4b109795232987698d9504195b133ca405dd2a57) | `` Updated repos/emacs ``  |
| [`3fd9c9cc`](https://github.com/nix-community/emacs-overlay/commit/3fd9c9cc73dad139a2e93d26db49990fbddd22c1) | `` Updated repos/elpa ``   |