### PR TITLE
chore(flake/nur): `d2fd7140` -> `4c057f13`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701741877,
-        "narHash": "sha256-Y9PsG80ia6UztBd/n9e5aygviC+8/YaLGaSOCmOgB4E=",
+        "lastModified": 1701744459,
+        "narHash": "sha256-vzz1nbcIyaa7nilwQXxBEj8UiWqCX2Ii1prwmOUQovI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d2fd7140af851e6a18c0cd9efd70385739d33bf0",
+        "rev": "4c057f13a621506f459dc8c0beadf7e8da755f4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4c057f13`](https://github.com/nix-community/NUR/commit/4c057f13a621506f459dc8c0beadf7e8da755f4d) | `` automatic update `` |
| [`db196d42`](https://github.com/nix-community/NUR/commit/db196d42994aab8c9939babbb2b195a4c537996d) | `` automatic update `` |
| [`6f1ad8a9`](https://github.com/nix-community/NUR/commit/6f1ad8a946a1053478aa78bfef5226a6ed0506f8) | `` automatic update `` |
| [`a237f390`](https://github.com/nix-community/NUR/commit/a237f390a753eb5a95e8f5e8eb431b386510e05d) | `` automatic update `` |