### PR TITLE
chore(flake/nur): `890e2ce5` -> `05ea95ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700394274,
-        "narHash": "sha256-RfC2EnmRVe6b6esm7wkZrvL7b8KDhdEWTx4bcpIhjR4=",
+        "lastModified": 1700405057,
+        "narHash": "sha256-nIm046ircBKBo5lM5B4dYXn/oygw+RkOaNWVyOU9k60=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "890e2ce588ff53cdcd6bd5aa0025ac3a19731bdb",
+        "rev": "05ea95ac9e519e30c3edd7622b9cc9fca1824d61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`05ea95ac`](https://github.com/nix-community/NUR/commit/05ea95ac9e519e30c3edd7622b9cc9fca1824d61) | `` automatic update `` |