### PR TITLE
chore(flake/emacs-overlay): `961ca255` -> `a8b7b06b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1695180754,
-        "narHash": "sha256-y7byYVJafoaW56NVhcez1TCjABebhYGyrW+WtJY5HVk=",
+        "lastModified": 1695207156,
+        "narHash": "sha256-xjivpe8RIJe5EhQ85r5kAy9CbTFbSb3s3GXNKQJJFKM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "961ca255c7a1016667f1515f236008785064321a",
+        "rev": "a8b7b06b6c6f47cbad4d7396188d6083eddaa13d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`a8b7b06b`](https://github.com/nix-community/emacs-overlay/commit/a8b7b06b6c6f47cbad4d7396188d6083eddaa13d) | `` Updated repos/nongnu `` |
| [`8013106f`](https://github.com/nix-community/emacs-overlay/commit/8013106f71c73c162e484c78eaa410479d8ac767) | `` Updated repos/melpa ``  |
| [`866ccd1c`](https://github.com/nix-community/emacs-overlay/commit/866ccd1c578a2d3e94d7bfe6bd20bbf4ed98fa90) | `` Updated repos/emacs ``  |