### PR TITLE
chore(flake/nixos-hardware): `ca41b8a2` -> `3ccd87fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -540,11 +540,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1694432324,
-        "narHash": "sha256-bo3Gv6Cp40vAXDBPi2XiDejzp/kyz65wZg4AnEWxAcY=",
+        "lastModified": 1694591211,
+        "narHash": "sha256-NPP7XGZH+Q5ey7nE2zGLrBrzKmLYPhj8YgsTSdhH0D4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "ca41b8a227dd235b1b308217f116c7e6e84ad779",
+        "rev": "3ccd87fcdae4732fe33773cefa4375c641a057e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`3ccd87fc`](https://github.com/NixOS/nixos-hardware/commit/3ccd87fcdae4732fe33773cefa4375c641a057e7) | `` starfive visionfive2: update u-boot to SDK version v3.6.1 ``  |
| [`e158702c`](https://github.com/NixOS/nixos-hardware/commit/e158702cb8e39dc484c594a8bd733ca623f3309c) | `` refactor: use nixpkgs naming conventions ``                   |
| [`c49c1210`](https://github.com/NixOS/nixos-hardware/commit/c49c1210d664de999fe210e95c6e83cbfb8bbbc8) | `` docs: add info about the default enabling ``                  |
| [`5e6fa0d4`](https://github.com/NixOS/nixos-hardware/commit/5e6fa0d4ae6e8e3d2bdba3798911fc001d85f7cc) | `` feature: enable the iGPU by default ``                        |
| [`5dbebb7c`](https://github.com/NixOS/nixos-hardware/commit/5dbebb7cfac62acb2a22ebbe91625c3a284bd6fa) | `` feat: copy bootloader to temp location ``                     |
| [`c8cd4f7e`](https://github.com/NixOS/nixos-hardware/commit/c8cd4f7ef455de718b9c74a24862cc457b8dcf5d) | `` feat: integrate into t2 module ``                             |
| [`bb215e68`](https://github.com/NixOS/nixos-hardware/commit/bb215e68e51f28abc08fd824d5eed4d72af5defb) | `` feat: add installer for apple-set-os-loader-installer ``      |
| [`128c0442`](https://github.com/NixOS/nixos-hardware/commit/128c0442981bfdf31906864b1e1551ec4d529e9c) | `` starfive visionfive2: update kernel to 6.5.0 ``               |
| [`12a6f302`](https://github.com/NixOS/nixos-hardware/commit/12a6f30214cfe2c64df5389dbaf834e66384479b) | `` Import module ``                                              |
| [`f8d3c754`](https://github.com/NixOS/nixos-hardware/commit/f8d3c754626e0ff3a0b8906fc0a22f9bda20c6a2) | `` Implement dt overlay for enabling built-in xhci controller `` |