### PR TITLE
chore(flake/srvos): `c80e971a` -> `59a3be17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -989,11 +989,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704457903,
-        "narHash": "sha256-GVEIP5xRnofVlGzfxmBXgfmHfddS7eWZ3kcchBb8TMY=",
+        "lastModified": 1704619109,
+        "narHash": "sha256-4KIMg92Leqv/DYkwN+fwNVRw5TcGeTdW5ZBvusjDlhI=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "c80e971a097b78fc6a6415fbacda6b9865651273",
+        "rev": "59a3be170de613321aa70e1228bfbe67a0e6ebd6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`aab69914`](https://github.com/nix-community/srvos/commit/aab699142f781c887ca173c9efc65f6ac7db47a6) | `` checks: run on aarch64-linux ``     |
| [`1f6877f9`](https://github.com/nix-community/srvos/commit/1f6877f9a50050f25135f95fb4e60a6540e12092) | `` checks: add prefix for nixosTest `` |