### PR TITLE
chore(flake/emacs-overlay): `edf63e4a` -> `57400456`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699752997,
-        "narHash": "sha256-L8SWAH0uWNXsKfjNe6e2bYN0d1Dg2sFrgTgn2kyfrX4=",
+        "lastModified": 1699781857,
+        "narHash": "sha256-0KFhWECrnADm/VKrB53BgT/3LD+jMJG1vVG+dQng+rk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "edf63e4ac22d6afc9e0513047c216504d3754e2d",
+        "rev": "574004568151819a92d44728614334e91a16c2c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`57400456`](https://github.com/nix-community/emacs-overlay/commit/574004568151819a92d44728614334e91a16c2c3) | `` Updated repos/melpa `` |
| [`c6a6721b`](https://github.com/nix-community/emacs-overlay/commit/c6a6721b733d8cccadba920af5acc682ec1e2cdb) | `` Updated repos/emacs `` |