### PR TITLE
chore(flake/emacs-overlay): `77229726` -> `b86758ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -346,11 +346,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1697080137,
-        "narHash": "sha256-X0IUwaX+uXoYF/xxKT69lHzV0GsEDgj0LZHIVaj7++Y=",
+        "lastModified": 1697101647,
+        "narHash": "sha256-NrnLTe4ljD4HW5Deod9fVLzCKUHFhHUveeWtja1kPtg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7722972664332248a4240cd40f6e55994ef1ddfa",
+        "rev": "b86758ad99b97f7c983c52078e3cfe1477adf9a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`b86758ad`](https://github.com/nix-community/emacs-overlay/commit/b86758ad99b97f7c983c52078e3cfe1477adf9a0) | `` Updated repos/melpa `` |