### PR TITLE
chore(flake/nur): `49d83460` -> `35e7e80e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703177762,
-        "narHash": "sha256-oVnrlffE5lyprw5JWwhI9TAbsVt0VZLkx8Fm+UCsmTM=",
+        "lastModified": 1703184342,
+        "narHash": "sha256-Ofp7blG/cJUeQfi6ZjJeHVCSEmtdUhGaJLFKvxbTKW0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "49d83460c7e8ff4eea9c27455521555e04ef15a6",
+        "rev": "35e7e80e378aedb2b4fc5ae0f560fc395b5653e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`35e7e80e`](https://github.com/nix-community/NUR/commit/35e7e80e378aedb2b4fc5ae0f560fc395b5653e3) | `` automatic update `` |