### PR TITLE
chore(flake/deploy-rs): `57d5071e` -> `e3f41832`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695029081,
-        "narHash": "sha256-1jpJoeDbxYXWViVRkiSyDxsT4SqqsxgYu5Cg7xisKrA=",
+        "lastModified": 1695052866,
+        "narHash": "sha256-agn7F9Oww4oU6nPiw+YiYI9Xb4vOOE73w8PAoBRP4AA=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "57d5071e60c1318ec27eb987f96504ce3d58cb34",
+        "rev": "e3f41832680801d0ee9e2ed33eb63af398b090e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                       |
| --------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`5617d39d`](https://github.com/serokell/deploy-rs/commit/5617d39d3a685539372260a8c38ee68a0abbc203) | `` [Chore] Run CI checks on 'pull_request' `` |