### PR TITLE
chore(flake/nur): `04cb4f53` -> `9fa0271d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700041515,
-        "narHash": "sha256-hv5i5aBEfGcv8Gzo/53ahNGHTk9ppfXVfXb7aaQoCIc=",
+        "lastModified": 1700048732,
+        "narHash": "sha256-ncnY/qA5KPSpgUV7LmhE9Gs99Kt6Z1rSn4h4P8p2rx8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "04cb4f53b1e6216ac2d89c8d9aa3d806ef0cea25",
+        "rev": "9fa0271dfd8d91e5502a11c43bec81590b7b7526",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9fa0271d`](https://github.com/nix-community/NUR/commit/9fa0271dfd8d91e5502a11c43bec81590b7b7526) | `` automatic update `` |
| [`4348c56a`](https://github.com/nix-community/NUR/commit/4348c56aac5a08a0264538f88bd846f4b7f5d7f1) | `` automatic update `` |