### PR TITLE
chore(flake/emacs-overlay): `9086be91` -> `5ce24eed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699203086,
-        "narHash": "sha256-ULkfO0UTdqPBEJS+LCnno1tjsGgzJmxWIAle86DXA8s=",
+        "lastModified": 1699237218,
+        "narHash": "sha256-4BRgCLbDJmU3Wbv8/nZ+S6MIuM4vC/s6X++N5Ao/I3Q=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9086be91a915ad3e5cce2d8ae6d2abc3c5ecdf47",
+        "rev": "5ce24eed757d854bb290a0a0499053226fec1fc8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`5ce24eed`](https://github.com/nix-community/emacs-overlay/commit/5ce24eed757d854bb290a0a0499053226fec1fc8) | `` Updated repos/nongnu `` |
| [`cd7727e9`](https://github.com/nix-community/emacs-overlay/commit/cd7727e9a8d4ff98659880b5121a8438fc53d8cd) | `` Updated repos/melpa ``  |
| [`4f8cd3e3`](https://github.com/nix-community/emacs-overlay/commit/4f8cd3e375b5433db24fd6756fea92f5a17d488a) | `` Updated repos/emacs ``  |
| [`652005f7`](https://github.com/nix-community/emacs-overlay/commit/652005f73d248e91bba4ec7d1164175668ba10fd) | `` Updated repos/elpa ``   |