### PR TITLE
chore(flake/nur): `4d3a6dac` -> `31a35829`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700269456,
-        "narHash": "sha256-TUJx5Ru7jplgMT8H7F3imXbgpI/ngicNTa1iGLUY1Gc=",
+        "lastModified": 1700286054,
+        "narHash": "sha256-Jpz4XOdlXPl3OtX64z8hYx8oOKkTBEL4NLNhEGYAP5Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4d3a6dacda5e893cfe90dd16bb2a77ad30520ed2",
+        "rev": "31a35829b8c7094b65abc7e3d7f11e556605d31d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`31a35829`](https://github.com/nix-community/NUR/commit/31a35829b8c7094b65abc7e3d7f11e556605d31d) | `` automatic update `` |
| [`6f85ec04`](https://github.com/nix-community/NUR/commit/6f85ec04339f4f7d639f4d0e89debaba25b0f8a1) | `` automatic update `` |
| [`b35beeab`](https://github.com/nix-community/NUR/commit/b35beeabb9cd6d2220f40a495079809f05d9e43e) | `` automatic update `` |
| [`7a58cacb`](https://github.com/nix-community/NUR/commit/7a58cacbdd76d4aedce2776c13b49241bf41d27c) | `` automatic update `` |
| [`498f1003`](https://github.com/nix-community/NUR/commit/498f10036e90ea35ba501dabf92cb68b369c98bf) | `` automatic update `` |
| [`b0d2f53e`](https://github.com/nix-community/NUR/commit/b0d2f53e1ef89e98758732a6ef7d24644d45a4b7) | `` automatic update `` |