### PR TITLE
chore(flake/srvos): `feca7b43` -> `48010180`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1007,11 +1007,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700095178,
-        "narHash": "sha256-RIo5vjRbOe4rJJp5t6rof2gTDMAH6UlPZ5WdZi25uRs=",
+        "lastModified": 1700099573,
+        "narHash": "sha256-4zjIWPenAMaBlZnCaQvnBdMyWDX/mTgT2fe+CVFajW8=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "feca7b4382f2f575d304cf88493181376417a5c9",
+        "rev": "48010180015cbda0b6cacf4555fcdd360054158d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------ |
| [`48010180`](https://github.com/nix-community/srvos/commit/48010180015cbda0b6cacf4555fcdd360054158d) | `` flake.lock: Update `` |