### PR TITLE
chore(flake/nur): `38f89206` -> `6430ea71`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701726579,
-        "narHash": "sha256-+new8xzhBSiKOgms/P9O+r6fTClwSlkF9ctDVPqevrs=",
+        "lastModified": 1701733494,
+        "narHash": "sha256-gwByRyaiMqFEgCAWhNUmlPiV9cZsh7GgqHEvbsdWgJQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "38f89206f18b419ac980c74b877826ba9736096c",
+        "rev": "6430ea716ea9569f3f5daf68519b067de6044dc0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6430ea71`](https://github.com/nix-community/NUR/commit/6430ea716ea9569f3f5daf68519b067de6044dc0) | `` automatic update `` |
| [`d8225402`](https://github.com/nix-community/NUR/commit/d8225402f22f93242485c0dc2d4ccb5f48fd1c46) | `` automatic update `` |
| [`8e57aa17`](https://github.com/nix-community/NUR/commit/8e57aa1789c01a3a1695538cc28e66e8bb269159) | `` automatic update `` |