### PR TITLE
chore(flake/emacs-overlay): `f69f384c` -> `7d102cbd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1695810420,
-        "narHash": "sha256-oouDhmjYigGcpk+si8pkzFU87fYAXPEKVHw5QaJ7oCA=",
+        "lastModified": 1695838568,
+        "narHash": "sha256-myeKKEfNzuEsD9OOA0yj+5YNq8pMkxhXoFzsoZ7j8WQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f69f384ca636e905e54d60ea59b0f47e6aa43a0c",
+        "rev": "7d102cbd9fb40fcfc4ee9145c0bff9c29f507c2f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`7d102cbd`](https://github.com/nix-community/emacs-overlay/commit/7d102cbd9fb40fcfc4ee9145c0bff9c29f507c2f) | `` Updated repos/melpa `` |
| [`5483c49a`](https://github.com/nix-community/emacs-overlay/commit/5483c49a377c93fe1f7cb675801dd5eb41659d2a) | `` Updated repos/emacs `` |
| [`e49d4559`](https://github.com/nix-community/emacs-overlay/commit/e49d4559d74ffebee805abaf095bd988d2edb280) | `` Updated repos/elpa ``  |