### PR TITLE
chore(flake/nixos-hardware): `0ab3ee71` -> `89c6109a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -540,11 +540,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1696161939,
-        "narHash": "sha256-HI1DxS//s46/qv9dcW06TzXaBjxL2DVTQP8R1QsnHzM=",
+        "lastModified": 1696483774,
+        "narHash": "sha256-cnNCH1MCmla7TDXcm5tu8FpqElneFX3flXc2gY8r0ZA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "0ab3ee718e964fb42dc57ace6170f19cb0b66532",
+        "rev": "89c6109adceb6fabf2ccda62ddfc4aa4fa19f25b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                   |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`89c6109a`](https://github.com/NixOS/nixos-hardware/commit/89c6109adceb6fabf2ccda62ddfc4aa4fa19f25b) | `` star64: linux: 5.15.128 -> 5.15.131 `` |