### PR TITLE
chore(flake/nur): `746a055f` -> `d2fd7140`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701737945,
-        "narHash": "sha256-FLgMuIR55a9g70lUgMcf20r2OoH4uKHN/klY3F8IRMM=",
+        "lastModified": 1701741877,
+        "narHash": "sha256-Y9PsG80ia6UztBd/n9e5aygviC+8/YaLGaSOCmOgB4E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "746a055f90505a5d9e085fc603badaadd9738899",
+        "rev": "d2fd7140af851e6a18c0cd9efd70385739d33bf0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d2fd7140`](https://github.com/nix-community/NUR/commit/d2fd7140af851e6a18c0cd9efd70385739d33bf0) | `` automatic update `` |
| [`dbe0a688`](https://github.com/nix-community/NUR/commit/dbe0a68891e323018af4eb34aa95e1f41b705e1d) | `` automatic update `` |