### PR TITLE
chore(flake/nur): `00d1fd06` -> `c1c8f8a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699119925,
-        "narHash": "sha256-Qo1s2q3TosiCr45i0VJ9qUayi/b1Bk9nbpryvN7e5VE=",
+        "lastModified": 1699122254,
+        "narHash": "sha256-l82RD6HUcDuID3zHiYYUeM3E8hMq/DACir2ZxWKhd4w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "00d1fd063d8c6fdf74cc126a39691bf3571b6de9",
+        "rev": "c1c8f8a39a44a222433a4f76b09f0af623b0e755",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c1c8f8a3`](https://github.com/nix-community/NUR/commit/c1c8f8a39a44a222433a4f76b09f0af623b0e755) | `` automatic update `` |