### PR TITLE
chore(flake/emacs-overlay): `8330eb06` -> `bfc5d3e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -362,11 +362,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696993480,
-        "narHash": "sha256-aubOw12u1v6upO2DjZuymcRFrBx6mutIxRE/2Ub46Vs=",
+        "lastModified": 1697016336,
+        "narHash": "sha256-LF+pvqueJE9WvqdwAPpRKBMY1jowfEjsbYrSpTWf7EA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8330eb06dc9f115afa70cf9c514505571f100120",
+        "rev": "bfc5d3e3517818755933a73cc736920e06092996",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`bfc5d3e3`](https://github.com/nix-community/emacs-overlay/commit/bfc5d3e3517818755933a73cc736920e06092996) | `` Updated repos/melpa `` |