### PR TITLE
chore(flake/nur): `9bbea869` -> `353b58f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698936045,
-        "narHash": "sha256-ARdJJ1ZfO7qeZHUZmMdWNaWa553MLkjbUePJ9gGb4dQ=",
+        "lastModified": 1698943651,
+        "narHash": "sha256-tdznVpKxo5R0Q5uMO6mXEXtIGuS0oaJWXKJYUEU7Y2s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9bbea8691f3086c3c30fcd0193ef7a54dc3f60b2",
+        "rev": "353b58f2dec75b73f542351a6e7f7571db50874b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`353b58f2`](https://github.com/nix-community/NUR/commit/353b58f2dec75b73f542351a6e7f7571db50874b) | `` automatic update `` |