### PR TITLE
chore(flake/emacs-overlay): `2308be43` -> `54087a1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696584115,
-        "narHash": "sha256-/fjFLHgXZ0WCxoAaSCT8H3AZ3MwA+D1fuHmuWrbtwGk=",
+        "lastModified": 1696616940,
+        "narHash": "sha256-q7dbd/GWJrQ2hSJFlSDsjFWfseR/OhjmisgeHNlhE7g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2308be4351ab8a152248a48baebf22649c83a487",
+        "rev": "54087a1b3a7ef51d0968bbfa7a700d2848ffae9c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`54087a1b`](https://github.com/nix-community/emacs-overlay/commit/54087a1b3a7ef51d0968bbfa7a700d2848ffae9c) | `` Updated repos/melpa `` |
| [`843e213a`](https://github.com/nix-community/emacs-overlay/commit/843e213a54b0e21a6cff48453ed06bd6133ff9c6) | `` Updated repos/emacs `` |
| [`27265eca`](https://github.com/nix-community/emacs-overlay/commit/27265eca82bc54d39e15d665ae871a6be6008f15) | `` Updated repos/elpa ``  |