### PR TITLE
chore(flake/emacs-overlay): `44e23c7e` -> `d532507e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694428058,
-        "narHash": "sha256-gMg+baJlp5OWHmdMmF8RVyxlm72BKMKWNH4c9YVv6PI=",
+        "lastModified": 1694459075,
+        "narHash": "sha256-3+sHHMLyzjc+y7VtELdNuvroFlGCW4TYEZdFeeLOVGU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "44e23c7e34d2db1aae968e2314bb65a410743c60",
+        "rev": "d532507e854bbfb3f311a9f30dcbffaeceeff83f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`d532507e`](https://github.com/nix-community/emacs-overlay/commit/d532507e854bbfb3f311a9f30dcbffaeceeff83f) | `` Updated repos/melpa `` |
| [`75585538`](https://github.com/nix-community/emacs-overlay/commit/75585538baf8be7ad06a652e7257201ce3eb676d) | `` Updated repos/emacs `` |
| [`3e6fd7ff`](https://github.com/nix-community/emacs-overlay/commit/3e6fd7ff09f69fb2a2698ed72754988093106a7e) | `` Updated repos/elpa ``  |