### PR TITLE
chore(flake/nur): `a91d9315` -> `06f325fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702953930,
-        "narHash": "sha256-4AlVsk+sYKsB+1Iy1B9zCo4jF1ZYng29o460ZWnvft8=",
+        "lastModified": 1702957303,
+        "narHash": "sha256-MspofgHcwmDRsfBtVoXRBluNz49OejQGvn7VM+aoSfc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a91d931519972df2ebb143ea0d6d08d2e34548b3",
+        "rev": "06f325fc281e404efda68baa45246ebc8a9e961b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`06f325fc`](https://github.com/nix-community/NUR/commit/06f325fc281e404efda68baa45246ebc8a9e961b) | `` automatic update `` |
| [`0e217c8e`](https://github.com/nix-community/NUR/commit/0e217c8e4c1ab0af232aac3c82c35c2aef6570e8) | `` automatic update `` |
| [`e83fd566`](https://github.com/nix-community/NUR/commit/e83fd566c5a7683d3e0dfcb34b9a178ff4e6ea2b) | `` automatic update `` |