### PR TITLE
chore(flake/home-manager): `f9041d12` -> `2b637f32`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -411,11 +411,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694338541,
-        "narHash": "sha256-+ZtaNbOwlO1QgYOEvWdhi5wkWjW5Csrboz4xy0WucDg=",
+        "lastModified": 1694341076,
+        "narHash": "sha256-P8zwpZP4VDKjmQk4BVswFY21fAnRs61UUufoiB0uo3s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f9041d12a90e8bc0c90e03be2ebe26a6c6e6fd70",
+        "rev": "2b637f3289772168800e4c95fa4168741a5886f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`2b637f32`](https://github.com/nix-community/home-manager/commit/2b637f3289772168800e4c95fa4168741a5886f1) | `` Translate using Weblate (Czech) ``       |
| [`3dd5470e`](https://github.com/nix-community/home-manager/commit/3dd5470e59deab403a1c832cd047dd2ca08fc897) | `` Add translation using Weblate (Czech) `` |
| [`11c91750`](https://github.com/nix-community/home-manager/commit/11c91750b0e056342fbee01fcf87548dda960fba) | `` Translate using Weblate (Czech) ``       |