### PR TITLE
chore(flake/nur): `fc7246b1` -> `5eb36fd2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702885405,
-        "narHash": "sha256-4zcF2NG2cBnP6McKLfIc30rrwdGPlaRGss2pCWx3tco=",
+        "lastModified": 1702889123,
+        "narHash": "sha256-hgdt5ZE76rBbOXVgaBfTY5pT8VezeAeeYomyofrs9RY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc7246b150c77137ae239cd9b2252e607a64b933",
+        "rev": "5eb36fd2d32f43177896e8dd5a7ba134d3d5e949",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5eb36fd2`](https://github.com/nix-community/NUR/commit/5eb36fd2d32f43177896e8dd5a7ba134d3d5e949) | `` automatic update `` |
| [`784c8293`](https://github.com/nix-community/NUR/commit/784c8293dc4f19f89a812f6d745aff28d47d24d9) | `` automatic update `` |
| [`a663c76c`](https://github.com/nix-community/NUR/commit/a663c76cc6b32cd341f6d0c649015d18384c3cbf) | `` automatic update `` |