### PR TITLE
chore(flake/nur): `17e04af4` -> `1bfff29c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699886661,
-        "narHash": "sha256-KSM1gEVS7pfIP+uiaJXG8Pj5k4nMqxFusuWsYtzznDY=",
+        "lastModified": 1699904747,
+        "narHash": "sha256-BNL/wqqfy+yJZfhh1ePXvq1fqLztJe9J83XaFOkZu64=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "17e04af4f65629e4fd1094b3fe52227cdd7e8b55",
+        "rev": "1bfff29ceec5930f1eddcaa8ab68eb3d1b9b2455",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1bfff29c`](https://github.com/nix-community/NUR/commit/1bfff29ceec5930f1eddcaa8ab68eb3d1b9b2455) | `` automatic update `` |