### PR TITLE
chore(flake/nur): `10e9c427` -> `3a537496`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700726166,
-        "narHash": "sha256-DxS/4cDvkC+lz3DqJH5DMPXd2Xl63rYzJra7ja1IBUQ=",
+        "lastModified": 1700726747,
+        "narHash": "sha256-TQzhrO3pdtBqMIxbCppg83k/kwsowKTRGxBx5u4FG88=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "10e9c4271fb7a2cb458236217371184e06294ed4",
+        "rev": "3a537496997f80f0457a92ee17a58638296f5db6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3a537496`](https://github.com/nix-community/NUR/commit/3a537496997f80f0457a92ee17a58638296f5db6) | `` automatic update `` |