### PR TITLE
chore(flake/nur): `bc310114` -> `aee42b4c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701853286,
-        "narHash": "sha256-xvei2n0BXYpk0+uCuzwxaMvSWYzU21ciiuF7K9r7rtI=",
+        "lastModified": 1701855867,
+        "narHash": "sha256-2gG1ShPbeOSQgm1ZQJJH0jRp4lYPt8yIBmq5KWT5n3w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bc3101148da3807041842e964ec420390402ccca",
+        "rev": "aee42b4cd55ad943b9227f5ce6cfdb184095cca4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aee42b4c`](https://github.com/nix-community/NUR/commit/aee42b4cd55ad943b9227f5ce6cfdb184095cca4) | `` automatic update `` |
| [`c1346ff1`](https://github.com/nix-community/NUR/commit/c1346ff1d426feb8aec74858da0742c2cfbd5f77) | `` automatic update `` |
| [`e8198fbf`](https://github.com/nix-community/NUR/commit/e8198fbf4d2976eb5485f941151d915df92d15f5) | `` automatic update `` |