### PR TITLE
chore(flake/home-manager): `df7f29a2` -> `2aff324c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -457,11 +457,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703835860,
-        "narHash": "sha256-Hi6AlTvlOaRY3pqxzw1ZnjqQKmaneLt05JxH0unHZgg=",
+        "lastModified": 1703838268,
+        "narHash": "sha256-SRg5nXcdPnrsQR2MTAp7en0NyJnQ2wB1ivmsgEbvN+o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "df7f29a231a483c88cbd00608db99634f854a8e1",
+        "rev": "2aff324cf65f5f98f89d878c056b779466b17db8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`2aff324c`](https://github.com/nix-community/home-manager/commit/2aff324cf65f5f98f89d878c056b779466b17db8) | `` bemenu: add module ``               |
| [`c48ae40d`](https://github.com/nix-community/home-manager/commit/c48ae40dbbb9193b4766c020bca116e127455ab9) | `` Translate using Weblate (German) `` |