### PR TITLE
chore(flake/nur): `af1b4aca` -> `cf99dd7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700992696,
-        "narHash": "sha256-+6MaIYfcpgCZeiMrZS1C0wzYQarG/c4yqwkTX4o6klU=",
+        "lastModified": 1700995462,
+        "narHash": "sha256-N1BBV7JEoek+3jL0+iJuK3C3UInQHPAU8lChYsMglEs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "af1b4acac79c5d0457920a4441031f4278c5afd3",
+        "rev": "cf99dd7d8a4162724d111117425f319289432cd1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cf99dd7d`](https://github.com/nix-community/NUR/commit/cf99dd7d8a4162724d111117425f319289432cd1) | `` automatic update `` |