### PR TITLE
chore(flake/nur): `77a15238` -> `9cacc3c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700812816,
-        "narHash": "sha256-H9m1tW6UB3fb6jJE/g6705NF6s7iYvZp32MebkNMT3I=",
+        "lastModified": 1700820007,
+        "narHash": "sha256-oCzYodrjp4LC4l/uvTnvs50sKJfkqwrICn11L9FevUM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "77a1523886994d58eca71572e994f4cda7b3457a",
+        "rev": "9cacc3c0579aa53d75725d300ff17ae055191c6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9cacc3c0`](https://github.com/nix-community/NUR/commit/9cacc3c0579aa53d75725d300ff17ae055191c6c) | `` automatic update `` |
| [`49ab578b`](https://github.com/nix-community/NUR/commit/49ab578b491c550ac99dafee3ab8a72eddfd2d66) | `` automatic update `` |
| [`3669296c`](https://github.com/nix-community/NUR/commit/3669296c327aaab19178a6f5dbc6002b2c992980) | `` automatic update `` |
| [`1f36f949`](https://github.com/nix-community/NUR/commit/1f36f94999fa2ff3b224d94f0fc751057cbc8a6e) | `` automatic update `` |
| [`05bbd118`](https://github.com/nix-community/NUR/commit/05bbd118ce31b9b37445526bb553dbfa48402845) | `` automatic update `` |