### PR TITLE
chore(flake/nur): `e2af1e4f` -> `c1e3ad81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700763946,
-        "narHash": "sha256-XKCp8Krcgpy/TbugfnCB83fq41s99qqg0IwNZ9I7KHg=",
+        "lastModified": 1700768661,
+        "narHash": "sha256-/1YNW+d3MIGh2gxkXeOqmLzw4jf0Zf/7oxdRqTbGK0A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e2af1e4fff08f6e9356a60a47e4207efaa2ef839",
+        "rev": "c1e3ad81377ef60f2572d0319aa41a604c03f700",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c1e3ad81`](https://github.com/nix-community/NUR/commit/c1e3ad81377ef60f2572d0319aa41a604c03f700) | `` automatic update `` |
| [`b92a4232`](https://github.com/nix-community/NUR/commit/b92a42322b956b5d0cbcc4d7173517d5771f7d40) | `` automatic update `` |