### PR TITLE
chore(flake/stylix): `4d76e2da` -> `eb007b79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1030,11 +1030,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696931185,
-        "narHash": "sha256-nBnTHXBTROX0VERZFlpEdlcu5uaJMTEGoC2qnGL/Lpw=",
+        "lastModified": 1696958573,
+        "narHash": "sha256-x4dtbfTFZzuBo6Qut8q5+S4X1Lk5fz117ecnpimY41U=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "4d76e2da7ccd5e3440605fe4560f6a038873ce23",
+        "rev": "eb007b79bd66bf057a5f8bdcd3af1096ccae3ff8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                |
| --------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`eb007b79`](https://github.com/danth/stylix/commit/eb007b79bd66bf057a5f8bdcd3af1096ccae3ff8) | `` Avoid IFD in Kitty module (#160) `` |