### PR TITLE
chore(flake/nur): `accb175a` -> `06ce749f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704766107,
-        "narHash": "sha256-eJT0P3M898TRqFf5MbbvkdMEGAgs7OmTVPvrotgK1mY=",
+        "lastModified": 1704771921,
+        "narHash": "sha256-MZcmtHuK36AieQQ9dkmGHy4L0QSkQTaMkMO9yDAUbLg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "accb175ad48179a7655f36dcd8bfd2187a74d8d7",
+        "rev": "06ce749f20d91e8755da6592b5ed4a90d43af558",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`06ce749f`](https://github.com/nix-community/NUR/commit/06ce749f20d91e8755da6592b5ed4a90d43af558) | `` automatic update `` |
| [`45203933`](https://github.com/nix-community/NUR/commit/4520393330946b968ba93cabffe5f753157458f6) | `` automatic update `` |
| [`a3103176`](https://github.com/nix-community/NUR/commit/a31031765ea6f8d070074f97f1598e804caea854) | `` automatic update `` |
| [`769bc4d6`](https://github.com/nix-community/NUR/commit/769bc4d645f2a638573d84ec6756ce7e48777a9b) | `` automatic update `` |
| [`91394f23`](https://github.com/nix-community/NUR/commit/91394f23b0a1b784fa8658116493c4513f1f4153) | `` automatic update `` |
| [`f5fa01d7`](https://github.com/nix-community/NUR/commit/f5fa01d70bfaa3de9a243ff1be9fa41f02f7ee4d) | `` automatic update `` |
| [`8a064707`](https://github.com/nix-community/NUR/commit/8a06470732be9f1757d5436a3256e793686648e4) | `` automatic update `` |
| [`e931d282`](https://github.com/nix-community/NUR/commit/e931d282cfc302d6a6808adf54c5db38b89e7923) | `` automatic update `` |