### PR TITLE
chore(flake/emacs-overlay): `7f45bea1` -> `ef992bca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1695896121,
-        "narHash": "sha256-kLxNtqWxQZWndMhhDJyrNZK1EWl+5ctR9BbcG8t+9dc=",
+        "lastModified": 1695921859,
+        "narHash": "sha256-9QUM3d1TxCwCMhunV7VvtV4+BOe9vynlwks8TByhFfA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7f45bea11d98f9f542bcdeadeeaa33472c1224e2",
+        "rev": "ef992bca01ef97e8bbd1136693d24665390f39ce",
         "type": "github"
       },
       "original": {
@@ -602,11 +602,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1695559356,
-        "narHash": "sha256-kXZ1pUoImD9OEbPCwpTz4tHsNTr4CIyIfXb3ocuR8sI=",
+        "lastModified": 1695825837,
+        "narHash": "sha256-4Ne11kNRnQsmSJCRSSNkFRSnHC4Y5gPDBIQGjjPfJiU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "261abe8a44a7e8392598d038d2e01f7b33cf26d0",
+        "rev": "5cfafa12d57374f48bcc36fda3274ada276cf69e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ef992bca`](https://github.com/nix-community/emacs-overlay/commit/ef992bca01ef97e8bbd1136693d24665390f39ce) | `` Updated repos/melpa ``  |
| [`49c6c177`](https://github.com/nix-community/emacs-overlay/commit/49c6c1776f5868115cdf85f69cb83a6cd044eeb3) | `` Updated repos/elpa ``   |
| [`ecfd9381`](https://github.com/nix-community/emacs-overlay/commit/ecfd9381b0bbaa06bf992fd7951b1e1e12eac936) | `` Updated flake inputs `` |