### PR TITLE
chore(flake/emacs-overlay): `67acc54c` -> `35d46b0c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -346,11 +346,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1697454219,
-        "narHash": "sha256-5VskFezqbiGzQaqzsxogFi2AXkqwrjhpRshe8zn4qyw=",
+        "lastModified": 1697477745,
+        "narHash": "sha256-5oY028h/pBNhT8FBsqL6tOM8nPPICRLiCq1grcPLvAI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "67acc54cceef38a92ba132e121659fef97698184",
+        "rev": "35d46b0cb203c534ddbd1293a573468031000596",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`35d46b0c`](https://github.com/nix-community/emacs-overlay/commit/35d46b0cb203c534ddbd1293a573468031000596) | `` Updated repos/emacs `` |
| [`ed4a8e8d`](https://github.com/nix-community/emacs-overlay/commit/ed4a8e8d0b339a847f6d0878955efdf91293559c) | `` Updated repos/elpa ``  |