### PR TITLE
chore(flake/nur): `fcd7f3c7` -> `57945491`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699546919,
-        "narHash": "sha256-nzvvJQNhFXLXAZnZsgJ2i4ynD7whIUR70GKQdFhL+Qo=",
+        "lastModified": 1699551883,
+        "narHash": "sha256-xpZQSU9iOY94XuE1JVo8w4UCDamUcrFMe8DI95vJJj8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fcd7f3c758880231ec7465d1441c7cede2466921",
+        "rev": "57945491bf1b9c84ad25dd31f1d3ba792a754a4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`57945491`](https://github.com/nix-community/NUR/commit/57945491bf1b9c84ad25dd31f1d3ba792a754a4a) | `` automatic update `` |