### PR TITLE
chore(flake/nur): `c4030da6` -> `d4bcfd77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700175621,
-        "narHash": "sha256-sj3N9y+afXMB1z0LQf+SCdNOB15Qolew+5osctuusmA=",
+        "lastModified": 1700176706,
+        "narHash": "sha256-wdaElcSzx3gSTyjFJ1AZ8bJYl12Pdpo99YEqbO77QwI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c4030da6892c521da5c4f6f31006ddf97ee63d8b",
+        "rev": "d4bcfd77f1fd82b603935b36466fca58a12b18a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d4bcfd77`](https://github.com/nix-community/NUR/commit/d4bcfd77f1fd82b603935b36466fca58a12b18a0) | `` automatic update `` |