### PR TITLE
chore(flake/emacs-overlay): `afe0c253` -> `a163b433`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1700274000,
-        "narHash": "sha256-oLAYuELjHByXzvvY5+Jsy5ASL1SSQ/1EgRaAfmU1VN4=",
+        "lastModified": 1700300278,
+        "narHash": "sha256-kiC0UziADqkBSst4GhkJEp54wrD0Hcxm/zQrOICBJ0k=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "afe0c2530f88b7a42f6a02fa5ac511892dab13b3",
+        "rev": "a163b43334a82ef433d8e11c1be767afd3ac0226",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`a163b433`](https://github.com/nix-community/emacs-overlay/commit/a163b43334a82ef433d8e11c1be767afd3ac0226) | `` Updated repos/melpa `` |
| [`e7fc10e8`](https://github.com/nix-community/emacs-overlay/commit/e7fc10e85984b4e14f371caf91a5e59819a5f4aa) | `` Updated repos/emacs `` |