### PR TITLE
chore(flake/agenix): `17090d10` -> `d0d4ad5b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,11 +13,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703107199,
-        "narHash": "sha256-Xx9Kkoqye520mkEWTZx/sKQRJsIeWOuwoh568uwHpNg=",
+        "lastModified": 1703260116,
+        "narHash": "sha256-ipqShkBmHKC9ft1ZAsA6aeKps32k7+XZSPwfxeHLsAU=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "17090d105af1b9f941109c1e12d6e3a596657f97",
+        "rev": "d0d4ad5be611da43da04321f49684ad72d705c7e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`08dc5068`](https://github.com/ryantm/agenix/commit/08dc5068e6b5f8c985dba6490c219ea439f48ac1) | `` Revert "contrib: add direct tests for agenix " `` |