### PR TITLE
chore(flake/flake-compat): `35bb57c0` -> `6256b599`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -266,11 +266,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696250921,
+        "narHash": "sha256-IRn6OkznMIUF4sjXQR9xKGC4ejEx3AUa+uqFn9RDTp4=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "6256b599c81a9ae3f9fc18f88ad4ab3d7cf2534f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                           |
| ------------------------------------------------------------------------------------------------------ | --------------------------------- |
| [`6256b599`](https://github.com/edolstra/flake-compat/commit/6256b599c81a9ae3f9fc18f88ad4ab3d7cf2534f) | `` Add description ``             |
| [`c30381e1`](https://github.com/edolstra/flake-compat/commit/c30381e188d2edb0a7bc866aa59d7ac1831f4b59) | `` Add flake.nix ``               |
| [`92556b85`](https://github.com/edolstra/flake-compat/commit/92556b853911f0ef60fd88d2e0fa4d67afbc8dba) | `` Add FlakeHub publish Action `` |
| [`bcb80df0`](https://github.com/edolstra/flake-compat/commit/bcb80df05106afa74c7149f74f3b8fabce052bac) | `` add support for sourcehut ``   |