### PR TITLE
chore(flake/nur): `8174921e` -> `cf2e367e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693636236,
-        "narHash": "sha256-B667H3lGPdNahklGr/tyVH1tvCztlQrAAxo0g8JKy+8=",
+        "lastModified": 1693647914,
+        "narHash": "sha256-OQUvZTrggr1j28B9U8jJlZ888rwvpiaCMFMus1Y34Es=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8174921e3be48805d3ab624afbd21c4570d711cf",
+        "rev": "cf2e367e579f1958741263154eb88c9c4413b828",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cf2e367e`](https://github.com/nix-community/NUR/commit/cf2e367e579f1958741263154eb88c9c4413b828) | `` automatic update `` |
| [`e68092ab`](https://github.com/nix-community/NUR/commit/e68092ab69d3b1a22858572d0af31298d976bc76) | `` automatic update `` |
| [`03a80e24`](https://github.com/nix-community/NUR/commit/03a80e2496ccd54e3dd52f4f6ad7ad449d8f1655) | `` automatic update `` |
| [`652f5c78`](https://github.com/nix-community/NUR/commit/652f5c78eb77c74bf8b0b7da41a8087601ecc0aa) | `` automatic update `` |