### PR TITLE
chore(flake/sops-nix): `84d6b27d` -> `275b2859`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -952,11 +952,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1698929376,
-        "narHash": "sha256-TmROaV9W6HArdTUgxLN334Kw+CradxWHw1HYM/3H6xI=",
+        "lastModified": 1699021419,
+        "narHash": "sha256-oy2j2OHXYcckifASMeZzpmbDLSvobMGt0V/RvoDotF4=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "84d6b27dc71ac02422e192c35806d06915d2bf67",
+        "rev": "275b28593ef3a1b9d05b6eeda3ddce2f45f5c06f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                          |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`275b2859`](https://github.com/Mic92/sops-nix/commit/275b28593ef3a1b9d05b6eeda3ddce2f45f5c06f) | `` sops-install-secrets: check that both uid & gid are correct on mountpoints `` |
| [`c59da7ac`](https://github.com/Mic92/sops-nix/commit/c59da7ac29f041954c0864bc7bbb2c66ee18eba5) | `` reformat with gofumpt ``                                                      |
| [`cc2cfe56`](https://github.com/Mic92/sops-nix/commit/cc2cfe56305ac53c43c447e4345cdc3dc767ba22) | `` don't chown mountpoint if already correct ``                                  |