### PR TITLE
chore(flake/nur): `30c0d9f4` -> `f53bd4e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704726196,
-        "narHash": "sha256-bZTODN1Y2RMW+SbFyuqdCDf95G/KwLQumZG3LvHyPi4=",
+        "lastModified": 1704743097,
+        "narHash": "sha256-LIvOz3JEuFE0t0PAl6G2Fx5VGu3gbsTkB9YVrqaUg2c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "30c0d9f4c844bf2c4a8cfe136f873aad83767457",
+        "rev": "f53bd4e7be4a0511d74f4c9b977eda365af5cce2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f53bd4e7`](https://github.com/nix-community/NUR/commit/f53bd4e7be4a0511d74f4c9b977eda365af5cce2) | `` automatic update `` |
| [`066bff75`](https://github.com/nix-community/NUR/commit/066bff759bdfd8e8ce30720a493fd1fe7417e0e4) | `` automatic update `` |
| [`020ad3ca`](https://github.com/nix-community/NUR/commit/020ad3caef94ba76f2c091c9a1a91c2cd002a9f3) | `` automatic update `` |
| [`c99ef039`](https://github.com/nix-community/NUR/commit/c99ef039f11ee2582870f797ed6b4868e074b168) | `` automatic update `` |
| [`16f5a6ee`](https://github.com/nix-community/NUR/commit/16f5a6eec7c2eee6189cb23b3af99ccaa59b7508) | `` automatic update `` |
| [`8c0c3eda`](https://github.com/nix-community/NUR/commit/8c0c3eda98dc1c35547d1e1d211867b0d5f90251) | `` automatic update `` |