### PR TITLE
chore(flake/nur): `46c622db` -> `ef1f4abd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699146297,
-        "narHash": "sha256-zZdnoL+gJUqhp5mKUxTBsjnkDfEc6SRyU3OQoexeqLo=",
+        "lastModified": 1699148602,
+        "narHash": "sha256-zxNmHB/DaMKautDpP1h3hZnsnzDJltPpuy+t83N/sXQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "46c622dbbb618bfff85bbf5d5c19286e2fc4a9fe",
+        "rev": "ef1f4abd4235068c1f1505730a063def47e9e3c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ef1f4abd`](https://github.com/nix-community/NUR/commit/ef1f4abd4235068c1f1505730a063def47e9e3c4) | `` automatic update `` |