### PR TITLE
chore(flake/emacs-overlay): `58305b28` -> `e5d3e66b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704850390,
-        "narHash": "sha256-BUPWo1wD3WQ9xzbR+tZeibF3h1F0IyOqK3uINvCA2nw=",
+        "lastModified": 1704905472,
+        "narHash": "sha256-cb3uqBDHcdHY+x1tXSm5FvScQx5e9+qdADGSEVkhnlM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "58305b28029922b981f333229500e9ff34896c72",
+        "rev": "e5d3e66bb146b77a9c978533dfb6028b9248f2fa",
         "type": "github"
       },
       "original": {
@@ -707,11 +707,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1704420045,
-        "narHash": "sha256-C36QmoJd5tdQ5R9MC1jM7fBkZW9zBUqbUCsgwS6j4QU=",
+        "lastModified": 1704732714,
+        "narHash": "sha256-ABqK/HggMYA/jMUXgYyqVAcQ8QjeMyr1jcXfTpSHmps=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c1be43e8e837b8dbee2b3665a007e761680f0c3d",
+        "rev": "6723fa4e4f1a30d42a633bef5eb01caeb281adc3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`e5d3e66b`](https://github.com/nix-community/emacs-overlay/commit/e5d3e66bb146b77a9c978533dfb6028b9248f2fa) | `` Updated melpa ``        |
| [`15237ecc`](https://github.com/nix-community/emacs-overlay/commit/15237ecc6c37985dcb55574d6df249d333f0dff7) | `` Updated elpa ``         |
| [`96b3adef`](https://github.com/nix-community/emacs-overlay/commit/96b3adefc7df872692b6263a50431662e4426cd6) | `` Updated flake inputs `` |
| [`4118d09e`](https://github.com/nix-community/emacs-overlay/commit/4118d09e3b6613425c4d48f4aa4b2ed944e5b801) | `` Updated melpa ``        |
| [`dbcecbaa`](https://github.com/nix-community/emacs-overlay/commit/dbcecbaa6f0e7b59851c395a23dad531efe4b17d) | `` Updated flake inputs `` |