### PR TITLE
chore(flake/nur): `7228b6c8` -> `be5bda3f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702751055,
-        "narHash": "sha256-q5olCoN1g6NuZcEG/fwSp9uJGiFwTAyVWEA59eoafyQ=",
+        "lastModified": 1702754887,
+        "narHash": "sha256-EBVnnqEUFKPpwNdhs9OHfTXeHl8qOA6a3Fs1R23Gn4w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7228b6c8a670781c9a0fbc9ec99211e672e99554",
+        "rev": "be5bda3f758c794fb3b56578b628a1f219d8aa2f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`be5bda3f`](https://github.com/nix-community/NUR/commit/be5bda3f758c794fb3b56578b628a1f219d8aa2f) | `` automatic update `` |