### PR TITLE
chore(flake/sops-nix): `4be58d80` -> `b1edbf5c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -986,11 +986,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1700967639,
-        "narHash": "sha256-uuUwD/O1QcVk+TWPZFwl4ioUkC8iACj0jEXSyE/wGPI=",
+        "lastModified": 1701127353,
+        "narHash": "sha256-qVNX0wOl0b7+I35aRu78xUphOyELh+mtUp1KBx89K1Q=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "4be58d802693d7def8622ff34d36714f8db40371",
+        "rev": "b1edbf5c0464b4cced90a3ba6f999e671f0af631",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`b1edbf5c`](https://github.com/Mic92/sops-nix/commit/b1edbf5c0464b4cced90a3ba6f999e671f0af631) | `` update vendorHash ``                                           |
| [`f9442c47`](https://github.com/Mic92/sops-nix/commit/f9442c477d6d606176417b45d35f1b6e675b60f6) | `` build(deps): bump golang.org/x/crypto from 0.15.0 to 0.16.0 `` |