### PR TITLE
chore(flake/nur): `dbd59102` -> `1b3c8c37`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700232815,
-        "narHash": "sha256-RT0KxFWMRAC/4XmTL81ZTa7GcD7XkWesz0HjPUaBqKw=",
+        "lastModified": 1700236091,
+        "narHash": "sha256-AMDjeSR9UaSZz1WXcBTxVO0rA/ZAuPJkcP4tby0heHE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dbd591020c5c846e0552860c3c8bd9673f66ec04",
+        "rev": "1b3c8c37ae17e5e8f42ac2a8c817c31eaf113e1d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1b3c8c37`](https://github.com/nix-community/NUR/commit/1b3c8c37ae17e5e8f42ac2a8c817c31eaf113e1d) | `` automatic update `` |