### PR TITLE
chore(flake/nur): `a9894300` -> `fe2963f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704476684,
-        "narHash": "sha256-E6QFl+0ojwWjmQENMEjPhMh9fOJagqDVN9vL18gVPi4=",
+        "lastModified": 1704481104,
+        "narHash": "sha256-WfgVZL7UJ/vNLoh4Smyv9yOvxXBGQLxoO/ame2AzkWc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a9894300c3f2d966abba98ff8de12b39254f7b60",
+        "rev": "fe2963f0e80eb6f9bc3febea2429709c107ddd6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fe2963f0`](https://github.com/nix-community/NUR/commit/fe2963f0e80eb6f9bc3febea2429709c107ddd6f) | `` automatic update `` |
| [`d321e7e7`](https://github.com/nix-community/NUR/commit/d321e7e78110d181d243ec9e2f6534d75547620e) | `` automatic update `` |