### PR TITLE
chore(flake/nur): `27a28bd4` -> `75341885`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704999567,
-        "narHash": "sha256-W4HtBzTglutth1q5uzxy76Z2QE3CuAgr5PiMAw6G/SM=",
+        "lastModified": 1705002794,
+        "narHash": "sha256-kOd7hd8A1sGFZSYJGn+cEH3RSpGVAQ004Pd1lZabuIo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "27a28bd4863bf31e7d7c422f8f780d6d11cfc786",
+        "rev": "753418854902ccec235420cf3ee6b8bb9da3de67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`75341885`](https://github.com/nix-community/NUR/commit/753418854902ccec235420cf3ee6b8bb9da3de67) | `` automatic update `` |
| [`f9278a3b`](https://github.com/nix-community/NUR/commit/f9278a3b6fbdf22c0797a79ef56dd0cb41358b9b) | `` automatic update `` |