### PR TITLE
chore(flake/nixpkgs): `666fc80e` -> `a9bf124c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -754,11 +754,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1702151865,
-        "narHash": "sha256-9VAt19t6yQa7pHZLDbil/QctAgVsA66DLnzdRGqDisg=",
+        "lastModified": 1702312524,
+        "narHash": "sha256-gkZJRDBUCpTPBvQk25G0B7vfbpEYM5s5OZqghkjZsnE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "666fc80e7b2afb570462423cb0e1cf1a3a34fedd",
+        "rev": "a9bf124c46ef298113270b1f84a164865987a91c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`f19c975d`](https://github.com/NixOS/nixpkgs/commit/f19c975dd53a2f1bfca97ad2e8eac61e0ee06471) | `` faircamp: 0.8.0 -> 0.11.0 ``                                         |
| [`1a6dc426`](https://github.com/NixOS/nixpkgs/commit/1a6dc4263a1ebd4c397db5ad74bb2c8fa48bf8c8) | `` python311Packages.virt-firmware: init at 23.10 (#267914) ``          |
| [`0ff62f08`](https://github.com/NixOS/nixpkgs/commit/0ff62f08722077a317b16eab864fda1fbee6623f) | `` path-of-building.data: 2.35.5 -> 2.36.1 ``                           |
| [`81f54715`](https://github.com/NixOS/nixpkgs/commit/81f547153617d8dd7fb2c36e32307a9d3347e6dc) | `` adw-gtk3: 5.1 -> 5.2 ``                                              |
| [`4c1fd031`](https://github.com/NixOS/nixpkgs/commit/4c1fd031b7ce79bf87f757d85b778a5b2c764135) | `` python311Packages.aws-lambda-builders: 1.42.0 -> 1.43.0 ``           |
| [`2a26ff2f`](https://github.com/NixOS/nixpkgs/commit/2a26ff2f5c579e53469f3f7043c11ac3ea5c16aa) | `` python311Packages.aws-sam-translator: 1.81.0 -> 1.82.0 ``            |
| [`49790326`](https://github.com/NixOS/nixpkgs/commit/497903264eb6e2de034fc543d2cdb9324d616c85) | `` nixos/firejail: fix typo ``                                          |
| [`433d2886`](https://github.com/NixOS/nixpkgs/commit/433d2886e47badd690cd0cb90cc8dde0fb491d30) | `` ariang: 1.3.6 -> 1.3.7 ``                                            |
| [`17f6e20d`](https://github.com/NixOS/nixpkgs/commit/17f6e20dc45384710129888f4aefc27b0d315106) | `` signal-desktop: refactor to make nix-update work ``                  |
| [`4d0a013f`](https://github.com/NixOS/nixpkgs/commit/4d0a013fde9720a165f236e46995eaba3fc1cec0) | `` homepage-dashboard: mark as broken for darwin ``                     |
| [`082f3bcf`](https://github.com/NixOS/nixpkgs/commit/082f3bcfb725d6ed1c5a5740348f5258991bdc30) | `` linux_6_1: 6.1.66 -> 6.1.67 ``                                       |
| [`b52a1136`](https://github.com/NixOS/nixpkgs/commit/b52a1136c3ec28131eeb2fa1673c81e8d6cd5410) | `` linux_6_6: 6.6.5 -> 6.6.6 ``                                         |
| [`1053f306`](https://github.com/NixOS/nixpkgs/commit/1053f306894a4c0e591bc65a082f31647f885b1e) | `` linux_testing: 6.7-rc4 -> 6.7-rc5 ``                                 |
| [`d3edf81c`](https://github.com/NixOS/nixpkgs/commit/d3edf81c96c91fdc2b96d4277db135bba638740f) | `` python311Packages.zeroconf: 0.128.0 -> 0.128.4 ``                    |
| [`3b235f07`](https://github.com/NixOS/nixpkgs/commit/3b235f07359a2fe5bf2bf005ede25ecab8f19f87) | `` akkoma-frontends.admin-fe: build with Node 18 ``                     |
| [`14655c8d`](https://github.com/NixOS/nixpkgs/commit/14655c8d9ae95c07b5878f22431d5bcbe923054e) | `` binaryen: fix build with Node 20 ``                                  |
| [`a95164a6`](https://github.com/NixOS/nixpkgs/commit/a95164a69ff9dcc5abe6bec0accfddeb8bb7611f) | `` python311Packages.hatasmota: refactor ``                             |
| [`e915c124`](https://github.com/NixOS/nixpkgs/commit/e915c124273fd11d0bfb0e59bb7fea0be3e9fae0) | `` python311Packages.hatasmota: 0.7.3 -> 0.8.0 ``                       |
| [`7c3de90b`](https://github.com/NixOS/nixpkgs/commit/7c3de90b5fab67bf9c50bf578c82b0d59375ce03) | `` sigma-cli: 0.7.10 -> 0.7.11 ``                                       |
| [`ec14b74f`](https://github.com/NixOS/nixpkgs/commit/ec14b74f3577761bff820f8491428c45b043d117) | `` python311Packages.ical: 6.1.0 -> 6.1.1 ``                            |
| [`9d899c07`](https://github.com/NixOS/nixpkgs/commit/9d899c0743a142ade38b713ad3234c4d65e722bc) | `` python311Packages.setupmeta: 3.5.2 -> 3.6.0 ``                       |
| [`773d00bc`](https://github.com/NixOS/nixpkgs/commit/773d00bcb5535917522800e6d1251643ace69460) | `` python311Packages.msldap: 0.5.7 -> 0.5.9 ``                          |
| [`9146a4aa`](https://github.com/NixOS/nixpkgs/commit/9146a4aaf66a556ff91c6e2c7c0f1f406c06e0e0) | `` python311Packages.minikerberos: 0.4.3 -> 0.4.4 ``                    |
| [`a9d2f909`](https://github.com/NixOS/nixpkgs/commit/a9d2f909ec2d20cc8f681b597d90a11b7a13c14f) | `` python311Packages.asyauth: 0.0.16 -> 0.0.18 ``                       |
| [`9feea720`](https://github.com/NixOS/nixpkgs/commit/9feea720c5b0dd3ce9aeb4f805fa14a2fd2eb8d8) | `` checkov: 3.1.27 -> 3.1.31 ``                                         |
| [`69d61d5a`](https://github.com/NixOS/nixpkgs/commit/69d61d5ab0500d9ee52881ebacfb8c8f268ca0d8) | `` nix-direnv: 2.5.1 -> 3.0.0 ``                                        |
| [`f8a4c1e8`](https://github.com/NixOS/nixpkgs/commit/f8a4c1e888c71bda3b970c9beffd284bf94e526f) | `` nix-direnv: migrate to by-name ``                                    |
| [`beec1faf`](https://github.com/NixOS/nixpkgs/commit/beec1fafb2b207130f657b9719805888762ead34) | `` commitizen: 3.12.0 -> 3.13.0 ``                                      |
| [`931fe055`](https://github.com/NixOS/nixpkgs/commit/931fe055f48d053993f071e7a150fb2d5610220c) | `` keycloak: 23.0.0 -> 23.0.1 ``                                        |
| [`96de580f`](https://github.com/NixOS/nixpkgs/commit/96de580f10f89e6f5774abebc1128094e9796a5a) | `` cockpit: 305 -> 306 ``                                               |
| [`de4942fc`](https://github.com/NixOS/nixpkgs/commit/de4942fcf0360455510904a48bf2127769c139df) | `` leftwm: add `meta.mainProgram` ``                                    |
| [`d2f88656`](https://github.com/NixOS/nixpkgs/commit/d2f88656bd36bf06ed501a170502d2f02c5aa0f6) | `` homepage-dashboard: 0.8.2 -> 0.8.3 ``                                |
| [`3fc9b986`](https://github.com/NixOS/nixpkgs/commit/3fc9b9866512166a3f648344fd1a5ce732e7bc9a) | `` maintainers/teams: Add frlan to team flyingcircus (#273495) ``       |
| [`3891a318`](https://github.com/NixOS/nixpkgs/commit/3891a3183e4f70ed7f4b7fcf6c44ea038682729f) | `` cmctl: 1.13.2 -> 1.13.3 ``                                           |
| [`08c8caf9`](https://github.com/NixOS/nixpkgs/commit/08c8caf96f4a04b39deb78e0e20ed18ea3359f2d) | `` clojure: 1.11.1.1413 -> 1.11.1.1429 ``                               |
| [`f20753f6`](https://github.com/NixOS/nixpkgs/commit/f20753f6d61f67330bfa0aac3d29fe88d7a6204b) | `` passmark-performancetest: init at 11.0.1002 ``                       |
| [`1c09cb43`](https://github.com/NixOS/nixpkgs/commit/1c09cb43cea8bee1fd8c4d629fab80f6582f2eeb) | `` nixos/avahi: rename remaining config options ``                      |
| [`93da378e`](https://github.com/NixOS/nixpkgs/commit/93da378e4de05b80d7fe6b1f7ff5531aaf4755d5) | `` vimPlugins.nvim-treesitter: update grammars ``                       |
| [`55071f35`](https://github.com/NixOS/nixpkgs/commit/55071f351d32d5dd29a0ca46db6e8fcf75577f6e) | `` vimPlugins: update on 2023-12-11 ``                                  |
| [`42d91a3a`](https://github.com/NixOS/nixpkgs/commit/42d91a3a06c8907da1e2f4cf6df69c5adcad659e) | `` vimPlugins.harpoon2: init at 2023-12-11 ``                           |
| [`cc9b8fd7`](https://github.com/NixOS/nixpkgs/commit/cc9b8fd70e37ce2a7314d29428c81d23a9e9395c) | `` vimPlugins.harpoon: track correct branch (master) ``                 |
| [`020354d1`](https://github.com/NixOS/nixpkgs/commit/020354d1ee9501c9200e42cf658da5970b07621e) | `` python311Packages.imageio: 2.33.0 -> 2.33.1 ``                       |
| [`e1d78ab7`](https://github.com/NixOS/nixpkgs/commit/e1d78ab772743ab4177e0331d7cc5269260281a8) | `` kor: 0.3.0 -> 0.3.2 ``                                               |
| [`a6ed8696`](https://github.com/NixOS/nixpkgs/commit/a6ed8696c8705f4a064a6f0d2f58d88d1d662a26) | `` genact: 1.2.2 -> 1.3.0 ``                                            |
| [`e97b3e41`](https://github.com/NixOS/nixpkgs/commit/e97b3e4186bcadf0ef1b6be22b8558eab1cdeb5d) | `` ocamlPackages.conduit: 6.2.0 → 6.2.1 ``                              |
| [`c37d28c2`](https://github.com/NixOS/nixpkgs/commit/c37d28c293a822bc1120e2391ff200651ea1d2d7) | `` dtools: 2.105.2 -> 2.106.0 ``                                        |
| [`930b7d74`](https://github.com/NixOS/nixpkgs/commit/930b7d743f401d8868348dc266d13c956fdecf56) | `` poretools: mark as broken ``                                         |
| [`fcab3fbd`](https://github.com/NixOS/nixpkgs/commit/fcab3fbd7127eaf5c09028be1693ae7098fb50ef) | `` circt: Add shared libs and split llvm ``                             |
| [`c275e75b`](https://github.com/NixOS/nixpkgs/commit/c275e75b198ee621cbfcc7224d5e36ef903b3f8e) | `` dmd: 2.105.2 -> 2.106.0 ``                                           |
| [`c8c2ae63`](https://github.com/NixOS/nixpkgs/commit/c8c2ae638aa2e723a2b3517c4390d3c46d671ee8) | `` lib.pipe: Avoid creating scopes ``                                   |
| [`f66cb202`](https://github.com/NixOS/nixpkgs/commit/f66cb20232b52bc40cb7b5d1e97f3e40b09181a3) | `` web-ext: Include only production dependencies in build ``            |
| [`4ef4032e`](https://github.com/NixOS/nixpkgs/commit/4ef4032e6dd2964da529add016c0b2b4e3338336) | `` squid: 5.9 -> 6.6 ``                                                 |
| [`bd817120`](https://github.com/NixOS/nixpkgs/commit/bd817120c4c6705e693274e50c578c15e5ca6c13) | `` lib.strings: Dont create scopes for getName/getVersion ``            |
| [`17c1cc55`](https://github.com/NixOS/nixpkgs/commit/17c1cc555b34a3dccb6abfe845bb654b48491731) | `` loki: remove stdenv override ``                                      |
| [`9585dfd3`](https://github.com/NixOS/nixpkgs/commit/9585dfd3bbe3663a7e778a8892388b726a07fe8a) | `` opendbx: remove stdenv override ``                                   |
| [`33f23ce7`](https://github.com/NixOS/nixpkgs/commit/33f23ce7ed30ae69a531200d07112abd46b983c1) | `` bambu-studio: 01.08.00.62 -> 01.08.01.57 (#273350) ``                |
| [`6cf771c1`](https://github.com/NixOS/nixpkgs/commit/6cf771c18174bf00ee229ff6de28a1b9a6d0650c) | `` frankenphp: fix loading php extensions and custom config ``          |
| [`ca8e89e8`](https://github.com/NixOS/nixpkgs/commit/ca8e89e82529cd5c2528e726aa6f7df0ba443710) | `` electron-bin: remove prusnak from maintainers ``                     |
| [`70e59937`](https://github.com/NixOS/nixpkgs/commit/70e59937439f7347c06816774c00598e600c24af) | `` non: fix build with gcc 11+ ``                                       |
| [`6bf97b30`](https://github.com/NixOS/nixpkgs/commit/6bf97b30505737257072a330a42575003ac77276) | `` vinegar: 1.5.8 -> 1.5.9 ``                                           |
| [`dd5012e1`](https://github.com/NixOS/nixpkgs/commit/dd5012e1669ff94dbcbb44ba6a1ee721c7533ad9) | `` xqilla: fix build with gcc 11+ ``                                    |
| [`ea483cfa`](https://github.com/NixOS/nixpkgs/commit/ea483cfa42dd5a8d7c67b35a26920c09e533657f) | `` drumgizmo: fix build with gcc 13 ``                                  |
| [`07f5f75d`](https://github.com/NixOS/nixpkgs/commit/07f5f75da675408023db689d5a39fe4a578c79e8) | `` flwrap: remove stdenv override ``                                    |
| [`8374ab21`](https://github.com/NixOS/nixpkgs/commit/8374ab2113c7522766acf5ab1af9d8c6824c06d4) | `` spicetify-cli: 2.27.2 -> 2.28.1 ``                                   |
| [`f2e3aba1`](https://github.com/NixOS/nixpkgs/commit/f2e3aba1e477517c4d3b87f98baae51c06cf3c61) | `` spicetify-cli: migrate to by-name ``                                 |
| [`a4c3ba0b`](https://github.com/NixOS/nixpkgs/commit/a4c3ba0b67183bb0b0a1dd12506ca0840446829b) | `` pocketbase: 0.19.4 -> 0.20.0 ``                                      |
| [`e377a77e`](https://github.com/NixOS/nixpkgs/commit/e377a77e8d795a199b01d7cb080efd09b059177a) | `` colima: 0.6.6 -> 0.6.7 ``                                            |
| [`5a64fb27`](https://github.com/NixOS/nixpkgs/commit/5a64fb279993d632a4866c16e26aa14e5769d903) | `` nixos/acme: add syntax highlighting to code blocks ``                |
| [`3ca45e2b`](https://github.com/NixOS/nixpkgs/commit/3ca45e2bbb1dfcece5222c5cb7a7642542ec49cb) | `` upx: add version test ``                                             |
| [`7bc4955a`](https://github.com/NixOS/nixpkgs/commit/7bc4955aaa5bcb4faa4bc81403dc8492480aa6ca) | `` upx: use finalAttrs ``                                               |
| [`dc522329`](https://github.com/NixOS/nixpkgs/commit/dc522329ea630b328d6f8ed2149f149c17914e2c) | `` rio: 0.0.29 -> 0.0.30 ``                                             |
| [`143e44f5`](https://github.com/NixOS/nixpkgs/commit/143e44f5760982bdfddc78a24f007c91282fb4fe) | `` metasploit: fix update script ``                                     |
| [`1b728319`](https://github.com/NixOS/nixpkgs/commit/1b72831944741de64c6c976639187935e83759a3) | `` yosys: propagate build inputs as need be for plugins ``              |
| [`da0bb5f6`](https://github.com/NixOS/nixpkgs/commit/da0bb5f6cf8652d3f57ac303a1a4c3547681e375) | `` vscode-extensions.nvarner.typst-lsp: fix hash ``                     |
| [`f05d38b8`](https://github.com/NixOS/nixpkgs/commit/f05d38b8d32d8d0e328024fb97ca780fa0677103) | `` php82Extensions.blackfire: 1.92.0 -> 1.92.3 ``                       |
| [`7930ab86`](https://github.com/NixOS/nixpkgs/commit/7930ab86461818fa0e559dbada0be68a34c34388) | `` kodiPackages.pvr-iptvsimple: 20.11.1 -> 20.13.0 ``                   |
| [`7e25c398`](https://github.com/NixOS/nixpkgs/commit/7e25c398095f7d620bdf64b65d4492bc248b5005) | `` php81Extensions.opcache: fix compile on zts build ``                 |
| [`022fc378`](https://github.com/NixOS/nixpkgs/commit/022fc378aaeefe09ae4c7e3bfcf772f7cddcc9cc) | `` Pass cargoTestFlags as array ``                                      |
| [`c3484979`](https://github.com/NixOS/nixpkgs/commit/c3484979ea7a297686a7e7f7c9db633ae30a9755) | `` Remove `cargo test --doc` run from dioxus-cli ``                     |
| [`841dae2c`](https://github.com/NixOS/nixpkgs/commit/841dae2c78fefa4445fa7c53aee82f1e4e7bdafb) | `` electron: bump default version to 28.x (#272759) ``                  |
| [`20f08c85`](https://github.com/NixOS/nixpkgs/commit/20f08c851867942993fcbe6ed524f948ac25b43c) | `` getdp: remove stdenv override ``                                     |
| [`4bd81b28`](https://github.com/NixOS/nixpkgs/commit/4bd81b280d5a3c841528cec0ade93766254706c2) | `` maintainers: add matrix account of katexochen ``                     |
| [`7c1035d2`](https://github.com/NixOS/nixpkgs/commit/7c1035d290622a28369124faadeefaf160640235) | `` quickjs: 2021-03-27 -> 2023-12-09 ``                                 |
| [`28a7eff8`](https://github.com/NixOS/nixpkgs/commit/28a7eff808ee3351401e362db532631d09030dd1) | `` python311Packages.homeassistant-stubs: 2023.12.0 -> 2023.12.1 ``     |
| [`d663a2d5`](https://github.com/NixOS/nixpkgs/commit/d663a2d536f670d0823479a402c25ea702da7974) | `` nomad: 1.6.3 -> 1.6.4 ``                                             |
| [`67ff144b`](https://github.com/NixOS/nixpkgs/commit/67ff144b06b4abd777577cbcb09895ece3b3986f) | `` nomad: add cottand to maintainers ``                                 |
| [`3e2418fc`](https://github.com/NixOS/nixpkgs/commit/3e2418fc27af7ea24675ec8f0610d378de51600d) | `` home-assistant: 2023.12.0 -> 2023.12.1 ``                            |
| [`5e7cd85f`](https://github.com/NixOS/nixpkgs/commit/5e7cd85ffe8a8425dd8f2571f997b34e2b7b38d1) | `` python311Packages.wyoming: 1.3.0 -> 1.4.0 ``                         |
| [`3b98859d`](https://github.com/NixOS/nixpkgs/commit/3b98859d6022e7f6a0c88dd662f404367d2ed98b) | `` python311Packages.apple-weatherkit: 1.1.1 -> 1.1.2 ``                |
| [`c4198e32`](https://github.com/NixOS/nixpkgs/commit/c4198e3251cbfa6fe57cffe1e6215f66a429ceb5) | `` python311Packages.dynd: mark as broken ``                            |
| [`0833abbd`](https://github.com/NixOS/nixpkgs/commit/0833abbd49b9f2abc7675a1e6c17a3ae251d8eb4) | `` libdynd: remove stdenv override ``                                   |
| [`a7556902`](https://github.com/NixOS/nixpkgs/commit/a7556902d1576637336b61f82fc201a5c7b858e5) | `` vscodium: 1.84.2.23319 -> 1.85.0.23343 ``                            |
| [`c2685f11`](https://github.com/NixOS/nixpkgs/commit/c2685f11a1dbed95e6bbd130936abd30267bbf32) | `` tandoor-recipes: Fix URL import ``                                   |
| [`58651820`](https://github.com/NixOS/nixpkgs/commit/58651820bf8d249319949b3bf282baac55eb5127) | `` idsk: refactor ``                                                    |
| [`3b7c6127`](https://github.com/NixOS/nixpkgs/commit/3b7c612749565c563a074d45d0e7dd17e7f0e8ac) | `` zram-generator: 1.1.2 -> 1.1.2 ``                                    |
| [`1b2394e2`](https://github.com/NixOS/nixpkgs/commit/1b2394e223e08d206d1d6ad0e8cf066df005ea83) | `` python311Packages.yargy: rename from yagry ``                        |
| [`9699f2da`](https://github.com/NixOS/nixpkgs/commit/9699f2da1e625c048e85f8c376ab230edf5745d0) | `` treewide: fix imports check ``                                       |
| [`7073d808`](https://github.com/NixOS/nixpkgs/commit/7073d808ddba65da1e9df0d3a5b6e0434336ce04) | `` zig-shell-completions: unstable-2023-08-17 -> unstable-2023-11-18 `` |
| [`2699484d`](https://github.com/NixOS/nixpkgs/commit/2699484d57ff42254c88197d4d4ac68c06d61df6) | `` muzika: unstable-2023-06-07 -> unstable-2023-11-07 ``                |