### PR TITLE
chore(flake/nur): `813d3e60` -> `3e09c868`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704945028,
-        "narHash": "sha256-S0i2ZChTimQqUWFFb4PH+y7qetoRM5kUWIIdtPNubm0=",
+        "lastModified": 1704948133,
+        "narHash": "sha256-E7IJJdLIlBNyRV5bIQtIq+DKlw+z/MjBveKf/obcVnI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "813d3e60730dacabd842ac7dbf6c7b46c6ded339",
+        "rev": "3e09c86852097d9c944b5f3d8e3887081afae8a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3e09c868`](https://github.com/nix-community/NUR/commit/3e09c86852097d9c944b5f3d8e3887081afae8a6) | `` automatic update `` |