### PR TITLE
chore(flake/nur): `27742503` -> `2fc4b568`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1694075959,
-        "narHash": "sha256-ad0xUoaoLndIxcqjBCwNAmuCxpj0mewjT1tbzyTKWzw=",
+        "lastModified": 1694078736,
+        "narHash": "sha256-f0u8g8SOx3i0Gy6gcleEvCpO6LefK0PVUtJUXai3Fw4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "277425032fbc926a2fb9ab333750a1becd9b4069",
+        "rev": "2fc4b5686f999a7f44389a9ae0939843dce0d5de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2fc4b568`](https://github.com/nix-community/NUR/commit/2fc4b5686f999a7f44389a9ae0939843dce0d5de) | `` automatic update `` |
| [`7429ea79`](https://github.com/nix-community/NUR/commit/7429ea79894f4046becca050427aa2e30bfa8d5a) | `` automatic update `` |