### PR TITLE
chore(flake/templates): `0fb94bf8` -> `98bc26d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1058,11 +1058,11 @@
     },
     "templates": {
       "locked": {
-        "lastModified": 1691421369,
-        "narHash": "sha256-Agfum0ykpUxUUS4AKYPVSWF+NeHPWay2o1TTNH0BFXA=",
+        "lastModified": 1697364028,
+        "narHash": "sha256-t7IGwY/nvopK9n9tgCVrHlLimhU2MuoP9VbVy07AR2A=",
         "owner": "NixOS",
         "repo": "templates",
-        "rev": "0fb94bf87144b18e42765693c3e15ac5f17eeab0",
+        "rev": "98bc26d94008617aac7cd0244fb09ff04d6c8cf6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                             |
| ------------------------------------------------------------------------------------------------ | ----------------------------------- |
| [`738e8195`](https://github.com/NixOS/templates/commit/738e81954a6bb53406221d43a34cd44095d3f3a3) | `` remove `test.sh`, unnecessary `` |
| [`f2217f7f`](https://github.com/NixOS/templates/commit/f2217f7fcd4808dd01658f4698a41a57d96a7af5) | `` haskell-flake example ``         |
| [`be0d2b61`](https://github.com/NixOS/templates/commit/be0d2b61134985152774ca6338b7cd34ff78163e) | `` `srid/haskell-template` ``       |