### PR TITLE
chore(flake/nur): `1bfff29c` -> `9693ccc6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699904747,
-        "narHash": "sha256-BNL/wqqfy+yJZfhh1ePXvq1fqLztJe9J83XaFOkZu64=",
+        "lastModified": 1699907094,
+        "narHash": "sha256-9Brl2FJ+xIBRk3CNYsFWzx4pvRYUuM5fSps+GVswTzE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1bfff29ceec5930f1eddcaa8ab68eb3d1b9b2455",
+        "rev": "9693ccc6b8835a960224c57cb1eb2faceabeda14",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9693ccc6`](https://github.com/nix-community/NUR/commit/9693ccc6b8835a960224c57cb1eb2faceabeda14) | `` automatic update `` |