### PR TITLE
chore(flake/nur): `5a59ca00` -> `d068810e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702158529,
-        "narHash": "sha256-Y2BftdxR9EleCp3wMkWhWQ7YOCHzG8NNn3xjJgLU0xo=",
+        "lastModified": 1702161971,
+        "narHash": "sha256-A1PO1dgLCk8hPsb/q8GesuW6pplRu2YsRMKznOnlfwE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5a59ca006e55ce86e924af2cee1977e9db5b2f43",
+        "rev": "d068810e22fb745f32c8c8891e816f3ad0f14cea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d068810e`](https://github.com/nix-community/NUR/commit/d068810e22fb745f32c8c8891e816f3ad0f14cea) | `` automatic update `` |