### PR TITLE
chore(flake/nix-index-database): `d5736190` -> `8aff4ca3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -591,11 +591,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699757840,
-        "narHash": "sha256-suDPrzpBmTz1km/mdhupzjkAyFOSBfdZePj6D1CRlAw=",
+        "lastModified": 1699760693,
+        "narHash": "sha256-u/gkNUHQR/q23voqE5J4xmEWQIAqR+g3lUnCtzn0k7Y=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "d573619090fce2bd9983dc48139671c18cbe696e",
+        "rev": "8aff4ca3dee60d1422489fe8d52c2f837b3ad113",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`8aff4ca3`](https://github.com/nix-community/nix-index-database/commit/8aff4ca3dee60d1422489fe8d52c2f837b3ad113) | `` update packages.nix to release 2023-11-12-034340 `` |