### PR TITLE
chore(flake/nur): `9c78123b` -> `fc8b614e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699071018,
-        "narHash": "sha256-NiaT2UCJ4Io2ZTlkSZkFci0ISWY3vjawQdAQqIFsGTI=",
+        "lastModified": 1699080158,
+        "narHash": "sha256-NQd7xugdy3CIA/jK+BRdGUnHXNiVkWS4sPLuGk/v13E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9c78123b61e225747b6b2dbf1f43cc79b1cc0fe8",
+        "rev": "fc8b614ea4f6c528bbd00171612756430a2a8a33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fc8b614e`](https://github.com/nix-community/NUR/commit/fc8b614ea4f6c528bbd00171612756430a2a8a33) | `` automatic update `` |