### PR TITLE
chore(flake/nur): `9e212abf` -> `178ad5f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699522024,
-        "narHash": "sha256-+6oCJpVbtckTxU6jZbSbkXFWoWBXFVCSaHznumHdIok=",
+        "lastModified": 1699526829,
+        "narHash": "sha256-JfVNjqhnAEV8ErhdXjwhdXyU0IkeBf47GPwROcHC8Og=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9e212abf199b189550448cd2e1c296d328ea2332",
+        "rev": "178ad5f314bfdb34bf59327bb303d076d5490205",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`178ad5f3`](https://github.com/nix-community/NUR/commit/178ad5f314bfdb34bf59327bb303d076d5490205) | `` automatic update `` |