### PR TITLE
chore(flake/nur): `13001183` -> `ddbe5c9d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701078355,
-        "narHash": "sha256-BIi0h4DwYk9sjm6JxCncZAYRNnuN+W2dggVM+rMkUDQ=",
+        "lastModified": 1701082388,
+        "narHash": "sha256-5eBuCAZZS28SuETFZe/wmX10Gqy3GOlc9cqCYPnEz7Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1300118335519d491e7a0bd2d45d07162c567380",
+        "rev": "ddbe5c9d41db49fed8db184b8de2034ec55d4bb2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ddbe5c9d`](https://github.com/nix-community/NUR/commit/ddbe5c9d41db49fed8db184b8de2034ec55d4bb2) | `` automatic update `` |
| [`a6a6faa2`](https://github.com/nix-community/NUR/commit/a6a6faa261c9324ec2c7154ebec87bd17820baff) | `` automatic update `` |
| [`1af599d2`](https://github.com/nix-community/NUR/commit/1af599d275dd49cf62eca391f43f4ae70d1f5017) | `` automatic update `` |