### PR TITLE
chore(flake/nur): `c13ed6de` -> `9b854f9f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703316283,
-        "narHash": "sha256-8e16P7YSmdSrqMfHD9/klGYWiwzORMNy5qgk9JDSIRM=",
+        "lastModified": 1703319183,
+        "narHash": "sha256-a3Yxwicu+GuSv1xyRf/M4WvQ66U058tq7HkkQkKwFzk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c13ed6dea8a3fa743142b7dc9b4d8e75335124f3",
+        "rev": "9b854f9f289fffdc162181df548fabef71cb8747",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9b854f9f`](https://github.com/nix-community/NUR/commit/9b854f9f289fffdc162181df548fabef71cb8747) | `` automatic update `` |