### PR TITLE
chore(flake/emacs-overlay): `57400456` -> `87219c66`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699781857,
-        "narHash": "sha256-0KFhWECrnADm/VKrB53BgT/3LD+jMJG1vVG+dQng+rk=",
+        "lastModified": 1699812904,
+        "narHash": "sha256-+74SKAZrAFMytXfn0O1Sd5/bIl8OV+XxfjkXuGYqbYo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "574004568151819a92d44728614334e91a16c2c3",
+        "rev": "87219c6667c12e5f4442d27c073b9c56dbf0c95e",
         "type": "github"
       },
       "original": {
@@ -693,11 +693,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1699291058,
-        "narHash": "sha256-5ggduoaAMPHUy4riL+OrlAZE14Kh7JWX4oLEs22ZqfU=",
+        "lastModified": 1699596684,
+        "narHash": "sha256-XSXP8zjBZJBVvpNb2WmY0eW8O2ce+sVyj1T0/iBRIvg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "41de143fda10e33be0f47eab2bfe08a50f234267",
+        "rev": "da4024d0ead5d7820f6bd15147d3fe2a0c0cec73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`87219c66`](https://github.com/nix-community/emacs-overlay/commit/87219c6667c12e5f4442d27c073b9c56dbf0c95e) | `` Updated repos/nongnu `` |
| [`a27b3c79`](https://github.com/nix-community/emacs-overlay/commit/a27b3c79d0eb23a47fb16c569c05e51d4f5aa76a) | `` Updated repos/melpa ``  |
| [`ab04a4ff`](https://github.com/nix-community/emacs-overlay/commit/ab04a4ff4a3648349b99cbb793ff5e12f5567c53) | `` Updated repos/emacs ``  |
| [`27c1ae56`](https://github.com/nix-community/emacs-overlay/commit/27c1ae56554f4ea2e32aaddfe61ff24be57d34d6) | `` Updated repos/elpa ``   |
| [`a2aab00b`](https://github.com/nix-community/emacs-overlay/commit/a2aab00bfc49d6a43d4c10eb0dcd9633885ff8f6) | `` Updated flake inputs `` |