### PR TITLE
chore(flake/nur): `d55abfbc` -> `00d8221e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702609386,
-        "narHash": "sha256-l5hvD187CmB9VmPBIm1NRZdZmLj2bT6pBPh+sziwYT0=",
+        "lastModified": 1702613319,
+        "narHash": "sha256-pPv4rb3TrLuNXqp4+LzKjaKh77gOu7yPHDoSaI1JUmw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d55abfbcea31ff18935d56ac2882cdad26870f36",
+        "rev": "00d8221e814d82ce862733c061f816a3cfa9f04f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`00d8221e`](https://github.com/nix-community/NUR/commit/00d8221e814d82ce862733c061f816a3cfa9f04f) | `` automatic update `` |