### PR TITLE
chore(flake/nur): `a44fbc7d` -> `9c8e2d44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699466124,
-        "narHash": "sha256-EDyxmgwQQX5smNumtejEnMmQtrI57x/7WoaSmm/bNhw=",
+        "lastModified": 1699476202,
+        "narHash": "sha256-jBmuxUc1UQjnE64rxzqp50hIrwchqLgI0XmoDy/tgaU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a44fbc7d60527d436a5f4100fbd89e01ba9db74e",
+        "rev": "9c8e2d44b65f76877456ea070c04d45467da1e76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9c8e2d44`](https://github.com/nix-community/NUR/commit/9c8e2d44b65f76877456ea070c04d45467da1e76) | `` automatic update `` |
| [`81e9f1d4`](https://github.com/nix-community/NUR/commit/81e9f1d441419facf976098b26a873b120d8f726) | `` automatic update `` |
| [`d71bb13d`](https://github.com/nix-community/NUR/commit/d71bb13d47497b89fe077d3e8cbc1c0feea381fe) | `` automatic update `` |