### PR TITLE
chore(flake/nur): `fe3bfaf2` -> `8b8e4441`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701935812,
-        "narHash": "sha256-M4OHaT4B7dmMzcsVVVs/lqI0DlCs5DJJZoEagJ9C+DU=",
+        "lastModified": 1701938659,
+        "narHash": "sha256-mMYO0vpKZWX1a0q5MACeApx6R1nD2pnyw0MhIprfGyE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fe3bfaf2b9dbb018d12ca47e64c85460628ba99f",
+        "rev": "8b8e4441c9b7cead1ca8c012b49e401a912f9b38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8b8e4441`](https://github.com/nix-community/NUR/commit/8b8e4441c9b7cead1ca8c012b49e401a912f9b38) | `` automatic update `` |