### PR TITLE
chore(flake/nur): `16e5e9c9` -> `f20bb778`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700146378,
-        "narHash": "sha256-v3k6dWEYxP30ecjLJMWIXnUzZmhLm3WkZbI7p7/NvZc=",
+        "lastModified": 1700152588,
+        "narHash": "sha256-TsKkTU3ESgw6A5ZOCKM+OdK1myXbW0w2wu1i9Nbacs8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "16e5e9c9d0d6a443eb69d627d2934e12fc2d2d2b",
+        "rev": "f20bb77807abae26832480b82199eef67ac81485",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f20bb778`](https://github.com/nix-community/NUR/commit/f20bb77807abae26832480b82199eef67ac81485) | `` automatic update `` |