### PR TITLE
chore(flake/emacs-overlay): `df15eee2` -> `2fe12926`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699897167,
-        "narHash": "sha256-pe8oBaI3w7QhmruPKuqpWPS0Q22Z4TLETpf9/ET4f3M=",
+        "lastModified": 1699928399,
+        "narHash": "sha256-tO/92xtGEvcYT4XqLRrD3DKj47XW8v/jTvcoTYowC3I=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "df15eee224e887ad80534d27f25d25adaaae4512",
+        "rev": "2fe12926dbe9b091fc7b01d33f8c7e0c3280a812",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`2fe12926`](https://github.com/nix-community/emacs-overlay/commit/2fe12926dbe9b091fc7b01d33f8c7e0c3280a812) | `` Updated repos/nongnu `` |
| [`0cac00bb`](https://github.com/nix-community/emacs-overlay/commit/0cac00bb83505d021348645f85818eb735ce737c) | `` Updated repos/melpa ``  |
| [`31536776`](https://github.com/nix-community/emacs-overlay/commit/31536776b83b783973c0e9f5e1ef8835ebc4a0e0) | `` Updated repos/emacs ``  |
| [`e477b6ee`](https://github.com/nix-community/emacs-overlay/commit/e477b6ee6df9f2753baf9a5af8ba38de8143ed5b) | `` Updated repos/elpa ``   |