### PR TITLE
chore(flake/darwin): `c8f38576` -> `0f1ad801`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -216,11 +216,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699569089,
-        "narHash": "sha256-MdOnyXrmMdVU9o7GpcbWKgehoK9L76ihp8rTikPcC1k=",
+        "lastModified": 1699704228,
+        "narHash": "sha256-NApWG385goidsXmsakWgFRjvbH+aw/n1CGGHn/UuXsc=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "c8f385766ba076a096caa794309c40f89894d88a",
+        "rev": "0f1ad801387445fdda01d080db8ecf169be8e793",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                      |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------- |
| [`4fa7b5cd`](https://github.com/LnL7/nix-darwin/commit/4fa7b5cdd14a0fee6edc8c8924e57422b0dcc9ef) | `` Add security.pki.installCACerts config `` |