### PR TITLE
chore(flake/pre-commit-hooks): `033453f8` -> `b039621a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1696158581,
-        "narHash": "sha256-h0vY4E7Lx95lpYQbG2w4QH4yG5wCYOvPJzK93wVQbT0=",
+        "lastModified": 1696510682,
+        "narHash": "sha256-Nki3ersvzmy9iQBkUI0yIRBHg6cQEHCT0oCd5BQMibg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "033453f85064ccac434dfd957f95d8457901ecd6",
+        "rev": "b039621ad7536841c8da7b12f59af588360f7725",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                          |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------- |
| [`1875015c`](https://github.com/cachix/pre-commit-hooks.nix/commit/1875015c254430daf78d24522f19bc957665b6ed) | `` Fix broken import (eclint) `` |
| [`13cee779`](https://github.com/cachix/pre-commit-hooks.nix/commit/13cee7793781f3137067c77b00aac7c9595fe7c5) | `` hooks: add psalm ``           |
| [`108539f9`](https://github.com/cachix/pre-commit-hooks.nix/commit/108539f9d8d3bde669bf1f8f5ad4f2c0aaab4ed1) | `` hooks: add phpstan ``         |