### PR TITLE
chore(flake/nur): `32bf7bf1` -> `963012f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704325526,
-        "narHash": "sha256-Zo/9HR5tA5rr1v5/audVw1/mWMj+MwRPLxsNKOki+aM=",
+        "lastModified": 1704332861,
+        "narHash": "sha256-XYVtmVqhLlMQ2YiL9rgKmE4yzFf3XlmYFhIHobst3f8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "32bf7bf1ffa88835045bd71acba6da621c18631e",
+        "rev": "963012f904f562575d1e1ba2fcb8c46785542c53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`963012f9`](https://github.com/nix-community/NUR/commit/963012f904f562575d1e1ba2fcb8c46785542c53) | `` automatic update `` |
| [`d45b2d9e`](https://github.com/nix-community/NUR/commit/d45b2d9e5ca4bc2cedec18765392c675205fc604) | `` automatic update `` |
| [`fe21ae92`](https://github.com/nix-community/NUR/commit/fe21ae92b489089d4fdca7c21360b50af43e1962) | `` automatic update `` |