### PR TITLE
chore(flake/nur): `3193e8f3` -> `383e747c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699155171,
-        "narHash": "sha256-0BfE6HEEI+r5I8SND4n2ZM9yn7TV4NY/p+RuyBZx6rY=",
+        "lastModified": 1699167578,
+        "narHash": "sha256-2v1Pkxt3a6+dNFXb7Cjyw6zqBqp11RpwshypzXukeMM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3193e8f33355609b1795f0610fa1875b2d909cf2",
+        "rev": "383e747c82bca258eccfb835235e32e6d30adfd4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`383e747c`](https://github.com/nix-community/NUR/commit/383e747c82bca258eccfb835235e32e6d30adfd4) | `` automatic update `` |
| [`d55097a0`](https://github.com/nix-community/NUR/commit/d55097a0c179189b50edd78fb614397e34f7567f) | `` automatic update `` |
| [`24391a0b`](https://github.com/nix-community/NUR/commit/24391a0b97fc0970202636d65ff6d691d12e39db) | `` automatic update `` |
| [`88abb29a`](https://github.com/nix-community/NUR/commit/88abb29a4bfbd84a2f20380c2595db77d36c3635) | `` automatic update `` |
| [`0cfd5dd9`](https://github.com/nix-community/NUR/commit/0cfd5dd9e3224fda304cfa39dd7a9fe1107908bc) | `` automatic update `` |