### PR TITLE
chore(flake/nur): `d060aa0d` -> `bc262e5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700626207,
-        "narHash": "sha256-FoCzn2GFs957UYijWUNT5lkQtU84/9Ust6I9bXbcCig=",
+        "lastModified": 1700632813,
+        "narHash": "sha256-VNl0QZU/77cIVIitSAEKiQHjwDMYV4QKcAhswjIx5dU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d060aa0d42f5c3ad75719573bc3128bd72aa7162",
+        "rev": "bc262e5eda937c4220994fef040b9bac8c90ae04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bc262e5e`](https://github.com/nix-community/NUR/commit/bc262e5eda937c4220994fef040b9bac8c90ae04) | `` automatic update `` |
| [`742eb63c`](https://github.com/nix-community/NUR/commit/742eb63c49cf620a6514a3b036a074383f466d66) | `` automatic update `` |
| [`4890e3bb`](https://github.com/nix-community/NUR/commit/4890e3bb08caa089b3222fefb736c6fafb011c71) | `` automatic update `` |