### PR TITLE
chore(flake/nur): `a164668c` -> `482244aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704375728,
-        "narHash": "sha256-Zb/VPVgjU0XZn5ccrE6dZwDQDib6HdeQlZ0mGc0iB0E=",
+        "lastModified": 1704378556,
+        "narHash": "sha256-sdx3IXUOwBMn0l5gUyfULiQRTBUcOq+6dLnHERYnEMY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a164668c8095caca1059b1bd8208769ae880404d",
+        "rev": "482244aa0deb5d2d86326859633ee6e2872cb500",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`482244aa`](https://github.com/nix-community/NUR/commit/482244aa0deb5d2d86326859633ee6e2872cb500) | `` automatic update `` |