### PR TITLE
chore(flake/emacs-overlay): `0c7b9e24` -> `956b70d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1702143514,
-        "narHash": "sha256-LtDzy6lGkiJF2R+y2SMQ9vjl0yvo0fOI4yZqu1aLy1w=",
+        "lastModified": 1702175135,
+        "narHash": "sha256-oiXRVftJwABfQ85KucnUp35RN8F4jxGDg3kXMURspXo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0c7b9e24eb801bb37870ce579d84b0f06ff8f5d6",
+        "rev": "956b70d64d5ff36c53242cd335fe8274c0cfa2e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`956b70d6`](https://github.com/nix-community/emacs-overlay/commit/956b70d64d5ff36c53242cd335fe8274c0cfa2e7) | `` Updated repos/nongnu `` |
| [`f789abe5`](https://github.com/nix-community/emacs-overlay/commit/f789abe560f5f0fbff08d8fec9244a3a576af2c6) | `` Updated repos/melpa ``  |
| [`82c5d6db`](https://github.com/nix-community/emacs-overlay/commit/82c5d6dbbbf0c99eccfd36d48a8e1e64f9faf399) | `` Updated repos/emacs ``  |
| [`9117ee18`](https://github.com/nix-community/emacs-overlay/commit/9117ee18977127784735f7604358dd154d9e0af7) | `` Updated repos/elpa ``   |