### PR TITLE
chore(flake/nur): `7cf29aef` -> `11299b3a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700127871,
-        "narHash": "sha256-Vc+CZ/Ev/MhzYdKGIX/qp8GGiKfztvfL6bJZSW2m6zE=",
+        "lastModified": 1700142333,
+        "narHash": "sha256-Mu0TH+JqVLCeEu2RFFnkTHluHmPc9FY7+vl4bW+EO6Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7cf29aef2e074a1ad6c12a196f3e4a140837f33f",
+        "rev": "11299b3ab33b7a5128031263b8a70e94ae47b671",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`11299b3a`](https://github.com/nix-community/NUR/commit/11299b3ab33b7a5128031263b8a70e94ae47b671) | `` automatic update `` |