### PR TITLE
chore(flake/emacs-overlay): `2cad7552` -> `58e2efaf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1701538716,
-        "narHash": "sha256-WDc/rlaXLvpWo/TBurDq9yHQ5+r6D8HewPynR4q0TNI=",
+        "lastModified": 1701567465,
+        "narHash": "sha256-DfG6CjCgeIhBi21TQQPQphx1Z2FoPUYgxjUSUVi8B6o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2cad7552433397581b0f3c8218c7c111b1896587",
+        "rev": "58e2efaf6e4d79332378b15c50277495c1198988",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`58e2efaf`](https://github.com/nix-community/emacs-overlay/commit/58e2efaf6e4d79332378b15c50277495c1198988) | `` Updated repos/melpa `` |
| [`eaf7ae54`](https://github.com/nix-community/emacs-overlay/commit/eaf7ae54eec482b10896d50b8b916898bcdf4cd9) | `` Updated repos/emacs `` |
| [`3a995e18`](https://github.com/nix-community/emacs-overlay/commit/3a995e180635a363358de231d2c5d533fa4c55ca) | `` Updated repos/elpa ``  |