### PR TITLE
chore(flake/home-manager): `abdc82d9` -> `b00a03b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -456,11 +456,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702681677,
-        "narHash": "sha256-Wa86ehEzoPXb9t1zXfDuKZ4ELQrFicnuuQjgFUCmxLk=",
+        "lastModified": 1702720862,
+        "narHash": "sha256-dh3dvtt+sl+uuhmJIFozFLtAkSAnLrhjWiTCZXCuAYc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "abdc82d930521448e47574b8ca1a0a450e861cca",
+        "rev": "b00a03b66868d052b2aa13c775404c00ad9d0f48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`5b339866`](https://github.com/nix-community/home-manager/commit/5b3398668b2b7f41607cf77fc9f1cb6402716882) | `` fish: Fix babelization of hm-session-vars `` |
| [`07754e93`](https://github.com/nix-community/home-manager/commit/07754e935a5e6f07f73e43c214f4f24f8ef82117) | `` docs: add considerate as maintainer ``       |
| [`6c82b1c9`](https://github.com/nix-community/home-manager/commit/6c82b1c9ce4dfb882cf53d1b9a09f01fbc9b0ba1) | `` docs: use .xhtml for appendices ``           |
| [`6fc71dc5`](https://github.com/nix-community/home-manager/commit/6fc71dc563c78f999386a55b1892c05039199e8f) | `` docs: add release-notes as appendix ``       |