### PR TITLE
chore(flake/nur): `788534af` -> `f842cff9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1694050786,
-        "narHash": "sha256-G3HaLOlA7BDv6Eido9zsVuBdm55d1P4u5iQTF7Katjc=",
+        "lastModified": 1694058296,
+        "narHash": "sha256-vSYMkq6f5Y2Dnb6GqDLvFmDQrpT+xIIUVzBDe38XJWQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "788534afd0d36d0e08e522d37d2de5f7f84d51a9",
+        "rev": "f842cff9c79d358b57273afc0b934750f716cfc0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f842cff9`](https://github.com/nix-community/NUR/commit/f842cff9c79d358b57273afc0b934750f716cfc0) | `` automatic update `` |
| [`b15c1a0a`](https://github.com/nix-community/NUR/commit/b15c1a0af8eea7373b22531311f0bed6ccb18538) | `` automatic update `` |