### PR TITLE
chore(flake/nur): `0dda7b26` -> `d83d6250`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699040735,
-        "narHash": "sha256-xVhYASvae81gmH+eTJ6wHgiaXDFMsSIDb5i0SkHCeBw=",
+        "lastModified": 1699046991,
+        "narHash": "sha256-O0Puo3J45XDu8xS8XaDXgrZQxcCnslAAVVwLRc0twEk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0dda7b26e311201a5ee6cc4ae58034666fb16cf8",
+        "rev": "d83d6250f6b930c260c908d06783b5459a060aca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d83d6250`](https://github.com/nix-community/NUR/commit/d83d6250f6b930c260c908d06783b5459a060aca) | `` automatic update `` |
| [`69e14f4c`](https://github.com/nix-community/NUR/commit/69e14f4cdfeac38d5bed38dc2694f9480e8915a5) | `` automatic update `` |
| [`02ad997e`](https://github.com/nix-community/NUR/commit/02ad997e272520a804903506a45b57a4976a38f4) | `` automatic update `` |