### PR TITLE
chore(flake/nur): `2a4da31a` -> `73a121a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700599986,
-        "narHash": "sha256-4sgooeExRWsXBiGFe6nv8T+JAasW5lDGJOvox0CdbJs=",
+        "lastModified": 1700603363,
+        "narHash": "sha256-0f/qOTj4lOsdYUDoxQg1gH9RgCRz5yy+H1bYK1CYOSc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2a4da31a2bc133a4ae5050690960878e8e1b1063",
+        "rev": "73a121a8cef922a2f65898af1953c206757589e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`73a121a8`](https://github.com/nix-community/NUR/commit/73a121a8cef922a2f65898af1953c206757589e1) | `` automatic update `` |
| [`e7d37680`](https://github.com/nix-community/NUR/commit/e7d3768059b87c735a91c64af28842cd85bcc2cf) | `` automatic update `` |