### PR TITLE
chore(flake/nur): `b1868c92` -> `71a6f012`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701595091,
-        "narHash": "sha256-vqncvyr9sXKjKo8i6TePntG9HaeihB7Lp0QxXVIdwNA=",
+        "lastModified": 1701606773,
+        "narHash": "sha256-UFr45Nj1w4pnaQvJpQ/6PaxwtFsBRct/KVtk4ljGLlM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b1868c9209bd28d9c76251649cfc4f0d72d87601",
+        "rev": "71a6f01290d706bd99a47901c0c46ad75cb1ab29",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`71a6f012`](https://github.com/nix-community/NUR/commit/71a6f01290d706bd99a47901c0c46ad75cb1ab29) | `` automatic update `` |