### PR TITLE
chore(flake/nur): `4c7a8af1` -> `36e8dbb1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700415498,
-        "narHash": "sha256-KJGcjJG4LnGYU2RifNMp2+y8JPlGWfXRoBWYIplqIxs=",
+        "lastModified": 1700423049,
+        "narHash": "sha256-1c/gugUl0zjy595Q9tSNbbG7kSjGKKXMpm99fZUxG10=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4c7a8af1432c0dd2a18e2560c8f58dcb8cfea87f",
+        "rev": "36e8dbb12702fecad6f719965bfaec655dfea9d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`36e8dbb1`](https://github.com/nix-community/NUR/commit/36e8dbb12702fecad6f719965bfaec655dfea9d0) | `` automatic update `` |
| [`1835c823`](https://github.com/nix-community/NUR/commit/1835c823616190ae5167b45a8a9ba851e1992ce6) | `` automatic update `` |
| [`c62516e3`](https://github.com/nix-community/NUR/commit/c62516e35d9b5d6612d5ca3da6d8d14f4b03aec4) | `` automatic update `` |