### PR TITLE
chore(flake/emacs-overlay): `b99f00b0` -> `48035733`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694602127,
-        "narHash": "sha256-8lcpkk35COSkygePlvsOtSpR7tZx1SIgxdltZ0UZvXM=",
+        "lastModified": 1694625433,
+        "narHash": "sha256-mfR9fy6010GY3QMCeT8JYu/jep4TEEHSLfy+wLJQxbM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b99f00b0bc835dd490b455c8df0bab2acc16021c",
+        "rev": "4803573315a823fb2155be6237f586d7e112d67f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`48035733`](https://github.com/nix-community/emacs-overlay/commit/4803573315a823fb2155be6237f586d7e112d67f) | `` Updated repos/melpa `` |
| [`480818d7`](https://github.com/nix-community/emacs-overlay/commit/480818d71dca89456112892d210e3e132f9b4dd3) | `` Updated repos/elpa ``  |