### PR TITLE
chore(flake/nur): `c812c0f0` -> `6396d62e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699714897,
-        "narHash": "sha256-3ZnImStH22BQCbwgL6Nsyc7SyFRkIkxqEHtlq4nrQ8M=",
+        "lastModified": 1699715884,
+        "narHash": "sha256-15yF8cRNVhCvmrdiSC/yArzd61a/yGp7SsOAYnhdEDk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c812c0f061e525b2cc5004ddf0d9f192b80a8cc3",
+        "rev": "6396d62eca70dafe5d912f1c2aff1d4ba726678a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6396d62e`](https://github.com/nix-community/NUR/commit/6396d62eca70dafe5d912f1c2aff1d4ba726678a) | `` automatic update `` |