### PR TITLE
chore(flake/nur): `c18524ff` -> `c821971e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702439038,
-        "narHash": "sha256-6BvuxUHwV5sCb+XAWATl6PJomqpQIQWcHm71HXGE0I0=",
+        "lastModified": 1702442241,
+        "narHash": "sha256-IfA1zbS1ReFeMWk7p+/fM28FMPtQz1VIzudmOaG4Npg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c18524ffa61618ae889f2718045f6a01585325b0",
+        "rev": "c821971ede20008661d5ded3e49750accc5b0f71",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c821971e`](https://github.com/nix-community/NUR/commit/c821971ede20008661d5ded3e49750accc5b0f71) | `` automatic update `` |
| [`d324bcae`](https://github.com/nix-community/NUR/commit/d324bcae8ed3737f634ebd3423e51e6ad7659b0c) | `` automatic update `` |