### PR TITLE
chore(flake/nur): `9693ccc6` -> `c972b465`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699907094,
-        "narHash": "sha256-9Brl2FJ+xIBRk3CNYsFWzx4pvRYUuM5fSps+GVswTzE=",
+        "lastModified": 1699912293,
+        "narHash": "sha256-I4j/1QsRZyl/ZYn7SmporL6FEzuGVzv73LigUxHrnAY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9693ccc6b8835a960224c57cb1eb2faceabeda14",
+        "rev": "c972b465ef3a0d3a0e51450253f6abe0e5ef2c70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c972b465`](https://github.com/nix-community/NUR/commit/c972b465ef3a0d3a0e51450253f6abe0e5ef2c70) | `` automatic update `` |
| [`f4d0be66`](https://github.com/nix-community/NUR/commit/f4d0be669539ee2676d4d98a06df48940cf564f4) | `` automatic update `` |