### PR TITLE
chore(flake/nix-index-database): `71d840d8` -> `9a5c4996`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -501,11 +501,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694316990,
-        "narHash": "sha256-ql9bLSR+9rE3mJ/8sle1KUGMvPhjhtsVefRb1Ah3juk=",
+        "lastModified": 1694430658,
+        "narHash": "sha256-8+OZ98kD63e/GaOiJimXHR/VYiTYwr25jTYGEHHOfq4=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "71d840d865b03ab1330d9b7f030a263991ee04e9",
+        "rev": "9a5c4996d0918a151269600dfdf6ad3b3748f6a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                            |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`9a5c4996`](https://github.com/nix-community/nix-index-database/commit/9a5c4996d0918a151269600dfdf6ad3b3748f6a4) | `` Bump cachix/install-nix-action from 22 to 23 `` |
| [`e18bb7ff`](https://github.com/nix-community/nix-index-database/commit/e18bb7ff330f3ddc132e0dd7331c6cd6ee3e65e9) | `` Bump actions/checkout from 3 to 4 ``            |
| [`f4fc78e3`](https://github.com/nix-community/nix-index-database/commit/f4fc78e3b870344c6aa8a72d089d1cce100a3f23) | `` update mergify configuration ``                 |