### PR TITLE
chore(flake/emacs-overlay): `f5276446` -> `83f62558`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1695639212,
-        "narHash": "sha256-RuFBZPJf1Y1t1HZByq95RQCoEJ4ANs05dLwd45pYdig=",
+        "lastModified": 1695752759,
+        "narHash": "sha256-Z3/tYemtSgRiXERrGvSRpXBQUakVbYuwMVddbfLEgXI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f52764468eeaa05affd95c9b9236bb0e2dbf2555",
+        "rev": "83f62558d3f1893b39f1d9ba4743e68ff686e175",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`83f62558`](https://github.com/nix-community/emacs-overlay/commit/83f62558d3f1893b39f1d9ba4743e68ff686e175) | `` Updated repos/melpa `` |
| [`89d3c18a`](https://github.com/nix-community/emacs-overlay/commit/89d3c18ab7b1c8c82988963e9c899818d7238530) | `` Updated repos/emacs `` |
| [`33a110d0`](https://github.com/nix-community/emacs-overlay/commit/33a110d0702c6be0c19300a400c252a15ac4b077) | `` Updated repos/elpa ``  |
| [`46b20ea5`](https://github.com/nix-community/emacs-overlay/commit/46b20ea5a73cd14d0d657482f5bc2bbaed51b100) | `` Updated repos/melpa `` |
| [`16ee19ac`](https://github.com/nix-community/emacs-overlay/commit/16ee19acf5814f52dd15e4c9a5746300792514c3) | `` Updated repos/emacs `` |
| [`bcb0cc66`](https://github.com/nix-community/emacs-overlay/commit/bcb0cc6626d0e79ff188c30cad72f52692c1048d) | `` Updated repos/melpa `` |
| [`6c91a132`](https://github.com/nix-community/emacs-overlay/commit/6c91a13299501344a571b7b8f03b91574761c2d2) | `` Updated repos/emacs `` |
| [`d9451a59`](https://github.com/nix-community/emacs-overlay/commit/d9451a5960c6579350cfacb48157511ef189fa6f) | `` Updated repos/elpa ``  |
| [`d1a316b5`](https://github.com/nix-community/emacs-overlay/commit/d1a316b529df678413ba05c970c0c9bdcb6c0d37) | `` Updated repos/melpa `` |
| [`267403ea`](https://github.com/nix-community/emacs-overlay/commit/267403ea06d2fd17b25f12bd9a4e7c7d9f2dc920) | `` Updated repos/emacs `` |
| [`564f10b3`](https://github.com/nix-community/emacs-overlay/commit/564f10b3d0bf2b8a654cc882f835e14e41e9a666) | `` Updated repos/elpa ``  |