### PR TITLE
chore(flake/nur): `0f54812e` -> `9ec9fae8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700544844,
-        "narHash": "sha256-YUpHqQJm4CM1cm0gC/teK6ye5UZ8Z4q2fKiLFeiPwQY=",
+        "lastModified": 1700547478,
+        "narHash": "sha256-oJiUFlo4kD7HZCTdBB/knvwdL8mrr0DUA3bIfXkdUVc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0f54812e129109bc0373057a430c855f9194378d",
+        "rev": "9ec9fae8b47f8a07048954b56070baca5523fb8e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ec9fae8`](https://github.com/nix-community/NUR/commit/9ec9fae8b47f8a07048954b56070baca5523fb8e) | `` automatic update `` |