### PR TITLE
chore(flake/nur): `9b682807` -> `f030fa26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704434496,
-        "narHash": "sha256-eRtff4W6lefWc4S/h3n0pbO6jMT9GG44dzvEbaMz2NE=",
+        "lastModified": 1704436512,
+        "narHash": "sha256-EYlBRpLor7SYT+qb9ZzcbgThFoDvBa8PEQVFzBoh4sk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9b682807c2fbe03df0a468a0d8cac65e16d5872f",
+        "rev": "f030fa26c8e5c4af54b1efb56f53b637b1796ac1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f030fa26`](https://github.com/nix-community/NUR/commit/f030fa26c8e5c4af54b1efb56f53b637b1796ac1) | `` automatic update `` |
| [`ce81ad34`](https://github.com/nix-community/NUR/commit/ce81ad34e3c52bb34e147a83bcd3fc75d2ff992f) | `` automatic update `` |