### PR TITLE
chore(flake/nur): `8cec71be` -> `9c4835e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699876708,
-        "narHash": "sha256-eSCR8fod3Lr22OQoH7Wet4BtWWgV77guYGzBc4AMsxk=",
+        "lastModified": 1699880405,
+        "narHash": "sha256-245U6zatNdFsPOkh4K047I9lTRMmeVvAU5NwrU8mBDs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8cec71be47f78d79f70a4ce7293a9bb77c291d9a",
+        "rev": "9c4835e5bcb05f0c40f4d54ccec7199f9050fde3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9c4835e5`](https://github.com/nix-community/NUR/commit/9c4835e5bcb05f0c40f4d54ccec7199f9050fde3) | `` automatic update `` |
| [`94db450d`](https://github.com/nix-community/NUR/commit/94db450d2f3cbfe49c0f2b63643706c280a59851) | `` automatic update `` |
| [`ea2e4385`](https://github.com/nix-community/NUR/commit/ea2e4385373ffbb188ff11bd33542c3eec9e3407) | `` automatic update `` |
| [`2b4f09a1`](https://github.com/nix-community/NUR/commit/2b4f09a1b8f0ff393a8bc38baae71db5329687af) | `` automatic update `` |