### PR TITLE
chore(flake/nixos-hardware): `61283b30` -> `adcfd6aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -540,11 +540,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1695541019,
-        "narHash": "sha256-rs++zfk41K9ArWkDAlmBDlGlKO8qeRIRzdjo+9SmNFI=",
+        "lastModified": 1695887975,
+        "narHash": "sha256-u3+5FR12dI305jCMb0fJNQx2qwoQ54lv1tPoEWp0hmg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "61283b30d11f27d5b76439d43f20d0c0c8ff5296",
+        "rev": "adcfd6aa860d1d129055039696bc457af7d50d0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`adcfd6aa`](https://github.com/NixOS/nixos-hardware/commit/adcfd6aa860d1d129055039696bc457af7d50d0e) | `` Thinkpad X1 11th Gen: init ``                        |
| [`89ec952f`](https://github.com/NixOS/nixos-hardware/commit/89ec952fd2a481461a86ad581fde2e730e5a951d) | `` chore: Add @emiller88 to CODEOWNERS for framework `` |