### PR TITLE
chore(flake/emacs-overlay): `40fcebc3` -> `60b1fbf2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694340916,
-        "narHash": "sha256-v7tfzIfKwrjYmLmp9qZYRXpFvd9PIn2OJc2jGzhI3Y8=",
+        "lastModified": 1694370368,
+        "narHash": "sha256-i1jfcu6uIGmEN9fKbY2jj4/EwlFdjfdQEwN9ylCWOv4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "40fcebc368859916fa886b550d75cc70af106e7b",
+        "rev": "60b1fbf240f3daec4d431ef002f084a6cd7564a1",
         "type": "github"
       },
       "original": {
@@ -602,11 +602,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1694211700,
-        "narHash": "sha256-ZYok+zqYorC6M/qtrnPVB9IHFWi2TzjlHLW/orMu0No=",
+        "lastModified": 1694304580,
+        "narHash": "sha256-5tIpNodDpEKT8mM/F5zCzWEAnidOg8eb1/x3SRaaBLs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "73e1976309fc789706b9f306407e9e7622a57d25",
+        "rev": "4c8cf44c5b9481a4f093f1df3b8b7ba997a7c760",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`60b1fbf2`](https://github.com/nix-community/emacs-overlay/commit/60b1fbf240f3daec4d431ef002f084a6cd7564a1) | `` Updated repos/melpa ``  |
| [`2ae5dd5b`](https://github.com/nix-community/emacs-overlay/commit/2ae5dd5b8cf58ef4190812c0515151c8f6fe9584) | `` Updated repos/emacs ``  |
| [`9e6bd8eb`](https://github.com/nix-community/emacs-overlay/commit/9e6bd8ebcbff30a258f55ccff6cd49c2df23ad70) | `` Updated repos/elpa ``   |
| [`56400bcc`](https://github.com/nix-community/emacs-overlay/commit/56400bccac1fa7ded7e52345660145f9bdfe1c4c) | `` Updated flake inputs `` |