### PR TITLE
chore(flake/nur): `de33a4db` -> `9bbea869`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698929819,
-        "narHash": "sha256-AgCHaH+eLZuRiNU7O1DeVG1q0S8BOirjP0XYrKTSK7k=",
+        "lastModified": 1698936045,
+        "narHash": "sha256-ARdJJ1ZfO7qeZHUZmMdWNaWa553MLkjbUePJ9gGb4dQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "de33a4db1ebf2f40bc4df479169c1efbf33da233",
+        "rev": "9bbea8691f3086c3c30fcd0193ef7a54dc3f60b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9bbea869`](https://github.com/nix-community/NUR/commit/9bbea8691f3086c3c30fcd0193ef7a54dc3f60b2) | `` automatic update `` |