### PR TITLE
chore(flake/nur): `8f526594` -> `4b24bd5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702986248,
-        "narHash": "sha256-fcKATgZsuj89KGeqy/a+DaP66kcm5SPJ0OvciJ444nQ=",
+        "lastModified": 1702990649,
+        "narHash": "sha256-CiBj9iAnplMRXUeHXaKI/kk0tHZ3XFN3uvV0/Oz1nvo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8f5265940d1c9f28cb55db6e1152e5dc2cc1a684",
+        "rev": "4b24bd5f1f5fed16415f1031e3416a5e3342f19f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4b24bd5f`](https://github.com/nix-community/NUR/commit/4b24bd5f1f5fed16415f1031e3416a5e3342f19f) | `` automatic update `` |