### PR TITLE
chore(flake/emacs-overlay): `0c2b75ce` -> `fa2c99af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -346,11 +346,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1697252192,
-        "narHash": "sha256-ryRgMOnBVYW+scs4aZgcztTD4vIdBm65nxTuTtdoPaE=",
+        "lastModified": 1697280510,
+        "narHash": "sha256-fQxxX/lrYnBXTt70qhxOKKRmUfoYLyFt6Sa/k1wVQ80=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0c2b75cef024e0756ba80b5411289d87584ecf43",
+        "rev": "fa2c99af244d425c43ef768cec348c995a98a1a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`fa2c99af`](https://github.com/nix-community/emacs-overlay/commit/fa2c99af244d425c43ef768cec348c995a98a1a5) | `` Updated repos/nongnu `` |
| [`24ebfe98`](https://github.com/nix-community/emacs-overlay/commit/24ebfe981a2d04e4d2d998f338854c07f38b7191) | `` Updated repos/melpa ``  |
| [`22cbeae9`](https://github.com/nix-community/emacs-overlay/commit/22cbeae9599ef284f44fccda64b304ee2e6c4075) | `` Updated repos/emacs ``  |