### PR TITLE
chore(flake/nur): `ada3b1d5` -> `fd6807f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698507913,
-        "narHash": "sha256-w3TpbKNZiEZK3kjoLCmNe6J0LCuSbURTQNGVUPwXEWw=",
+        "lastModified": 1698511990,
+        "narHash": "sha256-W8rzVGiE9BXSs5yqYd1w+xnVb1wfPVMPWN4qd4sTRW4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ada3b1d588cb065838577b83d87b8dc2cd369bb6",
+        "rev": "fd6807f3a3daef0483d6bc7311c5bbbfcc0f8ffb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fd6807f3`](https://github.com/nix-community/NUR/commit/fd6807f3a3daef0483d6bc7311c5bbbfcc0f8ffb) | `` automatic update `` |