### PR TITLE
chore(flake/nur): `227f0cc2` -> `1914d846`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704346813,
-        "narHash": "sha256-zi8q2vM8OsRrv3Rm/lGcJVZolNye43xhkDk6Ock4xqg=",
+        "lastModified": 1704351172,
+        "narHash": "sha256-TuFs+wAtTtRj867Cj0C0sGhZ7mlDqg/khVWOR0xvKm8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "227f0cc29271a4d5f9ae702f3cd7609ba7853eb2",
+        "rev": "1914d8460594a7b4abc194d834ceeeac1cadf029",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1914d846`](https://github.com/nix-community/NUR/commit/1914d8460594a7b4abc194d834ceeeac1cadf029) | `` automatic update `` |
| [`f1c9f519`](https://github.com/nix-community/NUR/commit/f1c9f519ab9ef714d0e0bea543c879a1bc6fcdad) | `` automatic update `` |
| [`04d4931c`](https://github.com/nix-community/NUR/commit/04d4931ce731a8eaae086f5109f3645975147621) | `` automatic update `` |