### PR TITLE
chore(flake/nur): `42b64e39` -> `159a0d9c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702716258,
-        "narHash": "sha256-GDtOh/zvK8KKWv9UQrU3qQwm57Kk/sbQjCoxJqozzP0=",
+        "lastModified": 1702734294,
+        "narHash": "sha256-5ivzlKj0LNyEK4B0JY2qS5sWm5gGMAeoV42JVtr+qws=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "42b64e39b12fdb35d233af927c1e44449a78ca3c",
+        "rev": "159a0d9ca13c0dcd3774d13b4e1b3bfab4d0faed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`159a0d9c`](https://github.com/nix-community/NUR/commit/159a0d9ca13c0dcd3774d13b4e1b3bfab4d0faed) | `` automatic update `` |