### PR TITLE
chore(flake/nur): `25619eba` -> `1d4330fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700384060,
-        "narHash": "sha256-/nDHMgW/Y+vGME/bTAFlI2+wJct471gFaks0dtbSnRk=",
+        "lastModified": 1700387397,
+        "narHash": "sha256-gPz8EvwXe2Bi+zUJMVPkUhOsOhl8PSbb+glUaCmq5fs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "25619eba03d94eeb9f7e504fa83d74c2153abc05",
+        "rev": "1d4330fee9d6e46c94a2046ce109f6f530b6d401",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1d4330fe`](https://github.com/nix-community/NUR/commit/1d4330fee9d6e46c94a2046ce109f6f530b6d401) | `` automatic update `` |
| [`348a3e03`](https://github.com/nix-community/NUR/commit/348a3e03e580b29f5296796a38d675b4b4b6c52f) | `` automatic update `` |