### PR TITLE
chore(flake/nur): `7afc4f1d` -> `6969ba18`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700457242,
-        "narHash": "sha256-GMGRabT6Z8RUHPz3CJMakcARmDRqUy3+yUy0vW7D2ww=",
+        "lastModified": 1700462733,
+        "narHash": "sha256-szJ3bU9FTAJ9QTYKlRvtHf+IBVQg3KSa+CyxobfGBO8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7afc4f1d1cf86e79e6db8bca6447160b50c40d4c",
+        "rev": "6969ba1812a56f4667a4956346347e1599270afe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6969ba18`](https://github.com/nix-community/NUR/commit/6969ba1812a56f4667a4956346347e1599270afe) | `` automatic update `` |