### PR TITLE
chore(flake/nur): `13deb9d2` -> `82470813`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702446038,
-        "narHash": "sha256-EQFYT5lqBHO3dzsVdxaHs10APzBSTvhwqJYopNvOvOs=",
+        "lastModified": 1702449493,
+        "narHash": "sha256-Cxb+spepDYndJZ7Ptaw6o0AiVkov9H+C8ERWfT59p9E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "13deb9d23daa58856053b7e2aaed25eb5e94bb7c",
+        "rev": "82470813b5394c2b4e51b3eb5b1142c65089e9c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`82470813`](https://github.com/nix-community/NUR/commit/82470813b5394c2b4e51b3eb5b1142c65089e9c6) | `` automatic update `` |