### PR TITLE
chore(flake/nur): `3cfab74a` -> `10e00f82`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699450798,
-        "narHash": "sha256-kNunBwAmToJjX+7aMwO/W9U2ZMw6ym9H9XIJgrfvjUY=",
+        "lastModified": 1699461953,
+        "narHash": "sha256-lxBN6ZsF+1/bo0VpomYY9A0FpgtvhsYojGmxDxA/3ho=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3cfab74a8aafa5b6229f47582cc9d9b22085a577",
+        "rev": "10e00f82b5b2d506f2217d0e6ea59f4e6b59e4a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`10e00f82`](https://github.com/nix-community/NUR/commit/10e00f82b5b2d506f2217d0e6ea59f4e6b59e4a0) | `` automatic update `` |
| [`6ddfd332`](https://github.com/nix-community/NUR/commit/6ddfd332e97644fa36f3ce70783f3f2e5c444217) | `` automatic update `` |
| [`0e5c7337`](https://github.com/nix-community/NUR/commit/0e5c733725c20e4ed2df7e9cbc7c003010997f04) | `` automatic update `` |