### PR TITLE
chore(flake/nixpkgs): `f99e5f03` -> `5e4c2ada`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -777,11 +777,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1696879762,
-        "narHash": "sha256-Ud6bH4DMcYHUDKavNMxAhcIpDGgHMyL/yaDEAVSImQY=",
+        "lastModified": 1697059129,
+        "narHash": "sha256-9NJcFF9CEYPvHJ5ckE8kvINvI84SZZ87PvqMbH6pro0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f99e5f03cc0aa231ab5950a15ed02afec45ed51a",
+        "rev": "5e4c2ada4fcd54b99d56d7bd62f384511a7e2593",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                    |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`ccd7abe1`](https://github.com/NixOS/nixpkgs/commit/ccd7abe1baa9784eb06fc1c129c869e20105b49b) | `` multimon-ng: 1.2.0 -> 1.3.0 ``                                          |
| [`4687df88`](https://github.com/NixOS/nixpkgs/commit/4687df882464f1f1946bd649e25c8ba16f63044c) | `` gerrit: use hash instead of sha256 ``                                   |
| [`5dcafc36`](https://github.com/NixOS/nixpkgs/commit/5dcafc36852cd8d96127f5cbfe42918bf262214e) | `` {nickel,nls}: make nls an output of nickel ``                           |
| [`6a26b003`](https://github.com/NixOS/nixpkgs/commit/6a26b0035b4f938375b967601515a19b9cfa6b0d) | `` gash-utils: use generic wrapping ``                                     |
| [`8620e988`](https://github.com/NixOS/nixpkgs/commit/8620e988be7824273966a5e5dbf8eb38b92746c9) | `` nmap-formatter: 2.1.2 -> 2.1.3 ``                                       |
| [`101d8a8f`](https://github.com/NixOS/nixpkgs/commit/101d8a8f8e34ba6af3808f82ae76f926d1573487) | `` grafana-agent: 0.36.2 -> 0.37.1 ``                                      |
| [`846bef93`](https://github.com/NixOS/nixpkgs/commit/846bef93c0ad59ad111cd0baaef81a1b13ec3288) | `` last-resort: remove myself as maintainer ``                             |
| [`f7af28c1`](https://github.com/NixOS/nixpkgs/commit/f7af28c1178e795ea6990985672439d689765563) | `` netbird: 0.23.6 -> 0.23.8 ``                                            |
| [`389be8db`](https://github.com/NixOS/nixpkgs/commit/389be8db81592ce4c5519a96a459593e07eb82f7) | `` lib.fileset: Minor contributor doc adjustments ``                       |
| [`4ecf0258`](https://github.com/NixOS/nixpkgs/commit/4ecf0258149f4e197e9dea4d71ab22756ffc5ece) | `` lib.fileset.intersection: init ``                                       |
| [`607f94b3`](https://github.com/NixOS/nixpkgs/commit/607f94b3d684e5dd1ce144e5a6ef036d6aeae39c) | `` cotp: 1.2.5 -> 1.3.0 ``                                                 |
| [`4ff8491a`](https://github.com/NixOS/nixpkgs/commit/4ff8491ac0c4f02d15d6089d2d1de169c9b78198) | `` nixpkgs release: leave breadcrumb about commented tests ``              |
| [`9321e71d`](https://github.com/NixOS/nixpkgs/commit/9321e71d93f652879c8fce2d27763aeded710a60) | `` nixpkgs release: replace outdated comment ``                            |
| [`0255c3a1`](https://github.com/NixOS/nixpkgs/commit/0255c3a1ef580b7e2202875faf227554920a4145) | `` nixpkgs release: explicitly add aarch64-darwin blockers ``              |
| [`6a5c6a9e`](https://github.com/NixOS/nixpkgs/commit/6a5c6a9e079e7a913dee97bd5020109fad1114f7) | `` unstable: include nix explicitly ``                                     |
| [`d183ac2b`](https://github.com/NixOS/nixpkgs/commit/d183ac2be4dcabb6eac6e411e604278d1d62647c) | `` nb: 7.5.1 -> 7.7.1 ``                                                   |
| [`f3ee3b96`](https://github.com/NixOS/nixpkgs/commit/f3ee3b965ff397bfbe99685d5463bcba9fb94762) | `` nats-server: 2.10.1 -> 2.10.2 ``                                        |
| [`aa6782b1`](https://github.com/NixOS/nixpkgs/commit/aa6782b165d88d2dc0fb26bdbc31b00b186f68e9) | `` n8n: 1.6.1 -> 1.9.3 ``                                                  |
| [`cb9e9684`](https://github.com/NixOS/nixpkgs/commit/cb9e968437faec0c0b72804d32e360042e05442c) | `` munin: 2.0.73 -> 2.0.74 ``                                              |
| [`11b8ce5a`](https://github.com/NixOS/nixpkgs/commit/11b8ce5aa7cb46f940ca3ef8f1a215dea0efba1b) | `` mympd: 12.0.2 -> 12.0.4 ``                                              |
| [`6ab3619d`](https://github.com/NixOS/nixpkgs/commit/6ab3619df7b2c30ca7d7c5e1d908e4c3411dee4e) | `` murex: 5.0.9310 -> 5.1.2210 ``                                          |
| [`6b989a01`](https://github.com/NixOS/nixpkgs/commit/6b989a018268833aa10d3802e4929f77a982bde9) | `` minetest-mapserver: init at 4.7.0 ``                                    |
| [`fe0c9571`](https://github.com/NixOS/nixpkgs/commit/fe0c95718c4e2b1d5607c385f8f4f32a70d99afb) | `` monkeysAudio: 10.22 -> 10.24 ``                                         |
| [`89e45f23`](https://github.com/NixOS/nixpkgs/commit/89e45f23db7cc2d234a2541561d3294f9d3e4aa1) | `` nixos/modules/security/wrappers: drop dead code ``                      |
| [`490f0c73`](https://github.com/NixOS/nixpkgs/commit/490f0c73792d2d926452e96b5bec9857683df178) | `` python311Packages.pyiqvia: 2023.08.1 -> 2023.10.0 ``                    |
| [`76a0ef31`](https://github.com/NixOS/nixpkgs/commit/76a0ef3145b1cd382a76f602a6cc3a6ee17e713f) | `` python311Packages.python-homewizard-energy: 2.1.0 -> 2.1.2 ``           |
| [`f5967852`](https://github.com/NixOS/nixpkgs/commit/f59678527053feec6508af9a8f1c8e65f653f0b8) | `` prowlarr: 1.7.4.3769 -> 1.8.6.3946 ``                                   |
| [`20664ee4`](https://github.com/NixOS/nixpkgs/commit/20664ee42297b78fe09efa204b4380743990ceee) | `` mlkit: 4.7.4 -> 4.7.5 ``                                                |
| [`13fc98b3`](https://github.com/NixOS/nixpkgs/commit/13fc98b318d9ecd1d6b2e0b755c91f563ecae3cb) | `` gpsprune: 23.1 -> 23.2 ``                                               |
| [`4a007737`](https://github.com/NixOS/nixpkgs/commit/4a00773718e16bc2a23176b1bb294cf6fd9f1965) | `` linux_4_14: 4.14.326 -> 4.14.327 ``                                     |
| [`61d8bb5f`](https://github.com/NixOS/nixpkgs/commit/61d8bb5ffc9eb3b81787110da6b60978bed290b1) | `` linux_4_19: 4.19.295 -> 4.19.296 ``                                     |
| [`66334643`](https://github.com/NixOS/nixpkgs/commit/663346436ff0b7554ee69371e164adbf7fcd1357) | `` linux_5_4: 5.4.257 -> 5.4.258 ``                                        |
| [`c6d2e732`](https://github.com/NixOS/nixpkgs/commit/c6d2e7324e195c0f7d2ea2d3474c2a3c5016cf4c) | `` linux_5_10: 5.10.197 -> 5.10.198 ``                                     |
| [`56ca3903`](https://github.com/NixOS/nixpkgs/commit/56ca3903159732034160e122645be96809fc9e78) | `` linux_5_15: 5.15.134 -> 5.15.135 ``                                     |
| [`d0429f6a`](https://github.com/NixOS/nixpkgs/commit/d0429f6a46dee94cf0aa91b9c21386a8eaf93543) | `` linux_6_1: 6.1.56 -> 6.1.57 ``                                          |
| [`082f2987`](https://github.com/NixOS/nixpkgs/commit/082f2987b0bf972309ad8952c250bd5b34d36f56) | `` linux_6_5: 6.5.6 -> 6.5.7 ``                                            |
| [`5b05cf6e`](https://github.com/NixOS/nixpkgs/commit/5b05cf6e7c79b58ffa90b583448d9026bbb706f3) | `` mkgmap: 4912 -> 4914 ``                                                 |
| [`7493212a`](https://github.com/NixOS/nixpkgs/commit/7493212ae8c22e03d3f5265cb17a43c67842cc65) | `` powershell: 7.3.7 -> 7.3.8 ``                                           |
| [`68e45760`](https://github.com/NixOS/nixpkgs/commit/68e457601406bd52714ccf5d2f04d84c6feba9c4) | `` trash-cli: 0.23.2.13.2 -> 0.23.9.23 ``                                  |
| [`df9861bd`](https://github.com/NixOS/nixpkgs/commit/df9861bd0410314929d589544c05e870bb062f4a) | `` metasploit: 6.3.36 -> 6.3.37 ``                                         |
| [`f4c57ca4`](https://github.com/NixOS/nixpkgs/commit/f4c57ca4917dd825097ce6ea94e9d8dc32bd1ef3) | `` python311Packages.appthreat-vulnerability-db: 5.5.0 -> 5.5.1 ``         |
| [`9471c74e`](https://github.com/NixOS/nixpkgs/commit/9471c74e2d4d5202e4bd7aba2ab5d9b4f04e689e) | `` python311Packages.apischema: 0.18.0 -> 0.18.1 ``                        |
| [`908bf008`](https://github.com/NixOS/nixpkgs/commit/908bf008b8d1dbf5b415b481c0afc6e9e84286cd) | `` python311Packages.faraday-plugins: 1.13.2 -> 1.14.0 ``                  |
| [`69ad83d8`](https://github.com/NixOS/nixpkgs/commit/69ad83d8d6e7fd7cc546f15a1a5442b9a9f765ff) | `` python311Packages.aioambient: 2023.08.0 -> 2023.10.1 ``                 |
| [`73301239`](https://github.com/NixOS/nixpkgs/commit/73301239b421f74c8af4f8c762e2cf10d254959e) | `` python311Packages.icmplib: 3.0.3 -> 3.0.4 ``                            |
| [`474ea784`](https://github.com/NixOS/nixpkgs/commit/474ea784dcb3f7fcb52850a2139fe9776f38bfd0) | `` python311Packages.pyduotecno: 2023.9.0 -> 2023.10.0 ``                  |
| [`e08137ec`](https://github.com/NixOS/nixpkgs/commit/e08137ec0627eadd71cbff19174e24020c3c9841) | `` atlauncher: 3.4.34.0 -> 3.4.34.2 ``                                     |
| [`f44c6f83`](https://github.com/NixOS/nixpkgs/commit/f44c6f838326071501afa1709a116b88cd6d05d6) | `` python311Packages.pyweatherflowudp: 1.4.4 -> 1.4.5 ``                   |
| [`604b4c5e`](https://github.com/NixOS/nixpkgs/commit/604b4c5e30b71a7e1bb71be94838337eb9598f4e) | `` python311Packages.hahomematic: 2023.10.6 -> 2023.10.7 ``                |
| [`d642cf37`](https://github.com/NixOS/nixpkgs/commit/d642cf37e5ee429165b7ff13e654d47d03708412) | `` python311Packages.env-canada: 0.5.37 -> 0.6.0 ``                        |
| [`68338bbd`](https://github.com/NixOS/nixpkgs/commit/68338bbd07804a58da3e9096da8708306d776523) | `` minesweep-rs: 6.0.34 -> 6.0.35 ``                                       |
| [`edf356bd`](https://github.com/NixOS/nixpkgs/commit/edf356bd895e28d204bcecd953ef223fb2882e46) | `` mill: 0.11.4 -> 0.11.5 ``                                               |
| [`74e50e8d`](https://github.com/NixOS/nixpkgs/commit/74e50e8d608c91c4066b00bee2589e9e31de3a7b) | `` yubikey-manager: 5.2.0 -> 5.2.1 ``                                      |
| [`5a41ee8c`](https://github.com/NixOS/nixpkgs/commit/5a41ee8c82eb851045c4deec37c56cda3925f6f6) | `` micropython: 1.20.0 -> 1.21.0 ``                                        |
| [`37c77680`](https://github.com/NixOS/nixpkgs/commit/37c7768047edc6c6f5acb0bbe513d2ce31da2aa8) | `` zfsUnstable: 2.2.0-rc4 -> 2.2.0-rc5 ``                                  |
| [`36aa2d90`](https://github.com/NixOS/nixpkgs/commit/36aa2d9072233ff2a27f8643a3b64b42a7a079a3) | `` ltris: 1.2.6 -> 1.2.7 ``                                                |
| [`a1a5e810`](https://github.com/NixOS/nixpkgs/commit/a1a5e810b108a16093c31f60ef6ef37bf8a1f1b8) | `` lpairs2: 2.2.1 -> 2.3 ``                                                |
| [`115b411a`](https://github.com/NixOS/nixpkgs/commit/115b411a4d64c2c87ebf110b09dfae46f245ed12) | `` mapcidr: 1.1.10 -> 1.1.11 ``                                            |
| [`1560943e`](https://github.com/NixOS/nixpkgs/commit/1560943e854c81ee05dc48c30b613c2ef8e11bff) | `` uiua: 0.0.17 -> 0.0.18 ``                                               |
| [`1d5cfbb0`](https://github.com/NixOS/nixpkgs/commit/1d5cfbb001eab442117c349ece5690dc24a9b127) | `` mainsail: 2.7.1 -> 2.8.0 ``                                             |
| [`1648c8d6`](https://github.com/NixOS/nixpkgs/commit/1648c8d66e0c7626c77f577871161bc6d6ea0e0d) | `` v2ray-domain-list-community: 20230926092720 -> 20231011001633 ``        |
| [`4831f57b`](https://github.com/NixOS/nixpkgs/commit/4831f57ba3440012ae12682014436e79f10b2f9d) | `` lokalise2-cli: 2.6.8 -> 2.6.10 ``                                       |
| [`13d6bf79`](https://github.com/NixOS/nixpkgs/commit/13d6bf79acf6bfb94dd6d285f78d01173585582c) | `` python310Packages.pyramid-multiauth: rename from pyramid_multiauth ``   |
| [`20d20c16`](https://github.com/NixOS/nixpkgs/commit/20d20c162a234c12dcfb3c5a390922fcf4d1c62d) | `` python310Packages.pyramid-mako: rename from pyramid_mako ``             |
| [`9520a334`](https://github.com/NixOS/nixpkgs/commit/9520a3344b57db944d2feb99605702fd99ce4a98) | `` python310Packages.pyramid-exclog: rename from pyramid_exclog ``         |
| [`4400a764`](https://github.com/NixOS/nixpkgs/commit/4400a764594949a786a7d990e0f4a72db9756525) | `` python310Packages.pyramid-chameleon: rename from pyramid_chameleon ``   |
| [`7b3d58a5`](https://github.com/NixOS/nixpkgs/commit/7b3d58a5d23909c6f7a4064e99a9544d3be09b2a) | `` python310Packages.pyramid-beaker: rename from pyramid_beaker ``         |
| [`4d731ea6`](https://github.com/NixOS/nixpkgs/commit/4d731ea676ce2b516022377d9f426b6c6e161bf2) | `` pulumi-bin: 3.78.1 -> 3.88.0 ``                                         |
| [`be7dedc5`](https://github.com/NixOS/nixpkgs/commit/be7dedc5b5ac3c840ea9a18fe1e99502438caf5d) | `` libva-utils: 2.19.0 -> 2.20.0 ``                                        |
| [`c2520aa8`](https://github.com/NixOS/nixpkgs/commit/c2520aa849c8ec6bf99e8a28a858a974b4e17bd4) | `` libutp_3_4: unstable-2023-03-05 -> unstable-2023-08-04 ``               |
| [`2e1d574a`](https://github.com/NixOS/nixpkgs/commit/2e1d574abb09df5960569a1c0f687a365d8fc497) | `` libsForQt5.qt5ct: 1.7 -> 1.8 ``                                         |
| [`16ef368c`](https://github.com/NixOS/nixpkgs/commit/16ef368cfbf7d28d61e04eee20dace02d02c385b) | `` tinygo: 0.26.0 -> 0.30.0 ``                                             |
| [`f29f111b`](https://github.com/NixOS/nixpkgs/commit/f29f111b2de1e61f3044e599de18e57b8e544c18) | `` terraform_1: 1.6.0 -> 1.6.1 ``                                          |
| [`1e0f3488`](https://github.com/NixOS/nixpkgs/commit/1e0f348818e40a34d5aedad85b465e272804a44a) | `` catppuccin: init at unstable-2023-10-09 ``                              |
| [`8c4d5db5`](https://github.com/NixOS/nixpkgs/commit/8c4d5db59fc1347a09c8b6767f6dd684385a8ac7) | `` linuxKernel.kernels.linux_zen: 6.5.6-zen2 -> 6.5.7-zen1 ``              |
| [`a68655c5`](https://github.com/NixOS/nixpkgs/commit/a68655c5eb93bc593f23a16b64a63edf9d2d9d21) | `` dialog: migrate to by-name ``                                           |
| [`50240f73`](https://github.com/NixOS/nixpkgs/commit/50240f732b4acbdc1180c897aa6ce38a82168814) | `` dialog: 1.3-20230209 -> 1.3-20231002 ``                                 |
| [`6e5cfb84`](https://github.com/NixOS/nixpkgs/commit/6e5cfb845fd70829f38235268cbcf00785ba5513) | `` arxiv-latex-cleaner: init at v1.0.1 ``                                  |
| [`da359b92`](https://github.com/NixOS/nixpkgs/commit/da359b9289ce0eadf79faa35b90546a3c3e25329) | `` vencord: 1.5.5 -> 1.5.6 ``                                              |
| [`111751e2`](https://github.com/NixOS/nixpkgs/commit/111751e2708ab5eb5c61ebe00507a188a0ca8027) | `` python310Packages.mmcv: 2.0.0 -> 2.0.1 ``                               |
| [`bd316a80`](https://github.com/NixOS/nixpkgs/commit/bd316a80e3e5b27b706969fae0fe32d14171d24d) | `` lefthook: 1.5.1 -> 1.5.2 ``                                             |
| [`dede93fc`](https://github.com/NixOS/nixpkgs/commit/dede93fc179b2cc7803505529ebd967b043613f2) | `` python3Packages.requests-ratelimiter: init at 0.4.2 ``                  |
| [`d75c2dbb`](https://github.com/NixOS/nixpkgs/commit/d75c2dbb23b9c6e65155bab9c623401e54e48489) | `` goodhosts: init at v1.1.1 ``                                            |
| [`2d496508`](https://github.com/NixOS/nixpkgs/commit/2d496508f8af773f9cad842b39267a4324d15238) | `` kubernetes-helmPlugins.helm-secrets: 4.5.0 -> 4.5.1 ``                  |
| [`cd676db1`](https://github.com/NixOS/nixpkgs/commit/cd676db17ce47d31409d98fd9cb24e3ebe94453e) | `` kubernetes-helmPlugins.helm-s3: 0.14.0 -> 0.15.1 ``                     |
| [`c085e659`](https://github.com/NixOS/nixpkgs/commit/c085e659039ef43d0974cea51a236d7b16a19286) | `` plantuml: 1.2023.10 -> 1.2023.11 ``                                     |
| [`cfd83744`](https://github.com/NixOS/nixpkgs/commit/cfd837442f529f10331e401e9975ae551360a4c4) | `` nixos/samba: start service after network activation ``                  |
| [`b21b9d79`](https://github.com/NixOS/nixpkgs/commit/b21b9d7956b118271655780a13429393134df46c) | `` go-cqhttp: 1.1.0 -> 1.2.0 ``                                            |
| [`08227984`](https://github.com/NixOS/nixpkgs/commit/082279849bcba59100e839a9676a4476de8f7428) | `` ginkgo: 2.12.1 -> 2.13.0 ``                                             |
| [`a06283d0`](https://github.com/NixOS/nixpkgs/commit/a06283d033c306440bf2f53a5467f9c985e20453) | `` wineasio: 1.1.0 -> 1.2.0 ``                                             |
| [`4f66eba8`](https://github.com/NixOS/nixpkgs/commit/4f66eba8964cf80f0fd51bc63cac878dddb2b74d) | `` gatekeeper: 3.13.0 -> 3.13.2 ``                                         |
| [`e528b7ca`](https://github.com/NixOS/nixpkgs/commit/e528b7ca303075b2e51b6756174bef4516d905a2) | `` meme-image-generator: add mainProgram ``                                |
| [`33203778`](https://github.com/NixOS/nixpkgs/commit/33203778370cae5d0ded4e52fb0a6781517a1998) | `` fulcio: 1.4.0 -> 1.4.1 ``                                               |
| [`ceff926e`](https://github.com/NixOS/nixpkgs/commit/ceff926e7b35b15058a8e97ec67c91ee8f5e8197) | `` nwchem: 7.2.0 -> 7.2.1 ``                                               |
| [`4042c7f5`](https://github.com/NixOS/nixpkgs/commit/4042c7f5a71fa7281b62a1a63fc82ef9c28bd682) | `` ddns-go: 5.6.2 -> 5.6.3 ``                                              |
| [`1f051810`](https://github.com/NixOS/nixpkgs/commit/1f051810d7223fe8b1187903f2da7bd9205ca5f9) | `` comodoro: 0.0.9 -> 0.0.10 ``                                            |
| [`9249380e`](https://github.com/NixOS/nixpkgs/commit/9249380e258107f27d599b7df29aaa4ec949542b) | `` gcc-arm-embedded-12: 12.2.rel1 -> 12.3.rel1 ``                          |
| [`e48aa60d`](https://github.com/NixOS/nixpkgs/commit/e48aa60ddf772d4492fbd3d8aabc680190f962f1) | `` nix-direnv: 2.3.0 -> 2.4.0 ``                                           |
| [`16d8d70a`](https://github.com/NixOS/nixpkgs/commit/16d8d70a2cc28b50081921f29aedea1b46471cf8) | `` cinnamon.cinnamon-gsettings-overrides: Add gsettings-desktop-schemas `` |
| [`1bc3823e`](https://github.com/NixOS/nixpkgs/commit/1bc3823e0917e8e63a7a189e347dfb221e7807c3) | `` xsel: 2020-05-27 -> 1.2.1 ``                                            |
| [`ed53966f`](https://github.com/NixOS/nixpkgs/commit/ed53966fa8e96c63122febb043003c8bda6180fd) | `` kodiPackages.pvr-hts: 20.6.2 -> 20.6.3 ``                               |