### PR TITLE
chore(flake/nur): `a0fdb439` -> `1a624093`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693758767,
-        "narHash": "sha256-tQcawV/hQcP+AS8bGDMzlgpAKFD3rgEeY9WwbTCEA2M=",
+        "lastModified": 1693761442,
+        "narHash": "sha256-gNWghROJb2eDF6XbGDUzvnvZpm3Tj0haGGQf77Vp0+w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a0fdb4399b123279e11fd2aaf1ba4d081085b431",
+        "rev": "1a62409356f16e10ed29501983c90154da95baf0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1a624093`](https://github.com/nix-community/NUR/commit/1a62409356f16e10ed29501983c90154da95baf0) | `` automatic update `` |
| [`209aef4d`](https://github.com/nix-community/NUR/commit/209aef4d7bb9e2c542af7d368b260df7fc0d6770) | `` automatic update `` |
| [`60dc6158`](https://github.com/nix-community/NUR/commit/60dc61586ed3ecae5db2424fcb2fbe64fedabd0a) | `` automatic update `` |