### PR TITLE
chore(flake/nur): `b03b857a` -> `ada3b1d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698501042,
-        "narHash": "sha256-tAvT41JeCd36XVyVd/+tgxy+cVCi2sTXur8xCWaqH/o=",
+        "lastModified": 1698507913,
+        "narHash": "sha256-w3TpbKNZiEZK3kjoLCmNe6J0LCuSbURTQNGVUPwXEWw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b03b857a70fe301429e27b8ba015428f485a4102",
+        "rev": "ada3b1d588cb065838577b83d87b8dc2cd369bb6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                      |
| -------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`ada3b1d5`](https://github.com/nix-community/NUR/commit/ada3b1d588cb065838577b83d87b8dc2cd369bb6) | `` automatic update ``       |
| [`08c700ff`](https://github.com/nix-community/NUR/commit/08c700ff0dc28f9d4a7f9b695feb945f3c9d7a28) | `` automatic update ``       |
| [`9397f101`](https://github.com/nix-community/NUR/commit/9397f10126c99e5741a975de852a693570e727fb) | `` automatic update ``       |
| [`e2e719d7`](https://github.com/nix-community/NUR/commit/e2e719d73b4ad5a65b7829870025b472a1ff6b01) | `` automatic update ``       |
| [`69ca919e`](https://github.com/nix-community/NUR/commit/69ca919e51584e21d3d214470837ceac1b6b40ef) | `` automatic update ``       |
| [`ee431d4e`](https://github.com/nix-community/NUR/commit/ee431d4e28441d071102fbcdbfcb047b770b6b92) | `` add mrtnvgr repository `` |