### PR TITLE
chore(flake/nur): `bc262e5e` -> `fdb08137`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700632813,
-        "narHash": "sha256-VNl0QZU/77cIVIitSAEKiQHjwDMYV4QKcAhswjIx5dU=",
+        "lastModified": 1700635964,
+        "narHash": "sha256-boqvyIXJDNbF+GVtiENn5aOHAqouzq9NimIx0IBM+oQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bc262e5eda937c4220994fef040b9bac8c90ae04",
+        "rev": "fdb0813792e89cb10551a8ac78d0e8bbcbd29010",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fdb08137`](https://github.com/nix-community/NUR/commit/fdb0813792e89cb10551a8ac78d0e8bbcbd29010) | `` automatic update `` |
| [`41eeb122`](https://github.com/nix-community/NUR/commit/41eeb122a38d3323d1df4464f7f3d83eeb0f1a0b) | `` automatic update `` |