### PR TITLE
chore(flake/nur): `37468c28` -> `044531cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702709486,
-        "narHash": "sha256-GocOS9p5hcZStRoDGAah66AWAWZaq/07XI3MylXfqyY=",
+        "lastModified": 1702710971,
+        "narHash": "sha256-Bj8PdoqAIJLvxpqyLbWptKEbGzdZ3v60djMELRZ9jws=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "37468c2815fa4b1a3be56697d1921fcf27f84199",
+        "rev": "044531cd9b4882623ef8e0e9ddf1cf0cfff541a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`044531cd`](https://github.com/nix-community/NUR/commit/044531cd9b4882623ef8e0e9ddf1cf0cfff541a7) | `` automatic update `` |
| [`d9beadda`](https://github.com/nix-community/NUR/commit/d9beaddaa7ab3d112394519c9fb84a4e7ba7cec7) | `` automatic update `` |