### PR TITLE
chore(flake/nur): `931dad38` -> `97002070`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698475509,
-        "narHash": "sha256-Y+nLXQ6Nl3xaOYAGIgbLTe+7xL8l47xSrzh6ruSRowY=",
+        "lastModified": 1698479881,
+        "narHash": "sha256-1tECyhfEe7KPs47DjP2vLD4uqkq5iIPGo2elpyrecPs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "931dad3825c18c98ddf4f4d3d5f54e96a1c8aea7",
+        "rev": "9700207021a6611091001f53cfed2435cf2f48b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`97002070`](https://github.com/nix-community/NUR/commit/9700207021a6611091001f53cfed2435cf2f48b9) | `` automatic update `` |
| [`8c364c48`](https://github.com/nix-community/NUR/commit/8c364c480dad6efb46968e8783607dfe982733db) | `` automatic update `` |