### PR TITLE
chore(flake/emacs-overlay): `a7464ad5` -> `1c1dd489`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1703466024,
-        "narHash": "sha256-fWpfKAWEzXvWx20/AwhquMTLSWcYex2GKe722b5dvLo=",
+        "lastModified": 1703521060,
+        "narHash": "sha256-6ziVUbKD85cWmyQvYKU2emMiRL+kkjiX6ChfrUGXiXo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a7464ad5b068547d0a86048e544283e3261ce756",
+        "rev": "1c1dd489e1c6c6a895a1648b540b9c4ee8cd0aa6",
         "type": "github"
       },
       "original": {
@@ -707,11 +707,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1703034876,
-        "narHash": "sha256-4bMPFv/bs5g1nEsXQwXlrAGJgjv1Ilr0ejdaTkBwQLs=",
+        "lastModified": 1703351344,
+        "narHash": "sha256-9FEelzftkE9UaJ5nqxidaJJPEhe9TPhbypLHmc2Mysc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "312ab59e8ade69e6083017bd9b98a2919f1fb86a",
+        "rev": "7790e078f8979a9fcd543f9a47427eeaba38f268",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`1c1dd489`](https://github.com/nix-community/emacs-overlay/commit/1c1dd489e1c6c6a895a1648b540b9c4ee8cd0aa6) | `` Updated elpa ``         |
| [`7340210b`](https://github.com/nix-community/emacs-overlay/commit/7340210bf9a1af035e2456fd4a5acc930fc45872) | `` Updated nongnu ``       |
| [`8f17c8c7`](https://github.com/nix-community/emacs-overlay/commit/8f17c8c7d793cde1b0b58a26c754690cbd683004) | `` Updated flake inputs `` |