### PR TITLE
chore(flake/darwin): `4b9b83d5` -> `010a625b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -216,11 +216,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700795494,
-        "narHash": "sha256-gzGLZSiOhf155FW7262kdHo2YDeugp3VuIFb4/GGng0=",
+        "lastModified": 1703271201,
+        "narHash": "sha256-9uB7x1XP+/+We4mYpxC8UMgxlC0efP6P+4dsgqFuxCU=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "4b9b83d5a92e8c1fbfd8eb27eda375908c11ec4d",
+        "rev": "010a625bd74bc623153344f52f71cc965b31d75a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                  |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
| [`f81fbc2b`](https://github.com/LnL7/nix-darwin/commit/f81fbc2bf78af3384dc435fdfb2e87c3a01ca047) | `` darwin-rebuild: fix sudo invocation on High Sierra `` |