### PR TITLE
chore(flake/nur): `6f62ac08` -> `9a3b9100`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704855287,
-        "narHash": "sha256-eE4IGyy9FrkkIrIJfhhevbkbikjjAKkVT7xiwzeRPsI=",
+        "lastModified": 1704860847,
+        "narHash": "sha256-we6GZeaF/hamtGLubZs8qPY/Rj8F4RiHjAvmKgzv3tc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6f62ac0852be8e43cde80fe6e308602c1c0a1f02",
+        "rev": "9a3b9100ab8635b46d1e23d6e369028f66e0e509",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9a3b9100`](https://github.com/nix-community/NUR/commit/9a3b9100ab8635b46d1e23d6e369028f66e0e509) | `` automatic update `` |
| [`c00d975d`](https://github.com/nix-community/NUR/commit/c00d975d715413a2fa71fb6c65572bf79213a168) | `` automatic update `` |
| [`e37b1000`](https://github.com/nix-community/NUR/commit/e37b10005ab2c90fe5ef36a4baa83355247af670) | `` automatic update `` |
| [`eeec15e6`](https://github.com/nix-community/NUR/commit/eeec15e61232a9f7d9113035e1a579cb19753a4e) | `` automatic update `` |
| [`c72ded2d`](https://github.com/nix-community/NUR/commit/c72ded2df7d24d60c409165864508586b8e8124e) | `` automatic update `` |