### PR TITLE
chore(flake/emacs-overlay): `5356ef4e` -> `4dfcfe37`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1700070109,
-        "narHash": "sha256-e0M3grWRpu0jJcOpTHstOSm4xe+TFlkpdOD8vbIluw0=",
+        "lastModified": 1700101333,
+        "narHash": "sha256-1X24GUfS5g0JA3CZl65G/gkgXxifYFPngK2jynHcN/U=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5356ef4e43d7829c5ac9e2a19ecaec24da9c8c63",
+        "rev": "4dfcfe37911921337dbe66ca0dac24c393f6beee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4dfcfe37`](https://github.com/nix-community/emacs-overlay/commit/4dfcfe37911921337dbe66ca0dac24c393f6beee) | `` Updated repos/nongnu `` |
| [`ce7bfa6c`](https://github.com/nix-community/emacs-overlay/commit/ce7bfa6c89c1ea73a57983c5f17b41f919085826) | `` Updated repos/melpa ``  |
| [`2349c8b8`](https://github.com/nix-community/emacs-overlay/commit/2349c8b85056fd1a64a5a7038e0391a944f6e25b) | `` Updated repos/emacs ``  |
| [`6391a4dd`](https://github.com/nix-community/emacs-overlay/commit/6391a4dd8c1a269dc84829c20abf7389cb90717b) | `` Updated repos/elpa ``   |