### PR TITLE
chore(flake/emacs-overlay): `87219c66` -> `fe55f8be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699812904,
-        "narHash": "sha256-+74SKAZrAFMytXfn0O1Sd5/bIl8OV+XxfjkXuGYqbYo=",
+        "lastModified": 1699847247,
+        "narHash": "sha256-5ol3yqTVkrNW0pIKSvU96QvrUST+rgQ/z3huxSHG1HU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "87219c6667c12e5f4442d27c073b9c56dbf0c95e",
+        "rev": "fe55f8be14c4537f42b037051e9f5cb7ffcad246",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`fe55f8be`](https://github.com/nix-community/emacs-overlay/commit/fe55f8be14c4537f42b037051e9f5cb7ffcad246) | `` Updated repos/nongnu `` |
| [`cc2ef318`](https://github.com/nix-community/emacs-overlay/commit/cc2ef3184e5489cdb29aa1d7eeb1922de919d113) | `` Updated repos/melpa ``  |
| [`b138783c`](https://github.com/nix-community/emacs-overlay/commit/b138783ca8ff6491102722a7736e45a4f349713c) | `` Updated repos/emacs ``  |
| [`c9d7a0f4`](https://github.com/nix-community/emacs-overlay/commit/c9d7a0f4575b6fa14e69660a0c3558611588d58b) | `` Updated repos/elpa ``   |