### PR TITLE
chore(flake/home-manager): `134deb46` -> `e1f3b36a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700695018,
-        "narHash": "sha256-MAiPLgBF4GLzSOlhnPCDWkWW5CDx4i7ApIYaR+TwTVg=",
+        "lastModified": 1700814342,
+        "narHash": "sha256-orNc5wfsE7arQ9TWSTJwvk+utDvJrJ36V84N8o+VI/Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "134deb46abd5d0889d913b8509413f6f38b0811e",
+        "rev": "e1f3b36ab01573fd35cae57d21f45d520433df61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`e1f3b36a`](https://github.com/nix-community/home-manager/commit/e1f3b36ab01573fd35cae57d21f45d520433df61) | `` home-manager: set unstable release to 24.05 `` |
| [`aeb2232d`](https://github.com/nix-community/home-manager/commit/aeb2232d7a32530d3448318790534d196bf9427a) | `` home-manager: set stable release to 23.11 ``   |