### PR TITLE
chore(flake/nix-index-database): `29977d07` -> `5a200628`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -591,11 +591,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697340827,
-        "narHash": "sha256-XlrR68N7jyaZ0bs8TPrhqcWG0IPG3pbjrKzJMpYOsos=",
+        "lastModified": 1697946153,
+        "narHash": "sha256-7k7qIwWLaYPgQ4fxmEdew3yCffhK6rM4I4Jo3X/79DA=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "29977d0796c058bbcfb2df5b18eb5badf1711007",
+        "rev": "5a2006282caaf32663cdcd582c5b18809c7d7d8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`5a200628`](https://github.com/nix-community/nix-index-database/commit/5a2006282caaf32663cdcd582c5b18809c7d7d8d) | `` update packages.nix to release 2023-10-22-034115 `` |
| [`d1d9ae91`](https://github.com/nix-community/nix-index-database/commit/d1d9ae914431177d3898605aabbaad0d37803649) | `` flake.lock: Update ``                               |