### PR TITLE
chore(flake/emacs-overlay): `285a626f` -> `dbf41b39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1703897863,
-        "narHash": "sha256-c1fzGuRbz6B2r9f3lT5a9C8rS1zYI3IeLd+NBuxKu1k=",
+        "lastModified": 1703953082,
+        "narHash": "sha256-hSxSE6vXqLze7yK9NpmGlnkYaLbY4hLfez9riVtvKP8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "285a626fe34c40d6f3e3f63f69f4ceb0cfc29e80",
+        "rev": "dbf41b3900117bb836118f7d3144bae6878a1c5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`dbf41b39`](https://github.com/nix-community/emacs-overlay/commit/dbf41b3900117bb836118f7d3144bae6878a1c5e) | `` Updated elpa ``         |
| [`abc8913c`](https://github.com/nix-community/emacs-overlay/commit/abc8913c8eb39cca83df7a878195f284af88e3ee) | `` Updated flake inputs `` |