### PR TITLE
chore(flake/nur): `54e3e8b1` -> `3ab28490`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700336675,
-        "narHash": "sha256-hWabdq/AFfXpExFtZI5/Jlp+DafWobCK6MAoi62EEgo=",
+        "lastModified": 1700340326,
+        "narHash": "sha256-Psn/12HSYb9sEMxY2qy7zseCdN4S+5MXTWfrpFHbdW8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "54e3e8b1f17c3978d1213a9a63129c230b8c5e72",
+        "rev": "3ab284900b9e3920b93c5a205390635c4938c576",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3ab28490`](https://github.com/nix-community/NUR/commit/3ab284900b9e3920b93c5a205390635c4938c576) | `` automatic update `` |