### PR TITLE
chore(flake/nur): `dfbf1982` -> `33b858fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698745553,
-        "narHash": "sha256-Fdip7ewCtZTjOu7ATDFUAy3OqrgcyvzDElLXhr4YmmI=",
+        "lastModified": 1698755639,
+        "narHash": "sha256-MeFyrG38qHTc567KQAxDuXAUv2IE8J6xtMANBBGkmIY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dfbf198236d40e9741db76936088f05107e19013",
+        "rev": "33b858fd05836bfedd67bafaffa654ee4fcaf103",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`33b858fd`](https://github.com/nix-community/NUR/commit/33b858fd05836bfedd67bafaffa654ee4fcaf103) | `` automatic update `` |
| [`d85d1b8e`](https://github.com/nix-community/NUR/commit/d85d1b8e7ece9059df20075989549bbd73018534) | `` automatic update `` |