### PR TITLE
chore(flake/stylix): `a1cbd987` -> `7ccd1293`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1023,11 +1023,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703473871,
-        "narHash": "sha256-ycthAgQEKE1Vz8stcK+mFw7/qr9ycBmaOrBHEr7j2iU=",
+        "lastModified": 1703528325,
+        "narHash": "sha256-ajoMmEPbLhp9xsReDDQFaY7xX+ayIqwfMlZNg8YxHnw=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "a1cbd98719daec528538d2b7d56279ddf68f90e6",
+        "rev": "7ccd1293a48f01eace7d0ce8d82af51919105b76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`7ccd1293`](https://github.com/danth/stylix/commit/7ccd1293a48f01eace7d0ce8d82af51919105b76) | `` Disable KDE behaviour which blocks Home Manager activation :bug: `` |