### PR TITLE
chore(flake/nur): `45fee78f` -> `77fbdb7b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701776756,
-        "narHash": "sha256-5F0RdyG7aIaEWZgObJP8l0HCND16ejIxo+HlEFaeIKA=",
+        "lastModified": 1701780125,
+        "narHash": "sha256-HtNkw7mbLPkxmSoz57FNXEMioFMIBp7yDy88dE3HsZA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "45fee78ff5643c463571289e543448d80afdee0c",
+        "rev": "77fbdb7bff2c28e35f755144d9313faf3f8121ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`77fbdb7b`](https://github.com/nix-community/NUR/commit/77fbdb7bff2c28e35f755144d9313faf3f8121ed) | `` automatic update `` |
| [`2c01265a`](https://github.com/nix-community/NUR/commit/2c01265a23fb8b3a67ac9f50a8f153960854ad72) | `` automatic update `` |
| [`84b04215`](https://github.com/nix-community/NUR/commit/84b042159809070be895c554f0731f48cb6c8f7e) | `` automatic update `` |
| [`bb2b9118`](https://github.com/nix-community/NUR/commit/bb2b91189d8f75ab0f44f3f36daaf6ad78a513b3) | `` automatic update `` |
| [`cc05ebc6`](https://github.com/nix-community/NUR/commit/cc05ebc625d68ad357e75260b157b9ef0febcf69) | `` automatic update `` |