### PR TITLE
chore(flake/nur): `8eb5a04d` -> `a179a5f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702596453,
-        "narHash": "sha256-TvMbr5PJCaA8479jaUNP5XyAPkdx8tkHwsIIbSnecv0=",
+        "lastModified": 1702602350,
+        "narHash": "sha256-Hjak9RHMjvFvY1zqhSRWxoX/KrqE0/VJ8g6/1c2sncA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8eb5a04d6ea6c65a0a58f2c8a994c92be0506b31",
+        "rev": "a179a5f334698fdb207ca1ec5187687bbb766ac0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a179a5f3`](https://github.com/nix-community/NUR/commit/a179a5f334698fdb207ca1ec5187687bbb766ac0) | `` automatic update `` |
| [`8cf518b0`](https://github.com/nix-community/NUR/commit/8cf518b0011e34505344cc78732a977d1d4ea453) | `` automatic update `` |