### PR TITLE
chore(flake/emacs-overlay): `f769dc27` -> `3bfd4b27`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704591445,
-        "narHash": "sha256-k6aXDCQBDJ5iwkdAXARiPkfn7hhEuuz3BFqgl9CSQ7s=",
+        "lastModified": 1704617367,
+        "narHash": "sha256-tvr6wCMQcQXZAcb86KIyqs8y2gdg93Vu6kuxC5QGiz4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f769dc272f7645f0ec7c50ca79490cef15123e25",
+        "rev": "3bfd4b274002a4dbbead2d61c93437c5458fed84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`3bfd4b27`](https://github.com/nix-community/emacs-overlay/commit/3bfd4b274002a4dbbead2d61c93437c5458fed84) | `` Updated melpa `` |