### PR TITLE
chore(flake/sops-nix): `8bca48cb` -> `e91ece6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -986,11 +986,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1701572436,
-        "narHash": "sha256-0anfOQqDend6kSuF8CmOSAZsiAS1nwOsin5VQukh6Q4=",
+        "lastModified": 1701728052,
+        "narHash": "sha256-7lOMc3PtW5a55vFReBJLLLOnopsoi1W7MkjJ93jPV4E=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "8bca48cb9a12bbd8766f359ad00336924e91b7f7",
+        "rev": "e91ece6d2cf5a0ae729796b8f0dedceab5107c3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                         |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`e91ece6d`](https://github.com/Mic92/sops-nix/commit/e91ece6d2cf5a0ae729796b8f0dedceab5107c3d) | `` build(deps): bump cachix/install-nix-action from 23 to 24 `` |