### PR TITLE
chore(flake/nur): `0d2c794f` -> `5767f4e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703418134,
-        "narHash": "sha256-Tj6rLQqW1wi2CvsMF7hy83qfGXFaaUYaBRK4Ju8kaQw=",
+        "lastModified": 1703422376,
+        "narHash": "sha256-1CjZ2a0h9nVg/ewRyYWjyiFi3jKT9EnAB3z8vAs0b8k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0d2c794f23783dfed37135301233ea88e54d0961",
+        "rev": "5767f4e74738c76e02676a9f7c0978901a4701b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5767f4e7`](https://github.com/nix-community/NUR/commit/5767f4e74738c76e02676a9f7c0978901a4701b2) | `` automatic update `` |