### PR TITLE
chore(flake/home-manager): `e13aa9e2` -> `93e804e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -457,11 +457,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704809957,
-        "narHash": "sha256-Z8sBeoeeY2O+BNqh5C+4Z1h1F1wQ2mij7yPZ2GY397M=",
+        "lastModified": 1704980804,
+        "narHash": "sha256-lPNNKdPqIYcjhhYIVwlajNt/HqVWbMOoSdNnwCvOP04=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e13aa9e287b3365473e5897e3667ea80a899cdfb",
+        "rev": "93e804e7f8a1eb88bde6117cd5046501e66aa4bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                   |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`93e804e7`](https://github.com/nix-community/home-manager/commit/93e804e7f8a1eb88bde6117cd5046501e66aa4bd) | `` docs: use alternative source of nmd `` |