### PR TITLE
chore(flake/deploy-rs): `514fa3bc` -> `2ccd5d99`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -258,11 +258,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702302389,
-        "narHash": "sha256-T+R3vX31dQH/qb+ojf/rGrOVbY6/fR9X6H+hb0nEnHw=",
+        "lastModified": 1702378423,
+        "narHash": "sha256-tuJ8NWjaH/OuZSZukS6T+suia7E1QIPXW2nzkuUCCNA=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "514fa3bc3d24fa85f338fa6a8247ca7e116ab9de",
+        "rev": "2ccd5d9939d41ac797c3ce769a689fdbc76fdebb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                 |
| --------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`99664561`](https://github.com/serokell/deploy-rs/commit/99664561ec91db45679c76c8816f42d420d9b7d3) | `` [Chore] Update "actions/checkout" `` |