### PR TITLE
chore(flake/nixos-hardware): `7763c6fd` -> `51c532cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -628,11 +628,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1702453208,
-        "narHash": "sha256-0wRi9SposfE2wHqjuKt8WO2izKB/ASDOV91URunIqgo=",
+        "lastModified": 1703534365,
+        "narHash": "sha256-/4nKg1QlMTKD3PcRvqKrAKhFpmfwBPYm9od5J4qIe0c=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "7763c6fd1f299cb9361ff2abf755ed9619ef01d6",
+        "rev": "51c532cc50e7960629c6e09ff7277441a01c236b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`51c532cc`](https://github.com/NixOS/nixos-hardware/commit/51c532cc50e7960629c6e09ff7277441a01c236b) | `` Lenovo Legion 16achg6: Fix gpu configuration to work with both x11/wayland  (#802) `` |
| [`e4ded1ec`](https://github.com/NixOS/nixos-hardware/commit/e4ded1ec8e9c152910c2b077443e1d87cd81ad4a) | `` gpd-win-max-2-2023: init ``                                                           |