### PR TITLE
chore(flake/nur): `e77ad2a4` -> `a03e1f16`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698918316,
-        "narHash": "sha256-RLT2wD8aTLX8Sgbemou258oXYUfqq2rHdT4V0zSJ2eY=",
+        "lastModified": 1698922063,
+        "narHash": "sha256-B3jD4pL8IgG+P4JDcV2GShRk1UtBZnFgVQBQ5g4BxBg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e77ad2a44db1d91f5e7c916966e6118bfdf6e565",
+        "rev": "a03e1f164d616bd838c9bfa7b2cb609c94775947",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a03e1f16`](https://github.com/nix-community/NUR/commit/a03e1f164d616bd838c9bfa7b2cb609c94775947) | `` automatic update `` |