### PR TITLE
chore(flake/nur): `9c8e2d44` -> `4b53db0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699476202,
-        "narHash": "sha256-jBmuxUc1UQjnE64rxzqp50hIrwchqLgI0XmoDy/tgaU=",
+        "lastModified": 1699479626,
+        "narHash": "sha256-UHfpPLK+D5PzQMECJQ7tDInf+Fa18eECcJj1rFAzT1o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9c8e2d44b65f76877456ea070c04d45467da1e76",
+        "rev": "4b53db0b292005c6eebd8bbaa4a23f0a3680a459",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4b53db0b`](https://github.com/nix-community/NUR/commit/4b53db0b292005c6eebd8bbaa4a23f0a3680a459) | `` automatic update `` |