### PR TITLE
chore(flake/nur): `fa1ebe8c` -> `77784830`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701703977,
-        "narHash": "sha256-b6s5cj4klcnfeLwXpxkBgqkEhGHNiZRjOCgDH3omaCM=",
+        "lastModified": 1701708973,
+        "narHash": "sha256-HF4m8nGUlNXCfHOdDSmVBi+nmiKID4j1YrEDDssyO1g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fa1ebe8c142e373b5c38d5bad28a64828c7055ab",
+        "rev": "777848302fa11952cc4237b7cec4528fee7b9c83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`77784830`](https://github.com/nix-community/NUR/commit/777848302fa11952cc4237b7cec4528fee7b9c83) | `` automatic update `` |
| [`33bae191`](https://github.com/nix-community/NUR/commit/33bae191ce937cab31b370eed923fa7bdf5e5e77) | `` automatic update `` |