### PR TITLE
chore(flake/nur): `ad32fbfa` -> `561105ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698968727,
-        "narHash": "sha256-IwJ/UogHH2BL62rSMzH1OeCvd5xKAWLT5UTcdJbb2co=",
+        "lastModified": 1698994020,
+        "narHash": "sha256-lNAJzKYm5TVAtkxy+K8c/4mPnzDYWZfbN6toDTZ+j8Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ad32fbfa34b4c7181d267bb11ca0328d71b31d5f",
+        "rev": "561105ca04595a96d8d786b6d19ce63a35fe8520",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`561105ca`](https://github.com/nix-community/NUR/commit/561105ca04595a96d8d786b6d19ce63a35fe8520) | `` automatic update `` |