### PR TITLE
chore(flake/emacs-overlay): `85ac1bf8` -> `3ada6ddb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704530953,
-        "narHash": "sha256-hfllh8Dd/XhbyxNensq2PAdnvJtPXJmxUQqWrKUdUCk=",
+        "lastModified": 1704559748,
+        "narHash": "sha256-dUNZOUCsa1VHAzSET7DJGKfXj1H/odHrt1HM29z3j5M=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "85ac1bf8543d2e179d7748f3788d58b06eacc758",
+        "rev": "3ada6ddb60f9313cb2ac977106605e09c857ffec",
         "type": "github"
       },
       "original": {
@@ -707,11 +707,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1704295289,
-        "narHash": "sha256-9WZDRfpMqCYL6g/HNWVvXF0hxdaAgwgIGeLYiOhmes8=",
+        "lastModified": 1704420045,
+        "narHash": "sha256-C36QmoJd5tdQ5R9MC1jM7fBkZW9zBUqbUCsgwS6j4QU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0b2c5445c64191fd8d0b31f2b1a34e45a64547d",
+        "rev": "c1be43e8e837b8dbee2b3665a007e761680f0c3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`3ada6ddb`](https://github.com/nix-community/emacs-overlay/commit/3ada6ddb60f9313cb2ac977106605e09c857ffec) | `` Updated melpa ``        |
| [`96a2809f`](https://github.com/nix-community/emacs-overlay/commit/96a2809fba7398dec610a5367c219d03dde07bf9) | `` Updated elpa ``         |
| [`4a17d22f`](https://github.com/nix-community/emacs-overlay/commit/4a17d22f425279621da0e9a3060031e5769ede0e) | `` Updated flake inputs `` |