### PR TITLE
chore(flake/emacs-overlay): `0de859c1` -> `dad180d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696643505,
-        "narHash": "sha256-S1EqR7QyspJVbcd0Nw8qgVA00Wji1uaQHrSsrVRam5Y=",
+        "lastModified": 1696673591,
+        "narHash": "sha256-zncyMO9Om74yHtU132nTtzI3xkk5Z6duFVFjwVHUY7M=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0de859c1a3cf76a4750d2e1252b124de588f1607",
+        "rev": "dad180d78df8942ca14116b42525cc510b0ddf8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`dad180d7`](https://github.com/nix-community/emacs-overlay/commit/dad180d78df8942ca14116b42525cc510b0ddf8d) | `` Updated repos/nongnu `` |
| [`01ec8b0a`](https://github.com/nix-community/emacs-overlay/commit/01ec8b0aa9297d8668c475a60b942ae79303c462) | `` Updated repos/melpa ``  |
| [`e47ab91a`](https://github.com/nix-community/emacs-overlay/commit/e47ab91a68eb9f5f283cea02bfbcb186332d496a) | `` Updated repos/emacs ``  |