### PR TITLE
chore(flake/sops-nix): `d7380c38` -> `6b32358c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -867,11 +867,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1696734395,
-        "narHash": "sha256-O/g/wwBqqSS7RQ53bE6Ssf0pXVTCYfN7NnJDhKfggQY=",
+        "lastModified": 1696890802,
+        "narHash": "sha256-q0cbDNjTnZ1ojoPdy4liEHWXokhQSNULnSKgURp4v2g=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "d7380c38d407eaf06d111832f4368ba3486b800e",
+        "rev": "6b32358c22d2718a5407d39a8236c7bd9608f447",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                        |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`6b32358c`](https://github.com/Mic92/sops-nix/commit/6b32358c22d2718a5407d39a8236c7bd9608f447) | `` update vendorHash ``                                        |
| [`65de920e`](https://github.com/Mic92/sops-nix/commit/65de920eb7d1e48a0ff5d1f80f1653b005d218d0) | `` build(deps): bump golang.org/x/sys from 0.12.0 to 0.13.0 `` |