### PR TITLE
chore(flake/nur): `ce95f602` -> `97c72989`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693964205,
-        "narHash": "sha256-vCfbglkLQKYKt9A0ehSvxAg5G2RDSJx4CH9yLBWcCa4=",
+        "lastModified": 1693967139,
+        "narHash": "sha256-yS+h1SFf+rnsgQpbEgik9i/doKXluVWu1/2VRxdGqrY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ce95f6021d6724600a26cb5f79848d79bd996349",
+        "rev": "97c729898e57335fe2c8a29b124287bebdba8d05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`97c72989`](https://github.com/nix-community/NUR/commit/97c729898e57335fe2c8a29b124287bebdba8d05) | `` automatic update `` |