### PR TITLE
chore(flake/nur): `91894669` -> `018808de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703364334,
-        "narHash": "sha256-hKeYU/nHvzN6VSTEF9mC4zC0a17hre8ewjRGY0qiLYA=",
+        "lastModified": 1703383186,
+        "narHash": "sha256-UTXqK4tTS4Fftl9bWDsjZGZ7yxXoXcG4CRtFK0jDfOs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "91894669516c1745ad97527feff7d28e1565f392",
+        "rev": "018808de16c855666a49d669cd54f443950e5149",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`018808de`](https://github.com/nix-community/NUR/commit/018808de16c855666a49d669cd54f443950e5149) | `` automatic update `` |
| [`73a94819`](https://github.com/nix-community/NUR/commit/73a9481942762081f423a288b815ba25aaa360bb) | `` automatic update `` |
| [`3846ec8f`](https://github.com/nix-community/NUR/commit/3846ec8fcb1fb45ff33f8f739c0922353d27503d) | `` automatic update `` |
| [`6ad38754`](https://github.com/nix-community/NUR/commit/6ad387543c354b07626b0e29792f3ba41fbe00c6) | `` automatic update `` |