### PR TITLE
chore(flake/nur): `284459b8` -> `37ad514d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698349907,
-        "narHash": "sha256-osw0ai9NkafXjqXIEB0j2TZqs28Yq0ZTSp1yXYv60nc=",
+        "lastModified": 1698354934,
+        "narHash": "sha256-M6HFIxpRbq2Ms77EPenadzCvBe0uqjXgzJ6atiDdYLU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "284459b884135bdff18e8142b7644c40ee21ec05",
+        "rev": "37ad514dd0471bd695e8f22369d11647a86bac70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`37ad514d`](https://github.com/nix-community/NUR/commit/37ad514dd0471bd695e8f22369d11647a86bac70) | `` automatic update `` |