### PR TITLE
chore(flake/nixos-hardware): `c3abafb0` -> `b006ec52`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -662,11 +662,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1700559156,
-        "narHash": "sha256-gL4epO/qf+wo30JjC3g+b5Bs8UrpxzkhNBBsUYxpw2g=",
+        "lastModified": 1701020860,
+        "narHash": "sha256-NwnRn04C8s+hH+KdVtGmVB1FFNIG7DtPJmQSCBDaET4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "c3abafb01cd7045dba522af29b625bd1e170c2fb",
+        "rev": "b006ec52fce23b1d57f6ab4a42d7400732e9a0a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`b006ec52`](https://github.com/NixOS/nixos-hardware/commit/b006ec52fce23b1d57f6ab4a42d7400732e9a0a2) | `` Bump linux-surface to a6eafcad32dc789ae92f42636b11e9aae6e7c879. `` |