### PR TITLE
chore(flake/nur): `7b48502f` -> `5f9f4107`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703443414,
-        "narHash": "sha256-MH9VAOGG/LfT5WMmfXqEngxTGjNMXk+J8vblE/+Z61o=",
+        "lastModified": 1703446910,
+        "narHash": "sha256-j2vcLXLkhnVTtJLaYiRWY2wKG+Jo+F4IYkxkKaKBVdA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7b48502fd7507a896456b4a73ea946dfd2851b45",
+        "rev": "5f9f410799cc9cec3873a7cc9c8ad582b31e053a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5f9f4107`](https://github.com/nix-community/NUR/commit/5f9f410799cc9cec3873a7cc9c8ad582b31e053a) | `` automatic update `` |
| [`cde7d8b2`](https://github.com/nix-community/NUR/commit/cde7d8b22e81948d7c0426ac5383c908a1be513e) | `` automatic update `` |