### PR TITLE
chore(flake/emacs-overlay): `723d8ec0` -> `ad989770`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1698341451,
-        "narHash": "sha256-l86yjvyaRIje0t++PuNTlBPLcyxf2/lZWrp4NbctgLY=",
+        "lastModified": 1698375999,
+        "narHash": "sha256-vfVNCx7XW72zhytqNEFGqsvwVD4kpIt2c5XfNWhHE1M=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "723d8ec014852d74bc04769c5b47446d5eee5a1d",
+        "rev": "ad98977084414cf12564f5cc45b8f9aef217aafa",
         "type": "github"
       },
       "original": {
@@ -693,11 +693,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1698160471,
-        "narHash": "sha256-lH7ZEItqQOWi21St9JyE6t3yyFNYGoQqSEcS90WMnBY=",
+        "lastModified": 1698288402,
+        "narHash": "sha256-jIIjApPdm+4yt8PglX8pUOexAdEiAax/DXW3S/Mb21E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "04f431fe64a5ba8ff129cbbbfec489cfe903982c",
+        "rev": "60b9db998f71ea49e1a9c41824d09aa274be1344",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ad989770`](https://github.com/nix-community/emacs-overlay/commit/ad98977084414cf12564f5cc45b8f9aef217aafa) | `` Updated repos/melpa ``  |
| [`8b102cba`](https://github.com/nix-community/emacs-overlay/commit/8b102cbad079bcbd98c746a84c44d4ec5b23a0c7) | `` Updated repos/emacs ``  |
| [`c49397ba`](https://github.com/nix-community/emacs-overlay/commit/c49397ba080188f64321bdf1c7650861a9587ca4) | `` Updated repos/elpa ``   |
| [`3e173560`](https://github.com/nix-community/emacs-overlay/commit/3e173560c72e4b22dd7dd8b7117b42130979fdf3) | `` Updated flake inputs `` |