### PR TITLE
chore(flake/nur): `bbf1ea20` -> `c44685fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703094317,
-        "narHash": "sha256-LvOdoYc1sSt0RhjeZexGyn37EoYdDnVmji4Ep2MHi1A=",
+        "lastModified": 1703101465,
+        "narHash": "sha256-lIJnB0M5dWXHB0AkasAp3ItdpsWuOR96wCygcOTL9qI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bbf1ea20193bd5f8a643f3cd1dceda72be110e75",
+        "rev": "c44685fcc602f336fc88e8e136db39f3a1e9f51c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c44685fc`](https://github.com/nix-community/NUR/commit/c44685fcc602f336fc88e8e136db39f3a1e9f51c) | `` automatic update `` |