### PR TITLE
chore(flake/srvos): `eacbc85e` -> `7afef00c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,22 +625,6 @@
         "type": "github"
       }
     },
-    "nixos-23_05": {
-      "locked": {
-        "lastModified": 1701615100,
-        "narHash": "sha256-7VI84NGBvlCTduw2aHLVB62NvCiZUlALLqBe5v684Aw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f06adb793d1cca5384907b3b8a4071d5d7cb19",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-23.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixos-hardware": {
       "locked": {
         "lastModified": 1702336390,
@@ -653,6 +637,22 @@
       "original": {
         "id": "nixos-hardware",
         "type": "indirect"
+      }
+    },
+    "nixos-stable": {
+      "locked": {
+        "lastModified": 1702233072,
+        "narHash": "sha256-H5G2wgbim2Ku6G6w+NSaQaauv6B6DlPhY9fMvArKqRo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "781e2a9797ecf0f146e81425c822dca69fe4a348",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs": {
@@ -982,17 +982,17 @@
     },
     "srvos": {
       "inputs": {
-        "nixos-23_05": "nixos-23_05",
+        "nixos-stable": "nixos-stable",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1701941438,
-        "narHash": "sha256-/nEW9L0AqH6jnDQwvbFyuslw/WEybLeA8vSh2fFetcY=",
+        "lastModified": 1702337325,
+        "narHash": "sha256-5o9TWvp76VedbpO3mB/AkdAZm+mIplXXkat57B5aDuM=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "eacbc85e04c012071eda81e4d26fc6d0b1194236",
+        "rev": "7afef00cd6bf9f18607dd297b39469e0faa48c8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                              |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`7afef00c`](https://github.com/nix-community/srvos/commit/7afef00cd6bf9f18607dd297b39469e0faa48c8f) | `` openssh: don't force authorizedKeysFiles if forgejo is enabled `` |
| [`34d5a252`](https://github.com/nix-community/srvos/commit/34d5a2527cce5d98da0f39aa1894a99408a8b92e) | `` hardware-hetzner-cloud-arm: enable early console ``               |
| [`1bed4f97`](https://github.com/nix-community/srvos/commit/1bed4f971b952a163337a5d744255e050a52459f) | `` flake.lock: Update ``                                             |
| [`8f04a723`](https://github.com/nix-community/srvos/commit/8f04a72366e9c7de1f8ab70c0c156ebf072faa49) | `` upgrade to 23.11 ``                                               |
| [`b47b9469`](https://github.com/nix-community/srvos/commit/b47b946903a5cf03069f0c707adf0118716da90b) | `` flake.lock: Update ``                                             |
| [`68608b4f`](https://github.com/nix-community/srvos/commit/68608b4fc02996ed3cf06eb73faf04c4203715a9) | `` flake.lock: Update ``                                             |