### PR TITLE
chore(flake/nur): `3dd5078c` -> `f1089799`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702409623,
-        "narHash": "sha256-LKhbhJ9G5dzqOxADg6kpJxwEIJPkqD0WNuEYQFsqlL8=",
+        "lastModified": 1702413863,
+        "narHash": "sha256-D0oFYxfj8T/WJXd5l6FzfN4PtSzo0IA19KMuuMbamyE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3dd5078cfc2cd74b83561fb67669acf05944c982",
+        "rev": "f10897998cc2c92bafb252b5450bc7af6a9fe006",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f1089799`](https://github.com/nix-community/NUR/commit/f10897998cc2c92bafb252b5450bc7af6a9fe006) | `` automatic update `` |