### PR TITLE
chore(flake/home-manager): `4d8f9020` -> `fcbc70a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -457,11 +457,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704276313,
-        "narHash": "sha256-4eD4RaAKHLj0ztw5pQcNFs3hGpxrsYb0e9Qir+Ute+w=",
+        "lastModified": 1704311514,
+        "narHash": "sha256-j6JsfCv31bW7LzV06q2L/27QZ4k1Zq7lEq2AR9R150A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4d8f90205c6c90be2e81d94d0e5eedf71c1ba34e",
+        "rev": "fcbc70a7ee064f2b65dc1fac1717ca2a9813bbe6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                             |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`fcbc70a7`](https://github.com/nix-community/home-manager/commit/fcbc70a7ee064f2b65dc1fac1717ca2a9813bbe6) | `` xdg-portal: add new module ``    |
| [`992b38f2`](https://github.com/nix-community/home-manager/commit/992b38f29cd7e50d88a2ae069133750beda010a4) | `` yazi: fix nushell integration `` |
| [`f772334b`](https://github.com/nix-community/home-manager/commit/f772334b357440e93e4c8f137d40b135720e3c83) | `` flake.lock: Update ``            |