### PR TITLE
chore(flake/nur): `de8195aa` -> `c1dfadd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703238248,
-        "narHash": "sha256-0vzcX5nHYNcrJYtzIPJeLgdF8q7ScbUOAjIkMioqAfY=",
+        "lastModified": 1703245291,
+        "narHash": "sha256-qZFGILqbEEDuBwIS/h2/ENV4mpEibycvQLi2MtwqpcQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "de8195aac09ca062e6cd39c115a39e37688c77a1",
+        "rev": "c1dfadd7ab30cd8e8fa7d25fa6d1398458f11027",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6b482278`](https://github.com/nix-community/NUR/commit/6b482278399a9836fba8ad5b8a7628ab9456eefd) | `` Update README.md `` |