### PR TITLE
chore(flake/nur): `21cae452` -> `f8e142a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698395170,
-        "narHash": "sha256-yLzotLSZHO9JPNGVj8PFxqBy7h5bNr6/S1kiWDvvxXo=",
+        "lastModified": 1698404193,
+        "narHash": "sha256-+mY/nIaT820wyx0IdLP517VVP0qi9gX3MdhDBH77jPM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "21cae4522f95ba372d79d21a9d78d173002737f2",
+        "rev": "f8e142a4c7c99ce1cb07beeb6853039259c5992c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f8e142a4`](https://github.com/nix-community/NUR/commit/f8e142a4c7c99ce1cb07beeb6853039259c5992c) | `` automatic update `` |
| [`8add1d6f`](https://github.com/nix-community/NUR/commit/8add1d6f5d69e9ab271b8c6ed36b8579947f2a43) | `` automatic update `` |