### PR TITLE
chore(flake/home-manager): `c067d57f` -> `76e7c05f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699290318,
-        "narHash": "sha256-weH8oEJo+g0yJtGGU+Zo2pg5kOxPUCAFl8v/5dEnH00=",
+        "lastModified": 1699345318,
+        "narHash": "sha256-JxMtX7/2PdxSUXu38S8ACH71TcZULiztlkv+elEq7og=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c067d57fc4552835987fd7611c3a6741ee32ebd5",
+        "rev": "76e7c05f7d3d5ffac219450af824043da52af1cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`76e7c05f`](https://github.com/nix-community/home-manager/commit/76e7c05f7d3d5ffac219450af824043da52af1cc) | `` home-cursor: fix typo in XDG data directory link `` |