### PR TITLE
chore(flake/nur): `d270e426` -> `2999af35`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699692816,
-        "narHash": "sha256-oYfl1ulJWZtcjBdxFlRrsdVoj/dY3Pme31xiBukR9FQ=",
+        "lastModified": 1699696572,
+        "narHash": "sha256-hnHyp2T4pkuj5xdkj/ZZme/ppmNJff47BcPRxwcJP00=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d270e426d4a359c90aa0e18ef27d263dbafc5625",
+        "rev": "2999af35ec973a0001ca92bb56b037ae18869f22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2999af35`](https://github.com/nix-community/NUR/commit/2999af35ec973a0001ca92bb56b037ae18869f22) | `` automatic update `` |