### PR TITLE
chore(flake/lanzaboote): `c865873f` -> `62ffd894`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -570,11 +570,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1697139361,
-        "narHash": "sha256-tH+QkHeLqEUV8EedLytnDNcwKASr/nOh3V3moft+Ujg=",
+        "lastModified": 1697302012,
+        "narHash": "sha256-GHDYRusc6QnAEI9dWryaLIpKG9LBqb+zQdL9l1FNqjU=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "c865873ff5f4372a6e4a42fb47e290db69c3cfd9",
+        "rev": "62ffd894f0a0eac29078e6db836752c1f8a21b38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                              |
| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`16c67767`](https://github.com/nix-community/lanzaboote/commit/16c67767639ccc89ed48527e41d899a4cf376917) | `` Fix build with `documentation.nixos.includeAllModules = true;` `` |