### PR TITLE
chore(flake/nur): `ab573e6f` -> `4c2346f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702404087,
-        "narHash": "sha256-HK91kYp2qVaEmXt82Zj0dhEtr2CYeFY0tpaIqsH/XSA=",
+        "lastModified": 1702406666,
+        "narHash": "sha256-1+90WIVb6pHBKD/dHtY/ZPjm8GNfL7YIc4CIAkdQk/s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ab573e6fe0b6de427749a0dd0a3ca1c955314c7d",
+        "rev": "4c2346f45fd7a97ff67a2e8f7d92ae1945b2a541",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4c2346f4`](https://github.com/nix-community/NUR/commit/4c2346f45fd7a97ff67a2e8f7d92ae1945b2a541) | `` automatic update `` |