### PR TITLE
chore(flake/emacs-overlay): `cd979f7d` -> `94a0f967`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1700127556,
-        "narHash": "sha256-R0R9WikfBi0Tc/Bloyg6h2quy6FBZCYCDSLVCjXILFY=",
+        "lastModified": 1700156459,
+        "narHash": "sha256-NkEcyi6qqaYBqeBbV6Y8aOSuhnX23mM/XJ413Nw8cDM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cd979f7df596efe5f2c832a9309da59df07edba8",
+        "rev": "94a0f967876bbb4b42292026d2c776cade605589",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`94a0f967`](https://github.com/nix-community/emacs-overlay/commit/94a0f967876bbb4b42292026d2c776cade605589) | `` Updated repos/melpa `` |
| [`5b38149b`](https://github.com/nix-community/emacs-overlay/commit/5b38149b09cd069163666ce106df0b6445ad579e) | `` Updated repos/emacs `` |
| [`e211eb49`](https://github.com/nix-community/emacs-overlay/commit/e211eb490496327b1af04a1466d457964a089df9) | `` Updated repos/elpa ``  |