### PR TITLE
chore(flake/nur): `36f67620` -> `9e74bf0d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700689520,
-        "narHash": "sha256-oHnhMu1UjB5+UB2ZvpVu8hKSS0rOHmOTEIFG2rDJZ1E=",
+        "lastModified": 1700692941,
+        "narHash": "sha256-kthn0TMnP/EmfO4ujKYwXdzzFXqKmf3jdzQt7lRONaA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "36f6762053dcc282923bda47de2582e2b7c5c878",
+        "rev": "9e74bf0dc3167149e484519440359a347c5b68f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9e74bf0d`](https://github.com/nix-community/NUR/commit/9e74bf0dc3167149e484519440359a347c5b68f4) | `` automatic update `` |