### PR TITLE
chore(flake/sops-nix): `6b32358c` -> `f995ea15`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -995,11 +995,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1696890802,
-        "narHash": "sha256-q0cbDNjTnZ1ojoPdy4liEHWXokhQSNULnSKgURp4v2g=",
+        "lastModified": 1697064251,
+        "narHash": "sha256-xxp2sB+4vqB6S6zC/L5J8LlRKgVbgIZOcYl9/TDrEzI=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "6b32358c22d2718a5407d39a8236c7bd9608f447",
+        "rev": "f995ea159252a53b25fa99824f2891e3b479d511",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                        |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`f995ea15`](https://github.com/Mic92/sops-nix/commit/f995ea159252a53b25fa99824f2891e3b479d511) | `` update vendorHash ``                                        |
| [`3607aaef`](https://github.com/Mic92/sops-nix/commit/3607aaef32bad3fbf73634e2a4c59e11e54f1c0f) | `` build(deps): bump golang.org/x/net from 0.10.0 to 0.17.0 `` |