### PR TITLE
chore(flake/nur): `9326ec75` -> `eab21a55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701104291,
-        "narHash": "sha256-K7BLWas1MveeSDZRAEOAhTJZMZVtqavDMMN5WGZhgxo=",
+        "lastModified": 1701107100,
+        "narHash": "sha256-8rSRheAjcEexKE1Hyf8To0AQeMTrvtBGP1iESX3PN4o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9326ec75ce265a65d1b305fed5059fa77f43d7dc",
+        "rev": "eab21a5514fd3dae3093b5c671b16ed7caabb402",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eab21a55`](https://github.com/nix-community/NUR/commit/eab21a5514fd3dae3093b5c671b16ed7caabb402) | `` automatic update `` |
| [`576b5f3d`](https://github.com/nix-community/NUR/commit/576b5f3d0a7fd0677f11498eb9a2d07f88c852ca) | `` automatic update `` |