### PR TITLE
chore(flake/nur): `f3e9bac6` -> `ed62b1ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700977241,
-        "narHash": "sha256-1toBTNtLkR8mq4WVq1M8bk4GvuuxNVIm2ITdXSplRTM=",
+        "lastModified": 1700981149,
+        "narHash": "sha256-a5TqoaOUXmVjuvxOswUnYoEm1qIo+aaP4aEq/TaWy1s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f3e9bac6b7cc491a052ff255d80226e3faa74bfb",
+        "rev": "ed62b1ecf8943fbd295b3320f049aba932d88886",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ed62b1ec`](https://github.com/nix-community/NUR/commit/ed62b1ecf8943fbd295b3320f049aba932d88886) | `` automatic update `` |