### PR TITLE
chore(flake/nur): `8b8e4441` -> `57e196f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701938659,
-        "narHash": "sha256-mMYO0vpKZWX1a0q5MACeApx6R1nD2pnyw0MhIprfGyE=",
+        "lastModified": 1701942344,
+        "narHash": "sha256-yxQsb8Dh6flw06k0Mhy/SRigkSSYkNu55ExsAy0PsTo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8b8e4441c9b7cead1ca8c012b49e401a912f9b38",
+        "rev": "57e196f2106873a42512768ce6923d360a385db8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`57e196f2`](https://github.com/nix-community/NUR/commit/57e196f2106873a42512768ce6923d360a385db8) | `` automatic update `` |