### PR TITLE
chore(flake/nur): `6b4561fe` -> `fa1ebe8c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701701082,
-        "narHash": "sha256-XXSnqw2SwcJwjwIMYtEFenb0QL86PF3fFCuXe3ilXxc=",
+        "lastModified": 1701703977,
+        "narHash": "sha256-b6s5cj4klcnfeLwXpxkBgqkEhGHNiZRjOCgDH3omaCM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6b4561fe34f1f4bf5058a7ba282dd40486efb921",
+        "rev": "fa1ebe8c142e373b5c38d5bad28a64828c7055ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fa1ebe8c`](https://github.com/nix-community/NUR/commit/fa1ebe8c142e373b5c38d5bad28a64828c7055ab) | `` automatic update `` |
| [`44316caa`](https://github.com/nix-community/NUR/commit/44316caa05cae9d6f63cec53ecd8abcdad47729b) | `` automatic update `` |
| [`92da31cf`](https://github.com/nix-community/NUR/commit/92da31cfcc9dcdac10d8cdd5c179e9bc14223ee3) | `` automatic update `` |