### PR TITLE
chore(flake/nixos-hardware): `c2bbfcfc` -> `d6b554a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -668,11 +668,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1696975083,
-        "narHash": "sha256-Wsita+TLmgKq+xE337FJdhzDUbgy8jJIBwUhxjAQegA=",
+        "lastModified": 1697049401,
+        "narHash": "sha256-I/wCJBpW/K23h3o42bUD3OIeRQ5TRVoecu/RGIpfx6w=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "c2bbfcfc3d12351919f8df7c7d6528f41751d0a3",
+        "rev": "d6b554a85caac840430a822aae963c811e9c7e26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`d6b554a8`](https://github.com/NixOS/nixos-hardware/commit/d6b554a85caac840430a822aae963c811e9c7e26) | `` pine64-pinebook-pro: remove superfluous ap6256-firmware package `` |
| [`922926aa`](https://github.com/NixOS/nixos-hardware/commit/922926aa1f58db7897c4cea756978d418b281545) | `` pine64-pinebook-pro: add initrd modules for boot-from-NVMe ``      |
| [`a6eecb4d`](https://github.com/NixOS/nixos-hardware/commit/a6eecb4d851240d7bc6622449cad371171a69eb3) | `` pine64-pinebook-pro: remove udev quirk for "keyboard mouse" ``     |
| [`0e1e24d2`](https://github.com/NixOS/nixos-hardware/commit/0e1e24d2fd6aa44fe0b9065f3f7f24ee369ff6da) | `` pine64-pinebook-pro: remove "internal keyboard" libinput quirk ``  |
| [`c1ebe3b4`](https://github.com/NixOS/nixos-hardware/commit/c1ebe3b471bdb097c07579748713b51fd835098d) | `` init: omen-16-n0005ne (#749) ``                                    |