### PR TITLE
chore(flake/nur): `43902606` -> `bf223184`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698677907,
-        "narHash": "sha256-+N7zKt6Yb7uRhcL0deEG5jxvyNTJZToH0msRBdHh48o=",
+        "lastModified": 1698682568,
+        "narHash": "sha256-tUivLGXEhY0d8+4oXn06S5E5xnufkGmubQuDqPoGwkw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "439026064d8c3eaacfba2160fb1e3736ee0f2b6e",
+        "rev": "bf223184b4e92b6c0c1d0a292a525606dcfe7f01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bf223184`](https://github.com/nix-community/NUR/commit/bf223184b4e92b6c0c1d0a292a525606dcfe7f01) | `` automatic update `` |