### PR TITLE
chore(flake/emacs-overlay): `d532507e` -> `a1e0d360`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694459075,
-        "narHash": "sha256-3+sHHMLyzjc+y7VtELdNuvroFlGCW4TYEZdFeeLOVGU=",
+        "lastModified": 1694487846,
+        "narHash": "sha256-UWNKxLBxWVOttz8xyIbzs0TWsm6yeiDYBnH6et+amZE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d532507e854bbfb3f311a9f30dcbffaeceeff83f",
+        "rev": "a1e0d3603a09f7c0f24748c18f820b38d660250c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`a1e0d360`](https://github.com/nix-community/emacs-overlay/commit/a1e0d3603a09f7c0f24748c18f820b38d660250c) | `` Updated repos/nongnu `` |
| [`852a183a`](https://github.com/nix-community/emacs-overlay/commit/852a183aff11700a4ea544cb175d0ad67ab78bc3) | `` Updated repos/melpa ``  |
| [`cb506eff`](https://github.com/nix-community/emacs-overlay/commit/cb506effff8359dd1f1e8bb25b7f14748246c8d9) | `` Updated repos/emacs ``  |
| [`0a11d513`](https://github.com/nix-community/emacs-overlay/commit/0a11d513b3ef0bf5d6c4dadab16e556285ef1b23) | `` Updated repos/elpa ``   |