### PR TITLE
chore(flake/nur): `8100f837` -> `6d06cec4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700952320,
-        "narHash": "sha256-5MP2bs4Go8rEel3JPAgeY1ybvuwGmlFS7lLPM0jI8do=",
+        "lastModified": 1700955854,
+        "narHash": "sha256-dRl/Q8CehO/W+YF06rurH5oxt75Jc9TrUmtIc8eCC2c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8100f837eec48bc910f2f11529e982fbc0ad057a",
+        "rev": "6d06cec40da7895c8e5278be921c785ffcb6e2ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6d06cec4`](https://github.com/nix-community/NUR/commit/6d06cec40da7895c8e5278be921c785ffcb6e2ea) | `` automatic update `` |