### PR TITLE
chore(flake/nur): `159a0d9c` -> `c522b3db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702734294,
-        "narHash": "sha256-5ivzlKj0LNyEK4B0JY2qS5sWm5gGMAeoV42JVtr+qws=",
+        "lastModified": 1702741489,
+        "narHash": "sha256-r/YRPRRJxAyHVyCE0gkjfhgZPyMporWBIgZt13bN4WU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "159a0d9ca13c0dcd3774d13b4e1b3bfab4d0faed",
+        "rev": "c522b3db8799f9887b11dc5c50221db8e14ab7b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c522b3db`](https://github.com/nix-community/NUR/commit/c522b3db8799f9887b11dc5c50221db8e14ab7b2) | `` automatic update `` |
| [`5507da3a`](https://github.com/nix-community/NUR/commit/5507da3a05bda4a1a53434418b318f35f282772d) | `` automatic update `` |