### PR TITLE
chore(flake/nur): `4e18c6e3` -> `38f89206`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701722684,
-        "narHash": "sha256-ukCjTx8rB8Tp7mHZYy53L74MO7wnfbwl0/XZfrMzHqc=",
+        "lastModified": 1701726579,
+        "narHash": "sha256-+new8xzhBSiKOgms/P9O+r6fTClwSlkF9ctDVPqevrs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4e18c6e346dc11ea5209660486ff888ae216e870",
+        "rev": "38f89206f18b419ac980c74b877826ba9736096c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`38f89206`](https://github.com/nix-community/NUR/commit/38f89206f18b419ac980c74b877826ba9736096c) | `` automatic update `` |
| [`9b3ff5cd`](https://github.com/nix-community/NUR/commit/9b3ff5cd039d91cf6d8d5f49d5fe9576b5791d17) | `` automatic update `` |