### PR TITLE
chore(flake/home-manager): `691cbcc0` -> `50e582b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699663185,
-        "narHash": "sha256-hI3CZPINBWstkMN+ptyzWibw5eRtFCiEvO7zR61bGBs=",
+        "lastModified": 1699748018,
+        "narHash": "sha256-28rwXnxgscLkeII6wj44cuP6RuiynhzZSa424ZwGt/s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "691cbcc03af6ad1b5384c0e0e0b5f2298f58c5ce",
+        "rev": "50e582b9f91e409ffd2e134017445d376659b32e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`50e582b9`](https://github.com/nix-community/home-manager/commit/50e582b9f91e409ffd2e134017445d376659b32e) | `` swayidle: always restart systemd unit on failure `` |
| [`fad880ea`](https://github.com/nix-community/home-manager/commit/fad880ea934808072cd224152854d4257034bd24) | `` firefox: minor documentation fix ``                 |
| [`d78f6693`](https://github.com/nix-community/home-manager/commit/d78f6693ee382ee3b94bf48f2b0d0034ce2d902b) | `` firefox: add finalPackage read-only option ``       |