### PR TITLE
chore(flake/emacs-overlay): `65957eda` -> `7f45bea1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1695870399,
-        "narHash": "sha256-wGKeVw2cWFBPITdNKXuMdg1IaULORxpb5CCFtn1XShs=",
+        "lastModified": 1695896121,
+        "narHash": "sha256-kLxNtqWxQZWndMhhDJyrNZK1EWl+5ctR9BbcG8t+9dc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "65957eda7abfdf4d64accd7562fa84e272bb1829",
+        "rev": "7f45bea11d98f9f542bcdeadeeaa33472c1224e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`7f45bea1`](https://github.com/nix-community/emacs-overlay/commit/7f45bea11d98f9f542bcdeadeeaa33472c1224e2) | `` Updated repos/melpa `` |
| [`dd15f47a`](https://github.com/nix-community/emacs-overlay/commit/dd15f47adcd1b6c9c089cb4267dfefa9a153de97) | `` Updated repos/emacs `` |