### PR TITLE
chore(flake/nur): `dea3d5a1` -> `99ed99c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702424693,
-        "narHash": "sha256-0wbdu3sy7AEbhWP5Lt07IfJm+NbFJ/5yQZWTGpur7ys=",
+        "lastModified": 1702431781,
+        "narHash": "sha256-1DeFU2m3GD21tTtRB40eHWFt8392ZZPUzIC8qLaaMag=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dea3d5a1c975e95dcaea4feb331e6beeaee325e7",
+        "rev": "99ed99c1edefe9896322e6b00c9fcbe4c4e579ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`99ed99c1`](https://github.com/nix-community/NUR/commit/99ed99c1edefe9896322e6b00c9fcbe4c4e579ce) | `` automatic update `` |