### PR TITLE
chore(flake/emacs-overlay): `4662917a` -> `c8b16cbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1694974510,
-        "narHash": "sha256-SaaX9KTAw/d68SJ4J3CXQhtjHrM+t60Vg/IwKDQqlqE=",
+        "lastModified": 1695005785,
+        "narHash": "sha256-45SlN8awbxS0vOUk7+HAStYfpGYsmma2Xb2MOAfov/o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4662917ab91fa7140b2d90aaead9f1c9d2bbdda5",
+        "rev": "c8b16cbc2dca35a619d513487be8c939d83b9869",
         "type": "github"
       },
       "original": {
@@ -602,11 +602,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1694753796,
-        "narHash": "sha256-QPE7dqcicQH/nq9aywVXJWWtci4FvxHaM+BSIEbGBvA=",
+        "lastModified": 1694937365,
+        "narHash": "sha256-iHZSGrb9gVpZRR4B2ishUN/1LRKWtSHZNO37C8z1SmA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "360a7d31c30abefdc490d203f80e3221b7a24af2",
+        "rev": "5d017a8822e0907fb96f7700a319f9fe2434de02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c8b16cbc`](https://github.com/nix-community/emacs-overlay/commit/c8b16cbc2dca35a619d513487be8c939d83b9869) | `` Updated repos/nongnu `` |
| [`ba7e09b5`](https://github.com/nix-community/emacs-overlay/commit/ba7e09b5699524e7eb0e157f75456bbf2dfecb33) | `` Updated repos/melpa ``  |
| [`7408d246`](https://github.com/nix-community/emacs-overlay/commit/7408d246b6277a5242de2f3f2ca9a1fd606256b2) | `` Updated repos/emacs ``  |
| [`43eef180`](https://github.com/nix-community/emacs-overlay/commit/43eef180576a34c22e4dac3728eb1fe83ca88912) | `` Updated repos/elpa ``   |
| [`3b7180ef`](https://github.com/nix-community/emacs-overlay/commit/3b7180ef6df579d3e313dfc21bc6ec04e29cae54) | `` Updated flake inputs `` |