### PR TITLE
chore(flake/nur): `d470d4c2` -> `ac604416`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699854185,
-        "narHash": "sha256-uLzBlkMFbOWS64EYyKXItAtMo6oPfbbPemP/g1dZQOA=",
+        "lastModified": 1699858418,
+        "narHash": "sha256-PJ7S5Ej0Gowg0XuVTa+68CEuZfLHSERK+3h3WAgT0ko=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d470d4c25eb70a18c1685e849be7aec191841d84",
+        "rev": "ac604416daf471d4644f3be174d095263f09f810",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ac604416`](https://github.com/nix-community/NUR/commit/ac604416daf471d4644f3be174d095263f09f810) | `` automatic update `` |