### PR TITLE
chore(flake/nur): `d0c6e2eb` -> `1b524516`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699220832,
-        "narHash": "sha256-i89TLmU1aNsZsSbMg63RoWrKWaYPCXUQQsfxg+bj2nY=",
+        "lastModified": 1699232832,
+        "narHash": "sha256-zzIWfeVgAafXLJn7+dd25VgL3Zym0XhXEfdgl9b8ZXw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d0c6e2ebb941d9141e68fd8922173d65d201b4b7",
+        "rev": "1b524516b87057edf85f63d9147617c10f87ab81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1b524516`](https://github.com/nix-community/NUR/commit/1b524516b87057edf85f63d9147617c10f87ab81) | `` automatic update `` |