### PR TITLE
chore(flake/nur): `c91db15c` -> `fde73434`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700207286,
-        "narHash": "sha256-MsdfNbDhvHMqd9+jAfo75moUyE4TkcBfkNoQ0DizV1Y=",
+        "lastModified": 1700208696,
+        "narHash": "sha256-9qSCx1Yqnt+vhSZ+BedawJrmOIHPH4mmPyc+NBL+w5k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c91db15cd437f4c9e0a03665197b469eb274a2ee",
+        "rev": "fde73434ccf36dcac1f3300f892ece3485d2ece7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fde73434`](https://github.com/nix-community/NUR/commit/fde73434ccf36dcac1f3300f892ece3485d2ece7) | `` automatic update `` |