### PR TITLE
chore(flake/srvos): `341c142a` -> `c80e971a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -989,11 +989,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704357296,
-        "narHash": "sha256-npRcwAqeoLRdilyn4yOG9qShTRJ3sXL/xpyVOi+j7nw=",
+        "lastModified": 1704457903,
+        "narHash": "sha256-GVEIP5xRnofVlGzfxmBXgfmHfddS7eWZ3kcchBb8TMY=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "341c142aad6609161b6b74cfc2d288f0ead01585",
+        "rev": "c80e971a097b78fc6a6415fbacda6b9865651273",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                       |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`93a91c8c`](https://github.com/nix-community/srvos/commit/93a91c8cc6ebb8161828727a307e32847972517a) | `` flake: enable checks on `aarch64-linux` `` |
| [`ea15fb6c`](https://github.com/nix-community/srvos/commit/ea15fb6c453e90518c6ecfd75ce7679b8cfb9ab4) | `` flake: drop `permittedInsecurePackages` `` |