### PR TITLE
chore(flake/emacs-overlay): `1d4ed29d` -> `c9f770c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1699954689,
-        "narHash": "sha256-gJtxMQotdEyiuGoiPPSdYqa8Pdw9ptgFFMrxKsWKj54=",
+        "lastModified": 1699982112,
+        "narHash": "sha256-l3rZbmjjsICqedBvIVEgsG6GsjCPF/cq9/LpuIXWKMY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1d4ed29d4d9d076210485697c325f8d6914d908f",
+        "rev": "c9f770c87c701375f28af95679af355d6c61f1ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c9f770c8`](https://github.com/nix-community/emacs-overlay/commit/c9f770c87c701375f28af95679af355d6c61f1ce) | `` Updated repos/melpa ``  |
| [`d8fa70aa`](https://github.com/nix-community/emacs-overlay/commit/d8fa70aacc3e2300a80c6652621ac3401d2872c1) | `` Updated repos/emacs ``  |
| [`5ca896a4`](https://github.com/nix-community/emacs-overlay/commit/5ca896a4f9ae416df9924ea429d5d78bc4b0da66) | `` Updated repos/elpa ``   |
| [`6eddd8a0`](https://github.com/nix-community/emacs-overlay/commit/6eddd8a050a7bcb950e8c906e876379f130a5182) | `` Updated flake inputs `` |