### PR TITLE
chore(flake/nur): `4af4073b` -> `de8195aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703234411,
-        "narHash": "sha256-Fh3+ze3tHTHT2+qZXGtK8zv63NkUHZBhnblCu3771F8=",
+        "lastModified": 1703238248,
+        "narHash": "sha256-0vzcX5nHYNcrJYtzIPJeLgdF8q7ScbUOAjIkMioqAfY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4af4073bd616e883c295c6dd981b87b2c892e5ec",
+        "rev": "de8195aac09ca062e6cd39c115a39e37688c77a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`de8195aa`](https://github.com/nix-community/NUR/commit/de8195aac09ca062e6cd39c115a39e37688c77a1) | `` automatic update `` |