### PR TITLE
chore(flake/home-manager): `e63c30fe` -> `b0e0d826`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -411,11 +411,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696371324,
-        "narHash": "sha256-0ycIheYRxzPOL9XBWiAm/af9cqRmsiy701OpjsRsKiw=",
+        "lastModified": 1696399669,
+        "narHash": "sha256-n2D5+im/0xtHRPSZ4eMCyfUGHQoK5lsDvEV1bcBBbSE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e63c30fe9792b57dea1eab98be6871a0e42a33c9",
+        "rev": "b0e0d82696297964f231c37a38e3c64b22ae03e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------- |
| [`b0e0d826`](https://github.com/nix-community/home-manager/commit/b0e0d82696297964f231c37a38e3c64b22ae03e5) | `` zsh-abbr: add module `` |
| [`4e52d9b7`](https://github.com/nix-community/home-manager/commit/4e52d9b7f7ed92bd98f9eb53f61d838a3928c9cb) | `` flake.lock: Update ``   |