### PR TITLE
chore(flake/nur): `39a70777` -> `34c38401`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702021852,
-        "narHash": "sha256-IEguaO3sOLryicxL0lnbAtgIZslJZjRqSZCh97yxNL0=",
+        "lastModified": 1702024792,
+        "narHash": "sha256-ikWMhlQ5ovO0kviI511kEGUANnE3nest8OIm8uRkWS0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "39a7077726894593208cb19c0edf29abd2c7c799",
+        "rev": "34c384017ea9808356c1d1f91525e7a17044d982",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`34c38401`](https://github.com/nix-community/NUR/commit/34c384017ea9808356c1d1f91525e7a17044d982) | `` automatic update `` |
| [`337600e6`](https://github.com/nix-community/NUR/commit/337600e622b8b1fad2494e9027b688e5f0b2170b) | `` automatic update `` |
| [`5ffb15d9`](https://github.com/nix-community/NUR/commit/5ffb15d9004d01bb28e5484ba7612752ad797c39) | `` automatic update `` |