### PR TITLE
chore(flake/nur): `2c5b0c18` -> `cc42b289`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702489548,
-        "narHash": "sha256-RBhZctSwWTlOifTRaeQeCP17FSCIdFfVL5wD0ldw7nw=",
+        "lastModified": 1702496748,
+        "narHash": "sha256-U9r7fvkUvlSE+CHVr3IiA2ctPPJiChp0rbYLxNpdnfU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2c5b0c182b06d14e20269c57aa39b7d113b441fb",
+        "rev": "cc42b2891d6dd40df7d8ba7a73e9fc4c478725db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cc42b289`](https://github.com/nix-community/NUR/commit/cc42b2891d6dd40df7d8ba7a73e9fc4c478725db) | `` automatic update `` |