### PR TITLE
chore(flake/nur): `1024b4a0` -> `b4f41b4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699558928,
-        "narHash": "sha256-tczVk7keduyBHdJU1T5OrI4fKbY2BMSlzOgmmQh3bP4=",
+        "lastModified": 1699562742,
+        "narHash": "sha256-5hAD6av1hlAfV+i+q4Gx9IpO2UJi8ox6OBYGx76ONW4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1024b4a0af15384b053273813e5bafeec3613c93",
+        "rev": "b4f41b4aaafe8f200d8f9cfa2b00a19a5dbd8180",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b4f41b4a`](https://github.com/nix-community/NUR/commit/b4f41b4aaafe8f200d8f9cfa2b00a19a5dbd8180) | `` automatic update `` |