### PR TITLE
chore(flake/nur): `46c2f225` -> `574dd118`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699966516,
-        "narHash": "sha256-VJU6nAW0slALbzmJlcIhWeCohxoAG3INeY/3Vg8hAyM=",
+        "lastModified": 1699973088,
+        "narHash": "sha256-F1sxeN74bHn+KG0GROgxQnDn/EMj76ejNeamBKRFGH4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "46c2f22502aabbaa038cc7e570915aa8f490ae1e",
+        "rev": "574dd1188450450d2d3c969a2312b3e5f99a53fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`574dd118`](https://github.com/nix-community/NUR/commit/574dd1188450450d2d3c969a2312b3e5f99a53fb) | `` automatic update `` |