### PR TITLE
chore(flake/nur): `b6b4c4d9` -> `0cd882b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699980276,
-        "narHash": "sha256-fPX4SVB//G0nTxdBru6/qCoUiWOaMiXjXs8cy33RVQo=",
+        "lastModified": 1699991129,
+        "narHash": "sha256-/nPdWheafJg7uWT9S7XOgYwYaB2kFFijGDgmao2S5C4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b6b4c4d9c1ffbbe8a494aae3257a08bf23048f5e",
+        "rev": "0cd882b8e2ec2c03f12b8fd43bcee9daac67c4b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0cd882b8`](https://github.com/nix-community/NUR/commit/0cd882b8e2ec2c03f12b8fd43bcee9daac67c4b2) | `` automatic update `` |
| [`ddee8e6c`](https://github.com/nix-community/NUR/commit/ddee8e6c6e2444c2490d2b1f8190c2b97a5890f8) | `` automatic update `` |
| [`7e97533c`](https://github.com/nix-community/NUR/commit/7e97533c584d2628f9bec24d1c44ad79409307af) | `` automatic update `` |