### PR TITLE
chore(flake/nur): `3a537496` -> `dad08828`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700726747,
-        "narHash": "sha256-TQzhrO3pdtBqMIxbCppg83k/kwsowKTRGxBx5u4FG88=",
+        "lastModified": 1700734926,
+        "narHash": "sha256-l+yzyMoBw/ghRu+/Kz3FhXqHUPDOQXdfbs4JdnUuc0Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3a537496997f80f0457a92ee17a58638296f5db6",
+        "rev": "dad0882851733400fa35fe14ba6b3fb4c99c5df9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dad08828`](https://github.com/nix-community/NUR/commit/dad0882851733400fa35fe14ba6b3fb4c99c5df9) | `` automatic update `` |