### PR TITLE
chore(flake/nur): `5392dcef` -> `7b48502f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703432511,
-        "narHash": "sha256-q1eYx9Lvbw6G7qjklae5xtK5XpShdBkEkt3SNLGFmZs=",
+        "lastModified": 1703443414,
+        "narHash": "sha256-MH9VAOGG/LfT5WMmfXqEngxTGjNMXk+J8vblE/+Z61o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5392dcefb7790f08991b7c0c0f29bac99fbc57fb",
+        "rev": "7b48502fd7507a896456b4a73ea946dfd2851b45",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7b48502f`](https://github.com/nix-community/NUR/commit/7b48502fd7507a896456b4a73ea946dfd2851b45) | `` automatic update `` |
| [`dba67bdf`](https://github.com/nix-community/NUR/commit/dba67bdf4444c4d9ff4a599ed193f39b6697db99) | `` automatic update `` |
| [`92a14ef8`](https://github.com/nix-community/NUR/commit/92a14ef8777026ad381aaab8648b55c4e675d874) | `` automatic update `` |
| [`01a95bfb`](https://github.com/nix-community/NUR/commit/01a95bfb0a9b80dc67ca7106cdb8261011d1e938) | `` automatic update `` |
| [`2011abbd`](https://github.com/nix-community/NUR/commit/2011abbdb8be03feb7283ac30b36c96305c2c5f8) | `` automatic update `` |
| [`8834fdd0`](https://github.com/nix-community/NUR/commit/8834fdd01835a72406af67263da041f79b7c8b49) | `` automatic update `` |