### PR TITLE
chore(flake/nur): `842aa749` -> `b8ad2b1f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701902726,
-        "narHash": "sha256-iKKaVeEs4SI1ySIapp/6jooxkrlww5rNkHpZUceyZ9M=",
+        "lastModified": 1701906331,
+        "narHash": "sha256-4dzaExoiung1HWn0nTp9xBHtB5rQMTsfOC2FtJuUoH4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "842aa7497dc4ca6f4d71fffed95d6247e7e25bae",
+        "rev": "b8ad2b1feccf3b75e2d7fabad6d97769318febf4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b8ad2b1f`](https://github.com/nix-community/NUR/commit/b8ad2b1feccf3b75e2d7fabad6d97769318febf4) | `` automatic update `` |