### PR TITLE
chore(flake/nur): `6d77f13e` -> `09dd04ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699914064,
-        "narHash": "sha256-FWFKUwKMtFZrFJ7ZGt02PzgmCOpDGRde9RlPwzz4ZWs=",
+        "lastModified": 1699923777,
+        "narHash": "sha256-PSk6tdqhcmKS8YvCNrEYjCOXFFq6c7UetSWfCT8JPD4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6d77f13eca4e5659c51ee2a75994a6369b536276",
+        "rev": "09dd04ca59851ba2cba3592c2ce68c4c3cbaa175",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`09dd04ca`](https://github.com/nix-community/NUR/commit/09dd04ca59851ba2cba3592c2ce68c4c3cbaa175) | `` automatic update `` |