### PR TITLE
chore(flake/nur): `52e08dd6` -> `c36d35ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699443984,
-        "narHash": "sha256-4KE9A2CEpAX65uwDXO9Mo+4af3neDx2CX6yw/8QtIx0=",
+        "lastModified": 1699447371,
+        "narHash": "sha256-Z7A7c4ixFVK7w5+lIjLlgv8I683klk51Fz/64gxgQy0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "52e08dd6de58a75c0c8e923eabc7bcb554a6d515",
+        "rev": "c36d35ab912bc500d23275006b3600d75dce9a40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c36d35ab`](https://github.com/nix-community/NUR/commit/c36d35ab912bc500d23275006b3600d75dce9a40) | `` automatic update `` |
| [`580795ff`](https://github.com/nix-community/NUR/commit/580795ffe3d37a1636febf9628ed619101bc4ffd) | `` automatic update `` |
| [`61b8d210`](https://github.com/nix-community/NUR/commit/61b8d2103a884d8fceb364fd4188dee726de6f94) | `` automatic update `` |