### PR TITLE
chore(flake/nur): `083cac92` -> `805f936f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701621964,
-        "narHash": "sha256-95N3m5gsC7AU8j7W22boYFwOTS1dfC4yKYlE0soDy78=",
+        "lastModified": 1701623572,
+        "narHash": "sha256-NBxGAGL+NqUON+2g9SjPJzcBIgov0gCM8WT8mZM83Xg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "083cac92751ce5abdc0706bd32e70d79c08753e8",
+        "rev": "805f936f3ce5589d53c2a2c5eeab4019a233e10d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`805f936f`](https://github.com/nix-community/NUR/commit/805f936f3ce5589d53c2a2c5eeab4019a233e10d) | `` automatic update `` |