### PR TITLE
chore(flake/emacs-overlay): `99adec38` -> `b383ed4c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696785550,
-        "narHash": "sha256-VO/Jmd5rbVoye6BhTr0/xXNJiJGEa7M31mIQvpafw7A=",
+        "lastModified": 1696822054,
+        "narHash": "sha256-M4nxMYXqcj9iDoMeBtsm8bsj0eIKc/XKdDJwGRZxkN4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "99adec381af79c58314bde4545cb08346406d4b7",
+        "rev": "b383ed4c8436167c24289af1d034ef76130f2bfc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b383ed4c`](https://github.com/nix-community/emacs-overlay/commit/b383ed4c8436167c24289af1d034ef76130f2bfc) | `` Updated repos/nongnu `` |
| [`9a644118`](https://github.com/nix-community/emacs-overlay/commit/9a64411895ed66edf61b8b6a4d30271565a471d2) | `` Updated repos/melpa ``  |
| [`2cb0bd49`](https://github.com/nix-community/emacs-overlay/commit/2cb0bd49ed9507478281ab0955df00302c0af5c6) | `` Updated repos/emacs ``  |
| [`d761233e`](https://github.com/nix-community/emacs-overlay/commit/d761233edac5c05d2ed785d345cde51d8d052491) | `` Updated repos/elpa ``   |