### PR TITLE
chore(flake/nur): `1a7ae3ba` -> `1f9c9c5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702103817,
-        "narHash": "sha256-8+GkwqWyftgOgO1JlqmBvPXixfDEAkn5OTdghrXOd84=",
+        "lastModified": 1702108468,
+        "narHash": "sha256-hNuB8JU/UWeccTm7NtEZ3WeKl/wkz1+qmU4gqpNCvI4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1a7ae3ba9818f166b1a33f6f65bb5306cb114c3d",
+        "rev": "1f9c9c5a92a1a1a9f1cd528658c3dfb6a8de77e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1f9c9c5a`](https://github.com/nix-community/NUR/commit/1f9c9c5a92a1a1a9f1cd528658c3dfb6a8de77e9) | `` automatic update `` |
| [`ce5f1b2d`](https://github.com/nix-community/NUR/commit/ce5f1b2d86e7978074d8e9452a4b6b43650aaa85) | `` automatic update `` |