### PR TITLE
chore(flake/nur): `e61ecd34` -> `753c45d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701842485,
-        "narHash": "sha256-XiLWxtXbDCzI0NPXIl6pQr5WdXkxS/485D7uWbcwxDc=",
+        "lastModified": 1701844649,
+        "narHash": "sha256-25L03EGoYxxqcJ/FViI+H7AXpoITOKeESKnqsFc+tbE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e61ecd3426fdbeeecdc137da715343ae9ca33868",
+        "rev": "753c45d2e5a156ed30c05feded9addb4a91c8727",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`753c45d2`](https://github.com/nix-community/NUR/commit/753c45d2e5a156ed30c05feded9addb4a91c8727) | `` automatic update `` |