### PR TITLE
chore(flake/emacs-overlay): `1c1dd489` -> `9147a422`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1703521060,
-        "narHash": "sha256-6ziVUbKD85cWmyQvYKU2emMiRL+kkjiX6ChfrUGXiXo=",
+        "lastModified": 1703552374,
+        "narHash": "sha256-frvgmneksi9w3J/dh4z9zaEG2JmWLpufHXuexpCFmyw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1c1dd489e1c6c6a895a1648b540b9c4ee8cd0aa6",
+        "rev": "9147a4227e3db2c461dac05f9e0e7c586f852fb9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`9147a422`](https://github.com/nix-community/emacs-overlay/commit/9147a4227e3db2c461dac05f9e0e7c586f852fb9) | `` Updated elpa ``   |
| [`d69ed241`](https://github.com/nix-community/emacs-overlay/commit/d69ed24198fbb8fc49deb92c727d1efc662b700f) | `` Updated nongnu `` |