### PR TITLE
chore(flake/nur): `7fdd8013` -> `a528bf70`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700677485,
-        "narHash": "sha256-XroX2wiwmVqOrhjkK/jmHYuAih7XlbG/l5BAcymCyQY=",
+        "lastModified": 1700682425,
+        "narHash": "sha256-lDaUtq0rVlzdATZFu0Q6+tcn05yUmYiirr1nH5QTg5k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7fdd8013975a458ed6a81e0368757ff56b2f4df6",
+        "rev": "a528bf7058faa967511785ec9967b661f07255aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a528bf70`](https://github.com/nix-community/NUR/commit/a528bf7058faa967511785ec9967b661f07255aa) | `` automatic update `` |