### PR TITLE
chore(flake/emacs-overlay): `5ce24eed` -> `5d65aad4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699237218,
-        "narHash": "sha256-4BRgCLbDJmU3Wbv8/nZ+S6MIuM4vC/s6X++N5Ao/I3Q=",
+        "lastModified": 1699264160,
+        "narHash": "sha256-8oSo+5vWNQybWWO61BU1n2JUNacgnprl9rgPVcWa4+8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5ce24eed757d854bb290a0a0499053226fec1fc8",
+        "rev": "5d65aad4ff2124f00cf68d154f1c85a14d62850f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`5d65aad4`](https://github.com/nix-community/emacs-overlay/commit/5d65aad4ff2124f00cf68d154f1c85a14d62850f) | `` Updated repos/emacs `` |