### PR TITLE
chore(flake/nix-index-database): `c7ff716e` -> `aca56a79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -615,11 +615,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693709843,
-        "narHash": "sha256-99RHjs6GxL8nxY7Q/Z/HZSGVdTJ4ZtTdO4yPsQxQvvM=",
+        "lastModified": 1693711723,
+        "narHash": "sha256-5QmlVzskLciJ0QzYmZ6ULvKA7bP6pgV9wwrLBB0V3j0=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "c7ff716eee877e60a6a729a74e13f8fe23efd54f",
+        "rev": "aca56a79afb82208af2b39d8459dd29c10989135",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`aca56a79`](https://github.com/nix-community/nix-index-database/commit/aca56a79afb82208af2b39d8459dd29c10989135) | `` update packages.nix to release 2023-09-03-032725 `` |