### PR TITLE
chore(flake/nur): `72ffcf71` -> `f14d91bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700833528,
-        "narHash": "sha256-NJptuSEWm0dnkZI81M0d1EMzrQq06x1nvkdl0s8oMks=",
+        "lastModified": 1700835226,
+        "narHash": "sha256-cRyXbpSRrmb+mOLCv/jYBZ/8GroSVNboXR6juyN/N9I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "72ffcf71bf98be49a626d870395be6a8d9e632a8",
+        "rev": "f14d91bf1ba6d86dfb96543ff450785b08842b7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f14d91bf`](https://github.com/nix-community/NUR/commit/f14d91bf1ba6d86dfb96543ff450785b08842b7a) | `` automatic update `` |