### PR TITLE
chore(flake/darwin): `7e8d2927` -> `4b9b83d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -216,11 +216,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700781037,
-        "narHash": "sha256-d2Tf+GXKA7fIrodvWQH+OonOjrCUMfj7REjLpncBM64=",
+        "lastModified": 1700795494,
+        "narHash": "sha256-gzGLZSiOhf155FW7262kdHo2YDeugp3VuIFb4/GGng0=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "7e8d292728e480e9e602f1884dbc124fe010e803",
+        "rev": "4b9b83d5a92e8c1fbfd8eb27eda375908c11ec4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                     |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
| [`09284ab0`](https://github.com/LnL7/nix-darwin/commit/09284ab00b2bf86b0d33bae8cf8b1a999bb512d9) | `` Install darwin-uninstall by default, which includes the 'empty' config it switches to `` |