### PR TITLE
chore(flake/nur): `1ded0078` -> `369f7da6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704584931,
-        "narHash": "sha256-Ct8RCvA6ha/nB4EWjyX1HpMkgeZYldi5EdbaswLa+tg=",
+        "lastModified": 1704592785,
+        "narHash": "sha256-w+lhRm5tueMiK0CrTYLadeFEMd9Gc38fZFxWtcazdZQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1ded0078d049439eb4285c3d12d7e7892331db05",
+        "rev": "369f7da63ee6bb0e61d8e0a2622c3b78f9988121",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`369f7da6`](https://github.com/nix-community/NUR/commit/369f7da63ee6bb0e61d8e0a2622c3b78f9988121) | `` automatic update `` |
| [`07c169cf`](https://github.com/nix-community/NUR/commit/07c169cf2be7a709af9f14ba6709ab79034f8af7) | `` automatic update `` |