### PR TITLE
chore(flake/nur): `e344b8a6` -> `815ae533`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702690372,
-        "narHash": "sha256-8WfT0oI5qI1qSF23MfB4GNxB8YNBWuNsDwbuIcNi2hc=",
+        "lastModified": 1702697764,
+        "narHash": "sha256-S3J2m2xJ6pvgv54tLy7yt3mXPEXo+LY+CtAxNdYEVkg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e344b8a64759fe2c5ada441a4baad6fde4fe56f5",
+        "rev": "815ae533a5b7f38f5bf0c1449259668c82e685c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`815ae533`](https://github.com/nix-community/NUR/commit/815ae533a5b7f38f5bf0c1449259668c82e685c8) | `` automatic update `` |
| [`554a3376`](https://github.com/nix-community/NUR/commit/554a3376c9dfe9207477b252c9fe4e808b8accbf) | `` automatic update `` |