### PR TITLE
chore(flake/nur): `f2edc65d` -> `8be1938c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698763247,
-        "narHash": "sha256-xWJX6rnY/OCLLSwrhtbHYq85C+TaTWmU/BxdCmQK+aA=",
+        "lastModified": 1698767206,
+        "narHash": "sha256-91bb1kY7H08ZWph0p2HFx3FzZ1gCOxZEVsStUPBb1Co=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f2edc65da4d36ffdf218beea015d14765ca331be",
+        "rev": "8be1938c49dbcb4a327a9ebbaba600c5245fe5a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8be1938c`](https://github.com/nix-community/NUR/commit/8be1938c49dbcb4a327a9ebbaba600c5245fe5a3) | `` automatic update `` |