### PR TITLE
chore(flake/nur): `805af141` -> `b6e21490`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698460976,
-        "narHash": "sha256-6tzHSS9+dnxd0WUeTLl9XD+Iw78nbsfyeln8wba16sM=",
+        "lastModified": 1698464627,
+        "narHash": "sha256-YmTkto14n218Lm8p4cP6OvgPIdRlrIzylYf77Ptefcg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "805af141dbf8edfd271235406610b48d6eaa2f88",
+        "rev": "b6e214902a62f367159780a00577c67072efbcb3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b6e21490`](https://github.com/nix-community/NUR/commit/b6e214902a62f367159780a00577c67072efbcb3) | `` automatic update `` |