### PR TITLE
chore(flake/nur): `46e3b23d` -> `784b598b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704459329,
-        "narHash": "sha256-22da2o7kh0WoocAVr7B9iynOd7tXFhONngcPQN46hfs=",
+        "lastModified": 1704467118,
+        "narHash": "sha256-qhN9zdFKZ4x3KOB0hPx6zxz+lyQHX4UMK//WdbF4fj0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "46e3b23d86f3ad1a594ecef91327a5c92a18fae9",
+        "rev": "784b598b006e691690283effc8e56115eae99bc8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`784b598b`](https://github.com/nix-community/NUR/commit/784b598b006e691690283effc8e56115eae99bc8) | `` automatic update `` |