### PR TITLE
chore(flake/nur): `299ccad4` -> `5bdebfbb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699508337,
-        "narHash": "sha256-BmPDFsP5Kui8YrI0E3omaY8B/6MEoeF5l9yxus3qIKY=",
+        "lastModified": 1699509948,
+        "narHash": "sha256-XQL/IrCTDRkXu/GFKkEy+6i8yMMYs/uf4Aw8J4z7ejw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "299ccad42771c1b0990ade8d1935386dcfa31e53",
+        "rev": "5bdebfbb2377fc258a2669df1e7c563883b614b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5bdebfbb`](https://github.com/nix-community/NUR/commit/5bdebfbb2377fc258a2669df1e7c563883b614b4) | `` automatic update `` |