### PR TITLE
chore(flake/nur): `a74ab283` -> `b64714e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702345471,
-        "narHash": "sha256-pm5eJWta+WGIZbhNGqD3uNK4DOaCsz8xe7ixtZI9vwo=",
+        "lastModified": 1702353966,
+        "narHash": "sha256-FgWpdLLQikPxsFxPf37NQM07J/Zg7RIaTm3rRapAjrs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a74ab283c88537f02e64833ace0f37f95c9cf169",
+        "rev": "b64714e488fec373dfddb508641b9f75cad57b97",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b64714e4`](https://github.com/nix-community/NUR/commit/b64714e488fec373dfddb508641b9f75cad57b97) | `` automatic update `` |
| [`6a0aec47`](https://github.com/nix-community/NUR/commit/6a0aec47bb3c199b7977fced23d01a3be517e3ab) | `` automatic update `` |
| [`4bc62b9e`](https://github.com/nix-community/NUR/commit/4bc62b9e18645c92fd4454b8ec018e49da3fec13) | `` automatic update `` |
| [`f2b0400d`](https://github.com/nix-community/NUR/commit/f2b0400d6357299486512768cc968562880be5b1) | `` automatic update `` |
| [`08e5015a`](https://github.com/nix-community/NUR/commit/08e5015a6fed13ed80a52dd770c0f34174b29a33) | `` automatic update `` |