### PR TITLE
chore(flake/nur): `d6e9e184` -> `9bfba90d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699767986,
-        "narHash": "sha256-STR4kVOxM6Aok859j3otvpMhoa4Sve0VGB3ms5J3CrE=",
+        "lastModified": 1699772023,
+        "narHash": "sha256-76Y2kBZ9rRxzyDTz6oNpXbZ8oWcnBUfNNEZsnsOOpD8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d6e9e184834f3a6eda244f43443b43955f4ba237",
+        "rev": "9bfba90da05caa2b1381bf67e60b4aac304cbf07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9bfba90d`](https://github.com/nix-community/NUR/commit/9bfba90da05caa2b1381bf67e60b4aac304cbf07) | `` automatic update `` |
| [`83768339`](https://github.com/nix-community/NUR/commit/837683390f1845699240380cf4bb391ae3ce03a9) | `` automatic update `` |