### PR TITLE
chore(flake/nixpkgs): `0cbe9f69` -> `fa804edf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -741,11 +741,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1698611440,
-        "narHash": "sha256-jPjHjrerhYDy3q9+s5EAsuhyhuknNfowY6yt6pjn9pc=",
+        "lastModified": 1698924604,
+        "narHash": "sha256-GCFbkl2tj8fEZBZCw3Tc0AkGo0v+YrQlohhEGJ/X4s0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0cbe9f69c234a7700596e943bfae7ef27a31b735",
+        "rev": "fa804edfb7869c9fb230e174182a8a1a7e512c40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                    |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`657f8ce3`](https://github.com/NixOS/nixpkgs/commit/657f8ce31927e61a2f2ec1174b882c453e95b38f) | `` eza: 0.15.1 -> 0.15.2 ``                                                |
| [`2bba5a3d`](https://github.com/NixOS/nixpkgs/commit/2bba5a3d6e20ec4a34fb6175be4bc982c92c0276) | `` littlefs-fuse: 2.7.2 -> 2.7.3 ``                                        |
| [`c196e474`](https://github.com/NixOS/nixpkgs/commit/c196e4741be4f7ebacc3faf588e3e4fa21cfb381) | `` pocket-casts: 0.6.0 -> 0.7.0 ``                                         |
| [`96ed7260`](https://github.com/NixOS/nixpkgs/commit/96ed7260120f397e71eb4ef60933c071b88a1a51) | `` tailwindcss-language-server: init at 0.0.14 ``                          |
| [`6d2aa33a`](https://github.com/NixOS/nixpkgs/commit/6d2aa33a17681a30777cb53411bd8243ac765555) | `` liblogging: add withSystemd option ``                                   |
| [`8b1d659c`](https://github.com/NixOS/nixpkgs/commit/8b1d659c6bda61723b373a4ea74a76c35c2af552) | `` ksmbd-tools: 3.4.9 -> 3.5.0 ``                                          |
| [`d57dc4b6`](https://github.com/NixOS/nixpkgs/commit/d57dc4b6993018ed347f3302848d9afc98a0b562) | `` node-packages: regenerate ``                                            |
| [`2327d2ae`](https://github.com/NixOS/nixpkgs/commit/2327d2ae6913fce91b5b4d7327d2f4607c62ee14) | `` python311Packages.hahomematic: 2023.10.14 -> 2023.11.0 ``               |
| [`7da4f5c0`](https://github.com/NixOS/nixpkgs/commit/7da4f5c058b5f70861965c9316c08d3cb71cdb3d) | `` python311Packages.aiosmb: 0.4.9 -> 0.4.10 ``                            |
| [`025b16e9`](https://github.com/NixOS/nixpkgs/commit/025b16e915342f4d66ca05f62801468491cdcbd4) | `` python311Packages.py-nextbusnext: 1.0.0 -> 1.0.1 ``                     |
| [`5c11795b`](https://github.com/NixOS/nixpkgs/commit/5c11795be0c6ad7420e59e97a5bec7a135197e3b) | `` python311Packages.aiowaqi: 2.1.0 -> 3.0.0 ``                            |
| [`f14cc031`](https://github.com/NixOS/nixpkgs/commit/f14cc031354d40513f9ca045d94607219e91c2a9) | `` exploitdb: 2023-11-01 -> 2023-11-02 ``                                  |
| [`90d39e46`](https://github.com/NixOS/nixpkgs/commit/90d39e46f0eaf738869ee548ad36fdac8b37db65) | `` pleroma: 2.5.5 -> 2.6.0 ``                                              |
| [`58538146`](https://github.com/NixOS/nixpkgs/commit/58538146ed1288a96a0b90ab91528c6229819721) | `` python311Packages.python-fsutil: update disabled ``                     |
| [`bbc2a9c5`](https://github.com/NixOS/nixpkgs/commit/bbc2a9c553316ca0574db7bc20219d3dd717a6dc) | `` python311Packages.python-fsutil: 0.10.0 -> 0.11.0 ``                    |
| [`686a5fca`](https://github.com/NixOS/nixpkgs/commit/686a5fca36d6ebc0e2fda1c4fac1717e318c4de5) | `` lighttpd: 1.4.72 -> 1.4.73 ``                                           |
| [`447001c4`](https://github.com/NixOS/nixpkgs/commit/447001c4b76d5adacd157788e90889c75a407700) | `` moon: 1.15.0 -> 1.16.0 ``                                               |
| [`fbd88879`](https://github.com/NixOS/nixpkgs/commit/fbd888797c5cd65f8c4a1b729bc93b40652c7ef7) | `` mkgmap: 4914 -> 4916 ``                                                 |
| [`b09fd364`](https://github.com/NixOS/nixpkgs/commit/b09fd3644e6936c49ee927c9b5236562f1127d5f) | `` minify: 2.20.1 -> 2.20.5 ``                                             |
| [`1ff092a1`](https://github.com/NixOS/nixpkgs/commit/1ff092a1123332a476d919fbc1d86dbf2312237c) | `` python3Packages.aw-core: 0.5.15 -> 0.5.16 ``                            |
| [`6c7ad5e7`](https://github.com/NixOS/nixpkgs/commit/6c7ad5e732428a4e8063144312d77544a867e08c) | `` nixos/systemd-lib: fix building of empty unit files ``                  |
| [`21aade21`](https://github.com/NixOS/nixpkgs/commit/21aade217360e880a72c4d15157e3161a88d691e) | `` linuxKernel.kernels.linux_lqx: 6.5.9-lqx1 ->6.5.9-lqx2 ``               |
| [`8d2ae0e9`](https://github.com/NixOS/nixpkgs/commit/8d2ae0e95e9fc59128fe55da2e484d4685561d24) | `` linuxKernel.kernels.linux_zen: 6.5.9-zen2 -> 6.6-zen1 ``                |
| [`2c732a9b`](https://github.com/NixOS/nixpkgs/commit/2c732a9b5a5a60d91c685c92b87db5b8f5cf5812) | `` gh: 2.37.0 -> 2.38.0 ``                                                 |
| [`f1d95608`](https://github.com/NixOS/nixpkgs/commit/f1d95608410910abda30bb7a1834ba11eee84d0a) | `` discord-canary: 0.0.320 -> 0.0.329 ``                                   |
| [`a7390c11`](https://github.com/NixOS/nixpkgs/commit/a7390c11c83310dac91d85c73f37aca47940b76b) | `` discord-ptb: 0.0.82 -> 0.0.84 ``                                        |
| [`5aa06e27`](https://github.com/NixOS/nixpkgs/commit/5aa06e27cf309a5bb3139f278f384f5f7bb8a320) | `` discord: 0.0.281 -> 0.0.282 ``                                          |
| [`2df8c660`](https://github.com/NixOS/nixpkgs/commit/2df8c660df4cb24f8db1b4e2b4e176873fa84b9a) | `` discord-ptb: 0.0.51 -> 0.0.53 ``                                        |
| [`938eaddc`](https://github.com/NixOS/nixpkgs/commit/938eaddcdfa7ef31770fd4b0bbbaf97607978dbe) | `` discord: 0.0.32 -> 0.0.33 ``                                            |
| [`ccddeea0`](https://github.com/NixOS/nixpkgs/commit/ccddeea081c179f90ee16224cb5f9fcce9d5ac0f) | `` discord-canary: 0.0.171 -> 0.0.173 ``                                   |
| [`826a8ff7`](https://github.com/NixOS/nixpkgs/commit/826a8ff757130a384276dee94d3ee0e8d95af76c) | `` zigbee2mqtt: 1.33.1 -> 1.33.2 ``                                        |
| [`a7e65a9e`](https://github.com/NixOS/nixpkgs/commit/a7e65a9e76f582d011883f6d40715f98c2626de5) | `` python311Packages.zha-quirks: test with pytest-asyncio ``               |
| [`3e7b6b1d`](https://github.com/NixOS/nixpkgs/commit/3e7b6b1decaec2b64e741b972ee104bb2bc08407) | `` reaper: 7.0 -> 7.02 ``                                                  |
| [`0b2ab262`](https://github.com/NixOS/nixpkgs/commit/0b2ab262bc4d935039fd392b43e94e63c18bf5ee) | `` home-assistant: 2023.10.5 -> 2023.11.0 ``                               |
| [`6b4b15b6`](https://github.com/NixOS/nixpkgs/commit/6b4b15b6e0f38d36f912f53847d45df82fa99532) | `` python311Packages.zigpy: 0.57.2 -> 0.58.1 ``                            |
| [`cb7df235`](https://github.com/NixOS/nixpkgs/commit/cb7df2351aeacf91c913f6b0d00308e0c6bc5c18) | `` python311Packages.zeroconf: 0.115.2 -> 0.119.0 (#260837) ``             |
| [`135d9b4a`](https://github.com/NixOS/nixpkgs/commit/135d9b4a6787faa200bcc207df3f77e609da2d09) | `` python311Packages.python-opensky: 0.2.1 -> 0.2.1 ``                     |
| [`545c6c0b`](https://github.com/NixOS/nixpkgs/commit/545c6c0bc493f5f600b3bd5c645b627d49b98c2c) | `` python311Packages.pyatv: 0.13.4 -> 0.14.4 ``                            |
| [`3086b37c`](https://github.com/NixOS/nixpkgs/commit/3086b37cc066fd25ea39d7e6a76365d3a9c31345) | `` python311Packages.matrix-nio: 0.21.2 -> 0.22.1 ``                       |
| [`eda0545f`](https://github.com/NixOS/nixpkgs/commit/eda0545f6a7999321830427d0fc9d4bf7bdb3258) | `` python311Packages.mastodon-py: unstable-2023-06-24 -> 1.8.1 ``          |
| [`3ab075da`](https://github.com/NixOS/nixpkgs/commit/3ab075da2bda3473334c8e61e6c89974013a87aa) | `` home-assistant.intents: 2023.10.2 -> 2023.10.16 ``                      |
| [`29f7506f`](https://github.com/NixOS/nixpkgs/commit/29f7506f5908f048a69f2a95e26388143a6bff41) | `` python311Packages.hass-nabucasa: 0.71.0 -> 0.74.0 ``                    |
| [`d835d882`](https://github.com/NixOS/nixpkgs/commit/d835d8825c235b9135d4f7c791b6d23160b7c957) | `` python311Packages.google-nest-sdm: 3.0.2 -> 3.0.3 ``                    |
| [`5b485896`](https://github.com/NixOS/nixpkgs/commit/5b4858966bcc421fb3ac18ffaeb50238b1b8876a) | `` python311Package.blinkpy: 0.22.0 -> 0.22.2 ``                           |
| [`7fbf06cc`](https://github.com/NixOS/nixpkgs/commit/7fbf06ccace68da3ac1cb1841c4cfa418d9dfb2e) | `` python311Packages.bleak-retry-connector: 3.2.1 -> 3.3.0 ``              |
| [`fdbcae96`](https://github.com/NixOS/nixpkgs/commit/fdbcae96424f260a40fa63325a7e1c944bc95f01) | `` python311Packages.aiovodafone: 0.3.1 -> 0.4.2 ``                        |
| [`cd6dc98e`](https://github.com/NixOS/nixpkgs/commit/cd6dc98e8b90705fae847dcaaf5ff4b25da83174) | `` python311Packages.aiounifi: 63 -> 64 ``                                 |
| [`c894753f`](https://github.com/NixOS/nixpkgs/commit/c894753fb90b722319d17c141d157defc2f7dd94) | `` python311Packages.aiohomekit: 3.0.6 -> 3.0.8 (#262700) ``               |
| [`4e995d14`](https://github.com/NixOS/nixpkgs/commit/4e995d14fc9d57b102c89351cef3ed6a63508776) | `` python311Packages.aiocomelit: 0.0.9 -> 0.3.0 ``                         |
| [`f75ae443`](https://github.com/NixOS/nixpkgs/commit/f75ae44378c7e76e2396e58ba2afa0b53598d78e) | `` python311Packages.aioairzone-cloud: 0.3.0 -> 0.3.1 ``                   |
| [`2a3aff26`](https://github.com/NixOS/nixpkgs/commit/2a3aff2620ec165364d93ae6341e0c067c90223d) | `` python3Packages.pandas: fix build on 32-bit platforms ``                |
| [`c2e92e90`](https://github.com/NixOS/nixpkgs/commit/c2e92e90663094cd4773a5f39db44fdc2f97c566) | `` fishPlugins.bobthefisher: unstable-2023-03-09 -> unstable-2023-10-25 `` |
| [`747e3067`](https://github.com/NixOS/nixpkgs/commit/747e3067461e130d9540c6a284b4e5c33fc0dde7) | `` owl-lisp: 0.2.1 -> 0.2.2 ``                                             |
| [`65d6075e`](https://github.com/NixOS/nixpkgs/commit/65d6075e14e41f5f8f6cf1ff715c382ebbcac387) | `` nixos/tests/predictable-interface-names: fix eval for systemd-stage1 `` |
| [`da939a89`](https://github.com/NixOS/nixpkgs/commit/da939a89352e034c705bf3e7634e9a5e1de972b3) | `` cosmic-icons: init at unstable-2023-08-30 ``                            |
| [`f4056409`](https://github.com/NixOS/nixpkgs/commit/f405640926e93ba0c31c0a05a49f1948525e45a7) | `` glamoroustoolkit: 1.0.1 -> 1.0.2 ``                                     |
| [`add25465`](https://github.com/NixOS/nixpkgs/commit/add254658af2e2904af0ee644a1b44b89f6c973a) | `` lib.filesystem: Don't test Nix-specific error messages ``               |
| [`fe2d8723`](https://github.com/NixOS/nixpkgs/commit/fe2d872327d7b171fc9f2f757c09e8466a6f37f0) | `` python311Packages.casbin: 1.32.0 -> 1.33.0 ``                           |
| [`7804201c`](https://github.com/NixOS/nixpkgs/commit/7804201cfc74c1ca423d2f8ac8075d608424e93c) | `` python311Packages.azure-mgmt-search: 9.0.0 -> 9.1.0 ``                  |
| [`5e53e7d0`](https://github.com/NixOS/nixpkgs/commit/5e53e7d0b36de0051a116c0197405d89109b6119) | `` python311Packages.awscrt: 0.19.3 -> 0.19.7 ``                           |
| [`14c2a59f`](https://github.com/NixOS/nixpkgs/commit/14c2a59f5ddc93391bab18cfcb1b97764df75f3a) | `` python311Packages.aioquic-mitmproxy: 0.9.20.3 -> 0.9.21.1 ``            |
| [`8d734dc1`](https://github.com/NixOS/nixpkgs/commit/8d734dc127ddee2a0dcb416ee032de51628d411a) | `` pscale: 0.156.0 -> 0.161.0 ``                                           |
| [`c04b30d8`](https://github.com/NixOS/nixpkgs/commit/c04b30d8aed7deb658c4ce0fdc7e00dab8dc9cba) | `` python311Packages.x-wr-timezone: disable tests ``                       |
| [`733f859c`](https://github.com/NixOS/nixpkgs/commit/733f859cfd9e3294e145aec0fe2286c932fb61d9) | `` python310Packages.recurring-ical-events: 2.0.2 -> 2.1.0 ``              |
| [`309d7744`](https://github.com/NixOS/nixpkgs/commit/309d7744dc70b6bebd79dc5314ffcdc3e2616475) | `` python310Packages.icalendar: 5.0.7 -> 5.0.10 ``                         |
| [`819198c1`](https://github.com/NixOS/nixpkgs/commit/819198c11ff2e5098c5a47591e50ccd1e301dc01) | `` celeste-classic: init at unstable-2020-12-08 ``                         |
| [`afc06f2f`](https://github.com/NixOS/nixpkgs/commit/afc06f2fe9e629b9a773f0711f8b334cd64aac7c) | `` triton: 7.15.4 -> 7.16.0 ``                                             |
| [`7d0b5b3a`](https://github.com/NixOS/nixpkgs/commit/7d0b5b3a94afcb751e4e79ec83f9ee8e3c5b8a0b) | `` nixos/nix-channnel: fix setting up the default channel again ``         |
| [`c52843c9`](https://github.com/NixOS/nixpkgs/commit/c52843c96733430374790359d68c3cd401c66092) | `` logseq: 0.9.19 -> 0.9.20 ``                                             |
| [`53da5fe9`](https://github.com/NixOS/nixpkgs/commit/53da5fe99640c35bd7ed6dcce3adf77656a6c6ff) | `` numbat: Add support for darwin ``                                       |
| [`3d830355`](https://github.com/NixOS/nixpkgs/commit/3d830355df1f901df12ac5c534649f78b8fd7579) | `` bbin: add updateScript ``                                               |
| [`86c4da96`](https://github.com/NixOS/nixpkgs/commit/86c4da960837e34a6b39f76896b9082130638060) | `` bbin: 0.1.5 -> 0.2.1 ``                                                 |
| [`5f262a8d`](https://github.com/NixOS/nixpkgs/commit/5f262a8d7ff73d5caf1dbc7038f0ab70b7365485) | `` vscode-extensions.rust-lang.rust-analyzer 2023-07-31 -> 2023-10-16 ``   |
| [`c03c3d40`](https://github.com/NixOS/nixpkgs/commit/c03c3d402f92aa0aab81b5ccb04830483d495abd) | `` vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.17.1 -> 0.17.5 ``      |
| [`157a6e7d`](https://github.com/NixOS/nixpkgs/commit/157a6e7d0bde56fefdb1377c1991020349503bc2) | `` maintainers: add chayleaf's GPG key ``                                  |
| [`f59d0319`](https://github.com/NixOS/nixpkgs/commit/f59d0319c67f5186149cffa6dcd5bb899ab24d84) | `` helm-ls: 0.0.6 -> 0.0.7 ``                                              |
| [`9750e40b`](https://github.com/NixOS/nixpkgs/commit/9750e40bd2f63d5a039f7adf4ff8b11c9b649b3b) | `` python3.pkgs.mastodon-py: 1.8.1 -> unstable-2023-06-24 (fixes build) `` |
| [`127c7e57`](https://github.com/NixOS/nixpkgs/commit/127c7e57875b42180a9ab87d8b6c35438e7b04a9) | `` ttop: 1.2.6 -> 1.2.7 ``                                                 |
| [`6a0d5a83`](https://github.com/NixOS/nixpkgs/commit/6a0d5a8384fd520790e83d03d156be58917e54ed) | `` maintainers: add mrtnvgr ``                                             |
| [`101e0bc3`](https://github.com/NixOS/nixpkgs/commit/101e0bc350c0bd4620d81fcad31030e2dfbc71c4) | `` vencord: 1.6.1 -> 1.6.2 ``                                              |
| [`05e36d61`](https://github.com/NixOS/nixpkgs/commit/05e36d61b9f0439c2ca816d3cc68f78e08f95a66) | `` heygpt: 0.4.0 -> 0.4.1 ``                                               |
| [`4d1a1769`](https://github.com/NixOS/nixpkgs/commit/4d1a17697f6d73c76986c65ac83aa05e12d734be) | `` imgcrypt: 1.1.8 -> 1.1.9 ``                                             |
| [`03f04550`](https://github.com/NixOS/nixpkgs/commit/03f045505106599ccd9a7b3e6ca2efd8799568ab) | `` python310Packages.dvc: update checksum ``                               |
| [`021b5dc7`](https://github.com/NixOS/nixpkgs/commit/021b5dc73110fc277681bfac8f98092b9952fe7a) | `` webcord: 4.5.0 -> 4.5.1 ``                                              |
| [`414cbddb`](https://github.com/NixOS/nixpkgs/commit/414cbddbf748ccbce1826475176fd12ef17d6106) | `` gobgpd: 3.19.0 -> 3.20.0 ``                                             |
| [`f091204d`](https://github.com/NixOS/nixpkgs/commit/f091204dc988858ecb058897e096d244816cc968) | `` fastfetch: 2.1.2 -> 2.2.0 ``                                            |
| [`2e086df2`](https://github.com/NixOS/nixpkgs/commit/2e086df2279b7373d47dfa15ebaa636e864c8761) | `` gobgp: 3.19.0 -> 3.20.0 ``                                              |
| [`b67ef8b1`](https://github.com/NixOS/nixpkgs/commit/b67ef8b189183264f82c274c8ff1e5561d833d56) | `` phel: add `postCheckInstall` step ``                                    |
| [`38bac4f0`](https://github.com/NixOS/nixpkgs/commit/38bac4f0cd333fd49eee2dc7190ff0f0d8be267e) | `` phel: unstable-2023-10-27 -> 0.12.0 ``                                  |
| [`0a09e168`](https://github.com/NixOS/nixpkgs/commit/0a09e168aa930b64b624616c3e455d926707fdc3) | `` act: 0.2.52 -> 0.2.53 ``                                                |
| [`3ac4cd15`](https://github.com/NixOS/nixpkgs/commit/3ac4cd157e075ad0c656d653e50243968e7834f7) | `` linuxPackages.nvidia_x11: 530.41.03 -> 545.29.02 ``                     |
| [`4d7a8b62`](https://github.com/NixOS/nixpkgs/commit/4d7a8b62cf677b17c1b6f1e84eeb29429991c768) | `` python311Packages.nitime: 0.10.1 -> 0.10.2 ``                           |
| [`39a33eca`](https://github.com/NixOS/nixpkgs/commit/39a33eca0ca9c889074af80d3006c99bc751cc9d) | `` python311Packages.jinja2-pluralize: enable tests ``                     |
| [`52d0117a`](https://github.com/NixOS/nixpkgs/commit/52d0117a7b91cdfbeb167a9e6b3dbbc7daa23d10) | `` python311Packages.jinja2-pluralize: rename from jinja2_pluralize ``     |
| [`454e0295`](https://github.com/NixOS/nixpkgs/commit/454e029519952ec658ce38f44fcc4087975b2822) | `` mmseqs2: 14-7e284 -> 15-6f452 ``                                        |
| [`74551cd6`](https://github.com/NixOS/nixpkgs/commit/74551cd62a724e97347bd321ac65d1c52b4373d8) | `` ft2-clone: 1.72.1 -> 1.73 ``                                            |
| [`a77245ec`](https://github.com/NixOS/nixpkgs/commit/a77245eccab85f7e24d939387eccd120794a0bbd) | `` pt2-clone: 1.64 -> 1.65.1 ``                                            |
| [`38458de9`](https://github.com/NixOS/nixpkgs/commit/38458de9286cc5c1bf5ff790458ec6a52a593dcc) | `` python311Packages.types-awscrt: 0.19.6 -> 0.19.7 ``                     |
| [`4ae49638`](https://github.com/NixOS/nixpkgs/commit/4ae49638cd9d1e88d8696e319dbcd0d406e19784) | `` libaribcaption: init at 1.1.1 ``                                        |
| [`6547a841`](https://github.com/NixOS/nixpkgs/commit/6547a841a1645dbc16e82ed509d465b8a47f8067) | `` python311Packages.pysolcast: 1.0.15 -> 2.0.0 ``                         |
| [`803bb08b`](https://github.com/NixOS/nixpkgs/commit/803bb08b6c6b6139c0e55a8de29b11a46c2a4368) | `` mapcidr: 1.1.13 -> 1.1.14 ``                                            |
| [`a0449aa5`](https://github.com/NixOS/nixpkgs/commit/a0449aa5ea10a2ffa41b75f5b5025a430413975f) | `` crun: 1.11 -> 1.11.1 ``                                                 |
| [`8d36e382`](https://github.com/NixOS/nixpkgs/commit/8d36e38261f9a7aef5a2030bb87b2f03d6d3482f) | `` runc: 1.1.9 -> 1.1.10 ``                                                |
| [`dcb886fb`](https://github.com/NixOS/nixpkgs/commit/dcb886fba70583e7313bfb3c5dcb670ea30ec548) | `` terraform-plugin-docs: ensure go is in the PATH ``                      |
| [`3ac34032`](https://github.com/NixOS/nixpkgs/commit/3ac34032569468f3abd21b31ad53722dbbb843ba) | `` terraform-plugin-docs: 0.14.1 -> 0.16.0 ``                              |
| [`a5f02131`](https://github.com/NixOS/nixpkgs/commit/a5f02131483e15b4bd71c63c2ba277ca5e2a966f) | `` terraform-plugin-docs: add passthru.{tests,updateScript} ``             |
| [`d7cd2337`](https://github.com/NixOS/nixpkgs/commit/d7cd2337c8e5929d6d33a2e21cbfff383e655634) | `` terraform-plugin-docs: add meta.{changelog,mainProgram} ``              |
| [`796b1d3f`](https://github.com/NixOS/nixpkgs/commit/796b1d3f0347eece6dbc30fe77b7ec8cdff38fc8) | `` chart-testing: 3.9.0 -> 3.10.0 ``                                       |
| [`445b0b43`](https://github.com/NixOS/nixpkgs/commit/445b0b4395b30c8ed6149183a12c2e310666c61a) | `` terraform-plugin-docs: rename from tfplugindocs ``                      |