### PR TITLE
chore(flake/nur): `52093580` -> `283b5a15`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701788471,
-        "narHash": "sha256-evQBm7ddG3dGI7aoOK+/BaXbksfBoQsZpnH2C0KJ46I=",
+        "lastModified": 1701792951,
+        "narHash": "sha256-npKhaNz7tRAqSITWoMTiN2g/69wWPXwnCSXff1oTBvg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "520935804773d246431f34da153a394fa83d1a59",
+        "rev": "283b5a15f210501c6b12b3d120f6016a3a01a8ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`283b5a15`](https://github.com/nix-community/NUR/commit/283b5a15f210501c6b12b3d120f6016a3a01a8ce) | `` automatic update `` |
| [`84e8d725`](https://github.com/nix-community/NUR/commit/84e8d725b2fe585436e3782368a82a828e76ccb7) | `` automatic update `` |