### PR TITLE
chore(flake/nur): `7a9418d6` -> `5c3f53c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702190726,
-        "narHash": "sha256-G131Rma1C/vnUlcCEBSBXGbAX52rth6G7ElWEM2LT5Y=",
+        "lastModified": 1702197840,
+        "narHash": "sha256-2ehZcpdU+4thpykyABbUF1cjDMocR+VM1YFMv5G4rc4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7a9418d69a67aa336554bd0db4fe4dee877b671f",
+        "rev": "5c3f53c97e6f52f7a771a5ccdcbe4b76c23d4675",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5c3f53c9`](https://github.com/nix-community/NUR/commit/5c3f53c97e6f52f7a771a5ccdcbe4b76c23d4675) | `` automatic update `` |
| [`63e85afb`](https://github.com/nix-community/NUR/commit/63e85afb241aebbe0b522426cb4240a9cc316deb) | `` automatic update `` |