### PR TITLE
chore(flake/nix-fast-build): `96805caf` -> `25e19950`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -548,11 +548,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1700146408,
-        "narHash": "sha256-T9hcGGGQv1Br9sm7oaEMs2OCDEBro5IU2i/dpTKSrQ4=",
+        "lastModified": 1701604846,
+        "narHash": "sha256-m0MxxMIy8at5CtCgoiBIHUez9+Dsh6XoifvOvlbSwBM=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "96805cafb2bc678ce15eda386989f9e79b28868b",
+        "rev": "25e19950f019adea4ca1b490e116a6acc0669e31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                   |
| ----------------------------------------------------------------------------------------------------- | ------------------------- |
| [`25e19950`](https://github.com/Mic92/nix-fast-build/commit/25e19950f019adea4ca1b490e116a6acc0669e31) | `` fix python tests ``    |
| [`1e77cb32`](https://github.com/Mic92/nix-fast-build/commit/1e77cb323578ff5d5e929e8541726c1e449e2aaa) | `` make tests a module `` |
| [`2d71dd8d`](https://github.com/Mic92/nix-fast-build/commit/2d71dd8d94d1d215fae8e57d6020583ef48dac33) | `` linting fixes ``       |
| [`c25b5a30`](https://github.com/Mic92/nix-fast-build/commit/c25b5a30868dcd087ebd8e660c00ab76080ba900) | `` enable more linting `` |