### PR TITLE
chore(flake/nur): `b19751eb` -> `bf59aad7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702136811,
-        "narHash": "sha256-BoCJiL2USHqvQnh35MiLzKb5ir0gIg7C2hILL1Ujthk=",
+        "lastModified": 1702143421,
+        "narHash": "sha256-97/5u6UpDWrgK5O4SBvY86RY4nMq5uBOuu4lWdMPecA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b19751eb5a8c24f84d7e44c6bb1677753ab81eb4",
+        "rev": "bf59aad763b8b6e1d23fed6101979fcf0b0bfcf3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bf59aad7`](https://github.com/nix-community/NUR/commit/bf59aad763b8b6e1d23fed6101979fcf0b0bfcf3) | `` automatic update `` |
| [`a6245fe2`](https://github.com/nix-community/NUR/commit/a6245fe2e69308392ff7768a7b2862346f1b6093) | `` automatic update `` |