### PR TITLE
chore(flake/nur): `ae97a12d` -> `30b04e1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701754848,
-        "narHash": "sha256-f9bdACIiEzB51qA1nz5brFF4nn3o21YQ8/WdaBcMB0c=",
+        "lastModified": 1701758258,
+        "narHash": "sha256-b19xAxwC9Gr7GASykFj91cr0GANY2i2YEpMEBShd5EI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ae97a12d67d64f2003c4ba786e6d9b544e7f9ae5",
+        "rev": "30b04e1c8c0762c63ccd712df3ec0054db95330b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`30b04e1c`](https://github.com/nix-community/NUR/commit/30b04e1c8c0762c63ccd712df3ec0054db95330b) | `` automatic update `` |