### PR TITLE
chore(flake/nur): `828e7b30` -> `c4c01d57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1694061733,
-        "narHash": "sha256-LjTvcCawHySxsEDh4qGfrWtWLFe9s9ecDTStvqRnjgE=",
+        "lastModified": 1694065153,
+        "narHash": "sha256-PB9lpFQ4eqMIm5AUZg2CoK1KxzVsvUfFoCSQSyXb1yU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "828e7b300235881e47d0603d6b3e77e377ba780b",
+        "rev": "c4c01d577d95714e1964ccb8f719bcc5b5da06c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c4c01d57`](https://github.com/nix-community/NUR/commit/c4c01d577d95714e1964ccb8f719bcc5b5da06c5) | `` automatic update `` |