### PR TITLE
chore(flake/nur): `7f334741` -> `8eb5a04d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702592869,
-        "narHash": "sha256-W0GECBr7FcaM02r3Xv/bmItXhEPrTzYmdjx6VHcZdPs=",
+        "lastModified": 1702596453,
+        "narHash": "sha256-TvMbr5PJCaA8479jaUNP5XyAPkdx8tkHwsIIbSnecv0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7f334741c3e99cbdeb76db62c81065138513d9e2",
+        "rev": "8eb5a04d6ea6c65a0a58f2c8a994c92be0506b31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8eb5a04d`](https://github.com/nix-community/NUR/commit/8eb5a04d6ea6c65a0a58f2c8a994c92be0506b31) | `` automatic update `` |