### PR TITLE
chore(flake/nur): `4561fa27` -> `5d62db85`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702902799,
-        "narHash": "sha256-KNTIeQ6gDVoX3QSW0tWgCVjvmJ3JO+FT8XwRxL9dZN0=",
+        "lastModified": 1702910532,
+        "narHash": "sha256-pbuL3mLubyEEJMTuNKHiIuzO6A4UFRSfsq2IZWswVcw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4561fa27240f2b30aeb1bfdc27162a32b77b0b8d",
+        "rev": "5d62db8546cf2cade0992be6d7a3878f3a88a4b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5d62db85`](https://github.com/nix-community/NUR/commit/5d62db8546cf2cade0992be6d7a3878f3a88a4b2) | `` automatic update `` |