### PR TITLE
chore(flake/sops-nix): `b1edbf5c` -> `e19071f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -986,11 +986,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1701127353,
-        "narHash": "sha256-qVNX0wOl0b7+I35aRu78xUphOyELh+mtUp1KBx89K1Q=",
+        "lastModified": 1701518298,
+        "narHash": "sha256-5t8yqKe0oVusV4xgfA+wW58hQJXFMmq0mmaR1gKES+Y=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "b1edbf5c0464b4cced90a3ba6f999e671f0af631",
+        "rev": "e19071f9958c8da4f4347d3d78790d97e98ba22f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                 |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`e19071f9`](https://github.com/Mic92/sops-nix/commit/e19071f9958c8da4f4347d3d78790d97e98ba22f) | `` README: link to infra repo instead of my dotfiles `` |
| [`4abfe901`](https://github.com/Mic92/sops-nix/commit/4abfe90153619addb63be7a719155b0c45c2c679) | `` README: link to video tutorial ``                    |