### PR TITLE
chore(flake/emacs-overlay): `844afe34` -> `b99f00b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694574651,
-        "narHash": "sha256-D+pBiAEMsCRO9WP8Jn5oPsisr+ftFz7fgZOaix6MYUM=",
+        "lastModified": 1694602127,
+        "narHash": "sha256-8lcpkk35COSkygePlvsOtSpR7tZx1SIgxdltZ0UZvXM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "844afe34cbe49d83e7ae016564db4f72237a0bfa",
+        "rev": "b99f00b0bc835dd490b455c8df0bab2acc16021c",
         "type": "github"
       },
       "original": {
@@ -602,11 +602,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1694426803,
-        "narHash": "sha256-osusXQo0zkEqs502SNMffsKp1O9evpDM54A37MuyT2Q=",
+        "lastModified": 1694499547,
+        "narHash": "sha256-R7xMz1Iia6JthWRHDn36s/E248WB1/je62ovC/dUVKI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9a74ffb2ca1fc91c6ccc48bd3f8cbc1501bf7b8a",
+        "rev": "e5f018cf150e29aac26c61dac0790ea023c46b24",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b99f00b0`](https://github.com/nix-community/emacs-overlay/commit/b99f00b0bc835dd490b455c8df0bab2acc16021c) | `` Updated repos/melpa ``  |
| [`8b3222a2`](https://github.com/nix-community/emacs-overlay/commit/8b3222a270a1c147f64907acc9304e74bdd9e817) | `` Updated repos/emacs ``  |
| [`f87fd033`](https://github.com/nix-community/emacs-overlay/commit/f87fd033970d2a96e998cd0542684797841fd983) | `` Updated flake inputs `` |