### PR TITLE
chore(flake/nur): `ce62f7d0` -> `1a63e668`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701686678,
-        "narHash": "sha256-v1R/vTxrVweW4OTxxYbBTtgsQ++u/LdSDKs60gG9mlo=",
+        "lastModified": 1701694777,
+        "narHash": "sha256-4aTDxvTwSROfbp7kZuA+bY0a7Ddj3pxqTH1AXK1+/Ek=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ce62f7d0fe46df0506c2585401a9ef9245ac5204",
+        "rev": "1a63e6685f79a406bdd18b1aea5b363c4a9716f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1a63e668`](https://github.com/nix-community/NUR/commit/1a63e6685f79a406bdd18b1aea5b363c4a9716f5) | `` automatic update `` |
| [`8494aa9e`](https://github.com/nix-community/NUR/commit/8494aa9e1e75978e1a46ffaab07562d8db7d49c1) | `` automatic update `` |
| [`542eb711`](https://github.com/nix-community/NUR/commit/542eb71129d3aa91765c5709ff90a4a6470ab170) | `` automatic update `` |
| [`8e6d088f`](https://github.com/nix-community/NUR/commit/8e6d088f0e2c463aea98bc38ad75af65acdc300d) | `` automatic update `` |