### PR TITLE
chore(flake/nur): `100b3019` -> `6f62ac08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704852279,
-        "narHash": "sha256-DlbWR3tUvMUN6am3PjYKdp3rYfBNyVVM0YuyY9BAAJU=",
+        "lastModified": 1704855287,
+        "narHash": "sha256-eE4IGyy9FrkkIrIJfhhevbkbikjjAKkVT7xiwzeRPsI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "100b3019a02cc3117074526da5c7badba8ffed88",
+        "rev": "6f62ac0852be8e43cde80fe6e308602c1c0a1f02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6f62ac08`](https://github.com/nix-community/NUR/commit/6f62ac0852be8e43cde80fe6e308602c1c0a1f02) | `` automatic update `` |
| [`8ddad3f5`](https://github.com/nix-community/NUR/commit/8ddad3f573977c23b1f52034d561dcff59527fe9) | `` automatic update `` |
| [`0594b0cb`](https://github.com/nix-community/NUR/commit/0594b0cbb2e8ae1a21cdf995b9c13ff68731284a) | `` automatic update `` |
| [`daced2d8`](https://github.com/nix-community/NUR/commit/daced2d8037d91ef3015e463e1ac8b9a7aff845c) | `` automatic update `` |