### PR TITLE
chore(flake/emacs-overlay): `7e26d097` -> `4662917a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694946219,
-        "narHash": "sha256-bZ7RCLzaOnqr/4WE2Rs7/HcY9tLhpYJl6ZkI4i7AZ4Q=",
+        "lastModified": 1694974510,
+        "narHash": "sha256-SaaX9KTAw/d68SJ4J3CXQhtjHrM+t60Vg/IwKDQqlqE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7e26d097d352f41e00fcc225529292843283010c",
+        "rev": "4662917ab91fa7140b2d90aaead9f1c9d2bbdda5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`4662917a`](https://github.com/nix-community/emacs-overlay/commit/4662917ab91fa7140b2d90aaead9f1c9d2bbdda5) | `` Updated repos/melpa `` |
| [`466a200c`](https://github.com/nix-community/emacs-overlay/commit/466a200c1b1dbb8756e37c5dac522bfa0a77799d) | `` Updated repos/emacs `` |
| [`6f58040d`](https://github.com/nix-community/emacs-overlay/commit/6f58040df928cb39590a23690ae0a2599e6d1c25) | `` Updated repos/elpa ``  |