### PR TITLE
chore(flake/emacs-overlay): `dc744ac6` -> `4c177e0f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1701711753,
-        "narHash": "sha256-pgeYzYB1s6is8M4xQa15T8pKRe1Ttt3DQ0dIDe9LRv4=",
+        "lastModified": 1701742910,
+        "narHash": "sha256-WVIkQ4yxBFJIyDP7b9m0lW9/Utdc5/RodNUMCUHJIEo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dc744ac6f2083258415507daa492937d14d44b55",
+        "rev": "4c177e0f890cb081e7ce1ae12649bbc93f727dd7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4c177e0f`](https://github.com/nix-community/emacs-overlay/commit/4c177e0f890cb081e7ce1ae12649bbc93f727dd7) | `` Updated repos/nongnu `` |
| [`629fdea1`](https://github.com/nix-community/emacs-overlay/commit/629fdea1a72f81c528ce88ffea7a9214c07b4cd1) | `` Updated repos/melpa ``  |
| [`658049b8`](https://github.com/nix-community/emacs-overlay/commit/658049b88f2f9b336658a9518069906e48147673) | `` Updated repos/emacs ``  |
| [`1840d8de`](https://github.com/nix-community/emacs-overlay/commit/1840d8de3947998fcc3c0277cb58ec2046cbad73) | `` Updated repos/elpa ``   |