### PR TITLE
chore(flake/sops-nix): `5bc2cde6` -> `0a9d5e41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -952,11 +952,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1699153251,
-        "narHash": "sha256-CGx98mbAy9svKTa1dzlrVmkJwgGSXpAQUdMh7U0szts=",
+        "lastModified": 1699252567,
+        "narHash": "sha256-WCzEBCu17uXilT9OZ3XSy/c4Gk/j3L7AUxBRHzNlQ4Y=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "5bc2cde6e53241e7df0e8f5df5872223983efa72",
+        "rev": "0a9d5e41f6013a1b8b66573822f9beb827902968",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`0a9d5e41`](https://github.com/Mic92/sops-nix/commit/0a9d5e41f6013a1b8b66573822f9beb827902968) | `` fixup! Rename passwordFile to hashedPasswordFile `` |
| [`4e3f66f7`](https://github.com/Mic92/sops-nix/commit/4e3f66f703bae28116f39b0ba877e6a4e025aa25) | `` Rename passwordFile to hashedPasswordFile ``        |