### PR TITLE
chore(flake/emacs-overlay): `6636656a` -> `037752e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704296211,
-        "narHash": "sha256-C8fw0FbR81PCSy3600TYmWL9KrIEX4LEhTgMXVBii5M=",
+        "lastModified": 1704300583,
+        "narHash": "sha256-J7eZ8lWwhC5ytBgrtDYhrWOAir9g2JzgucY48R9HVW8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6636656a0ec16a34641ba5bfa5f0b1de5724cc7f",
+        "rev": "037752e56a049798a44a9a07dec53617bdba5bc0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`037752e5`](https://github.com/nix-community/emacs-overlay/commit/037752e56a049798a44a9a07dec53617bdba5bc0) | `` Updated melpa `` |
| [`f1d372c3`](https://github.com/nix-community/emacs-overlay/commit/f1d372c3cc8c5524c6f0c937a5629365203c351b) | `` Updated elpa ``  |