### PR TITLE
chore(flake/nur): `574dd118` -> `b6b4c4d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699973088,
-        "narHash": "sha256-F1sxeN74bHn+KG0GROgxQnDn/EMj76ejNeamBKRFGH4=",
+        "lastModified": 1699980276,
+        "narHash": "sha256-fPX4SVB//G0nTxdBru6/qCoUiWOaMiXjXs8cy33RVQo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "574dd1188450450d2d3c969a2312b3e5f99a53fb",
+        "rev": "b6b4c4d9c1ffbbe8a494aae3257a08bf23048f5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b6b4c4d9`](https://github.com/nix-community/NUR/commit/b6b4c4d9c1ffbbe8a494aae3257a08bf23048f5e) | `` automatic update `` |