### PR TITLE
chore(flake/emacs-overlay): `cda419bc` -> `40fcebc3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694317719,
-        "narHash": "sha256-Z3M1vktETVP0QTRWGJdr8NEqAabe8T01Qwyv/WbI5Qk=",
+        "lastModified": 1694340916,
+        "narHash": "sha256-v7tfzIfKwrjYmLmp9qZYRXpFvd9PIn2OJc2jGzhI3Y8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cda419bccab17c45d00f200a987d30e9c93c9590",
+        "rev": "40fcebc368859916fa886b550d75cc70af106e7b",
         "type": "github"
       },
       "original": {
@@ -602,11 +602,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1694048570,
-        "narHash": "sha256-PEQptwFCVaJ+jLFJgrZll2shQ9VI/7xVhrCYkJo8iIw=",
+        "lastModified": 1694211700,
+        "narHash": "sha256-ZYok+zqYorC6M/qtrnPVB9IHFWi2TzjlHLW/orMu0No=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4f77ea639305f1de0a14d9d41eef83313360638c",
+        "rev": "73e1976309fc789706b9f306407e9e7622a57d25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`40fcebc3`](https://github.com/nix-community/emacs-overlay/commit/40fcebc368859916fa886b550d75cc70af106e7b) | `` Updated repos/nongnu `` |
| [`7c354859`](https://github.com/nix-community/emacs-overlay/commit/7c354859bf3c9f0e475d3c0f94117b5928ec1a3c) | `` Updated repos/melpa ``  |
| [`2d0f7488`](https://github.com/nix-community/emacs-overlay/commit/2d0f74881662ce78e7e81d7216e63aef25c270a6) | `` Updated repos/emacs ``  |
| [`a362619e`](https://github.com/nix-community/emacs-overlay/commit/a362619e417b203069af72b4aa9c04898e271d67) | `` Updated flake inputs `` |