### PR TITLE
chore(flake/nur): `78dbc710` -> `25fe4f96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698944992,
-        "narHash": "sha256-ZjhUQ8VnUJj2Q52JgSDgaRLBUj1RZR8IEuq0rWE3Oxk=",
+        "lastModified": 1698950687,
+        "narHash": "sha256-AKkChLuvzogM8pwi2srRYjPDndg0EbPgw0wuNMmDtjk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "78dbc71089049f99086fd69c74ad87ae1d418a0d",
+        "rev": "25fe4f96599b744f6258c2f0272ab5e402b31e59",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`25fe4f96`](https://github.com/nix-community/NUR/commit/25fe4f96599b744f6258c2f0272ab5e402b31e59) | `` automatic update `` |
| [`a90880da`](https://github.com/nix-community/NUR/commit/a90880da8f1c30cb77ba67badbaa9ca1ea25f95c) | `` automatic update `` |