### PR TITLE
chore(flake/impermanence): `0f317c2e` -> `0c893cf0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -471,11 +471,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1697303681,
-        "narHash": "sha256-caJ0rXeagaih+xTgRduYtYKL1rZ9ylh06CIrt1w5B4g=",
+        "lastModified": 1702948936,
+        "narHash": "sha256-pWG4bn5idGphFspC9RBIMHPXvRf0aQb5JG0pAKpUedE=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "0f317c2e9e56550ce12323eb39302d251618f5b5",
+        "rev": "0c893cf08a6c9559e482466340e82ac1f569937d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                   |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`0c893cf0`](https://github.com/nix-community/impermanence/commit/0c893cf08a6c9559e482466340e82ac1f569937d) | `` README: Expand with more details on system setup and a better intro `` |