### PR TITLE
chore(flake/nur): `25c6efd0` -> `52e08dd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699433556,
-        "narHash": "sha256-wkMetUfKWfjjSHO9D0UQcTVXgG4AdeBhSKd1T6I8ecU=",
+        "lastModified": 1699443984,
+        "narHash": "sha256-4KE9A2CEpAX65uwDXO9Mo+4af3neDx2CX6yw/8QtIx0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "25c6efd08f98ed2e4799097f0dd1c4eb3570cbb2",
+        "rev": "52e08dd6de58a75c0c8e923eabc7bcb554a6d515",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`52e08dd6`](https://github.com/nix-community/NUR/commit/52e08dd6de58a75c0c8e923eabc7bcb554a6d515) | `` automatic update `` |
| [`67cc4051`](https://github.com/nix-community/NUR/commit/67cc40513ff15de9339e985bcce874ae1ca73d4b) | `` automatic update `` |
| [`9249f2ba`](https://github.com/nix-community/NUR/commit/9249f2baa49a8ba139eb084128e092073ed88c4e) | `` automatic update `` |