### PR TITLE
chore(flake/nur): `36b62d63` -> `d8d0a4bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702925118,
-        "narHash": "sha256-zKbf79A2BTSyZIYpDYdx69YQh5TQM/CAfVRYZh+KhPE=",
+        "lastModified": 1702927598,
+        "narHash": "sha256-PldTMI0Lo8AlfzCsDdpougMAKTZTe/jl36mIC9Yz0L8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "36b62d6324a6aa28487cc45e369e3789e25a0df6",
+        "rev": "d8d0a4bdc7b0eb5562df998a7c95ead6780afb00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                    |
| -------------------------------------------------------------------------------------------------- | -------------------------- |
| [`d8d0a4bd`](https://github.com/nix-community/NUR/commit/d8d0a4bdc7b0eb5562df998a7c95ead6780afb00) | `` automatic update ``     |
| [`47bcf66a`](https://github.com/nix-community/NUR/commit/47bcf66a01c7ec97477f10bbc247c54856f4fc5b) | `` add endle repository `` |