### PR TITLE
chore(flake/emacs-overlay): `9206a7ac` -> `94b6e684`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704387047,
-        "narHash": "sha256-YiQoAg5EOAdNfXBWDWcnIb7GrZ1Al4ThZy9V0VakCtQ=",
+        "lastModified": 1704416418,
+        "narHash": "sha256-vsipNcGyMERHHgjx3IX1utNcbcpTHz2npUwW/PEcE7o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9206a7acdc0dd951d5d229b09405c7c6205bcef4",
+        "rev": "94b6e68490568844771f136728d551af61c3f0bb",
         "type": "github"
       },
       "original": {
@@ -707,11 +707,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1704145853,
-        "narHash": "sha256-G/1AMt9ibpeMlcxvD1vNaC8imGaK+g7zZ99e29BLgWw=",
+        "lastModified": 1704295289,
+        "narHash": "sha256-9WZDRfpMqCYL6g/HNWVvXF0hxdaAgwgIGeLYiOhmes8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2d2ea8eab9e400618748ab1a6a108255233b602c",
+        "rev": "b0b2c5445c64191fd8d0b31f2b1a34e45a64547d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`94b6e684`](https://github.com/nix-community/emacs-overlay/commit/94b6e68490568844771f136728d551af61c3f0bb) | `` Updated elpa ``         |
| [`fb4a5d51`](https://github.com/nix-community/emacs-overlay/commit/fb4a5d5160bb70801603b46e4a1bc4623c945694) | `` Updated flake inputs `` |