### PR TITLE
chore(flake/nur): `c675b938` -> `4486267d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700509460,
-        "narHash": "sha256-PaYlk7QiTSz2HfQY3WrOh6N6jbH2wULNri/PZwuxMEk=",
+        "lastModified": 1700512041,
+        "narHash": "sha256-fAl29aDdOj4AjORaEh85hS0GkCCfjFFCymuOfF4P+Ek=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c675b9383a72d828b70f4553340b7310e776656c",
+        "rev": "4486267d862ccc8fbbac6c112ccf1f0595cfbd74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4486267d`](https://github.com/nix-community/NUR/commit/4486267d862ccc8fbbac6c112ccf1f0595cfbd74) | `` automatic update `` |