### PR TITLE
chore(flake/nur): `a4842789` -> `fc44d5d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700885377,
-        "narHash": "sha256-iULLmi/wp0QBpmKMBLeB+OtEpXoCAymuTkGGbLzaGrM=",
+        "lastModified": 1700889287,
+        "narHash": "sha256-Eocoz7DZtPxW6aC8w44UgL+OJPbKG0am4DE+Q0Qyrgc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a484278909b1360587e1053e5b2cbb55ac343778",
+        "rev": "fc44d5d4a552505f0b585d861512b3ae3365688b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fc44d5d4`](https://github.com/nix-community/NUR/commit/fc44d5d4a552505f0b585d861512b3ae3365688b) | `` automatic update `` |