### PR TITLE
chore(flake/emacs-overlay): `804c3f5e` -> `bff45ef9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696529826,
-        "narHash": "sha256-H8qj+C6vbn629zxLkj5sOCDhTbqsyrcrDd78tjvgqMY=",
+        "lastModified": 1696561446,
+        "narHash": "sha256-NLemrT9Cu5ve3Fd5raE2VuZATMMveRPWBHI06Cl5SbA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "804c3f5ecc955fd7fa2e70be2f2937b5a2c05f26",
+        "rev": "bff45ef9a6e5bb1e8c5cb08ecf4bc9f8823be7c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`bff45ef9`](https://github.com/nix-community/emacs-overlay/commit/bff45ef9a6e5bb1e8c5cb08ecf4bc9f8823be7c7) | `` Updated repos/nongnu `` |
| [`d800f754`](https://github.com/nix-community/emacs-overlay/commit/d800f754cd0717a45052f9feef10b7357f5b0a14) | `` Updated repos/melpa ``  |
| [`21521dc7`](https://github.com/nix-community/emacs-overlay/commit/21521dc7d053e232dd6efd2d219a4225241a500a) | `` Updated repos/emacs ``  |
| [`2a7fb653`](https://github.com/nix-community/emacs-overlay/commit/2a7fb653cc84efc62bfd460709fcf6c1ab8752f9) | `` Updated repos/elpa ``   |