### PR TITLE
chore(flake/nur): `7502a833` -> `6fe0213b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704609320,
-        "narHash": "sha256-JOrDeb31bb7oHaPMj3s/B8nPpnD9IgD8fDWtrgdq5fY=",
+        "lastModified": 1704616763,
+        "narHash": "sha256-ysXM6aokc5QjpLXBM6jwdZXDNolLX941i/VuWU6t+eI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7502a8334877f63564a30b9f5be89d7208a006d4",
+        "rev": "6fe0213bf13f89a1a0bc725a5a4fe6f9ac72ae05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6fe0213b`](https://github.com/nix-community/NUR/commit/6fe0213bf13f89a1a0bc725a5a4fe6f9ac72ae05) | `` automatic update `` |
| [`4d233ae5`](https://github.com/nix-community/NUR/commit/4d233ae5c39c37b263a1f94869b6113ec38f942c) | `` automatic update `` |
| [`a65b1e04`](https://github.com/nix-community/NUR/commit/a65b1e041038c22a20a8a7e91a24c4eb5bcb3440) | `` automatic update `` |