### PR TITLE
chore(flake/emacs-overlay): `e709d677` -> `e91d53d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1694025025,
-        "narHash": "sha256-MrKcNTAevAGliEAW0TSo1E7khLVFGG/VV27jj0nR81M=",
+        "lastModified": 1694057476,
+        "narHash": "sha256-x3DpM4FCAjONAJboEjMDf9Q2diXwV/I/+Qny8HAy1u0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e709d677e1cbe46b784e990c5796a8c7592d256c",
+        "rev": "e91d53d2fa6595fb241187971a7c344420ea1d32",
         "type": "github"
       },
       "original": {
@@ -732,11 +732,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1693771906,
-        "narHash": "sha256-32EnPCaVjOiEERZ+o/2Ir7JH9pkfwJZJ27SKHNvt4yk=",
+        "lastModified": 1693953029,
+        "narHash": "sha256-1+28KQl4YC4IBzKo/epvEyK5KH4MlgoYueJ8YwLGbOc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da5adce0ffaff10f6d0fee72a02a5ed9d01b52fc",
+        "rev": "4077a0e4ac3356222bc1f0a070af7939c3098535",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`e91d53d2`](https://github.com/nix-community/emacs-overlay/commit/e91d53d2fa6595fb241187971a7c344420ea1d32) | `` Updated repos/melpa ``  |
| [`7b13830d`](https://github.com/nix-community/emacs-overlay/commit/7b13830d8a7265a2bd8d5ef0b864a3001cf8d076) | `` Updated repos/emacs ``  |
| [`2a00aaf9`](https://github.com/nix-community/emacs-overlay/commit/2a00aaf989a1f8b16a2e79b31661bdd31753ab4b) | `` Updated repos/elpa ``   |
| [`e398890f`](https://github.com/nix-community/emacs-overlay/commit/e398890fc3ec845082e63b81bca41eb13f06a77d) | `` Updated flake inputs `` |