### PR TITLE
chore(flake/nur): `fd6807f3` -> `984c4715`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698511990,
-        "narHash": "sha256-W8rzVGiE9BXSs5yqYd1w+xnVb1wfPVMPWN4qd4sTRW4=",
+        "lastModified": 1698513999,
+        "narHash": "sha256-JFWbAmExdWkghvKLjbNdWq2oNyrg5qcxTcCHrN1MTeA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fd6807f3a3daef0483d6bc7311c5bbbfcc0f8ffb",
+        "rev": "984c4715454a4f5fdd753a1b667893c206729ab5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`984c4715`](https://github.com/nix-community/NUR/commit/984c4715454a4f5fdd753a1b667893c206729ab5) | `` automatic update `` |