### PR TITLE
chore(flake/nur): `e756b33d` -> `b3e53ef7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693766735,
-        "narHash": "sha256-3gkH/ig6PTtyzoME7fwaQOQNfCmNjrkWFqRK5933HcI=",
+        "lastModified": 1693770387,
+        "narHash": "sha256-6mbBzZd7oKsBIo4143yd8JbKJiC3ngTuXcQtoI3BCN4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e756b33db1b6a774c44241bdd7221702de8d08c9",
+        "rev": "b3e53ef7d95f00f6bdded43c75f3f4c6a5a0ec79",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b3e53ef7`](https://github.com/nix-community/NUR/commit/b3e53ef7d95f00f6bdded43c75f3f4c6a5a0ec79) | `` automatic update `` |
| [`e513241a`](https://github.com/nix-community/NUR/commit/e513241a333c28dea8961a2e6f03e9d3c4f4a6b0) | `` automatic update `` |