### PR TITLE
chore(flake/emacs-overlay): `e59b3046` -> `3adaef3b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693853711,
-        "narHash": "sha256-Gt3aZ88wyNEKQryFCXyaDSoL7qJzM6E9FwCIyi3ZZeI=",
+        "lastModified": 1693879203,
+        "narHash": "sha256-0CGMa3MxeG3YsVetUtxg6eZumQIe8FJ+WHVfR2ko9zM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e59b3046f1033e7186cd887b1eaea1a064889418",
+        "rev": "3adaef3b1bebdc244a03ee19f705f5a3190a33d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`3adaef3b`](https://github.com/nix-community/emacs-overlay/commit/3adaef3b1bebdc244a03ee19f705f5a3190a33d9) | `` Updated repos/nongnu `` |
| [`8eb732ee`](https://github.com/nix-community/emacs-overlay/commit/8eb732ee438ceeb0f509f98b38b1d34443c9b92c) | `` Updated repos/melpa ``  |
| [`2d21a318`](https://github.com/nix-community/emacs-overlay/commit/2d21a318ffc4f55bd904ab5f0325ee1a31e4d1de) | `` Updated repos/elpa ``   |