### PR TITLE
chore(flake/nur): `7415275a` -> `45fee78f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701769945,
-        "narHash": "sha256-YwN1bQPaQE5oyzeir9a5uAGW/ReGyvG54l0n8nu7oB4=",
+        "lastModified": 1701776756,
+        "narHash": "sha256-5F0RdyG7aIaEWZgObJP8l0HCND16ejIxo+HlEFaeIKA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7415275abeadc29b8c564bf76ec4c2c15179027f",
+        "rev": "45fee78ff5643c463571289e543448d80afdee0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`45fee78f`](https://github.com/nix-community/NUR/commit/45fee78ff5643c463571289e543448d80afdee0c) | `` automatic update `` |