### PR TITLE
chore(flake/emacs-overlay): `58e2efaf` -> `b9765a41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1701567465,
-        "narHash": "sha256-DfG6CjCgeIhBi21TQQPQphx1Z2FoPUYgxjUSUVi8B6o=",
+        "lastModified": 1701593495,
+        "narHash": "sha256-cZviahu0z3t3jTbvx1Mhjhd45aiDvKRKbNE7OI6yIbg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "58e2efaf6e4d79332378b15c50277495c1198988",
+        "rev": "b9765a4102f23b014d17d71aa0283d8e047477f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`b9765a41`](https://github.com/nix-community/emacs-overlay/commit/b9765a4102f23b014d17d71aa0283d8e047477f6) | `` Updated repos/melpa `` |
| [`c5359301`](https://github.com/nix-community/emacs-overlay/commit/c5359301a75608fec3fe2f112de053d32d79a0ea) | `` Updated repos/emacs `` |