### PR TITLE
chore(flake/emacs-overlay): `47798c4a` -> `d1755a1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1702399955,
-        "narHash": "sha256-FnB5O1RVFzj3h7Ayf7UxFnOL1gsJuG6gn1LCTd9dKFs=",
+        "lastModified": 1703379790,
+        "narHash": "sha256-EvPV2L6ixy4kYhrwGZ93jjgpKdnI4obl2+2WDqJa2+s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "47798c4ab07d5f055bb2625010cf6d8e3f384923",
+        "rev": "d1755a1bc7482123a229cef72b526944f6085891",
         "type": "github"
       },
       "original": {
@@ -707,11 +707,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1702221085,
-        "narHash": "sha256-Br3GCSkkvkmw46cT6wCz6ro2H1WgDMWbKE0qctbdtL0=",
+        "lastModified": 1703034876,
+        "narHash": "sha256-4bMPFv/bs5g1nEsXQwXlrAGJgjv1Ilr0ejdaTkBwQLs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c2786e7084cbad90b4f9472d5b5e35ecb57958af",
+        "rev": "312ab59e8ade69e6083017bd9b98a2919f1fb86a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                               |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
| [`d1755a1b`](https://github.com/nix-community/emacs-overlay/commit/d1755a1bc7482123a229cef72b526944f6085891) | `` Updated elpa ``                                                    |
| [`1683e36d`](https://github.com/nix-community/emacs-overlay/commit/1683e36d107e35e1786126fa64cfbe41e8b4e572) | `` Updated nongnu ``                                                  |
| [`0dfd7c9b`](https://github.com/nix-community/emacs-overlay/commit/0dfd7c9bdd4323a805781e0bdf6bcae7251742a3) | `` Revert "Update bytecomp-revert.patch" ``                           |
| [`dbd5468d`](https://github.com/nix-community/emacs-overlay/commit/dbd5468d4387c66a94e07170d1373ab76dcc9ab3) | `` Revert "fixup! Update bytecomp-revert.patch" ``                    |
| [`53918e94`](https://github.com/nix-community/emacs-overlay/commit/53918e94a1f0ea236f96a4e566c0544a0174593c) | `` Revert "Updated emacs" ``                                          |
| [`f0ae3cf0`](https://github.com/nix-community/emacs-overlay/commit/f0ae3cf0dd629934f66b83c05269ea3b5685ebf7) | `` Revert "Updated emacs" ``                                          |
| [`c0ef7074`](https://github.com/nix-community/emacs-overlay/commit/c0ef7074c168adcb5f4038d9848eaedaeb5a27bc) | `` Temporarily disable "emacs" update ``                              |
| [`9e5d9f80`](https://github.com/nix-community/emacs-overlay/commit/9e5d9f807ad49485bcbfddbb6672e72891bae079) | `` fixup! Update bytecomp-revert.patch ``                             |
| [`1d5a4b9d`](https://github.com/nix-community/emacs-overlay/commit/1d5a4b9d76843020600c204620440d919249d0fb) | `` Update bytecomp-revert.patch ``                                    |
| [`20e3f5a3`](https://github.com/nix-community/emacs-overlay/commit/20e3f5a3c65d2d3a5adda15359c429958b41f73e) | `` Updated emacs ``                                                   |
| [`561c5343`](https://github.com/nix-community/emacs-overlay/commit/561c5343ce83d4b37c7c29d8d989884a8e584113) | `` Updated emacs ``                                                   |
| [`3ef6bde7`](https://github.com/nix-community/emacs-overlay/commit/3ef6bde7aa16dbae70c9c9010801abf0d785b1d2) | `` repos/emacs: And also remove no-out-link ``                        |
| [`4e6ae198`](https://github.com/nix-community/emacs-overlay/commit/4e6ae19845aa817da2180dfc6255493e48766bc3) | `` repos/emacs: Only instantiate derivations on update, dont build `` |
| [`5e0a5419`](https://github.com/nix-community/emacs-overlay/commit/5e0a54199dc27917676036c5ae5f57c24d16b651) | `` Updated elpa ``                                                    |
| [`1b650fad`](https://github.com/nix-community/emacs-overlay/commit/1b650fad0b5f88c337b733640887be737e98bf04) | `` Updated nongnu ``                                                  |
| [`b99616e7`](https://github.com/nix-community/emacs-overlay/commit/b99616e7c7e16b1ae002cc5e59554bf5982a3710) | `` update: fixup repos ``                                             |
| [`b7b1eb0a`](https://github.com/nix-community/emacs-overlay/commit/b7b1eb0a0a09728f9a4762b217028039635f38db) | `` Revert "repos: fix tests" ``                                       |
| [`8ff52408`](https://github.com/nix-community/emacs-overlay/commit/8ff5240882365441f5fe54d2f89104bb23b6160c) | `` update: fixup repos for git diff ``                                |
| [`9893e2a6`](https://github.com/nix-community/emacs-overlay/commit/9893e2a61442d7bbe8a46755c62385ff0bcd9cd5) | `` Updated flake inputs ``                                            |
| [`541a166c`](https://github.com/nix-community/emacs-overlay/commit/541a166cfb1fa8f2c1ea397e1a1f8cb3989e3f3b) | `` .github: Remove flake input update from repo update matrix ``      |
| [`e7f1d35a`](https://github.com/nix-community/emacs-overlay/commit/e7f1d35ad19df15a8facab256d75617c7b022086) | `` .github: Execute updates in a matrix ``                            |
| [`e27b8ee6`](https://github.com/nix-community/emacs-overlay/commit/e27b8ee6ec4a7886b7f1960736dc1c97f607146f) | `` repos: fix tests ``                                                |