### PR TITLE
chore(flake/nur): `1a43e4b9` -> `f5650128`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705031957,
-        "narHash": "sha256-ODY28iYgvHmEjSwiyMRblQh0zADp0g6lb5eTpH3DAeY=",
+        "lastModified": 1705040154,
+        "narHash": "sha256-UK7o4fScOBAbO3egkvsY/GV9uX3H6YNVMlz4hEmzRcU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1a43e4b9c02d33694e9d1d0d7a9423fb9b17a947",
+        "rev": "f56501287c4df6117012146ac5a3d2349ef93246",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f5650128`](https://github.com/nix-community/NUR/commit/f56501287c4df6117012146ac5a3d2349ef93246) | `` automatic update `` |