### PR TITLE
chore(flake/emacs-overlay): `3e0b8c25` -> `5a93a5da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -346,11 +346,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1697334893,
-        "narHash": "sha256-QIsCKVKqVDIZ4L7tmIvFrfj3oob633b9EwNgju7ap98=",
+        "lastModified": 1697365465,
+        "narHash": "sha256-u/el/Iwy6dXwsPrxkEk9CG4OxD9VuzO/+K1qOgP5D30=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3e0b8c25548dc7ba1fd9f479f25e7caa39a29976",
+        "rev": "5a93a5dad00a9028b8e54a40208f878c4aaf5a1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`5a93a5da`](https://github.com/nix-community/emacs-overlay/commit/5a93a5dad00a9028b8e54a40208f878c4aaf5a1c) | `` Updated repos/nongnu `` |
| [`a6b92160`](https://github.com/nix-community/emacs-overlay/commit/a6b92160f12d1caa2c67d7785ec312df4cbefe29) | `` Updated repos/melpa ``  |
| [`3598717d`](https://github.com/nix-community/emacs-overlay/commit/3598717dc0d3c80ba0438f5161537ed7ddbcb96c) | `` Updated repos/emacs ``  |