### PR TITLE
chore(flake/nur): `f842cff9` -> `828e7b30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1694058296,
-        "narHash": "sha256-vSYMkq6f5Y2Dnb6GqDLvFmDQrpT+xIIUVzBDe38XJWQ=",
+        "lastModified": 1694061733,
+        "narHash": "sha256-LjTvcCawHySxsEDh4qGfrWtWLFe9s9ecDTStvqRnjgE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f842cff9c79d358b57273afc0b934750f716cfc0",
+        "rev": "828e7b300235881e47d0603d6b3e77e377ba780b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`828e7b30`](https://github.com/nix-community/NUR/commit/828e7b300235881e47d0603d6b3e77e377ba780b) | `` automatic update `` |
| [`a09165da`](https://github.com/nix-community/NUR/commit/a09165da1d8e7dd79acbbeca58291079d6d91da3) | `` automatic update `` |