### PR TITLE
chore(flake/emacs-overlay): `8966ec83` -> `2e23449b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704646164,
-        "narHash": "sha256-2kZDhYpVWgpDBzE5NPkKnDZBtPPeXIy6lDsg6uExMc0=",
+        "lastModified": 1704677642,
+        "narHash": "sha256-0dZ3Vl3DnnznbZKUM7vjAKUz5C7e3taTDmMm23Kbpms=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8966ec83cb59493c07a06c12d25f0d7439abfe5e",
+        "rev": "2e23449b445bbe200c9bd8e880662747ef99e4ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`2e23449b`](https://github.com/nix-community/emacs-overlay/commit/2e23449b445bbe200c9bd8e880662747ef99e4ae) | `` Updated melpa `` |
| [`475d3b2d`](https://github.com/nix-community/emacs-overlay/commit/475d3b2df3e517d96b60bfa08bf7dfe226b51d5e) | `` Updated elpa ``  |