### PR TITLE
chore(flake/srvos): `68534ccc` -> `3d589b35`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1007,11 +1007,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701309178,
-        "narHash": "sha256-m25xDeKRWhhgD3/i4UT9mcywFE+ka9jCm1P8b/MmGSc=",
+        "lastModified": 1701356315,
+        "narHash": "sha256-Vh69W3rBa3CPvQzaluptM778ChZNFpmjJvxbvi5w2gQ=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "68534cccf14de8010a6d837013f2fd3488966b01",
+        "rev": "3d589b35735e97d9bdc02fe46272725636ee68d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`49eaf04a`](https://github.com/nix-community/srvos/commit/49eaf04a8809b67a2a61116346f787cb55c5e61f) | `` Add .direnv to .gitignore. ``                       |
| [`d18368b7`](https://github.com/nix-community/srvos/commit/d18368b774799bc303a1321a355f95ada8f38adf) | `` Fix tests. ``                                       |
| [`1e416610`](https://github.com/nix-community/srvos/commit/1e416610428ff871e4e13e8740001765bf151b41) | `` Don't set nixpkgs.config, it breaks some setups. `` |