### PR TITLE
chore(flake/nur): `d754bccc` -> `a4842789`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700880146,
-        "narHash": "sha256-lgsD/vGn0f9XkamUlWAPagqsJwGxb31MqN9OyhPCaV8=",
+        "lastModified": 1700885377,
+        "narHash": "sha256-iULLmi/wp0QBpmKMBLeB+OtEpXoCAymuTkGGbLzaGrM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d754bccc0094ac3267aaa41f96b243ab9d0cf8e8",
+        "rev": "a484278909b1360587e1053e5b2cbb55ac343778",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a4842789`](https://github.com/nix-community/NUR/commit/a484278909b1360587e1053e5b2cbb55ac343778) | `` automatic update `` |