### PR TITLE
chore(flake/emacs-overlay): `4d65e731` -> `918199ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694687465,
-        "narHash": "sha256-rbAxvy9cIAsVb8Uc/oZdoR4W9C3dPPv10JRE06jU73E=",
+        "lastModified": 1694716032,
+        "narHash": "sha256-PQbomjq3tZ7WYAbbM1NO6RMoPbnEbSCVnBhvD4+rgog=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4d65e731b6c3891445cdd80ad0c3c94f7955b039",
+        "rev": "918199aeaa2c9b9d0f73e304a187a05b99fd9050",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`918199ae`](https://github.com/nix-community/emacs-overlay/commit/918199aeaa2c9b9d0f73e304a187a05b99fd9050) | `` Updated repos/melpa `` |
| [`6c42e237`](https://github.com/nix-community/emacs-overlay/commit/6c42e23739b535610f0215da4562612511a662ed) | `` Updated repos/emacs `` |
| [`389e2bb8`](https://github.com/nix-community/emacs-overlay/commit/389e2bb8464805f2172f1d28e123772c90b71ba9) | `` Updated repos/elpa ``  |