### PR TITLE
chore(flake/nur): `a476ab8b` -> `da202906`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702622349,
-        "narHash": "sha256-fXNfhIcPOaKcp9B7fhSY+BTPqj2vRbHtGnsqF7LSDZ4=",
+        "lastModified": 1702626412,
+        "narHash": "sha256-lTXyxHdOvUVsKczZ1dYMJWy38Q/PiYm2DucjTyMDqxk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a476ab8b1871639b8ac3759df28267b8485a46df",
+        "rev": "da202906673e666a728d7db1fff88aa3cecda0f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`da202906`](https://github.com/nix-community/NUR/commit/da202906673e666a728d7db1fff88aa3cecda0f3) | `` automatic update `` |
| [`76f22ae9`](https://github.com/nix-community/NUR/commit/76f22ae9407459965d1e6617d85bec0b8c7c93f3) | `` automatic update `` |