### PR TITLE
chore(flake/emacs-overlay): `ed7548e5` -> `2e5f6063`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1698833797,
-        "narHash": "sha256-PyyLuk2Uovf1DrdVNoD6gg8XwoEVO2N/zd3gl1aLdYM=",
+        "lastModified": 1698862967,
+        "narHash": "sha256-55BytnRi93FzZMxgx+mXdcZh/2efpIAkM2cHZv6WmK4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ed7548e554d9649d37e821f178c3f01f6f566072",
+        "rev": "2e5f60632355d27bbe73bf1aecab1775303233cd",
         "type": "github"
       },
       "original": {
@@ -693,11 +693,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1698562188,
-        "narHash": "sha256-9nkxGnA/T+jLhHAMFRW157Qi/zfbf5dF1q7HfKROl3o=",
+        "lastModified": 1698696950,
+        "narHash": "sha256-FHFL58t6lMumvWqwundC8fDDDLOIvc+JJBNIAlPjrDY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e10c80821dedb93592682379f476745f370a58e",
+        "rev": "017ef2132a5bda50bd713aeabce8f918502d4ec1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`2e5f6063`](https://github.com/nix-community/emacs-overlay/commit/2e5f60632355d27bbe73bf1aecab1775303233cd) | `` Updated repos/melpa ``  |
| [`f03559d1`](https://github.com/nix-community/emacs-overlay/commit/f03559d12e9b9ead9e242c88239782c19e682ea4) | `` Updated repos/emacs ``  |
| [`40870a5f`](https://github.com/nix-community/emacs-overlay/commit/40870a5f35fda3e501f895dde1b01df57757c77f) | `` Updated repos/elpa ``   |
| [`886cc758`](https://github.com/nix-community/emacs-overlay/commit/886cc7587d9c1113c5e17e0415dc1543cd51d4df) | `` Updated flake inputs `` |