### PR TITLE
chore(flake/nur): `b8868a0b` -> `f1427666`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702917950,
-        "narHash": "sha256-fuR/EF06eYdRNd6If/UVVbdtNtbPEqKPLvhaxVCbn2w=",
+        "lastModified": 1702919033,
+        "narHash": "sha256-uVzMTinnA0glleBbEPWLGtgK+96KsnTj5o7xL40EkHs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b8868a0bd4b1c4e86111ecaafbef8c5695138e8f",
+        "rev": "f1427666b27e98e3852748dacbdc41f2586aa194",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f1427666`](https://github.com/nix-community/NUR/commit/f1427666b27e98e3852748dacbdc41f2586aa194) | `` automatic update `` |