### PR TITLE
chore(flake/nur): `3dccf86d` -> `44a069ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700113229,
-        "narHash": "sha256-wM/YjXv7m2vwTI2Um9eurJS1Qw+bOyKP2zAY1E4i5Y0=",
+        "lastModified": 1700117147,
+        "narHash": "sha256-yiFRF451tHsfUjcD8WzFQBGNm/1mKfWxHF/1jEU8HBU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3dccf86d195f8e164fdd19f336a11d0a98aac5c6",
+        "rev": "44a069ef0a65f2c0799362de993f4f0bdf6f6b5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`44a069ef`](https://github.com/nix-community/NUR/commit/44a069ef0a65f2c0799362de993f4f0bdf6f6b5d) | `` automatic update `` |