### PR TITLE
chore(flake/emacs-overlay): `94a0f967` -> `cc0ff3db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1700156459,
-        "narHash": "sha256-NkEcyi6qqaYBqeBbV6Y8aOSuhnX23mM/XJ413Nw8cDM=",
+        "lastModified": 1700187611,
+        "narHash": "sha256-JElnXwyhonblsjvOvKvpixk+APihZ8sHyQHhBR/M7SQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "94a0f967876bbb4b42292026d2c776cade605589",
+        "rev": "cc0ff3db579aa280610a5400c0d9a389281d093e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`cc0ff3db`](https://github.com/nix-community/emacs-overlay/commit/cc0ff3db579aa280610a5400c0d9a389281d093e) | `` Updated repos/nongnu `` |
| [`4b4cdad6`](https://github.com/nix-community/emacs-overlay/commit/4b4cdad6d7ca394d228b104177cf9ee6e977d45e) | `` Updated repos/melpa ``  |
| [`47e326ed`](https://github.com/nix-community/emacs-overlay/commit/47e326ed0f913e12ff7e06a8b51578a89ca6ae44) | `` Updated repos/emacs ``  |
| [`aff8c63e`](https://github.com/nix-community/emacs-overlay/commit/aff8c63e9377c97dd8642997914f87422e90a4c6) | `` Updated repos/elpa ``   |
| [`aa60bde0`](https://github.com/nix-community/emacs-overlay/commit/aa60bde03afeaffa88c92d09d5d93a5e88938b52) | `` Updated flake inputs `` |