### PR TITLE
chore(flake/nixos-hardware): `22ae59fe` -> `316bc983`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -628,11 +628,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1703879120,
-        "narHash": "sha256-oMJ5xtDswlBWxs0DT/aYKEUIhjEpGZJ9GbIxOclYP8I=",
+        "lastModified": 1704061647,
+        "narHash": "sha256-M/Kxfmb/fkgOz94jQ9eLFpXOhjQJ3CRmdPhVIVXqJmg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "22ae59fec26591ef72ce4ccb5538c42c5f090fe3",
+        "rev": "316bc98323fe3a7e7f72dbbbe68dce0cce3d4984",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`316bc983`](https://github.com/NixOS/nixos-hardware/commit/316bc98323fe3a7e7f72dbbbe68dce0cce3d4984) | `` Add TUXEDO InfinityBook Pro 14 - Gen7 config ``               |
| [`062e4810`](https://github.com/NixOS/nixos-hardware/commit/062e4810d8bee4954d32cf78145602e5b66c8704) | `` starfive visionfive2: update u-boot to SDK version v5.10.3 `` |