### PR TITLE
chore(flake/nur): `1a481719` -> `c9ea2508`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699345929,
-        "narHash": "sha256-MBW4V6UPs+KEMQI3BDFOOaSCR+DmtsoBJRF2ppgFBIk=",
+        "lastModified": 1699372416,
+        "narHash": "sha256-ologSu5mzykSJ+WnEQH2Ona8AKM1+qbtM6BXJAWByBI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1a48171960608a6ff4e7f73a3e381bf005b625d7",
+        "rev": "c9ea2508a2d90ae5908583cbca3753e9ba31cb81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c9ea2508`](https://github.com/nix-community/NUR/commit/c9ea2508a2d90ae5908583cbca3753e9ba31cb81) | `` automatic update `` |
| [`68fed7a7`](https://github.com/nix-community/NUR/commit/68fed7a7ca52c1fdd9df51192eba707d2b73fc42) | `` automatic update `` |