### PR TITLE
chore(flake/emacs-overlay): `9b19cc20` -> `6feb2028`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693910265,
-        "narHash": "sha256-OWWi7ym3ycK8y0wUhEdaBfqbo8ilOen+Dxi8Cbf90c4=",
+        "lastModified": 1693937894,
+        "narHash": "sha256-LTCjxonSnCCUIyYBKN3jlGL9lc/PktKYAtOKIzvQ0Hc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9b19cc202da6dcb1eda2ad2f6a1cc8548001fb29",
+        "rev": "6feb20284f9c670836d9ffb1c074f7d347a3458a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`6feb2028`](https://github.com/nix-community/emacs-overlay/commit/6feb20284f9c670836d9ffb1c074f7d347a3458a) | `` Updated repos/melpa `` |
| [`737dadc8`](https://github.com/nix-community/emacs-overlay/commit/737dadc85f5c0a7d01d1fff2b44feda88f98e5ea) | `` Updated repos/emacs `` |
| [`cfc2d6ce`](https://github.com/nix-community/emacs-overlay/commit/cfc2d6cee919f9ea64ea1a13cc275ed41e0621f4) | `` Updated repos/elpa ``  |