### PR TITLE
chore(flake/nur): `41f41a14` -> `21cae452`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698379659,
-        "narHash": "sha256-YYSqOCqptQoCgE05p0XcPhW6onWFj3O4KaLfpvdO3UY=",
+        "lastModified": 1698395170,
+        "narHash": "sha256-yLzotLSZHO9JPNGVj8PFxqBy7h5bNr6/S1kiWDvvxXo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "41f41a1462b8a778a140a0be42f3fa0ac59eacd7",
+        "rev": "21cae4522f95ba372d79d21a9d78d173002737f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`21cae452`](https://github.com/nix-community/NUR/commit/21cae4522f95ba372d79d21a9d78d173002737f2) | `` automatic update `` |
| [`fbbe6d43`](https://github.com/nix-community/NUR/commit/fbbe6d43dea07e2ac468f8ba1625adf551dcf6f1) | `` automatic update `` |
| [`61f3c949`](https://github.com/nix-community/NUR/commit/61f3c949b802a883b3f73b063f9073b23b6c8bab) | `` automatic update `` |
| [`f76b2b0b`](https://github.com/nix-community/NUR/commit/f76b2b0b17aa5d352ccc39fd75537d4165f7c083) | `` automatic update `` |