### PR TITLE
chore(flake/nur): `75d9951e` -> `62313c72`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698839260,
-        "narHash": "sha256-umE4k9Sb6EEBAVTTRU73kuFRyioqb/MCzSLAxmEtWvY=",
+        "lastModified": 1698846311,
+        "narHash": "sha256-NDGWPNWL2NnR98CvZwhXwcGOZQseJ6BYdw3MWbxmakk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "75d9951ea73cd0101fcfab9bc30e92be95d384a2",
+        "rev": "62313c72f21a899a058ddb7e6cd1778197e8d4d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`62313c72`](https://github.com/nix-community/NUR/commit/62313c72f21a899a058ddb7e6cd1778197e8d4d0) | `` automatic update `` |