### PR TITLE
chore(flake/nur): `6f0e939e` -> `bc310114`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701847820,
-        "narHash": "sha256-ICwnntTtBcYU9jst+SXcA1z+7jFMHtxbDaH898rnM1A=",
+        "lastModified": 1701853286,
+        "narHash": "sha256-xvei2n0BXYpk0+uCuzwxaMvSWYzU21ciiuF7K9r7rtI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6f0e939e4370c454807aabf90a0dca167d619f4d",
+        "rev": "bc3101148da3807041842e964ec420390402ccca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bc310114`](https://github.com/nix-community/NUR/commit/bc3101148da3807041842e964ec420390402ccca) | `` automatic update `` |
| [`7af92bc9`](https://github.com/nix-community/NUR/commit/7af92bc9091a5551537abd08552ba94190bc5983) | `` automatic update `` |
| [`171ba60c`](https://github.com/nix-community/NUR/commit/171ba60c32231fe518c0af8c136ef8e764c41258) | `` automatic update `` |