### PR TITLE
chore(flake/emacs-overlay): `238d4cd5` -> `269ac5a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1698689977,
-        "narHash": "sha256-IFcxvIEyQCSFz/Gu0iBFEASVQ4usEiSiQK1jnyTfmoc=",
+        "lastModified": 1698749262,
+        "narHash": "sha256-BEOyludqsLp7wAYxqfuPdYuVZde7lS0NCQpFwpzkKMo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "238d4cd5adee2a5dd893e27f0cf7e5af856d576e",
+        "rev": "269ac5a3bbd2f0f4d2e0912f219f973441271bd4",
         "type": "github"
       },
       "original": {
@@ -693,11 +693,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1698434055,
-        "narHash": "sha256-Phxi5mUKSoL7A0IYUiYtkI9e8NcGaaV5PJEaJApU1Ko=",
+        "lastModified": 1698562188,
+        "narHash": "sha256-9nkxGnA/T+jLhHAMFRW157Qi/zfbf5dF1q7HfKROl3o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1a3c95e3b23b3cdb26750621c08cc2f1560cb883",
+        "rev": "3e10c80821dedb93592682379f476745f370a58e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`269ac5a3`](https://github.com/nix-community/emacs-overlay/commit/269ac5a3bbd2f0f4d2e0912f219f973441271bd4) | `` Updated repos/melpa ``  |
| [`c791f97f`](https://github.com/nix-community/emacs-overlay/commit/c791f97fb1ff0abc57347a15ba18371da9861bef) | `` Updated repos/emacs ``  |
| [`01d1e79b`](https://github.com/nix-community/emacs-overlay/commit/01d1e79b05736977a013b7efd69afb4504d707dc) | `` Updated repos/elpa ``   |
| [`cdd8610d`](https://github.com/nix-community/emacs-overlay/commit/cdd8610dc89433e7648067847270273f74951b45) | `` Updated flake inputs `` |