### PR TITLE
chore(flake/srvos): `ea2180fd` -> `eacbc85e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -988,11 +988,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701913958,
-        "narHash": "sha256-W44kFPSN8Pv8OXg7xYtyvqMLoWBHJXZf7cic6fQiZBk=",
+        "lastModified": 1701941438,
+        "narHash": "sha256-/nEW9L0AqH6jnDQwvbFyuslw/WEybLeA8vSh2fFetcY=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "ea2180fd9728d47cc3953d0868175d02c28de980",
+        "rev": "eacbc85e04c012071eda81e4d26fc6d0b1194236",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`bd074019`](https://github.com/nix-community/srvos/commit/bd074019fc105fb5724743c092146f534a64a03f) | `` nix-experimental: enable configurable-impure-env, fetch-closure, recursive-nix `` |
| [`838660fb`](https://github.com/nix-community/srvos/commit/838660fbfe3945c3c8c14b7f014b83880975ef14) | `` nix-experimental: disable impure derivations ``                                   |