### PR TITLE
chore(flake/nur): `ad973afa` -> `975d5723`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701828145,
-        "narHash": "sha256-tw+UyFZVTgk0odcU9XGs64GK+wGTXZJV+PgMI72CeDc=",
+        "lastModified": 1701829239,
+        "narHash": "sha256-qeBNHyQr3eCZ6f95ploVB+65tin7LZUFvamm2NcnSb4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ad973afa34375285960aff960e921157569755ab",
+        "rev": "975d572349a97dc1ebf0db3dc89cf66a3bd12b86",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`975d5723`](https://github.com/nix-community/NUR/commit/975d572349a97dc1ebf0db3dc89cf66a3bd12b86) | `` automatic update `` |