### PR TITLE
chore(flake/nur): `c1dfadd7` -> `0bed4f7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703245291,
-        "narHash": "sha256-qZFGILqbEEDuBwIS/h2/ENV4mpEibycvQLi2MtwqpcQ=",
+        "lastModified": 1703249666,
+        "narHash": "sha256-5oFknmphw3YNzTi0Kdgm8zDhgQZtP8H3Xr99mw1L5qQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c1dfadd7ab30cd8e8fa7d25fa6d1398458f11027",
+        "rev": "0bed4f7d4f14a121bba5cf8bdccbb8a3ff061ea5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0bed4f7d`](https://github.com/nix-community/NUR/commit/0bed4f7d4f14a121bba5cf8bdccbb8a3ff061ea5) | `` automatic update `` |
| [`2979c0f5`](https://github.com/nix-community/NUR/commit/2979c0f57ff3d1e1a1dea8693b28f8f0f10dcab8) | `` automatic update `` |
| [`41d3fc3b`](https://github.com/nix-community/NUR/commit/41d3fc3b6d0277ca57cb8f385f97f76d0f51f6e7) | `` automatic update `` |