### PR TITLE
chore(flake/nur): `835b3bcc` -> `9e212abf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699515408,
-        "narHash": "sha256-V9uAZ77ufNz8bOaX7Ybhve4ln/reFM9z0RYUnJwElyg=",
+        "lastModified": 1699522024,
+        "narHash": "sha256-+6oCJpVbtckTxU6jZbSbkXFWoWBXFVCSaHznumHdIok=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "835b3bcc90617409fe63065a5bf0e7dea3a68f4c",
+        "rev": "9e212abf199b189550448cd2e1c296d328ea2332",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9e212abf`](https://github.com/nix-community/NUR/commit/9e212abf199b189550448cd2e1c296d328ea2332) | `` automatic update `` |