### PR TITLE
chore(flake/nur): `97c72989` -> `ad0c6d87`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693967139,
-        "narHash": "sha256-yS+h1SFf+rnsgQpbEgik9i/doKXluVWu1/2VRxdGqrY=",
+        "lastModified": 1693976098,
+        "narHash": "sha256-VWgYidcX3gXXB2LK76C7/sdWQeEpouyamasoPhkIywg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "97c729898e57335fe2c8a29b124287bebdba8d05",
+        "rev": "ad0c6d8734c2eaa13e7275c5d23014b93eb054a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ad0c6d87`](https://github.com/nix-community/NUR/commit/ad0c6d8734c2eaa13e7275c5d23014b93eb054a0) | `` automatic update `` |
| [`2e89d958`](https://github.com/nix-community/NUR/commit/2e89d9589985e067fbc21f16ef21017c00a520fd) | `` automatic update `` |
| [`0c44b2f9`](https://github.com/nix-community/NUR/commit/0c44b2f9006f3a9ae107988b5d59685b1295155c) | `` automatic update `` |
| [`0415ccd1`](https://github.com/nix-community/NUR/commit/0415ccd1507865798e75cd53f5e51831a5ba3b07) | `` automatic update `` |