### PR TITLE
chore(flake/emacs-overlay): `db5f62b4` -> `1a47948b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699523543,
-        "narHash": "sha256-Kv+y3Aj0hq9vC/EccyX8KWL6dTVyZTtO2EbUnST648A=",
+        "lastModified": 1699551543,
+        "narHash": "sha256-ebN9O4T4wFu9C0vXNsnDREtBP1FUi0M1aqfABGMA5P0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "db5f62b4e53ec885fd7777a61f872b3a7bdf269d",
+        "rev": "1a47948bbbe3eea50deaabf5f260d3b2a233aaa5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`1a47948b`](https://github.com/nix-community/emacs-overlay/commit/1a47948bbbe3eea50deaabf5f260d3b2a233aaa5) | `` Updated repos/melpa `` |
| [`68bc2c77`](https://github.com/nix-community/emacs-overlay/commit/68bc2c77ec96d2e5cb1e9953e8b8ea864aaf1c79) | `` Updated repos/emacs `` |