### PR TITLE
chore(flake/nur): `61db677a` -> `35e1f313`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701003367,
-        "narHash": "sha256-clMYIO3VaQ8GKMBDkUcZ8ZAmlyJ03jCOiAmL5Rbu0T4=",
+        "lastModified": 1701007301,
+        "narHash": "sha256-d2leg5K4aj2jM/PcCPsRGVPximzWHgJJquFrVQZ+8yQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "61db677ad39c3a922735f664f4d23834a0580a3e",
+        "rev": "35e1f3133c549ee9833a92a42330569070b2ad5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`35e1f313`](https://github.com/nix-community/NUR/commit/35e1f3133c549ee9833a92a42330569070b2ad5d) | `` automatic update `` |
| [`59303699`](https://github.com/nix-community/NUR/commit/59303699fb59181462b0d3fb76de7205799975f1) | `` automatic update `` |