### PR TITLE
chore(flake/emacs-overlay): `2e5f6063` -> `6b4f2d7b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1698862967,
-        "narHash": "sha256-55BytnRi93FzZMxgx+mXdcZh/2efpIAkM2cHZv6WmK4=",
+        "lastModified": 1698893706,
+        "narHash": "sha256-vv7dQNyN3MyjjipH4YhHoXfwLM64y24xxadv1jNbOFc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2e5f60632355d27bbe73bf1aecab1775303233cd",
+        "rev": "6b4f2d7b574ccbabb8bd4964650a82482a08d3fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`6b4f2d7b`](https://github.com/nix-community/emacs-overlay/commit/6b4f2d7b574ccbabb8bd4964650a82482a08d3fa) | `` Updated repos/melpa `` |
| [`c7079b66`](https://github.com/nix-community/emacs-overlay/commit/c7079b66c30dfef0f3dd5a428dae497618d1eff1) | `` Updated repos/emacs `` |
| [`8f8b4a41`](https://github.com/nix-community/emacs-overlay/commit/8f8b4a41ca2c32a8d20bfb7298af35618cef47ba) | `` Updated repos/elpa ``  |