### PR TITLE
chore(flake/emacs-overlay): `8f964138` -> `99fb18c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1698981203,
-        "narHash": "sha256-CN6S81JON0tOY3RXK1AK+MkF8F7k3Zfp+cuaAbLERJI=",
+        "lastModified": 1699008765,
+        "narHash": "sha256-UdtqkpdCcFHtNQhNX20sY+b5EDakACMh/hFDuHX496k=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8f964138749616526f0d2792e05e06aa5d509741",
+        "rev": "99fb18c4f0b7abdcd2d93c98c94e6d3d745ee283",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`99fb18c4`](https://github.com/nix-community/emacs-overlay/commit/99fb18c4f0b7abdcd2d93c98c94e6d3d745ee283) | `` Updated repos/nongnu `` |
| [`32c56bb4`](https://github.com/nix-community/emacs-overlay/commit/32c56bb4b8020d2f73e887dc37b1afcbd2eb24cc) | `` Updated repos/melpa ``  |
| [`27a7f669`](https://github.com/nix-community/emacs-overlay/commit/27a7f6697d55dd859c1dea8193fc3ca15c3bb280) | `` Updated repos/emacs ``  |
| [`ae8e816e`](https://github.com/nix-community/emacs-overlay/commit/ae8e816eda343dfcce11adb7428e61c2870506eb) | `` Updated flake inputs `` |