### PR TITLE
chore(flake/nur): `c36d35ab` -> `3cfab74a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699447371,
-        "narHash": "sha256-Z7A7c4ixFVK7w5+lIjLlgv8I683klk51Fz/64gxgQy0=",
+        "lastModified": 1699450798,
+        "narHash": "sha256-kNunBwAmToJjX+7aMwO/W9U2ZMw6ym9H9XIJgrfvjUY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c36d35ab912bc500d23275006b3600d75dce9a40",
+        "rev": "3cfab74a8aafa5b6229f47582cc9d9b22085a577",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3cfab74a`](https://github.com/nix-community/NUR/commit/3cfab74a8aafa5b6229f47582cc9d9b22085a577) | `` automatic update `` |