### PR TITLE
chore(flake/nur): `e9a91d76` -> `607e0e48`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704494748,
-        "narHash": "sha256-xGcoKP6UUnaraC0x+RTChotZbNfeNkh6g5zX/pY8Pfs=",
+        "lastModified": 1704508433,
+        "narHash": "sha256-eIPCUWYRk2egfNJPXj4ZSfKbbGcvqN8QUnuwTUqzckQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e9a91d76e3d02eb86e304a91fe0b1486bb2d4fcb",
+        "rev": "607e0e48c2bf0451acd29f85ffe0b4bdb07fc265",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`607e0e48`](https://github.com/nix-community/NUR/commit/607e0e48c2bf0451acd29f85ffe0b4bdb07fc265) | `` automatic update `` |
| [`17201170`](https://github.com/nix-community/NUR/commit/17201170bc033a8f1847995d7b788668666434eb) | `` automatic update `` |
| [`6093bd1a`](https://github.com/nix-community/NUR/commit/6093bd1aa15508364c814684112c35bb91d9bd5b) | `` automatic update `` |
| [`98989265`](https://github.com/nix-community/NUR/commit/989892658362304e05fdad819c1dea75ab2b6003) | `` automatic update `` |
| [`1dcce361`](https://github.com/nix-community/NUR/commit/1dcce3612333fffb390ab4eacc251d7f8bc1595c) | `` automatic update `` |
| [`d47d3e3d`](https://github.com/nix-community/NUR/commit/d47d3e3df6fa14b1945e4539ce4d3ac0d85b5711) | `` automatic update `` |
| [`effffaab`](https://github.com/nix-community/NUR/commit/effffaabc49fb1ad19f45085165eadb27d2c1c2c) | `` automatic update `` |