### PR TITLE
chore(flake/emacs-overlay): `4ed08388` -> `df15eee2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699870846,
-        "narHash": "sha256-PHOVgZpU5npMT40Y+aB69dFSkhj7hADPghMgDXQ0Wwo=",
+        "lastModified": 1699897167,
+        "narHash": "sha256-pe8oBaI3w7QhmruPKuqpWPS0Q22Z4TLETpf9/ET4f3M=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4ed083888eac6202ec4887b02577cc168352d10f",
+        "rev": "df15eee224e887ad80534d27f25d25adaaae4512",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`df15eee2`](https://github.com/nix-community/emacs-overlay/commit/df15eee224e887ad80534d27f25d25adaaae4512) | `` Updated repos/melpa `` |
| [`438e0a00`](https://github.com/nix-community/emacs-overlay/commit/438e0a009ad538ed7e16d4e5d60792101c1b2498) | `` Updated repos/emacs `` |
| [`9b07f5fb`](https://github.com/nix-community/emacs-overlay/commit/9b07f5fb18b7a5eb8da3c7f57c6c34dd242bd33e) | `` Updated repos/elpa ``  |