### PR TITLE
chore(flake/nur): `5676341d` -> `6205d8f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693992105,
-        "narHash": "sha256-JuJDhXDL2ixrcyIYDhljHfiMdvPRKnjijXVvNgs9kkQ=",
+        "lastModified": 1693997186,
+        "narHash": "sha256-gH3BZaCfMdII40D/y7yGr917gl8fwgY5Dp9hd1AOXg8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5676341d273d8440dcdbca608f5e59ba747a0f6a",
+        "rev": "6205d8f5f1c9210186f61f4a7c9cf7326c156140",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6205d8f5`](https://github.com/nix-community/NUR/commit/6205d8f5f1c9210186f61f4a7c9cf7326c156140) | `` automatic update `` |