### PR TITLE
chore(flake/nur): `75341885` -> `1a43e4b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705002794,
-        "narHash": "sha256-kOd7hd8A1sGFZSYJGn+cEH3RSpGVAQ004Pd1lZabuIo=",
+        "lastModified": 1705031957,
+        "narHash": "sha256-ODY28iYgvHmEjSwiyMRblQh0zADp0g6lb5eTpH3DAeY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "753418854902ccec235420cf3ee6b8bb9da3de67",
+        "rev": "1a43e4b9c02d33694e9d1d0d7a9423fb9b17a947",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1a43e4b9`](https://github.com/nix-community/NUR/commit/1a43e4b9c02d33694e9d1d0d7a9423fb9b17a947) | `` automatic update `` |
| [`7792a534`](https://github.com/nix-community/NUR/commit/7792a534e255fcde947f58df04a030d629422ed3) | `` automatic update `` |