### PR TITLE
chore(flake/nur): `ecea80d8` -> `7afc4f1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700455140,
-        "narHash": "sha256-tnjrTqcfWGGEYMgJAfMw+84HLuA9igA6nj77+UAMdxg=",
+        "lastModified": 1700457242,
+        "narHash": "sha256-GMGRabT6Z8RUHPz3CJMakcARmDRqUy3+yUy0vW7D2ww=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ecea80d860ca3485d3aa9cae6d0829adff5d3e5d",
+        "rev": "7afc4f1d1cf86e79e6db8bca6447160b50c40d4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7afc4f1d`](https://github.com/nix-community/NUR/commit/7afc4f1d1cf86e79e6db8bca6447160b50c40d4c) | `` automatic update `` |