### PR TITLE
chore(flake/emacs-overlay): `bd7432a6` -> `723d8ec0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1698313543,
-        "narHash": "sha256-wCDVzbvUxXX08lFXjcGvKlC0Cm+oawVkm6K8he9mrvI=",
+        "lastModified": 1698341451,
+        "narHash": "sha256-l86yjvyaRIje0t++PuNTlBPLcyxf2/lZWrp4NbctgLY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bd7432a6da29d334f634e22b368621e269a8e6b5",
+        "rev": "723d8ec014852d74bc04769c5b47446d5eee5a1d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`723d8ec0`](https://github.com/nix-community/emacs-overlay/commit/723d8ec014852d74bc04769c5b47446d5eee5a1d) | `` Updated repos/emacs `` |
| [`52539f93`](https://github.com/nix-community/emacs-overlay/commit/52539f937d2ffe62392aede3b37965582659a298) | `` Updated repos/elpa ``  |