### PR TITLE
chore(flake/nur): `08c0a2f2` -> `e7d5551b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701642690,
-        "narHash": "sha256-wPybssbaibcQDrxiQem23JAP16FIxC7tgGS0fMdCITk=",
+        "lastModified": 1701645127,
+        "narHash": "sha256-MhsntrTDlOnlGW3HRTxs1H+BUCHbA0uYb0i3pwxugi8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "08c0a2f25fe91fdcfc7b81a8a8d09d583b15ff1b",
+        "rev": "e7d5551b1d558382e503c8b827c6ff48cd50baa7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e7d5551b`](https://github.com/nix-community/NUR/commit/e7d5551b1d558382e503c8b827c6ff48cd50baa7) | `` automatic update `` |