### PR TITLE
chore(flake/nur): `471263c9` -> `1367f14e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703071396,
-        "narHash": "sha256-hxoh4t81FFuoA1VJoAeR9h6cvnGvGEA3BJs7YEVJOUc=",
+        "lastModified": 1703076631,
+        "narHash": "sha256-4QnntZP+6xaCkKGvSg57mRN3RtCzdR2i67C7R3AXld8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "471263c9a9e14f635761af844e048c6fae27e44d",
+        "rev": "1367f14eadcb8a4fa6d15f773ff05f9dbd6065eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1367f14e`](https://github.com/nix-community/NUR/commit/1367f14eadcb8a4fa6d15f773ff05f9dbd6065eb) | `` automatic update `` |
| [`075964f8`](https://github.com/nix-community/NUR/commit/075964f8e9a623bb8df3e414a682b2715b9c4b6e) | `` automatic update `` |
| [`a2bc1582`](https://github.com/nix-community/NUR/commit/a2bc1582b5fc1b6f52d6fd5c517dd5c08f3b4bf2) | `` automatic update `` |