### PR TITLE
chore(flake/nur): `480b66c5` -> `853db989`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1694029508,
-        "narHash": "sha256-1fsduKlZbqwn7RTno0Wx38KGs0fZoZQ9H661jSnN6z4=",
+        "lastModified": 1694033987,
+        "narHash": "sha256-a6czgEX4PRtaqUjgAJpXNsXmGJHku7fUWfdiBfTecfU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "480b66c5d96e175da28368be096d24052ce314fd",
+        "rev": "853db98956ceb254b7d28181727070c7867cefaf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`853db989`](https://github.com/nix-community/NUR/commit/853db98956ceb254b7d28181727070c7867cefaf) | `` automatic update `` |
| [`dcb23ac3`](https://github.com/nix-community/NUR/commit/dcb23ac37bea61a90103a2f40df8c01cb7e0b725) | `` automatic update `` |