### PR TITLE
chore(flake/emacs-overlay): `995ac3a4` -> `d72b6439`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1703664928,
-        "narHash": "sha256-nkJTUz2dqXX4S/Niod1iydmkkQ/oTPsQF/CvoWQN5zs=",
+        "lastModified": 1703693864,
+        "narHash": "sha256-ILirBd/nTvyVrZINdSj5IJEDs76R0uIgzy4vKMj0Oe4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "995ac3a4535431f4236df0e7e0b1c0f669cdb02d",
+        "rev": "d72b6439873ce66a1183d1b28e00a173e8a63ed7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`d72b6439`](https://github.com/nix-community/emacs-overlay/commit/d72b6439873ce66a1183d1b28e00a173e8a63ed7) | `` Updated elpa `` |