### PR TITLE
chore(flake/nur): `a63b970f` -> `4be22176`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698878866,
-        "narHash": "sha256-hHHSoV7IBQHQeSSEQ6WtlSlzhH66TDeAMhNB9ZHlFzA=",
+        "lastModified": 1698887803,
+        "narHash": "sha256-QFGfkafxpDHvHj7r8L8/4eK+vEyRRKBDsS4uThScVIQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a63b970f2be77e0416b7db7d7f2c4cbfc7319a7c",
+        "rev": "4be22176b4b6f0e618bb7f7b163e7bddf6147933",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4be22176`](https://github.com/nix-community/NUR/commit/4be22176b4b6f0e618bb7f7b163e7bddf6147933) | `` automatic update `` |