### PR TITLE
chore(flake/nur): `9e74bf0d` -> `af3f6533`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700692941,
-        "narHash": "sha256-kthn0TMnP/EmfO4ujKYwXdzzFXqKmf3jdzQt7lRONaA=",
+        "lastModified": 1700704811,
+        "narHash": "sha256-lUCpVxiQxjAYtBgMN6tkHInrxbOQz30a0iOKrMyffvk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9e74bf0dc3167149e484519440359a347c5b68f4",
+        "rev": "af3f65338fe6a3fcb641c5978a7561d3440e7816",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`af3f6533`](https://github.com/nix-community/NUR/commit/af3f65338fe6a3fcb641c5978a7561d3440e7816) | `` automatic update `` |
| [`c3b91288`](https://github.com/nix-community/NUR/commit/c3b91288a4ee84ca3032c5e9b6c4d93b56bec3b9) | `` automatic update `` |
| [`7f3b35cf`](https://github.com/nix-community/NUR/commit/7f3b35cfdd903926f2d928abd6dfeee49ce5e24f) | `` automatic update `` |