### PR TITLE
chore(flake/nur): `4ec250ea` -> `679449a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700608092,
-        "narHash": "sha256-Y6wVZDmhhiJn6mrEqd2skL8je0e0cgZAS1DcdfY2AsM=",
+        "lastModified": 1700612875,
+        "narHash": "sha256-2FraoQWa5xaNibTJ3Gph9aCn+S7U5ix7eXoA5RAxvgY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ec250ea764a617c90312fd676a1ccf4ec28f130",
+        "rev": "679449a92d2ca5bb9f9e93b8ac6a4af84b167585",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`679449a9`](https://github.com/nix-community/NUR/commit/679449a92d2ca5bb9f9e93b8ac6a4af84b167585) | `` automatic update `` |
| [`c9af8661`](https://github.com/nix-community/NUR/commit/c9af8661cad384bf6f4fa94fd3f2012bd1326f27) | `` automatic update `` |