### PR TITLE
chore(flake/emacs-overlay): `b3e43b61` -> `dc09405b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699407189,
-        "narHash": "sha256-k5naceprGqk1fRpYNgO5a08Z73zHYAT7VGTQOBEuNIo=",
+        "lastModified": 1699436319,
+        "narHash": "sha256-gRYGKnYfXE1dugjGJ0Xx5P3x3BOT505gxEFxDBohSiM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b3e43b61c5ffa8fd51ef0d2746f57f8183610ffd",
+        "rev": "dc09405b5f031852d3e930b1fa91e973b5206ef8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`dc09405b`](https://github.com/nix-community/emacs-overlay/commit/dc09405b5f031852d3e930b1fa91e973b5206ef8) | `` Updated repos/melpa `` |
| [`1760a51c`](https://github.com/nix-community/emacs-overlay/commit/1760a51c56aacd6a34e098657c799e73dd2665c4) | `` Updated repos/emacs `` |