### PR TITLE
chore(flake/emacs-overlay): `7b4ab613` -> `f69f384c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1695785595,
-        "narHash": "sha256-A1dbQO3kSZsDBHszNCAfZyDINJfARqlPrNDSmLGPP30=",
+        "lastModified": 1695810420,
+        "narHash": "sha256-oouDhmjYigGcpk+si8pkzFU87fYAXPEKVHw5QaJ7oCA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7b4ab613acffae47fd39dc1977d282e5fbdcf147",
+        "rev": "f69f384ca636e905e54d60ea59b0f47e6aa43a0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`f69f384c`](https://github.com/nix-community/emacs-overlay/commit/f69f384ca636e905e54d60ea59b0f47e6aa43a0c) | `` Updated repos/melpa `` |
| [`6327ed2e`](https://github.com/nix-community/emacs-overlay/commit/6327ed2edf881db9cd85a5a378d2c38b75fa76b2) | `` Updated repos/emacs `` |