### PR TITLE
chore(flake/nur): `4f0841f5` -> `6226a48f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699130648,
-        "narHash": "sha256-OzaJ8XYqkpoIyRGHMmaaTHY1nNGOhil7gMI93bByc5M=",
+        "lastModified": 1699131694,
+        "narHash": "sha256-dKWORPD0ODREKihqCZqEqc1zJ3wACmoMmuf2BGg3DbE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4f0841f58f18f0219970a37654e81d8b7a25d4a8",
+        "rev": "6226a48fb329802a63da2babbdd2d375713af333",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6226a48f`](https://github.com/nix-community/NUR/commit/6226a48fb329802a63da2babbdd2d375713af333) | `` automatic update `` |