### PR TITLE
chore(flake/nur): `679449a9` -> `c5f009eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700612875,
-        "narHash": "sha256-2FraoQWa5xaNibTJ3Gph9aCn+S7U5ix7eXoA5RAxvgY=",
+        "lastModified": 1700617566,
+        "narHash": "sha256-i9uvNWafW959K0vLN6SIIe1j/K0kcTnnKHUHTK+gBW8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "679449a92d2ca5bb9f9e93b8ac6a4af84b167585",
+        "rev": "c5f009ebd6302071042a4ff1f19e4ba48a7b3036",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c5f009eb`](https://github.com/nix-community/NUR/commit/c5f009ebd6302071042a4ff1f19e4ba48a7b3036) | `` automatic update `` |