### PR TITLE
chore(flake/nur): `2fc4b568` -> `a2c830b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1694078736,
-        "narHash": "sha256-f0u8g8SOx3i0Gy6gcleEvCpO6LefK0PVUtJUXai3Fw4=",
+        "lastModified": 1694087079,
+        "narHash": "sha256-BGZDbKgBrCXi0vlnihqsUqVEGZ4mayKKgIFhMAA79Y0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2fc4b5686f999a7f44389a9ae0939843dce0d5de",
+        "rev": "a2c830b335fbd7fd7d73171f66f1cd589d2459f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a2c830b3`](https://github.com/nix-community/NUR/commit/a2c830b335fbd7fd7d73171f66f1cd589d2459f9) | `` automatic update `` |