### PR TITLE
chore(flake/nur): `6acc7d37` -> `8264140f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699488851,
-        "narHash": "sha256-TwIZrrGYeAC44nVLDlKHFuDhGnYHeeRM+EsO8LEObvY=",
+        "lastModified": 1699494065,
+        "narHash": "sha256-1BCnBsEQsf+41TXu3lyBFzR26yl2838z9C8ruWRebz0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6acc7d37d3705062816cc981bd9f7ce0b8e523b8",
+        "rev": "8264140fefaa005ecb1b0934b1ff20c7728a7945",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8264140f`](https://github.com/nix-community/NUR/commit/8264140fefaa005ecb1b0934b1ff20c7728a7945) | `` automatic update `` |