### PR TITLE
chore(flake/stylix): `7ccd1293` -> `9c3b6122`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1023,11 +1023,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703528325,
-        "narHash": "sha256-ajoMmEPbLhp9xsReDDQFaY7xX+ayIqwfMlZNg8YxHnw=",
+        "lastModified": 1703773575,
+        "narHash": "sha256-H7JYVnqK7EOa/xq45NCq+my4VAAyTUOlxW8++/Hxa1o=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "7ccd1293a48f01eace7d0ce8d82af51919105b76",
+        "rev": "9c3b61224afab35604508d063f6a27894bffc273",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`9c3b6122`](https://github.com/danth/stylix/commit/9c3b61224afab35604508d063f6a27894bffc273) | `` Fix stylixLookAndFeel failing on non-NixOS :bug: `` |