### PR TITLE
chore(flake/srvos): `cdc612b3` -> `ea2180fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -646,11 +646,11 @@
     },
     "nixos-23_05": {
       "locked": {
-        "lastModified": 1701540982,
-        "narHash": "sha256-5ajSy6ODgGmAbmymRdHnjfVnuVrACjI8wXoGVvrtvww=",
+        "lastModified": 1701615100,
+        "narHash": "sha256-7VI84NGBvlCTduw2aHLVB62NvCiZUlALLqBe5v684Aw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6386d8aafc28b3a7ed03880a57bdc6eb4465491d",
+        "rev": "e9f06adb793d1cca5384907b3b8a4071d5d7cb19",
         "type": "github"
       },
       "original": {
@@ -1007,11 +1007,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701895800,
-        "narHash": "sha256-gJ2nR69sstJJU9yeDOWy02Jyy0Y7r84Uha+I7Z+PkpY=",
+        "lastModified": 1701913958,
+        "narHash": "sha256-W44kFPSN8Pv8OXg7xYtyvqMLoWBHJXZf7cic6fQiZBk=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "cdc612b37adc1738ecf78f9b1423a1ec3c7f6078",
+        "rev": "ea2180fd9728d47cc3953d0868175d02c28de980",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------ |
| [`ea2180fd`](https://github.com/nix-community/srvos/commit/ea2180fd9728d47cc3953d0868175d02c28de980) | `` flake.lock: Update `` |
| [`a812307a`](https://github.com/nix-community/srvos/commit/a812307a97fe038ffa46fc4bd33311767facb9d3) | `` flake.lock: Update `` |