### PR TITLE
chore(flake/lanzaboote): `7f92dd1e` -> `644dc8a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -458,11 +458,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1694697985,
-        "narHash": "sha256-tAa0pyDOazvMfEjDhajcyLadu5a3euSMzzwia37J8x8=",
+        "lastModified": 1695948072,
+        "narHash": "sha256-wj//4FXRCzHrZKFUAS/iyFjryXUmNBlTjhFj3jDIa+I=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "7f92dd1e7b0ff92c65856cd9015f651c151f0229",
+        "rev": "644dc8a26978a3804e8a7b03ae16b954cbd646c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                                                |
| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`7951cbc6`](https://github.com/nix-community/lanzaboote/commit/7951cbc66893e6ebf1d49a1fa048710240c0141c) | `` flake: bump to get systemd v254 ``                                                  |
| [`976faf9b`](https://github.com/nix-community/lanzaboote/commit/976faf9bf56a46a51d92777b04c0d3f9fc078074) | `` flake: use proper uefi target in general ``                                         |
| [`0b5ce324`](https://github.com/nix-community/lanzaboote/commit/0b5ce324d7fb9ace6e1bab20f2eaf513585b2aea) | `` tool: clean up a few minor details ``                                               |
| [`3bf55f92`](https://github.com/nix-community/lanzaboote/commit/3bf55f92b871bae05a1832542c724314c1ef1ff0) | `` test: clean up a few minor details ``                                               |
| [`f81c30d7`](https://github.com/nix-community/lanzaboote/commit/f81c30d7d957e901994acc54241db8a6e51ab5ed) | `` module: use kernel package hostPlatform if nixpkgs.hostPlatform is not available `` |
| [`13302920`](https://github.com/nix-community/lanzaboote/commit/1330292008775aff4155b3825cf69be167718271) | `` tool/systemd: make clippy happy I guess ``                                          |
| [`0107754d`](https://github.com/nix-community/lanzaboote/commit/0107754d62dd5b5738c2f648cd1a9815ae813677) | `` tool(architecture): make it generic ``                                              |
| [`609c11f2`](https://github.com/nix-community/lanzaboote/commit/609c11f26d7e035abcd66f3691171151b1b41a0e) | `` tool(systemd-boot): install it once instead of checking for each generation ``      |
| [`e5c1d74e`](https://github.com/nix-community/lanzaboote/commit/e5c1d74e3fe5a6d3ec7544ebff59c2eebe029b1c) | `` tool: introduce --target-system to choose target architecture ``                    |
| [`acc4c2e0`](https://github.com/nix-community/lanzaboote/commit/acc4c2e0a1dde9bfa31594524775d81822e733f4) | `` tool(tests): use library to use the "target architecture" properly in tests ``      |
| [`7a6c9945`](https://github.com/nix-community/lanzaboote/commit/7a6c9945b86261c8e5e62a9d008d9bca8d93fb2d) | `` tool: introduce a library ``                                                        |
| [`9af0e565`](https://github.com/nix-community/lanzaboote/commit/9af0e56527b9db105e282d4c64d59b54c67711ff) | `` tool(esp): add systemd stub filenames mapping for systems ``                        |
| [`7acb1b21`](https://github.com/nix-community/lanzaboote/commit/7acb1b218a58c4dcec00f636f2f7a080d7b89d0a) | `` tool: implement general architecture support - for aarch64, x86 for now ``          |
| [`4521ae21`](https://github.com/nix-community/lanzaboote/commit/4521ae21fc37d00698f17560c23ad458e0f3b8ca) | `` platform: clean up flake.nix for aarch64 support ``                                 |
| [`18771d30`](https://github.com/nix-community/lanzaboote/commit/18771d30f4558811963eebc70f744e51e495768d) | `` lanzaboote: add aarch64-unknown-efi target ``                                       |