### PR TITLE
chore(flake/nur): `05ab78f4` -> `f1fd8aa4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700901925,
-        "narHash": "sha256-JaHjlzMBhRD4Tx4Sxv32fqZhO7BCKmBr4CWDLBEuySc=",
+        "lastModified": 1700905501,
+        "narHash": "sha256-1YsdXNts9pLBs+kYSwvrL39c9XsTer3sEUgNjqqnHz0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "05ab78f4f46c5f6ce3f84ab5e041cf943a22f941",
+        "rev": "f1fd8aa4751304d1f63ccd8857e3e5dcf6b35f54",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f1fd8aa4`](https://github.com/nix-community/NUR/commit/f1fd8aa4751304d1f63ccd8857e3e5dcf6b35f54) | `` automatic update `` |