### PR TITLE
chore(flake/nur): `8c4a408d` -> `9b682807`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704426242,
-        "narHash": "sha256-6fIc6X1gYjcUTh8T5OGkksDFZbH3Klmh277C7gbgLtI=",
+        "lastModified": 1704434496,
+        "narHash": "sha256-eRtff4W6lefWc4S/h3n0pbO6jMT9GG44dzvEbaMz2NE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8c4a408d039e3a183ae60893c71f514621b03527",
+        "rev": "9b682807c2fbe03df0a468a0d8cac65e16d5872f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9b682807`](https://github.com/nix-community/NUR/commit/9b682807c2fbe03df0a468a0d8cac65e16d5872f) | `` automatic update `` |
| [`89245a60`](https://github.com/nix-community/NUR/commit/89245a60f0e9f840232cc7cff449d0976c1ab3c1) | `` automatic update `` |