### PR TITLE
chore(flake/nur): `faf5446f` -> `05186359`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699664569,
-        "narHash": "sha256-xQUVAkVeNVy2KI5FXzN3OJD3HuBwYzSgXsPx9OY21hw=",
+        "lastModified": 1699669594,
+        "narHash": "sha256-JoBm7M7bLvBjmsVOwaTEGrdtC07FAvcWWgPH4GRCFJU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "faf5446fa2d2af6f74190493db4b65b90ad41184",
+        "rev": "05186359993dfaae9be0bebdd8b2c63a75aec8ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`05186359`](https://github.com/nix-community/NUR/commit/05186359993dfaae9be0bebdd8b2c63a75aec8ee) | `` automatic update `` |