### PR TITLE
chore(flake/nur): `6396d62e` -> `6f400d47`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699715884,
-        "narHash": "sha256-15yF8cRNVhCvmrdiSC/yArzd61a/yGp7SsOAYnhdEDk=",
+        "lastModified": 1699724767,
+        "narHash": "sha256-TFZ6wQXaJx/8EEhR8rJQcJgASM4fAvgvppSYSI9GNl8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6396d62eca70dafe5d912f1c2aff1d4ba726678a",
+        "rev": "6f400d47c7847ff469ad1384bd28aa7e5e51ff99",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6f400d47`](https://github.com/nix-community/NUR/commit/6f400d47c7847ff469ad1384bd28aa7e5e51ff99) | `` automatic update `` |
| [`c67c99b0`](https://github.com/nix-community/NUR/commit/c67c99b0a06e2fc6d9da236f38293eb6f9418b06) | `` automatic update `` |