### PR TITLE
chore(flake/home-manager): `07c322a7` -> `de913414`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -456,11 +456,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703265279,
-        "narHash": "sha256-5jVtOwyMH1FzclxHrsFWzBdB+VyjUUSu1wyZhZlR6WU=",
+        "lastModified": 1703355189,
+        "narHash": "sha256-fflRwsyW+R3u0kScApX6uP7oSln9ToFoFy9/5LOKTK0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "07c322a7cff03267fd881adae1afe63367c5d608",
+        "rev": "de9134144b456104953c2533debb27a02787891f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`de913414`](https://github.com/nix-community/home-manager/commit/de9134144b456104953c2533debb27a02787891f) | `` unison: better retry/restart reporting failures ``       |
| [`7184dfe6`](https://github.com/nix-community/home-manager/commit/7184dfe663ec35629802ed2a739147989173422a) | `` firefox: update docs example for nativeMessagingHosts `` |