### PR TITLE
chore(flake/nur): `c7cb3e63` -> `65e5dea5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698430738,
-        "narHash": "sha256-gQ+UdpX8+wPKKdkQGv+NewNKXLfyQM6TMILBQSivuKU=",
+        "lastModified": 1698436025,
+        "narHash": "sha256-x45HIUTAP0FXsMl1j/Rfdx7tUnHNk1sc8sU/hNoi8ZE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c7cb3e6301bf76ef39fc60da3cc92544fb9165c4",
+        "rev": "65e5dea519e3291c33c20c773f32dc8046c8d602",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`65e5dea5`](https://github.com/nix-community/NUR/commit/65e5dea519e3291c33c20c773f32dc8046c8d602) | `` automatic update `` |