### PR TITLE
chore(flake/nur): `17201e50` -> `4cf69a36`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698776721,
-        "narHash": "sha256-4VuFjw7GwfZSv8nGc4n3Fmm7vLSjKdR8fD7na3lrnV4=",
+        "lastModified": 1698795974,
+        "narHash": "sha256-1CZZY3nvgo46hdSP9Z+0PDvPpTOuaDh6xfKldZGgJ3M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "17201e50caa672a13f2356a316a018d510f8c1d1",
+        "rev": "4cf69a3615da6869af93d17f784404f821a7d7b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4cf69a36`](https://github.com/nix-community/NUR/commit/4cf69a3615da6869af93d17f784404f821a7d7b1) | `` automatic update `` |
| [`4bf3e10d`](https://github.com/nix-community/NUR/commit/4bf3e10da362546b3ca56ad23ae2811cf92e7515) | `` automatic update `` |