### PR TITLE
chore(flake/nur): `b074cd5e` -> `39a70777`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702017428,
-        "narHash": "sha256-3b0s8/s3Yi5pP7BnqVvDP1oTn+ameD2I4SyYMTnTppQ=",
+        "lastModified": 1702021852,
+        "narHash": "sha256-IEguaO3sOLryicxL0lnbAtgIZslJZjRqSZCh97yxNL0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b074cd5e1522756e8a53a8a97d945667b5630dd8",
+        "rev": "39a7077726894593208cb19c0edf29abd2c7c799",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`39a70777`](https://github.com/nix-community/NUR/commit/39a7077726894593208cb19c0edf29abd2c7c799) | `` automatic update `` |
| [`bef77138`](https://github.com/nix-community/NUR/commit/bef77138c70307bb53ef50a78400344e041a8b58) | `` automatic update `` |