### PR TITLE
chore(flake/emacs-overlay): `8b0bd6d0` -> `f9c303fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699585900,
-        "narHash": "sha256-jKlRkfq41tulZMxVR53fr1PYEKNQ8pa8r5ZKnvprOxc=",
+        "lastModified": 1699612229,
+        "narHash": "sha256-4G4bwnIBd+WJipVNZ01THUpJfn5nYUsbcwep9d0LUNk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8b0bd6d04e48e1b2431b8143a16db93ef53ff08a",
+        "rev": "f9c303fcf115b77cfd285f8f2f83efb072c04c69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`f9c303fc`](https://github.com/nix-community/emacs-overlay/commit/f9c303fcf115b77cfd285f8f2f83efb072c04c69) | `` Updated repos/melpa `` |
| [`f0585f48`](https://github.com/nix-community/emacs-overlay/commit/f0585f48d11b1f9962496369ed8d081121ecba8f) | `` Updated repos/emacs `` |