### PR TITLE
chore(flake/impermanence): `8d16ac97` -> `3d599bd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -472,11 +472,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1703562375,
-        "narHash": "sha256-T46GgRVnSUo0DrCVAHreLNMgeCYmFvo469qj1Z6dYDQ=",
+        "lastModified": 1703606475,
+        "narHash": "sha256-ztFe33E2f+XmrvOFOy9NDvQCkvfQUE6K/BBV+ZtCZLs=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "8d16ac97980b3641078dd7c11337bfaa77b45789",
+        "rev": "3d599bd65eb383bc36191ba39ed6084674b0d7b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`3d599bd6`](https://github.com/nix-community/impermanence/commit/3d599bd65eb383bc36191ba39ed6084674b0d7b2) | `` Partial revert of 8d16ac97980b3641078dd7c11337bfaa77b45789 `` |