### PR TITLE
chore(flake/sops-nix): `30a0ba4a` -> `014e44d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -937,11 +937,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1697943852,
-        "narHash": "sha256-DaBxUPaZhQ3yLCmAATshYB7qo7NwcMvSFWz9T3bjYYY=",
+        "lastModified": 1698273636,
+        "narHash": "sha256-swsqg/ckSVJnravx7ie9NFQSKIH27owtlk0wh4+xStk=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "30a0ba4a20703b4bfe047fe5def1fc24978e322c",
+        "rev": "014e44d334a39481223a5d163530d4c4ca2e75cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                              |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`014e44d3`](https://github.com/Mic92/sops-nix/commit/014e44d334a39481223a5d163530d4c4ca2e75cb) | `` update vendorHash ``                                              |
| [`e40b19ad`](https://github.com/Mic92/sops-nix/commit/e40b19ad42db05b7624e8e7bfe0b592b95fe58bf) | `` build(deps): bump google.golang.org/grpc from 1.53.0 to 1.56.3 `` |