### PR TITLE
chore(flake/nur): `fac951fb` -> `a0fdb439`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693752070,
-        "narHash": "sha256-EegZzsO5Nco5ZD1w0otB2qr6e91CeodEWHYh3tLafck=",
+        "lastModified": 1693758767,
+        "narHash": "sha256-tQcawV/hQcP+AS8bGDMzlgpAKFD3rgEeY9WwbTCEA2M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fac951fbe4e8c2bec08e4ee3949c7d8284b4b991",
+        "rev": "a0fdb4399b123279e11fd2aaf1ba4d081085b431",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a0fdb439`](https://github.com/nix-community/NUR/commit/a0fdb4399b123279e11fd2aaf1ba4d081085b431) | `` automatic update `` |
| [`85f0da35`](https://github.com/nix-community/NUR/commit/85f0da350c9bfe3d4744298f79274ac2b383959a) | `` automatic update `` |