### PR TITLE
chore(flake/nur): `27a5954c` -> `4364937d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698566424,
-        "narHash": "sha256-CYLEcLo34Nc2XD+jabwwP33ep6XVeYx4UT+Fn1pcFSg=",
+        "lastModified": 1698576302,
+        "narHash": "sha256-1NYfEphk3EXgEt+iDJG1qpsdCRe35BQLNLvVoVe29HM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "27a5954c465244f1e8be091a7fc0728bcc2d9f14",
+        "rev": "4364937d33ca6b79cd8b66fdf4ee1758ff279e62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4364937d`](https://github.com/nix-community/NUR/commit/4364937d33ca6b79cd8b66fdf4ee1758ff279e62) | `` automatic update `` |