### PR TITLE
chore(flake/srvos): `de6b3cd1` -> `f2525dd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -989,11 +989,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704069690,
-        "narHash": "sha256-bYNDSi3uoja1V/pFFNAJeVItA4lIgEKcrHF9WLhfnXQ=",
+        "lastModified": 1704074312,
+        "narHash": "sha256-gXvY1zxdKlp4juzsi4dtGmn7yDnt3QYDoKc5oxN/2SA=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "de6b3cd1f82b9b0c4d6e0370998a6b0f923df125",
+        "rev": "f2525dd60b7bfe0c39187bd80e810aae24817a93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------ |
| [`f2525dd6`](https://github.com/nix-community/srvos/commit/f2525dd60b7bfe0c39187bd80e810aae24817a93) | `` flake.lock: Update `` |