### PR TITLE
chore(flake/nur): `33ac9895` -> `910ab73d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704535142,
-        "narHash": "sha256-iNCliUH8hvi7KF6HGDvWa80qZR4FW+ajz4VJ6zQb4gg=",
+        "lastModified": 1704545659,
+        "narHash": "sha256-1vQ8lZmQ03v9V0gs9oHDIfSjgPC6G09x6ndAaH/HowM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "33ac9895fdc714eff02e0ccf3b80711a5fd34913",
+        "rev": "910ab73d26e2423b3461700eb6cd5b163ab0ddae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`910ab73d`](https://github.com/nix-community/NUR/commit/910ab73d26e2423b3461700eb6cd5b163ab0ddae) | `` automatic update `` |