### PR TITLE
chore(flake/nur): `5d62db85` -> `b8868a0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702910532,
-        "narHash": "sha256-pbuL3mLubyEEJMTuNKHiIuzO6A4UFRSfsq2IZWswVcw=",
+        "lastModified": 1702917950,
+        "narHash": "sha256-fuR/EF06eYdRNd6If/UVVbdtNtbPEqKPLvhaxVCbn2w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5d62db8546cf2cade0992be6d7a3878f3a88a4b2",
+        "rev": "b8868a0bd4b1c4e86111ecaafbef8c5695138e8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b8868a0b`](https://github.com/nix-community/NUR/commit/b8868a0bd4b1c4e86111ecaafbef8c5695138e8f) | `` automatic update `` |