### PR TITLE
chore(flake/emacs-overlay): `a8239b33` -> `8153d977`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696097650,
-        "narHash": "sha256-x18DxTOaox0DyoBWw3fBKDNho1fGj1PDI8Msk2TGW4k=",
+        "lastModified": 1696129818,
+        "narHash": "sha256-xC3SZQ5/j0h3962NmCscT0UBJc+sh/+/Cfhvbc6WlWc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a8239b33859352caabc400e051c649481f4a02b2",
+        "rev": "8153d977806a632fe03acee3764cce5a8ed12cd8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`8153d977`](https://github.com/nix-community/emacs-overlay/commit/8153d977806a632fe03acee3764cce5a8ed12cd8) | `` Updated repos/nongnu `` |
| [`35cd314b`](https://github.com/nix-community/emacs-overlay/commit/35cd314b91697767a763df184ef4e94400a96b86) | `` Updated repos/melpa ``  |
| [`3da47d84`](https://github.com/nix-community/emacs-overlay/commit/3da47d846ea672a2e7a3c8a9e538618fdd19b9f7) | `` Updated repos/emacs ``  |
| [`59c639a9`](https://github.com/nix-community/emacs-overlay/commit/59c639a964b9cd9b00dca16cec0a5bb2ee26dcf7) | `` Updated repos/elpa ``   |