### PR TITLE
chore(flake/nur): `0bed4f7d` -> `606c868d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703249666,
-        "narHash": "sha256-5oFknmphw3YNzTi0Kdgm8zDhgQZtP8H3Xr99mw1L5qQ=",
+        "lastModified": 1703252653,
+        "narHash": "sha256-7ZdQ2AOVvzOabB9fIkvnaJAwptcDijJtwOvXoezrRho=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0bed4f7d4f14a121bba5cf8bdccbb8a3ff061ea5",
+        "rev": "606c868d0b4adf9c186043723f7f3c11ee147f76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`606c868d`](https://github.com/nix-community/NUR/commit/606c868d0b4adf9c186043723f7f3c11ee147f76) | `` automatic update `` |
| [`584c8f61`](https://github.com/nix-community/NUR/commit/584c8f61167a8ef9fe7fa153f150a92b239332c5) | `` automatic update `` |