### PR TITLE
chore(flake/nur): `e47af032` -> `227f0cc2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704340499,
-        "narHash": "sha256-8RTRE2YXshIKs0W1QSM8bLy1zeOPG+FmuHb/yIclg4k=",
+        "lastModified": 1704346813,
+        "narHash": "sha256-zi8q2vM8OsRrv3Rm/lGcJVZolNye43xhkDk6Ock4xqg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e47af03268bf305bc0df6eee3462889b8c37de89",
+        "rev": "227f0cc29271a4d5f9ae702f3cd7609ba7853eb2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`227f0cc2`](https://github.com/nix-community/NUR/commit/227f0cc29271a4d5f9ae702f3cd7609ba7853eb2) | `` automatic update `` |
| [`9dd48cb3`](https://github.com/nix-community/NUR/commit/9dd48cb3a578d6dafb9dba995cc61668e05a326b) | `` automatic update `` |
| [`a7e17a2d`](https://github.com/nix-community/NUR/commit/a7e17a2d3ce6c436dc58986d0927c03ca940a9f3) | `` automatic update `` |