### PR TITLE
chore(flake/emacs-overlay): `60b1fbf2` -> `42157ddb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694370368,
-        "narHash": "sha256-i1jfcu6uIGmEN9fKbY2jj4/EwlFdjfdQEwN9ylCWOv4=",
+        "lastModified": 1694401466,
+        "narHash": "sha256-FvWoxgvZoYmzXrTbASX3pqDQeeUFj1ucne82dOhSskA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "60b1fbf240f3daec4d431ef002f084a6cd7564a1",
+        "rev": "42157ddb4e4a255d16e6a50a792893cbd1a3098c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`42157ddb`](https://github.com/nix-community/emacs-overlay/commit/42157ddb4e4a255d16e6a50a792893cbd1a3098c) | `` Updated repos/melpa `` |
| [`bf93c44f`](https://github.com/nix-community/emacs-overlay/commit/bf93c44f6282008e2d37aae2b046c9b7cd2a5c27) | `` Updated repos/emacs `` |
| [`7d8e7e2e`](https://github.com/nix-community/emacs-overlay/commit/7d8e7e2ede87daff5723eb1a289ed0f414c52f0f) | `` Updated repos/elpa ``  |