### PR TITLE
chore(flake/emacs-overlay): `4728a809` -> `8e42a346`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699064312,
-        "narHash": "sha256-HL9hzxpdocboN5GaRm5We0JWyIWoSMDjguHTDqV270k=",
+        "lastModified": 1699090626,
+        "narHash": "sha256-QOE2Cf5WDBfgP4ENQQHJs+u2MPrGE1LZKUri3ERgBcA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4728a80913ec511fef8f1777da37c31733f515c2",
+        "rev": "8e42a3463ac1a25a9948e965e2fefc570fadd702",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`8e42a346`](https://github.com/nix-community/emacs-overlay/commit/8e42a3463ac1a25a9948e965e2fefc570fadd702) | `` Updated repos/melpa `` |
| [`285aa518`](https://github.com/nix-community/emacs-overlay/commit/285aa51899fc52761535aa920f7fe9e57b5a0437) | `` Updated repos/emacs `` |