### PR TITLE
chore(flake/nur): `6f197be0` -> `7300a85e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700192437,
-        "narHash": "sha256-uu17XUYM5zZZh3r2dRJ4PZHDzsS8Bn5pAig6Xk2/GDw=",
+        "lastModified": 1700199772,
+        "narHash": "sha256-jE6yHsiSlGLc6bcC18wSbynvzskRV1DylThM+qbKmCE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6f197be0058315c21d8181e7e7ccccc741adbf71",
+        "rev": "7300a85ee2f77ad0e65e461835f4fcb39daeb0bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7300a85e`](https://github.com/nix-community/NUR/commit/7300a85ee2f77ad0e65e461835f4fcb39daeb0bf) | `` automatic update `` |
| [`27c1c2fc`](https://github.com/nix-community/NUR/commit/27c1c2fcbc1f7bc0222c049a1455e2f07096241b) | `` automatic update `` |