### PR TITLE
chore(flake/nur): `a04eea76` -> `5d091c37`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702997397,
-        "narHash": "sha256-th/EqbtB6jDFhe12kTsssDzF9Ev0p9Yq/oaiWXS3H9w=",
+        "lastModified": 1703007878,
+        "narHash": "sha256-sMYj2VxCHmV3PBaWXYWB57SXGqhieYSXM39YoecghqU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a04eea76ecdc42258fc3ed8391ba838145d0b96a",
+        "rev": "5d091c377eec89a596767b44cecf0813ace9e49a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5d091c37`](https://github.com/nix-community/NUR/commit/5d091c377eec89a596767b44cecf0813ace9e49a) | `` automatic update `` |
| [`b71756cd`](https://github.com/nix-community/NUR/commit/b71756cd7af7ae3b552d78fc42f1a9b7e8e5b917) | `` automatic update `` |