### PR TITLE
chore(flake/emacs-overlay): `8153d977` -> `5f14ec7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696129818,
-        "narHash": "sha256-xC3SZQ5/j0h3962NmCscT0UBJc+sh/+/Cfhvbc6WlWc=",
+        "lastModified": 1696155289,
+        "narHash": "sha256-zu3ezMdLQBOwx9Aq6ZBQWjoOVOEXG5fXMcQMOwuoTPY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8153d977806a632fe03acee3764cce5a8ed12cd8",
+        "rev": "5f14ec7a4977810a06f8eacb0169374fb4e282e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`5f14ec7a`](https://github.com/nix-community/emacs-overlay/commit/5f14ec7a4977810a06f8eacb0169374fb4e282e9) | `` Updated repos/melpa ``  |
| [`f2236bf5`](https://github.com/nix-community/emacs-overlay/commit/f2236bf572eee26ca93fe164eed298ad53d61126) | `` Updated repos/emacs ``  |
| [`b54ed5aa`](https://github.com/nix-community/emacs-overlay/commit/b54ed5aa66cc7c4635a7614c6328c25106e6c21b) | `` Updated flake inputs `` |