### PR TITLE
chore(flake/nur): `19a07aa8` -> `72ffcf71`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700824070,
-        "narHash": "sha256-p92pX5JOgejIPg00/iV9aquh4lAUPpnADL0ue2wKLyI=",
+        "lastModified": 1700833528,
+        "narHash": "sha256-NJptuSEWm0dnkZI81M0d1EMzrQq06x1nvkdl0s8oMks=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "19a07aa81c698fb0875365114c615aafb6b31260",
+        "rev": "72ffcf71bf98be49a626d870395be6a8d9e632a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`72ffcf71`](https://github.com/nix-community/NUR/commit/72ffcf71bf98be49a626d870395be6a8d9e632a8) | `` automatic update `` |
| [`88d1b011`](https://github.com/nix-community/NUR/commit/88d1b0111ee5b76fdbf86b79b955e6158de19cc2) | `` automatic update `` |