### PR TITLE
chore(flake/nur): `5767f4e7` -> `1b23cd59`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703422376,
-        "narHash": "sha256-1CjZ2a0h9nVg/ewRyYWjyiFi3jKT9EnAB3z8vAs0b8k=",
+        "lastModified": 1703425305,
+        "narHash": "sha256-WOdiADpQdqWB9LYdj+8GLV6k/VtobkhjzS4GGBctlag=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5767f4e74738c76e02676a9f7c0978901a4701b2",
+        "rev": "1b23cd590af6fea03dae2872153236ac928967a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1b23cd59`](https://github.com/nix-community/NUR/commit/1b23cd590af6fea03dae2872153236ac928967a8) | `` automatic update `` |