### PR TITLE
chore(flake/nur): `1b0a621e` -> `04d24fb0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700163942,
-        "narHash": "sha256-77nGw+TS7jAuLZ/SA7+AQXgTXj0XRRkdD2QqkuA+D0g=",
+        "lastModified": 1700166954,
+        "narHash": "sha256-f9+JUFDUzwmM+em8wqWgHvgTO4qCCYtKPUZ+nlVIirA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1b0a621ebc9ffc44f25b8336e32147fb171216a5",
+        "rev": "04d24fb0e6258af7bbe51b29308e670de81a7d2f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`04d24fb0`](https://github.com/nix-community/NUR/commit/04d24fb0e6258af7bbe51b29308e670de81a7d2f) | `` automatic update `` |