### PR TITLE
chore(flake/nur): `aea25d13` -> `0572f3d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1694000701,
-        "narHash": "sha256-BId39YNl6kF3OBJfY8hSxfYw/cWEEdn2c0JwvZVafdo=",
+        "lastModified": 1694011534,
+        "narHash": "sha256-gB7LM/w61gjZ2n75JN7FQKAF4o2QumqI33Pac16ZvjI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aea25d13f8b3e93ca513c87adc4b89d715774146",
+        "rev": "0572f3d2f4d1b231196f8ed7a3280c7f0724c95e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0572f3d2`](https://github.com/nix-community/NUR/commit/0572f3d2f4d1b231196f8ed7a3280c7f0724c95e) | `` automatic update `` |