### PR TITLE
chore(flake/emacs-overlay): `badf38fc` -> `a9bbef37`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694199122,
-        "narHash": "sha256-EiNBp2AWX/y+fWua91kVgNEwk3iFpy2ru8EjyHTp8iA=",
+        "lastModified": 1694228071,
+        "narHash": "sha256-OxEzUiIu2LFSdhsayV8Jk8DKg+kwLBSSKezURwjkFQU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "badf38fcef05e02764781847ffe498016401e5a5",
+        "rev": "a9bbef37c102aafd6a9247c011f2ae90f3c71b16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`a9bbef37`](https://github.com/nix-community/emacs-overlay/commit/a9bbef37c102aafd6a9247c011f2ae90f3c71b16) | `` Updated repos/nongnu `` |
| [`4595bf8d`](https://github.com/nix-community/emacs-overlay/commit/4595bf8d14331aa4f7650445d99d3cee152cf921) | `` Updated repos/melpa ``  |
| [`87e7e6a9`](https://github.com/nix-community/emacs-overlay/commit/87e7e6a91c5f065056fbf5b3f0bcb1e457363c5f) | `` Updated repos/emacs ``  |
| [`c1555251`](https://github.com/nix-community/emacs-overlay/commit/c1555251c5bc7a8ff486271891b99384faa3a62f) | `` Updated repos/elpa ``   |