### PR TITLE
chore(flake/nur): `9657803c` -> `e77ad2a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698912004,
-        "narHash": "sha256-1231gzJoh5Ix03uAfZuIVTs+eT00E+EvCHdpmce8zaU=",
+        "lastModified": 1698918316,
+        "narHash": "sha256-RLT2wD8aTLX8Sgbemou258oXYUfqq2rHdT4V0zSJ2eY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9657803c2d7c60bd4fcf30ef99fc282cc757511c",
+        "rev": "e77ad2a44db1d91f5e7c916966e6118bfdf6e565",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e77ad2a4`](https://github.com/nix-community/NUR/commit/e77ad2a44db1d91f5e7c916966e6118bfdf6e565) | `` automatic update `` |