### PR TITLE
chore(flake/nur): `45d3fff4` -> `4c7a8af1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700411019,
-        "narHash": "sha256-9swk2mTTeXUTNQIS6u82uNUoASHRr6GttUtAnMepLys=",
+        "lastModified": 1700415498,
+        "narHash": "sha256-KJGcjJG4LnGYU2RifNMp2+y8JPlGWfXRoBWYIplqIxs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "45d3fff4006ebb02c681e79dca6fcfdcc9c4b7d8",
+        "rev": "4c7a8af1432c0dd2a18e2560c8f58dcb8cfea87f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4c7a8af1`](https://github.com/nix-community/NUR/commit/4c7a8af1432c0dd2a18e2560c8f58dcb8cfea87f) | `` automatic update `` |