### PR TITLE
chore(flake/nur): `1914d846` -> `e4e9adde`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704351172,
-        "narHash": "sha256-TuFs+wAtTtRj867Cj0C0sGhZ7mlDqg/khVWOR0xvKm8=",
+        "lastModified": 1704365057,
+        "narHash": "sha256-4vjmHhXshC8MOxavTM7O51ueMwiWsE0q0bJMSc+68FA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1914d8460594a7b4abc194d834ceeeac1cadf029",
+        "rev": "e4e9adde15848d34a1f35940f762c29dda69c07c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e4e9adde`](https://github.com/nix-community/NUR/commit/e4e9adde15848d34a1f35940f762c29dda69c07c) | `` automatic update `` |
| [`955af6b5`](https://github.com/nix-community/NUR/commit/955af6b533ffe2799bfa54911a9ffa211305be71) | `` automatic update `` |
| [`db76fe7d`](https://github.com/nix-community/NUR/commit/db76fe7dfebf7d8266d050f424849b4bed7960ca) | `` automatic update `` |