### PR TITLE
chore(flake/emacs-overlay): `2276b94b` -> `cda419bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694283324,
-        "narHash": "sha256-VEFE3B1AmEZDRT1/W7cslWLHRFNoajUKZiksgoa7Kyg=",
+        "lastModified": 1694317719,
+        "narHash": "sha256-Z3M1vktETVP0QTRWGJdr8NEqAabe8T01Qwyv/WbI5Qk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2276b94b3d43467372de17708ab3468a5821fcfc",
+        "rev": "cda419bccab17c45d00f200a987d30e9c93c9590",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`cda419bc`](https://github.com/nix-community/emacs-overlay/commit/cda419bccab17c45d00f200a987d30e9c93c9590) | `` Updated repos/melpa ``  |
| [`caa1559a`](https://github.com/nix-community/emacs-overlay/commit/caa1559ab0a460c78bcfe9d84b70f134226cb66b) | `` Updated repos/emacs ``  |
| [`dd8d6900`](https://github.com/nix-community/emacs-overlay/commit/dd8d6900f5d674037c80c904ef8a5aeaf7dc9a3d) | `` Updated repos/elpa ``   |
| [`f0695fd2`](https://github.com/nix-community/emacs-overlay/commit/f0695fd28524a8750948797e44d6ea55ba14c277) | `` Updated flake inputs `` |