### PR TITLE
chore(flake/lanzaboote): `9c8d7c56` -> `781303ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1698658315,
-        "narHash": "sha256-6dH5y00E9nA9MDAStmcqVDoU63Oz9GcxTWdru+ovdek=",
+        "lastModified": 1698669922,
+        "narHash": "sha256-qgx17PQkAwF4S2jdXk2bs2wifOhjesiAdVAmFqL5GNM=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "9c8d7c56b3ca9ff831d46fa4c83905206abd214e",
+        "rev": "781303ad7ca3e41d38d18b6fd293163a61d4b319",
         "type": "github"
       },
       "original": {
@@ -914,11 +914,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698545594,
-        "narHash": "sha256-Bf0UKNXBOg1OWe3GkfUNKpAlihiuuhcyzPDcMfJvUOg=",
+        "lastModified": 1698631970,
+        "narHash": "sha256-uO+iqGslP1TdH0q3pMkpo6XHtzoEa6bjjF3dEQJSDcc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "66eb7c2fb4597c94e66a4124ee77d9827e46c14f",
+        "rev": "44210df7a70dcf0a81a5919f9422b6ae589ee673",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                    |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`18594916`](https://github.com/nix-community/lanzaboote/commit/1859491609d879b9403273684fb0aa41e980f283) | `` tests: add 5 minutes default timeout `` |
| [`2ed44821`](https://github.com/nix-community/lanzaboote/commit/2ed44821338885c7628a1c63cb443bb74c7296e5) | `` chore(deps): lock file maintenance ``   |