### PR TITLE
chore(flake/nur): `d9757f6a` -> `13b97535`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702550744,
-        "narHash": "sha256-Cnbt5rFau5JqfBul2RxGwx3oQMiX0R6WIIjE36nG0o8=",
+        "lastModified": 1702554293,
+        "narHash": "sha256-QHDoxi/t7GFk7nDFIHc27kqg5mpQKpOzYi1xu4ERaow=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d9757f6a19644c8ba31f2432bb14fc92694552ef",
+        "rev": "13b975354a77cc216d0f51146dec24f7aba239b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`13b97535`](https://github.com/nix-community/NUR/commit/13b975354a77cc216d0f51146dec24f7aba239b8) | `` automatic update `` |