### PR TITLE
chore(flake/nixpkgs): `54aac082` -> `6df37dc6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -755,11 +755,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1703013332,
-        "narHash": "sha256-+tFNwMvlXLbJZXiMHqYq77z/RfmpfpiI3yjL6o/Zo9M=",
+        "lastModified": 1703255338,
+        "narHash": "sha256-Z6wfYJQKmDN9xciTwU3cOiOk+NElxdZwy/FiHctCzjU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "54aac082a4d9bb5bbc5c4e899603abfb76a3f6d6",
+        "rev": "6df37dc6a77654682fe9f071c62b4242b5342e04",
         "type": "github"
       },
       "original": {

--- a/nix/hosts.nix
+++ b/nix/hosts.nix
@@ -57,12 +57,12 @@ in
     address = "laptop";
     pubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEIs8Ait2j8oYQB0cWPLZIw9vObzuWxo4E00awCNw2rZ root@nixos";
   };
-  work = mkHost {
-    type = "nixos";
-    hostPlatform = "x86_64-linux";
-    address = "bbigras-work";
-    pubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKEfhY66gBDU0xgjaQgm9V991wuxI/R3bm3Yt6Kdv9Au root@nixos";
-  };
+  # work = mkHost {
+  #   type = "nixos";
+  #   hostPlatform = "x86_64-linux";
+  #   address = "bbigras-work";
+  #   pubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKEfhY66gBDU0xgjaQgm9V991wuxI/R3bm3Yt6Kdv9Au root@nixos";
+  # };
   # pixel6 = mkHost {
   #   type = "nix-on-droid";
   #   hostPlatform = "aarch64-linux";


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`6df37dc6`](https://github.com/NixOS/nixpkgs/commit/6df37dc6a77654682fe9f071c62b4242b5342e04) | `` vimPlugins.guard-nvim: init at 2023-11-27 ``                                       |
| [`d09d2d6a`](https://github.com/NixOS/nixpkgs/commit/d09d2d6a7a2fdfc3d39e5bcfe3dcbbd322597fd8) | `` vimPlugins.guard-collection: init at 2023-11-13 ``                                 |
| [`6ee48dce`](https://github.com/NixOS/nixpkgs/commit/6ee48dcedd948cc9b1f29a2ebeb5f0cde5180e4d) | `` ocamlPackages.cryptokit: 1.18 → 1.19 ``                                            |
| [`9610ad2f`](https://github.com/NixOS/nixpkgs/commit/9610ad2feed0429be3bae67089f7187415c871ec) | `` ocamlPackages.janestreet: use 0.16.0 tag rather than 0.16 branch ``                |
| [`3dbd0292`](https://github.com/NixOS/nixpkgs/commit/3dbd0292da754d0a8a75dfa93056ecf08927b7ce) | `` python310Packages.ring-doorbell: 0.8.3 -> 0.8.5 ``                                 |
| [`6acbbb27`](https://github.com/NixOS/nixpkgs/commit/6acbbb27345c72fee35dc74f1b4eede736e0a264) | `` python310Packages.rapidgzip: 0.10.4 -> 0.11.0 ``                                   |
| [`5023c10c`](https://github.com/NixOS/nixpkgs/commit/5023c10cbf0938fd7c4bc178e08b69471e83eeca) | `` php.packages.grumphp: 2.1.0 -> 2.4.0 ``                                            |
| [`7af913d5`](https://github.com/NixOS/nixpkgs/commit/7af913d5dc8a60e5cc22a6192f773b12c5cde79b) | `` python310Packages.qdrant-client: 1.6.2 -> 1.7.0 ``                                 |
| [`df22fb01`](https://github.com/NixOS/nixpkgs/commit/df22fb01dfdd4e35ddb6b8edbb3c709deaa353a2) | `` julia.withPackages: better error message on missing nix-sha256 hash ``             |
| [`820f1a3b`](https://github.com/NixOS/nixpkgs/commit/820f1a3bbed58ce341b63b1fe6678a36059fbafe) | `` julia.withPackages: bump the augmented registry to pick up a few hash fixes ``     |
| [`ded8563f`](https://github.com/NixOS/nixpkgs/commit/ded8563fb360bf5c7b1283236cfaef1772903ee9) | `` llama-cpp: assert that only one of the *Support arguments is true ``               |
| [`4ef37025`](https://github.com/NixOS/nixpkgs/commit/4ef37025e674dfe5bf362d22e64c64d6d5a58c04) | `` python310Packages.pytile: 2023.10.0 -> 2023.12.0 ``                                |
| [`5381f312`](https://github.com/NixOS/nixpkgs/commit/5381f312a6cbad38ea2b68ee35a04ee4bf3384a4) | `` python310Packages.python-gvm: 23.11.0 -> 23.12.0 ``                                |
| [`a4fcc87a`](https://github.com/NixOS/nixpkgs/commit/a4fcc87af0bb09d6f95339625c89737120ee2c23) | `` ocamlPackages.minttea: init at 0.0.1 ``                                            |
| [`d6706ffa`](https://github.com/NixOS/nixpkgs/commit/d6706ffac7501d62ab0c57b87727c39520a43f20) | `` python310Packages.pytenable: 1.4.14 -> 1.4.16 ``                                   |
| [`aa73ab5c`](https://github.com/NixOS/nixpkgs/commit/aa73ab5c6a6d6df8244429a1254583c0a4023576) | `` python310Packages.pytelegrambotapi: 4.14.0 -> 4.14.1 ``                            |
| [`cef1da4d`](https://github.com/NixOS/nixpkgs/commit/cef1da4d3257f61aef75e75ceddcb36da5593f63) | `` python310Packages.pyswitchbot: 0.41.0 -> 0.42.0 ``                                 |
| [`8cd0f10b`](https://github.com/NixOS/nixpkgs/commit/8cd0f10bbdfd1ce502f4ed97ad51d0087d437a1b) | `` cri-o-unwrapped: 1.28.2 -> 1.29.0 ``                                               |
| [`2eee8ab5`](https://github.com/NixOS/nixpkgs/commit/2eee8ab5a1ab94228d2cad45d2eecdc111192616) | `` cargo-component: 0.5.0 -> 0.6.0 ``                                                 |
| [`412d278e`](https://github.com/NixOS/nixpkgs/commit/412d278e2acb3fe8fe645ee5475eaa4497942ec1) | `` python310Packages.pysigma: 0.10.9 -> 0.10.10 ``                                    |
| [`be7eb56f`](https://github.com/NixOS/nixpkgs/commit/be7eb56fe07ebad22eb9ce71ae3ea2ee2a5830ff) | `` python310Packages.pyreadstat: 1.2.5 -> 1.2.6 ``                                    |
| [`a6851f8d`](https://github.com/NixOS/nixpkgs/commit/a6851f8df33c9bbe84ad6dadd1994b2d636a351b) | `` linuxptp: 4.1 -> 4.2 ``                                                            |
| [`adf74e11`](https://github.com/NixOS/nixpkgs/commit/adf74e11438ad4e1d6349c920476e1ab6fb8bfda) | `` giada: 0.26.0 -> 0.26.1 ``                                                         |
| [`be64b52d`](https://github.com/NixOS/nixpkgs/commit/be64b52d294fefabf3009d189947927de34bb2fa) | `` grype: 0.73.4 -> 0.73.5 ``                                                         |
| [`cc61f62d`](https://github.com/NixOS/nixpkgs/commit/cc61f62dfe25bec07f85c3c298e6a42dd5036bde) | `` python310Packages.pyoverkiz: 1.13.3 -> 1.13.4 ``                                   |
| [`f0020814`](https://github.com/NixOS/nixpkgs/commit/f00208148de5ea9440e0bcf8a6cf852cbe88f635) | `` cryptowatch-desktop: remove ``                                                     |
| [`d48eb1e7`](https://github.com/NixOS/nixpkgs/commit/d48eb1e795c177ac0613c32ab6d96df9b916f5ed) | `` nuclei: 3.1.2 -> 3.1.3 ``                                                          |
| [`a6ac7f52`](https://github.com/NixOS/nixpkgs/commit/a6ac7f52ce043d50004476f61ff7040adf6cf3ee) | `` python310Packages.pyopenuv: 2023.11.0 -> 2023.12.0 ``                              |
| [`8d36d938`](https://github.com/NixOS/nixpkgs/commit/8d36d9384e1572902d4da64f01ad5fa5164a6dfb) | `` ungoogled-chromium: 120.0.6099.109-1 -> 120.0.6099.129-1 ``                        |
| [`027ec17c`](https://github.com/NixOS/nixpkgs/commit/027ec17c01327a7db9ef1d4946f9294cf22b9c50) | `` chromium: 120.0.6099.109 -> 120.0.6099.129 ``                                      |
| [`f96d36a2`](https://github.com/NixOS/nixpkgs/commit/f96d36a28db7d6ba9549a45d0af3407b55dd5547) | `` chromedriver: 120.0.6099.71 -> 120.0.6099.109 ``                                   |
| [`5d14747f`](https://github.com/NixOS/nixpkgs/commit/5d14747fdc3032a92d0d686d574f8da856eacb09) | `` systemd: Add withBootloader to ukify assertion ``                                  |
| [`1a39d6d1`](https://github.com/NixOS/nixpkgs/commit/1a39d6d109385b6a157882e59222865465c7fc99) | `` python310Packages.pyngo: 1.6.0 -> 1.7.0 ``                                         |
| [`7d1f2d40`](https://github.com/NixOS/nixpkgs/commit/7d1f2d40afac2b7fe58b7d9fe7d5196720467b96) | `` python311Packages.cacheyou: remove ``                                              |
| [`237011e6`](https://github.com/NixOS/nixpkgs/commit/237011e6d8a541359ffc24b0477fc72410176b73) | `` python311Packages.optuna: 3.4.0 -> 3.5.0 ``                                        |
| [`c2f8e670`](https://github.com/NixOS/nixpkgs/commit/c2f8e670dd138deb783e6f212f706d5e1976780b) | `` python310Packages.pymc: 5.10.2 -> 5.10.3 ``                                        |
| [`4ecc674e`](https://github.com/NixOS/nixpkgs/commit/4ecc674e46bb7bf93eed4ca89fbb4ab2dd036c89) | `` tailscale-nginx-auth: Remove unneeded definition in all-packages.nix ``            |
| [`e130ee33`](https://github.com/NixOS/nixpkgs/commit/e130ee33a11ae90585e9f9c09b189c3ccfe70632) | `` pkgs/test/nixpkgs-check-by-name/scripts: Various improvements ``                   |
| [`f882df78`](https://github.com/NixOS/nixpkgs/commit/f882df781ca7eab4ee66fa31dda445937ccaedd3) | `` maintainers/scripts/check-by-name.sh: Introduce symlink alias ``                   |
| [`e3ca8030`](https://github.com/NixOS/nixpkgs/commit/e3ca8030852cd391fdba9eed9dd3da88c83e9538) | `` maintainers: add r-burns to geospatial team ``                                     |
| [`c69f16c8`](https://github.com/NixOS/nixpkgs/commit/c69f16c8ef5a5da94affb329474f9cdbc870bc19) | `` python310Packages.pyinsteon: 1.5.2 -> 1.5.3 ``                                     |
| [`f2449d80`](https://github.com/NixOS/nixpkgs/commit/f2449d80e4e256eb1c258c1bf57cda28736a3ca5) | `` python310Packages.pyiqvia: 2023.10.0 -> 2023.12.0 ``                               |
| [`4b01795b`](https://github.com/NixOS/nixpkgs/commit/4b01795b389ef461fa9e9b4ccacfa1d8a5ccd027) | `` python310Packages.pygtkspellcheck: 5.0.2 -> 5.0.3 ``                               |
| [`cf436245`](https://github.com/NixOS/nixpkgs/commit/cf436245785d651423c0d54ceb62484abedf8100) | `` flowtime: fix build ``                                                             |
| [`6b3932ed`](https://github.com/NixOS/nixpkgs/commit/6b3932ed4ac315951f8fdcbf7bd42ebace6b56a0) | `` harmonia: fix build on darwin ``                                                   |
| [`32957cdf`](https://github.com/NixOS/nixpkgs/commit/32957cdfabd1dcae65351000f2139583b3506fdb) | `` python311Packages.slackclient: 3.26.0 -> 3.26.1 ``                                 |
| [`03735b2b`](https://github.com/NixOS/nixpkgs/commit/03735b2b3dacb683737abbb18b536d774bf6a29f) | `` python310Packages.pydrive2: 1.17.0 -> 1.18.1 ``                                    |
| [`c4933514`](https://github.com/NixOS/nixpkgs/commit/c493351419cceb59cdda786095fd58f2ece38ba0) | `` python310Packages.pydrawise: 2023.11.0 -> 2023.12.0 ``                             |
| [`a0f1bb16`](https://github.com/NixOS/nixpkgs/commit/a0f1bb16a2a40200b41344457fe1495658fb2eb3) | `` python311Packages.devialet: 1.4.3 -> 1.4.5 ``                                      |
| [`74e47e4b`](https://github.com/NixOS/nixpkgs/commit/74e47e4bf3c95ac378ba7aa876cbd9e8dfab2902) | `` python311Packages.habluetooth: 1.0.0 -> 2.0.0 ``                                   |
| [`ad07fbfa`](https://github.com/NixOS/nixpkgs/commit/ad07fbfa1e65d96927f880f91a3a316faa2493a4) | ``  python310Packages.ocifs: update changelog entry ``                                |
| [`e016ac8b`](https://github.com/NixOS/nixpkgs/commit/e016ac8b741fcee62c3527d81315ef747356205a) | `` python310Packages.pyairvisual: remove postPatch section ``                         |
| [`062a0f6f`](https://github.com/NixOS/nixpkgs/commit/062a0f6f61e685edfc3671113a10d4b9148ec7db) | `` python310Packages.pyairvisual: 2023.11.0 -> 2023.12.0 ``                           |
| [`72ff6b5f`](https://github.com/NixOS/nixpkgs/commit/72ff6b5fcf58e093b5b53d4d7508df860c4f2528) | `` tree-sitter-grammars.tree-sitter-nu: use official repo ``                          |
| [`7225eb64`](https://github.com/NixOS/nixpkgs/commit/7225eb645b94f8598b6cc13a87a74ab2e95cc4df) | `` python310Packages.publicsuffixlist: 0.10.0.20231122 -> 0.10.0.20231214 ``          |
| [`6141d1bd`](https://github.com/NixOS/nixpkgs/commit/6141d1bdd564db542b9c2d3ee1ec6f25c02d740f) | `` llama-cpp: 1573 -> 1671 ``                                                         |
| [`25f831de`](https://github.com/NixOS/nixpkgs/commit/25f831dea6df6a87bd91c39e6dcacf39f5cb6074) | `` deno: 1.39.0 -> 1.39.1 ``                                                          |
| [`b6755f13`](https://github.com/NixOS/nixpkgs/commit/b6755f13b7c0f56bf9a2953dbfea3cfbad8513e4) | `` python310Packages.google-cloud-bigquery-logging: refactor ``                       |
| [`9943f17e`](https://github.com/NixOS/nixpkgs/commit/9943f17e0da860a291e4e5d9d86557a3235254a8) | `` python310Packages.podman: 4.8.0.post1 -> 4.8.1 ``                                  |
| [`c757971d`](https://github.com/NixOS/nixpkgs/commit/c757971da1e72fba651fd0e77488bbe172b05420) | `` clang17Stdenv: add definition ``                                                   |
| [`33e277b4`](https://github.com/NixOS/nixpkgs/commit/33e277b41590a1ed0ec87f89a598b846bcca5fe8) | `` python311Packages.oracledb: refactor ``                                            |
| [`25c947b3`](https://github.com/NixOS/nixpkgs/commit/25c947b3fc7b219e8ce3302b35d868194c57a20f) | `` steam: make privateTmp overrideable ``                                             |
| [`aa070a5d`](https://github.com/NixOS/nixpkgs/commit/aa070a5d9a9d217c186a172fc44877992c5c5542) | `` buildFHSEnv: fix privateTmp for sddm ``                                            |
| [`d17d1a37`](https://github.com/NixOS/nixpkgs/commit/d17d1a370d18fd9927991145fbabb96bb9e044b5) | `` ocamlPackages.tty: init at 0.0.2 ``                                                |
| [`ecd5cfdc`](https://github.com/NixOS/nixpkgs/commit/ecd5cfdc16b01656a9ca3ff98051f16fd5067362) | `` python310Packages.peft: 0.6.2 -> 0.7.1 ``                                          |
| [`04f1b554`](https://github.com/NixOS/nixpkgs/commit/04f1b554cedecb9940b86d6963a2bfebe2e1e2fd) | `` tectonic: redefine to wrap it with `biber-for-tectonic` ``                         |
| [`0a85473c`](https://github.com/NixOS/nixpkgs/commit/0a85473c1244cb285a96877febb7944c67c50559) | `` tectonic: symlink nextonic for all platforms ``                                    |
| [`b37adfc0`](https://github.com/NixOS/nixpkgs/commit/b37adfc009b0a292caf0a222405e85e9808bb0f7) | `` doc: Clarify dependency propagation ``                                             |
| [`8ac1c151`](https://github.com/NixOS/nixpkgs/commit/8ac1c1519dd5e1fa9105f9eae3398c906b0e7bfe) | `` python310Packages.peaqevcore: 19.5.21 -> 19.5.23 ``                                |
| [`a1aee655`](https://github.com/NixOS/nixpkgs/commit/a1aee655a02c2b53a0e706eda043b2d2a9e6957d) | `` crate2nix: 0.11.0 -> 0.12.0 ``                                                     |
| [`6c991227`](https://github.com/NixOS/nixpkgs/commit/6c991227dcd7253858340335ae1a706ff9605e54) | `` python310Packages.parametrize-from-file: 0.18.0 -> 0.19.0 ``                       |
| [`e36f5af1`](https://github.com/NixOS/nixpkgs/commit/e36f5af1c2bc808a8cae71fa743a87acce66d08a) | `` talosctl: 1.5.5 -> 1.6.0 ``                                                        |
| [`324c5e79`](https://github.com/NixOS/nixpkgs/commit/324c5e79859c2553d79a0b15f699f31ec37a8cb9) | `` python310Packages.packageurl-python: 0.11.2 -> 0.13.1 ``                           |
| [`ee22046a`](https://github.com/NixOS/nixpkgs/commit/ee22046a6ba80a8269fcf08fb221fb75343fcd66) | `` ooniprobe-cli: unpin go1.20 ``                                                     |
| [`61db89f4`](https://github.com/NixOS/nixpkgs/commit/61db89f44d68c4d183a62c051fbdbbc9d0aa3b42) | `` eos-installer: 5.0.2 -> 5.1.0 ``                                                   |
| [`dad9f6fa`](https://github.com/NixOS/nixpkgs/commit/dad9f6fa02de0b7fc98f70e0656079ac54fee7ad) | `` atomic-swap: 0.4.2 -> 0.4.3 ``                                                     |
| [`6a39c235`](https://github.com/NixOS/nixpkgs/commit/6a39c2355fd07f1b6e94fea02ad6fc6f2e1a41e6) | `` evince.meta.mainProgram: init ``                                                   |
| [`0ebee702`](https://github.com/NixOS/nixpkgs/commit/0ebee702bd4b855d3759ef747f60e190001aa8e9) | `` python310Packages.ossfs: 2023.8.0 -> 2023.12.0 ``                                  |
| [`da79a3c5`](https://github.com/NixOS/nixpkgs/commit/da79a3c547e946e8b9d3973f8361cc2bef6b3158) | `` python310Packages.oracledb: 1.4.2 -> 2.0.0 ``                                      |
| [`666c6b29`](https://github.com/NixOS/nixpkgs/commit/666c6b294424f5631ec70e5282e1cc915e51a90d) | `` cinnamon.cinnamon-screensaver: 6.0.0 -> 6.0.1 ``                                   |
| [`ec93a698`](https://github.com/NixOS/nixpkgs/commit/ec93a69823ef0b8cc45b0134f8b6bafbe371f0ca) | `` cinnamon.mint-y-icons: 1.7.0 -> 1.7.1 ``                                           |
| [`a68d59d0`](https://github.com/NixOS/nixpkgs/commit/a68d59d0796e999da4db62a9bdfd4539b8c54091) | `` gnuradioMinimal: 3.10.7.0 -> 3.10.8.0 ``                                           |
| [`2b348b79`](https://github.com/NixOS/nixpkgs/commit/2b348b79c1daf73c9bb436d71e470e6d4e51fed6) | `` gnuradio3_9Minimal: use a backported modtool patch ``                              |
| [`06bec0d0`](https://github.com/NixOS/nixpkgs/commit/06bec0d01b31197c4b5fb3f72cbab76f0c239475) | `` nixosTests.musescore: fix for version 4.2.0 ``                                     |
| [`4be85af6`](https://github.com/NixOS/nixpkgs/commit/4be85af63e78aadaa0afebf7b431a3b485061a2c) | `` python311Packages.justnimbus: update disabled ``                                   |
| [`701dae72`](https://github.com/NixOS/nixpkgs/commit/701dae72f54684ecb2d3d89e5cbd0556a9d6e289) | `` zotero_7: change platforms to x86_64-linux only ``                                 |
| [`687239b5`](https://github.com/NixOS/nixpkgs/commit/687239b5708a346165825fc07e9759b5ebb8b698) | `` planify: 4.3.1 -> 4.3.2 ``                                                         |
| [`6ce1bc17`](https://github.com/NixOS/nixpkgs/commit/6ce1bc17b65ce6effcce0ae9405889a6a2810feb) | `` zotero: change platforms to x86_64-linux only ``                                   |
| [`97ae679e`](https://github.com/NixOS/nixpkgs/commit/97ae679e7fccad1003a3bfd72664aa2d13245130) | `` pcsx2: 1.7.5004 -> 1.7.5318 ``                                                     |
| [`130c0ef3`](https://github.com/NixOS/nixpkgs/commit/130c0ef342ffd0dcac677e7e3ab27937da7e2a78) | `` python310Packages.onnxmltools: 1.11.2 -> 1.12.0 ``                                 |
| [`9dfb0b34`](https://github.com/NixOS/nixpkgs/commit/9dfb0b342a5d69b0e9845eba5d240d4093a63169) | `` python310Packages.okta: 2.9.3 -> 2.9.5 ``                                          |
| [`1ab2c857`](https://github.com/NixOS/nixpkgs/commit/1ab2c8570953ddb48a4d297acc1a31669af7323c) | `` asusctl: 5.0.0 -> 5.0.2 ``                                                         |
| [`0ecaa59c`](https://github.com/NixOS/nixpkgs/commit/0ecaa59c7bb7ae53a4b129545e175554eebb7dc1) | `` honk: 1.1.1 -> 1.2.0 ``                                                            |
| [`292ea0d9`](https://github.com/NixOS/nixpkgs/commit/292ea0d917b1eae4ed51e6cde8b79bb519b5fdd3) | `` doc: migrate examples in testers chapter to admonitions (#275791) ``               |
| [`aeeb6556`](https://github.com/NixOS/nixpkgs/commit/aeeb655646bf2561d6a8c1a801193ec1c10a174e) | `` service buildkite-agent: make it possible add groups to agent users ``             |
| [`8d102bc4`](https://github.com/NixOS/nixpkgs/commit/8d102bc4fb196d599f50361372b8c63307fa750b) | `` python310Packages.oelint-parser: 2.12.0 -> 2.12.1 ``                               |
| [`9e046794`](https://github.com/NixOS/nixpkgs/commit/9e046794a8a9bc168e970cc12dfd39623a7ed9bf) | `` flutter: dont fail on missing lockfile ``                                          |
| [`145c291c`](https://github.com/NixOS/nixpkgs/commit/145c291ca67f58813547a47b0a1837c303649ce7) | `` fetchDartDeps: Use add milliseconds to date in package_config.json ``              |
| [`03ae92a1`](https://github.com/NixOS/nixpkgs/commit/03ae92a17d0f9683a1da5eaee77b0497a0d7ba66) | `` flutter: Remove aarch64-darwin platform ``                                         |
| [`133d03eb`](https://github.com/NixOS/nixpkgs/commit/133d03eb429f942ff7b901395655d305fe38760a) | `` flutter: Set FLUTTER_ALREADY_LOCKED to prevent writes to the immutable lockfile `` |
| [`d8b20d93`](https://github.com/NixOS/nixpkgs/commit/d8b20d93adc539114de5401514f4d937aaac34aa) | `` flutter: Remove FLUTTER_CACHE_DIR ``                                               |
| [`98183187`](https://github.com/NixOS/nixpkgs/commit/981831870d06f028245751b64fd5a3c012343ede) | `` flutter: Remove runHooks in fetch-artifacts.nix runCommand ``                      |
| [`27f61f5e`](https://github.com/NixOS/nixpkgs/commit/27f61f5e1b695a9accb71886f380513e1b0e4ef3) | `` flutter: Remove existing .git directories ``                                       |
| [`456779ed`](https://github.com/NixOS/nixpkgs/commit/456779edc2c55bb0cdd4220d1850b4a7e1ff161a) | `` flutter: Move artifact override logic to fetch-artifacts.nix ``                    |
| [`c969311b`](https://github.com/NixOS/nixpkgs/commit/c969311bc58e5a62b7bf6e334ded06cfbfdce948) | `` flutter: Add artifact hashes for all platforms ``                                  |
| [`c5244273`](https://github.com/NixOS/nixpkgs/commit/c524427335774e952acd9af74bd84b6ee9267304) | `` flutter: Set host platform at compilation ``                                       |
| [`17a034de`](https://github.com/NixOS/nixpkgs/commit/17a034deaf62ad70fc7b4744dcbdd02610c63893) | `` flutter: Add platform artifact derivations to cacheDir passthru ``                 |
| [`ef3625ff`](https://github.com/NixOS/nixpkgs/commit/ef3625ff565e62fe618804e86716f65ba14e26df) | `` flutter: Link in the fluter_tools package_config.json ``                           |