### PR TITLE
chore(flake/nur): `bd8216c0` -> `ce803108`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704679888,
-        "narHash": "sha256-cUEOZgOE234GzpUqVUqoHgpFoZGGOsc9RSdCOZVkBjc=",
+        "lastModified": 1704680432,
+        "narHash": "sha256-7tL7xOJmwvuXN+CEcB4/ZgScgXTW+L3H0i0XiEcDjG4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bd8216c05cd8dce37217d682b9a1abee45d78933",
+        "rev": "ce80310894b5c8c4db0ae20efd881d50dd266e79",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ce803108`](https://github.com/nix-community/NUR/commit/ce80310894b5c8c4db0ae20efd881d50dd266e79) | `` automatic update `` |