### PR TITLE
chore(flake/emacs-overlay): `83bc5d5b` -> `0012b376`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699669117,
-        "narHash": "sha256-gRdUwzoLHiXVj0DL1KOvghmIJ04Ba0aYjOJych1omo4=",
+        "lastModified": 1699695447,
+        "narHash": "sha256-T83ACUKjvPklV5FncCChuvyMOhXdfmmO1lRqs8UPCmw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "83bc5d5bbb6dd272222aa94ebe96cc0430256b99",
+        "rev": "0012b3768be7411000ba6d18b4f2571315564760",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`0012b376`](https://github.com/nix-community/emacs-overlay/commit/0012b3768be7411000ba6d18b4f2571315564760) | `` Updated repos/melpa `` |
| [`9300cab7`](https://github.com/nix-community/emacs-overlay/commit/9300cab78679876a48e29095a13316e6e0115d4f) | `` Updated repos/emacs `` |