### PR TITLE
chore(flake/sops-nix): `9de50ec9` -> `746c7fa1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -634,11 +634,11 @@
     },
     "nixpkgs-stable_4": {
       "locked": {
-        "lastModified": 1694908564,
-        "narHash": "sha256-ducA98AuWWJu5oUElIzN24Q22WlO8bOfixGzBgzYdVc=",
+        "lastModified": 1696123266,
+        "narHash": "sha256-S6MZEneQeE4M/E/C8SMnr7B7oBnjH/hbm96Kak5hAAI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "596611941a74be176b98aeba9328aa9d01b8b322",
+        "rev": "dbe90e63a36762f1fbde546e26a84af774a32455",
         "type": "github"
       },
       "original": {
@@ -867,11 +867,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1696319273,
-        "narHash": "sha256-j26ojz7xSerGG6gz9cZrBX9ksbvG7XcFcgNWj+C6ENU=",
+        "lastModified": 1696320910,
+        "narHash": "sha256-fbuEc6wylH+0VxG48lhPBK+SQJHfo2lusUwWHZNipIM=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "9de50ec9e52632dcdb047b02fd2b92bb7249da3a",
+        "rev": "746c7fa1a64c1671a4bf287737c27fdc7101c4c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                  |
| ----------------------------------------------------------------------------------------------- | ------------------------ |
| [`746c7fa1`](https://github.com/Mic92/sops-nix/commit/746c7fa1a64c1671a4bf287737c27fdc7101c4c2) | `` flake.lock: Update `` |