### PR TITLE
chore(flake/nur): `613dcbe6` -> `d63d8a56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703022265,
-        "narHash": "sha256-OrslrrSsZWjvRWyuAVTiipe5vUOk8dznZiojHRDkieE=",
+        "lastModified": 1703028230,
+        "narHash": "sha256-7i04yJU/xbexLKJ0BggD1Xjx1qKApgdaVRp72RQ0qQg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "613dcbe6a9fb7b24910b28a866e6f8d340106a84",
+        "rev": "d63d8a56df30124ebbf1b746a68fa1fe232e1a3c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d63d8a56`](https://github.com/nix-community/NUR/commit/d63d8a56df30124ebbf1b746a68fa1fe232e1a3c) | `` automatic update `` |
| [`708a3cce`](https://github.com/nix-community/NUR/commit/708a3ccec178943b779b86e9f483fdc4fd75fee7) | `` automatic update `` |