### PR TITLE
chore(flake/nur): `53caf62f` -> `78024342`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699310700,
-        "narHash": "sha256-ikf86iIwAyGoJVuJhdX32yKseCzerxcuehJnq/peuZk=",
+        "lastModified": 1699319019,
+        "narHash": "sha256-zcdZT20cBShnXx75yfj3g9Y94KVfMshlAWY5uaqoVcs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "53caf62f38d288c3ee1d11e8c5c94b6168343784",
+        "rev": "7802434225217c52839e9bbb35a448a288113543",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`78024342`](https://github.com/nix-community/NUR/commit/7802434225217c52839e9bbb35a448a288113543) | `` automatic update `` |
| [`d7abc50d`](https://github.com/nix-community/NUR/commit/d7abc50d02e77a3ad44db53818667c07e6a92033) | `` automatic update `` |