### PR TITLE
chore(flake/pre-commit-hooks): `8cc349bf` -> `bd38df3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1697746376,
-        "narHash": "sha256-gu77VkgdfaHgNCVufeb6WP9oqFLjwK4jHcoPZmBVF3E=",
+        "lastModified": 1698227354,
+        "narHash": "sha256-Fi5H9jbaQLmLw9qBi/mkR33CoFjNbobo5xWdX4tKz1Q=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "8cc349bfd082da8782b989cad2158c9ad5bd70fd",
+        "rev": "bd38df3d508dfcdff52cd243d297f218ed2257bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                           |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
| [`8364aa05`](https://github.com/cachix/pre-commit-hooks.nix/commit/8364aa05c9e92d758dca0bd8a03c9fa400c41fd9) | `` Add optional settings to `latexindent` hook `` |