### PR TITLE
chore(flake/emacs-overlay): `5eba7d96` -> `804c3f5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696501026,
-        "narHash": "sha256-hC+GuCi3HfuOoubS7gMPr2xHCBN33N07QfkFFEbhr8M=",
+        "lastModified": 1696529826,
+        "narHash": "sha256-H8qj+C6vbn629zxLkj5sOCDhTbqsyrcrDd78tjvgqMY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5eba7d96a70b1aad7918b07a4f6563362a8255b7",
+        "rev": "804c3f5ecc955fd7fa2e70be2f2937b5a2c05f26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`804c3f5e`](https://github.com/nix-community/emacs-overlay/commit/804c3f5ecc955fd7fa2e70be2f2937b5a2c05f26) | `` Updated repos/melpa `` |
| [`06671e10`](https://github.com/nix-community/emacs-overlay/commit/06671e1036d2e51cc0a2a7de43affef851246439) | `` Updated repos/emacs `` |
| [`16d6c700`](https://github.com/nix-community/emacs-overlay/commit/16d6c70044fc735d863f2181e0e63a7f1fac5db1) | `` Updated repos/elpa ``  |