### PR TITLE
chore(flake/nur): `39b1022f` -> `e7a51f59`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701910967,
-        "narHash": "sha256-khksjhjw6cGo66tGgLVMLXIDn8j8nYAzqagpDt6QVaw=",
+        "lastModified": 1701921432,
+        "narHash": "sha256-U/NBfeQPB/ULjvf5mAzdj68eyAc3cyosl1u8nmsH99s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "39b1022fcfdd468eef04855d95338ae10ac27352",
+        "rev": "e7a51f59ded90a8edc3d7cc2e82df1664533760b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e7a51f59`](https://github.com/nix-community/NUR/commit/e7a51f59ded90a8edc3d7cc2e82df1664533760b) | `` automatic update `` |
| [`33d97c9b`](https://github.com/nix-community/NUR/commit/33d97c9be48630982d3ad9ba32b535d2a61be737) | `` automatic update `` |
| [`0aa2c2ed`](https://github.com/nix-community/NUR/commit/0aa2c2ede9676a20091b7f3b45863c65174c0622) | `` automatic update `` |