### PR TITLE
chore(flake/nur): `71d46644` -> `fcd7f3c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699536582,
-        "narHash": "sha256-xW16bouhkI9fx6wMLy8002cbLvB3UK4B3J10+Anq9BU=",
+        "lastModified": 1699546919,
+        "narHash": "sha256-nzvvJQNhFXLXAZnZsgJ2i4ynD7whIUR70GKQdFhL+Qo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "71d46644e40610ea90c7e97ba32667de90c5f1a5",
+        "rev": "fcd7f3c758880231ec7465d1441c7cede2466921",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fcd7f3c7`](https://github.com/nix-community/NUR/commit/fcd7f3c758880231ec7465d1441c7cede2466921) | `` automatic update `` |