### PR TITLE
chore(flake/emacs-overlay): `4dfcfe37` -> `cd979f7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1700101333,
-        "narHash": "sha256-1X24GUfS5g0JA3CZl65G/gkgXxifYFPngK2jynHcN/U=",
+        "lastModified": 1700127556,
+        "narHash": "sha256-R0R9WikfBi0Tc/Bloyg6h2quy6FBZCYCDSLVCjXILFY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4dfcfe37911921337dbe66ca0dac24c393f6beee",
+        "rev": "cd979f7df596efe5f2c832a9309da59df07edba8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`cd979f7d`](https://github.com/nix-community/emacs-overlay/commit/cd979f7df596efe5f2c832a9309da59df07edba8) | `` Updated repos/melpa `` |
| [`8bc596fb`](https://github.com/nix-community/emacs-overlay/commit/8bc596fb2d0723b9bc53468faaa38b23cb8b1949) | `` Updated repos/emacs `` |