### PR TITLE
chore(flake/nur): `3ae8d2d1` -> `af1b4aca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700986582,
-        "narHash": "sha256-iZwoHtJk0+eryg50+dAVsYTuq/u2/FCMVp/jFM4kaPw=",
+        "lastModified": 1700992696,
+        "narHash": "sha256-+6MaIYfcpgCZeiMrZS1C0wzYQarG/c4yqwkTX4o6klU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3ae8d2d1acdb1b4bb2b07ec2780e3be7e5aa24bd",
+        "rev": "af1b4acac79c5d0457920a4441031f4278c5afd3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`af1b4aca`](https://github.com/nix-community/NUR/commit/af1b4acac79c5d0457920a4441031f4278c5afd3) | `` automatic update `` |
| [`b51dbb62`](https://github.com/nix-community/NUR/commit/b51dbb62003aeae301c75a56ec3e92a748f7d565) | `` automatic update `` |
| [`8e03b974`](https://github.com/nix-community/NUR/commit/8e03b9749c6490c602688ac4efb63cab31212156) | `` automatic update `` |