### PR TITLE
chore(flake/nur): `fabd0926` -> `0a1ba78c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699272556,
-        "narHash": "sha256-xpwl5y0701QK9A/h2lWpiJ5LiPgq/48gSSzoMEZfSgk=",
+        "lastModified": 1699278213,
+        "narHash": "sha256-wurZjHhhPfZSmF9RaAZSIoh5MYr8Wl+6sz4l+bp+aJI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fabd09269879db3fb52c762c0df6eff20ad88ed1",
+        "rev": "0a1ba78ce2e70c2d2375aa494ab761ba96b5734b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0a1ba78c`](https://github.com/nix-community/NUR/commit/0a1ba78ce2e70c2d2375aa494ab761ba96b5734b) | `` automatic update `` |
| [`53101eed`](https://github.com/nix-community/NUR/commit/53101eed7ccfea382393c7e10dd65d5feb274351) | `` automatic update `` |