### PR TITLE
chore(flake/nur): `1e112df1` -> `f486fe92`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698450089,
-        "narHash": "sha256-fh2TuuwOYiM/QsYA1d9ZreicfDi/rMFPrKrHiHKNaCM=",
+        "lastModified": 1698456965,
+        "narHash": "sha256-05KrHmdIB4DoQUSbXcsfnXfoR6BV7aWC7eO4+c3QZYA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1e112df114ea3bce397b399995fa42ccbabda7ac",
+        "rev": "f486fe92326da55d3c6d99424ddd152407c1461d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f486fe92`](https://github.com/nix-community/NUR/commit/f486fe92326da55d3c6d99424ddd152407c1461d) | `` automatic update `` |