### PR TITLE
chore(flake/nur): `753c45d2` -> `6f0e939e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701844649,
-        "narHash": "sha256-25L03EGoYxxqcJ/FViI+H7AXpoITOKeESKnqsFc+tbE=",
+        "lastModified": 1701847820,
+        "narHash": "sha256-ICwnntTtBcYU9jst+SXcA1z+7jFMHtxbDaH898rnM1A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "753c45d2e5a156ed30c05feded9addb4a91c8727",
+        "rev": "6f0e939e4370c454807aabf90a0dca167d619f4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6f0e939e`](https://github.com/nix-community/NUR/commit/6f0e939e4370c454807aabf90a0dca167d619f4d) | `` automatic update `` |
| [`92304585`](https://github.com/nix-community/NUR/commit/92304585812932cd010676f8e3aeeb15a80177a3) | `` automatic update `` |