### PR TITLE
chore(flake/nur): `0a9473ee` -> `89b1adf6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703466531,
-        "narHash": "sha256-oXt1pXz3Mo7SV+0NlQTzsMn4YD+mkpWcMbi/deMgtxM=",
+        "lastModified": 1704318258,
+        "narHash": "sha256-xZHtsT1RhAIrbIufyxjMuaA3A1vvFhb+lUcIFaHRDj8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0a9473eec8f1a18bd2c42dbaecbad3410f044475",
+        "rev": "89b1adf64e178c08b6590f58ae20703bf952158a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                        |
| -------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`89b1adf6`](https://github.com/nix-community/NUR/commit/89b1adf64e178c08b6590f58ae20703bf952158a) | `` automatic update ``         |
| [`66bed8c7`](https://github.com/nix-community/NUR/commit/66bed8c7853673ba7919664f94a99deea137b916) | `` automatic update ``         |
| [`db4386e7`](https://github.com/nix-community/NUR/commit/db4386e7cc973ff586b908d8bbe1a633f1c99abd) | `` automatic update ``         |
| [`38754d8a`](https://github.com/nix-community/NUR/commit/38754d8aa5465f4901897d4611dfc5d54cc495fd) | `` automatic update ``         |
| [`1fa84d31`](https://github.com/nix-community/NUR/commit/1fa84d31a6d8a254ce76f2786d1cbeddd36b5313) | `` automatic update ``         |
| [`b1fd39a9`](https://github.com/nix-community/NUR/commit/b1fd39a9b3723045717cc34b5bf53497a95eb44c) | `` automatic update ``         |
| [`2b70a81b`](https://github.com/nix-community/NUR/commit/2b70a81bc17f303a957c000e149930256456ae6e) | `` automatic update ``         |
| [`741fa837`](https://github.com/nix-community/NUR/commit/741fa837c5fcf4fd65b05211973164d7dfdd3cd2) | `` automatic update ``         |
| [`66f8fbde`](https://github.com/nix-community/NUR/commit/66f8fbded8a9b9a6f4e17a5d8105bcd29d4ec7f8) | `` automatic update ``         |
| [`f1b9bd10`](https://github.com/nix-community/NUR/commit/f1b9bd1063d15007b9d1aa65908b82c8450e74c8) | `` automatic update ``         |
| [`80b09327`](https://github.com/nix-community/NUR/commit/80b09327e4473663fcb1551d81ae80d7e2222ad2) | `` automatic update ``         |
| [`a18213c7`](https://github.com/nix-community/NUR/commit/a18213c74e43dd6e941c41d77382377938c77caf) | `` automatic update ``         |
| [`dcb7c95d`](https://github.com/nix-community/NUR/commit/dcb7c95dddac213211a5bf1d97eed5a9f70c60d2) | `` automatic update ``         |
| [`d6e705ac`](https://github.com/nix-community/NUR/commit/d6e705ac9128d0a11b63c038e7650167db53512d) | `` automatic update ``         |
| [`02ace585`](https://github.com/nix-community/NUR/commit/02ace58544351917b59b7f0013c188912e47ebe5) | `` automatic update ``         |
| [`87aee2a2`](https://github.com/nix-community/NUR/commit/87aee2a230db9b4cca350d474fc4473edec95122) | `` automatic update ``         |
| [`bf390c04`](https://github.com/nix-community/NUR/commit/bf390c044dfeeb7471fc931f5953c723028ce0fe) | `` automatic update ``         |
| [`a0adf78e`](https://github.com/nix-community/NUR/commit/a0adf78e6680b8b132ae861c8a9bd6adc3c8f454) | `` automatic update ``         |
| [`fc626f5c`](https://github.com/nix-community/NUR/commit/fc626f5c98706d0fb9957e368c9edda7164285d6) | `` automatic update ``         |
| [`cf625284`](https://github.com/nix-community/NUR/commit/cf62528497fa3e11c7daafd05821dac5d2fe448d) | `` automatic update ``         |
| [`1dc7195c`](https://github.com/nix-community/NUR/commit/1dc7195c56853f34d000548acf34a0beda1f2d1e) | `` automatic update ``         |
| [`5467d9da`](https://github.com/nix-community/NUR/commit/5467d9dafb4ec6ef3c0e586a19edeca471e35d74) | `` automatic update ``         |
| [`eb659aad`](https://github.com/nix-community/NUR/commit/eb659aad761c1bee0d9c43dd1dbef0a89fe1c8e6) | `` automatic update ``         |
| [`e3b2a9db`](https://github.com/nix-community/NUR/commit/e3b2a9dbc39951b17715d8693d922a511908eea9) | `` automatic update ``         |
| [`67ab1d8d`](https://github.com/nix-community/NUR/commit/67ab1d8d9ce6ae6fd90e3a2d232dc456d68054af) | `` automatic update ``         |
| [`15c21804`](https://github.com/nix-community/NUR/commit/15c21804fe31e8b130e0ddbdc399206893c7b2e9) | `` automatic update ``         |
| [`beeec86f`](https://github.com/nix-community/NUR/commit/beeec86f761b1bf829816dcd76f0c4a4b0c04f1f) | `` automatic update ``         |
| [`1fe60928`](https://github.com/nix-community/NUR/commit/1fe60928196cd99c6ee4174e45807bac14157b44) | `` automatic update ``         |
| [`f80fe108`](https://github.com/nix-community/NUR/commit/f80fe108a0330346750c8046f5317bbf3142f3b2) | `` automatic update ``         |
| [`bd8edaef`](https://github.com/nix-community/NUR/commit/bd8edaefd4b718f18a54b50dfc019d4984165bd4) | `` automatic update ``         |
| [`54dbeb7f`](https://github.com/nix-community/NUR/commit/54dbeb7fa6a0bd93c2d718f208475a917bef8583) | `` automatic update ``         |
| [`aec84dd1`](https://github.com/nix-community/NUR/commit/aec84dd179f5624519bb6de40a851bc478d95087) | `` automatic update ``         |
| [`f5649c29`](https://github.com/nix-community/NUR/commit/f5649c296d674ba1e0f453ea2c7f0ec4b3fe1a85) | `` automatic update ``         |
| [`c4f5f8be`](https://github.com/nix-community/NUR/commit/c4f5f8beacb9819f19dbae1d1e09c2dfd404d542) | `` automatic update ``         |
| [`73591ab8`](https://github.com/nix-community/NUR/commit/73591ab82b405fb016505209a5976d728bf0bc74) | `` automatic update ``         |
| [`41ca16a8`](https://github.com/nix-community/NUR/commit/41ca16a8bbaf2c9b4987e12cad98629fb5f9cb86) | `` automatic update ``         |
| [`4756ed6d`](https://github.com/nix-community/NUR/commit/4756ed6d2e9ae5b23cc56a03b9871ba0e90134d7) | `` automatic update ``         |
| [`587d5e66`](https://github.com/nix-community/NUR/commit/587d5e66dea3eea71ef5e195264699e040309d43) | `` automatic update ``         |
| [`50b26b41`](https://github.com/nix-community/NUR/commit/50b26b41841d7f618c9dbe0c6826b2a603acb456) | `` automatic update ``         |
| [`5aaff8bf`](https://github.com/nix-community/NUR/commit/5aaff8bf9354976e682c034b184a3298c8c30f3e) | `` automatic update ``         |
| [`6a4c627e`](https://github.com/nix-community/NUR/commit/6a4c627e8b6504f328d60a0cb1f373f6f6e3f40e) | `` automatic update ``         |
| [`4d8d1aae`](https://github.com/nix-community/NUR/commit/4d8d1aae1d7051cd50ad1edffb5a5a357b309ac4) | `` automatic update ``         |
| [`10d8f5cc`](https://github.com/nix-community/NUR/commit/10d8f5cc60bf34234f7458f7de4c2f6a9a8e269e) | `` automatic update ``         |
| [`e38743b3`](https://github.com/nix-community/NUR/commit/e38743b38ea8d67057d36b71af414e3d8aee68e1) | `` automatic update ``         |
| [`c8fdd6ad`](https://github.com/nix-community/NUR/commit/c8fdd6ad6e3d41b1af7b9547bacf154831533949) | `` add fanbb2333 repository `` |
| [`57697230`](https://github.com/nix-community/NUR/commit/57697230c5cbfab52f2b381c2a3f8a1ba9576840) | `` automatic update ``         |
| [`ecd50a02`](https://github.com/nix-community/NUR/commit/ecd50a0280e27bb4f21226996e9748635116bf66) | `` automatic update ``         |
| [`83b31a89`](https://github.com/nix-community/NUR/commit/83b31a89dd9cdb757f9afbab8671f8b8394ad937) | `` automatic update ``         |
| [`f3ab696b`](https://github.com/nix-community/NUR/commit/f3ab696ba7cb134655e10046fa20a0c416fa0870) | `` automatic update ``         |
| [`f7695851`](https://github.com/nix-community/NUR/commit/f7695851ed39b95d6d76a19074a3cda8a7649c57) | `` automatic update ``         |
| [`5bdfeb3f`](https://github.com/nix-community/NUR/commit/5bdfeb3f39c979ca6316b814334c4473af1a2af2) | `` automatic update ``         |
| [`4de02a5e`](https://github.com/nix-community/NUR/commit/4de02a5e743d4a4c48556c56d6248fbef8b2fe63) | `` automatic update ``         |
| [`53d3ef23`](https://github.com/nix-community/NUR/commit/53d3ef23e9a372e36d297a82788e322cdff9211e) | `` automatic update ``         |
| [`08b00e3e`](https://github.com/nix-community/NUR/commit/08b00e3e5a6934452fbfaeea217e0afe35cd2107) | `` automatic update ``         |
| [`831a8dde`](https://github.com/nix-community/NUR/commit/831a8dde2ee59d3b950981ecfc12472240431d14) | `` automatic update ``         |
| [`820a4b9b`](https://github.com/nix-community/NUR/commit/820a4b9b2f9111fb71d41794b38ffd46bb7e81ed) | `` automatic update ``         |
| [`df1a53ad`](https://github.com/nix-community/NUR/commit/df1a53ad85c6582efda6403ed55ea9cb0cd04725) | `` automatic update ``         |
| [`e536b1fe`](https://github.com/nix-community/NUR/commit/e536b1fe291512fe69a33c3833c5458a4e941f89) | `` automatic update ``         |
| [`68dc852a`](https://github.com/nix-community/NUR/commit/68dc852ad8dd574496177886c6391624aa2d5cf4) | `` automatic update ``         |
| [`c56ab874`](https://github.com/nix-community/NUR/commit/c56ab874a3d53b630e946536612e748a7cd9f2f4) | `` automatic update ``         |
| [`0529839a`](https://github.com/nix-community/NUR/commit/0529839a62a15cda326e38353f9c10a4efa01d60) | `` automatic update ``         |
| [`a46e51e4`](https://github.com/nix-community/NUR/commit/a46e51e4007f5149ad968b9fea4e1ede810e9d4f) | `` automatic update ``         |
| [`a5413575`](https://github.com/nix-community/NUR/commit/a5413575b81cb56dce59556c7abd06471ea48079) | `` automatic update ``         |
| [`208f690e`](https://github.com/nix-community/NUR/commit/208f690e4d018ea3e13881585437ae0d06c6065e) | `` automatic update ``         |
| [`973881d7`](https://github.com/nix-community/NUR/commit/973881d7f88dedc2c649cb45e07643cde908d1fa) | `` automatic update ``         |
| [`6f294785`](https://github.com/nix-community/NUR/commit/6f294785b6ca79518ddfebe0c40adfdb9cf1ea07) | `` automatic update ``         |
| [`4eb694e7`](https://github.com/nix-community/NUR/commit/4eb694e7267683422b14c1d74e3ffe002f1e1aec) | `` automatic update ``         |
| [`efcd827b`](https://github.com/nix-community/NUR/commit/efcd827bf9525a5651210cbc086805098a592521) | `` automatic update ``         |
| [`bf45725e`](https://github.com/nix-community/NUR/commit/bf45725e8b11129ea5a1d72379a4c0e345953877) | `` automatic update ``         |
| [`3c017cea`](https://github.com/nix-community/NUR/commit/3c017ceae9a15b87410f851dcdfb2c6c02926b46) | `` automatic update ``         |
| [`92108644`](https://github.com/nix-community/NUR/commit/92108644e553bf238967b8c2e94d95601d735ade) | `` automatic update ``         |
| [`2036de4f`](https://github.com/nix-community/NUR/commit/2036de4fc4565b2846550f1b394c90925fcb9a35) | `` automatic update ``         |
| [`23c0b204`](https://github.com/nix-community/NUR/commit/23c0b204f84d2102a74bf2d418176c1d4d68ae7b) | `` automatic update ``         |
| [`a2afdf62`](https://github.com/nix-community/NUR/commit/a2afdf627e282fb8d49ec6b350a918c2dbcc3841) | `` automatic update ``         |
| [`2e4c857d`](https://github.com/nix-community/NUR/commit/2e4c857ddaed1504a75e65798e674f5900c1ec65) | `` automatic update ``         |
| [`8b173557`](https://github.com/nix-community/NUR/commit/8b173557cc4e5d4863d124305d22439a59897fef) | `` automatic update ``         |
| [`1d141c1e`](https://github.com/nix-community/NUR/commit/1d141c1e5a40fdbb0d6bda1a3659abe9473f35cb) | `` automatic update ``         |
| [`6008b120`](https://github.com/nix-community/NUR/commit/6008b1209f94b267180d0aef36282ac475da1ca6) | `` automatic update ``         |
| [`d1c91de8`](https://github.com/nix-community/NUR/commit/d1c91de8254a62482196c47e76bc843fe8a59737) | `` automatic update ``         |
| [`d9d55ae5`](https://github.com/nix-community/NUR/commit/d9d55ae54f313a47a57a611bbf598146191ad909) | `` automatic update ``         |
| [`7fba18f4`](https://github.com/nix-community/NUR/commit/7fba18f465bfcaa2db914bf7dc34890d50bc36b4) | `` automatic update ``         |
| [`ad3024a9`](https://github.com/nix-community/NUR/commit/ad3024a9a3c60c6cae8e745e3102ce21c2d3c1c1) | `` automatic update ``         |
| [`de139669`](https://github.com/nix-community/NUR/commit/de13966951704dce6336c96abc916609c854010b) | `` automatic update ``         |
| [`f570501d`](https://github.com/nix-community/NUR/commit/f570501d5051709bb88d85401e38f80ec66bebc0) | `` automatic update ``         |
| [`05c37c23`](https://github.com/nix-community/NUR/commit/05c37c231776633626f2faf483c9a67f7352399a) | `` automatic update ``         |
| [`4c613fb6`](https://github.com/nix-community/NUR/commit/4c613fb62e6c49b856eb1caba3e6be6ab7fbbb5a) | `` automatic update ``         |
| [`f0124b3e`](https://github.com/nix-community/NUR/commit/f0124b3e793839c29f88d9b50f32517b370fcff9) | `` automatic update ``         |
| [`ce876c96`](https://github.com/nix-community/NUR/commit/ce876c96e286d1f53e683fc4343335bbff9e9670) | `` automatic update ``         |
| [`fbb8789b`](https://github.com/nix-community/NUR/commit/fbb8789b92dce8870606027d97b0074435d91ffc) | `` automatic update ``         |
| [`74bee334`](https://github.com/nix-community/NUR/commit/74bee334e8d3cadfe11fefea2ae426e0c25246d7) | `` automatic update ``         |
| [`e3a2c227`](https://github.com/nix-community/NUR/commit/e3a2c227b7de1a72acd98028d8c0cb6f3e2cec60) | `` automatic update ``         |
| [`482be435`](https://github.com/nix-community/NUR/commit/482be435861d41bbd09d9184ad15b29227d08e9a) | `` automatic update ``         |
| [`007a7cfd`](https://github.com/nix-community/NUR/commit/007a7cfd5ce34ae23ff23b643e8f10c7c83ad5c1) | `` automatic update ``         |
| [`9dea3c00`](https://github.com/nix-community/NUR/commit/9dea3c00808304777d56dfda1b52ef942538c299) | `` automatic update ``         |
| [`f675fc1d`](https://github.com/nix-community/NUR/commit/f675fc1d7301e8ad2c0d2c66a8d4970951cb7e58) | `` automatic update ``         |
| [`cb219cf4`](https://github.com/nix-community/NUR/commit/cb219cf4a8d325e5033b62d49f199630033daa43) | `` automatic update ``         |
| [`dabcec65`](https://github.com/nix-community/NUR/commit/dabcec657ae9207298c8b7aa88ff2311d531a970) | `` automatic update ``         |
| [`3863e560`](https://github.com/nix-community/NUR/commit/3863e5608ec295f87d67ce2a24518147ba85e0f9) | `` automatic update ``         |
| [`78f570d4`](https://github.com/nix-community/NUR/commit/78f570d42d724fd1f2af27bc8dbcd908c372c702) | `` automatic update ``         |
| [`ca692c7f`](https://github.com/nix-community/NUR/commit/ca692c7f2a99c8e7f3b8e0e5dcf46b487f7d070f) | `` automatic update ``         |
| [`226929e8`](https://github.com/nix-community/NUR/commit/226929e8cc2b5d634c27b5bf1b1ebb4fcc2ec9d5) | `` automatic update ``         |
| [`c1a78c7e`](https://github.com/nix-community/NUR/commit/c1a78c7eeacb194aef527a7f41910f3866e2f14b) | `` automatic update ``         |
| [`7872cce6`](https://github.com/nix-community/NUR/commit/7872cce6f656b96c49a1f79b76d97492b87c6185) | `` automatic update ``         |
| [`2143145a`](https://github.com/nix-community/NUR/commit/2143145af49db2c3cd1b379b147bf34492e0e0a7) | `` automatic update ``         |
| [`630d6092`](https://github.com/nix-community/NUR/commit/630d609286dfd153f2fcd404527d71214196ba8d) | `` automatic update ``         |
| [`19501f4f`](https://github.com/nix-community/NUR/commit/19501f4ff5561cd21fce3e6602a9fd6325038fd0) | `` automatic update ``         |
| [`4c3eb3a9`](https://github.com/nix-community/NUR/commit/4c3eb3a95083bfe47b5bd0ba58bb161d3abad053) | `` automatic update ``         |
| [`8d103e25`](https://github.com/nix-community/NUR/commit/8d103e25b2d71e2e17b0893a3005c757ac79b71a) | `` automatic update ``         |
| [`2c3a6ba2`](https://github.com/nix-community/NUR/commit/2c3a6ba262d51397ea99def5b9f792533812970b) | `` automatic update ``         |
| [`5b1aa66b`](https://github.com/nix-community/NUR/commit/5b1aa66bea0076ffcf00c2491ae9be1015fd8533) | `` automatic update ``         |
| [`ac64c155`](https://github.com/nix-community/NUR/commit/ac64c1551114d5eb7343e55d8a83f2d84d21884b) | `` automatic update ``         |
| [`27b04d28`](https://github.com/nix-community/NUR/commit/27b04d2815108642a2427e471ad93695e297fa10) | `` automatic update ``         |
| [`796747b3`](https://github.com/nix-community/NUR/commit/796747b378e54debbca6324327ca33b886f54612) | `` automatic update ``         |
| [`da98676b`](https://github.com/nix-community/NUR/commit/da98676bb8b9485a0f828aa05653f12bebf93bbf) | `` automatic update ``         |
| [`d3aae6da`](https://github.com/nix-community/NUR/commit/d3aae6da4d1546ffe8ee461076ddf79c8aeef142) | `` automatic update ``         |
| [`0e355dee`](https://github.com/nix-community/NUR/commit/0e355dee364d5d78cb87db503709bb16bf4b3c52) | `` automatic update ``         |
| [`3bd965ac`](https://github.com/nix-community/NUR/commit/3bd965ac372d2d65800cdab1308c47f6adf8f505) | `` automatic update ``         |
| [`095f3462`](https://github.com/nix-community/NUR/commit/095f3462691861ac39f3b42e77f8f5bba56bfa88) | `` automatic update ``         |
| [`7c6b68d9`](https://github.com/nix-community/NUR/commit/7c6b68d9805e5ba7d62ff169ce16702b59af0a39) | `` automatic update ``         |
| [`ad45251f`](https://github.com/nix-community/NUR/commit/ad45251f54e0a7cee3592e3af1ec58b568d2f02c) | `` automatic update ``         |
| [`046445f2`](https://github.com/nix-community/NUR/commit/046445f2b38b7a8ddc5c41463e10dad5d1fc01da) | `` automatic update ``         |
| [`03922b58`](https://github.com/nix-community/NUR/commit/03922b5827645eb91d9e3b617d9cb3965840fae2) | `` automatic update ``         |
| [`6522bf5b`](https://github.com/nix-community/NUR/commit/6522bf5bce59a0bc9960c9d79a70765204f64af0) | `` automatic update ``         |
| [`a2e8e02e`](https://github.com/nix-community/NUR/commit/a2e8e02eb768e57c578a9ce4feb1c58e497e34d2) | `` automatic update ``         |
| [`945e1bb3`](https://github.com/nix-community/NUR/commit/945e1bb3d8888a3bb2dcf7cfe29e650335055399) | `` automatic update ``         |
| [`4f34e72a`](https://github.com/nix-community/NUR/commit/4f34e72a0067ca8dfef7ced6fdff29bc3a09506c) | `` automatic update ``         |
| [`f5549b8a`](https://github.com/nix-community/NUR/commit/f5549b8ac21dfaace961708d6b1f0578ef94d82f) | `` automatic update ``         |
| [`ba98d148`](https://github.com/nix-community/NUR/commit/ba98d1482678650833e821f1c63e9082d2d1829e) | `` automatic update ``         |
| [`97e5f700`](https://github.com/nix-community/NUR/commit/97e5f7007b4d4fc46fad892dd27a145b8bf0a4b9) | `` automatic update ``         |
| [`ffba221d`](https://github.com/nix-community/NUR/commit/ffba221d7183cf64704411fc640d213e00413198) | `` automatic update ``         |
| [`ada6f2df`](https://github.com/nix-community/NUR/commit/ada6f2dfa25176e735f0a1899e83ec93ff422d46) | `` automatic update ``         |
| [`7bfff817`](https://github.com/nix-community/NUR/commit/7bfff817d4921694d50c96571d8702b38d1831cd) | `` automatic update ``         |
| [`8a656820`](https://github.com/nix-community/NUR/commit/8a65682071fd22a17950575fdbf5703297ecfb23) | `` automatic update ``         |
| [`ae6fb319`](https://github.com/nix-community/NUR/commit/ae6fb319f88d5a995cb8dc4502c2d81c5fc1e578) | `` automatic update ``         |
| [`ab31dcd1`](https://github.com/nix-community/NUR/commit/ab31dcd1445522e950a2ce0ae0dc4cbdc32a20fc) | `` automatic update ``         |
| [`9286fb2f`](https://github.com/nix-community/NUR/commit/9286fb2fd0d017bc4657678cdfb3c948389f8a0a) | `` automatic update ``         |
| [`a41eea0f`](https://github.com/nix-community/NUR/commit/a41eea0f67c4bcc0c735ccb7e4f1b474a2527e3b) | `` automatic update ``         |
| [`023410bc`](https://github.com/nix-community/NUR/commit/023410bcd1995f6f27b0dcd36a456d20f9299aa4) | `` automatic update ``         |
| [`bc4e5a2c`](https://github.com/nix-community/NUR/commit/bc4e5a2c2894cf2cf7369cb34ed47c72409eb3a7) | `` automatic update ``         |
| [`e7438892`](https://github.com/nix-community/NUR/commit/e7438892ac72dca7b5876bb0a0ecdfb1750ccc9a) | `` automatic update ``         |
| [`74624d97`](https://github.com/nix-community/NUR/commit/74624d97f4892360083e51a2609ca3d3d10c445b) | `` automatic update ``         |
| [`7bccffe7`](https://github.com/nix-community/NUR/commit/7bccffe70f9cba167ab86dfed52d44954c5c2fc1) | `` automatic update ``         |
| [`0c1ee9f7`](https://github.com/nix-community/NUR/commit/0c1ee9f70ecc53c62a9621fad899325a043c4ba6) | `` automatic update ``         |
| [`0c482ca4`](https://github.com/nix-community/NUR/commit/0c482ca4bf19209dc57596182b0a67104e61e4a8) | `` automatic update ``         |
| [`85f9196a`](https://github.com/nix-community/NUR/commit/85f9196afc954e5b23cb9629fb854b746db71575) | `` automatic update ``         |
| [`e422ef8f`](https://github.com/nix-community/NUR/commit/e422ef8f4639f5542dae1a5e9ec54a5bb2344f10) | `` automatic update ``         |
| [`193c938c`](https://github.com/nix-community/NUR/commit/193c938c3f5ad919dd1f71df64e543b2c7dc2dae) | `` automatic update ``         |
| [`ee71b34d`](https://github.com/nix-community/NUR/commit/ee71b34d951f22777efe61347b734e1764c304f5) | `` automatic update ``         |
| [`0e6880cf`](https://github.com/nix-community/NUR/commit/0e6880cf5f8ff087e2ec040ba9dcf82699c73da5) | `` automatic update ``         |
| [`4a8f8f53`](https://github.com/nix-community/NUR/commit/4a8f8f5355cb9d3334d311cb25fc6ab641b501dc) | `` automatic update ``         |
| [`d33b3175`](https://github.com/nix-community/NUR/commit/d33b31759dd8e3bb431529c0937eb3692c09fa9a) | `` automatic update ``         |
| [`89aaaf04`](https://github.com/nix-community/NUR/commit/89aaaf04fadc7ccfc0eedd64a07caead0cc724f4) | `` automatic update ``         |
| [`a2d1b337`](https://github.com/nix-community/NUR/commit/a2d1b337dff56fdcd367543c81b83fd3691cd1d2) | `` automatic update ``         |
| [`cbadac33`](https://github.com/nix-community/NUR/commit/cbadac330a86378a6329db095e8117b7a1caee74) | `` automatic update ``         |
| [`41501f11`](https://github.com/nix-community/NUR/commit/41501f116aa6342148bed96fe95e119ee75c0f10) | `` automatic update ``         |
| [`b34bc8a2`](https://github.com/nix-community/NUR/commit/b34bc8a22c11c874c50af0eab9a54936d1309062) | `` automatic update ``         |
| [`2ab02ea2`](https://github.com/nix-community/NUR/commit/2ab02ea28ae5c71d3c8222c138fedc21b23a3ac2) | `` automatic update ``         |
| [`9971cac4`](https://github.com/nix-community/NUR/commit/9971cac4cee4283043474d8b060c893b11774011) | `` automatic update ``         |
| [`b96cc681`](https://github.com/nix-community/NUR/commit/b96cc681612efb6d3792e1a27624b8797dab066d) | `` automatic update ``         |
| [`585f717d`](https://github.com/nix-community/NUR/commit/585f717d2a87856781fc5dd1ea455c53acaa365c) | `` automatic update ``         |
| [`612af3a2`](https://github.com/nix-community/NUR/commit/612af3a2e918a1ad837e513b5223874a4e22dee4) | `` automatic update ``         |
| [`79993d3b`](https://github.com/nix-community/NUR/commit/79993d3b2bdab4bd9e89e63100a394d8acdcc59d) | `` automatic update ``         |
| [`ba245e1b`](https://github.com/nix-community/NUR/commit/ba245e1bc1934a2ec910cf2ba662f358930d2bb9) | `` automatic update ``         |
| [`2fb90927`](https://github.com/nix-community/NUR/commit/2fb909274c2cd4b4fab94784b9ce0aa357f3e546) | `` automatic update ``         |
| [`356e44fb`](https://github.com/nix-community/NUR/commit/356e44fbd597da1b2bd76edfbe79e835292e84b7) | `` automatic update ``         |
| [`04460f8e`](https://github.com/nix-community/NUR/commit/04460f8e23bcbd81ca3349f7cd02f1d8e2a2000f) | `` automatic update ``         |
| [`d52a4f82`](https://github.com/nix-community/NUR/commit/d52a4f82a23f183e5a4262f2d1d06f709575b668) | `` automatic update ``         |
| [`e287e175`](https://github.com/nix-community/NUR/commit/e287e175bfa6bfceced446de1ae35565051b787c) | `` automatic update ``         |
| [`bbdb3703`](https://github.com/nix-community/NUR/commit/bbdb3703460e678104c85bc010c5cb6c048a731a) | `` automatic update ``         |
| [`363c3de2`](https://github.com/nix-community/NUR/commit/363c3de20f7a3ceebdc26c45763f863bbb4f20e8) | `` automatic update ``         |
| [`c7564cb6`](https://github.com/nix-community/NUR/commit/c7564cb6467fe98d6f7d69be744f6c044400ed6c) | `` automatic update ``         |
| [`c5559571`](https://github.com/nix-community/NUR/commit/c55595716339a31cc05473395203f1444d546f3f) | `` automatic update ``         |
| [`cee45814`](https://github.com/nix-community/NUR/commit/cee4581467953d2c1be3e57450fb0023d52f342e) | `` automatic update ``         |
| [`d52c3b8e`](https://github.com/nix-community/NUR/commit/d52c3b8e906cc63efe311ae6277867f7b68f3bca) | `` automatic update ``         |
| [`e8be9903`](https://github.com/nix-community/NUR/commit/e8be990308f12ae81ecf8a64df7ae1e015420911) | `` automatic update ``         |
| [`f844dc36`](https://github.com/nix-community/NUR/commit/f844dc36ea88877a0a673f938668e36954e57683) | `` automatic update ``         |
| [`1f7ee403`](https://github.com/nix-community/NUR/commit/1f7ee403b664b9e7c48805b57435e49fb37ba84a) | `` automatic update ``         |
| [`35b54f7a`](https://github.com/nix-community/NUR/commit/35b54f7a8f4965f07422b8aa21b06678b24b676c) | `` automatic update ``         |
| [`f058750c`](https://github.com/nix-community/NUR/commit/f058750c396c0afab41384476bae177d5d483624) | `` automatic update ``         |
| [`e3a23952`](https://github.com/nix-community/NUR/commit/e3a23952344fd903df67ff1d4cc895f354e18631) | `` automatic update ``         |
| [`734119e8`](https://github.com/nix-community/NUR/commit/734119e8a0a9eb808fafb9226d11386308a6df73) | `` automatic update ``         |
| [`e348ad64`](https://github.com/nix-community/NUR/commit/e348ad64a29ac9e47a59db9d4e2d7467363d1b95) | `` automatic update ``         |
| [`a3457762`](https://github.com/nix-community/NUR/commit/a3457762e421ad9ea74a4ffc68fcf96c44836669) | `` automatic update ``         |
| [`1ab2dd64`](https://github.com/nix-community/NUR/commit/1ab2dd641dcc59d6c8f19f130ea138ff27c0e3a0) | `` automatic update ``         |
| [`db2144bf`](https://github.com/nix-community/NUR/commit/db2144bf7f54ce3d0c9519dfd6d342f761e7159e) | `` automatic update ``         |
| [`0e68c96e`](https://github.com/nix-community/NUR/commit/0e68c96e8fc25b76666cd0ed5daa822eb8aa6ed7) | `` automatic update ``         |
| [`2b0eeddf`](https://github.com/nix-community/NUR/commit/2b0eeddf3204f2af77ab051f911f372d6f6ccea7) | `` automatic update ``         |
| [`8df7eb39`](https://github.com/nix-community/NUR/commit/8df7eb39e347fe6cf2d172d3cda9a93cd9e6b6ba) | `` automatic update ``         |
| [`f0dd3564`](https://github.com/nix-community/NUR/commit/f0dd356478a436d94891481336471d6061da527a) | `` automatic update ``         |
| [`e4ff8935`](https://github.com/nix-community/NUR/commit/e4ff893588c411ce803042b407c054e1a9c4a66e) | `` automatic update ``         |
| [`4d4e8575`](https://github.com/nix-community/NUR/commit/4d4e8575055b7d834bc711ed8bdec7e5e9f3af65) | `` automatic update ``         |
| [`6dd0993a`](https://github.com/nix-community/NUR/commit/6dd0993a099f6ddc68c8dbe564b673e1189a3e63) | `` automatic update ``         |
| [`bcac070e`](https://github.com/nix-community/NUR/commit/bcac070e0ecea73adf9d6dd43559c81743e741fd) | `` automatic update ``         |
| [`b00fc2a5`](https://github.com/nix-community/NUR/commit/b00fc2a535d4a2d869460da829bb0a08dbb63be2) | `` automatic update ``         |
| [`2461abc7`](https://github.com/nix-community/NUR/commit/2461abc793980def8d06f23bb846ef94adb6c90d) | `` automatic update ``         |
| [`c2fac218`](https://github.com/nix-community/NUR/commit/c2fac2182a694971a3974018371027a931da1ff6) | `` automatic update ``         |
| [`f6d4cb01`](https://github.com/nix-community/NUR/commit/f6d4cb01806cf5836cf907bad740ee4d768b47c8) | `` automatic update ``         |
| [`5f831c8d`](https://github.com/nix-community/NUR/commit/5f831c8dba3b92c863497c5422652ed46b53fd01) | `` automatic update ``         |
| [`e21bafac`](https://github.com/nix-community/NUR/commit/e21bafac0b2de6947ce95cdc7a17058fb98a6fe8) | `` automatic update ``         |
| [`83306ebb`](https://github.com/nix-community/NUR/commit/83306ebb8cca356a168ecfd9697664766245707f) | `` automatic update ``         |
| [`89c7ff47`](https://github.com/nix-community/NUR/commit/89c7ff47b90fe0e6cf91ade4e5cffbe83492fe32) | `` automatic update ``         |
| [`e1001856`](https://github.com/nix-community/NUR/commit/e1001856d8f2c5cc72f9288754122da84459bf49) | `` automatic update ``         |
| [`5ffa50aa`](https://github.com/nix-community/NUR/commit/5ffa50aa486e9e203bec5d0374354d4b0eac69b8) | `` automatic update ``         |
| [`de9b2c75`](https://github.com/nix-community/NUR/commit/de9b2c75516c957d9bcb8dbe37a8579147ce1fb2) | `` automatic update ``         |
| [`c87af07c`](https://github.com/nix-community/NUR/commit/c87af07ce867559cc69406350b6b83a7b015bd25) | `` automatic update ``         |
| [`0976440a`](https://github.com/nix-community/NUR/commit/0976440a978762424e00b29fc3896be286f7dcc4) | `` automatic update ``         |
| [`9b29b6af`](https://github.com/nix-community/NUR/commit/9b29b6af5a3189c253f3d558942b6947e61be44b) | `` automatic update ``         |
| [`c19379eb`](https://github.com/nix-community/NUR/commit/c19379eb0ff74e34a546cdfec94f5a7313cd0899) | `` automatic update ``         |
| [`b121e90a`](https://github.com/nix-community/NUR/commit/b121e90ae08cbd33362c5c3a6c301773803e2f77) | `` automatic update ``         |
| [`6b1053d8`](https://github.com/nix-community/NUR/commit/6b1053d885bf5f7a672a53822c7114669e73152b) | `` automatic update ``         |
| [`3ac52481`](https://github.com/nix-community/NUR/commit/3ac52481bc380fe84574f76402b6f9abcbe556b7) | `` automatic update ``         |
| [`24dfdcb8`](https://github.com/nix-community/NUR/commit/24dfdcb8178ac846687ec5035bc69fb0677bb488) | `` automatic update ``         |
| [`706544a2`](https://github.com/nix-community/NUR/commit/706544a26f8415f193d5a9c0f825b90ad463383d) | `` automatic update ``         |
| [`d26de410`](https://github.com/nix-community/NUR/commit/d26de4108965a685c8d85fe4db1fc5904e03c359) | `` automatic update ``         |
| [`4e02c8a2`](https://github.com/nix-community/NUR/commit/4e02c8a23a7153534306ef5e21a3dc77fe61f931) | `` automatic update ``         |
| [`da172d8a`](https://github.com/nix-community/NUR/commit/da172d8ad18cd296f7174e2d1c46ab84625d1c4f) | `` automatic update ``         |
| [`eacde6f9`](https://github.com/nix-community/NUR/commit/eacde6f9403222e20a511995f87cb30b3d445b10) | `` automatic update ``         |
| [`ddd1a3db`](https://github.com/nix-community/NUR/commit/ddd1a3db18697d791c26c5f372948c1afe769e62) | `` automatic update ``         |
| [`544f12df`](https://github.com/nix-community/NUR/commit/544f12dfd015f630784a654d31f2dcbad6af3d0d) | `` automatic update ``         |
| [`9f98452a`](https://github.com/nix-community/NUR/commit/9f98452a12d5214423cd26a9b2d1c713654b1312) | `` automatic update ``         |
| [`1e2a5cb8`](https://github.com/nix-community/NUR/commit/1e2a5cb870dc8f4b04e19b948cacf42053221368) | `` automatic update ``         |
| [`9243f9c8`](https://github.com/nix-community/NUR/commit/9243f9c8e1e2ca2b73b62572f7cb1cb1e92fd8c4) | `` automatic update ``         |
| [`37316d96`](https://github.com/nix-community/NUR/commit/37316d96a2d37c8d399922483dac769ffd5dbf38) | `` automatic update ``         |
| [`363ffe21`](https://github.com/nix-community/NUR/commit/363ffe2170c5ff1bb78ee7c156cfd26fb587e383) | `` automatic update ``         |
| [`21c86cf3`](https://github.com/nix-community/NUR/commit/21c86cf3e57d0e0d5259c917ce89c44f0d06a169) | `` automatic update ``         |
| [`64dd7ce9`](https://github.com/nix-community/NUR/commit/64dd7ce9a659297cf581c2b034d42c834e896bed) | `` automatic update ``         |
| [`ee0dc74d`](https://github.com/nix-community/NUR/commit/ee0dc74d9fe06ab1a7736e505a4523aef74525d6) | `` automatic update ``         |
| [`1a15c29d`](https://github.com/nix-community/NUR/commit/1a15c29d2db118ba4bd50fe309fa35642d944881) | `` automatic update ``         |
| [`f94da38b`](https://github.com/nix-community/NUR/commit/f94da38b867ae2aa49161a46c0924b3de2adc519) | `` automatic update ``         |
| [`f0e4ba44`](https://github.com/nix-community/NUR/commit/f0e4ba441f1b7a9568bc9ef00c5965333935004d) | `` automatic update ``         |
| [`8d246efc`](https://github.com/nix-community/NUR/commit/8d246efce3b379865a4a745eec421c00d1a0cbb2) | `` automatic update ``         |
| [`1830a38c`](https://github.com/nix-community/NUR/commit/1830a38cc171d76d5e86ca12ab1d70b23beb6110) | `` automatic update ``         |
| [`19f42c15`](https://github.com/nix-community/NUR/commit/19f42c15735b6ba7a74b9fec2f56bd27fd0ffc29) | `` automatic update ``         |
| [`ce591652`](https://github.com/nix-community/NUR/commit/ce59165220f83fe5eeb5e9ffbe2a6dfa5221ea5b) | `` automatic update ``         |
| [`0d2ffe75`](https://github.com/nix-community/NUR/commit/0d2ffe75a173b2d2c187b7a8602bcc708d79ff49) | `` automatic update ``         |
| [`77148af8`](https://github.com/nix-community/NUR/commit/77148af843e8f11c0f0c41849c83715744f052da) | `` automatic update ``         |
| [`578ae34a`](https://github.com/nix-community/NUR/commit/578ae34abeca4f76eb7ac9a2f74475653b8a3537) | `` automatic update ``         |
| [`8e0c5261`](https://github.com/nix-community/NUR/commit/8e0c526141a835dbbc22982b496e5e2e3d6eb435) | `` automatic update ``         |
| [`e65636be`](https://github.com/nix-community/NUR/commit/e65636be64a336e7110fc82cf7aab577f1ed8233) | `` automatic update ``         |
| [`057540a6`](https://github.com/nix-community/NUR/commit/057540a62d095ef5c3728d2d4e57d627570342fb) | `` automatic update ``         |
| [`9e89bb05`](https://github.com/nix-community/NUR/commit/9e89bb052cdd33452d93e8547854676007bf811e) | `` automatic update ``         |
| [`2a88d2ed`](https://github.com/nix-community/NUR/commit/2a88d2edda986b90847d29f62137a3a0b6c5b7d8) | `` automatic update ``         |
| [`188e6dc1`](https://github.com/nix-community/NUR/commit/188e6dc171c5b75885687c4fd04bfc07c7e73ec0) | `` automatic update ``         |
| [`8d5bf37f`](https://github.com/nix-community/NUR/commit/8d5bf37f932e3fd4f55406d318f5f0466c47d250) | `` automatic update ``         |
| [`5ab0fe70`](https://github.com/nix-community/NUR/commit/5ab0fe70169261b454aa0d657e750cc336dc2f66) | `` automatic update ``         |
| [`6561f85a`](https://github.com/nix-community/NUR/commit/6561f85abf01b5f47ce49407d34ea7b3332d11a7) | `` automatic update ``         |
| [`b9dbf025`](https://github.com/nix-community/NUR/commit/b9dbf0253330edcc52bcbd108f20ce7effd1e074) | `` automatic update ``         |
| [`e1d82c8f`](https://github.com/nix-community/NUR/commit/e1d82c8f0ed97aede712c874e85eb59542f738e4) | `` automatic update ``         |
| [`ad049d15`](https://github.com/nix-community/NUR/commit/ad049d154d06135d90dbb8199f6bbd48186c84a4) | `` automatic update ``         |
| [`1da5be11`](https://github.com/nix-community/NUR/commit/1da5be1115392fb61132573830eef294ba91e661) | `` automatic update ``         |