### PR TITLE
chore(flake/nur): `f8d15f19` -> `5400c2b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700480813,
-        "narHash": "sha256-WICrrmyn9Y7tZrqKBtw9rGjOJdZeSXJO9q+l7BZDa7g=",
+        "lastModified": 1700482126,
+        "narHash": "sha256-4zLW96revlLur8prOh1t+Ka4yIzWge+3B2Cgg89sOQk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f8d15f19746eedce261e4f869634f48705de0716",
+        "rev": "5400c2b8e6cad21911ee8d7258319dbadac87879",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5400c2b8`](https://github.com/nix-community/NUR/commit/5400c2b8e6cad21911ee8d7258319dbadac87879) | `` automatic update `` |