### PR TITLE
chore(flake/flake-compat): `5a16547d` -> `0f9255e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -266,11 +266,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1696416586,
-        "narHash": "sha256-Dk1zfIAQeVBzBtI2LdkFJDj9Z4e3Xb6Fy0gTRy6uAIE=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "5a16547d46553d7bdd1dfc2cf418f5f7d236f6ad",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
| [`0f9255e0`](https://github.com/edolstra/flake-compat/commit/0f9255e01c2351cc7d116c072cb317785dd33b33) | `` Force root sources like "./." into the Nix store `` |