### PR TITLE
chore(flake/deploy-rs): `b709d63d` -> `1776009f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -259,11 +259,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703087360,
-        "narHash": "sha256-0VUbWBW8VyiDRuimMuLsEO4elGuUw/nc2WDeuO1eN1M=",
+        "lastModified": 1704875591,
+        "narHash": "sha256-eWRLbqRcrILgztU/m/k7CYLzETKNbv0OsT2GjkaNm8A=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "b709d63debafce9f5645a5ba550c9e0983b3d1f7",
+        "rev": "1776009f1f3fb2b5d236b84d9815f2edee463a9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                      |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`3f919119`](https://github.com/serokell/deploy-rs/commit/3f91911972d4b1576b23e42feec9804bdcfb7fe0) | `` Remove note about unstable nix version `` |