### PR TITLE
chore(flake/emacs-overlay): `c6b64ca1` -> `77229726`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -362,11 +362,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1697050265,
-        "narHash": "sha256-k5638iL7pgLe2jTg0K84FialP3ZrqJGrq4FRCbBUJsA=",
+        "lastModified": 1697080137,
+        "narHash": "sha256-X0IUwaX+uXoYF/xxKT69lHzV0GsEDgj0LZHIVaj7++Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c6b64ca167953829cc318920f7e254d751d08295",
+        "rev": "7722972664332248a4240cd40f6e55994ef1ddfa",
         "type": "github"
       },
       "original": {
@@ -730,11 +730,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1696697597,
-        "narHash": "sha256-q26Qv4DQ+h6IeozF2o1secyQG0jt2VUT3V0K58jr3pg=",
+        "lastModified": 1696983906,
+        "narHash": "sha256-L7GyeErguS7Pg4h8nK0wGlcUTbfUMDu+HMf1UcyP72k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5a237aecb57296f67276ac9ab296a41c23981f56",
+        "rev": "bd1cde45c77891214131cbbea5b1203e485a9d51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`77229726`](https://github.com/nix-community/emacs-overlay/commit/7722972664332248a4240cd40f6e55994ef1ddfa) | `` Updated repos/melpa ``  |
| [`e86c4bfc`](https://github.com/nix-community/emacs-overlay/commit/e86c4bfc8df3d51b888b48f90b2a44d54ad4f882) | `` Updated repos/emacs ``  |
| [`81011518`](https://github.com/nix-community/emacs-overlay/commit/810115184d16b4c787659f86c0d4fbb86bd34a37) | `` Updated repos/elpa ``   |
| [`3f386997`](https://github.com/nix-community/emacs-overlay/commit/3f3869978d932178b1a7c74d1140f583fbce780e) | `` Updated flake inputs `` |