### PR TITLE
chore(flake/emacs-overlay): `6feb2028` -> `f3945cc2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693937894,
-        "narHash": "sha256-LTCjxonSnCCUIyYBKN3jlGL9lc/PktKYAtOKIzvQ0Hc=",
+        "lastModified": 1693970835,
+        "narHash": "sha256-0B/LIH10ejPoTbEG+re//argOav/ScsTz49VN1NX0UY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6feb20284f9c670836d9ffb1c074f7d347a3458a",
+        "rev": "f3945cc285cf84244759db727a91a2056649f4b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`f3945cc2`](https://github.com/nix-community/emacs-overlay/commit/f3945cc285cf84244759db727a91a2056649f4b5) | `` Updated repos/nongnu `` |
| [`86d5dd1a`](https://github.com/nix-community/emacs-overlay/commit/86d5dd1ae7f1fe5ef478a8fa47481bcd0eb1d27f) | `` Updated repos/melpa ``  |
| [`4aaf3131`](https://github.com/nix-community/emacs-overlay/commit/4aaf3131bea8e1cacefdc8b6d892af1b60a20c73) | `` Updated repos/emacs ``  |
| [`6fb937f3`](https://github.com/nix-community/emacs-overlay/commit/6fb937f3e64795fb7f3309f571b76933a40ab9e2) | `` Updated repos/elpa ``   |