### PR TITLE
chore(flake/home-manager): `77c698fa` -> `df7f29a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -457,11 +457,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703808179,
-        "narHash": "sha256-svlFDbozZlZJwnnSoeh5yE9jEnCmgmuRMRX866CL4J0=",
+        "lastModified": 1703835860,
+        "narHash": "sha256-Hi6AlTvlOaRY3pqxzw1ZnjqQKmaneLt05JxH0unHZgg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "77c698fa4b3081b6019ad77d1bfedf06dbbde0db",
+        "rev": "df7f29a231a483c88cbd00608db99634f854a8e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                   |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`df7f29a2`](https://github.com/nix-community/home-manager/commit/df7f29a231a483c88cbd00608db99634f854a8e1) | `` zoxide: fix use with recent Nushell `` |