### PR TITLE
chore(flake/nur): `1f9c9c5a` -> `cf726f9e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702108468,
-        "narHash": "sha256-hNuB8JU/UWeccTm7NtEZ3WeKl/wkz1+qmU4gqpNCvI4=",
+        "lastModified": 1702112198,
+        "narHash": "sha256-5EcovsczyBvR2nujUox07eCcUwAHggP9TobX+0iZbqI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1f9c9c5a92a1a1a9f1cd528658c3dfb6a8de77e9",
+        "rev": "cf726f9ebf2db87141ebbde0663a5b906be76aef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cf726f9e`](https://github.com/nix-community/NUR/commit/cf726f9ebf2db87141ebbde0663a5b906be76aef) | `` automatic update `` |
| [`276e9a8b`](https://github.com/nix-community/NUR/commit/276e9a8b905a3b21195f2adbbf631cd5084036d8) | `` automatic update `` |
| [`bbe77963`](https://github.com/nix-community/NUR/commit/bbe779636f52ea98222c6f9c7b4f1da488efa031) | `` automatic update `` |