### PR TITLE
chore(flake/emacs-overlay): `c5f0c468` -> `edf63e4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699724244,
-        "narHash": "sha256-I3+cOlXU4jIoqnyYWezbNc26/56EI4YwwDQf80hdbeI=",
+        "lastModified": 1699752997,
+        "narHash": "sha256-L8SWAH0uWNXsKfjNe6e2bYN0d1Dg2sFrgTgn2kyfrX4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c5f0c468f8e92246473c1eabe997ad1c41fb6a1a",
+        "rev": "edf63e4ac22d6afc9e0513047c216504d3754e2d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`edf63e4a`](https://github.com/nix-community/emacs-overlay/commit/edf63e4ac22d6afc9e0513047c216504d3754e2d) | `` Updated repos/nongnu `` |
| [`9c34acf8`](https://github.com/nix-community/emacs-overlay/commit/9c34acf849fb9781b22045d2a6d9acf6add631e1) | `` Updated repos/melpa ``  |
| [`a50f51b0`](https://github.com/nix-community/emacs-overlay/commit/a50f51b0f729a640296fbda65bd5a78c7c06541b) | `` Updated repos/emacs ``  |
| [`e1b33c57`](https://github.com/nix-community/emacs-overlay/commit/e1b33c574d27c6de6612fe0b073043c8d1f8d362) | `` Updated repos/elpa ``   |