### PR TITLE
chore(flake/nur): `31a35829` -> `8f01ffd1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700286054,
-        "narHash": "sha256-Jpz4XOdlXPl3OtX64z8hYx8oOKkTBEL4NLNhEGYAP5Y=",
+        "lastModified": 1700294221,
+        "narHash": "sha256-Oy7W4Ix60yCAsCJTkMm61OEG7Xn8U7U1pNRWpohclh0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "31a35829b8c7094b65abc7e3d7f11e556605d31d",
+        "rev": "8f01ffd1c26e833e56a4fde3321215b179d0e488",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8f01ffd1`](https://github.com/nix-community/NUR/commit/8f01ffd1c26e833e56a4fde3321215b179d0e488) | `` automatic update `` |