### PR TITLE
chore(flake/nur): `5b543aa2` -> `218c0b56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701085559,
-        "narHash": "sha256-BHT8Zxl/4iQ4NQ8N+fvJhi+LoblGNUz8p+axv40RDjY=",
+        "lastModified": 1701097243,
+        "narHash": "sha256-7XXQWhjUEfJghQ1KJIcNNOfjw+BUKGEXHMFw8wPEWdg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5b543aa25fdc06ae3f60c45acc050bd0876541bc",
+        "rev": "218c0b566f8519bad3ada0e25fc5e328e4720a66",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`218c0b56`](https://github.com/nix-community/NUR/commit/218c0b566f8519bad3ada0e25fc5e328e4720a66) | `` automatic update `` |
| [`42b61488`](https://github.com/nix-community/NUR/commit/42b61488351ba57a489eb46fd8ceb97ee4e19b06) | `` automatic update `` |
| [`86d3b5ab`](https://github.com/nix-community/NUR/commit/86d3b5ab992cece6c79bf2a3b30c8d6cde47bbf3) | `` automatic update `` |