### PR TITLE
chore(flake/nur): `a64c1608` -> `21100922`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702835092,
-        "narHash": "sha256-NtgOSBp69TnfMzFKa/wBNsEdR9ubxuWvgH+KuwPxcNY=",
+        "lastModified": 1702838362,
+        "narHash": "sha256-ft1fzEDtKJjjgMF7JWmzkxiJo9FxZ1HFMJ08hRGbYt0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a64c16086ebd52548ed4d132efc8dcb14a5270ad",
+        "rev": "211009227f02cc46ca6239891c1cc005ae8c00f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`21100922`](https://github.com/nix-community/NUR/commit/211009227f02cc46ca6239891c1cc005ae8c00f9) | `` automatic update `` |
| [`31b51fa0`](https://github.com/nix-community/NUR/commit/31b51fa05c8aecb6c931bbefd9331097e331e971) | `` automatic update `` |