### PR TITLE
chore(flake/home-manager): `a2523ea0` -> `16fcb967`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -457,11 +457,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703368619,
-        "narHash": "sha256-ZGPMYL7FMA6enhuwby961bBANmoFX14EA86m2/Jw5Jo=",
+        "lastModified": 1703413401,
+        "narHash": "sha256-pc3SzlsRDe5KW3SqOntNH17Z+/czlln0j2Je2jjeBSg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a2523ea0343b056ba240abbac90ab5f116a7aa7b",
+        "rev": "16fcb9674a71220313f91446e0c259bce5c20f0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`16fcb967`](https://github.com/nix-community/home-manager/commit/16fcb9674a71220313f91446e0c259bce5c20f0f) | `` home-environment: fix incompatible profile error `` |