### PR TITLE
chore(flake/srvos): `786fd4c8` -> `68534ccc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1007,11 +1007,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701304793,
-        "narHash": "sha256-rLMzlRD+MDpAm7Mc+50zgOyF2WDUTAQEvd+g3WvyNJY=",
+        "lastModified": 1701309178,
+        "narHash": "sha256-m25xDeKRWhhgD3/i4UT9mcywFE+ka9jCm1P8b/MmGSc=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "786fd4c8130f71708c8a8e5c743fb5fc2b5c8f9d",
+        "rev": "68534cccf14de8010a6d837013f2fd3488966b01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------ |
| [`68534ccc`](https://github.com/nix-community/srvos/commit/68534cccf14de8010a6d837013f2fd3488966b01) | `` flake.lock: Update `` |