### PR TITLE
chore(flake/flake-parts): `88a2cd81` -> `07f63952`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -348,11 +348,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1704152458,
-        "narHash": "sha256-DS+dGw7SKygIWf9w4eNBUZsK+4Ug27NwEWmn2tnbycg=",
+        "lastModified": 1704982712,
+        "narHash": "sha256-2Ptt+9h8dczgle2Oo6z5ni5rt/uLMG47UFTR1ry/wgg=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "88a2cd8166694ba0b6cb374700799cec53aef527",
+        "rev": "07f6395285469419cf9d078f59b5b49993198c00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                                         |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`528a7d0c`](https://github.com/hercules-ci/flake-parts/commit/528a7d0cb9668fb633d0ce39fb2255c94e4f8250) | `` transposition: Explain incomplete usage of transposition ``                  |
| [`3a0408e3`](https://github.com/hercules-ci/flake-parts/commit/3a0408e3acf785354d8a9b4074b9d4dbb0a12852) | `` perSystem: Check that inputs'.<name> is a flake, for better error message `` |
| [`ac5d0b2d`](https://github.com/hercules-ci/flake-parts/commit/ac5d0b2d4d51a53a1cd4a4a10d22f4a12c3fe652) | `` transposition: Improve perInput error message ``                             |
| [`7de0c651`](https://github.com/hercules-ci/flake-parts/commit/7de0c651b7f50d66138f405c883ebc66aef6b9db) | `` raise error when flake attribute doesn't exist ``                            |