### PR TITLE
chore(flake/nur): `f1fd8aa4` -> `570366ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700905501,
-        "narHash": "sha256-1YsdXNts9pLBs+kYSwvrL39c9XsTer3sEUgNjqqnHz0=",
+        "lastModified": 1700911661,
+        "narHash": "sha256-QDzLtjS08CNvAU9s9KfLVz3lTg3oW32uqv/ymyRHpu8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f1fd8aa4751304d1f63ccd8857e3e5dcf6b35f54",
+        "rev": "570366ae78d90bb077ba46873f7ef3515bb4009a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`570366ae`](https://github.com/nix-community/NUR/commit/570366ae78d90bb077ba46873f7ef3515bb4009a) | `` automatic update `` |