### PR TITLE
chore(flake/emacs-overlay): `e70494fc` -> `45659cab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1698488700,
-        "narHash": "sha256-I4K8SoXduZraQfaaPokxtk7YC6nmjslzc4X/xTWTmZ8=",
+        "lastModified": 1698519020,
+        "narHash": "sha256-4x+AvrljebasPoRRUAY1qI79w5Bev2olPoV+SxQDd/I=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e70494fcb4466020552ee39b1d39f7910dee27f0",
+        "rev": "45659cab8b875d266146821df333ea443b935212",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`45659cab`](https://github.com/nix-community/emacs-overlay/commit/45659cab8b875d266146821df333ea443b935212) | `` Updated repos/melpa `` |
| [`28af8e36`](https://github.com/nix-community/emacs-overlay/commit/28af8e36fd9b6b668ffa3e164d76ac470456bea8) | `` Updated repos/emacs `` |
| [`b6189be5`](https://github.com/nix-community/emacs-overlay/commit/b6189be517dd256fbb01021a2351272857a6288b) | `` Updated repos/elpa ``  |