### PR TITLE
chore(flake/nixos-hardware): `fa194fc4` -> `030edbb6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -643,11 +643,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1701656485,
-        "narHash": "sha256-xDFormrGCKKGqngHa2Bz1GTeKlFMMjLnHhTDRdMJ1hs=",
+        "lastModified": 1702245580,
+        "narHash": "sha256-tTVRB42Ljo2uWGP7ei5h5/qQjOsdXoz0GHRy9hrVrdw=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "fa194fc484fd7270ab324bb985593f71102e84d1",
+        "rev": "030edbb68e69f2b97231479f98a9597024650df2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`030edbb6`](https://github.com/NixOS/nixos-hardware/commit/030edbb68e69f2b97231479f98a9597024650df2) | `` lenovo: add ideapad s145-15api to readme.md ``       |
| [`b3211356`](https://github.com/NixOS/nixos-hardware/commit/b32113560acaadb92251efcd6bef67419797839b) | `` lenovo: reference ideapad s145-15api on flake.nix `` |
| [`c78145fc`](https://github.com/NixOS/nixos-hardware/commit/c78145fc512a703af114aec176658dee872e4e90) | `` lenovo: add config for ideapad s145-15api ``         |