### PR TITLE
chore(flake/emacs-overlay): `2e23449b` -> `3a855a7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704677642,
-        "narHash": "sha256-0dZ3Vl3DnnznbZKUM7vjAKUz5C7e3taTDmMm23Kbpms=",
+        "lastModified": 1704703887,
+        "narHash": "sha256-o+7au3GsD4FHU8SUgT1zDWWH9BObWLs+Se76CfNIpL4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2e23449b445bbe200c9bd8e880662747ef99e4ae",
+        "rev": "3a855a7a6f5f092ef81b45416c84f794b076f7ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`3a855a7a`](https://github.com/nix-community/emacs-overlay/commit/3a855a7a6f5f092ef81b45416c84f794b076f7ed) | `` Updated melpa ``        |
| [`0ed4fcf5`](https://github.com/nix-community/emacs-overlay/commit/0ed4fcf55a8d866cfc0f4dcfc37158634da8d251) | `` Updated flake inputs `` |