### PR TITLE
chore(flake/nur): `e51798a8` -> `d754bccc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700874374,
-        "narHash": "sha256-aJlAjLZfmXAUvdksPDWXKfUTeqtu0xwTsCyCw8z7N40=",
+        "lastModified": 1700880146,
+        "narHash": "sha256-lgsD/vGn0f9XkamUlWAPagqsJwGxb31MqN9OyhPCaV8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e51798a838e6e49a8c3f0a58054c973829e2f806",
+        "rev": "d754bccc0094ac3267aaa41f96b243ab9d0cf8e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d754bccc`](https://github.com/nix-community/NUR/commit/d754bccc0094ac3267aaa41f96b243ab9d0cf8e8) | `` automatic update `` |