### PR TITLE
chore(flake/nur): `e4e9adde` -> `69d08a65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704365057,
-        "narHash": "sha256-4vjmHhXshC8MOxavTM7O51ueMwiWsE0q0bJMSc+68FA=",
+        "lastModified": 1704372847,
+        "narHash": "sha256-qSP2JCnbuaUfIw2t5duoALnYPbo+laojKZIrWlspmzc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e4e9adde15848d34a1f35940f762c29dda69c07c",
+        "rev": "69d08a65433ca69ac51208fbb30c5b0401054225",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`69d08a65`](https://github.com/nix-community/NUR/commit/69d08a65433ca69ac51208fbb30c5b0401054225) | `` automatic update `` |
| [`231a12ab`](https://github.com/nix-community/NUR/commit/231a12ab070fbe02ebb0764606874da82b6cc05d) | `` automatic update `` |
| [`f3eb8f9e`](https://github.com/nix-community/NUR/commit/f3eb8f9ec8e3c58c7f4d453e275139cc9488efb7) | `` automatic update `` |