### PR TITLE
chore(flake/nur): `c20ec9db` -> `7e2f0149`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698861349,
-        "narHash": "sha256-sp2aFZbF3IaCI+cvmkqW30K/nUSOH5IhLcbcblA6quY=",
+        "lastModified": 1698867916,
+        "narHash": "sha256-U83bh1HWcrKeQECPJkIUUymBCXeztQXQkclbSAZO9aw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c20ec9db4b94e3a09aba0f0968dc56842417405d",
+        "rev": "7e2f0149b3ae92920dbb4b6f7fb7b91f85184d09",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7e2f0149`](https://github.com/nix-community/NUR/commit/7e2f0149b3ae92920dbb4b6f7fb7b91f85184d09) | `` automatic update `` |