### PR TITLE
chore(flake/nur): `dede7b9a` -> `45d3fff4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700408657,
-        "narHash": "sha256-HpVoYPheiBrhu9p3aXEcu9n34ZKVKJpyxN5fpAkbhY0=",
+        "lastModified": 1700411019,
+        "narHash": "sha256-9swk2mTTeXUTNQIS6u82uNUoASHRr6GttUtAnMepLys=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dede7b9ab898ce24e2a7775742be6301affa8f4d",
+        "rev": "45d3fff4006ebb02c681e79dca6fcfdcc9c4b7d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`45d3fff4`](https://github.com/nix-community/NUR/commit/45d3fff4006ebb02c681e79dca6fcfdcc9c4b7d8) | `` automatic update `` |