### PR TITLE
chore(flake/nur): `8fd7f7a1` -> `52698b2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698900326,
-        "narHash": "sha256-L544+qU8nC7qqNQP9hyJOM9lepnuIo9/F8CSPi4/+1Q=",
+        "lastModified": 1698906274,
+        "narHash": "sha256-y6qK418UFqEOZashgBx1GxmpFu2wuJsCwx+AdAfQ0Oo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8fd7f7a16e7f613043c39f0613c7200fa4e6f2d9",
+        "rev": "52698b2dfe6bd0c572a92fef4ed28d3129e0e740",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`52698b2d`](https://github.com/nix-community/NUR/commit/52698b2dfe6bd0c572a92fef4ed28d3129e0e740) | `` automatic update `` |