### PR TITLE
chore(flake/nur): `979cb01e` -> `26281a3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700214441,
-        "narHash": "sha256-XxlEZnScK5p4rwH8JE7pnMWUwx2TeMPTpgIDmPAFpSw=",
+        "lastModified": 1700221664,
+        "narHash": "sha256-tjQ9qZTNkckFhoTDCzjrw2VAMHnlthTXZR9w2AYi6os=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "979cb01e94dd8312cfad34275a6c1a6deace2382",
+        "rev": "26281a3db7f6552a22a00e28a0b5099ae83b6c12",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`26281a3d`](https://github.com/nix-community/NUR/commit/26281a3db7f6552a22a00e28a0b5099ae83b6c12) | `` automatic update `` |