### PR TITLE
chore(flake/emacs-overlay): `bb6e486a` -> `223007e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704764004,
-        "narHash": "sha256-WbuWIgv2gDcRtXTc6m/UfjgacV73pXUUFzj+26PRiaI=",
+        "lastModified": 1704790239,
+        "narHash": "sha256-WyH/mG9x5z/G+dzfC5BtQBuLM3QhjW7q1vaB+8vboV4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bb6e486a9fcb96868b15741ff4ee446cc731db43",
+        "rev": "223007e4c62a86896fc662af5f9fd21a11cdb41b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`223007e4`](https://github.com/nix-community/emacs-overlay/commit/223007e4c62a86896fc662af5f9fd21a11cdb41b) | `` Updated melpa `` |