### PR TITLE
chore(flake/nix-index-database): `5ddcb3bf` -> `9d2bcc47`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -501,11 +501,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694919446,
-        "narHash": "sha256-j2OSAwbjMkvTl3Uk+Emxw6PV/SkAfIqyL01WAkQzuCc=",
+        "lastModified": 1694921880,
+        "narHash": "sha256-yU36cs5UdzhTwsM9bUWUz43N//ELzQ1ro69C07pU/8E=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "5ddcb3bfb29aef87f92abc2a8edcef7f58f6602c",
+        "rev": "9d2bcc47110b3b6217dfebd6761ba20bc78aedf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`9d2bcc47`](https://github.com/nix-community/nix-index-database/commit/9d2bcc47110b3b6217dfebd6761ba20bc78aedf2) | `` update packages.nix to release 2023-09-17-033648 `` |