### PR TITLE
chore(flake/nur): `4be22176` -> `6cc87c12`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698887803,
-        "narHash": "sha256-QFGfkafxpDHvHj7r8L8/4eK+vEyRRKBDsS4uThScVIQ=",
+        "lastModified": 1698890329,
+        "narHash": "sha256-jfLe7E18aaOR0UPfXwoHjjkbHI1AXtXKPMpQI1DHFx4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4be22176b4b6f0e618bb7f7b163e7bddf6147933",
+        "rev": "6cc87c1234748574a5303912d6b4326089e3ebbd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6cc87c12`](https://github.com/nix-community/NUR/commit/6cc87c1234748574a5303912d6b4326089e3ebbd) | `` automatic update `` |
| [`45139312`](https://github.com/nix-community/NUR/commit/45139312e7f81a85db5be33d5e588c4b24766e4d) | `` automatic update `` |