### PR TITLE
chore(flake/nur): `77e2aeb7` -> `d2dc2f25`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704865232,
-        "narHash": "sha256-HUy8GefgK/OlXtMntJqIvtrR0fQN7ngP4ahX7Rv28n0=",
+        "lastModified": 1704880769,
+        "narHash": "sha256-75IQ7G/K+CjAOj92pLqhCDRytK4SqinJjgtzkkxwhek=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "77e2aeb7e6b566022ff97196e3d75cc01700335e",
+        "rev": "d2dc2f25e0ea3ca5409555d4a96f78104b0be173",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                         |
| -------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`d2dc2f25`](https://github.com/nix-community/NUR/commit/d2dc2f25e0ea3ca5409555d4a96f78104b0be173) | `` automatic update ``          |
| [`6586527c`](https://github.com/nix-community/NUR/commit/6586527c60f58a568fbb91744799dc7c7b6a2982) | `` repo: add NUR for Armaria `` |
| [`f708a68d`](https://github.com/nix-community/NUR/commit/f708a68dbdce8c1c5688ee8097e47f5cef8e232f) | `` automatic update ``          |