### PR TITLE
chore(flake/nur): `06e9177f` -> `1f0b3515`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702359639,
-        "narHash": "sha256-9fjfBe91bkDPaXCS9JD+8JWsBMSWckakj/e7WX9f6dU=",
+        "lastModified": 1702363946,
+        "narHash": "sha256-cWP/nn2XugnuHVuFRVQhK2v4ZaDm8PgXO6hNN8zZ2q8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "06e9177f0af7d209181112a686616f33f161322c",
+        "rev": "1f0b35155592748d8fe4fc31eaf36942b97120b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1f0b3515`](https://github.com/nix-community/NUR/commit/1f0b35155592748d8fe4fc31eaf36942b97120b4) | `` automatic update `` |
| [`ba17dae4`](https://github.com/nix-community/NUR/commit/ba17dae4a1dc1c378d2e69c6970a24f236833709) | `` automatic update `` |
| [`a9277f1a`](https://github.com/nix-community/NUR/commit/a9277f1a00c6c16b86677dc88ca3b092a719423a) | `` automatic update `` |