### PR TITLE
chore(flake/nur): `21100922` -> `9d153a49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702838362,
-        "narHash": "sha256-ft1fzEDtKJjjgMF7JWmzkxiJo9FxZ1HFMJ08hRGbYt0=",
+        "lastModified": 1702841125,
+        "narHash": "sha256-yPgjDe5ODxMyeiyP1U+NZfw747r1InxONA1Ia51qKD0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "211009227f02cc46ca6239891c1cc005ae8c00f9",
+        "rev": "9d153a4961b858bd3260b99dcff65c59e91a008f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9d153a49`](https://github.com/nix-community/NUR/commit/9d153a4961b858bd3260b99dcff65c59e91a008f) | `` automatic update `` |
| [`f9e38685`](https://github.com/nix-community/NUR/commit/f9e3868558cbbfb617c798a64dbeb6578a572a8e) | `` automatic update `` |
| [`bb33c4be`](https://github.com/nix-community/NUR/commit/bb33c4be2b363d45dc1523164fbee66e55284ab1) | `` automatic update `` |