### PR TITLE
chore(flake/nur): `1986d63b` -> `480b66c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1694020178,
-        "narHash": "sha256-1FJT97lTUNL/sjAA85Ysmv8BAExcWohaaHlLJOqb48g=",
+        "lastModified": 1694029508,
+        "narHash": "sha256-1fsduKlZbqwn7RTno0Wx38KGs0fZoZQ9H661jSnN6z4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1986d63bbafb176538af97ab6e4001ce5bb2718f",
+        "rev": "480b66c5d96e175da28368be096d24052ce314fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`480b66c5`](https://github.com/nix-community/NUR/commit/480b66c5d96e175da28368be096d24052ce314fd) | `` automatic update `` |