### PR TITLE
chore(flake/nur): `13c5a474` -> `26d97ee7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699416378,
-        "narHash": "sha256-gO5Cz6lccRyETBPqNx16hUkmrjm4lWu+5VlJYF89VKY=",
+        "lastModified": 1699423254,
+        "narHash": "sha256-kSGLPExV0N5xbkF8sPNvsxw4NQKn9UGw8W+QQFMFBJE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "13c5a4743e82d422dc082955af1561b4e5a6644b",
+        "rev": "26d97ee794ee1ac28d444eeb68712cf73c06609f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`26d97ee7`](https://github.com/nix-community/NUR/commit/26d97ee794ee1ac28d444eeb68712cf73c06609f) | `` automatic update `` |
| [`71e28872`](https://github.com/nix-community/NUR/commit/71e2887264c5f5b92dbd0482419d1e01717f8fb4) | `` automatic update `` |