### PR TITLE
chore(flake/nur): `126e6fcc` -> `2a4da31a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700595869,
-        "narHash": "sha256-W7LQXIU3EJpWH21KmqxA2NEPW4ONZ0s5syNayyZmIsk=",
+        "lastModified": 1700599986,
+        "narHash": "sha256-4sgooeExRWsXBiGFe6nv8T+JAasW5lDGJOvox0CdbJs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "126e6fccb34982d37f8afbd3f95245ae2874eec8",
+        "rev": "2a4da31a2bc133a4ae5050690960878e8e1b1063",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2a4da31a`](https://github.com/nix-community/NUR/commit/2a4da31a2bc133a4ae5050690960878e8e1b1063) | `` automatic update `` |
| [`0c23fa83`](https://github.com/nix-community/NUR/commit/0c23fa83248598ff38b4590d3191d7d55af8225e) | `` automatic update `` |