### PR TITLE
chore(flake/emacs-overlay): `6b4f2d7b` -> `271cf1c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1698893706,
-        "narHash": "sha256-vv7dQNyN3MyjjipH4YhHoXfwLM64y24xxadv1jNbOFc=",
+        "lastModified": 1698921055,
+        "narHash": "sha256-QKvhkk2Frdt+NcP5VPv7R6IILcLOBKewtVk3IXs8UBg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6b4f2d7b574ccbabb8bd4964650a82482a08d3fa",
+        "rev": "271cf1c48c036ca3a40335b0ed3b04d8d44d3824",
         "type": "github"
       },
       "original": {
@@ -693,11 +693,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1698696950,
-        "narHash": "sha256-FHFL58t6lMumvWqwundC8fDDDLOIvc+JJBNIAlPjrDY=",
+        "lastModified": 1698846319,
+        "narHash": "sha256-4jyW/dqFBVpWFnhl0nvP6EN4lP7/ZqPxYRjl6var0Oc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "017ef2132a5bda50bd713aeabce8f918502d4ec1",
+        "rev": "34bdaaf1f0b7fb6d9091472edc968ff10a8c2857",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`271cf1c4`](https://github.com/nix-community/emacs-overlay/commit/271cf1c48c036ca3a40335b0ed3b04d8d44d3824) | `` Updated repos/nongnu `` |
| [`80c0d258`](https://github.com/nix-community/emacs-overlay/commit/80c0d258d4cef4463a9d7076c1d279dae2170386) | `` Updated repos/melpa ``  |
| [`ef923b59`](https://github.com/nix-community/emacs-overlay/commit/ef923b59e35f8d4328d9e6bdbbdd580eb9dcecdc) | `` Updated repos/emacs ``  |
| [`d1a8d64f`](https://github.com/nix-community/emacs-overlay/commit/d1a8d64f28fd7ad9a6c84917cd99ddf7fdb6ed80) | `` Updated flake inputs `` |