### PR TITLE
chore(flake/nur): `9bfba90d` -> `218d85e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699772023,
-        "narHash": "sha256-76Y2kBZ9rRxzyDTz6oNpXbZ8oWcnBUfNNEZsnsOOpD8=",
+        "lastModified": 1699779646,
+        "narHash": "sha256-GLpcLuewbrASiPTfBNVdvmyP6YfAApRQ3py0IohBTL4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9bfba90da05caa2b1381bf67e60b4aac304cbf07",
+        "rev": "218d85e2e1fabfe686b12c23b5191822277b7db4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`218d85e2`](https://github.com/nix-community/NUR/commit/218d85e2e1fabfe686b12c23b5191822277b7db4) | `` automatic update `` |
| [`3de8e664`](https://github.com/nix-community/NUR/commit/3de8e6649dd89bb70eccf94a5e41c110b250aefd) | `` automatic update `` |