### PR TITLE
chore(flake/lanzaboote): `3dc8778c` -> `7ef2b137`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -458,11 +458,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1694623396,
-        "narHash": "sha256-P4ZQNqMxlnlcmtAF2hF/Kouv3YMgR1qHu1PFB1MwdBE=",
+        "lastModified": 1694683444,
+        "narHash": "sha256-zEUeaXsFo7889GLtyZ/h3wR7kpp7Y5RAbInvDPyIOm4=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "3dc8778c32bbdd082e91e264b9b3dc9ffab277a4",
+        "rev": "7ef2b13780a25a3b11c6ccb35c34c76cf3fb1e50",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                     |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`0c7606cd`](https://github.com/nix-community/lanzaboote/commit/0c7606cd18add2846f4341d0035c602532c42342) | `` flake: use an appropriate description `` |
| [`e766f364`](https://github.com/nix-community/lanzaboote/commit/e766f364414f61b97a0af7e38bc881d652d4afc1) | `` Fix lzbt, stub path links ``             |