### PR TITLE
chore(flake/nur): `ebf2c682` -> `7ddd84ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700855055,
-        "narHash": "sha256-QKjcrEntfghcXBsrenDE46OxaF/4YQVStAQfyDOQcPA=",
+        "lastModified": 1700865924,
+        "narHash": "sha256-3OvmS6b3bD1a3bCH3roDO7uBJrYVPhMLd+eUbmzahxk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ebf2c68214f10ee5b9372ae4960a7b54af514bd3",
+        "rev": "7ddd84acfc35469739ebddbaa2f58f9eebd60869",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7ddd84ac`](https://github.com/nix-community/NUR/commit/7ddd84acfc35469739ebddbaa2f58f9eebd60869) | `` automatic update `` |