### PR TITLE
chore(flake/nur): `2e1b8cbb` -> `08c0a2f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701639924,
-        "narHash": "sha256-basG9pSWmj29Cv3JE7AJimNsJl4ocKrJt4HCPRs5fZ0=",
+        "lastModified": 1701642690,
+        "narHash": "sha256-wPybssbaibcQDrxiQem23JAP16FIxC7tgGS0fMdCITk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2e1b8cbb0c0cf3ffe6b58e011e4a5fe1439c084f",
+        "rev": "08c0a2f25fe91fdcfc7b81a8a8d09d583b15ff1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`08c0a2f2`](https://github.com/nix-community/NUR/commit/08c0a2f25fe91fdcfc7b81a8a8d09d583b15ff1b) | `` automatic update `` |