### PR TITLE
chore(flake/nur): `35e1f313` -> `4663f337`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701007301,
-        "narHash": "sha256-d2leg5K4aj2jM/PcCPsRGVPximzWHgJJquFrVQZ+8yQ=",
+        "lastModified": 1701010279,
+        "narHash": "sha256-C9lWInm4Si6THKvmAqmHwdumkY41gyr1vRuDCixo9iw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "35e1f3133c549ee9833a92a42330569070b2ad5d",
+        "rev": "4663f337fea6a45fc0fe82e63da1e0dcb5cfd2fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                   |
| -------------------------------------------------------------------------------------------------- | ------------------------- |
| [`4663f337`](https://github.com/nix-community/NUR/commit/4663f337fea6a45fc0fe82e63da1e0dcb5cfd2fb) | `` automatic update ``    |
| [`8685d16d`](https://github.com/nix-community/NUR/commit/8685d16d14bbe586a46192ae9c672de3105317ac) | `` automatic update ``    |
| [`e02a78d6`](https://github.com/nix-community/NUR/commit/e02a78d67b50894533340e80efe3ad9ab5c0325a) | `` add chen repository `` |