### PR TITLE
chore(flake/nix-index-database): `6f22fe45` -> `71d840d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -501,11 +501,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694314642,
-        "narHash": "sha256-5M4/9f0PaeiWg7NSX+0oU52HLzb5gkEy04UgHgwdG2I=",
+        "lastModified": 1694316990,
+        "narHash": "sha256-ql9bLSR+9rE3mJ/8sle1KUGMvPhjhtsVefRb1Ah3juk=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "6f22fe45afe3b1e9229aee8037ba1c2bb56c4937",
+        "rev": "71d840d865b03ab1330d9b7f030a263991ee04e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`71d840d8`](https://github.com/nix-community/nix-index-database/commit/71d840d865b03ab1330d9b7f030a263991ee04e9) | `` update packages.nix to release 2023-09-10-033525 `` |