### PR TITLE
chore(flake/impermanence): `0c893cf0` -> `123e9420`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -471,11 +471,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1702948936,
-        "narHash": "sha256-pWG4bn5idGphFspC9RBIMHPXvRf0aQb5JG0pAKpUedE=",
+        "lastModified": 1702984171,
+        "narHash": "sha256-reIUBrUXibohXmvXRsgpvtlCE0QQSvWSA+qQCKohgR0=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "0c893cf08a6c9559e482466340e82ac1f569937d",
+        "rev": "123e94200f63952639492796b8878e588a4a2851",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`bcfdc06b`](https://github.com/nix-community/impermanence/commit/bcfdc06b2372f196ac908cf60cc888d28db6b344) | `` Fix error when target is `/` ``                         |
| [`554d7e6f`](https://github.com/nix-community/impermanence/commit/554d7e6fd13d5ff43e8738c128a2bd09b51c78d9) | `` forgot te replace `persistentStoragePath` occurrence `` |
| [`dc6d092d`](https://github.com/nix-community/impermanence/commit/dc6d092da5fb31a0cdb7ee430e99e1cc94ec1d00) | `` home-manager: add persistentStoragePath option ``       |