### PR TITLE
chore(flake/emacs-overlay): `2b203b7f` -> `a0ba952a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1698605432,
-        "narHash": "sha256-fpvTThLMa9wlY4aAVz5+tbE9b7qnb+ldSnbX4rVpV8s=",
+        "lastModified": 1698636632,
+        "narHash": "sha256-yCG7Neb0RrAmpRZRBVmuYH6Nqvjv2cPijLyaYutsNWI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2b203b7f03b4494235afe7667dde4d65d231202d",
+        "rev": "a0ba952a747d0bd4ba53a050ee9ef3f8f15af994",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`a0ba952a`](https://github.com/nix-community/emacs-overlay/commit/a0ba952a747d0bd4ba53a050ee9ef3f8f15af994) | `` Updated repos/nongnu `` |
| [`74962565`](https://github.com/nix-community/emacs-overlay/commit/74962565868a528ea92f4fc1ae79feef55bda8d2) | `` Updated repos/melpa ``  |
| [`244859eb`](https://github.com/nix-community/emacs-overlay/commit/244859ebc7c524fc223cf7d10838cd573e815f08) | `` Updated repos/emacs ``  |
| [`2dec052c`](https://github.com/nix-community/emacs-overlay/commit/2dec052c6dd34e80bdb5733955891c8b74a91329) | `` Updated repos/elpa ``   |