### PR TITLE
chore(flake/nur): `c95210dd` -> `ad973afa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701825073,
-        "narHash": "sha256-tz2fszBT8VVqm2WDdZ428O58XPyQw+0ojTbh8EWtnUQ=",
+        "lastModified": 1701828145,
+        "narHash": "sha256-tw+UyFZVTgk0odcU9XGs64GK+wGTXZJV+PgMI72CeDc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c95210dd8684aca78f8d52a2ae21e944564b6d00",
+        "rev": "ad973afa34375285960aff960e921157569755ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ad973afa`](https://github.com/nix-community/NUR/commit/ad973afa34375285960aff960e921157569755ab) | `` automatic update `` |
| [`2e83dd29`](https://github.com/nix-community/NUR/commit/2e83dd29ad04000515593f32de01d6e7ae9f63bc) | `` automatic update `` |