### PR TITLE
chore(flake/nur): `ab71702f` -> `bbf1ea20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703079888,
-        "narHash": "sha256-UlYms7GfpIfvw+33vlMD8FkBJBXqZe3dmNHCVbbcxq4=",
+        "lastModified": 1703094317,
+        "narHash": "sha256-LvOdoYc1sSt0RhjeZexGyn37EoYdDnVmji4Ep2MHi1A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ab71702fafee4be31d7b6f08e7f023c528eb7572",
+        "rev": "bbf1ea20193bd5f8a643f3cd1dceda72be110e75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bbf1ea20`](https://github.com/nix-community/NUR/commit/bbf1ea20193bd5f8a643f3cd1dceda72be110e75) | `` automatic update `` |
| [`f133fc54`](https://github.com/nix-community/NUR/commit/f133fc54e2a2495d19f6020120717240068ce0f3) | `` automatic update `` |
| [`d19b0ed1`](https://github.com/nix-community/NUR/commit/d19b0ed13ad371fe975f20872d7d198d50ecf763) | `` automatic update `` |