### PR TITLE
chore(flake/nur): `853db989` -> `b8a79d8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1694033987,
-        "narHash": "sha256-a6czgEX4PRtaqUjgAJpXNsXmGJHku7fUWfdiBfTecfU=",
+        "lastModified": 1694036674,
+        "narHash": "sha256-L5eX+nSzjRxIHk8huih8D4tn28id2mLbL3CFW9Gd/4A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "853db98956ceb254b7d28181727070c7867cefaf",
+        "rev": "b8a79d8e92964bc10c9999c801a1bb19aae7f04f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b8a79d8e`](https://github.com/nix-community/NUR/commit/b8a79d8e92964bc10c9999c801a1bb19aae7f04f) | `` automatic update `` |