### PR TITLE
chore(flake/nur): `78024342` -> `4921d033`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699319019,
-        "narHash": "sha256-zcdZT20cBShnXx75yfj3g9Y94KVfMshlAWY5uaqoVcs=",
+        "lastModified": 1699324986,
+        "narHash": "sha256-F6+k9PHcb5CqG9zWUeZ5FCmKowVTMTpE2u+IIl4QYoA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7802434225217c52839e9bbb35a448a288113543",
+        "rev": "4921d033d56a6daa10558d684e67b95f05269807",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4921d033`](https://github.com/nix-community/NUR/commit/4921d033d56a6daa10558d684e67b95f05269807) | `` automatic update `` |