### PR TITLE
chore(flake/nur): `914f77f7` -> `076a6203`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699825898,
-        "narHash": "sha256-Bo6DLA4y4HNPI0z6OQKs1Tfi/W0HAfTgQ8W8L3cm7Gs=",
+        "lastModified": 1699829219,
+        "narHash": "sha256-6SMSRpM5TL9UG/Vrt821YKe894WcIzu40nvbxkGxP0U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "914f77f7be81bd0aa0e154086028641ae738460f",
+        "rev": "076a620318b0b53f159538414025b3dacada784f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`076a6203`](https://github.com/nix-community/NUR/commit/076a620318b0b53f159538414025b3dacada784f) | `` automatic update `` |