### PR TITLE
chore(flake/nur): `f8123e00` -> `120395ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699994922,
-        "narHash": "sha256-UMklwAE7pGHp0y4yDshqWu8pIwiD5+osDYnmPmN4ZXg=",
+        "lastModified": 1700005540,
+        "narHash": "sha256-H1YlTMY8AYvJ2jE+dDTBC80OdtxQFt+l6Lp06uiejQ0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f8123e008226bbbfd5ad0adbcbac25a08176572d",
+        "rev": "120395ed25da56dc5f55f8599ac9eb4dfe1a699f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`120395ed`](https://github.com/nix-community/NUR/commit/120395ed25da56dc5f55f8599ac9eb4dfe1a699f) | `` automatic update `` |