### PR TITLE
chore(flake/nur): `221628c3` -> `d0fb6dfe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698637508,
-        "narHash": "sha256-Q63s83k6TAVYg1gU1IolOGNc0qxKyUQ+660JKHOsZnU=",
+        "lastModified": 1698640866,
+        "narHash": "sha256-DMi0hNx5j9hp0ln0XKFselLbN6BMNUWZVwDVz0fQHso=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "221628c397701541fd65351dd5459b9837e0df1a",
+        "rev": "d0fb6dfe0b93fb95c8acffe749278c6edabba67f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d0fb6dfe`](https://github.com/nix-community/NUR/commit/d0fb6dfe0b93fb95c8acffe749278c6edabba67f) | `` automatic update `` |
| [`61eed309`](https://github.com/nix-community/NUR/commit/61eed309cf1d9ebd93b293d5a2a59973e2aa8b96) | `` automatic update `` |
| [`a0e6cadc`](https://github.com/nix-community/NUR/commit/a0e6cadcd47222c86d9bd829ab1c419231cf4128) | `` automatic update `` |
| [`b0098cf9`](https://github.com/nix-community/NUR/commit/b0098cf99fa3c6f099e3a5984f6cc56076b53277) | `` automatic update `` |