### PR TITLE
chore(flake/nur): `e289bc25` -> `0245d5f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1694097926,
-        "narHash": "sha256-sGxy9wiiYlLqO//VI9ug2owT7FmK4pflBZtzC+jSybs=",
+        "lastModified": 1694101605,
+        "narHash": "sha256-+xJtp999ikE7E52FZRoruGKuaXp6bU1u+94IDoe19VE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e289bc25271b826cc141cc5a736001fe2cdec586",
+        "rev": "0245d5f18bbfe1e75e8ce7cc38e6f43a80499fa2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0245d5f1`](https://github.com/nix-community/NUR/commit/0245d5f18bbfe1e75e8ce7cc38e6f43a80499fa2) | `` automatic update `` |
| [`8fdfd6e2`](https://github.com/nix-community/NUR/commit/8fdfd6e2992cef5d1886f26b0d09e7d584c374b5) | `` automatic update `` |
| [`aa773e07`](https://github.com/nix-community/NUR/commit/aa773e07de482a89c699cc98be0f1a888cc25b31) | `` automatic update `` |