### PR TITLE
chore(flake/nur): `9d0be1d5` -> `f198e75e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702088965,
-        "narHash": "sha256-BDFU7ZTIfwfq9PWDAgRZN3+6NHOAMz+htOqqwZaZ3go=",
+        "lastModified": 1702097856,
+        "narHash": "sha256-A7FV/jCLWLbNXNk1AbWTAVu5TAbjb9LzijcMoEOa2ts=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9d0be1d56b9cfa45610490c3f05110070a3721d0",
+        "rev": "f198e75e3443d432bd5f68dd330337bfe059ac19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f198e75e`](https://github.com/nix-community/NUR/commit/f198e75e3443d432bd5f68dd330337bfe059ac19) | `` automatic update `` |
| [`d28df64b`](https://github.com/nix-community/NUR/commit/d28df64b9effcba2060e83808d9b065c9ff1f2f1) | `` automatic update `` |
| [`921381a4`](https://github.com/nix-community/NUR/commit/921381a4ca1e1f9587c8eb71155ca426701968c7) | `` automatic update `` |