### PR TITLE
chore(flake/nur): `e0a66087` -> `4561fa27`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702899884,
-        "narHash": "sha256-dGnBx+exsDmOO3S//bRQAulL2/QD20OHntzQeIUTpIY=",
+        "lastModified": 1702902799,
+        "narHash": "sha256-KNTIeQ6gDVoX3QSW0tWgCVjvmJ3JO+FT8XwRxL9dZN0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e0a6608756107b312ca46eb0920639c6a78a8fd1",
+        "rev": "4561fa27240f2b30aeb1bfdc27162a32b77b0b8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4561fa27`](https://github.com/nix-community/NUR/commit/4561fa27240f2b30aeb1bfdc27162a32b77b0b8d) | `` automatic update `` |