### PR TITLE
chore(flake/nur): `7a3b52cf` -> `e27861bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702582814,
-        "narHash": "sha256-D+m/Cyh9P3eowO564+FURJTuuO+kebFqGy/9YcnfwHA=",
+        "lastModified": 1702586801,
+        "narHash": "sha256-M+EZL4w5NCr3wJWD4Sajo62KKT4ZZxYHZJdbEIE44yg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7a3b52cf4fa2d4fdfdc3a34ed66da80862506f73",
+        "rev": "e27861bd55d4c36ba8ff9325ec6cafff008e16ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e27861bd`](https://github.com/nix-community/NUR/commit/e27861bd55d4c36ba8ff9325ec6cafff008e16ec) | `` automatic update `` |