### PR TITLE
chore(flake/emacs-overlay): `56689381` -> `32cf0314`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1695092339,
-        "narHash": "sha256-sNzTBI6wqcS4OvxhoICjcNfIFdL/E1JEAYluSPmkI3E=",
+        "lastModified": 1695119543,
+        "narHash": "sha256-TIaKAHM5qFrK0q+mfT/Oa1QvGjB6eXdwJ3zhMu6IxJ8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "56689381ea01e234a5ac331227002fbf22b794f3",
+        "rev": "32cf0314159f4b2eb85970483124e7df730e3413",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`32cf0314`](https://github.com/nix-community/emacs-overlay/commit/32cf0314159f4b2eb85970483124e7df730e3413) | `` Updated repos/melpa ``  |
| [`981ebc68`](https://github.com/nix-community/emacs-overlay/commit/981ebc687900a6253ba5af9c9a78755e0e1c6d1e) | `` Updated repos/emacs ``  |
| [`7f5e241f`](https://github.com/nix-community/emacs-overlay/commit/7f5e241fec8046e55c27f3bb06c077d61e61d985) | `` Updated flake inputs `` |