### PR TITLE
chore(flake/emacs-overlay): `64b05ab3` -> `a2f3aa88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694835075,
-        "narHash": "sha256-CSckVsiz3utdNAIqlOIF5tIW2IR81D+h5Koj0RaiIYU=",
+        "lastModified": 1694861701,
+        "narHash": "sha256-zeLAIrXNGx4yafDJA/50HzgDd/LB5ypszKqJV4KL/jY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "64b05ab33999b6dbe0ef96d2b864f5ae86bb15f9",
+        "rev": "a2f3aa88ca33c18c3d0601d17a83005d02d68a2d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`a2f3aa88`](https://github.com/nix-community/emacs-overlay/commit/a2f3aa88ca33c18c3d0601d17a83005d02d68a2d) | `` Updated repos/melpa `` |
| [`e99d7455`](https://github.com/nix-community/emacs-overlay/commit/e99d7455e1e97867fdbce7833a8082dbf6db947b) | `` Updated repos/emacs `` |