### PR TITLE
chore(flake/nur): `d76c6e4d` -> `53d8bbdc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700183050,
-        "narHash": "sha256-sf10J/I0xdSVzufCq4r/Ad94yDNhecKKB/Lc7PyA+aI=",
+        "lastModified": 1700189839,
+        "narHash": "sha256-hPXzEkUzliKDYLi73w6yRtiSpxcYFp4WKlK2Dx0osfY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d76c6e4d1870d551f54f47045966f685e0249053",
+        "rev": "53d8bbdc834de7bc80a10a47855d36966f910500",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`53d8bbdc`](https://github.com/nix-community/NUR/commit/53d8bbdc834de7bc80a10a47855d36966f910500) | `` automatic update `` |