### PR TITLE
chore(flake/nur): `452bdab5` -> `a991dad3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702849536,
-        "narHash": "sha256-kGYoCw+KyLx5PpsCI3p2LxgyOsWYJon6ghq8Iq0XU6c=",
+        "lastModified": 1702865044,
+        "narHash": "sha256-O0OI7hrcnR+XpDk+44SST4nMlezJII8zBQEJXj2tPx8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "452bdab51c4eebec9aa2db7b84da63340dacb52d",
+        "rev": "a991dad3055d970d8ebd5234851577a2a81452b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a991dad3`](https://github.com/nix-community/NUR/commit/a991dad3055d970d8ebd5234851577a2a81452b2) | `` automatic update `` |
| [`f24e7436`](https://github.com/nix-community/NUR/commit/f24e7436305d726bcc4bcb37d055b7c294950d1d) | `` automatic update `` |
| [`a875e8ef`](https://github.com/nix-community/NUR/commit/a875e8ef638950879a704f51219bfeb6a031eebc) | `` automatic update `` |
| [`e70153af`](https://github.com/nix-community/NUR/commit/e70153af147c168642de3e0ad2cc09412f3f6205) | `` automatic update `` |