### PR TITLE
chore(flake/nur): `e2172b7d` -> `9bf14f1a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702367790,
-        "narHash": "sha256-OeCxCEj0rah6xIjH1N6lESF9xq29zKycTqNn+cwRCak=",
+        "lastModified": 1702370742,
+        "narHash": "sha256-kOz90hRXpucRgiR1BOsZNtpKiMoFYgmXgoLf5w4miok=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e2172b7d7c678c67bd55951e9e1ff637348d1e42",
+        "rev": "9bf14f1a4c465c703efd08ece4592db2b2e9125f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9bf14f1a`](https://github.com/nix-community/NUR/commit/9bf14f1a4c465c703efd08ece4592db2b2e9125f) | `` automatic update `` |
| [`4b5a199d`](https://github.com/nix-community/NUR/commit/4b5a199daa8bc45a03dace5b7e16fe96b6a3c95a) | `` automatic update `` |