### PR TITLE
chore(flake/nur): `c2110f8c` -> `9297adf9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702745097,
-        "narHash": "sha256-CAFt+ps9fbeD+t0ky44ulnqCTCS9N1tzHVakJrFKd3g=",
+        "lastModified": 1702748716,
+        "narHash": "sha256-JqaWFuEMxm5PRggv2PqizT9CGXuq9K0E8Hq+kWtO6Eg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c2110f8c85f9253d5d792af36a94ff4880355c22",
+        "rev": "9297adf98ec59a92f1867bfc695f350373968e38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9297adf9`](https://github.com/nix-community/NUR/commit/9297adf98ec59a92f1867bfc695f350373968e38) | `` automatic update `` |