### PR TITLE
chore(flake/pre-commit-hooks): `e1d203c2` -> `007a45d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1702325376,
-        "narHash": "sha256-biLGx2LzU2+/qPwq+kWwVBgXs3MVYT1gPa0fCwpLplU=",
+        "lastModified": 1702456155,
+        "narHash": "sha256-I2XhXGAecdGlqi6hPWYT83AQtMgL+aa3ulA85RAEgOk=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "e1d203c2fa7e2593c777e490213958ef81f71977",
+        "rev": "007a45d064c1c32d04e1b8a0de5ef00984c419bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                         |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
| [`97f9b483`](https://github.com/cachix/pre-commit-hooks.nix/commit/97f9b48312ebe4129e0490ac589c58c9102f16ad) | `` Add require_serial hook config to pre-commit json ``         |
| [`51916ed7`](https://github.com/cachix/pre-commit-hooks.nix/commit/51916ed7a1d9d68b80f84b6f06d7a1f5696f1672) | `` Add fail_fast hook config to pre-commit json ``              |
| [`ef6d60d4`](https://github.com/cachix/pre-commit-hooks.nix/commit/ef6d60d47853d799dcfbf7e0800d9fce826494ba) | `` List inherited config attributes in same order as defined `` |