### PR TITLE
chore(flake/nur): `b495f967` -> `613dcbe6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703018664,
-        "narHash": "sha256-4dg2al2i5zQAtdd2QzEJfnohskzE2CUQu730dR8710o=",
+        "lastModified": 1703022265,
+        "narHash": "sha256-OrslrrSsZWjvRWyuAVTiipe5vUOk8dznZiojHRDkieE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b495f96757696e896c541c7a3a69ca03d44ddae7",
+        "rev": "613dcbe6a9fb7b24910b28a866e6f8d340106a84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`613dcbe6`](https://github.com/nix-community/NUR/commit/613dcbe6a9fb7b24910b28a866e6f8d340106a84) | `` automatic update `` |