### PR TITLE
chore(flake/sops-nix): `f5fbcc0f` -> `0ded5741`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -968,11 +968,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1704596510,
-        "narHash": "sha256-tupdwwg1WeX2hNMOQrvtyafTaTVty0QC/gQp7yaYJic=",
+        "lastModified": 1704753304,
+        "narHash": "sha256-9shh5fYLfLJrxr4NnIoWcO9T3bTFuO5QW9v/wDpq9Xg=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "f5fbcc0f50e7fc60c4f806fa7a09abccf0826d8a",
+        "rev": "0ded57412079011f1210c2fcc10e112427d4c0e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`0ded5741`](https://github.com/Mic92/sops-nix/commit/0ded57412079011f1210c2fcc10e112427d4c0e6) | `` update vendorHash ``                                           |
| [`6a5082dc`](https://github.com/Mic92/sops-nix/commit/6a5082dcc248fa91f65a744f5e8a613428557e2c) | `` build(deps): bump golang.org/x/crypto from 0.17.0 to 0.18.0 `` |