### PR TITLE
chore(flake/nur): `d1ddb9f3` -> `27a28bd4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704996003,
-        "narHash": "sha256-D1kTOJovWUozVWDWKmZ8yqdxgvYOJdIlD18V/SaP3PQ=",
+        "lastModified": 1704999567,
+        "narHash": "sha256-W4HtBzTglutth1q5uzxy76Z2QE3CuAgr5PiMAw6G/SM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d1ddb9f3facb26e47fa8498508f2de6ac8d51ef4",
+        "rev": "27a28bd4863bf31e7d7c422f8f780d6d11cfc786",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`27a28bd4`](https://github.com/nix-community/NUR/commit/27a28bd4863bf31e7d7c422f8f780d6d11cfc786) | `` automatic update `` |
| [`e39159c3`](https://github.com/nix-community/NUR/commit/e39159c36817a9993b927ebf503be1d3ed4bacdc) | `` automatic update `` |