### PR TITLE
chore(flake/nur): `0bbb4524` -> `b2e12cbd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699944264,
-        "narHash": "sha256-5SakNv+ExEb+JXOwP/ygdoCH/uabHD5jyaiDKAZ8wfs=",
+        "lastModified": 1699948785,
+        "narHash": "sha256-W9VvHkxysAQL/qmkXSZM3c8VUuwbLY7S1IZfZ/kWqO0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0bbb4524e8e93cf54abc795bc85834a01b00cc31",
+        "rev": "b2e12cbd2e6e39fd79f04faf9cae65c5e7f09a94",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b2e12cbd`](https://github.com/nix-community/NUR/commit/b2e12cbd2e6e39fd79f04faf9cae65c5e7f09a94) | `` automatic update `` |
| [`8a957b39`](https://github.com/nix-community/NUR/commit/8a957b393098d51c9c216086f4a731f16db9ab39) | `` automatic update `` |