### PR TITLE
chore(flake/nur): `08e5b9ec` -> `46e3b23d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704455140,
-        "narHash": "sha256-WQu6OjuA+TXBA8RAs+OQk7/NVFqZZEmHsZ82tfYHS3o=",
+        "lastModified": 1704459329,
+        "narHash": "sha256-22da2o7kh0WoocAVr7B9iynOd7tXFhONngcPQN46hfs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "08e5b9ecf1e65b89a66cd0f91927388bab9fedca",
+        "rev": "46e3b23d86f3ad1a594ecef91327a5c92a18fae9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`46e3b23d`](https://github.com/nix-community/NUR/commit/46e3b23d86f3ad1a594ecef91327a5c92a18fae9) | `` automatic update `` |