### PR TITLE
chore(flake/nixpkgs): `cfc3698c` -> `b0d36bd0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -755,11 +755,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1703637592,
-        "narHash": "sha256-8MXjxU0RfFfzl57Zy3OfXCITS0qWDNLzlBAdwxGZwfY=",
+        "lastModified": 1703961334,
+        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cfc3698c31b1fb9cdcf10f36c9643460264d0ca8",
+        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`da90576a`](https://github.com/NixOS/nixpkgs/commit/da90576aace1c178811ec136607e595d4f39dbae) | `` nixos/lxd-agent: fix evaluation regression caused by nixos/nixpkgs#271326 ``                   |
| [`5b2eefcc`](https://github.com/NixOS/nixpkgs/commit/5b2eefcc03d53975afae837bf15d94f142b94d71) | `` far2l: 2.4.1 -> 2.5.3 ``                                                                       |
| [`b13feabb`](https://github.com/NixOS/nixpkgs/commit/b13feabbf1c5ab9ea0923f5a20fd798a0b521469) | `` dkimproxy: fix running (#277729) ``                                                            |
| [`79ed4d99`](https://github.com/NixOS/nixpkgs/commit/79ed4d99dcbf447eaeb03adfd12740681f893f6a) | `` surrealdb-migrations: 1.0.0 -> 1.0.1 ``                                                        |
| [`036d7e31`](https://github.com/NixOS/nixpkgs/commit/036d7e31f9d6012fc75afdabf70515a511723991) | `` mtail: build all binaries, enable tests ``                                                     |
| [`9267f03e`](https://github.com/NixOS/nixpkgs/commit/9267f03edf26e2d2be1206fd92fe9ff5b128ce9f) | `` sing-box: set meta.mainProgram ``                                                              |
| [`cd2a28ef`](https://github.com/NixOS/nixpkgs/commit/cd2a28ef958916db14f68dcc292cc57cdb18388d) | `` python311Packages.pymc: fix hash mismatch ``                                                   |
| [`92531c3d`](https://github.com/NixOS/nixpkgs/commit/92531c3d37f2e2c7d5fe6b23d55cd7e90c654849) | `` sequoia-sq: 0.31.0 -> 0.32.0 ``                                                                |
| [`9c09d092`](https://github.com/NixOS/nixpkgs/commit/9c09d09241284cfc329d8193af152bf33e16ea6d) | `` revanced-cli: 4.3.0 -> 4.4.0 ``                                                                |
| [`6f2b434b`](https://github.com/NixOS/nixpkgs/commit/6f2b434b36e1ee5d76dea8515eca7e24beef4f51) | `` vimPlugins.sniprun: 1.3.9 -> 1.3.10 ``                                                         |
| [`20f64b5d`](https://github.com/NixOS/nixpkgs/commit/20f64b5d7752f87ab5dacc3cf9f0759b6945c4e8) | `` agate: 3.3.1 → 3.3.3 ``                                                                        |
| [`73a0ea12`](https://github.com/NixOS/nixpkgs/commit/73a0ea127b58a1242926e42ef13d4b63ad7f48a1) | `` wl-mirror: update description to match upstream description ``                                 |
| [`7f8b667d`](https://github.com/NixOS/nixpkgs/commit/7f8b667d08de49f6336fa171c7b650dedd7a4271) | `` wl-mirror: 0.14.2 -> 0.15.0 ``                                                                 |
| [`d7e85937`](https://github.com/NixOS/nixpkgs/commit/d7e85937ee89edcb56ad9b713d733adaa9e6b586) | `` octoprint: fix `octoprint-dashboard` alias definition ``                                       |
| [`c83b707f`](https://github.com/NixOS/nixpkgs/commit/c83b707f2f6795eeeed7d3f24bb21de3a20531a7) | `` minishift: remove ``                                                                           |
| [`1e9ffe17`](https://github.com/NixOS/nixpkgs/commit/1e9ffe1725055605e1759714ffcae64d2a5b83ce) | `` sqls: 0.2.27 -> 0.2.28 ``                                                                      |
| [`1878ed25`](https://github.com/NixOS/nixpkgs/commit/1878ed25eb2aa90e652854dc85b706d545c43f49) | `` ov: 0.32.1 -> 0.33.0 ``                                                                        |
| [`09c33746`](https://github.com/NixOS/nixpkgs/commit/09c337469128b8f8897b9a0ca1cfc1770cbbb29c) | `` sqls: 0.2.22 -> 0.2.27 ``                                                                      |
| [`c6aef2e8`](https://github.com/NixOS/nixpkgs/commit/c6aef2e8b7948b2b13b3b931a1ee7ff90b5cfb8a) | `` python311Packages.skodaconnect: update disabled ``                                             |
| [`47d6b219`](https://github.com/NixOS/nixpkgs/commit/47d6b21930a651faf1fd9f217423281c5332dc9f) | `` flake.nix: Add caveats ``                                                                      |
| [`834f8f42`](https://github.com/NixOS/nixpkgs/commit/834f8f42c220a1dcbbbc8b848e7e9b98f5a9dc41) | `` gtree: 1.10.4 -> 1.10.7 ``                                                                     |
| [`d99161d1`](https://github.com/NixOS/nixpkgs/commit/d99161d19121f75ce0ad568803693a9599dd5d04) | `` plymouth: 23.356.9 -> 23.360.11 ``                                                             |
| [`b60e4a8d`](https://github.com/NixOS/nixpkgs/commit/b60e4a8df1be97a74078d81d8540ec9973b1c444) | `` python311Packages.pycrdt: 0.7.2 -> 0.8.2 ``                                                    |
| [`f6ac391a`](https://github.com/NixOS/nixpkgs/commit/f6ac391a8be1a80bf4fb98a1a56bf931b664f677) | `` python311Packages.velbus-aio: 2023.11.0 -> 2023.12.0 ``                                        |
| [`806f73ae`](https://github.com/NixOS/nixpkgs/commit/806f73ae7d6881f2dcac477e78f8c0d360e36699) | `` qovery-cli: 0.77.0 -> 0.79.0 ``                                                                |
| [`890d5d2b`](https://github.com/NixOS/nixpkgs/commit/890d5d2b2a2cc2e7b026ff4882095874c29d0f6e) | `` thepeg: 2.2.3 -> 2.3.0 ``                                                                      |
| [`98d8b599`](https://github.com/NixOS/nixpkgs/commit/98d8b599cd111a828c29b754a7a7570238e817bc) | `` sfeed: 1.9 -> 2.0 ``                                                                           |
| [`97825d37`](https://github.com/NixOS/nixpkgs/commit/97825d37abf46a9ba9af74e4e9a8798fd6c8b207) | `` python311Packages.tplink-omada-client: 1.3.6 -> 1.3.7 ``                                       |
| [`d7b7c399`](https://github.com/NixOS/nixpkgs/commit/d7b7c399cd93cae44d7aaed1a24134562dc91532) | `` python311Packages.pycrdt-websocket: 0.12.5 -> 0.12.6 ``                                        |
| [`7fc1ba51`](https://github.com/NixOS/nixpkgs/commit/7fc1ba51589476315f8cec905dd0ca4efe6d2cb6) | `` python311Packages.roombapy: 1.6.9 -> 1.6.10 ``                                                 |
| [`5a54c339`](https://github.com/NixOS/nixpkgs/commit/5a54c339b5ef0413f4b330b7304f9e361852a916) | `` python311Packages.plexapi: 4.15.6 -> 4.15.7 ``                                                 |
| [`2ecaa715`](https://github.com/NixOS/nixpkgs/commit/2ecaa715f36015cf897e24eea14b02da2a6bff0f) | `` htmx-lsp: init at 0.1.0 ``                                                                     |
| [`a7133106`](https://github.com/NixOS/nixpkgs/commit/a71331063266bc65b48e61793d252e485efa1381) | `` twm: 0.8.1 -> 0.8.2 ``                                                                         |
| [`52c26b44`](https://github.com/NixOS/nixpkgs/commit/52c26b4473feed01612ccc2cd24c02c7f372160a) | `` vscode-extensions.dracula-theme.theme-dracula: 2.24.2 -> 2.24.3 ``                             |
| [`a13a9271`](https://github.com/NixOS/nixpkgs/commit/a13a92713e28e2c641f5cb44df9de5e36b3152b6) | `` obs-studio-plugins.obs-move-transition: 2.9.6 -> 2.9.8 ``                                      |
| [`65e75d69`](https://github.com/NixOS/nixpkgs/commit/65e75d699ce56e0f8a125d784885305e4c1eddce) | `` vscode-extensions.serayuzgur.crates: 0.6.0 -> 0.6.5 ``                                         |
| [`7322f0f2`](https://github.com/NixOS/nixpkgs/commit/7322f0f2adf88d0cc24b2b4af379488978934527) | `` just: 1.20.0 -> 1.21.0 ``                                                                      |
| [`068e9d43`](https://github.com/NixOS/nixpkgs/commit/068e9d43248e90d69f292b8afd752b0a99e428ea) | `` sing-box: 1.7.6 -> 1.7.7 ``                                                                    |
| [`90718307`](https://github.com/NixOS/nixpkgs/commit/90718307e88117d6cce03e6f47cec2ff9a3a8f72) | `` tdlib: 1.8.22 -> 1.8.23 ``                                                                     |
| [`a1422a7f`](https://github.com/NixOS/nixpkgs/commit/a1422a7f8f12b68e307b92b7daa254f412e9ff96) | `` build-support/go: fix eval of `vendorSha256` accesses ``                                       |
| [`32f27641`](https://github.com/NixOS/nixpkgs/commit/32f27641a0ffc60ef734b2ea338fe5eb56cd6641) | `` buildbot-worker: mark broken on darwin ``                                                      |
| [`2b0e5f12`](https://github.com/NixOS/nixpkgs/commit/2b0e5f1244169655c4613e63d4e812b4e5ab0353) | `` buildbot: sqlalchemy: 1.4.49 -> 1.4.50 ``                                                      |
| [`41e3e7ef`](https://github.com/NixOS/nixpkgs/commit/41e3e7ef30819ecad84389c40827f62c7b7acbb6) | `` buildbot: 3.10.0 -> 3.10.1 ``                                                                  |
| [`4011dd66`](https://github.com/NixOS/nixpkgs/commit/4011dd666b312834166426bf9073423efa7d82fa) | `` talosctl: 1.6.0 -> 1.6.1 ``                                                                    |
| [`594c284f`](https://github.com/NixOS/nixpkgs/commit/594c284fa7ec4539b5defd432951dd7dcc5f1e75) | `` home-assistant-custom-lovelace-modules.light-entity-card: 6.1.0 -> 6.1.1 ``                    |
| [`ec390d5e`](https://github.com/NixOS/nixpkgs/commit/ec390d5e514d82c00dad1205f33293a8fa0e35ec) | `` supabase-cli: 1.129.0 -> 1.129.1 ``                                                            |
| [`750935f7`](https://github.com/NixOS/nixpkgs/commit/750935f7f0df9b21d86f716bc2afa80d10161a5c) | `` stgit: 2.4.1 -> 2.4.2 ``                                                                       |
| [`5a500574`](https://github.com/NixOS/nixpkgs/commit/5a500574ebf4747912e733435f39e4a6ffed2ea0) | `` luaPackages.toml-edit: 0.1.4 -> 0.1.5 ``                                                       |
| [`de9dba61`](https://github.com/NixOS/nixpkgs/commit/de9dba61f9b08748bb4388963d6477cfb11d41d1) | `` yubihsm-connector: fix cross compilation ``                                                    |
| [`e9cdd5fa`](https://github.com/NixOS/nixpkgs/commit/e9cdd5fae80497c1fefaffff872416822566e04c) | `` julia.withPackages: handle non-archive artifacts (fixes #277410) ``                            |
| [`84e76aef`](https://github.com/NixOS/nixpkgs/commit/84e76aef99911253445faf69f9d1682e65c392b8) | `` snappymail: 2.31.0 -> 2.32.0 ``                                                                |
| [`04df6aa7`](https://github.com/NixOS/nixpkgs/commit/04df6aa7bad237aeeb69f603e1f4ec1a2c28a4da) | `` organicmaps: 2023.11.17-17 -> 2023.12.20-4 ``                                                  |
| [`2ca9b484`](https://github.com/NixOS/nixpkgs/commit/2ca9b484dd3ccfedb1f938cf2396fa0e1fe8aeda) | `` denaro: 2023.9.2 -> 2023.11.0 ``                                                               |
| [`aea1f78a`](https://github.com/NixOS/nixpkgs/commit/aea1f78ac32b247f45210c7394ede6c0dd106205) | `` python311Packages.opensensemap-api: 0.3.1 -> 0.3.2 ``                                          |
| [`a3048a66`](https://github.com/NixOS/nixpkgs/commit/a3048a660d85b28924c5681abb59281d534ff391) | `` sd-local: 1.0.50 -> 1.0.51 ``                                                                  |
| [`4d96a0f9`](https://github.com/NixOS/nixpkgs/commit/4d96a0f96f69eeb26e058417441f93638c2a9e9a) | `` envfs: 1.0.2 -> 1.0.3 ``                                                                       |
| [`a60dcc7f`](https://github.com/NixOS/nixpkgs/commit/a60dcc7fc14c658e16fb306800f7157682dc0cbe) | `` jellyfin-ffmpeg: fix `tests` eval ``                                                           |
| [`62455ade`](https://github.com/NixOS/nixpkgs/commit/62455ade3cb6fcc9635ab8e7591a12f1c0d88f08) | `` qgis-ltr: 3.28.13 -> 3.28.14 ``                                                                |
| [`d32abf7f`](https://github.com/NixOS/nixpkgs/commit/d32abf7f983ac73cdc30b7c8540f94ad2f658814) | `` qgis: 3.34.1 -> 3.34.2 ``                                                                      |
| [`39adbc54`](https://github.com/NixOS/nixpkgs/commit/39adbc54560e1f0072fc84d5228a5b6063ba6300) | `` devpod: fix `tests` eval ``                                                                    |
| [`02ebf149`](https://github.com/NixOS/nixpkgs/commit/02ebf149d53e5ac815e3dd4f668a088faa671dd3) | `` nixos/release-notes: more details about Nextcloud options rename ``                            |
| [`d3fdf4df`](https://github.com/NixOS/nixpkgs/commit/d3fdf4df0ac2456fa04842b66e7f7b418b0614eb) | `` findup: fix `tests` eval ``                                                                    |
| [`ce228ed6`](https://github.com/NixOS/nixpkgs/commit/ce228ed6bd232d33d35f5a1a8595c6b96c67ecc9) | `` fakeroot: fix `tests` eval ``                                                                  |
| [`25f25d78`](https://github.com/NixOS/nixpkgs/commit/25f25d78bfd668e32679f7c7dca5e8e964d598d9) | `` ryujinx: 1.1.1100 -> 1.1.1102 ``                                                               |
| [`e8e5c07a`](https://github.com/NixOS/nixpkgs/commit/e8e5c07ad0b7ba7e068cf3de81823cb0fe238c3c) | `` nixos/matrix-sliding-sync: rename, init dendrite ``                                            |
| [`bb90caa7`](https://github.com/NixOS/nixpkgs/commit/bb90caa75c509a1d26f8f52fc3678de9552e9fd3) | `` rure: 0.2.2 -> 0.2.2 ``                                                                        |
| [`bae5e651`](https://github.com/NixOS/nixpkgs/commit/bae5e6516269cc804974ef2d5f494d46f7a012c1) | `` nixos/nextcloud: fix nginx routing to store and nix apps ``                                    |
| [`bf3b6842`](https://github.com/NixOS/nixpkgs/commit/bf3b68426906c08b10f4e6f99729b7d2214a9d15) | `` tigervnc: fix `tests` eval ``                                                                  |
| [`1038d49c`](https://github.com/NixOS/nixpkgs/commit/1038d49c331c07cb0750c23f1f32dc15e3d49b68) | `` netbootxyz-efi: 2.0.60 -> 2.0.75 ``                                                            |
| [`ea34b38d`](https://github.com/NixOS/nixpkgs/commit/ea34b38d74f1aca48d0baa99c40bfd0378c056b6) | `` jasmin-compiler: 2023.06.1 → 2023.06.2 ``                                                      |
| [`a3ec62e6`](https://github.com/NixOS/nixpkgs/commit/a3ec62e683c5236889a5b2856bf3ad5219835041) | `` python3Packages.monitorcontrol: init at 3.1.0 ``                                               |
| [`eac0d1a0`](https://github.com/NixOS/nixpkgs/commit/eac0d1a0a4e84ab4e4f9323a668f56c0a024f29d) | `` python3Packages.python-djvulibre: init at 0.9.0 ``                                             |
| [`93d39734`](https://github.com/NixOS/nixpkgs/commit/93d39734d9e77abfdaed12824b480ee8bad0beff) | `` wakapi: 2.10.0 -> 2.10.2 ``                                                                    |
| [`ff085288`](https://github.com/NixOS/nixpkgs/commit/ff0852881078880b1bd5d04bf954e641cda776bf) | `` planner: 0.14.91 -> 0.14.92 ``                                                                 |
| [`d05b9fdc`](https://github.com/NixOS/nixpkgs/commit/d05b9fdc8fd83705acf6677371391d10651d0a7b) | `` evolution-ews: 3.50.1 → 3.50.2 ``                                                              |
| [`626c0e3f`](https://github.com/NixOS/nixpkgs/commit/626c0e3f7c574122300631c68323cbd972a02719) | `` qownnotes: 23.12.3 -> 23.12.5 ``                                                               |
| [`67a799c4`](https://github.com/NixOS/nixpkgs/commit/67a799c40f1e177950d70bb0ea1073c4b6273b0f) | `` nixos/ollama: init ``                                                                          |
| [`dfc1bdb9`](https://github.com/NixOS/nixpkgs/commit/dfc1bdb916552e0e6b3ea649e72e56477dc5ce3b) | `` ddgr: 2.1 -> 2.2 ``                                                                            |
| [`03387a3e`](https://github.com/NixOS/nixpkgs/commit/03387a3e63e7ad76dea7432bb65a9d8f42b24874) | `` git-releaser: 0.1.1 -> 0.1.2 ``                                                                |
| [`836e74d6`](https://github.com/NixOS/nixpkgs/commit/836e74d69553b74c557613e1763d99a0ffed0a6e) | `` python312Packages.array-record: improve eval error ``                                          |
| [`0403c41f`](https://github.com/NixOS/nixpkgs/commit/0403c41f61bbb3065d9d894ee5b4e799af872c4d) | `` nixos/installer: add a link to how to actually upgrade your system to the stateVersion note `` |
| [`3def6e47`](https://github.com/NixOS/nixpkgs/commit/3def6e473c41d8b5b97de959bb0c808649c4d862) | `` python310Packages.withings-sync: 4.2.1 -> 4.2.2 ``                                             |
| [`915c004e`](https://github.com/NixOS/nixpkgs/commit/915c004e3690a47cc731f30eb4c61e20a9ab3c4d) | `` Revert "melpa2nix: update to work with Emacs HEAD" ``                                          |
| [`9f847b82`](https://github.com/NixOS/nixpkgs/commit/9f847b827e4396143ef7687307cd1d4569a5d5b5) | `` xfce.thunar: 4.18.8 -> 4.18.9 ``                                                               |
| [`34d2421d`](https://github.com/NixOS/nixpkgs/commit/34d2421d7196d7382dda2b76fe3c28c9e606c06e) | `` satty: 0.8.2 -> 0.8.3 ``                                                                       |
| [`48956956`](https://github.com/NixOS/nixpkgs/commit/48956956edbba59fdf3ac4552d6be7b57e30a566) | `` symfony-cli: 5.7.6 -> 5.7.7 ``                                                                 |
| [`089b731d`](https://github.com/NixOS/nixpkgs/commit/089b731d87d41e03f57cb46a712381c98e37bfa6) | `` python/hooks: fix `test` attribute eval ``                                                     |
| [`d95aaab1`](https://github.com/NixOS/nixpkgs/commit/d95aaab15364d7f30167cab4cd003a166c37d52d) | `` python310Packages.textdistance: 4.6.0 -> 4.6.1 ``                                              |
| [`ef51456d`](https://github.com/NixOS/nixpkgs/commit/ef51456d0f2b01674d62f658ff5f5b286e27d24b) | `` mpvScripts: Immediately error on collisions between `scope` and `aliases` ``                   |
| [`08de7bd9`](https://github.com/NixOS/nixpkgs/commit/08de7bd96147bca47ee7428c620707cbb34cef9f) | `` mpvScripts: Refactor `default.nix` ``                                                          |
| [`614afa60`](https://github.com/NixOS/nixpkgs/commit/614afa6014f7d289f606c46c6840c81976948a3a) | `` mpvScripts: Make into a scope ``                                                               |
| [`6b186414`](https://github.com/NixOS/nixpkgs/commit/6b186414ded05f306218883a861f958386450252) | `` mpvScripts.buildLua: Expose to nixpkgs users ``                                                |
| [`81d6df02`](https://github.com/NixOS/nixpkgs/commit/81d6df0268747d1a32ea85d37b4276fd23a9795d) | `` mpvScripts: Avoid mixing `//` and `callPackage` ``                                             |
| [`0e7633f4`](https://github.com/NixOS/nixpkgs/commit/0e7633f486912c0375f9f243f43113eb1469a9db) | `` esphome: improve error message ``                                                              |
| [`18e61acd`](https://github.com/NixOS/nixpkgs/commit/18e61acd4a88da0f543e7fcebb9e493430985354) | `` pgmoneta: 0.7.2 -> 0.7.3 ``                                                                    |
| [`4eb331ef`](https://github.com/NixOS/nixpkgs/commit/4eb331ef94a58a068717771f6d6fd0f6c64ef5b9) | `` automatic-timezoned: 1.0.137 -> 1.0.138 ``                                                     |
| [`5803e670`](https://github.com/NixOS/nixpkgs/commit/5803e6701fb03f092f377c7802b6027588aa131c) | `` static-web-server: 2.24.1 -> 2.24.2 ``                                                         |
| [`8c994854`](https://github.com/NixOS/nixpkgs/commit/8c994854f2f53acaca889949ee35a2ed924759cc) | `` juicefs: 1.1.0 -> 1.1.1 ``                                                                     |