### PR TITLE
chore(flake/nur): `dbb3b5e5` -> `61188926`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699006720,
-        "narHash": "sha256-A7Vyh43yT5cix2zNvjN214TUDm8OFNkBtCTfsKdYNkg=",
+        "lastModified": 1699019213,
+        "narHash": "sha256-QxQsO88lV2s/zr8hEksriNyemzSZPQsO44sXDK89UNE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dbb3b5e55618ba573fda5c64178c4df34975ceec",
+        "rev": "61188926d449a41414cd0709084d4aad03829386",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`61188926`](https://github.com/nix-community/NUR/commit/61188926d449a41414cd0709084d4aad03829386) | `` automatic update `` |
| [`d1e379e2`](https://github.com/nix-community/NUR/commit/d1e379e2e0f55f5bb75f00ca57c146a3feb5b241) | `` automatic update `` |
| [`7a051f1f`](https://github.com/nix-community/NUR/commit/7a051f1f238a0784daafc3d618c9629af59e7096) | `` automatic update `` |
| [`da74efa9`](https://github.com/nix-community/NUR/commit/da74efa9f7892149723b79d082aa85f218c02522) | `` automatic update `` |