### PR TITLE
chore(flake/nur): `473af602` -> `ff495b6b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699730859,
-        "narHash": "sha256-B4NwfVftZRH9W53XJQ4BCPbAl3F/yyBJwn4qJLHAIIk=",
+        "lastModified": 1699751149,
+        "narHash": "sha256-hcWsurEJSVYWHoI5YvB5ZVaCY+Sg2Qd0ZumKn7dLjI0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "473af602cdfaf46f0a0d0b06e7678622f623f006",
+        "rev": "ff495b6b6763bcb879b97c105eedc1db23260bab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ff495b6b`](https://github.com/nix-community/NUR/commit/ff495b6b6763bcb879b97c105eedc1db23260bab) | `` automatic update `` |
| [`66a42b61`](https://github.com/nix-community/NUR/commit/66a42b610333e1ed8db9d396210f63286d62052c) | `` automatic update `` |