### PR TITLE
chore(flake/nixos-hardware): `627bc9b8` -> `b689465d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1699159446,
-        "narHash": "sha256-cL63IjsbPl2otS7R4kdXbVOJOXYMpGw5KGZoWgdCuCM=",
+        "lastModified": 1699701045,
+        "narHash": "sha256-mDzUXK7jNO/utInWpSWEX1NgEEunVIpJg+LyPsDTfy0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "627bc9b88256379578885a7028c9e791c29fb581",
+        "rev": "b689465d0c5d88e158e7d76094fca08cc0223aad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`b689465d`](https://github.com/NixOS/nixos-hardware/commit/b689465d0c5d88e158e7d76094fca08cc0223aad) | `` Add note to mark change as temporary ``                                       |
| [`55b4caf9`](https://github.com/NixOS/nixos-hardware/commit/55b4caf931477fdfd70b86bae2ca000de18eab88) | `` Add 13-inch directory to framework and move new module ``                     |
| [`376cecdb`](https://github.com/NixOS/nixos-hardware/commit/376cecdbb2cf2806881af4b3cb325c7a472ab605) | `` Do not suggest sudo for running fwupdmgr ``                                   |
| [`24596674`](https://github.com/NixOS/nixos-hardware/commit/24596674bb4edd16d28f82e23c445794144db7e2) | `` Remove unnecessary configuration for FW13 7040; use linux_latest above 6.1 `` |
| [`edc1a8ec`](https://github.com/NixOS/nixos-hardware/commit/edc1a8ecbc40459f15c6a75e6993f941aa06674f) | `` FW13 7040: Add configuration as default.nix ``                                |
| [`9f40c108`](https://github.com/NixOS/nixos-hardware/commit/9f40c1088f5630dc8b93f22165325fff86935c71) | `` feat(asus/zephyrus): add GU603H (2021 Zephyrus M16) ``                        |