### PR TITLE
chore(flake/nixos-hardware): `b31be8f1` -> `f4ef5df9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -540,11 +540,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1696592614,
-        "narHash": "sha256-2gnRtjflKQ9G3X039bk/resUwf/c1GM4sojcQzP/tgA=",
+        "lastModified": 1696593747,
+        "narHash": "sha256-0PKfC46HRnWZ+P/ASUtV/rn50QPHcNxyppYQWhoAVb0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b31be8f11493e0f79a840370fd17153cd60b9009",
+        "rev": "f4ef5df944429e2ce3308bdbe69da940fffc5942",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`f4ef5df9`](https://github.com/NixOS/nixos-hardware/commit/f4ef5df944429e2ce3308bdbe69da940fffc5942) | `` pine64-rockpro64: init `` |