### PR TITLE
chore(flake/nur): `eb0430d2` -> `0dd9bd9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693620304,
-        "narHash": "sha256-uciMuPdngMBrjKtRowsNViB6wWRD13u39ihEqKWnKC0=",
+        "lastModified": 1693627293,
+        "narHash": "sha256-7Ig62eaAQzSPuoqudN5qMbGqCXcSrEectSenaIxPTWw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eb0430d214b5f70fa5db5809b798274fffbee80c",
+        "rev": "0dd9bd9a823498d6fca5dbe1ab0d729b0f3b1662",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0dd9bd9a`](https://github.com/nix-community/NUR/commit/0dd9bd9a823498d6fca5dbe1ab0d729b0f3b1662) | `` automatic update `` |
| [`4e5001b0`](https://github.com/nix-community/NUR/commit/4e5001b0e79c2299a200cebefa6f57d16e4f259d) | `` automatic update `` |
| [`bb887c5e`](https://github.com/nix-community/NUR/commit/bb887c5e8570bc765b70725e5ee727779baf31fd) | `` automatic update `` |