### PR TITLE
chore(flake/nur): `f5363f3c` -> `5ced9941`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702507562,
-        "narHash": "sha256-z2jMUCEluvM0HRk9lkvkRMgsw3yT0Tj3Nyi2uTBIhTM=",
+        "lastModified": 1702511108,
+        "narHash": "sha256-DypYWfpRqMLFX8euXxJ4yzLcemBRMtJdeVcXwEMZ3BA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f5363f3c1cae0c91d0e8db76cde3876487869719",
+        "rev": "5ced9941645336c3cca15e4a679d7106625a2c7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5ced9941`](https://github.com/nix-community/NUR/commit/5ced9941645336c3cca15e4a679d7106625a2c7f) | `` automatic update `` |