### PR TITLE
chore(flake/nur): `443f5476` -> `af2b856e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700243801,
-        "narHash": "sha256-6SLmyUcvOLYX5X/p/whxHsvgJ9IOTk+cksGfhIBP2N8=",
+        "lastModified": 1700246751,
+        "narHash": "sha256-xXo58VUg5YmCoeuDihTM0HGmSfv3vrM24oBL47fSy8Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "443f5476d046f5431a47f024c40d7b46a1241f99",
+        "rev": "af2b856e79fe606ab789fa10e2278b96ec5b87c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`af2b856e`](https://github.com/nix-community/NUR/commit/af2b856e79fe606ab789fa10e2278b96ec5b87c0) | `` automatic update `` |
| [`e4e8705d`](https://github.com/nix-community/NUR/commit/e4e8705d4716d0609c25225676bfccd36ae5a99a) | `` automatic update `` |