### PR TITLE
chore(flake/nur): `a6ad0a5a` -> `88394192`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702533618,
-        "narHash": "sha256-h6yXxVdIkHfx9CnuxBqRRD77ZcMj5Qgx984RyzWaRTc=",
+        "lastModified": 1702536280,
+        "narHash": "sha256-sX5HTOBHtS+tVg9O2bcBl2N3TlnYtioz4spaGRGcH1E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a6ad0a5ad644ebbc944b267726f5a6779e374cb7",
+        "rev": "88394192c8debbe57fe0827cae1383508700cd79",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`88394192`](https://github.com/nix-community/NUR/commit/88394192c8debbe57fe0827cae1383508700cd79) | `` automatic update `` |
| [`1dd5c1c1`](https://github.com/nix-community/NUR/commit/1dd5c1c17fdb4dcfd502fa00787fec7528bebe18) | `` automatic update `` |
| [`e5ed117f`](https://github.com/nix-community/NUR/commit/e5ed117f56ed3a6525c78173005bb201046c63cd) | `` automatic update `` |