### PR TITLE
chore(flake/nur): `12386cbc` -> `ca0d61f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702932337,
-        "narHash": "sha256-oyqNQXokf8nlu03g5bO3L3D1SHBWuizUW+LQO2CvVKY=",
+        "lastModified": 1702951437,
+        "narHash": "sha256-M/nfQFKzKbc1PaYnnHEp31sFvfLvIHWgE9fwuwStHK4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "12386cbc26ffc94b73ace5f47e6b640674862544",
+        "rev": "ca0d61f10724f603723d6feb303c64a585b618b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ca0d61f1`](https://github.com/nix-community/NUR/commit/ca0d61f10724f603723d6feb303c64a585b618b1) | `` automatic update `` |
| [`a986d4b1`](https://github.com/nix-community/NUR/commit/a986d4b19eb2436c3bebb7d05a755b5786ee9993) | `` automatic update `` |
| [`e3f15013`](https://github.com/nix-community/NUR/commit/e3f15013fb1597e3cf88325f93035bfc7c4dc129) | `` automatic update `` |