### PR TITLE
chore(flake/nix-index-database): `a132935e` -> `29977d07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -613,11 +613,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697338642,
-        "narHash": "sha256-+zBL3J00Tapta83Ah5g2mykX6UQEaqTJg0yQTDk5Rnw=",
+        "lastModified": 1697340827,
+        "narHash": "sha256-XlrR68N7jyaZ0bs8TPrhqcWG0IPG3pbjrKzJMpYOsos=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "a132935e28f27a4aad7a7a2535a5bf45d711ef7b",
+        "rev": "29977d0796c058bbcfb2df5b18eb5badf1711007",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`29977d07`](https://github.com/nix-community/nix-index-database/commit/29977d0796c058bbcfb2df5b18eb5badf1711007) | `` update packages.nix to release 2023-10-15-033241 `` |