### PR TITLE
chore(flake/nur): `cf726f9e` -> `89ddb7a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702112198,
-        "narHash": "sha256-5EcovsczyBvR2nujUox07eCcUwAHggP9TobX+0iZbqI=",
+        "lastModified": 1702118209,
+        "narHash": "sha256-k1m1DtnqBMGr3J0vyS6CyBQwJni820lLXdfhJDmcrdQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cf726f9ebf2db87141ebbde0663a5b906be76aef",
+        "rev": "89ddb7a494640ae6209d2c5937db3776928e6ff8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`89ddb7a4`](https://github.com/nix-community/NUR/commit/89ddb7a494640ae6209d2c5937db3776928e6ff8) | `` automatic update `` |
| [`771232ff`](https://github.com/nix-community/NUR/commit/771232ffb62d0d2f6de65a6c69882f9ebc1f7fe6) | `` automatic update `` |