### PR TITLE
chore(flake/darwin): `eb2b9b64` -> `c8f38576`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -216,11 +216,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699437533,
-        "narHash": "sha256-lMoPz9c89CpPVuJ95OFFesM9JagCF0soGbQatj3ZhqM=",
+        "lastModified": 1699569089,
+        "narHash": "sha256-MdOnyXrmMdVU9o7GpcbWKgehoK9L76ihp8rTikPcC1k=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "eb2b9b64238349bd351561e32e260cac15db6f9a",
+        "rev": "c8f385766ba076a096caa794309c40f89894d88a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                  |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
| [`a4b4cf70`](https://github.com/LnL7/nix-darwin/commit/a4b4cf70dcf93353ff49a227a012b62cdc9629f8) | `` Update pkgs/nix-tools/darwin-rebuild.sh ``            |
| [`26a59d50`](https://github.com/LnL7/nix-darwin/commit/26a59d504b69448c1a7f1527ffc3f5e4999821fb) | `` fix(#798): darwin-rebuild support for Cyberark EPM `` |