### PR TITLE
chore(flake/emacs-overlay): `b383ed4c` -> `460e804f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696822054,
-        "narHash": "sha256-M4nxMYXqcj9iDoMeBtsm8bsj0eIKc/XKdDJwGRZxkN4=",
+        "lastModified": 1696875558,
+        "narHash": "sha256-hKZ+XS7UeTRHLktpxjJAUd0nHMAhPmxg2RbYTbi6Rzg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b383ed4c8436167c24289af1d034ef76130f2bfc",
+        "rev": "460e804ff3575ceaa3db71d9f1c1afa4de33e0e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`460e804f`](https://github.com/nix-community/emacs-overlay/commit/460e804ff3575ceaa3db71d9f1c1afa4de33e0e1) | `` Updated repos/melpa `` |
| [`3e5397cf`](https://github.com/nix-community/emacs-overlay/commit/3e5397cf6e91582f37186842b2f561246d590c00) | `` Updated repos/emacs `` |
| [`8cbc4395`](https://github.com/nix-community/emacs-overlay/commit/8cbc4395c5eb0deb2ae37c43c1f2b4a3fc387598) | `` Updated repos/elpa ``  |
| [`bdbe672d`](https://github.com/nix-community/emacs-overlay/commit/bdbe672d553baaf44aa6b5b97b3515fa307558a3) | `` Updated repos/melpa `` |
| [`7bdac242`](https://github.com/nix-community/emacs-overlay/commit/7bdac242d7b8359da8aa494c8b36e3236c81d2c5) | `` Updated repos/emacs `` |