### PR TITLE
chore(flake/nur): `4d625a25` -> `d9095384`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701967638,
-        "narHash": "sha256-NV4HTm+DnOWVx8y1Li2vEqhbJSl+z7rpAz8lD1NvF/c=",
+        "lastModified": 1701971067,
+        "narHash": "sha256-t8QBdaFWUwkCrLIanOPrPuMeI8RA5qnsxqoHJtao2lI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4d625a255dcaed7b3670fc0fb7cf4d0159496890",
+        "rev": "d90953847c55edd3cc21da68760c1f6cb52b4995",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d9095384`](https://github.com/nix-community/NUR/commit/d90953847c55edd3cc21da68760c1f6cb52b4995) | `` automatic update `` |