### PR TITLE
chore(flake/nur): `5e5fc963` -> `09c1d2b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703105059,
-        "narHash": "sha256-EtwOps2u2HaV85OAXbsb4SvXpguVO7eA8gW6wb7Hm9A=",
+        "lastModified": 1703121339,
+        "narHash": "sha256-bZBO3WrkToThVVlN/XXxy2GVUy4Y/18VFCxSN5sbSEg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5e5fc9633fb8157b82a0ceab57d2077ce1c8a454",
+        "rev": "09c1d2b44d388396902e02bd1a92ca83f36767df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`09c1d2b4`](https://github.com/nix-community/NUR/commit/09c1d2b44d388396902e02bd1a92ca83f36767df) | `` automatic update `` |
| [`e3498139`](https://github.com/nix-community/NUR/commit/e34981394ba3e9cde3b0f51a71c46e602a00ced1) | `` automatic update `` |
| [`eef232c5`](https://github.com/nix-community/NUR/commit/eef232c53c6ebf77ff116a330047f541b6a941b6) | `` automatic update `` |