### PR TITLE
chore(flake/nur): `391da2e0` -> `deff83b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702482340,
-        "narHash": "sha256-xQcX7v9WrnkuOuVYaO5S4QEvILbE5Wij1iqZnxdjj3s=",
+        "lastModified": 1702486295,
+        "narHash": "sha256-GNf7oaCOJDKK8v3wc9wx+MyBlrCoZ/JYdAv1DxGU4Vk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "391da2e0ed3b5008c7f2faaf47cc0c2d565cb780",
+        "rev": "deff83b654473ec574849954dbc2095f7e555a2f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`deff83b6`](https://github.com/nix-community/NUR/commit/deff83b654473ec574849954dbc2095f7e555a2f) | `` automatic update `` |
| [`658414fd`](https://github.com/nix-community/NUR/commit/658414fdbf10eb42b82b4801e3c80af3be188886) | `` automatic update `` |