### PR TITLE
chore(flake/nur): `6cc87c12` -> `b55a2b6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698890329,
-        "narHash": "sha256-jfLe7E18aaOR0UPfXwoHjjkbHI1AXtXKPMpQI1DHFx4=",
+        "lastModified": 1698895998,
+        "narHash": "sha256-Hq8Hz5mD2cKgOMpS1s7gJtpx8U55ejk1FwuMmq7twc8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6cc87c1234748574a5303912d6b4326089e3ebbd",
+        "rev": "b55a2b6dd9b6f28cf9f4f3c269382d34e9c6f318",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b55a2b6d`](https://github.com/nix-community/NUR/commit/b55a2b6dd9b6f28cf9f4f3c269382d34e9c6f318) | `` automatic update `` |