### PR TITLE
chore(flake/nur): `1d374446` -> `2c0a9d26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702770334,
-        "narHash": "sha256-MVILxIF9ZVIk0f9w3yYZpy8auwxgey0MFzdoIFFvQNU=",
+        "lastModified": 1702783718,
+        "narHash": "sha256-ziKSe5All0C4hzr4B97SVmyTjkhUSUPJzCSXdr8BfKU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1d37444620523278aa163bb9e30104f5d1152061",
+        "rev": "2c0a9d26046635c891bb4a435f78297e9a5434ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2c0a9d26`](https://github.com/nix-community/NUR/commit/2c0a9d26046635c891bb4a435f78297e9a5434ae) | `` automatic update `` |
| [`ddb4fe1f`](https://github.com/nix-community/NUR/commit/ddb4fe1f170116376c1c300883b239d4ce45f939) | `` automatic update `` |