### PR TITLE
chore(flake/nur): `410b87d7` -> `80012e6c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693706306,
-        "narHash": "sha256-tnKTVs9D/qqjkmN6nVNHwTKvZTvHldW9No4j7L3eErc=",
+        "lastModified": 1693715521,
+        "narHash": "sha256-3W2/i/laSMvkZpA/2BVCBUkcfUKhSGYOzVHb4tLUzWg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "410b87d7a4bfd2b57581c0d4d075bcca2fc5012d",
+        "rev": "80012e6c2de5ea9c4101948b0d58c745e7813180",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`80012e6c`](https://github.com/nix-community/NUR/commit/80012e6c2de5ea9c4101948b0d58c745e7813180) | `` automatic update `` |
| [`895e22f9`](https://github.com/nix-community/NUR/commit/895e22f9de943db58d45ed2a6e81e86f21453115) | `` automatic update `` |
| [`4e184e04`](https://github.com/nix-community/NUR/commit/4e184e04176c6f5ec791a5a7e29ac788648a8d35) | `` automatic update `` |
| [`a10231a4`](https://github.com/nix-community/NUR/commit/a10231a408120d79ddb5319c85fc09a40a947ab5) | `` automatic update `` |
| [`1b78a89a`](https://github.com/nix-community/NUR/commit/1b78a89a5a2342c25c043e9e97a3633f23ee83be) | `` automatic update `` |