### PR TITLE
chore(flake/nur): `d4bcfd77` -> `d76c6e4d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700176706,
-        "narHash": "sha256-wdaElcSzx3gSTyjFJ1AZ8bJYl12Pdpo99YEqbO77QwI=",
+        "lastModified": 1700183050,
+        "narHash": "sha256-sf10J/I0xdSVzufCq4r/Ad94yDNhecKKB/Lc7PyA+aI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d4bcfd77f1fd82b603935b36466fca58a12b18a0",
+        "rev": "d76c6e4d1870d551f54f47045966f685e0249053",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d76c6e4d`](https://github.com/nix-community/NUR/commit/d76c6e4d1870d551f54f47045966f685e0249053) | `` automatic update `` |