### PR TITLE
chore(flake/nur): `482244aa` -> `a6e4a0b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704378556,
-        "narHash": "sha256-sdx3IXUOwBMn0l5gUyfULiQRTBUcOq+6dLnHERYnEMY=",
+        "lastModified": 1704389243,
+        "narHash": "sha256-JV97bQ9dikG4AITMoEUsDYKRcbxzEHoUpHcweF2ZkJA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "482244aa0deb5d2d86326859633ee6e2872cb500",
+        "rev": "a6e4a0b4a1c9e3e3fc1b2174f5fc5bd766a6e8db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a6e4a0b4`](https://github.com/nix-community/NUR/commit/a6e4a0b4a1c9e3e3fc1b2174f5fc5bd766a6e8db) | `` automatic update `` |
| [`cde264f5`](https://github.com/nix-community/NUR/commit/cde264f59eda6177e4a47c4f16c041e0ba28561c) | `` automatic update `` |
| [`06ba407c`](https://github.com/nix-community/NUR/commit/06ba407c86000456def0c7cd2607754ad59d3b37) | `` automatic update `` |
| [`85b4c251`](https://github.com/nix-community/NUR/commit/85b4c25102ce25dc8a89fc56730a6fd5650d0ab6) | `` automatic update `` |