### PR TITLE
chore(flake/nur): `95e98b19` -> `409805c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699681304,
-        "narHash": "sha256-YEG7eoUUT6rw09K1WBvJprYL0Mztb3JaJ8Dz3jJrS4A=",
+        "lastModified": 1699685082,
+        "narHash": "sha256-UDtuFnr6zjOkuWSHZpQkHIXuwFSNC5eer5x4q34fuvY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "95e98b19686ba3c1436a7ac7e320e1f950f6e62a",
+        "rev": "409805c769f0f8cc58a0748f2cb312df883fc1eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`409805c7`](https://github.com/nix-community/NUR/commit/409805c769f0f8cc58a0748f2cb312df883fc1eb) | `` automatic update `` |