### PR TITLE
chore(flake/nur): `a55ba997` -> `898d9bac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700251368,
-        "narHash": "sha256-tQ5g4/0FjR55k5I/YkauHGFNgT2j/ioi0vt8RtypZCo=",
+        "lastModified": 1700257494,
+        "narHash": "sha256-+4jwpP5GGeEM2hbUgRFfpfWjBgxPnuGvgG12XzZ5Iwc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a55ba997f3085181d888e08a420cf33ba4e2d744",
+        "rev": "898d9bac94ce894e9c50601dbe0360fd7aaa7b21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`898d9bac`](https://github.com/nix-community/NUR/commit/898d9bac94ce894e9c50601dbe0360fd7aaa7b21) | `` automatic update `` |