### PR TITLE
chore(flake/nur): `54a5a291` -> `8e10481a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700102765,
-        "narHash": "sha256-i137FErvaLGj6L9LSW9sP/K59Nm4lQc/piDPv/gM3ek=",
+        "lastModified": 1700109580,
+        "narHash": "sha256-rsruiP/uLuQcmmkjtBJAAfnplETAqAcW6bEOaZ3RjS0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "54a5a2916f1224c6847fd1bbd60867407988e577",
+        "rev": "8e10481ac96459cb427b855fdb4e6180c92edb4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8e10481a`](https://github.com/nix-community/NUR/commit/8e10481ac96459cb427b855fdb4e6180c92edb4b) | `` automatic update `` |
| [`1e555523`](https://github.com/nix-community/NUR/commit/1e55552384b6371c5a159c50cb5ddfa1702f3e41) | `` automatic update `` |
| [`34784a44`](https://github.com/nix-community/NUR/commit/34784a44a169425129cce75a00dc27edf0adf7e3) | `` automatic update `` |
| [`6631b64e`](https://github.com/nix-community/NUR/commit/6631b64eaf2ac16d9db5a4a29bc06848a36fd7df) | `` automatic update `` |
| [`3f16cbb1`](https://github.com/nix-community/NUR/commit/3f16cbb1503d5c1273e218f964dd644e8aa3e054) | `` automatic update `` |