### PR TITLE
chore(flake/nur): `77784830` -> `13a3297b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701708973,
-        "narHash": "sha256-HF4m8nGUlNXCfHOdDSmVBi+nmiKID4j1YrEDDssyO1g=",
+        "lastModified": 1701711234,
+        "narHash": "sha256-BMlQOR7YVXsSeEfG9G6vQwzvD2qj3d5EbfC9P2lBfpE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "777848302fa11952cc4237b7cec4528fee7b9c83",
+        "rev": "13a3297b67cdff85fc70131c0f9de91f4a2cc27e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`13a3297b`](https://github.com/nix-community/NUR/commit/13a3297b67cdff85fc70131c0f9de91f4a2cc27e) | `` automatic update `` |
| [`d5029eaf`](https://github.com/nix-community/NUR/commit/d5029eaf679f588d0c17f73d118b882de68290d7) | `` automatic update `` |