### PR TITLE
chore(flake/nur): `6f45c295` -> `6a10f806`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698660117,
-        "narHash": "sha256-igqh+GeQGJg1s14kNAWIDs0r1OEB8dkBjUWphEHRHI4=",
+        "lastModified": 1698667006,
+        "narHash": "sha256-Rs/7y8YUUb3o0Va454781lkCgSVFZCQWdvvHTd+DvSI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6f45c2951fd194519f4e62753d04fb96391a4bf4",
+        "rev": "6a10f806c953eea5c71f40e2cabd5ea2de5871ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e81d8d5c`](https://github.com/nix-community/NUR/commit/e81d8d5c8f81a219e5238511958a7c9ea76683b8) | `` Update README.md `` |
| [`4a6eb25a`](https://github.com/nix-community/NUR/commit/4a6eb25ae16a282984045d0a4a0b7bdb9a452d08) | `` automatic update `` |