### PR TITLE
chore(flake/nur): `779a1f07` -> `1a7ae3ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702100560,
-        "narHash": "sha256-lyHUHpNOdU4hNtRTRpc07NOAUcW6y3jlJnZbGhm4KaE=",
+        "lastModified": 1702103817,
+        "narHash": "sha256-8+GkwqWyftgOgO1JlqmBvPXixfDEAkn5OTdghrXOd84=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "779a1f075c7a32bd01edd503c55d5092c6b08493",
+        "rev": "1a7ae3ba9818f166b1a33f6f65bb5306cb114c3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1a7ae3ba`](https://github.com/nix-community/NUR/commit/1a7ae3ba9818f166b1a33f6f65bb5306cb114c3d) | `` automatic update `` |
| [`fb3ef4f1`](https://github.com/nix-community/NUR/commit/fb3ef4f130e48f8838a7bf37b51704f89e7f1289) | `` automatic update `` |
| [`0569bb56`](https://github.com/nix-community/NUR/commit/0569bb56689da91bc0690ad3fe2ae9fabe5bb56b) | `` automatic update `` |