### PR TITLE
chore(flake/nur): `425a8911` -> `4e7f047b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693799169,
-        "narHash": "sha256-XJj9LFTV2Ekj7oji1f+c7OY18Bgfy8uwUS8bJhI+xW4=",
+        "lastModified": 1693800460,
+        "narHash": "sha256-vIt1SUka6m+96JlP830NNk1Ya948Qo/zc63OzOOxBf0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "425a8911e9ba69e397b88ad1a9282969d2d96823",
+        "rev": "4e7f047be2aa1a89b63f3d5bb791253ac9e79442",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4e7f047b`](https://github.com/nix-community/NUR/commit/4e7f047be2aa1a89b63f3d5bb791253ac9e79442) | `` automatic update `` |