### PR TITLE
chore(flake/nur): `1d9489ab` -> `7636d4db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698486372,
-        "narHash": "sha256-gLMfZbqjUHh46rrGFjjzScQvuYyx8OZD3akEuo8IT6A=",
+        "lastModified": 1698493525,
+        "narHash": "sha256-7LGGsrtUrvKZYPMNoEE2A4uHX7gU85RiLPwr/6QY4V4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1d9489ab1c262752a1ccddf01e8a4054cd2cb45c",
+        "rev": "7636d4dbfd7aa1a05239272a856c34e2c28724df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7636d4db`](https://github.com/nix-community/NUR/commit/7636d4dbfd7aa1a05239272a856c34e2c28724df) | `` automatic update `` |