### PR TITLE
chore(flake/nixpkgs): `46ae0210` -> `317484b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -755,11 +755,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1704538339,
-        "narHash": "sha256-1734d3mQuux9ySvwf6axRWZRBhtcZA9Q8eftD6EZg6U=",
+        "lastModified": 1704722960,
+        "narHash": "sha256-mKGJ3sPsT6//s+Knglai5YflJUF2DGj7Ai6Ynopz0kI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "46ae0210ce163b3cba6c7da08840c1d63de9c701",
+        "rev": "317484b1ead87b9c1b8ac5261a8d2dd748a0492d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`e6ba94f1`](https://github.com/NixOS/nixpkgs/commit/e6ba94f191c169b0ed198353121e55bdcba8e41f) | `` pdal: add pkg-config and version tests ``                                      |
| [`51ae8643`](https://github.com/NixOS/nixpkgs/commit/51ae8643e49278898a4a82788b723950587d462e) | `` pdal: alphabetical re-ordering of dependencies ``                              |
| [`c6e8d2b3`](https://github.com/NixOS/nixpkgs/commit/c6e8d2b31ed1a686cbd402d713af0cae281e609d) | `` pdal: add package tests ``                                                     |
| [`afa089e8`](https://github.com/NixOS/nixpkgs/commit/afa089e86dbf166f6e47ebecf30ca697cc249571) | `` manifest-tool: fix static build and update 2.0.6 -> 2.1.5 (#279451) ``         |
| [`788c45eb`](https://github.com/NixOS/nixpkgs/commit/788c45eb575e7db2e7a104d586059958e61ab916) | `` partition-manager: move to aliases.nix ``                                      |
| [`211f1d86`](https://github.com/NixOS/nixpkgs/commit/211f1d86a9b7f3e3543118e1d1668ca02a531d4a) | `` release-haskell.nix: test pkgs.pakcs ``                                        |
| [`df9e485b`](https://github.com/NixOS/nixpkgs/commit/df9e485b6ce646df2d0a769ce48252eee5fcae98) | `` pakcs: 2.2.1 -> 3.6.0 ``                                                       |
| [`25c0077a`](https://github.com/NixOS/nixpkgs/commit/25c0077a31203850dff6d8ad554bcf9c76ec1018) | `` doc: add note on which variables are effective ``                              |
| [`7ae1fdc9`](https://github.com/NixOS/nixpkgs/commit/7ae1fdc9a7407947885e2cd006dc766e12e4d71a) | `` doc: reformat ``                                                               |
| [`ea94f6b8`](https://github.com/NixOS/nixpkgs/commit/ea94f6b89327d96f0c23b61be473f020a7e73ab6) | `` doc: update the kernel config documentation to use `nix-shell` (#265057) ``    |
| [`b227d785`](https://github.com/NixOS/nixpkgs/commit/b227d7851b5b38ccbe5eef1b8fedf57981a115ee) | `` pkgs/top-level/release.nix: drop already removed `llvmPackages_7` mention ``   |
| [`ef190570`](https://github.com/NixOS/nixpkgs/commit/ef190570b8639a8d96c2e1cd25be117d79d5d5ef) | `` nixos/bcachefs: use linuxPackages_latest ``                                    |
| [`9df8e99f`](https://github.com/NixOS/nixpkgs/commit/9df8e99f3db26d188d946cd74daa2fef601846b2) | `` disko: init at 1.3.0 ``                                                        |
| [`549529d5`](https://github.com/NixOS/nixpkgs/commit/549529d5548919eb85c12dfce536643b9015e0ce) | `` linux_6_7: init at 6.7 ``                                                      |
| [`c9022830`](https://github.com/NixOS/nixpkgs/commit/c90228308d575befa4df7b16a27ddb0dca6d91fc) | `` expr: 1.15.7 -> 1.15.8 ``                                                      |
| [`2300905b`](https://github.com/NixOS/nixpkgs/commit/2300905b7c2dc9935e41e7aa4f1df2aa0547868b) | `` vdrPlugins.softhddevice: 2.0.7 -> 2.0.9 ``                                     |
| [`bb460aff`](https://github.com/NixOS/nixpkgs/commit/bb460aff88872cc93306538b9df891577d3c38e1) | `` vdrPlugins.markad: 3.4.2 -> 3.4.3 ``                                           |
| [`99bf09f2`](https://github.com/NixOS/nixpkgs/commit/99bf09f282f8ede00812e963f0d6a633497c683e) | `` tidal-hifi: 5.7.1 -> 5.8.0 ``                                                  |
| [`f577e084`](https://github.com/NixOS/nixpkgs/commit/f577e0844ec514d3498268cab115044daf1c95d8) | `` cargo-careful: 0.4.0 -> 0.4.1 ``                                               |
| [`ad51bcc6`](https://github.com/NixOS/nixpkgs/commit/ad51bcc62abee5437b981380a065809ca9ec13ab) | `` phoc: add passthru.updateScript ``                                             |
| [`2c7d6a26`](https://github.com/NixOS/nixpkgs/commit/2c7d6a26fc10f870e6ca76f034918bba44bed1dc) | `` php81Extensions.blackfire: 1.92.5 -> 1.92.6 ``                                 |
| [`7e16bc1a`](https://github.com/NixOS/nixpkgs/commit/7e16bc1a69448c5a47b8d58fa9625abda45e3d15) | `` libsodium: drop mingw patch ``                                                 |
| [`56df6683`](https://github.com/NixOS/nixpkgs/commit/56df668386ac83c5bcddf9849c645cf0d25706d7) | `` lib.callPackageWith: Use abort, not throw ``                                   |
| [`3e929146`](https://github.com/NixOS/nixpkgs/commit/3e929146cf01b532ec68a2f73af22271effdc75d) | `` pythonPackages.snakemake-interface-common: Fix eval with allowAliases false `` |
| [`9be716fb`](https://github.com/NixOS/nixpkgs/commit/9be716fb75bc10db65584a18635243d8d5ad784e) | `` cudaPackages.autoAddCudaCompatRunpathHook: Fix eval w/o cuda_compat ``         |
| [`69460711`](https://github.com/NixOS/nixpkgs/commit/69460711750d4bb4718516fdb155145e922ff610) | `` tests.checkpoint-build: Fix evaluation with allowAliases false ``              |
| [`046d653f`](https://github.com/NixOS/nixpkgs/commit/046d653f7e5ccb746a3133f1d3aca58156827533) | `` pythonPackages.sqlalchemy_1_4: Fix evaluation with allowAliases false ``       |
| [`199a63aa`](https://github.com/NixOS/nixpkgs/commit/199a63aa10609022f44491af56c6e95643425636) | `` mate.mate-user-share: Fix evaluation with allowAliases false ``                |
| [`1797094f`](https://github.com/NixOS/nixpkgs/commit/1797094f8b929f12ada2e57772d32151ee7cf843) | `` pythonPackages.dnf-plugins-core: Fix eval with allowAliases false ``           |
| [`e1d9ca4f`](https://github.com/NixOS/nixpkgs/commit/e1d9ca4f0799172a84db709ed2ab2401aa60632c) | `` abcde: Fix evaluation ``                                                       |
| [`627a628d`](https://github.com/NixOS/nixpkgs/commit/627a628d5403570905aa0cbf55df7c0b724eee36) | `` wl-clip-persist: remove thiagokokada from maintainers ``                       |
| [`4141b29a`](https://github.com/NixOS/nixpkgs/commit/4141b29a792cf7f98dabb708bb2ab291e1b57bc1) | `` amdctl: remove thiagokokada from maintainers ``                                |
| [`8a9938b0`](https://github.com/NixOS/nixpkgs/commit/8a9938b06c2b4ffd1dca47507802877f09144eb5) | `` clj-kondo: remove thiagokokada from maintainers ``                             |
| [`3698d80e`](https://github.com/NixOS/nixpkgs/commit/3698d80e3728547dcb4b53fddd8f7e62a086fc19) | `` unar: remove thiagokokada from maintainers ``                                  |
| [`a1f364d6`](https://github.com/NixOS/nixpkgs/commit/a1f364d69493fab6d3426301253cc6dec32f58ab) | `` python2.7: remove thiagokokada from maintainers ``                             |
| [`5e566860`](https://github.com/NixOS/nixpkgs/commit/5e5668608a082d4137d86148c530f8709a626497) | `` gittyup: remove thiagokokada from maintainers ``                               |
| [`f654c434`](https://github.com/NixOS/nixpkgs/commit/f654c434964bd0f8373d6ca07a90a22116f96b17) | `` guestfs-tools: remove thiagokokada from maintainers ``                         |
| [`f6d7b201`](https://github.com/NixOS/nixpkgs/commit/f6d7b201d7c794f1db1f244d97ccc63c5b421276) | `` ockam: 0.114.0 -> 0.115.0 ``                                                   |
| [`8694fb41`](https://github.com/NixOS/nixpkgs/commit/8694fb4187be13dec82b75ccef37fc5509f12e43) | `` python311Packages.linear-operator: rename from linear_operator (#279258) ``    |
| [`fa07b7c2`](https://github.com/NixOS/nixpkgs/commit/fa07b7c27db4e57f9b598f1f479c6193fff35d76) | `` rio: 0.0.33 -> 0.0.34 ``                                                       |
| [`5ec5f047`](https://github.com/NixOS/nixpkgs/commit/5ec5f0477181d16ffbb16dec4bf7127c50910150) | `` okteta: 0.26.14 -> 0.26.15 ``                                                  |
| [`2adcc884`](https://github.com/NixOS/nixpkgs/commit/2adcc8846aa5244c4d87446e0267c9657a6f281b) | `` python311Packages.wxpython: rename from wxPython_4_2 ``                        |
| [`427046dd`](https://github.com/NixOS/nixpkgs/commit/427046dd872e1687d7e93c7a805170928cfd824b) | `` heroic: 2.11.0 -> 2.12.0 ``                                                    |
| [`e253a1d1`](https://github.com/NixOS/nixpkgs/commit/e253a1d1746afa9b9a8ef8df68364d863d8897d7) | `` python311Packages.trezor-agent: rename from trezor_agent ``                    |
| [`015448a9`](https://github.com/NixOS/nixpkgs/commit/015448a913f3bcf72bfbc28cd34ac06ba99c1f1b) | `` python311Packages.ax: 0.3.4 -> 0.3.6 (#279342) ``                              |
| [`e10c14a0`](https://github.com/NixOS/nixpkgs/commit/e10c14a05bb4ee7d57db9eebd722a504ecd6ba97) | `` libsForQt5.kpmcore, partition-manager: move to applications/kde ``             |
| [`aa629d98`](https://github.com/NixOS/nixpkgs/commit/aa629d9877cdeac2638223c8e75936657a590647) | `` gogs: mark as insecure ``                                                      |
| [`f078fb07`](https://github.com/NixOS/nixpkgs/commit/f078fb0786b033213cf23b0c0b72f6f1c4e796f1) | `` moon: 1.18.5 -> 1.19.0 ``                                                      |
| [`d4b11ca4`](https://github.com/NixOS/nixpkgs/commit/d4b11ca47ce5944e0331895ff50fce1391d2b24f) | `` qrtool: 0.10.1 -> 0.10.2 ``                                                    |
| [`cbcf1d97`](https://github.com/NixOS/nixpkgs/commit/cbcf1d977b94592aa375044a85d2977f7e8cdf0d) | `` evcc: 0.123.2 -> 0.123.7 ``                                                    |
| [`255ec950`](https://github.com/NixOS/nixpkgs/commit/255ec95023ee8c2a51528a68a78416b92c85a094) | `` python311Packages.thumborPexif: remove ``                                      |
| [`7af53089`](https://github.com/NixOS/nixpkgs/commit/7af53089c65513a7f8cc5bfb4c2c16dfbe7b04bf) | `` helm-ls: 0.0.8 -> 0.0.9 ``                                                     |
| [`ed51a1cf`](https://github.com/NixOS/nixpkgs/commit/ed51a1cfeb70df5769cd0202fcc2e543d621adc0) | `` zigbee2mqtt: 1.35.0 -> 1.35.1 ``                                               |
| [`0148d8e4`](https://github.com/NixOS/nixpkgs/commit/0148d8e4d299a930efe8022282b339dfef9bcf52) | `` symfony-cli: add nssTools as a runtime dependency ``                           |
| [`560694be`](https://github.com/NixOS/nixpkgs/commit/560694bec2da60f32f920db0ad240ba4411e1a50) | `` python311Packages.py-scrypt: rename from py_scrypt ``                          |
| [`a3e1ee7c`](https://github.com/NixOS/nixpkgs/commit/a3e1ee7c602cf595ab1d5fe3db404bdf61ba4cde) | `` virt-manager: fix tests ``                                                     |
| [`0ee3eeed`](https://github.com/NixOS/nixpkgs/commit/0ee3eeedb357881aa1794459e1e42681de6e6d23) | `` osinfo-db: 20230308 -> 20231215 ``                                             |
| [`9ea3a3cf`](https://github.com/NixOS/nixpkgs/commit/9ea3a3cfaa995c201b68c1cd3877bd35e1d7dd04) | `` pleroma: 2.6.0 -> 2.6.1 ``                                                     |
| [`07c3a423`](https://github.com/NixOS/nixpkgs/commit/07c3a4234d9466bda52c80bff760b7134687c7a2) | `` python311Packages.radicale-infcloud: rename from radicale_infcloud ``          |
| [`ba2ae3cf`](https://github.com/NixOS/nixpkgs/commit/ba2ae3cfd7a6962e83551fb8c4959814f14d8475) | `` linuxKernel.kernels.linux_lqx: 6.6.9-lqx1 -> 6.6.10-lqx1 ``                    |
| [`4592bcbd`](https://github.com/NixOS/nixpkgs/commit/4592bcbd739a7c5226b51cc0036a8fcfb4a90f58) | `` linuxKernel.kernels.linux_zen: 6.6.9-zen1 -> 6.6.10-zen1 ``                    |
| [`fc680ef5`](https://github.com/NixOS/nixpkgs/commit/fc680ef5ecfe7ea6e9e26f9dfb8c1c3142500fcb) | `` memtest86plus: 6.20 -> 7.00 ``                                                 |
| [`c74d8906`](https://github.com/NixOS/nixpkgs/commit/c74d8906b5251e0aa9e872ba06d0d16f60c0a54c) | `` signaturepdf: Fix postInstall hook ``                                          |
| [`396995f0`](https://github.com/NixOS/nixpkgs/commit/396995f006e93374d9f9f8ad1965374f30eb0b9c) | `` valhalla: upstream fix for `gcc-13` build ``                                   |
| [`9ceeed4c`](https://github.com/NixOS/nixpkgs/commit/9ceeed4ccf1c7a9afc7c7570a03811c98452b503) | `` python311Packages.aiowithings: 2.0.0 -> 2.1.0 ``                               |
| [`4f809c6c`](https://github.com/NixOS/nixpkgs/commit/4f809c6c676f994e0af5a034484fc2470c100750) | `` moar: 1.18.6 -> 1.21.0 ``                                                      |
| [`7cb3f2dd`](https://github.com/NixOS/nixpkgs/commit/7cb3f2ddba2499b10062151dfd87331e907415e2) | `` minio-client: 2023-10-30T18-43-32Z -> 2024-01-05T05-04-32Z ``                  |
| [`454a9d84`](https://github.com/NixOS/nixpkgs/commit/454a9d84cfb73f64f67ab44f3a1510bced11ebb8) | `` emacs.pkgs.wat-mode: convert to melpaBuild ``                                  |
| [`fd33bbc7`](https://github.com/NixOS/nixpkgs/commit/fd33bbc7af1306687f32ff50abd26ff61d13e95e) | `` python311Packages.spark-parser: rename from spark_parser ``                    |
| [`c6394f7c`](https://github.com/NixOS/nixpkgs/commit/c6394f7c41e04f90043705d371bde03e7c750fa7) | `` typesense: fix test failure due to initialization timing ``                    |
| [`f85116aa`](https://github.com/NixOS/nixpkgs/commit/f85116aa0d54e30ac4850176436b0cd5333c4d32) | `` python311Packages.sysv-ipc: rename from sysv_ipc ``                            |
| [`b294316d`](https://github.com/NixOS/nixpkgs/commit/b294316d50d0802096c750fa2306febb35b7afd5) | `` alacritty-theme: fix install by packaging `*.toml` files ``                    |
| [`e5597afc`](https://github.com/NixOS/nixpkgs/commit/e5597afc62a93af60afadc1c87404f2276f97e78) | `` python311Packages.ufolib2: rename from ufoLib2 ``                              |
| [`853037bb`](https://github.com/NixOS/nixpkgs/commit/853037bbb081a09a13e7de445b2b2621a2ce9624) | `` python311Packages.pystatgrab: init at 0.7.2 ``                                 |
| [`0668d341`](https://github.com/NixOS/nixpkgs/commit/0668d341012923d2a2a129959619dba6d1b48059) | `` difftastic: 0.53.1 -> 0.54.0 ``                                                |
| [`f7c25138`](https://github.com/NixOS/nixpkgs/commit/f7c25138ea7d9019f0a34a19cfcfe05a1dac5ac2) | `` nixos/bitwarden-directory-connector: init at version ``                        |
| [`57b09a85`](https://github.com/NixOS/nixpkgs/commit/57b09a855f7b69769de6d50fc9346deec2d77b86) | `` bitwarden-directory-connector: init at 2023.10.0 ``                            |
| [`62d82846`](https://github.com/NixOS/nixpkgs/commit/62d82846df0ebffac4c08cfeabe53c6b92cbe829) | `` pantheon-tweaks: 1.1.1 -> 1.1.2 ``                                             |
| [`6dca6dc2`](https://github.com/NixOS/nixpkgs/commit/6dca6dc2f0f491fa1ac39fc99b13a0fd08949257) | `` micronaut: 4.2.2 -> 4.2.3 ``                                                   |
| [`e650bbd6`](https://github.com/NixOS/nixpkgs/commit/e650bbd6eb58318bb85408bd4e8fd9ca63b46456) | `` haskell.packages.ghc90.ghc-tags: 1.5 -> 1.6 ``                                 |
| [`6652baf4`](https://github.com/NixOS/nixpkgs/commit/6652baf493bb1092f9d7db1c0e29d493f10c9f16) | `` haskellPackages: mark builds failing on hydra as broken ``                     |
| [`0e7499d4`](https://github.com/NixOS/nixpkgs/commit/0e7499d40713e023b431271f5ad5c26e8d1adb3c) | `` python311Packages.mir-eval: rename from mir_eval ``                            |
| [`1b8764b4`](https://github.com/NixOS/nixpkgs/commit/1b8764b40af6ffbf2f39ad9b294f31e6492078ca) | `` memtree: unstable-2023-11-22 -> unstable-2024-01-04 ``                         |
| [`3985a758`](https://github.com/NixOS/nixpkgs/commit/3985a7581c0f59b5504dbb40f1b851b1e38589aa) | `` python311Packages.mac-alias: rename from mac_alias ``                          |
| [`5c4b0056`](https://github.com/NixOS/nixpkgs/commit/5c4b00560cae0d96bbebce6c97e320699c13740e) | `` haskellPackages.typst: temporarily disable on Hydra ``                         |
| [`1fe98d8b`](https://github.com/NixOS/nixpkgs/commit/1fe98d8b20911bcf822eb45c05dec8a56b9124d7) | `` maskromtool: 2023-12-07 -> 2024-01-1 ``                                        |
| [`b7c875b4`](https://github.com/NixOS/nixpkgs/commit/b7c875b4922eead4af30ed08708dacc266f713c2) | `` haskellPackages.pantry_0_9_3_1: don't test in default package set ``           |
| [`ef6d05eb`](https://github.com/NixOS/nixpkgs/commit/ef6d05eb1b223866a46fc9d3f7dc0664641402d3) | `` haskellPackages.fourmolu_0_14_*: don't test in all package sets ``             |
| [`01dbc95b`](https://github.com/NixOS/nixpkgs/commit/01dbc95b2d9e7c73667c90dbc3b63f06b9d345a7) | `` snapshot: 45.1 → 45.2 ``                                                       |
| [`dbfe04d8`](https://github.com/NixOS/nixpkgs/commit/dbfe04d85412da86cd26d45fb7ba3c3417cf01f6) | `` orca: 45.1 → 45.2 ``                                                           |
| [`47f483b1`](https://github.com/NixOS/nixpkgs/commit/47f483b1708103119d30cc56a47070696efc44c4) | `` gvfs: 1.52.1 → 1.52.2 ``                                                       |
| [`e65466e2`](https://github.com/NixOS/nixpkgs/commit/e65466e20f779ebad4f4911c8ec466b4379ddcd9) | `` gnome.zenity: 4.0.0 → 4.0.1 ``                                                 |
| [`1c83fb92`](https://github.com/NixOS/nixpkgs/commit/1c83fb9294b6f4f21902b6c79618eefb3affb6f5) | `` gnome.gnome-sudoku: 45.3 → 45.4 ``                                             |
| [`27fe24d5`](https://github.com/NixOS/nixpkgs/commit/27fe24d5a70190f79f9cab36ff30325895e827dd) | `` gnome.gnome-software: 45.2 → 45.3 ``                                           |
| [`fa9355cc`](https://github.com/NixOS/nixpkgs/commit/fa9355cc18a4fc0dd6d3ab3d5202406881bea1f2) | `` gnome.gnome-settings-daemon: 45.0 → 45.1 ``                                    |
| [`c6a8328b`](https://github.com/NixOS/nixpkgs/commit/c6a8328bcfc7638a4afce7ce0da35e2c2c3fd081) | `` gnome.gnome-maps: 45.2 → 45.3 ``                                               |
| [`ab4a44cd`](https://github.com/NixOS/nixpkgs/commit/ab4a44cd73d16abbe9773e52ddaf4e6da9ea12a6) | `` gnome.eog: 45.1 → 45.2 ``                                                      |
| [`c51ca39f`](https://github.com/NixOS/nixpkgs/commit/c51ca39fa8524e0f0784d4b6aae0788be6e701ae) | `` templ: 0.2.501 -> 0.2.513 ``                                                   |
| [`0e6cf34d`](https://github.com/NixOS/nixpkgs/commit/0e6cf34d00466c8e14387823595989aa1ea125e4) | `` python311Packages.aiohappyeyeballs: update changelog entry ``                  |
| [`e67666d9`](https://github.com/NixOS/nixpkgs/commit/e67666d989de9fa0a0a95e5e48ff1a683ba2ea1e) | `` tpm2-pkcs11: Remove myself as maintainer ``                                    |
| [`e9304d7d`](https://github.com/NixOS/nixpkgs/commit/e9304d7d3d3b09f36213e3e29c9075cf5f6e8569) | `` libvmi: Remove myself as maintainer ``                                         |
| [`6ad7e6fb`](https://github.com/NixOS/nixpkgs/commit/6ad7e6fb312a15d05766e4be5723bd1c25d20bf2) | `` Revert "gocode: remove" ``                                                     |
| [`d17e4c38`](https://github.com/NixOS/nixpkgs/commit/d17e4c38959d229642144723b0df3c0aeeb1bb75) | `` python311Packages.aiohappyeyeballs: 2.3.0 -> 2.3.2 ``                          |
| [`72b8d400`](https://github.com/NixOS/nixpkgs/commit/72b8d400fe8f51b991451615280c054a3c16395a) | `` mitmproxy2swagger: 0.11.0 -> 0.13.0 ``                                         |
| [`1803ab94`](https://github.com/NixOS/nixpkgs/commit/1803ab9411cd209f66eaaba83da82ed4259b15b1) | `` cnspec: 9.12.3 -> 9.13.0 ``                                                    |
| [`5a928c61`](https://github.com/NixOS/nixpkgs/commit/5a928c61aa552b876fc56d2838adefbb327b6856) | `` terraform-providers.tencentcloud: 1.81.60 -> 1.81.64 ``                        |