### PR TITLE
chore(flake/nur): `917654e0` -> `27a5954c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698562065,
-        "narHash": "sha256-xj9XDn9zzHFZ9v4N7wjUuby1SwySwTO/n3zK4uiYeF4=",
+        "lastModified": 1698566424,
+        "narHash": "sha256-CYLEcLo34Nc2XD+jabwwP33ep6XVeYx4UT+Fn1pcFSg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "917654e08b58bfff16b34aa33e69798e17a33600",
+        "rev": "27a5954c465244f1e8be091a7fc0728bcc2d9f14",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`27a5954c`](https://github.com/nix-community/NUR/commit/27a5954c465244f1e8be091a7fc0728bcc2d9f14) | `` automatic update `` |