### PR TITLE
chore(flake/nixos-hardware): `d6b554a8` -> `fb6af288`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -652,11 +652,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1697049401,
-        "narHash": "sha256-I/wCJBpW/K23h3o42bUD3OIeRQ5TRVoecu/RGIpfx6w=",
+        "lastModified": 1697100850,
+        "narHash": "sha256-qSAzJVzNRIo+r3kBjL8TcpJctcgcHlnZyqdzpWgtg0M=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d6b554a85caac840430a822aae963c811e9c7e26",
+        "rev": "fb6af288f6cf0f00d3af60cf9d5110433b954565",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`fb6af288`](https://github.com/NixOS/nixos-hardware/commit/fb6af288f6cf0f00d3af60cf9d5110433b954565) | `` fix(common/gpu/amd): use new rocmPackages `` |
| [`3d4a18fa`](https://github.com/NixOS/nixos-hardware/commit/3d4a18fac8850697714bfc2307211268beb63715) | `` Microchip Icicle Kit BSP update ``           |