### PR TITLE
chore(flake/sops-nix): `632c3161` -> `84d6b27d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -952,11 +952,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1698548647,
-        "narHash": "sha256-7c03OjBGqnwDW0FBaBc+NjfEBxMkza+dxZGJPyIzfFE=",
+        "lastModified": 1698929376,
+        "narHash": "sha256-TmROaV9W6HArdTUgxLN334Kw+CradxWHw1HYM/3H6xI=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "632c3161a6cc24142c8e3f5529f5d81042571165",
+        "rev": "84d6b27dc71ac02422e192c35806d06915d2bf67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                        |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`84d6b27d`](https://github.com/Mic92/sops-nix/commit/84d6b27dc71ac02422e192c35806d06915d2bf67) | `` Suggest command to encrypt binary that respect .sopy.aml `` |