### PR TITLE
chore(flake/nixos-hardware): `51c532cc` -> `05fc10e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -628,11 +628,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1703534365,
-        "narHash": "sha256-/4nKg1QlMTKD3PcRvqKrAKhFpmfwBPYm9od5J4qIe0c=",
+        "lastModified": 1703537399,
+        "narHash": "sha256-UXLtyffpCzEp3/ggsARM7VRpj84odwM4yh/clyZsz2I=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "51c532cc50e7960629c6e09ff7277441a01c236b",
+        "rev": "05fc10e09377a5e28c54b723da8691daaf44b0b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                    |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`05fc10e0`](https://github.com/NixOS/nixos-hardware/commit/05fc10e09377a5e28c54b723da8691daaf44b0b5) | `` add pyproject.toml for ruff lints ``    |
| [`e91914c6`](https://github.com/NixOS/nixos-hardware/commit/e91914c6cc8bfb3fb2a9bf6a95a0c62299672d4a) | `` apply ruff lints ``                     |
| [`453896ef`](https://github.com/NixOS/nixos-hardware/commit/453896efd821ef562793681568ac64caed3a3c8e) | `` tests/run.py: reformat with ruff ``     |
| [`3e3571c8`](https://github.com/NixOS/nixos-hardware/commit/3e3571c832d41227ac27867784f609099e2a1e16) | `` add lenovo/thinkpad/x13/yoga/3th-gen `` |
| [`b7747f0f`](https://github.com/NixOS/nixos-hardware/commit/b7747f0f60bbdc50f840a49ab77d480d1d018cf9) | `` remove unused variables with deadnix `` |
| [`249a94e7`](https://github.com/NixOS/nixos-hardware/commit/249a94e715a3d6cc0217b37b0172dea1edd4afd2) | `` surface: linux 6.6.6 -> 6.6.8 ``        |