### PR TITLE
chore(flake/nur): `93c85294` -> `c7cb3e63`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698426052,
-        "narHash": "sha256-/p6PSMs+4auXqWTta/s9krBIQByyYtnEGI+9I8makok=",
+        "lastModified": 1698430738,
+        "narHash": "sha256-gQ+UdpX8+wPKKdkQGv+NewNKXLfyQM6TMILBQSivuKU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "93c852940337711397cf861f0e5572fbbfc2a6f2",
+        "rev": "c7cb3e6301bf76ef39fc60da3cc92544fb9165c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c7cb3e63`](https://github.com/nix-community/NUR/commit/c7cb3e6301bf76ef39fc60da3cc92544fb9165c4) | `` automatic update `` |
| [`4e9076eb`](https://github.com/nix-community/NUR/commit/4e9076eb91e065eae3271629fda22090ff9a7857) | `` automatic update `` |
| [`60aa3c58`](https://github.com/nix-community/NUR/commit/60aa3c58ff1de876a6e00e9129415298dc7dd3b9) | `` automatic update `` |
| [`59597bc4`](https://github.com/nix-community/NUR/commit/59597bc4aabe17dac5ea44113d28dc627a3fa3bf) | `` automatic update `` |
| [`2f21ff0d`](https://github.com/nix-community/NUR/commit/2f21ff0debad6b047032b4908c86c7b067ed0c30) | `` automatic update `` |