### PR TITLE
chore(flake/nur): `fc17dbe5` -> `97ec7d19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693924894,
-        "narHash": "sha256-QPofGmNhIsdmt/GjvTnJWKJHYF3fShItFKe9GUhn1ak=",
+        "lastModified": 1693934318,
+        "narHash": "sha256-1LY4jKryPK5Utbc5Ob/LsibP0I/WmbFSJGZrPlL+ygY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc17dbe52350a3c4756a630a0d2dce0bc94de1a8",
+        "rev": "97ec7d19bf6fd09c735bbe89f035c331ad267a66",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`97ec7d19`](https://github.com/nix-community/NUR/commit/97ec7d19bf6fd09c735bbe89f035c331ad267a66) | `` automatic update `` |
| [`fcd4417a`](https://github.com/nix-community/NUR/commit/fcd4417a2f85a29ebc24ce86df880903b03abc06) | `` automatic update `` |
| [`5e0796a8`](https://github.com/nix-community/NUR/commit/5e0796a865b94706f31cbfa5b6bfe2f9d7af9ea0) | `` automatic update `` |