### PR TITLE
chore(flake/nix-fast-build): `77c76498` -> `96805caf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -548,11 +548,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1699459690,
-        "narHash": "sha256-0qS0X7KaQ6fjNG3UexNFK1Up9esZEGjevVHHbxjuk9E=",
+        "lastModified": 1700146408,
+        "narHash": "sha256-T9hcGGGQv1Br9sm7oaEMs2OCDEBro5IU2i/dpTKSrQ4=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "77c764981a9738aadb55b80e3e0891e6f2572477",
+        "rev": "96805cafb2bc678ce15eda386989f9e79b28868b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                      |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`96805caf`](https://github.com/Mic92/nix-fast-build/commit/96805cafb2bc678ce15eda386989f9e79b28868b) | `` nix-fast-build: fix typo ``                                                               |
| [`3903f1d5`](https://github.com/Mic92/nix-fast-build/commit/3903f1d5b648c19bc1bbbfe4dc06eb965dc1a2cf) | `` increase large buffer for large lines ``                                                  |
| [`96944ce9`](https://github.com/Mic92/nix-fast-build/commit/96944ce9b357208726360aac51ecdf5153e15b3f) | `` QueueWithContext: only call task_done if we successfully retrieved an element ``          |
| [`f3d465c9`](https://github.com/Mic92/nix-fast-build/commit/f3d465c96b13fe93d5a22798a83062c7bd6a088e) | `` fix more process.kill race conditions ``                                                  |
| [`47256ffc`](https://github.com/Mic92/nix-fast-build/commit/47256ffcdc942fb4eb444717379394b068f73839) | `` fix race condition when nix-eval-jobs already terminated after timeout but before kill `` |