### PR TITLE
chore(flake/home-manager): `6f882433` -> `3e7202c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -411,11 +411,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695158069,
-        "narHash": "sha256-bLenMfnHKs0O7kQyLqnLGfrywFMa9BGcJ5Uk9+d0tkU=",
+        "lastModified": 1695182357,
+        "narHash": "sha256-sdJvxsLLe/BpSQwasq5LhgvC765PhJ0Jlat9YbGkA30=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6f88243322c315360c1f31a8fc6c43006db51465",
+        "rev": "3e7202c6387b744dca4feb4217459512886761b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`3e7202c6`](https://github.com/nix-community/home-manager/commit/3e7202c6387b744dca4feb4217459512886761b5) | `` flake.lock: Update `` |