### PR TITLE
chore(flake/nur): `2f100fe2` -> `74c46041`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701881320,
-        "narHash": "sha256-X43sV6Xtvb8iNms06ASPf+gI6BCZ3sO7EB89e45z7t4=",
+        "lastModified": 1701884762,
+        "narHash": "sha256-aAWZzKMuEq91rNO8DUh8WlcnSSsrVcB9FINfS1r/5Ic=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2f100fe2b8d7748ead7167f395a5436f55fb10fb",
+        "rev": "74c460412d1d4dc267e0be789584650be9638594",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`74c46041`](https://github.com/nix-community/NUR/commit/74c460412d1d4dc267e0be789584650be9638594) | `` automatic update `` |