### PR TITLE
chore(flake/nur): `771f9aa3` -> `07db1ead`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698688819,
-        "narHash": "sha256-254arBoa3wwWyn0vV1hs6mmDjZIKiHuvltkqSioMy0M=",
+        "lastModified": 1698689917,
+        "narHash": "sha256-zPJsUM2SMuKzs5R+KuRvl5M3OZqMjs9X6hw6rMTs/0U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "771f9aa3a168b4221484c983f96c125b24b3904f",
+        "rev": "07db1eade4b7e49005853d0d9b0380d6b3ffe670",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                      |
| -------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`07db1ead`](https://github.com/nix-community/NUR/commit/07db1eade4b7e49005853d0d9b0380d6b3ffe670) | `` automatic update ``       |
| [`13248275`](https://github.com/nix-community/NUR/commit/132482758ccf8b19b8fdaffb1b6f3e17c04d1c2d) | `` add presto8 repository `` |
| [`c63eb5c4`](https://github.com/nix-community/NUR/commit/c63eb5c4426eb635fbaf063d0fb8148e28da68a3) | `` automatic update ``       |