### PR TITLE
chore(flake/nur): `32d33c9c` -> `a02c30dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704936003,
-        "narHash": "sha256-RPvR8m9D64pG4JwvYzSh84+lj5sLJRxi5n80AuLjVZc=",
+        "lastModified": 1704938608,
+        "narHash": "sha256-pUiWNQsleGH/0cn9Jsyl+gYiAzWdYWJgCqaKqBY6h2A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "32d33c9c00790e687cbe9984fec35c3d0e03e22d",
+        "rev": "a02c30dd3487ec92a678d904053c1018ae87fbbe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a02c30dd`](https://github.com/nix-community/NUR/commit/a02c30dd3487ec92a678d904053c1018ae87fbbe) | `` automatic update `` |
| [`257f6fa9`](https://github.com/nix-community/NUR/commit/257f6fa98b9e9865714ed0908d7d7f2b7894cf01) | `` automatic update `` |
| [`c637e32e`](https://github.com/nix-community/NUR/commit/c637e32e807063f156814851a47bc2cfc2d63bf2) | `` automatic update `` |