### PR TITLE
chore(flake/nix-index-database): `ef1a36f6` -> `1f0981f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -591,11 +591,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698548241,
-        "narHash": "sha256-g/+etzZ7P2iZv1TiZ0KvPepcha0lFLuGgs0xclRKKGQ=",
+        "lastModified": 1698550809,
+        "narHash": "sha256-Um8+Wi6EAH5dCgfgl7OqaVd4wFJn6FKLafcP5QPr/98=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "ef1a36f692d7324a9c3648ce616111ddcb5d2373",
+        "rev": "1f0981f5baeb78e3c89a8980ff1a39f06876fa8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`1f0981f5`](https://github.com/nix-community/nix-index-database/commit/1f0981f5baeb78e3c89a8980ff1a39f06876fa8c) | `` update packages.nix to release 2023-10-29-033859 `` |