### PR TITLE
chore(flake/nur): `0f3c510d` -> `a64c1608`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702820084,
-        "narHash": "sha256-Y8z31CWQB8hKRDiovx40s9AAOixrG9PBlfgPntjWVBc=",
+        "lastModified": 1702835092,
+        "narHash": "sha256-NtgOSBp69TnfMzFKa/wBNsEdR9ubxuWvgH+KuwPxcNY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0f3c510de06615a8cf9a2ad3b77758bb9d155753",
+        "rev": "a64c16086ebd52548ed4d132efc8dcb14a5270ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a64c1608`](https://github.com/nix-community/NUR/commit/a64c16086ebd52548ed4d132efc8dcb14a5270ad) | `` automatic update `` |