### PR TITLE
chore(flake/nur): `9297adf9` -> `7228b6c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702748716,
-        "narHash": "sha256-JqaWFuEMxm5PRggv2PqizT9CGXuq9K0E8Hq+kWtO6Eg=",
+        "lastModified": 1702751055,
+        "narHash": "sha256-q5olCoN1g6NuZcEG/fwSp9uJGiFwTAyVWEA59eoafyQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9297adf98ec59a92f1867bfc695f350373968e38",
+        "rev": "7228b6c8a670781c9a0fbc9ec99211e672e99554",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7228b6c8`](https://github.com/nix-community/NUR/commit/7228b6c8a670781c9a0fbc9ec99211e672e99554) | `` automatic update `` |