### PR TITLE
chore(flake/nur): `0114c61b` -> `1b2a4225`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703400129,
-        "narHash": "sha256-kiXO+y5RDHfb/0QR0B72NWjuwu3/eSzLJUX90w3VSkE=",
+        "lastModified": 1703403895,
+        "narHash": "sha256-PjKHyeUXuswo2y9RZk//po6Wi8yg0xFlOkZHn6WuuN0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0114c61b5a5fba47ae13d6144825691cc39ca104",
+        "rev": "1b2a4225e5ef9efab0c3b890e8c9288ac0a2d8c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1b2a4225`](https://github.com/nix-community/NUR/commit/1b2a4225e5ef9efab0c3b890e8c9288ac0a2d8c7) | `` automatic update `` |
| [`382e3d67`](https://github.com/nix-community/NUR/commit/382e3d672e400c73e772e97472d10ac98e2e0be6) | `` automatic update `` |
| [`598ad6be`](https://github.com/nix-community/NUR/commit/598ad6be50a8eb57c525982825819bfe63c573f1) | `` automatic update `` |