### PR TITLE
chore(flake/home-manager): `8f38f1a2` -> `3bfaacf4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -456,11 +456,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703112948,
-        "narHash": "sha256-EK0D9P/tNVJuQK6VrRPwjsfJ+TBvBLYUEXMVEXSr++0=",
+        "lastModified": 1703113217,
+        "narHash": "sha256-7ulcXOk63TIT2lVDSExj7XzFx09LpdSAPtvgtM7yQPE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8f38f1a231547a9d9bc9f0233eb9c92cfb89f025",
+        "rev": "3bfaacf46133c037bb356193bd2f1765d9dc82c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`3bfaacf4`](https://github.com/nix-community/home-manager/commit/3bfaacf46133c037bb356193bd2f1765d9dc82c1) | `` direnv: Make lines shorter ``                          |
| [`bc52cdd5`](https://github.com/nix-community/home-manager/commit/bc52cdd5795e60850e860b5ccce7e8b9537d86f9) | `` direnv: Use ${getExe pkg} instead of ${pkg}/bin/pkg `` |
| [`67c4c05c`](https://github.com/nix-community/home-manager/commit/67c4c05c29d2bd72cef7376c38351cb30af4d708) | `` direnv: Apply nushell env transformations ``           |