### PR TITLE
chore(flake/emacs-overlay): `fe55f8be` -> `4ed08388`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699847247,
-        "narHash": "sha256-5ol3yqTVkrNW0pIKSvU96QvrUST+rgQ/z3huxSHG1HU=",
+        "lastModified": 1699870846,
+        "narHash": "sha256-PHOVgZpU5npMT40Y+aB69dFSkhj7hADPghMgDXQ0Wwo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fe55f8be14c4537f42b037051e9f5cb7ffcad246",
+        "rev": "4ed083888eac6202ec4887b02577cc168352d10f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4ed08388`](https://github.com/nix-community/emacs-overlay/commit/4ed083888eac6202ec4887b02577cc168352d10f) | `` Updated repos/nongnu `` |
| [`e71b61bf`](https://github.com/nix-community/emacs-overlay/commit/e71b61bfab4cbe8895935d54d5ea6635725f48db) | `` Updated repos/melpa ``  |
| [`e385e6bb`](https://github.com/nix-community/emacs-overlay/commit/e385e6bbcf25fbe136c6bdd85415486c86b8e1b4) | `` Updated repos/emacs ``  |