### PR TITLE
chore(flake/nur): `d4b205cb` -> `a5a974d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700498677,
-        "narHash": "sha256-ABtiINPf4cwNHsWQ1dnriQvvuhRBoqScYtXYEhvevN0=",
+        "lastModified": 1700505868,
+        "narHash": "sha256-269dv6rf9ARVCrIzZG+nmLh716FUfJDZeOZCT1kOZtY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d4b205cb1f70e9bda87c0db04e70e70b54047696",
+        "rev": "a5a974d333be5beeaad61dc6aa71624606263ef8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a5a974d3`](https://github.com/nix-community/NUR/commit/a5a974d333be5beeaad61dc6aa71624606263ef8) | `` automatic update `` |