### PR TITLE
chore(flake/nur): `05186359` -> `95e98b19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699669594,
-        "narHash": "sha256-JoBm7M7bLvBjmsVOwaTEGrdtC07FAvcWWgPH4GRCFJU=",
+        "lastModified": 1699681304,
+        "narHash": "sha256-YEG7eoUUT6rw09K1WBvJprYL0Mztb3JaJ8Dz3jJrS4A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "05186359993dfaae9be0bebdd8b2c63a75aec8ee",
+        "rev": "95e98b19686ba3c1436a7ac7e320e1f950f6e62a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`95e98b19`](https://github.com/nix-community/NUR/commit/95e98b19686ba3c1436a7ac7e320e1f950f6e62a) | `` automatic update `` |
| [`5db81a15`](https://github.com/nix-community/NUR/commit/5db81a159b3f381012155430d199808f331011cd) | `` automatic update `` |