### PR TITLE
chore(flake/nur): `784b598b` -> `a9894300`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704467118,
-        "narHash": "sha256-qhN9zdFKZ4x3KOB0hPx6zxz+lyQHX4UMK//WdbF4fj0=",
+        "lastModified": 1704476684,
+        "narHash": "sha256-E6QFl+0ojwWjmQENMEjPhMh9fOJagqDVN9vL18gVPi4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "784b598b006e691690283effc8e56115eae99bc8",
+        "rev": "a9894300c3f2d966abba98ff8de12b39254f7b60",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a9894300`](https://github.com/nix-community/NUR/commit/a9894300c3f2d966abba98ff8de12b39254f7b60) | `` automatic update `` |