### PR TITLE
chore(flake/nur): `d508a2ee` -> `4d6665ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703304188,
-        "narHash": "sha256-mdx5zksri/J1zcGyjlGtcjwG8CRSBIPt2eZtQ2vqmNY=",
+        "lastModified": 1703310287,
+        "narHash": "sha256-PQU8KCIH5a6/Khm02MPQn5SCD5JuMhoU9lMgqqXO11c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d508a2ee79171465889019fcfb7562a8c6ffb45a",
+        "rev": "4d6665efc940d159275d21566db5f1ad231c1adc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4d6665ef`](https://github.com/nix-community/NUR/commit/4d6665efc940d159275d21566db5f1ad231c1adc) | `` automatic update `` |