### PR TITLE
chore(flake/nur): `d3cb9c46` -> `4792487a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699205864,
-        "narHash": "sha256-eiuXv1syErhwDdd7AYEseZd9twUZXOjTDvNt+9U2m2Y=",
+        "lastModified": 1699213705,
+        "narHash": "sha256-/EgQRDwS4M26h3FbxHvsrH+urirDgou0fKYLizwqf8Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d3cb9c46faa539fa21728a29c729c937c06f1cfe",
+        "rev": "4792487a5c5dd0c81adde9539b39a7d4c5a40839",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4792487a`](https://github.com/nix-community/NUR/commit/4792487a5c5dd0c81adde9539b39a7d4c5a40839) | `` automatic update `` |