### PR TITLE
chore(flake/emacs-overlay): `861a8a63` -> `7733a8f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1700415467,
-        "narHash": "sha256-2QOsMnp+c6IRSnYw3Sq+GbOZRsFg3CVA2ijBpSlE+pc=",
+        "lastModified": 1700446912,
+        "narHash": "sha256-GoQ0PYcWs4geE/+OTm1mUzUudnV9eRn1lOqWfIif9nQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "861a8a638959672f1dfe694a18a536a842e6cf84",
+        "rev": "7733a8f0d3aca4be0c95145ff9a36ecc01538395",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1700272409,
-        "narHash": "sha256-Mge6iOvomplBsvQ47sIeVAwAUGSVXH4qCW4pLUt/qMI=",
+        "lastModified": 1700403855,
+        "narHash": "sha256-Q0Uzjik9kUTN9pd/kp52XJi5kletBhy29ctBlAG+III=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8e5e424b1c059e9ccf5db6a652458e30de05fa3a",
+        "rev": "0c5678df521e1407884205fe3ce3cf1d7df297db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`7733a8f0`](https://github.com/nix-community/emacs-overlay/commit/7733a8f0d3aca4be0c95145ff9a36ecc01538395) | `` Updated repos/melpa ``  |
| [`d87a188b`](https://github.com/nix-community/emacs-overlay/commit/d87a188b26262db0e9b5299d77265a315ecef026) | `` Updated repos/emacs ``  |
| [`040d5918`](https://github.com/nix-community/emacs-overlay/commit/040d59181718758b3e6eccbc296752b4773c070c) | `` Updated repos/elpa ``   |
| [`6379ddd2`](https://github.com/nix-community/emacs-overlay/commit/6379ddd2b71bdbbf2f905f7c45f9d7210e5dc7cb) | `` Updated flake inputs `` |