### PR TITLE
chore(flake/nur): `af3f6533` -> `cb2ae869`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700704811,
-        "narHash": "sha256-lUCpVxiQxjAYtBgMN6tkHInrxbOQz30a0iOKrMyffvk=",
+        "lastModified": 1700707474,
+        "narHash": "sha256-7D7OPIsdXwE62cXsdJNippZKPTzIxU0vCiWtNUH1nRA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "af3f65338fe6a3fcb641c5978a7561d3440e7816",
+        "rev": "cb2ae8692d2de442ace6ea871d16dc98d0a78c4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cb2ae869`](https://github.com/nix-community/NUR/commit/cb2ae8692d2de442ace6ea871d16dc98d0a78c4b) | `` automatic update `` |
| [`ee40cb22`](https://github.com/nix-community/NUR/commit/ee40cb22a5c59aceec4d8792e7a7a8073b6d207e) | `` automatic update `` |