### PR TITLE
chore(flake/nur): `ad0c6d87` -> `0fb6f656`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693976098,
-        "narHash": "sha256-VWgYidcX3gXXB2LK76C7/sdWQeEpouyamasoPhkIywg=",
+        "lastModified": 1693978784,
+        "narHash": "sha256-dls1m+jzk6fGzt5k7Er/M2KMHkaaYTpcl0ogXOIj4O0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ad0c6d8734c2eaa13e7275c5d23014b93eb054a0",
+        "rev": "0fb6f656cd65d91059b8f2bdb030ed05e0ad74aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0fb6f656`](https://github.com/nix-community/NUR/commit/0fb6f656cd65d91059b8f2bdb030ed05e0ad74aa) | `` automatic update `` |
| [`ae9d73be`](https://github.com/nix-community/NUR/commit/ae9d73beb5ddbd4ad4eb9da2cd66ecdeb01fab4a) | `` automatic update `` |
| [`46711039`](https://github.com/nix-community/NUR/commit/4671103915d807b040acadeafd24261e4892c644) | `` automatic update `` |