### PR TITLE
chore(flake/nur): `bff0c852` -> `b2320c1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1694116620,
-        "narHash": "sha256-r8jIpwWHfC2kMr9zVnWeh+RjRtbdNzcuC1nSHlitq5s=",
+        "lastModified": 1694123079,
+        "narHash": "sha256-1aHaOCjnKObLyBEQHv0pmLoCri36/yJLHw2UD1hjk+Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bff0c8526bab152ef83efb734d01fa54ed517b0f",
+        "rev": "b2320c1bcc2055ac479d91c21f2b3fa037a65439",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b2320c1b`](https://github.com/nix-community/NUR/commit/b2320c1bcc2055ac479d91c21f2b3fa037a65439) | `` automatic update `` |
| [`a3cf7c00`](https://github.com/nix-community/NUR/commit/a3cf7c0076d03b0ee4dd06056fc330a2b81cf3a4) | `` automatic update `` |