### PR TITLE
chore(flake/templates): `98bc26d9` -> `98c7477e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1083,11 +1083,11 @@
     },
     "templates": {
       "locked": {
-        "lastModified": 1697364028,
-        "narHash": "sha256-t7IGwY/nvopK9n9tgCVrHlLimhU2MuoP9VbVy07AR2A=",
+        "lastModified": 1704736606,
+        "narHash": "sha256-VuawBfkTfOoKnMZ8Ggj+VWvRn64N2ORTkWP/ylIjSsY=",
         "owner": "NixOS",
         "repo": "templates",
-        "rev": "98bc26d94008617aac7cd0244fb09ff04d6c8cf6",
+        "rev": "98c7477e11781bf3dba94cabf6e3b0b789935b1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
| [`cad507ec`](https://github.com/NixOS/templates/commit/cad507ec3d55d8499eba98a1322a256d121ccb8e) | `` fix: remove lock per PR 72 ``                       |
| [`5dacec60`](https://github.com/NixOS/templates/commit/5dacec60600958a3646d7ae8ba2df512b2bcf8fd) | `` fix: update python template to use nix-community `` |
| [`fb0b8776`](https://github.com/NixOS/templates/commit/fb0b87761fe02bb61a5201af864330df299b5a36) | `` Remove all flake.lock files ``                      |
| [`cadb6894`](https://github.com/NixOS/templates/commit/cadb68944a9ea47d35f6f2c644eedec1b4af764f) | `` python: Add flake.lock to allow `nix develop` ``    |
| [`006a3efe`](https://github.com/NixOS/templates/commit/006a3efeec02563f9e2ffa4ea487c9125dc12c49) | `` Basic .NET template ``                              |