### PR TITLE
chore(flake/nur): `096b79f3` -> `56f0e72a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699784453,
-        "narHash": "sha256-6eER58RQlHFlTe+y0FvNPpJ7afo2NM0JU9VgejS3Tp0=",
+        "lastModified": 1699793701,
+        "narHash": "sha256-g5oQmDi/Re2f5oYMpehC7SVUJbTjwIf82aCT+IzEwug=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "096b79f390af07f3bb7b15f5b2b73ad228f00e68",
+        "rev": "56f0e72ad005cb178a9add7fa923d75e4a295ff5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`56f0e72a`](https://github.com/nix-community/NUR/commit/56f0e72ad005cb178a9add7fa923d75e4a295ff5) | `` automatic update `` |
| [`cafc94f2`](https://github.com/nix-community/NUR/commit/cafc94f2fafd3bc7ef0a2f35a3484dd2df64f111) | `` automatic update `` |