### PR TITLE
chore(flake/emacs-overlay): `fa2c99af` -> `e7b748e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -346,11 +346,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1697280510,
-        "narHash": "sha256-fQxxX/lrYnBXTt70qhxOKKRmUfoYLyFt6Sa/k1wVQ80=",
+        "lastModified": 1697307343,
+        "narHash": "sha256-fTWgAQ9sIxd2IZyr1RzQ6GYAv9yZnTE/Wf2LYgAKCv8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fa2c99af244d425c43ef768cec348c995a98a1a5",
+        "rev": "e7b748e9a98d6fb4864fa61f809ae1e5f60bffbb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`e7b748e9`](https://github.com/nix-community/emacs-overlay/commit/e7b748e9a98d6fb4864fa61f809ae1e5f60bffbb) | `` Updated repos/melpa `` |
| [`1c04ae0f`](https://github.com/nix-community/emacs-overlay/commit/1c04ae0fa14e3c4e6f6bdbd597d40e48d0ec8db8) | `` Updated repos/emacs `` |
| [`ba47e17e`](https://github.com/nix-community/emacs-overlay/commit/ba47e17ea69555dbf2e3e32e5cc78273468c5be0) | `` Updated repos/elpa ``  |