### PR TITLE
chore(flake/nur): `73ddd465` -> `bbb4c54c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703054084,
-        "narHash": "sha256-h0LRBpGZsLO+m00NALu5HNWZsEJG+p+OWc2l1z/Ylwg=",
+        "lastModified": 1703056986,
+        "narHash": "sha256-Gg/A1Vt0JoJJIE5GFpa3cG3CSo7yXSUm8a6zuwWHIZQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "73ddd465ba3fa1757e9f72be6420aabd78b5a764",
+        "rev": "bbb4c54c0af005c9d919148259169ee8865dc933",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bbb4c54c`](https://github.com/nix-community/NUR/commit/bbb4c54c0af005c9d919148259169ee8865dc933) | `` automatic update `` |