### PR TITLE
chore(flake/nur): `1b2a4225` -> `67820117`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703403895,
-        "narHash": "sha256-PjKHyeUXuswo2y9RZk//po6Wi8yg0xFlOkZHn6WuuN0=",
+        "lastModified": 1703410951,
+        "narHash": "sha256-eGBfFaHJeVztLR2rCHAnw2d4DQeZfl57at1MGUVkkhw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1b2a4225e5ef9efab0c3b890e8c9288ac0a2d8c7",
+        "rev": "67820117ff715d8428a3240e60e2d9fa6226e6df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`67820117`](https://github.com/nix-community/NUR/commit/67820117ff715d8428a3240e60e2d9fa6226e6df) | `` automatic update `` |
| [`46403c0c`](https://github.com/nix-community/NUR/commit/46403c0c8d4d0a4d2e97fcf1548131a7ae9801dc) | `` automatic update `` |