### PR TITLE
chore(flake/nur): `2cbe8a17` -> `0a442e5d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700739901,
-        "narHash": "sha256-6J/4xjztxyEEVmMS3tqPD98Z+Lt1WQKbygLAKt4DTFY=",
+        "lastModified": 1700744239,
+        "narHash": "sha256-EWBV0TNr8HPSlRjSy+LOjI7Isly4PDgsG+Ce2AOGNHo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2cbe8a174bb45236eee9c268b4b30417842336df",
+        "rev": "0a442e5d4e79f9b70deb909d0cae4e735ec70df3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0a442e5d`](https://github.com/nix-community/NUR/commit/0a442e5d4e79f9b70deb909d0cae4e735ec70df3) | `` automatic update `` |
| [`8f73b413`](https://github.com/nix-community/NUR/commit/8f73b4136a35d5071ed0434046f401c6ae335b3b) | `` automatic update `` |
| [`d0d22888`](https://github.com/nix-community/NUR/commit/d0d22888151ba6ab7c4d5c0dcf69bbcc8858dc0f) | `` automatic update `` |