### PR TITLE
chore(flake/nur): `5e65b695` -> `48e4a70c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699335326,
-        "narHash": "sha256-rQPcUvyNoP7GOuvpiEec+r4/12jzhLzy1kaLPC3l1Dw=",
+        "lastModified": 1699343762,
+        "narHash": "sha256-s5A3Bpz8kEUDW2zsx2FcRKXE/NyjsmJUWqgmkk+3Pc8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5e65b69580243319e9919f75b94b0ec20d76c044",
+        "rev": "48e4a70ca092eb7b9d8face5a5f8ac6d16cc721b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`48e4a70c`](https://github.com/nix-community/NUR/commit/48e4a70ca092eb7b9d8face5a5f8ac6d16cc721b) | `` automatic update `` |
| [`d6dd8052`](https://github.com/nix-community/NUR/commit/d6dd8052c1cece3fab341c2d8111696f4caf32ed) | `` automatic update `` |