### PR TITLE
chore(flake/home-manager): `5e9d1fe1` -> `0e2e443f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -456,11 +456,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702510888,
-        "narHash": "sha256-+7Bd9j47gDjD1DD0K9zKwA+8TjnTdTRGMVCERh6w2L0=",
+        "lastModified": 1702538064,
+        "narHash": "sha256-At5GwJPu2tzvS9dllhBoZmqK6lkkh/sOp2YefWRlaL8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5e9d1fe19f2d17cdfeb3b7e5e668f763e430cd28",
+        "rev": "0e2e443ff24f9d75925e91b89d1da44b863734af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`0e2e443f`](https://github.com/nix-community/home-manager/commit/0e2e443ff24f9d75925e91b89d1da44b863734af) | `` hyprland: mark plugin setting as important `` |
| [`be97e96d`](https://github.com/nix-community/home-manager/commit/be97e96dab93e766b7ed57cf5529a49eb765fad3) | `` flake: add packages for tests ``              |
| [`7a88cded`](https://github.com/nix-community/home-manager/commit/7a88cdedbda35f808ed2f329a7a811e0511870f9) | `` hyprland: improve config reload ``            |