### PR TITLE
chore(flake/nur): `f1089799` -> `55ff7c9e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702413863,
-        "narHash": "sha256-D0oFYxfj8T/WJXd5l6FzfN4PtSzo0IA19KMuuMbamyE=",
+        "lastModified": 1702417575,
+        "narHash": "sha256-89HhMpiU48+PrZW/nkYxl9A2uRt94ud/J/FIf6k0dW8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f10897998cc2c92bafb252b5450bc7af6a9fe006",
+        "rev": "55ff7c9e06b3dd19be193158fb39df1a4623ea70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`55ff7c9e`](https://github.com/nix-community/NUR/commit/55ff7c9e06b3dd19be193158fb39df1a4623ea70) | `` automatic update `` |