### PR TITLE
chore(flake/srvos): `a9ac3d13` -> `c5a8eeab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1007,11 +1007,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701654786,
-        "narHash": "sha256-zGwjl3Job3xdrBWHPNzhK+pXyQsEJWtb7nffhv5a+W4=",
+        "lastModified": 1701779264,
+        "narHash": "sha256-behT1fILfFnoof83tMvHSewC4FlHkpllJYznmq2tBio=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "a9ac3d13c29667fe1df525190bb4cca80611da43",
+        "rev": "c5a8eeab295c3db4132e076826f05c0631a2e814",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                         |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`c5a8eeab`](https://github.com/nix-community/srvos/commit/c5a8eeab295c3db4132e076826f05c0631a2e814) | `` ci: fix for nix 2.19 ``                                      |
| [`cd13781d`](https://github.com/nix-community/srvos/commit/cd13781dc4a8f682c712a83e5249274a3137ee58) | `` build(deps): bump cachix/install-nix-action from 23 to 24 `` |