### PR TITLE
chore(flake/home-manager): `db1878f0` -> `ef908825`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701071203,
-        "narHash": "sha256-lQywA7QU/vzTdZ1apI0PfgCWNyQobXUYghVrR5zuIeM=",
+        "lastModified": 1701369906,
+        "narHash": "sha256-WwICfQ661I2hL2m9s449PjCR74d+9JtrhQeBoIaQ8/Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "db1878f013b52ba5e4034db7c1b63e8d04173a86",
+        "rev": "ef9088253c120d9b4dc26c5e41dd6c3c781ee9f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`ef908825`](https://github.com/nix-community/home-manager/commit/ef9088253c120d9b4dc26c5e41dd6c3c781ee9f0) | `` Translate using Weblate (Russian) ``             |
| [`3d154dab`](https://github.com/nix-community/home-manager/commit/3d154dab14aef8fcf510e291030cecc53b02985a) | `` Translate using Weblate (Russian) ``             |
| [`2a604e61`](https://github.com/nix-community/home-manager/commit/2a604e614f974af7e4f9296f1560ce275d2e3786) | `` Translate using Weblate (Portuguese (Brazil)) `` |