### PR TITLE
chore(flake/emacs-overlay): `b2224dca` -> `6c391a70`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1694113790,
-        "narHash": "sha256-R07WLySfhjywXNZbuWMFJ/cqfEgAPEzTPGEe5hwn77g=",
+        "lastModified": 1694145944,
+        "narHash": "sha256-TVotu2rG6ie63qc4FeZIYk4VNP0X/Q1WFRbHFA09b3w=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b2224dca4b778d6bf0e0b827eee9d122ecf2d125",
+        "rev": "6c391a705bdcbbe43c4b17bf7732d7e4cbbe77b1",
         "type": "github"
       },
       "original": {
@@ -732,11 +732,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1693953029,
-        "narHash": "sha256-1+28KQl4YC4IBzKo/epvEyK5KH4MlgoYueJ8YwLGbOc=",
+        "lastModified": 1694048570,
+        "narHash": "sha256-PEQptwFCVaJ+jLFJgrZll2shQ9VI/7xVhrCYkJo8iIw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4077a0e4ac3356222bc1f0a070af7939c3098535",
+        "rev": "4f77ea639305f1de0a14d9d41eef83313360638c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                              |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`a48229b4`](https://github.com/nix-community/emacs-overlay/commit/a48229b413cb78c1d4a1a2dfb52072d1777d600f) | `` Updated repos/nongnu ``                           |
| [`17e3463d`](https://github.com/nix-community/emacs-overlay/commit/17e3463ddecf5c59ab2ef2bea4723a7c7fde042f) | `` Updated repos/melpa ``                            |
| [`df79d003`](https://github.com/nix-community/emacs-overlay/commit/df79d0032f3b92b9e0b43899bb5b102adebe0751) | `` Updated repos/emacs ``                            |
| [`e0776709`](https://github.com/nix-community/emacs-overlay/commit/e0776709537c54f894092483f72b65fd0f42efe4) | `` Updated repos/elpa ``                             |
| [`3ec6e142`](https://github.com/nix-community/emacs-overlay/commit/3ec6e142fb4f95e5eebcb527ff8bdfd2720a41c2) | `` Updated flake inputs ``                           |
| [`e04309d1`](https://github.com/nix-community/emacs-overlay/commit/e04309d19514494ae641111c75883c953e518a65) | `` elisp.nix: improve pname of default.le package `` |
| [`96f28387`](https://github.com/nix-community/emacs-overlay/commit/96f28387962e0cbe7a1c861b47411246bd4d5e1b) | `` elisp.nix: add version for default.el package ``  |