### PR TITLE
chore(flake/nur): `e44770a9` -> `b2d050bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698806731,
-        "narHash": "sha256-K2JANCYKWR4sdkASBZ7aniBeYT1DsbdldL6zSG8aeI8=",
+        "lastModified": 1698810240,
+        "narHash": "sha256-tGawNp4wL7kkK2FuZ6HdPkpFl1g4vrc2jD6hE+FMFFQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e44770a9fceba88cb9aeed473a09b9ab6ad2c94a",
+        "rev": "b2d050bd0f46d021f8cad638fe35a5b9df21a7d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b2d050bd`](https://github.com/nix-community/NUR/commit/b2d050bd0f46d021f8cad638fe35a5b9df21a7d8) | `` automatic update `` |
| [`08a9daa1`](https://github.com/nix-community/NUR/commit/08a9daa11c026eb9917de990d43848bc6df6de7a) | `` automatic update `` |