### PR TITLE
chore(flake/emacs-overlay): `905fa765` -> `a791cc56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699463439,
-        "narHash": "sha256-nu6o6Fw2YOvwpfq+xJ/nPzfTr3YQplrQ38BMHTmKKY8=",
+        "lastModified": 1699496795,
+        "narHash": "sha256-kZirbNufd6DPfmsLy6P6BJfoLbVZ1sn80G99YsFsyVc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "905fa7654037fc22b5d96f88bea5e4aab4c1f007",
+        "rev": "a791cc561a2fe5a1c13a0b102a06bfbab4bb121f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`a791cc56`](https://github.com/nix-community/emacs-overlay/commit/a791cc561a2fe5a1c13a0b102a06bfbab4bb121f) | `` Updated repos/emacs `` |
| [`1588e483`](https://github.com/nix-community/emacs-overlay/commit/1588e483bb22ff36a0235fc4bb8ce3fea3999f81) | `` Updated repos/elpa ``  |