### PR TITLE
chore(flake/nur): `223bab8a` -> `4d3a6dac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700264658,
-        "narHash": "sha256-TCZtOIAw1q6atxZTjVooxJRb/LDQIPI8qbpo4XqnjHk=",
+        "lastModified": 1700269456,
+        "narHash": "sha256-TUJx5Ru7jplgMT8H7F3imXbgpI/ngicNTa1iGLUY1Gc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "223bab8a08ffe19c5760807e6c93ccaa51ca5dac",
+        "rev": "4d3a6dacda5e893cfe90dd16bb2a77ad30520ed2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4d3a6dac`](https://github.com/nix-community/NUR/commit/4d3a6dacda5e893cfe90dd16bb2a77ad30520ed2) | `` automatic update `` |