### PR TITLE
chore(flake/nur): `b0afbed1` -> `e33adfd2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699296298,
-        "narHash": "sha256-hbj53TH5H6rrYcvBURGrWOnaIxdxKOkmVpVO/1P1how=",
+        "lastModified": 1699299910,
+        "narHash": "sha256-9JOYGct7O8ASbhy9KvBf42y7SmSl2xAObSJFtBP9fv0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b0afbed1ca032c5a94cd8a136222608e9c896e4f",
+        "rev": "e33adfd25623bc21f7e8c9c6c02fc044aff680fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e33adfd2`](https://github.com/nix-community/NUR/commit/e33adfd25623bc21f7e8c9c6c02fc044aff680fc) | `` automatic update `` |