### PR TITLE
chore(flake/nur): `7e2f0149` -> `bff4d0cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698867916,
-        "narHash": "sha256-U83bh1HWcrKeQECPJkIUUymBCXeztQXQkclbSAZO9aw=",
+        "lastModified": 1698874155,
+        "narHash": "sha256-TOcSzWiydS3C67dI69scm8IoYNXafMBeqCwK4YYiP5o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7e2f0149b3ae92920dbb4b6f7fb7b91f85184d09",
+        "rev": "bff4d0cfb090e8847d43a3869aff124f7c152ae4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bff4d0cf`](https://github.com/nix-community/NUR/commit/bff4d0cfb090e8847d43a3869aff124f7c152ae4) | `` automatic update `` |
| [`0c98bbfd`](https://github.com/nix-community/NUR/commit/0c98bbfd083eabf927ff00298ed976377b224ab9) | `` automatic update `` |