### PR TITLE
chore(flake/combobulate): `9a77a0e3` -> `d51ca572`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -85,11 +85,11 @@
     "combobulate": {
       "flake": false,
       "locked": {
-        "lastModified": 1694945642,
-        "narHash": "sha256-AP9EjWzfBV4geZOiZaWBdIPmtn221ag+j5lly/pcSYg=",
+        "lastModified": 1695034590,
+        "narHash": "sha256-YZgYaRVX8cO5W90MUD9CJO8sfiqhDyJDV58hE7utbVI=",
         "owner": "mickeynp",
         "repo": "combobulate",
-        "rev": "9a77a0e37f941c51b8038f9e92f1e61cf12ca969",
+        "rev": "d51ca57221f8c2689665da4dbe55dc618f0d04e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`f0e7357d`](https://github.com/mickeynp/combobulate/commit/f0e7357d0018d49a86ed2488c123b1a13b264e84) | `` feat: add combobulate-query-mode support for hideshow minor mode `` |