### PR TITLE
chore(flake/combobulate): `c6b80689` -> `9a77a0e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -85,11 +85,11 @@
     "combobulate": {
       "flake": false,
       "locked": {
-        "lastModified": 1694675816,
-        "narHash": "sha256-6SwsBCTBwtujpzpga5hzokjP1dfVxEfHAbtL8VenzHg=",
+        "lastModified": 1694945642,
+        "narHash": "sha256-AP9EjWzfBV4geZOiZaWBdIPmtn221ag+j5lly/pcSYg=",
         "owner": "mickeynp",
         "repo": "combobulate",
-        "rev": "c6b80689ef5d53f9c64ae3291fdeabd4ebc7c7a0",
+        "rev": "9a77a0e37f941c51b8038f9e92f1e61cf12ca969",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`0ed37602`](https://github.com/mickeynp/combobulate/commit/0ed37602fdf94a6aa568a561e5e7a68c7acbaba0) | `` autoload combobulate-mode `` |