### PR TITLE
chore(flake/nur): `66198b71` -> `ecea80d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700442691,
-        "narHash": "sha256-21xOcUyw/KgHYxAw2yFj9hKfDPM3rDcCzLeE7YCr2A0=",
+        "lastModified": 1700455140,
+        "narHash": "sha256-tnjrTqcfWGGEYMgJAfMw+84HLuA9igA6nj77+UAMdxg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "66198b719b41baca22d8799c343441224d296ccf",
+        "rev": "ecea80d860ca3485d3aa9cae6d0829adff5d3e5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ecea80d8`](https://github.com/nix-community/NUR/commit/ecea80d860ca3485d3aa9cae6d0829adff5d3e5d) | `` automatic update `` |
| [`02766feb`](https://github.com/nix-community/NUR/commit/02766feb63060b05d4e68cdbbc1fd5714c368e59) | `` automatic update `` |