### PR TITLE
chore(flake/nur): `b91ed607` -> `9d0be1d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702086156,
-        "narHash": "sha256-Y22+YHBkqlin7gfANi+ULFIteYgQrH1H9pgooe6Gj74=",
+        "lastModified": 1702088965,
+        "narHash": "sha256-BDFU7ZTIfwfq9PWDAgRZN3+6NHOAMz+htOqqwZaZ3go=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b91ed607ce7a2e4aed8d0e9e53c9f313d0a960c8",
+        "rev": "9d0be1d56b9cfa45610490c3f05110070a3721d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9d0be1d5`](https://github.com/nix-community/NUR/commit/9d0be1d56b9cfa45610490c3f05110070a3721d0) | `` automatic update `` |