### PR TITLE
chore(flake/lanzaboote): `cbafc8f8` -> `43582b56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1700811440,
-        "narHash": "sha256-wrJpW3JCJ9egZpYUMne4c3PFEp+vmkTj5VFpPAT4xdY=",
+        "lastModified": 1701284014,
+        "narHash": "sha256-k/7fo0a/G8T6NYtIFTv1MPE9oxiLeiXONgvWfGmkeOs=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "cbafc8f8fe388fba6f2c27224276f5f984f9ae47",
+        "rev": "43582b56cfd104e5944d38166839d10c7a0d292f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                 |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`d48eac71`](https://github.com/nix-community/lanzaboote/commit/d48eac71a41a517843e960a1ba4c22b67960ac34) | `` flake: remove moving away the `unsupportedChecks` `` |