### PR TITLE
chore(flake/emacs-overlay): `269ac5a3` -> `cc3249d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1698749262,
-        "narHash": "sha256-BEOyludqsLp7wAYxqfuPdYuVZde7lS0NCQpFwpzkKMo=",
+        "lastModified": 1698779724,
+        "narHash": "sha256-MvHzvY5uoYxLqhKmhALpxkB4q4A/94Ba/9NmF/eTudA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "269ac5a3bbd2f0f4d2e0912f219f973441271bd4",
+        "rev": "cc3249d5b0eb6600f253a1f7be45343ffcc4b89e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`cc3249d5`](https://github.com/nix-community/emacs-overlay/commit/cc3249d5b0eb6600f253a1f7be45343ffcc4b89e) | `` Updated repos/melpa ``  |
| [`7b50d324`](https://github.com/nix-community/emacs-overlay/commit/7b50d3245f7561378c28678390a15ffcf10c555a) | `` Updated repos/emacs ``  |
| [`25d375fe`](https://github.com/nix-community/emacs-overlay/commit/25d375fea6325da22ea1cea07db1d010f5e17a32) | `` Updated repos/elpa ``   |
| [`c151c851`](https://github.com/nix-community/emacs-overlay/commit/c151c85112f55859e138c83c754b69fb4a69510b) | `` Updated flake inputs `` |