### PR TITLE
chore(flake/nur): `9f4e9ee0` -> `e44770a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698800633,
-        "narHash": "sha256-xsBF0uW0kVGyWHjuy1/qstC8gJzmWGyuk0FRNUF4IZQ=",
+        "lastModified": 1698806731,
+        "narHash": "sha256-K2JANCYKWR4sdkASBZ7aniBeYT1DsbdldL6zSG8aeI8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9f4e9ee03cc48f1ac086cc4d142dfc39b5fdbb7f",
+        "rev": "e44770a9fceba88cb9aeed473a09b9ab6ad2c94a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e44770a9`](https://github.com/nix-community/NUR/commit/e44770a9fceba88cb9aeed473a09b9ab6ad2c94a) | `` automatic update `` |
| [`097f602b`](https://github.com/nix-community/NUR/commit/097f602b262e512dccc5dd628a6ff24a93beaa18) | `` automatic update `` |
| [`814a7b5a`](https://github.com/nix-community/NUR/commit/814a7b5a1b4110d16dfdc8132891da0f38ef9d60) | `` automatic update `` |