### PR TITLE
chore(flake/nur): `08eae4b2` -> `b19751eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702133107,
-        "narHash": "sha256-tD+gVxs6tZInNQwSXC5guU2W5cZ5xZnJNwvUe5Ns4pQ=",
+        "lastModified": 1702136811,
+        "narHash": "sha256-BoCJiL2USHqvQnh35MiLzKb5ir0gIg7C2hILL1Ujthk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "08eae4b28e0d3095426a89c42cc268baa061ae75",
+        "rev": "b19751eb5a8c24f84d7e44c6bb1677753ab81eb4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b19751eb`](https://github.com/nix-community/NUR/commit/b19751eb5a8c24f84d7e44c6bb1677753ab81eb4) | `` automatic update `` |
| [`bd70b307`](https://github.com/nix-community/NUR/commit/bd70b307e2cb3a8f0dd9f68ce21f6e4e2156133f) | `` automatic update `` |