### PR TITLE
chore(flake/emacs-overlay): `5f14ec7a` -> `7b82fa15`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696155289,
-        "narHash": "sha256-zu3ezMdLQBOwx9Aq6ZBQWjoOVOEXG5fXMcQMOwuoTPY=",
+        "lastModified": 1696185805,
+        "narHash": "sha256-8TfxSDXyqlOsdgABawG28qJMJwvk6QMs516jfeuKsZs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5f14ec7a4977810a06f8eacb0169374fb4e282e9",
+        "rev": "7b82fa153cc9f8961e1f9b3ef28f2a1dd423706d",
         "type": "github"
       },
       "original": {
@@ -602,11 +602,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1695825837,
-        "narHash": "sha256-4Ne11kNRnQsmSJCRSSNkFRSnHC4Y5gPDBIQGjjPfJiU=",
+        "lastModified": 1696039360,
+        "narHash": "sha256-g7nIUV4uq1TOVeVIDEZLb005suTWCUjSY0zYOlSBsyE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5cfafa12d57374f48bcc36fda3274ada276cf69e",
+        "rev": "32dcb45f66c0487e92db8303a798ebc548cadedc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`7b82fa15`](https://github.com/nix-community/emacs-overlay/commit/7b82fa153cc9f8961e1f9b3ef28f2a1dd423706d) | `` Updated repos/melpa ``  |
| [`3d75bfc1`](https://github.com/nix-community/emacs-overlay/commit/3d75bfc1e3b4c392d4a3d27e2285b7aee128493d) | `` Updated repos/emacs ``  |
| [`ca517642`](https://github.com/nix-community/emacs-overlay/commit/ca5176423287022792ad6f6786c4ed398ad27126) | `` Updated repos/elpa ``   |
| [`0f5d0409`](https://github.com/nix-community/emacs-overlay/commit/0f5d040994de82f841b7439b833b7b4e72fc34a7) | `` Updated flake inputs `` |