### PR TITLE
chore(flake/emacs-overlay): `c8b16cbc` -> `c724333b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1695005785,
-        "narHash": "sha256-45SlN8awbxS0vOUk7+HAStYfpGYsmma2Xb2MOAfov/o=",
+        "lastModified": 1695032245,
+        "narHash": "sha256-FXUBdn1xH4HqUzKiYZGvwW5BX1AbDgw8w+WDI7rLkZE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c8b16cbc2dca35a619d513487be8c939d83b9869",
+        "rev": "c724333b2d3235b01101d62908ed1d43d18ac515",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`c724333b`](https://github.com/nix-community/emacs-overlay/commit/c724333b2d3235b01101d62908ed1d43d18ac515) | `` Updated repos/melpa `` |
| [`3f4de408`](https://github.com/nix-community/emacs-overlay/commit/3f4de4086b6a6a8c18d404e03cbb15b472031f1b) | `` Updated repos/emacs `` |