### PR TITLE
chore(flake/nur): `c9ea2508` -> `e215d070`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699372416,
-        "narHash": "sha256-ologSu5mzykSJ+WnEQH2Ona8AKM1+qbtM6BXJAWByBI=",
+        "lastModified": 1699375264,
+        "narHash": "sha256-+SKYol1e+t+DYsblpmmo787UPPtUcIy920IibOA1D4Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c9ea2508a2d90ae5908583cbca3753e9ba31cb81",
+        "rev": "e215d070b51f66cca91f974f1cee45fb0e71d492",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e215d070`](https://github.com/nix-community/NUR/commit/e215d070b51f66cca91f974f1cee45fb0e71d492) | `` automatic update `` |
| [`24aa8b88`](https://github.com/nix-community/NUR/commit/24aa8b881ab9f6befe1fff2acbce532e2b72e60d) | `` automatic update `` |