### PR TITLE
chore(flake/nur): `44a069ef` -> `143e0047`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700117147,
-        "narHash": "sha256-yiFRF451tHsfUjcD8WzFQBGNm/1mKfWxHF/1jEU8HBU=",
+        "lastModified": 1700120697,
+        "narHash": "sha256-tHu33Zyvi7oUnm3LQaX5YkAMYHCmQ1P+B6HBMBvZ7iI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "44a069ef0a65f2c0799362de993f4f0bdf6f6b5d",
+        "rev": "143e00473a3625bf9e49c53c477d75fdc5b62684",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`143e0047`](https://github.com/nix-community/NUR/commit/143e00473a3625bf9e49c53c477d75fdc5b62684) | `` automatic update `` |