### PR TITLE
chore(flake/nixos-hardware): `b0f82bcf` -> `0cc0f972`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -540,11 +540,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1695027437,
-        "narHash": "sha256-LnwQAaC0/queabmmFbXtFVpFUGq+ZE0FjFjNYV5gp08=",
+        "lastModified": 1695030252,
+        "narHash": "sha256-LYLYHOe7jy3ZgBJQNc1esykHyHEMa5sDtwxYIknfdE0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b0f82bcf524924fa9672be7f81292731d7d8c133",
+        "rev": "0cc0f9721256dfbbac57b0479d4f28ea1ec812e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`0cc0f972`](https://github.com/NixOS/nixos-hardware/commit/0cc0f9721256dfbbac57b0479d4f28ea1ec812e9) | `` surface: cleanup, remove linux 5.19.17 and 6.0.17 `` |
| [`455453f4`](https://github.com/NixOS/nixos-hardware/commit/455453f48d9ce7e09c69d722081691550d3d79ed) | `` surface: linux 6.1.18 -> 6.1.53 ``                   |
| [`55fc5e69`](https://github.com/NixOS/nixos-hardware/commit/55fc5e69cb1f2d9a6981aff0d18176af45215199) | `` surface: linux 6.4.14 -> 6.4.16 ``                   |
| [`77d8ac78`](https://github.com/NixOS/nixos-hardware/commit/77d8ac78a61d499b9675268bf55481a8c48f0579) | `` build-profile: also accept nvidia license ``         |