### PR TITLE
chore(flake/nur): `6e9faa24` -> `299ccad4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699498520,
-        "narHash": "sha256-2GxbPnHhyb/ekFrd2iopxRA/kHRGPwjTTLTc1Jzu3fQ=",
+        "lastModified": 1699508337,
+        "narHash": "sha256-BmPDFsP5Kui8YrI0E3omaY8B/6MEoeF5l9yxus3qIKY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6e9faa24f32be9ffffff0f2f9de29cca213ea5ff",
+        "rev": "299ccad42771c1b0990ade8d1935386dcfa31e53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`299ccad4`](https://github.com/nix-community/NUR/commit/299ccad42771c1b0990ade8d1935386dcfa31e53) | `` automatic update `` |