### PR TITLE
chore(flake/emacs-overlay): `dad180d7` -> `e8cbdc1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696673591,
-        "narHash": "sha256-zncyMO9Om74yHtU132nTtzI3xkk5Z6duFVFjwVHUY7M=",
+        "lastModified": 1696703225,
+        "narHash": "sha256-WllpbGrP0lsLyXxB2RTuNlezwc2EoCQSl6EQokKrrTo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dad180d78df8942ca14116b42525cc510b0ddf8d",
+        "rev": "e8cbdc1b2799fdaa6a4967ca65b4320853b35672",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`e8cbdc1b`](https://github.com/nix-community/emacs-overlay/commit/e8cbdc1b2799fdaa6a4967ca65b4320853b35672) | `` Updated repos/melpa `` |
| [`bf9c7c8f`](https://github.com/nix-community/emacs-overlay/commit/bf9c7c8fd7951982c3df20335eac205b971b86c8) | `` Updated repos/emacs `` |
| [`cd2751d7`](https://github.com/nix-community/emacs-overlay/commit/cd2751d7cd750f6fa8233bfffc1e3a472cba3167) | `` Updated repos/elpa ``  |