### PR TITLE
chore(flake/nur): `8c3299fb` -> `6aa9e259`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702796013,
-        "narHash": "sha256-iWW6hSFCY5v7xMddGqcG8imUQeVByLhy6RLjaqYyKnY=",
+        "lastModified": 1702798348,
+        "narHash": "sha256-y0G29F63nC+abA2q0IaqvQu1c5jwIZU1VOnKHjfrc5w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8c3299fbee8a32e726c2f86d4d73448d528cac2a",
+        "rev": "6aa9e259444e15430f307f53ebb715eb9be64566",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6aa9e259`](https://github.com/nix-community/NUR/commit/6aa9e259444e15430f307f53ebb715eb9be64566) | `` automatic update `` |