### PR TITLE
chore(flake/nur): `ca0d61f1` -> `a91d9315`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702951437,
-        "narHash": "sha256-M/nfQFKzKbc1PaYnnHEp31sFvfLvIHWgE9fwuwStHK4=",
+        "lastModified": 1702953930,
+        "narHash": "sha256-4AlVsk+sYKsB+1Iy1B9zCo4jF1ZYng29o460ZWnvft8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ca0d61f10724f603723d6feb303c64a585b618b1",
+        "rev": "a91d931519972df2ebb143ea0d6d08d2e34548b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a91d9315`](https://github.com/nix-community/NUR/commit/a91d931519972df2ebb143ea0d6d08d2e34548b3) | `` automatic update `` |