### PR TITLE
chore(flake/nur): `bbb4c54c` -> `a404a219`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703056986,
-        "narHash": "sha256-Gg/A1Vt0JoJJIE5GFpa3cG3CSo7yXSUm8a6zuwWHIZQ=",
+        "lastModified": 1703061842,
+        "narHash": "sha256-ukiFj8+PXKQ6zLkH3YhW4mW26xOt+VVz6j3nQZ/2nMk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bbb4c54c0af005c9d919148259169ee8865dc933",
+        "rev": "a404a21923e210932e60b3d6da030f7e19b627a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a404a219`](https://github.com/nix-community/NUR/commit/a404a21923e210932e60b3d6da030f7e19b627a2) | `` automatic update `` |
| [`be3e24a6`](https://github.com/nix-community/NUR/commit/be3e24a6a4823b573bcb32086f254551f8fe75c8) | `` automatic update `` |