### PR TITLE
chore(flake/nur): `7575a97a` -> `b0afbed1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699284072,
-        "narHash": "sha256-8wuY5s+NA/6ezNoc6UsbRqe4FAshQu3d9RCfM3qouHU=",
+        "lastModified": 1699296298,
+        "narHash": "sha256-hbj53TH5H6rrYcvBURGrWOnaIxdxKOkmVpVO/1P1how=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7575a97afb5aed1b8382065603cf8628d41df706",
+        "rev": "b0afbed1ca032c5a94cd8a136222608e9c896e4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b0afbed1`](https://github.com/nix-community/NUR/commit/b0afbed1ca032c5a94cd8a136222608e9c896e4f) | `` automatic update `` |