### PR TITLE
chore(flake/nur): `905c680b` -> `0f09c575`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701017102,
-        "narHash": "sha256-yVQmfLJf2r+Tr7j0Yra36+BjA8UqL7ZeNtEvBf6p02k=",
+        "lastModified": 1701020654,
+        "narHash": "sha256-SqHs2wMEL5JEL+shaJokeYpC7XvDLOqfHkAP5l1iFLY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "905c680b20414c91fdfba54728383664a950c8b0",
+        "rev": "0f09c5753c8804f98d8b9ec6ba7c3026c878b5a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0f09c575`](https://github.com/nix-community/NUR/commit/0f09c5753c8804f98d8b9ec6ba7c3026c878b5a5) | `` automatic update `` |