### PR TITLE
chore(flake/nur): `73a121a8` -> `b254aa97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700603363,
-        "narHash": "sha256-0f/qOTj4lOsdYUDoxQg1gH9RgCRz5yy+H1bYK1CYOSc=",
+        "lastModified": 1700607216,
+        "narHash": "sha256-tXJQLgn5Wu18OKQywbc/x7960fRwwO1DfKLDweOcUxE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "73a121a8cef922a2f65898af1953c206757589e1",
+        "rev": "b254aa9757344441eeaa8e89b60ac03c7da97516",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b254aa97`](https://github.com/nix-community/NUR/commit/b254aa9757344441eeaa8e89b60ac03c7da97516) | `` automatic update `` |
| [`7afbfe09`](https://github.com/nix-community/NUR/commit/7afbfe09dd47e1efee26f2839cc160e3314c6f0d) | `` automatic update `` |