### PR TITLE
chore(flake/nur): `42069c1c` -> `b469b05f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698594452,
-        "narHash": "sha256-brFqqX8poiH/xGZJ9sbphlsD3jgyYZoxb/he0JV4okY=",
+        "lastModified": 1698606514,
+        "narHash": "sha256-TjtNq/joqNqy4DGDJg3M5fO0gttlJxA6Hzo17+eRGK8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "42069c1c18fca0829d3852670bb0ee0c09d80f0f",
+        "rev": "b469b05f57cdc5810b943d85f1ba2b9fd8732ac4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b469b05f`](https://github.com/nix-community/NUR/commit/b469b05f57cdc5810b943d85f1ba2b9fd8732ac4) | `` automatic update `` |
| [`b88af563`](https://github.com/nix-community/NUR/commit/b88af56385402a6600835e7611813f04d0218a43) | `` automatic update `` |