### PR TITLE
chore(flake/srvos): `c89d0acb` -> `b41442d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1007,11 +1007,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700445214,
-        "narHash": "sha256-QmzM21vIpiMk2tkHNwfoyKrKetOVLe6lw8VdQKSTZtM=",
+        "lastModified": 1700643359,
+        "narHash": "sha256-SZdNAkCcpilfBlEqBboKPdnIVb+qUy4ZYLPBswGWP/g=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "c89d0acb7c447a85f9f3d751321e9012ea21e8e1",
+        "rev": "b41442d517ccb663df0517f0ec558645e3799fbb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                           |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`b41442d5`](https://github.com/nix-community/srvos/commit/b41442d517ccb663df0517f0ec558645e3799fbb) | `` boot.initrd.systemd: also enable if initrd networkd is used `` |