### PR TITLE
chore(flake/nur): `1aadb20d` -> `25619eba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700372432,
-        "narHash": "sha256-9WN+DZ4KzVhslrrVX3s1bOvgzoYtJTmQtHAO5VgEJPU=",
+        "lastModified": 1700384060,
+        "narHash": "sha256-/nDHMgW/Y+vGME/bTAFlI2+wJct471gFaks0dtbSnRk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1aadb20d8b13d9cc969490e8811b422ee04b00c6",
+        "rev": "25619eba03d94eeb9f7e504fa83d74c2153abc05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`25619eba`](https://github.com/nix-community/NUR/commit/25619eba03d94eeb9f7e504fa83d74c2153abc05) | `` automatic update `` |