### PR TITLE
chore(flake/nur): `64544766` -> `9ef37017`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703151853,
-        "narHash": "sha256-gprJXHmq/n0jrNx0EYKuBT4ejtIDyVAfiT6ZPyyLcPI=",
+        "lastModified": 1703159048,
+        "narHash": "sha256-TcW0kf7nd/OEZwwxPs1y07YU4oZe18ezolScRbXXWZA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "645447668a47f90ce4745356a46cf2dcb3977205",
+        "rev": "9ef37017837733a76fe18680264fcd815df1eea6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ef37017`](https://github.com/nix-community/NUR/commit/9ef37017837733a76fe18680264fcd815df1eea6) | `` automatic update `` |
| [`bdaabf54`](https://github.com/nix-community/NUR/commit/bdaabf5464db4a581778c5f3b58cf82980d2204a) | `` automatic update `` |