### PR TITLE
chore(flake/nur): `d2dc2f25` -> `7446d0fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704880769,
-        "narHash": "sha256-75IQ7G/K+CjAOj92pLqhCDRytK4SqinJjgtzkkxwhek=",
+        "lastModified": 1704913619,
+        "narHash": "sha256-RpdG4vYs+WLCYzDZXDC4sYp5eD/De3CBeO5/CheyZxM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d2dc2f25e0ea3ca5409555d4a96f78104b0be173",
+        "rev": "7446d0fcbcadfcfcbc9197c5b836cf442896590c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7446d0fc`](https://github.com/nix-community/NUR/commit/7446d0fcbcadfcfcbc9197c5b836cf442896590c) | `` automatic update `` |
| [`6509c7fd`](https://github.com/nix-community/NUR/commit/6509c7fd6e383a375fe0652a435941b0e63ace08) | `` automatic update `` |
| [`c29f47e7`](https://github.com/nix-community/NUR/commit/c29f47e7c08d48b7b9188d8accc1ed730b9cf7d0) | `` automatic update `` |
| [`0b34dc4f`](https://github.com/nix-community/NUR/commit/0b34dc4f624fe005afd64627f4a68d39315d650c) | `` automatic update `` |
| [`85ccecd5`](https://github.com/nix-community/NUR/commit/85ccecd524665a8ac2a043e9ced63f336476fe94) | `` automatic update `` |