### PR TITLE
chore(flake/home-manager): `e504e8d0` -> `ac721691`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701609479,
-        "narHash": "sha256-mcEnMz7XB3K57ZX16VXoEkswljSNGXdMuUu5+g8a8R8=",
+        "lastModified": 1701728041,
+        "narHash": "sha256-x0pyrI1vC8evVDxCxyO6olOyr4wlFg9+VS3C3p4xFYQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e504e8d01f950776c3a3160ba38c5957a1b89e66",
+        "rev": "ac7216918cd65f3824ba7817dea8f22e61221eaf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`ac721691`](https://github.com/nix-community/home-manager/commit/ac7216918cd65f3824ba7817dea8f22e61221eaf) | `` firefox: fix folders not showing in toolbar `` |
| [`948703f3`](https://github.com/nix-community/home-manager/commit/948703f3e71f1332a0cb535ebaf5cb14946e3724) | `` broot: Add nushell integration (#4714) ``      |