### PR TITLE
chore(flake/emacs-overlay): `8e921c1a` -> `2276b94b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694255179,
-        "narHash": "sha256-T/GkCkdkvE/r6FFu5srD4tQnJ1Wz8r3XOHOMP+5OLDM=",
+        "lastModified": 1694283324,
+        "narHash": "sha256-VEFE3B1AmEZDRT1/W7cslWLHRFNoajUKZiksgoa7Kyg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8e921c1a525227797dcceff637dff1077a57c223",
+        "rev": "2276b94b3d43467372de17708ab3468a5821fcfc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`2276b94b`](https://github.com/nix-community/emacs-overlay/commit/2276b94b3d43467372de17708ab3468a5821fcfc) | `` Updated repos/melpa `` |
| [`63ee207a`](https://github.com/nix-community/emacs-overlay/commit/63ee207a9b728848c54a813da243dc35fabf4b55) | `` Updated repos/emacs `` |
| [`67cc794e`](https://github.com/nix-community/emacs-overlay/commit/67cc794e38f1bacd7e910ae25700297cfe122b58) | `` Updated repos/elpa ``  |