### PR TITLE
chore(flake/nixos-hardware): `f4ef5df9` -> `bb2db418`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -540,11 +540,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1696593747,
-        "narHash": "sha256-0PKfC46HRnWZ+P/ASUtV/rn50QPHcNxyppYQWhoAVb0=",
+        "lastModified": 1696614066,
+        "narHash": "sha256-nAyYhO7TCr1tikacP37O9FnGr2USOsVBD3IgvndUYjM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f4ef5df944429e2ce3308bdbe69da940fffc5942",
+        "rev": "bb2db418b616fea536b1be7f6ee72fb45c11afe0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                           |
| ----------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`bb2db418`](https://github.com/NixOS/nixos-hardware/commit/bb2db418b616fea536b1be7f6ee72fb45c11afe0) | `` chore: Add Dell XPS 15 9510 `` |
| [`455496f1`](https://github.com/NixOS/nixos-hardware/commit/455496f1b4a2318924326ba1cbde9b485a3dac57) | `` chore: Add DELL XPS 9510 ``    |
| [`93fcc5fb`](https://github.com/NixOS/nixos-hardware/commit/93fcc5fb824833e2c8fb03768d8ffb915024dc6b) | `` OLIMEX Teres-I: Init ``        |