### PR TITLE
chore(flake/nur): `4c798870` -> `fe3bfaf2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701927660,
-        "narHash": "sha256-WdcrX7COQuIwNP55nAxzPS0T2EmY8vG+2AvK5nVoPHc=",
+        "lastModified": 1701935812,
+        "narHash": "sha256-M4OHaT4B7dmMzcsVVVs/lqI0DlCs5DJJZoEagJ9C+DU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4c79887009c5cd89e02b9f972d3662911df243d8",
+        "rev": "fe3bfaf2b9dbb018d12ca47e64c85460628ba99f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fe3bfaf2`](https://github.com/nix-community/NUR/commit/fe3bfaf2b9dbb018d12ca47e64c85460628ba99f) | `` automatic update `` |
| [`f6f429ca`](https://github.com/nix-community/NUR/commit/f6f429ca785f0626aedd056e175c40f4213a6a07) | `` automatic update `` |
| [`2a395236`](https://github.com/nix-community/NUR/commit/2a39523613fbd643d4873fe4926f768f6263ab1c) | `` automatic update `` |
| [`7b6930b3`](https://github.com/nix-community/NUR/commit/7b6930b33742a5cd9262f112d8cc1c1e5b12b81f) | `` automatic update `` |