### PR TITLE
chore(flake/nur): `018808de` -> `f361a813`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703383186,
-        "narHash": "sha256-UTXqK4tTS4Fftl9bWDsjZGZ7yxXoXcG4CRtFK0jDfOs=",
+        "lastModified": 1703393074,
+        "narHash": "sha256-FOf2/5pHrBN/AM0JQVkGZ4JYEZSF3dZXlat5xDKzyAQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "018808de16c855666a49d669cd54f443950e5149",
+        "rev": "f361a813dad1da89fcc4b8296e6fdc9fe4d94981",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f361a813`](https://github.com/nix-community/NUR/commit/f361a813dad1da89fcc4b8296e6fdc9fe4d94981) | `` automatic update `` |
| [`942e2e20`](https://github.com/nix-community/NUR/commit/942e2e2015ff22b2d146c19c87117d928f285795) | `` automatic update `` |
| [`b4a02c08`](https://github.com/nix-community/NUR/commit/b4a02c08599e07b1043b093c3aae212f3f76c00e) | `` automatic update `` |
| [`9635e037`](https://github.com/nix-community/NUR/commit/9635e03766c79607c3b31db24afea13a6071e7b9) | `` automatic update `` |
| [`81381473`](https://github.com/nix-community/NUR/commit/81381473f8421cb32ac85a0364a2e91f54acab1f) | `` automatic update `` |
| [`7cda913e`](https://github.com/nix-community/NUR/commit/7cda913e543dff9e083f4b05426715a2b8675f6f) | `` automatic update `` |
| [`9923842e`](https://github.com/nix-community/NUR/commit/9923842ec58cb6c5970bdadd511c9fe5e5dea5f8) | `` automatic update `` |
| [`a9760646`](https://github.com/nix-community/NUR/commit/a97606469725824015fe886b48b4a65df4120921) | `` automatic update `` |
| [`d4f46612`](https://github.com/nix-community/NUR/commit/d4f4661260f8b1a836cf20235573b8223b229617) | `` automatic update `` |
| [`65caee0f`](https://github.com/nix-community/NUR/commit/65caee0fd028c20a22aa98aa25af47381dea0402) | `` automatic update `` |
| [`186b5f4f`](https://github.com/nix-community/NUR/commit/186b5f4f95ac03e43caa4e2d079e6678b6b1ad8c) | `` automatic update `` |
| [`76485715`](https://github.com/nix-community/NUR/commit/76485715f11612d70d234bf44152634d6e386fab) | `` automatic update `` |