### PR TITLE
chore(flake/home-manager): `ecd0a800` -> `9a4725af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700261686,
-        "narHash": "sha256-kplQg6hKFNuWKrOyGp9D//G/WH1nHGJ43r2m7fagTYY=",
+        "lastModified": 1700386809,
+        "narHash": "sha256-2IPxWo0Yplv+70EueZVLTwRAijax0tirYp5Jh0QV1A4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ecd0a800f716b80a6eac58a7ac34d6d33e6fa5ee",
+        "rev": "9a4725afa67db35cdf7be89f30527d745194cafa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                       |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`7af96988`](https://github.com/nix-community/home-manager/commit/7af969886b0792be6d1d2c13404052e6393a8eb3) | `` home-manager: improve comment in example configuration ``                  |
| [`6fd3a5b7`](https://github.com/nix-community/home-manager/commit/6fd3a5b728e71922945a388501886922bef11eaf) | `` flake.lock: Update ``                                                      |
| [`1160454c`](https://github.com/nix-community/home-manager/commit/1160454c791fa777ce59373fca86c25ad075265a) | `` qt: support gtk3 platform theme ``                                         |
| [`1e80a0b3`](https://github.com/nix-community/home-manager/commit/1e80a0b3d8ef2a9ffc0399b32edcd588ac396fa6) | `` qt: allow usage without setting platformTheme ``                           |
| [`55eee5bd`](https://github.com/nix-community/home-manager/commit/55eee5bd67fee341e86a457646bd4b78c5a77d26) | `` qt: use sessionVariablesExtra to export QT_PLUGIN_PATH/QML2_IMPORT_PATH `` |
| [`eaee696b`](https://github.com/nix-community/home-manager/commit/eaee696b6e77b8ec848fe6c49c9bc0fdfadafb3a) | `` qt: simplify style.name mappings ``                                        |
| [`bc53e4c2`](https://github.com/nix-community/home-manager/commit/bc53e4c240ea71d2f4b271d95c262369ab7adc7c) | `` qt: add qgnomeplatform-qt6 when platformTheme is set to gnome ``           |
| [`541d32d8`](https://github.com/nix-community/home-manager/commit/541d32d8b868753b0a627d542182cba9216325d9) | `` qt: add support for platformTheme lxqt ``                                  |
| [`4ba652d8`](https://github.com/nix-community/home-manager/commit/4ba652d8a8a02348790100ffec69c8787aca9fe9) | `` qt: add style mappings for Qt 6 ``                                         |
| [`3452e14e`](https://github.com/nix-community/home-manager/commit/3452e14ec729e0582a5fb120c14ed5c6d7fb64d3) | `` qt: workaround issue when i18n.inputMethod.enabled = 'fcitx5' ``           |
| [`4b2d3b03`](https://github.com/nix-community/home-manager/commit/4b2d3b03becc184f2d1485e109c6a55f94d5f886) | `` qt: remove top-level `with lib` ``                                         |
| [`5744ebf3`](https://github.com/nix-community/home-manager/commit/5744ebf3593ed95516e47d1895b7f19f57de7eb4) | `` qt: export QT_PLUGIN_PATH/QML2_IMPORT_PATH ``                              |
| [`b4ea37c6`](https://github.com/nix-community/home-manager/commit/b4ea37c633d809eaa1b998f72d9d86c1a6a558cb) | `` qt: remove remaining Qt 4 support ``                                       |