### PR TITLE
chore(flake/emacs-overlay): `037752e5` -> `2cb3fceb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704300583,
-        "narHash": "sha256-J7eZ8lWwhC5ytBgrtDYhrWOAir9g2JzgucY48R9HVW8=",
+        "lastModified": 1704330016,
+        "narHash": "sha256-FT9rJ+V/ou5FLgx6TylsSJdGHquD7poTvV17ktKepYA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "037752e56a049798a44a9a07dec53617bdba5bc0",
+        "rev": "2cb3fceb716d51d798a2efe63926e56b502ecc0b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`2cb3fceb`](https://github.com/nix-community/emacs-overlay/commit/2cb3fceb716d51d798a2efe63926e56b502ecc0b) | `` Updated elpa ``         |
| [`1f1b99ff`](https://github.com/nix-community/emacs-overlay/commit/1f1b99ff99e4603e9ecbd218f1611c50c32baf53) | `` Updated flake inputs `` |