### PR TITLE
chore(flake/deploy-rs): `660180bb` -> `514fa3bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -258,11 +258,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698921442,
-        "narHash": "sha256-7KmvhQ7FuXlT/wG4zjTssap6maVqeAMBdtel+VjClSM=",
+        "lastModified": 1702302389,
+        "narHash": "sha256-T+R3vX31dQH/qb+ojf/rGrOVbY6/fR9X6H+hb0nEnHw=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "660180bbbeae7d60dad5a92b30858306945fd427",
+        "rev": "514fa3bc3d24fa85f338fa6a8247ca7e116ab9de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                                |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`b076e35c`](https://github.com/serokell/deploy-rs/commit/b076e35c4ac157110b894032fe3155172668cdd8) | `` [#245] Return non-zero exit code in case of confirmation timeout `` |