### PR TITLE
chore(flake/lanzaboote): `644dc8a2` -> `8154cef1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -458,11 +458,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1695948072,
-        "narHash": "sha256-wj//4FXRCzHrZKFUAS/iyFjryXUmNBlTjhFj3jDIa+I=",
+        "lastModified": 1696021232,
+        "narHash": "sha256-YtbcN4I5S85XRdYFnORCJfbd5z6l8uVp8r3wI48vPs0=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "644dc8a26978a3804e8a7b03ae16b954cbd646c7",
+        "rev": "8154cef11cdde65a7a1f75319c95dfe038b2df46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                            |
| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`d5e6d91b`](https://github.com/nix-community/lanzaboote/commit/d5e6d91b4ff2f85e38940d2b0f2b6828410f8456) | `` Fix eval in flakes when aliases are disabled `` |
| [`a55db483`](https://github.com/nix-community/lanzaboote/commit/a55db483fba64daa7b3de573433af2d12ad924b4) | `` nix/modules/uki: fix ukify build ``             |