### PR TITLE
chore(flake/nur): `ed28748f` -> `d28a36df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699844110,
-        "narHash": "sha256-Ogl8lo2YAyVeAOuTwy35U1mjZZL3rBT36FbFWv4IKnE=",
+        "lastModified": 1699847092,
+        "narHash": "sha256-UuAJYOng3e0uXQeJ8JR2rqZT65ePceKQk69L0nOs95o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed28748f4e2546a3e7564d2dbf5adf72bfd56ccc",
+        "rev": "d28a36dfcaf81417cc4025965e404a4adb98a107",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d28a36df`](https://github.com/nix-community/NUR/commit/d28a36dfcaf81417cc4025965e404a4adb98a107) | `` automatic update `` |