### PR TITLE
chore(flake/agenix): `d0d4ad5b` -> `457669db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,14 +10,15 @@
         ],
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1703260116,
-        "narHash": "sha256-ipqShkBmHKC9ft1ZAsA6aeKps32k7+XZSPwfxeHLsAU=",
+        "lastModified": 1703371241,
+        "narHash": "sha256-f7ZcabJ5iAH2IRfVuI55xSPZ9TbegFzvFxoKtIPNEn8=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "d0d4ad5be611da43da04321f49684ad72d705c7e",
+        "rev": "457669db4259ff69d1ac1183aaa6000420940c1f",
         "type": "github"
       },
       "original": {
@@ -362,7 +363,7 @@
     },
     "flake-utils": {
       "inputs": {
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1701680307,
@@ -380,7 +381,7 @@
     },
     "flake-utils_2": {
       "inputs": {
-        "systems": "systems_2"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1685518550,
@@ -1051,6 +1052,21 @@
       }
     },
     "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",


### PR DESCRIPTION
| Commit                                                                                         | Message                                        |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`6ce42cc7`](https://github.com/ryantm/agenix/commit/6ce42cc7684cb59b3a9390256f68909d7dfb9af0) | `` Fix CI for darwin ``                        |
| [`23d4d5d2`](https://github.com/ryantm/agenix/commit/23d4d5d29193a5ab1b1514375d578209a6119392) | `` maybe this fixes darwin checks? ``          |
| [`b6aa6180`](https://github.com/ryantm/agenix/commit/b6aa6180dbfc8a5df9296db264c01b49eb173f4c) | `` test removing installer ``                  |
| [`58017c0c`](https://github.com/ryantm/agenix/commit/58017c0c932f24787d60c93c54df2b0f7bb9a766) | `` update inputs ``                            |
| [`bd86c069`](https://github.com/ryantm/agenix/commit/bd86c0696163645c78fcecc2724a94d74840e2f7) | `` fix doc build ``                            |
| [`eb3b5cf4`](https://github.com/ryantm/agenix/commit/eb3b5cf4fd2e177a7dd020b1f62eb1219ad78f68) | `` update nixpkgs ``                           |
| [`5c1198a3`](https://github.com/ryantm/agenix/commit/5c1198a352b5fac579be4aff9cd9cbfe2920c282) | `` feat: switch from rage to age ``            |
| [`344f9855`](https://github.com/ryantm/agenix/commit/344f98552660520eb2b5f354d16cf3534f0849bf) | `` dev: remove i686 support; simplify flake `` |