### PR TITLE
chore(flake/nixpkgs): `7c9cc5a6` -> `8efd5d1e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -741,11 +741,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1697723726,
-        "narHash": "sha256-SaTWPkI8a5xSHX/rrKzUe+/uVNy6zCGMXgoeMb7T9rg=",
+        "lastModified": 1698134075,
+        "narHash": "sha256-foCD+nuKzfh49bIoiCBur4+Fx1nozo+4C/6k8BYk4sg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7c9cc5a6e5d38010801741ac830a3f8fd667a7a0",
+        "rev": "8efd5d1e283604f75a808a20e6cde0ef313d07d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`1ec4e9de`](https://github.com/NixOS/nixpkgs/commit/1ec4e9dea427d9da06b2c8e174d09267974602ba) | `` nixos/release-combined: drop nixos-rebuild-install-bootloader ``                 |
| [`a9c0720d`](https://github.com/NixOS/nixpkgs/commit/a9c0720daf7f166918002e6b2fcc272615c95ae0) | `` ocamlPackages.yojson: 2.1.0 → 2.1.1 ``                                           |
| [`4bccad99`](https://github.com/NixOS/nixpkgs/commit/4bccad99646094d2b8bc78a4c4e126503f82fdb3) | `` ocamlPackages.core: mark version 0.15 as broken for OCaml ≥ 5.1 ``               |
| [`a76d914f`](https://github.com/NixOS/nixpkgs/commit/a76d914fe778ed748d04f1225a7cf31b3fc80bae) | `` logmein-hamachi: fix wrong base address (#262973) ``                             |
| [`efba8b23`](https://github.com/NixOS/nixpkgs/commit/efba8b23367136880684c5f0a07b2c9cb3100c06) | `` gitkraken: fix runtime error on darwin ``                                        |
| [`055ae344`](https://github.com/NixOS/nixpkgs/commit/055ae344ea5d5782d7c994f0b56b66ccb81b42a0) | `` cinny: 2.2.6 -> 3.0.0 ``                                                         |
| [`601a8b59`](https://github.com/NixOS/nixpkgs/commit/601a8b593d5c70b531559f05046fbd613ddaaa15) | `` cinny: add ashkitten as maintainer ``                                            |
| [`88cf4bb8`](https://github.com/NixOS/nixpkgs/commit/88cf4bb8d3fa735a6f78b6b6e79fb7153a02f1ea) | `` python311Packages.catppuccin: fix build and refactor (#262967) ``                |
| [`6f5d72df`](https://github.com/NixOS/nixpkgs/commit/6f5d72df0bda3f32863778dbae3f9c126b896d5a) | `` packages-config: don't export minimal-bootstrap packages ``                      |
| [`52308bd7`](https://github.com/NixOS/nixpkgs/commit/52308bd7b4056ffe232d7e1256b0cfe598b74290) | `` vimPlugins.conform-nvim: init at 2023-10-22 (#262943) ``                         |
| [`6bed1ae7`](https://github.com/NixOS/nixpkgs/commit/6bed1ae7945064482c7ec4199b4849ed51d951ae) | `` nixos/tests: fix nixos-rebuild-specialisations test definition ``                |
| [`0d55b3fa`](https://github.com/NixOS/nixpkgs/commit/0d55b3faeabdfc77e9c00f7e80b70273462e3806) | `` woodpecker-plugin-git: 2.1.1 -> 2.2.0 ``                                         |
| [`109c7760`](https://github.com/NixOS/nixpkgs/commit/109c77608e9d62f3e2d054c7eba32af43da15675) | `` wasmtime: 13.0.0 -> 14.0.1 ``                                                    |
| [`978d7305`](https://github.com/NixOS/nixpkgs/commit/978d7305cb39a8946e2046a44fba29f63f104524) | `` cargo-hack: 0.6.11 -> 0.6.13 ``                                                  |
| [`343cdd3d`](https://github.com/NixOS/nixpkgs/commit/343cdd3dbff42a41947fbcafe388db02a6f56e99) | `` tts: 0.17.4 -> 0.18.2 ``                                                         |
| [`f6eb3693`](https://github.com/NixOS/nixpkgs/commit/f6eb36936788afc8d6874d7d378b9e8f6cc59eab) | `` whisper-ctranslate2: 0.3.1 -> 0.3.2 ``                                           |
| [`6532b41c`](https://github.com/NixOS/nixpkgs/commit/6532b41c2dd17cbe453af774b73f91acede8c713) | `` cargo-binstall: 1.4.3 -> 1.4.4 ``                                                |
| [`fae968ee`](https://github.com/NixOS/nixpkgs/commit/fae968ee4223e1b209c208dd8bb29e1f7f198e1b) | `` wget2: 2.0.1 -> 2.1.0 ``                                                         |
| [`ff6aa76a`](https://github.com/NixOS/nixpkgs/commit/ff6aa76a84c0437e59034d58598209af3edf1c59) | `` fclones: 0.32.2 -> 0.33.1 ``                                                     |
| [`4bbcae56`](https://github.com/NixOS/nixpkgs/commit/4bbcae56626ea3daee8ce75ea008380f038a6290) | `` pulumiPackages.pulumi-azure-native: 1.92 -> 2.11 (#260456) ``                    |
| [`cc6c2d32`](https://github.com/NixOS/nixpkgs/commit/cc6c2d32f297744e7ef7848fdf5b1886fa04ba4f) | `` rosenpass: refactor, add module and test (#254813) ``                            |
| [`a0d3542f`](https://github.com/NixOS/nixpkgs/commit/a0d3542fe8fb7b2558df84f4cc1f84e60ec3230c) | `` xh: 0.19.3 -> 0.19.4 ``                                                          |
| [`7541547f`](https://github.com/NixOS/nixpkgs/commit/7541547f0127416cd944be63090f69b51de4f23d) | `` audiobookshelf: 2.4.3 -> 2.4.4 ``                                                |
| [`28acb681`](https://github.com/NixOS/nixpkgs/commit/28acb681a2cd11f72facd2285d71ed2cac3b722c) | `` oxlint: 0.0.13 -> 0.0.14 ``                                                      |
| [`c9defce8`](https://github.com/NixOS/nixpkgs/commit/c9defce801f32868d64a75fcc2b0b730a1a15ed7) | `` batman-adv: 2023.1 -> 2023.2 ``                                                  |
| [`09231d6b`](https://github.com/NixOS/nixpkgs/commit/09231d6bdaa3ebf8adf4fbfb977bd9e016dd9dbd) | `` webanalyze: 0.3.8 -> 0.3.9 ``                                                    |
| [`924c6826`](https://github.com/NixOS/nixpkgs/commit/924c682627d1b9779bf9f1455e732c6eac3d3b29) | `` sbt-with-scala-native: 1.9.6 -> 1.9.7 (#262938) ``                               |
| [`a12b4ec8`](https://github.com/NixOS/nixpkgs/commit/a12b4ec80eb6e719a2af2386e0ec012800ce0fe8) | `` at: 3.1.23 -> 3.2.5 ``                                                           |
| [`46e09be1`](https://github.com/NixOS/nixpkgs/commit/46e09be13b3461c36dbde155fcb6d35302856bd9) | `` tuxedo-rs: 0.2.2 -> 0.2.3 ``                                                     |
| [`5237796f`](https://github.com/NixOS/nixpkgs/commit/5237796f2bd081eb4fd44687ecb49e720308d8ae) | `` nixos/ferretdb: fix broken link to documentation ``                              |
| [`fc4325b6`](https://github.com/NixOS/nixpkgs/commit/fc4325b62c13c4b570a50857815eed11a2a64d2d) | `` Update batman-adv to 2023.2 ``                                                   |
| [`a2f9450f`](https://github.com/NixOS/nixpkgs/commit/a2f9450f851c5aa49db37c275e04a2a1696dfbdb) | `` onedrivegui: init at 1.0.3 ``                                                    |
| [`966f527f`](https://github.com/NixOS/nixpkgs/commit/966f527ffa97b2c437c6c7d2f9d830410e4ea66e) | `` wdt: unstable-2022-12-19 -> unstable-2023-07-11 ``                               |
| [`c50c9619`](https://github.com/NixOS/nixpkgs/commit/c50c9619ffa2f9b17b195067f57be1326fa00c92) | `` cargo-semver-checks: 0.24.0 -> 0.24.1 ``                                         |
| [`e4c8b2da`](https://github.com/NixOS/nixpkgs/commit/e4c8b2da5cdb0a13b5a2f51182b8e6e0f96a43d8) | `` git-mit: 5.12.163 -> 5.12.164 ``                                                 |
| [`db1bfc4d`](https://github.com/NixOS/nixpkgs/commit/db1bfc4d8f43a0862d01cd0c5ee8a4b318590fe0) | `` vimPlugins: ferris-nvim -> rustaceanvim ``                                       |
| [`fa28b174`](https://github.com/NixOS/nixpkgs/commit/fa28b174ca1e9575337405d6984c31aaf6c24807) | `` luaPackages: ferris-nvim -> rustaceanvim ``                                      |
| [`7ace862b`](https://github.com/NixOS/nixpkgs/commit/7ace862b960a63d146907833c10fa8d3b7816c9c) | `` firefox-esr-115-unwrapped: 115.3.1esr -> 115.4.0esr ``                           |
| [`d81477df`](https://github.com/NixOS/nixpkgs/commit/d81477df498b088cfa4bc555dd0e17d9890c2a4a) | `` firefox-bin-unwrapped: 118.0.2 -> 119.0 ``                                       |
| [`fba3a50a`](https://github.com/NixOS/nixpkgs/commit/fba3a50a3f1cc1bdb279b0f450683be31b51a450) | `` firefox-unwrapped: 118.0.2 -> 119.0 ``                                           |
| [`3c8a8010`](https://github.com/NixOS/nixpkgs/commit/3c8a8010e1257958267b81d2bd4638bdc8d2c13b) | `` cargo-nextest: fix build on darwin ``                                            |
| [`860e6144`](https://github.com/NixOS/nixpkgs/commit/860e6144808a939c175043ca632b43bc93eec6dd) | `` wakapi: 2.8.2 -> 2.9.1 ``                                                        |
| [`a2f5518c`](https://github.com/NixOS/nixpkgs/commit/a2f5518ca79e848a7c9d9866c5e8d1d7e846039d) | `` waffle: 1.7.2 -> 1.8.0 ``                                                        |
| [`973cca0f`](https://github.com/NixOS/nixpkgs/commit/973cca0ffbc0ed280e0d4f2dd6596f7ee0c6c37c) | `` ventoy-full: 1.0.95 -> 1.0.96 ``                                                 |
| [`e56f2db3`](https://github.com/NixOS/nixpkgs/commit/e56f2db3fc7c55c1ca663cd9107ea4ba94ee09b8) | `` python311Packages.oauthenticator: 16.1.0 -> 16.1.1 ``                            |
| [`7aec39cc`](https://github.com/NixOS/nixpkgs/commit/7aec39cc1f89bb10ff865a50790e40a263be7569) | `` nixos/release-combined: drop ZFS+i686 from blockers ``                           |
| [`46dd712c`](https://github.com/NixOS/nixpkgs/commit/46dd712c1bd2d2050cd0c95f61592818eb465d73) | `` vultr-cli: 2.18.2 -> 2.19.0 ``                                                   |
| [`15e24de9`](https://github.com/NixOS/nixpkgs/commit/15e24de9f85d9be4e3e501bd738fe5502217002a) | `` python311Packages.hcloud: 1.30.0 -> 1.31.0 ``                                    |
| [`6fe52125`](https://github.com/NixOS/nixpkgs/commit/6fe521251563b75fe30597d5b1ba1ba848fdaf82) | `` python311Packages.google-cloud-speech: 2.21.0 -> 2.21.1 ``                       |
| [`64754a98`](https://github.com/NixOS/nixpkgs/commit/64754a988e7b0615c2ea94aea4b5e251228466e8) | `` python311Packages.google-cloud-trace: 1.11.2 -> 1.11.3 ``                        |
| [`af557a58`](https://github.com/NixOS/nixpkgs/commit/af557a587bc65669154d30607affd0d416f2b938) | `` typora: 1.7.5 -> 1.7.6 ``                                                        |
| [`a845a716`](https://github.com/NixOS/nixpkgs/commit/a845a7162cb493dcf9c743533c2dbaff3cea40a2) | `` tf-summarize: 0.3.3 -> 0.3.6 ``                                                  |
| [`a3fcdd0c`](https://github.com/NixOS/nixpkgs/commit/a3fcdd0c3dd8f489946c2e0941e0ba7799d0f005) | `` svd2rust: 0.30.1 -> 0.30.2 ``                                                    |
| [`61658462`](https://github.com/NixOS/nixpkgs/commit/616584627a1a341ae7070db3f1c1fcd9a6980534) | `` mullvad: 2023.3 -> 2023.5 ``                                                     |
| [`f9656cc7`](https://github.com/NixOS/nixpkgs/commit/f9656cc72b93948a794cefcc4641296618833084) | `` quake3-wrapper: Fix paths ``                                                     |
| [`2f90fcb9`](https://github.com/NixOS/nixpkgs/commit/2f90fcb9734fe0cd7ce414c32bb157ceb9309701) | `` neovim-qt-unwrapped: 0.2.17 -> 0.2.18 ``                                         |
| [`7570b91f`](https://github.com/NixOS/nixpkgs/commit/7570b91f6819d5017abf57a5eb9cb95c6095ff3e) | `` hdf5: fix runtime error on darwin ``                                             |
| [`7ffbdbaa`](https://github.com/NixOS/nixpkgs/commit/7ffbdbaa41070fb7dfafbdfaf7cf99736ba8410d) | `` python311Packages.drf-spectacular: fix tests ``                                  |
| [`61a9e5e7`](https://github.com/NixOS/nixpkgs/commit/61a9e5e7c6c0f17018e0d2709c67d0cb68e8ead6) | `` pipx: 1.2.0 -> 1.2.1 ``                                                          |
| [`bd1fbd67`](https://github.com/NixOS/nixpkgs/commit/bd1fbd67f2eb1db6d353a3fa08ef7302d5692f78) | `` sphinx-automodapi: fix import check, tests, use pyproject ``                     |
| [`cfea4923`](https://github.com/NixOS/nixpkgs/commit/cfea4923c62373e861fbefb87d866a004a24c342) | `` pgmoneta: 0.7.0 -> 0.7.1 ``                                                      |
| [`c85bf013`](https://github.com/NixOS/nixpkgs/commit/c85bf0137df4d686cf080b05520800f92ee2a1d6) | `` python311Packages.aioapns: 3.0 -> 3.1 ``                                         |
| [`189c3c75`](https://github.com/NixOS/nixpkgs/commit/189c3c75fd5fb4594dba010c36065e8a3b985c02) | `` sing-box: 1.5.3 -> 1.5.4 ``                                                      |
| [`483eaea5`](https://github.com/NixOS/nixpkgs/commit/483eaea5f28ff1c8e9813f40ed86c9c8992cc82e) | `` python311Packages.adguardhome: 0.6.1 -> 0.6.2 ``                                 |
| [`f10674a4`](https://github.com/NixOS/nixpkgs/commit/f10674a42c75319027e57ffc609030b3d884128e) | `` python311Packages.dj-rest-auth: fix tests ``                                     |
| [`2201fa71`](https://github.com/NixOS/nixpkgs/commit/2201fa719978b02da5fab81c197c2002f1d081f4) | `` nu_scripts: unstable-2023-10-07 -> unstable-2023-10-19 ``                        |
| [`12a27740`](https://github.com/NixOS/nixpkgs/commit/12a2774096e81b39981023a7a6e1f405fc59fb75) | `` nushellPlugins.regex: remove unused arg ``                                       |
| [`cee03e76`](https://github.com/NixOS/nixpkgs/commit/cee03e7670305dac6e28b815f01095adc4a62057) | `` nushellPlugins.net: init at unstable-2023-09-27 ``                               |
| [`100603f1`](https://github.com/NixOS/nixpkgs/commit/100603f1ad8dfbd09ac76db4456d692bb9375b11) | `` nushellPlugins: update to nushell 0.86.0 ``                                      |
| [`40920ff1`](https://github.com/NixOS/nixpkgs/commit/40920ff12b330460167b597fdfbf80fecac91bcb) | `` evcc: 0.120.3 -> 0.121.2 ``                                                      |
| [`47ea99dd`](https://github.com/NixOS/nixpkgs/commit/47ea99dd5a56b14b8bc9c86e2909d9492eba65b7) | `` armcord: remove unnecessary `splitString` ``                                     |
| [`87ea53f7`](https://github.com/NixOS/nixpkgs/commit/87ea53f7c9b1093cc5f74b282e5e6ef1710be5cb) | `` lgogdownloader: 3.11 -> 3.12 ``                                                  |
| [`65cb8b4e`](https://github.com/NixOS/nixpkgs/commit/65cb8b4e01c43d20b820e8c938f53a54f76cc3b1) | `` nixos/tests: make nixos-rebuild tests x86_64-linux only ``                       |
| [`ab3ca40d`](https://github.com/NixOS/nixpkgs/commit/ab3ca40d2e2145ca342cb7725ad21bb14190a05d) | `` nixos/release-combined: add nixos-rebuild-specialisations to release-combined `` |
| [`ccebc899`](https://github.com/NixOS/nixpkgs/commit/ccebc899547d6962a01fb07a98c863caec7d7486) | `` nixos/tests: add nixos-rebuild-install-bootloader ``                             |
| [`6ae8e334`](https://github.com/NixOS/nixpkgs/commit/6ae8e33459cc9b720d68cbe472fd2c200215fb01) | `` python311Packages.publicsuffixlist: 0.10.0.20231020 -> 0.10.0.20231022 ``        |
| [`9593318c`](https://github.com/NixOS/nixpkgs/commit/9593318c0d89b6f6ba2147347ab7b5c14f189553) | `` extremetuxracer: set meta.mainProgram ``                                         |
| [`b20261a2`](https://github.com/NixOS/nixpkgs/commit/b20261a2f29f9f6fb210b856c14c21cf9ebc801f) | `` vtm: 0.9.9u -> 0.9.9w.1 ``                                                       |
| [`d4b380d6`](https://github.com/NixOS/nixpkgs/commit/d4b380d6a7efdb772c0fa31d4c3b4c15c3051c36) | `` knot-dns: test exporter in passthru.tests ``                                     |
| [`715afeb4`](https://github.com/NixOS/nixpkgs/commit/715afeb48ba1eb511548b85e6fa792d768fac44e) | `` nixos/tests/prometheus-exporters/knot: update for new exporter version ``        |
| [`589ccfda`](https://github.com/NixOS/nixpkgs/commit/589ccfdac1ec6ae0e38f4f253f69be50c8713e1b) | `` nixos/prometheus-exporters/knot: update for new exporter ``                      |
| [`46b989f9`](https://github.com/NixOS/nixpkgs/commit/46b989f924f4d0f450ec1948b2de99293d563669) | `` prometheus-knot-exporter: 2021-08-21 -> 3.3.2 ``                                 |
| [`514a558d`](https://github.com/NixOS/nixpkgs/commit/514a558d64ab10271a773fff2d40008a30d5c05f) | `` python310Packages.libknot: init at 3.3.2 ``                                      |
| [`c9fd3c63`](https://github.com/NixOS/nixpkgs/commit/c9fd3c63b228951eb21c769023dde9561f5ecf0a) | `` unifont_upper: 15.1.02 -> 15.1.03 ``                                             |
| [`2f7e9723`](https://github.com/NixOS/nixpkgs/commit/2f7e972374bc999e13dc6c40fb7d4d313db21bf6) | `` tellico: 3.5.1 -> 3.5.2 ``                                                       |
| [`14019b72`](https://github.com/NixOS/nixpkgs/commit/14019b7268883067e35bbdedcc84c8c297692f4f) | `` sbt: 1.9.6 -> 1.9.7 ``                                                           |
| [`c315a411`](https://github.com/NixOS/nixpkgs/commit/c315a4118a0cd9f62ecb194450f02adb555359d3) | `` python311Packages.python-gvm: 23.10.0 -> 23.10.1 ``                              |
| [`ee0d2695`](https://github.com/NixOS/nixpkgs/commit/ee0d269562057bdeee36b0415db317313a4b49c0) | `` proverif: 2.04 → 2.05 ``                                                         |
| [`5bc9a594`](https://github.com/NixOS/nixpkgs/commit/5bc9a5944ef8fac0fd49dbcc9c3a9e95f42e9453) | `` python311Packages.validobj: 1.0 -> 1.1 ``                                        |
| [`3ceea278`](https://github.com/NixOS/nixpkgs/commit/3ceea2785ec8111283cece7085903876d6f2f396) | `` evcxr: 0.15.1 -> 0.16.0 ``                                                       |
| [`c8ae9117`](https://github.com/NixOS/nixpkgs/commit/c8ae9117bf2d47fdb5bff1c27b3b5b4e8ab14d1e) | `` lzlib: fix cross ``                                                              |
| [`90b4574e`](https://github.com/NixOS/nixpkgs/commit/90b4574eafe92caddd634fe9e9a41a38c338a5b8) | `` python311Packages.qbittorrent-api: 2023.9.53 -> 2023.10.54 ``                    |
| [`4c597607`](https://github.com/NixOS/nixpkgs/commit/4c5976077891c9fe8a78adeaa83f0b0db77d1361) | `` python311Packages.pywemo: 1.3.0 -> 1.3.1 ``                                      |
| [`69919a28`](https://github.com/NixOS/nixpkgs/commit/69919a28af1c181dc84523b100a8ed45d4071304) | `` verilator: 5.012 -> 5.016 ``                                                     |
| [`7b9fa5f6`](https://github.com/NixOS/nixpkgs/commit/7b9fa5f6c36e91b3ea6b2e97c647a062af951c46) | `` crate2nix: 0.10.0 -> 0.11.0 ``                                                   |
| [`4fc0e336`](https://github.com/NixOS/nixpkgs/commit/4fc0e3369810899279f0423699e2604e7088ff76) | `` buildRustPackage: add isMips64n32 to badPlatforms ``                             |
| [`3bd3809d`](https://github.com/NixOS/nixpkgs/commit/3bd3809d0e5cb8ada73d0ee856b6ad9121cc907e) | `` buildRustCrate: add isMips64n32 to badPlatforms ``                               |
| [`9c61d0ff`](https://github.com/NixOS/nixpkgs/commit/9c61d0ff06d4e3da1f981e67713eefc34095f151) | `` python311Packages.pyfibaro: 0.7.5 -> 0.7.6 ``                                    |
| [`b9b49e5e`](https://github.com/NixOS/nixpkgs/commit/b9b49e5ee5ec34e8303c7d9affe83143f73fbb10) | `` python310Packages.correctionlib: fix build ``                                    |
| [`0c9d2b67`](https://github.com/NixOS/nixpkgs/commit/0c9d2b67b38b4dc48dbd1e9972ac5a8994569ec4) | `` python310Packages.coffea: 2023.7.0.rc0 -> 2023.10.0.rc1 ``                       |
| [`366f7811`](https://github.com/NixOS/nixpkgs/commit/366f7811baf29849cdadd0cbe3d832e0dde89ced) | `` python310Packages.uproot: 5.0.12 -> 5.1.2 ``                                     |
| [`ed8ef58f`](https://github.com/NixOS/nixpkgs/commit/ed8ef58fd9c4a6c2eadd8c48e63fd0f5710a1194) | `` python310Packages.dask-gateway-server: 2022.10.0 -> 2023.9.0 ``                  |
| [`af8a670c`](https://github.com/NixOS/nixpkgs/commit/af8a670c87a49576c29929cd25b77c4601a9e033) | `` python310Packages.dask-awkward: 2023.8.1 -> 2023.10.0 ``                         |
| [`ab8a1d6e`](https://github.com/NixOS/nixpkgs/commit/ab8a1d6efc5028b45fa7c0fb64945720351d0d53) | `` python310Packages.distributed: 2023.8.1 -> 2023.10.0 ``                          |
| [`53491174`](https://github.com/NixOS/nixpkgs/commit/534911741f908919e0103b2e51010a0f24dfc1c9) | `` python310Packages.dask: 2023.8.0 -> 2023.10.0 ``                                 |
| [`6bdb8010`](https://github.com/NixOS/nixpkgs/commit/6bdb80100eb27b64060c4cae0e1602ac83834a8d) | `` python310Packages.awkward: 2.3.1 -> 2.4.6 ``                                     |