### PR TITLE
chore(flake/pre-commit-hooks): `4f883a76` -> `cb770e93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1694364351,
-        "narHash": "sha256-oadhSCqopYXxURwIA6/Anpe5IAG11q2LhvTJNP5zE6o=",
+        "lastModified": 1695576016,
+        "narHash": "sha256-71KxwRhTfVuh7kNrg3/edNjYVg9DCyKZl2QIKbhRggg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "4f883a76282bc28eb952570afc3d8a1bf6f481d7",
+        "rev": "cb770e93516a1609652fa8e945a0f310e98f10c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                         |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`b239875e`](https://github.com/cachix/pre-commit-hooks.nix/commit/b239875ee4b00a71b8a3dafa0e5216075c1421ee) | `` Add hook for flynt ``                        |
| [`e468d8c5`](https://github.com/cachix/pre-commit-hooks.nix/commit/e468d8c5d419aa57d32d77aaffa7841e52a2b495) | `` Refactoring ``                               |
| [`e646271a`](https://github.com/cachix/pre-commit-hooks.nix/commit/e646271a37309fd1eec6b603a5fe576b665e14fa) | `` Use enum for verbosity for alejandra hook `` |
| [`44117e5d`](https://github.com/cachix/pre-commit-hooks.nix/commit/44117e5da1cf03fa2d2bbd67d96465380881e1e6) | `` Add args to alejandra hook ``                |
| [`1b3798ab`](https://github.com/cachix/pre-commit-hooks.nix/commit/1b3798abea0b3bd59bb5dd08e31f4c0fb74ae572) | `` feat: upgrade PHP hooks to PHP 8.2 ``        |