### PR TITLE
chore(flake/emacs-overlay): `2350e5c3` -> `b2a33ede`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -346,11 +346,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1697393750,
-        "narHash": "sha256-YULy5/xS/SgT+yzNZlWJesP7MxJrZ55D2EWPnxEhUsU=",
+        "lastModified": 1697421847,
+        "narHash": "sha256-xx4bN07u8hRd3x+9EjlyR4kdIBlAEAXUNA66o2/dYOI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2350e5c3843d7fd47018e4491ad061facb39e4de",
+        "rev": "b2a33ede1b5ba9c3d8b79f8d42dec4adde89649e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b2a33ede`](https://github.com/nix-community/emacs-overlay/commit/b2a33ede1b5ba9c3d8b79f8d42dec4adde89649e) | `` Updated repos/nongnu `` |
| [`37d80624`](https://github.com/nix-community/emacs-overlay/commit/37d80624de5630aa4787fffe489b6191b819a010) | `` Updated repos/emacs ``  |
| [`856029b7`](https://github.com/nix-community/emacs-overlay/commit/856029b7ef712eaa801a1eacb8f1a7bf9fa50d97) | `` Updated repos/elpa ``   |