### PR TITLE
chore(flake/emacs-overlay): `accc684e` -> `5356ef4e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1700039860,
-        "narHash": "sha256-khtUI3bCyjaXTviQBhd0m991Tj/GWDB6c535LdCin1I=",
+        "lastModified": 1700070109,
+        "narHash": "sha256-e0M3grWRpu0jJcOpTHstOSm4xe+TFlkpdOD8vbIluw0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "accc684eb6fceac1b504fc6bec7298263dae3f86",
+        "rev": "5356ef4e43d7829c5ac9e2a19ecaec24da9c8c63",
         "type": "github"
       },
       "original": {
@@ -693,11 +693,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1699596684,
-        "narHash": "sha256-XSXP8zjBZJBVvpNb2WmY0eW8O2ce+sVyj1T0/iBRIvg=",
+        "lastModified": 1699994397,
+        "narHash": "sha256-xxNeIcMNMXH2EA9IAX6Cny+50mvY22LhIBiGZV363gc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da4024d0ead5d7820f6bd15147d3fe2a0c0cec73",
+        "rev": "d4b5a67bbe9ef750bd2fdffd4cad400dd5553af8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`5356ef4e`](https://github.com/nix-community/emacs-overlay/commit/5356ef4e43d7829c5ac9e2a19ecaec24da9c8c63) | `` Updated repos/melpa ``  |
| [`81b4a3b4`](https://github.com/nix-community/emacs-overlay/commit/81b4a3b457be5409d85dd404ddc312d0b4e2baeb) | `` Updated repos/emacs ``  |
| [`c31a5f2a`](https://github.com/nix-community/emacs-overlay/commit/c31a5f2a131b06d703841aeaf652f5d83f2ba34a) | `` Updated repos/elpa ``   |
| [`4bd146ea`](https://github.com/nix-community/emacs-overlay/commit/4bd146eaf6f124248d4e17499a0552e321128606) | `` Updated flake inputs `` |