### PR TITLE
chore(flake/nix-index-database): `25d6369c` -> `686d4f15`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -501,11 +501,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695526222,
-        "narHash": "sha256-/NwZz3QcVplrfiDKk1thYg1EIHLSNucVHNUi2uwO3RI=",
+        "lastModified": 1696129041,
+        "narHash": "sha256-iRO8Foc848PJGeKOD/K/6ksfJOSa+htazcEXD5iIp0A=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "25d6369c232bbea1ec1f90226fd17982e7a0a647",
+        "rev": "686d4f15b4f01621da7ec4de123d530ebb3b23ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                  |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`686d4f15`](https://github.com/nix-community/nix-index-database/commit/686d4f15b4f01621da7ec4de123d530ebb3b23ac) | `` flake.lock: Update `` |