### PR TITLE
chore(flake/nur): `9cfdd1c8` -> `37468c28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702701110,
-        "narHash": "sha256-m4Y5HQThNqDWR+jh160Wrc4yqhHvQviiL2rcQrlYkTA=",
+        "lastModified": 1702709486,
+        "narHash": "sha256-GocOS9p5hcZStRoDGAah66AWAWZaq/07XI3MylXfqyY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9cfdd1c87396b2bac372a6d8c2d3ce452b3401d1",
+        "rev": "37468c2815fa4b1a3be56697d1921fcf27f84199",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`37468c28`](https://github.com/nix-community/NUR/commit/37468c2815fa4b1a3be56697d1921fcf27f84199) | `` automatic update `` |
| [`00bbf94c`](https://github.com/nix-community/NUR/commit/00bbf94cccca4d8c4875c47fe79ed2c73321de88) | `` automatic update `` |