### PR TITLE
chore(flake/pre-commit-hooks): `ea758da1` -> `e558068c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -874,11 +874,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1699271226,
-        "narHash": "sha256-8Jt1KW3xTjolD6c6OjJm9USx/jmL+VVmbooADCkdDfU=",
+        "lastModified": 1700064067,
+        "narHash": "sha256-1ZWNDzhu8UlVCK7+DUN9dVQfiHX1bv6OQP9VxstY/gs=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ea758da1a6dcde6dc36db348ed690d09b9864128",
+        "rev": "e558068cba67b23b4fbc5537173dbb43748a17e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                 |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`a22a571c`](https://github.com/cachix/pre-commit-hooks.nix/commit/a22a571c4b82f0e0ca46c1f7bbbe208029ac6fb0) | `` Fix hooksPath when configured from a subdirectory `` |