### PR TITLE
chore(flake/templates): `98c7477e` -> `105b28c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1083,11 +1083,11 @@
     },
     "templates": {
       "locked": {
-        "lastModified": 1704736606,
-        "narHash": "sha256-VuawBfkTfOoKnMZ8Ggj+VWvRn64N2ORTkWP/ylIjSsY=",
+        "lastModified": 1704737624,
+        "narHash": "sha256-ypprYGtIL/DbV7D0zNA36gRdMqcv8LHgoxHjwTm7EGY=",
         "owner": "NixOS",
         "repo": "templates",
-        "rev": "98c7477e11781bf3dba94cabf6e3b0b789935b1a",
+        "rev": "105b28c09033d1c137704cab544ed3cc4bc9ac40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                            |
| ------------------------------------------------------------------------------------------------ | ---------------------------------- |
| [`e3c26292`](https://github.com/NixOS/templates/commit/e3c2629294a373f303b7e66071b1ced0787146f1) | `` Added utils-generic template `` |
| [`d321f6a3`](https://github.com/NixOS/templates/commit/d321f6a37ed4ef198686c8974fb565e0a471b017) | `` empty: init ``                  |