### PR TITLE
chore(flake/emacs-overlay): `c19de550` -> `905528b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705021365,
-        "narHash": "sha256-r8M2U86h2v7U8wf+W/7Spw1O5dRXrbV+msjlblEknNM=",
+        "lastModified": 1705023316,
+        "narHash": "sha256-Y5KLXR7O1RnBT/NNCgmci05zvCVmIPkk+/FvOIUxqkw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c19de550027db6d9d1ba85b63b4cb78fdf73ee00",
+        "rev": "905528b5c9c5eac4c82c86493aec69f85ea1c050",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`905528b5`](https://github.com/nix-community/emacs-overlay/commit/905528b5c9c5eac4c82c86493aec69f85ea1c050) | `` Updated melpa `` |