### PR TITLE
chore(flake/emacs-overlay): `3a855a7a` -> `e765064d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704703887,
-        "narHash": "sha256-o+7au3GsD4FHU8SUgT1zDWWH9BObWLs+Se76CfNIpL4=",
+        "lastModified": 1704732633,
+        "narHash": "sha256-IgsEDPPc5SRlSK/X2SHGS631mmcOdwElt4EjJ+IM5kc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3a855a7a6f5f092ef81b45416c84f794b076f7ed",
+        "rev": "e765064de63acb093a8ecb4483dd76860f4d9c70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`e765064d`](https://github.com/nix-community/emacs-overlay/commit/e765064de63acb093a8ecb4483dd76860f4d9c70) | `` Updated melpa ``  |
| [`6ca69191`](https://github.com/nix-community/emacs-overlay/commit/6ca691917cbb7a260a58168544d757b915d901ec) | `` Updated elpa ``   |
| [`aa5b925d`](https://github.com/nix-community/emacs-overlay/commit/aa5b925d130417c34a20dc90e50c9812a70f7d9e) | `` Updated nongnu `` |