### PR TITLE
chore(flake/nur): `0f09c575` -> `f393a1d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701020654,
-        "narHash": "sha256-SqHs2wMEL5JEL+shaJokeYpC7XvDLOqfHkAP5l1iFLY=",
+        "lastModified": 1701026589,
+        "narHash": "sha256-EUwYtkwiEPp5Hx7RtfGBT/3QGyOriP7GUsaWjYd/G8w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0f09c5753c8804f98d8b9ec6ba7c3026c878b5a5",
+        "rev": "f393a1d1972accabcaca7d4443b32ced35a5bde2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f393a1d1`](https://github.com/nix-community/NUR/commit/f393a1d1972accabcaca7d4443b32ced35a5bde2) | `` automatic update `` |