### PR TITLE
chore(flake/emacs-overlay): `75f353b4` -> `7e26d097`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694920154,
-        "narHash": "sha256-qp/CkujtfvsOY9XWF7/oCVzRno4wGRdugrarvCv3B/Q=",
+        "lastModified": 1694946219,
+        "narHash": "sha256-bZ7RCLzaOnqr/4WE2Rs7/HcY9tLhpYJl6ZkI4i7AZ4Q=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "75f353b459cda9fc4143da18ece3320920c1cfc1",
+        "rev": "7e26d097d352f41e00fcc225529292843283010c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`7e26d097`](https://github.com/nix-community/emacs-overlay/commit/7e26d097d352f41e00fcc225529292843283010c) | `` Updated repos/nongnu `` |
| [`2c1b7d3f`](https://github.com/nix-community/emacs-overlay/commit/2c1b7d3f7338992d737f8bff5d2325b67f4d8b56) | `` Updated repos/melpa ``  |
| [`2b2087a9`](https://github.com/nix-community/emacs-overlay/commit/2b2087a9164ed16c72456f7f3e06495ab358c074) | `` Updated repos/emacs ``  |