### PR TITLE
chore(flake/nur): `c5f009eb` -> `4eb42007`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700617566,
-        "narHash": "sha256-i9uvNWafW959K0vLN6SIIe1j/K0kcTnnKHUHTK+gBW8=",
+        "lastModified": 1700621264,
+        "narHash": "sha256-KKE7hZdPWIV5xjeaj5vV0r4+P0dihAkZ3ZXBMN85XFk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c5f009ebd6302071042a4ff1f19e4ba48a7b3036",
+        "rev": "4eb42007225fbb9482eb8d7ebc6aac5f68d97383",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4eb42007`](https://github.com/nix-community/NUR/commit/4eb42007225fbb9482eb8d7ebc6aac5f68d97383) | `` automatic update `` |