### PR TITLE
chore(flake/nur): `031e5677` -> `184fa856`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704574301,
-        "narHash": "sha256-RuNPbSaWPSWCBm2kvAPqXgxMCdYbB3Py3CJtfObyZ1w=",
+        "lastModified": 1704577526,
+        "narHash": "sha256-wd+vD3yVEvnDnyYH7nJaYrQaF55rLGYETQLzYB2xd78=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "031e567712130530a787ef20b9ab4f5a97b0bfeb",
+        "rev": "184fa8562d7c06507315534a2f578b59faae2877",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`184fa856`](https://github.com/nix-community/NUR/commit/184fa8562d7c06507315534a2f578b59faae2877) | `` automatic update `` |