### PR TITLE
chore(flake/nur): `d4cb17a8` -> `30c0d9f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704718628,
-        "narHash": "sha256-nZZyBYxvZvxewXN+Y9Pq4P9E4dH0UZj5LwvuNEjN60w=",
+        "lastModified": 1704726196,
+        "narHash": "sha256-bZTODN1Y2RMW+SbFyuqdCDf95G/KwLQumZG3LvHyPi4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d4cb17a8108aadd110001d5213a1c2f3526a802e",
+        "rev": "30c0d9f4c844bf2c4a8cfe136f873aad83767457",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`30c0d9f4`](https://github.com/nix-community/NUR/commit/30c0d9f4c844bf2c4a8cfe136f873aad83767457) | `` automatic update `` |