### PR TITLE
chore(flake/nur): `4b24bd5f` -> `a04eea76`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702990649,
-        "narHash": "sha256-CiBj9iAnplMRXUeHXaKI/kk0tHZ3XFN3uvV0/Oz1nvo=",
+        "lastModified": 1702997397,
+        "narHash": "sha256-th/EqbtB6jDFhe12kTsssDzF9Ev0p9Yq/oaiWXS3H9w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4b24bd5f1f5fed16415f1031e3416a5e3342f19f",
+        "rev": "a04eea76ecdc42258fc3ed8391ba838145d0b96a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a04eea76`](https://github.com/nix-community/NUR/commit/a04eea76ecdc42258fc3ed8391ba838145d0b96a) | `` automatic update `` |
| [`323e61a2`](https://github.com/nix-community/NUR/commit/323e61a2ca46ff0214f7b9aca70c28ad5ab20d3e) | `` automatic update `` |