### PR TITLE
chore(flake/nur): `c21bb3ca` -> `8100f837`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700948727,
-        "narHash": "sha256-j+eL8kXTlbNEIaCzdWR/IUJz5ONUOQ3CblhMp4A1/wQ=",
+        "lastModified": 1700952320,
+        "narHash": "sha256-5MP2bs4Go8rEel3JPAgeY1ybvuwGmlFS7lLPM0jI8do=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c21bb3cafbc37346254c67f2c755f6f28016fb13",
+        "rev": "8100f837eec48bc910f2f11529e982fbc0ad057a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8100f837`](https://github.com/nix-community/NUR/commit/8100f837eec48bc910f2f11529e982fbc0ad057a) | `` automatic update `` |