### PR TITLE
chore(flake/nur): `d9095384` -> `cc0b1a85`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701971067,
-        "narHash": "sha256-t8QBdaFWUwkCrLIanOPrPuMeI8RA5qnsxqoHJtao2lI=",
+        "lastModified": 1701978270,
+        "narHash": "sha256-SI8Cs55udPrkaOfdzYEsy1hqPhvTTSSvU2i3eTy3eF0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d90953847c55edd3cc21da68760c1f6cb52b4995",
+        "rev": "cc0b1a8578f0a9ed6e342f85e6b3ef42ccbfcf33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cc0b1a85`](https://github.com/nix-community/NUR/commit/cc0b1a8578f0a9ed6e342f85e6b3ef42ccbfcf33) | `` automatic update `` |
| [`a2374c9f`](https://github.com/nix-community/NUR/commit/a2374c9f722a828b141e7116dc24c0acd81dd093) | `` automatic update `` |