### PR TITLE
chore(flake/darwin): `0f1ad801` -> `e67f2bf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -216,11 +216,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699704228,
-        "narHash": "sha256-NApWG385goidsXmsakWgFRjvbH+aw/n1CGGHn/UuXsc=",
+        "lastModified": 1699867978,
+        "narHash": "sha256-+arl45HUOcBdKiRGrKXZYXDyBQ6MQGkYPZa/28f6Yzo=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "0f1ad801387445fdda01d080db8ecf169be8e793",
+        "rev": "e67f2bf515343da378c3f82f098df8ca01bccc5f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                  |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------- |
| [`39a412d4`](https://github.com/LnL7/nix-darwin/commit/39a412d47ddb87f84e1a0d3eb168b0ce0d30498e) | `` Fix unbound variable `etcProblems` `` |