### PR TITLE
chore(flake/nur): `342388a7` -> `6f45c295`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698655860,
-        "narHash": "sha256-DzJIwLKgUanY17tLTF1DaZFzaDgEB71n8H/OmKHrX3U=",
+        "lastModified": 1698660117,
+        "narHash": "sha256-igqh+GeQGJg1s14kNAWIDs0r1OEB8dkBjUWphEHRHI4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "342388a75e84671977fc45e1b1b8a9d83c695d69",
+        "rev": "6f45c2951fd194519f4e62753d04fb96391a4bf4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6f45c295`](https://github.com/nix-community/NUR/commit/6f45c2951fd194519f4e62753d04fb96391a4bf4) | `` automatic update `` |
| [`5a247f3e`](https://github.com/nix-community/NUR/commit/5a247f3eb1139e5d882a7ee225c87d10bc959b84) | `` automatic update `` |