### PR TITLE
chore(flake/nur): `e3ef2421` -> `6449de3b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701798379,
-        "narHash": "sha256-o+uFCoZalr5csUdWD84I2ELd78VGxt9+8PZbJXwaHA8=",
+        "lastModified": 1701805471,
+        "narHash": "sha256-u88qW06pUoMVcGkxgT4xZSvTxmjjAqLsOlkooki0juk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e3ef2421e85a36a8b5650cfb3cc9096f53059609",
+        "rev": "6449de3b41548c4d8c9429b5a86797bc225a7588",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6449de3b`](https://github.com/nix-community/NUR/commit/6449de3b41548c4d8c9429b5a86797bc225a7588) | `` automatic update `` |
| [`e0a3a41f`](https://github.com/nix-community/NUR/commit/e0a3a41f7eda806d692c7cdc92c83557cc033e9f) | `` automatic update `` |
| [`a32c124c`](https://github.com/nix-community/NUR/commit/a32c124cd6f7ee024e6f06791a10b6d0b197e4b9) | `` automatic update `` |