### PR TITLE
chore(flake/emacs-overlay): `f6bd5b51` -> `25ec9844`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1700330352,
-        "narHash": "sha256-eNQ/Q1Ln9wfFDTEJB8wJ0qFVfA6HVPv5slt/B7NTrHo=",
+        "lastModified": 1700360681,
+        "narHash": "sha256-yhZ/jK+ajv9+ZqieeCWx0rf/Y8Py8T3o6a3oPWS/PcE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f6bd5b516e016b4dec94bdf72ace884771a561e3",
+        "rev": "25ec984429d5935a4755041357141983f13d0815",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`25ec9844`](https://github.com/nix-community/emacs-overlay/commit/25ec984429d5935a4755041357141983f13d0815) | `` Updated repos/nongnu `` |
| [`a45554ee`](https://github.com/nix-community/emacs-overlay/commit/a45554eee3f64ac9fa109527972b4819ca6a4d30) | `` Updated repos/melpa ``  |
| [`9fd6de0d`](https://github.com/nix-community/emacs-overlay/commit/9fd6de0d4213bf3a27ffb6936d700cc8b0e8a801) | `` Updated repos/emacs ``  |
| [`c9fb0127`](https://github.com/nix-community/emacs-overlay/commit/c9fb0127acb2f5e3e2ee994ed2af2e224106d260) | `` Updated repos/elpa ``   |