### PR TITLE
chore(flake/emacs-overlay): `b6fa0a73` -> `170e8603`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1701970815,
-        "narHash": "sha256-lNkdPPfTx+9Pvg+j1jh0gjblgWCQVjmB4YaOZ/SZoo8=",
+        "lastModified": 1702002149,
+        "narHash": "sha256-KAtAAnpfogr6XzdskJ33ytdrd0c6UU4OT94u84eWvpQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b6fa0a7314fbcca7257770e1064bfef44d9d7293",
+        "rev": "170e86030361a09053abe3ca36b0fefa1292a13e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`170e8603`](https://github.com/nix-community/emacs-overlay/commit/170e86030361a09053abe3ca36b0fefa1292a13e) | `` Updated repos/nongnu `` |
| [`45ed406c`](https://github.com/nix-community/emacs-overlay/commit/45ed406ced5d2d1483aed1e0e844dcfa8ba9e0b1) | `` Updated repos/melpa ``  |
| [`ecb8fcd4`](https://github.com/nix-community/emacs-overlay/commit/ecb8fcd4dc2c9bc63e33d28a0543b5dc7fd69ea7) | `` Updated repos/emacs ``  |
| [`9f6f0e77`](https://github.com/nix-community/emacs-overlay/commit/9f6f0e77688d72a5314041b048e4efa7f1b8f224) | `` Updated repos/elpa ``   |