### PR TITLE
chore(flake/nur): `0b44c1ac` -> `7fdd8013`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700662260,
-        "narHash": "sha256-mEqx6EyEhDqgIKFKGgsTcaWLzgOeM2NymOX6E+1Rr18=",
+        "lastModified": 1700677485,
+        "narHash": "sha256-XroX2wiwmVqOrhjkK/jmHYuAih7XlbG/l5BAcymCyQY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0b44c1ac9ae6105b4c57123913fb2a969305c75a",
+        "rev": "7fdd8013975a458ed6a81e0368757ff56b2f4df6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7fdd8013`](https://github.com/nix-community/NUR/commit/7fdd8013975a458ed6a81e0368757ff56b2f4df6) | `` automatic update `` |