### PR TITLE
chore(flake/nur): `002f5d73` -> `e2af1e4f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700757912,
-        "narHash": "sha256-F/BxjKmPYSnZNoGQDPeu7EMjrCIcjGTT/6VmJxFJRS8=",
+        "lastModified": 1700763946,
+        "narHash": "sha256-XKCp8Krcgpy/TbugfnCB83fq41s99qqg0IwNZ9I7KHg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "002f5d738bfea6272d286678868de7693414362b",
+        "rev": "e2af1e4fff08f6e9356a60a47e4207efaa2ef839",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e2af1e4f`](https://github.com/nix-community/NUR/commit/e2af1e4fff08f6e9356a60a47e4207efaa2ef839) | `` automatic update `` |