### PR TITLE
chore(flake/nur): `c522b3db` -> `c2110f8c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702741489,
-        "narHash": "sha256-r/YRPRRJxAyHVyCE0gkjfhgZPyMporWBIgZt13bN4WU=",
+        "lastModified": 1702745097,
+        "narHash": "sha256-CAFt+ps9fbeD+t0ky44ulnqCTCS9N1tzHVakJrFKd3g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c522b3db8799f9887b11dc5c50221db8e14ab7b2",
+        "rev": "c2110f8c85f9253d5d792af36a94ff4880355c22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c2110f8c`](https://github.com/nix-community/NUR/commit/c2110f8c85f9253d5d792af36a94ff4880355c22) | `` automatic update `` |