### PR TITLE
chore(flake/emacs-overlay): `a9bbef37` -> `8e921c1a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694228071,
-        "narHash": "sha256-OxEzUiIu2LFSdhsayV8Jk8DKg+kwLBSSKezURwjkFQU=",
+        "lastModified": 1694255179,
+        "narHash": "sha256-T/GkCkdkvE/r6FFu5srD4tQnJ1Wz8r3XOHOMP+5OLDM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a9bbef37c102aafd6a9247c011f2ae90f3c71b16",
+        "rev": "8e921c1a525227797dcceff637dff1077a57c223",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`8e921c1a`](https://github.com/nix-community/emacs-overlay/commit/8e921c1a525227797dcceff637dff1077a57c223) | `` Updated repos/nongnu `` |
| [`8a991ee0`](https://github.com/nix-community/emacs-overlay/commit/8a991ee0e84c21f1a9e85558900a23d17fd86ebc) | `` Updated repos/melpa ``  |
| [`3ee9b625`](https://github.com/nix-community/emacs-overlay/commit/3ee9b6259e19628bb91632cc2979eb2a3ca0d53e) | `` Updated repos/emacs ``  |