### PR TITLE
chore(flake/nur): `7cee1785` -> `904cdaba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699407631,
-        "narHash": "sha256-tXn9pXUUdE4MGq0iDBKUktb736KCwEMbW8kd/c1p7DY=",
+        "lastModified": 1699414916,
+        "narHash": "sha256-kBN95kuWmOSeQSHrTUDtLzqX54O7ef3fx5DAU0h3lKE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7cee178515eebdb34dd14384d5aeeddcbb1cad28",
+        "rev": "904cdaba5678bcc689879355dead8f509bdff865",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`904cdaba`](https://github.com/nix-community/NUR/commit/904cdaba5678bcc689879355dead8f509bdff865) | `` automatic update `` |
| [`543d02fb`](https://github.com/nix-community/NUR/commit/543d02fb53c5fb8adf406dad620733d3d6b57d9a) | `` automatic update `` |
| [`f9d9fca2`](https://github.com/nix-community/NUR/commit/f9d9fca224d74a560145dd3a544331f80eba8ce7) | `` automatic update `` |