### PR TITLE
chore(flake/nur): `1f0b3515` -> `e2172b7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702363946,
-        "narHash": "sha256-cWP/nn2XugnuHVuFRVQhK2v4ZaDm8PgXO6hNN8zZ2q8=",
+        "lastModified": 1702367790,
+        "narHash": "sha256-OeCxCEj0rah6xIjH1N6lESF9xq29zKycTqNn+cwRCak=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1f0b35155592748d8fe4fc31eaf36942b97120b4",
+        "rev": "e2172b7d7c678c67bd55951e9e1ff637348d1e42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e2172b7d`](https://github.com/nix-community/NUR/commit/e2172b7d7c678c67bd55951e9e1ff637348d1e42) | `` automatic update `` |