### PR TITLE
chore(flake/nur): `4cf69a36` -> `9f4e9ee0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698795974,
-        "narHash": "sha256-1CZZY3nvgo46hdSP9Z+0PDvPpTOuaDh6xfKldZGgJ3M=",
+        "lastModified": 1698800633,
+        "narHash": "sha256-xsBF0uW0kVGyWHjuy1/qstC8gJzmWGyuk0FRNUF4IZQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4cf69a3615da6869af93d17f784404f821a7d7b1",
+        "rev": "9f4e9ee03cc48f1ac086cc4d142dfc39b5fdbb7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9f4e9ee0`](https://github.com/nix-community/NUR/commit/9f4e9ee03cc48f1ac086cc4d142dfc39b5fdbb7f) | `` automatic update `` |