### PR TITLE
chore(flake/nur): `7e62dd55` -> `a04f2649`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693733350,
-        "narHash": "sha256-5QKYiWfNF58hEdU1o0h+78tVtJUgTmlyNnpxrpjdZwc=",
+        "lastModified": 1693739064,
+        "narHash": "sha256-m755VozDcyWE4TCLI3iqFAtn06aQrgNws5dYOXkPA2E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7e62dd55582646dbf8b87fed72854ebe3911985d",
+        "rev": "a04f26492fc25324103175c80ab21b95cf74da91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a04f2649`](https://github.com/nix-community/NUR/commit/a04f26492fc25324103175c80ab21b95cf74da91) | `` automatic update `` |
| [`88ac3edd`](https://github.com/nix-community/NUR/commit/88ac3eddc343928201bebb608fd2899644b02bd8) | `` automatic update `` |