### PR TITLE
chore(flake/home-manager): `a4a72ffd` -> `d4a5076e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -523,11 +523,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696996762,
-        "narHash": "sha256-ys0FpQnA/zhYr5Y/rDWUXzZ7Cho7nlQPNBQtw87vfvo=",
+        "lastModified": 1697323135,
+        "narHash": "sha256-tlAv11c0NIRTk2IzpFxYknHrveeFXojVyCTAMg749Zg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a4a72ffd76f2c974601e7adff356e5c277e08077",
+        "rev": "d4a5076ea8c2c063c45e0165f9f75f69ef583e20",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`d4a5076e`](https://github.com/nix-community/home-manager/commit/d4a5076ea8c2c063c45e0165f9f75f69ef583e20) | `` borgmatic: improve support for version 1.8.0 `` |
| [`9a2ce656`](https://github.com/nix-community/home-manager/commit/9a2ce6569752bb00b86c075ade7ffd47242f3827) | `` zsh: generalize zsh-history-substring-search `` |