### PR TITLE
chore(flake/home-manager): `2e8634c2` -> `6e91c5df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -457,11 +457,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703995158,
-        "narHash": "sha256-oYMwbObpWheGeeNWY1LjO/+omrbAWDNdyzNDxTr2jo8=",
+        "lastModified": 1704100519,
+        "narHash": "sha256-SgZC3cxquvwTN07vrYYT9ZkfvuhS5Y1k1F4+AMsuflc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2e8634c252890cb38c60ab996af04926537cbc27",
+        "rev": "6e91c5df192395753d8e6d55a0352109cb559790",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`6e91c5df`](https://github.com/nix-community/home-manager/commit/6e91c5df192395753d8e6d55a0352109cb559790) | `` i3blocks: added configuration module ``       |
| [`f06edaf1`](https://github.com/nix-community/home-manager/commit/f06edaf18b119da7bb301eebbf87971bbb9fb162) | `` lorri: unbreak due to too tight sandboxing `` |
| [`b7ef79bc`](https://github.com/nix-community/home-manager/commit/b7ef79bcf47c002bd6ae81a52bd3f233297edbde) | `` Translate using Weblate (Ukrainian) ``        |