### PR TITLE
chore(flake/nix-index-database): `9d2bcc47` -> `25d6369c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -501,11 +501,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694921880,
-        "narHash": "sha256-yU36cs5UdzhTwsM9bUWUz43N//ELzQ1ro69C07pU/8E=",
+        "lastModified": 1695526222,
+        "narHash": "sha256-/NwZz3QcVplrfiDKk1thYg1EIHLSNucVHNUi2uwO3RI=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "9d2bcc47110b3b6217dfebd6761ba20bc78aedf2",
+        "rev": "25d6369c232bbea1ec1f90226fd17982e7a0a647",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`25d6369c`](https://github.com/nix-community/nix-index-database/commit/25d6369c232bbea1ec1f90226fd17982e7a0a647) | `` update packages.nix to release 2023-09-24-032915 `` |
| [`597e3de1`](https://github.com/nix-community/nix-index-database/commit/597e3de1d1422763ec5f3b183df14846060343e9) | `` flake.lock: Update ``                               |