### PR TITLE
chore(flake/nur): `283b5a15` -> `e3ef2421`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701792951,
-        "narHash": "sha256-npKhaNz7tRAqSITWoMTiN2g/69wWPXwnCSXff1oTBvg=",
+        "lastModified": 1701798379,
+        "narHash": "sha256-o+uFCoZalr5csUdWD84I2ELd78VGxt9+8PZbJXwaHA8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "283b5a15f210501c6b12b3d120f6016a3a01a8ce",
+        "rev": "e3ef2421e85a36a8b5650cfb3cc9096f53059609",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e3ef2421`](https://github.com/nix-community/NUR/commit/e3ef2421e85a36a8b5650cfb3cc9096f53059609) | `` automatic update `` |
| [`6d56b081`](https://github.com/nix-community/NUR/commit/6d56b0811db9b92313e970f72633251aa180d89a) | `` automatic update `` |