### PR TITLE
chore(flake/home-manager): `ae631b0b` -> `09587fbb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697838989,
-        "narHash": "sha256-hwVlO+st8vWJO6iy3/JbMHrUyY4Ak7xUSmffoWqBPUg=",
+        "lastModified": 1698250431,
+        "narHash": "sha256-qs2gTeH4wpnWPO6Oi6sOhp2IhG0i0DzcnrJxIY3/CP8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ae631b0b20f06f7d239d160723d228891ddb2fe0",
+        "rev": "09587fbbc6a669f7725613e044c2577dc5d43ab5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                      |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`09587fbb`](https://github.com/nix-community/home-manager/commit/09587fbbc6a669f7725613e044c2577dc5d43ab5) | `` hyprland: add tray.target ``              |
| [`9d0f799c`](https://github.com/nix-community/home-manager/commit/9d0f799c669833677df31306149d763dbff00e6f) | `` helix: add extraPackages option ``        |
| [`14b54157`](https://github.com/nix-community/home-manager/commit/14b54157201fd574b0fa1b3ce7394c9d3a87fbc1) | `` sxhkd: set scope OOMPolicy to continue `` |
| [`6045b68e`](https://github.com/nix-community/home-manager/commit/6045b68ee725167ed0487f0fb88123202ba61923) | `` cava: add module ``                       |
| [`f540f30f`](https://github.com/nix-community/home-manager/commit/f540f30f1f3c76b68922550dcf5f78f42732fd37) | `` cbatticon: Add support for batteryId ``   |
| [`219d268a`](https://github.com/nix-community/home-manager/commit/219d268a69512ff520fe8da1739ac22d95d52355) | `` aerc: fix config paths on darwin ``       |
| [`81ab1462`](https://github.com/nix-community/home-manager/commit/81ab14626273ca38cba947d9a989c9d72b5e7593) | `` readme: major cleanup ``                  |
| [`4c0bcf5d`](https://github.com/nix-community/home-manager/commit/4c0bcf5dff03c48c4b047c9ab304c74b2bcdcdeb) | `` exa: add aliases to nushell ``            |