### PR TITLE
chore(flake/nur): `2bd179e3` -> `0a618d23`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700653534,
-        "narHash": "sha256-Q6DeqqLbBV8XJoYKD8bbS/s6p8IGQDoLiftU1bnKy4k=",
+        "lastModified": 1700657176,
+        "narHash": "sha256-0UlsFBxu++5PXO+FIArbiNWsFHUH8klYwXiW9jKj8jU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2bd179e349e8ae99fef5dbcbf1d636104582d55e",
+        "rev": "0a618d2328f9100bc713a4d4a59a83acd98c9a2d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0a618d23`](https://github.com/nix-community/NUR/commit/0a618d2328f9100bc713a4d4a59a83acd98c9a2d) | `` automatic update `` |