### PR TITLE
chore(flake/emacs-overlay): `a0ba952a` -> `9716242d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1698636632,
-        "narHash": "sha256-yCG7Neb0RrAmpRZRBVmuYH6Nqvjv2cPijLyaYutsNWI=",
+        "lastModified": 1698661082,
+        "narHash": "sha256-ju60wCA5A+JpiGZV056kroBNvvyC9vNCyYb/eIwZaYo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a0ba952a747d0bd4ba53a050ee9ef3f8f15af994",
+        "rev": "9716242daed6b500616e0d2378a06f5eba53ca2b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`9716242d`](https://github.com/nix-community/emacs-overlay/commit/9716242daed6b500616e0d2378a06f5eba53ca2b) | `` Updated repos/melpa `` |
| [`b9d2a391`](https://github.com/nix-community/emacs-overlay/commit/b9d2a391c3ec265e8ddfaf6c8542e386ba6a5edc) | `` Updated repos/emacs `` |