### PR TITLE
chore(flake/nur): `317ba125` -> `b4ef1d56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699243549,
-        "narHash": "sha256-Tkr2HhdBELt1rm3/x8a69/EzftVucA8jLQ05VOwye7M=",
+        "lastModified": 1699252313,
+        "narHash": "sha256-jg0xV5GGErrD1RAjbVWnYoDHkM/ThSuCYBbWIUF795o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "317ba125ddc790a837c2d89c394077fe38eba705",
+        "rev": "b4ef1d56c2e7e64220728be8a1a3d7ef72d8687e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b4ef1d56`](https://github.com/nix-community/NUR/commit/b4ef1d56c2e7e64220728be8a1a3d7ef72d8687e) | `` automatic update `` |
| [`65a7898a`](https://github.com/nix-community/NUR/commit/65a7898a7484e9d9b93d6687d53c77c517c1db4a) | `` automatic update `` |