### PR TITLE
chore(flake/nur): `de04bec8` -> `71d46644`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699534248,
-        "narHash": "sha256-rKTrnG3T4rt41Hd+YGIe4ZHBClhwZXE1XJLyOetX5K0=",
+        "lastModified": 1699536582,
+        "narHash": "sha256-xW16bouhkI9fx6wMLy8002cbLvB3UK4B3J10+Anq9BU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "de04bec88111c9b9c427c35feebe10c18586534c",
+        "rev": "71d46644e40610ea90c7e97ba32667de90c5f1a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`71d46644`](https://github.com/nix-community/NUR/commit/71d46644e40610ea90c7e97ba32667de90c5f1a5) | `` automatic update `` |
| [`3ff28b62`](https://github.com/nix-community/NUR/commit/3ff28b62bd755f2cc091db76b07cc579a873f343) | `` automatic update `` |