### PR TITLE
chore(flake/srvos): `b41442d5` -> `71fca173`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -646,11 +646,11 @@
     },
     "nixos-23_05": {
       "locked": {
-        "lastModified": 1700403855,
-        "narHash": "sha256-Q0Uzjik9kUTN9pd/kp52XJi5kletBhy29ctBlAG+III=",
+        "lastModified": 1700501263,
+        "narHash": "sha256-M0U063Ba2DKL4lMYI7XW13Rsk5tfUXnIYiAVa39AV/0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c5678df521e1407884205fe3ce3cf1d7df297db",
+        "rev": "f741f8a839912e272d7e87ccf4b9dbc6012cdaf9",
         "type": "github"
       },
       "original": {
@@ -1007,11 +1007,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700643359,
-        "narHash": "sha256-SZdNAkCcpilfBlEqBboKPdnIVb+qUy4ZYLPBswGWP/g=",
+        "lastModified": 1700704312,
+        "narHash": "sha256-xjzksktEQMd+JCNMp7l+/6DjlQrv/KStm9WDbkY6mmQ=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "b41442d517ccb663df0517f0ec558645e3799fbb",
+        "rev": "71fca17388b50899341c78294a0861031527cc53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------ |
| [`71fca173`](https://github.com/nix-community/srvos/commit/71fca17388b50899341c78294a0861031527cc53) | `` flake.lock: Update `` |
| [`8585c004`](https://github.com/nix-community/srvos/commit/8585c004d74e490ca5173ed3be3d91a145964b4e) | `` flake.lock: Update `` |