### PR TITLE
chore(flake/nix-index-database): `5a200628` -> `ef1a36f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -591,11 +591,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697946153,
-        "narHash": "sha256-7k7qIwWLaYPgQ4fxmEdew3yCffhK6rM4I4Jo3X/79DA=",
+        "lastModified": 1698548241,
+        "narHash": "sha256-g/+etzZ7P2iZv1TiZ0KvPepcha0lFLuGgs0xclRKKGQ=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "5a2006282caaf32663cdcd582c5b18809c7d7d8d",
+        "rev": "ef1a36f692d7324a9c3648ce616111ddcb5d2373",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                  |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`ef1a36f6`](https://github.com/nix-community/nix-index-database/commit/ef1a36f692d7324a9c3648ce616111ddcb5d2373) | `` flake.lock: Update `` |