### PR TITLE
chore(flake/nur): `f4ef199f` -> `5d1b2d02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698828687,
-        "narHash": "sha256-4R9er7gXSYDA4Fln/DSw2T+xvuOBlvdejbGJFmjyLGk=",
+        "lastModified": 1698831793,
+        "narHash": "sha256-O5aeleQUS/lJB7oke9O2MszmDOyJVCubuDUlkPxI8fY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f4ef199f1a8eb1127052ea20f4ba347059fd2704",
+        "rev": "5d1b2d02ceed81a97ad36a814a00353dc617ff26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5d1b2d02`](https://github.com/nix-community/NUR/commit/5d1b2d02ceed81a97ad36a814a00353dc617ff26) | `` automatic update `` |