### PR TITLE
chore(flake/nur): `37de1a77` -> `77be844f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698997129,
-        "narHash": "sha256-73Dei04HuFHb5nVjbFKiSgmU4nLn3NrC6ZCdxQ5DHJU=",
+        "lastModified": 1698998629,
+        "narHash": "sha256-GTtpmmkfmNXLnyNfMN+g1kz1KAzaAABG5WJbywSM7yI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "37de1a771da42b531be31d612adeedc641eda2d8",
+        "rev": "77be844f9f98a9abd055dca953f60a15f4f457e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`77be844f`](https://github.com/nix-community/NUR/commit/77be844f9f98a9abd055dca953f60a15f4f457e3) | `` automatic update `` |