### PR TITLE
chore(flake/emacs-overlay): `a5a0ccee` -> `fd93bcba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694513880,
-        "narHash": "sha256-YIObImZHBDjU+UBTC7ku0xtawRAQBaLkOco0eA1xXN8=",
+        "lastModified": 1694544769,
+        "narHash": "sha256-UxBEBHXESHyTXKaL0+guA7ROSXsDSHVQswtUI2LvlsE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a5a0cceea2af1920bcd6b1ae6d1c4e4f7a2ac229",
+        "rev": "fd93bcba17ac65351337668e0b711d27583ce0b4",
         "type": "github"
       },
       "original": {
@@ -602,11 +602,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1694304580,
-        "narHash": "sha256-5tIpNodDpEKT8mM/F5zCzWEAnidOg8eb1/x3SRaaBLs=",
+        "lastModified": 1694426803,
+        "narHash": "sha256-osusXQo0zkEqs502SNMffsKp1O9evpDM54A37MuyT2Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4c8cf44c5b9481a4f093f1df3b8b7ba997a7c760",
+        "rev": "9a74ffb2ca1fc91c6ccc48bd3f8cbc1501bf7b8a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`fd93bcba`](https://github.com/nix-community/emacs-overlay/commit/fd93bcba17ac65351337668e0b711d27583ce0b4) | `` Updated repos/melpa ``  |
| [`1a5448dc`](https://github.com/nix-community/emacs-overlay/commit/1a5448dc1217f6ac60abb5642eb93325cfc32d15) | `` Updated repos/emacs ``  |
| [`966cd565`](https://github.com/nix-community/emacs-overlay/commit/966cd5652fa19276f5c0c619f151ddd08d55c001) | `` Updated repos/elpa ``   |
| [`865b6c6d`](https://github.com/nix-community/emacs-overlay/commit/865b6c6d2b89b057792ef2ec76402d89631d7c11) | `` Updated flake inputs `` |