### PR TITLE
chore(flake/emacs-overlay): `c9995f7c` -> `85b061ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -362,11 +362,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696908231,
-        "narHash": "sha256-tQ8A9Dci37G1U0Hp3gSG4SYng5oJ0YxrMe9pfJ/cM8E=",
+        "lastModified": 1696934970,
+        "narHash": "sha256-YbBmyDeoyzTeQsx2aO+lijWvYPAOhTjbc5jtqMuH36k=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c9995f7cd865c9d3b1dc27cf25999fd2f9e10ef7",
+        "rev": "85b061aefa29e54da20356aaab9abe6a2cb824d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`85b061ae`](https://github.com/nix-community/emacs-overlay/commit/85b061aefa29e54da20356aaab9abe6a2cb824d7) | `` Updated repos/melpa `` |
| [`1c755624`](https://github.com/nix-community/emacs-overlay/commit/1c755624c21271ccac9e6039506a31472674b31a) | `` Updated repos/emacs `` |