### PR TITLE
chore(flake/nur): `179595aa` -> `5676341d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693990099,
-        "narHash": "sha256-//4VDyKOXGb8vDHqINPBYdkYBGlpvY1D6C9wdu4Vy74=",
+        "lastModified": 1693992105,
+        "narHash": "sha256-JuJDhXDL2ixrcyIYDhljHfiMdvPRKnjijXVvNgs9kkQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "179595aa7aff94fa1954d51b0af3cd3f2499d74e",
+        "rev": "5676341d273d8440dcdbca608f5e59ba747a0f6a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5676341d`](https://github.com/nix-community/NUR/commit/5676341d273d8440dcdbca608f5e59ba747a0f6a) | `` automatic update `` |