### PR TITLE
chore(flake/nur): `ef0c4a7e` -> `6897f1bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703454138,
-        "narHash": "sha256-mbnYnp7SVMTJmDxmhDlInFbDFxIkvtwmi81AeUOOC98=",
+        "lastModified": 1703457699,
+        "narHash": "sha256-9t6VB6JbVEeGuxNTsQPHxnfmGN/O0JjAR+LcjR7QsJI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ef0c4a7ef25cc6fd8be8bda4579a20fef020c467",
+        "rev": "6897f1bcf8dcccc980554939f0808c37a0d45113",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6897f1bc`](https://github.com/nix-community/NUR/commit/6897f1bcf8dcccc980554939f0808c37a0d45113) | `` automatic update `` |