### PR TITLE
chore(flake/nur): `05ea95ac` -> `dede7b9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700405057,
-        "narHash": "sha256-nIm046ircBKBo5lM5B4dYXn/oygw+RkOaNWVyOU9k60=",
+        "lastModified": 1700408657,
+        "narHash": "sha256-HpVoYPheiBrhu9p3aXEcu9n34ZKVKJpyxN5fpAkbhY0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "05ea95ac9e519e30c3edd7622b9cc9fca1824d61",
+        "rev": "dede7b9ab898ce24e2a7775742be6301affa8f4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dede7b9a`](https://github.com/nix-community/NUR/commit/dede7b9ab898ce24e2a7775742be6301affa8f4d) | `` automatic update `` |