### PR TITLE
chore(flake/nixpkgs): `6500b458` -> `8a86b98f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -665,11 +665,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1695644571,
-        "narHash": "sha256-asS9dCCdlt1lPq0DLwkVBbVoEKuEuz+Zi3DG7pR/RxA=",
+        "lastModified": 1695830400,
+        "narHash": "sha256-gToZXQVr0G/1WriO83olnqrLSHF2Jb8BPcmCt497ro0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6500b4580c2a1f3d0f980d32d285739d8e156d92",
+        "rev": "8a86b98f0ba1c405358f1b71ff8b5e1d317f5db2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`03fe55d3`](https://github.com/NixOS/nixpkgs/commit/03fe55d3540815409fce6b898528fc2c8e087cd2) | `` glasgow: fix on non-NixOS ``                                              |
| [`4d011cb1`](https://github.com/NixOS/nixpkgs/commit/4d011cb112133dfcb1bcc3a07a9768b5f60702bc) | `` glasgow: fix tests on darwin ``                                           |
| [`d2aef1a1`](https://github.com/NixOS/nixpkgs/commit/d2aef1a14553f41a12749070b8bbe082dbdf7bd1) | `` luaPackages: remove unused and wrong self reference ``                    |
| [`23e84231`](https://github.com/NixOS/nixpkgs/commit/23e8423184b0b22058b8a257538bde10e3cdade2) | `` self: drop package ``                                                     |
| [`8ac0795c`](https://github.com/NixOS/nixpkgs/commit/8ac0795c1f54546caf49c759063a34e2a1e232a8) | `` doc: fix wrong flag in description of `bindnow` ``                        |
| [`ce860f6a`](https://github.com/NixOS/nixpkgs/commit/ce860f6a1e0989d041556c45832b0b370a3d59a3) | `` ocamlPackages.merlin: 4.10 → 4.12 ``                                      |
| [`91ab8ed2`](https://github.com/NixOS/nixpkgs/commit/91ab8ed21d681fc9f23f2a85df20e0f5c81efad3) | `` ocamlPackages.merlin: Fix OCaml version shortening ``                     |
| [`52dce480`](https://github.com/NixOS/nixpkgs/commit/52dce4809ca6fcf21ad4757466a341f4891dd603) | `` heygpt: init at 0.4.0 (#257460) ``                                        |
| [`c564a122`](https://github.com/NixOS/nixpkgs/commit/c564a122a65edafd67aa75625e04198fda45664f) | `` oq: fix tests with jq-1.7 ``                                              |
| [`ec9c5e49`](https://github.com/NixOS/nixpkgs/commit/ec9c5e493d0249c9dfe4674c6628498e702848e4) | `` spotify: 1.2.11.916.geb595a67 -> 1.2.13.661.ga588f749 ``                  |
| [`0168e735`](https://github.com/NixOS/nixpkgs/commit/0168e735a91a68b12cb64809e385cfa659575e2c) | `` python311Packages.dissect-volume: disable failing tests ``                |
| [`cc27cd5f`](https://github.com/NixOS/nixpkgs/commit/cc27cd5fdf89fb57a99316ad4938a4014570d55f) | `` conserve: 23.5.0 -> 23.9.0 ``                                             |
| [`9a66522c`](https://github.com/NixOS/nixpkgs/commit/9a66522c819f46400376c8087c9343f7174fbd97) | `` python311Packages.pymyq: 3.1.6 -> 3.1.9 ``                                |
| [`e4203f22`](https://github.com/NixOS/nixpkgs/commit/e4203f2200b69b1d6dfd0e787513e8e0d47a813a) | `` python311Packages.async-upnp-client: 0.35.1 -> 0.36.1 ``                  |
| [`de0e90b2`](https://github.com/NixOS/nixpkgs/commit/de0e90b2e3d395e2a940a105c0ae850493c128b1) | `` python311Packages.zeroconf: 0.114.0 -> 0.115.0 ``                         |
| [`11f76629`](https://github.com/NixOS/nixpkgs/commit/11f7662912e124b4d884a4fc29d7c9ad394eca4d) | `` python311Packages.zeroconf: 0.113.0 -> 0.114.0 ``                         |
| [`db89ce7e`](https://github.com/NixOS/nixpkgs/commit/db89ce7e1e6e4145a7c7671e3d7986342de8a1e0) | `` python311Packages.zeroconf: 0.112.0 -> 0.113.0 ``                         |
| [`50143539`](https://github.com/NixOS/nixpkgs/commit/501435396be654409aa541ae8039d5d56921f27e) | `` yuzu: 1557 -> 1569, yuzu-ea: 3864 -> 3897 ``                              |
| [`1e8b8e6d`](https://github.com/NixOS/nixpkgs/commit/1e8b8e6d38be9bc0ec887e71e4ee8b0f50a4ddcd) | `` nixos/usbguard: don't use path literal for pure evaluation ``             |
| [`a7cdfa40`](https://github.com/NixOS/nixpkgs/commit/a7cdfa40e7eea4b86710908eea66f1313f190175) | `` wasm-tools: 1.0.42 -> 1.0.43 ``                                           |
| [`3bab155d`](https://github.com/NixOS/nixpkgs/commit/3bab155d848b693afa302ba98f99ca091c02fddf) | `` tor-browser-bundle-bin: 12.5.4 -> 12.5.5 ``                               |
| [`9f0e76b6`](https://github.com/NixOS/nixpkgs/commit/9f0e76b6f89a4d2807f47ad8b8f066efaf703f43) | `` python311Packages.dissect: 3.8.1 -> 3.9 ``                                |
| [`17cf006e`](https://github.com/NixOS/nixpkgs/commit/17cf006eeea67a863824e0394ac8103221d6c95e) | `` python311Packages.acquire: 3.8 -> 3.9 ``                                  |
| [`4207ee66`](https://github.com/NixOS/nixpkgs/commit/4207ee6638758dc2a27b7cfd48864a02953f0e53) | `` python311Packages.dissect-volume: 3.6 -> 3.7 ``                           |
| [`d35fb2b3`](https://github.com/NixOS/nixpkgs/commit/d35fb2b3ed54a3d5876a163322cec9dd14675ca9) | `` python311Packages.dissect-util: 3.10 -> 3.11 ``                           |
| [`61c18791`](https://github.com/NixOS/nixpkgs/commit/61c18791d19e0bac930b087dbf121a92868f9bf0) | `` python311Packages.dissect-target: 3.11.1 -> 3.12 ``                       |
| [`26efd90a`](https://github.com/NixOS/nixpkgs/commit/26efd90a01202262c9f7ae9b64cd1eead6139bb0) | `` python311Packages.dissect-hypervisor: 3.8 -> 3.9 ``                       |
| [`49b78965`](https://github.com/NixOS/nixpkgs/commit/49b7896528c8be1a4ebd2a5aba3521c93a2f3747) | `` python311Packages.dissect-evidence: 3.6 -> 3.7 ``                         |
| [`416962d1`](https://github.com/NixOS/nixpkgs/commit/416962d153498a974bac17d4f422802eaf62b79b) | `` python311Packages.dissect-esedb: 3.8 -> 3.9 ``                            |
| [`e1e1df53`](https://github.com/NixOS/nixpkgs/commit/e1e1df5365758a68f3c42c8d9205460385207ca1) | `` python311Packages.dissect-thumbcache: 1.5 -> 1.6 ``                       |
| [`0949501a`](https://github.com/NixOS/nixpkgs/commit/0949501aff16bbb68c679cd9e35752d4b4ae4177) | `` python311Packages.dissect-cstruct: 3.9 -> 3.10 ``                         |
| [`5d435189`](https://github.com/NixOS/nixpkgs/commit/5d435189dff533815d09ebd845da6552668a8a8f) | `` python311Packages.flow-record: 3.11 -> 3.12 ``                            |
| [`b6e1361a`](https://github.com/NixOS/nixpkgs/commit/b6e1361abd643b3a5d1a5c1efb1361a9c4979290) | `` python311Packages.mypy-boto3-s3: 1.28.52 -> 1.28.55 ``                    |
| [`4fc1f845`](https://github.com/NixOS/nixpkgs/commit/4fc1f8457b4fc4d5de45787f6de6bffc2c6e019c) | `` python311Packages.publicsuffixlist: 0.10.0.20230920 -> 0.10.0.20230927 `` |
| [`3b8abbec`](https://github.com/NixOS/nixpkgs/commit/3b8abbec44d208a0e974bb77e19db961b64d9cc0) | `` python311Packages.qcs-api-client: 0.21.6 -> 0.23.1 ``                     |
| [`66f561c0`](https://github.com/NixOS/nixpkgs/commit/66f561c0f28a2b6ffdd84c7d86634e4fe3964070) | `` zkg: 2.13.0 -> 2.14.0 ``                                                  |
| [`0f96276d`](https://github.com/NixOS/nixpkgs/commit/0f96276d781caa3ae8d9753018ae5bcea6f9a8d0) | `` ocamlPackages.higlo: 0.8 → 0.9 ``                                         |
| [`44c948f5`](https://github.com/NixOS/nixpkgs/commit/44c948f56a0cf23d3b76f29e844a614abd2a402c) | `` python311Packages.netio: 1.0.10 -> 1.0.13 ``                              |
| [`d6cfdcec`](https://github.com/NixOS/nixpkgs/commit/d6cfdcec45b1aee392700c6b7c8574ac690fc54f) | `` qovery-cli: 0.70.1 -> 0.72.0 ``                                           |
| [`e167e63e`](https://github.com/NixOS/nixpkgs/commit/e167e63e6faf1f3929ecd06c3ecb6d4c42c73657) | `` tgpt: 1.8.0 -> 1.9.0 ``                                                   |
| [`1ae673cd`](https://github.com/NixOS/nixpkgs/commit/1ae673cd438f0534f191cf1758aabad80c55b248) | `` python311Packages.types-requests: 2.31.0.4 -> 2.31.0.6 ``                 |
| [`7a719805`](https://github.com/NixOS/nixpkgs/commit/7a719805bbd1b8c35ddd8e6b66758989b6b45b7c) | `` python311Packages.syncedlyrics: 0.6.0 -> 0.6.1 ``                         |
| [`fb268fd3`](https://github.com/NixOS/nixpkgs/commit/fb268fd3cee0ab326b73f19a87e1670c9a07f74f) | `` python311Packages.ttls: 1.8.0 -> 1.8.1 ``                                 |
| [`82da7f46`](https://github.com/NixOS/nixpkgs/commit/82da7f46eb9226de57322d7be899435c9d82bdd7) | `` python311Packages.zha-quirks: 0.0.103 -> 0.0.104 ``                       |
| [`66edd2c5`](https://github.com/NixOS/nixpkgs/commit/66edd2c5904b32d59b9b54ae6f71167070607155) | `` python311Packages.levenshtein: 0.21.1 -> 0.22.0 ``                        |
| [`845a8acb`](https://github.com/NixOS/nixpkgs/commit/845a8acbff64edefadecda40a67f61268a168657) | `` python311Packages.pynobo: 1.6.1 -> 1.7.0 ``                               |
| [`4dcfb005`](https://github.com/NixOS/nixpkgs/commit/4dcfb005b4e94e5f6a769592874bb83e7189a947) | `` python311Packages.pyrisco: 0.5.7 -> 0.5.8 ``                              |
| [`733b52c6`](https://github.com/NixOS/nixpkgs/commit/733b52c63c6b7050e94016d218e29697019907a4) | `` mullvad-browser: 12.5.4 -> 12.5.5 ``                                      |
| [`dd4dd9b2`](https://github.com/NixOS/nixpkgs/commit/dd4dd9b223f2d994effc3ed26e64fc223386c7e7) | `` python311Packages.aiosmb: 0.4.6 -> 0.4.7 ``                               |
| [`1e7d2cec`](https://github.com/NixOS/nixpkgs/commit/1e7d2cecef3a9418ab3a6562531b2abdd8cfb97b) | `` python311Packages.pyduotecno: 2023.8.4 -> 2023.9.0 ``                     |
| [`5b9bb655`](https://github.com/NixOS/nixpkgs/commit/5b9bb6553f9b9c7b9d2d56dfdaeb18a0117f4dfd) | `` python311Packages.pygitguardian: 1.10.0 -> 1.10.0 ``                      |
| [`8720fd01`](https://github.com/NixOS/nixpkgs/commit/8720fd01333220331f3fd3081b7506a53dff6e96) | `` python311Packages.pydrawise: 2023.8.0 -> 2023.9.2 ``                      |
| [`071cdce1`](https://github.com/NixOS/nixpkgs/commit/071cdce139ee3d9a274fcff4fc67a992c9c6aff1) | `` python311Packages.meshtastic: 2.2.6 -> 2.2.7 ``                           |
| [`d03f8ecb`](https://github.com/NixOS/nixpkgs/commit/d03f8ecbb93660ca7d18d4b94ed353dc5be26d22) | `` python311Packages.meilisearch: 0.28.2 -> 0.28.4 ``                        |
| [`ae34de28`](https://github.com/NixOS/nixpkgs/commit/ae34de283a14ff76c852f5a295ab0716da7ffdb7) | `` python311Packages.dvclive: 3.0.0 -> 3.0.1 ``                              |
| [`6974f3d0`](https://github.com/NixOS/nixpkgs/commit/6974f3d0346c5188aafd3196d3417fbf4d85e9be) | `` python311Packages.dvc-data: 2.16.3 -> 2.16.4 ``                           |
| [`1701501f`](https://github.com/NixOS/nixpkgs/commit/1701501f480389fb58936c47a0f1e842ded89c66) | `` python311Packages.asyauth: 0.0.15 -> 0.0.16 ``                            |
| [`e248ad91`](https://github.com/NixOS/nixpkgs/commit/e248ad9190c10df7e1423822db53cfb0d54cc1ce) | `` python311Packages.aiohomekit: 3.0.4 -> 3.0.5 ``                           |
| [`10e101aa`](https://github.com/NixOS/nixpkgs/commit/10e101aacfed6c12f20c2dc428854ff2081dfa22) | `` python311Packages.certipy-ad: 4.8.1 -> 4.8.2 ``                           |
| [`d10be2a0`](https://github.com/NixOS/nixpkgs/commit/d10be2a00b4f01b871d33712745b9c259e91399e) | `` python311Packages.dvc: 3.22.1 -> 3.23.0 ``                                |
| [`034c58f8`](https://github.com/NixOS/nixpkgs/commit/034c58f8e271dd119549160dfa4177d002282edd) | `` python311Packages.dvc: 3.22.0 -> 3.22.1 ``                                |
| [`514b21be`](https://github.com/NixOS/nixpkgs/commit/514b21be0a56818931b311e7f3409f121665bfc9) | `` python311Packages.boschshcpy: 0.2.67 -> 0.2.68 ``                         |
| [`0123e7c5`](https://github.com/NixOS/nixpkgs/commit/0123e7c5df4cde1317fb8e3c2d26e37c0464ed2f) | `` python311Packages.cle: update binaries for testing ``                     |
| [`0d236eea`](https://github.com/NixOS/nixpkgs/commit/0d236eea6687e259a9b2825e20a3e41cf5f64a32) | `` python311Packages.aiovodafone: 0.2.1 -> 0.3.1 ``                          |
| [`fe259a4a`](https://github.com/NixOS/nixpkgs/commit/fe259a4af1627b7e5a5d72cd1d715234b3e999e5) | `` python311Packages.aioairzone-cloud: 0.2.1 -> 0.2.2 ``                     |
| [`3a10f058`](https://github.com/NixOS/nixpkgs/commit/3a10f058b59ce3219fa016e23424da43fd28f944) | `` python311Packages.aioesphomeapi: 16.0.6 -> 17.0.0 ``                      |
| [`9d57599d`](https://github.com/NixOS/nixpkgs/commit/9d57599d7d1a439d6920ee9e785a542483a29b81) | `` unrar: 6.2.5 -> 6.2.11 ``                                                 |
| [`93e4b8d1`](https://github.com/NixOS/nixpkgs/commit/93e4b8d1f62139f95e40fcb7f0b1c0c9536ce1fa) | `` python311Packages.botocore-stubs: 1.31.53 -> 1.31.55 ``                   |
| [`8f0c9e79`](https://github.com/NixOS/nixpkgs/commit/8f0c9e79b899f979c141d388d9b15361d026f3a8) | `` python311Packages.angr: 9.2.69 -> 9.2.70 ``                               |
| [`afa9af3e`](https://github.com/NixOS/nixpkgs/commit/afa9af3e38de17d371a2f4a0b2da571453cb6a8e) | `` python311Packages.cle: 9.2.69 -> 9.2.70 ``                                |
| [`9372a980`](https://github.com/NixOS/nixpkgs/commit/9372a980dbfd26f68817d5d68ecba32d44c36c69) | `` python311Packages.claripy: 9.2.69 -> 9.2.70 ``                            |
| [`c9dca019`](https://github.com/NixOS/nixpkgs/commit/c9dca01943b616fee0c6635d86d8a236ea7a2fcb) | `` python311Packages.pyvex: 9.2.69 -> 9.2.70 ``                              |
| [`c9deb1f1`](https://github.com/NixOS/nixpkgs/commit/c9deb1f1d2627c0610722e0752c154c8e44d69f9) | `` python311Packages.ailment: 9.2.69 -> 9.2.70 ``                            |
| [`401cd928`](https://github.com/NixOS/nixpkgs/commit/401cd928776cb66b8cbf49db1a9f96e6be2ccf36) | `` python311Packages.archinfo: 9.2.69 -> 9.2.70 ``                           |
| [`4d3a8e21`](https://github.com/NixOS/nixpkgs/commit/4d3a8e215ab9aa10e35f3ab0b5bfce6c6ccd0b1b) | `` ocamlPackages.parany: 13.0.1 -> 14.0.0 ``                                 |
| [`f58ac83d`](https://github.com/NixOS/nixpkgs/commit/f58ac83d631aca1156e9b308a20eb2d68f455ecb) | `` ldeep: 1.0.34 -> 1.0.35 ``                                                |
| [`a951eadf`](https://github.com/NixOS/nixpkgs/commit/a951eadf051a3bcc834903b3023946aaed2a59e2) | `` ggshield: 1.18.0 -> 1.19.1 ``                                             |
| [`8102b9c1`](https://github.com/NixOS/nixpkgs/commit/8102b9c12978c30748008b620c0640b19b85a178) | `` checkov: 2.4.48 -> 2.4.50 ``                                              |
| [`29c7d51c`](https://github.com/NixOS/nixpkgs/commit/29c7d51c458947202f9052a0cbc8e81516ad4cb8) | `` python310Packages.dataclasses-json: 0.6.0 -> 0.6.1 ``                     |
| [`be3058c2`](https://github.com/NixOS/nixpkgs/commit/be3058c27cffcdc236cfb701fa0ab7bd21225fcc) | `` dbeaver: Fix webbrowser support for spatial data ``                       |
| [`18e14d75`](https://github.com/NixOS/nixpkgs/commit/18e14d7534349b71e404d2d76cfb287688039bae) | `` nextcloud-client: enable fortify hardening ``                             |
| [`ab4c206c`](https://github.com/NixOS/nixpkgs/commit/ab4c206cfbacccfa6fd412f49f97b33d3eab7dc6) | `` rocketchat-desktop: 3.9.7 -> 3.9.8 ``                                     |
| [`8fc138bb`](https://github.com/NixOS/nixpkgs/commit/8fc138bbdb237def7fdfe5e480306409790aacb4) | `` qq: 3.1.2-13107 -> 3.2.1-17153 ``                                         |
| [`bbf12a91`](https://github.com/NixOS/nixpkgs/commit/bbf12a916929e8b361a159f44a1e31d59b6c2d2a) | `` matrix-hookshot: 4.4.1 -> 4.5.1 ``                                        |
| [`631f5829`](https://github.com/NixOS/nixpkgs/commit/631f5829f689f9203bbd061577f3785f83fcef4d) | `` python310Packages.limnoria: 2023.8.10 -> 2023.9.24 ``                     |
| [`2bcbd250`](https://github.com/NixOS/nixpkgs/commit/2bcbd2505e5a69f8f41caab75744eb9643419367) | `` python310Packages.msldap: 0.5.5 -> 0.5.6 ``                               |
| [`0c101e7a`](https://github.com/NixOS/nixpkgs/commit/0c101e7a04f04ee97aa273f59a67284322d6f535) | `` blender: Add pkg test for rendering (#245613) ``                          |
| [`f9584c98`](https://github.com/NixOS/nixpkgs/commit/f9584c98d621bd33da50d67f912606080fc3ab27) | `` yq-go: 4.35.1 -> 4.35.2 (#257418) ``                                      |
| [`575b4a2c`](https://github.com/NixOS/nixpkgs/commit/575b4a2c3fc2d282cb515fca692df14547087d4a) | `` python310Packages.casbin: 1.28.0 -> 1.31.0 ``                             |
| [`5681b77d`](https://github.com/NixOS/nixpkgs/commit/5681b77ddef714aacd3ea2ac81845f9aa4db6991) | `` python310Packages.hist: 2.7.1 -> 2.7.2 (#257544) ``                       |
| [`be2b474c`](https://github.com/NixOS/nixpkgs/commit/be2b474c001f6ac3a5ccf2d48b0b3f583f6b6db0) | `` nixos/tlp fix NetworkManager RDW dispatcher script location ``            |
| [`fb1176c0`](https://github.com/NixOS/nixpkgs/commit/fb1176c04f030c7e8f19ef789f969805aaab2e54) | `` eksctl: 0.157.0 -> 0.158.0 ``                                             |
| [`e6f70986`](https://github.com/NixOS/nixpkgs/commit/e6f709868d46a91b54e4a2fc8ba9385c5d83121d) | `` hiraeth: 1.0.1 -> 1.1.1 ``                                                |
| [`c5130315`](https://github.com/NixOS/nixpkgs/commit/c513031504f0b91e50f4701a2de8c0c50993650d) | `` clash-geoip: 20230812 -> 20230912 ``                                      |
| [`27b728ac`](https://github.com/NixOS/nixpkgs/commit/27b728aca907cfcbac7458fa7b0932975a6548f4) | `` bilibili: 1.12.0-1 -> 1.12.0-2 ``                                         |
| [`14f76a96`](https://github.com/NixOS/nixpkgs/commit/14f76a96e8c25caa9f1cd278f4799e4ad37e2bb4) | `` fetch-yarn-deps: warn on undefined expected hash ``                       |
| [`3ffce56f`](https://github.com/NixOS/nixpkgs/commit/3ffce56f46a454bf912a6b7043063f734eef8c21) | `` mastodon: generate and read yarn hash from dependencies dir ``            |
| [`0905c403`](https://github.com/NixOS/nixpkgs/commit/0905c403d8d8ecf5e2f339a8b32a68819226f967) | `` bolt: 0.9.5 → 0.9.6 ``                                                    |
| [`a2f529ef`](https://github.com/NixOS/nixpkgs/commit/a2f529ef3101b7d9e65dbf68d008eea9adc2343b) | `` freerdpUnstable: 2.11.1 -> 2.11.2 ``                                      |
| [`47ccff87`](https://github.com/NixOS/nixpkgs/commit/47ccff8746ca54551bd5be41174f58ec595098f9) | `` simdjson: 3.2.3 -> 3.3.0 ``                                               |
| [`961c446d`](https://github.com/NixOS/nixpkgs/commit/961c446d786dbbb6c6e031d8589a9ebbee7880d4) | `` panotools: 2.9.21 -> 2.9.22 ``                                            |
| [`89d3b709`](https://github.com/NixOS/nixpkgs/commit/89d3b709481825fd10a1d5c893934ac9d922ecaf) | `` saml2aws: 2.36.10 -> 2.36.11 ``                                           |
| [`dbaa3656`](https://github.com/NixOS/nixpkgs/commit/dbaa365633dc13ee805930c124d3f8ae9d9da471) | `` guile-gnutls: 3.7.12 -> 4.0.0 ``                                          |
| [`dd7e31dd`](https://github.com/NixOS/nixpkgs/commit/dd7e31dd84bdf7297e5b4a71fe829f9adaedeece) | `` soju: install sojuctl manpage ``                                          |
| [`1b2d72a5`](https://github.com/NixOS/nixpkgs/commit/1b2d72a552bbd56b48f5612dfe1e4f9f5e928cef) | `` soju: build all subPackages ``                                            |
| [`01cc0a60`](https://github.com/NixOS/nixpkgs/commit/01cc0a605a03e0d6ad0b3482c964a67c3fdff01d) | `` nixos/tuxedo-rs: init at 0.2.2 ``                                         |
| [`c9e2bc69`](https://github.com/NixOS/nixpkgs/commit/c9e2bc6920c01684b3fd4a7724716ba730bfa903) | `` tuxedo-rs: init at 0.2.2 ``                                               |
| [`95946586`](https://github.com/NixOS/nixpkgs/commit/95946586fbff9e5ac037170f42b5de2fa392c062) | `` maintainers: add mrcjkb ``                                                |
| [`ef0d6a72`](https://github.com/NixOS/nixpkgs/commit/ef0d6a7268a3252570e270d89335c2228161e329) | `` libpinyin: Enable strictDeps ``                                           |
| [`1d829295`](https://github.com/NixOS/nixpkgs/commit/1d829295dfcfe9962bb9acce79b08ce0a1cc84af) | `` fx: 30.1.1 -> 30.2.0 ``                                                   |
| [`ca37d341`](https://github.com/NixOS/nixpkgs/commit/ca37d3417ea7bb95c48100e9ed038900bd4cdf37) | `` glow: install shell completions (#257282) ``                              |
| [`ba07d338`](https://github.com/NixOS/nixpkgs/commit/ba07d3384385e84f32e26f30975a25a2bdb03adf) | `` cargo-bump: init at 1.1.1 (#257410) ``                                    |
| [`e40e7b32`](https://github.com/NixOS/nixpkgs/commit/e40e7b32440aa2ff7f141ae061c2ab0127c234e5) | `` wpg: 6.5.7 -> 6.5.9 (#257249) ``                                          |
| [`a5d66a9f`](https://github.com/NixOS/nixpkgs/commit/a5d66a9fab1074ad16edeabe8b275f48d3be842c) | `` mecab: add support for the UTF-8 charset ``                               |
| [`3042d624`](https://github.com/NixOS/nixpkgs/commit/3042d6245baa46a8cc5d51a417613050cacb21d0) | `` mecab: refactor ``                                                        |
| [`ea3cfdb0`](https://github.com/NixOS/nixpkgs/commit/ea3cfdb020cfaa925c1d4c1b80fa3f57da7fbd21) | `` snac2: fix build on x86_64-darwin ``                                      |
| [`70a77051`](https://github.com/NixOS/nixpkgs/commit/70a770512cae136d93b92fe538709e26cd16c8db) | `` subgit: 3.3.16 -> 3.3.17 ``                                               |
| [`d40fb881`](https://github.com/NixOS/nixpkgs/commit/d40fb8811a56bab650ee266c6c6e956857a928c7) | `` caprine: remove redundant mainProgram specification ``                    |
| [`15db659f`](https://github.com/NixOS/nixpkgs/commit/15db659f35b09b01eb3522ab7dbe8f7812355322) | `` cargo-modules: 0.9.2 -> 0.9.3 ``                                          |
| [`d1d89daa`](https://github.com/NixOS/nixpkgs/commit/d1d89daacb606c20984c161e409e3217a9163891) | `` standardnotes: 3.167.2 -> 3.173.4 ``                                      |
| [`f501e8a9`](https://github.com/NixOS/nixpkgs/commit/f501e8a9b3bbba1f424ee94696cfa10fbd997f17) | `` rust-script: 0.31.0 -> 0.32.0 ``                                          |
| [`25be61c6`](https://github.com/NixOS/nixpkgs/commit/25be61c66ea9b55d1b6da87f9a0a08175d0d7692) | `` kubernetes-helmPlugins.helm-secrets: 4.4.2 -> 4.5.0 ``                    |
| [`87a11361`](https://github.com/NixOS/nixpkgs/commit/87a1136163150626113336096eb5f327926213bb) | `` nixos-generators: 1.7.0 -> 1.8.0 ``                                       |
| [`3a5fe598`](https://github.com/NixOS/nixpkgs/commit/3a5fe598a5769004c3186211560fe7169459f912) | `` gql: 0.7.0 -> 0.7.1 ``                                                    |
| [`415c6275`](https://github.com/NixOS/nixpkgs/commit/415c6275f3660e8799aa1ba4be5d22b7ce0853b7) | `` cargo-llvm-cov: 0.5.32 -> 0.5.33 ``                                       |
| [`0b644730`](https://github.com/NixOS/nixpkgs/commit/0b644730e29514853000dff342fc0175e8e45928) | `` signalbackup-tools: 20230925 -> 20230926 ``                               |
| [`33f5fb16`](https://github.com/NixOS/nixpkgs/commit/33f5fb167ef14032badcf70481c63b825a654145) | `` matrix-synapse: 1.92.1 -> 1.93.0 ``                                       |
| [`d9bd2eb8`](https://github.com/NixOS/nixpkgs/commit/d9bd2eb8a5857e49e91e4d2e8d2e9d8933ba58df) | `` factorio-headless: 1.1.91 -> 1.1.92 ``                                    |
| [`903dcb60`](https://github.com/NixOS/nixpkgs/commit/903dcb60c25aff218ddfbe5142c38fe0064a06fd) | `` factorio-demo: 1.1.91 -> 1.1.92 ``                                        |
| [`240c29db`](https://github.com/NixOS/nixpkgs/commit/240c29db38f0bacb8faad50a1139c28a856a1985) | `` factorio-alpha: 1.1.91 -> 1.1.92 ``                                       |
| [`abf588aa`](https://github.com/NixOS/nixpkgs/commit/abf588aa6cf6bf55355eed36b83df39b8a2b5c6d) | `` talosctl: 1.5.2 -> 1.5.3 ``                                               |
| [`f3a0b6fd`](https://github.com/NixOS/nixpkgs/commit/f3a0b6fd70a796c901a0e4f8209356f52bda96be) | `` python310Packages.openai: 0.28.0 -> 0.28.1 ``                             |
| [`22f949fd`](https://github.com/NixOS/nixpkgs/commit/22f949fd9826a1adc28d72bb08b183ed78fd11ad) | `` python310Packages.clarifai-grpc: 9.8.0 -> 9.8.4 ``                        |
| [`fa922e12`](https://github.com/NixOS/nixpkgs/commit/fa922e12d792a31696b49cebe328d38c83fe55a7) | `` snac2: 2.35 -> 2.41 ``                                                    |