### PR TITLE
chore(flake/nur): `414962dd` -> `33ac9895`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704530682,
-        "narHash": "sha256-hjfKj0Zt6ZpDYBorM2NJ5M2HMnuAZyfCiidZqc2IG08=",
+        "lastModified": 1704535142,
+        "narHash": "sha256-iNCliUH8hvi7KF6HGDvWa80qZR4FW+ajz4VJ6zQb4gg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "414962ddd2edeeaad1a63a4149061454479eb3c1",
+        "rev": "33ac9895fdc714eff02e0ccf3b80711a5fd34913",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`33ac9895`](https://github.com/nix-community/NUR/commit/33ac9895fdc714eff02e0ccf3b80711a5fd34913) | `` automatic update `` |
| [`1edb3faf`](https://github.com/nix-community/NUR/commit/1edb3fafedb1f417b5dbe3aaf0c99e8f04c12d7c) | `` automatic update `` |