### PR TITLE
chore(flake/nur): `b25a9238` -> `fc17dbe5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693889546,
-        "narHash": "sha256-Q/DW5boEoN8xXi3Vlt8HyG9DGNoe9KzFn9KbXgWWzGE=",
+        "lastModified": 1693924894,
+        "narHash": "sha256-QPofGmNhIsdmt/GjvTnJWKJHYF3fShItFKe9GUhn1ak=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b25a9238e90ef27a0d5dd441cf8d47dcb914ff31",
+        "rev": "fc17dbe52350a3c4756a630a0d2dce0bc94de1a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fc17dbe5`](https://github.com/nix-community/NUR/commit/fc17dbe52350a3c4756a630a0d2dce0bc94de1a8) | `` automatic update `` |
| [`c944e46e`](https://github.com/nix-community/NUR/commit/c944e46e05b814077c03d6b9efbc5823849dc75e) | `` automatic update `` |
| [`981cdb8d`](https://github.com/nix-community/NUR/commit/981cdb8d5aee193ec8d18dc258d350e3e2e5e34e) | `` automatic update `` |
| [`b1e550c8`](https://github.com/nix-community/NUR/commit/b1e550c82b587f19dfc8ddd26fd03cf4988334e1) | `` automatic update `` |
| [`4cfbeb7c`](https://github.com/nix-community/NUR/commit/4cfbeb7c9c4a92d40c970eef55d1866e21529b3a) | `` automatic update `` |
| [`7951160b`](https://github.com/nix-community/NUR/commit/7951160bc79c4f7d70afe5b0456f71d3eb1574f2) | `` automatic update `` |
| [`283964d2`](https://github.com/nix-community/NUR/commit/283964d2452632c9b0ccc8eff08d242a073b022f) | `` automatic update `` |
| [`4106bca2`](https://github.com/nix-community/NUR/commit/4106bca27246bcf246515ba9e8ea2ca1f572908a) | `` automatic update `` |
| [`d914dfcb`](https://github.com/nix-community/NUR/commit/d914dfcbb7fdd85b4d1dd543de77571774aacbd1) | `` automatic update `` |
| [`10207887`](https://github.com/nix-community/NUR/commit/102078874cdd2bad7d4701ad49404985172193b0) | `` automatic update `` |
| [`c415eb9e`](https://github.com/nix-community/NUR/commit/c415eb9ea005ac351c794796e2f8fbc42c6a7488) | `` automatic update `` |
| [`55130030`](https://github.com/nix-community/NUR/commit/551300301773a3a5f6c5cdafc7e228b10d57841b) | `` automatic update `` |
| [`c2d28b26`](https://github.com/nix-community/NUR/commit/c2d28b2651390a1598ab1f3b3a8c2ef61ba9d3a0) | `` automatic update `` |