### PR TITLE
chore(flake/nur): `06ce749f` -> `6122342e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704771921,
-        "narHash": "sha256-MZcmtHuK36AieQQ9dkmGHy4L0QSkQTaMkMO9yDAUbLg=",
+        "lastModified": 1704779076,
+        "narHash": "sha256-8Uu7WXuRfpaOACjS0qNkNa5m1UvI/K5U5TauokQXJe0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "06ce749f20d91e8755da6592b5ed4a90d43af558",
+        "rev": "6122342ef657331003089bc12cf6086329e2d836",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6122342e`](https://github.com/nix-community/NUR/commit/6122342ef657331003089bc12cf6086329e2d836) | `` automatic update `` |