### PR TITLE
chore(flake/nur): `3381e1ed` -> `2f100fe2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701873733,
-        "narHash": "sha256-dIa3uHV7w6fh8k0o69U1IMbCTgGy/l2vNrDZOYRPntA=",
+        "lastModified": 1701881320,
+        "narHash": "sha256-X43sV6Xtvb8iNms06ASPf+gI6BCZ3sO7EB89e45z7t4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3381e1ed869eb16a62fa3504df1d96ea99766e82",
+        "rev": "2f100fe2b8d7748ead7167f395a5436f55fb10fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2f100fe2`](https://github.com/nix-community/NUR/commit/2f100fe2b8d7748ead7167f395a5436f55fb10fb) | `` automatic update `` |