### PR TITLE
chore(flake/nur): `9ee4563c` -> `2bd179e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700649906,
-        "narHash": "sha256-xckq5YgckXTgToEn5biO/Rl167OOknG4ndturr1iUaY=",
+        "lastModified": 1700653534,
+        "narHash": "sha256-Q6DeqqLbBV8XJoYKD8bbS/s6p8IGQDoLiftU1bnKy4k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ee4563cf0b4c9b6dd78bce8c45fa32103be97d4",
+        "rev": "2bd179e349e8ae99fef5dbcbf1d636104582d55e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2bd179e3`](https://github.com/nix-community/NUR/commit/2bd179e349e8ae99fef5dbcbf1d636104582d55e) | `` automatic update `` |