### PR TITLE
chore(flake/nur): `2f3b7670` -> `e9bf801b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704684948,
-        "narHash": "sha256-ILktVtlJTi+MohLA7ppBhU/wfLdmx1PjALOjVKvnp5U=",
+        "lastModified": 1704695916,
+        "narHash": "sha256-lp3h0NBa+VMQ6rRLzWzWl664ayJrHNhwiy3NEGN9CKk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2f3b767054ff95e56899f22e090da623de063f3f",
+        "rev": "e9bf801b54e57f9297040831d819b8db9b2e3c7e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e9bf801b`](https://github.com/nix-community/NUR/commit/e9bf801b54e57f9297040831d819b8db9b2e3c7e) | `` automatic update `` |
| [`c8881da4`](https://github.com/nix-community/NUR/commit/c8881da4aaa833f4b60f94cb5a698136a322836c) | `` automatic update `` |
| [`0c2e0672`](https://github.com/nix-community/NUR/commit/0c2e0672caa72f21ff4a4ea5ff8141bce26d3f7b) | `` automatic update `` |
| [`9544da2c`](https://github.com/nix-community/NUR/commit/9544da2c270234b497a03556afc37c4db2e5263f) | `` automatic update `` |