### PR TITLE
chore(flake/nur): `ec654ca6` -> `179595aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693982009,
-        "narHash": "sha256-VgIXvE2bDqkpyuMIwlA2dJwLvSbEONsix5Btj52K1uU=",
+        "lastModified": 1693990099,
+        "narHash": "sha256-//4VDyKOXGb8vDHqINPBYdkYBGlpvY1D6C9wdu4Vy74=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ec654ca68cb8f588e6a8e02e007e70ba325a6fd9",
+        "rev": "179595aa7aff94fa1954d51b0af3cd3f2499d74e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`179595aa`](https://github.com/nix-community/NUR/commit/179595aa7aff94fa1954d51b0af3cd3f2499d74e) | `` automatic update `` |
| [`886deea2`](https://github.com/nix-community/NUR/commit/886deea24b0cf2f687104af8ffe6bb37bf46c1d1) | `` automatic update `` |