### PR TITLE
chore(flake/nur): `e2a9e96c` -> `414962dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704522923,
-        "narHash": "sha256-7mrOGpfyqmBB/3FUUNXWd845zNsL7v0rlUBJYkCLchA=",
+        "lastModified": 1704530682,
+        "narHash": "sha256-hjfKj0Zt6ZpDYBorM2NJ5M2HMnuAZyfCiidZqc2IG08=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e2a9e96c34e0aeeb7454396a5a031da1b0510d05",
+        "rev": "414962ddd2edeeaad1a63a4149061454479eb3c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`414962dd`](https://github.com/nix-community/NUR/commit/414962ddd2edeeaad1a63a4149061454479eb3c1) | `` automatic update `` |
| [`1afead7f`](https://github.com/nix-community/NUR/commit/1afead7fb8935b36eeb9af9b6101b26a626327ee) | `` automatic update `` |