### PR TITLE
chore(flake/nur): `6205d8f5` -> `aea25d13`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693997186,
-        "narHash": "sha256-gH3BZaCfMdII40D/y7yGr917gl8fwgY5Dp9hd1AOXg8=",
+        "lastModified": 1694000701,
+        "narHash": "sha256-BId39YNl6kF3OBJfY8hSxfYw/cWEEdn2c0JwvZVafdo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6205d8f5f1c9210186f61f4a7c9cf7326c156140",
+        "rev": "aea25d13f8b3e93ca513c87adc4b89d715774146",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aea25d13`](https://github.com/nix-community/NUR/commit/aea25d13f8b3e93ca513c87adc4b89d715774146) | `` automatic update `` |