### PR TITLE
chore(flake/nur): `cc0b1a85` -> `57ddc7c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701978270,
-        "narHash": "sha256-SI8Cs55udPrkaOfdzYEsy1hqPhvTTSSvU2i3eTy3eF0=",
+        "lastModified": 1701980766,
+        "narHash": "sha256-s2tSTMKNI6w4CZ6fKnVR91pff8DzI1qxWixhlwdWvqA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cc0b1a8578f0a9ed6e342f85e6b3ef42ccbfcf33",
+        "rev": "57ddc7c919acf1e41438cf7091c87f013a29b2a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`57ddc7c9`](https://github.com/nix-community/NUR/commit/57ddc7c919acf1e41438cf7091c87f013a29b2a7) | `` automatic update `` |