### PR TITLE
chore(flake/nur): `cf2e367e` -> `e9bb89a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693647914,
-        "narHash": "sha256-OQUvZTrggr1j28B9U8jJlZ888rwvpiaCMFMus1Y34Es=",
+        "lastModified": 1693655178,
+        "narHash": "sha256-3kPoYla6QunRmiQ05wP27hwdHvmbin30p3+tHW28mvw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cf2e367e579f1958741263154eb88c9c4413b828",
+        "rev": "e9bb89a7e0da4827f1ddbee6046095d6a9287d10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e9bb89a7`](https://github.com/nix-community/NUR/commit/e9bb89a7e0da4827f1ddbee6046095d6a9287d10) | `` automatic update `` |
| [`773722ba`](https://github.com/nix-community/NUR/commit/773722ba7d9c50a2b5330ba3139b7af083314564) | `` automatic update `` |