### PR TITLE
chore(flake/nur): `9f2fffa2` -> `391da2e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702478525,
-        "narHash": "sha256-Jsnvwcro6o+zYMuvI6LeLY6msHBeyQi0r6Xc9MkQ7a8=",
+        "lastModified": 1702482340,
+        "narHash": "sha256-xQcX7v9WrnkuOuVYaO5S4QEvILbE5Wij1iqZnxdjj3s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9f2fffa26cbe70a7e55942a8de656665e16afa4c",
+        "rev": "391da2e0ed3b5008c7f2faaf47cc0c2d565cb780",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`391da2e0`](https://github.com/nix-community/NUR/commit/391da2e0ed3b5008c7f2faaf47cc0c2d565cb780) | `` automatic update `` |