### PR TITLE
chore(flake/emacs-overlay): `3bfd4b27` -> `8966ec83`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704617367,
-        "narHash": "sha256-tvr6wCMQcQXZAcb86KIyqs8y2gdg93Vu6kuxC5QGiz4=",
+        "lastModified": 1704646164,
+        "narHash": "sha256-2kZDhYpVWgpDBzE5NPkKnDZBtPPeXIy6lDsg6uExMc0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3bfd4b274002a4dbbead2d61c93437c5458fed84",
+        "rev": "8966ec83cb59493c07a06c12d25f0d7439abfe5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`8966ec83`](https://github.com/nix-community/emacs-overlay/commit/8966ec83cb59493c07a06c12d25f0d7439abfe5e) | `` Updated melpa `` |
| [`581db622`](https://github.com/nix-community/emacs-overlay/commit/581db622349edd9c3b1110999fd942e1d3271728) | `` Updated elpa ``  |