### PR TITLE
chore(flake/nix-index-database): `cabd674e` -> `27920146`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -607,11 +607,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700362638,
-        "narHash": "sha256-znWxRBgHuBfIfG50azn/egFrXJm1uXHVfgh5MN0kBqk=",
+        "lastModified": 1700363379,
+        "narHash": "sha256-fBEVPFwSZ6AmBE1s1oT7E9WVuqRghruxTnSQ8UUlMkw=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "cabd674eb65b394a4d8c9c73091f408027fde28f",
+        "rev": "27920146e671a0d565aaa7452907383be14d8d82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`27920146`](https://github.com/nix-community/nix-index-database/commit/27920146e671a0d565aaa7452907383be14d8d82) | `` update packages.nix to release 2023-11-19-030847 `` |