### PR TITLE
chore(flake/sops-nix): `f995ea15` -> `7711514b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -979,11 +979,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1697064251,
-        "narHash": "sha256-xxp2sB+4vqB6S6zC/L5J8LlRKgVbgIZOcYl9/TDrEzI=",
+        "lastModified": 1697321388,
+        "narHash": "sha256-3TdXq13fSYIj3BGo320vuGFjDQUJPQUrhXJ5jaMk7lo=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "f995ea159252a53b25fa99824f2891e3b479d511",
+        "rev": "7711514b8543891eea6ae84392c74a379c5010de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                         |
| ----------------------------------------------------------------------------------------------- | ------------------------------- |
| [`7711514b`](https://github.com/Mic92/sops-nix/commit/7711514b8543891eea6ae84392c74a379c5010de) | `` don't substitute binaries `` |