### PR TITLE
chore(flake/nur): `67ffd6ff` -> `3ae8d2d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700985135,
-        "narHash": "sha256-K0WmLcQDyFTQsfIU7i/sQmwZrAajpnIhrhI7JiUQJjE=",
+        "lastModified": 1700986582,
+        "narHash": "sha256-iZwoHtJk0+eryg50+dAVsYTuq/u2/FCMVp/jFM4kaPw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "67ffd6ff0b060fed7181334878a0dd302df15180",
+        "rev": "3ae8d2d1acdb1b4bb2b07ec2780e3be7e5aa24bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3ae8d2d1`](https://github.com/nix-community/NUR/commit/3ae8d2d1acdb1b4bb2b07ec2780e3be7e5aa24bd) | `` automatic update `` |