### PR TITLE
chore(flake/nur): `cbc22a4b` -> `2dcd66cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699598741,
-        "narHash": "sha256-gv+xNyutyfWIqea7nl/jgodsl5VIgWn1/R8ZE1ZsFh8=",
+        "lastModified": 1699608730,
+        "narHash": "sha256-S7VN6GXb0/gOcwMSEHCAcwzZ08o/PyzERiK3UuNUrD8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cbc22a4baf87dcb663340036d626abef225fcdfc",
+        "rev": "2dcd66cb2d658078ea5740f90c9f22439a83b537",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2dcd66cb`](https://github.com/nix-community/NUR/commit/2dcd66cb2d658078ea5740f90c9f22439a83b537) | `` automatic update `` |