### PR TITLE
chore(flake/emacs-overlay): `9716242d` -> `238d4cd5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1698661082,
-        "narHash": "sha256-ju60wCA5A+JpiGZV056kroBNvvyC9vNCyYb/eIwZaYo=",
+        "lastModified": 1698689977,
+        "narHash": "sha256-IFcxvIEyQCSFz/Gu0iBFEASVQ4usEiSiQK1jnyTfmoc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9716242daed6b500616e0d2378a06f5eba53ca2b",
+        "rev": "238d4cd5adee2a5dd893e27f0cf7e5af856d576e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`238d4cd5`](https://github.com/nix-community/emacs-overlay/commit/238d4cd5adee2a5dd893e27f0cf7e5af856d576e) | `` Updated repos/melpa `` |
| [`edd1db81`](https://github.com/nix-community/emacs-overlay/commit/edd1db81a528627587fde38231411f97c6807a60) | `` Updated repos/emacs `` |
| [`d23c399c`](https://github.com/nix-community/emacs-overlay/commit/d23c399c5bee87780e713b4c56152dead5b0ebdb) | `` Updated repos/elpa ``  |