### PR TITLE
chore(flake/emacs-overlay): `0d9122dd` -> `5be1f7f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1702229890,
-        "narHash": "sha256-yMCnGYLKtna5Jjf5tE51AMPGPgwcEEBK0zm+MM4xXbU=",
+        "lastModified": 1702313668,
+        "narHash": "sha256-isIJzA0xfhj865cRI6+W8T0EXm5wkm1r7JmdWVuAsFs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0d9122ddb0e9677458d5cfaa81810b5f05399b00",
+        "rev": "5be1f7f9d0c327557a246599a7af345b123c9491",
         "type": "github"
       },
       "original": {
@@ -706,11 +706,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1701805708,
-        "narHash": "sha256-hh0S14E816Img0tPaNQSEKFvSscSIrvu1ypubtfh6M4=",
+        "lastModified": 1702221085,
+        "narHash": "sha256-Br3GCSkkvkmw46cT6wCz6ro2H1WgDMWbKE0qctbdtL0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0561103cedb11e7554cf34cea81e5f5d578a4753",
+        "rev": "c2786e7084cbad90b4f9472d5b5e35ecb57958af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`5be1f7f9`](https://github.com/nix-community/emacs-overlay/commit/5be1f7f9d0c327557a246599a7af345b123c9491) | `` Updated repos/melpa ``  |
| [`bdb723bd`](https://github.com/nix-community/emacs-overlay/commit/bdb723bde52828879ef73fcba1097a8a26532e7d) | `` Updated repos/elpa ``   |
| [`27171bad`](https://github.com/nix-community/emacs-overlay/commit/27171bad183b4791319c7b1253794e11fd5718ec) | `` Updated flake inputs `` |
| [`5075b8df`](https://github.com/nix-community/emacs-overlay/commit/5075b8df3d8d4d28e73e921acb46a2cf7f34ad28) | `` Updated repos/melpa ``  |
| [`a57e6b7b`](https://github.com/nix-community/emacs-overlay/commit/a57e6b7bc4e2906503d89755c9fbfab536c46e88) | `` Updated repos/emacs ``  |
| [`61c35019`](https://github.com/nix-community/emacs-overlay/commit/61c35019e3080f199aae18b978c06ffdc4153e32) | `` Updated repos/nongnu `` |
| [`c9ef46c1`](https://github.com/nix-community/emacs-overlay/commit/c9ef46c1eb4fa852e76cdcc57a14d24b8e3bc141) | `` Updated repos/melpa ``  |
| [`007ca6bf`](https://github.com/nix-community/emacs-overlay/commit/007ca6bf56c63dbe2546a39b10a5e9d42ae48f52) | `` Updated repos/emacs ``  |
| [`d947dcdc`](https://github.com/nix-community/emacs-overlay/commit/d947dcdc615bf6d776597fa8e9726620690dc9ed) | `` Updated repos/elpa ``   |