### PR TITLE
chore(flake/nur): `353b58f2` -> `78dbc710`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698943651,
-        "narHash": "sha256-tdznVpKxo5R0Q5uMO6mXEXtIGuS0oaJWXKJYUEU7Y2s=",
+        "lastModified": 1698944992,
+        "narHash": "sha256-ZjhUQ8VnUJj2Q52JgSDgaRLBUj1RZR8IEuq0rWE3Oxk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "353b58f2dec75b73f542351a6e7f7571db50874b",
+        "rev": "78dbc71089049f99086fd69c74ad87ae1d418a0d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`78dbc710`](https://github.com/nix-community/NUR/commit/78dbc71089049f99086fd69c74ad87ae1d418a0d) | `` automatic update `` |