### PR TITLE
chore(flake/emacs-overlay): `2cbc820d` -> `e3280b27`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -346,11 +346,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1697192335,
-        "narHash": "sha256-HoFrRYXx+vOiCcB9kD+IEGDwsF/CibqkFf7cvap9jgE=",
+        "lastModified": 1697223193,
+        "narHash": "sha256-syR6I4iUL2X1q22uxJBhP//lPsUKTSaf6BIc9pY/+f8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2cbc820d1a06d284a48f521fc66c4072ea071fbc",
+        "rev": "e3280b2745253e6e312bb4ee1aab68feb71b34ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`e3280b27`](https://github.com/nix-community/emacs-overlay/commit/e3280b2745253e6e312bb4ee1aab68feb71b34ff) | `` Updated repos/melpa ``  |
| [`b6b23de1`](https://github.com/nix-community/emacs-overlay/commit/b6b23de1802a3ac435c9b8c7cc79bcb505085b2c) | `` Updated repos/emacs ``  |
| [`db7f4ccd`](https://github.com/nix-community/emacs-overlay/commit/db7f4ccd23fbcf5b102114d90d2f79f1769dcc99) | `` Updated repos/elpa ``   |
| [`9364ba0a`](https://github.com/nix-community/emacs-overlay/commit/9364ba0aef0a32331f4f6c1dd4d0f3488b1431e3) | `` Updated flake inputs `` |