### PR TITLE
chore(flake/nixpkgs): `5f64a12a` -> `cfc3698c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -755,11 +755,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1703438236,
-        "narHash": "sha256-aqVBq1u09yFhL7bj1/xyUeJjzr92fXVvQSSEx6AdB1M=",
+        "lastModified": 1703637592,
+        "narHash": "sha256-8MXjxU0RfFfzl57Zy3OfXCITS0qWDNLzlBAdwxGZwfY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5f64a12a728902226210bf01d25ec6cbb9d9265b",
+        "rev": "cfc3698c31b1fb9cdcf10f36c9643460264d0ca8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`6a9bfbfa`](https://github.com/NixOS/nixpkgs/commit/6a9bfbfa1001235034f486b52791830451bf0bf1) | `` spire: 1.8.3 -> 1.8.7 ``                                                 |
| [`2f8686ce`](https://github.com/NixOS/nixpkgs/commit/2f8686ce1767836793797f97a498c47383bd934a) | `` nixos/frigate: restart the service on failure ``                         |
| [`b3a184a4`](https://github.com/NixOS/nixpkgs/commit/b3a184a4aabf53ab3f408291a006b2e5835a4afa) | `` lean4: clean up colliding files ``                                       |
| [`7cef1a98`](https://github.com/NixOS/nixpkgs/commit/7cef1a983305fa38a913dc400bca117a3de9f3df) | `` scummvm: 2.7.1 -> 2.8.0 ``                                               |
| [`d7e9503a`](https://github.com/NixOS/nixpkgs/commit/d7e9503ac14a69b059633d85dab3ba252f5942f4) | `` twm: 0.8.0 -> 0.8.1 ``                                                   |
| [`9dbb6db7`](https://github.com/NixOS/nixpkgs/commit/9dbb6db78b5312a02b425385cf30699ccae2959b) | `` maintainers/ma27: drop pgp fp ``                                         |
| [`7b7b4967`](https://github.com/NixOS/nixpkgs/commit/7b7b4967d43eb281bc995f1debcc20911fa222e8) | `` lib/licenses: add missing spdxids ``                                     |
| [`c31565f9`](https://github.com/NixOS/nixpkgs/commit/c31565f9b35e02d5f73300a4edeac9c9b2029bdf) | `` pkgsStatic.libao: fix build ``                                           |
| [`fd41fdd3`](https://github.com/NixOS/nixpkgs/commit/fd41fdd34af55fe739863b233a2db94a0ebe14a4) | `` sox: fix build with enableOpusfile = false ``                            |
| [`98a73e1c`](https://github.com/NixOS/nixpkgs/commit/98a73e1caf11c5c750cea73d9d42b25463dd70b9) | `` orca-slicer: init at 1.8.1 (#275638) ``                                  |
| [`fc38d28b`](https://github.com/NixOS/nixpkgs/commit/fc38d28b26904c294b33b64cdce0866e778b6bc8) | `` qemu: 8.1.3 -> 8.2.0 ``                                                  |
| [`436509cb`](https://github.com/NixOS/nixpkgs/commit/436509cb3113e3d2c73dcbe7ce8293d5e20a6131) | `` discord-stable: 0.0.38 -> 0.0.39 ``                                      |
| [`0392a075`](https://github.com/NixOS/nixpkgs/commit/0392a075113e55b636018f45d9c9e5e8981e5156) | `` nixos/lib/make-disk-image: Create build products metadata ``             |
| [`c6518b3b`](https://github.com/NixOS/nixpkgs/commit/c6518b3b0b20b8b27427c1c964b38110eaadaa80) | `` kubevpn: 2.1.3 -> 2.2.0 ``                                               |
| [`3a22fbfd`](https://github.com/NixOS/nixpkgs/commit/3a22fbfdd26dd39702028d388d6da18b73fbd3ea) | `` kubefirst: 2.3.6 -> 2.3.7 ``                                             |
| [`4db68fa4`](https://github.com/NixOS/nixpkgs/commit/4db68fa4fdf0cd3d6b521f2562c681ebb91bec6a) | `` kaniko: 1.19.1 -> 1.19.2 ``                                              |
| [`be0c33ca`](https://github.com/NixOS/nixpkgs/commit/be0c33cafc4c2a5287a3ed366fd880b75ead9c3e) | `` luaPackages.image-nvim: init at 1.2 ``                                   |
| [`ced1438d`](https://github.com/NixOS/nixpkgs/commit/ced1438d5beebeeb2649978118e2b4f4e3c7c5f5) | `` maintainers/teams: remove adisbladis from podman ``                      |
| [`85ac3a4b`](https://github.com/NixOS/nixpkgs/commit/85ac3a4bc64fd1f3db41e3f4c2c32d98cfd7cad0) | `` nanomq: 0.18.2 → 0.20.8 ``                                               |
| [`22c832a9`](https://github.com/NixOS/nixpkgs/commit/22c832a9bad7837b60478f151d7724cd45d5ef17) | `` wallust: 2.8.0 -> 2.9.0 ``                                               |
| [`e663cbe6`](https://github.com/NixOS/nixpkgs/commit/e663cbe65d0161e7c74919831c77313cb81b5911) | `` passage: add ma27 as maintainer ``                                       |
| [`f6dcece2`](https://github.com/NixOS/nixpkgs/commit/f6dcece2d0a0595050a7eb37b0bebc8b49c4515d) | `` passage: add additional deps to wrapper ``                               |
| [`d6a18d34`](https://github.com/NixOS/nixpkgs/commit/d6a18d3407d02f1913728f093a35b422e2f737da) | `` bitmagnet: 0.0.6 -> 0.4.1 ``                                             |
| [`b46592ce`](https://github.com/NixOS/nixpkgs/commit/b46592cef4387bc553f6859412708abadaef79dc) | `` flyctl: drop maintainer ``                                               |
| [`17d827c7`](https://github.com/NixOS/nixpkgs/commit/17d827c75334fdf35ab9edab6aec3a8ef71649b6) | `` httplib: 0.14.2 -> 0.14.3 ``                                             |
| [`62dbffc2`](https://github.com/NixOS/nixpkgs/commit/62dbffc2d7afc8f92bdbd861ddeb39e19fe39b2f) | `` electron_26: 26.6.2 -> 26.6.3 ``                                         |
| [`2ca04021`](https://github.com/NixOS/nixpkgs/commit/2ca040210d9bc5acbceab753c69d781da715f12d) | `` electron_27: 27.1.3 -> 27.2.0 ``                                         |
| [`9c531999`](https://github.com/NixOS/nixpkgs/commit/9c531999c7ce9f34a297de5856e644fc642217f3) | `` electron_28: 28.0.0 -> 28.1.0 ``                                         |
| [`68c90094`](https://github.com/NixOS/nixpkgs/commit/68c90094fcf0161f65b500f6b6cf826887873e4b) | `` hsd: 6.0.0 -> 6.1.1 ``                                                   |
| [`0b522b24`](https://github.com/NixOS/nixpkgs/commit/0b522b2429c27eeadd8e928d8e1eca274df62c90) | `` nixos/pgadmin: add package option ``                                     |
| [`4aa38869`](https://github.com/NixOS/nixpkgs/commit/4aa388695e8daba3fdb914442c0063d3800d0ccc) | `` hcloud: 1.41.0 -> 1.41.1 ``                                              |
| [`662f6cfd`](https://github.com/NixOS/nixpkgs/commit/662f6cfde25fb6f42089943b0137d25f82b36a6a) | `` dep: remove ``                                                           |
| [`a3248182`](https://github.com/NixOS/nixpkgs/commit/a324818224fa385350fafc6fabf2d4b84d91cb95) | `` gtop: 1.1.3 -> 1.1.5 ``                                                  |
| [`181393b0`](https://github.com/NixOS/nixpkgs/commit/181393b02daa12f9c11946c54b1a93847766ba68) | `` govendor: remove ``                                                      |
| [`9bbc992a`](https://github.com/NixOS/nixpkgs/commit/9bbc992a7b0f1b2d9b79f3bc3302339958558666) | `` python311Packages.ttls: 1.8.1 -> 1.8.2 ``                                |
| [`2314f8df`](https://github.com/NixOS/nixpkgs/commit/2314f8dfe29af7d16f4204059a1da797a2afbae8) | `` python311Packages.types-s3transfer: 0.8.2 -> 0.10.0 ``                   |
| [`b899e29b`](https://github.com/NixOS/nixpkgs/commit/b899e29b06210ea6fce52baf7c8f3a96e863a218) | `` python311Packages.usb-devices: 0.4.1 -> 0.4.5 ``                         |
| [`9fa84672`](https://github.com/NixOS/nixpkgs/commit/9fa84672bdb4520093e622cc77db98875e0c2508) | `` python311Packages.whois: 0.99.27 -> 0.99.3 ``                            |
| [`d33f2cd4`](https://github.com/NixOS/nixpkgs/commit/d33f2cd4703abe97ea4c197f6c123152c208c9a5) | `` ocamlPackages.poll: init at 0.3.1 ``                                     |
| [`678dffb6`](https://github.com/NixOS/nixpkgs/commit/678dffb6d8a0fbb83282d6d913c41c47e88ac967) | `` python311Packages.types-awscrt: 0.19.18 -> 0.20.0 ``                     |
| [`86c73ad2`](https://github.com/NixOS/nixpkgs/commit/86c73ad2221c85ee39b26052a4a0dfde962d6ace) | `` python311Packages.stdlibs: 2023.11.2 -> 2023.12.15 ``                    |
| [`f4ad5cd1`](https://github.com/NixOS/nixpkgs/commit/f4ad5cd16c6eff28e1e69ddd09b531641c30add8) | `` gotify-server: remove unused buildGoPackage ``                           |
| [`61b08e65`](https://github.com/NixOS/nixpkgs/commit/61b08e6536f06f99fe39789c0fcf9aa27253eda1) | `` argo: remove unused buildGoPackage ``                                    |
| [`7ebd5b81`](https://github.com/NixOS/nixpkgs/commit/7ebd5b81b74e9f9ddb341473bb50059b4123f565) | `` influxdb2-cli: remove unused buildGoPackage ``                           |
| [`1bc797b6`](https://github.com/NixOS/nixpkgs/commit/1bc797b6cf816ae47581e19d741bfe832574ac90) | `` python311Packages.sendgrid: 6.10.0 -> 6.11.0 ``                          |
| [`ca6dbf53`](https://github.com/NixOS/nixpkgs/commit/ca6dbf534a0dc3aee0409df3fff67a4921eb58d8) | `` granted: 0.20.3 -> 0.20.5 ``                                             |
| [`31d6103d`](https://github.com/NixOS/nixpkgs/commit/31d6103d82a1a5ce413599f41febe716a243ef2d) | `` python311Packages.scmrepo: 1.5.0 -> 2.0.2 ``                             |
| [`ea3b769d`](https://github.com/NixOS/nixpkgs/commit/ea3b769d47538b79a7c30d336b95fb9de0cfee5a) | `` python311Packages.pywerview: refactor ``                                 |
| [`f9fcccc4`](https://github.com/NixOS/nixpkgs/commit/f9fcccc40960eaaea221410cdf244692347274b7) | `` python311Packages.pywerview: 0.5.2 -> 0.6 ``                             |
| [`2d73c0b3`](https://github.com/NixOS/nixpkgs/commit/2d73c0b3b1e29b4991d9cdba8cf6040b511b8488) | `` python311Packages.pyvicare: 2.29.0 -> 2.30.0 ``                          |
| [`529ccb0c`](https://github.com/NixOS/nixpkgs/commit/529ccb0c2f3dea7156485d2c3d4b2819b05c3c5a) | `` python311Packages.python-roborock: 0.36.2 -> 0.38.0 ``                   |
| [`0d3c51e1`](https://github.com/NixOS/nixpkgs/commit/0d3c51e1f2714e381d6ae5ea9e7fab6c7d8c1132) | `` python311Packages.pyatv: 0.14.4 -> 0.14.5 ``                             |
| [`bfa30dc6`](https://github.com/NixOS/nixpkgs/commit/bfa30dc6e824521096d61bdb7c26cbc4d083fc25) | `` python311Packages.pyenphase: 1.15.1 -> 1.15.2 ``                         |
| [`20de361b`](https://github.com/NixOS/nixpkgs/commit/20de361bc4fa3a4c8bd17d9a7e8d78968593faf2) | `` glooctl: 1.15.17 -> 1.15.18 ``                                           |
| [`f96d4b3e`](https://github.com/NixOS/nixpkgs/commit/f96d4b3eec23fe2b68431b317f25376ec935237a) | `` git-mit: 5.12.180 -> 5.12.181 ``                                         |
| [`dd0652f2`](https://github.com/NixOS/nixpkgs/commit/dd0652f2d58bbe6e6757c67f5d424947fbc176e7) | `` svtplay-dl: 4.28.1 -> 4.69 ``                                            |
| [`40d0de07`](https://github.com/NixOS/nixpkgs/commit/40d0de07e18f3e20199767d775d1770865bd41c3) | `` codux: 15.16.1 -> 15.16.2 ``                                             |
| [`af486ebc`](https://github.com/NixOS/nixpkgs/commit/af486ebc8b87aaa13ea8a843e4c62e7a77395b3e) | `` dua: 2.23.0 -> 2.24.1 ``                                                 |
| [`7215f205`](https://github.com/NixOS/nixpkgs/commit/7215f205cd6dd443a01b40cb14da04c57d930295) | `` buttercup-desktop: 2.24.3 -> 2.24.4 ``                                   |
| [`8b9099ae`](https://github.com/NixOS/nixpkgs/commit/8b9099aed6613d0372a75652cc2b8da798d2764b) | `` broot: 1.30.1 -> 1.30.2 ``                                               |
| [`618d7fcf`](https://github.com/NixOS/nixpkgs/commit/618d7fcf2a4346b9b0e70a2162318a082dc7409f) | `` lirc: fix cross-compilation ``                                           |
| [`a08466f3`](https://github.com/NixOS/nixpkgs/commit/a08466f3b30d6f4c53ac5a541e2d6f5d17799368) | `` pacproxy: add meta.mainProgram, move to pkgs/by-name ``                  |
| [`d8403f1f`](https://github.com/NixOS/nixpkgs/commit/d8403f1fe672b111498390d9b282e4a013ccb906) | `` bento4: 1.6.0-640 -> 1.6.0-641 ``                                        |
| [`9b1f47a4`](https://github.com/NixOS/nixpkgs/commit/9b1f47a401f231fbc014b7394eaccd454a69d271) | `` frp: 0.52.0 -> 0.53.2 ``                                                 |
| [`91b7b94b`](https://github.com/NixOS/nixpkgs/commit/91b7b94bccbd67d335064fe6c25e14883124fd07) | `` flyctl: 0.1.134 -> 0.1.135 ``                                            |
| [`760807bc`](https://github.com/NixOS/nixpkgs/commit/760807bc1e72ac669247623cb9f0847de84b6a40) | `` flow: 0.224.0 -> 0.225.1 ``                                              |
| [`9b3a560a`](https://github.com/NixOS/nixpkgs/commit/9b3a560a8a255cc7d5b42e7499f90ef161b49061) | `` flarectl: 0.83.0 -> 0.84.0 ``                                            |
| [`33f24ac8`](https://github.com/NixOS/nixpkgs/commit/33f24ac84ad42f222cb29a58b860ca0136e321e4) | `` fits-cloudctl: 0.12.11 -> 0.12.12 ``                                     |
| [`08041d34`](https://github.com/NixOS/nixpkgs/commit/08041d345eb1b33f26f325df7467ed10ef6df591) | `` firebase-tools: 12.4.8 -> 13.0.2 ``                                      |
| [`b7ffddbc`](https://github.com/NixOS/nixpkgs/commit/b7ffddbce34c2bfb40048ba503080957ee312608) | `` fingerprintx: 1.1.12 -> 1.1.13 ``                                        |
| [`cf214375`](https://github.com/NixOS/nixpkgs/commit/cf214375c9bc03f458dc6dad04990fd5774c6bb7) | `` cudaPackages: manifest-builder: fake url/sha256 instead of exceptions `` |
| [`576c4f4a`](https://github.com/NixOS/nixpkgs/commit/576c4f4af5094340f6bbd1a74a54a5e28b6e916d) | `` cudaPackages: eliminate exceptions ``                                    |
| [`cedbec08`](https://github.com/NixOS/nixpkgs/commit/cedbec08b50e6b8b6ab2ed85a1a005f08b91829d) | `` fastcdr: 1.1.1 -> 2.1.2 ``                                               |
| [`251c448e`](https://github.com/NixOS/nixpkgs/commit/251c448e7859d1ff36f2dc603ba94a2eaf12e733) | `` eksctl: 0.165.0 -> 0.167.0 ``                                            |
| [`9329efea`](https://github.com/NixOS/nixpkgs/commit/9329efeadc238dc9c169751403611481086f2d10) | `` xdg-desktop-portal-hyprland: 1.2.5 -> 1.2.6 ``                           |
| [`4c5759ed`](https://github.com/NixOS/nixpkgs/commit/4c5759ed4a35483515c57a67c027e6d743c6be7a) | `` wxmaxima: 23.11.0 -> 23.12.0 ``                                          |
| [`a44afba8`](https://github.com/NixOS/nixpkgs/commit/a44afba8444dfa8642e4225accd36585d094001b) | `` aliyun-cli: 3.0.189 -> 3.0.190 ``                                        |
| [`9d95ddfa`](https://github.com/NixOS/nixpkgs/commit/9d95ddfac4de893bf3b01d577e7622a4c5ef4a73) | `` spleen: 2.0.1 -> 2.0.2 ``                                                |
| [`90fa8361`](https://github.com/NixOS/nixpkgs/commit/90fa8361436f59618f1d75f5afc5987ae6fdd6fa) | `` qjournalctl: 0.6.3 -> 0.6.4 ``                                           |
| [`03a26af7`](https://github.com/NixOS/nixpkgs/commit/03a26af731656deb7d4ea515e1f9fc8baa5a5f7f) | `` speedtest-go: 1.6.9 -> 1.6.10 ``                                         |
| [`593d5806`](https://github.com/NixOS/nixpkgs/commit/593d58068494fe0ea19367644c2cfe71979085c8) | `` python311Packages.python-google-nest: 5.2.0 -> 5.2.1 ``                  |
| [`c21d0c38`](https://github.com/NixOS/nixpkgs/commit/c21d0c384484712202bb9f5a69858739f31742f5) | `` anydesk: use desktopItems, move passthru before meta ``                  |
| [`8cd60f25`](https://github.com/NixOS/nixpkgs/commit/8cd60f251eba14ef68b28d7a3fde3dd3d0d23a56) | `` esphome: 2023.11.6 -> 2023.12.5 ``                                       |
| [`2293e040`](https://github.com/NixOS/nixpkgs/commit/2293e04065f706a7af08c50e0a30e72193c23c7d) | `` python311Packages.simplisafe-python: refactor ``                         |
| [`e34a5602`](https://github.com/NixOS/nixpkgs/commit/e34a56026c1032ec48170b82739c0770f5d638f6) | `` telegram-desktop: 4.12.2 -> 4.13.1 ``                                    |
| [`b442b2a9`](https://github.com/NixOS/nixpkgs/commit/b442b2a9b54a4100dd564e370ebd3ad2f0d8e25c) | `` telegram-desktop.tg_owt: unstable-2023-11-17 -> unstable-2023-12-21 ``   |
| [`d2fa06b6`](https://github.com/NixOS/nixpkgs/commit/d2fa06b609085385a43afc81251af98b7bab0434) | `` python311Packages.mysqlclient: 2.2.0 -> 2.2.1 ``                         |
| [`a61b910f`](https://github.com/NixOS/nixpkgs/commit/a61b910f3b8ac6db90145b2b93942ee37b06d94a) | `` prometheus-consul-exporter: 0.9.0 -> 0.11.0 ``                           |
| [`76cd213e`](https://github.com/NixOS/nixpkgs/commit/76cd213e1eadfb172be69b1bfd25ca21e766c8a8) | `` ligolo-ng: 0.4.4 -> 0.4.5 ``                                             |
| [`0d1e4efb`](https://github.com/NixOS/nixpkgs/commit/0d1e4efbde674b4c852ab4f5097763413c87bd8b) | `` fbc: 1.10.0 -> 1.10.1 ``                                                 |
| [`c7d08402`](https://github.com/NixOS/nixpkgs/commit/c7d08402867652debf2964a68922f711bd10d3f9) | `` cudaPackages.cudart: stubs: add the libcuda.so.1 soname ``               |
| [`7da4af6d`](https://github.com/NixOS/nixpkgs/commit/7da4af6d7274e0c29b03ad1ad3622a65b4668ced) | `` bacon: 2.13.0 -> 2.14.1 ``                                               |
| [`27eefe02`](https://github.com/NixOS/nixpkgs/commit/27eefe02e08eba3a0c57ef35e9298331475c6d27) | `` python311Packages.mypy-boto3-*: 1.33.0 -> 1.34.0 ``                      |
| [`2100a51e`](https://github.com/NixOS/nixpkgs/commit/2100a51ebdcf1373105e76f4e6b0e56f1083e53c) | `` phpExtensions.apcu: remove obsolete patch ``                             |
| [`afbd598e`](https://github.com/NixOS/nixpkgs/commit/afbd598e18aa97412edc67891207b55692e42dc2) | `` frankenphp: 1.0.1 -> 1.0.2 ``                                            |
| [`2dc30cae`](https://github.com/NixOS/nixpkgs/commit/2dc30cae79baac0848ca5d8228154479721f0c8f) | `` libtraceevent: 1.7.3 -> 1.8.0 ``                                         |
| [`e03340a3`](https://github.com/NixOS/nixpkgs/commit/e03340a3873201ba282966b5bc2626a01e6c5d4e) | `` python311Packages.irc: 20.3.0 -> 20.3.1 ``                               |
| [`51bbafd6`](https://github.com/NixOS/nixpkgs/commit/51bbafd6a7e1df7317d8df9d9d85d3bd6c482398) | `` python311Packages.jaraco-logging: 3.2.0 -> 3.3.0 ``                      |
| [`36d19bc3`](https://github.com/NixOS/nixpkgs/commit/36d19bc398634ba0d91f44f6b8b85bce27ba0ff9) | `` kubecm: 0.25.0 -> 0.26.0 ``                                              |
| [`52f8a4ca`](https://github.com/NixOS/nixpkgs/commit/52f8a4caad3e07466d9f882e214d273e261a477a) | `` helmfile: 0.159.0 -> 0.160.0 ``                                          |