### PR TITLE
chore(flake/emacs-overlay): `88a6b098` -> `7e6cc3c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1698401973,
-        "narHash": "sha256-ITmrkooGUmat5f9T3yzKqoqu5eO8QfHq2JNOa0tPb1E=",
+        "lastModified": 1698430543,
+        "narHash": "sha256-8i/cKFQ1M6d5NPRsWD79KDQpbLl8/wI6ZUMUo58AMCY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "88a6b098a9e77718eebd801b650695765e54136a",
+        "rev": "7e6cc3c97847651f7c3035274430daaeed94e153",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`7e6cc3c9`](https://github.com/nix-community/emacs-overlay/commit/7e6cc3c97847651f7c3035274430daaeed94e153) | `` Updated repos/melpa `` |
| [`b06cb636`](https://github.com/nix-community/emacs-overlay/commit/b06cb63603a599e42483d5541c9c107122be0c0e) | `` Updated repos/emacs `` |
| [`5c51c0c6`](https://github.com/nix-community/emacs-overlay/commit/5c51c0c662020d4f69c954416c7966814748eee9) | `` Updated repos/elpa ``  |