### PR TITLE
chore(flake/nur): `7b5f75ad` -> `8cec71be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699862277,
-        "narHash": "sha256-SmtANzj840vIfqOSHbhZ6+Xo8u4DDOElwlcbFEBfoGQ=",
+        "lastModified": 1699876708,
+        "narHash": "sha256-eSCR8fod3Lr22OQoH7Wet4BtWWgV77guYGzBc4AMsxk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7b5f75ad624728f00cdae8c980aefd1b36e9cb48",
+        "rev": "8cec71be47f78d79f70a4ce7293a9bb77c291d9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8cec71be`](https://github.com/nix-community/NUR/commit/8cec71be47f78d79f70a4ce7293a9bb77c291d9a) | `` automatic update `` |
| [`4e107637`](https://github.com/nix-community/NUR/commit/4e1076378e9d07595c357eab971436b6d57888fa) | `` automatic update `` |