### PR TITLE
chore(flake/nur): `4c1e757a` -> `49a6f64d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700070307,
-        "narHash": "sha256-TCo1cSUoSD9srzFR32wZKEGAIy6vo6nBpIpx+dqGLVM=",
+        "lastModified": 1700072577,
+        "narHash": "sha256-7jriJotHLpP/3jNoPW9Xc0mDKx2lOzOcLnwUfdpa51Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4c1e757af8a089fc4be45cdfcde8f83dc5824d73",
+        "rev": "49a6f64d2b6dcba38a8fb2312315c13e3fe488f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`49a6f64d`](https://github.com/nix-community/NUR/commit/49a6f64d2b6dcba38a8fb2312315c13e3fe488f1) | `` automatic update `` |