### PR TITLE
chore(flake/emacs-overlay): `20703168` -> `205b18fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696266493,
-        "narHash": "sha256-12LU0LNPKWdxlASlkRTJFgg3WWa2kq1TAcOELR4V1tU=",
+        "lastModified": 1696301657,
+        "narHash": "sha256-MGBjt+CJbxrcDYK5TtYh4RXeUfi1V3qv5XnGcJzIk4A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "20703168b6bcafacef5bf87962d81e00be7a4a15",
+        "rev": "205b18fcd20edad37e79c8598f6a799b70a6d4a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`205b18fc`](https://github.com/nix-community/emacs-overlay/commit/205b18fcd20edad37e79c8598f6a799b70a6d4a3) | `` Updated repos/nongnu `` |
| [`9519fc6b`](https://github.com/nix-community/emacs-overlay/commit/9519fc6bbeed69a3f94e9989fe27feb9425ecadc) | `` Updated repos/melpa ``  |
| [`563b70a5`](https://github.com/nix-community/emacs-overlay/commit/563b70a53de0172fc239b8efe136909deff63b21) | `` Updated repos/emacs ``  |
| [`0dee9a72`](https://github.com/nix-community/emacs-overlay/commit/0dee9a72e827a826937a249ac1abf212e1d2d6d7) | `` Updated repos/elpa ``   |