### PR TITLE
chore(flake/emacs-overlay): `5205fb0c` -> `a405e8be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1703780246,
-        "narHash": "sha256-lCy2ImLouEoIdZKzczdrLvW6B2uomJSf7QkBZSWe2r0=",
+        "lastModified": 1703796062,
+        "narHash": "sha256-xUcmgr007TeEshv4ZVZLAqTh0QWWCdJV40TltcPkv/c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5205fb0c0ac5dfdb3f468b7581cd4fd4e289a4d9",
+        "rev": "a405e8becb24d38d7e0c465b6432ea3155da66c6",
         "type": "github"
       },
       "original": {
@@ -707,16 +707,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1703351344,
-        "narHash": "sha256-9FEelzftkE9UaJ5nqxidaJJPEhe9TPhbypLHmc2Mysc=",
+        "lastModified": 1703467016,
+        "narHash": "sha256-/5A/dNPhbQx/Oa2d+Get174eNI3LERQ7u6WTWOlR1eQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7790e078f8979a9fcd543f9a47427eeaba38f268",
+        "rev": "d02d818f22c777aa4e854efc3242ec451e5d462a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }


### PR DESCRIPTION
| Commit                                                                                                       | Message                              |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------ |
| [`71ccac2c`](https://github.com/nix-community/emacs-overlay/commit/71ccac2c15e3cef22b64de400df51132dbd45fd7) | `` Update github action version ``   |
| [`12a5452d`](https://github.com/nix-community/emacs-overlay/commit/12a5452d0edc6cb0e11391c069aef5538ebed31c) | `` Update nixpkgs-stable to 23.11 `` |