### PR TITLE
chore(flake/nur): `2d89dc5e` -> `fac951fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693745548,
-        "narHash": "sha256-fJln8nYG5Cblc/N9CU2oR8uC6keB21wxWqn6cFuuiAc=",
+        "lastModified": 1693752070,
+        "narHash": "sha256-EegZzsO5Nco5ZD1w0otB2qr6e91CeodEWHYh3tLafck=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2d89dc5e6d5ec937d8366dc8c9543c3585029847",
+        "rev": "fac951fbe4e8c2bec08e4ee3949c7d8284b4b991",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fac951fb`](https://github.com/nix-community/NUR/commit/fac951fbe4e8c2bec08e4ee3949c7d8284b4b991) | `` automatic update `` |