### PR TITLE
chore(flake/nur): `69d08a65` -> `a164668c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704372847,
-        "narHash": "sha256-qSP2JCnbuaUfIw2t5duoALnYPbo+laojKZIrWlspmzc=",
+        "lastModified": 1704375728,
+        "narHash": "sha256-Zb/VPVgjU0XZn5ccrE6dZwDQDib6HdeQlZ0mGc0iB0E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "69d08a65433ca69ac51208fbb30c5b0401054225",
+        "rev": "a164668c8095caca1059b1bd8208769ae880404d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a164668c`](https://github.com/nix-community/NUR/commit/a164668c8095caca1059b1bd8208769ae880404d) | `` automatic update `` |
| [`98df3ede`](https://github.com/nix-community/NUR/commit/98df3ede28866d6b2752f280ac398404258d3285) | `` automatic update `` |
| [`06abc89e`](https://github.com/nix-community/NUR/commit/06abc89e7815120b7637a3cef02f76018c2530b5) | `` automatic update `` |
| [`2cd9f021`](https://github.com/nix-community/NUR/commit/2cd9f02182eea3c0dea9985706ca0b1d3d0ff3c0) | `` automatic update `` |