### PR TITLE
chore(flake/emacs-overlay): `e588a8c9` -> `b2224dca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1694082307,
-        "narHash": "sha256-cWkVD4mrHEUOHL/X8M7nN2wPBy00Ygw2Nn7PgFupBo4=",
+        "lastModified": 1694113790,
+        "narHash": "sha256-R07WLySfhjywXNZbuWMFJ/cqfEgAPEzTPGEe5hwn77g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e588a8c946f68523ccc20b1ffef899054da44cdc",
+        "rev": "b2224dca4b778d6bf0e0b827eee9d122ecf2d125",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b2224dca`](https://github.com/nix-community/emacs-overlay/commit/b2224dca4b778d6bf0e0b827eee9d122ecf2d125) | `` Updated repos/melpa ``  |
| [`e21e1400`](https://github.com/nix-community/emacs-overlay/commit/e21e1400290ad1720eec89bc6b7f7edfa034f19a) | `` Updated repos/emacs ``  |
| [`25cc11bc`](https://github.com/nix-community/emacs-overlay/commit/25cc11bc1da4b54d6dae2823e0cd1d590eeb1fa6) | `` Updated repos/elpa ``   |
| [`b28f670a`](https://github.com/nix-community/emacs-overlay/commit/b28f670a73c4c434c247daed1519ab5255d88250) | `` Updated flake inputs `` |