### PR TITLE
chore(flake/nur): `1a63e668` -> `6b4561fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701694777,
-        "narHash": "sha256-4aTDxvTwSROfbp7kZuA+bY0a7Ddj3pxqTH1AXK1+/Ek=",
+        "lastModified": 1701701082,
+        "narHash": "sha256-XXSnqw2SwcJwjwIMYtEFenb0QL86PF3fFCuXe3ilXxc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1a63e6685f79a406bdd18b1aea5b363c4a9716f5",
+        "rev": "6b4561fe34f1f4bf5058a7ba282dd40486efb921",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6b4561fe`](https://github.com/nix-community/NUR/commit/6b4561fe34f1f4bf5058a7ba282dd40486efb921) | `` automatic update `` |
| [`40d6cf5a`](https://github.com/nix-community/NUR/commit/40d6cf5a51c6a08e7636a4a75dfcbcf6bfd01bc7) | `` automatic update `` |
| [`636b02d4`](https://github.com/nix-community/NUR/commit/636b02d4972ecc1511b3a850091f04b05fc50bc8) | `` automatic update `` |
| [`7e8359f4`](https://github.com/nix-community/NUR/commit/7e8359f44bfca49dfa2037b60d59fb5cac2c5dc8) | `` automatic update `` |