### PR TITLE
chore(flake/pre-commit-hooks): `e5ee5c5f` -> `e1d203c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1700922917,
-        "narHash": "sha256-ej2fch/T584b5K9sk1UhmZF7W6wEfDHuoUYpFN8dtvM=",
+        "lastModified": 1702325376,
+        "narHash": "sha256-biLGx2LzU2+/qPwq+kWwVBgXs3MVYT1gPa0fCwpLplU=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "e5ee5c5f3844550c01d2131096c7271cec5e9b78",
+        "rev": "e1d203c2fa7e2593c777e490213958ef81f71977",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                   |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
| [`88990864`](https://github.com/cachix/pre-commit-hooks.nix/commit/889908642a8fcc1cd8a7be3d94ccfaf93c1800bd) | `` Add conform ``                         |
| [`d3708281`](https://github.com/cachix/pre-commit-hooks.nix/commit/d37082815fea8febd96babebf75eb4294cb899ff) | `` hooks: fix deno fmt/lint configPath `` |