### PR TITLE
chore(flake/emacs-overlay): `5e4e57b1` -> `4b77b102`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704473338,
-        "narHash": "sha256-o+KDrmI7ty98H7p2JejEOuzVNbmtjRSHKpfuj5SORqE=",
+        "lastModified": 1704502758,
+        "narHash": "sha256-t1J7BJk3uGVAZK7jD1+wRiK7FHXYnLEflLd3zozdAQA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5e4e57b1e3aecf7318550156aebd6605c00e1eb7",
+        "rev": "4b77b102b4dfef209af4875478dabcde03e4dea5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`4b77b102`](https://github.com/nix-community/emacs-overlay/commit/4b77b102b4dfef209af4875478dabcde03e4dea5) | `` Updated elpa `` |