### PR TITLE
chore(flake/srvos): `48010180` -> `8c3bcd72`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -646,11 +646,11 @@
     },
     "nixos-23_05": {
       "locked": {
-        "lastModified": 1699994397,
-        "narHash": "sha256-xxNeIcMNMXH2EA9IAX6Cny+50mvY22LhIBiGZV363gc=",
+        "lastModified": 1700403855,
+        "narHash": "sha256-Q0Uzjik9kUTN9pd/kp52XJi5kletBhy29ctBlAG+III=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d4b5a67bbe9ef750bd2fdffd4cad400dd5553af8",
+        "rev": "0c5678df521e1407884205fe3ce3cf1d7df297db",
         "type": "github"
       },
       "original": {
@@ -1007,11 +1007,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700099573,
-        "narHash": "sha256-4zjIWPenAMaBlZnCaQvnBdMyWDX/mTgT2fe+CVFajW8=",
+        "lastModified": 1700440795,
+        "narHash": "sha256-uW5Gstmg+tBkbPPV5dxuZN/jpkG4/QCqoR1mVF8oQLA=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "48010180015cbda0b6cacf4555fcdd360054158d",
+        "rev": "8c3bcd723c1d813b744c09860cd8c57c455786bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------ |
| [`8c3bcd72`](https://github.com/nix-community/srvos/commit/8c3bcd723c1d813b744c09860cd8c57c455786bc) | `` flake.lock: Update `` |