### PR TITLE
chore(flake/emacs-overlay): `61ba9eca` -> `d1a4d78b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696410469,
-        "narHash": "sha256-N8gQTrqQVW+d3bUcWKkfKPKvctMH3SzkzkFtysruPc4=",
+        "lastModified": 1696443528,
+        "narHash": "sha256-qDbSu5i3cQpE6u0JL+qZ6EUTlk4HwADZNPjfEaWtGiU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "61ba9eca21db0a7e8a6471d11f3f6f74b79a70ba",
+        "rev": "d1a4d78b072580fa4a627b667cec417aea995f15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`d1a4d78b`](https://github.com/nix-community/emacs-overlay/commit/d1a4d78b072580fa4a627b667cec417aea995f15) | `` Updated repos/melpa `` |
| [`75661d12`](https://github.com/nix-community/emacs-overlay/commit/75661d121061e9605faf797288c7607182c6b9f3) | `` Updated repos/emacs `` |
| [`58658cd3`](https://github.com/nix-community/emacs-overlay/commit/58658cd3561df53984a7059330744302bfa72d22) | `` Updated repos/elpa ``  |