### PR TITLE
chore(flake/nur): `615d38e4` -> `d52153ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701632688,
-        "narHash": "sha256-Va+evEgkW+CFTZv4CRVPwtnbDcwS97lTBfQFNlHOYpU=",
+        "lastModified": 1701636328,
+        "narHash": "sha256-tUG15xG0nx5aG1Ezw3Y3OOdVqb0NFiXDu7Dnla+T6Vs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "615d38e4ff63e68cc76d08ff25429e27d25d80a1",
+        "rev": "d52153ca963cb8072332dc18c3665626fec86647",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d52153ca`](https://github.com/nix-community/NUR/commit/d52153ca963cb8072332dc18c3665626fec86647) | `` automatic update `` |
| [`bee580a0`](https://github.com/nix-community/NUR/commit/bee580a017988d84194317fb2c17bc6ecd0bcd0e) | `` automatic update `` |