### PR TITLE
chore(flake/nur): `d8d0a4bd` -> `12386cbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702927598,
-        "narHash": "sha256-PldTMI0Lo8AlfzCsDdpougMAKTZTe/jl36mIC9Yz0L8=",
+        "lastModified": 1702932337,
+        "narHash": "sha256-oyqNQXokf8nlu03g5bO3L3D1SHBWuizUW+LQO2CvVKY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d8d0a4bdc7b0eb5562df998a7c95ead6780afb00",
+        "rev": "12386cbc26ffc94b73ace5f47e6b640674862544",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`12386cbc`](https://github.com/nix-community/NUR/commit/12386cbc26ffc94b73ace5f47e6b640674862544) | `` automatic update `` |