### PR TITLE
chore(flake/nur): `09c1d2b4` -> `6ef873fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703121339,
-        "narHash": "sha256-bZBO3WrkToThVVlN/XXxy2GVUy4Y/18VFCxSN5sbSEg=",
+        "lastModified": 1703127279,
+        "narHash": "sha256-UM6itq1tyrkrBdccBuNM4VU056TsFCOVPq8ia/YITrk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "09c1d2b44d388396902e02bd1a92ca83f36767df",
+        "rev": "6ef873fbdc437dec894c4c0f28ada39a5eb359d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6ef873fb`](https://github.com/nix-community/NUR/commit/6ef873fbdc437dec894c4c0f28ada39a5eb359d3) | `` automatic update `` |