### PR TITLE
chore(flake/nur): `816239c7` -> `0dc39b0e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1694105990,
-        "narHash": "sha256-QpTHhBelSBPI88YC0cvjvKy7rhaXNGiVTZJ24NQ7sts=",
+        "lastModified": 1694112361,
+        "narHash": "sha256-5yidq4l2xcQS3MHIM93Oy4cm2SPUueyj23JdA6uM4Tc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "816239c7b97f01e5340118b6e579efdbaf568a46",
+        "rev": "0dc39b0e2fc4d2ca3df704fb306f418a9f7e1dcd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0dc39b0e`](https://github.com/nix-community/NUR/commit/0dc39b0e2fc4d2ca3df704fb306f418a9f7e1dcd) | `` automatic update `` |
| [`1ab660e2`](https://github.com/nix-community/NUR/commit/1ab660e215898a8c99aac70b8ef5f1a67f15cbeb) | `` automatic update `` |