### PR TITLE
chore(flake/nur): `3a7dd170` -> `f8d15f19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700477143,
-        "narHash": "sha256-43dtFRTcFxQJXmy0jvXGDttXD7fAuGIZ0D8frdIg84M=",
+        "lastModified": 1700480813,
+        "narHash": "sha256-WICrrmyn9Y7tZrqKBtw9rGjOJdZeSXJO9q+l7BZDa7g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3a7dd170a152b8525e64e1a21b3f95d402ead2b8",
+        "rev": "f8d15f19746eedce261e4f869634f48705de0716",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f8d15f19`](https://github.com/nix-community/NUR/commit/f8d15f19746eedce261e4f869634f48705de0716) | `` automatic update `` |