### PR TITLE
chore(flake/nur): `71a6f012` -> `4b3abfa7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701606773,
-        "narHash": "sha256-UFr45Nj1w4pnaQvJpQ/6PaxwtFsBRct/KVtk4ljGLlM=",
+        "lastModified": 1701614072,
+        "narHash": "sha256-zFtXkvayYkr5FRsb44q0clMjNdEsgHDuScGuLJXicAE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "71a6f01290d706bd99a47901c0c46ad75cb1ab29",
+        "rev": "4b3abfa77801746cb02d3e7113c9da666729a263",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4b3abfa7`](https://github.com/nix-community/NUR/commit/4b3abfa77801746cb02d3e7113c9da666729a263) | `` automatic update `` |
| [`c5c03c6c`](https://github.com/nix-community/NUR/commit/c5c03c6cd217b510f52fc7df5834c8d9daceee20) | `` automatic update `` |