### PR TITLE
chore(flake/nur): `4921d033` -> `d4a8624a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699324986,
-        "narHash": "sha256-F6+k9PHcb5CqG9zWUeZ5FCmKowVTMTpE2u+IIl4QYoA=",
+        "lastModified": 1699329878,
+        "narHash": "sha256-O6OlQMKxBjbzz1/8qhCpkn9j7uzm07ULFNEM3xsjABA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4921d033d56a6daa10558d684e67b95f05269807",
+        "rev": "d4a8624a266335bbcf8a55cfe7ec3e5c17f05b0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d4a8624a`](https://github.com/nix-community/NUR/commit/d4a8624a266335bbcf8a55cfe7ec3e5c17f05b0e) | `` automatic update `` |