### PR TITLE
chore(flake/nur): `f98e29d5` -> `0d83b017`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -745,11 +745,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1694173527,
-        "narHash": "sha256-wfu/rPjyapZLe3afW6Zey/d2e0wqCHwYtyP8vWTNHrk=",
+        "lastModified": 1694187987,
+        "narHash": "sha256-UuoxSsXSlMV9hTbw2509SAeHF1xObnk6neWUempdys8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f98e29d5f2406c4bfeca4d1003d4a95bca0b8ed8",
+        "rev": "0d83b01718f7353592390891f9cde9431cf6e944",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0d83b017`](https://github.com/nix-community/NUR/commit/0d83b01718f7353592390891f9cde9431cf6e944) | `` automatic update `` |
| [`d5da9851`](https://github.com/nix-community/NUR/commit/d5da98515ff0d19661ac4951cb04f960d61248d3) | `` automatic update `` |
| [`f466511d`](https://github.com/nix-community/NUR/commit/f466511d83fba7555b3a7354bfe620ebd5986315) | `` automatic update `` |