### PR TITLE
chore(flake/emacs-overlay): `85b061ae` -> `f5a40daa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -362,11 +362,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696934970,
-        "narHash": "sha256-YbBmyDeoyzTeQsx2aO+lijWvYPAOhTjbc5jtqMuH36k=",
+        "lastModified": 1696962651,
+        "narHash": "sha256-4ETXHQzxUEUvWl8epgbYEnnk1kgcRfjbuvH8U8npGB0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "85b061aefa29e54da20356aaab9abe6a2cb824d7",
+        "rev": "f5a40daaee5ccbea1675a7a4e47a84ce919e769f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`f5a40daa`](https://github.com/nix-community/emacs-overlay/commit/f5a40daaee5ccbea1675a7a4e47a84ce919e769f) | `` Updated repos/melpa `` |
| [`302084dd`](https://github.com/nix-community/emacs-overlay/commit/302084ddd0bb81f51633d32148710da14a6d82d8) | `` Updated repos/emacs `` |
| [`4ae79826`](https://github.com/nix-community/emacs-overlay/commit/4ae7982669b68a7b1dcc40753530b5d5a63f72e1) | `` Updated repos/elpa ``  |