### PR TITLE
chore(flake/nur): `a991dad3` -> `d033b7ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702865044,
-        "narHash": "sha256-O0OI7hrcnR+XpDk+44SST4nMlezJII8zBQEJXj2tPx8=",
+        "lastModified": 1702878022,
+        "narHash": "sha256-C1/k8igiHbYMmH27XjH76sXYSSGXUoodO/MKkeW8L4k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a991dad3055d970d8ebd5234851577a2a81452b2",
+        "rev": "d033b7ed1a921f404b35829a63cea080aeb81c62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d033b7ed`](https://github.com/nix-community/NUR/commit/d033b7ed1a921f404b35829a63cea080aeb81c62) | `` automatic update `` |