### PR TITLE
chore(flake/nur): `4e2b2624` -> `2d450c2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701859538,
-        "narHash": "sha256-+1iOR503UL/TVJmKtD5L4QSaYoY+kWfau5YoqgDi8lU=",
+        "lastModified": 1701866502,
+        "narHash": "sha256-n3GxadMvBeT/e/eWMSGFXAlhVE3I7wmfa9Eg2px13AE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4e2b2624c5ada214efd2074b9af7be96800a237d",
+        "rev": "2d450c2dad91591ed61cb18ed4a9965f6f2ab9af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2d450c2d`](https://github.com/nix-community/NUR/commit/2d450c2dad91591ed61cb18ed4a9965f6f2ab9af) | `` automatic update `` |
| [`391305c1`](https://github.com/nix-community/NUR/commit/391305c17684c7874de26dbf414ce1d9248460ac) | `` automatic update `` |