### PR TITLE
chore(flake/nur): `74e1c12e` -> `b5580cbb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700034260,
-        "narHash": "sha256-O+Lyoik7gk3K9fs9ek+adbGNRIeSjTBDgCtTfHLy5KU=",
+        "lastModified": 1700037860,
+        "narHash": "sha256-W6aR1bSC93OBF7LQInndmIr2WgQyQJMRD2u4UNN1mck=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "74e1c12e705c1951936ad2a57103f0352efac4da",
+        "rev": "b5580cbbad96d065736670b0bd24c7994eb417dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b5580cbb`](https://github.com/nix-community/NUR/commit/b5580cbbad96d065736670b0bd24c7994eb417dd) | `` automatic update `` |