### PR TITLE
chore(flake/emacs-overlay): `dc657642` -> `afe0c253`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1700240115,
-        "narHash": "sha256-zdCu7VHHD6Qs81XZMpzlgzUXe1MORAFkpYFQ1Uo8cS0=",
+        "lastModified": 1700274000,
+        "narHash": "sha256-oLAYuELjHByXzvvY5+Jsy5ASL1SSQ/1EgRaAfmU1VN4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dc6576424d581145d8f9601974f39a979a1a4e7b",
+        "rev": "afe0c2530f88b7a42f6a02fa5ac511892dab13b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`afe0c253`](https://github.com/nix-community/emacs-overlay/commit/afe0c2530f88b7a42f6a02fa5ac511892dab13b3) | `` Updated repos/melpa `` |
| [`c8fca3f6`](https://github.com/nix-community/emacs-overlay/commit/c8fca3f6aea811a21964939963acaecb2f86b4c4) | `` Updated repos/emacs `` |
| [`bf1df2c2`](https://github.com/nix-community/emacs-overlay/commit/bf1df2c2f61d240286086c713b9b161a41a02dad) | `` Updated repos/elpa ``  |