### PR TITLE
chore(flake/nur): `3fbed9bd` -> `58b45305`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704554033,
-        "narHash": "sha256-4sgRZyamI4sh6VRk3kgkM/ojW+KCc4iDD0RRa4ed/7k=",
+        "lastModified": 1704567137,
+        "narHash": "sha256-qWW+fj3zX4lnCQbhaYGbQSoxtnrdctAXAdeq+2AoijQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3fbed9bd2b3c6eced12baea4b61b3a060cd39b8d",
+        "rev": "58b453053d52a5c6ff9e76859ff2aa63f0aca4af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`58b45305`](https://github.com/nix-community/NUR/commit/58b453053d52a5c6ff9e76859ff2aa63f0aca4af) | `` automatic update `` |
| [`8a1b4b0c`](https://github.com/nix-community/NUR/commit/8a1b4b0c1574f5f6dafab6d2c087efcea4736e98) | `` automatic update `` |