### PR TITLE
chore(flake/emacs-overlay): `a3807ae3` -> `db6c96d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696012364,
-        "narHash": "sha256-UvVsjzwYvsDmiXijFA6VPzhyI92KC7ALXtgOBuNuUSc=",
+        "lastModified": 1696043078,
+        "narHash": "sha256-0zPC5BR/6JyX6HponF9rQPhpQBDyMZMpGIBWOIvvX8E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a3807ae37389f6effb13e30cc12933cfdd325d80",
+        "rev": "db6c96d74eb0e60e7e344e81a56b33390e33474d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`db6c96d7`](https://github.com/nix-community/emacs-overlay/commit/db6c96d74eb0e60e7e344e81a56b33390e33474d) | `` Updated repos/nongnu `` |
| [`eb779447`](https://github.com/nix-community/emacs-overlay/commit/eb77944798e364a4030aa7eb6ee54023d42ebf1f) | `` Updated repos/melpa ``  |
| [`fde36a82`](https://github.com/nix-community/emacs-overlay/commit/fde36a82921c45a7ceb2b381c7df40f4a331bf6f) | `` Updated repos/emacs ``  |
| [`28901d49`](https://github.com/nix-community/emacs-overlay/commit/28901d491eff866b2dd60901061a11c8b087589c) | `` Updated repos/elpa ``   |