### PR TITLE
chore(flake/nur): `217e6259` -> `ae4f2079`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699085705,
-        "narHash": "sha256-264YHR0Q6rjatEB76TVGoIX8YERpBJDN0fhnZedukrA=",
+        "lastModified": 1699105543,
+        "narHash": "sha256-ZAArNdE3cO59tIlomzhWPksA4enZ0LoGR7VEtFHYaXI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "217e62597f064fa4b53251ff9f5a6d1d97432dae",
+        "rev": "ae4f2079a94ebbf4f3ec66f7d25372de5d4b346d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ae4f2079`](https://github.com/nix-community/NUR/commit/ae4f2079a94ebbf4f3ec66f7d25372de5d4b346d) | `` automatic update `` |