### PR TITLE
chore(flake/nur): `4e6eb2a8` -> `57872d30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699801071,
-        "narHash": "sha256-SqmsLHF9cODwx/2vANAtz8J36wlw/na5IjI2WYFtvzU=",
+        "lastModified": 1699807176,
+        "narHash": "sha256-JCMIDx9qClWLMYTkkH8yn/fN8t0b/kRDadhbesp6HrE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4e6eb2a854b90102de555f884e120b4270db2763",
+        "rev": "57872d30294ced31a8e1856824b1ad0c2c648791",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`57872d30`](https://github.com/nix-community/NUR/commit/57872d30294ced31a8e1856824b1ad0c2c648791) | `` automatic update `` |