### PR TITLE
chore(flake/nur): `c1c8f8a3` -> `4f0841f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699122254,
-        "narHash": "sha256-l82RD6HUcDuID3zHiYYUeM3E8hMq/DACir2ZxWKhd4w=",
+        "lastModified": 1699130648,
+        "narHash": "sha256-OzaJ8XYqkpoIyRGHMmaaTHY1nNGOhil7gMI93bByc5M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c1c8f8a39a44a222433a4f76b09f0af623b0e755",
+        "rev": "4f0841f58f18f0219970a37654e81d8b7a25d4a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4f0841f5`](https://github.com/nix-community/NUR/commit/4f0841f58f18f0219970a37654e81d8b7a25d4a8) | `` automatic update `` |