### PR TITLE
chore(flake/nur): `9197ae18` -> `7575a97a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699281661,
-        "narHash": "sha256-/b0nkGLG2LSwoLwDQh9cek6mOeV8UC18OH6KokfM0vQ=",
+        "lastModified": 1699284072,
+        "narHash": "sha256-8wuY5s+NA/6ezNoc6UsbRqe4FAshQu3d9RCfM3qouHU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9197ae18cb610996171a0620009ef00f9b19a553",
+        "rev": "7575a97afb5aed1b8382065603cf8628d41df706",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7575a97a`](https://github.com/nix-community/NUR/commit/7575a97afb5aed1b8382065603cf8628d41df706) | `` automatic update `` |