### PR TITLE
chore(flake/nur): `fb3bc75b` -> `24bed8be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700927050,
-        "narHash": "sha256-vEhBkO4neVMxBlDGZqgsC6ReqW7HF2l/uBV2v9a1QZw=",
+        "lastModified": 1700930741,
+        "narHash": "sha256-it/l+fZ43hA0tG8oyehuLZeVbmrrjwXxCwcMyqtIhNs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fb3bc75bb1dc92d0f61ebc3530c8ab8deda83abc",
+        "rev": "24bed8be0a3ffb70bf517ae06b35ebf5c8d2fd16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`24bed8be`](https://github.com/nix-community/NUR/commit/24bed8be0a3ffb70bf517ae06b35ebf5c8d2fd16) | `` automatic update `` |