### PR TITLE
chore(flake/nur): `b8a79d8e` -> `788534af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1694036674,
-        "narHash": "sha256-L5eX+nSzjRxIHk8huih8D4tn28id2mLbL3CFW9Gd/4A=",
+        "lastModified": 1694050786,
+        "narHash": "sha256-G3HaLOlA7BDv6Eido9zsVuBdm55d1P4u5iQTF7Katjc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b8a79d8e92964bc10c9999c801a1bb19aae7f04f",
+        "rev": "788534afd0d36d0e08e522d37d2de5f7f84d51a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`788534af`](https://github.com/nix-community/NUR/commit/788534afd0d36d0e08e522d37d2de5f7f84d51a9) | `` automatic update `` |