### PR TITLE
chore(flake/emacs-overlay): `bff45ef9` -> `2308be43`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696561446,
-        "narHash": "sha256-NLemrT9Cu5ve3Fd5raE2VuZATMMveRPWBHI06Cl5SbA=",
+        "lastModified": 1696584115,
+        "narHash": "sha256-/fjFLHgXZ0WCxoAaSCT8H3AZ3MwA+D1fuHmuWrbtwGk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bff45ef9a6e5bb1e8c5cb08ecf4bc9f8823be7c7",
+        "rev": "2308be4351ab8a152248a48baebf22649c83a487",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`2308be43`](https://github.com/nix-community/emacs-overlay/commit/2308be4351ab8a152248a48baebf22649c83a487) | `` Updated repos/nongnu `` |
| [`d281e212`](https://github.com/nix-community/emacs-overlay/commit/d281e212b96ccacf6d768b14f21ac392f55d36ef) | `` Updated repos/melpa ``  |
| [`b3bcc646`](https://github.com/nix-community/emacs-overlay/commit/b3bcc6462565999f840a3eed7db528d768ba55c4) | `` Updated repos/emacs ``  |