### PR TITLE
chore(flake/nur): `3a1b2862` -> `4e18c6e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701718677,
-        "narHash": "sha256-ZyvEyzEk5Q+dJi54KdqZh55NxE/adbq567oUQ3udaT0=",
+        "lastModified": 1701722684,
+        "narHash": "sha256-ukCjTx8rB8Tp7mHZYy53L74MO7wnfbwl0/XZfrMzHqc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3a1b2862fc4507e9abca9d8e2bf1a54f3a3dbe83",
+        "rev": "4e18c6e346dc11ea5209660486ff888ae216e870",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4e18c6e3`](https://github.com/nix-community/NUR/commit/4e18c6e346dc11ea5209660486ff888ae216e870) | `` automatic update `` |
| [`4dd1755e`](https://github.com/nix-community/NUR/commit/4dd1755e1b126775568abaa2731dea9646257cf5) | `` automatic update `` |
| [`8ec3b786`](https://github.com/nix-community/NUR/commit/8ec3b786386a1e76657a3c7409076855e5df5d07) | `` automatic update `` |