### PR TITLE
chore(flake/emacs-overlay): `456374df` -> `47798c4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1702371196,
-        "narHash": "sha256-DSIjit6/hzo0LK6tJ9/cSvRqJmnlGtJ9PW5VKsDnRQQ=",
+        "lastModified": 1702399955,
+        "narHash": "sha256-FnB5O1RVFzj3h7Ayf7UxFnOL1gsJuG6gn1LCTd9dKFs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "456374df242902ba4a749260f218d0e4fa646bc7",
+        "rev": "47798c4ab07d5f055bb2625010cf6d8e3f384923",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`47798c4a`](https://github.com/nix-community/emacs-overlay/commit/47798c4ab07d5f055bb2625010cf6d8e3f384923) | `` Updated repos/melpa `` |
| [`bf07a8a5`](https://github.com/nix-community/emacs-overlay/commit/bf07a8a5c05e4323b4d5628968bc76bb7face009) | `` Updated repos/elpa ``  |