### PR TITLE
chore(flake/nur): `4d6665ef` -> `2c2a8e54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703310287,
-        "narHash": "sha256-PQU8KCIH5a6/Khm02MPQn5SCD5JuMhoU9lMgqqXO11c=",
+        "lastModified": 1703313294,
+        "narHash": "sha256-+YjMw6U2OiSLObYG2mMQ53z18nbrwAvs+eY54mihl5o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4d6665efc940d159275d21566db5f1ad231c1adc",
+        "rev": "2c2a8e54cd7685bab7b7aa14669ac1897a5eaa8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2c2a8e54`](https://github.com/nix-community/NUR/commit/2c2a8e54cd7685bab7b7aa14669ac1897a5eaa8b) | `` automatic update `` |