### PR TITLE
chore(flake/nur): `218d85e2` -> `12f4cf2f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699779646,
-        "narHash": "sha256-GLpcLuewbrASiPTfBNVdvmyP6YfAApRQ3py0IohBTL4=",
+        "lastModified": 1699783249,
+        "narHash": "sha256-J8gl7OojdTwnh7BnAyY0Alk4+OTUExIlv2ICJUnLrGs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "218d85e2e1fabfe686b12c23b5191822277b7db4",
+        "rev": "12f4cf2f5439286621efeef6cc0d6197c367a894",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`12f4cf2f`](https://github.com/nix-community/NUR/commit/12f4cf2f5439286621efeef6cc0d6197c367a894) | `` automatic update `` |
| [`ea3cf8f8`](https://github.com/nix-community/NUR/commit/ea3cf8f81f06409352c4129ea923059d83929e4d) | `` automatic update `` |
| [`cb766b5a`](https://github.com/nix-community/NUR/commit/cb766b5ae57c9711b0a43a4c45b7845c9237ac10) | `` automatic update `` |