### PR TITLE
chore(flake/emacs-overlay): `c724333b` -> `88b2f014`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1695032245,
-        "narHash": "sha256-FXUBdn1xH4HqUzKiYZGvwW5BX1AbDgw8w+WDI7rLkZE=",
+        "lastModified": 1695060976,
+        "narHash": "sha256-yIZRa3dbOdbz+yoovGkWVTO4zJMBB38mZMD+J4J8Uq4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c724333b2d3235b01101d62908ed1d43d18ac515",
+        "rev": "88b2f01437587ee4ffb2bf4a866cf731f05fe270",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`88b2f014`](https://github.com/nix-community/emacs-overlay/commit/88b2f01437587ee4ffb2bf4a866cf731f05fe270) | `` Updated repos/melpa `` |
| [`82acb54a`](https://github.com/nix-community/emacs-overlay/commit/82acb54af089e147adb1cd0ce640bd1eea42d65a) | `` Updated repos/emacs `` |
| [`c79cb9a9`](https://github.com/nix-community/emacs-overlay/commit/c79cb9a91b9d0b251f91628f171fd45765be6605) | `` Updated repos/elpa ``  |