### PR TITLE
chore(flake/nur): `933eb790` -> `3eccbee9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703256164,
-        "narHash": "sha256-4SFNBbR3g73HxNGxt9lBxHPjeU4d6xlaNyhBCeO//Do=",
+        "lastModified": 1703274336,
+        "narHash": "sha256-1WshKO8MKumqSioWVRMU91+W7nQQfvvMD+iTSNz1QeE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "933eb79090b3304eeb66c3c4729d55638566842a",
+        "rev": "3eccbee91a8bf34eb1acc9a582054cc50581fec9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3eccbee9`](https://github.com/nix-community/NUR/commit/3eccbee91a8bf34eb1acc9a582054cc50581fec9) | `` automatic update `` |
| [`53e26433`](https://github.com/nix-community/NUR/commit/53e2643314d1071e343ab4dc731001a2df2b064e) | `` automatic update `` |
| [`6ac58bfb`](https://github.com/nix-community/NUR/commit/6ac58bfb11ede5948350e5390c7cdc88a42d9c1d) | `` automatic update `` |
| [`63642bb0`](https://github.com/nix-community/NUR/commit/63642bb0fe7a32aaf41bfc915befa56d4029909d) | `` automatic update `` |
| [`9aae08f4`](https://github.com/nix-community/NUR/commit/9aae08f4f51ae21f6ba0c68089d5482ea1152072) | `` automatic update `` |