### PR TITLE
chore(flake/nur): `da202906` -> `aafce790`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702626412,
-        "narHash": "sha256-lTXyxHdOvUVsKczZ1dYMJWy38Q/PiYm2DucjTyMDqxk=",
+        "lastModified": 1702630847,
+        "narHash": "sha256-O35NxVzcWJuiLI71E7fHGCDjgNmPC81NzgBihzxQkfU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "da202906673e666a728d7db1fff88aa3cecda0f3",
+        "rev": "aafce7906a49aef5bd7552b338cc59df4fa16e5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                     |
| -------------------------------------------------------------------------------------------------- | --------------------------- |
| [`aafce790`](https://github.com/nix-community/NUR/commit/aafce7906a49aef5bd7552b338cc59df4fa16e5e) | `` automatic update ``      |
| [`737bae45`](https://github.com/nix-community/NUR/commit/737bae458e329b06bdca56eb2fbbbbf328d4a97c) | `` add cherrypiejam repo `` |
| [`81f4c786`](https://github.com/nix-community/NUR/commit/81f4c7864a0ce0c1b91cee4278044e747c421f0a) | `` Update repos.json ``     |
| [`fb46a85c`](https://github.com/nix-community/NUR/commit/fb46a85c803d2260bf573c214e176cdc768782cf) | `` automatic update ``      |