### PR TITLE
chore(flake/nur): `fe2963f0` -> `9c4f6b66`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704481104,
-        "narHash": "sha256-WfgVZL7UJ/vNLoh4Smyv9yOvxXBGQLxoO/ame2AzkWc=",
+        "lastModified": 1704483764,
+        "narHash": "sha256-SuMEUsYHFbYYVZr3wWC64/tc1K/iI2/CJGdDixk6J5c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fe2963f0e80eb6f9bc3febea2429709c107ddd6f",
+        "rev": "9c4f6b66f05fc6f6285df25e89f825b441ec9705",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9c4f6b66`](https://github.com/nix-community/NUR/commit/9c4f6b66f05fc6f6285df25e89f825b441ec9705) | `` automatic update `` |
| [`6bf44adb`](https://github.com/nix-community/NUR/commit/6bf44adb1f887e5e7e6ee5601a718ab8ae9e8e9b) | `` automatic update `` |