### PR TITLE
chore(flake/emacs-overlay): `48035733` -> `1e357455`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694625433,
-        "narHash": "sha256-mfR9fy6010GY3QMCeT8JYu/jep4TEEHSLfy+wLJQxbM=",
+        "lastModified": 1694662762,
+        "narHash": "sha256-Q95z8sK9uRK+YlNcaFssb0TS6SQ6s3JCL/8gx18s7e4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4803573315a823fb2155be6237f586d7e112d67f",
+        "rev": "1e357455afc8b9a4d027a3d4204fee5090f9ebc8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`1e357455`](https://github.com/nix-community/emacs-overlay/commit/1e357455afc8b9a4d027a3d4204fee5090f9ebc8) | `` Updated repos/melpa `` |
| [`12e00cd9`](https://github.com/nix-community/emacs-overlay/commit/12e00cd9135799e5d242d06cb5052973e888a4cc) | `` Updated repos/emacs `` |
| [`f36b068e`](https://github.com/nix-community/emacs-overlay/commit/f36b068e0de24fee824a22ac5ae43a434dfa6e52) | `` Updated repos/elpa ``  |