### PR TITLE
chore(flake/nixos-hardware): `17238531` -> `c478b3d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -628,11 +628,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1704458188,
-        "narHash": "sha256-f6BYEuIqnbrs6J/9m1/1VdkJ6d63hO9kUC09kTPuOqE=",
+        "lastModified": 1704632650,
+        "narHash": "sha256-83J/nd/NoLqo3vj0S0Ppqe8L+ijIFiGL6HNDfCCUD/Q=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "172385318068519900a7d71c1024242fa6af75f0",
+        "rev": "c478b3d56969006e015e55aaece4931f3600c1b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`c478b3d5`](https://github.com/NixOS/nixos-hardware/commit/c478b3d56969006e015e55aaece4931f3600c1b2) | `` surface: remove linux 6.1 ``                        |
| [`34bcc25f`](https://github.com/NixOS/nixos-hardware/commit/34bcc25fcd921666c0de80a0753f8a4feef3e0fb) | `` surface: set default kernel to major version 6.6 `` |
| [`5a721ef5`](https://github.com/NixOS/nixos-hardware/commit/5a721ef5f1460d01aa1571fab7f62efa51abf135) | `` surface: linux 6.6.8 -> 6.6.10 ``                   |