### PR TITLE
chore(flake/nur): `1789d781` -> `d1c5cd50`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702171554,
-        "narHash": "sha256-1c1oBxZKHrwFSjSlJzmrglyiEiU3iK2wCa8uPUKyWbs=",
+        "lastModified": 1702181660,
+        "narHash": "sha256-5Vwghl++Thy+ptc0PqwAy2PzhCUMgjE0GcN2aLeEDRM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1789d781eb8d1698761aa62ebbcf201a9ce842cd",
+        "rev": "d1c5cd50ecfc9ee3e97dd12407e97a5eb87fb22f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d1c5cd50`](https://github.com/nix-community/NUR/commit/d1c5cd50ecfc9ee3e97dd12407e97a5eb87fb22f) | `` automatic update `` |
| [`14a75292`](https://github.com/nix-community/NUR/commit/14a75292b51fc53762b28f8db1ed64f2655c5f43) | `` automatic update `` |
| [`6b3d8b19`](https://github.com/nix-community/NUR/commit/6b3d8b1926e2e23e5fa44435fa80b638ea229754) | `` automatic update `` |
| [`ac4da7f7`](https://github.com/nix-community/NUR/commit/ac4da7f70a7d669cc3072d308a97fdac668c365b) | `` automatic update `` |
| [`be7ffe62`](https://github.com/nix-community/NUR/commit/be7ffe627e0a74da807928cc3e7ce9f594a16c9e) | `` automatic update `` |