### PR TITLE
chore(flake/nur): `3f4bcf8e` -> `8bb2dfcc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702568728,
-        "narHash": "sha256-nok14kbSsEE7vG0L5383RxRFLtA/kRLnILmvcrz7YZI=",
+        "lastModified": 1702573084,
+        "narHash": "sha256-wJbcYi+53XzP4hONIaRvMPJgXgOssIz5W/h9saCuGVM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3f4bcf8ea93c2d2e5b169e2db096cbff5aa89536",
+        "rev": "8bb2dfcc0159e3e65568d50f408e0b75e4c3efd6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8bb2dfcc`](https://github.com/nix-community/NUR/commit/8bb2dfcc0159e3e65568d50f408e0b75e4c3efd6) | `` automatic update `` |