### PR TITLE
chore(flake/nur): `f393a1d1` -> `a122c9db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701026589,
-        "narHash": "sha256-EUwYtkwiEPp5Hx7RtfGBT/3QGyOriP7GUsaWjYd/G8w=",
+        "lastModified": 1701035126,
+        "narHash": "sha256-XLbBLYDPLCINtqp2Hi1/kR8ApVdZNFvvYDJ6Q4ff+qk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f393a1d1972accabcaca7d4443b32ced35a5bde2",
+        "rev": "a122c9db8f724bbe8fd90ac3970ce1b75d929d19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a122c9db`](https://github.com/nix-community/NUR/commit/a122c9db8f724bbe8fd90ac3970ce1b75d929d19) | `` automatic update `` |