### PR TITLE
chore(flake/nur): `5d1b2d02` -> `4c248463`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698831793,
-        "narHash": "sha256-O5aeleQUS/lJB7oke9O2MszmDOyJVCubuDUlkPxI8fY=",
+        "lastModified": 1698835584,
+        "narHash": "sha256-2ljVCc2VjvdnRhKRzfZfGwS3mrsHO24Nsr7zf5NxTIg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5d1b2d02ceed81a97ad36a814a00353dc617ff26",
+        "rev": "4c248463ef00cf5a5116940f36f8c154b78b4ded",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4c248463`](https://github.com/nix-community/NUR/commit/4c248463ef00cf5a5116940f36f8c154b78b4ded) | `` automatic update `` |