### PR TITLE
chore(flake/nur): `486672da` -> `cd84eb75`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702035892,
-        "narHash": "sha256-GUwLSZGBQq90l5fHZFFZDR+AsrDQmkXuLaG7GIF1bIs=",
+        "lastModified": 1702039804,
+        "narHash": "sha256-LnZxc0jr5UKNCqJFoZgftAvPWCAhhQ8sZmoagFjGWsw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "486672da7b0f7e5f3148ab704b5a8a133bc369c5",
+        "rev": "cd84eb75ea45a711d2d3cddd6936d42b336e26af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cd84eb75`](https://github.com/nix-community/NUR/commit/cd84eb75ea45a711d2d3cddd6936d42b336e26af) | `` automatic update `` |
| [`1dd4ced2`](https://github.com/nix-community/NUR/commit/1dd4ced2bd92ec2d4c53a6507d6b569efa7cd3b2) | `` automatic update `` |
| [`6fef751d`](https://github.com/nix-community/NUR/commit/6fef751d5a53a52182e1136a636b1fae539ecede) | `` automatic update `` |