### PR TITLE
chore(flake/nur): `08fa10b1` -> `beef92b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702470966,
-        "narHash": "sha256-s9M/9KFgeUyHToI27HJ3PgnIoiLS2J+JfxZfDte79gU=",
+        "lastModified": 1702475151,
+        "narHash": "sha256-KDC2Lnvdx1+Zx6t7d2NbWV/sgHsKpZLqYLI+oz2NJ2I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "08fa10b13aece35a0c257096c64a473f70a7b852",
+        "rev": "beef92b34992174a653433ebad426ef6e252cae3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`beef92b3`](https://github.com/nix-community/NUR/commit/beef92b34992174a653433ebad426ef6e252cae3) | `` automatic update `` |