### PR TITLE
chore(flake/nur): `54886e86` -> `1aadb20d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700359574,
-        "narHash": "sha256-zLmuj7erfDHnBDw3cEUzKnj19KVFb/MZ4i017F9z5DY=",
+        "lastModified": 1700372432,
+        "narHash": "sha256-9WN+DZ4KzVhslrrVX3s1bOvgzoYtJTmQtHAO5VgEJPU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "54886e860ee709d2be4289eb122502b0de20d44a",
+        "rev": "1aadb20d8b13d9cc969490e8811b422ee04b00c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1aadb20d`](https://github.com/nix-community/NUR/commit/1aadb20d8b13d9cc969490e8811b422ee04b00c6) | `` automatic update `` |
| [`e6a5da39`](https://github.com/nix-community/NUR/commit/e6a5da3917c9af773f6da264be8b262663c406da) | `` automatic update `` |
| [`4ca4985e`](https://github.com/nix-community/NUR/commit/4ca4985ef016c94528fdebbc7161d3691d3d63fa) | `` automatic update `` |
| [`828ac55f`](https://github.com/nix-community/NUR/commit/828ac55fb99d313fef0251b614226684a2ee8181) | `` automatic update `` |
| [`628725d9`](https://github.com/nix-community/NUR/commit/628725d9d3981a9692454db13e4f27a8e26337bf) | `` automatic update `` |
| [`ccc428bc`](https://github.com/nix-community/NUR/commit/ccc428bc61759da07fc25307f7e2807c6651a964) | `` automatic update `` |
| [`6e6b3573`](https://github.com/nix-community/NUR/commit/6e6b3573b37769a189d91da08c39a5e647b5e746) | `` automatic update `` |