### PR TITLE
chore(flake/nur): `6449de3b` -> `0647be9d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701805471,
-        "narHash": "sha256-u88qW06pUoMVcGkxgT4xZSvTxmjjAqLsOlkooki0juk=",
+        "lastModified": 1701812680,
+        "narHash": "sha256-AUGWR2wkUf5hAf825jgyTN0CdT0+SxT4G9U4esUcQg0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6449de3b41548c4d8c9429b5a86797bc225a7588",
+        "rev": "0647be9dcaf61dfa3f367ad08aa11d77f35b5aa6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0647be9d`](https://github.com/nix-community/NUR/commit/0647be9dcaf61dfa3f367ad08aa11d77f35b5aa6) | `` automatic update `` |