### PR TITLE
chore(flake/nur): `a528bf70` -> `36f67620`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700682425,
-        "narHash": "sha256-lDaUtq0rVlzdATZFu0Q6+tcn05yUmYiirr1nH5QTg5k=",
+        "lastModified": 1700689520,
+        "narHash": "sha256-oHnhMu1UjB5+UB2ZvpVu8hKSS0rOHmOTEIFG2rDJZ1E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a528bf7058faa967511785ec9967b661f07255aa",
+        "rev": "36f6762053dcc282923bda47de2582e2b7c5c878",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`36f67620`](https://github.com/nix-community/NUR/commit/36f6762053dcc282923bda47de2582e2b7c5c878) | `` automatic update `` |