### PR TITLE
chore(flake/nixos-hardware): `6ea13c2d` -> `c2bbfcfc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -668,11 +668,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1696951896,
-        "narHash": "sha256-QTXye5EpcANIG82qlcIR6UbDcWYRsO34JdfIOALOKyk=",
+        "lastModified": 1696975083,
+        "narHash": "sha256-Wsita+TLmgKq+xE337FJdhzDUbgy8jJIBwUhxjAQegA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "6ea13c2df412306793311f8b8c58f5cd9127fb55",
+        "rev": "c2bbfcfc3d12351919f8df7c7d6528f41751d0a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                              |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`c2bbfcfc`](https://github.com/NixOS/nixos-hardware/commit/c2bbfcfc3d12351919f8df7c7d6528f41751d0a3) | `` fix compileDTS overlay for raspberry-pi (#754) `` |