### PR TITLE
chore(flake/nur): `4ad11f38` -> `54886e86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700355786,
-        "narHash": "sha256-8eJjpNIR1fpOtYyDgBSkC8Nimq+pMS2xQC6MN76Dayc=",
+        "lastModified": 1700359574,
+        "narHash": "sha256-zLmuj7erfDHnBDw3cEUzKnj19KVFb/MZ4i017F9z5DY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ad11f3822613a7162a3cc7133f77864f5db7d70",
+        "rev": "54886e860ee709d2be4289eb122502b0de20d44a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`54886e86`](https://github.com/nix-community/NUR/commit/54886e860ee709d2be4289eb122502b0de20d44a) | `` automatic update `` |
| [`c3b0e86a`](https://github.com/nix-community/NUR/commit/c3b0e86a2e294a84565d190130ac404b00cb491a) | `` automatic update `` |
| [`c0391def`](https://github.com/nix-community/NUR/commit/c0391def147dc9908b19a0f3b2bd18e5fdd3c153) | `` automatic update `` |