### PR TITLE
chore(flake/nur): `ce803108` -> `2f3b7670`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704680432,
-        "narHash": "sha256-7tL7xOJmwvuXN+CEcB4/ZgScgXTW+L3H0i0XiEcDjG4=",
+        "lastModified": 1704684948,
+        "narHash": "sha256-ILktVtlJTi+MohLA7ppBhU/wfLdmx1PjALOjVKvnp5U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ce80310894b5c8c4db0ae20efd881d50dd266e79",
+        "rev": "2f3b767054ff95e56899f22e090da623de063f3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2f3b7670`](https://github.com/nix-community/NUR/commit/2f3b767054ff95e56899f22e090da623de063f3f) | `` automatic update `` |
| [`403ae298`](https://github.com/nix-community/NUR/commit/403ae2983f42507b0805cd18551c502906d03e02) | `` automatic update `` |
| [`c3c23490`](https://github.com/nix-community/NUR/commit/c3c2349004ff0e29688bb45b755262e80c5881b1) | `` automatic update `` |
| [`9053e394`](https://github.com/nix-community/NUR/commit/9053e394278a62488ed10e96f991bf35ff22873a) | `` automatic update `` |
| [`af336c86`](https://github.com/nix-community/NUR/commit/af336c86270077428a76457c8f5628d6a3dbf1fc) | `` automatic update `` |