### PR TITLE
chore(flake/nur): `3e09c868` -> `d1ddb9f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704948133,
-        "narHash": "sha256-E7IJJdLIlBNyRV5bIQtIq+DKlw+z/MjBveKf/obcVnI=",
+        "lastModified": 1704996003,
+        "narHash": "sha256-D1kTOJovWUozVWDWKmZ8yqdxgvYOJdIlD18V/SaP3PQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3e09c86852097d9c944b5f3d8e3887081afae8a6",
+        "rev": "d1ddb9f3facb26e47fa8498508f2de6ac8d51ef4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d1ddb9f3`](https://github.com/nix-community/NUR/commit/d1ddb9f3facb26e47fa8498508f2de6ac8d51ef4) | `` automatic update `` |
| [`e001a689`](https://github.com/nix-community/NUR/commit/e001a689b8338fef133330de7ab187eaa3fc9be9) | `` automatic update `` |
| [`7970185d`](https://github.com/nix-community/NUR/commit/7970185d9e3fd1eed750ca2953469335467ed05b) | `` automatic update `` |
| [`9fc1df5c`](https://github.com/nix-community/NUR/commit/9fc1df5c3c1599c59668083fae4a9ea6ed9897d1) | `` automatic update `` |
| [`08aad74d`](https://github.com/nix-community/NUR/commit/08aad74d0910faa799ac332a15ad11c1d9b3e818) | `` automatic update `` |
| [`3593af22`](https://github.com/nix-community/NUR/commit/3593af227e6c50ece72ec5ffc217c87efbb7f307) | `` automatic update `` |
| [`7b9e67b3`](https://github.com/nix-community/NUR/commit/7b9e67b39a3b336fe2098d2bd0e2db552480371d) | `` automatic update `` |
| [`54da7131`](https://github.com/nix-community/NUR/commit/54da71315497f57371fcadb4f02885ae20674bc7) | `` automatic update `` |
| [`312de864`](https://github.com/nix-community/NUR/commit/312de864bc7aa114e4d2037e5dc8a8138ec07af2) | `` automatic update `` |
| [`4782fd51`](https://github.com/nix-community/NUR/commit/4782fd513cba8dd02eda30b30d72b8a90585a881) | `` automatic update `` |