### PR TITLE
chore(flake/nur): `764f0e8f` -> `a0e751e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701041509,
-        "narHash": "sha256-nGY8al2BAB0MBNZTp+fQqYFdmU+aXJMAsBCYW6cjdfQ=",
+        "lastModified": 1701050629,
+        "narHash": "sha256-7XirQpplmxvzA7KJiGtyU+fV14+YIOo9dHS+LnN0Hpk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "764f0e8fee3edcc6c8a6b3f6bfa21b105365a5bf",
+        "rev": "a0e751e325d83b0350a32afe946bc3ca46ebe095",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a0e751e3`](https://github.com/nix-community/NUR/commit/a0e751e325d83b0350a32afe946bc3ca46ebe095) | `` automatic update `` |
| [`f69fe2f3`](https://github.com/nix-community/NUR/commit/f69fe2f32f963f16b2abeeb941866a0273142af7) | `` automatic update `` |