### PR TITLE
chore(flake/emacs-overlay): `b9765a41` -> `b633dc11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1701593495,
-        "narHash": "sha256-cZviahu0z3t3jTbvx1Mhjhd45aiDvKRKbNE7OI6yIbg=",
+        "lastModified": 1701625056,
+        "narHash": "sha256-BT0BxazzmBYPkQymftsYrFtzi7M+28VtRCz5UDQ0nBg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b9765a4102f23b014d17d71aa0283d8e047477f6",
+        "rev": "b633dc1183ad4f2e1eaaec541d655920e3b1f1da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b633dc11`](https://github.com/nix-community/emacs-overlay/commit/b633dc1183ad4f2e1eaaec541d655920e3b1f1da) | `` Updated repos/nongnu `` |
| [`41aca908`](https://github.com/nix-community/emacs-overlay/commit/41aca908ef62507056270f2b6f7109cfe2f94995) | `` Updated repos/melpa ``  |
| [`abec2ee6`](https://github.com/nix-community/emacs-overlay/commit/abec2ee68af6f81cd2d51a880b2a46f87bc584f3) | `` Updated repos/emacs ``  |
| [`7235502b`](https://github.com/nix-community/emacs-overlay/commit/7235502b7fd057fac31ccf2638011f249d8ccaef) | `` Updated repos/elpa ``   |