### PR TITLE
chore(flake/nur): `68f4dc1c` -> `bfde44eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700712715,
-        "narHash": "sha256-v6nwFPDjYYrWnLhZyQOvjqW8rkoZ7TIbugCJJuf3Q+k=",
+        "lastModified": 1700719231,
+        "narHash": "sha256-GZuIX/u2OYTeRW+A2AQ4tCT6z+/qQFdIVfwSvOHFNOY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "68f4dc1c03f6fbd2849cdd9779c870940b0077c6",
+        "rev": "bfde44eb22da27541fc986fef31e2514468cf615",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bfde44eb`](https://github.com/nix-community/NUR/commit/bfde44eb22da27541fc986fef31e2514468cf615) | `` automatic update `` |
| [`dde12658`](https://github.com/nix-community/NUR/commit/dde1265896e26b818ed4077d8d8dc9e534459d48) | `` automatic update `` |