### PR TITLE
chore(flake/nur): `9a3b9100` -> `77e2aeb7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704860847,
-        "narHash": "sha256-we6GZeaF/hamtGLubZs8qPY/Rj8F4RiHjAvmKgzv3tc=",
+        "lastModified": 1704865232,
+        "narHash": "sha256-HUy8GefgK/OlXtMntJqIvtrR0fQN7ngP4ahX7Rv28n0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9a3b9100ab8635b46d1e23d6e369028f66e0e509",
+        "rev": "77e2aeb7e6b566022ff97196e3d75cc01700335e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`77e2aeb7`](https://github.com/nix-community/NUR/commit/77e2aeb7e6b566022ff97196e3d75cc01700335e) | `` automatic update `` |
| [`cf86a7b9`](https://github.com/nix-community/NUR/commit/cf86a7b9811c2eb26643e92b288a3233f296f347) | `` automatic update `` |