### PR TITLE
chore(flake/nur): `392c3030` -> `4e6eb2a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699798856,
-        "narHash": "sha256-gW/7h1Vsz7YFuRmuIGL7D0AiQXxXHwX6SpZYCjUG8Kw=",
+        "lastModified": 1699801071,
+        "narHash": "sha256-SqmsLHF9cODwx/2vANAtz8J36wlw/na5IjI2WYFtvzU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "392c30309165a4dd98e85b975e4b17b295d75968",
+        "rev": "4e6eb2a854b90102de555f884e120b4270db2763",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4e6eb2a8`](https://github.com/nix-community/NUR/commit/4e6eb2a854b90102de555f884e120b4270db2763) | `` automatic update `` |