### PR TITLE
chore(flake/nur): `b55a2b6d` -> `8fd7f7a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698895998,
-        "narHash": "sha256-Hq8Hz5mD2cKgOMpS1s7gJtpx8U55ejk1FwuMmq7twc8=",
+        "lastModified": 1698900326,
+        "narHash": "sha256-L544+qU8nC7qqNQP9hyJOM9lepnuIo9/F8CSPi4/+1Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b55a2b6dd9b6f28cf9f4f3c269382d34e9c6f318",
+        "rev": "8fd7f7a16e7f613043c39f0613c7200fa4e6f2d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8fd7f7a1`](https://github.com/nix-community/NUR/commit/8fd7f7a16e7f613043c39f0613c7200fa4e6f2d9) | `` automatic update `` |