### PR TITLE
chore(flake/nur): `f14d91bf` -> `3b34dcf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700835226,
-        "narHash": "sha256-cRyXbpSRrmb+mOLCv/jYBZ/8GroSVNboXR6juyN/N9I=",
+        "lastModified": 1700844319,
+        "narHash": "sha256-AUs6NJC7HXGW2oCG9NlBKH9C+hPvVbc9DnvmpZXhlvw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f14d91bf1ba6d86dfb96543ff450785b08842b7a",
+        "rev": "3b34dcf501cf8490dd94c7b8303aae0260d280be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3b34dcf5`](https://github.com/nix-community/NUR/commit/3b34dcf501cf8490dd94c7b8303aae0260d280be) | `` automatic update `` |