### PR TITLE
chore(flake/nur): `e7a51f59` -> `4c798870`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701921432,
-        "narHash": "sha256-U/NBfeQPB/ULjvf5mAzdj68eyAc3cyosl1u8nmsH99s=",
+        "lastModified": 1701927660,
+        "narHash": "sha256-WdcrX7COQuIwNP55nAxzPS0T2EmY8vG+2AvK5nVoPHc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e7a51f59ded90a8edc3d7cc2e82df1664533760b",
+        "rev": "4c79887009c5cd89e02b9f972d3662911df243d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4c798870`](https://github.com/nix-community/NUR/commit/4c79887009c5cd89e02b9f972d3662911df243d8) | `` automatic update `` |
| [`e4506413`](https://github.com/nix-community/NUR/commit/e45064135a449faa39cdf4459166eb07c150ac18) | `` automatic update `` |