### PR TITLE
chore(flake/emacs-overlay): `7a2b06b1` -> `b6fa0a73`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1701941994,
-        "narHash": "sha256-b76hEma5VOUVctWWKKfm9a7gZCKQSqvMFFMDVfyxvC4=",
+        "lastModified": 1701970815,
+        "narHash": "sha256-lNkdPPfTx+9Pvg+j1jh0gjblgWCQVjmB4YaOZ/SZoo8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7a2b06b15c0497ebb75a059dfabadc1d707dd6d0",
+        "rev": "b6fa0a7314fbcca7257770e1064bfef44d9d7293",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b6fa0a73`](https://github.com/nix-community/emacs-overlay/commit/b6fa0a7314fbcca7257770e1064bfef44d9d7293) | `` Updated repos/nongnu `` |
| [`433f8ba3`](https://github.com/nix-community/emacs-overlay/commit/433f8ba396eb78f6e3ac80d0be76083e0fcb4640) | `` Updated repos/melpa ``  |
| [`481128e0`](https://github.com/nix-community/emacs-overlay/commit/481128e0e763ea1bdfd7b2f1fb54b2c32ae7fe65) | `` Updated repos/emacs ``  |
| [`431cf541`](https://github.com/nix-community/emacs-overlay/commit/431cf541ab443c366d47d87ca387ecdff098a170) | `` Updated repos/elpa ``   |