### PR TITLE
chore(flake/impermanence): `e3a7acd1` -> `e9643d08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -426,11 +426,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1690797372,
-        "narHash": "sha256-GImz19e33SeVcIvBB7NnhbJSbTpFFmNtWLh7Z85Y188=",
+        "lastModified": 1694622745,
+        "narHash": "sha256-z397+eDhKx9c2qNafL1xv75lC0Q4nOaFlhaU1TINqb8=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "e3a7acd113903269a1b5c8b527e84ce7ee859851",
+        "rev": "e9643d08d0d193a2e074a19d4d90c67a874d932e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                               |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`e9643d08`](https://github.com/nix-community/impermanence/commit/e9643d08d0d193a2e074a19d4d90c67a874d932e) | `` nixos: Prevent redundant fstrim `` |