### PR TITLE
chore(flake/emacs-overlay): `c231089a` -> `20703168`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696244446,
-        "narHash": "sha256-IAQEXDLlwrXaCSmt5bxuoqdhZiF8en/3NpiTrJt1bhE=",
+        "lastModified": 1696266493,
+        "narHash": "sha256-12LU0LNPKWdxlASlkRTJFgg3WWa2kq1TAcOELR4V1tU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c231089aff799637747034d067fc4459753aa717",
+        "rev": "20703168b6bcafacef5bf87962d81e00be7a4a15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`20703168`](https://github.com/nix-community/emacs-overlay/commit/20703168b6bcafacef5bf87962d81e00be7a4a15) | `` Updated repos/melpa `` |
| [`2e4925af`](https://github.com/nix-community/emacs-overlay/commit/2e4925af108af1e7d0903ed2d199341897a1ca6b) | `` Updated repos/elpa ``  |