### PR TITLE
chore(flake/emacs-overlay): `ec14828e` -> `a3807ae3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1695978843,
-        "narHash": "sha256-xeKBrbNT5dQK3ZkZWrji7/mqRJNf+Avbz93zR67t+XQ=",
+        "lastModified": 1696012364,
+        "narHash": "sha256-UvVsjzwYvsDmiXijFA6VPzhyI92KC7ALXtgOBuNuUSc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ec14828ed25f48db0c94f49d29ebe1a455a5a58c",
+        "rev": "a3807ae37389f6effb13e30cc12933cfdd325d80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`a3807ae3`](https://github.com/nix-community/emacs-overlay/commit/a3807ae37389f6effb13e30cc12933cfdd325d80) | `` Updated repos/melpa `` |
| [`9c4a1eb0`](https://github.com/nix-community/emacs-overlay/commit/9c4a1eb0f410dcb312b0f0bee3db246628a8cf48) | `` Updated repos/emacs `` |
| [`11b1dc12`](https://github.com/nix-community/emacs-overlay/commit/11b1dc12267a6d02ae74cd1cdfeeea41bc4a7d25) | `` Updated repos/elpa ``  |