### PR TITLE
chore(flake/nur): `d979c404` -> `917654e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698559016,
-        "narHash": "sha256-siUizj6tsixqEXKqMXZuH8BKXEs+Bwoqa32McGbEDvM=",
+        "lastModified": 1698562065,
+        "narHash": "sha256-xj9XDn9zzHFZ9v4N7wjUuby1SwySwTO/n3zK4uiYeF4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d979c4045f4570ff65edf8897c49ee3990f7e3f8",
+        "rev": "917654e08b58bfff16b34aa33e69798e17a33600",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`917654e0`](https://github.com/nix-community/NUR/commit/917654e08b58bfff16b34aa33e69798e17a33600) | `` automatic update `` |
| [`cf84e15e`](https://github.com/nix-community/NUR/commit/cf84e15e3d6162fbedfea295d580a612384b0da1) | `` automatic update `` |