### PR TITLE
chore(flake/nur): `ff495b6b` -> `d6e9e184`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699751149,
-        "narHash": "sha256-hcWsurEJSVYWHoI5YvB5ZVaCY+Sg2Qd0ZumKn7dLjI0=",
+        "lastModified": 1699767986,
+        "narHash": "sha256-STR4kVOxM6Aok859j3otvpMhoa4Sve0VGB3ms5J3CrE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ff495b6b6763bcb879b97c105eedc1db23260bab",
+        "rev": "d6e9e184834f3a6eda244f43443b43955f4ba237",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d6e9e184`](https://github.com/nix-community/NUR/commit/d6e9e184834f3a6eda244f43443b43955f4ba237) | `` automatic update `` |