### PR TITLE
chore(flake/nur): `6e37a837` -> `faf5446f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699660768,
-        "narHash": "sha256-ZeavTOAhcZQ4tbsENYP/O0oyMCO+1Ikk6aIztpxvrSo=",
+        "lastModified": 1699664569,
+        "narHash": "sha256-xQUVAkVeNVy2KI5FXzN3OJD3HuBwYzSgXsPx9OY21hw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6e37a8372f66a4bc8bd150ea3953fcb2ce13eeb9",
+        "rev": "faf5446fa2d2af6f74190493db4b65b90ad41184",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`faf5446f`](https://github.com/nix-community/NUR/commit/faf5446fa2d2af6f74190493db4b65b90ad41184) | `` automatic update `` |
| [`525fc139`](https://github.com/nix-community/NUR/commit/525fc139cb033ec1135496f6beed6e1060f1bf23) | `` automatic update `` |