### PR TITLE
chore(flake/emacs-overlay): `7186cb7a` -> `2a5b681a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1698227597,
-        "narHash": "sha256-0hWisYhj+ZttndXjTCCDEhzi7D34hNlaHzKH2pIKpIo=",
+        "lastModified": 1698294534,
+        "narHash": "sha256-PbJHPi9gGITjSNF9Vrcz19QqNjOYhRugx2QuQ2IAIwY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7186cb7a20f6a34f5d1cbc82cf9181aab4342a54",
+        "rev": "2a5b681a554bc4afdf840201b4f51a09ab23e9b8",
         "type": "github"
       },
       "original": {
@@ -693,11 +693,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1697851979,
-        "narHash": "sha256-lJ8k4qkkwdvi+t/Xc6Fn74kUuobpu9ynPGxNZR6OwoA=",
+        "lastModified": 1697957990,
+        "narHash": "sha256-LlyEQ4z1immaiZV+MQMUXM3KpNoRY/xZVm8mmN5j3yg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5550a85a087c04ddcace7f892b0bdc9d8bb080c8",
+        "rev": "b3ddf9649fdac7db15aeea95cb3114c13594d265",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`2a5b681a`](https://github.com/nix-community/emacs-overlay/commit/2a5b681a554bc4afdf840201b4f51a09ab23e9b8) | `` Updated repos/nongnu `` |
| [`93d8aab7`](https://github.com/nix-community/emacs-overlay/commit/93d8aab7c650884586df44458ff9ab5901be4dd2) | `` Updated repos/melpa ``  |
| [`f03d1b7b`](https://github.com/nix-community/emacs-overlay/commit/f03d1b7b58df777a18dec85fb7b2868b562d35ef) | `` Updated repos/emacs ``  |
| [`f45b8da7`](https://github.com/nix-community/emacs-overlay/commit/f45b8da7645a176174fbd47ea9a29053be37bc5a) | `` Updated repos/elpa ``   |
| [`55d5447d`](https://github.com/nix-community/emacs-overlay/commit/55d5447daffff63db04495bbf9d06c5dde894c12) | `` Updated flake inputs `` |
| [`5bf36bac`](https://github.com/nix-community/emacs-overlay/commit/5bf36bac3904c4138ffc2eb85523d2ffb60ef010) | `` Updated repos/melpa ``  |
| [`c8754202`](https://github.com/nix-community/emacs-overlay/commit/c875420205f936ec0df3a009dca1e6a27808927a) | `` Updated repos/emacs ``  |
| [`4c11a382`](https://github.com/nix-community/emacs-overlay/commit/4c11a382257599b25ca1c077cbba9d87baf006e8) | `` Updated repos/elpa ``   |
| [`56c53da5`](https://github.com/nix-community/emacs-overlay/commit/56c53da59719a22d16492ffd1494ba427dc2374c) | `` Updated flake inputs `` |