### PR TITLE
chore(flake/srvos): `71fca173` -> `396f6d3f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1007,11 +1007,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700704312,
-        "narHash": "sha256-xjzksktEQMd+JCNMp7l+/6DjlQrv/KStm9WDbkY6mmQ=",
+        "lastModified": 1700815597,
+        "narHash": "sha256-7xz5LhCvULziXmCuim896vVoHXodwsamtwlr8lsA8RM=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "71fca17388b50899341c78294a0861031527cc53",
+        "rev": "396f6d3fa41a594b7ea02fa0d34f0c6975983e6e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                           |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`396f6d3f`](https://github.com/nix-community/srvos/commit/396f6d3fa41a594b7ea02fa0d34f0c6975983e6e) | `` serial: fix shebang in resize script (#318) `` |