### PR TITLE
chore(flake/nur): `f53bd4e7` -> `accb175a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704743097,
-        "narHash": "sha256-LIvOz3JEuFE0t0PAl6G2Fx5VGu3gbsTkB9YVrqaUg2c=",
+        "lastModified": 1704766107,
+        "narHash": "sha256-eJT0P3M898TRqFf5MbbvkdMEGAgs7OmTVPvrotgK1mY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f53bd4e7be4a0511d74f4c9b977eda365af5cce2",
+        "rev": "accb175ad48179a7655f36dcd8bfd2187a74d8d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`accb175a`](https://github.com/nix-community/NUR/commit/accb175ad48179a7655f36dcd8bfd2187a74d8d7) | `` automatic update `` |
| [`fd4b13b7`](https://github.com/nix-community/NUR/commit/fd4b13b7f5e698cbabb8a822e9cf4a78b417ef81) | `` automatic update `` |
| [`07a92fab`](https://github.com/nix-community/NUR/commit/07a92fabc8d035feb484592d64b4ca7d83bf752c) | `` automatic update `` |
| [`7fd7f053`](https://github.com/nix-community/NUR/commit/7fd7f05372ca0a97691bbf45fbae0964bbadac4a) | `` automatic update `` |
| [`9ddd1391`](https://github.com/nix-community/NUR/commit/9ddd139133c202ab77be24be48a6303046729d37) | `` automatic update `` |