### PR TITLE
chore(flake/emacs-overlay): `bd5c5e9a` -> `88770e2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -346,11 +346,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1697137147,
-        "narHash": "sha256-s1KYOB3t5TVxQJDlrM699O9Hx7iY/St2UG3SuKnVa4g=",
+        "lastModified": 1697162679,
+        "narHash": "sha256-nT11sBYEy9Y6a+hG0s197ameo1EPh1qeuaFaMabLEvg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bd5c5e9a9b460a275df97c7226f573cd88cb27ef",
+        "rev": "88770e2e1dc7ad3920acb8011529121bbea9ce32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`88770e2e`](https://github.com/nix-community/emacs-overlay/commit/88770e2e1dc7ad3920acb8011529121bbea9ce32) | `` Updated repos/nongnu `` |
| [`cf54306a`](https://github.com/nix-community/emacs-overlay/commit/cf54306a663c6103b37001599ee9b094ff7810ca) | `` Updated repos/melpa ``  |
| [`609b9e74`](https://github.com/nix-community/emacs-overlay/commit/609b9e7454201865c97cab177e0ffc2c589dad9d) | `` Updated repos/emacs ``  |
| [`800454ab`](https://github.com/nix-community/emacs-overlay/commit/800454ab6b35eb622592f5ccdb7425391c9c046f) | `` Updated repos/elpa ``   |