### PR TITLE
chore(flake/nixos-hardware): `0cc0f972` -> `161b0271`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -540,11 +540,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1695030252,
-        "narHash": "sha256-LYLYHOe7jy3ZgBJQNc1esykHyHEMa5sDtwxYIknfdE0=",
+        "lastModified": 1695033975,
+        "narHash": "sha256-GIUxbgLBhVyaKRxQw/NWYFLx7/jbKW3+U0HoSsMLPAs=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "0cc0f9721256dfbbac57b0479d4f28ea1ec812e9",
+        "rev": "161b027169b19d3a0ad6bd0a8948edf0c0fb0f64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`161b0271`](https://github.com/NixOS/nixos-hardware/commit/161b027169b19d3a0ad6bd0a8948edf0c0fb0f64) | `` Fix typo in README.md ``                                                  |
| [`d53069de`](https://github.com/NixOS/nixos-hardware/commit/d53069def4fb2d92da1ec062b583c088426dc61a) | `` fix: enable enableOffloadCmd in prime.nix only when offload is enabled `` |
| [`504893e0`](https://github.com/NixOS/nixos-hardware/commit/504893e09108db7a0dfca0c3fab6f22476a8f4b3) | `` chore: replace writeShellScriptBin in prime.nix with enableOffloadCmd ``  |