### PR TITLE
chore(flake/nur): `6b54f2e0` -> `0f3c510d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702804894,
-        "narHash": "sha256-01dLnohKcRu3APpSC/BqXvJKzS1mY8gsuLle9DTLOmE=",
+        "lastModified": 1702820084,
+        "narHash": "sha256-Y8z31CWQB8hKRDiovx40s9AAOixrG9PBlfgPntjWVBc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6b54f2e0fa11305378175e46788749c271a68710",
+        "rev": "0f3c510de06615a8cf9a2ad3b77758bb9d155753",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                    |
| -------------------------------------------------------------------------------------------------- | -------------------------- |
| [`0f3c510d`](https://github.com/nix-community/NUR/commit/0f3c510de06615a8cf9a2ad3b77758bb9d155753) | `` automatic update ``     |
| [`47e505f4`](https://github.com/nix-community/NUR/commit/47e505f4e877fb5d469764f8e0d48f1bfcdfde55) | `` automatic update ``     |
| [`16d0de2b`](https://github.com/nix-community/NUR/commit/16d0de2b068078ac4a3bbd6c6b368910dc6673cc) | `` automatic update ``     |
| [`80b8fd82`](https://github.com/nix-community/NUR/commit/80b8fd82c85fe213cbf0a08405a5caed980431f5) | `` 7mind NUR repository `` |