### PR TITLE
chore(flake/nur): `aee42b4c` -> `4e2b2624`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701855867,
-        "narHash": "sha256-2gG1ShPbeOSQgm1ZQJJH0jRp4lYPt8yIBmq5KWT5n3w=",
+        "lastModified": 1701859538,
+        "narHash": "sha256-+1iOR503UL/TVJmKtD5L4QSaYoY+kWfau5YoqgDi8lU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aee42b4cd55ad943b9227f5ce6cfdb184095cca4",
+        "rev": "4e2b2624c5ada214efd2074b9af7be96800a237d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4e2b2624`](https://github.com/nix-community/NUR/commit/4e2b2624c5ada214efd2074b9af7be96800a237d) | `` automatic update `` |
| [`df1365a4`](https://github.com/nix-community/NUR/commit/df1365a4d2ef9d053615d342b80de97e23d75365) | `` automatic update `` |