### PR TITLE
chore(flake/nixpkgs): `91050ea1` -> `2c7f3c0f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -754,11 +754,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1701436327,
-        "narHash": "sha256-tRHbnoNI8SIM5O5xuxOmtSLnswEByzmnQcGGyNRjxsE=",
+        "lastModified": 1701718080,
+        "narHash": "sha256-6ovz0pG76dE0P170pmmZex1wWcQoeiomUZGggfH9XPs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "91050ea1e57e50388fa87a3302ba12d188ef723a",
+        "rev": "2c7f3c0fb7c08a0814627611d9d7d45ab6d75335",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                        |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`d23df73a`](https://github.com/NixOS/nixpkgs/commit/d23df73a07a8cb8a3b8fb0630a8a861a2afc74b6) | `` ctranslate2: enable cuDNN only if it is available ``                                        |
| [`5bf016e1`](https://github.com/NixOS/nixpkgs/commit/5bf016e1e98accfd62c5bbd5a6dea3049af72595) | `` python3Packages.torch: enable cuDNN & NCCL only if available ``                             |
| [`5ac7bc51`](https://github.com/NixOS/nixpkgs/commit/5ac7bc5197516267524bfc740456f700867745fb) | `` ncurses: gate postFixup related to unicode support (closes #271716) ``                      |
| [`4e40a200`](https://github.com/NixOS/nixpkgs/commit/4e40a200f55a2160fadbfbe37901fe9c65b7c737) | `` haskellPackages: mark builds failing on hydra as broken ``                                  |
| [`2252b262`](https://github.com/NixOS/nixpkgs/commit/2252b26260f64ab7d21bddd3b6d1ceb2564c30c2) | `` python3Packages.jaxlib-bin: move asserts to broken to avoid breaking eval ``                |
| [`28608b04`](https://github.com/NixOS/nixpkgs/commit/28608b04486f5c9218ba6b74f347456253ea9f4f) | `` nixos/clevis: skip filesystem with null devices ``                                          |
| [`9b6b9349`](https://github.com/NixOS/nixpkgs/commit/9b6b934949a02ef19868f76df0f5dbcef67a8278) | `` nixos/clevis: guard zfs code behind config.clevis.boot.initrd.enable ``                     |
| [`e9269d82`](https://github.com/NixOS/nixpkgs/commit/e9269d82f7842c0c3050c402ee98ebfdc20524bb) | `` python311Packages.torchaudio: fix build when cudaSupport is enabled ``                      |
| [`08419410`](https://github.com/NixOS/nixpkgs/commit/084194100c0d39ecfd4b4fb9d21551ceccab9c1b) | `` rure: update Cargo.lock ``                                                                  |
| [`023cd82d`](https://github.com/NixOS/nixpkgs/commit/023cd82d0402e74886696699f9b681e9dc7194f0) | `` vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.17.5 -> 0.17.10 ``                         |
| [`c64d6957`](https://github.com/NixOS/nixpkgs/commit/c64d69574ac1c00be11d77c72003560c1b522267) | `` python3.pkgs.ariadne: remove opentracing dependency (#271999) ``                            |
| [`f509382c`](https://github.com/NixOS/nixpkgs/commit/f509382c11ed445b52f249efa6e2fe66d1b56fa7) | `` node-red_service: correct package to nodePackages.node-red ``                               |
| [`66ec462b`](https://github.com/NixOS/nixpkgs/commit/66ec462bfd4d294323db26ed2b1c49a245e79ece) | `` python310Packages.oelint-parser: 2.11.6 -> 2.12.0 ``                                        |
| [`26bb95da`](https://github.com/NixOS/nixpkgs/commit/26bb95dae986aa902d4596287a3a9b37328f7b4b) | `` python311Packages.azure-identity: fix propogatedBuildImports and darwin ``                  |
| [`3d00512f`](https://github.com/NixOS/nixpkgs/commit/3d00512fce24402f2d6a3580d1d4238dda7f2139) | `` linuxKernel.kernels.linux_lqx: 6.6.3-lqx1 -> 6.6.4-lqx1 ``                                  |
| [`7fba22e3`](https://github.com/NixOS/nixpkgs/commit/7fba22e321209e45d14264da6d169d614d26fbd7) | `` linuxKernel.kernels.linux_zen: 6.6.3-zen1 -> 6.6.4-zen1 ``                                  |
| [`43029b50`](https://github.com/NixOS/nixpkgs/commit/43029b506fcf3dc2a346c9ac3003e8ab93348f77) | `` weechat-unwrapped: 4.1.1 -> 4.1.2 ``                                                        |
| [`f729a8e6`](https://github.com/NixOS/nixpkgs/commit/f729a8e68c9e722946127f8d75aa27eda65f79d8) | `` fastgron: 0.6.5 -> 0.7.0 ``                                                                 |
| [`00accfe5`](https://github.com/NixOS/nixpkgs/commit/00accfe5651cdd279e9b705f592e387c5fc4e129) | `` vscode-extensions.davidanson.vscode-markdownlint: 0.52.0 -> 0.53.0 ``                       |
| [`406772bf`](https://github.com/NixOS/nixpkgs/commit/406772bf9953775aa19ddadb6abde5681a1d916e) | `` python310Packages.oauthenticator: 16.2.0 -> 16.2.1 ``                                       |
| [`1f3e5702`](https://github.com/NixOS/nixpkgs/commit/1f3e570272d9aa504808fe9c418b36a80f7d4085) | `` python311Packages.syncedlyrics: refactor ``                                                 |
| [`451238c2`](https://github.com/NixOS/nixpkgs/commit/451238c21663fd523bf8301fc32a5c8c300b68b6) | `` python311Packages.syncedlyrics: 0.6.1 -> 0.7.0 ``                                           |
| [`a358f634`](https://github.com/NixOS/nixpkgs/commit/a358f6347aae695c52c39f9f54799c67daa855b2) | `` python310Packages.numpy-stl: 3.0.1 -> 3.1.1 ``                                              |
| [`c817976d`](https://github.com/NixOS/nixpkgs/commit/c817976de50d26c5c6593af6dc234ada9245d1f0) | `` pulumi-bin: 3.94.0 -> 3.95.0 ``                                                             |
| [`fc8fa7c2`](https://github.com/NixOS/nixpkgs/commit/fc8fa7c26bd4033979de1eddf01fbc8e061121b2) | `` treewide: remove unused qmake and cmake ``                                                  |
| [`e4c124c5`](https://github.com/NixOS/nixpkgs/commit/e4c124c5a1741478ba8279951869beec642dfa17) | `` treewide: replace `inherit (libsForQt5)` with `libsForQt5.callPackage` where possible ``    |
| [`eefffd00`](https://github.com/NixOS/nixpkgs/commit/eefffd003a2c2cac2206e48ea9801bfa5ccee74b) | `` python310Packages.mkdocstrings: refactor ``                                                 |
| [`608e8f6e`](https://github.com/NixOS/nixpkgs/commit/608e8f6e87c385545bf353e069d0e8ea8db00d65) | `` python310Packages.millheater: 0.11.6 -> 0.11.7 ``                                           |
| [`515f0d1b`](https://github.com/NixOS/nixpkgs/commit/515f0d1b59abaa8194c75544eb0d8859915a3edd) | `` python310Packages.mkdocstrings: 0.23.0 -> 0.24.0 ``                                         |
| [`4e5d8476`](https://github.com/NixOS/nixpkgs/commit/4e5d847614831d79759cdcbfa83b4b5e7f6f1870) | `` python310Packages.mkdocs-swagger-ui-tag: 0.6.6 -> 0.6.7 ``                                  |
| [`e76d8d1a`](https://github.com/NixOS/nixpkgs/commit/e76d8d1a326fcbdde58241d4e6d1c9716823c460) | `` python310Packages.meep: 1.27.0 -> 1.28.0 ``                                                 |
| [`3f916c8d`](https://github.com/NixOS/nixpkgs/commit/3f916c8d59ab7d8e4c9b9cc107f4711064a7b3cf) | `` starsector: added missing build input ``                                                    |
| [`e270b7be`](https://github.com/NixOS/nixpkgs/commit/e270b7beff7c137a8aa0d34867e960febd2a346c) | `` php: use a versioned url for install-pear-nozlib.phar ``                                    |
| [`34deb05e`](https://github.com/NixOS/nixpkgs/commit/34deb05e5599997d5685387e4f44376915f1e561) | `` nixos/buildbot: fix worker package ``                                                       |
| [`54557f8b`](https://github.com/NixOS/nixpkgs/commit/54557f8bfa59351354524053d4787ce2ee5c4f90) | `` sshx-server: add web ui ``                                                                  |
| [`673c8d72`](https://github.com/NixOS/nixpkgs/commit/673c8d72ca29bc6a3d69008e4ca76947f4b5827a) | `` sshx: split components, unstable-2023-11-04 -> unstable-2023-11-23 ``                       |
| [`3768e103`](https://github.com/NixOS/nixpkgs/commit/3768e103ef9786850fb2fdca268f387c03c962f4) | `` pynitrokey: 0.4.42 -> 0.4.43 ``                                                             |
| [`9e71df9f`](https://github.com/NixOS/nixpkgs/commit/9e71df9f5ef28c3868430b50c9e532b34a719751) | `` python311Packages.litellm: 0.11.1 -> 1.7.11 ``                                              |
| [`5f69f0ed`](https://github.com/NixOS/nixpkgs/commit/5f69f0ed2eb1751e24e0cb7f4100bd973dd2db69) | `` python311Packages.openai: 0.28.1 -> 1.3.7 ``                                                |
| [`0108269b`](https://github.com/NixOS/nixpkgs/commit/0108269b3882c72e60fa4d24b4ab3d586b8ef8e0) | `` python311Packages.html2image: init at 2.0.4.3 ``                                            |
| [`df6a845b`](https://github.com/NixOS/nixpkgs/commit/df6a845b71064dfdde801a0962e1dac76258fa51) | `` aws-workspaces: 4.6.0 include missing xcbutil dependency ``                                 |
| [`e8d71f69`](https://github.com/NixOS/nixpkgs/commit/e8d71f6901f728999168b8fbffbed319dff5c27f) | `` handlr-regex: 0.8.5 -> 0.9.0 ``                                                             |
| [`cbf69c83`](https://github.com/NixOS/nixpkgs/commit/cbf69c83d3b2bdc5eca341aa9e44e0406794af81) | `` nixos/mastodon: clarify the need to set streamingProcesses ``                               |
| [`db4ce465`](https://github.com/NixOS/nixpkgs/commit/db4ce465edd23222973fff494b0cc3a522d7a3dc) | `` handlr-regex: migrate to pkgs/by-name ``                                                    |
| [`294645a0`](https://github.com/NixOS/nixpkgs/commit/294645a07a96e2135a3ff43cee7a8585665c8c65) | `` python310Packages.latexify-py: 0.4.1 -> 0.4.2 ``                                            |
| [`5286ff07`](https://github.com/NixOS/nixpkgs/commit/5286ff070a0631800f328ce77172d7b185d59866) | `` grafana: 10.2.0 -> 10.2.2 ``                                                                |
| [`37a54300`](https://github.com/NixOS/nixpkgs/commit/37a543002cce2fea56ab92ed46baef2abc9df6de) | `` themix-gui: init at 1.15.1 ``                                                               |
| [`7a553c4d`](https://github.com/NixOS/nixpkgs/commit/7a553c4d2962266fae443c3c17d134e9279d819e) | `` python310Packages.langsmith: 0.0.63 -> 0.0.69 ``                                            |
| [`6befd082`](https://github.com/NixOS/nixpkgs/commit/6befd082e7c9eceab9fb247c9ee013db680fab7b) | `` ia-writer-quattro: init at unstable-2023-06-16 ``                                           |
| [`78079efb`](https://github.com/NixOS/nixpkgs/commit/78079efb8d5f2185fafb181b3180fb6a92bd1dcb) | `` maintainers: add x0ba ``                                                                    |
| [`de1aca9b`](https://github.com/NixOS/nixpkgs/commit/de1aca9bcf597856fbe22babff3481646195fdb7) | `` vimPlugins.nvim-treesitter: update grammars ``                                              |
| [`393847dd`](https://github.com/NixOS/nixpkgs/commit/393847ddf81675da96fe76b037a03ee2fa170853) | `` vimPlugins: update on 2023-12-03 ``                                                         |
| [`1d17fa36`](https://github.com/NixOS/nixpkgs/commit/1d17fa361b0fe462ecdc67b623e6b68578bf4c18) | `` vimPlugins.wtf-nvim: init at 2023-11-11 ``                                                  |
| [`7e886531`](https://github.com/NixOS/nixpkgs/commit/7e886531a2b9be8ca3fd43bde8e82cbae9b9e4a0) | `` qt6.qtmultimedia: Fix failure to load libva.so ``                                           |
| [`d3de574b`](https://github.com/NixOS/nixpkgs/commit/d3de574b8ccc0e98b4490197265f60b03b36c0e9) | `` qt6.qtmultimedia: Compile hardware-accelerated VAAPI ``                                     |
| [`91b8e472`](https://github.com/NixOS/nixpkgs/commit/91b8e472a5b7661bcc2f930a1abe14881f335a73) | `` qt6.qtmultimedia: Compile ffmpeg multimedia plugin ``                                       |
| [`0ebea895`](https://github.com/NixOS/nixpkgs/commit/0ebea895518328b58d169c27860433d5594f4823) | `` qt6.qtmultimedia: Enable Spatial Audio (Quick3D) ``                                         |
| [`37b106f9`](https://github.com/NixOS/nixpkgs/commit/37b106f9b04cdb35d0b2cecd9858e7fa9c3e6625) | `` postgresql.pkgs.timescaledb_toolkit: 1.16.0 -> 1.18.0 ``                                    |
| [`5aa5b3c1`](https://github.com/NixOS/nixpkgs/commit/5aa5b3c1a7f614c030a9662fe64083818b949336) | `` linux-rt_6_1: 6.1.59-rt16 -> 6.1.64-rt17 ``                                                 |
| [`430fc02b`](https://github.com/NixOS/nixpkgs/commit/430fc02b433acc512d8f676b672e7cc1a821739a) | `` linux_5_15: 5.15.140 -> 5.15.141 ``                                                         |
| [`a7db5f67`](https://github.com/NixOS/nixpkgs/commit/a7db5f67e13e1b83430569b7a1d0278fd0925c17) | `` linux_6_1: 6.1.64 -> 6.1.65 ``                                                              |
| [`518742c7`](https://github.com/NixOS/nixpkgs/commit/518742c78e3a6ef1c2b5dd971bb310673e1ad913) | `` linux_6_6: 6.6.3 -> 6.6.4 ``                                                                |
| [`03de3c5c`](https://github.com/NixOS/nixpkgs/commit/03de3c5c3fda2d9f290117b3675b76c5c5ca2a95) | `` linux_testing: 6.7-rc3 -> 6.7-rc4 ``                                                        |
| [`43b372ab`](https://github.com/NixOS/nixpkgs/commit/43b372ab66e1590de505f4c0ef96be2a75b416bf) | `` virtiofsd.meta.mainProgram: init ``                                                         |
| [`4a6045a4`](https://github.com/NixOS/nixpkgs/commit/4a6045a41b9caff2028a7d37a8d51e25f1aa45f8) | `` emacs: Use lib.withFeature ``                                                               |
| [`b3e34832`](https://github.com/NixOS/nixpkgs/commit/b3e348323eea142b8bdff8a4e693c7de8c8e5039) | `` wireplumber: 0.4.16 -> 0.4.17 ``                                                            |
| [`2d6601b2`](https://github.com/NixOS/nixpkgs/commit/2d6601b2795c9bae574338f7fd67754b47ba46fe) | `` maintainers/team-list: add nialov to geospatial team ``                                     |
| [`193f6e7f`](https://github.com/NixOS/nixpkgs/commit/193f6e7fd279dbafd764c0886a6ee952e5b1316e) | `` python310Packages.jplephem: 2.20 -> 2.21 ``                                                 |
| [`642e0543`](https://github.com/NixOS/nixpkgs/commit/642e05439052539ed9053775ae5044da4d481912) | `` maintainers.moni: fix github id ``                                                          |
| [`1769cf41`](https://github.com/NixOS/nixpkgs/commit/1769cf416ed58df2fc5fc9e8e7a0c0284a5ae0c9) | `` contour: 0.3.1.200 -> 0.3.12.262 ``                                                         |
| [`550b95e2`](https://github.com/NixOS/nixpkgs/commit/550b95e22c148071bf155573f9ced0bf96e2d408) | `` bup: Fix build on Darwin with LLVM 16 ``                                                    |
| [`f171058d`](https://github.com/NixOS/nixpkgs/commit/f171058dcc574168b9e683ef1dae2bd97e7b9d8d) | `` mpvScripts.mpv-webm: Set `updateScript` ``                                                  |
| [`ba0dc5b5`](https://github.com/NixOS/nixpkgs/commit/ba0dc5b5d3007816cd0f5b9520d8bbb15365fd93) | `` python311Packages.example-robot-data: 4.0.8 -> 4.0.9 ``                                     |
| [`e8978c7b`](https://github.com/NixOS/nixpkgs/commit/e8978c7baa00ec684ea4c085320542b716060c94) | `` light: Add `meta.mainProgram` ``                                                            |
| [`1ccdf7c3`](https://github.com/NixOS/nixpkgs/commit/1ccdf7c36905a785ba4451973928801cf0a02789) | `` fusuma: 3.1.0 -> 3.3.1 ``                                                                   |
| [`5568a104`](https://github.com/NixOS/nixpkgs/commit/5568a1043c570f02be9522d0f5aa1acfb6a5156d) | `` python310Packages.intellifire4py: 3.1.30 -> 3.5.0 ``                                        |
| [`edbc1427`](https://github.com/NixOS/nixpkgs/commit/edbc14275838c7d018d2a55a54df40e8ea3189b0) | `` python310Packages.inquirer: 3.1.3 -> 3.1.4 ``                                               |
| [`f0362972`](https://github.com/NixOS/nixpkgs/commit/f03629728793cce0025338357105a65e3d9b3bbf) | `` hareThirdParty.hare-json: init at unstable-2023-09-21 ``                                    |
| [`d873210f`](https://github.com/NixOS/nixpkgs/commit/d873210f1eb182d4dea8e116d291f8d58600ee16) | `` pjsip: 2.13.1 -> 2.14 ``                                                                    |
| [`79567db9`](https://github.com/NixOS/nixpkgs/commit/79567db9149d508c99f03b83b7fed6d32faaa971) | `` pjsip: fix build on clang/darwin ``                                                         |
| [`922e4c14`](https://github.com/NixOS/nixpkgs/commit/922e4c14a4112f0da1496fe9478e3e4cac85fe3d) | `` python310Packages.icontract: 2.6.4 -> 2.6.6 ``                                              |
| [`03982f1f`](https://github.com/NixOS/nixpkgs/commit/03982f1ffd811863e8ab82f8abdf66e050333dc9) | `` python310Packages.duecredit: drop dependency on six, raise minimum python version to 3.8 `` |
| [`20f5e3a1`](https://github.com/NixOS/nixpkgs/commit/20f5e3a1374531bec4fa77ab9f54d87ba798f191) | `` addOpenGLRunpath: Add comment for deprecation schedule ``                                   |