### PR TITLE
chore(flake/nur): `20954abd` -> `5dc6daff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701068004,
-        "narHash": "sha256-4U9oZqidE/gf2M7/0Sfzl6A2HRGDiqggTRp9J2CBEdo=",
+        "lastModified": 1701071582,
+        "narHash": "sha256-ZgR2FBSL349fqklqp9TQvvG4fMh1hd0+Mvvgjxvve1I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "20954abdd52e1941e13c0ab3ea676097ccec0183",
+        "rev": "5dc6daff2a68f6e9cbda6b8a482c3c9dafa0a874",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5dc6daff`](https://github.com/nix-community/NUR/commit/5dc6daff2a68f6e9cbda6b8a482c3c9dafa0a874) | `` automatic update `` |
| [`4182df9d`](https://github.com/nix-community/NUR/commit/4182df9d7f62c58a7be42a3a3a23014cd557c996) | `` automatic update `` |