### PR TITLE
chore(flake/nur): `01a5560b` -> `8b2db25a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702223236,
-        "narHash": "sha256-38F/ZsyqwpKcj/1KR5JJ4j8O6R+tUni0FMjvkkeGvgk=",
+        "lastModified": 1702226788,
+        "narHash": "sha256-/V9TxMu1apAoVfCgXDwq/ayN1TLyrfp5fXqWOBVM/Zc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "01a5560bf047a8cdfb9152dd65696bd1916b1960",
+        "rev": "8b2db25a3a8a03abca25979e8fb49c4d0d9c1a1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8b2db25a`](https://github.com/nix-community/NUR/commit/8b2db25a3a8a03abca25979e8fb49c4d0d9c1a1f) | `` automatic update `` |