### PR TITLE
chore(flake/nur): `ec93c7df` -> `2a4f182b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703138894,
-        "narHash": "sha256-wI6cx5XRNlCfd3BlVwDwpa7+YCkUpLAn8vsGWwFnRkc=",
+        "lastModified": 1703145466,
+        "narHash": "sha256-15PXK2JqLI6cGvTj3HPXwAN/2xEeEeFRxC/ccdeKTVs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ec93c7df12823cdb8106ef22c137dab36f447694",
+        "rev": "2a4f182b69b39d3c875a73c094f7addff6aa9335",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2a4f182b`](https://github.com/nix-community/NUR/commit/2a4f182b69b39d3c875a73c094f7addff6aa9335) | `` automatic update `` |