### PR TITLE
chore(flake/nur): `aa77c3b4` -> `08560126`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703187919,
-        "narHash": "sha256-r28tTx9xuc2h3tCA1zmotrLnJDffaFHMMSy5hDpkegU=",
+        "lastModified": 1703209706,
+        "narHash": "sha256-KTb2pZR20R4l4Vhj844TYUTKFrLrT27pEi2aIWd+73w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aa77c3b4f6b8dba86c5e75269b1f6a123168d4df",
+        "rev": "0856012664025f0362a8d25bdf0463702b0c9e82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`08560126`](https://github.com/nix-community/NUR/commit/0856012664025f0362a8d25bdf0463702b0c9e82) | `` automatic update `` |
| [`2f1c7d6a`](https://github.com/nix-community/NUR/commit/2f1c7d6adb41afb3af4a3e8fa6a3e1710756d9e0) | `` automatic update `` |