### PR TITLE
chore(flake/nur): `e84ed059` -> `95f40329`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701955519,
-        "narHash": "sha256-xu2MWIClYrNbXq5rYPEEgVWa7pB64u/KCPMceaZK86c=",
+        "lastModified": 1701960135,
+        "narHash": "sha256-jmBWNDjFV4w8zrfExq7BkNR6sz1/bPtrM2BhbOGlYHE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e84ed059a4145720429f38352b5852b303888733",
+        "rev": "95f4032933ca6b85f97e89495a452921a392460e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`95f40329`](https://github.com/nix-community/NUR/commit/95f4032933ca6b85f97e89495a452921a392460e) | `` automatic update `` |