### PR TITLE
chore(flake/home-manager): `a88df2fb` -> `0f4e5b49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -411,11 +411,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695550077,
-        "narHash": "sha256-xoxR/iY69/3lTnnZDP6gf3J46DUKPcf+Y1jH03tfZXE=",
+        "lastModified": 1695738267,
+        "narHash": "sha256-LTNAbTQ96xSj17xBfsFrFS9i56U2BMLpD0BduhrsVkU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a88df2fb101778bfd98a17556b3a2618c6c66091",
+        "rev": "0f4e5b4999fd6a42ece5da8a3a2439a50e48e486",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`0f4e5b49`](https://github.com/nix-community/home-manager/commit/0f4e5b4999fd6a42ece5da8a3a2439a50e48e486) | `` keychain: fix edge-cases in nushell integration `` |
| [`dd88dbc6`](https://github.com/nix-community/home-manager/commit/dd88dbc69438384bd94f8282584a86798750028c) | `` neovim: expose `finalPackage` ``                   |