### PR TITLE
chore(flake/nur): `805f936f` -> `615d38e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701623572,
-        "narHash": "sha256-NBxGAGL+NqUON+2g9SjPJzcBIgov0gCM8WT8mZM83Xg=",
+        "lastModified": 1701632688,
+        "narHash": "sha256-Va+evEgkW+CFTZv4CRVPwtnbDcwS97lTBfQFNlHOYpU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "805f936f3ce5589d53c2a2c5eeab4019a233e10d",
+        "rev": "615d38e4ff63e68cc76d08ff25429e27d25d80a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`615d38e4`](https://github.com/nix-community/NUR/commit/615d38e4ff63e68cc76d08ff25429e27d25d80a1) | `` automatic update `` |
| [`f554dbd2`](https://github.com/nix-community/NUR/commit/f554dbd2dcd9d58516150d617f80f35ba6c52e25) | `` automatic update `` |
| [`c86b373d`](https://github.com/nix-community/NUR/commit/c86b373ddc98700d29f91e8a665169f78d2e0e45) | `` automatic update `` |
| [`3e0fd333`](https://github.com/nix-community/NUR/commit/3e0fd333e9c561243a2b10cc4d8d49c4f2ea430a) | `` automatic update `` |