### PR TITLE
chore(flake/nur): `6ac30188` -> `b91ed607`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702083789,
-        "narHash": "sha256-0jM8IAoeM18YcFbpbUrSQyOyEGBCj0KCg9YNOCi1xmU=",
+        "lastModified": 1702086156,
+        "narHash": "sha256-Y22+YHBkqlin7gfANi+ULFIteYgQrH1H9pgooe6Gj74=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6ac3018820f4d975222dbb94073e2011b7f10e08",
+        "rev": "b91ed607ce7a2e4aed8d0e9e53c9f313d0a960c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b91ed607`](https://github.com/nix-community/NUR/commit/b91ed607ce7a2e4aed8d0e9e53c9f313d0a960c8) | `` automatic update `` |