### PR TITLE
chore(flake/nur): `975d5723` -> `647e8bbb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701829239,
-        "narHash": "sha256-qeBNHyQr3eCZ6f95ploVB+65tin7LZUFvamm2NcnSb4=",
+        "lastModified": 1701838584,
+        "narHash": "sha256-vUVdTsbgW7nP9tM4Di5EvoxOXk6cRg+BwLEPI+R+XSc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "975d572349a97dc1ebf0db3dc89cf66a3bd12b86",
+        "rev": "647e8bbb9e4adefc677c614ff6043e6f8fa32aaf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`647e8bbb`](https://github.com/nix-community/NUR/commit/647e8bbb9e4adefc677c614ff6043e6f8fa32aaf) | `` automatic update `` |
| [`db729d8b`](https://github.com/nix-community/NUR/commit/db729d8b67e985eb6fdaabde63ec0e06bd92d971) | `` automatic update `` |
| [`adfe50da`](https://github.com/nix-community/NUR/commit/adfe50da3f5f7e2eb864d1c07654b5482b4d2327) | `` automatic update `` |
| [`365717a2`](https://github.com/nix-community/NUR/commit/365717a2976484bb9b1c0af66a6ea39b5f34f4c6) | `` automatic update `` |
| [`5717c3e9`](https://github.com/nix-community/NUR/commit/5717c3e93c36208d814fd7623a64be3844cc65a5) | `` automatic update `` |