### PR TITLE
chore(flake/home-manager): `3bfaacf4` -> `8b797c8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -456,11 +456,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703113217,
-        "narHash": "sha256-7ulcXOk63TIT2lVDSExj7XzFx09LpdSAPtvgtM7yQPE=",
+        "lastModified": 1703155327,
+        "narHash": "sha256-Q25AEghhhOp+ImNN4PsAExi7DIB1INMlBSaggGz7q4w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3bfaacf46133c037bb356193bd2f1765d9dc82c1",
+        "rev": "8b797c8eea1eba7dfb47f6964103e6e0d134255f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`8b797c8e`](https://github.com/nix-community/home-manager/commit/8b797c8eea1eba7dfb47f6964103e6e0d134255f) | `` fish: escape abbr expansions once again ``         |
| [`b897544a`](https://github.com/nix-community/home-manager/commit/b897544a798d487044d7356ff4cf6d4748ac231a) | `` direnv: Fix nushell integration ENV_CONVERSIONS `` |