### PR TITLE
chore(flake/nur): `561105ca` -> `37de1a77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698994020,
-        "narHash": "sha256-lNAJzKYm5TVAtkxy+K8c/4mPnzDYWZfbN6toDTZ+j8Q=",
+        "lastModified": 1698997129,
+        "narHash": "sha256-73Dei04HuFHb5nVjbFKiSgmU4nLn3NrC6ZCdxQ5DHJU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "561105ca04595a96d8d786b6d19ce63a35fe8520",
+        "rev": "37de1a771da42b531be31d612adeedc641eda2d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`37de1a77`](https://github.com/nix-community/NUR/commit/37de1a771da42b531be31d612adeedc641eda2d8) | `` automatic update `` |
| [`d1969fde`](https://github.com/nix-community/NUR/commit/d1969fde7313890d88dd2510e5b1d623191fedc6) | `` automatic update `` |