### PR TITLE
chore(flake/nur): `25751704` -> `751a8587`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698324085,
-        "narHash": "sha256-7XjqwpW3JEaI9lhW7F/5Ap6xL9qlwutLu6I9GmxsmtE=",
+        "lastModified": 1698328047,
+        "narHash": "sha256-DhtJmX8p+5CPBSWM7qX8KfZF7HUk1Wi2p68mNMeBrK8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2575170458c3d76a4c5e807f85b0fb70ec4d75eb",
+        "rev": "751a85878936a77aa428f7711ba00380cd37a794",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`751a8587`](https://github.com/nix-community/NUR/commit/751a85878936a77aa428f7711ba00380cd37a794) | `` automatic update `` |