### PR TITLE
chore(flake/nur): `6a10f806` -> `43902606`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698667006,
-        "narHash": "sha256-Rs/7y8YUUb3o0Va454781lkCgSVFZCQWdvvHTd+DvSI=",
+        "lastModified": 1698677907,
+        "narHash": "sha256-+N7zKt6Yb7uRhcL0deEG5jxvyNTJZToH0msRBdHh48o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6a10f806c953eea5c71f40e2cabd5ea2de5871ef",
+        "rev": "439026064d8c3eaacfba2160fb1e3736ee0f2b6e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`43902606`](https://github.com/nix-community/NUR/commit/439026064d8c3eaacfba2160fb1e3736ee0f2b6e) | `` automatic update `` |
| [`9a1a107f`](https://github.com/nix-community/NUR/commit/9a1a107fc246a416e44e2e965a31d79983614541) | `` automatic update `` |
| [`cbf9ee2e`](https://github.com/nix-community/NUR/commit/cbf9ee2e3e2c6d168b5b9e804d7cb0d9b46a49d7) | `` automatic update `` |
| [`f71681e5`](https://github.com/nix-community/NUR/commit/f71681e5f9cb801a8e8a81aeafe5a9eca626dbd6) | `` automatic update `` |