### PR TITLE
chore(flake/emacs-overlay): `aee5e8a4` -> `961ca255`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1695149611,
-        "narHash": "sha256-RCxUQJ9uQdioFcHe2HYiJQBo3qVLBTzd3DTHRXLlVlM=",
+        "lastModified": 1695180754,
+        "narHash": "sha256-y7byYVJafoaW56NVhcez1TCjABebhYGyrW+WtJY5HVk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "aee5e8a427c8a942458d2bad7b97cbad30b75aec",
+        "rev": "961ca255c7a1016667f1515f236008785064321a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`961ca255`](https://github.com/nix-community/emacs-overlay/commit/961ca255c7a1016667f1515f236008785064321a) | `` Updated repos/nongnu `` |
| [`4400a216`](https://github.com/nix-community/emacs-overlay/commit/4400a216f0f6970dc8e9c6fd9917efd3c34978b7) | `` Updated repos/melpa ``  |
| [`6ac47686`](https://github.com/nix-community/emacs-overlay/commit/6ac47686676d3b3447cf9fce39702706fd6349a1) | `` Updated repos/emacs ``  |
| [`a75f68b8`](https://github.com/nix-community/emacs-overlay/commit/a75f68b8e2ca8197b8349d59020051a410ecb462) | `` Updated repos/elpa ``   |