### PR TITLE
chore(flake/nur): `92780bd2` -> `05ab78f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700896827,
-        "narHash": "sha256-34Ya3sbVR7lJoghlygj8fPImzIj4Y1nN/B+zm/gVjoE=",
+        "lastModified": 1700901925,
+        "narHash": "sha256-JaHjlzMBhRD4Tx4Sxv32fqZhO7BCKmBr4CWDLBEuySc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "92780bd20e4fa0526f63e0136fb6f3bbeac6bf9a",
+        "rev": "05ab78f4f46c5f6ce3f84ab5e041cf943a22f941",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`05ab78f4`](https://github.com/nix-community/NUR/commit/05ab78f4f46c5f6ce3f84ab5e041cf943a22f941) | `` automatic update `` |