### PR TITLE
chore(flake/nur): `2a468906` -> `3381e1ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701870651,
-        "narHash": "sha256-ArXa73E9NLN+saw51ZzsI2nOMAEc2+MEcemkD5h5QFo=",
+        "lastModified": 1701873733,
+        "narHash": "sha256-dIa3uHV7w6fh8k0o69U1IMbCTgGy/l2vNrDZOYRPntA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2a46890691db81ef6e71751dd1b415883b343864",
+        "rev": "3381e1ed869eb16a62fa3504df1d96ea99766e82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3381e1ed`](https://github.com/nix-community/NUR/commit/3381e1ed869eb16a62fa3504df1d96ea99766e82) | `` automatic update `` |
| [`ad1670af`](https://github.com/nix-community/NUR/commit/ad1670afc074ed6e1255b60bfe18cbaf113c00f0) | `` automatic update `` |