### PR TITLE
chore(flake/home-manager): `b62f5496` -> `d9b88b43`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -411,11 +411,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694642908,
-        "narHash": "sha256-0Opzs/56VW03COlVdoBrHJZGxQ7gzLDEWADnccC8ras=",
+        "lastModified": 1694643239,
+        "narHash": "sha256-pv2k/5FvyirDE8g4TNehzwZ0T4UOMMmqWSQnM/luRtE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b62f549653e97d78392c1e282b8ca76546a86585",
+        "rev": "d9b88b43524db1591fb3d9410a21428198d75d49",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`d9b88b43`](https://github.com/nix-community/home-manager/commit/d9b88b43524db1591fb3d9410a21428198d75d49) | `` Update translation files `` |