### PR TITLE
chore(flake/nur): `deff83b6` -> `2c5b0c18`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702486295,
-        "narHash": "sha256-GNf7oaCOJDKK8v3wc9wx+MyBlrCoZ/JYdAv1DxGU4Vk=",
+        "lastModified": 1702489548,
+        "narHash": "sha256-RBhZctSwWTlOifTRaeQeCP17FSCIdFfVL5wD0ldw7nw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "deff83b654473ec574849954dbc2095f7e555a2f",
+        "rev": "2c5b0c182b06d14e20269c57aa39b7d113b441fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2c5b0c18`](https://github.com/nix-community/NUR/commit/2c5b0c182b06d14e20269c57aa39b7d113b441fb) | `` automatic update `` |
| [`a79b4a62`](https://github.com/nix-community/NUR/commit/a79b4a624fc2773e0ad4d1c93e8722d0b10e6f05) | `` automatic update `` |