### PR TITLE
chore(flake/nur): `a04f2649` -> `2d89dc5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693739064,
-        "narHash": "sha256-m755VozDcyWE4TCLI3iqFAtn06aQrgNws5dYOXkPA2E=",
+        "lastModified": 1693745548,
+        "narHash": "sha256-fJln8nYG5Cblc/N9CU2oR8uC6keB21wxWqn6cFuuiAc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a04f26492fc25324103175c80ab21b95cf74da91",
+        "rev": "2d89dc5e6d5ec937d8366dc8c9543c3585029847",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2d89dc5e`](https://github.com/nix-community/NUR/commit/2d89dc5e6d5ec937d8366dc8c9543c3585029847) | `` automatic update `` |
| [`87f0488c`](https://github.com/nix-community/NUR/commit/87f0488c05a983b2fb27226a3b13f140245cacd9) | `` automatic update `` |