### PR TITLE
chore(flake/emacs-overlay): `384abdc7` -> `ff627044`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1701829164,
-        "narHash": "sha256-1b09sNIyYcUsXRR2rk3yxKDPCtnKrsM81d8FRXs96HU=",
+        "lastModified": 1701855622,
+        "narHash": "sha256-Mv3J3L61hn9MShgwboviXCdqHvl13atJMHl0rZMCmdI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "384abdc7504cb95d3df0ea1f72f01f1b5b2b039f",
+        "rev": "ff6270444ab7e1ab6fac3464d173b03aa8cb7a75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`ff627044`](https://github.com/nix-community/emacs-overlay/commit/ff6270444ab7e1ab6fac3464d173b03aa8cb7a75) | `` Updated repos/melpa `` |
| [`6d41130f`](https://github.com/nix-community/emacs-overlay/commit/6d41130ffc00158f8c86a913c96d3d98463a7c90) | `` Updated repos/emacs `` |