### PR TITLE
chore(flake/emacs-overlay): `e7b748e9` -> `3e0b8c25`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -346,11 +346,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1697307343,
-        "narHash": "sha256-fTWgAQ9sIxd2IZyr1RzQ6GYAv9yZnTE/Wf2LYgAKCv8=",
+        "lastModified": 1697334893,
+        "narHash": "sha256-QIsCKVKqVDIZ4L7tmIvFrfj3oob633b9EwNgju7ap98=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e7b748e9a98d6fb4864fa61f809ae1e5f60bffbb",
+        "rev": "3e0b8c25548dc7ba1fd9f479f25e7caa39a29976",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`3e0b8c25`](https://github.com/nix-community/emacs-overlay/commit/3e0b8c25548dc7ba1fd9f479f25e7caa39a29976) | `` Updated repos/melpa `` |
| [`8072e138`](https://github.com/nix-community/emacs-overlay/commit/8072e1387e967b3ee08f6b6687c97807c552e8f2) | `` Updated repos/elpa ``  |