### PR TITLE
chore(flake/nur): `36cffb92` -> `c95210dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701817202,
-        "narHash": "sha256-ReuTsHGgs99DIO8Gg32Ho9aIKnW0rcZa42ltdHWfkD8=",
+        "lastModified": 1701825073,
+        "narHash": "sha256-tz2fszBT8VVqm2WDdZ428O58XPyQw+0ojTbh8EWtnUQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "36cffb929d12255feafaa6ba4d286e13ba41f8e1",
+        "rev": "c95210dd8684aca78f8d52a2ae21e944564b6d00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c95210dd`](https://github.com/nix-community/NUR/commit/c95210dd8684aca78f8d52a2ae21e944564b6d00) | `` automatic update `` |
| [`a29aa7e3`](https://github.com/nix-community/NUR/commit/a29aa7e3cfe30e877c50fd734dc955249184335f) | `` automatic update `` |