### PR TITLE
chore(flake/nur): `5553baf4` -> `f1f4985e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703065816,
-        "narHash": "sha256-enPnF3+pWamipXcYNKUOjxcY1ONWccRR5uM3MB0/qbM=",
+        "lastModified": 1703069117,
+        "narHash": "sha256-yty3mfujzGOH+gx7MGXjcJsg49TLH2VoU6E0Z9eFnjc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5553baf4adcbbd2ff21acb81627799a33be3d05e",
+        "rev": "f1f4985e27c2a52c5d6d1758401d01207804c460",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f1f4985e`](https://github.com/nix-community/NUR/commit/f1f4985e27c2a52c5d6d1758401d01207804c460) | `` automatic update `` |