### PR TITLE
chore(flake/nur): `9ec9fae8` -> `8b3658a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700547478,
-        "narHash": "sha256-oJiUFlo4kD7HZCTdBB/knvwdL8mrr0DUA3bIfXkdUVc=",
+        "lastModified": 1700555959,
+        "narHash": "sha256-RAG0hhJZKnzS1Pi+wNhsTsNAPK1rDwtMviaX5mGbp20=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ec9fae8b47f8a07048954b56070baca5523fb8e",
+        "rev": "8b3658a6b7ee7f50ded645b99304dfead02c0394",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8b3658a6`](https://github.com/nix-community/NUR/commit/8b3658a6b7ee7f50ded645b99304dfead02c0394) | `` automatic update `` |
| [`422b1c01`](https://github.com/nix-community/NUR/commit/422b1c017ac0baf98c3e89f55ca015d8acad6feb) | `` automatic update `` |
| [`6ea56dac`](https://github.com/nix-community/NUR/commit/6ea56dac2ca94b8c6b6d4315468bf49ad4e538ac) | `` automatic update `` |
| [`d48fddd0`](https://github.com/nix-community/NUR/commit/d48fddd04a75dec3d49102ad88808539974be192) | `` automatic update `` |
| [`92bf57e8`](https://github.com/nix-community/NUR/commit/92bf57e8e9a4472ea494e73580d60310ee9d3371) | `` automatic update `` |