### PR TITLE
chore(flake/home-manager): `e1f3b36a` -> `8cedd63e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700814342,
-        "narHash": "sha256-orNc5wfsE7arQ9TWSTJwvk+utDvJrJ36V84N8o+VI/Y=",
+        "lastModified": 1700847865,
+        "narHash": "sha256-uWaOIemGl9LF813MW0AEgCBpKwFo2t1Wv3BZc6e5Frw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e1f3b36ab01573fd35cae57d21f45d520433df61",
+        "rev": "8cedd63eede4c22deb192f1721dd67e7460e1ebe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`8cedd63e`](https://github.com/nix-community/home-manager/commit/8cedd63eede4c22deb192f1721dd67e7460e1ebe) | `` fish: support flexible abbreviations `` |