### PR TITLE
chore(flake/stylix): `91e46dec` -> `7a7987c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -969,11 +969,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698085074,
-        "narHash": "sha256-0lNNuIkkyG5FhJD/I9qIZ9dynZBWfIFSXe/YGUuEzSU=",
+        "lastModified": 1698499630,
+        "narHash": "sha256-OGJUX84240wSlhRyXjrJikXmHX1VeN2ZXvfdLvrAh0o=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "91e46dec675ec37fd3f9745754d10bb7e392db98",
+        "rev": "7a7987c7828050ef9a8ca6af07ca98485053776b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                    |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`7a7987c7`](https://github.com/danth/stylix/commit/7a7987c7828050ef9a8ca6af07ca98485053776b) | `` Fix group variable changes in Hyprland module (#169) `` |