### PR TITLE
chore(flake/emacs-overlay): `c00836a1` -> `5b560c5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693736693,
-        "narHash": "sha256-hp+TywvmjMaGX1y8P3Oqjya1arLqpE6rrTOpygXlerQ=",
+        "lastModified": 1693764991,
+        "narHash": "sha256-0YIkCKO29g5Rej4p3Dw9whXHaAsIqjOKPj9EHMKCKlk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c00836a1827db0b69310ef64a778b30dd73e433c",
+        "rev": "5b560c5fa73d718fb546404418a234e31d8bacf0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`5b560c5f`](https://github.com/nix-community/emacs-overlay/commit/5b560c5fa73d718fb546404418a234e31d8bacf0) | `` Updated repos/melpa ``  |
| [`6543d3cf`](https://github.com/nix-community/emacs-overlay/commit/6543d3cfe16ee58be0bf7a8451b5bb17330757bd) | `` Updated repos/emacs ``  |
| [`3072f404`](https://github.com/nix-community/emacs-overlay/commit/3072f40414cc3b106a9750ca8183aa35eec8cfc3) | `` Updated repos/elpa ``   |
| [`58f69930`](https://github.com/nix-community/emacs-overlay/commit/58f69930f1da1f15e792c302b96de2eccf3b4be8) | `` Updated flake inputs `` |