### PR TITLE
chore(flake/nur): `678544c9` -> `9c78123b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699069465,
-        "narHash": "sha256-S76529ISBbO5rltCitUhrl+Vhvo5SWv8DJSFAyu85II=",
+        "lastModified": 1699071018,
+        "narHash": "sha256-NiaT2UCJ4Io2ZTlkSZkFci0ISWY3vjawQdAQqIFsGTI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "678544c92fa378d6889c1486b5a4e737c2fd039d",
+        "rev": "9c78123b61e225747b6b2dbf1f43cc79b1cc0fe8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9c78123b`](https://github.com/nix-community/NUR/commit/9c78123b61e225747b6b2dbf1f43cc79b1cc0fe8) | `` automatic update `` |