### PR TITLE
chore(flake/nixpkgs): `3e52e76b` -> `aa8aa7e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -810,11 +810,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1693471703,
-        "narHash": "sha256-0l03ZBL8P1P6z8MaSDS/MvuU8E75rVxe5eE1N6gxeTo=",
+        "lastModified": 1693565476,
+        "narHash": "sha256-ya00zHt7YbPo3ve/wNZ/6nts61xt7wK/APa6aZAfey0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3e52e76b70d5508f3cec70b882a29199f4d1ee85",
+        "rev": "aa8aa7e2ea35ce655297e8322dc82bf77a31d04b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`aa8aa7e2`](https://github.com/NixOS/nixpkgs/commit/aa8aa7e2ea35ce655297e8322dc82bf77a31d04b) | `` python310Packages.paddleocr: init at 2.7.0.1 ``                                  |
| [`83d358d2`](https://github.com/NixOS/nixpkgs/commit/83d358d2a297c321dc732facd0bdb89bd18c9ad2) | `` lunarml: unstable-2023-07-25 → unstable-2023-08-25 ``                            |
| [`ba7b67c7`](https://github.com/NixOS/nixpkgs/commit/ba7b67c70d1870351470ce168e91745ea2055dcd) | `` hyperscan: add checkPhase ``                                                     |
| [`5cc3fd82`](https://github.com/NixOS/nixpkgs/commit/5cc3fd82094dffb1c0ec93f3122b7a40c2f0c81d) | `` appflowy: remove openssl_1_1 dependency ``                                       |
| [`3405add3`](https://github.com/NixOS/nixpkgs/commit/3405add33fade4d04774be01419e64b42dae70e4) | `` typesense: 0.24.1 -> 0.25.0 ``                                                   |
| [`e788d84b`](https://github.com/NixOS/nixpkgs/commit/e788d84be2c1a2bd8c8b0f009e3aaf9cdb445050) | `` python311Packages.mkdocs-swagger-ui-tag: 0.6.2 -> 0.6.4 ``                       |
| [`94612033`](https://github.com/NixOS/nixpkgs/commit/946120336e4576d99b5dc33755424d0dc8d50b11) | `` ocamlPackages.elpi: 1.16.5 → 1.17.0 ``                                           |
| [`da086132`](https://github.com/NixOS/nixpkgs/commit/da086132033c0fec25fd88042f0528e33ab22567) | `` python311Packages.dataclasses-json: 0.5.14 -> 0.5.15 ``                          |
| [`a4614ff2`](https://github.com/NixOS/nixpkgs/commit/a4614ff22fc5a478a0fbf51fcd827f08204d83bd) | `` python310Packages.funsor: 0.4.5 -> 0.4.6 ``                                      |
| [`c0f70ef5`](https://github.com/NixOS/nixpkgs/commit/c0f70ef54734f830b578651ad4947a679afba76a) | `` python311Packages.aiolifx-themes: 0.4.7 -> 0.4.8 ``                              |
| [`f477b3ef`](https://github.com/NixOS/nixpkgs/commit/f477b3efdbf349fc94bb1df957ff8fe84a05bd40) | `` clairvoyance: 2.0.6 -> 2.5.3 ``                                                  |
| [`2152e273`](https://github.com/NixOS/nixpkgs/commit/2152e273c7bbc100299c3136aad8058e8da62fcc) | `` where-is-my-sddm-theme: 1.3.0 -> 1.5.0 ``                                        |
| [`d7af9e2b`](https://github.com/NixOS/nixpkgs/commit/d7af9e2bc5192de694d9411a7fde9ea4eb6313ce) | `` python311Packages.celery: update disabled ``                                     |
| [`7957669c`](https://github.com/NixOS/nixpkgs/commit/7957669c08b76759f0ca58f8ab0e42d3b3fe02aa) | `` python311Packages.celery: add changelog to meta ``                               |
| [`686cda02`](https://github.com/NixOS/nixpkgs/commit/686cda02605cac70eafc2a82f16bfde654f9ca2b) | `` python311Packages.kombu: 5.3.1 -> 5.3.2 ``                                       |
| [`a9b00e91`](https://github.com/NixOS/nixpkgs/commit/a9b00e91aca4c24e8802793b4f3818a275e4dc83) | `` python310Packages.json5: 0.9.9 -> 0.9.14 ``                                      |
| [`76b80682`](https://github.com/NixOS/nixpkgs/commit/76b80682f7143ff59dee85723e13dca7c157eb49) | `` python311Packages.celery: 5.3.1 -> 5.3.3 ``                                      |
| [`95a8895f`](https://github.com/NixOS/nixpkgs/commit/95a8895f6caabdcf634b0cba4cb2a046f4a28992) | `` jackett: 0.21.705 -> 0.21.719 ``                                                 |
| [`0d729125`](https://github.com/NixOS/nixpkgs/commit/0d729125d2754f2846ccfddc84f39c7659a617b0) | `` python311Packages.neo4j: 5.11.0 -> 5.12.0 ``                                     |
| [`2707aea0`](https://github.com/NixOS/nixpkgs/commit/2707aea0112173a62f6211597e6060f87b136d66) | `` python311Packages.hahomematic: 2023.8.13 -> 2023.8.14 ``                         |
| [`6f8ee2f3`](https://github.com/NixOS/nixpkgs/commit/6f8ee2f39bc638407e3c60b62f32a690eaafc0de) | `` python311Packages.censys: 2.2.4 -> 2.2.5 ``                                      |
| [`0e40a09d`](https://github.com/NixOS/nixpkgs/commit/0e40a09d4bdf80d030fd18b4024d17e880f38303) | `` python311Packages.appthreat-vulnerability-db: 5.2.3 -> 5.2.5 ``                  |
| [`31becd13`](https://github.com/NixOS/nixpkgs/commit/31becd13b66afa03ef956ee2403ef5ab0c30113c) | `` python311Packages.botocore-stubs: 1.31.38 -> 1.31.39 ``                          |
| [`75b91006`](https://github.com/NixOS/nixpkgs/commit/75b9100678070d6701c9c478538fb72d28df7ff5) | `` python311Packages.asyncsleepiq: 1.3.6 -> 1.3.7 ``                                |
| [`89972b39`](https://github.com/NixOS/nixpkgs/commit/89972b3943caffd4f3f95642e987527fc7556424) | `` python310Packages.oci: 2.110.2 -> 2.111.0 ``                                     |
| [`addd09af`](https://github.com/NixOS/nixpkgs/commit/addd09afcb725f65cbe846ca2d788914f8b2f4a9) | `` clojure: 1.11.1.1405 -> 1.11.1.1413 ``                                           |
| [`bd4106e9`](https://github.com/NixOS/nixpkgs/commit/bd4106e971c975619ea36e9a1493f4d1c7ed09cb) | `` checkov: 2.4.19 -> 2.4.22 ``                                                     |
| [`0caa6364`](https://github.com/NixOS/nixpkgs/commit/0caa63647017eb3a00fca869dc4aa71d583826b1) | `` python3Packages.pyhepmc: add disabled ``                                         |
| [`a6d40084`](https://github.com/NixOS/nixpkgs/commit/a6d40084501b898847028937aefbfb5129795c31) | `` python3Packages.pyhepmc: add changelog to meta ``                                |
| [`476ff6ee`](https://github.com/NixOS/nixpkgs/commit/476ff6eed2b93c1a3c7a77e838d78032d6e598b4) | `` python310Packages.jupyter-collaboration: update meta ``                          |
| [`f824c671`](https://github.com/NixOS/nixpkgs/commit/f824c671956e0b34dceb063b89c39b5edf31c175) | `` python310Packages.awkward-cpp: update disabled ``                                |
| [`21ed70c8`](https://github.com/NixOS/nixpkgs/commit/21ed70c8443cdde1d7d3859157b96f3655b2b9f7) | `` cosign: 2.1.1 -> 2.2.0 ``                                                        |
| [`55dca060`](https://github.com/NixOS/nixpkgs/commit/55dca060e30db95820afcd57a3e485078295d3db) | `` moar: 1.15.4 -> 1.16.0 ``                                                        |
| [`e0e4e1d9`](https://github.com/NixOS/nixpkgs/commit/e0e4e1d98ac9431a7912b71bf2adc820c190bf45) | `` libisoburn: 1.5.4 -> 1.5.6 ``                                                    |
| [`50cd06aa`](https://github.com/NixOS/nixpkgs/commit/50cd06aaecf710a3a347ddfbe5b906849d49e3e6) | `` python311Packages.coredis: 4.15.1 -> 4.16.0 ``                                   |
| [`7cef7ca5`](https://github.com/NixOS/nixpkgs/commit/7cef7ca5b22b244bd2bf428a6bbce7b035cc2861) | `` tektoncd-cli: 0.31.1 -> 0.31.2 ``                                                |
| [`a51ae3f4`](https://github.com/NixOS/nixpkgs/commit/a51ae3f4d9791ed0840a581c9eaf14fec05a402d) | `` ocamlPackages.krb: add v0.16 ``                                                  |
| [`d7389124`](https://github.com/NixOS/nixpkgs/commit/d73891245eabbd230f04e87066d6d614aeac9e0e) | `` supabase-cli: 1.86.1 -> 1.88.0 ``                                                |
| [`8f607e1c`](https://github.com/NixOS/nixpkgs/commit/8f607e1cf9b8aaef68c98f75ad65138c3d95b77d) | `` python311Packages.casbin: 1.25.0 -> 1.26.0 ``                                    |
| [`e063cb48`](https://github.com/NixOS/nixpkgs/commit/e063cb481d9e224551cc9c186a3b9db67ae1d6ff) | `` containerd: 1.7.3 -> 1.7.5 ``                                                    |
| [`8ce23e17`](https://github.com/NixOS/nixpkgs/commit/8ce23e17f1edf13cfaf2292e6b1a989820648f6a) | `` python3Packages.pyhepmc: init at 2.12.0 ``                                       |
| [`220c0354`](https://github.com/NixOS/nixpkgs/commit/220c035420cc17054fab059b08485b7fda14ddde) | `` ollama: 0.0.15 -> 0.0.17 ``                                                      |
| [`6d7c0fbd`](https://github.com/NixOS/nixpkgs/commit/6d7c0fbdf81da238326f04bd76c911e27080afd7) | `` grype: 0.65.2 -> 0.66.0 ``                                                       |
| [`d814890e`](https://github.com/NixOS/nixpkgs/commit/d814890e47fb1eac3cebf6a80b6babf8cb93a89d) | `` jsonnet-language-server: 0.12.1 -> 0.13.0 ``                                     |
| [`a7ab28c0`](https://github.com/NixOS/nixpkgs/commit/a7ab28c08d8382fc520ce2bfb037bce318edbb10) | `` act: 0.2.49 -> 0.2.50 ``                                                         |
| [`334d23c5`](https://github.com/NixOS/nixpkgs/commit/334d23c5cb436c4ddc9758313eb3249a87b96cd1) | `` python310Packages.awkward-cpp: 21 -> 22 ``                                       |
| [`41bf5f47`](https://github.com/NixOS/nixpkgs/commit/41bf5f47439d40153ef14a901462e27f6987e847) | `` python310Packages.jupyter-collaboration: 1.0.1 -> 1.1.0 ``                       |
| [`f47790ec`](https://github.com/NixOS/nixpkgs/commit/f47790ec47bcfb2434d26aabd12d61c9bee57a4a) | `` biome: init at 1.0.0 ``                                                          |
| [`4e418cd4`](https://github.com/NixOS/nixpkgs/commit/4e418cd487ed96c64d7beeab0d76a01634c50d7e) | `` doublecmd: 1.0.11 -> 1.1.1 ``                                                    |
| [`76ae447f`](https://github.com/NixOS/nixpkgs/commit/76ae447f06e8be22c1adba3d979bcf5a3b7b14b9) | `` .github/workflows/update-terraform-providers.yml: re-enable workflow_dispatch `` |
| [`1ca7a4f7`](https://github.com/NixOS/nixpkgs/commit/1ca7a4f7bd69c344bd8faaf6a8adfe4ed196a2ac) | `` unciv: 4.7.17-patch1 -> 4.7.19 ``                                                |
| [`af4468e1`](https://github.com/NixOS/nixpkgs/commit/af4468e199bee24cc852bf1c487f950796930508) | `` ipinfo: 2.10.1 -> 3.0.1 ``                                                       |
| [`296d4f22`](https://github.com/NixOS/nixpkgs/commit/296d4f228c61cdd89416f919eaa77975512e4103) | `` maintainers: add viktornordling ``                                               |
| [`926db2b1`](https://github.com/NixOS/nixpkgs/commit/926db2b1447012a91bf77aa5395562ade27ac901) | `` .github/workflows/update-terraform-providers.yml: disable ``                     |
| [`b3dacf0b`](https://github.com/NixOS/nixpkgs/commit/b3dacf0b74edaeec8a54af0d5dcc8bad9dc73e1c) | `` freetube: change electron to electron_22 (#252061) ``                            |
| [`7b1777b1`](https://github.com/NixOS/nixpkgs/commit/7b1777b1e47d730dea558a5cd9b381cdee7b4f14) | `` yash: fix build on darwin ``                                                     |
| [`ddd4ff16`](https://github.com/NixOS/nixpkgs/commit/ddd4ff164ea736d25df33d86b494e0ae19c5e5ec) | `` aspectj: 1.9.19 -> 1.9.20 ``                                                     |
| [`ec417504`](https://github.com/NixOS/nixpkgs/commit/ec417504b06a79aa3d4335b8fd055397061e34d0) | `` python310Packages.bentoml: 1.1.3 -> 1.1.4 ``                                     |
| [`fbf7cd57`](https://github.com/NixOS/nixpkgs/commit/fbf7cd5729674a0e9ca5358a9cb6dfe7c16ca6b3) | `` python311Packages.argilla: 1.13.2 -> 1.15.0 ``                                   |
| [`1694e821`](https://github.com/NixOS/nixpkgs/commit/1694e8218ad343b38c34795faa2516196389602c) | `` sqlcipher: 4.5.4 -> 4.5.5 ``                                                     |
| [`1730eb68`](https://github.com/NixOS/nixpkgs/commit/1730eb685f3e4233e022ffd4b1148fee1f61cdde) | `` xdaliclock: 2.47 -> 2.48 ``                                                      |
| [`9181483d`](https://github.com/NixOS/nixpkgs/commit/9181483d663aef4b23b7b953edd29c5c8566f20b) | `` nixos/cloudlog: remove pin for PHP 8.1 ``                                        |
| [`66c49eba`](https://github.com/NixOS/nixpkgs/commit/66c49eba0d6c2c5520f4e38ef8dbacc5f460b317) | `` aliyun-cli: 3.0.177 -> 3.0.179 ``                                                |
| [`9bcbe437`](https://github.com/NixOS/nixpkgs/commit/9bcbe437dfbafe8253e5d604bd7fb0f9f9e68845) | `` cloudlog: 2.4.5 -> 2.4.8 ``                                                      |
| [`8ddac5f5`](https://github.com/NixOS/nixpkgs/commit/8ddac5f5e2eb6b15173a5f4ce7054aeb216cdd9a) | `` terraform-providers.doppler: init at 1.2.4 ``                                    |
| [`f67bf208`](https://github.com/NixOS/nixpkgs/commit/f67bf208a56baf16446de3c4df9af330c17d0574) | `` stratisd: 3.5.8 -> 3.5.9 ``                                                      |
| [`d0ad5703`](https://github.com/NixOS/nixpkgs/commit/d0ad5703716b6b7db33a8dae1d115529774f8d57) | `` mozjpeg: 4.1.3 -> 4.1.4 (#252619) ``                                             |
| [`c9766c53`](https://github.com/NixOS/nixpkgs/commit/c9766c533506b94294bbdd34fa96df0001c4f986) | `` awsebcli: 3.20.7 -> 3.20.9 ``                                                    |
| [`8068ea27`](https://github.com/NixOS/nixpkgs/commit/8068ea271a2a9c4bd7a3bbf0b7280e01c8729a31) | `` expr: 1.14.3 -> 1.15.0 (#252565) ``                                              |
| [`451ae26e`](https://github.com/NixOS/nixpkgs/commit/451ae26ed246f1c1297a2012c88e9ac67369c105) | `` python310Packages.hdfs: 2.5.8 -> 2.7.2 (#251851) ``                              |
| [`127ea2d8`](https://github.com/NixOS/nixpkgs/commit/127ea2d80e3b08608807909216bc6e46618e4699) | `` htop: fix configure.am error with --enable-sensors ``                            |
| [`b25c5289`](https://github.com/NixOS/nixpkgs/commit/b25c5289d76a106d8bc302872a8c6dc25ddb23cc) | `` spacer: 0.1.8 -> 0.2 ``                                                          |
| [`a27bb795`](https://github.com/NixOS/nixpkgs/commit/a27bb795e5f6b580eb351c08b65a0579ddf1bf78) | `` ttdl: 4.0.0 -> 4.1.0 ``                                                          |
| [`0e43eb9c`](https://github.com/NixOS/nixpkgs/commit/0e43eb9c645704f9443651b7c3318eb6c055805c) | `` lr: 1.5.1 -> 1.6 ``                                                              |
| [`0f4255bf`](https://github.com/NixOS/nixpkgs/commit/0f4255bf112a34a6d4f8a159d2444d176f2d79db) | `` emacs: fix `env` shallow merge ``                                                |
| [`bb555fb8`](https://github.com/NixOS/nixpkgs/commit/bb555fb845fe47d47a944cefdebd28a7c3a74682) | `` python310Packages.py-partiql-parser: 0.3.6 -> 0.3.7 ``                           |
| [`b421be37`](https://github.com/NixOS/nixpkgs/commit/b421be37da1c92fbf2cec7363c78b465cb90d0f4) | `` maintainers: Add frederictobaisc ``                                              |
| [`c95bbfb8`](https://github.com/NixOS/nixpkgs/commit/c95bbfb817480450428557b9745d98d072015d40) | `` python311Packages.procmon-parser: init at 0.3.13 ``                              |
| [`b9540d2f`](https://github.com/NixOS/nixpkgs/commit/b9540d2fe95240edde9966a3eb2e86de1153540b) | `` python310Packages.zigpy: 0.56.4 -> 0.57.0 ``                                     |
| [`acf53d31`](https://github.com/NixOS/nixpkgs/commit/acf53d31d64c1a556563376a46cdb95827ac3b78) | `` ocamlPackages.lame: 0.3.6 -> 0.3.7 ``                                            |
| [`bc9a863d`](https://github.com/NixOS/nixpkgs/commit/bc9a863d9162e900068b1f82c4e9fbc778e44e6c) | `` chatterino2: 2.4.4 -> 2.4.5 ``                                                   |
| [`6c7ac3f2`](https://github.com/NixOS/nixpkgs/commit/6c7ac3f2f30a6a98ebb9ea0f14a28e71ca848bd6) | `` daemon: 0.8.2 -> 0.8.4 ``                                                        |
| [`c7bb13c6`](https://github.com/NixOS/nixpkgs/commit/c7bb13c661e20f49cbe3af71e61e66968ec803bf) | `` blackshades: 2.4.9 -> 2.5.1 ``                                                   |
| [`e61aef03`](https://github.com/NixOS/nixpkgs/commit/e61aef03430e0439df9d5b6dac421f30100adb0c) | `` python310Packages.pulumi-aws: 5.42.0 -> 6.0.3 ``                                 |
| [`bad50db3`](https://github.com/NixOS/nixpkgs/commit/bad50db3c9d6d6a265049a95393964cd522950cc) | `` python311Packages.clr-loader: 0.2.5 -> 0.2.6 ``                                  |
| [`6881f726`](https://github.com/NixOS/nixpkgs/commit/6881f7264a03956968039ddbe096a99b61d2a35a) | `` pdns-recursor: 4.9.0 -> 4.9.1 ``                                                 |
| [`f1012af1`](https://github.com/NixOS/nixpkgs/commit/f1012af12f8e022d5bd5378caa5964dd25a4bb76) | `` dpkg: 1.21.22 -> 1.22.0 ``                                                       |
| [`118a61fa`](https://github.com/NixOS/nixpkgs/commit/118a61fadd13b186df175cee2aa16762e9d29724) | `` tamarin-prover: 1.6.1 -> 1.8.0 ``                                                |
| [`b2b7e36e`](https://github.com/NixOS/nixpkgs/commit/b2b7e36e57a8132958f1264f8d55896cf307e86e) | `` lighthouse-steamvr: 1.0.0 -> 1.1.1 ``                                            |
| [`eeecd453`](https://github.com/NixOS/nixpkgs/commit/eeecd453c5002dedd9616afa0d344c8579c9e026) | `` cobang: 0.9.6 -> 0.10.1 ``                                                       |
| [`eb78158e`](https://github.com/NixOS/nixpkgs/commit/eb78158e9cfc4ab7b2089eed2883589faad7be2a) | `` klaus: 2.0.2 -> 2.0.3 ``                                                         |
| [`5b9a5471`](https://github.com/NixOS/nixpkgs/commit/5b9a5471c1706e02ed671cc2649a509a1945872a) | `` python311Packages.dbt-core: relax logbook constraint ``                          |
| [`621ea0a5`](https://github.com/NixOS/nixpkgs/commit/621ea0a5d090a1e779b6d8ad57e475dec6d46715) | `` php83: 8.3.0beta3 -> 8.3.0RC1 ``                                                 |
| [`17c37b2c`](https://github.com/NixOS/nixpkgs/commit/17c37b2c4452ca349ab1f19b4b5798892ced2fd3) | `` python311Packages.logbook: 1.5.3 -> 1.6.0 ``                                     |
| [`45b5ebde`](https://github.com/NixOS/nixpkgs/commit/45b5ebde0974d13ce51cba0d1bd9977c4788ed42) | `` python311Packages.logbook: switch to pytestCheckHook ``                          |
| [`d2ebe575`](https://github.com/NixOS/nixpkgs/commit/d2ebe5752479f84e54af453231af89baaff0add6) | `` python311Packages.logbook: add pythonImportsCheck ``                             |
| [`1fa7b1e2`](https://github.com/NixOS/nixpkgs/commit/1fa7b1e2675c13b9bc13542d9829b45650d7400e) | `` python311Packages.logbook: equalize content ``                                   |
| [`e4b40c4c`](https://github.com/NixOS/nixpkgs/commit/e4b40c4c4b51ce671eaf9028965292b8e357e019) | `` python311Packages.logbook: update meta ``                                        |
| [`b9968e7e`](https://github.com/NixOS/nixpkgs/commit/b9968e7e505bb01733a436ba766059b92359aeca) | `` python311Packages.dataproperty: 0.55.0 -> 1.0.1 ``                               |
| [`75b7e0dd`](https://github.com/NixOS/nixpkgs/commit/75b7e0ddd6337377e3de91505e7952de1a44dd51) | `` hugo: 0.117.0 -> 0.118.2 ``                                                      |
| [`f607a785`](https://github.com/NixOS/nixpkgs/commit/f607a7851619a6efda5f7c57f0345018a3ea403c) | `` emacs-macport: build on LLVM 14 ``                                               |
| [`e161990d`](https://github.com/NixOS/nixpkgs/commit/e161990d40c97c649a5e7df9d3347c0ea3896bde) | `` mailman: remove docutils input ``                                                |
| [`6061f5db`](https://github.com/NixOS/nixpkgs/commit/6061f5dbdd53ffe33e06762cff10ac7da16a1f3e) | `` python311Packages.pytablewriter: disable failing test ``                         |
| [`6f692f64`](https://github.com/NixOS/nixpkgs/commit/6f692f64c9dbcc5558d68658c5dd30dc1b6a8266) | `` python311Packages.typepy: add optional-dependencies ``                           |
| [`69267569`](https://github.com/NixOS/nixpkgs/commit/692675696e0a8624580533c34e90714a074b4d53) | `` python311Packages.wcmatch: 8.4.1 -> 8.5 ``                                       |
| [`aa358236`](https://github.com/NixOS/nixpkgs/commit/aa3582365788752b915e07e297bfc5e359dd3d18) | `` python311Packages.web3: fix darwin builds ``                                     |
| [`8709579b`](https://github.com/NixOS/nixpkgs/commit/8709579b0272334273b50caecc2a492e2979fe14) | `` python311Packages.web3: add hellwolf to maintainers ``                           |
| [`179964f9`](https://github.com/NixOS/nixpkgs/commit/179964f9e0514278d779fd718663c59e088ccdfc) | `` git-mit: 5.12.146 -> 5.12.147 ``                                                 |
| [`7afe4e32`](https://github.com/NixOS/nixpkgs/commit/7afe4e3282a9a5fbce0729ad68843fc0572247b5) | `` balena-cli: Fix darwin build ``                                                  |
| [`4c71343f`](https://github.com/NixOS/nixpkgs/commit/4c71343f93b6fe705ca4db3633bb675d58b1f4e8) | `` zarf: 0.29.0 -> 0.29.1 ``                                                        |
| [`334ce239`](https://github.com/NixOS/nixpkgs/commit/334ce2392b9532c60c86ff62ff5e5b8e4d7bf0df) | `` cargo-expand: 1.0.64 -> 1.0.65 ``                                                |
| [`7efb5f38`](https://github.com/NixOS/nixpkgs/commit/7efb5f38694eb9c324179fed8f4f977136cfb5fd) | `` typstfmt: 0.2.0 -> 0.2.1 ``                                                      |
| [`36a37639`](https://github.com/NixOS/nixpkgs/commit/36a37639fdd7578f4e63156af1947bbe95969ca1) | `` dos2unix: 7.5.0 -> 7.5.1 ``                                                      |
| [`b88f54c7`](https://github.com/NixOS/nixpkgs/commit/b88f54c7bace57cfc31d8fd8408c045a92f77019) | `` maintainers: add gmemstr ``                                                      |
| [`d8bdaf3e`](https://github.com/NixOS/nixpkgs/commit/d8bdaf3e75c33feaf9eeb8f3bbfc7fa2e03ebe87) | `` python310Packages.django-admin-datta: 1.0.7 -> 1.0.10 ``                         |
| [`9f1ced33`](https://github.com/NixOS/nixpkgs/commit/9f1ced334e310d7cfa34a84ed2c93ae28fea9c18) | `` CuboCore.corekeyboard: 4.4.0 -> 4.5.0 ``                                         |