### PR TITLE
chore(flake/nur): `434f3388` -> `0a9473ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703461311,
-        "narHash": "sha256-RK/WWQzTf68Dkjtja4YkFEbpFRJnhcVeSG1VQN78HlU=",
+        "lastModified": 1703466531,
+        "narHash": "sha256-oXt1pXz3Mo7SV+0NlQTzsMn4YD+mkpWcMbi/deMgtxM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "434f338861c39a701740df89d78ef9c8e8211d2a",
+        "rev": "0a9473eec8f1a18bd2c42dbaecbad3410f044475",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0a9473ee`](https://github.com/nix-community/NUR/commit/0a9473eec8f1a18bd2c42dbaecbad3410f044475) | `` automatic update `` |
| [`0754d379`](https://github.com/nix-community/NUR/commit/0754d379f3d3a9ee951b402775c6289eb7852d38) | `` automatic update `` |