### PR TITLE
chore(flake/nixpkgs): `a9bf124c` -> `54aac082`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -755,11 +755,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1702312524,
-        "narHash": "sha256-gkZJRDBUCpTPBvQk25G0B7vfbpEYM5s5OZqghkjZsnE=",
+        "lastModified": 1703013332,
+        "narHash": "sha256-+tFNwMvlXLbJZXiMHqYq77z/RfmpfpiI3yjL6o/Zo9M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a9bf124c46ef298113270b1f84a164865987a91c",
+        "rev": "54aac082a4d9bb5bbc5c4e899603abfb76a3f6d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`54aac082`](https://github.com/NixOS/nixpkgs/commit/54aac082a4d9bb5bbc5c4e899603abfb76a3f6d6) | `` prometheus-collectd-exporter: 0.5.0 -> 0.6.0 (#275097) ``                     |
| [`fc219f85`](https://github.com/NixOS/nixpkgs/commit/fc219f85fac1fae8979f6e921ec932ae5591fc0c) | `` prometheus-mysqld-exporter: 0.15.0 -> 0.15.1 (#275110) ``                     |
| [`fa9727cf`](https://github.com/NixOS/nixpkgs/commit/fa9727cf1e4916d948529946b877eae7f0a61b0d) | `` lib: `modules.sh` should check JSON output for predictability ``              |
| [`8596226c`](https://github.com/NixOS/nixpkgs/commit/8596226c93614fc9032ec585deffd668c2f4be5a) | `` CODEOWNERS: Watch the maintainers lists ``                                    |
| [`0fc323ee`](https://github.com/NixOS/nixpkgs/commit/0fc323eeef556d9803aa74956a826318bb42ee5a) | `` moonraker: disable check_klipper_config if klipper is immutable ``            |
| [`321daa01`](https://github.com/NixOS/nixpkgs/commit/321daa018b9ee425d2cdfa8a6c50861507398668) | `` python310Packages.fschat: 0.2.33 -> 0.2.34 ``                                 |
| [`4ca8ae0d`](https://github.com/NixOS/nixpkgs/commit/4ca8ae0d1f4355e6938eb88da67d640dbd6dff98) | `` libbsd: mark unsupported on microblaze ``                                     |
| [`fcec8edc`](https://github.com/NixOS/nixpkgs/commit/fcec8edc3f69b67115f28623225f9e72c135fe66) | `` libseccomp: mark unsupported on microblaze and m68k ``                        |
| [`752e3add`](https://github.com/NixOS/nixpkgs/commit/752e3add0751e76914a25ea4a0efb81b929af834) | `` pcre2: fix build for s390x ``                                                 |
| [`2b76501a`](https://github.com/NixOS/nixpkgs/commit/2b76501a4b83976b59a44fbad445e39eb4cc0704) | `` systemd: disable bpf on powerpc64le ``                                        |
| [`385cb5a5`](https://github.com/NixOS/nixpkgs/commit/385cb5a5f85c922eb9a28f5646872aea1df5b547) | `` python3Packages.trimesh: 4.0.5 -> 4.0.6 ``                                    |
| [`5fff7f40`](https://github.com/NixOS/nixpkgs/commit/5fff7f40788a9fc09f7e8cf5ba54d100754d4ba0) | `` Update zerotierone.nix per input ``                                           |
| [`7b83a839`](https://github.com/NixOS/nixpkgs/commit/7b83a839dc9f2dd17e8b9b041f6c1b691df00ec8) | `` Fix bash prestart script syntax error ``                                      |
| [`996bbe5b`](https://github.com/NixOS/nixpkgs/commit/996bbe5bd96ee6e99004b7986a7a71adafa51738) | `` delete trailing whitespace at row 70 ``                                       |
| [`8af401d3`](https://github.com/NixOS/nixpkgs/commit/8af401d3cfc4322beb5c8786c48fc09d568c7785) | `` Update zerotierone.nix per input ``                                           |
| [`b233faab`](https://github.com/NixOS/nixpkgs/commit/b233faab8289d208a0398d19cc08fd53db5efec8) | `` Update zerotierone.nix ``                                                     |
| [`36791bab`](https://github.com/NixOS/nixpkgs/commit/36791bab6a507e440f433c6238318b612a4c8556) | `` Update zerotierone.nix ``                                                     |
| [`0b357293`](https://github.com/NixOS/nixpkgs/commit/0b357293e8b14db8cab16c6e8fd7612217248e57) | `` Update zerotierone.nix ``                                                     |
| [`097f2b67`](https://github.com/NixOS/nixpkgs/commit/097f2b673741570eaf0d475127b3f5c6edbd2f0f) | `` Update zerotierone.nix ``                                                     |
| [`9f3d0870`](https://github.com/NixOS/nixpkgs/commit/9f3d0870058fe9fe7623ae34ba9a44bd8b57646e) | `` nix-serve-ng: unbreak. ``                                                     |
| [`7a991545`](https://github.com/NixOS/nixpkgs/commit/7a9915455b632af6b8261716bb2aee2bafbb0c6e) | `` fd: 8.7.1 -> 9.0.0 ``                                                         |
| [`5a267192`](https://github.com/NixOS/nixpkgs/commit/5a26719285c0f45cd584d14c3b7691a23654e04b) | `` python310Packages.flask-jwt-extended: 4.5.3 -> 4.6.0 ``                       |
| [`4e8975a9`](https://github.com/NixOS/nixpkgs/commit/4e8975a97a26a61e00bd732c96a996adbd0030b2) | `` gleam: 0.32.4 -> 0.33.0 ``                                                    |
| [`08d11dc8`](https://github.com/NixOS/nixpkgs/commit/08d11dc8be02072f63a3dcb62932e092af630413) | `` python310Packages.flake8-bugbear: 23.11.28 -> 23.12.2 ``                      |
| [`76bf1b26`](https://github.com/NixOS/nixpkgs/commit/76bf1b26a36916d8b23c9a16cb92a75f2572280b) | `` python310Packages.findpython: 0.4.0 -> 0.4.1 ``                               |
| [`4ae92838`](https://github.com/NixOS/nixpkgs/commit/4ae92838239e69c262d3a6388f45ac1b40af700e) | `` linux-rt_6_1: 6.1.65-rt18 -> 6.1.67-rt20 ``                                   |
| [`dd9b63a9`](https://github.com/NixOS/nixpkgs/commit/dd9b63a911646b87c49044f99f7cbd5842438108) | `` linux_testing: 6.7-rc5 -> 6.7-rc6 ``                                          |
| [`0dad0923`](https://github.com/NixOS/nixpkgs/commit/0dad09239dbf7accd00dcad4815b287dd0e1aa94) | `` rio: 0.0.32 -> 0.0.33 ``                                                      |
| [`33308800`](https://github.com/NixOS/nixpkgs/commit/333088006cc26591250fd1e2b8cc972855aa9c4b) | `` pkgsLLVM.llvmPackages.compiler-rt: fix for RISC-V ``                          |
| [`8b5ecc55`](https://github.com/NixOS/nixpkgs/commit/8b5ecc55e1801f3db13bde4d558c9a4a572530b0) | `` clang-tools: 14.0.6 -> 16.0.6 ``                                              |
| [`a13a4a04`](https://github.com/NixOS/nixpkgs/commit/a13a4a04eaf0a3b8cc74c75de29496405ea83aef) | `` pluto: 5.18.6 -> 5.19.0 ``                                                    |
| [`c4b3e4f5`](https://github.com/NixOS/nixpkgs/commit/c4b3e4f5f89b2d5a96a0280e81eaa880c91b075a) | `` dbus-broker: avoid errors when reloading when /tmp got remounted ``           |
| [`eacc407e`](https://github.com/NixOS/nixpkgs/commit/eacc407e1f560988d29333f924e6e5bcfedbf46c) | `` nostr-rs-relay: 0.8.12 -> 0.8.13 ``                                           |
| [`848aeefe`](https://github.com/NixOS/nixpkgs/commit/848aeefeb46e92485489cbecd2850d2e80ecb374) | `` python311Packages.caldav: 1.3.8 -> 1.3.9 ``                                   |
| [`8cdf0312`](https://github.com/NixOS/nixpkgs/commit/8cdf03122ff68f0ea72b8f5f357b9ce627c1ad65) | `` nix-direnv: 3.0.0 -> 3.0.1 ``                                                 |
| [`18e9441d`](https://github.com/NixOS/nixpkgs/commit/18e9441d06e3323c328220fb555c7949951a1b7f) | `` dbus-broker: 33 -> 34 ``                                                      |
| [`0d059066`](https://github.com/NixOS/nixpkgs/commit/0d059066e7cb3467b230de1471ee7851e855ef70) | `` sqlboiler: 4.14.2 -> 4.15.0 ``                                                |
| [`c3deab04`](https://github.com/NixOS/nixpkgs/commit/c3deab041fe5d6742e722c7dec93c8291cad2ad8) | `` python311Packages.python-didl-lite: refactor ``                               |
| [`cb861324`](https://github.com/NixOS/nixpkgs/commit/cb861324193cb78814ac7a6eb30533765c944f14) | `` clamtk: 6.16 -> 6.17 ``                                                       |
| [`3df514a5`](https://github.com/NixOS/nixpkgs/commit/3df514a5c588e20fdc0f5eae4b4450475ffa3680) | `` python311Packages.python-didl-lite: 1.3.2 -> 1.4.0 ``                         |
| [`f12cc4da`](https://github.com/NixOS/nixpkgs/commit/f12cc4da785c2c9952c013aff65f43ab18faa3cd) | `` kubedog: 0.9.12 -> 0.10.0 ``                                                  |
| [`dce218f4`](https://github.com/NixOS/nixpkgs/commit/dce218f4f35440622d2056f93ddc335351763bb4) | `` python310Packages.enlighten: 1.12.2 -> 1.12.3 ``                              |
| [`12fc644d`](https://github.com/NixOS/nixpkgs/commit/12fc644daf90c7b5d96185ef328a4fdea0d5ccba) | `` plantuml: 1.2023.12 -> 1.2023.13 ``                                           |
| [`972626f1`](https://github.com/NixOS/nixpkgs/commit/972626f1422fbdfa9be799c97a83fd30c5de5d90) | `` mopidy: make service wait until system is online ``                           |
| [`3ed9b7f8`](https://github.com/NixOS/nixpkgs/commit/3ed9b7f8052900190b37ad0c5a28cdeb3acf989a) | `` pip-audit: 2.6.1 -> 2.6.2 ``                                                  |
| [`1bca50d8`](https://github.com/NixOS/nixpkgs/commit/1bca50d8fbd2459362913d1653b7babad3bd8d8a) | `` python310Packages.djangorestframework-simplejwt: update disabled ``           |
| [`791894c1`](https://github.com/NixOS/nixpkgs/commit/791894c10c6ce9252f36b92582eafb14e2c46896) | `` google-java-format: 1.18.1 -> 1.19.0 ``                                       |
| [`68a8f62a`](https://github.com/NixOS/nixpkgs/commit/68a8f62ad3f5fa8f9939d016f9d0153d7f67519c) | `` frankenphp: 1.0.0 -> 1.0.1 ``                                                 |
| [`5a57cde1`](https://github.com/NixOS/nixpkgs/commit/5a57cde1105ddfaa1f24d5661f74adbd8787ce6d) | `` nixos/systemd/initrd: add systemd-makefs unconditionally ``                   |
| [`df51ffbc`](https://github.com/NixOS/nixpkgs/commit/df51ffbcfc3beb5f523267a325fa137d35419a03) | `` ddns-go: 5.6.6 -> 5.6.7 ``                                                    |
| [`56507658`](https://github.com/NixOS/nixpkgs/commit/565076587a53f4b1ce1a8bc8033bfceae4466146) | `` python310Packages.anthropic: 0.7.4 -> 0.7.8 ``                                |
| [`a720e207`](https://github.com/NixOS/nixpkgs/commit/a720e20762e53eede21a53777ec4835e7b10fb09) | `` uiua: 0.7.0 -> 0.7.1 ``                                                       |
| [`52b1e193`](https://github.com/NixOS/nixpkgs/commit/52b1e193034abec02eb3cf3c6e0e2bfeda8f1b8d) | `` path-of-building.data: 2.38.0 -> 2.38.2 ``                                    |
| [`fa4741ec`](https://github.com/NixOS/nixpkgs/commit/fa4741ecb52244c36b8d237df5a692e4e2b6aa13) | `` python310Packages.fastembed: 0.1.1 -> 0.1.2 ``                                |
| [`49f9ceb4`](https://github.com/NixOS/nixpkgs/commit/49f9ceb4f71274bb25bfdd54f3974115d40d647c) | `` maintainer-list: drop gm6k ``                                                 |
| [`cdbfd046`](https://github.com/NixOS/nixpkgs/commit/cdbfd046bffaf2a61ae1b9ef6aecb68fb6b312ec) | `` ollama: 0.1.11 -> 0.1.17 ``                                                   |
| [`8b522701`](https://github.com/NixOS/nixpkgs/commit/8b52270180c947ed2d2cf5c1f3815f52670927a0) | `` python310Packages.farm-haystack: 1.22.1 -> 1.23.0 ``                          |
| [`432aa817`](https://github.com/NixOS/nixpkgs/commit/432aa817203416d969d18285114da356237aa6f8) | `` vscodium: 1.85.0.23343 -> 1.85.1.23348 ``                                     |
| [`3c553dbb`](https://github.com/NixOS/nixpkgs/commit/3c553dbb434bce2ecd7e418ecc07197f1b35c631) | `` python310Packages.elasticsearch8: 8.11.0 -> 8.11.1 ``                         |
| [`e4a8fef4`](https://github.com/NixOS/nixpkgs/commit/e4a8fef4ab57588c36cb974a1b3717409bef2314) | `` python310Packages.edk2-pytool-library: 0.19.6 -> 0.19.8 ``                    |
| [`24770ef3`](https://github.com/NixOS/nixpkgs/commit/24770ef35f74380a49938975a8f5410e7aea7ca8) | `` python310Packages.dvclive: 3.3.1 -> 3.4.1 ``                                  |
| [`941397c1`](https://github.com/NixOS/nixpkgs/commit/941397c1b1414dd8c9ce3181df873281f771c16a) | `` mpvScripts.{blacklistExtensions, seekTo}: unstable-2022-10-02 → 2023-12-18 `` |
| [`19a8f086`](https://github.com/NixOS/nixpkgs/commit/19a8f0868aa93ce18150bad16b3c6a482659695b) | `` python310Packages.dvc-studio-client: 0.17.0 -> 0.18.0 ``                      |
| [`21c14e70`](https://github.com/NixOS/nixpkgs/commit/21c14e7095229a27f8ac4d403350467542794aa9) | `` mpvScripts.{blacklistExtensions, seekTo}: Add (hacky) `updateScript` ``       |
| [`94e3fd7a`](https://github.com/NixOS/nixpkgs/commit/94e3fd7aac9080078868f99e0ce1a6abea5a0a5c) | `` python310Packages.dvc-data: 2.24.0 -> 3.0.1 ``                                |
| [`4b1ee3e6`](https://github.com/NixOS/nixpkgs/commit/4b1ee3e616190461004dbe50fd26014506eaf85e) | `` gnomeExtensions.system-monitor: Remove in favor of system-monitor-next ``     |
| [`dc58efc6`](https://github.com/NixOS/nixpkgs/commit/dc58efc69cc430dc5bf08cf5b69fdfdd763e343c) | `` gnomeExtensions.system-monitor-next: Patch to fix runtime errors ``           |
| [`517916e9`](https://github.com/NixOS/nixpkgs/commit/517916e94f7d588929db327634a027fd9c99c851) | `` vsmtp: drop as upstream has gone ``                                           |
| [`cea1ae36`](https://github.com/NixOS/nixpkgs/commit/cea1ae3633c1cffba0a43e2ca057d03afff9ac0d) | `` argos: unstable-20230404 → unstable-2023-09-26 ``                             |
| [`b25b7d9e`](https://github.com/NixOS/nixpkgs/commit/b25b7d9e40d1cc24b7b79ad728d5fcb0a38fdf3e) | `` lomiri.lomiri-download-manager: init at 0.1.2 ``                              |
| [`16ddc355`](https://github.com/NixOS/nixpkgs/commit/16ddc355d39f5a2f67d4105e101154bdfb3fba5e) | `` python310Packages.djangorestframework-simplejwt: 5.3.0 -> 5.3.1 ``            |
| [`09aa95a7`](https://github.com/NixOS/nixpkgs/commit/09aa95a74efc9b018307a3a5160a61121d0849fc) | `` python310Packages.djangoql: 0.17.1 -> 0.18.0 ``                               |
| [`dfb1eeb6`](https://github.com/NixOS/nixpkgs/commit/dfb1eeb6203f1f5717bad06cba0c5feed74f0b52) | `` python310Packages.botorch: 0.9.4 -> 0.9.5 ``                                  |
| [`fc4e60a5`](https://github.com/NixOS/nixpkgs/commit/fc4e60a5214a22be6086c25cc601bfedf4da6cb8) | `` vulkan-tools-lunarg: add qt5 ``                                               |
| [`9ee8211c`](https://github.com/NixOS/nixpkgs/commit/9ee8211ce30ddd5b738bf6ef3bd1b05b6ebec209) | `` python310Packages.django-rest-registration: 0.8.2 -> 0.8.3 ``                 |
| [`640831bf`](https://github.com/NixOS/nixpkgs/commit/640831bf79564a52b1b7108af1221621642a1dc9) | `` python310Packages.django-rq: 2.9.0 -> 2.10.1 ``                               |
| [`c597e026`](https://github.com/NixOS/nixpkgs/commit/c597e026873894d69e3661d4a335f7321c8841e7) | `` protoc-gen-rust-grpc: init at 0.8.3 ``                                        |
| [`c9df5dba`](https://github.com/NixOS/nixpkgs/commit/c9df5dbaec08a3167838321c596621f47f0dd564) | `` python310Packages.django-ipware: 6.0.1 -> 6.0.3 ``                            |
| [`4a49de9d`](https://github.com/NixOS/nixpkgs/commit/4a49de9da680ee8b826b679f6599dcc368f85aed) | `` python310Packages.django-import-export: 3.3.3 -> 3.3.4 ``                     |
| [`ea960719`](https://github.com/NixOS/nixpkgs/commit/ea960719b48c581b2061de7e34cdf8646c2c9248) | `` signald: Add xargs and sed dependencies to wrapper ``                         |
| [`0bac154c`](https://github.com/NixOS/nixpkgs/commit/0bac154c969c7f65434e8106db513f1cc2a5a400) | `` sqlboiler: refactor ``                                                        |
| [`3e4e8411`](https://github.com/NixOS/nixpkgs/commit/3e4e8411244ca4e3969ab71deeff33330634b53a) | `` python311Packages.acquire: 3.10 -> 3.11 ``                                    |
| [`994fc1f9`](https://github.com/NixOS/nixpkgs/commit/994fc1f931869d8c01096ee5099141c6f87c04ef) | `` python311Packages.dissect-target: 3.13 -> 3.14 ``                             |
| [`5ca627ad`](https://github.com/NixOS/nixpkgs/commit/5ca627ad2b43c104d6d9960106bf918fe93ae3ca) | `` python311Packages.dissect-util: 3.12 -> 3.13 ``                               |
| [`10380ec4`](https://github.com/NixOS/nixpkgs/commit/10380ec4b06a4c2ef179a78942d72ca3becd04b9) | `` osu-lazer: 2023.1026.0 -> 2023.1218.1 ``                                      |
| [`39c3f5fe`](https://github.com/NixOS/nixpkgs/commit/39c3f5fe38844ff7521741967fcb5706084931b1) | `` osu-lazer-bin: 2023.1130.0 -> 2023.1218.1 ``                                  |
| [`27582799`](https://github.com/NixOS/nixpkgs/commit/27582799515ded5ad7cf9255de32cae0ef452f24) | `` python310Packages.dissect-extfs: 3.6 -> 3.7 ``                                |
| [`e2a49d95`](https://github.com/NixOS/nixpkgs/commit/e2a49d958215321048bd0dac8efbae07417cb626) | `` python310Packages.dissect-esedb: 3.9 -> 3.10 ``                               |
| [`501585ea`](https://github.com/NixOS/nixpkgs/commit/501585eac1b1de29a2747490d722d02f0951c0f6) | `` obs-studio-plugins.wlrobs: remove self as maintainer ``                       |
| [`1eb75826`](https://github.com/NixOS/nixpkgs/commit/1eb75826beb297ffc9800c2673ae3f9a7b8555bb) | `` obs-studio: remove self as maintainer ``                                      |
| [`a18f2d40`](https://github.com/NixOS/nixpkgs/commit/a18f2d4085e48ed84233aabe3c7ab54b0efd7a96) | `` python310Packages.dissect: 3.10 -> 3.11 ``                                    |
| [`63c77c23`](https://github.com/NixOS/nixpkgs/commit/63c77c2361cd1cb27a8566b1dffa2a626fc79a08) | `` python311Packages.qingping-ble: 0.8.2 -> 0.9.0 ``                             |
| [`bdd67c91`](https://github.com/NixOS/nixpkgs/commit/bdd67c91f25dfa977152fd9c15dfe9c0b9a68aef) | `` python311Packages.aiodiscover: 1.5.1 -> 1.6.0 ``                              |
| [`2592a670`](https://github.com/NixOS/nixpkgs/commit/2592a6704ef820f60b2c7c41037e508a9d14a252) | `` python311Packages.cached-ipaddress: init at 0.3.0 ``                          |
| [`15a64317`](https://github.com/NixOS/nixpkgs/commit/15a643171de00bfcfba1d061e4ca62b1d2c4d15b) | `` xwayland-run: init at 0.0.2 ``                                                |
| [`8ea50098`](https://github.com/NixOS/nixpkgs/commit/8ea5009875e9901b56a2cfbb97ba0514c4a6c0d8) | `` gcfflasher: set platforms ``                                                  |