### PR TITLE
chore(flake/nur): `2f972e33` -> `fb3bc75b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700919861,
-        "narHash": "sha256-F/jUXU3AkwrFiI3nGhw0kFTdwmsG4hUEGgEOAnZSukI=",
+        "lastModified": 1700927050,
+        "narHash": "sha256-vEhBkO4neVMxBlDGZqgsC6ReqW7HF2l/uBV2v9a1QZw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2f972e33b2323c947f9cbf6538b552d5d9205dc7",
+        "rev": "fb3bc75bb1dc92d0f61ebc3530c8ab8deda83abc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fb3bc75b`](https://github.com/nix-community/NUR/commit/fb3bc75bb1dc92d0f61ebc3530c8ab8deda83abc) | `` automatic update `` |
| [`981600da`](https://github.com/nix-community/NUR/commit/981600da923af46f6e2f1728b0c167262f25247c) | `` automatic update `` |
| [`2644c4a3`](https://github.com/nix-community/NUR/commit/2644c4a32642a32ea01dc63fd780404c21c82d7a) | `` automatic update `` |