### PR TITLE
chore(flake/emacs-overlay): `5be1f7f9` -> `edfe7ad2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1702313668,
-        "narHash": "sha256-isIJzA0xfhj865cRI6+W8T0EXm5wkm1r7JmdWVuAsFs=",
+        "lastModified": 1702347689,
+        "narHash": "sha256-TNAlSnA0Z7zjIQytCUao/bbfplTVoyIjAxxeN8J3IQo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5be1f7f9d0c327557a246599a7af345b123c9491",
+        "rev": "edfe7ad2a87fad08c9c8ae6f65e0ecf5e824e601",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`edfe7ad2`](https://github.com/nix-community/emacs-overlay/commit/edfe7ad2a87fad08c9c8ae6f65e0ecf5e824e601) | `` Updated repos/nongnu `` |
| [`e4dd7bd3`](https://github.com/nix-community/emacs-overlay/commit/e4dd7bd3566a43bdec8e3d5cc239ef0a86046c59) | `` Updated repos/melpa ``  |
| [`84f8ab02`](https://github.com/nix-community/emacs-overlay/commit/84f8ab0290cefe329974ed9a57cb947494fdcd10) | `` Updated repos/emacs ``  |
| [`d335aa71`](https://github.com/nix-community/emacs-overlay/commit/d335aa7178443668e97a8b906cad0e1da6402687) | `` Updated repos/elpa ``   |