### PR TITLE
chore(flake/nur): `5bdebfbb` -> `835b3bcc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699509948,
-        "narHash": "sha256-XQL/IrCTDRkXu/GFKkEy+6i8yMMYs/uf4Aw8J4z7ejw=",
+        "lastModified": 1699515408,
+        "narHash": "sha256-V9uAZ77ufNz8bOaX7Ybhve4ln/reFM9z0RYUnJwElyg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5bdebfbb2377fc258a2669df1e7c563883b614b4",
+        "rev": "835b3bcc90617409fe63065a5bf0e7dea3a68f4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`835b3bcc`](https://github.com/nix-community/NUR/commit/835b3bcc90617409fe63065a5bf0e7dea3a68f4c) | `` automatic update `` |
| [`76369e70`](https://github.com/nix-community/NUR/commit/76369e707497fc6e335ab8d58529f8b5949137d5) | `` automatic update `` |