### PR TITLE
chore(flake/emacs-overlay): `fd93bcba` -> `844afe34`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694544769,
-        "narHash": "sha256-UxBEBHXESHyTXKaL0+guA7ROSXsDSHVQswtUI2LvlsE=",
+        "lastModified": 1694574651,
+        "narHash": "sha256-D+pBiAEMsCRO9WP8Jn5oPsisr+ftFz7fgZOaix6MYUM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fd93bcba17ac65351337668e0b711d27583ce0b4",
+        "rev": "844afe34cbe49d83e7ae016564db4f72237a0bfa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`844afe34`](https://github.com/nix-community/emacs-overlay/commit/844afe34cbe49d83e7ae016564db4f72237a0bfa) | `` Updated repos/melpa `` |
| [`1d04123e`](https://github.com/nix-community/emacs-overlay/commit/1d04123efb9db2b0404059e542c145d169ec4b38) | `` Updated repos/emacs `` |
| [`677acb34`](https://github.com/nix-community/emacs-overlay/commit/677acb34345aa0a6f2f53cd1c96cbf0de1e4f011) | `` Updated repos/elpa ``  |