### PR TITLE
chore(flake/nur): `4719257d` -> `c163d1fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698735312,
-        "narHash": "sha256-cnjcR4csewhSgW4iPpX8e/vNpDm+o/iZjqPFb/XShBk=",
+        "lastModified": 1698738746,
+        "narHash": "sha256-n+LsqWw4mJ36TncyGEy/irGeRzq8xW6CGXKEHxMyV3E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4719257de4ee4c3f0227c7bab2dc6250f4a032f1",
+        "rev": "c163d1fd0c8b2cfee3143112e38a317ea5996a53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c163d1fd`](https://github.com/nix-community/NUR/commit/c163d1fd0c8b2cfee3143112e38a317ea5996a53) | `` automatic update `` |
| [`2b43cebb`](https://github.com/nix-community/NUR/commit/2b43cebbbe9f472c93ee5a1d343e939844d6e3db) | `` automatic update `` |
| [`8131e619`](https://github.com/nix-community/NUR/commit/8131e6191b33c4ad85bf653d6f143aeb58e2f34f) | `` automatic update `` |