### PR TITLE
chore(flake/nur): `dcb2c3c7` -> `c75f9ae9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698648419,
-        "narHash": "sha256-C736F4+HwHsSNbWmuZLA1IpKS6xFt9Yvg5DSzL56M6k=",
+        "lastModified": 1698651264,
+        "narHash": "sha256-9BYnd0nSdIGdNb9iTxexfJJO+uQEVV1DxVODd5MIcO0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dcb2c3c7afd60ca9210d9dc5abe2201564da68e5",
+        "rev": "c75f9ae97b7102b5ed28d7cba7e73f3e1c478f7d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c75f9ae9`](https://github.com/nix-community/NUR/commit/c75f9ae97b7102b5ed28d7cba7e73f3e1c478f7d) | `` automatic update `` |