### PR TITLE
chore(flake/nur): `cd3d310a` -> `7f334741`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702590404,
-        "narHash": "sha256-mESYm6YnmdkbDXxAggaFhdQ5dCebqWXfiKv7QptB3Rw=",
+        "lastModified": 1702592869,
+        "narHash": "sha256-W0GECBr7FcaM02r3Xv/bmItXhEPrTzYmdjx6VHcZdPs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cd3d310adf9a6dfa381942e68665e29aae6c096e",
+        "rev": "7f334741c3e99cbdeb76db62c81065138513d9e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7f334741`](https://github.com/nix-community/NUR/commit/7f334741c3e99cbdeb76db62c81065138513d9e2) | `` automatic update `` |