### PR TITLE
chore(flake/nur): `4aea4ac3` -> `931dad38`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698471624,
-        "narHash": "sha256-gNqin42Da8Qa1L29cyXK9M6tT9GGrq+em8exW7RXFKk=",
+        "lastModified": 1698475509,
+        "narHash": "sha256-Y+nLXQ6Nl3xaOYAGIgbLTe+7xL8l47xSrzh6ruSRowY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4aea4ac3d631d42e4f98240f68ae1953ad67e2fb",
+        "rev": "931dad3825c18c98ddf4f4d3d5f54e96a1c8aea7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`931dad38`](https://github.com/nix-community/NUR/commit/931dad3825c18c98ddf4f4d3d5f54e96a1c8aea7) | `` automatic update `` |