### PR TITLE
chore(flake/lanzaboote): `82530e53` -> `0df60a2b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -570,11 +570,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1697381239,
-        "narHash": "sha256-eWq9IToEq8wVpmREERX89EhHJzCBFc63J82o3sl2z0o=",
+        "lastModified": 1697444965,
+        "narHash": "sha256-YrtxJnP7y7dHVTWMshUP1vYRbn0I+vTLFdYmMPEmiMA=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "82530e530b8aba52ded2b124c978ed663c6b6a2c",
+        "rev": "0df60a2b2e765a0fb197b66802189281cebeb67e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                   |
| --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`b02a7e2a`](https://github.com/nix-community/lanzaboote/commit/b02a7e2a7f5f91054ac1dbac3d271cfd613698a2) | `` stub: use command line from loader in insecure mode `` |
| [`db39223a`](https://github.com/nix-community/lanzaboote/commit/db39223a7c8a479d80c266fddfcb48f277f28052) | `` stub: make handling of insecure boot more explicit ``  |