### PR TITLE
chore(flake/home-manager): `26b8adb3` -> `51e44a13`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -457,11 +457,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704383912,
-        "narHash": "sha256-Be7O73qoOj/z+4ZCgizdLlu+5BkVvO2KO299goZ9cW8=",
+        "lastModified": 1704498488,
+        "narHash": "sha256-yINKdShHrtjdiJhov+q0s3Y3B830ujRoSbHduUNyKag=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "26b8adb300e50efceb51fff6859a1a6ba1ade4f7",
+        "rev": "51e44a13acea71b36245e8bd8c7db53e0a3e61ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`51e44a13`](https://github.com/nix-community/home-manager/commit/51e44a13acea71b36245e8bd8c7db53e0a3e61ee) | `` Translate using Weblate (Czech) ``         |
| [`294c13fa`](https://github.com/nix-community/home-manager/commit/294c13fa4b430b74733e66034ba12d6a11ef788e) | `` home-manager: update --version to 24.05 `` |