### PR TITLE
chore(flake/nur): `ddbb0362` -> `126e6fcc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700578383,
-        "narHash": "sha256-ij/q6/GJc/z7hML30aAVHw+bTKSV+Qfx4iGLimrZ0lw=",
+        "lastModified": 1700595869,
+        "narHash": "sha256-W7LQXIU3EJpWH21KmqxA2NEPW4ONZ0s5syNayyZmIsk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ddbb03620f56d5e27fdb494a712f3735a97da448",
+        "rev": "126e6fccb34982d37f8afbd3f95245ae2874eec8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`126e6fcc`](https://github.com/nix-community/NUR/commit/126e6fccb34982d37f8afbd3f95245ae2874eec8) | `` automatic update `` |
| [`3b1fe6c7`](https://github.com/nix-community/NUR/commit/3b1fe6c776e4a69d7decabaa5a0094d5726f432a) | `` automatic update `` |