### PR TITLE
chore(flake/nur): `d52153ca` -> `2e1b8cbb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701636328,
-        "narHash": "sha256-tUG15xG0nx5aG1Ezw3Y3OOdVqb0NFiXDu7Dnla+T6Vs=",
+        "lastModified": 1701639924,
+        "narHash": "sha256-basG9pSWmj29Cv3JE7AJimNsJl4ocKrJt4HCPRs5fZ0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d52153ca963cb8072332dc18c3665626fec86647",
+        "rev": "2e1b8cbb0c0cf3ffe6b58e011e4a5fe1439c084f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2e1b8cbb`](https://github.com/nix-community/NUR/commit/2e1b8cbb0c0cf3ffe6b58e011e4a5fe1439c084f) | `` automatic update `` |