### PR TITLE
chore(flake/nur): `6969ba18` -> `dceea9c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700462733,
-        "narHash": "sha256-szJ3bU9FTAJ9QTYKlRvtHf+IBVQg3KSa+CyxobfGBO8=",
+        "lastModified": 1700466986,
+        "narHash": "sha256-fIo3/il98fHXKC5XWUyeV3/kF1L4MWK1Cobctbb3w4k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6969ba1812a56f4667a4956346347e1599270afe",
+        "rev": "dceea9c120d99dc75ddeec5e6f8ea3c80b10d938",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dceea9c1`](https://github.com/nix-community/NUR/commit/dceea9c120d99dc75ddeec5e6f8ea3c80b10d938) | `` automatic update `` |
| [`d4e34502`](https://github.com/nix-community/NUR/commit/d4e3450273bd805e8f95896cad2abf4b01325be2) | `` automatic update `` |
| [`d7df2542`](https://github.com/nix-community/NUR/commit/d7df2542cef5e3563aa39e7d979b8623fd2bdc03) | `` automatic update `` |
| [`5bfd6b7f`](https://github.com/nix-community/NUR/commit/5bfd6b7f418dbf33b5f6ace07b7723212de9aa47) | `` automatic update `` |