### PR TITLE
chore(flake/nur): `bfde44eb` -> `10e9c427`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700719231,
-        "narHash": "sha256-GZuIX/u2OYTeRW+A2AQ4tCT6z+/qQFdIVfwSvOHFNOY=",
+        "lastModified": 1700726166,
+        "narHash": "sha256-DxS/4cDvkC+lz3DqJH5DMPXd2Xl63rYzJra7ja1IBUQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bfde44eb22da27541fc986fef31e2514468cf615",
+        "rev": "10e9c4271fb7a2cb458236217371184e06294ed4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`10e9c427`](https://github.com/nix-community/NUR/commit/10e9c4271fb7a2cb458236217371184e06294ed4) | `` automatic update `` |
| [`f5ae63c5`](https://github.com/nix-community/NUR/commit/f5ae63c5a722e387aa82f781c84cb03a78dc295b) | `` automatic update `` |