### PR TITLE
chore(flake/emacs-overlay): `cc0ff3db` -> `80f73d68`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1700187611,
-        "narHash": "sha256-JElnXwyhonblsjvOvKvpixk+APihZ8sHyQHhBR/M7SQ=",
+        "lastModified": 1700213955,
+        "narHash": "sha256-9hqsWiMKXI3TTLdbZc/RC/6HXv5AbGwV7b1X/G2vw9o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cc0ff3db579aa280610a5400c0d9a389281d093e",
+        "rev": "80f73d6844f13f9be025d96cab116126349339f8",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1699994397,
-        "narHash": "sha256-xxNeIcMNMXH2EA9IAX6Cny+50mvY22LhIBiGZV363gc=",
+        "lastModified": 1700097215,
+        "narHash": "sha256-ODQ3gBTv1iHd7lG21H+ErVISB5wVeOhd/dEogOqHs/I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d4b5a67bbe9ef750bd2fdffd4cad400dd5553af8",
+        "rev": "9fb122519e9cd465d532f736a98c1e1eb541ef6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`80f73d68`](https://github.com/nix-community/emacs-overlay/commit/80f73d6844f13f9be025d96cab116126349339f8) | `` Updated repos/melpa ``  |
| [`6548dfc7`](https://github.com/nix-community/emacs-overlay/commit/6548dfc7daa4057fd345ae5ed8801ad0bc2b96e6) | `` Updated repos/emacs ``  |
| [`64026aa4`](https://github.com/nix-community/emacs-overlay/commit/64026aa44893fa270730471a9dff263e3795c1ea) | `` Updated flake inputs `` |