### PR TITLE
chore(flake/emacs-overlay): `88b2f014` -> `56689381`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1695060976,
-        "narHash": "sha256-yIZRa3dbOdbz+yoovGkWVTO4zJMBB38mZMD+J4J8Uq4=",
+        "lastModified": 1695092339,
+        "narHash": "sha256-sNzTBI6wqcS4OvxhoICjcNfIFdL/E1JEAYluSPmkI3E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "88b2f01437587ee4ffb2bf4a866cf731f05fe270",
+        "rev": "56689381ea01e234a5ac331227002fbf22b794f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`56689381`](https://github.com/nix-community/emacs-overlay/commit/56689381ea01e234a5ac331227002fbf22b794f3) | `` Updated repos/melpa `` |
| [`7766f0c1`](https://github.com/nix-community/emacs-overlay/commit/7766f0c176748b8a5c26579e06c626ac9c2bf3ae) | `` Updated repos/emacs `` |
| [`8f241476`](https://github.com/nix-community/emacs-overlay/commit/8f241476c2088beedbb28400e100bc2edee89331) | `` Updated repos/elpa ``  |