### PR TITLE
chore(flake/nur): `2aeb4290` -> `89eea2ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700023110,
-        "narHash": "sha256-wXvB+5jJja0Rprhe7Lzvp1zjOGqkgJzRUFodMdmEK/Q=",
+        "lastModified": 1700026913,
+        "narHash": "sha256-tDep0ctEmsm/VCUvhjE0EaIeIArvdfnxkoTmX6Q4JD8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2aeb4290b178f401c27f279f6228a7a99b8bb304",
+        "rev": "89eea2ba1860809b7ed9e9cab9d9ac0e312f833a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`89eea2ba`](https://github.com/nix-community/NUR/commit/89eea2ba1860809b7ed9e9cab9d9ac0e312f833a) | `` automatic update `` |