### PR TITLE
chore(flake/emacs-overlay): `75d58280` -> `3750376a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704071125,
-        "narHash": "sha256-fJ/SDPHdX09UfTs+20sLINGFq7vft2OBY6NCKen2wKc=",
+        "lastModified": 1704096994,
+        "narHash": "sha256-EB1u0Cj03eHEqjFULc86FgeM3pc0IRzm5iHDNM0MSWA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "75d582804c561bb16f726916096ee22272d156cc",
+        "rev": "3750376a60b55eb5f2b62d7e89b34cde0c4f048e",
         "type": "github"
       },
       "original": {
@@ -707,11 +707,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1703900474,
-        "narHash": "sha256-Zu+chYVYG2cQ4FCbhyo6rc5Lu0ktZCjRbSPE0fDgukI=",
+        "lastModified": 1703992652,
+        "narHash": "sha256-C0o8AUyu8xYgJ36kOxJfXIroy9if/G6aJbNOpA5W0+M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9dd7699928e26c3c00d5d46811f1358524081062",
+        "rev": "32f63574c85fbc80e4ba1fbb932cde9619bad25e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`3750376a`](https://github.com/nix-community/emacs-overlay/commit/3750376a60b55eb5f2b62d7e89b34cde0c4f048e) | `` Updated flake inputs `` |