### PR TITLE
chore(flake/nixpkgs): `3a2786ee` -> `e35dcc04`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -665,11 +665,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1694422566,
-        "narHash": "sha256-lHJ+A9esOz9vln/3CJG23FV6Wd2OoOFbDeEs4cMGMqc=",
+        "lastModified": 1695360818,
+        "narHash": "sha256-JlkN3R/SSoMTa+CasbxS1gq+GpGxXQlNZRUh9+LIy/0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3a2786eea085f040a66ecde1bc3ddc7099f6dbeb",
+        "rev": "e35dcc04a3853da485a396bdd332217d0ac9054f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`e35dcc04`](https://github.com/NixOS/nixpkgs/commit/e35dcc04a3853da485a396bdd332217d0ac9054f) | `` streamdeck-ui: set mainProgram ``                                                        |
| [`e025e615`](https://github.com/NixOS/nixpkgs/commit/e025e615f2c187cab7ca8abec9daca7ea3f05659) | `` bob: add completion ``                                                                   |
| [`9f66359b`](https://github.com/NixOS/nixpkgs/commit/9f66359b60cca2f9688fa97902eb9c17f28ce5de) | `` iouyap: remove ``                                                                        |
| [`f9fb9349`](https://github.com/NixOS/nixpkgs/commit/f9fb93497be530edef7393a397e4ac6352b4e707) | `` waypaper: fix missing dependency, and cleanup ``                                         |
| [`c1b3bfba`](https://github.com/NixOS/nixpkgs/commit/c1b3bfba4f2993d8d789cc86b0cae13db75862c0) | `` doc: include short docs about bmake ``                                                   |
| [`ae8fff74`](https://github.com/NixOS/nixpkgs/commit/ae8fff7469df9bb6f6c9a544a7a4b51c2bf2972c) | `` bmake: more accurate metainfo about brokenness ``                                        |
| [`db00521f`](https://github.com/NixOS/nixpkgs/commit/db00521fb5fd08d325fe20b9cb54f336f38190b3) | `` bmake: 20230723 -> 20230909 ``                                                           |
| [`8a75a8f4`](https://github.com/NixOS/nixpkgs/commit/8a75a8f4cf0683006e2fb90df7ad6b832c041547) | `` bmake: move to by-name ``                                                                |
| [`e4c3cc5c`](https://github.com/NixOS/nixpkgs/commit/e4c3cc5c17a714d0d343a5232190f72e51ff1710) | `` ddcci-driver: 0.4.3 -> 0.4.4 ``                                                          |
| [`ad3239f9`](https://github.com/NixOS/nixpkgs/commit/ad3239f992917d434cd70979bf3f207e47b919f0) | `` tabnine: 4.4.282 -> 4.10.0 ``                                                            |
| [`3da524ca`](https://github.com/NixOS/nixpkgs/commit/3da524ca62cc4a12c5e677ba044ab7c74a65ad0f) | `` Revert "go_1_21: install from distpack archive" ``                                       |
| [`0bdb1c1d`](https://github.com/NixOS/nixpkgs/commit/0bdb1c1d30c8eb63610a483f63704ed53c9ad7d0) | `` python310Packages.amaranth: fix dependencies ``                                          |
| [`dd52d0fc`](https://github.com/NixOS/nixpkgs/commit/dd52d0fc96ab70de119cfb55a44b0cf1535193b6) | `` grafana: fix update script ``                                                            |
| [`e3ea6e8b`](https://github.com/NixOS/nixpkgs/commit/e3ea6e8b2c541b20622c9f5adcaf713c646a4269) | `` fluxcd: fix update script ``                                                             |
| [`fc5941fa`](https://github.com/NixOS/nixpkgs/commit/fc5941fad307f711cedc9171a81e993a71787627) | `` wasmtime: 12.0.1 -> 13.0.0 ``                                                            |
| [`51d1f7a9`](https://github.com/NixOS/nixpkgs/commit/51d1f7a911916d7a98c9324e0dcc03088b999d6f) | `` unison-ucm: M5f -> M5g ``                                                                |
| [`ee4463f0`](https://github.com/NixOS/nixpkgs/commit/ee4463f00bafd5f662d866726a28853d9786084c) | `` python310Packages.garminconnect: 0.2.6 -> 0.2.7 ``                                       |
| [`a2a6075e`](https://github.com/NixOS/nixpkgs/commit/a2a6075ea331d328aef8fc05ae78bf11d0ce1c4e) | `` python311Packages.onnx: use c++14 on darwin ``                                           |
| [`22c5e1a0`](https://github.com/NixOS/nixpkgs/commit/22c5e1a0a017bf8235d47c15ecf3f6c8a557954c) | `` guile-ssh: clean up the package (#256541) ``                                             |
| [`b4e54f1f`](https://github.com/NixOS/nixpkgs/commit/b4e54f1fa803fc8a2bc091ccf97e4c6922145145) | `` python310Packages.aesara: 2.9.1 -> 2.9.2 ``                                              |
| [`d126740f`](https://github.com/NixOS/nixpkgs/commit/d126740fe55b81881abf908b5b4020a9a5af7a64) | `` sunpaper: add meta.mainProgram, fix license, and other cleanup (#256437) ``              |
| [`a59952de`](https://github.com/NixOS/nixpkgs/commit/a59952ded851c8914aa5cdf6c2408f8a71e5fa0f) | `` forgejo: 1.20.4-0 -> 1.20.4-1 ``                                                         |
| [`f6d810e1`](https://github.com/NixOS/nixpkgs/commit/f6d810e163b07e02571a48b72f47e181a427a860) | `` jenkins: 2.414.1 -> 2.414.2 ``                                                           |
| [`0007dfa3`](https://github.com/NixOS/nixpkgs/commit/0007dfa33e35bed42062f09266367dfebbdd9e00) | `` alerta: fix dependency error ``                                                          |
| [`2798da40`](https://github.com/NixOS/nixpkgs/commit/2798da406dd1800d92d83dd65b2d520b6ee39528) | `` interactsh: 1.1.6 -> 1.1.7 ``                                                            |
| [`84d94055`](https://github.com/NixOS/nixpkgs/commit/84d940553855effc498c4bdfebc0b85e9973ec90) | `` linkerd: fix update script ``                                                            |
| [`1e43c3d0`](https://github.com/NixOS/nixpkgs/commit/1e43c3d01039a1750959d608ae522f5d529a04f2) | `` kubeclarity: 2.19.0 -> 2.21.0 ``                                                         |
| [`d62f7fef`](https://github.com/NixOS/nixpkgs/commit/d62f7fef9ff91546ff57b3e7cab966247d0081f6) | `` linuxPackages.nvidia_x11_legacy470: fix hash ``                                          |
| [`c57e7d56`](https://github.com/NixOS/nixpkgs/commit/c57e7d5622bed85759f3153db62fd991dcd43fa6) | `` gnome3.adwaita-icon-theme.meta.homepage: init ``                                         |
| [`e2b91903`](https://github.com/NixOS/nixpkgs/commit/e2b919039a5b081e235ad840491343e3665f99b7) | `` linuxPackages.nvidiaPackages.production: 535.104.05 -> 535.113.01 ``                     |
| [`713a0b8a`](https://github.com/NixOS/nixpkgs/commit/713a0b8a428fb4cf7913f4e6cff8d5d085493f81) | `` sublime-merge: add aarch64 support ``                                                    |
| [`1f617f34`](https://github.com/NixOS/nixpkgs/commit/1f617f349ecbbb6cc786308fca6d4711ced970e2) | `` sublime-merge-dev: 2085 → 2090 ``                                                        |
| [`0d34c066`](https://github.com/NixOS/nixpkgs/commit/0d34c0660e31f28262454bd231e41202c0ad8b73) | `` sublime-merge: 2083 → 2091 ``                                                            |
| [`3f06fac5`](https://github.com/NixOS/nixpkgs/commit/3f06fac504711ae2e7706a5223f938faa2f5e88a) | `` sublime-merge: sync with sublime4 ``                                                     |
| [`e1248311`](https://github.com/NixOS/nixpkgs/commit/e12483116b3b51a185a33a272bf351e357ba9a99) | `` elixir_1_15: 1.15.5 -> 1.15.6 ``                                                         |
| [`3d6ac5ca`](https://github.com/NixOS/nixpkgs/commit/3d6ac5ca6118337a4df7108ee98007fe8a6d95e0) | `` signalbackup-tools: 20230919 -> 20230921 ``                                              |
| [`2c968344`](https://github.com/NixOS/nixpkgs/commit/2c9683445afb802583a057f23aa01ecd45d27059) | `` soupault: 4.6.0 → 4.7.0 ``                                                               |
| [`d3848592`](https://github.com/NixOS/nixpkgs/commit/d38485921a4f8187dd5ec145337db1ac4e3d7d06) | `` treewide: vendorSha256 -> vendorHash (#256514) ``                                        |
| [`2d2bc0a9`](https://github.com/NixOS/nixpkgs/commit/2d2bc0a994d9f34a34632742c5270759c784e875) | `` mediamtx: 1.0.3 -> 1.1.0 ``                                                              |
| [`a36cc31c`](https://github.com/NixOS/nixpkgs/commit/a36cc31cd66caa348988b35af62d2fd73ceba54b) | `` python3.pkgs.amaranth-soc: 2021-12-10 -> 2023-09-15 ``                                   |
| [`117a9e2e`](https://github.com/NixOS/nixpkgs/commit/117a9e2ed8d2375f64f162b751bdd11272ee0659) | `` glasgow: 2023-04-15 -> 2023-09-20: bump ``                                               |
| [`2d69907a`](https://github.com/NixOS/nixpkgs/commit/2d69907ac8e7ecceb4390c541bf3d4dee4b5b7aa) | `` python3.pkgs.fx2: 0.11 -> 2023-09-20: bump ``                                            |
| [`7964742d`](https://github.com/NixOS/nixpkgs/commit/7964742d222748cc11c22f3e21f4e304315e8aad) | `` python3.pkgs.amaranth: 0.3 -> 0.4.dev197: bump ``                                        |
| [`294c4ec9`](https://github.com/NixOS/nixpkgs/commit/294c4ec95607b82b10ccb79eaeedf865fb258091) | `` nixos/glasgow: init hardware module ``                                                   |
| [`c05123ba`](https://github.com/NixOS/nixpkgs/commit/c05123ba4ae325d64dcebdd8ab1888d6397eb590) | `` glasgow: include udev rules ``                                                           |
| [`9ce4d87d`](https://github.com/NixOS/nixpkgs/commit/9ce4d87dde7b572addfaf0cb4e22ebab42ce2d0d) | `` dub: add jtbx to meta.maintainers ``                                                     |
| [`6272cc6e`](https://github.com/NixOS/nixpkgs/commit/6272cc6e4043416063d80bad79da6c359ae3b6f4) | `` dub: 1.30.0 -> 1.33.0 ``                                                                 |
| [`f0083384`](https://github.com/NixOS/nixpkgs/commit/f0083384d9519c4105a6abe91299769b945ba884) | `` Literate: fix build on dub 1.33.0 ``                                                     |
| [`9a1a55c2`](https://github.com/NixOS/nixpkgs/commit/9a1a55c2c331dfaadeca8b576ee7e9046bfd32e2) | `` licenses: fix full name of inria-icesl ``                                                |
| [`43454dfc`](https://github.com/NixOS/nixpkgs/commit/43454dfc99ea0bfb1bd0b8023583dfc97dde4cef) | `` deepin.deepin-terminal: 6.0.6 -> 6.0.7 ``                                                |
| [`5b4304c9`](https://github.com/NixOS/nixpkgs/commit/5b4304c92b5db8ebc0aeb7f6250bb9d09f430d12) | `` linuxKernel.kernels.linux_zen: 6.5.4-zen1 -> 6.5.4-zen2 ``                               |
| [`390b4834`](https://github.com/NixOS/nixpkgs/commit/390b4834686087a44dd869f1add21c8059a8c6d9) | `` nextcloud27: 27.1.0 -> 27.1.1 ``                                                         |
| [`3aa88bee`](https://github.com/NixOS/nixpkgs/commit/3aa88bee8a6f126c9fb8e2c3f526d6fe1b380216) | `` nextcloud26: 26.0.6 -> 26.0.7 ``                                                         |
| [`5c22d118`](https://github.com/NixOS/nixpkgs/commit/5c22d118614441806e8b3a51b60fc358e2c89065) | `` nextcloud25: 25.0.11 -> 25.0.12 ``                                                       |
| [`802428e4`](https://github.com/NixOS/nixpkgs/commit/802428e4e0f901361b2dfb8835a3b1a940a23cf8) | `` dart-sass: 1.66.1 -> 1.68.0 ``                                                           |
| [`327f0e62`](https://github.com/NixOS/nixpkgs/commit/327f0e62543626ace0d297145606834391529073) | `` python310Packages.appthreat-vulnerability-db: 5.4.2 -> 5.4.3 ``                          |
| [`577d4f76`](https://github.com/NixOS/nixpkgs/commit/577d4f76277ac3e9c105032eed62b451aaea85af) | `` cargo-shuttle: 0.26.0 -> 0.27.0 ``                                                       |
| [`77356593`](https://github.com/NixOS/nixpkgs/commit/7735659333e1d39a813ccc26b31757e191192a8c) | `` treewide: use sri hash (#256481) ``                                                      |
| [`66b71032`](https://github.com/NixOS/nixpkgs/commit/66b710324b8cbabff2d37f0e8d67af36742f8027) | `` runme: 1.7.3 -> 1.7.4 ``                                                                 |
| [`7fd7b57d`](https://github.com/NixOS/nixpkgs/commit/7fd7b57ddc11b9f1a9a9f361e3d26a2dc95bb80d) | `` release-notes: mention networking.networkmanager.firewallBackend ``                      |
| [`9a85d771`](https://github.com/NixOS/nixpkgs/commit/9a85d7715274f615e14e2bbbb3ebc942a7e48872) | `` nixos/networkmanager: default firewallBackend to nftables, remove firewallBackend ``     |
| [`8df9a90b`](https://github.com/NixOS/nixpkgs/commit/8df9a90b91f6d56e9f141123a4570ae87935d621) | `` typstfmt: 0.2.4 -> 0.2.5 ``                                                              |
| [`ad86daf6`](https://github.com/NixOS/nixpkgs/commit/ad86daf6ff7b57fc81a7e8b9292d03345823074a) | `` mastodon: 4.1.8 -> 4.1.9 ``                                                              |
| [`ad0ca163`](https://github.com/NixOS/nixpkgs/commit/ad0ca163e1338f37201f221075167d4e1797bca6) | `` nixos/networkmanager: cleanup, fix example rendering ``                                  |
| [`70940eb4`](https://github.com/NixOS/nixpkgs/commit/70940eb40a440c48267e809ac86d7e1c20aeebc2) | `` lxd-unwrapped: 5.17 -> 5.18 ``                                                           |
| [`1029384b`](https://github.com/NixOS/nixpkgs/commit/1029384bd8424b9c27fa8c31894b99c523e98c59) | `` python310Packages.upcloud-api: 2.5.0 -> 2.5.1 ``                                         |
| [`8a017c26`](https://github.com/NixOS/nixpkgs/commit/8a017c265bde902d6028eadd1d4da079c1ad1877) | `` vscodium: 1.82.1.23255 -> 1.82.2.23257 ``                                                |
| [`b5bfaee7`](https://github.com/NixOS/nixpkgs/commit/b5bfaee746c9d420089da6b75490b39928acb937) | `` lunarml: unstable-2023-09-16 → unstable-2023-09-21 ``                                    |
| [`77837702`](https://github.com/NixOS/nixpkgs/commit/7783770213e7a5ba3aaf756f7e0ada22257f9357) | `` grype: 0.68.1 -> 0.69.0 ``                                                               |
| [`08106b36`](https://github.com/NixOS/nixpkgs/commit/08106b367f05923ec140655436a6021a0a20ece3) | `` python311Packages.yalexs: 1.9.0 -> 1.10.0 ``                                             |
| [`1f0adda7`](https://github.com/NixOS/nixpkgs/commit/1f0adda715786b214727b02d48d6cb164e753aa9) | `` python311Packages.twilio: 8.8.0 -> 8.9.0 ``                                              |
| [`9cd89f35`](https://github.com/NixOS/nixpkgs/commit/9cd89f35decc031a7f15377e235f693556b71f7f) | `` python311Packages.skodaconnect: 1.3.6 -> 1.3.7 ``                                        |
| [`d4a17aba`](https://github.com/NixOS/nixpkgs/commit/d4a17abab8c0b2761fa0083279ef2d476c549f2e) | `` python311Packages.aardwolf: 0.2.7 -> 0.2.8 ``                                            |
| [`0ee02d5b`](https://github.com/NixOS/nixpkgs/commit/0ee02d5b428714ffd66fed882c691b6a83be4a5c) | `` snagboot: move passthru before meta ``                                                   |
| [`55f434b1`](https://github.com/NixOS/nixpkgs/commit/55f434b1d4e370bb2d059fa865795b6f42fad8c8) | `` snagboot: 1.1 -> 1.2 ``                                                                  |
| [`48399b71`](https://github.com/NixOS/nixpkgs/commit/48399b718226b324569e35f4c22290923a5a2a44) | `` maestro: 1.32.0 -> 1.33.0 ``                                                             |
| [`72877e87`](https://github.com/NixOS/nixpkgs/commit/72877e87cc8966a486760b12439282ea9ae3a09d) | `` rust-analyzer-unwrapped: 2023-09-11 -> 2023-09-18 ``                                     |
| [`fbcab1b3`](https://github.com/NixOS/nixpkgs/commit/fbcab1b35b581669df87d3499ad6882bd6edc66e) | `` dynamips: add meta.mainProgram ``                                                        |
| [`04bb2f1f`](https://github.com/NixOS/nixpkgs/commit/04bb2f1fcdd08c8b4cd005d2723104cf3f9ead35) | `` dynamips: enable darwin support ``                                                       |
| [`f35534ca`](https://github.com/NixOS/nixpkgs/commit/f35534ca8065e803cb3708f25eaaa7930bbf74ba) | `` nushell: 0.84.0 -> 0.85.0 ``                                                             |
| [`05e47082`](https://github.com/NixOS/nixpkgs/commit/05e470828d4afc60431aca0d1f25192681ed2abf) | `` python3Packages.scikit-posthocs: init at 0.7.0 ``                                        |
| [`c5855106`](https://github.com/NixOS/nixpkgs/commit/c585510601a674bea989329e817a00962bc3ddc9) | `` seaborn-data: init at unstable-2023-01-26 ``                                             |
| [`35892c0b`](https://github.com/NixOS/nixpkgs/commit/35892c0b590f1417f69a18c39a52d56c91ed1528) | `` ocamlPackages.lustre-v6: 6.107.3 -> 6.107.4 ``                                           |
| [`1a3b8dc9`](https://github.com/NixOS/nixpkgs/commit/1a3b8dc96300648a27ed5df4e647a1b784e012b9) | `` ubridge: add meta.mainProgram ``                                                         |
| [`5c05b25c`](https://github.com/NixOS/nixpkgs/commit/5c05b25c9c931c1114e55e82b07e9cd02280746a) | `` ubridge: add passthru.tests.version ``                                                   |
| [`86f0874b`](https://github.com/NixOS/nixpkgs/commit/86f0874b38c7e7706ab3f7a98d796d10ee7c964a) | `` ubridge: enable darwin support ``                                                        |
| [`5742d5a8`](https://github.com/NixOS/nixpkgs/commit/5742d5a8fdee5dd31035b9b497458f1eea931a5b) | `` perlPackages.SDL: import patch ``                                                        |
| [`59ce52e5`](https://github.com/NixOS/nixpkgs/commit/59ce52e553023f18155b25705032117773bd6994) | `` dmenu-bluetooth: init at unstable-2023-07-16 ``                                          |
| [`7c33c8d4`](https://github.com/NixOS/nixpkgs/commit/7c33c8d4529c5f40237c39d83ea4a6e2b32d50a7) | `` coqPackages.itauto: enable for Coq 8.18 ``                                               |
| [`2abfae9e`](https://github.com/NixOS/nixpkgs/commit/2abfae9e9b4afed840705484990575537fc586ed) | `` coq: 8.17.1 -> 8.18.0 ``                                                                 |
| [`0de60535`](https://github.com/NixOS/nixpkgs/commit/0de60535c958d6631744a1ad803b851b27e62128) | `` coqPackages.flocq: 4.1.1 → 4.1.3 ``                                                      |
| [`3b49077f`](https://github.com/NixOS/nixpkgs/commit/3b49077fbe5f783047edb21e8d69354d5a2a80c8) | `` ocamlPackages.opam-publish: init at 2.2.0 ``                                             |
| [`702f067f`](https://github.com/NixOS/nixpkgs/commit/702f067ff0c698ac9daf9d5ab63c6f8c0b2c1688) | `` licenses: add OCaml LGPL Linking Exception ``                                            |
| [`8ace65ff`](https://github.com/NixOS/nixpkgs/commit/8ace65ff3d7696b7a03ea9583b39df27b3153984) | `` treewide: use finalAttrs in all packages I maintain (#255902) ``                         |
| [`dd2277f8`](https://github.com/NixOS/nixpkgs/commit/dd2277f8b23bae087fbef069b83befd93b2d2df0) | `` bottles: move GStreamer deps in a separate variable ``                                   |
| [`e19d87d2`](https://github.com/NixOS/nixpkgs/commit/e19d87d2ec8a6606b3cf2ceaea5553aac4aadc2c) | `` bottles: fix GStreamer on 32 bit apps ``                                                 |
| [`daf602d9`](https://github.com/NixOS/nixpkgs/commit/daf602d9fcd3380801320fde6e17396b954c5881) | `` displaylink: add passthru.tests.displaylink ``                                           |
| [`89052d98`](https://github.com/NixOS/nixpkgs/commit/89052d98aa294912afdac99d3de02549c9a86b67) | `` displaylink: 5.7.0-61.129 -> 5.8.0-63.33 ``                                              |
| [`812b1f29`](https://github.com/NixOS/nixpkgs/commit/812b1f2955400970332f1058050588288b78d675) | `` linuxPackages.evdi: 1.13.1 -> 1.14.1 ``                                                  |
| [`8dcd2545`](https://github.com/NixOS/nixpkgs/commit/8dcd2545ab40875dc0a8e7aa41d2229479fb946c) | `` homepage-dashboard: 0.6.29 -> 0.6.35 ``                                                  |
| [`b60565ed`](https://github.com/NixOS/nixpkgs/commit/b60565ed4d41584adb62cf3ab2afee85bf6f8144) | `` bluej: use dpkg instead of manual preUnpackHook ``                                       |
| [`11e7a416`](https://github.com/NixOS/nixpkgs/commit/11e7a4161fc41c639567e6f76b39d74bffe4ce9c) | `` greenfoot: 3.7.1 -> 3.8.0 ``                                                             |
| [`3b6bbfa6`](https://github.com/NixOS/nixpkgs/commit/3b6bbfa609b44e6673a1dea40baaeefafe90ee1e) | `` python311Packages.dvc-data: 2.16.1 -> 2.16.3 ``                                          |
| [`0ee55af2`](https://github.com/NixOS/nixpkgs/commit/0ee55af2ec95b87332c9b803b8869766e2f63a01) | `` python311Packages.scrapy: disable failing test ``                                        |
| [`1293c418`](https://github.com/NixOS/nixpkgs/commit/1293c4180008548d7cc8461833b345cc68fa9895) | `` foot: enable debug info ``                                                               |
| [`2690299f`](https://github.com/NixOS/nixpkgs/commit/2690299f1897adeea19555336ad637acd22fa004) | `` microcodeAmd: fix cross-compilation ``                                                   |
| [`8ec182e5`](https://github.com/NixOS/nixpkgs/commit/8ec182e5704dfdbc6540d281e2a3bac38e4fa836) | `` nixos/prometheus: fix blackbox exporter ``                                               |
| [`5c3a366f`](https://github.com/NixOS/nixpkgs/commit/5c3a366f0c49278394e0e30b39e1cbb117a29cbf) | `` Make postman and beekeeper compatible with NIXOS_OZONE_WL ``                             |
| [`37cd85b2`](https://github.com/NixOS/nixpkgs/commit/37cd85b2e46291b4e6ed31d19e0a8e37f5ce6f6d) | `` python311Packages.botocore-stubs: 1.31.50 -> 1.31.52 ``                                  |
| [`ea61be41`](https://github.com/NixOS/nixpkgs/commit/ea61be413c2505319aa5ed0073cd7412c08115aa) | `` gcc: set GFORTRAN_FOR_TARGET on cross-built native compilers ``                          |
| [`9d98f3bb`](https://github.com/NixOS/nixpkgs/commit/9d98f3bbaa0b39d28143fe6f33f28e0c4a0ad2d0) | `` invidious: unstable-2023-08-25 -> unstable-2023-09-18 ``                                 |
| [`f084177d`](https://github.com/NixOS/nixpkgs/commit/f084177d1919e45ed0dc38ce9db095061763cb52) | `` ifmetric: set meta.mainProgram ``                                                        |
| [`d86d9f30`](https://github.com/NixOS/nixpkgs/commit/d86d9f30b19f91ebbea1a72476d64b077110aaff) | `` ocamlPackages.ca-certs-nss: 3.86 → 3.92 ``                                               |
| [`b802bf0b`](https://github.com/NixOS/nixpkgs/commit/b802bf0b9518e53d5ae676f9019be578e50f4f38) | `` ocamlPackages.ocaml-migrate-parsetree-2: disable for OCaml ≥ 5.1 ``                      |
| [`db242cd9`](https://github.com/NixOS/nixpkgs/commit/db242cd9b7f74a1bcc97a922f99c4a068f5ee579) | `` nwg-panel: 0.9.12 -> 0.9.13 ``                                                           |
| [`4f6b3ac8`](https://github.com/NixOS/nixpkgs/commit/4f6b3ac83018238ea3940c1a1f208669cf1331a3) | `` signal-desktop: 6.30.2 -> 6.31.0, signal-desktop-beta: 6.31.0-beta.1 -> 6.32.0-beta.1 `` |
| [`3e811005`](https://github.com/NixOS/nixpkgs/commit/3e811005e06193d6843cb794bfaca0f862f48c1f) | `` symbolicator: 23.9.0 -> 23.9.1 ``                                                        |
| [`ea5228f2`](https://github.com/NixOS/nixpkgs/commit/ea5228f2c8fa2d2cf466a0dbed3ac11590735ad5) | `` libspelling: unstable-2023-07-17 -> 0.2.0 ``                                             |
| [`0a361800`](https://github.com/NixOS/nixpkgs/commit/0a36180095e482d6a4ebd0bebf91118b7ba1b1d9) | `` xorriso: 1.5.6.pl02 -> 1.5.7 ``                                                          |
| [`6e8e316f`](https://github.com/NixOS/nixpkgs/commit/6e8e316fdebd8378aaad9d6dd2cf59bc348cde56) | `` xorriso: migrate to by-name ``                                                           |