### PR TITLE
chore(flake/nixos-hardware): `11d50c5d` -> `87f84033`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1698853384,
-        "narHash": "sha256-/FQ2WeCjdjdNo9eGTO7JruGAjO2Ccime8y1OU4/Aesk=",
+        "lastModified": 1699044561,
+        "narHash": "sha256-3uHmbq74CicpBPP40a6NHp830S7Rvh33uFgfIIC+7nw=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "11d50c5d52472ed40d3cb109daad03c836d2b328",
+        "rev": "87f8403371fa74d9ad21ed677403cc235f37b96c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                     |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`87f84033`](https://github.com/NixOS/nixos-hardware/commit/87f8403371fa74d9ad21ed677403cc235f37b96c) | `` chore: Add OPENGL settings ``            |
| [`ce606807`](https://github.com/NixOS/nixos-hardware/commit/ce6068070b5fbbbdfdacfc38dff88b5ec6af87ec) | `` chore: Tunning WiFi ``                   |
| [`097764c8`](https://github.com/NixOS/nixos-hardware/commit/097764c8930ad8b0632f6eb9d96eb9c9b65a62f5) | `` Add HP Elitebook 845 g7 configuration `` |