### PR TITLE
chore(flake/nur): `09dd04ca` -> `c14d73d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699923777,
-        "narHash": "sha256-PSk6tdqhcmKS8YvCNrEYjCOXFFq6c7UetSWfCT8JPD4=",
+        "lastModified": 1699926094,
+        "narHash": "sha256-v9NXBEkxEjelXykUCuJVySix7kt/YCC45dcr64WTGzo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "09dd04ca59851ba2cba3592c2ce68c4c3cbaa175",
+        "rev": "c14d73d1969e99562f8a1813adbf2af3d3e97de1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c14d73d1`](https://github.com/nix-community/NUR/commit/c14d73d1969e99562f8a1813adbf2af3d3e97de1) | `` automatic update `` |