### PR TITLE
chore(flake/emacs-overlay): `2dc0beb6` -> `83bc5d5b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699641089,
-        "narHash": "sha256-GFCZUagiE11YLA9FV6CXlrVtNe/LbxrX35Sp2wdZ1LE=",
+        "lastModified": 1699669117,
+        "narHash": "sha256-gRdUwzoLHiXVj0DL1KOvghmIJ04Ba0aYjOJych1omo4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2dc0beb6d0f3d19c577faab69b6338fb5a1ce17e",
+        "rev": "83bc5d5bbb6dd272222aa94ebe96cc0430256b99",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`83bc5d5b`](https://github.com/nix-community/emacs-overlay/commit/83bc5d5bbb6dd272222aa94ebe96cc0430256b99) | `` Updated repos/nongnu `` |
| [`d8505e66`](https://github.com/nix-community/emacs-overlay/commit/d8505e66a5955db4690f40e9aecf17b35fa8da8d) | `` Updated repos/melpa ``  |
| [`64713415`](https://github.com/nix-community/emacs-overlay/commit/64713415368a53970d79c1dd5dc909a84433b7cc) | `` Updated repos/emacs ``  |
| [`b6a20bc2`](https://github.com/nix-community/emacs-overlay/commit/b6a20bc29328bccb1a706d5c326026a1f9d67b64) | `` Updated repos/elpa ``   |