### PR TITLE
chore(flake/emacs-overlay): `3f942773` -> `c7ac54dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696730756,
-        "narHash": "sha256-u+UbAnVCD3RnMyXgvo5k0fDmyRNAixDh07lrOSdtZgs=",
+        "lastModified": 1696760954,
+        "narHash": "sha256-XsbxElB7PjHUC15MKzuRMInQyIPSOohIUvrWs7d+knc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3f942773192735d987ab517ceaae2a0479d4e601",
+        "rev": "c7ac54dd8409046d50d17c11d4fa29a782b37804",
         "type": "github"
       },
       "original": {
@@ -602,11 +602,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1696374741,
-        "narHash": "sha256-gt8B3G0ryizT9HSB4cCO8QoxdbsHnrQH+/BdKxOwqF0=",
+        "lastModified": 1696697597,
+        "narHash": "sha256-q26Qv4DQ+h6IeozF2o1secyQG0jt2VUT3V0K58jr3pg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a4c17493e5c39769f79117937c79e1c88de6729",
+        "rev": "5a237aecb57296f67276ac9ab296a41c23981f56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c7ac54dd`](https://github.com/nix-community/emacs-overlay/commit/c7ac54dd8409046d50d17c11d4fa29a782b37804) | `` Updated repos/nongnu `` |
| [`809579eb`](https://github.com/nix-community/emacs-overlay/commit/809579ebfa30e1f557dab8fef3ab848f1f7a4312) | `` Updated repos/melpa ``  |
| [`7b990e2f`](https://github.com/nix-community/emacs-overlay/commit/7b990e2f1e4644d8a0a868380389c58f90868299) | `` Updated repos/emacs ``  |
| [`01a70684`](https://github.com/nix-community/emacs-overlay/commit/01a70684f761ce069ca29185fea6e1e2d4b6b99f) | `` Updated flake inputs `` |