### PR TITLE
chore(flake/nur): `3db34f87` -> `1032f991`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704818955,
-        "narHash": "sha256-andwUQj1sfSMYeZUJ5I++DzlSCK5IHD/U1ziD8cJt5g=",
+        "lastModified": 1704824620,
+        "narHash": "sha256-Uzj+UNJDJRCqpbSZ+wpgYCYfpzs07YnORoEoXFom9/A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3db34f87f0972308898521c41a8bbcc4745066ea",
+        "rev": "1032f99123786d6a85cb853237126b971332fe10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1032f991`](https://github.com/nix-community/NUR/commit/1032f99123786d6a85cb853237126b971332fe10) | `` automatic update `` |
| [`dba52051`](https://github.com/nix-community/NUR/commit/dba520515e209f3be2fc388374c671635e1a478e) | `` automatic update `` |