### PR TITLE
chore(flake/nur): `6aa9e259` -> `78d14dad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702798348,
-        "narHash": "sha256-y0G29F63nC+abA2q0IaqvQu1c5jwIZU1VOnKHjfrc5w=",
+        "lastModified": 1702802728,
+        "narHash": "sha256-HvCd9vrrtc5sdzZNAiW7pABkaKUYONO8krABNVuXq1o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6aa9e259444e15430f307f53ebb715eb9be64566",
+        "rev": "78d14dad775c02d884b29dc7100e0c27476e1571",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`78d14dad`](https://github.com/nix-community/NUR/commit/78d14dad775c02d884b29dc7100e0c27476e1571) | `` automatic update `` |
| [`f8c4923b`](https://github.com/nix-community/NUR/commit/f8c4923bef68100b71b076db83a3c4ddf9b60ec8) | `` automatic update `` |