### PR TITLE
chore(flake/nur): `bf223184` -> `771f9aa3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698682568,
-        "narHash": "sha256-tUivLGXEhY0d8+4oXn06S5E5xnufkGmubQuDqPoGwkw=",
+        "lastModified": 1698688819,
+        "narHash": "sha256-254arBoa3wwWyn0vV1hs6mmDjZIKiHuvltkqSioMy0M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bf223184b4e92b6c0c1d0a292a525606dcfe7f01",
+        "rev": "771f9aa3a168b4221484c983f96c125b24b3904f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                     |
| -------------------------------------------------------------------------------------------------- | --------------------------- |
| [`771f9aa3`](https://github.com/nix-community/NUR/commit/771f9aa3a168b4221484c983f96c125b24b3904f) | `` add dagger repository `` |