### PR TITLE
chore(flake/home-manager): `55ce64c3` -> `e63c30fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -411,11 +411,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696349083,
-        "narHash": "sha256-hs7GLezeY40EQpZSYYhfgcKhAogF3MBYKWZ1o+Bxrog=",
+        "lastModified": 1696371324,
+        "narHash": "sha256-0ycIheYRxzPOL9XBWiAm/af9cqRmsiy701OpjsRsKiw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "55ce64c3ca031eefb1adac85bb0025887ed7a221",
+        "rev": "e63c30fe9792b57dea1eab98be6871a0e42a33c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`e63c30fe`](https://github.com/nix-community/home-manager/commit/e63c30fe9792b57dea1eab98be6871a0e42a33c9) | `` home-manager: fix assignment to read-only variable `` |
| [`30d2dc8d`](https://github.com/nix-community/home-manager/commit/30d2dc8d689a9060290892164aa4000778e1b42b) | `` flake.lock: Update ``                                 |