### PR TITLE
chore(flake/nur): `d74c5472` -> `c17913c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702658531,
-        "narHash": "sha256-0WRUj6xW6yZP4O3m2cEY6bRp1vKbB3xDT4CCd/mYNPs=",
+        "lastModified": 1702665904,
+        "narHash": "sha256-WN3ERnDYYHahnoxUn26jD0d1iviS8GK5m9b458isxbU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d74c5472884bd57dd48b77e93e9a9ea971033522",
+        "rev": "c17913c1d4ccb0f5bbba4f7597698de1a8ac761e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c17913c1`](https://github.com/nix-community/NUR/commit/c17913c1d4ccb0f5bbba4f7597698de1a8ac761e) | `` automatic update `` |