### PR TITLE
chore(flake/nur): `8f3230a0` -> `d3cb9c46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699191847,
-        "narHash": "sha256-9iP+Ua0hbEcCvxxR820A9dW33OjLWf3/xs1Iv+779I8=",
+        "lastModified": 1699205864,
+        "narHash": "sha256-eiuXv1syErhwDdd7AYEseZd9twUZXOjTDvNt+9U2m2Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8f3230a0d95affd914435cbbbe76f7794c12b8b3",
+        "rev": "d3cb9c46faa539fa21728a29c729c937c06f1cfe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d3cb9c46`](https://github.com/nix-community/NUR/commit/d3cb9c46faa539fa21728a29c729c937c06f1cfe) | `` automatic update `` |
| [`176b974e`](https://github.com/nix-community/NUR/commit/176b974e824592c80ded03b540bf4246c2701f53) | `` automatic update `` |