### PR TITLE
chore(flake/nur): `66ea2223` -> `ae97a12d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701751086,
-        "narHash": "sha256-W6xZpsEbS7lUwEgmYni6C/v9/4WRjqidK2awqsJbOyg=",
+        "lastModified": 1701754848,
+        "narHash": "sha256-f9bdACIiEzB51qA1nz5brFF4nn3o21YQ8/WdaBcMB0c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "66ea2223edebf6231874bcdeb1cd8499e58d6bbc",
+        "rev": "ae97a12d67d64f2003c4ba786e6d9b544e7f9ae5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ae97a12d`](https://github.com/nix-community/NUR/commit/ae97a12d67d64f2003c4ba786e6d9b544e7f9ae5) | `` automatic update `` |
| [`1b1002ae`](https://github.com/nix-community/NUR/commit/1b1002aeb18bc5f77d3154c7c313ddbb660c66e3) | `` automatic update `` |
| [`6fb47439`](https://github.com/nix-community/NUR/commit/6fb47439bea6a15ea5cc1eec09a5227f25669e16) | `` automatic update `` |