### PR TITLE
chore(flake/nur): `3df75c48` -> `0b435607`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703011543,
-        "narHash": "sha256-zCAKHZ8cTT/J+sr16vLhM5Qlc+O7MbML9xgQa8QTjRc=",
+        "lastModified": 1703015152,
+        "narHash": "sha256-5HnPYQRcnMd4YK5qfNciXQXAkEyBKokOeHtei6ZqiAg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3df75c4890e142d2e4a25ea714eb364e3f770be7",
+        "rev": "0b435607a86979ec23cbc6db39a1f7be5aad2276",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0b435607`](https://github.com/nix-community/NUR/commit/0b435607a86979ec23cbc6db39a1f7be5aad2276) | `` automatic update `` |