### PR TITLE
chore(flake/nix-index-database): `d6510ce1` -> `5243a943`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703992163,
-        "narHash": "sha256-709CGmwU34dxv8DjSpRBZ+HibVJIVaFcA4JH+GFnhyM=",
+        "lastModified": 1704596241,
+        "narHash": "sha256-6kYeX1EacuLoXvFsjEvSyCtsVCKOuFZcRY3l0NqE5Ko=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "d6510ce144f5da7dd9bac667ba3d5a4946c00d11",
+        "rev": "5243a943a37fa010e9d8f141c07a6870fde1060b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                  |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`5243a943`](https://github.com/nix-community/nix-index-database/commit/5243a943a37fa010e9d8f141c07a6870fde1060b) | `` flake.lock: Update `` |