### PR TITLE
chore(flake/sops-nix): `faf21ac1` -> `ea208e55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -867,11 +867,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1693898833,
-        "narHash": "sha256-OIrMAGNYNeLs6IvBynxcXub7aSW3GEUvWNsb7zx6zuU=",
+        "lastModified": 1694495315,
+        "narHash": "sha256-sZEYXs9T1NVHZSSbMqBEtEm2PGa7dEDcx0ttQkArORc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "faf21ac162173c2deb54e5fdeed002a9bd6e8623",
+        "rev": "ea208e55f8742fdcc0986b256bdfa8986f5e4415",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`ea208e55`](https://github.com/Mic92/sops-nix/commit/ea208e55f8742fdcc0986b256bdfa8986f5e4415) | `` update vendorHash ``                                           |
| [`6d099e95`](https://github.com/Mic92/sops-nix/commit/6d099e958ef1945f9616e993e6e672fba2442d63) | `` build(deps): bump golang.org/x/crypto from 0.12.0 to 0.13.0 `` |