### PR TITLE
chore(flake/nur): `af946deb` -> `d74c5472`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702655179,
-        "narHash": "sha256-00W3Z5XODQgZFtxtgyMMcieFYdh7bFRNDxBe/66Jtvw=",
+        "lastModified": 1702658531,
+        "narHash": "sha256-0WRUj6xW6yZP4O3m2cEY6bRp1vKbB3xDT4CCd/mYNPs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "af946deb05cf232c2e8147b780383bea47b81e20",
+        "rev": "d74c5472884bd57dd48b77e93e9a9ea971033522",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d74c5472`](https://github.com/nix-community/NUR/commit/d74c5472884bd57dd48b77e93e9a9ea971033522) | `` automatic update `` |
| [`490fc283`](https://github.com/nix-community/NUR/commit/490fc283e431303fc90c26dadc0c69288f2e1c3d) | `` automatic update `` |