### PR TITLE
chore(flake/emacs-overlay): `bfc5d3e3` -> `c6b64ca1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -362,11 +362,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1697016336,
-        "narHash": "sha256-LF+pvqueJE9WvqdwAPpRKBMY1jowfEjsbYrSpTWf7EA=",
+        "lastModified": 1697050265,
+        "narHash": "sha256-k5638iL7pgLe2jTg0K84FialP3ZrqJGrq4FRCbBUJsA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bfc5d3e3517818755933a73cc736920e06092996",
+        "rev": "c6b64ca167953829cc318920f7e254d751d08295",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`c6b64ca1`](https://github.com/nix-community/emacs-overlay/commit/c6b64ca167953829cc318920f7e254d751d08295) | `` Updated repos/melpa `` |
| [`ea18d7b0`](https://github.com/nix-community/emacs-overlay/commit/ea18d7b097a2fcbd03ef5d7f858fa9e0c45de6fb) | `` Updated repos/emacs `` |
| [`9246f949`](https://github.com/nix-community/emacs-overlay/commit/9246f9495f7a7cab27972b28eabcc6104d4675f5) | `` Updated repos/elpa ``  |