### PR TITLE
chore(flake/nur): `91ccb8b6` -> `410b87d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693680361,
-        "narHash": "sha256-U2tpyxb/WuNvvzOYmGEbaiy3VTAevuUwZdo94qzIn78=",
+        "lastModified": 1693706306,
+        "narHash": "sha256-tnKTVs9D/qqjkmN6nVNHwTKvZTvHldW9No4j7L3eErc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "91ccb8b645a380a508704c57fa509e09b8b2b33b",
+        "rev": "410b87d7a4bfd2b57581c0d4d075bcca2fc5012d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`410b87d7`](https://github.com/nix-community/NUR/commit/410b87d7a4bfd2b57581c0d4d075bcca2fc5012d) | `` automatic update `` |
| [`6f2a6238`](https://github.com/nix-community/NUR/commit/6f2a6238669605a88ec925e7f652a852fffb8431) | `` automatic update `` |