### PR TITLE
chore(flake/emacs-overlay): `6a88aa2f` -> `5e4e57b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704444616,
-        "narHash": "sha256-LAc3yBhmhpkTFcxsaUp9KqV+bbFYczOQqPVKndA7qt4=",
+        "lastModified": 1704473338,
+        "narHash": "sha256-o+KDrmI7ty98H7p2JejEOuzVNbmtjRSHKpfuj5SORqE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6a88aa2f7cd8e96ca5abc9433c7aea997a4f794e",
+        "rev": "5e4e57b1e3aecf7318550156aebd6605c00e1eb7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`5e4e57b1`](https://github.com/nix-community/emacs-overlay/commit/5e4e57b1e3aecf7318550156aebd6605c00e1eb7) | `` Updated melpa `` |
| [`b6d2d8bd`](https://github.com/nix-community/emacs-overlay/commit/b6d2d8bde643a02e3bc74ecd15a534c31ea328c1) | `` Updated elpa ``  |