### PR TITLE
chore(flake/srvos): `608e7e13` -> `0c7eefd1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -988,11 +988,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703123383,
-        "narHash": "sha256-QxiQqL+blpH6SLsXZGbxCOxLTCLa9WJv9uB+jafU/c8=",
+        "lastModified": 1703258052,
+        "narHash": "sha256-gWGQxht/xRJRnA+35aHtpmev7snsM+2GBdaPyarXNqU=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "608e7e13de1c052742a9549608691cea0b4c2e91",
+        "rev": "0c7eefd13776730f33ea28fb984dd95cb5357e8e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`0c7eefd1`](https://github.com/nix-community/srvos/commit/0c7eefd13776730f33ea28fb984dd95cb5357e8e) | `` Fix typo in hardware.md (#342) `` |