### PR TITLE
chore(flake/nur): `c4c01d57` -> `27742503`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1694065153,
-        "narHash": "sha256-PB9lpFQ4eqMIm5AUZg2CoK1KxzVsvUfFoCSQSyXb1yU=",
+        "lastModified": 1694075959,
+        "narHash": "sha256-ad0xUoaoLndIxcqjBCwNAmuCxpj0mewjT1tbzyTKWzw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c4c01d577d95714e1964ccb8f719bcc5b5da06c5",
+        "rev": "277425032fbc926a2fb9ab333750a1becd9b4069",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`27742503`](https://github.com/nix-community/NUR/commit/277425032fbc926a2fb9ab333750a1becd9b4069) | `` automatic update `` |
| [`31f7e623`](https://github.com/nix-community/NUR/commit/31f7e623eae3f6dd1ae06c8a3bba6c51f9898133) | `` automatic update `` |
| [`c6ee3b24`](https://github.com/nix-community/NUR/commit/c6ee3b245ed923ca5da85e4571a2b9642903505a) | `` automatic update `` |
| [`b459a40a`](https://github.com/nix-community/NUR/commit/b459a40a1e394444e1fe19791ddeac454521697a) | `` automatic update `` |