### PR TITLE
chore(flake/nur): `aa895aaa` -> `16866662`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701671414,
-        "narHash": "sha256-UenBgSExrXHXFBS9c+IV8J4m63zcYKfTd9IBLxCdsoM=",
+        "lastModified": 1701676849,
+        "narHash": "sha256-qNFZbtdq0trLwwDlBPzlDyKZiqsGg3MJKvN2VQqVNvo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aa895aaa4b607e772d2d18afffff97b2c9b63554",
+        "rev": "16866662f50d3e5410c809cde11bba9f2d3fe8ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                            |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`16866662`](https://github.com/nix-community/NUR/commit/16866662f50d3e5410c809cde11bba9f2d3fe8ce) | `` Bump cachix/install-nix-action from 23 to 24 `` |
| [`62d48f3c`](https://github.com/nix-community/NUR/commit/62d48f3cb18904c682595c65b862b2da3333ab0a) | `` automatic update ``                             |
| [`0100a4c2`](https://github.com/nix-community/NUR/commit/0100a4c2817e40c1695bd5f42ec1819ab988f4dc) | `` automatic update ``                             |