### PR TITLE
chore(flake/sops-nix): `0a9d5e41` -> `66418753`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -952,11 +952,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1699252567,
-        "narHash": "sha256-WCzEBCu17uXilT9OZ3XSy/c4Gk/j3L7AUxBRHzNlQ4Y=",
+        "lastModified": 1699311858,
+        "narHash": "sha256-W/sQrghPAn5J9d+9kMnHqi4NPVWVpy0V/qzQeZfS/dM=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "0a9d5e41f6013a1b8b66573822f9beb827902968",
+        "rev": "664187539871f63857bda2d498f452792457b998",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                        |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`66418753`](https://github.com/Mic92/sops-nix/commit/664187539871f63857bda2d498f452792457b998) | `` update vendorHash ``                                        |
| [`f06b968c`](https://github.com/Mic92/sops-nix/commit/f06b968c4c4a1d77cd9249b04695e92ea2d7d668) | `` build(deps): bump golang.org/x/sys from 0.13.0 to 0.14.0 `` |