### PR TITLE
chore(flake/nur): `25f4052a` -> `5a59ca00`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702154858,
-        "narHash": "sha256-jjLWEdor/ynwQfmKC6f7YW1rPcK6gHWoP4pxoRv3VSo=",
+        "lastModified": 1702158529,
+        "narHash": "sha256-Y2BftdxR9EleCp3wMkWhWQ7YOCHzG8NNn3xjJgLU0xo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "25f4052a47d6ef4ed1fccdd55bb94e57ea664432",
+        "rev": "5a59ca006e55ce86e924af2cee1977e9db5b2f43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5a59ca00`](https://github.com/nix-community/NUR/commit/5a59ca006e55ce86e924af2cee1977e9db5b2f43) | `` automatic update `` |