### PR TITLE
chore(flake/nur): `b8fd5ed9` -> `bd8216c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704675837,
-        "narHash": "sha256-yQlSTrIp3BYy8SzIdA9KItObGpF0IMRSCLGSP/y42tI=",
+        "lastModified": 1704679888,
+        "narHash": "sha256-cUEOZgOE234GzpUqVUqoHgpFoZGGOsc9RSdCOZVkBjc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b8fd5ed94c22502cf037679bd3b7f6f971c9a102",
+        "rev": "bd8216c05cd8dce37217d682b9a1abee45d78933",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bd8216c0`](https://github.com/nix-community/NUR/commit/bd8216c05cd8dce37217d682b9a1abee45d78933) | `` automatic update `` |
| [`c8e668be`](https://github.com/nix-community/NUR/commit/c8e668bef74e9071671b554a13284f6a094a7967) | `` automatic update `` |
| [`6febb52d`](https://github.com/nix-community/NUR/commit/6febb52db8402f4b9831577fef1dcc85fc1cd8ff) | `` automatic update `` |
| [`a381ca89`](https://github.com/nix-community/NUR/commit/a381ca898bb3e8007c252ce9873b285e3d53017e) | `` automatic update `` |