### PR TITLE
chore(flake/nur): `95f618e3` -> `61db677a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700999123,
-        "narHash": "sha256-cHUigiOX70G8tZ6Utdl7IkYZ879GDeUkdoI9urX2WcM=",
+        "lastModified": 1701003367,
+        "narHash": "sha256-clMYIO3VaQ8GKMBDkUcZ8ZAmlyJ03jCOiAmL5Rbu0T4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "95f618e3eaf6156578985fb5d14da500b811c52e",
+        "rev": "61db677ad39c3a922735f664f4d23834a0580a3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`61db677a`](https://github.com/nix-community/NUR/commit/61db677ad39c3a922735f664f4d23834a0580a3e) | `` automatic update `` |