### PR TITLE
chore(flake/nixpkgs): `7c9cc5a6` -> `0cbe9f69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -741,11 +741,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1697723726,
-        "narHash": "sha256-SaTWPkI8a5xSHX/rrKzUe+/uVNy6zCGMXgoeMb7T9rg=",
+        "lastModified": 1698611440,
+        "narHash": "sha256-jPjHjrerhYDy3q9+s5EAsuhyhuknNfowY6yt6pjn9pc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7c9cc5a6e5d38010801741ac830a3f8fd667a7a0",
+        "rev": "0cbe9f69c234a7700596e943bfae7ef27a31b735",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
| [`0cbe9f69`](https://github.com/NixOS/nixpkgs/commit/0cbe9f69c234a7700596e943bfae7ef27a31b735) | `` nongnu-packages: updated 2023-10-28 (from overlay) ``                                               |
| [`9e12287e`](https://github.com/NixOS/nixpkgs/commit/9e12287efbae92b5de0f6f7e0fa56f87df90a12f) | `` melpa-packages: updated 2023-10-28 (from overlay) ``                                                |
| [`2447435c`](https://github.com/NixOS/nixpkgs/commit/2447435c7616e1fdde5d1199a372d77539d6d4f7) | `` elpa-devel-packages: updated 2023-10-28 (from overlay) ``                                           |
| [`69d9a16a`](https://github.com/NixOS/nixpkgs/commit/69d9a16a3c8b8659df7f4800dfec4426c0ed358c) | `` elpa-packages: updated 2023-10-28 (from overlay) ``                                                 |
| [`b2fae248`](https://github.com/NixOS/nixpkgs/commit/b2fae2486e42f967aa465e91fd596280aeca7798) | `` emacs: small rewrite ``                                                                             |
| [`1fa1861e`](https://github.com/NixOS/nixpkgs/commit/1fa1861e2edda76fa0573f5a052b9e5ea2aaec25) | `` emacs: move generic.nix to make-emacs.nix ``                                                        |
| [`22db6e5e`](https://github.com/NixOS/nixpkgs/commit/22db6e5e47c8b8e3e87be4d5728feeb84bf2751f) | `` Remove mistakenly committed test output ``                                                          |
| [`82bddde9`](https://github.com/NixOS/nixpkgs/commit/82bddde9da3434d680af6eccca0a936c14c41799) | `` telegram-desktop: override glibmm to 2.78.0 ``                                                      |
| [`334cdcb7`](https://github.com/NixOS/nixpkgs/commit/334cdcb78fad7304acd59acb979b644a05a2c39c) | `` nvme-cli: only use libhugetlbfs if not broken ``                                                    |
| [`f15e58cb`](https://github.com/NixOS/nixpkgs/commit/f15e58cbeb6bf7a01c171ed6d36d53ea2f8505ea) | `` luarocks-packages-update: init (#262156) ``                                                         |
| [`5061ffb8`](https://github.com/NixOS/nixpkgs/commit/5061ffb8c3f8ede7d050e5121fde6652d52d62a0) | `` libhugetlbfs: move broken to badPlatforms + update brokenness status ``                             |
| [`8581d363`](https://github.com/NixOS/nixpkgs/commit/8581d363d907e1293ca80e3595410467a2b2c355) | `` mm-common: set strictDeps, add python3 and bash to buildInputs for shebangs ``                      |
| [`372997d7`](https://github.com/NixOS/nixpkgs/commit/372997d766b0cc5727824ed0bc150f821e293382) | `` telegram-desktop: 4.8.4 -> 4.11.1 ``                                                                |
| [`972f7a99`](https://github.com/NixOS/nixpkgs/commit/972f7a99cb0f20804645dceeab3474772ad82ef3) | `` telegram-desktop.tg_owt: unstable-2023-08-15 -> unstable-2023-10-17 ``                              |
| [`c7b3a19d`](https://github.com/NixOS/nixpkgs/commit/c7b3a19df6005495b56cba838ec693ea7791c963) | `` erigon: add package option to override default version ``                                           |
| [`c9e3cc43`](https://github.com/NixOS/nixpkgs/commit/c9e3cc43c7baea00c41a4aa24a5e31a08fbfb894) | `` nixos: fix iproute2 invocations (#263976) ``                                                        |
| [`78aa5599`](https://github.com/NixOS/nixpkgs/commit/78aa55991398d7e1ddbe9aa8737bd80b07fcb7c0) | `` netdata: don't use absolute path for `echo` ``                                                      |
| [`7ea67d7c`](https://github.com/NixOS/nixpkgs/commit/7ea67d7cb6d25ba4dbc2899bf2f09fe80861cd29) | `` Revert "nixos/activation: remove specialfs activationScript" ``                                     |
| [`d51318c4`](https://github.com/NixOS/nixpkgs/commit/d51318c492e102ed776dc2034c66c14bd68ba2c8) | `` python3.pkgs.complycube: init at 1.1.6 (#236895) ``                                                 |
| [`200c2340`](https://github.com/NixOS/nixpkgs/commit/200c2340f0bc3a26092aaa574feffc1ab86f54cc) | `` kodiPackages.somafm: init at 2.0.1 ``                                                               |
| [`4c84eb4e`](https://github.com/NixOS/nixpkgs/commit/4c84eb4e490602c69d05ad9bf58cae372b570692) | `` schildichat-desktop: use electron 25 ``                                                             |
| [`02fad9ee`](https://github.com/NixOS/nixpkgs/commit/02fad9eefdba1b8dfda4cb494c0940c79a7367ab) | `` super-slicer-latest: 2.4.58.3 -> 2.4.58.5; super-slicer-beta: init at 2.5.59.2 ``                   |
| [`318af65e`](https://github.com/NixOS/nixpkgs/commit/318af65e514f77d413929f0d21d364e23d47cc15) | `` livebook: 0.11.1 -> 0.11.3 ``                                                                       |
| [`c03b7422`](https://github.com/NixOS/nixpkgs/commit/c03b74224a01016bb64f1e458870d95e86bdc87a) | `` erigon: fix SIGILL error due to missing CGO_CFLAGS ``                                               |
| [`f9139b2b`](https://github.com/NixOS/nixpkgs/commit/f9139b2b99bc45eb681d5ef949498e30b468df03) | `` kodiPackages.radioparadise: init at 1.0.5 ``                                                        |
| [`d2362002`](https://github.com/NixOS/nixpkgs/commit/d236200278aa043974194adecd0b22bcdeda6dfd) | `` lagrange-tui: fix build ``                                                                          |
| [`424b0cef`](https://github.com/NixOS/nixpkgs/commit/424b0cefa44c3b08e1f71ae48e3621a72931739a) | `` nixos/version: rewrite stateVersion documentation ``                                                |
| [`fb1ccc91`](https://github.com/NixOS/nixpkgs/commit/fb1ccc91f74d28b24698b547bdbefd9231834bb6) | `` nixos-generate-config: rewrite stateVersion comment again ``                                        |
| [`05dd78cf`](https://github.com/NixOS/nixpkgs/commit/05dd78cf4b22b4c15d2ddcf5958c8e508616b86e) | `` nixos/lib/test-driver: add driver-timeout as a passthru test ``                                     |
| [`c9021963`](https://github.com/NixOS/nixpkgs/commit/c90219633c40eaeb9ca69c7a8cea75123a13d596) | `` nixos/tests/nixos-test-driver: test timeout failures ``                                             |
| [`a0dc17bd`](https://github.com/NixOS/nixpkgs/commit/a0dc17bd572018e9a4c6f77e30583f5fc292c5d5) | `` nixos/lib/testing/run: expose `rawTestDerivation` ``                                                |
| [`d4d75501`](https://github.com/NixOS/nixpkgs/commit/d4d7550108e4e3fe6f9303e2a57379fba10da77d) | `` nixos/test-driver: provide a global timeout ``                                                      |
| [`3f70a50c`](https://github.com/NixOS/nixpkgs/commit/3f70a50cc5507c2a11e28db2343904dbb65b45e8) | `` nfpm: 2.33.1 -> 2.34.0 ``                                                                           |
| [`cb714c77`](https://github.com/NixOS/nixpkgs/commit/cb714c774e096f5dbbd3f2c3033b5964f6015752) | `` evcc: 0.121.3 -> 0.121.5 ``                                                                         |
| [`71ef7ea8`](https://github.com/NixOS/nixpkgs/commit/71ef7ea8fe2aff7c21cf2e7ec7283a4276a2f366) | `` libcxxrt: unstable-2022-08-08 -> unstable-2023-10-11 ``                                             |
| [`f461ddf2`](https://github.com/NixOS/nixpkgs/commit/f461ddf2e979880ebeb648a5187a603d822ac7b8) | `` miniaudio: 0.11.17 -> 0.11.18 ``                                                                    |
| [`307cb4e1`](https://github.com/NixOS/nixpkgs/commit/307cb4e16102ae0f067869d768ca802fc7c3ee83) | `` ibus-engines.m17n: 1.4.22 -> 1.4.23 ``                                                              |
| [`fcafe52b`](https://github.com/NixOS/nixpkgs/commit/fcafe52bfe44549ddf296a4cfe9a44ca50b1fd70) | `` alacritty-theme: unstable-2023-10-12 -> unstable-2023-10-26 ``                                      |
| [`88ea002e`](https://github.com/NixOS/nixpkgs/commit/88ea002eed685cb804619847e812a5a53d40ca9e) | `` bosh-cli: 7.4.0 -> 7.4.1 ``                                                                         |
| [`1c3fef88`](https://github.com/NixOS/nixpkgs/commit/1c3fef88f8c8c9dce50549b887669d1e5c9483f3) | `` bonmin: 1.8.8 -> 1.8.9 ``                                                                           |
| [`b46d9323`](https://github.com/NixOS/nixpkgs/commit/b46d9323e61d2ae111f99bbd0f156abad8cc10a5) | `` vesktop: 0.4.1 -> 0.4.2 ``                                                                          |
| [`c0ea6469`](https://github.com/NixOS/nixpkgs/commit/c0ea646933ccbebcdf93fb46deb9a78078686972) | `` beeper: 3.82.8 -> 3.83.13 ``                                                                        |
| [`67be9f80`](https://github.com/NixOS/nixpkgs/commit/67be9f80f8550c42462b31a7b4bffa4ba7f44c6d) | `` bdf2psf: 1.222 -> 1.223 ``                                                                          |
| [`7ea1c13f`](https://github.com/NixOS/nixpkgs/commit/7ea1c13fee47894749f22910f05178c23ad48ad6) | `` python3Packages.tensorflow-probability: invalidate hash since tensorflow is broken ``               |
| [`ba070497`](https://github.com/NixOS/nixpkgs/commit/ba0704979d88e12f56b614e25e44ce8a6f551b4d) | `` python3Packages.jaxlib: Update hashes after bazel_6 upgrade ``                                      |
| [`7fa6816c`](https://github.com/NixOS/nixpkgs/commit/7fa6816c0cf417c9a2da691f3c41f55f43a64697) | `` envoy: Update hash after bazel_6 upgrade ``                                                         |
| [`4212f807`](https://github.com/NixOS/nixpkgs/commit/4212f807208ff7573dacccae5ff5833171bc38a0) | `` envoy: Downgrade go to 1.20 ``                                                                      |
| [`211bc94a`](https://github.com/NixOS/nixpkgs/commit/211bc94a890968aa61fc05763fdb6864f3945123) | `` python311Packages.nuitka: add propagatedBuildInputs and enable pythonImportsCheck and checkPhase `` |
| [`67b9ab1b`](https://github.com/NixOS/nixpkgs/commit/67b9ab1b0cf2dfb3bbbda74d00eb9bfac53cf39c) | `` python311Packages.google-cloud-firestore: 2.12.0 -> 2.13.0 ``                                       |
| [`e0660043`](https://github.com/NixOS/nixpkgs/commit/e06600438bafc3601f766fc4bf7811022f89a521) | `` terragrunt: 0.52.3 -> 0.53.0 ``                                                                     |
| [`726ca9bd`](https://github.com/NixOS/nixpkgs/commit/726ca9bdb9392d827c58d00f3bff3c2dc59e1766) | `` karmor: 0.14 -> 0.14.2 ``                                                                           |
| [`4eed1626`](https://github.com/NixOS/nixpkgs/commit/4eed162617d66e2bafbd447d6a797e83d5207558) | `` lexicon: 3.16.0 -> 3.16.1 ``                                                                        |
| [`ccb5cea4`](https://github.com/NixOS/nixpkgs/commit/ccb5cea4a85c5360a8b92289552b872c9be0178f) | `` lagrange: 1.17.0 -> 1.17.2 ``                                                                       |
| [`7c3e4348`](https://github.com/NixOS/nixpkgs/commit/7c3e43481d5e0c581888222e3abd0d38e9b935a8) | `` kubeseal: 0.24.1 -> 0.24.2 ``                                                                       |
| [`a2deca4d`](https://github.com/NixOS/nixpkgs/commit/a2deca4d6a18a5669e337d6c353bf4b85130d370) | `` kubecfg: 0.34.1 -> 0.34.2 ``                                                                        |
| [`449c5207`](https://github.com/NixOS/nixpkgs/commit/449c520747fac40641acb3c1786520a931e0ccb5) | `` zarf: 0.29.2 -> 0.30.0 ``                                                                           |
| [`e9d82967`](https://github.com/NixOS/nixpkgs/commit/e9d82967021236ad42d70928a8be0af097459dfa) | `` komga: 1.5.1 -> 1.6.4 ``                                                                            |
| [`137a3c13`](https://github.com/NixOS/nixpkgs/commit/137a3c1303104df0f564684b4e8f0c51e14e65e9) | `` systemd domainname service - fix missing domainname binary ``                                       |
| [`d7a8b63c`](https://github.com/NixOS/nixpkgs/commit/d7a8b63cede06bf3514377c988e995a1a7a384e2) | `` kodiPackages.arteplussept: 1.4.0 -> 1.4.1 ``                                                        |
| [`12268976`](https://github.com/NixOS/nixpkgs/commit/122689763ab33ae2ebeb21f1e25961dd8d639fa4) | `` vgmstream: unstable-2022-02-21 -> 1879 ``                                                           |
| [`61df5d13`](https://github.com/NixOS/nixpkgs/commit/61df5d13187b0633e6f264f4c9adb052d020399a) | `` python311Packages.nuitka: 1.1.5 -> 1.8.4 ``                                                         |
| [`904decfc`](https://github.com/NixOS/nixpkgs/commit/904decfcce89cf206c03087a4a73428116d32424) | `` kaldi: unstable-2023-05-02 -> unstable-2023-10-13 ``                                                |
| [`e3bfec92`](https://github.com/NixOS/nixpkgs/commit/e3bfec924843abcc82252ee2413ecc53ef264558) | `` python310Packages.openrazer: 3.5.1 -> 3.6.1 ``                                                      |
| [`dab520c3`](https://github.com/NixOS/nixpkgs/commit/dab520c3f6c35b3b3515e89620d244ee15dda759) | `` fsautocomplete: 0.66.1 -> 0.67.0 ``                                                                 |
| [`289d2f9b`](https://github.com/NixOS/nixpkgs/commit/289d2f9b7548ac224693e8db4045a4d2ba61c37c) | `` jackett: 0.21.993 -> 0.21.1096 ``                                                                   |
| [`7d7d9b8c`](https://github.com/NixOS/nixpkgs/commit/7d7d9b8cf10504b8f483fb1a317353a889d94d5b) | `` direwolf: 1.6 -> 1.7 ``                                                                             |
| [`32ad2f63`](https://github.com/NixOS/nixpkgs/commit/32ad2f638e63daa97614d522a366ff5f63da46c0) | `` hclfmt: 2.18.1 -> 2.19.1 (#264053) ``                                                               |
| [`132dc357`](https://github.com/NixOS/nixpkgs/commit/132dc357481c3c8db4c8b7b703d0f87c7f6a6941) | `` iosevka: 27.3.1 -> 27.3.2 ``                                                                        |
| [`bf12f889`](https://github.com/NixOS/nixpkgs/commit/bf12f88950b6efa41d911f0eaf6a2e1dea7c0d65) | `` grpcui: 1.3.2 -> 1.3.3 ``                                                                           |
| [`e84db52e`](https://github.com/NixOS/nixpkgs/commit/e84db52ea5c497cdb7cf8b7b43c84533cf73a878) | `` python311Packages.identify: 2.5.30 -> 2.5.31 ``                                                     |
| [`1ab0c809`](https://github.com/NixOS/nixpkgs/commit/1ab0c80981205f5cfe756310bcaa09ea6b7af0a8) | `` python311Packages.heatzypy: 2.1.5 -> 2.1.7 ``                                                       |
| [`88e82879`](https://github.com/NixOS/nixpkgs/commit/88e82879f4ed8d87ab586f6affa04b0101e70a89) | `` nixos/unifi: fix use of optionalString ``                                                           |
| [`5b007e61`](https://github.com/NixOS/nixpkgs/commit/5b007e6148cb55adde5310f08e3c781daa5cdca1) | `` graalvmCEPackages.graalpy: 23.1.0 -> 23.1.1 ``                                                      |
| [`da8eff2e`](https://github.com/NixOS/nixpkgs/commit/da8eff2e19b2b98e11240b486028616089d9a11c) | `` graalvmCEPackages.truffleruby: 23.1.0 -> 23.1.1 ``                                                  |
| [`95471452`](https://github.com/NixOS/nixpkgs/commit/95471452758a787167a2987233e477024c21c56a) | `` python311Packages.griffe: 0.36.8 -> 0.36.9 ``                                                       |
| [`8489a01f`](https://github.com/NixOS/nixpkgs/commit/8489a01f7bfc8ccc844cf1042fbfc1e6871b3975) | `` python311Packages.hahomematic: 2023.10.12 -> 2023.10.13 ``                                          |
| [`9ae3af67`](https://github.com/NixOS/nixpkgs/commit/9ae3af67eccd169fcadfe914028f95982df03f5b) | `` drawio: 22.0.2 -> 22.0.3 ``                                                                         |
| [`2db0f7c8`](https://github.com/NixOS/nixpkgs/commit/2db0f7c87a0bdd283a3a577f352c1e8b676effed) | `` rclone: set meta.mainProgram ``                                                                     |
| [`da11cef1`](https://github.com/NixOS/nixpkgs/commit/da11cef1e5be180d392d39b632d85ae4759a3752) | `` tesh: 0.3.0 -> 0.3.2 ``                                                                             |
| [`9586930a`](https://github.com/NixOS/nixpkgs/commit/9586930ab62f8089f4990af909f840442ec0baa8) | `` graalvm-ce: 21.0.0 -> 21.0.1 ``                                                                     |
| [`e3008e72`](https://github.com/NixOS/nixpkgs/commit/e3008e720fc3b426b9ec8f116aea60a7c3b2ecad) | `` gpxsee: 13.9 -> 13.10 ``                                                                            |
| [`7f4a5d13`](https://github.com/NixOS/nixpkgs/commit/7f4a5d13bdf57fd99d5b4fff1ef877dfaa70b8c9) | `` lanzaboote-tool: init at 0.3.0 ``                                                                   |
| [`d66747a3`](https://github.com/NixOS/nixpkgs/commit/d66747a3c3b9ed71a12568ccd0e65fe79e4ee561) | `` cargo-run-bin: 1.4.1 -> 1.5.0 ``                                                                    |
| [`fc3755a0`](https://github.com/NixOS/nixpkgs/commit/fc3755a058bbd69c7264209e920ecca6020241f3) | `` goimports-reviser: 3.4.5 -> 3.5.6 ``                                                                |
| [`419c865d`](https://github.com/NixOS/nixpkgs/commit/419c865d5b3a06ffd37449072979d134f35b0f62) | `` daktilo: init at 0.5.0 ``                                                                           |
| [`a55085f4`](https://github.com/NixOS/nixpkgs/commit/a55085f41bee0e638822a787fa8019d4994d5aea) | `` zeek: 6.0.1 -> 6.0.2 ``                                                                             |
| [`ccfa698a`](https://github.com/NixOS/nixpkgs/commit/ccfa698aafff6da4ae293139ca68705f5b36379d) | `` speedtest-go: 1.6.6 -> 1.6.7 ``                                                                     |
| [`bc16a8df`](https://github.com/NixOS/nixpkgs/commit/bc16a8dfd3ceeccd3ce68360bf37df683dabc7b4) | `` nxpmicro-mfgtools: drop conflicting patch ``                                                        |
| [`cc8ba216`](https://github.com/NixOS/nixpkgs/commit/cc8ba2162979b33eba280b8e20d4477871628c53) | `` nixos/sshd: add comment explaining different list option types ``                                   |
| [`126b5036`](https://github.com/NixOS/nixpkgs/commit/126b50369edc1681d1dbb7c981d68a1762e5fe37) | `` evcc: 0.121.2 -> 0.121.3 ``                                                                         |
| [`0ef5d069`](https://github.com/NixOS/nixpkgs/commit/0ef5d0692071603f2e9eb41d6e54b9ab6f429875) | `` bloom: init at 1.0.0 ``                                                                             |
| [`5a17bd2b`](https://github.com/NixOS/nixpkgs/commit/5a17bd2b3e3df8cf233f9b3f4778cc4e4ae2fdf0) | `` python311Packages.cwcwidth: 0.1.8 -> 0.1.9 ``                                                       |
| [`fd607d72`](https://github.com/NixOS/nixpkgs/commit/fd607d72ade44d86be5d4378674611ce457d3179) | `` swlay: actually enable tests ``                                                                     |
| [`f128c2a5`](https://github.com/NixOS/nixpkgs/commit/f128c2a5a764b1cb0098efc9c3735c0dccb582ae) | `` disarchive: rename from guile-disarchive, fix program ``                                            |
| [`98d93b76`](https://github.com/NixOS/nixpkgs/commit/98d93b765250c076027520fecec14b6c505096dc) | `` keybase: fix source hash ``                                                                         |
| [`53d0f6b8`](https://github.com/NixOS/nixpkgs/commit/53d0f6b8e3596f0c3a136c0e4d0f287cfa71a0e2) | `` alacritty-theme: init at unstable-2023-10-12 ``                                                     |
| [`d44b7c3c`](https://github.com/NixOS/nixpkgs/commit/d44b7c3c7c27ce6bf17284d3d10f898e6590aff0) | `` libnvme: fix musl build ``                                                                          |
| [`4002cdeb`](https://github.com/NixOS/nixpkgs/commit/4002cdeba20f47d082f6e36f44470e802769ba1e) | `` nvme-cli: 2.4 -> 2.6 ``                                                                             |
| [`4765f6dd`](https://github.com/NixOS/nixpkgs/commit/4765f6dd401f8d70e075e0aa51fa2e39f76cce55) | `` libnvme: 1.4 -> 1.6 ``                                                                              |
| [`6dbd371f`](https://github.com/NixOS/nixpkgs/commit/6dbd371f94254b4702887d7510ad1036630cf4c3) | `` python3Packages.pymongo-inmemory: 0.3.1 -> 0.4.0 ``                                                 |
| [`4815708f`](https://github.com/NixOS/nixpkgs/commit/4815708fe5dddb267eea5aff70d4f8a0a4b3da46) | `` net-news-wire: init at 6.1.4 ``                                                                     |
| [`a000d9ff`](https://github.com/NixOS/nixpkgs/commit/a000d9fff682f4117b7587bf5050c5c60fd51e1b) | `` tests/netdata: fix test after upgrade to 1.43.0 ``                                                  |
| [`b9addb4b`](https://github.com/NixOS/nixpkgs/commit/b9addb4b769c5b52622281eb941cdd251e84c53d) | `` brogue-ce: init at 1.12 ``                                                                          |
| [`508da653`](https://github.com/NixOS/nixpkgs/commit/508da65355083ea17446a6860864020480fa70f8) | `` sketchybar: 2.17.1 -> 2.18.0 ``                                                                     |
| [`c8e7ce71`](https://github.com/NixOS/nixpkgs/commit/c8e7ce71bbdb32ae51f53a6c5f6810c5e0a7e1e4) | `` git-credential-keepassxc: 0.13.0 -> 0.14.0 ``                                                       |
| [`61774635`](https://github.com/NixOS/nixpkgs/commit/61774635013d7a16e42fcc8b97f428be6ada5f95) | `` nixos/netboot: fix eval on non x86_64 systems ``                                                    |
| [`44c3048f`](https://github.com/NixOS/nixpkgs/commit/44c3048f284b34a5d1452e2c2af4d073d8b915b5) | `` cadence: remove, archived upstream ``                                                               |
| [`5d4e8d1e`](https://github.com/NixOS/nixpkgs/commit/5d4e8d1e10fde39f4b4dcf279532e4a8275c79e2) | `` python310Packages.nats-py: 2.5.0 -> 2.6.0 ``                                                        |