### PR TITLE
chore(flake/deploy-rs): `91532751` -> `b709d63d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -258,11 +258,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702460489,
-        "narHash": "sha256-H6s6oVLvx7PCjUcvfkB89Bb+kbaiJxTAgWfMjiQTjA0=",
+        "lastModified": 1703087360,
+        "narHash": "sha256-0VUbWBW8VyiDRuimMuLsEO4elGuUw/nc2WDeuO1eN1M=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "915327515f5fd1b7719c06e2f1eb304ee0bdd803",
+        "rev": "b709d63debafce9f5645a5ba550c9e0983b3d1f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                     |
| --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`56ba8c39`](https://github.com/serokell/deploy-rs/commit/56ba8c3929802fb00c4803452024e23cdb54cc99) | `` [Chore] Add missing documentation for timeout options `` |