### PR TITLE
chore(flake/nur): `10e00f82` -> `a44fbc7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699461953,
-        "narHash": "sha256-lxBN6ZsF+1/bo0VpomYY9A0FpgtvhsYojGmxDxA/3ho=",
+        "lastModified": 1699466124,
+        "narHash": "sha256-EDyxmgwQQX5smNumtejEnMmQtrI57x/7WoaSmm/bNhw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "10e00f82b5b2d506f2217d0e6ea59f4e6b59e4a0",
+        "rev": "a44fbc7d60527d436a5f4100fbd89e01ba9db74e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a44fbc7d`](https://github.com/nix-community/NUR/commit/a44fbc7d60527d436a5f4100fbd89e01ba9db74e) | `` automatic update `` |