### PR TITLE
chore(flake/nur): `57945491` -> `1024b4a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699551883,
-        "narHash": "sha256-xpZQSU9iOY94XuE1JVo8w4UCDamUcrFMe8DI95vJJj8=",
+        "lastModified": 1699558928,
+        "narHash": "sha256-tczVk7keduyBHdJU1T5OrI4fKbY2BMSlzOgmmQh3bP4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "57945491bf1b9c84ad25dd31f1d3ba792a754a4a",
+        "rev": "1024b4a0af15384b053273813e5bafeec3613c93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1024b4a0`](https://github.com/nix-community/NUR/commit/1024b4a0af15384b053273813e5bafeec3613c93) | `` automatic update `` |