### PR TITLE
chore(flake/lanzaboote): `0df60a2b` -> `778e2173`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -570,11 +570,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1697444965,
-        "narHash": "sha256-YrtxJnP7y7dHVTWMshUP1vYRbn0I+vTLFdYmMPEmiMA=",
+        "lastModified": 1697447002,
+        "narHash": "sha256-SEirTeG4nOa78j8f/bvwyykUiURYPIQc/gkdxycDKSc=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "0df60a2b2e765a0fb197b66802189281cebeb67e",
+        "rev": "778e21733b2b7d11771caee2b4678524042dfd51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                  |
| --------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`bb5b2de5`](https://github.com/nix-community/lanzaboote/commit/bb5b2de5450ab6a725f35ab1512b59cbbcaf7830) | `` stub: pin goblin (again) ``           |
| [`ace18ed4`](https://github.com/nix-community/lanzaboote/commit/ace18ed4bde61df6ab0d5fec2492f5170e9d4f39) | `` renovate: ignore goblin updates ``    |
| [`eabbae0e`](https://github.com/nix-community/lanzaboote/commit/eabbae0e0cc4949c7da0e83d4052c3e4abd8b835) | `` fix(deps): update all dependencies `` |