### PR TITLE
chore(flake/nur): `c6691556` -> `e73f9926`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693805970,
-        "narHash": "sha256-SPx6YI4OOs7cIO4ajsfoT7jTM4n9/dGJ5eXh4a/uluA=",
+        "lastModified": 1693810608,
+        "narHash": "sha256-Ws51RoLQFnX4BaWsW8ixstOfFq/Hp0c9KSUAHS2GPaY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c66915566e157e5300159b781c5a22968a19f39d",
+        "rev": "e73f99265813fec5e5211d10059e2352e4dfee93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e73f9926`](https://github.com/nix-community/NUR/commit/e73f99265813fec5e5211d10059e2352e4dfee93) | `` automatic update `` |
| [`c2ee02b4`](https://github.com/nix-community/NUR/commit/c2ee02b418623b23959515aa65f5d16e107e7984) | `` automatic update `` |
| [`5a1fec59`](https://github.com/nix-community/NUR/commit/5a1fec592cd4c50d4d2fb83d201a6980a53c9e81) | `` automatic update `` |