### PR TITLE
chore(flake/nur): `b042d2a7` -> `3a7dd170`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700473479,
-        "narHash": "sha256-eyGKUhN3ZNLiuHXC19P6/6Jl7mFCSGhemE16pQ3MCLs=",
+        "lastModified": 1700477143,
+        "narHash": "sha256-43dtFRTcFxQJXmy0jvXGDttXD7fAuGIZ0D8frdIg84M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b042d2a79af823b2271d4c890a837e8c23028507",
+        "rev": "3a7dd170a152b8525e64e1a21b3f95d402ead2b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3a7dd170`](https://github.com/nix-community/NUR/commit/3a7dd170a152b8525e64e1a21b3f95d402ead2b8) | `` automatic update `` |