### PR TITLE
chore(flake/nixos-hardware): `b006ec52` -> `8772491e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -662,11 +662,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1701020860,
-        "narHash": "sha256-NwnRn04C8s+hH+KdVtGmVB1FFNIG7DtPJmQSCBDaET4=",
+        "lastModified": 1701250978,
+        "narHash": "sha256-ohu3cz4edjpGxs2qUTgbs0WrnewOX4crnUJNEB6Jox4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b006ec52fce23b1d57f6ab4a42d7400732e9a0a2",
+        "rev": "8772491ed75f150f02552c60694e1beff9f46013",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`8772491e`](https://github.com/NixOS/nixos-hardware/commit/8772491ed75f150f02552c60694e1beff9f46013) | `` Minimize whitespace changes. ``                       |
| [`6c114d0c`](https://github.com/NixOS/nixos-hardware/commit/6c114d0ccf990b90c22590561e12a898276c617a) | `` Change linux-surface rev to tag. ``                   |
| [`b236a781`](https://github.com/NixOS/nixos-hardware/commit/b236a7817a95b42a4392327ee77f3262755e11e1) | `` Write iptsd configuration file. ``                    |
| [`44612096`](https://github.com/NixOS/nixos-hardware/commit/4461209624a1fef22411c70b62b114c92218c172) | `` FW13 7040: workaround for SuspendThenHibernate bug `` |