### PR TITLE
chore(flake/nur): `11299b3a` -> `16e5e9c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700142333,
-        "narHash": "sha256-Mu0TH+JqVLCeEu2RFFnkTHluHmPc9FY7+vl4bW+EO6Y=",
+        "lastModified": 1700146378,
+        "narHash": "sha256-v3k6dWEYxP30ecjLJMWIXnUzZmhLm3WkZbI7p7/NvZc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "11299b3ab33b7a5128031263b8a70e94ae47b671",
+        "rev": "16e5e9c9d0d6a443eb69d627d2934e12fc2d2d2b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`16e5e9c9`](https://github.com/nix-community/NUR/commit/16e5e9c9d0d6a443eb69d627d2934e12fc2d2d2b) | `` automatic update `` |
| [`78f478eb`](https://github.com/nix-community/NUR/commit/78f478eb0e74663561f787ed9fed46f9b45ac987) | `` automatic update `` |