### PR TITLE
chore(flake/nur): `c1d42314` -> `b14098b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704398166,
-        "narHash": "sha256-U1no670Oyrpf3/ygBvPELayTQYDmy/CpV4A7uy8UjnQ=",
+        "lastModified": 1704404755,
+        "narHash": "sha256-Y3Vv7LJJC6xrp7Jym5ehJOXncdJSX4r/ywyizvBPG5s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c1d423142bc69c2b9cc9244f9da9b1a4c199f3c9",
+        "rev": "b14098b335d5651eb9ad1bd12ddecc79c411f6d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b14098b3`](https://github.com/nix-community/NUR/commit/b14098b335d5651eb9ad1bd12ddecc79c411f6d0) | `` automatic update `` |