### PR TITLE
chore(flake/srvos): `8c3bcd72` -> `c89d0acb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1007,11 +1007,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700440795,
-        "narHash": "sha256-uW5Gstmg+tBkbPPV5dxuZN/jpkG4/QCqoR1mVF8oQLA=",
+        "lastModified": 1700445214,
+        "narHash": "sha256-QmzM21vIpiMk2tkHNwfoyKrKetOVLe6lw8VdQKSTZtM=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "8c3bcd723c1d813b744c09860cd8c57c455786bc",
+        "rev": "c89d0acb7c447a85f9f3d751321e9012ea21e8e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------ |
| [`c89d0acb`](https://github.com/nix-community/srvos/commit/c89d0acb7c447a85f9f3d751321e9012ea21e8e1) | `` flake.lock: Update `` |