### PR TITLE
chore(flake/nur): `41baba34` -> `f3e9bac6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700969927,
-        "narHash": "sha256-eb1fxSIn9h8G7bkQ/7yIVJc1OShB4aCBOk5Ho0zR9aY=",
+        "lastModified": 1700977241,
+        "narHash": "sha256-1toBTNtLkR8mq4WVq1M8bk4GvuuxNVIm2ITdXSplRTM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "41baba347708b140c1dde7dc387ae1b16a396448",
+        "rev": "f3e9bac6b7cc491a052ff255d80226e3faa74bfb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f3e9bac6`](https://github.com/nix-community/NUR/commit/f3e9bac6b7cc491a052ff255d80226e3faa74bfb) | `` automatic update `` |
| [`9a5c43cf`](https://github.com/nix-community/NUR/commit/9a5c43cffc04beb342e4f0299b5b31c87db39b38) | `` automatic update `` |