### PR TITLE
chore(flake/nur): `71ab6db9` -> `f8325601`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702519359,
-        "narHash": "sha256-6cGY/OLUlpqFacNkApNAP7IijFey0/kYjAVSG2+MXOQ=",
+        "lastModified": 1702525340,
+        "narHash": "sha256-azI+GkUpwS6SNY1NnJaNaefk2KeSW34xq5nMeevHvus=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "71ab6db9b868b33145a3cab0c42ba4d1c414884b",
+        "rev": "f83256016db9d8a463785b808eca5c592e7a14f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f8325601`](https://github.com/nix-community/NUR/commit/f83256016db9d8a463785b808eca5c592e7a14f2) | `` automatic update `` |