### PR TITLE
chore(flake/nixos-hardware): `9c3a4125` -> `22ae59fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -628,11 +628,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1703855975,
-        "narHash": "sha256-9s/q/Rt06D17+s70zVs0IhRO8iWf/Xk6T5oLQrnRtWg=",
+        "lastModified": 1703879120,
+        "narHash": "sha256-oMJ5xtDswlBWxs0DT/aYKEUIhjEpGZJ9GbIxOclYP8I=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "9c3a41257898f632792a6f948d43a6123ae9a5f2",
+        "rev": "22ae59fec26591ef72ce4ccb5538c42c5f090fe3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                   |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`22ae59fe`](https://github.com/NixOS/nixos-hardware/commit/22ae59fec26591ef72ce4ccb5538c42c5f090fe3) | `` Update dell/xps/13-9310/default.nix `` |
| [`72fea207`](https://github.com/NixOS/nixos-hardware/commit/72fea2077cbd6febb1fa83b697d1ae4950bfc75d) | `` Update config for xps-13-9010 ``       |