### PR TITLE
chore(flake/emacs-overlay): `a99d70ad` -> `e9e995a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1703810938,
-        "narHash": "sha256-x2Cg5mdW1CvQV7p6TPlbaN1ZVgpk2Ff3utEwhg109ng=",
+        "lastModified": 1703866754,
+        "narHash": "sha256-BvHW5KCttQaV7Pxq58uX2ZiFc2ezkEL9dZLa1kgLBRk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a99d70addcc094dfb2c93d74073850c11c0b5a7f",
+        "rev": "e9e995a2f582217b7c4efe38415fafbbc06274d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`e9e995a2`](https://github.com/nix-community/emacs-overlay/commit/e9e995a2f582217b7c4efe38415fafbbc06274d2) | `` Updated elpa ``   |
| [`86bc6834`](https://github.com/nix-community/emacs-overlay/commit/86bc6834b2e1adffca92c6faf0431c1a453cb73f) | `` Updated nongnu `` |