### PR TITLE
chore(flake/nur): `bf59aad7` -> `10ef4a58`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702143421,
-        "narHash": "sha256-97/5u6UpDWrgK5O4SBvY86RY4nMq5uBOuu4lWdMPecA=",
+        "lastModified": 1702151183,
+        "narHash": "sha256-nEem8VtQht1qlXefxQyIlAPMjy22wrVoy2tCGpdIxo8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bf59aad763b8b6e1d23fed6101979fcf0b0bfcf3",
+        "rev": "10ef4a5836c1408a77f83f4a603cc2a8a7fc0236",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`10ef4a58`](https://github.com/nix-community/NUR/commit/10ef4a5836c1408a77f83f4a603cc2a8a7fc0236) | `` automatic update `` |
| [`24419c77`](https://github.com/nix-community/NUR/commit/24419c772b056dc6d5f13a6b36e796b4474e121c) | `` automatic update `` |
| [`d82790e3`](https://github.com/nix-community/NUR/commit/d82790e3d29b263c490c5d885cf210b8c74202dc) | `` automatic update `` |