### PR TITLE
chore(flake/emacs-overlay): `e8cbdc1b` -> `3f942773`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696703225,
-        "narHash": "sha256-WllpbGrP0lsLyXxB2RTuNlezwc2EoCQSl6EQokKrrTo=",
+        "lastModified": 1696730756,
+        "narHash": "sha256-u+UbAnVCD3RnMyXgvo5k0fDmyRNAixDh07lrOSdtZgs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e8cbdc1b2799fdaa6a4967ca65b4320853b35672",
+        "rev": "3f942773192735d987ab517ceaae2a0479d4e601",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`3f942773`](https://github.com/nix-community/emacs-overlay/commit/3f942773192735d987ab517ceaae2a0479d4e601) | `` Updated repos/nongnu `` |
| [`82456a79`](https://github.com/nix-community/emacs-overlay/commit/82456a7911d6c945538faf9c3939502cbea0c4a7) | `` Updated repos/melpa ``  |
| [`11317e83`](https://github.com/nix-community/emacs-overlay/commit/11317e83c74dcc4b08065e50f266de3dfa37440c) | `` Updated repos/emacs ``  |
| [`75739329`](https://github.com/nix-community/emacs-overlay/commit/75739329e524fe4cb1cbab10f52541c8ea9241a7) | `` Updated repos/elpa ``   |
| [`fd9abdf5`](https://github.com/nix-community/emacs-overlay/commit/fd9abdf529d2eae96f62d665c795d0806262f117) | `` Updated flake inputs `` |