### PR TITLE
chore(flake/nur): `fa7ead45` -> `b074cd5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702014032,
-        "narHash": "sha256-AYEqEM8Tf38YbhsYV4v2WLmys5fNC8efn2s4SMqVDck=",
+        "lastModified": 1702017428,
+        "narHash": "sha256-3b0s8/s3Yi5pP7BnqVvDP1oTn+ameD2I4SyYMTnTppQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fa7ead45de7fd560c5817487f59c7b5ea32e6ad3",
+        "rev": "b074cd5e1522756e8a53a8a97d945667b5630dd8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b074cd5e`](https://github.com/nix-community/NUR/commit/b074cd5e1522756e8a53a8a97d945667b5630dd8) | `` automatic update `` |