### PR TITLE
chore(flake/nur): `beef92b3` -> `9f2fffa2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702475151,
-        "narHash": "sha256-KDC2Lnvdx1+Zx6t7d2NbWV/sgHsKpZLqYLI+oz2NJ2I=",
+        "lastModified": 1702478525,
+        "narHash": "sha256-Jsnvwcro6o+zYMuvI6LeLY6msHBeyQi0r6Xc9MkQ7a8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "beef92b34992174a653433ebad426ef6e252cae3",
+        "rev": "9f2fffa26cbe70a7e55942a8de656665e16afa4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9f2fffa2`](https://github.com/nix-community/NUR/commit/9f2fffa26cbe70a7e55942a8de656665e16afa4c) | `` automatic update `` |