### PR TITLE
chore(flake/srvos): `a3f6322d` -> `23c8e6a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -989,11 +989,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703727919,
-        "narHash": "sha256-uVkW5/H+r1GTvyiyYsncbj5aYFdbGqjVNAANaooYlxY=",
+        "lastModified": 1704017909,
+        "narHash": "sha256-Eh4Iqcoq5ZcaXXY5+lN8oU9IUrMTktx4EyvmMGWlWP8=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "a3f6322dfa62aa40dc4faa9d5b2f1542a6e9a95d",
+        "rev": "23c8e6a9ca1365b9c281e2fb609e30932518b9a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                        |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`23c8e6a9`](https://github.com/nix-community/srvos/commit/23c8e6a9ca1365b9c281e2fb609e30932518b9a0) | `` cloud-init: set network config to silence warning (#347) `` |