### PR TITLE
chore(flake/nur): `ba1f83ae` -> `ab573e6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702396005,
-        "narHash": "sha256-Kl8ojKXM2IUnk6pvW+mT8k5yInr/0bmkemcM8YRAfbc=",
+        "lastModified": 1702404087,
+        "narHash": "sha256-HK91kYp2qVaEmXt82Zj0dhEtr2CYeFY0tpaIqsH/XSA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ba1f83ae768a4156108087078792da671b5cff61",
+        "rev": "ab573e6fe0b6de427749a0dd0a3ca1c955314c7d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ab573e6f`](https://github.com/nix-community/NUR/commit/ab573e6fe0b6de427749a0dd0a3ca1c955314c7d) | `` automatic update `` |
| [`57f42201`](https://github.com/nix-community/NUR/commit/57f42201f76e03ab61399e5be14e7e4189a31ae5) | `` automatic update `` |
| [`4364c134`](https://github.com/nix-community/NUR/commit/4364c134309c00c0d6bec9613809e8795262970d) | `` automatic update `` |