### PR TITLE
chore(flake/nur): `48e4a70c` -> `1a481719`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699343762,
-        "narHash": "sha256-s5A3Bpz8kEUDW2zsx2FcRKXE/NyjsmJUWqgmkk+3Pc8=",
+        "lastModified": 1699345929,
+        "narHash": "sha256-MBW4V6UPs+KEMQI3BDFOOaSCR+DmtsoBJRF2ppgFBIk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "48e4a70ca092eb7b9d8face5a5f8ac6d16cc721b",
+        "rev": "1a48171960608a6ff4e7f73a3e381bf005b625d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1a481719`](https://github.com/nix-community/NUR/commit/1a48171960608a6ff4e7f73a3e381bf005b625d7) | `` automatic update `` |