### PR TITLE
chore(flake/nur): `56f0e72a` -> `392c3030`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699793701,
-        "narHash": "sha256-g5oQmDi/Re2f5oYMpehC7SVUJbTjwIf82aCT+IzEwug=",
+        "lastModified": 1699798856,
+        "narHash": "sha256-gW/7h1Vsz7YFuRmuIGL7D0AiQXxXHwX6SpZYCjUG8Kw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "56f0e72ad005cb178a9add7fa923d75e4a295ff5",
+        "rev": "392c30309165a4dd98e85b975e4b17b295d75968",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`392c3030`](https://github.com/nix-community/NUR/commit/392c30309165a4dd98e85b975e4b17b295d75968) | `` automatic update `` |