### PR TITLE
chore(flake/emacs-overlay): `a202ec0d` -> `d88c1d26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696328081,
-        "narHash": "sha256-bLByhTgLUi5VNwagMyHtG2+wJ7HDjf8rNjokDgN3wCw=",
+        "lastModified": 1696357822,
+        "narHash": "sha256-wAXP7mk5zJ2sIW9cH1Oxf/f1AY3jtAgLFwvQMvJ9o4s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a202ec0db49962241a811481ba15ac7e98ebad04",
+        "rev": "d88c1d26a6874ab9ef657753e170bbcee7506ce1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`d88c1d26`](https://github.com/nix-community/emacs-overlay/commit/d88c1d26a6874ab9ef657753e170bbcee7506ce1) | `` Updated repos/melpa `` |
| [`a46a8e95`](https://github.com/nix-community/emacs-overlay/commit/a46a8e95edc4bd84f37feff0cdb52e65fdcc12a7) | `` Updated repos/emacs `` |
| [`09babb5c`](https://github.com/nix-community/emacs-overlay/commit/09babb5c45cfbb1580319f1786f9288172dc1f57) | `` Updated repos/elpa ``  |