### PR TITLE
chore(flake/nixos-hardware): `80d98a7d` -> `11d50c5d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1698053470,
-        "narHash": "sha256-sP8D/41UiwC2qn0X40oi+DfuVzNHMROqIWdSdCI/AYA=",
+        "lastModified": 1698853384,
+        "narHash": "sha256-/FQ2WeCjdjdNo9eGTO7JruGAjO2Ccime8y1OU4/Aesk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "80d98a7d55c6e27954a166cb583a41325e9512d7",
+        "rev": "11d50c5d52472ed40d3cb109daad03c836d2b328",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                          |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`11d50c5d`](https://github.com/NixOS/nixos-hardware/commit/11d50c5d52472ed40d3cb109daad03c836d2b328) | `` raspberrypi."4": add DigiAMP+ overlay ``      |
| [`71e0de71`](https://github.com/NixOS/nixos-hardware/commit/71e0de7199f4117140ee6e9c699a0f160e9301d6) | `` feat(asus/rog-strix/g513im): added profile `` |
| [`f40197be`](https://github.com/NixOS/nixos-hardware/commit/f40197be9ad0142b8612c4e47366945667ae4ef4) | `` pine64-rockpro64: add fancontrol ``           |