### PR TITLE
chore(flake/nur): `0fb6f656` -> `ec654ca6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693978784,
-        "narHash": "sha256-dls1m+jzk6fGzt5k7Er/M2KMHkaaYTpcl0ogXOIj4O0=",
+        "lastModified": 1693982009,
+        "narHash": "sha256-VgIXvE2bDqkpyuMIwlA2dJwLvSbEONsix5Btj52K1uU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0fb6f656cd65d91059b8f2bdb030ed05e0ad74aa",
+        "rev": "ec654ca68cb8f588e6a8e02e007e70ba325a6fd9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ec654ca6`](https://github.com/nix-community/NUR/commit/ec654ca68cb8f588e6a8e02e007e70ba325a6fd9) | `` automatic update `` |