### PR TITLE
chore(flake/emacs-overlay): `d88c1d26` -> `412726c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696357822,
-        "narHash": "sha256-wAXP7mk5zJ2sIW9cH1Oxf/f1AY3jtAgLFwvQMvJ9o4s=",
+        "lastModified": 1696389430,
+        "narHash": "sha256-jw9XA9UO6x1KPxrMvHKoSIElBQY+MWpsGNPgx0kcgV8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d88c1d26a6874ab9ef657753e170bbcee7506ce1",
+        "rev": "412726c6afe83d316116883d0e67411c7b92f2cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`412726c6`](https://github.com/nix-community/emacs-overlay/commit/412726c6afe83d316116883d0e67411c7b92f2cd) | `` Updated repos/nongnu `` |
| [`f2cbadb9`](https://github.com/nix-community/emacs-overlay/commit/f2cbadb9c68d0562f15961ee79e9152c4e4ede4f) | `` Updated repos/melpa ``  |
| [`7e50eac2`](https://github.com/nix-community/emacs-overlay/commit/7e50eac2420a044e5dd81c214c9ceaca332a75e7) | `` Updated repos/emacs ``  |
| [`61b9351c`](https://github.com/nix-community/emacs-overlay/commit/61b9351cbccfe5381124189d84a680047b45f5d0) | `` Updated repos/elpa ``   |
| [`ae7bf9cb`](https://github.com/nix-community/emacs-overlay/commit/ae7bf9cb51d89d4ebdadeedacb505ec2452957c9) | `` Updated flake inputs `` |