### PR TITLE
chore(flake/srvos): `59a3be17` -> `560fd5f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
     },
     "nixos-stable": {
       "locked": {
-        "lastModified": 1703992652,
-        "narHash": "sha256-C0o8AUyu8xYgJ36kOxJfXIroy9if/G6aJbNOpA5W0+M=",
+        "lastModified": 1704420045,
+        "narHash": "sha256-C36QmoJd5tdQ5R9MC1jM7fBkZW9zBUqbUCsgwS6j4QU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "32f63574c85fbc80e4ba1fbb932cde9619bad25e",
+        "rev": "c1be43e8e837b8dbee2b3665a007e761680f0c3d",
         "type": "github"
       },
       "original": {
@@ -989,11 +989,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704619109,
-        "narHash": "sha256-4KIMg92Leqv/DYkwN+fwNVRw5TcGeTdW5ZBvusjDlhI=",
+        "lastModified": 1704678919,
+        "narHash": "sha256-Wv7deGdMNhQ8gBcZk24zpdqMsxKT3BC/ZIUi4RboRjY=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "59a3be170de613321aa70e1228bfbe67a0e6ebd6",
+        "rev": "560fd5f7f182b41c7f8e843542b570343afca3d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------ |
| [`560fd5f7`](https://github.com/nix-community/srvos/commit/560fd5f7f182b41c7f8e843542b570343afca3d0) | `` flake.lock: Update `` |
| [`91684f50`](https://github.com/nix-community/srvos/commit/91684f503f133266446e9dd61c7ceeb0734a0821) | `` flake.lock: Update `` |