### PR TITLE
chore(flake/emacs-overlay): `3bad6461` -> `7a2b06b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1701917137,
-        "narHash": "sha256-NhTDV70GXlqR6YpLIxhIbWcgNU6AbOKvDedYvAkRnjI=",
+        "lastModified": 1701941994,
+        "narHash": "sha256-b76hEma5VOUVctWWKKfm9a7gZCKQSqvMFFMDVfyxvC4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3bad646173201de59d462f1825c5f5116cafa36f",
+        "rev": "7a2b06b15c0497ebb75a059dfabadc1d707dd6d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`7a2b06b1`](https://github.com/nix-community/emacs-overlay/commit/7a2b06b15c0497ebb75a059dfabadc1d707dd6d0) | `` Updated repos/melpa `` |
| [`348e66ff`](https://github.com/nix-community/emacs-overlay/commit/348e66ffa3eeea21a62fc25d13e625dbfc8ac899) | `` Updated repos/emacs `` |