### PR TITLE
chore(flake/nur): `d349e1d4` -> `bbdd2efb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1694144690,
-        "narHash": "sha256-fvlgH3pBKrgP27btBpY6FPupL8e4OB1sqjboxACyOQo=",
+        "lastModified": 1694148841,
+        "narHash": "sha256-AHgW4l41y3+mv5TSAfg6H3MzJGezjD8ZcpMHfgRn4D8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d349e1d492758eff8f85d649d4f7d280d91327f1",
+        "rev": "bbdd2efb447404e27c26ca91f30f0fc7eb7c13f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bbdd2efb`](https://github.com/nix-community/NUR/commit/bbdd2efb447404e27c26ca91f30f0fc7eb7c13f0) | `` automatic update `` |
| [`61dfcfa6`](https://github.com/nix-community/NUR/commit/61dfcfa68a97375fe1226638a29cf655021cc5b0) | `` automatic update `` |
| [`d35822dc`](https://github.com/nix-community/NUR/commit/d35822dcb9cede93e0b225f64ec6416725cc9b26) | `` automatic update `` |
| [`fc1fe0d7`](https://github.com/nix-community/NUR/commit/fc1fe0d7dc2c7b37bf0f5a7c2180428ef991f51c) | `` automatic update `` |