### PR TITLE
chore(flake/srvos): `ea2716d3` -> `a9ac3d13`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1007,11 +1007,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701650342,
-        "narHash": "sha256-BeXvHqWmyn5oO020b4rO60R0ZZnLFR35Kyawdo9Itj8=",
+        "lastModified": 1701654786,
+        "narHash": "sha256-zGwjl3Job3xdrBWHPNzhK+pXyQsEJWtb7nffhv5a+W4=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "ea2716d3f904721c8bb2d77afbd7d9f2933b714f",
+        "rev": "a9ac3d13c29667fe1df525190bb4cca80611da43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------ |
| [`a9ac3d13`](https://github.com/nix-community/srvos/commit/a9ac3d13c29667fe1df525190bb4cca80611da43) | `` flake.lock: Update `` |