### PR TITLE
chore(flake/nur): `c26dfaef` -> `825de74f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701762273,
-        "narHash": "sha256-0hYwum5CqgYVWzFbw5l7cSTAta+PWF9aVHTof0FJdLI=",
+        "lastModified": 1701765971,
+        "narHash": "sha256-X1BuQXNTbubUU+caZdoe5ExdQfzuUnqXNe99eiF3xEI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c26dfaef0b98ff0acc4e62fc92797f4864f785d5",
+        "rev": "825de74f0091d76117cb454a313370cc53abc43a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`825de74f`](https://github.com/nix-community/NUR/commit/825de74f0091d76117cb454a313370cc53abc43a) | `` automatic update `` |
| [`ebf9b889`](https://github.com/nix-community/NUR/commit/ebf9b889caa654bdd7d152b32efc88b6943bb851) | `` automatic update `` |