### PR TITLE
chore(flake/nur): `98491fa3` -> `bd69cf8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698417368,
-        "narHash": "sha256-yZ3cz2zlQ3qW0nR/47u7w1Xq747sii62HvtO6a0gu6Q=",
+        "lastModified": 1698419948,
+        "narHash": "sha256-kOzpkpcnVUSgDV+RFjBr5F00ogIpRYzjcs+sAZFoLzA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "98491fa36fef5a4c01a40864cc8f500eba077701",
+        "rev": "bd69cf8ece4131596cb77dcf98917b952120ba29",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bd69cf8e`](https://github.com/nix-community/NUR/commit/bd69cf8ece4131596cb77dcf98917b952120ba29) | `` automatic update `` |