### PR TITLE
chore(flake/nur): `89eea2ba` -> `74e1c12e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700026913,
-        "narHash": "sha256-tDep0ctEmsm/VCUvhjE0EaIeIArvdfnxkoTmX6Q4JD8=",
+        "lastModified": 1700034260,
+        "narHash": "sha256-O+Lyoik7gk3K9fs9ek+adbGNRIeSjTBDgCtTfHLy5KU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "89eea2ba1860809b7ed9e9cab9d9ac0e312f833a",
+        "rev": "74e1c12e705c1951936ad2a57103f0352efac4da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`74e1c12e`](https://github.com/nix-community/NUR/commit/74e1c12e705c1951936ad2a57103f0352efac4da) | `` automatic update `` |
| [`3dd061fc`](https://github.com/nix-community/NUR/commit/3dd061fccef3e2a3e764079bcebd3e275aff4c31) | `` automatic update `` |