### PR TITLE
chore(flake/nur): `743c9976` -> `3f4bcf8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702564911,
-        "narHash": "sha256-lrKHEhLkwZYnRIPJ6Y1fsBUmw9N4adm7Aje+60kU5NM=",
+        "lastModified": 1702568728,
+        "narHash": "sha256-nok14kbSsEE7vG0L5383RxRFLtA/kRLnILmvcrz7YZI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "743c9976764a2888edee27cd247c382368e06efa",
+        "rev": "3f4bcf8ea93c2d2e5b169e2db096cbff5aa89536",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3f4bcf8e`](https://github.com/nix-community/NUR/commit/3f4bcf8ea93c2d2e5b169e2db096cbff5aa89536) | `` automatic update `` |
| [`2839af02`](https://github.com/nix-community/NUR/commit/2839af026c2433d238b9b4c111e2ddf4381ee993) | `` automatic update `` |