### PR TITLE
chore(flake/nur): `ce4bf2a6` -> `4ad11f38`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700347453,
-        "narHash": "sha256-T/a9YAJczC8wfpAQJ7GKI9+WB/s0wfezmMZqxaY9+zc=",
+        "lastModified": 1700355786,
+        "narHash": "sha256-8eJjpNIR1fpOtYyDgBSkC8Nimq+pMS2xQC6MN76Dayc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ce4bf2a6f08aea6c6824cffd7f511058764d83ab",
+        "rev": "4ad11f3822613a7162a3cc7133f77864f5db7d70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4ad11f38`](https://github.com/nix-community/NUR/commit/4ad11f3822613a7162a3cc7133f77864f5db7d70) | `` automatic update `` |