### PR TITLE
chore(flake/nur): `4c2346f4` -> `3dd5078c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702406666,
-        "narHash": "sha256-1+90WIVb6pHBKD/dHtY/ZPjm8GNfL7YIc4CIAkdQk/s=",
+        "lastModified": 1702409623,
+        "narHash": "sha256-LKhbhJ9G5dzqOxADg6kpJxwEIJPkqD0WNuEYQFsqlL8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4c2346f45fd7a97ff67a2e8f7d92ae1945b2a541",
+        "rev": "3dd5078cfc2cd74b83561fb67669acf05944c982",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3dd5078c`](https://github.com/nix-community/NUR/commit/3dd5078cfc2cd74b83561fb67669acf05944c982) | `` automatic update `` |
| [`82d6c288`](https://github.com/nix-community/NUR/commit/82d6c2887abbcc767962134c212b2b766390f7c7) | `` automatic update `` |
| [`b826d6c5`](https://github.com/nix-community/NUR/commit/b826d6c5443660754ffee97885affc1256309985) | `` automatic update `` |