### PR TITLE
chore(flake/agenix): `572baca9` -> `1f677b3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,11 +13,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694793763,
-        "narHash": "sha256-y6gTE1C9mIoSkymRYyzCmv62PFgy+hbZ5j8fuiQK5KI=",
+        "lastModified": 1695384796,
+        "narHash": "sha256-TYlE4B0ktPtlJJF9IFxTWrEeq+XKG8Ny0gc2FGEAdj0=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "572baca9b0c592f71982fca0790db4ce311e3c75",
+        "rev": "1f677b3e161d3bdbfd08a939e8f25de2568e0ef4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                              |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`115e5610`](https://github.com/ryantm/agenix/commit/115e561054afd80d22ac6225772ca89333112632) | `` fix: add --strict nix-instantiate to support builtins.readFile `` |
| [`da763b2c`](https://github.com/ryantm/agenix/commit/da763b2c4bfac0310e8c1d972199e10967ad38b8) | `` Don't need concatStringSep if using jq to parse json arrays ``    |
| [`eb1386f3`](https://github.com/ryantm/agenix/commit/eb1386f3b246ae563c99ecadaaeff6b6d36fc9a5) | `` Use jq instead of sed ``                                          |