### PR TITLE
chore(flake/emacs-overlay): `4f81073c` -> `b3e43b61`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699378729,
-        "narHash": "sha256-WH3CEdPqp1wQeE5hi0yik+MwwSQelFUZCnB3Iqwa1wE=",
+        "lastModified": 1699407189,
+        "narHash": "sha256-k5naceprGqk1fRpYNgO5a08Z73zHYAT7VGTQOBEuNIo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4f81073c44bfa46c97cdd739345e6dc05494c69a",
+        "rev": "b3e43b61c5ffa8fd51ef0d2746f57f8183610ffd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b3e43b61`](https://github.com/nix-community/emacs-overlay/commit/b3e43b61c5ffa8fd51ef0d2746f57f8183610ffd) | `` Updated repos/nongnu `` |
| [`f5a09ade`](https://github.com/nix-community/emacs-overlay/commit/f5a09ade2e3a111288c2dd54f3f86813a87daa6e) | `` Updated repos/melpa ``  |
| [`96f8613e`](https://github.com/nix-community/emacs-overlay/commit/96f8613e5e5ff1ae9fdd9a691233e5784c658827) | `` Updated repos/elpa ``   |