### PR TITLE
chore(flake/nur): `3a84b46a` -> `54e3e8b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700329523,
-        "narHash": "sha256-Uw8eUG/zdRB9lQbk1DUi9hOG2BVGCfPhuomQCZ+IgRc=",
+        "lastModified": 1700336675,
+        "narHash": "sha256-hWabdq/AFfXpExFtZI5/Jlp+DafWobCK6MAoi62EEgo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3a84b46a853a1cf7aab96719ab8b45efd3c4f572",
+        "rev": "54e3e8b1f17c3978d1213a9a63129c230b8c5e72",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`54e3e8b1`](https://github.com/nix-community/NUR/commit/54e3e8b1f17c3978d1213a9a63129c230b8c5e72) | `` automatic update `` |