### PR TITLE
chore(flake/nur): `f0a59b43` -> `1b0a621e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700155100,
-        "narHash": "sha256-Aod0fylWCnnk24q4/W+TgudcZ1HX5VShZ87ChmIr7WA=",
+        "lastModified": 1700163942,
+        "narHash": "sha256-77nGw+TS7jAuLZ/SA7+AQXgTXj0XRRkdD2QqkuA+D0g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f0a59b437b4331ad543404ff1ef5d590e4a1bfb2",
+        "rev": "1b0a621ebc9ffc44f25b8336e32147fb171216a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1b0a621e`](https://github.com/nix-community/NUR/commit/1b0a621ebc9ffc44f25b8336e32147fb171216a5) | `` automatic update `` |