### PR TITLE
chore(flake/nur): `3fa6af79` -> `7b7f05a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699386262,
-        "narHash": "sha256-HhQkbZC2+o2/UzWPmq+ihEaL/soaVMS8h+87qnM5t6g=",
+        "lastModified": 1699388282,
+        "narHash": "sha256-alOfCpz7ZU/oTks9HOlTsiooR41xAju3gPwoWnMzapo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3fa6af79e79fd8c4fb77dc19bcef491751385b9a",
+        "rev": "7b7f05a1669f4552b22490b271683dd0f0d0833a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7b7f05a1`](https://github.com/nix-community/NUR/commit/7b7f05a1669f4552b22490b271683dd0f0d0833a) | `` automatic update `` |