### PR TITLE
chore(flake/nur): `7446d0fc` -> `32d33c9c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704913619,
-        "narHash": "sha256-RpdG4vYs+WLCYzDZXDC4sYp5eD/De3CBeO5/CheyZxM=",
+        "lastModified": 1704936003,
+        "narHash": "sha256-RPvR8m9D64pG4JwvYzSh84+lj5sLJRxi5n80AuLjVZc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7446d0fcbcadfcfcbc9197c5b836cf442896590c",
+        "rev": "32d33c9c00790e687cbe9984fec35c3d0e03e22d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`32d33c9c`](https://github.com/nix-community/NUR/commit/32d33c9c00790e687cbe9984fec35c3d0e03e22d) | `` automatic update `` |
| [`45a706bc`](https://github.com/nix-community/NUR/commit/45a706bce225239a923b84019d693ba3d656c8ee) | `` automatic update `` |
| [`9a62b18e`](https://github.com/nix-community/NUR/commit/9a62b18e7f08d7ffae324679d206fac6a9b6e7de) | `` automatic update `` |