### PR TITLE
chore(flake/nur): `1b3c8c37` -> `443f5476`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700236091,
-        "narHash": "sha256-AMDjeSR9UaSZz1WXcBTxVO0rA/ZAuPJkcP4tby0heHE=",
+        "lastModified": 1700243801,
+        "narHash": "sha256-6SLmyUcvOLYX5X/p/whxHsvgJ9IOTk+cksGfhIBP2N8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1b3c8c37ae17e5e8f42ac2a8c817c31eaf113e1d",
+        "rev": "443f5476d046f5431a47f024c40d7b46a1241f99",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                               |
| -------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`443f5476`](https://github.com/nix-community/NUR/commit/443f5476d046f5431a47f024c40d7b46a1241f99) | `` add Samuel-Martineau repository `` |
| [`cd8feb18`](https://github.com/nix-community/NUR/commit/cd8feb182056c9cacfd86712b5e559aa2e2adec8) | `` automatic update ``                |