### PR TITLE
chore(flake/nur): `0cd882b8` -> `f8123e00`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699991129,
-        "narHash": "sha256-/nPdWheafJg7uWT9S7XOgYwYaB2kFFijGDgmao2S5C4=",
+        "lastModified": 1699994922,
+        "narHash": "sha256-UMklwAE7pGHp0y4yDshqWu8pIwiD5+osDYnmPmN4ZXg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0cd882b8e2ec2c03f12b8fd43bcee9daac67c4b2",
+        "rev": "f8123e008226bbbfd5ad0adbcbac25a08176572d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f8123e00`](https://github.com/nix-community/NUR/commit/f8123e008226bbbfd5ad0adbcbac25a08176572d) | `` automatic update `` |