### PR TITLE
chore(flake/nur): `97725a22` -> `77a15238`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700808742,
-        "narHash": "sha256-rG3/9ZbTOLVLMSKFhAXWcFThYZIaDsP/S/Qasn8nEXE=",
+        "lastModified": 1700812816,
+        "narHash": "sha256-H9m1tW6UB3fb6jJE/g6705NF6s7iYvZp32MebkNMT3I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "97725a22f2446e4033d1e336ab0d3197335d9927",
+        "rev": "77a1523886994d58eca71572e994f4cda7b3457a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`77a15238`](https://github.com/nix-community/NUR/commit/77a1523886994d58eca71572e994f4cda7b3457a) | `` automatic update `` |
| [`a3730be8`](https://github.com/nix-community/NUR/commit/a3730be8de9efcd74ae604cf7479a818f7b8df41) | `` automatic update `` |