### PR TITLE
chore(flake/nur): `1aef911a` -> `c812c0f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699709300,
-        "narHash": "sha256-VkMjz0/zfJS3zJbIIqauzKdlMlM7aYbMAVQwBEmXCW0=",
+        "lastModified": 1699714897,
+        "narHash": "sha256-3ZnImStH22BQCbwgL6Nsyc7SyFRkIkxqEHtlq4nrQ8M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1aef911a8e0eea8b1fb817ce723d11ffa444cb8a",
+        "rev": "c812c0f061e525b2cc5004ddf0d9f192b80a8cc3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                      |
| -------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`c812c0f0`](https://github.com/nix-community/NUR/commit/c812c0f061e525b2cc5004ddf0d9f192b80a8cc3) | `` automatic update ``       |
| [`c682a7dd`](https://github.com/nix-community/NUR/commit/c682a7dd66a829589c8b129858f023dffd88de6b) | `` automatic update ``       |
| [`5a3cd689`](https://github.com/nix-community/NUR/commit/5a3cd68971e770675f49aef28e2064a4fdbd36f1) | `` add 1235467 repository `` |
| [`bce1f6df`](https://github.com/nix-community/NUR/commit/bce1f6df91815f3b1f9f943f2f962e78e9e7cd39) | `` automatic update ``       |