### PR TITLE
chore(flake/nur): `088c626d` -> `e088795a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698724042,
-        "narHash": "sha256-ctvij3yAc79rM8EnVJUAsuiUUO9DELjlHreQ/BekfKU=",
+        "lastModified": 1698727165,
+        "narHash": "sha256-E/dsCZH2UiWbfFWeQVuuTy8acVnC284BrflOGRbdV+8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "088c626de0a9d7bd40d339f912da31cffc4f2b59",
+        "rev": "e088795acb74593d68a87bd5be42842448de8118",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e088795a`](https://github.com/nix-community/NUR/commit/e088795acb74593d68a87bd5be42842448de8118) | `` automatic update `` |
| [`850ab982`](https://github.com/nix-community/NUR/commit/850ab982b336433afffa75fe5ee3a245d1055914) | `` automatic update `` |