### PR TITLE
chore(flake/nur): `aedb070e` -> `678544c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699062694,
-        "narHash": "sha256-RHlxEsyaSeB4K3cX6TOul8t70mxDr4kuSm0cT9qlrk0=",
+        "lastModified": 1699069465,
+        "narHash": "sha256-S76529ISBbO5rltCitUhrl+Vhvo5SWv8DJSFAyu85II=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aedb070e6d80a4180901a5b274d2bafa13d14c8c",
+        "rev": "678544c92fa378d6889c1486b5a4e737c2fd039d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`678544c9`](https://github.com/nix-community/NUR/commit/678544c92fa378d6889c1486b5a4e737c2fd039d) | `` automatic update `` |
| [`357ed8a4`](https://github.com/nix-community/NUR/commit/357ed8a446c08150f016b3e13e20ccbd4a4d2e75) | `` automatic update `` |