### PR TITLE
chore(flake/nur): `4e7f047b` -> `c6691556`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693800460,
-        "narHash": "sha256-vIt1SUka6m+96JlP830NNk1Ya948Qo/zc63OzOOxBf0=",
+        "lastModified": 1693805970,
+        "narHash": "sha256-SPx6YI4OOs7cIO4ajsfoT7jTM4n9/dGJ5eXh4a/uluA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4e7f047be2aa1a89b63f3d5bb791253ac9e79442",
+        "rev": "c66915566e157e5300159b781c5a22968a19f39d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c6691556`](https://github.com/nix-community/NUR/commit/c66915566e157e5300159b781c5a22968a19f39d) | `` automatic update `` |
| [`871815df`](https://github.com/nix-community/NUR/commit/871815df37cd1752c9ed5bcbbea2e52138a3651b) | `` automatic update `` |