### PR TITLE
chore(flake/emacs-overlay): `bc5ac6ca` -> `e59b3046`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693792112,
-        "narHash": "sha256-xGe/hWfD/PEQ6YC0MK1chZLnGRmoY4D16vLA/zqFNik=",
+        "lastModified": 1693853711,
+        "narHash": "sha256-Gt3aZ88wyNEKQryFCXyaDSoL7qJzM6E9FwCIyi3ZZeI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bc5ac6ca9244f20811900632def4e00c6e6ac20e",
+        "rev": "e59b3046f1033e7186cd887b1eaea1a064889418",
         "type": "github"
       },
       "original": {
@@ -732,11 +732,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1693636127,
-        "narHash": "sha256-ZlS/lFGzK7BJXX2YVGnP3yZi3T9OLOEtBCyMJsb91U8=",
+        "lastModified": 1693771906,
+        "narHash": "sha256-32EnPCaVjOiEERZ+o/2Ir7JH9pkfwJZJ27SKHNvt4yk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9075cba53e86dc318d159aee55dc9a7c9a4829c1",
+        "rev": "da5adce0ffaff10f6d0fee72a02a5ed9d01b52fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`e59b3046`](https://github.com/nix-community/emacs-overlay/commit/e59b3046f1033e7186cd887b1eaea1a064889418) | `` Updated repos/melpa ``  |
| [`aed704c7`](https://github.com/nix-community/emacs-overlay/commit/aed704c73686bb8a8f16feadd5b7e76f1f9af5d2) | `` Updated repos/emacs ``  |
| [`1ba22842`](https://github.com/nix-community/emacs-overlay/commit/1ba22842a27171ecc9cc73a6b0e2a6a2d25a3244) | `` Updated repos/elpa ``   |
| [`adfa2fd7`](https://github.com/nix-community/emacs-overlay/commit/adfa2fd70583ef3c87df4a12f23d86d84bc5882d) | `` Updated flake inputs `` |
| [`cbdbd456`](https://github.com/nix-community/emacs-overlay/commit/cbdbd45697307d0e2d2a58e446953080da590b12) | `` Updated repos/melpa ``  |
| [`eaaca1ae`](https://github.com/nix-community/emacs-overlay/commit/eaaca1aeaa49dce375a7ba2e83581f3d366b99ab) | `` Updated repos/emacs ``  |