### PR TITLE
chore(flake/darwin): `c465a67a` -> `7e8d2927`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -216,11 +216,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700732776,
-        "narHash": "sha256-Q4hhnBVg4EVaqCQb9R84oGJNDqLg0KK9FY2LbCL0oV8=",
+        "lastModified": 1700781037,
+        "narHash": "sha256-d2Tf+GXKA7fIrodvWQH+OonOjrCUMfj7REjLpncBM64=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "c465a67a54aa34cf2883536c97d4e856fa4a373d",
+        "rev": "7e8d292728e480e9e602f1884dbc124fe010e803",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                           |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
| [`49ae6b92`](https://github.com/LnL7/nix-darwin/commit/49ae6b92ffe7199622bdddcff13e649bdf12f9d0) | `` fix: tests failing to build on unstable Nix `` |