### PR TITLE
chore(flake/nur): `d6378b9d` -> `5a52d761`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700637792,
-        "narHash": "sha256-qWcKTZ3hI9m7D+umudU27hgStMJEar2iyTJNDvWRwOI=",
+        "lastModified": 1700646339,
+        "narHash": "sha256-xn5tkcLbXyAesWS7nqeFNwjCGuDyKVJnyNmBfeYagwk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d6378b9db2653ac1854e6de93acc26315cd2f20e",
+        "rev": "5a52d761ad540a2162cd336847f87d704bfd2ba2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                     |
| -------------------------------------------------------------------------------------------------- | --------------------------- |
| [`5a52d761`](https://github.com/nix-community/NUR/commit/5a52d761ad540a2162cd336847f87d704bfd2ba2) | `` automatic update ``      |
| [`86dc8be0`](https://github.com/nix-community/NUR/commit/86dc8be032c2f36df24cee3d9eab2b7b7e6497cb) | `` automatic update ``      |
| [`1e634db2`](https://github.com/nix-community/NUR/commit/1e634db256e3631598d046197532b6e7feaf2843) | `` add fooker repository `` |