### PR TITLE
chore(flake/nur): `1dd930e5` -> `425a8911`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693791551,
-        "narHash": "sha256-M9Y0T1ZDVkK67iwd8x1a7r/EbTrLuIxygx7HSJ28uoU=",
+        "lastModified": 1693799169,
+        "narHash": "sha256-XJj9LFTV2Ekj7oji1f+c7OY18Bgfy8uwUS8bJhI+xW4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1dd930e5ad57f580d9a77f6bd2843913de50cad0",
+        "rev": "425a8911e9ba69e397b88ad1a9282969d2d96823",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`425a8911`](https://github.com/nix-community/NUR/commit/425a8911e9ba69e397b88ad1a9282969d2d96823) | `` automatic update `` |
| [`73df532d`](https://github.com/nix-community/NUR/commit/73df532d3e3d3d445408786547844bb9eda6058a) | `` automatic update `` |
| [`1c0b349e`](https://github.com/nix-community/NUR/commit/1c0b349e0b944222be4521c4fe9b19649c2b0ed2) | `` automatic update `` |