### PR TITLE
chore(flake/emacs-overlay): `c1ecbd6e` -> `4728a809`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699031794,
-        "narHash": "sha256-yf69PmHplQwg8G81Y+vOUxAqIvcpEjKCeftE8B5R69M=",
+        "lastModified": 1699064312,
+        "narHash": "sha256-HL9hzxpdocboN5GaRm5We0JWyIWoSMDjguHTDqV270k=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c1ecbd6ee4b45991444b511a22f88af2b920aee1",
+        "rev": "4728a80913ec511fef8f1777da37c31733f515c2",
         "type": "github"
       },
       "original": {
@@ -693,11 +693,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1698846319,
-        "narHash": "sha256-4jyW/dqFBVpWFnhl0nvP6EN4lP7/ZqPxYRjl6var0Oc=",
+        "lastModified": 1698942558,
+        "narHash": "sha256-/UmnB+mEd6Eg3mJBrAgqRcyZX//RSjHphcCO7Ig9Bpk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "34bdaaf1f0b7fb6d9091472edc968ff10a8c2857",
+        "rev": "621f51253edffa1d6f08d5fce4f08614c852d17e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4728a809`](https://github.com/nix-community/emacs-overlay/commit/4728a80913ec511fef8f1777da37c31733f515c2) | `` Updated repos/nongnu `` |
| [`cabc363c`](https://github.com/nix-community/emacs-overlay/commit/cabc363cbd1892dffdcc4cfc7090d080fe8957fb) | `` Updated repos/melpa ``  |
| [`c4b40176`](https://github.com/nix-community/emacs-overlay/commit/c4b40176fdb653c2fd9e4fcff9df5e3c6063cc73) | `` Updated repos/emacs ``  |
| [`f7e314a0`](https://github.com/nix-community/emacs-overlay/commit/f7e314a02983cd3da607543cd4f8d3d06bc1b414) | `` Updated repos/elpa ``   |
| [`6b1b2aec`](https://github.com/nix-community/emacs-overlay/commit/6b1b2aec5740bfd9975667c1dc18c7a0c9731e64) | `` Updated flake inputs `` |