### PR TITLE
chore(flake/emacs-overlay): `83f62558` -> `7b4ab613`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1695752759,
-        "narHash": "sha256-Z3/tYemtSgRiXERrGvSRpXBQUakVbYuwMVddbfLEgXI=",
+        "lastModified": 1695785595,
+        "narHash": "sha256-A1dbQO3kSZsDBHszNCAfZyDINJfARqlPrNDSmLGPP30=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "83f62558d3f1893b39f1d9ba4743e68ff686e175",
+        "rev": "7b4ab613acffae47fd39dc1977d282e5fbdcf147",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`7b4ab613`](https://github.com/nix-community/emacs-overlay/commit/7b4ab613acffae47fd39dc1977d282e5fbdcf147) | `` Updated repos/nongnu `` |
| [`1ed073b9`](https://github.com/nix-community/emacs-overlay/commit/1ed073b93b1683386f8b5570bb184ae4571acdf8) | `` Updated repos/melpa ``  |
| [`ae922112`](https://github.com/nix-community/emacs-overlay/commit/ae922112b4bc3b057f140c2034a058ebfdff790a) | `` Updated repos/emacs ``  |
| [`339d2749`](https://github.com/nix-community/emacs-overlay/commit/339d2749956728f28faea2802f017eb5adb2905d) | `` Updated repos/elpa ``   |
| [`bca27e2c`](https://github.com/nix-community/emacs-overlay/commit/bca27e2c4357d43f5341d7be6f948d812974b406) | `` Updated flake inputs `` |