### PR TITLE
chore(flake/emacs-overlay): `ef992bca` -> `f32c6288`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1695921859,
-        "narHash": "sha256-9QUM3d1TxCwCMhunV7VvtV4+BOe9vynlwks8TByhFfA=",
+        "lastModified": 1695956969,
+        "narHash": "sha256-mSwhyEAq7c/4MgxCTKNg86YrrWkKAuJejVK2XEY5Sl4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ef992bca01ef97e8bbd1136693d24665390f39ce",
+        "rev": "f32c6288cc50298c04a86364e5947c28981c2f7d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`f32c6288`](https://github.com/nix-community/emacs-overlay/commit/f32c6288cc50298c04a86364e5947c28981c2f7d) | `` Updated repos/emacs ``  |
| [`e92c05be`](https://github.com/nix-community/emacs-overlay/commit/e92c05be6950bd466c9d469b20139b9664d20339) | `` Updated repos/elpa ``   |
| [`39fb8ab9`](https://github.com/nix-community/emacs-overlay/commit/39fb8ab905f7ea939596b81d9ab080d337735f6d) | `` Updated flake inputs `` |