### PR TITLE
chore(flake/emacs-overlay): `32cf0314` -> `aee5e8a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1695119543,
-        "narHash": "sha256-TIaKAHM5qFrK0q+mfT/Oa1QvGjB6eXdwJ3zhMu6IxJ8=",
+        "lastModified": 1695149611,
+        "narHash": "sha256-RCxUQJ9uQdioFcHe2HYiJQBo3qVLBTzd3DTHRXLlVlM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "32cf0314159f4b2eb85970483124e7df730e3413",
+        "rev": "aee5e8a427c8a942458d2bad7b97cbad30b75aec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`aee5e8a4`](https://github.com/nix-community/emacs-overlay/commit/aee5e8a427c8a942458d2bad7b97cbad30b75aec) | `` Updated repos/melpa `` |
| [`6c9b7336`](https://github.com/nix-community/emacs-overlay/commit/6c9b73360f6df363192a6c6e91923c166a7c46b7) | `` Updated repos/emacs `` |
| [`b13ebf36`](https://github.com/nix-community/emacs-overlay/commit/b13ebf36c5f6e474a4a72c377f13570ed90a3497) | `` Updated repos/elpa ``  |