### PR TITLE
chore(flake/nur): `53d8bbdc` -> `6f197be0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700189839,
-        "narHash": "sha256-hPXzEkUzliKDYLi73w6yRtiSpxcYFp4WKlK2Dx0osfY=",
+        "lastModified": 1700192437,
+        "narHash": "sha256-uu17XUYM5zZZh3r2dRJ4PZHDzsS8Bn5pAig6Xk2/GDw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "53d8bbdc834de7bc80a10a47855d36966f910500",
+        "rev": "6f197be0058315c21d8181e7e7ccccc741adbf71",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6f197be0`](https://github.com/nix-community/NUR/commit/6f197be0058315c21d8181e7e7ccccc741adbf71) | `` automatic update `` |
| [`ce389bbb`](https://github.com/nix-community/NUR/commit/ce389bbb27fe0b3613de4ed459e6203add66e98a) | `` automatic update `` |