### PR TITLE
chore(flake/nur): `178ad5f3` -> `de04bec8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699526829,
-        "narHash": "sha256-JfVNjqhnAEV8ErhdXjwhdXyU0IkeBf47GPwROcHC8Og=",
+        "lastModified": 1699534248,
+        "narHash": "sha256-rKTrnG3T4rt41Hd+YGIe4ZHBClhwZXE1XJLyOetX5K0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "178ad5f314bfdb34bf59327bb303d076d5490205",
+        "rev": "de04bec88111c9b9c427c35feebe10c18586534c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`de04bec8`](https://github.com/nix-community/NUR/commit/de04bec88111c9b9c427c35feebe10c18586534c) | `` automatic update `` |
| [`09a3f21f`](https://github.com/nix-community/NUR/commit/09a3f21f9110cb7fc7e1c439e019bcd757689ef5) | `` automatic update `` |
| [`3c10777d`](https://github.com/nix-community/NUR/commit/3c10777da41e25bb8d9cf37aa6c3e2aeb65fdd30) | `` automatic update `` |
| [`142b259e`](https://github.com/nix-community/NUR/commit/142b259e3287d29ab9dcffd0e94f1d29c405af65) | `` automatic update `` |