### PR TITLE
chore(flake/nur): `8b2db25a` -> `0a778b28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702226788,
-        "narHash": "sha256-/V9TxMu1apAoVfCgXDwq/ayN1TLyrfp5fXqWOBVM/Zc=",
+        "lastModified": 1702232791,
+        "narHash": "sha256-QS7GwSwAPDlyWtMQttaXtlQ5gIffR5/KnfGeX39+xqE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8b2db25a3a8a03abca25979e8fb49c4d0d9c1a1f",
+        "rev": "0a778b284baf0b846ee42e0effc432a9743949f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0a778b28`](https://github.com/nix-community/NUR/commit/0a778b284baf0b846ee42e0effc432a9743949f6) | `` automatic update `` |
| [`4fa0e7e9`](https://github.com/nix-community/NUR/commit/4fa0e7e9638cfd05101f403a9086cd0b422bd7d0) | `` automatic update `` |
| [`e8df0ab9`](https://github.com/nix-community/NUR/commit/e8df0ab92de3616deda58f08c930c3bf29a8a24a) | `` automatic update `` |