### PR TITLE
chore(flake/nur): `12f4cf2f` -> `096b79f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699783249,
-        "narHash": "sha256-J8gl7OojdTwnh7BnAyY0Alk4+OTUExIlv2ICJUnLrGs=",
+        "lastModified": 1699784453,
+        "narHash": "sha256-6eER58RQlHFlTe+y0FvNPpJ7afo2NM0JU9VgejS3Tp0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "12f4cf2f5439286621efeef6cc0d6197c367a894",
+        "rev": "096b79f390af07f3bb7b15f5b2b73ad228f00e68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`096b79f3`](https://github.com/nix-community/NUR/commit/096b79f390af07f3bb7b15f5b2b73ad228f00e68) | `` automatic update `` |