### PR TITLE
chore(flake/emacs-overlay): `0cfbf704` -> `23f1e77b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693625609,
-        "narHash": "sha256-KQMDLH/l7/yobW0VZCdDmcwDDPCkClkKQ+yUmB7Ua38=",
+        "lastModified": 1693651902,
+        "narHash": "sha256-opTnrFR6gDGg5BP2AldZHz6QmKwvJXtJm0ovlucP/Ms=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0cfbf7042022ba9e823e9d5dfb5fb6385ceba45a",
+        "rev": "23f1e77b20b424b57434559c1151fa0476664b03",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`23f1e77b`](https://github.com/nix-community/emacs-overlay/commit/23f1e77b20b424b57434559c1151fa0476664b03) | `` Updated repos/melpa ``  |
| [`de69125c`](https://github.com/nix-community/emacs-overlay/commit/de69125c2723bc7dd69dca2576cd79f3b79d0213) | `` Updated repos/emacs ``  |
| [`f1108d88`](https://github.com/nix-community/emacs-overlay/commit/f1108d889900fc41737a17b1c3547eb5998c3352) | `` Updated flake inputs `` |