### PR TITLE
chore(flake/lanzaboote): `bc0fd4e1` -> `81975f3b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1699469975,
-        "narHash": "sha256-TVYObcXFB6c3z5vF/aLZKDL7u+Rt0OZLWpvIdMcJZ4Q=",
+        "lastModified": 1699626196,
+        "narHash": "sha256-/arAIgFkEOTss4BsppCJn1DIBxvx1ESgWOj9CJqx4lQ=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "bc0fd4e1d9cbba5f8dce5df845246d77eb7c01d6",
+        "rev": "81975f3bc4a7f3f4c689c43645110c2e1aac56b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                      |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`b7f3d607`](https://github.com/nix-community/lanzaboote/commit/b7f3d6070869a9ffde75a9788a752a93f358ed20) | `` feat(flake): perform final fixups to the flake outputs `` |