### PR TITLE
chore(flake/flake-compat): `4f910c98` -> `5a16547d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -266,11 +266,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1696267196,
-        "narHash": "sha256-AAQ/2sD+0D18bb8hKuEEVpHUYD1GmO2Uh/taFamn6XQ=",
+        "lastModified": 1696416586,
+        "narHash": "sha256-Dk1zfIAQeVBzBtI2LdkFJDj9Z4e3Xb6Fy0gTRy6uAIE=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "4f910c9827911b1ec2bf26b5a062cd09f8d89f85",
+        "rev": "5a16547d46553d7bdd1dfc2cf418f5f7d236f6ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                          |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
| [`5a16547d`](https://github.com/edolstra/flake-compat/commit/5a16547d46553d7bdd1dfc2cf418f5f7d236f6ad) | `` Prevent double copying and work around an apparent Nix bug `` |