### PR TITLE
chore(flake/nur): `f5958970` -> `002f5d73`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700750700,
-        "narHash": "sha256-GqKkNp385rEUJuEs5YsVIsve63XH8caYUS+jbEPZtSo=",
+        "lastModified": 1700757912,
+        "narHash": "sha256-F/BxjKmPYSnZNoGQDPeu7EMjrCIcjGTT/6VmJxFJRS8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f59589704acf8e8d441c04ad1aa519bf4ca12033",
+        "rev": "002f5d738bfea6272d286678868de7693414362b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`002f5d73`](https://github.com/nix-community/NUR/commit/002f5d738bfea6272d286678868de7693414362b) | `` automatic update `` |
| [`f6c75b9f`](https://github.com/nix-community/NUR/commit/f6c75b9f136dce133bf97ea254410511c478a912) | `` automatic update `` |