### PR TITLE
chore(flake/nixos-hardware): `bb2db418` -> `6ea13c2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -668,11 +668,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1696614066,
-        "narHash": "sha256-nAyYhO7TCr1tikacP37O9FnGr2USOsVBD3IgvndUYjM=",
+        "lastModified": 1696951896,
+        "narHash": "sha256-QTXye5EpcANIG82qlcIR6UbDcWYRsO34JdfIOALOKyk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "bb2db418b616fea536b1be7f6ee72fb45c11afe0",
+        "rev": "6ea13c2df412306793311f8b8c58f5cd9127fb55",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`6ea13c2d`](https://github.com/NixOS/nixos-hardware/commit/6ea13c2df412306793311f8b8c58f5cd9127fb55) | `` starfive visionfive2: update u-boot to SDK version v3.7.5 `` |