### PR TITLE
chore(flake/nur): `af2b856e` -> `a55ba997`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700246751,
-        "narHash": "sha256-xXo58VUg5YmCoeuDihTM0HGmSfv3vrM24oBL47fSy8Y=",
+        "lastModified": 1700251368,
+        "narHash": "sha256-tQ5g4/0FjR55k5I/YkauHGFNgT2j/ioi0vt8RtypZCo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "af2b856e79fe606ab789fa10e2278b96ec5b87c0",
+        "rev": "a55ba997f3085181d888e08a420cf33ba4e2d744",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a55ba997`](https://github.com/nix-community/NUR/commit/a55ba997f3085181d888e08a420cf33ba4e2d744) | `` automatic update `` |