### PR TITLE
chore(flake/nixpkgs): `3c15feef` -> `0bffda19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -665,11 +665,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1693844670,
-        "narHash": "sha256-t69F2nBB8DNQUWHD809oJZJVE+23XBrth4QZuVd6IE0=",
+        "lastModified": 1693985761,
+        "narHash": "sha256-K5b+7j7Tt3+AqbWkcw+wMeqOAWyCD1MH26FPZyWXpdo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3c15feef7770eb5500a4b8792623e2d6f598c9c1",
+        "rev": "0bffda19b8af722f8069d09d8b6a24594c80b352",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`0bffda19`](https://github.com/NixOS/nixpkgs/commit/0bffda19b8af722f8069d09d8b6a24594c80b352) | `` buildbot: 3.9.0 -> 3.9.2 ``                                          |
| [`6ab91385`](https://github.com/NixOS/nixpkgs/commit/6ab913850d39aae112a1397ca2491e82c7bd2465) | `` garage: 0.8.3 -> 0.8.4 (#253542) ``                                  |
| [`39cec7b9`](https://github.com/NixOS/nixpkgs/commit/39cec7b937c2075c0c53ab97fe20a5988c326a2d) | `` gotify-server: add passthru.tests ``                                 |
| [`94bce8f0`](https://github.com/NixOS/nixpkgs/commit/94bce8f014caaea1e414a155d2acae8a2f663ac4) | `` gotify-server: use fetchYarnDeps ``                                  |
| [`91ca9989`](https://github.com/NixOS/nixpkgs/commit/91ca9989d119ad95229cae2390e7e5851a533e14) | `` surrealdb: 1.0.0-beta.10 -> 1.0.0-beta.11 ``                         |
| [`109efd45`](https://github.com/NixOS/nixpkgs/commit/109efd459d6e397a9128b55f8d0138f1fa1380e3) | `` cargo-pgrx: 0.9.8 -> 0.10.0 ``                                       |
| [`024f043a`](https://github.com/NixOS/nixpkgs/commit/024f043a27715bda2b8dd409e2c5402ad2f6ee72) | `` redpanda: mark broken ``                                             |
| [`4917499e`](https://github.com/NixOS/nixpkgs/commit/4917499ea5012dff288237b50f9a1344609e8907) | `` unstructured-api: 0.0.39 -> 0.0.41 ``                                |
| [`b608b10b`](https://github.com/NixOS/nixpkgs/commit/b608b10be419c78665cb82a93d10588e3ddac24e) | `` python310Packages.unstructured: 0.9.1 -> 0.10.12 ``                  |
| [`36ec0a4a`](https://github.com/NixOS/nixpkgs/commit/36ec0a4aed6d4a5dbef0a74e3e812f801599d112) | `` fix: update helm-s3 package description ``                           |
| [`74c029e4`](https://github.com/NixOS/nixpkgs/commit/74c029e4c9fd0ff09f27a24ae57f100222a9b1cb) | `` chore: update 'sha256' to 'hash' ``                                  |
| [`c1de92d1`](https://github.com/NixOS/nixpkgs/commit/c1de92d18893579032dbb69e180806609018084c) | `` coffeescript: use buildNpmPackage ``                                 |
| [`05f82739`](https://github.com/NixOS/nixpkgs/commit/05f82739df7cf884907db8ee9b22c76a7efb6edb) | `` emilua: init at 0.4.3 ``                                             |
| [`9814d9d6`](https://github.com/NixOS/nixpkgs/commit/9814d9d6c971c80c0f1dac448887a8ff76a7d165) | `` maintainers: add manipuladordedados ``                               |
| [`cae7f23e`](https://github.com/NixOS/nixpkgs/commit/cae7f23ed8a325039d9143d5c4899a985d2e05c1) | `` build-support/emacs: fix name when overrideAttrs is used ``          |
| [`35ccb9db`](https://github.com/NixOS/nixpkgs/commit/35ccb9db3f4f0872f05d175cf53d0e1f87ff09ea) | `` build-support/emacs: make version non-optional ``                    |
| [`15bb8a8e`](https://github.com/NixOS/nixpkgs/commit/15bb8a8e7ea7ae54b0f72a9a01d2d39da5337df3) | `` mympd: 11.0.4 -> 11.0.5 ``                                           |
| [`6921c501`](https://github.com/NixOS/nixpkgs/commit/6921c5014eaa6d045f7b802c231bb9363b9b53c1) | `` turbo: 1.10.7 -> 1.10.13 ``                                          |
| [`4769537b`](https://github.com/NixOS/nixpkgs/commit/4769537b2696d552d208a2515686c096f14e44ec) | `` focuswriter: added qtwayland and wrapped application ``              |
| [`256814f1`](https://github.com/NixOS/nixpkgs/commit/256814f16e6c77a9cffc9a14fa0db38c05010fce) | `` focuswriter: switch from `fetchurl` to `fetchFromGitHub` ``          |
| [`7af18574`](https://github.com/NixOS/nixpkgs/commit/7af1857466e2d73599b897f2b04ad95beb860169) | `` focuswriter: added kashw2 maintainer ``                              |
| [`f94a5ef5`](https://github.com/NixOS/nixpkgs/commit/f94a5ef5fa022ed04988edf7aa9d8403d1edd5b7) | `` focuswriter: 1.7.6 -> 1.8.5 ``                                       |
| [`9f052e13`](https://github.com/NixOS/nixpkgs/commit/9f052e1393c76d75b24f1f5a1d4c330a317cd188) | `` python310Packages.pymilvus: 2.2.15 -> 2.3.0 ``                       |
| [`92dff202`](https://github.com/NixOS/nixpkgs/commit/92dff2020a6fe5e09cb622e6bafbdd34bea57e1c) | `` ipscan: set alias angryipscanner for package (#252555) ``            |
| [`736cfed3`](https://github.com/NixOS/nixpkgs/commit/736cfed3efe617e32ca582eb24c9cacaaa8cd1a6) | `` asciiquarium-transparent: init at unstable-2023-02-19 (#253439) ``   |
| [`16644266`](https://github.com/NixOS/nixpkgs/commit/166442660b176cc886777c291cc8599ea187aab1) | `` lomiri.geonames: Use devdoc for documentation instead (#253407) ``   |
| [`50e9b1cc`](https://github.com/NixOS/nixpkgs/commit/50e9b1cca95a549d87ef97bd46e63fbd1559553d) | `` wofi-emoji: 2022-08-19 -> 2023-06-19 (#253449) ``                    |
| [`2ca2346b`](https://github.com/NixOS/nixpkgs/commit/2ca2346b60f72fc75bcc570367e24e1d68d55b18) | `` virtiofsd: add astro to maintainers ``                               |
| [`51224aa9`](https://github.com/NixOS/nixpkgs/commit/51224aa9fedd82dd850ab936728dc168b974622a) | `` virtiofsd: 1.6.1 -> 1.8.0 ``                                         |
| [`c0215b52`](https://github.com/NixOS/nixpkgs/commit/c0215b520f6f99be654e048c988abb345ff16b69) | `` shadowsocks-rust: 1.16.0 -> 1.16.1 ``                                |
| [`fbd2c21f`](https://github.com/NixOS/nixpkgs/commit/fbd2c21ff03b75ff828c3caffa15d0fe73b46fcd) | `` mastodon: 4.1.6 -> 4.1.7 ``                                          |
| [`00918cc4`](https://github.com/NixOS/nixpkgs/commit/00918cc46d3a94c8a383094edb1a681c172d900a) | `` sssnake: init at 0.3.2 (#253441) ``                                  |
| [`af66f4fd`](https://github.com/NixOS/nixpkgs/commit/af66f4fd2a5e008f923a9f76e92c0f8665744fd8) | `` cawbird: remove due to being broken and abandoned ``                 |
| [`3e185fa7`](https://github.com/NixOS/nixpkgs/commit/3e185fa73a9d99b42cc69c2565237f866647fab7) | `` femtolisp: add meta.mainProgram ``                                   |
| [`c2daa614`](https://github.com/NixOS/nixpkgs/commit/c2daa614001faf43f61b2c190f5d268f3eb18230) | `` drawterm: add meta.mainProgram ``                                    |
| [`502a0837`](https://github.com/NixOS/nixpkgs/commit/502a08376864b2c4b731845d1e5234ba9f8e076f) | `` pc: add meta.mainProgram ``                                          |
| [`0d6cbeb1`](https://github.com/NixOS/nixpkgs/commit/0d6cbeb1a0fdd1fe7fc8424f1d1321d77cc5b85c) | `` apache-jena-fuseki: add darwin support ``                            |
| [`4aa3e842`](https://github.com/NixOS/nixpkgs/commit/4aa3e8423e2f01f72f00fdc4c9c450fb46390e43) | `` prometheus-redis-exporter: 1.52.0 -> 1.53.0 ``                       |
| [`5d778d1f`](https://github.com/NixOS/nixpkgs/commit/5d778d1f030ace7e20548a48323120e7c97b7309) | `` Add `programs.ecryptfs` for mount wrappers. ``                       |
| [`10e58711`](https://github.com/NixOS/nixpkgs/commit/10e5871142adfe84aeabe1e65f0b51abf276d163) | `` checkov: 2.4.25 -> 2.4.27 ``                                         |
| [`0aeda97a`](https://github.com/NixOS/nixpkgs/commit/0aeda97a9b07cac8f68123c9b0057a8230228b8f) | `` python311Packages.millheater: 0.11.1 -> 0.11.2 ``                    |
| [`d6b1bfce`](https://github.com/NixOS/nixpkgs/commit/d6b1bfcea532040ab3b06d7a2a53cbfd108fc804) | `` python311Packages.zamg: 0.2.4 -> 0.3.0 ``                            |
| [`75fd3513`](https://github.com/NixOS/nixpkgs/commit/75fd35131c5b9a335e6eec01577584e98cb33878) | `` rustypaste-cli: 0.7.0 -> 0.8.0 ``                                    |
| [`0df47e24`](https://github.com/NixOS/nixpkgs/commit/0df47e242e9e88be9da6e7778ae829cb383df7ee) | `` wayland-logout: init at 1.4 ``                                       |
| [`707808af`](https://github.com/NixOS/nixpkgs/commit/707808af53ddc8e5429036b80f7cdcf040b6661c) | `` vimPlugins.sg-nvim: fix cargoHash ``                                 |
| [`a562ae92`](https://github.com/NixOS/nixpkgs/commit/a562ae92a5908263dc71482b21621c686dafe9e8) | `` rustypaste: 0.13.0 -> 0.14.0 ``                                      |
| [`18b3f70c`](https://github.com/NixOS/nixpkgs/commit/18b3f70ce82c74afaefbcb45d7e781ce131b911e) | `` zoom-us: 5.15.11.7239 -> 5.15.12.7665 ``                             |
| [`fa0ab731`](https://github.com/NixOS/nixpkgs/commit/fa0ab7312d147fb2fa7f24384854c8b05d16165a) | `` exploitdb: 2023-08-30 -> 2023-09-05 ``                               |
| [`df9991c8`](https://github.com/NixOS/nixpkgs/commit/df9991c8c2c83a2346723bcc53d8dcd745437969) | `` gash-utils: init at 0.2.0 ``                                         |
| [`d249a077`](https://github.com/NixOS/nixpkgs/commit/d249a07758187b40ff8377e70c74defc188bea03) | `` gash: init at 0.3.0 ``                                               |
| [`65373919`](https://github.com/NixOS/nixpkgs/commit/65373919b7287dc9f629bc41134bbe5bda4889d0) | `` ttop: 1.2.1 -> 1.2.2 ``                                              |
| [`3098d238`](https://github.com/NixOS/nixpkgs/commit/3098d238efaeb0de4eb238bc9e5a87453a75c1a3) | `` carapace: 0.26.0 -> 0.27.0 (#253444) ``                              |
| [`22ee1b2f`](https://github.com/NixOS/nixpkgs/commit/22ee1b2f270b3dfa4275153aa6544c35f07ee109) | `` foomatic-db: unstable-2023-08-02 -> unstable-2023-09-02 (#253424) `` |
| [`b88b2905`](https://github.com/NixOS/nixpkgs/commit/b88b2905129a151a0e615ad48461a207baf0f321) | `` cargo-codspeed: 2.1.0 -> 2.2.0 ``                                    |
| [`05943194`](https://github.com/NixOS/nixpkgs/commit/059431944617ae2440a3d4960955948bb3ed3e2d) | `` signalbackup-tools: 20230730 -> 20230905-3 ``                        |
| [`955f30b2`](https://github.com/NixOS/nixpkgs/commit/955f30b26a76a1319d8604e8f87ad31b7ffe5985) | `` norminette: 3.3.53 -> 3.3.54 ``                                      |
| [`6082c70c`](https://github.com/NixOS/nixpkgs/commit/6082c70c964939a9bad89bef6789b7f74473a714) | `` moon: 1.10.1 -> 1.13.0 ``                                            |
| [`607125a0`](https://github.com/NixOS/nixpkgs/commit/607125a0c2a0eee6d88ac7f24382f3b5956f84c1) | `` yaml-language-server: use mkYarnPackage ``                           |
| [`f2d6764d`](https://github.com/NixOS/nixpkgs/commit/f2d6764d13471fddd1340802e7202536bf38ff10) | `` fsautocomplete: 0.61.1 -> 0.62.0 ``                                  |
| [`5de613d1`](https://github.com/NixOS/nixpkgs/commit/5de613d18c4189622c40c8e20bfea0f3444533cf) | `` python311Packages.pyvista: 0.41.1 -> 0.42.0 ``                       |
| [`c811cf64`](https://github.com/NixOS/nixpkgs/commit/c811cf643f19b8067dcbf16d05987c439e8961b4) | `` nixos/tests/lxd: disable virtual-machine test on aarch64 ``          |
| [`a90385c6`](https://github.com/NixOS/nixpkgs/commit/a90385c62b75df48f3ebd29f99d017f06966c569) | `` nixos/lxd: add preseed option ``                                     |
| [`85c14ff2`](https://github.com/NixOS/nixpkgs/commit/85c14ff2ff52d44ed05990ea57f1551f175ecece) | `` nixos/lxd: remove with lib ``                                        |
| [`0b53a140`](https://github.com/NixOS/nixpkgs/commit/0b53a1402668071476ce51b20517265596eedcaa) | `` python310Packages.dataclasses-json: 0.5.15 -> 0.6.0 ``               |
| [`5e347a5d`](https://github.com/NixOS/nixpkgs/commit/5e347a5d3e88ffa0d0e1f0dd89d5d699acfafb88) | `` ktlint: 0.50.0 -> 1.0.0 ``                                           |
| [`1f3194ff`](https://github.com/NixOS/nixpkgs/commit/1f3194ffb15aab628c1c76ae54587b3e745a4878) | `` okteto: 2.19.0 -> 2.19.2 ``                                          |
| [`8bc7bc50`](https://github.com/NixOS/nixpkgs/commit/8bc7bc50cb96d6efcc2dc6045da6f7416a250e8d) | `` sbs: init at 1.0.0 ``                                                |
| [`a8c7ed76`](https://github.com/NixOS/nixpkgs/commit/a8c7ed766c63478db961aa9054827fe979c91530) | `` multus-cni: 3.9.3 -> 4.0.2 (#253393) ``                              |
| [`0a573e55`](https://github.com/NixOS/nixpkgs/commit/0a573e5589a5ae0ee3158ca8363821308c11d73c) | `` bindle: drop .cargo/config ``                                        |
| [`f225dc96`](https://github.com/NixOS/nixpkgs/commit/f225dc96e83fa100a026ed11c0b6008efadd62ab) | `` vdrPlugins.softhddevice: 1.11.2 -> 1.12.1 ``                         |
| [`5b1dcdf1`](https://github.com/NixOS/nixpkgs/commit/5b1dcdf16ab07c5031224d8c55080e9e1ca99c37) | `` lilypond-unstable: 2.25.6 -> 2.25.7 ``                               |
| [`9f3e5b4b`](https://github.com/NixOS/nixpkgs/commit/9f3e5b4b718b7035435df8b4ecc12b04d773f51b) | `` keymapper: 2.7.0 -> 2.7.1 ``                                         |
| [`77d50b03`](https://github.com/NixOS/nixpkgs/commit/77d50b03e4388f22e1f36a2621a9287a12a138be) | `` hello: Move to pkgs/by-name ``                                       |
| [`87f7f164`](https://github.com/NixOS/nixpkgs/commit/87f7f1641ce421870d72a5fabaa934fe5de44c2d) | `` pkgs/README.md: Update to mention pkgs/by-name ``                    |
| [`f6467c35`](https://github.com/NixOS/nixpkgs/commit/f6467c357419d70d8f32816fe68b9bde6278f8b0) | `` pkgs/by-name: Introduce ``                                           |
| [`49ac5ba2`](https://github.com/NixOS/nixpkgs/commit/49ac5ba2a52ad88c424ba6b02632f52483129055) | `` sarasa-gothic: 0.41.6 -> 0.41.8 ``                                   |
| [`bd3d466e`](https://github.com/NixOS/nixpkgs/commit/bd3d466ee202aa902589e7a56cdf79563624cb14) | `` unciv: 4.7.19 -> 4.8.0 ``                                            |
| [`65e83d87`](https://github.com/NixOS/nixpkgs/commit/65e83d87c42cf992e27ba3ff0ffd498f9ee6e0f6) | `` pot: 1.10.0 -> 2.0.0 ``                                              |
| [`dbaf3c0b`](https://github.com/NixOS/nixpkgs/commit/dbaf3c0b98d15d274abc25414ade069122de2b90) | `` phpunit: 10.2.6 -> 10.3.2 ``                                         |
| [`cc083150`](https://github.com/NixOS/nixpkgs/commit/cc083150d0c25d3963799bb9c6d63c0332ab77c6) | `` oha: 0.6.2 -> 0.6.3 ``                                               |
| [`6cae90b6`](https://github.com/NixOS/nixpkgs/commit/6cae90b62891e0dbd1f6b79d6934f9a7ba00b649) | `` hayagriva: 0.3.0 -> 0.3.2 ``                                         |
| [`2f5e0f7a`](https://github.com/NixOS/nixpkgs/commit/2f5e0f7a8187259fff9a1f0da8e1ae2bf5aea561) | `` dit: 0.7 -> 0.9 ``                                                   |
| [`3c32f28b`](https://github.com/NixOS/nixpkgs/commit/3c32f28bf9780dadd2531b56e194f4842c17a3b5) | `` gh-markdown-preview: 1.4.1 -> 1.4.2 ``                               |
| [`7310af91`](https://github.com/NixOS/nixpkgs/commit/7310af91d483c0b84e7a32a7661f866ffce35183) | `` cytoscape: 3.10.0 -> 3.10.1 ``                                       |
| [`c04722cf`](https://github.com/NixOS/nixpkgs/commit/c04722cf0c4309b7a0d1c2fad5edb8a5abe2bd53) | `` rl-2311: Mention faulty GitLab database schema ``                    |
| [`1a226276`](https://github.com/NixOS/nixpkgs/commit/1a226276032e2ec4d93ee19d9089d461fad652ea) | `` nixos/gitlab: Add a warning message ``                               |
| [`69dd555b`](https://github.com/NixOS/nixpkgs/commit/69dd555be1df048d423fc89d9d42482bed7cc118) | `` gitlab-container-registry: 3.79.0 -> 3.82.0 ``                       |
| [`97dfc365`](https://github.com/NixOS/nixpkgs/commit/97dfc365e6828a7c6663414d8d3ab5d77a81f665) | `` gitlab: 16.1.4 -> 16.3.1 ``                                          |
| [`0bd77e27`](https://github.com/NixOS/nixpkgs/commit/0bd77e27b452f0bcec8be1afcaa9320706a03b8a) | `` ytmdl: 2022.03.16 -> 2023.07.27 ``                                   |
| [`4d1f7863`](https://github.com/NixOS/nixpkgs/commit/4d1f7863346bc593a3b77c683955f8ada2e6973e) | `` intel-cmt-cat: 4.6.0 -> 23.08 ``                                     |
| [`975adcab`](https://github.com/NixOS/nixpkgs/commit/975adcab9e705e088b8579aba0670631c1426dc0) | `` jackett: 0.21.724 -> 0.21.747 ``                                     |
| [`54f9a6ee`](https://github.com/NixOS/nixpkgs/commit/54f9a6ee0c4477cfe101b82fc2ed2e705b63ee0d) | `` ddccontrol: 0.6.2 -> 0.6.3 ``                                        |