### PR TITLE
chore(flake/nur): `cc79f42a` -> `a0613f4b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698813952,
-        "narHash": "sha256-aKC41jSTOKVf3gV+5B74KnPZov/DriP1hTmwZ1Nu8Mo=",
+        "lastModified": 1698821628,
+        "narHash": "sha256-ayji1Kny5A9meEvKUfJ5T0RpFaid2J5IdJqhHM8v3k0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cc79f42ab7e6a676234254d4723fa58c1744b82d",
+        "rev": "a0613f4bcc0fac04e7f6247c909a5b08f9ffad73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a0613f4b`](https://github.com/nix-community/NUR/commit/a0613f4bcc0fac04e7f6247c909a5b08f9ffad73) | `` automatic update `` |