### PR TITLE
chore(flake/emacs-overlay): `4b0b67c3` -> `c19de550`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704991943,
-        "narHash": "sha256-9fHkDwiat/Z78rTALw6GJE5dmKpTHDUSiimBDNQauNc=",
+        "lastModified": 1705021365,
+        "narHash": "sha256-r8M2U86h2v7U8wf+W/7Spw1O5dRXrbV+msjlblEknNM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4b0b67c374297a8dd880fbfc13eddf495197b308",
+        "rev": "c19de550027db6d9d1ba85b63b4cb78fdf73ee00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`c19de550`](https://github.com/nix-community/emacs-overlay/commit/c19de550027db6d9d1ba85b63b4cb78fdf73ee00) | `` Updated elpa ``   |
| [`b1042ceb`](https://github.com/nix-community/emacs-overlay/commit/b1042cebf0e7cf4a8a805c590f67dcd0c398c0fd) | `` Updated nongnu `` |