### PR TITLE
chore(flake/nix-index-database): `27920146` -> `bd3aec0e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -607,11 +607,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700363379,
-        "narHash": "sha256-fBEVPFwSZ6AmBE1s1oT7E9WVuqRghruxTnSQ8UUlMkw=",
+        "lastModified": 1700968077,
+        "narHash": "sha256-Lax+2g7G3Fe+ckMrHLYTl+97unbmNDmN1qS9MLBkxr4=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "27920146e671a0d565aaa7452907383be14d8d82",
+        "rev": "bd3aec0ecb0fdde863a7ed2c6caa220c47e22c07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`bd3aec0e`](https://github.com/nix-community/nix-index-database/commit/bd3aec0ecb0fdde863a7ed2c6caa220c47e22c07) | `` update packages.nix to release 2023-11-26-030655 `` |
| [`d189d05f`](https://github.com/nix-community/nix-index-database/commit/d189d05f9de237d3b554c91029f9cb78efec8ace) | `` flake.lock: Update ``                               |