### PR TITLE
chore(flake/nur): `b4ef1d56` -> `d5aefa52`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699252313,
-        "narHash": "sha256-jg0xV5GGErrD1RAjbVWnYoDHkM/ThSuCYBbWIUF795o=",
+        "lastModified": 1699257631,
+        "narHash": "sha256-YUQkmB89uI3zpMuuxUxfXe93Wgl7uE7atxBXQYwlwvY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b4ef1d56c2e7e64220728be8a1a3d7ef72d8687e",
+        "rev": "d5aefa5241773918fa0f086119f96f90963109a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d5aefa52`](https://github.com/nix-community/NUR/commit/d5aefa5241773918fa0f086119f96f90963109a0) | `` automatic update `` |