### PR TITLE
chore(flake/nur): `f5650128` -> `59b19303`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705040154,
-        "narHash": "sha256-UK7o4fScOBAbO3egkvsY/GV9uX3H6YNVMlz4hEmzRcU=",
+        "lastModified": 1705049972,
+        "narHash": "sha256-dQDF/YP2BZ4yxsUBPlkQdKnM/XAlA9CSexxyEboBs4I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f56501287c4df6117012146ac5a3d2349ef93246",
+        "rev": "59b193033007f646cdd9dbf1e9f8696a04f53d5f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`59b19303`](https://github.com/nix-community/NUR/commit/59b193033007f646cdd9dbf1e9f8696a04f53d5f) | `` automatic update `` |