### PR TITLE
chore(flake/home-manager): `a462e731` -> `7c97c46d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700900274,
-        "narHash": "sha256-KWoKDP5I1viHR4bG3ENnJ7H1DD16tXWH4ROvS0IfXw8=",
+        "lastModified": 1701040754,
+        "narHash": "sha256-rHld3E3CeVI/GUxH3xE+mqAo+IX2hTbXVfXKahCrG5I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a462e7315deaa8194b0821f726709bb7e51a850c",
+        "rev": "7c97c46dc4f45f2a78df536a6ebe15252831b800",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`7c97c46d`](https://github.com/nix-community/home-manager/commit/7c97c46dc4f45f2a78df536a6ebe15252831b800) | `` signaturepdf: add service `` |
| [`8340c0b4`](https://github.com/nix-community/home-manager/commit/8340c0b4d9986a91ca0ef746637839df99c43d3e) | `` flake.lock: Update ``        |