### PR TITLE
chore(flake/nur): `044531cd` -> `42b64e39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702710971,
-        "narHash": "sha256-Bj8PdoqAIJLvxpqyLbWptKEbGzdZ3v60djMELRZ9jws=",
+        "lastModified": 1702716258,
+        "narHash": "sha256-GDtOh/zvK8KKWv9UQrU3qQwm57Kk/sbQjCoxJqozzP0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "044531cd9b4882623ef8e0e9ddf1cf0cfff541a7",
+        "rev": "42b64e39b12fdb35d233af927c1e44449a78ca3c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`42b64e39`](https://github.com/nix-community/NUR/commit/42b64e39b12fdb35d233af927c1e44449a78ca3c) | `` automatic update `` |