### PR TITLE
chore(flake/nur): `444a9b5c` -> `a74ab283`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702237445,
-        "narHash": "sha256-gCfV7eIdLghN/1NG2xngn4q0SXPO92cZ4/hPJepCw1w=",
+        "lastModified": 1702345471,
+        "narHash": "sha256-pm5eJWta+WGIZbhNGqD3uNK4DOaCsz8xe7ixtZI9vwo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "444a9b5c426db74aea5e9dc8123705e4cf757815",
+        "rev": "a74ab283c88537f02e64833ace0f37f95c9cf169",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                |
| -------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`a74ab283`](https://github.com/nix-community/NUR/commit/a74ab283c88537f02e64833ace0f37f95c9cf169) | `` automatic update ``                 |
| [`46e1aa64`](https://github.com/nix-community/NUR/commit/46e1aa641b2a4109132b6071c1374cf2690643ef) | `` automatic update ``                 |
| [`bc19da80`](https://github.com/nix-community/NUR/commit/bc19da80d49164d27953c60e804095094a74e0c4) | `` automatic update ``                 |
| [`7c966e4b`](https://github.com/nix-community/NUR/commit/7c966e4b321b0cb4c3ca407007c783d1ec998dfd) | `` automatic update ``                 |
| [`e45022e0`](https://github.com/nix-community/NUR/commit/e45022e0e4959af1106b264205980b11b97f9396) | `` automatic update ``                 |
| [`3b37d0db`](https://github.com/nix-community/NUR/commit/3b37d0db4bf5aa8385856a4a8558e5b814b39ac7) | `` automatic update ``                 |
| [`62e336ca`](https://github.com/nix-community/NUR/commit/62e336ca5f76b56b76a40947479f695edffcfebd) | `` automatic update ``                 |
| [`c9f94301`](https://github.com/nix-community/NUR/commit/c9f94301dcc66bc59eb88d37366fa3a8b39a2d64) | `` automatic update ``                 |
| [`a7203c4a`](https://github.com/nix-community/NUR/commit/a7203c4adab66958fa6b16e3bbe230b6e492eb9f) | `` automatic update ``                 |
| [`d85e40bf`](https://github.com/nix-community/NUR/commit/d85e40bfe20c7227f8d639c633c6ef98d17b5fa0) | `` automatic update ``                 |
| [`327af75b`](https://github.com/nix-community/NUR/commit/327af75b5ee5baa288a9f2d39d01902ef30325d7) | `` feature(repos): add moraxyc repo `` |
| [`621aae94`](https://github.com/nix-community/NUR/commit/621aae944d776922f3ac9f74b478464a73353660) | `` automatic update ``                 |
| [`dbd6b276`](https://github.com/nix-community/NUR/commit/dbd6b276563c591fb4951d6766f552ab71ab59fd) | `` automatic update ``                 |
| [`5840f9a1`](https://github.com/nix-community/NUR/commit/5840f9a1a21b9d59c77b8c7f9b5abf85167eb69a) | `` automatic update ``                 |
| [`d4783e9a`](https://github.com/nix-community/NUR/commit/d4783e9ad140cacaa6229c85ed31a5f9703b2669) | `` automatic update ``                 |
| [`e222a3c4`](https://github.com/nix-community/NUR/commit/e222a3c43b58005c093e36135ef03705a1953077) | `` automatic update ``                 |
| [`ef26848b`](https://github.com/nix-community/NUR/commit/ef26848b55f0bc1777ac9d41b07c4795fa9e7a04) | `` automatic update ``                 |
| [`9337067e`](https://github.com/nix-community/NUR/commit/9337067ea082642fab02c47076844f38d207248e) | `` automatic update ``                 |
| [`6f5d3e90`](https://github.com/nix-community/NUR/commit/6f5d3e909a700d7db205ea7115e9661a15bee445) | `` automatic update ``                 |
| [`8a050a16`](https://github.com/nix-community/NUR/commit/8a050a16dd5cc27d1ca6c04b8fd185005268ad7f) | `` automatic update ``                 |
| [`0118cbca`](https://github.com/nix-community/NUR/commit/0118cbcae172204814dd1212d810fb4cf3334339) | `` automatic update ``                 |
| [`170baf7b`](https://github.com/nix-community/NUR/commit/170baf7bf29d02aa4af4abc72848c8203a3603d7) | `` automatic update ``                 |
| [`407a4259`](https://github.com/nix-community/NUR/commit/407a4259dc1aca845f3ca3304010b361819f8286) | `` automatic update ``                 |
| [`0f00d969`](https://github.com/nix-community/NUR/commit/0f00d969e0b410c3e88c63d271ab2e4faa79ae5a) | `` automatic update ``                 |
| [`d2d10266`](https://github.com/nix-community/NUR/commit/d2d10266002f9bcfdb1189982fa903f992f738ed) | `` automatic update ``                 |
| [`d6cb6fae`](https://github.com/nix-community/NUR/commit/d6cb6fae53067701b03b49446f699053e11d3bd9) | `` automatic update ``                 |
| [`58bfc3d5`](https://github.com/nix-community/NUR/commit/58bfc3d5a5a5240bced606eedd33a2968cf918bc) | `` automatic update ``                 |
| [`648cedc4`](https://github.com/nix-community/NUR/commit/648cedc44712544ee4b339821768e91fa8d1b22f) | `` automatic update ``                 |
| [`ff00f33e`](https://github.com/nix-community/NUR/commit/ff00f33ed0829d340523158e6528af911e5aab61) | `` automatic update ``                 |
| [`d546cfc5`](https://github.com/nix-community/NUR/commit/d546cfc5811812af2e427d23942d3165ef4efa0c) | `` automatic update ``                 |
| [`1a0d7f78`](https://github.com/nix-community/NUR/commit/1a0d7f7844e029c6414090b1d4a68c83600d251c) | `` automatic update ``                 |
| [`96392008`](https://github.com/nix-community/NUR/commit/9639200816f3de675da94cfcc1bb8d0d083088f4) | `` automatic update ``                 |
| [`8b1d0b12`](https://github.com/nix-community/NUR/commit/8b1d0b12d60673842c9364be6e5fb098fa99d235) | `` automatic update ``                 |
| [`a22ba88f`](https://github.com/nix-community/NUR/commit/a22ba88f91b9cb7c98732ca7821bbf359e6c5f60) | `` automatic update ``                 |