### PR TITLE
chore(flake/nur): `2d450c2d` -> `2a468906`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701866502,
-        "narHash": "sha256-n3GxadMvBeT/e/eWMSGFXAlhVE3I7wmfa9Eg2px13AE=",
+        "lastModified": 1701870651,
+        "narHash": "sha256-ArXa73E9NLN+saw51ZzsI2nOMAEc2+MEcemkD5h5QFo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2d450c2dad91591ed61cb18ed4a9965f6f2ab9af",
+        "rev": "2a46890691db81ef6e71751dd1b415883b343864",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2a468906`](https://github.com/nix-community/NUR/commit/2a46890691db81ef6e71751dd1b415883b343864) | `` automatic update `` |
| [`db07b738`](https://github.com/nix-community/NUR/commit/db07b7381f3fe3b484aa6a23ed7f25c088bb17f1) | `` automatic update `` |
| [`a1f532a7`](https://github.com/nix-community/NUR/commit/a1f532a7ef00e32af1e848910ad79e87ed20a6b2) | `` automatic update `` |
| [`65739afa`](https://github.com/nix-community/NUR/commit/65739afa2656acfe601a28069b9138449fe8fd28) | `` automatic update `` |
| [`462bc797`](https://github.com/nix-community/NUR/commit/462bc797a02c47d7ffe011babb303bba3baf509e) | `` automatic update `` |
| [`9f7eb0cf`](https://github.com/nix-community/NUR/commit/9f7eb0cf1b7050e8a730397dbcc26c1806eac09d) | `` automatic update `` |