### PR TITLE
chore(flake/nur): `b6e21490` -> `4aea4ac3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698464627,
-        "narHash": "sha256-YmTkto14n218Lm8p4cP6OvgPIdRlrIzylYf77Ptefcg=",
+        "lastModified": 1698471624,
+        "narHash": "sha256-gNqin42Da8Qa1L29cyXK9M6tT9GGrq+em8exW7RXFKk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b6e214902a62f367159780a00577c67072efbcb3",
+        "rev": "4aea4ac3d631d42e4f98240f68ae1953ad67e2fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4aea4ac3`](https://github.com/nix-community/NUR/commit/4aea4ac3d631d42e4f98240f68ae1953ad67e2fb) | `` automatic update `` |