### PR TITLE
chore(flake/nur): `0a442e5d` -> `f5958970`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700744239,
-        "narHash": "sha256-EWBV0TNr8HPSlRjSy+LOjI7Isly4PDgsG+Ce2AOGNHo=",
+        "lastModified": 1700750700,
+        "narHash": "sha256-GqKkNp385rEUJuEs5YsVIsve63XH8caYUS+jbEPZtSo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0a442e5d4e79f9b70deb909d0cae4e735ec70df3",
+        "rev": "f59589704acf8e8d441c04ad1aa519bf4ca12033",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f5958970`](https://github.com/nix-community/NUR/commit/f59589704acf8e8d441c04ad1aa519bf4ca12033) | `` automatic update `` |