### PR TITLE
chore(flake/nur): `c2f795e1` -> `221628c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698615966,
-        "narHash": "sha256-q1VPpP8EcrZ+GNQUJ4dWAoHhs8qcIBuZywX3jnT7JK0=",
+        "lastModified": 1698637508,
+        "narHash": "sha256-Q63s83k6TAVYg1gU1IolOGNc0qxKyUQ+660JKHOsZnU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c2f795e116a7e9bb92a48fe3a5b6350daf2ebe5f",
+        "rev": "221628c397701541fd65351dd5459b9837e0df1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`221628c3`](https://github.com/nix-community/NUR/commit/221628c397701541fd65351dd5459b9837e0df1a) | `` automatic update `` |
| [`ca73b6d1`](https://github.com/nix-community/NUR/commit/ca73b6d140a91b3763a07c72efddce9ff8146d2d) | `` automatic update `` |