### PR TITLE
chore(flake/nur): `0a618d23` -> `0707dd06`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700657176,
-        "narHash": "sha256-0UlsFBxu++5PXO+FIArbiNWsFHUH8klYwXiW9jKj8jU=",
+        "lastModified": 1700660661,
+        "narHash": "sha256-1+//5oLdqYo8ptS/ZpaGEzgnQ6FWJOjLPyTuiD6mPjY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0a618d2328f9100bc713a4d4a59a83acd98c9a2d",
+        "rev": "0707dd061f4fb82393f3c96c6ed10c60396d7f9c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0707dd06`](https://github.com/nix-community/NUR/commit/0707dd061f4fb82393f3c96c6ed10c60396d7f9c) | `` automatic update `` |