### PR TITLE
chore(flake/pre-commit-hooks): `007a45d0` -> `7f35ec30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -888,11 +888,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1702456155,
-        "narHash": "sha256-I2XhXGAecdGlqi6hPWYT83AQtMgL+aa3ulA85RAEgOk=",
+        "lastModified": 1703426812,
+        "narHash": "sha256-aODSOH8Og8ne4JylPJn+hZ6lyv6K7vE5jFo4KAGIebM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "007a45d064c1c32d04e1b8a0de5ef00984c419bc",
+        "rev": "7f35ec30d16b38fe0eed8005933f418d1a4693ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                  |
| ------------------------------------------------------------------------------------------------------------ | ------------------------ |
| [`88f314e1`](https://github.com/cachix/pre-commit-hooks.nix/commit/88f314e149eb5f65b161cd7d123fa4f624aa4121) | `` feat: add typstfmt `` |