### PR TITLE
chore(flake/nur): `677cef10` -> `486672da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702028344,
-        "narHash": "sha256-4x9G1ZDVD0//fnQc1ELZrE+s7114A7dUYd/MmoDpAaU=",
+        "lastModified": 1702035892,
+        "narHash": "sha256-GUwLSZGBQq90l5fHZFFZDR+AsrDQmkXuLaG7GIF1bIs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "677cef10a7ae871c821e9169250c7fe86340bffc",
+        "rev": "486672da7b0f7e5f3148ab704b5a8a133bc369c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`486672da`](https://github.com/nix-community/NUR/commit/486672da7b0f7e5f3148ab704b5a8a133bc369c5) | `` automatic update `` |
| [`27a43dd7`](https://github.com/nix-community/NUR/commit/27a43dd7fd3b8e0fe854400c6b34d3bb4b9df400) | `` automatic update `` |
| [`9ef7dada`](https://github.com/nix-community/NUR/commit/9ef7dadafd3b461ca5ef3a43cc3a072292c6b53d) | `` automatic update `` |
| [`f346d21a`](https://github.com/nix-community/NUR/commit/f346d21af439fedcf10ab5b3ce2614858e24b275) | `` automatic update `` |