### PR TITLE
chore(flake/nur): `232eb653` -> `c1d42314`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704393905,
-        "narHash": "sha256-JKCYbqvSThs4IHxFZnFj/BABHNWBFJSPBxsqB21dSrw=",
+        "lastModified": 1704398166,
+        "narHash": "sha256-U1no670Oyrpf3/ygBvPELayTQYDmy/CpV4A7uy8UjnQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "232eb653d10b214283e7e687ca438914125b030d",
+        "rev": "c1d423142bc69c2b9cc9244f9da9b1a4c199f3c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c1d42314`](https://github.com/nix-community/NUR/commit/c1d423142bc69c2b9cc9244f9da9b1a4c199f3c9) | `` automatic update `` |
| [`d403964e`](https://github.com/nix-community/NUR/commit/d403964ef619819088c8f7099bfff7de5f6cc084) | `` automatic update `` |
| [`8fa9ed46`](https://github.com/nix-community/NUR/commit/8fa9ed463904fb2d8891e613457787bab3f14f67) | `` automatic update `` |
| [`f08eb802`](https://github.com/nix-community/NUR/commit/f08eb8028c08ff52425d51164e9e707af280d3e6) | `` automatic update `` |