### PR TITLE
chore(flake/nur): `4b53db0b` -> `b29e57a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699479626,
-        "narHash": "sha256-UHfpPLK+D5PzQMECJQ7tDInf+Fa18eECcJj1rFAzT1o=",
+        "lastModified": 1699487473,
+        "narHash": "sha256-s6vDJLvhpaSXLFNbWKMpZqTIBdqrCCx+JSAKTK7dyDE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4b53db0b292005c6eebd8bbaa4a23f0a3680a459",
+        "rev": "b29e57a1942be479a161cdcbae27718db5f92903",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b29e57a1`](https://github.com/nix-community/NUR/commit/b29e57a1942be479a161cdcbae27718db5f92903) | `` automatic update `` |
| [`18febb91`](https://github.com/nix-community/NUR/commit/18febb9105b60f15f8bf9a2099211ceb8c97ff80) | `` automatic update `` |
| [`a865eb8d`](https://github.com/nix-community/NUR/commit/a865eb8d6829bd7317360abcb53a94381a21eeb1) | `` automatic update `` |