### PR TITLE
chore(flake/nur): `815ae533` -> `9cfdd1c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702697764,
-        "narHash": "sha256-S3J2m2xJ6pvgv54tLy7yt3mXPEXo+LY+CtAxNdYEVkg=",
+        "lastModified": 1702701110,
+        "narHash": "sha256-m4Y5HQThNqDWR+jh160Wrc4yqhHvQviiL2rcQrlYkTA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "815ae533a5b7f38f5bf0c1449259668c82e685c8",
+        "rev": "9cfdd1c87396b2bac372a6d8c2d3ce452b3401d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9cfdd1c8`](https://github.com/nix-community/NUR/commit/9cfdd1c87396b2bac372a6d8c2d3ce452b3401d1) | `` automatic update `` |