### PR TITLE
chore(flake/nixos-hardware): `6d05cccc` -> `b31be8f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -540,11 +540,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1696488240,
-        "narHash": "sha256-m9H4XDHaO7fGXLWTgNFrKFbBbMvrJpB7Sj6BcTM/2UE=",
+        "lastModified": 1696592614,
+        "narHash": "sha256-2gnRtjflKQ9G3X039bk/resUwf/c1GM4sojcQzP/tgA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "6d05cccc80feaf93d5f3d6837f8c2db582b29cf8",
+        "rev": "b31be8f11493e0f79a840370fd17153cd60b9009",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`b31be8f1`](https://github.com/NixOS/nixos-hardware/commit/b31be8f11493e0f79a840370fd17153cd60b9009) | `` edit readme ``                                 |
| [`d79fe3a2`](https://github.com/NixOS/nixos-hardware/commit/d79fe3a25c2bf264ac37ef84fbf03a8d0641fca4) | `` add to flake ``                                |
| [`2eb2fc28`](https://github.com/NixOS/nixos-hardware/commit/2eb2fc2889fdc28b233330e775f833d43a2425d5) | `` init: omen/15-en1007sa ``                      |
| [`a149e3d3`](https://github.com/NixOS/nixos-hardware/commit/a149e3d37e77543205f73017015fe22632907ff9) | `` Lenovo IdeaPad Slim 5: init ``                 |
| [`de516d0d`](https://github.com/NixOS/nixos-hardware/commit/de516d0deebf2f8c8d607867b2a3f679e216c0b7) | `` surface/surface-go: set kernel to 6.1.55 ``    |
| [`afc5a294`](https://github.com/NixOS/nixos-hardware/commit/afc5a2949bb79c43d06b0e8ff4679f408be85106) | `` surface: linux 6.4.16 -> 6.5.5 ``              |
| [`3b14571f`](https://github.com/NixOS/nixos-hardware/commit/3b14571fc964e5343fb876ea3615f189b3a840cb) | `` surface: linux-surface 32c55fe0 -> b82e8acd `` |
| [`ca0cd502`](https://github.com/NixOS/nixos-hardware/commit/ca0cd502fb5f00d6da1a0283faa2f76b78878791) | `` surface: linux 6.1.53 -> 6.1.55 ``             |