### PR TITLE
chore(flake/nur): `f8e142a4` -> `55831c4f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698404193,
-        "narHash": "sha256-+mY/nIaT820wyx0IdLP517VVP0qi9gX3MdhDBH77jPM=",
+        "lastModified": 1698414381,
+        "narHash": "sha256-dqeFzaYrkL3swiQFY919hSqmd2D6D0AFBT6zvk/EUUE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f8e142a4c7c99ce1cb07beeb6853039259c5992c",
+        "rev": "55831c4f594b877658d454d2a51aa06b989d79cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`55831c4f`](https://github.com/nix-community/NUR/commit/55831c4f594b877658d454d2a51aa06b989d79cc) | `` automatic update `` |
| [`90805d6a`](https://github.com/nix-community/NUR/commit/90805d6a556b7d71a6db41f861ee695d12c94869) | `` automatic update `` |
| [`4a4d1f3e`](https://github.com/nix-community/NUR/commit/4a4d1f3e77250d21250c5ea1787d42d4f74ca985) | `` automatic update `` |