### PR TITLE
chore(flake/emacs-overlay): `02592572` -> `90182afc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694775225,
-        "narHash": "sha256-fGZihROooCeEJ2Dv2leCXHOr7n9+UvVIn6TokMR84zQ=",
+        "lastModified": 1694801846,
+        "narHash": "sha256-+mYOCAuqDR4+4lPLiwGSN8fYhvmNyfUBbWpDHnBWGtM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "02592572580285c9930aae5c6503b7396694f54d",
+        "rev": "90182afcb4fdb564a653959a8a2d818714e115fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`90182afc`](https://github.com/nix-community/emacs-overlay/commit/90182afcb4fdb564a653959a8a2d818714e115fb) | `` Updated repos/melpa `` |
| [`8025128b`](https://github.com/nix-community/emacs-overlay/commit/8025128bdbd073959a5117108aae6203e4f57859) | `` Updated repos/emacs `` |
| [`a600dd5e`](https://github.com/nix-community/emacs-overlay/commit/a600dd5e1af89a6a6f0b7124e9b08f2906da2f4d) | `` Updated repos/elpa ``  |