### PR TITLE
chore(flake/nur): `858daad7` -> `46c622db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699137851,
-        "narHash": "sha256-2SkeYY9W6uXqwDANYzURTcSDGT/faYdZz5YdZkhHpWg=",
+        "lastModified": 1699146297,
+        "narHash": "sha256-zZdnoL+gJUqhp5mKUxTBsjnkDfEc6SRyU3OQoexeqLo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "858daad74c9a62de7ac9350d3051a103b99c7b59",
+        "rev": "46c622dbbb618bfff85bbf5d5c19286e2fc4a9fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`46c622db`](https://github.com/nix-community/NUR/commit/46c622dbbb618bfff85bbf5d5c19286e2fc4a9fe) | `` automatic update `` |