### PR TITLE
chore(flake/nur): `a5a974d3` -> `c675b938`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700505868,
-        "narHash": "sha256-269dv6rf9ARVCrIzZG+nmLh716FUfJDZeOZCT1kOZtY=",
+        "lastModified": 1700509460,
+        "narHash": "sha256-PaYlk7QiTSz2HfQY3WrOh6N6jbH2wULNri/PZwuxMEk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a5a974d333be5beeaad61dc6aa71624606263ef8",
+        "rev": "c675b9383a72d828b70f4553340b7310e776656c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c675b938`](https://github.com/nix-community/NUR/commit/c675b9383a72d828b70f4553340b7310e776656c) | `` automatic update `` |