### PR TITLE
chore(flake/nur): `2df7b09c` -> `4657978e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704829465,
-        "narHash": "sha256-8skpBoxObEsT4Dmr1ZYAtnsV+54kCgLgO7sPD+SUgTY=",
+        "lastModified": 1704840324,
+        "narHash": "sha256-Bt16Bq+o/HgBi4T9bvvFGvQ6IxAZ+w0LD5gQwm5vPnA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2df7b09ccbd91a563c8b79e7be76ab5d92cd359b",
+        "rev": "4657978e02a45a3f90dcba0f5a878d8d4ff439a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4657978e`](https://github.com/nix-community/NUR/commit/4657978e02a45a3f90dcba0f5a878d8d4ff439a5) | `` automatic update `` |