### PR TITLE
chore(flake/emacs-overlay): `f9c303fc` -> `2dc0beb6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699612229,
-        "narHash": "sha256-4G4bwnIBd+WJipVNZ01THUpJfn5nYUsbcwep9d0LUNk=",
+        "lastModified": 1699641089,
+        "narHash": "sha256-GFCZUagiE11YLA9FV6CXlrVtNe/LbxrX35Sp2wdZ1LE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f9c303fcf115b77cfd285f8f2f83efb072c04c69",
+        "rev": "2dc0beb6d0f3d19c577faab69b6338fb5a1ce17e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`2dc0beb6`](https://github.com/nix-community/emacs-overlay/commit/2dc0beb6d0f3d19c577faab69b6338fb5a1ce17e) | `` Updated repos/melpa `` |
| [`e8d2afbc`](https://github.com/nix-community/emacs-overlay/commit/e8d2afbcf27ea0748fd20c46c171eaf20cfdb6bf) | `` Updated repos/emacs `` |
| [`5449f26d`](https://github.com/nix-community/emacs-overlay/commit/5449f26ddb7efb807d92fe76c600902f857035f4) | `` Updated repos/elpa ``  |