### PR TITLE
chore(flake/nur): `e14dbd8b` -> `8c4a408d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704420238,
-        "narHash": "sha256-0w5eQA2Wc6b8PruU+++m9sl0ryZ6yX7Cot1FAsgXFN4=",
+        "lastModified": 1704426242,
+        "narHash": "sha256-6fIc6X1gYjcUTh8T5OGkksDFZbH3Klmh277C7gbgLtI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e14dbd8b06c9e1ee386c0402527465aff6ff873e",
+        "rev": "8c4a408d039e3a183ae60893c71f514621b03527",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8c4a408d`](https://github.com/nix-community/NUR/commit/8c4a408d039e3a183ae60893c71f514621b03527) | `` automatic update `` |
| [`0ecf8658`](https://github.com/nix-community/NUR/commit/0ecf86584ec1abbb2eb8e898c11456f17ee1046a) | `` automatic update `` |
| [`86f7dac5`](https://github.com/nix-community/NUR/commit/86f7dac53e5829bf3e5970fd30bdc6ee223eb01a) | `` automatic update `` |