### PR TITLE
chore(flake/nur): `aafce790` -> `476bb9ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702630847,
-        "narHash": "sha256-O35NxVzcWJuiLI71E7fHGCDjgNmPC81NzgBihzxQkfU=",
+        "lastModified": 1702640491,
+        "narHash": "sha256-+mKwkPnutEB1adKn51ykH2SbKXh2gcB4YWrIM9do7IU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aafce7906a49aef5bd7552b338cc59df4fa16e5e",
+        "rev": "476bb9eacb33dace8b614bf35bdc04129faeaae2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`476bb9ea`](https://github.com/nix-community/NUR/commit/476bb9eacb33dace8b614bf35bdc04129faeaae2) | `` automatic update `` |