### PR TITLE
chore(flake/emacs-overlay): `db6c96d7` -> `e9fcd775`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696043078,
-        "narHash": "sha256-0zPC5BR/6JyX6HponF9rQPhpQBDyMZMpGIBWOIvvX8E=",
+        "lastModified": 1696069438,
+        "narHash": "sha256-PnYonOqe2gKcpR9WKcnFba2ChuEM0BKFwyVaNKcKV78=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "db6c96d74eb0e60e7e344e81a56b33390e33474d",
+        "rev": "e9fcd7753afabc19f5987d82759afe218d3bc70b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`e9fcd775`](https://github.com/nix-community/emacs-overlay/commit/e9fcd7753afabc19f5987d82759afe218d3bc70b) | `` Updated repos/nongnu `` |
| [`2987da8f`](https://github.com/nix-community/emacs-overlay/commit/2987da8f34f6f17ebfaf17ea1494498d2317f8f8) | `` Updated repos/melpa ``  |
| [`51291b4c`](https://github.com/nix-community/emacs-overlay/commit/51291b4c1d10902528ac26f05e61c3631ecb5800) | `` Updated repos/emacs ``  |