### PR TITLE
chore(flake/emacs-overlay): `75c826ce` -> `e70494fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1698459189,
-        "narHash": "sha256-ncpC0Dn7CsxGcKVDezkCs+hRh3495xZeRiSyRt4WDQo=",
+        "lastModified": 1698488700,
+        "narHash": "sha256-I4K8SoXduZraQfaaPokxtk7YC6nmjslzc4X/xTWTmZ8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "75c826ceb5898607333b7030b41060b2030e3e75",
+        "rev": "e70494fcb4466020552ee39b1d39f7910dee27f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`e70494fc`](https://github.com/nix-community/emacs-overlay/commit/e70494fcb4466020552ee39b1d39f7910dee27f0) | `` Updated repos/melpa `` |
| [`4136a5c0`](https://github.com/nix-community/emacs-overlay/commit/4136a5c099d27ba91ec431639e9348eae57094b9) | `` Updated repos/emacs `` |