### PR TITLE
chore(flake/nur): `47496730` -> `52bf9b8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701891878,
-        "narHash": "sha256-eBpEu2QN2SmR/8IWrf0Vz1TSZI6AWjOiLq2yLdV4k8E=",
+        "lastModified": 1701895548,
+        "narHash": "sha256-ukg5+dJSa82+CpCNmca10wLjdzVN8thlkOfswsZqf+s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "47496730cfb1f41a38e428845b350858ce73313f",
+        "rev": "52bf9b8e019cd6e9ec6ff604e7b06c82ad487867",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`52bf9b8e`](https://github.com/nix-community/NUR/commit/52bf9b8e019cd6e9ec6ff604e7b06c82ad487867) | `` automatic update `` |