### PR TITLE
chore(flake/nur): `d63d8a56` -> `3878f144`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703028230,
-        "narHash": "sha256-7i04yJU/xbexLKJ0BggD1Xjx1qKApgdaVRp72RQ0qQg=",
+        "lastModified": 1703036507,
+        "narHash": "sha256-PgnZWN6g63Qg3HVU/GykJhsU1wIcn8wi0OVVc2V7oeY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d63d8a56df30124ebbf1b746a68fa1fe232e1a3c",
+        "rev": "3878f144cfd520006706955f8c34cae696dbda31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3878f144`](https://github.com/nix-community/NUR/commit/3878f144cfd520006706955f8c34cae696dbda31) | `` automatic update `` |
| [`eb093e7b`](https://github.com/nix-community/NUR/commit/eb093e7bd7df6824eadeb7b54a71da08574b834a) | `` automatic update `` |
| [`7d10cd42`](https://github.com/nix-community/NUR/commit/7d10cd423b547844845673cd2325ff6a1b095e9f) | `` automatic update `` |
| [`94757c76`](https://github.com/nix-community/NUR/commit/94757c76440dfe1590ca912e1729c52445b2d94e) | `` automatic update `` |
| [`6b4cc234`](https://github.com/nix-community/NUR/commit/6b4cc234fe24b71b22b2f1509f80d9e8e45426c6) | `` automatic update `` |