### PR TITLE
chore(flake/nur): `a3410486` -> `c20ec9db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698849913,
-        "narHash": "sha256-G++LfDxC0EfCYpIHREpWokvcMQHpWetdS9S3MJSSbi0=",
+        "lastModified": 1698861349,
+        "narHash": "sha256-sp2aFZbF3IaCI+cvmkqW30K/nUSOH5IhLcbcblA6quY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a3410486812eaab0b0bbe6e38b6e3edd36e9a9ce",
+        "rev": "c20ec9db4b94e3a09aba0f0968dc56842417405d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c20ec9db`](https://github.com/nix-community/NUR/commit/c20ec9db4b94e3a09aba0f0968dc56842417405d) | `` automatic update `` |
| [`14edf6c1`](https://github.com/nix-community/NUR/commit/14edf6c17035ae8de272844821922b3c2f1bc894) | `` automatic update `` |
| [`24bf2849`](https://github.com/nix-community/NUR/commit/24bf2849faa0739447bf9263cdb429323a630a84) | `` automatic update `` |
| [`315bb598`](https://github.com/nix-community/NUR/commit/315bb598ee461d283f522d9dd1d0d8ed2f215552) | `` automatic update `` |
| [`224a6757`](https://github.com/nix-community/NUR/commit/224a675778b25ce3cff4717fd6bdab3875618814) | `` automatic update `` |