### PR TITLE
chore(flake/emacs-overlay): `c4e45eff` -> `9206a7ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704358182,
-        "narHash": "sha256-BRBf4DMHfsw1LHRYbRkxT9OjyDD/BjKHOUMHJpnRhuc=",
+        "lastModified": 1704387047,
+        "narHash": "sha256-YiQoAg5EOAdNfXBWDWcnIb7GrZ1Al4ThZy9V0VakCtQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c4e45eff568029ef3309817cb4610f04be604353",
+        "rev": "9206a7acdc0dd951d5d229b09405c7c6205bcef4",
         "type": "github"
       },
       "original": {
@@ -707,11 +707,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1703992652,
-        "narHash": "sha256-C0o8AUyu8xYgJ36kOxJfXIroy9if/G6aJbNOpA5W0+M=",
+        "lastModified": 1704145853,
+        "narHash": "sha256-G/1AMt9ibpeMlcxvD1vNaC8imGaK+g7zZ99e29BLgWw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "32f63574c85fbc80e4ba1fbb932cde9619bad25e",
+        "rev": "2d2ea8eab9e400618748ab1a6a108255233b602c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`9206a7ac`](https://github.com/nix-community/emacs-overlay/commit/9206a7acdc0dd951d5d229b09405c7c6205bcef4) | `` Updated melpa ``        |
| [`5872f588`](https://github.com/nix-community/emacs-overlay/commit/5872f588832d7db88fa8471b87878e4a409718ed) | `` Updated elpa ``         |
| [`fb0d8b86`](https://github.com/nix-community/emacs-overlay/commit/fb0d8b86460a2eaba3bea2dcae5346a24aab0822) | `` Updated nongnu ``       |
| [`46787d20`](https://github.com/nix-community/emacs-overlay/commit/46787d2076b8a828425daffb81e64acdbb8fa2b8) | `` Updated flake inputs `` |