### PR TITLE
chore(flake/nur): `c6aaa7dd` -> `fa20a5d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693820830,
-        "narHash": "sha256-4eTnS0fQYpmJoGWf7hRvKqlwjtRI2tMR1Cr7C9kjBN0=",
+        "lastModified": 1693827516,
+        "narHash": "sha256-t7VIP6phYyYK7+GcscymEUctQ1KHP7JlSERkZWTXOf8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c6aaa7dd19e46dec72be486d98a8e84203604aad",
+        "rev": "fa20a5d187c3369fc0a3d4c76ba34043e1d1ef64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fa20a5d1`](https://github.com/nix-community/NUR/commit/fa20a5d187c3369fc0a3d4c76ba34043e1d1ef64) | `` automatic update `` |