### PR TITLE
chore(flake/nur): `9ffcf2dd` -> `6e37a837`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699645538,
-        "narHash": "sha256-CKzsVfYM/9ccp0VDgzB91c33Ts8KSub7q5FWLNJouXk=",
+        "lastModified": 1699660768,
+        "narHash": "sha256-ZeavTOAhcZQ4tbsENYP/O0oyMCO+1Ikk6aIztpxvrSo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ffcf2dd6ac13cd0469a0ac2664296f45d879ffb",
+        "rev": "6e37a8372f66a4bc8bd150ea3953fcb2ce13eeb9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6e37a837`](https://github.com/nix-community/NUR/commit/6e37a8372f66a4bc8bd150ea3953fcb2ce13eeb9) | `` automatic update `` |
| [`54321420`](https://github.com/nix-community/NUR/commit/543214208978dc5b879c279af7912863807dc079) | `` automatic update `` |