### PR TITLE
chore(flake/emacs-overlay): `73c7af80` -> `5eba7d96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696474516,
-        "narHash": "sha256-Wlk3enen/Omu8R/2LeVYTfLIYPacyD2eqJv7k/eR6yg=",
+        "lastModified": 1696501026,
+        "narHash": "sha256-hC+GuCi3HfuOoubS7gMPr2xHCBN33N07QfkFFEbhr8M=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "73c7af80973a82e17a598076f098847e1f41e95c",
+        "rev": "5eba7d96a70b1aad7918b07a4f6563362a8255b7",
         "type": "github"
       },
       "original": {
@@ -602,11 +602,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1696323343,
-        "narHash": "sha256-u7WLUrh5eb+6SBYwtkaGL2ryHpLcHzmLml+a+VqKJWE=",
+        "lastModified": 1696374741,
+        "narHash": "sha256-gt8B3G0ryizT9HSB4cCO8QoxdbsHnrQH+/BdKxOwqF0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3b79cc4bcd9c09b5aa68ea1957c25e437dc6bc58",
+        "rev": "8a4c17493e5c39769f79117937c79e1c88de6729",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`5eba7d96`](https://github.com/nix-community/emacs-overlay/commit/5eba7d96a70b1aad7918b07a4f6563362a8255b7) | `` Updated repos/melpa ``  |
| [`1546b25d`](https://github.com/nix-community/emacs-overlay/commit/1546b25de198b62919855da6c6c4f0061abba5dc) | `` Updated repos/emacs ``  |
| [`7dc7aec2`](https://github.com/nix-community/emacs-overlay/commit/7dc7aec2339f0e4d200bcd13b309cc14ec59bd2b) | `` Updated flake inputs `` |