### PR TITLE
chore(flake/nur): `f1427666` -> `36b62d63`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702919033,
-        "narHash": "sha256-uVzMTinnA0glleBbEPWLGtgK+96KsnTj5o7xL40EkHs=",
+        "lastModified": 1702925118,
+        "narHash": "sha256-zKbf79A2BTSyZIYpDYdx69YQh5TQM/CAfVRYZh+KhPE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f1427666b27e98e3852748dacbdc41f2586aa194",
+        "rev": "36b62d6324a6aa28487cc45e369e3789e25a0df6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`36b62d63`](https://github.com/nix-community/NUR/commit/36b62d6324a6aa28487cc45e369e3789e25a0df6) | `` automatic update `` |
| [`a29569e0`](https://github.com/nix-community/NUR/commit/a29569e000b9f81ade1dc408a20bfaf26fa7bedb) | `` automatic update `` |