### PR TITLE
chore(flake/nur): `3257fcb1` -> `3fa6af79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699379055,
-        "narHash": "sha256-KftNe3a8WzzwK7XCygHyW9baEog5Vzh/zJPVWgVRbhc=",
+        "lastModified": 1699386262,
+        "narHash": "sha256-HhQkbZC2+o2/UzWPmq+ihEaL/soaVMS8h+87qnM5t6g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3257fcb157d76c78c73695e6b17299067d37fa07",
+        "rev": "3fa6af79e79fd8c4fb77dc19bcef491751385b9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3fa6af79`](https://github.com/nix-community/NUR/commit/3fa6af79e79fd8c4fb77dc19bcef491751385b9a) | `` automatic update `` |
| [`685c5fa1`](https://github.com/nix-community/NUR/commit/685c5fa1e9a3e24c84a9be9e1d8e719f4873178b) | `` automatic update `` |