### PR TITLE
chore(flake/nur): `ae4f2079` -> `5d84ca87`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699105543,
-        "narHash": "sha256-ZAArNdE3cO59tIlomzhWPksA4enZ0LoGR7VEtFHYaXI=",
+        "lastModified": 1699112727,
+        "narHash": "sha256-osBRQlNvSjnFQVslCMh/ZdAxHdbEAoaazubfixsBLxg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ae4f2079a94ebbf4f3ec66f7d25372de5d4b346d",
+        "rev": "5d84ca875c8f019afcaf45563a7341f66d811668",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5d84ca87`](https://github.com/nix-community/NUR/commit/5d84ca875c8f019afcaf45563a7341f66d811668) | `` automatic update `` |