### PR TITLE
chore(flake/nur): `bbdd2efb` -> `eb160cb2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1694148841,
-        "narHash": "sha256-AHgW4l41y3+mv5TSAfg6H3MzJGezjD8ZcpMHfgRn4D8=",
+        "lastModified": 1694153211,
+        "narHash": "sha256-OIL9YP7xmm4M2q4JH1mRtiriRLELLlNRruqqWugd6eA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bbdd2efb447404e27c26ca91f30f0fc7eb7c13f0",
+        "rev": "eb160cb24c678b1b381d7940f0278fbcf559f154",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eb160cb2`](https://github.com/nix-community/NUR/commit/eb160cb24c678b1b381d7940f0278fbcf559f154) | `` automatic update `` |