### PR TITLE
chore(flake/emacs-overlay): `7087b02d` -> `8f9af3a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1702057198,
-        "narHash": "sha256-aLt6sBFYNrL43VMGNl+/tPpe/OOzTqGUfl0bDGl1qe0=",
+        "lastModified": 1702088378,
+        "narHash": "sha256-PfuJt+YGLP+vNsry+RzQ+ptN/PopIxZc0bMfDZ+rZnU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7087b02d82d945bef0936b7d7781a520cd6e55e5",
+        "rev": "8f9af3a191e8d5ebf884e7f39ccabbc383213058",
         "type": "github"
       },
       "original": {
@@ -706,11 +706,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1701615100,
-        "narHash": "sha256-7VI84NGBvlCTduw2aHLVB62NvCiZUlALLqBe5v684Aw=",
+        "lastModified": 1701805708,
+        "narHash": "sha256-hh0S14E816Img0tPaNQSEKFvSscSIrvu1ypubtfh6M4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9f06adb793d1cca5384907b3b8a4071d5d7cb19",
+        "rev": "0561103cedb11e7554cf34cea81e5f5d578a4753",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`8f9af3a1`](https://github.com/nix-community/emacs-overlay/commit/8f9af3a191e8d5ebf884e7f39ccabbc383213058) | `` Updated repos/melpa ``  |
| [`a1417924`](https://github.com/nix-community/emacs-overlay/commit/a1417924d2fdfc3c5a8b5113cb42e4b2d9308710) | `` Updated repos/emacs ``  |
| [`c53ad5f8`](https://github.com/nix-community/emacs-overlay/commit/c53ad5f833eace3644c895457b78fb5a7475ea02) | `` Updated repos/elpa ``   |
| [`c4bd6164`](https://github.com/nix-community/emacs-overlay/commit/c4bd61649b43078a4946b08d9a66c419a52d3380) | `` Updated flake inputs `` |