### PR TITLE
chore(flake/nur): `56dc22b2` -> `42069c1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698590454,
-        "narHash": "sha256-gKmW0id7q0nlOsZYRB7Qy4sw6Hr8JQNok0riyc7SMmQ=",
+        "lastModified": 1698594452,
+        "narHash": "sha256-brFqqX8poiH/xGZJ9sbphlsD3jgyYZoxb/he0JV4okY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "56dc22b2f910e44b73fca7cb3b9156b09bfa12be",
+        "rev": "42069c1c18fca0829d3852670bb0ee0c09d80f0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`42069c1c`](https://github.com/nix-community/NUR/commit/42069c1c18fca0829d3852670bb0ee0c09d80f0f) | `` automatic update `` |