### PR TITLE
chore(flake/sops-nix): `2fc3c9ed` -> `074ff78f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -952,11 +952,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1699770333,
-        "narHash": "sha256-tWIifHuqPZKCuAVjewewX/LyC6LCf5dsIkyDHlXr7DM=",
+        "lastModified": 1699915071,
+        "narHash": "sha256-EVZTfDVsB/g34pxieNIFwcUIbq8BmQL8Eu7K+VKbBz0=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "2fc3c9edc3029ed396ec917f39a7253acc3d8999",
+        "rev": "074ff78f8d6d9d3867ee34bad81fd424973e6509",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`074ff78f`](https://github.com/Mic92/sops-nix/commit/074ff78f8d6d9d3867ee34bad81fd424973e6509) | `` update vendorHash ``                                           |
| [`1eca5a66`](https://github.com/Mic92/sops-nix/commit/1eca5a668a8d57f8833827f3845605230b2184d5) | `` build(deps): bump golang.org/x/crypto from 0.14.0 to 0.15.0 `` |