### PR TITLE
chore(flake/nur): `e9bf801b` -> `6559903e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704695916,
-        "narHash": "sha256-lp3h0NBa+VMQ6rRLzWzWl664ayJrHNhwiy3NEGN9CKk=",
+        "lastModified": 1704703461,
+        "narHash": "sha256-wrALL/W2fmV+ct+LWb+ThFCwap+48jyTXNBA2Qozqpw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e9bf801b54e57f9297040831d819b8db9b2e3c7e",
+        "rev": "6559903e1813f675e5f72ca092d6f3afa727e1fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6559903e`](https://github.com/nix-community/NUR/commit/6559903e1813f675e5f72ca092d6f3afa727e1fc) | `` automatic update `` |
| [`3b2effe0`](https://github.com/nix-community/NUR/commit/3b2effe0553470589c7e40fc745ce1227564dfab) | `` automatic update `` |