### PR TITLE
chore(flake/nur): `34dadf63` -> `46c2f225`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699957785,
-        "narHash": "sha256-N7XJ+Otvn5GERktkIxw6K757JsmfvyO7I95VPgk38Z8=",
+        "lastModified": 1699966516,
+        "narHash": "sha256-VJU6nAW0slALbzmJlcIhWeCohxoAG3INeY/3Vg8hAyM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "34dadf63b2715951bec44a3ba01c4e72e07900dc",
+        "rev": "46c2f22502aabbaa038cc7e570915aa8f490ae1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`46c2f225`](https://github.com/nix-community/NUR/commit/46c2f22502aabbaa038cc7e570915aa8f490ae1e) | `` automatic update `` |
| [`bf2ef727`](https://github.com/nix-community/NUR/commit/bf2ef7276d35e01c7dd7af9408e80a482d1add8e) | `` automatic update `` |