### PR TITLE
chore(flake/nur): `ef1f4abd` -> `3193e8f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699148602,
-        "narHash": "sha256-zxNmHB/DaMKautDpP1h3hZnsnzDJltPpuy+t83N/sXQ=",
+        "lastModified": 1699155171,
+        "narHash": "sha256-0BfE6HEEI+r5I8SND4n2ZM9yn7TV4NY/p+RuyBZx6rY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ef1f4abd4235068c1f1505730a063def47e9e3c4",
+        "rev": "3193e8f33355609b1795f0610fa1875b2d909cf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3193e8f3`](https://github.com/nix-community/NUR/commit/3193e8f33355609b1795f0610fa1875b2d909cf2) | `` automatic update `` |