### PR TITLE
chore(flake/pre-commit-hooks): `ea07fa07` -> `ea96f0c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -888,11 +888,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1704714581,
-        "narHash": "sha256-AO8LuCC4atd4JJe1gKtgZ1LgWhanqsDCIIUhLIzQswY=",
+        "lastModified": 1704725188,
+        "narHash": "sha256-qq8NbkhRZF1vVYQFt1s8Mbgo8knj+83+QlL5LBnYGpI=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ea07fa07f222a5c4baacbcdbf529276ef0ddc6ca",
+        "rev": "ea96f0c05924341c551a797aaba8126334c505d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                      |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------- |
| [`132ffd57`](https://github.com/cachix/pre-commit-hooks.nix/commit/132ffd57209171cdca31916f47cfebe7584cdcad) | `` doc: improve README.md `` |