### PR TITLE
chore(flake/emacs-overlay): `a9375fdc` -> `babeb3ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699291558,
-        "narHash": "sha256-DXhifxtQx95gez85kbKncUqt3bgLQBI93RPDy1tRoHA=",
+        "lastModified": 1699323531,
+        "narHash": "sha256-RugJfc6F5ERr0IVtlm+xRWGSJLg3nRnC4Rnku2EpyYM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a9375fdc81c04aa20f197c195720de179360b4f5",
+        "rev": "babeb3ae6fa3af3ca3adadc306bc353c8d9fccc5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`babeb3ae`](https://github.com/nix-community/emacs-overlay/commit/babeb3ae6fa3af3ca3adadc306bc353c8d9fccc5) | `` Updated repos/melpa `` |
| [`3c9b8daf`](https://github.com/nix-community/emacs-overlay/commit/3c9b8daf760a0c803c55f287b98576cf725a47bc) | `` Updated repos/emacs `` |
| [`aeb0d24a`](https://github.com/nix-community/emacs-overlay/commit/aeb0d24a0ab32efd4e0f46c4d58091630e0e71d5) | `` Updated repos/elpa ``  |