### PR TITLE
chore(flake/lanzaboote): `f01c3666` -> `9c8d7c56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1698625475,
-        "narHash": "sha256-XA6w+XlwEHffdX594p3ynOn2OUCQtfuMWYAFKa99nsY=",
+        "lastModified": 1698658315,
+        "narHash": "sha256-6dH5y00E9nA9MDAStmcqVDoU63Oz9GcxTWdru+ovdek=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "f01c3666ea0f20d9d4f0a5ae144ffcb3d1e605d5",
+        "rev": "9c8d7c56b3ca9ff831d46fa4c83905206abd214e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                  |
| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`3cb657f5`](https://github.com/nix-community/lanzaboote/commit/3cb657f5c3e6f8e009e5bf2854d60dd0360c4889) | `` tool: silence resolver version warning ``             |
| [`87d2087a`](https://github.com/nix-community/lanzaboote/commit/87d2087a7a5dfacb37579d2b4060c7334804d6f8) | `` tool: drop unused dependencies via machete ``         |
| [`1e5145a0`](https://github.com/nix-community/lanzaboote/commit/1e5145a0fad64518f1d3982a43e237e7ce34d6c3) | `` nix: trim down shell environment ``                   |
| [`2ee75d5d`](https://github.com/nix-community/lanzaboote/commit/2ee75d5d913a7a3c9242a847533de5ccdbb1f5cc) | `` docs: clarify migration path for new installations `` |