### PR TITLE
chore(flake/sops-nix): `097f8214` -> `21f2b8f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -967,11 +967,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1702782046,
-        "narHash": "sha256-TBmAZPuraG8cHP6QgNZc6UqP0ezARVZonc5/WqjIS6s=",
+        "lastModified": 1702812162,
+        "narHash": "sha256-18cKptpAAfkatdQgjO5SZXZsbc1IVPRoYx2AxaiooL4=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "097f8214883547417cd234c6fbcdb54e8093c8ed",
+        "rev": "21f2b8f123a1601fef3cf6bbbdf5171257290a77",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                             |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`21f2b8f1`](https://github.com/Mic92/sops-nix/commit/21f2b8f123a1601fef3cf6bbbdf5171257290a77) | `` Remove confusing and redundant left over text `` |