### PR TITLE
chore(flake/nur): `8e10481a` -> `3dccf86d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700109580,
-        "narHash": "sha256-rsruiP/uLuQcmmkjtBJAAfnplETAqAcW6bEOaZ3RjS0=",
+        "lastModified": 1700113229,
+        "narHash": "sha256-wM/YjXv7m2vwTI2Um9eurJS1Qw+bOyKP2zAY1E4i5Y0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8e10481ac96459cb427b855fdb4e6180c92edb4b",
+        "rev": "3dccf86d195f8e164fdd19f336a11d0a98aac5c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3dccf86d`](https://github.com/nix-community/NUR/commit/3dccf86d195f8e164fdd19f336a11d0a98aac5c6) | `` automatic update `` |