### PR TITLE
chore(flake/nur): `e088795a` -> `4719257d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698727165,
-        "narHash": "sha256-E/dsCZH2UiWbfFWeQVuuTy8acVnC284BrflOGRbdV+8=",
+        "lastModified": 1698735312,
+        "narHash": "sha256-cnjcR4csewhSgW4iPpX8e/vNpDm+o/iZjqPFb/XShBk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e088795acb74593d68a87bd5be42842448de8118",
+        "rev": "4719257de4ee4c3f0227c7bab2dc6250f4a032f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4719257d`](https://github.com/nix-community/NUR/commit/4719257de4ee4c3f0227c7bab2dc6250f4a032f1) | `` automatic update `` |
| [`92561439`](https://github.com/nix-community/NUR/commit/925614393fc330694dda63547d5fb2048d49aa9e) | `` automatic update `` |