### PR TITLE
chore(flake/nix-index-database): `8aff4ca3` -> `cabd674e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -607,11 +607,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699760693,
-        "narHash": "sha256-u/gkNUHQR/q23voqE5J4xmEWQIAqR+g3lUnCtzn0k7Y=",
+        "lastModified": 1700362638,
+        "narHash": "sha256-znWxRBgHuBfIfG50azn/egFrXJm1uXHVfgh5MN0kBqk=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "8aff4ca3dee60d1422489fe8d52c2f837b3ad113",
+        "rev": "cabd674eb65b394a4d8c9c73091f408027fde28f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                  |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`cabd674e`](https://github.com/nix-community/nix-index-database/commit/cabd674eb65b394a4d8c9c73091f408027fde28f) | `` flake.lock: Update `` |