### PR TITLE
chore(flake/srvos): `c70c1713` -> `a3f6322d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -989,11 +989,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703723806,
-        "narHash": "sha256-F87+g/c/uiGWfLUWWbyxFwkFAiKg5R9R7Zc84ypQnHM=",
+        "lastModified": 1703727919,
+        "narHash": "sha256-uVkW5/H+r1GTvyiyYsncbj5aYFdbGqjVNAANaooYlxY=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "c70c1713c919c8e712aedfe14cf4f1fc7fd97eec",
+        "rev": "a3f6322dfa62aa40dc4faa9d5b2f1542a6e9a95d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------ |
| [`a3f6322d`](https://github.com/nix-community/srvos/commit/a3f6322dfa62aa40dc4faa9d5b2f1542a6e9a95d) | `` flake.lock: Update `` |