### PR TITLE
chore(flake/nur): `6ef873fb` -> `d7a908da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703127279,
-        "narHash": "sha256-UM6itq1tyrkrBdccBuNM4VU056TsFCOVPq8ia/YITrk=",
+        "lastModified": 1703130127,
+        "narHash": "sha256-CJXvhR+9ll90kAglFjkCPngQsIB9D3kubajgdvvWy0M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6ef873fbdc437dec894c4c0f28ada39a5eb359d3",
+        "rev": "d7a908da7b572abe5936af323f5918d5f13c7cb5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d7a908da`](https://github.com/nix-community/NUR/commit/d7a908da7b572abe5936af323f5918d5f13c7cb5) | `` automatic update `` |
| [`2c85b840`](https://github.com/nix-community/NUR/commit/2c85b84079e932aac96af74dc1317f0d7995eaf9) | `` automatic update `` |