### PR TITLE
chore(flake/nur): `fc44d5d4` -> `145de74c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700889287,
-        "narHash": "sha256-Eocoz7DZtPxW6aC8w44UgL+OJPbKG0am4DE+Q0Qyrgc=",
+        "lastModified": 1700895159,
+        "narHash": "sha256-J9myEMY9C/BmarDu/7JYsH2Tq8wodA29jD1IhJWfEZc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc44d5d4a552505f0b585d861512b3ae3365688b",
+        "rev": "145de74c6f8ccbd62c6ea4d9b9d8e45ee8382f23",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`145de74c`](https://github.com/nix-community/NUR/commit/145de74c6f8ccbd62c6ea4d9b9d8e45ee8382f23) | `` automatic update `` |
| [`1e4badf8`](https://github.com/nix-community/NUR/commit/1e4badf8f18a90273efbca61061851a508a9ac18) | `` automatic update `` |