### PR TITLE
chore(flake/nur): `52698b2d` -> `9657803c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698906274,
-        "narHash": "sha256-y6qK418UFqEOZashgBx1GxmpFu2wuJsCwx+AdAfQ0Oo=",
+        "lastModified": 1698912004,
+        "narHash": "sha256-1231gzJoh5Ix03uAfZuIVTs+eT00E+EvCHdpmce8zaU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "52698b2dfe6bd0c572a92fef4ed28d3129e0e740",
+        "rev": "9657803c2d7c60bd4fcf30ef99fc282cc757511c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9657803c`](https://github.com/nix-community/NUR/commit/9657803c2d7c60bd4fcf30ef99fc282cc757511c) | `` automatic update `` |
| [`1ad75754`](https://github.com/nix-community/NUR/commit/1ad7575439ee887f2e4f2542619959c5891da4a4) | `` automatic update `` |