### PR TITLE
chore(flake/nur): `fd1a4f8b` -> `97725a22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700804423,
-        "narHash": "sha256-NKNiRxxOb3/J81iTLTwjqK4Zf2twckPKm3528MdGicc=",
+        "lastModified": 1700808742,
+        "narHash": "sha256-rG3/9ZbTOLVLMSKFhAXWcFThYZIaDsP/S/Qasn8nEXE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fd1a4f8bec4d8533081380fc69bbb1dc967671ae",
+        "rev": "97725a22f2446e4033d1e336ab0d3197335d9927",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`97725a22`](https://github.com/nix-community/NUR/commit/97725a22f2446e4033d1e336ab0d3197335d9927) | `` automatic update `` |