### PR TITLE
chore(flake/emacs-overlay): `54087a1b` -> `0de859c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696616940,
-        "narHash": "sha256-q7dbd/GWJrQ2hSJFlSDsjFWfseR/OhjmisgeHNlhE7g=",
+        "lastModified": 1696643505,
+        "narHash": "sha256-S1EqR7QyspJVbcd0Nw8qgVA00Wji1uaQHrSsrVRam5Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "54087a1b3a7ef51d0968bbfa7a700d2848ffae9c",
+        "rev": "0de859c1a3cf76a4750d2e1252b124de588f1607",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`0de859c1`](https://github.com/nix-community/emacs-overlay/commit/0de859c1a3cf76a4750d2e1252b124de588f1607) | `` Updated repos/melpa ``  |
| [`4c0652ca`](https://github.com/nix-community/emacs-overlay/commit/4c0652caa2d9f958b4b7a243b8339936dafb4a43) | `` Updated repos/emacs ``  |
| [`8f8a0690`](https://github.com/nix-community/emacs-overlay/commit/8f8a0690bd203e7418ebf20456acb8893a96661b) | `` Updated repos/elpa ``   |
| [`f8804319`](https://github.com/nix-community/emacs-overlay/commit/f8804319371a4a5eb2e1d211da5ce25f70c7d932) | `` Updated flake inputs `` |