### PR TITLE
chore(flake/nur): `fa20a5d1` -> `487ff2d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693827516,
-        "narHash": "sha256-t7VIP6phYyYK7+GcscymEUctQ1KHP7JlSERkZWTXOf8=",
+        "lastModified": 1693870983,
+        "narHash": "sha256-WuwBXFHYsquhEUh5lhm3LFxmPvPhK5LBYl9TsvZvb0E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fa20a5d187c3369fc0a3d4c76ba34043e1d1ef64",
+        "rev": "487ff2d47250893ab3570d7fd8c5bbd3713f7056",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`487ff2d4`](https://github.com/nix-community/NUR/commit/487ff2d47250893ab3570d7fd8c5bbd3713f7056) | `` automatic update `` |
| [`132e8dd1`](https://github.com/nix-community/NUR/commit/132e8dd163097c08da221eeec4ba8ddca8e9566a) | `` automatic update `` |
| [`1a6d4a0a`](https://github.com/nix-community/NUR/commit/1a6d4a0a96f8e280bd8409e7e958bd51a4eeec5c) | `` automatic update `` |
| [`2c54f34a`](https://github.com/nix-community/NUR/commit/2c54f34a1ce48fc4c9a27b2da1537475761a81ce) | `` automatic update `` |
| [`1b2f5741`](https://github.com/nix-community/NUR/commit/1b2f5741e4717a3420b7ec7d91196e24f76d4323) | `` automatic update `` |
| [`648ef0fe`](https://github.com/nix-community/NUR/commit/648ef0fea873bd59db6b120bafc57b27bef243da) | `` automatic update `` |
| [`72f3f5d0`](https://github.com/nix-community/NUR/commit/72f3f5d0ef0a2407cd206f95a9e43d9651c3732e) | `` automatic update `` |
| [`5e3744ba`](https://github.com/nix-community/NUR/commit/5e3744ba7065a2eb94576d571a6cdd4940c8b29f) | `` automatic update `` |
| [`f0aa19bb`](https://github.com/nix-community/NUR/commit/f0aa19bb8900ac5997350cdcf0fe32db99048337) | `` automatic update `` |
| [`88e7a95c`](https://github.com/nix-community/NUR/commit/88e7a95c269af98c70c6b513caea3b08dce89866) | `` automatic update `` |
| [`91f33352`](https://github.com/nix-community/NUR/commit/91f33352d75e22be263accbf27ca49970ec200ab) | `` automatic update `` |
| [`3a288e41`](https://github.com/nix-community/NUR/commit/3a288e4110f1f81162aabd1793ce14444549595c) | `` automatic update `` |
| [`b28e6a89`](https://github.com/nix-community/NUR/commit/b28e6a89036069d77b7a6907bc4b9f0648a066c2) | `` automatic update `` |
| [`0ad1166c`](https://github.com/nix-community/NUR/commit/0ad1166c23a331b4e34b9c8d10c1a4b82ed7d2e6) | `` automatic update `` |
| [`842d867e`](https://github.com/nix-community/NUR/commit/842d867e0ed13e2a50db3e0a918eb54c410f0e57) | `` automatic update `` |
| [`2ad9c82e`](https://github.com/nix-community/NUR/commit/2ad9c82e56d5d6328c5d174e8f0a70c46dc74ef0) | `` automatic update `` |
| [`9a5379eb`](https://github.com/nix-community/NUR/commit/9a5379eb91766020c4e90ca45caa98022f84db1f) | `` automatic update `` |