### PR TITLE
chore(flake/envrc): `880e6c3c` -> `4ece907a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -298,11 +298,11 @@
     "envrc": {
       "flake": false,
       "locked": {
-        "lastModified": 1640071200,
-        "narHash": "sha256-9ETx8XNNJSPrEngkJCWIFOejeFXqaPUIvfwTdbgjoOs=",
+        "lastModified": 1700025959,
+        "narHash": "sha256-65O6e5HrOcf4IHodwEjkT8Sg6ryv9kWulkvyASjg1Uo=",
         "owner": "siddharthverma314",
         "repo": "envrc",
-        "rev": "880e6c3ca24a46decfce5b5e280fd41e6e8460e0",
+        "rev": "4ece907a72b29b1fffcfc196ca177bb52fbff6cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                                    |
| -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`4ece907a`](https://github.com/siddharthverma314/envrc/commit/4ece907a72b29b1fffcfc196ca177bb52fbff6cf) | `` Add TRAMP support ``                                                    |
| [`1385e72a`](https://github.com/siddharthverma314/envrc/commit/1385e72a730924664697a0961d43516a47a977d7) | `` Fix build badge URL (broken recently by GitHub) ``                      |
| [`13537571`](https://github.com/siddharthverma314/envrc/commit/13537571f1a32b2ba1ca5c1a24c2b017e284ae3f) | `` chore(deps): bump actions/checkout from 2 to 4 ``                       |
| [`b3b631ce`](https://github.com/siddharthverma314/envrc/commit/b3b631ce8dfe472476d2745ab76953424813a2cf) | `` Fix transposed chars in makefile ``                                     |
| [`873f47cf`](https://github.com/siddharthverma314/envrc/commit/873f47cf36a1b31f52ea24225e9b9cd3a41fdbeb) | `` Don't forget to run tests ``                                            |
| [`535897e8`](https://github.com/siddharthverma314/envrc/commit/535897e8e7c642f1e67089b20e3bbccdc5169470) | `` Don't install package-lint for build steps ``                           |
| [`68561c40`](https://github.com/siddharthverma314/envrc/commit/68561c4074f9bd1e826299aaea740646fb7d8356) | `` Add Emacs 29.1 to matrix, and only package-lint with that version ``    |
| [`4f9ae5d4`](https://github.com/siddharthverma314/envrc/commit/4f9ae5d4d1fcb32c844b50ccda34305884d68be3) | `` Declare sh-set-shell ``                                                 |
| [`1262d95d`](https://github.com/siddharthverma314/envrc/commit/1262d95dda4fbe1d311a1d4947ef4e6ba3b3b18e) | `` chore(deps): bump cachix/install-nix-action from 22 to 23 ``            |
| [`89c6dc49`](https://github.com/siddharthverma314/envrc/commit/89c6dc4927779b4d88170e884e856a491fbf5ca5) | `` chore(deps): bump actions/checkout from 3 to 4 ``                       |
| [`7effcda0`](https://github.com/siddharthverma314/envrc/commit/7effcda0c9870247da72e7bc56bcac2ca12fcbde) | `` Update info-directory-list from INFOPATH if set ``                      |
| [`7b7d8296`](https://github.com/siddharthverma314/envrc/commit/7b7d829674ed1dd957dcd53817adc6f0b3023122) | `` Prefer derived-mode-p to checking major-mode ``                         |
| [`ebeca3e0`](https://github.com/siddharthverma314/envrc/commit/ebeca3e059645fa57031d520415946c40e789d2f) | `` Add fuction & keybind to show envrc log buffer ``                       |
| [`015cc2a9`](https://github.com/siddharthverma314/envrc/commit/015cc2a98f97643a8a0d72e09352e88ebe728d5c) | `` Add support for updating environment on directory change in eshell ``   |
| [`d8fe5d29`](https://github.com/siddharthverma314/envrc/commit/d8fe5d293253a0d431034cd7294e6fb561c4950f) | `` Release 0.6 ``                                                          |
| [`a763eadd`](https://github.com/siddharthverma314/envrc/commit/a763eadd28df8078d4331fa1dc71eb8a09ae4582) | `` Fix mismatched buffer name ``                                           |
| [`6389a8f5`](https://github.com/siddharthverma314/envrc/commit/6389a8f5b8903bdeb2abfa289c010971f67e4176) | `` Make envrc-reload call "direnv reload", not just "direnv export" ``     |
| [`45ec62dc`](https://github.com/siddharthverma314/envrc/commit/45ec62dc3703986407daedc84d94001f9c7f9973) | `` Include emacs release-snapshot in CI matrix ``                          |
| [`7fccb591`](https://github.com/siddharthverma314/envrc/commit/7fccb591d67dd27962b127d6a0e646e94345602d) | `` Use nicer character in *envrc* buffer banners ``                        |
| [`e4675871`](https://github.com/siddharthverma314/envrc/commit/e467587134f1da1904c21dd14c711828a5a6f171) | `` chore(deps): bump cachix/install-nix-action from 20 to 22 ``            |
| [`519386da`](https://github.com/siddharthverma314/envrc/commit/519386daa4d6c5f5b56053ca13182817b93165f9) | `` Add dependabot config ``                                                |
| [`14883cb8`](https://github.com/siddharthverma314/envrc/commit/14883cb88ec09c9bc406c7e9d6beef6d06ad8a18) | `` Unconditionally use bash syntax in `enrc-file-mode` ``                  |
| [`15af9608`](https://github.com/siddharthverma314/envrc/commit/15af96080772af415a56b680acdd7d2010a68ffa) | `` Bump Actions versions, slim down CI matrix ``                           |
| [`a9d8d24f`](https://github.com/siddharthverma314/envrc/commit/a9d8d24fc2128031044379f64d5ed3876a2becba) | `` Make direnv execution interruptible in a graceful way ``                |
| [`417285c4`](https://github.com/siddharthverma314/envrc/commit/417285c4e259abab8ae43e2d72b0e1110563efbc) | `` Shorten docstring to resolve bytecomp warning ``                        |
| [`fd5847c0`](https://github.com/siddharthverma314/envrc/commit/fd5847c01f6f371ccd4aeba7b6104d5ab7591ae2) | `` Use exec-path variable rather than the function ``                      |
| [`c54bf9e6`](https://github.com/siddharthverma314/envrc/commit/c54bf9e6972c563d345e20571ffd44d7bfb56974) | `` Also propagate environment for async-shell-command ``                   |
| [`2a4812d0`](https://github.com/siddharthverma314/envrc/commit/2a4812d0f315756700fffe4e864b41157dda9e5b) | `` Fix setting of PATH in eshell for Emacs 29.0.1 ``                       |
| [`0cd450ae`](https://github.com/siddharthverma314/envrc/commit/0cd450ae74af2b927db2403bc3c9b81f43c8e29b) | `` Remove defunct note from README ``                                      |
| [`08cffdcb`](https://github.com/siddharthverma314/envrc/commit/08cffdcba1bc3989cc4b42bfa32671390c464762) | `` Clarify README wording ``                                               |
| [`433df846`](https://github.com/siddharthverma314/envrc/commit/433df846529f25074955791869797ec4e929d4aa) | `` Fix other quoting issues ``                                             |
| [`437cc27b`](https://github.com/siddharthverma314/envrc/commit/437cc27b845998c5ae6201da95b2cdda90ba1376) | `` Unquote `envrc-direnv-executable` to have executable in process call `` |
| [`fb68fd24`](https://github.com/siddharthverma314/envrc/commit/fb68fd2480ec524ad8e2f3461a059fc6536efe07) | `` Use `envrc-direnv-executable` custom variable in tests ``               |
| [`ef192d2c`](https://github.com/siddharthverma314/envrc/commit/ef192d2cf812f9056723895fd8a778823d77657e) | `` In test harness, handle when envrc-debug is unset ``                    |
| [`8a73947a`](https://github.com/siddharthverma314/envrc/commit/8a73947a2b2a50b57e842f4781f4c1de0d471c29) | `` Add defcustom for envrc-direnv-executable ``                            |
| [`9b772cee`](https://github.com/siddharthverma314/envrc/commit/9b772cee4feb887210201f7e6ec4c3701321bf62) | `` envrc-file-extra-keywords: Restore use_{guix,flake,nix} ``              |
| [`c4d430e1`](https://github.com/siddharthverma314/envrc/commit/c4d430e1687ee64f3632e0bf80a78451b53151d7) | `` Add Emacs 28.2 to CI ``                                                 |
| [`936e45e4`](https://github.com/siddharthverma314/envrc/commit/936e45e4a2abec407c4823859c35c402bf863c8c) | `` add new stdlib keywords ``                                              |
| [`7f36664f`](https://github.com/siddharthverma314/envrc/commit/7f36664fc6d97a7ca77c6c3e0c6577b72fa0b70d) | `` Stop supporting Emacs 24.x ``                                           |
| [`a5c554ea`](https://github.com/siddharthverma314/envrc/commit/a5c554ea6f4eb84698cec492adeae026f2288b9e) | `` Show debug output when tests fail ``                                    |
| [`27fba214`](https://github.com/siddharthverma314/envrc/commit/27fba21478b8512c98d5ab0a29a996fd977ab2fe) | `` Revert "Enable envrc-debug while testing" ``                            |
| [`33eef328`](https://github.com/siddharthverma314/envrc/commit/33eef328b5c09c877fc850cd911edab8224c84da) | `` Disable test for .env vs .envrc file support ``                         |
| [`95c14bfb`](https://github.com/siddharthverma314/envrc/commit/95c14bfbdd4b52fca3e2cb36e88ad4a56e686d3b) | `` Enable envrc-debug while testing ``                                     |
| [`f4908a72`](https://github.com/siddharthverma314/envrc/commit/f4908a728afe2da5511fe2ace104f00207dcd47b) | `` Explicitly test that direnv is installed ``                             |
| [`afead639`](https://github.com/siddharthverma314/envrc/commit/afead63931e408b5adabad5da3ff1566106663c8) | `` Ensure direnv is installed in CI environment ``                         |
| [`addfbdc8`](https://github.com/siddharthverma314/envrc/commit/addfbdc8df83c648148be6459ed38087fda46031) | `` Add use_flake to envrc-file-extra-keywords ``                           |
| [`82675211`](https://github.com/siddharthverma314/envrc/commit/8267521147bf14fbacd51b3afcd2ef27d2f0b587) | `` makefile: remove extra --eval in make test ``                           |
| [`0f4e44d7`](https://github.com/siddharthverma314/envrc/commit/0f4e44d7f177e201b470d2870a11583eeb6e4073) | `` Force ert to exit with a non 0 errcode + errmsg in case of test fail `` |
| [`1a158045`](https://github.com/siddharthverma314/envrc/commit/1a158045d1dc23057978192675cff8ce0b4f2b23) | `` Add Emacs 28.1 to CI matrix ``                                          |
| [`57d78f01`](https://github.com/siddharthverma314/envrc/commit/57d78f0138d9c676dff182e713249ad055ccf85d) | `` Support .env files in addition to .envrc ``                             |
| [`12485e71`](https://github.com/siddharthverma314/envrc/commit/12485e71d5154b02858628fce84396ac03f95630) | `` Use cl-gensym, not gensym ``                                            |
| [`cef2061b`](https://github.com/siddharthverma314/envrc/commit/cef2061bb70797a7db6b1bc739b2dbb41ce79748) | `` Assert that global env vars can be overridden with direnv ``            |
| [`edd1cb82`](https://github.com/siddharthverma314/envrc/commit/edd1cb8262e186370ea5a26c040a055da5dd8a99) | `` Always run direnv in global env, see #33 ``                             |
| [`8cc4bbdd`](https://github.com/siddharthverma314/envrc/commit/8cc4bbdd4f25345772c7a356bd833799dc203893) | `` Show stderr output in debug buffer ``                                   |
| [`e161624b`](https://github.com/siddharthverma314/envrc/commit/e161624b9155b5d171d7f64d35531313ca1075d6) | `` Add basic test suite ``                                                 |
| [`49ae0d7f`](https://github.com/siddharthverma314/envrc/commit/49ae0d7fdbcd13094bdc684b954cd14009fb7045) | `` Remove unused functions ``                                              |
| [`456c4100`](https://github.com/siddharthverma314/envrc/commit/456c4100de41d2cb50813058a9e727b6e83c5d1e) | `` Note about troubleshooting and use of inheritenv ``                     |
| [`f0a056e6`](https://github.com/siddharthverma314/envrc/commit/f0a056e6e2f461919523ea6be54b9921a2d83e0a) | `` Also advise org-babel-eval, see #28 ``                                  |
| [`891ed146`](https://github.com/siddharthverma314/envrc/commit/891ed146099b2d8c2c207c262f483ca95ad4954c) | `` Update claims about direnv.el ``                                        |
| [`fc23f4f3`](https://github.com/siddharthverma314/envrc/commit/fc23f4f342ee100a865b50bb5bd9a54681a6387e) | `` Set indent-tabs-mode explicitly ``                                      |