### PR TITLE
chore(flake/emacs-overlay): `80810571` -> `6a88aa2f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704418337,
-        "narHash": "sha256-rUhcUbFMO8PI3PRVuBfTpzt5QC/5CC6fizEemmtNzoo=",
+        "lastModified": 1704444616,
+        "narHash": "sha256-LAc3yBhmhpkTFcxsaUp9KqV+bbFYczOQqPVKndA7qt4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "80810571751109b3d71213763c7197f1128b7898",
+        "rev": "6a88aa2f7cd8e96ca5abc9433c7aea997a4f794e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`6a88aa2f`](https://github.com/nix-community/emacs-overlay/commit/6a88aa2f7cd8e96ca5abc9433c7aea997a4f794e) | `` Updated melpa `` |