### PR TITLE
chore(flake/emacs-overlay): `1a47948b` -> `8b0bd6d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699551543,
-        "narHash": "sha256-ebN9O4T4wFu9C0vXNsnDREtBP1FUi0M1aqfABGMA5P0=",
+        "lastModified": 1699585900,
+        "narHash": "sha256-jKlRkfq41tulZMxVR53fr1PYEKNQ8pa8r5ZKnvprOxc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1a47948bbbe3eea50deaabf5f260d3b2a233aaa5",
+        "rev": "8b0bd6d04e48e1b2431b8143a16db93ef53ff08a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`8b0bd6d0`](https://github.com/nix-community/emacs-overlay/commit/8b0bd6d04e48e1b2431b8143a16db93ef53ff08a) | `` Updated repos/nongnu `` |
| [`c5096406`](https://github.com/nix-community/emacs-overlay/commit/c5096406b8513c224447d3f99554064c12ac8c32) | `` Updated repos/melpa ``  |
| [`e1a2dbb3`](https://github.com/nix-community/emacs-overlay/commit/e1a2dbb36f1aced2ef19f76fd2baccf626758ba9) | `` Updated repos/emacs ``  |
| [`89ba3af7`](https://github.com/nix-community/emacs-overlay/commit/89ba3af71159e8e078aeaf2ee84c50314bf663c4) | `` Updated repos/elpa ``   |