### PR TITLE
chore(flake/nur): `5ee34762` -> `91894669`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703360676,
-        "narHash": "sha256-7DXqxiCTzuien5ZHpboMfLJ0Cs3ri76icIsRP9H0DaQ=",
+        "lastModified": 1703364334,
+        "narHash": "sha256-hKeYU/nHvzN6VSTEF9mC4zC0a17hre8ewjRGY0qiLYA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5ee347629c6df3d44cef3440c26ad26fadf71485",
+        "rev": "91894669516c1745ad97527feff7d28e1565f392",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`91894669`](https://github.com/nix-community/NUR/commit/91894669516c1745ad97527feff7d28e1565f392) | `` automatic update `` |