### PR TITLE
chore(flake/nur): `f030fa26` -> `bcd4c2a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704436512,
-        "narHash": "sha256-EYlBRpLor7SYT+qb9ZzcbgThFoDvBa8PEQVFzBoh4sk=",
+        "lastModified": 1704446423,
+        "narHash": "sha256-nIc4tSSzoacSN6P8rw6PUvaRBfAtKpKDIR+USjCOje4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f030fa26c8e5c4af54b1efb56f53b637b1796ac1",
+        "rev": "bcd4c2a8d317b1556605be563abf2070d2b9da31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                        |
| -------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`bcd4c2a8`](https://github.com/nix-community/NUR/commit/bcd4c2a8d317b1556605be563abf2070d2b9da31) | `` automatic update ``         |
| [`52509a70`](https://github.com/nix-community/NUR/commit/52509a70e1b03cb9fa56967c59eb3a5962296b4c) | `` automatic update ``         |
| [`6eeec455`](https://github.com/nix-community/NUR/commit/6eeec4554b64deed350b3938ca1492a5430c36e4) | `` automatic update ``         |
| [`de18c08e`](https://github.com/nix-community/NUR/commit/de18c08e1c04feb670882c41ddddc199fbf31cf2) | `` add chordtoll repository `` |