### PR TITLE
chore(flake/nur): `63a15bbd` -> `41f41a14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698378405,
-        "narHash": "sha256-hSKDgvDdYq+KNvD4mzHvtW53/ox/YA8u0jf7NQTVa8E=",
+        "lastModified": 1698379659,
+        "narHash": "sha256-YYSqOCqptQoCgE05p0XcPhW6onWFj3O4KaLfpvdO3UY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "63a15bbd1bd5d1a00fb43595b724ad113a4c4b58",
+        "rev": "41f41a1462b8a778a140a0be42f3fa0ac59eacd7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`41f41a14`](https://github.com/nix-community/NUR/commit/41f41a1462b8a778a140a0be42f3fa0ac59eacd7) | `` automatic update `` |