### PR TITLE
chore(flake/nur): `ac604416` -> `7b5f75ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699858418,
-        "narHash": "sha256-PJ7S5Ej0Gowg0XuVTa+68CEuZfLHSERK+3h3WAgT0ko=",
+        "lastModified": 1699862277,
+        "narHash": "sha256-SmtANzj840vIfqOSHbhZ6+Xo8u4DDOElwlcbFEBfoGQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ac604416daf471d4644f3be174d095263f09f810",
+        "rev": "7b5f75ad624728f00cdae8c980aefd1b36e9cb48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7b5f75ad`](https://github.com/nix-community/NUR/commit/7b5f75ad624728f00cdae8c980aefd1b36e9cb48) | `` automatic update `` |