### PR TITLE
chore(flake/nur): `09920ba9` -> `905c680b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701012725,
-        "narHash": "sha256-fnNXt4t4Ugllos7cHlCDh8AaGEoMEoXGcdZieqwcP98=",
+        "lastModified": 1701017102,
+        "narHash": "sha256-yVQmfLJf2r+Tr7j0Yra36+BjA8UqL7ZeNtEvBf6p02k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "09920ba97be4d52fbd850cb4bad4f3840760db19",
+        "rev": "905c680b20414c91fdfba54728383664a950c8b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                      |
| -------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`905c680b`](https://github.com/nix-community/NUR/commit/905c680b20414c91fdfba54728383664a950c8b0) | `` automatic update ``       |
| [`68ce8f77`](https://github.com/nix-community/NUR/commit/68ce8f77d521cb4e7dd127d993f80fd2e842f52f) | `` automatic update ``       |
| [`815c5c12`](https://github.com/nix-community/NUR/commit/815c5c12fc40e3fe3267a6107cbf28e9ed05695a) | `` add procyon repository `` |
| [`35aa8b6a`](https://github.com/nix-community/NUR/commit/35aa8b6a66479d577067300adfe323406724c467) | `` automatic update ``       |