### PR TITLE
chore(flake/nur): `a6e4a0b4` -> `232eb653`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704389243,
-        "narHash": "sha256-JV97bQ9dikG4AITMoEUsDYKRcbxzEHoUpHcweF2ZkJA=",
+        "lastModified": 1704393905,
+        "narHash": "sha256-JKCYbqvSThs4IHxFZnFj/BABHNWBFJSPBxsqB21dSrw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a6e4a0b4a1c9e3e3fc1b2174f5fc5bd766a6e8db",
+        "rev": "232eb653d10b214283e7e687ca438914125b030d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`232eb653`](https://github.com/nix-community/NUR/commit/232eb653d10b214283e7e687ca438914125b030d) | `` automatic update `` |
| [`28945c26`](https://github.com/nix-community/NUR/commit/28945c269006d452d55669c0cefe247f153eece5) | `` automatic update `` |
| [`d3085d53`](https://github.com/nix-community/NUR/commit/d3085d53c1206861198095273310be60a8eb59ae) | `` automatic update `` |