### PR TITLE
chore(flake/nur): `5a52d761` -> `9ee4563c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700646339,
-        "narHash": "sha256-xn5tkcLbXyAesWS7nqeFNwjCGuDyKVJnyNmBfeYagwk=",
+        "lastModified": 1700649906,
+        "narHash": "sha256-xckq5YgckXTgToEn5biO/Rl167OOknG4ndturr1iUaY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5a52d761ad540a2162cd336847f87d704bfd2ba2",
+        "rev": "9ee4563cf0b4c9b6dd78bce8c45fa32103be97d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ee4563c`](https://github.com/nix-community/NUR/commit/9ee4563cf0b4c9b6dd78bce8c45fa32103be97d4) | `` automatic update `` |