### PR TITLE
chore(flake/nur): `963012f9` -> `e47af032`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704332861,
-        "narHash": "sha256-XYVtmVqhLlMQ2YiL9rgKmE4yzFf3XlmYFhIHobst3f8=",
+        "lastModified": 1704340499,
+        "narHash": "sha256-8RTRE2YXshIKs0W1QSM8bLy1zeOPG+FmuHb/yIclg4k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "963012f904f562575d1e1ba2fcb8c46785542c53",
+        "rev": "e47af03268bf305bc0df6eee3462889b8c37de89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e47af032`](https://github.com/nix-community/NUR/commit/e47af03268bf305bc0df6eee3462889b8c37de89) | `` automatic update `` |
| [`6b88f0e2`](https://github.com/nix-community/NUR/commit/6b88f0e26e031b74a42fb743c7de9267279f3994) | `` automatic update `` |
| [`fa464984`](https://github.com/nix-community/NUR/commit/fa4649846215d088b8a517ce1e5e6e9b95343a4d) | `` automatic update `` |
| [`1f294305`](https://github.com/nix-community/NUR/commit/1f294305265d59b0027411708a0b0b76a913f266) | `` automatic update `` |
| [`c98c5a89`](https://github.com/nix-community/NUR/commit/c98c5a895db56cbcae6e3139da4ff4c6033f7306) | `` automatic update `` |