### PR TITLE
chore(flake/nur): `4663f337` -> `09920ba9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701010279,
-        "narHash": "sha256-C9lWInm4Si6THKvmAqmHwdumkY41gyr1vRuDCixo9iw=",
+        "lastModified": 1701012725,
+        "narHash": "sha256-fnNXt4t4Ugllos7cHlCDh8AaGEoMEoXGcdZieqwcP98=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4663f337fea6a45fc0fe82e63da1e0dcb5cfd2fb",
+        "rev": "09920ba97be4d52fbd850cb4bad4f3840760db19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`09920ba9`](https://github.com/nix-community/NUR/commit/09920ba97be4d52fbd850cb4bad4f3840760db19) | `` automatic update `` |
| [`1f1a69f3`](https://github.com/nix-community/NUR/commit/1f1a69f3dbc9b711f3490156dd686c822fc4b0ae) | `` automatic update `` |