### PR TITLE
chore(flake/impermanence): `3d599bd6` -> `033643a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -472,11 +472,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1703606475,
-        "narHash": "sha256-ztFe33E2f+XmrvOFOy9NDvQCkvfQUE6K/BBV+ZtCZLs=",
+        "lastModified": 1703656108,
+        "narHash": "sha256-hCSUqdFJKHHbER8Cenf5JRzjMlBjIdwdftGQsO0xoJs=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "3d599bd65eb383bc36191ba39ed6084674b0d7b2",
+        "rev": "033643a45a4a920660ef91caa391fbffb14da466",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message           |
| ----------------------------------------------------------------------------------------------------------- | ----------------- |
| [`033643a4`](https://github.com/nix-community/impermanence/commit/033643a45a4a920660ef91caa391fbffb14da466) | `` Fix grammar `` |