### PR TITLE
chore(flake/emacs-overlay): `26f0a46f` -> `c231089a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696216013,
-        "narHash": "sha256-snbu70DDPZXk8mhzpwMD8I+hk5sgOKYqBvPckUY3U6Q=",
+        "lastModified": 1696244446,
+        "narHash": "sha256-IAQEXDLlwrXaCSmt5bxuoqdhZiF8en/3NpiTrJt1bhE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "26f0a46fa1840073d942353c29ef634a4d5db146",
+        "rev": "c231089aff799637747034d067fc4459753aa717",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c231089a`](https://github.com/nix-community/emacs-overlay/commit/c231089aff799637747034d067fc4459753aa717) | `` Updated repos/nongnu `` |
| [`f7181b8a`](https://github.com/nix-community/emacs-overlay/commit/f7181b8a48e4087826dfc1eeea51521a638bbc8e) | `` Updated repos/melpa ``  |
| [`9f78ee90`](https://github.com/nix-community/emacs-overlay/commit/9f78ee906eb5034ed79c90d22dfd5680f27d7136) | `` Updated repos/emacs ``  |