### PR TITLE
chore(flake/srvos): `7cfe944f` -> `786fd4c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -646,11 +646,11 @@
     },
     "nixos-23_05": {
       "locked": {
-        "lastModified": 1700851152,
-        "narHash": "sha256-3PWITNJZyA3jz5IGREJRfSykM6xSLmD8u5A3WpBCyDM=",
+        "lastModified": 1701053011,
+        "narHash": "sha256-8QQ7rFbKFqgKgLoaXVJRh7Ik5LtI3pyBBCfOnNOGkF0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1216a5ba22a93a4a3a3bfdb4bff0f4727c576fcc",
+        "rev": "5b528f99f73c4fad127118a8c1126b5e003b01a9",
         "type": "github"
       },
       "original": {
@@ -1007,11 +1007,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701050004,
-        "narHash": "sha256-w99xQptGb2lLNtdum/AB5GZAzLgCa1IF1MjlzQ6FRE0=",
+        "lastModified": 1701304793,
+        "narHash": "sha256-rLMzlRD+MDpAm7Mc+50zgOyF2WDUTAQEvd+g3WvyNJY=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "7cfe944f7b24a0fd11d7b8e029705064931577ed",
+        "rev": "786fd4c8130f71708c8a8e5c743fb5fc2b5c8f9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------ |
| [`786fd4c8`](https://github.com/nix-community/srvos/commit/786fd4c8130f71708c8a8e5c743fb5fc2b5c8f9d) | `` flake.lock: Update `` |