### PR TITLE
chore(flake/nur): `a02c30dd` -> `813d3e60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704938608,
-        "narHash": "sha256-pUiWNQsleGH/0cn9Jsyl+gYiAzWdYWJgCqaKqBY6h2A=",
+        "lastModified": 1704945028,
+        "narHash": "sha256-S0i2ZChTimQqUWFFb4PH+y7qetoRM5kUWIIdtPNubm0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a02c30dd3487ec92a678d904053c1018ae87fbbe",
+        "rev": "813d3e60730dacabd842ac7dbf6c7b46c6ded339",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`813d3e60`](https://github.com/nix-community/NUR/commit/813d3e60730dacabd842ac7dbf6c7b46c6ded339) | `` automatic update `` |
| [`ee3f34cc`](https://github.com/nix-community/NUR/commit/ee3f34ccfee8439d8841118ce6f8931a3c760b12) | `` automatic update `` |
| [`725e4c11`](https://github.com/nix-community/NUR/commit/725e4c1197f735213c8eb05811fb26a9bd0470df) | `` automatic update `` |
| [`c733916c`](https://github.com/nix-community/NUR/commit/c733916c1fc8d165335af2c8906345b831fc802a) | `` automatic update `` |
| [`df2dfc87`](https://github.com/nix-community/NUR/commit/df2dfc870aaed88af16e165d6f51923a4da487e8) | `` automatic update `` |
| [`2369a187`](https://github.com/nix-community/NUR/commit/2369a187d23f70a03fde7902189772c361da82ff) | `` automatic update `` |
| [`c701c8c1`](https://github.com/nix-community/NUR/commit/c701c8c10ca74b6f6fffe7be4f995d4ee04d183b) | `` automatic update `` |
| [`77704096`](https://github.com/nix-community/NUR/commit/77704096cce07855a86f2108525a33cda818283a) | `` automatic update `` |
| [`950dd31e`](https://github.com/nix-community/NUR/commit/950dd31ee60cde1b6cf6f3e71c5779aca9fedb0d) | `` automatic update `` |