### PR TITLE
chore(flake/pre-commit-hooks): `8edf336c` -> `42e1b609`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1696773021,
-        "narHash": "sha256-JzjKl1h96cM5iSrkNvZX7Fgo+e3lisv2tn+uIMnXmD4=",
+        "lastModified": 1696846637,
+        "narHash": "sha256-0hv4kbXxci2+pxhuXlVgftj/Jq79VSmtAyvfabCCtYk=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "8edf336c5ca85efe20004d076747f91b85a6d087",
+        "rev": "42e1b6095ef80a51f79595d9951eb38e91c4e6ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                         |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`67d6c44f`](https://github.com/cachix/pre-commit-hooks.nix/commit/67d6c44fe1f2c092417bd8395fe30420fa55ffde) | `` Switch type to one supported by precommit `` |