### PR TITLE
chore(flake/emacs-overlay): `e9fcd775` -> `a8239b33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696069438,
-        "narHash": "sha256-PnYonOqe2gKcpR9WKcnFba2ChuEM0BKFwyVaNKcKV78=",
+        "lastModified": 1696097650,
+        "narHash": "sha256-x18DxTOaox0DyoBWw3fBKDNho1fGj1PDI8Msk2TGW4k=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e9fcd7753afabc19f5987d82759afe218d3bc70b",
+        "rev": "a8239b33859352caabc400e051c649481f4a02b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`a8239b33`](https://github.com/nix-community/emacs-overlay/commit/a8239b33859352caabc400e051c649481f4a02b2) | `` Updated repos/melpa `` |
| [`45d7c2af`](https://github.com/nix-community/emacs-overlay/commit/45d7c2af760a90ca776210ba5b75f085ccea63f3) | `` Updated repos/emacs `` |
| [`7f325c66`](https://github.com/nix-community/emacs-overlay/commit/7f325c66ddf7b2297386238af3dbf556e8826075) | `` Updated repos/elpa ``  |