### PR TITLE
chore(flake/nur): `eb160cb2` -> `f98e29d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1694153211,
-        "narHash": "sha256-OIL9YP7xmm4M2q4JH1mRtiriRLELLlNRruqqWugd6eA=",
+        "lastModified": 1694173527,
+        "narHash": "sha256-wfu/rPjyapZLe3afW6Zey/d2e0wqCHwYtyP8vWTNHrk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eb160cb24c678b1b381d7940f0278fbcf559f154",
+        "rev": "f98e29d5f2406c4bfeca4d1003d4a95bca0b8ed8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f98e29d5`](https://github.com/nix-community/NUR/commit/f98e29d5f2406c4bfeca4d1003d4a95bca0b8ed8) | `` automatic update `` |
| [`fb92b60e`](https://github.com/nix-community/NUR/commit/fb92b60e2b104df0f963e146399f5303770dee01) | `` automatic update `` |
| [`4c19ab0b`](https://github.com/nix-community/NUR/commit/4c19ab0bcb86f3bedea5fdbfcf6099862e6fdd00) | `` automatic update `` |
| [`5c59aef7`](https://github.com/nix-community/NUR/commit/5c59aef73cf8fb0101ac227d563e3e904694b283) | `` automatic update `` |
| [`0d0fe8bb`](https://github.com/nix-community/NUR/commit/0d0fe8bb4183a77abef66afae6b574b94e716058) | `` automatic update `` |