### PR TITLE
chore(flake/nur): `e2c94e7b` -> `b1868c92`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701584668,
-        "narHash": "sha256-F7uYa1WHgifZ6uzO65Zkoh8decAKcSxgmllBNjjLPFk=",
+        "lastModified": 1701595091,
+        "narHash": "sha256-vqncvyr9sXKjKo8i6TePntG9HaeihB7Lp0QxXVIdwNA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e2c94e7b39f3b9f4f82310a8c4168c886d7bd204",
+        "rev": "b1868c9209bd28d9c76251649cfc4f0d72d87601",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b1868c92`](https://github.com/nix-community/NUR/commit/b1868c9209bd28d9c76251649cfc4f0d72d87601) | `` automatic update `` |
| [`c408d778`](https://github.com/nix-community/NUR/commit/c408d77824d798e87249207c747a2c742745e6bf) | `` automatic update `` |