### PR TITLE
chore(flake/nur): `cb2ae869` -> `68f4dc1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700707474,
-        "narHash": "sha256-7D7OPIsdXwE62cXsdJNippZKPTzIxU0vCiWtNUH1nRA=",
+        "lastModified": 1700712715,
+        "narHash": "sha256-v6nwFPDjYYrWnLhZyQOvjqW8rkoZ7TIbugCJJuf3Q+k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cb2ae8692d2de442ace6ea871d16dc98d0a78c4b",
+        "rev": "68f4dc1c03f6fbd2849cdd9779c870940b0077c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`68f4dc1c`](https://github.com/nix-community/NUR/commit/68f4dc1c03f6fbd2849cdd9779c870940b0077c6) | `` automatic update `` |
| [`1f6e5cdf`](https://github.com/nix-community/NUR/commit/1f6e5cdfd39c57a1e240d46cee3bc91567c97a7a) | `` automatic update `` |