### PR TITLE
chore(flake/nur): `143e0047` -> `7cf29aef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700120697,
-        "narHash": "sha256-tHu33Zyvi7oUnm3LQaX5YkAMYHCmQ1P+B6HBMBvZ7iI=",
+        "lastModified": 1700127871,
+        "narHash": "sha256-Vc+CZ/Ev/MhzYdKGIX/qp8GGiKfztvfL6bJZSW2m6zE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "143e00473a3625bf9e49c53c477d75fdc5b62684",
+        "rev": "7cf29aef2e074a1ad6c12a196f3e4a140837f33f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7cf29aef`](https://github.com/nix-community/NUR/commit/7cf29aef2e074a1ad6c12a196f3e4a140837f33f) | `` automatic update `` |