### PR TITLE
chore(flake/nur): `2a6b7948` -> `13deb9d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702442714,
-        "narHash": "sha256-pq6bi54Pt/k/WWLbhr17LxctPZVOnNEJp3TscLXWwS8=",
+        "lastModified": 1702446038,
+        "narHash": "sha256-EQFYT5lqBHO3dzsVdxaHs10APzBSTvhwqJYopNvOvOs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2a6b79487f1477b619f8f0386d46f94de529849a",
+        "rev": "13deb9d23daa58856053b7e2aaed25eb5e94bb7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`13deb9d2`](https://github.com/nix-community/NUR/commit/13deb9d23daa58856053b7e2aaed25eb5e94bb7c) | `` automatic update `` |