### PR TITLE
chore(flake/nur): `8264140f` -> `6e9faa24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699494065,
-        "narHash": "sha256-1BCnBsEQsf+41TXu3lyBFzR26yl2838z9C8ruWRebz0=",
+        "lastModified": 1699498520,
+        "narHash": "sha256-2GxbPnHhyb/ekFrd2iopxRA/kHRGPwjTTLTc1Jzu3fQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8264140fefaa005ecb1b0934b1ff20c7728a7945",
+        "rev": "6e9faa24f32be9ffffff0f2f9de29cca213ea5ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6e9faa24`](https://github.com/nix-community/NUR/commit/6e9faa24f32be9ffffff0f2f9de29cca213ea5ff) | `` automatic update `` |
| [`53e12435`](https://github.com/nix-community/NUR/commit/53e12435185ad2d2f5057ccb96c216d105c3ea7c) | `` automatic update `` |
| [`645b0131`](https://github.com/nix-community/NUR/commit/645b013109ba16629d8708dcae1e2d449a281805) | `` automatic update `` |