### PR TITLE
chore(flake/nur): `1f46f2bd` -> `d0c6e2eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699217225,
-        "narHash": "sha256-e/ciDmyKgxRrbA++fipIHmqZuP+mXiO+K5zzppmQco4=",
+        "lastModified": 1699220832,
+        "narHash": "sha256-i89TLmU1aNsZsSbMg63RoWrKWaYPCXUQQsfxg+bj2nY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1f46f2bd8d5b0e436a41e9bbc646aad67ca2f04a",
+        "rev": "d0c6e2ebb941d9141e68fd8922173d65d201b4b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d0c6e2eb`](https://github.com/nix-community/NUR/commit/d0c6e2ebb941d9141e68fd8922173d65d201b4b7) | `` automatic update `` |