### PR TITLE
chore(flake/stylix): `a15c3196` -> `17a452c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1041,11 +1041,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700302760,
-        "narHash": "sha256-JpOJf9Nj260rTrVuYonP9CiGzj+43AGPOfhF72XkQvU=",
+        "lastModified": 1701532764,
+        "narHash": "sha256-Jrizp/nITbul2HBIraQRDw5lyJnzTsj0K9wZUFYX2gg=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "a15c3196c1d620c18cbee8229092598384a89fef",
+        "rev": "17a452c5d58bb90057d49c7e3e613b5e6dc1c0f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                               |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`17a452c5`](https://github.com/danth/stylix/commit/17a452c5d58bb90057d49c7e3e613b5e6dc1c0f4) | `` Remove repetition of Waybar CSS (#192) ``          |
| [`8b3f6172`](https://github.com/danth/stylix/commit/8b3f61727f3b86c27096c3c014ae602aa40670ba) | `` Support GNOME 45 and Libadwaita updates :alien: `` |