### PR TITLE
chore(flake/nur): `b839a2ba` -> `743c9976`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702558663,
-        "narHash": "sha256-MHq/DdwsBwsTRqwFg1JuFtcoGArgvaH/XwbxgWQ4Zn0=",
+        "lastModified": 1702564911,
+        "narHash": "sha256-lrKHEhLkwZYnRIPJ6Y1fsBUmw9N4adm7Aje+60kU5NM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b839a2bae27c0c14dd99dcc1f6d18f83b0af59bd",
+        "rev": "743c9976764a2888edee27cd247c382368e06efa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`743c9976`](https://github.com/nix-community/NUR/commit/743c9976764a2888edee27cd247c382368e06efa) | `` automatic update `` |