### PR TITLE
chore(flake/flake-parts): `c9afaba3` -> `f76e870d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -347,11 +347,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1696343447,
-        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
+        "lastModified": 1698579227,
+        "narHash": "sha256-KVWjFZky+gRuWennKsbo6cWyo7c/z/VgCte5pR9pEKg=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
+        "rev": "f76e870d64779109e41370848074ac4eaa1606ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                                    |
| -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`e21f5944`](https://github.com/hercules-ci/flake-parts/commit/e21f594423a34944b2eece27e62f1fcca0c1c90a) | `` Fix error location ``                                                   |
| [`c8c8e566`](https://github.com/hercules-ci/flake-parts/commit/c8c8e5661e2b93f2459b0ed6da1cbe31c7dba347) | `` Remove errorLocation from the tests ``                                  |
| [`f427ecf1`](https://github.com/hercules-ci/flake-parts/commit/f427ecf1a05493c788a94ee3b70bccd7285a64b5) | `` Repurpose moduleLocation impl for new errorLocation ``                  |
| [`fc749398`](https://github.com/hercules-ci/flake-parts/commit/fc74939824cc92da3a39a6eb37ae2b7df89f55c3) | `` mkFlake: Prefer unsafeGetAttrPos over self.outPath for error message `` |
| [`1e8a89e5`](https://github.com/hercules-ci/flake-parts/commit/1e8a89e5f81bca67c5f649318179fc11727262d0) | `` Add moduleLocation to mkFlake argument ``                               |