### PR TITLE
chore(flake/nur): `b0d642dc` -> `100b3019`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704848647,
-        "narHash": "sha256-1IviMpJ0Ab22hMXH31u5d56VPmiSmvHe/qq8J9ewBsw=",
+        "lastModified": 1704852279,
+        "narHash": "sha256-DlbWR3tUvMUN6am3PjYKdp3rYfBNyVVM0YuyY9BAAJU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b0d642dc5a4d2fcf7ca7b5fe10121c77a8e2792d",
+        "rev": "100b3019a02cc3117074526da5c7badba8ffed88",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`100b3019`](https://github.com/nix-community/NUR/commit/100b3019a02cc3117074526da5c7badba8ffed88) | `` automatic update `` |
| [`91e7b02a`](https://github.com/nix-community/NUR/commit/91e7b02a3f520f354fccc85863793482b033c9bb) | `` automatic update `` |