### PR TITLE
chore(flake/srvos): `23c8e6a9` -> `de6b3cd1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
     },
     "nixos-stable": {
       "locked": {
-        "lastModified": 1703467016,
-        "narHash": "sha256-/5A/dNPhbQx/Oa2d+Get174eNI3LERQ7u6WTWOlR1eQ=",
+        "lastModified": 1703900474,
+        "narHash": "sha256-Zu+chYVYG2cQ4FCbhyo6rc5Lu0ktZCjRbSPE0fDgukI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d02d818f22c777aa4e854efc3242ec451e5d462a",
+        "rev": "9dd7699928e26c3c00d5d46811f1358524081062",
         "type": "github"
       },
       "original": {
@@ -989,11 +989,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704017909,
-        "narHash": "sha256-Eh4Iqcoq5ZcaXXY5+lN8oU9IUrMTktx4EyvmMGWlWP8=",
+        "lastModified": 1704069690,
+        "narHash": "sha256-bYNDSi3uoja1V/pFFNAJeVItA4lIgEKcrHF9WLhfnXQ=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "23c8e6a9ca1365b9c281e2fb609e30932518b9a0",
+        "rev": "de6b3cd1f82b9b0c4d6e0370998a6b0f923df125",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------ |
| [`de6b3cd1`](https://github.com/nix-community/srvos/commit/de6b3cd1f82b9b0c4d6e0370998a6b0f923df125) | `` flake.lock: Update `` |