### PR TITLE
chore(flake/nixos-hardware): `cb4dc98f` -> `61283b30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -540,11 +540,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1695109627,
-        "narHash": "sha256-4rpyoVzmunIG6xWA/EonnSSqC69bDBzciFi6SjBze/0=",
+        "lastModified": 1695541019,
+        "narHash": "sha256-rs++zfk41K9ArWkDAlmBDlGlKO8qeRIRzdjo+9SmNFI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "cb4dc98f776ddb6af165e6f06b2902efe31ca67a",
+        "rev": "61283b30d11f27d5b76439d43f20d0c0c8ff5296",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                               |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`61283b30`](https://github.com/NixOS/nixos-hardware/commit/61283b30d11f27d5b76439d43f20d0c0c8ff5296) | `` framework/*: add fw-ectool for led control, etc `` |
| [`08add92f`](https://github.com/NixOS/nixos-hardware/commit/08add92f1745edd3418b1ea017f8732735a9d9b9) | `` Enabling hp-wmi driver after PR merge ``           |
| [`06178532`](https://github.com/NixOS/nixos-hardware/commit/061785322d93f63b0fa4882ac92030008932a083) | `` Add Omen 15-en0010ca ``                            |