### PR TITLE
chore(flake/home-manager): `f092a922` -> `feb70061`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -411,11 +411,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695069742,
-        "narHash": "sha256-wKL5C+TqmqkPeDZ9E6dGEGUln3LJ0EmiVkG8MDLo6vE=",
+        "lastModified": 1695074256,
+        "narHash": "sha256-aqaq+mp0YdLzhyHlgI3GNno7XwK5P82uLCFTCIgYjMc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f092a9220220e390c76605b6c4e2238774050f8b",
+        "rev": "feb70061596134d403e14cc5ef7b01ab114d1dbd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`feb70061`](https://github.com/nix-community/home-manager/commit/feb70061596134d403e14cc5ef7b01ab114d1dbd) | `` git: replace gitToInit with lib function `` |