### PR TITLE
chore(flake/emacs-overlay): `90182afc` -> `64b05ab3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694801846,
-        "narHash": "sha256-+mYOCAuqDR4+4lPLiwGSN8fYhvmNyfUBbWpDHnBWGtM=",
+        "lastModified": 1694835075,
+        "narHash": "sha256-CSckVsiz3utdNAIqlOIF5tIW2IR81D+h5Koj0RaiIYU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "90182afcb4fdb564a653959a8a2d818714e115fb",
+        "rev": "64b05ab33999b6dbe0ef96d2b864f5ae86bb15f9",
         "type": "github"
       },
       "original": {
@@ -602,11 +602,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1694499547,
-        "narHash": "sha256-R7xMz1Iia6JthWRHDn36s/E248WB1/je62ovC/dUVKI=",
+        "lastModified": 1694753796,
+        "narHash": "sha256-QPE7dqcicQH/nq9aywVXJWWtci4FvxHaM+BSIEbGBvA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e5f018cf150e29aac26c61dac0790ea023c46b24",
+        "rev": "360a7d31c30abefdc490d203f80e3221b7a24af2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`64b05ab3`](https://github.com/nix-community/emacs-overlay/commit/64b05ab33999b6dbe0ef96d2b864f5ae86bb15f9) | `` Updated repos/nongnu `` |
| [`09dcac84`](https://github.com/nix-community/emacs-overlay/commit/09dcac84503438c493cc9dd89133812ad4cd56cb) | `` Updated repos/melpa ``  |
| [`17ccac7c`](https://github.com/nix-community/emacs-overlay/commit/17ccac7c829aa5c813d56d345982c76ea63c5c7d) | `` Updated repos/emacs ``  |
| [`221c84d8`](https://github.com/nix-community/emacs-overlay/commit/221c84d8e1c39493d346156c7dd691bf0894f79d) | `` Updated repos/elpa ``   |
| [`3bfa9b49`](https://github.com/nix-community/emacs-overlay/commit/3bfa9b49784a7ab06eff13bbe00ad113463b6ce1) | `` Updated flake inputs `` |