### PR TITLE
chore(flake/emacs-overlay): `7fd5b5b7` -> `575fcd2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704125861,
-        "narHash": "sha256-irEN/GpvFmSMS63jmcz6lit2POJUnjlu1Yu99v5lWpk=",
+        "lastModified": 1704157128,
+        "narHash": "sha256-BAna+70nf43RJ5wOOl4grL4W/o4FRNtgWZtwt/LTZvE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7fd5b5b760ea726aa4c7670be7d93623936f9bf3",
+        "rev": "575fcd2ddb0e7c40611ba68d4a977e0cdc729669",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`575fcd2d`](https://github.com/nix-community/emacs-overlay/commit/575fcd2ddb0e7c40611ba68d4a977e0cdc729669) | `` Updated elpa ``         |
| [`4778b6a4`](https://github.com/nix-community/emacs-overlay/commit/4778b6a4e51b4784b31d57ee5a291d8b6d5d4635) | `` Updated flake inputs `` |