### PR TITLE
chore(flake/nur): `789c2b7f` -> `75b5a480`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698335243,
-        "narHash": "sha256-udePNLabfEU2kPHG41lhoo0DwvTy6TRHVqOqgbm3+o0=",
+        "lastModified": 1698339118,
+        "narHash": "sha256-x/SDQxnads2gINAxpg/fe4P484LPyge5GsO1FQu/KjU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "789c2b7f214aad69020cdc548743b850061f74e1",
+        "rev": "75b5a480b2e5ac42559a56e6322d04185dc1f073",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`75b5a480`](https://github.com/nix-community/NUR/commit/75b5a480b2e5ac42559a56e6322d04185dc1f073) | `` automatic update `` |