### PR TITLE
chore(flake/nur): `94ca7c9b` -> `4af4073b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703227952,
-        "narHash": "sha256-VcXhoV2uja+h0tcVc4M2rTAza/ARgwxK3hR1W65+a4c=",
+        "lastModified": 1703234411,
+        "narHash": "sha256-Fh3+ze3tHTHT2+qZXGtK8zv63NkUHZBhnblCu3771F8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "94ca7c9bb72c153c5670124aec6887340a61a319",
+        "rev": "4af4073bd616e883c295c6dd981b87b2c892e5ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4af4073b`](https://github.com/nix-community/NUR/commit/4af4073bd616e883c295c6dd981b87b2c892e5ec) | `` automatic update `` |