### PR TITLE
chore(flake/nur): `503b834c` -> `c2834572`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701058359,
-        "narHash": "sha256-Q61lHoddLHT8t9QQ02/wzYAsgF1w5WjQdJQYQ0mFGZQ=",
+        "lastModified": 1701063297,
+        "narHash": "sha256-bVL2hzIhsQjJhl/uCowaeNFi3gntBmolRAG/Rnepy90=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "503b834c86a5fcebe8c824e9a2f9ccade2f1e9fa",
+        "rev": "c2834572c536aeb582412ffb6358f169b1225b71",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c2834572`](https://github.com/nix-community/NUR/commit/c2834572c536aeb582412ffb6358f169b1225b71) | `` automatic update `` |
| [`4ac04b17`](https://github.com/nix-community/NUR/commit/4ac04b17a0cc259c37cdbf8d916cfa7325d4e5ee) | `` automatic update `` |