### PR TITLE
chore(flake/nixos-hardware): `72d53d51` -> `80d98a7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1697748412,
-        "narHash": "sha256-5VSB63UE/O191cuZiGHbCJ9ipc7cGKB8cHp0cfusuyo=",
+        "lastModified": 1698053470,
+        "narHash": "sha256-sP8D/41UiwC2qn0X40oi+DfuVzNHMROqIWdSdCI/AYA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "72d53d51704295f1645d20384cd13aecc182f624",
+        "rev": "80d98a7d55c6e27954a166cb583a41325e9512d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`80d98a7d`](https://github.com/NixOS/nixos-hardware/commit/80d98a7d55c6e27954a166cb583a41325e9512d7) | `` feat(tuxedo/pulse/15/gen2): use default 'hardware.amdgpu.loadInInitrd' ``       |
| [`cdf84962`](https://github.com/NixOS/nixos-hardware/commit/cdf849625bd019a433d8665ebcf9895c8bd1aceb) | `` refactor(tuxedo/pulse/15/gen2): simplify device expression ``                   |
| [`ccf63681`](https://github.com/NixOS/nixos-hardware/commit/ccf6368108fd52c7c9436df62c82ed0fbe0b844d) | `` refactor(tuxedo/pulse/15/gen2): revert device expression simplification ``      |
| [`0de78480`](https://github.com/NixOS/nixos-hardware/commit/0de78480a2999d6da4aea501335fcc7e096d35f9) | `` refactor(tuxedo/pulse/15/gen2): simplify device expression ``                   |
| [`ae8f623d`](https://github.com/NixOS/nixos-hardware/commit/ae8f623d5bdf2e70eaab1abc9050caec1cb7f211) | `` refactor(tuxedo/pulse/15/gen2): use 'builtins' instead of 'lib' ``              |
| [`dd18dc77`](https://github.com/NixOS/nixos-hardware/commit/dd18dc771432c64ea42592aeba5ea0e078126ddb) | `` fix(tuxedo/pulse/15/gen2): prevent 'Secure display: Generic Failure' warning `` |
| [`256f598a`](https://github.com/NixOS/nixos-hardware/commit/256f598a1b48455fd8b844d6e29cda08b9674c5b) | `` fix(tuxedo/pulse/15/gen2): properly suspend the system ``                       |
| [`b93eed75`](https://github.com/NixOS/nixos-hardware/commit/b93eed7525342ff65c4e510a223264419dc3d304) | `` feat(tuxedo/pulse/15/gen2): import common functionality ``                      |
| [`f9acbf64`](https://github.com/NixOS/nixos-hardware/commit/f9acbf645e73ad2eaa5d164caa17c6dc1b5b2865) | `` feat(tuxedo/pulse/15/gen2): add flake output ``                                 |
| [`6856dab0`](https://github.com/NixOS/nixos-hardware/commit/6856dab060354653f370bc9f1530b263c76f1043) | `` docs(tuxedo/pulse/15/gen2): include in README ``                                |
| [`cf64d806`](https://github.com/NixOS/nixos-hardware/commit/cf64d8064c7c1fe7b57fa64c8e0909b78f2d6897) | `` docs(tuxedo/pulse/15/gen2): reference official webpage ``                       |
| [`e07351b3`](https://github.com/NixOS/nixos-hardware/commit/e07351b303d56802a79e8ecb00f9c738ce10dfae) | `` docs(tuxedo/pulse/15/gen2): add code owner ``                                   |