### PR TITLE
chore(flake/nur): `dddf83e9` -> `fb54d657`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699811115,
-        "narHash": "sha256-1vhHyoDTdt3Qb38Vymcc0ELMQfCTLhl8m41JXn0C0/c=",
+        "lastModified": 1699818241,
+        "narHash": "sha256-/XUTGdo+vE8Zjh/b8PnFTO4C/KxBNmTT9W/1P9wRkv0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dddf83e9b15048a710e8002eeabc023ec682d83e",
+        "rev": "fb54d657e896084db1cacb63505fb363d8303535",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fb54d657`](https://github.com/nix-community/NUR/commit/fb54d657e896084db1cacb63505fb363d8303535) | `` automatic update `` |