### PR TITLE
chore(flake/nur): `4c057f13` -> `66ea2223`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701744459,
-        "narHash": "sha256-vzz1nbcIyaa7nilwQXxBEj8UiWqCX2Ii1prwmOUQovI=",
+        "lastModified": 1701751086,
+        "narHash": "sha256-W6xZpsEbS7lUwEgmYni6C/v9/4WRjqidK2awqsJbOyg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4c057f13a621506f459dc8c0beadf7e8da755f4d",
+        "rev": "66ea2223edebf6231874bcdeb1cd8499e58d6bbc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`66ea2223`](https://github.com/nix-community/NUR/commit/66ea2223edebf6231874bcdeb1cd8499e58d6bbc) | `` automatic update `` |
| [`31c3e278`](https://github.com/nix-community/NUR/commit/31c3e27811fab9ae17dec4bab144269d96233723) | `` automatic update `` |
| [`04d8e4a7`](https://github.com/nix-community/NUR/commit/04d8e4a790c372b042f2930168f337e64a98ec7d) | `` automatic update `` |
| [`123bbbd8`](https://github.com/nix-community/NUR/commit/123bbbd82502254ccf8779a2396bbc3a9abffec1) | `` automatic update `` |
| [`c0b14cea`](https://github.com/nix-community/NUR/commit/c0b14cea9675f74d9d82f89570b73dbfa6196b48) | `` automatic update `` |
| [`c321716b`](https://github.com/nix-community/NUR/commit/c321716b68165499d084a62b1c9714da8b8c24a7) | `` automatic update `` |