### PR TITLE
chore(flake/nur): `34c38401` -> `677cef10`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702024792,
-        "narHash": "sha256-ikWMhlQ5ovO0kviI511kEGUANnE3nest8OIm8uRkWS0=",
+        "lastModified": 1702028344,
+        "narHash": "sha256-4x9G1ZDVD0//fnQc1ELZrE+s7114A7dUYd/MmoDpAaU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "34c384017ea9808356c1d1f91525e7a17044d982",
+        "rev": "677cef10a7ae871c821e9169250c7fe86340bffc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`677cef10`](https://github.com/nix-community/NUR/commit/677cef10a7ae871c821e9169250c7fe86340bffc) | `` automatic update `` |
| [`a846e58f`](https://github.com/nix-community/NUR/commit/a846e58f03cb2e501e421626043b6ad52b3950fd) | `` automatic update `` |