### PR TITLE
chore(flake/nur): `4cd37582` -> `ed28748f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699837452,
-        "narHash": "sha256-aUg0+0MOPgDZtyDa4kcTLC7+zpnQWb5B3k9THN0uAOc=",
+        "lastModified": 1699844110,
+        "narHash": "sha256-Ogl8lo2YAyVeAOuTwy35U1mjZZL3rBT36FbFWv4IKnE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4cd37582b4d49983cf61ef3789f9dc58ff4a54f1",
+        "rev": "ed28748f4e2546a3e7564d2dbf5adf72bfd56ccc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ed28748f`](https://github.com/nix-community/NUR/commit/ed28748f4e2546a3e7564d2dbf5adf72bfd56ccc) | `` automatic update `` |