### PR TITLE
chore(flake/emacs-overlay): `f5a40daa` -> `8330eb06`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -362,11 +362,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696962651,
-        "narHash": "sha256-4ETXHQzxUEUvWl8epgbYEnnk1kgcRfjbuvH8U8npGB0=",
+        "lastModified": 1696993480,
+        "narHash": "sha256-aubOw12u1v6upO2DjZuymcRFrBx6mutIxRE/2Ub46Vs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f5a40daaee5ccbea1675a7a4e47a84ce919e769f",
+        "rev": "8330eb06dc9f115afa70cf9c514505571f100120",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`8330eb06`](https://github.com/nix-community/emacs-overlay/commit/8330eb06dc9f115afa70cf9c514505571f100120) | `` Updated repos/melpa ``  |
| [`3f80bd5f`](https://github.com/nix-community/emacs-overlay/commit/3f80bd5f0173b6252c9784b6268ffa3587cd7ebb) | `` Updated repos/emacs ``  |
| [`3e06da38`](https://github.com/nix-community/emacs-overlay/commit/3e06da389d8aa4c0aaa11d5b72f63568b3b7d48d) | `` Updated repos/elpa ``   |
| [`dca77684`](https://github.com/nix-community/emacs-overlay/commit/dca776848490f315cfa4e6f0c44b7206929043ff) | `` Updated flake inputs `` |