### PR TITLE
chore(flake/emacs-overlay): `9e85d89e` -> `0c7b9e24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1702114640,
-        "narHash": "sha256-K4x1UvRUp2pxLxB/WGYyhrMjZ1R1JNgfGcfriWSU3zk=",
+        "lastModified": 1702143514,
+        "narHash": "sha256-LtDzy6lGkiJF2R+y2SMQ9vjl0yvo0fOI4yZqu1aLy1w=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9e85d89e1938256adc3e1886e5c03319c0d94630",
+        "rev": "0c7b9e24eb801bb37870ce579d84b0f06ff8f5d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`0c7b9e24`](https://github.com/nix-community/emacs-overlay/commit/0c7b9e24eb801bb37870ce579d84b0f06ff8f5d6) | `` Updated repos/nongnu `` |
| [`5fd742dc`](https://github.com/nix-community/emacs-overlay/commit/5fd742dc7aa5e5642461b0def2afac00da9103f6) | `` Updated repos/melpa ``  |
| [`530c6a6b`](https://github.com/nix-community/emacs-overlay/commit/530c6a6b7b78c00aac4e6c91f7c440566366873e) | `` Updated repos/emacs ``  |
| [`acfdbe09`](https://github.com/nix-community/emacs-overlay/commit/acfdbe097cc7bf9f7412345a6ec54eb3582c2867) | `` Updated repos/elpa ``   |