### PR TITLE
chore(flake/nur): `ed62b1ec` -> `67ffd6ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700981149,
-        "narHash": "sha256-a5TqoaOUXmVjuvxOswUnYoEm1qIo+aaP4aEq/TaWy1s=",
+        "lastModified": 1700985135,
+        "narHash": "sha256-K0WmLcQDyFTQsfIU7i/sQmwZrAajpnIhrhI7JiUQJjE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed62b1ecf8943fbd295b3320f049aba932d88886",
+        "rev": "67ffd6ff0b060fed7181334878a0dd302df15180",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`67ffd6ff`](https://github.com/nix-community/NUR/commit/67ffd6ff0b060fed7181334878a0dd302df15180) | `` automatic update `` |
| [`245d3aaf`](https://github.com/nix-community/NUR/commit/245d3aaf5f7c690b78aef8ef645bab4be19af1d1) | `` automatic update `` |
| [`3252372b`](https://github.com/nix-community/NUR/commit/3252372bffefdd35d976d7b51058f2e99a7b4a7f) | `` automatic update `` |