### PR TITLE
chore(flake/emacs-overlay): `1e357455` -> `4d65e731`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694662762,
-        "narHash": "sha256-Q95z8sK9uRK+YlNcaFssb0TS6SQ6s3JCL/8gx18s7e4=",
+        "lastModified": 1694687465,
+        "narHash": "sha256-rbAxvy9cIAsVb8Uc/oZdoR4W9C3dPPv10JRE06jU73E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1e357455afc8b9a4d027a3d4204fee5090f9ebc8",
+        "rev": "4d65e731b6c3891445cdd80ad0c3c94f7955b039",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`4d65e731`](https://github.com/nix-community/emacs-overlay/commit/4d65e731b6c3891445cdd80ad0c3c94f7955b039) | `` Updated repos/melpa `` |
| [`d39b2ded`](https://github.com/nix-community/emacs-overlay/commit/d39b2ded7ba4c09cb533bdb5f20bcbfb1fb9fcf1) | `` Updated repos/emacs `` |