### PR TITLE
chore(flake/nur): `11c9f0fa` -> `303e9654`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700791260,
-        "narHash": "sha256-6uhU05Hd47am44HokLpaeycoDAxQn6JKThhQT5NiyP8=",
+        "lastModified": 1700797200,
+        "narHash": "sha256-dAECheU4+MsKmLf//LQMxo3NzPp4qGYkbSe7oYSsE68=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "11c9f0fa9e875325b772e7b758066ca2128a5605",
+        "rev": "303e965454cf3390a3c6093c695e52bc196e31ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`303e9654`](https://github.com/nix-community/NUR/commit/303e965454cf3390a3c6093c695e52bc196e31ac) | `` automatic update `` |