### PR TITLE
chore(flake/nur): `487ff2d4` -> `b25a9238`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693870983,
-        "narHash": "sha256-WuwBXFHYsquhEUh5lhm3LFxmPvPhK5LBYl9TsvZvb0E=",
+        "lastModified": 1693889546,
+        "narHash": "sha256-Q/DW5boEoN8xXi3Vlt8HyG9DGNoe9KzFn9KbXgWWzGE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "487ff2d47250893ab3570d7fd8c5bbd3713f7056",
+        "rev": "b25a9238e90ef27a0d5dd441cf8d47dcb914ff31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b25a9238`](https://github.com/nix-community/NUR/commit/b25a9238e90ef27a0d5dd441cf8d47dcb914ff31) | `` automatic update `` |
| [`46c86c32`](https://github.com/nix-community/NUR/commit/46c86c327cc8591c861d065edc82939aa156d074) | `` automatic update `` |
| [`2daa434e`](https://github.com/nix-community/NUR/commit/2daa434e6464f1b7e187e3d0de9ee5914650a1e2) | `` automatic update `` |
| [`ed84d07f`](https://github.com/nix-community/NUR/commit/ed84d07faf54fb0ca2e981cc23cecd349db8c5a5) | `` automatic update `` |
| [`a2d61643`](https://github.com/nix-community/NUR/commit/a2d61643ebf93243c5a74bb5d27aa6d654638275) | `` automatic update `` |