### PR TITLE
chore(flake/stylix): `5c6f7fd7` -> `a15c3196`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1041,11 +1041,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699477454,
-        "narHash": "sha256-PueVBJDRM+q/ONSwMptLH4i6cny7BnNcuBpjI2e5rYo=",
+        "lastModified": 1700302760,
+        "narHash": "sha256-JpOJf9Nj260rTrVuYonP9CiGzj+43AGPOfhF72XkQvU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "5c6f7fd709be441505998fc51a25b645a44d359e",
+        "rev": "a15c3196c1d620c18cbee8229092598384a89fef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                |
| --------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`a15c3196`](https://github.com/danth/stylix/commit/a15c3196c1d620c18cbee8229092598384a89fef) | `` Fix default cursor in X11 (#189) `` |