### PR TITLE
chore(flake/home-manager): `feb70061` -> `92364581`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -411,11 +411,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695074256,
-        "narHash": "sha256-aqaq+mp0YdLzhyHlgI3GNno7XwK5P82uLCFTCIgYjMc=",
+        "lastModified": 1695103414,
+        "narHash": "sha256-/kr1AQ8aPWl3OaTzZARhGPSS044vZq1Vh4wYX77T1DE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "feb70061596134d403e14cc5ef7b01ab114d1dbd",
+        "rev": "92364581dd3ada6981c4ddc5def8a35a1b945e75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                             |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`92364581`](https://github.com/nix-community/home-manager/commit/92364581dd3ada6981c4ddc5def8a35a1b945e75) | `` tests: sort test list ``         |
| [`8045eb45`](https://github.com/nix-community/home-manager/commit/8045eb45a79b5e585df781c02500d33c9ed96ae0) | `` pasystray: add `extraOptions` `` |