### PR TITLE
chore(flake/sops-nix): `21f2b8f1` -> `f7db64b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -967,11 +967,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1702812162,
-        "narHash": "sha256-18cKptpAAfkatdQgjO5SZXZsbc1IVPRoYx2AxaiooL4=",
+        "lastModified": 1702937567,
+        "narHash": "sha256-bUNl3GPqRgTGp13+oV1DrYa1/NHuGHo5SKmr+RqC/2g=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "21f2b8f123a1601fef3cf6bbbdf5171257290a77",
+        "rev": "f7db64b88dabc95e4f7bee20455f418e7ab805d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`f7db64b8`](https://github.com/Mic92/sops-nix/commit/f7db64b88dabc95e4f7bee20455f418e7ab805d4) | `` update vendorHash ``                                           |
| [`87bacb81`](https://github.com/Mic92/sops-nix/commit/87bacb8118989402066e437d81efbc61e1ca7f41) | `` build(deps): bump golang.org/x/crypto from 0.16.0 to 0.17.0 `` |