### PR TITLE
chore(flake/nur): `d033b7ed` -> `b1588af9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702878022,
-        "narHash": "sha256-C1/k8igiHbYMmH27XjH76sXYSSGXUoodO/MKkeW8L4k=",
+        "lastModified": 1702881590,
+        "narHash": "sha256-3/OOv1yzDc15Nj2aY1laMxkBYj0AQSVjPK/cLc7+L9Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d033b7ed1a921f404b35829a63cea080aeb81c62",
+        "rev": "b1588af9f3e7509e180ff10db4fac4443c238ae5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b1588af9`](https://github.com/nix-community/NUR/commit/b1588af9f3e7509e180ff10db4fac4443c238ae5) | `` automatic update `` |