### PR TITLE
chore(flake/emacs-overlay): `ad989770` -> `88a6b098`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1698375999,
-        "narHash": "sha256-vfVNCx7XW72zhytqNEFGqsvwVD4kpIt2c5XfNWhHE1M=",
+        "lastModified": 1698401973,
+        "narHash": "sha256-ITmrkooGUmat5f9T3yzKqoqu5eO8QfHq2JNOa0tPb1E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ad98977084414cf12564f5cc45b8f9aef217aafa",
+        "rev": "88a6b098a9e77718eebd801b650695765e54136a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`88a6b098`](https://github.com/nix-community/emacs-overlay/commit/88a6b098a9e77718eebd801b650695765e54136a) | `` Updated repos/melpa `` |
| [`72a4241f`](https://github.com/nix-community/emacs-overlay/commit/72a4241f1b63ba150a8691517036d10015302a6d) | `` Updated repos/emacs `` |