### PR TITLE
chore(flake/darwin): `fb9ed3f0` -> `6e0f4e58`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -216,11 +216,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700696815,
-        "narHash": "sha256-Grs+Sb2cvTty9WqicaocT7xOEqhblMOqTtmRyfgV7HU=",
+        "lastModified": 1700710264,
+        "narHash": "sha256-7JSlj4iWgt3bsqmkPenIy1z+9f9oGuKEk9Lt6ebFyNg=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "fb9ed3f0532e7e05d52062ca834045a8a88b879d",
+        "rev": "6e0f4e58a622dd3a34b09f56fdcab9eddc641a67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                    |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------ |
| [`89248225`](https://github.com/LnL7/nix-darwin/commit/892482250c3726b8f4b255d3aff7f4208bbfba97) | `` [yabai] Configure scripting addition `` |