### PR TITLE
chore(flake/nur): `4dcb65d5` -> `06e9177f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702356285,
-        "narHash": "sha256-iC0juyi8Qdq7bV3HMNfMrr+A6Z3KeTClF06a9s/Oo7M=",
+        "lastModified": 1702359639,
+        "narHash": "sha256-9fjfBe91bkDPaXCS9JD+8JWsBMSWckakj/e7WX9f6dU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4dcb65d572d80be05fb9155a2fc38d069b10ce20",
+        "rev": "06e9177f0af7d209181112a686616f33f161322c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`06e9177f`](https://github.com/nix-community/NUR/commit/06e9177f0af7d209181112a686616f33f161322c) | `` automatic update `` |
| [`28e619c1`](https://github.com/nix-community/NUR/commit/28e619c145f4c5599cf1e8dad65198a2f1144ff7) | `` automatic update `` |
| [`278041d5`](https://github.com/nix-community/NUR/commit/278041d55cfe6430a9070b6289ebf5dadf07fbf4) | `` automatic update `` |