### PR TITLE
chore(flake/nur): `36ddbacb` -> `b7decf2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702604761,
-        "narHash": "sha256-RjSU3xToxay4CmzrLu+VegsHtK/auiTPUVO6o1hL79w=",
+        "lastModified": 1702608526,
+        "narHash": "sha256-uLc3ExOgjXBh+pBcCvJynhHpLitHX7ArJb2TDWKHMOo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "36ddbacb4442366161d569f5bbe2f6310e22bb1d",
+        "rev": "b7decf2d362ef891a2085944808b51ed344f3dfc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b7decf2d`](https://github.com/nix-community/NUR/commit/b7decf2d362ef891a2085944808b51ed344f3dfc) | `` automatic update `` |
| [`73a781ff`](https://github.com/nix-community/NUR/commit/73a781ff9db70a8558861583ec68649af6c08625) | `` automatic update `` |