### PR TITLE
chore(flake/lanzaboote): `9a9b0962` -> `3dc8778c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -458,11 +458,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1694617138,
-        "narHash": "sha256-2mtfvb2WReI19Bb5g74VN7WnFkQ9DW36+2uQvwciKWw=",
+        "lastModified": 1694623396,
+        "narHash": "sha256-P4ZQNqMxlnlcmtAF2hF/Kouv3YMgR1qHu1PFB1MwdBE=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "9a9b09628b0ec66a2eba5a92fdd91809d9a2cb18",
+        "rev": "3dc8778c32bbdd082e91e264b9b3dc9ffab277a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                                       |
| --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`83f43769`](https://github.com/nix-community/lanzaboote/commit/83f437692968005e7f96b754b061789cc299af66) | `` uefi: move uefi code to separate workspace ``                              |
| [`64f17609`](https://github.com/nix-community/lanzaboote/commit/64f17609449c687abdf680d0ca7649ed28f6e99f) | `` flake: add cargo-machete to machete the unused crates in our Cargo.toml `` |
| [`51d9c1df`](https://github.com/nix-community/lanzaboote/commit/51d9c1dff829502bf20a010408fcf3267998c863) | `` stub: split up into a linux-bootloader crate ``                            |