### PR TITLE
chore(flake/nur): `a122c9db` -> `764f0e8f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701035126,
-        "narHash": "sha256-XLbBLYDPLCINtqp2Hi1/kR8ApVdZNFvvYDJ6Q4ff+qk=",
+        "lastModified": 1701041509,
+        "narHash": "sha256-nGY8al2BAB0MBNZTp+fQqYFdmU+aXJMAsBCYW6cjdfQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a122c9db8f724bbe8fd90ac3970ce1b75d929d19",
+        "rev": "764f0e8fee3edcc6c8a6b3f6bfa21b105365a5bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`764f0e8f`](https://github.com/nix-community/NUR/commit/764f0e8fee3edcc6c8a6b3f6bfa21b105365a5bf) | `` automatic update `` |
| [`734c11c4`](https://github.com/nix-community/NUR/commit/734c11c46ead41333c95b789774a88c0854af521) | `` automatic update `` |