### PR TITLE
chore(flake/nur): `26281a3d` -> `f0d5432e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700221664,
-        "narHash": "sha256-tjQ9qZTNkckFhoTDCzjrw2VAMHnlthTXZR9w2AYi6os=",
+        "lastModified": 1700224867,
+        "narHash": "sha256-dzXfPpSoWoCJhzybYjXf96X0BmLZ/caHWZtF4zODNUI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "26281a3db7f6552a22a00e28a0b5099ae83b6c12",
+        "rev": "f0d5432e121a587e78dedb4cf096993775a9a5bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f0d5432e`](https://github.com/nix-community/NUR/commit/f0d5432e121a587e78dedb4cf096993775a9a5bf) | `` automatic update `` |