### PR TITLE
chore(flake/emacs-overlay): `a2f3aa88` -> `058738a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694861701,
-        "narHash": "sha256-zeLAIrXNGx4yafDJA/50HzgDd/LB5ypszKqJV4KL/jY=",
+        "lastModified": 1694888792,
+        "narHash": "sha256-va90aQlteK27tOvnigScT+P7Kf4+/Se2kwLHUY/aBd4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a2f3aa88ca33c18c3d0601d17a83005d02d68a2d",
+        "rev": "058738a9f775d36eba4c98c6bb1f8dcccc2c4d0d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`058738a9`](https://github.com/nix-community/emacs-overlay/commit/058738a9f775d36eba4c98c6bb1f8dcccc2c4d0d) | `` Updated repos/melpa `` |
| [`ded7f657`](https://github.com/nix-community/emacs-overlay/commit/ded7f65789c7947de345b5841fb510549e29fb40) | `` Updated repos/emacs `` |
| [`0b8cb044`](https://github.com/nix-community/emacs-overlay/commit/0b8cb0442f66eb4c0794027e01e9353e8a56e535) | `` Updated repos/elpa ``  |