### PR TITLE
chore(flake/nur): `647e8bbb` -> `e61ecd34`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701838584,
-        "narHash": "sha256-vUVdTsbgW7nP9tM4Di5EvoxOXk6cRg+BwLEPI+R+XSc=",
+        "lastModified": 1701842485,
+        "narHash": "sha256-XiLWxtXbDCzI0NPXIl6pQr5WdXkxS/485D7uWbcwxDc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "647e8bbb9e4adefc677c614ff6043e6f8fa32aaf",
+        "rev": "e61ecd3426fdbeeecdc137da715343ae9ca33868",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e61ecd34`](https://github.com/nix-community/NUR/commit/e61ecd3426fdbeeecdc137da715343ae9ca33868) | `` automatic update `` |
| [`ccb02865`](https://github.com/nix-community/NUR/commit/ccb02865f948776f3e53aaa7f1bc55ecc74a6e23) | `` automatic update `` |
| [`f3c96b7f`](https://github.com/nix-community/NUR/commit/f3c96b7fc42c35e63375f6be37898aab4364c318) | `` automatic update `` |