### PR TITLE
chore(flake/srvos): `cc35cf20` -> `341c142a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -989,11 +989,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704332984,
-        "narHash": "sha256-OU7jtY9rq9FjeUBcojUbBO3ufczXTLOq1d6ekxFvTKg=",
+        "lastModified": 1704357296,
+        "narHash": "sha256-npRcwAqeoLRdilyn4yOG9qShTRJ3sXL/xpyVOi+j7nw=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "cc35cf20ff9ba65d3b3cfae02bc1976da29505ee",
+        "rev": "341c142aad6609161b6b74cfc2d288f0ead01585",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                               |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`dbc61568`](https://github.com/nix-community/srvos/commit/dbc61568e12d4220b79121c27f2f24208ba7090d) | `` add hardware-hetzner-online-arm `` |