### PR TITLE
chore(flake/nur): `3a216c26` -> `7502a833`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704598626,
-        "narHash": "sha256-HrjPegJaedzo3dPJq/AYZatn8ARTELen2m1vwC5yjHY=",
+        "lastModified": 1704609320,
+        "narHash": "sha256-JOrDeb31bb7oHaPMj3s/B8nPpnD9IgD8fDWtrgdq5fY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3a216c262c910b70e23ee01a4479dcc40c58599b",
+        "rev": "7502a8334877f63564a30b9f5be89d7208a006d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7502a833`](https://github.com/nix-community/NUR/commit/7502a8334877f63564a30b9f5be89d7208a006d4) | `` automatic update `` |