### PR TITLE
chore(flake/nur): `dceea9c1` -> `b042d2a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700466986,
-        "narHash": "sha256-fIo3/il98fHXKC5XWUyeV3/kF1L4MWK1Cobctbb3w4k=",
+        "lastModified": 1700473479,
+        "narHash": "sha256-eyGKUhN3ZNLiuHXC19P6/6Jl7mFCSGhemE16pQ3MCLs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dceea9c120d99dc75ddeec5e6f8ea3c80b10d938",
+        "rev": "b042d2a79af823b2271d4c890a837e8c23028507",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b042d2a7`](https://github.com/nix-community/NUR/commit/b042d2a79af823b2271d4c890a837e8c23028507) | `` automatic update `` |