### PR TITLE
chore(flake/nur): `82470813` -> `f3550dc7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702449493,
-        "narHash": "sha256-Cxb+spepDYndJZ7Ptaw6o0AiVkov9H+C8ERWfT59p9E=",
+        "lastModified": 1702460512,
+        "narHash": "sha256-UE93UWFM0TfMyHL4Yu948v29hzPkEqF+I+GGe7VMSsg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "82470813b5394c2b4e51b3eb5b1142c65089e9c6",
+        "rev": "f3550dc776b9af2f2dbd03477c4f67be599232c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f3550dc7`](https://github.com/nix-community/NUR/commit/f3550dc776b9af2f2dbd03477c4f67be599232c5) | `` automatic update `` |
| [`3a6222ba`](https://github.com/nix-community/NUR/commit/3a6222ba50170f00911b20e14d0893be19502464) | `` automatic update `` |
| [`3a28ece6`](https://github.com/nix-community/NUR/commit/3a28ece61e8065df10b761f9f9cc0a2a5dc08fec) | `` automatic update `` |
| [`0ee220eb`](https://github.com/nix-community/NUR/commit/0ee220eb9acd37aaee74edbf9c926734d0ec4c9d) | `` automatic update `` |
| [`d981a698`](https://github.com/nix-community/NUR/commit/d981a6989b399a63bb04b8b1f2e54c3a4f9dcf1b) | `` automatic update `` |