### PR TITLE
chore(flake/nur): `a404a219` -> `5553baf4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703061842,
-        "narHash": "sha256-ukiFj8+PXKQ6zLkH3YhW4mW26xOt+VVz6j3nQZ/2nMk=",
+        "lastModified": 1703065816,
+        "narHash": "sha256-enPnF3+pWamipXcYNKUOjxcY1ONWccRR5uM3MB0/qbM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a404a21923e210932e60b3d6da030f7e19b627a2",
+        "rev": "5553baf4adcbbd2ff21acb81627799a33be3d05e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5553baf4`](https://github.com/nix-community/NUR/commit/5553baf4adcbbd2ff21acb81627799a33be3d05e) | `` automatic update `` |