### PR TITLE
chore(flake/nur): `2a4f182b` -> `64544766`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703145466,
-        "narHash": "sha256-15PXK2JqLI6cGvTj3HPXwAN/2xEeEeFRxC/ccdeKTVs=",
+        "lastModified": 1703151853,
+        "narHash": "sha256-gprJXHmq/n0jrNx0EYKuBT4ejtIDyVAfiT6ZPyyLcPI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2a4f182b69b39d3c875a73c094f7addff6aa9335",
+        "rev": "645447668a47f90ce4745356a46cf2dcb3977205",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`64544766`](https://github.com/nix-community/NUR/commit/645447668a47f90ce4745356a46cf2dcb3977205) | `` automatic update `` |