### PR TITLE
chore(flake/nur): `77fbdb7b` -> `52093580`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701780125,
-        "narHash": "sha256-HtNkw7mbLPkxmSoz57FNXEMioFMIBp7yDy88dE3HsZA=",
+        "lastModified": 1701788471,
+        "narHash": "sha256-evQBm7ddG3dGI7aoOK+/BaXbksfBoQsZpnH2C0KJ46I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "77fbdb7bff2c28e35f755144d9313faf3f8121ed",
+        "rev": "520935804773d246431f34da153a394fa83d1a59",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`52093580`](https://github.com/nix-community/NUR/commit/520935804773d246431f34da153a394fa83d1a59) | `` automatic update `` |
| [`bac53b69`](https://github.com/nix-community/NUR/commit/bac53b69f4a1f17d81152bf10c67f6ddf4e8b4bd) | `` automatic update `` |
| [`42c3633c`](https://github.com/nix-community/NUR/commit/42c3633c979940dc4bee643b1fb21abebfbb367b) | `` automatic update `` |
| [`57a43cd4`](https://github.com/nix-community/NUR/commit/57a43cd4871363104369c27e71ea3efce3bef712) | `` automatic update `` |
| [`7f0f0eb3`](https://github.com/nix-community/NUR/commit/7f0f0eb3101ac98b1aa44d83aa2007f3dcba09f3) | `` automatic update `` |