### PR TITLE
chore(flake/emacs-overlay): `ff627044` -> `0a9317a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1701855622,
-        "narHash": "sha256-Mv3J3L61hn9MShgwboviXCdqHvl13atJMHl0rZMCmdI=",
+        "lastModified": 1701884478,
+        "narHash": "sha256-YgrbYNjpfVfHDVlHULhkxmk1khK+8pk4VFD7D6c4zpU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ff6270444ab7e1ab6fac3464d173b03aa8cb7a75",
+        "rev": "0a9317a71ebb8407a46834b55eaa3ce84eb27a46",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1701540982,
-        "narHash": "sha256-5ajSy6ODgGmAbmymRdHnjfVnuVrACjI8wXoGVvrtvww=",
+        "lastModified": 1701615100,
+        "narHash": "sha256-7VI84NGBvlCTduw2aHLVB62NvCiZUlALLqBe5v684Aw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6386d8aafc28b3a7ed03880a57bdc6eb4465491d",
+        "rev": "e9f06adb793d1cca5384907b3b8a4071d5d7cb19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`0a9317a7`](https://github.com/nix-community/emacs-overlay/commit/0a9317a71ebb8407a46834b55eaa3ce84eb27a46) | `` Updated repos/melpa ``  |
| [`7d353e91`](https://github.com/nix-community/emacs-overlay/commit/7d353e914a05e4f06ed0bf6d4efb03e827ce23db) | `` Updated repos/emacs ``  |
| [`36401611`](https://github.com/nix-community/emacs-overlay/commit/36401611ddff3ed053837dc8d4630b566d081574) | `` Updated repos/elpa ``   |
| [`06c4ff77`](https://github.com/nix-community/emacs-overlay/commit/06c4ff77a025f5f14756edca62181460f51a81bf) | `` Updated flake inputs `` |