### PR TITLE
chore(flake/emacs-overlay): `d194712b` -> `12ae810b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1698551104,
-        "narHash": "sha256-Omc6xE2nghLcsJC0G9Irwi6rE8XJ2r6HoC3LTU/zUyE=",
+        "lastModified": 1698576340,
+        "narHash": "sha256-9G2WuDGn7bVHZQ93phckDRYiOGhs2/+qOPrWYyAhvok=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d194712b55853051456bc47f39facc39d03cbc40",
+        "rev": "12ae810bf81432484baf86610a848cb9479f29e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`12ae810b`](https://github.com/nix-community/emacs-overlay/commit/12ae810bf81432484baf86610a848cb9479f29e8) | `` Updated repos/melpa `` |
| [`8e8e318e`](https://github.com/nix-community/emacs-overlay/commit/8e8e318e0e896a490564481d4310f903ae54cdac) | `` Updated repos/emacs `` |