### PR TITLE
chore(flake/emacs-overlay): `fd47dc60` -> `9086be91`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699179340,
-        "narHash": "sha256-JEApD6GmauFofJy3mRZInWaaPQ19QpcYr2Dikt0OEpE=",
+        "lastModified": 1699203086,
+        "narHash": "sha256-ULkfO0UTdqPBEJS+LCnno1tjsGgzJmxWIAle86DXA8s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fd47dc60f7d4ec23ce097573b41f14b996181242",
+        "rev": "9086be91a915ad3e5cce2d8ae6d2abc3c5ecdf47",
         "type": "github"
       },
       "original": {
@@ -693,11 +693,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1699110214,
-        "narHash": "sha256-L2TU4RgtiqF69W8Gacg2jEkEYJrW+Kp0Mp4plwQh5b8=",
+        "lastModified": 1699169573,
+        "narHash": "sha256-cvUb1xZkvOp3W2SzylStrTirhVd9zCeo5utJl9nSIhw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "78f3a4ae19f0e99d5323dd2e3853916b8ee4afee",
+        "rev": "aeefe2054617cae501809b82b44a8e8f7be7cc4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`9086be91`](https://github.com/nix-community/emacs-overlay/commit/9086be91a915ad3e5cce2d8ae6d2abc3c5ecdf47) | `` Updated repos/melpa ``  |
| [`9616eb6d`](https://github.com/nix-community/emacs-overlay/commit/9616eb6d4c50064068159bbc29d6a7ddef53ac80) | `` Updated repos/emacs ``  |
| [`808f3d03`](https://github.com/nix-community/emacs-overlay/commit/808f3d03a6e393605833ce9a8482619c3be73718) | `` Updated repos/elpa ``   |
| [`06b231d9`](https://github.com/nix-community/emacs-overlay/commit/06b231d93f89edad1e209097827cf6287a9ad55a) | `` Updated flake inputs `` |