### PR TITLE
chore(flake/nur): `6f400d47` -> `473af602`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699724767,
-        "narHash": "sha256-TFZ6wQXaJx/8EEhR8rJQcJgASM4fAvgvppSYSI9GNl8=",
+        "lastModified": 1699730859,
+        "narHash": "sha256-B4NwfVftZRH9W53XJQ4BCPbAl3F/yyBJwn4qJLHAIIk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6f400d47c7847ff469ad1384bd28aa7e5e51ff99",
+        "rev": "473af602cdfaf46f0a0d0b06e7678622f623f006",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`473af602`](https://github.com/nix-community/NUR/commit/473af602cdfaf46f0a0d0b06e7678622f623f006) | `` automatic update `` |
| [`bbdb0ee2`](https://github.com/nix-community/NUR/commit/bbdb0ee2568af03afe5c331863e9d79721655dc3) | `` automatic update `` |
| [`f143edcc`](https://github.com/nix-community/NUR/commit/f143edccb094a9325059dd1b8462b79209d8fb42) | `` automatic update `` |