### PR TITLE
chore(flake/emacs-overlay): `205b18fc` -> `a202ec0d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696301657,
-        "narHash": "sha256-MGBjt+CJbxrcDYK5TtYh4RXeUfi1V3qv5XnGcJzIk4A=",
+        "lastModified": 1696328081,
+        "narHash": "sha256-bLByhTgLUi5VNwagMyHtG2+wJ7HDjf8rNjokDgN3wCw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "205b18fcd20edad37e79c8598f6a799b70a6d4a3",
+        "rev": "a202ec0db49962241a811481ba15ac7e98ebad04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`a202ec0d`](https://github.com/nix-community/emacs-overlay/commit/a202ec0db49962241a811481ba15ac7e98ebad04) | `` Updated repos/melpa `` |
| [`8c635c17`](https://github.com/nix-community/emacs-overlay/commit/8c635c17a58475fc040e5e667611a562b2d852aa) | `` Updated repos/emacs `` |