### PR TITLE
chore(flake/nur): `e329dc95` -> `e14dbd8b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704409697,
-        "narHash": "sha256-nKi0q9agRHR2gXXQ3sUiJOr40e+20YyXC6yl6yDvZMU=",
+        "lastModified": 1704420238,
+        "narHash": "sha256-0w5eQA2Wc6b8PruU+++m9sl0ryZ6yX7Cot1FAsgXFN4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e329dc95214e8a0dd28d04d512263098fd7f4493",
+        "rev": "e14dbd8b06c9e1ee386c0402527465aff6ff873e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e14dbd8b`](https://github.com/nix-community/NUR/commit/e14dbd8b06c9e1ee386c0402527465aff6ff873e) | `` automatic update `` |
| [`a7b5b9e4`](https://github.com/nix-community/NUR/commit/a7b5b9e4b9b16fbc93c5307f5427597f51a37873) | `` automatic update `` |
| [`823b04b3`](https://github.com/nix-community/NUR/commit/823b04b39ec717d2069e87be82d6606d68d01ec7) | `` automatic update `` |