### PR TITLE
chore(flake/lanzaboote): `241cedde` -> `bc0fd4e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1699447590,
-        "narHash": "sha256-galcUm/T+8iYsWE3hKtgmv009hjJWB0jBrLJb9i2K2k=",
+        "lastModified": 1699469975,
+        "narHash": "sha256-TVYObcXFB6c3z5vF/aLZKDL7u+Rt0OZLWpvIdMcJZ4Q=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "241cedde7e4e83a681ad3163c1d4b3d13a56f91a",
+        "rev": "bc0fd4e1d9cbba5f8dce5df845246d77eb7c01d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                  |
| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`dd729cda`](https://github.com/nix-community/lanzaboote/commit/dd729cdaeb7d9335f7b7ac48be02df0c24293f02) | `` fix(deps): update rust crate serde_json to 1.0.108 `` |