### PR TITLE
chore(flake/emacs-overlay): `e3280b27` -> `0c2b75ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -346,11 +346,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1697223193,
-        "narHash": "sha256-syR6I4iUL2X1q22uxJBhP//lPsUKTSaf6BIc9pY/+f8=",
+        "lastModified": 1697252192,
+        "narHash": "sha256-ryRgMOnBVYW+scs4aZgcztTD4vIdBm65nxTuTtdoPaE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e3280b2745253e6e312bb4ee1aab68feb71b34ff",
+        "rev": "0c2b75cef024e0756ba80b5411289d87584ecf43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`0c2b75ce`](https://github.com/nix-community/emacs-overlay/commit/0c2b75cef024e0756ba80b5411289d87584ecf43) | `` Updated repos/nongnu `` |
| [`c1d54371`](https://github.com/nix-community/emacs-overlay/commit/c1d5437118f4a64aa404681c4e89095539083378) | `` Updated repos/melpa ``  |
| [`e9fd8456`](https://github.com/nix-community/emacs-overlay/commit/e9fd84562259ba5bd07c57c7766789ca6ae1e513) | `` Updated repos/emacs ``  |
| [`19f86eb0`](https://github.com/nix-community/emacs-overlay/commit/19f86eb0df14744f711d13ff484d69a5174a59b3) | `` Updated repos/elpa ``   |