### PR TITLE
chore(flake/emacs-overlay): `7733a8f0` -> `2cad7552`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1700446912,
-        "narHash": "sha256-GoQ0PYcWs4geE/+OTm1mUzUudnV9eRn1lOqWfIif9nQ=",
+        "lastModified": 1701538716,
+        "narHash": "sha256-WDc/rlaXLvpWo/TBurDq9yHQ5+r6D8HewPynR4q0TNI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7733a8f0d3aca4be0c95145ff9a36ecc01538395",
+        "rev": "2cad7552433397581b0f3c8218c7c111b1896587",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1700403855,
-        "narHash": "sha256-Q0Uzjik9kUTN9pd/kp52XJi5kletBhy29ctBlAG+III=",
+        "lastModified": 1701362232,
+        "narHash": "sha256-GVdzxL0lhEadqs3hfRLuj+L1OJFGiL/L7gCcelgBlsw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c5678df521e1407884205fe3ce3cf1d7df297db",
+        "rev": "d2332963662edffacfddfad59ff4f709dde80ffe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`2cad7552`](https://github.com/nix-community/emacs-overlay/commit/2cad7552433397581b0f3c8218c7c111b1896587) | `` Updated repos/nongnu `` |
| [`bf63d14c`](https://github.com/nix-community/emacs-overlay/commit/bf63d14c647476891713198bbb7ffef48b523ad6) | `` Updated repos/melpa ``  |
| [`eb4bf0e2`](https://github.com/nix-community/emacs-overlay/commit/eb4bf0e26c40eadb6add3fad57a43c2d892d7b8c) | `` Updated repos/emacs ``  |
| [`9168578d`](https://github.com/nix-community/emacs-overlay/commit/9168578dade9b93ec70b3563ac023b9b2c3fc3f1) | `` Updated repos/elpa ``   |
| [`590e9947`](https://github.com/nix-community/emacs-overlay/commit/590e99479d5f34c57781252f5ac3f956e4c0d237) | `` Updated repos/melpa ``  |
| [`13b5aff9`](https://github.com/nix-community/emacs-overlay/commit/13b5aff9fe02d0338729b4de0dd0d795578aa778) | `` Updated repos/emacs ``  |
| [`8baf9759`](https://github.com/nix-community/emacs-overlay/commit/8baf97591f1df81ce5ef7305a66a4bb0404009bd) | `` Updated repos/nongnu `` |
| [`eee7ae9d`](https://github.com/nix-community/emacs-overlay/commit/eee7ae9d0f4bfea569c0af9973fa089395e2daea) | `` Updated repos/melpa ``  |
| [`c0952561`](https://github.com/nix-community/emacs-overlay/commit/c0952561b32efddbff65efcc4ab5f31df932b8b0) | `` Updated repos/elpa ``   |
| [`8dc16b0f`](https://github.com/nix-community/emacs-overlay/commit/8dc16b0f0edfb3560497724dfe8d214d5b251c65) | `` Updated flake inputs `` |
| [`d6f9a741`](https://github.com/nix-community/emacs-overlay/commit/d6f9a7414ece512046f84b1ece1ba9538cbd1ea2) | `` Updated repos/melpa ``  |
| [`2038bd98`](https://github.com/nix-community/emacs-overlay/commit/2038bd988f6947699561832f81f4250ad37462a6) | `` Updated repos/emacs ``  |
| [`e3751b87`](https://github.com/nix-community/emacs-overlay/commit/e3751b876974295bf3dd93a31c5ac554ff6ddb2b) | `` Updated repos/elpa ``   |
| [`ead33b53`](https://github.com/nix-community/emacs-overlay/commit/ead33b53bddac6d9e4e01d1e80e6dc1d8d30d2a3) | `` Updated repos/melpa ``  |
| [`e46350d4`](https://github.com/nix-community/emacs-overlay/commit/e46350d4cf8bc8a41dc18b75979b6c6129a1304e) | `` Updated repos/emacs ``  |
| [`a5f0ee16`](https://github.com/nix-community/emacs-overlay/commit/a5f0ee16ab1c9cb38b4a855d70961b75427a5161) | `` Updated flake inputs `` |
| [`f7753ffa`](https://github.com/nix-community/emacs-overlay/commit/f7753ffa160ec5e2960357290267bc7b7171e6d9) | `` Updated repos/nongnu `` |
| [`19a1e4de`](https://github.com/nix-community/emacs-overlay/commit/19a1e4de1ebe4c0ffd4436a395b2b6fbef2a6773) | `` Updated repos/melpa ``  |
| [`9bbd47c3`](https://github.com/nix-community/emacs-overlay/commit/9bbd47c38f3525817ff2733e4cf6e7ea3ff1b5b8) | `` Updated repos/emacs ``  |
| [`0e3354d2`](https://github.com/nix-community/emacs-overlay/commit/0e3354d28739e65339fe0ad8c31a5d638f420168) | `` Updated repos/elpa ``   |
| [`1b8163de`](https://github.com/nix-community/emacs-overlay/commit/1b8163de282e43d005b28e768fd156d417d441d9) | `` Updated repos/melpa ``  |
| [`9fd67695`](https://github.com/nix-community/emacs-overlay/commit/9fd67695e4a5e49d0861724613361b99480ff688) | `` Updated repos/emacs ``  |
| [`cfb162b4`](https://github.com/nix-community/emacs-overlay/commit/cfb162b4ee59399c2433d339d0e5789ead3b2690) | `` Updated repos/elpa ``   |
| [`913e44a1`](https://github.com/nix-community/emacs-overlay/commit/913e44a13636fd111139ee683a6741ccb4c28672) | `` Updated repos/melpa ``  |
| [`da71fb8e`](https://github.com/nix-community/emacs-overlay/commit/da71fb8eea8f0b3be18ea25f17e2d28dd6ee4139) | `` Updated repos/nongnu `` |
| [`62af4a0a`](https://github.com/nix-community/emacs-overlay/commit/62af4a0abcc6ab9734504c3e0b50f30deb989af1) | `` Updated repos/melpa ``  |
| [`b9ab22d5`](https://github.com/nix-community/emacs-overlay/commit/b9ab22d55dc3737d77db13de79260ee0adda5d4f) | `` Updated repos/emacs ``  |
| [`26649a0d`](https://github.com/nix-community/emacs-overlay/commit/26649a0d3fbfe92b0b00e8cb46d50c6937e0ec7f) | `` Updated repos/elpa ``   |
| [`ffe08c51`](https://github.com/nix-community/emacs-overlay/commit/ffe08c51b289d92ee8d82f13dd069a54b8bdf3f1) | `` Updated repos/nongnu `` |
| [`b7e97741`](https://github.com/nix-community/emacs-overlay/commit/b7e9774116a69ea997a4c4789f9dde30d11325b0) | `` Updated repos/melpa ``  |
| [`9e1f9e55`](https://github.com/nix-community/emacs-overlay/commit/9e1f9e5515a4d99699fdf956e1ac7edf2e4d3b72) | `` Updated repos/emacs ``  |
| [`0fe3cdd7`](https://github.com/nix-community/emacs-overlay/commit/0fe3cdd7a3711e79d52bdf44d8081af1ab24b141) | `` Updated repos/elpa ``   |
| [`f59e99c3`](https://github.com/nix-community/emacs-overlay/commit/f59e99c3973f99a9338bdb03876b9072400589aa) | `` Updated repos/melpa ``  |
| [`644bbbd9`](https://github.com/nix-community/emacs-overlay/commit/644bbbd9491ee2329df1aeeef18c86ef788034a5) | `` Updated repos/emacs ``  |
| [`c9af8570`](https://github.com/nix-community/emacs-overlay/commit/c9af857061186f215f7052b7c85553e28eac948d) | `` Updated flake inputs `` |
| [`e81dd4bf`](https://github.com/nix-community/emacs-overlay/commit/e81dd4bf787abe60101b867f84abb414599afa37) | `` Updated repos/nongnu `` |
| [`784d9301`](https://github.com/nix-community/emacs-overlay/commit/784d9301071b98c581b5be0096929408b35558bc) | `` Updated repos/melpa ``  |
| [`61c8cf26`](https://github.com/nix-community/emacs-overlay/commit/61c8cf26da93bf7574c64c7eebd241d4b160e091) | `` Updated repos/elpa ``   |
| [`f9e492d4`](https://github.com/nix-community/emacs-overlay/commit/f9e492d455d655f3853f424ae55e504c663318b6) | `` Updated repos/melpa ``  |
| [`77a49fa6`](https://github.com/nix-community/emacs-overlay/commit/77a49fa6ee1e63b43ff755c58775b1ff72bda4fc) | `` Updated repos/elpa ``   |
| [`4c85f50c`](https://github.com/nix-community/emacs-overlay/commit/4c85f50cbc21792b0922848cff0ab8de6b95573e) | `` Updated repos/melpa ``  |
| [`a8c4f67e`](https://github.com/nix-community/emacs-overlay/commit/a8c4f67ed6a0d1cc4b4c29fb520a95f4032fd67a) | `` Updated flake inputs `` |
| [`87af8a9f`](https://github.com/nix-community/emacs-overlay/commit/87af8a9faf5cfbbd25795d9fe7574808bef46870) | `` Updated repos/nongnu `` |
| [`3dbc3235`](https://github.com/nix-community/emacs-overlay/commit/3dbc3235fb7a7fd48d9c164bac12a3f1cf4b68c8) | `` Updated repos/melpa ``  |
| [`edc2d972`](https://github.com/nix-community/emacs-overlay/commit/edc2d972c21aaf62cd0220727fe7716bf2ff045d) | `` Updated repos/emacs ``  |
| [`d1a64036`](https://github.com/nix-community/emacs-overlay/commit/d1a64036ea1761e094e0baa019176071350494ac) | `` Updated repos/elpa ``   |
| [`ff495a31`](https://github.com/nix-community/emacs-overlay/commit/ff495a3172537a9a5d05fadd0699daf5deb48dc0) | `` Updated repos/melpa ``  |
| [`7fad827e`](https://github.com/nix-community/emacs-overlay/commit/7fad827ecbb2789760562b2c9112f2abe60efea2) | `` Updated repos/emacs ``  |
| [`d3129804`](https://github.com/nix-community/emacs-overlay/commit/d3129804485f1bb11c9d13d44388948743079bed) | `` Updated repos/elpa ``   |
| [`2527e136`](https://github.com/nix-community/emacs-overlay/commit/2527e1367b92eea59652378b88108b162484e7d1) | `` Updated repos/melpa ``  |
| [`199d39af`](https://github.com/nix-community/emacs-overlay/commit/199d39af661ae5a8b28d7da71319eee61d61d6a2) | `` Updated repos/emacs ``  |
| [`b624204e`](https://github.com/nix-community/emacs-overlay/commit/b624204e3066a662fea1a6860f5fabef4630275e) | `` Updated flake inputs `` |
| [`14bfb2ab`](https://github.com/nix-community/emacs-overlay/commit/14bfb2ab205d5040420b4daf90a69f9e169fdb2a) | `` Updated repos/melpa ``  |
| [`38d5883a`](https://github.com/nix-community/emacs-overlay/commit/38d5883a401207c889c8e993519908048b88170f) | `` Updated repos/emacs ``  |
| [`12af9b0c`](https://github.com/nix-community/emacs-overlay/commit/12af9b0c63590db14aa2ec9a9022edff58173cf8) | `` Updated repos/elpa ``   |
| [`10aa8610`](https://github.com/nix-community/emacs-overlay/commit/10aa8610c73002d869b67eb261c609201dd24757) | `` Updated repos/nongnu `` |
| [`8ca0b1e7`](https://github.com/nix-community/emacs-overlay/commit/8ca0b1e7f427edf5e4b54485500aa8620aa8288c) | `` Updated repos/melpa ``  |
| [`c651f509`](https://github.com/nix-community/emacs-overlay/commit/c651f5094b14ec1475c6504bec1c4da2d6d58e39) | `` Updated repos/emacs ``  |
| [`4448eae1`](https://github.com/nix-community/emacs-overlay/commit/4448eae1e86582f4c8fa14fd6866b95a7a269853) | `` Updated repos/elpa ``   |
| [`88dc6d60`](https://github.com/nix-community/emacs-overlay/commit/88dc6d6095da5b9436c69c47b44558230fa4fee7) | `` Updated repos/melpa ``  |
| [`783005da`](https://github.com/nix-community/emacs-overlay/commit/783005dadd5fd10a1237b64659ff3dde88a4dc38) | `` Updated repos/emacs ``  |
| [`eca0a5db`](https://github.com/nix-community/emacs-overlay/commit/eca0a5db94fc129bccc66c36c944b45ac78198b7) | `` Updated repos/nongnu `` |
| [`0c42825c`](https://github.com/nix-community/emacs-overlay/commit/0c42825cc6084148895c853c3824687337ace4c8) | `` Updated repos/melpa ``  |
| [`42bbaab9`](https://github.com/nix-community/emacs-overlay/commit/42bbaab936bfb1f5c7a332eb41b19580f686ad85) | `` Updated repos/emacs ``  |
| [`c74c8e1f`](https://github.com/nix-community/emacs-overlay/commit/c74c8e1ff4452759a8c46599cb8c704e0444db2e) | `` Updated repos/elpa ``   |
| [`6ef4c47e`](https://github.com/nix-community/emacs-overlay/commit/6ef4c47e8aa6f2e83249e85b81adff48adea7ce6) | `` Updated flake inputs `` |
| [`3119a254`](https://github.com/nix-community/emacs-overlay/commit/3119a25433fbbdcd459e4b95d2b9a3d00f5914cc) | `` Updated repos/nongnu `` |
| [`acbc9c3b`](https://github.com/nix-community/emacs-overlay/commit/acbc9c3b2f1babf2e2ad8bd090f88cb3a6b7204f) | `` Updated repos/elpa ``   |
| [`5e9d681b`](https://github.com/nix-community/emacs-overlay/commit/5e9d681b6e5d1b28aa9e6f63af25d95bdcd072cf) | `` Updated flake inputs `` |
| [`309f6092`](https://github.com/nix-community/emacs-overlay/commit/309f6092a689e3b402a32a589bb5a6ead9abe528) | `` Updated repos/melpa ``  |
| [`421c04cf`](https://github.com/nix-community/emacs-overlay/commit/421c04cf6b136010d947dfde1c0ba2f24888cb7d) | `` Updated repos/emacs ``  |
| [`873e9d01`](https://github.com/nix-community/emacs-overlay/commit/873e9d018737305ecc1c2c9195f7e5ffa2a86873) | `` Updated repos/nongnu `` |
| [`f7360e45`](https://github.com/nix-community/emacs-overlay/commit/f7360e4587f3bd2974e76028748bb3bdbad204c4) | `` Updated repos/melpa ``  |
| [`66914e86`](https://github.com/nix-community/emacs-overlay/commit/66914e8616678b47426b43557d167ec47324b6ec) | `` Updated repos/emacs ``  |
| [`c966a4b1`](https://github.com/nix-community/emacs-overlay/commit/c966a4b1819da5be0dbd9a9b37a45af2a11cb039) | `` Updated repos/elpa ``   |
| [`d419c32b`](https://github.com/nix-community/emacs-overlay/commit/d419c32b00f86aa2bdf56ad8e1f4516b796539b9) | `` Updated repos/nongnu `` |
| [`a424ad5c`](https://github.com/nix-community/emacs-overlay/commit/a424ad5cf8aadc89bf7c3dac2584fa003be833a5) | `` Updated repos/melpa ``  |
| [`782a3303`](https://github.com/nix-community/emacs-overlay/commit/782a33039695862aecbab3b24439204dacf047f8) | `` Updated repos/emacs ``  |
| [`cc49b5aa`](https://github.com/nix-community/emacs-overlay/commit/cc49b5aa6d48df28920893e3c84cf24cec632b7a) | `` Updated repos/elpa ``   |
| [`312d910d`](https://github.com/nix-community/emacs-overlay/commit/312d910d5c8e738ed280ebcc7535d6cbc1c44f16) | `` Updated repos/melpa ``  |
| [`f45d71a4`](https://github.com/nix-community/emacs-overlay/commit/f45d71a43b8e62821787d1540be5c1c5e148f633) | `` Updated repos/emacs ``  |
| [`cc8840b8`](https://github.com/nix-community/emacs-overlay/commit/cc8840b8c004b94164b38d003581cba25bb44c99) | `` Updated repos/nongnu `` |
| [`22c99a85`](https://github.com/nix-community/emacs-overlay/commit/22c99a85d9188d7eaea0f8db050240f35c65eca7) | `` Updated repos/melpa ``  |
| [`196217c9`](https://github.com/nix-community/emacs-overlay/commit/196217c959824d2fb46bec1f3a40770574b914d5) | `` Updated repos/emacs ``  |
| [`e722bacb`](https://github.com/nix-community/emacs-overlay/commit/e722bacb7f4a72d22000b3580c731bd928b82952) | `` Updated repos/elpa ``   |
| [`e3c7a4f3`](https://github.com/nix-community/emacs-overlay/commit/e3c7a4f33728880fe9b35d9e2984ea7594dc996d) | `` Updated flake inputs `` |
| [`95e53f0f`](https://github.com/nix-community/emacs-overlay/commit/95e53f0f4b8227d57cb121c2bdf81c6aa9165ad6) | `` Updated repos/nongnu `` |
| [`3515d563`](https://github.com/nix-community/emacs-overlay/commit/3515d5633e2e52e30466c674a02233500add2965) | `` Updated repos/melpa ``  |
| [`673f7368`](https://github.com/nix-community/emacs-overlay/commit/673f736848f8e286c0e4efa39d290ce125725f9c) | `` Updated repos/emacs ``  |
| [`7b005fd9`](https://github.com/nix-community/emacs-overlay/commit/7b005fd943883e2c49328bd697680f462b8e9aa3) | `` Updated repos/elpa ``   |
| [`ab2f15a1`](https://github.com/nix-community/emacs-overlay/commit/ab2f15a1cdcb2d5490714062ce28dbe0f9ba56ea) | `` Update README.org ``    |
| [`b60a4a64`](https://github.com/nix-community/emacs-overlay/commit/b60a4a64a9659c58aa5e28724e4a9dae7872a546) | `` Updated repos/melpa ``  |
| [`391eb599`](https://github.com/nix-community/emacs-overlay/commit/391eb59948708ee2d3ea6e12ad5a880f61b679f4) | `` Updated repos/emacs ``  |
| [`7d58a5b0`](https://github.com/nix-community/emacs-overlay/commit/7d58a5b06d126ef3bfac51a17f359201374a7490) | `` Updated repos/melpa ``  |
| [`4ddb760e`](https://github.com/nix-community/emacs-overlay/commit/4ddb760e705fb711641381105bd50b94b5395e17) | `` Updated repos/emacs ``  |
| [`2043e43f`](https://github.com/nix-community/emacs-overlay/commit/2043e43fcb47f0e263488d5ccc66b07dc57940a5) | `` Updated repos/elpa ``   |
| [`a94c0d43`](https://github.com/nix-community/emacs-overlay/commit/a94c0d43748d2830aed62bfe11e3a302f0fc56f6) | `` Updated flake inputs `` |
| [`9fc2e308`](https://github.com/nix-community/emacs-overlay/commit/9fc2e308b7892d8a04008d681233225cfd4e4f65) | `` Updated repos/nongnu `` |
| [`7fc25b0a`](https://github.com/nix-community/emacs-overlay/commit/7fc25b0a6adf43e1ba62864cdf180c7011065f69) | `` Updated repos/melpa ``  |
| [`5385f8d8`](https://github.com/nix-community/emacs-overlay/commit/5385f8d83fe3a55e513e76643b5d570f4d30e7b6) | `` Updated repos/emacs ``  |
| [`a22b1c3d`](https://github.com/nix-community/emacs-overlay/commit/a22b1c3d775b1a050f589914c22b25b584c58979) | `` Updated repos/elpa ``   |
| [`00fe9cdc`](https://github.com/nix-community/emacs-overlay/commit/00fe9cdc30398cb126f104a8bebbfaf3b2344ccb) | `` Updated repos/melpa ``  |
| [`aa3f9624`](https://github.com/nix-community/emacs-overlay/commit/aa3f9624307c54b3a9d613a65f23a366cfd3ca1d) | `` Updated repos/emacs ``  |
| [`908226aa`](https://github.com/nix-community/emacs-overlay/commit/908226aa3ed86ccb9bb45b146a1991ea89f52dbb) | `` Updated repos/nongnu `` |
| [`5acfcf9e`](https://github.com/nix-community/emacs-overlay/commit/5acfcf9ee1b725773890aebbab8059920e4ee483) | `` Updated repos/melpa ``  |
| [`3417e220`](https://github.com/nix-community/emacs-overlay/commit/3417e220e04211bb58e3aa3864f92c909229b945) | `` Updated repos/elpa ``   |
| [`b2f0ca4a`](https://github.com/nix-community/emacs-overlay/commit/b2f0ca4a3a73528460ec8b1e2178e3fe478235e2) | `` Updated repos/melpa ``  |
| [`f289f869`](https://github.com/nix-community/emacs-overlay/commit/f289f869efe4e3f732071cc30c6370b334ab1a50) | `` Updated repos/emacs ``  |
| [`cb8a0a23`](https://github.com/nix-community/emacs-overlay/commit/cb8a0a230c396bbce39e8c987bdc8564d99ff57c) | `` Updated repos/elpa ``   |
| [`3fa87242`](https://github.com/nix-community/emacs-overlay/commit/3fa8724200bc0329d2d7ca3becf623dbed61431b) | `` Updated repos/melpa ``  |
| [`2735b538`](https://github.com/nix-community/emacs-overlay/commit/2735b53860344f8a83bba3c550c363d77697717c) | `` Updated repos/emacs ``  |
| [`9e60cd75`](https://github.com/nix-community/emacs-overlay/commit/9e60cd75324d794cc59b66003ccadbb83729967e) | `` Updated repos/melpa ``  |
| [`d5277bfe`](https://github.com/nix-community/emacs-overlay/commit/d5277bfee08f3bb41377695e370a1bd810a63cbe) | `` Updated repos/emacs ``  |
| [`3df19fb0`](https://github.com/nix-community/emacs-overlay/commit/3df19fb06c4e76dcb5e4074506b69a30a76df434) | `` Updated repos/elpa ``   |
| [`21926f29`](https://github.com/nix-community/emacs-overlay/commit/21926f291e61451d93c5f51b155f6f6507748c49) | `` Updated repos/melpa ``  |
| [`28c02064`](https://github.com/nix-community/emacs-overlay/commit/28c02064560b89926b01bea9c3ea5cdda562afa6) | `` Updated repos/emacs ``  |
| [`8292591d`](https://github.com/nix-community/emacs-overlay/commit/8292591d3162fa481a46a41ed393fa252635a3cb) | `` Updated repos/elpa ``   |
| [`a70fd6e9`](https://github.com/nix-community/emacs-overlay/commit/a70fd6e93de6f0d0bca3c02f9cc1acbaa914254e) | `` Updated repos/melpa ``  |
| [`f575a6d1`](https://github.com/nix-community/emacs-overlay/commit/f575a6d16e0404e32fb30021e3e2a758c47372b7) | `` Updated flake inputs `` |