### PR TITLE
chore(flake/nixos-hardware): `1721da31` -> `2b00bc76`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -662,11 +662,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1700315735,
-        "narHash": "sha256-zlSLW6dX5XwBEwN87CIVtMr8zDSKvTRFmWmIQ9FfWgo=",
+        "lastModified": 1700392353,
+        "narHash": "sha256-KARn8aVJu5fdW0jdJYoOQ1SPqWlNdz4l7r90NbArWSY=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "1721da31f9b30cbf4460c4ec5068b3b6174a4694",
+        "rev": "2b00bc76dc893cd996a3d76a2f059d657a5ef37a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                       |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`89e68213`](https://github.com/NixOS/nixos-hardware/commit/89e68213709d78509994178dc3e56643cc2af629) | `` add and use mkDisableOption ``             |
| [`a742fe3a`](https://github.com/NixOS/nixos-hardware/commit/a742fe3a04105756d6a700ef1e885b326b7e57cd) | `` raspberry-pi/4: add led disable overlay `` |
| [`9d09a745`](https://github.com/NixOS/nixos-hardware/commit/9d09a7452ccf99f2ddfca1a349758312cc5d569c) | `` raspberry-pi/4: format ``                  |