### PR TITLE
chore(flake/nur): `dad08828` -> `2cbe8a17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700734926,
-        "narHash": "sha256-l+yzyMoBw/ghRu+/Kz3FhXqHUPDOQXdfbs4JdnUuc0Q=",
+        "lastModified": 1700739901,
+        "narHash": "sha256-6J/4xjztxyEEVmMS3tqPD98Z+Lt1WQKbygLAKt4DTFY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dad0882851733400fa35fe14ba6b3fb4c99c5df9",
+        "rev": "2cbe8a174bb45236eee9c268b4b30417842336df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2cbe8a17`](https://github.com/nix-community/NUR/commit/2cbe8a174bb45236eee9c268b4b30417842336df) | `` automatic update `` |