### PR TITLE
chore(flake/nur): `f361a813` -> `0114c61b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703393074,
-        "narHash": "sha256-FOf2/5pHrBN/AM0JQVkGZ4JYEZSF3dZXlat5xDKzyAQ=",
+        "lastModified": 1703400129,
+        "narHash": "sha256-kiXO+y5RDHfb/0QR0B72NWjuwu3/eSzLJUX90w3VSkE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f361a813dad1da89fcc4b8296e6fdc9fe4d94981",
+        "rev": "0114c61b5a5fba47ae13d6144825691cc39ca104",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0114c61b`](https://github.com/nix-community/NUR/commit/0114c61b5a5fba47ae13d6144825691cc39ca104) | `` automatic update `` |
| [`baf0685e`](https://github.com/nix-community/NUR/commit/baf0685ed3c61b15a3f30de518fe27a20d90e80c) | `` automatic update `` |