### PR TITLE
chore(flake/sops-nix): `2f375ed8` -> `9de50ec9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -867,11 +867,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1695284550,
-        "narHash": "sha256-z9fz/wz9qo9XePEvdduf+sBNeoI9QG8NJKl5ssA8Xl4=",
+        "lastModified": 1696319273,
+        "narHash": "sha256-j26ojz7xSerGG6gz9cZrBX9ksbvG7XcFcgNWj+C6ENU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "2f375ed8702b0d8ee2430885059d5e7975e38f78",
+        "rev": "9de50ec9e52632dcdb047b02fd2b92bb7249da3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                          |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`9de50ec9`](https://github.com/Mic92/sops-nix/commit/9de50ec9e52632dcdb047b02fd2b92bb7249da3a) | `` README: keys group is not required anymore for a long time `` |
| [`f5ddf92f`](https://github.com/Mic92/sops-nix/commit/f5ddf92f75fb196626e873d3e5cad76264ccc8cf) | `` mergify: rebase prs ``                                        |
| [`e73ba207`](https://github.com/Mic92/sops-nix/commit/e73ba2078c3d169b29b3d5e677472d156bf82c39) | `` docs: fix recommendation comment ``                           |