### PR TITLE
chore(flake/nur): `ece5318a` -> `7e62dd55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693724128,
-        "narHash": "sha256-puR8Sft6NKKZu5SgtpH2QrNyofzu51uTy+PdTrYU08U=",
+        "lastModified": 1693733350,
+        "narHash": "sha256-5QKYiWfNF58hEdU1o0h+78tVtJUgTmlyNnpxrpjdZwc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ece5318a0bd48ddb7e00d555a067058c2d62869b",
+        "rev": "7e62dd55582646dbf8b87fed72854ebe3911985d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7e62dd55`](https://github.com/nix-community/NUR/commit/7e62dd55582646dbf8b87fed72854ebe3911985d) | `` automatic update `` |