### PR TITLE
chore(flake/nur): `26d97ee7` -> `f88d358c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699423254,
-        "narHash": "sha256-kSGLPExV0N5xbkF8sPNvsxw4NQKn9UGw8W+QQFMFBJE=",
+        "lastModified": 1699428148,
+        "narHash": "sha256-bYKMR5GNquEDYqxYGTq3hqYHJwCXWDobhJCPMep/L9Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "26d97ee794ee1ac28d444eeb68712cf73c06609f",
+        "rev": "f88d358caf2ae8b24010f94debc8699f993cddd6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f88d358c`](https://github.com/nix-community/NUR/commit/f88d358caf2ae8b24010f94debc8699f993cddd6) | `` automatic update `` |
| [`7697a04f`](https://github.com/nix-community/NUR/commit/7697a04fbabcf58fe44fc8af9d8fb076ff18794e) | `` automatic update `` |
| [`de716699`](https://github.com/nix-community/NUR/commit/de716699c325dde290d0d6c40e41f7104c7d7f32) | `` automatic update `` |
| [`092710e3`](https://github.com/nix-community/NUR/commit/092710e34306197322c69aa605ecc4a0f0c3de86) | `` automatic update `` |