### PR TITLE
chore(flake/nur): `62313c72` -> `a3410486`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698846311,
-        "narHash": "sha256-NDGWPNWL2NnR98CvZwhXwcGOZQseJ6BYdw3MWbxmakk=",
+        "lastModified": 1698849913,
+        "narHash": "sha256-G++LfDxC0EfCYpIHREpWokvcMQHpWetdS9S3MJSSbi0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "62313c72f21a899a058ddb7e6cd1778197e8d4d0",
+        "rev": "a3410486812eaab0b0bbe6e38b6e3edd36e9a9ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a3410486`](https://github.com/nix-community/NUR/commit/a3410486812eaab0b0bbe6e38b6e3edd36e9a9ce) | `` automatic update `` |
| [`f4d88e3e`](https://github.com/nix-community/NUR/commit/f4d88e3ec0905e0786d5658eb1b406f9d6d33d32) | `` automatic update `` |