### PR TITLE
chore(flake/nur): `0dd9bd9a` -> `8174921e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693627293,
-        "narHash": "sha256-7Ig62eaAQzSPuoqudN5qMbGqCXcSrEectSenaIxPTWw=",
+        "lastModified": 1693636236,
+        "narHash": "sha256-B667H3lGPdNahklGr/tyVH1tvCztlQrAAxo0g8JKy+8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0dd9bd9a823498d6fca5dbe1ab0d729b0f3b1662",
+        "rev": "8174921e3be48805d3ab624afbd21c4570d711cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8174921e`](https://github.com/nix-community/NUR/commit/8174921e3be48805d3ab624afbd21c4570d711cf) | `` automatic update `` |
| [`5556c7a2`](https://github.com/nix-community/NUR/commit/5556c7a25a5e08cea6098092b8ab1d4f7f606d4b) | `` automatic update `` |
| [`b078ff38`](https://github.com/nix-community/NUR/commit/b078ff38cf20026abd8db1d85f1ae07008093874) | `` automatic update `` |
| [`f9cb32b8`](https://github.com/nix-community/NUR/commit/f9cb32b858f9cf1d93569904a9ddec421fb8dbf0) | `` automatic update `` |