### PR TITLE
chore(flake/nur): `1b23cd59` -> `5392dcef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703425305,
-        "narHash": "sha256-WOdiADpQdqWB9LYdj+8GLV6k/VtobkhjzS4GGBctlag=",
+        "lastModified": 1703432511,
+        "narHash": "sha256-q1eYx9Lvbw6G7qjklae5xtK5XpShdBkEkt3SNLGFmZs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1b23cd590af6fea03dae2872153236ac928967a8",
+        "rev": "5392dcefb7790f08991b7c0c0f29bac99fbc57fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5392dcef`](https://github.com/nix-community/NUR/commit/5392dcefb7790f08991b7c0c0f29bac99fbc57fb) | `` automatic update `` |
| [`177feff8`](https://github.com/nix-community/NUR/commit/177feff8c83f8d1ae09c90daf314f72ad29633a2) | `` automatic update `` |