### PR TITLE
chore(flake/nur): `906fb47a` -> `94ca7c9b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703216542,
-        "narHash": "sha256-2Wfjw5pO8i+3UfyuRcUi4qztKCMzOobT74xtR8TI1MY=",
+        "lastModified": 1703227952,
+        "narHash": "sha256-VcXhoV2uja+h0tcVc4M2rTAza/ARgwxK3hR1W65+a4c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "906fb47acd897c968e33a7b7ba94d3d3e0103edb",
+        "rev": "94ca7c9bb72c153c5670124aec6887340a61a319",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`94ca7c9b`](https://github.com/nix-community/NUR/commit/94ca7c9bb72c153c5670124aec6887340a61a319) | `` automatic update `` |
| [`591baec9`](https://github.com/nix-community/NUR/commit/591baec90f0d0b69316ea44ef231812f0f66a508) | `` automatic update `` |