### PR TITLE
chore(flake/emacs-overlay): `f0bd17d9` -> `4f81073c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699347154,
-        "narHash": "sha256-VeI2Aizp4n5tEajnA27bdNOdBC34qKgRLE41LSQ/Ioo=",
+        "lastModified": 1699378729,
+        "narHash": "sha256-WH3CEdPqp1wQeE5hi0yik+MwwSQelFUZCnB3Iqwa1wE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f0bd17d91055f9d9b55e6bf7b51835ad63c52e5c",
+        "rev": "4f81073c44bfa46c97cdd739345e6dc05494c69a",
         "type": "github"
       },
       "original": {
@@ -693,11 +693,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1699169573,
-        "narHash": "sha256-cvUb1xZkvOp3W2SzylStrTirhVd9zCeo5utJl9nSIhw=",
+        "lastModified": 1699291058,
+        "narHash": "sha256-5ggduoaAMPHUy4riL+OrlAZE14Kh7JWX4oLEs22ZqfU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aeefe2054617cae501809b82b44a8e8f7be7cc4b",
+        "rev": "41de143fda10e33be0f47eab2bfe08a50f234267",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4f81073c`](https://github.com/nix-community/emacs-overlay/commit/4f81073c44bfa46c97cdd739345e6dc05494c69a) | `` Updated repos/melpa ``  |
| [`36318fc2`](https://github.com/nix-community/emacs-overlay/commit/36318fc21b60dd9f4f40928af3ff5e5f52bac83c) | `` Updated repos/emacs ``  |
| [`a15257b6`](https://github.com/nix-community/emacs-overlay/commit/a15257b6603b0d40aa6b4c37b1f90792b44af4e7) | `` Updated repos/elpa ``   |
| [`9f6fe2c8`](https://github.com/nix-community/emacs-overlay/commit/9f6fe2c8d5b0800e4beeda0854c4b16c9580a2d9) | `` Updated flake inputs `` |