### PR TITLE
chore(flake/emacs-overlay): `f5c2366c` -> `e709d677`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1693996518,
-        "narHash": "sha256-UZGLPvG9QzjS9ViC31WNZPBg+qd+mFXrf3pCC6c1EMQ=",
+        "lastModified": 1694025025,
+        "narHash": "sha256-MrKcNTAevAGliEAW0TSo1E7khLVFGG/VV27jj0nR81M=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f5c2366c5d8f241b8c66e4b18be8ad25ffdb4e48",
+        "rev": "e709d677e1cbe46b784e990c5796a8c7592d256c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`e709d677`](https://github.com/nix-community/emacs-overlay/commit/e709d677e1cbe46b784e990c5796a8c7592d256c) | `` Updated repos/melpa ``  |
| [`b8f6a2f5`](https://github.com/nix-community/emacs-overlay/commit/b8f6a2f5d913541a40fb3d31795b2092dfaf53da) | `` Updated repos/emacs ``  |
| [`747473dc`](https://github.com/nix-community/emacs-overlay/commit/747473dc2ef8f0d55a91864ccf1c1d24062828fe) | `` Updated repos/elpa ``   |
| [`ae6d90ea`](https://github.com/nix-community/emacs-overlay/commit/ae6d90ea7e65c6ddcfcbaa5554eadc35eb4ee6c9) | `` Updated flake inputs `` |