### PR TITLE
chore(flake/nur): `a0613f4b` -> `f4ef199f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698821628,
-        "narHash": "sha256-ayji1Kny5A9meEvKUfJ5T0RpFaid2J5IdJqhHM8v3k0=",
+        "lastModified": 1698828687,
+        "narHash": "sha256-4R9er7gXSYDA4Fln/DSw2T+xvuOBlvdejbGJFmjyLGk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a0613f4bcc0fac04e7f6247c909a5b08f9ffad73",
+        "rev": "f4ef199f1a8eb1127052ea20f4ba347059fd2704",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f4ef199f`](https://github.com/nix-community/NUR/commit/f4ef199f1a8eb1127052ea20f4ba347059fd2704) | `` automatic update `` |