### PR TITLE
chore(flake/nur): `1a624093` -> `e756b33d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693761442,
-        "narHash": "sha256-gNWghROJb2eDF6XbGDUzvnvZpm3Tj0haGGQf77Vp0+w=",
+        "lastModified": 1693766735,
+        "narHash": "sha256-3gkH/ig6PTtyzoME7fwaQOQNfCmNjrkWFqRK5933HcI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1a62409356f16e10ed29501983c90154da95baf0",
+        "rev": "e756b33db1b6a774c44241bdd7221702de8d08c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e756b33d`](https://github.com/nix-community/NUR/commit/e756b33db1b6a774c44241bdd7221702de8d08c9) | `` automatic update `` |