### PR TITLE
chore(flake/nur): `076a6203` -> `4cd37582`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699829219,
-        "narHash": "sha256-6SMSRpM5TL9UG/Vrt821YKe894WcIzu40nvbxkGxP0U=",
+        "lastModified": 1699837452,
+        "narHash": "sha256-aUg0+0MOPgDZtyDa4kcTLC7+zpnQWb5B3k9THN0uAOc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "076a620318b0b53f159538414025b3dacada784f",
+        "rev": "4cd37582b4d49983cf61ef3789f9dc58ff4a54f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4cd37582`](https://github.com/nix-community/NUR/commit/4cd37582b4d49983cf61ef3789f9dc58ff4a54f1) | `` automatic update `` |