### PR TITLE
chore(flake/nur): `f1f4985e` -> `471263c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703069117,
-        "narHash": "sha256-yty3mfujzGOH+gx7MGXjcJsg49TLH2VoU6E0Z9eFnjc=",
+        "lastModified": 1703071396,
+        "narHash": "sha256-hxoh4t81FFuoA1VJoAeR9h6cvnGvGEA3BJs7YEVJOUc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f1f4985e27c2a52c5d6d1758401d01207804c460",
+        "rev": "471263c9a9e14f635761af844e048c6fae27e44d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`471263c9`](https://github.com/nix-community/NUR/commit/471263c9a9e14f635761af844e048c6fae27e44d) | `` automatic update `` |
| [`c3e9ef4a`](https://github.com/nix-community/NUR/commit/c3e9ef4a5fd38e7ab6ec75bdf66b9cc52decdc48) | `` automatic update `` |