### PR TITLE
chore(flake/nixos-hardware): `f752581d` -> `5bf829d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -628,11 +628,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1704124233,
-        "narHash": "sha256-lBHs/yUtkcGgapHRS31oOb5NqvnVrikvktGOW8rK+sE=",
+        "lastModified": 1704228290,
+        "narHash": "sha256-M3y1ADeFVdPTV/bJXvO5QHDYFujzpJNblkfIgECTxGc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f752581d6723a10da7dfe843e917a3b5e4d8115a",
+        "rev": "5bf829d72ccdc05be3343afd81bd922d5748ef4e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`5bf829d7`](https://github.com/NixOS/nixos-hardware/commit/5bf829d72ccdc05be3343afd81bd922d5748ef4e) | `` Update lenovo/legion/16aph8/default.nix ``                                     |
| [`a5028e96`](https://github.com/NixOS/nixos-hardware/commit/a5028e96cc8cabb78ab58edc251e122e9ac7c7b2) | `` Small cleanup ``                                                                |
| [`0f29eb0b`](https://github.com/NixOS/nixos-hardware/commit/0f29eb0b0f2edaae76e1f83f50b9593e57b9ebeb) | `` Force to only "nvidia" for xserver.videoDrivers to avoid blank screen issues `` |
| [`d10b7958`](https://github.com/NixOS/nixos-hardware/commit/d10b79582330966723efc10df3bc4167cf22fdfe) | `` Disable modesetting ``                                                          |
| [`158afdea`](https://github.com/NixOS/nixos-hardware/commit/158afdeaf85065c481d888d70c4f2975cce61b2b) | `` Corrected nix-info from an earlier build ``                                     |
| [`c2f991b9`](https://github.com/NixOS/nixos-hardware/commit/c2f991b91ec4d0da53d04317914eacad354ad0a6) | `` Added support for Lenovo Legion Slim 5 (16APH8) ``                              |