### PR TITLE
chore(flake/nur): `07db1ead` -> `5722d807`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698689917,
-        "narHash": "sha256-zPJsUM2SMuKzs5R+KuRvl5M3OZqMjs9X6hw6rMTs/0U=",
+        "lastModified": 1698696436,
+        "narHash": "sha256-blvCqY4Dg3antoWlQddQOkIwh0VtRVHt8SRRh7jpQGs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "07db1eade4b7e49005853d0d9b0380d6b3ffe670",
+        "rev": "5722d8070affc2a0f573cb12f73b6ddbe58bc0db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f5c95db8`](https://github.com/nix-community/NUR/commit/f5c95db8008b858270e76b90c823d3c528acbc02) | `` Update README.md `` |