### PR TITLE
chore(flake/nur): `4b8baee6` -> `5caebd36`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700534878,
-        "narHash": "sha256-iJweMf0YExz6RKFLKMil0Z/aPC7r3KewV6gFtDOO50s=",
+        "lastModified": 1700537893,
+        "narHash": "sha256-7W9R/kxNZN6NYuS2Wzi2p6AyR1/coN0gZ04NpBFuaPE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4b8baee6f7a185992f365116159820453b9bc9e7",
+        "rev": "5caebd36cdf6272e3fa245878474a3ba56f25019",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5caebd36`](https://github.com/nix-community/NUR/commit/5caebd36cdf6272e3fa245878474a3ba56f25019) | `` automatic update `` |