### PR TITLE
chore(flake/emacs-overlay): `94b6e684` -> `80810571`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704416418,
-        "narHash": "sha256-vsipNcGyMERHHgjx3IX1utNcbcpTHz2npUwW/PEcE7o=",
+        "lastModified": 1704418337,
+        "narHash": "sha256-rUhcUbFMO8PI3PRVuBfTpzt5QC/5CC6fizEemmtNzoo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "94b6e68490568844771f136728d551af61c3f0bb",
+        "rev": "80810571751109b3d71213763c7197f1128b7898",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`80810571`](https://github.com/nix-community/emacs-overlay/commit/80810571751109b3d71213763c7197f1128b7898) | `` Updated melpa `` |