### PR TITLE
chore(flake/nur): `fb54d657` -> `914f77f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699818241,
-        "narHash": "sha256-/XUTGdo+vE8Zjh/b8PnFTO4C/KxBNmTT9W/1P9wRkv0=",
+        "lastModified": 1699825898,
+        "narHash": "sha256-Bo6DLA4y4HNPI0z6OQKs1Tfi/W0HAfTgQ8W8L3cm7Gs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fb54d657e896084db1cacb63505fb363d8303535",
+        "rev": "914f77f7be81bd0aa0e154086028641ae738460f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`914f77f7`](https://github.com/nix-community/NUR/commit/914f77f7be81bd0aa0e154086028641ae738460f) | `` automatic update `` |