### PR TITLE
chore(flake/emacs-overlay): `170e8603` -> `ea9cd7c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1702002149,
-        "narHash": "sha256-KAtAAnpfogr6XzdskJ33ytdrd0c6UU4OT94u84eWvpQ=",
+        "lastModified": 1702028397,
+        "narHash": "sha256-FNlJm0IJ0mjMYVKL7qiTFIdmF0yEyBUJeeCxDjg72gE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "170e86030361a09053abe3ca36b0fefa1292a13e",
+        "rev": "ea9cd7c22194345e4db85e334b8ff40cc384c536",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`ea9cd7c2`](https://github.com/nix-community/emacs-overlay/commit/ea9cd7c22194345e4db85e334b8ff40cc384c536) | `` Updated repos/melpa `` |
| [`d9cd5f09`](https://github.com/nix-community/emacs-overlay/commit/d9cd5f09f121ae0e2673f5ca8f4ece7a320fa659) | `` Updated repos/emacs `` |