### PR TITLE
chore(flake/nur): `96cf61d6` -> `80c77775`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700306951,
-        "narHash": "sha256-WemXLeS3PXOEyT8swDCcPXlgSro3unTBjMmR37jEW9s=",
+        "lastModified": 1700326167,
+        "narHash": "sha256-3QgtSmCuiD1G30z2PCQoa90RWP+twF8VAH+I0GLYdfQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "96cf61d637bfc709f50e34b3eaf543df0fb23126",
+        "rev": "80c7777582e50c12f074eda40c3500d9749bf9a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`80c77775`](https://github.com/nix-community/NUR/commit/80c7777582e50c12f074eda40c3500d9749bf9a2) | `` automatic update `` |
| [`96ba76ae`](https://github.com/nix-community/NUR/commit/96ba76ae235d4fd57921f49449f47313e15a365e) | `` automatic update `` |