### PR TITLE
chore(flake/combobulate): `e37e24de` -> `c6b80689`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -85,11 +85,11 @@
     "combobulate": {
       "flake": false,
       "locked": {
-        "lastModified": 1692027991,
-        "narHash": "sha256-CUv78OrkVPBxzJlk/px2yJPuLMv4tyJJGvgabjIWi1I=",
+        "lastModified": 1694675816,
+        "narHash": "sha256-6SwsBCTBwtujpzpga5hzokjP1dfVxEfHAbtL8VenzHg=",
         "owner": "mickeynp",
         "repo": "combobulate",
-        "rev": "e37e24de1afa577a19974b6967a4837a2ae5cb98",
+        "rev": "c6b80689ef5d53f9c64ae3291fdeabd4ebc7c7a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`c6b80689`](https://github.com/mickeynp/combobulate/commit/c6b80689ef5d53f9c64ae3291fdeabd4ebc7c7a0) | `` Update README ``                                                             |
| [`32ac5a56`](https://github.com/mickeynp/combobulate/commit/32ac5a56698a3e01bbed07dbfd366031c130abe8) | `` Update html-ts-mode support to match the new release ``                      |
| [`8f5a8647`](https://github.com/mickeynp/combobulate/commit/8f5a86474f5f77d6266988d6e1c5f01d21dfd926) | `` Do not match end of string if there are newlines ``                          |
| [`e7bb4ab2`](https://github.com/mickeynp/combobulate/commit/e7bb4ab24f5e80cc89c40054554a4c2b62fd7a24) | `` Prefer older way of converting to string ``                                  |
| [`ea3e02a7`](https://github.com/mickeynp/combobulate/commit/ea3e02a73854a76128d52b5112f793627ea507cf) | `` Add mark, before, after (as they are used in Combobulate editing) ``         |
| [`2a5c11e7`](https://github.com/mickeynp/combobulate/commit/2a5c11e776d288a793325a9c3a6d8830cdb57be7) | `` Sorting does not matter here ``                                              |
| [`76241c4f`](https://github.com/mickeynp/combobulate/commit/76241c4f0e5284f895bcd5cdbb0908af2367a2a6) | `` Allow regular faces as capture nodes ``                                      |
| [`d1f101cb`](https://github.com/mickeynp/combobulate/commit/d1f101cb70e8dcf1c3e5ef716ba15a575e97930a) | `` Warn about missing capture groups ``                                         |
| [`98f2c147`](https://github.com/mickeynp/combobulate/commit/98f2c147b29e2f08de6eef7880254a9fdcd725d1) | `` Expand around jsx_text ``                                                    |
| [`3ca55d0d`](https://github.com/mickeynp/combobulate/commit/3ca55d0d5df9e3cdeaf324c032917aa70c8f2865) | `` Allow nodes in an else clause to be dragged ``                               |
| [`1683279f`](https://github.com/mickeynp/combobulate/commit/1683279fe1b425fbf59f58a8274376782e77b19d) | `` Envelop more node types by default, incl. expressions and more statements `` |
| [`8b673a0a`](https://github.com/mickeynp/combobulate/commit/8b673a0a09c7b3863d383353155c2b8734bb1c0b) | `` Undo envelopes properly if the user keyboard quits midway through ``         |
| [`9f631c2e`](https://github.com/mickeynp/combobulate/commit/9f631c2e1fb5c36ead8fbf239b0276f4311a37dd) | `` Fix docstring ``                                                             |
| [`41d636dc`](https://github.com/mickeynp/combobulate/commit/41d636dc212f6cabfd6db7259ee106962483fa3a) | `` Standardise the behaviour of M-k so it acts on the current sibling ``        |
| [`c6418082`](https://github.com/mickeynp/combobulate/commit/c64180827e6bbbb706a24bd5a332872f4f0809d4) | `` Add regex to sexp list ``                                                    |