### PR TITLE
chore(flake/nix-index-database): `f4340c1a` -> `2b2e6047`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703387252,
-        "narHash": "sha256-XKJqGj0BaEn/zyctEnkgVIh6Ba1rgTRc+UBi9EU8Y54=",
+        "lastModified": 1703991440,
+        "narHash": "sha256-wm4iyCD/7kV9M0fWbGecV+5fcB0JRPV/bhTiFYzztVw=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "f4340c1a42c38d79293ba69bfd839fbd6268a538",
+        "rev": "2b2e6047a258a5522b2ec8e5e01107bea7ae2d0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                  |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`2b2e6047`](https://github.com/nix-community/nix-index-database/commit/2b2e6047a258a5522b2ec8e5e01107bea7ae2d0c) | `` flake.lock: Update `` |