### PR TITLE
chore(flake/nur): `825de74f` -> `7415275a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701765971,
-        "narHash": "sha256-X1BuQXNTbubUU+caZdoe5ExdQfzuUnqXNe99eiF3xEI=",
+        "lastModified": 1701769945,
+        "narHash": "sha256-YwN1bQPaQE5oyzeir9a5uAGW/ReGyvG54l0n8nu7oB4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "825de74f0091d76117cb454a313370cc53abc43a",
+        "rev": "7415275abeadc29b8c564bf76ec4c2c15179027f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7415275a`](https://github.com/nix-community/NUR/commit/7415275abeadc29b8c564bf76ec4c2c15179027f) | `` automatic update `` |
| [`ade83ea1`](https://github.com/nix-community/NUR/commit/ade83ea1cfc5823b1652dfc5b93a2881deb639bb) | `` automatic update `` |