### PR TITLE
chore(flake/srvos): `c3c1e0d2` -> `a6d74c0d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -988,11 +988,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702860025,
-        "narHash": "sha256-VCfLcCaMs87pCCvsPgFzovNXMe+tW/ZDWw3FtLD8p/M=",
+        "lastModified": 1702864386,
+        "narHash": "sha256-mgpgshYfQnbKrRlO6uzLr3aVBm/6X52D1OEPd+vJRgU=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "c3c1e0d2acc1b714bb5526379d21bca33f2b44ae",
+        "rev": "a6d74c0d939434fcf31015ed880578e8c8340130",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------ |
| [`a6d74c0d`](https://github.com/nix-community/srvos/commit/a6d74c0d939434fcf31015ed880578e8c8340130) | `` flake.lock: Update `` |