### PR TITLE
chore(flake/nur): `a03e1f16` -> `de33a4db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698922063,
-        "narHash": "sha256-B3jD4pL8IgG+P4JDcV2GShRk1UtBZnFgVQBQ5g4BxBg=",
+        "lastModified": 1698929819,
+        "narHash": "sha256-AgCHaH+eLZuRiNU7O1DeVG1q0S8BOirjP0XYrKTSK7k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a03e1f164d616bd838c9bfa7b2cb609c94775947",
+        "rev": "de33a4db1ebf2f40bc4df479169c1efbf33da233",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`de33a4db`](https://github.com/nix-community/NUR/commit/de33a4db1ebf2f40bc4df479169c1efbf33da233) | `` automatic update `` |
| [`177cf2b9`](https://github.com/nix-community/NUR/commit/177cf2b9d244f0896efd68ee32d201a2dc5b099a) | `` automatic update `` |