### PR TITLE
chore(flake/nur): `145de74c` -> `92780bd2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700895159,
-        "narHash": "sha256-J9myEMY9C/BmarDu/7JYsH2Tq8wodA29jD1IhJWfEZc=",
+        "lastModified": 1700896827,
+        "narHash": "sha256-34Ya3sbVR7lJoghlygj8fPImzIj4Y1nN/B+zm/gVjoE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "145de74c6f8ccbd62c6ea4d9b9d8e45ee8382f23",
+        "rev": "92780bd20e4fa0526f63e0136fb6f3bbeac6bf9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`92780bd2`](https://github.com/nix-community/NUR/commit/92780bd20e4fa0526f63e0136fb6f3bbeac6bf9a) | `` automatic update `` |