### PR TITLE
chore(flake/nur): `369f7da6` -> `3a216c26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704592785,
-        "narHash": "sha256-w+lhRm5tueMiK0CrTYLadeFEMd9Gc38fZFxWtcazdZQ=",
+        "lastModified": 1704598626,
+        "narHash": "sha256-HrjPegJaedzo3dPJq/AYZatn8ARTELen2m1vwC5yjHY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "369f7da63ee6bb0e61d8e0a2622c3b78f9988121",
+        "rev": "3a216c262c910b70e23ee01a4479dcc40c58599b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3a216c26`](https://github.com/nix-community/NUR/commit/3a216c262c910b70e23ee01a4479dcc40c58599b) | `` automatic update `` |
| [`a7689677`](https://github.com/nix-community/NUR/commit/a7689677ab9edb9e8c57fc0ee21fde26f0016748) | `` automatic update `` |
| [`76d881db`](https://github.com/nix-community/NUR/commit/76d881db6bb44e6625296d1cd9e3856bc0e85763) | `` automatic update `` |
| [`1f5d132b`](https://github.com/nix-community/NUR/commit/1f5d132b21378a7bec41677e156d5dd79a43ee75) | `` automatic update `` |
| [`b9ed90b3`](https://github.com/nix-community/NUR/commit/b9ed90b36bdba313e0f694fe5cc65848e3d43833) | `` automatic update `` |
| [`3b715e8e`](https://github.com/nix-community/NUR/commit/3b715e8ee9f65d6f13a7926be26e4d516a95ae16) | `` automatic update `` |