### PR TITLE
chore(flake/emacs-overlay): `92d18002` -> `861a8a63`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1700386683,
-        "narHash": "sha256-NyfJIAGWuMIBE108CVgfnS2tuhb+yBppQ4Df+w1IyYY=",
+        "lastModified": 1700415467,
+        "narHash": "sha256-2QOsMnp+c6IRSnYw3Sq+GbOZRsFg3CVA2ijBpSlE+pc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "92d180024e1bc6c96af2cd71da752b7706b47857",
+        "rev": "861a8a638959672f1dfe694a18a536a842e6cf84",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1700097215,
-        "narHash": "sha256-ODQ3gBTv1iHd7lG21H+ErVISB5wVeOhd/dEogOqHs/I=",
+        "lastModified": 1700272409,
+        "narHash": "sha256-Mge6iOvomplBsvQ47sIeVAwAUGSVXH4qCW4pLUt/qMI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9fb122519e9cd465d532f736a98c1e1eb541ef6f",
+        "rev": "8e5e424b1c059e9ccf5db6a652458e30de05fa3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`861a8a63`](https://github.com/nix-community/emacs-overlay/commit/861a8a638959672f1dfe694a18a536a842e6cf84) | `` Updated repos/melpa ``  |
| [`937984e1`](https://github.com/nix-community/emacs-overlay/commit/937984e1f3d6c9f962975309069ceeae05e81571) | `` Updated repos/emacs ``  |
| [`082589e3`](https://github.com/nix-community/emacs-overlay/commit/082589e33e0df473749140a012ed2c8d4f3eda41) | `` Updated repos/elpa ``   |
| [`21c9b484`](https://github.com/nix-community/emacs-overlay/commit/21c9b484ed1bdd23ed4a4631b35e449e06cc801a) | `` Updated flake inputs `` |