### PR TITLE
chore(flake/sops-nix): `0ded5741` -> `c0b3a5af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -968,11 +968,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1704753304,
-        "narHash": "sha256-9shh5fYLfLJrxr4NnIoWcO9T3bTFuO5QW9v/wDpq9Xg=",
+        "lastModified": 1704908274,
+        "narHash": "sha256-74W9Yyomv3COGRmKi8zvyA5tL2KLiVkBeaYmYLjXyOw=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "0ded57412079011f1210c2fcc10e112427d4c0e6",
+        "rev": "c0b3a5af90fae3ba95645bbf85d2b64880addd76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                         |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`c0b3a5af`](https://github.com/Mic92/sops-nix/commit/c0b3a5af90fae3ba95645bbf85d2b64880addd76) | `` fix wrong error message in ssh key import `` |
| [`020dcff7`](https://github.com/Mic92/sops-nix/commit/020dcff707252fa93884036eebf7b02e53d54a43) | `` allow ssh key import to fail ``              |
| [`5bd3f71f`](https://github.com/Mic92/sops-nix/commit/5bd3f71f071308cbd50a229a32f1dd88419060d1) | `` Update README.md ``                          |
| [`4cf46717`](https://github.com/Mic92/sops-nix/commit/4cf467173b686d845be316a4bf4d8d22bf70f618) | `` Update README.md ``                          |
| [`6db9bd9a`](https://github.com/Mic92/sops-nix/commit/6db9bd9acef5ace8293a067e545180c04e9bc333) | `` fix typo in README.md ``                     |