### PR TITLE
chore(flake/nur): `6b35830e` -> `d4cb17a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704710672,
-        "narHash": "sha256-4lkd1XPxxr00kz+DXY0il6TG0pvK5Go3xkgISX1Gnks=",
+        "lastModified": 1704718628,
+        "narHash": "sha256-nZZyBYxvZvxewXN+Y9Pq4P9E4dH0UZj5LwvuNEjN60w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6b35830e8b50fd1c6cf096f74a76cb9c5e0793cc",
+        "rev": "d4cb17a8108aadd110001d5213a1c2f3526a802e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                  |
| -------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`d4cb17a8`](https://github.com/nix-community/NUR/commit/d4cb17a8108aadd110001d5213a1c2f3526a802e) | `` automatic update ``                   |
| [`530bf879`](https://github.com/nix-community/NUR/commit/530bf87937d1893b306aa045f33d7d1e874ff740) | `` Move federicoschonborn to Codeberg `` |