### PR TITLE
chore(flake/nur): `d4a19e55` -> `ef0c4a7e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703450513,
-        "narHash": "sha256-PP7bxSlSIgPIvWK0ajm4ONutPL9/c844uOjVbOBV47Q=",
+        "lastModified": 1703454138,
+        "narHash": "sha256-mbnYnp7SVMTJmDxmhDlInFbDFxIkvtwmi81AeUOOC98=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d4a19e55673212a350b6f1c3a22eb04173759fab",
+        "rev": "ef0c4a7ef25cc6fd8be8bda4579a20fef020c467",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ef0c4a7e`](https://github.com/nix-community/NUR/commit/ef0c4a7ef25cc6fd8be8bda4579a20fef020c467) | `` automatic update `` |