### PR TITLE
chore(flake/nur): `32a38be3` -> `25751704`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698317227,
-        "narHash": "sha256-jzSJjjxJr/IPvoPSWB1ZobmlAKku6eeggh9ffGV7Sig=",
+        "lastModified": 1698324085,
+        "narHash": "sha256-7XjqwpW3JEaI9lhW7F/5Ap6xL9qlwutLu6I9GmxsmtE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "32a38be31067b0a2f4919fd9e7a49bbefc34d25f",
+        "rev": "2575170458c3d76a4c5e807f85b0fb70ec4d75eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`25751704`](https://github.com/nix-community/NUR/commit/2575170458c3d76a4c5e807f85b0fb70ec4d75eb) | `` automatic update `` |
| [`a4431129`](https://github.com/nix-community/NUR/commit/a443112918f305bba17143adc22d82be8b00db7a) | `` automatic update `` |