### PR TITLE
chore(flake/nur): `4792487a` -> `1f46f2bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699213705,
-        "narHash": "sha256-/EgQRDwS4M26h3FbxHvsrH+urirDgou0fKYLizwqf8Q=",
+        "lastModified": 1699217225,
+        "narHash": "sha256-e/ciDmyKgxRrbA++fipIHmqZuP+mXiO+K5zzppmQco4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4792487a5c5dd0c81adde9539b39a7d4c5a40839",
+        "rev": "1f46f2bd8d5b0e436a41e9bbc646aad67ca2f04a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1f46f2bd`](https://github.com/nix-community/NUR/commit/1f46f2bd8d5b0e436a41e9bbc646aad67ca2f04a) | `` automatic update `` |