### PR TITLE
chore(flake/nur): `9fa0271d` -> `b5b271ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700048732,
-        "narHash": "sha256-ncnY/qA5KPSpgUV7LmhE9Gs99Kt6Z1rSn4h4P8p2rx8=",
+        "lastModified": 1700053136,
+        "narHash": "sha256-2WbtMI0f4bzMnSxnRE3V83KDICKdScLPlQp+ZQc9DCA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9fa0271dfd8d91e5502a11c43bec81590b7b7526",
+        "rev": "b5b271acce7379794ff4e3cfd920e464690ddd0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b5b271ac`](https://github.com/nix-community/NUR/commit/b5b271acce7379794ff4e3cfd920e464690ddd0e) | `` automatic update `` |