### PR TITLE
chore(flake/emacs-overlay): `7b82fa15` -> `26f0a46f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696185805,
-        "narHash": "sha256-8TfxSDXyqlOsdgABawG28qJMJwvk6QMs516jfeuKsZs=",
+        "lastModified": 1696216013,
+        "narHash": "sha256-snbu70DDPZXk8mhzpwMD8I+hk5sgOKYqBvPckUY3U6Q=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7b82fa153cc9f8961e1f9b3ef28f2a1dd423706d",
+        "rev": "26f0a46fa1840073d942353c29ef634a4d5db146",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`26f0a46f`](https://github.com/nix-community/emacs-overlay/commit/26f0a46fa1840073d942353c29ef634a4d5db146) | `` Updated repos/melpa `` |
| [`fa9806ca`](https://github.com/nix-community/emacs-overlay/commit/fa9806caeeb75411ad9a1640d4c6b5b2698abca7) | `` Updated repos/emacs `` |
| [`02a8a841`](https://github.com/nix-community/emacs-overlay/commit/02a8a8417837a9198bd008ed6b5016c0c83452e3) | `` Updated repos/elpa ``  |