### PR TITLE
chore(flake/emacs-overlay): `23f1e77b` -> `b0c67285`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693651902,
-        "narHash": "sha256-opTnrFR6gDGg5BP2AldZHz6QmKwvJXtJm0ovlucP/Ms=",
+        "lastModified": 1693678518,
+        "narHash": "sha256-fb8M/O+6EmXRCXDfjnng4XUXcvn4/nF/Yg1KrbU0UDA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "23f1e77b20b424b57434559c1151fa0476664b03",
+        "rev": "b0c6728523179f33d2d3b1842f042dcd6d017d15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`b0c67285`](https://github.com/nix-community/emacs-overlay/commit/b0c6728523179f33d2d3b1842f042dcd6d017d15) | `` Updated repos/melpa `` |
| [`66c46e81`](https://github.com/nix-community/emacs-overlay/commit/66c46e81a1687c4ae52691c82e180bb4bcb19de8) | `` Updated repos/emacs `` |
| [`0433e4ec`](https://github.com/nix-community/emacs-overlay/commit/0433e4ecf91a2befec43722a1129c3f724a260c0) | `` Updated repos/elpa ``  |