### PR TITLE
chore(flake/nur): `ca61de8f` -> `3ed287ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702975444,
-        "narHash": "sha256-fkXyNYhf8TMF3FPouMfml6/Yn0OdU1XnRh6ydNM5StI=",
+        "lastModified": 1702982704,
+        "narHash": "sha256-tm9uU0bEbD3T1rCyxbjYsy1FL8XIBh5DhTu6l55NSPw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ca61de8f2817c3e0ec1b7fabedb0617af3c05cf9",
+        "rev": "3ed287ae9ed76f5fae0f779b945561752951e272",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3ed287ae`](https://github.com/nix-community/NUR/commit/3ed287ae9ed76f5fae0f779b945561752951e272) | `` automatic update `` |