### PR TITLE
chore(flake/srvos): `cd802e29` -> `c3c1e0d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -641,11 +641,11 @@
     },
     "nixos-stable": {
       "locked": {
-        "lastModified": 1702346276,
-        "narHash": "sha256-eAQgwIWApFQ40ipeOjVSoK4TEHVd6nbSd9fApiHIw5A=",
+        "lastModified": 1702645756,
+        "narHash": "sha256-qKI6OR3TYJYQB3Q8mAZ+DG4o/BR9ptcv9UnRV2hzljc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cf28ee258fd5f9a52de6b9865cdb93a1f96d09b7",
+        "rev": "40c3c94c241286dd2243ea34d3aef8a488f9e4d0",
         "type": "github"
       },
       "original": {
@@ -988,11 +988,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702518612,
-        "narHash": "sha256-AGqIpvEMqo0FKXslmKL8ydt01pJFs8q3nUtz7gksoig=",
+        "lastModified": 1702860025,
+        "narHash": "sha256-VCfLcCaMs87pCCvsPgFzovNXMe+tW/ZDWw3FtLD8p/M=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "cd802e2933c567ea91de48dbe8968f41a5d9a642",
+        "rev": "c3c1e0d2acc1b714bb5526379d21bca33f2b44ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------ |
| [`c3c1e0d2`](https://github.com/nix-community/srvos/commit/c3c1e0d2acc1b714bb5526379d21bca33f2b44ae) | `` flake.lock: Update `` |