### PR TITLE
chore(flake/home-manager): `ab1459a1` -> `c1a03312`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700087144,
-        "narHash": "sha256-LJP1RW0hKNWmv2yRhnjkUptMXInKpn/rV6V6ofuZkHU=",
+        "lastModified": 1700118404,
+        "narHash": "sha256-XkqpZpVoy1FV7UbiLkP+fQxxv/6KnwLYkFEHgE8z2IQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ab1459a1fb646c40419c732d05ec0bf2416d4506",
+        "rev": "c1a033122df8a3c74fda3780c83a104a7d60873c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`c1a03312`](https://github.com/nix-community/home-manager/commit/c1a033122df8a3c74fda3780c83a104a7d60873c) | `` Translate using Weblate (French) ``  |
| [`18ce0de4`](https://github.com/nix-community/home-manager/commit/18ce0de460a6f291926fd4ca03f2df9b0a291c6f) | `` Translate using Weblate (Turkish) `` |
| [`f6c1a4f2`](https://github.com/nix-community/home-manager/commit/f6c1a4f23b99543270c1319500d3eefcd731586d) | `` Translate using Weblate (Italian) `` |