### PR TITLE
chore(flake/home-manager): `fc2a8842` -> `48b0a302`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698860414,
-        "narHash": "sha256-ejtFTDbo7tT8j8AIQfN9g+4dlQmrUDoC3dEaw77jVcY=",
+        "lastModified": 1698873617,
+        "narHash": "sha256-FfGFcfbULwbK1vD+H0rslIOfmy4g8f2hXiPkQG3ZCTk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fc2a8842ea5106640eb89ec522dde9120df82d8a",
+        "rev": "48b0a30202516e25d9885525fbb200a045f23f26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`48b0a302`](https://github.com/nix-community/home-manager/commit/48b0a30202516e25d9885525fbb200a045f23f26) | `` granted: add module ``                            |
| [`a4218048`](https://github.com/nix-community/home-manager/commit/a421804890cd0581af03534886abae32a213c085) | `` borgmatic: preparing upcoming borgmatic change `` |