### PR TITLE
chore(flake/nur): `b3e53ef7` -> `114927b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693770387,
-        "narHash": "sha256-6mbBzZd7oKsBIo4143yd8JbKJiC3ngTuXcQtoI3BCN4=",
+        "lastModified": 1693778755,
+        "narHash": "sha256-ZsveW7C8+zj81bEiX64c2S6ifuT18aVh+aLQ3dw+GsA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b3e53ef7d95f00f6bdded43c75f3f4c6a5a0ec79",
+        "rev": "114927b109da5b3388b9b5827334368a96b5e675",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`114927b1`](https://github.com/nix-community/NUR/commit/114927b109da5b3388b9b5827334368a96b5e675) | `` automatic update `` |
| [`8bb262f6`](https://github.com/nix-community/NUR/commit/8bb262f6b34035cd549ec8e282b4a1a0666a9097) | `` automatic update `` |