### PR TITLE
chore(flake/nur): `bd69cf8e` -> `93c85294`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698419948,
-        "narHash": "sha256-kOzpkpcnVUSgDV+RFjBr5F00ogIpRYzjcs+sAZFoLzA=",
+        "lastModified": 1698426052,
+        "narHash": "sha256-/p6PSMs+4auXqWTta/s9krBIQByyYtnEGI+9I8makok=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bd69cf8ece4131596cb77dcf98917b952120ba29",
+        "rev": "93c852940337711397cf861f0e5572fbbfc2a6f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`93c85294`](https://github.com/nix-community/NUR/commit/93c852940337711397cf861f0e5572fbbfc2a6f2) | `` automatic update `` |
| [`6c78a261`](https://github.com/nix-community/NUR/commit/6c78a26198809d199ba6e5f162124e446c9d8e58) | `` automatic update `` |
| [`cdbebbc0`](https://github.com/nix-community/NUR/commit/cdbebbc0c521ae11acccf49acbb9f3cf25eed43c) | `` automatic update `` |