### PR TITLE
chore(flake/emacs-overlay): `5126615a` -> `58305b28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704819029,
-        "narHash": "sha256-y4ZxBTf6X9G73J/X1rjuu5Mm7WvJKxljbaImB8Qycp8=",
+        "lastModified": 1704850390,
+        "narHash": "sha256-BUPWo1wD3WQ9xzbR+tZeibF3h1F0IyOqK3uINvCA2nw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5126615a62f93c7b2311eb9180e420e460ed8515",
+        "rev": "58305b28029922b981f333229500e9ff34896c72",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`58305b28`](https://github.com/nix-community/emacs-overlay/commit/58305b28029922b981f333229500e9ff34896c72) | `` Updated melpa `` |
| [`2e9e4ff1`](https://github.com/nix-community/emacs-overlay/commit/2e9e4ff10f436778688759f440917228373b2e82) | `` Updated elpa ``  |