### PR TITLE
chore(flake/pre-commit-hooks): `b0265634` -> `54d60d19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -888,11 +888,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1704913983,
-        "narHash": "sha256-K/GuHFFriQhH3VPWMhm6bYelDuPyGGjGu1OF1EWUn5k=",
+        "lastModified": 1705056064,
+        "narHash": "sha256-pi9UtBFD5/U48Jrc6uvA8ZCmW4xnceUDp2QysBEkZCw=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "b0265634df1dc584585c159b775120e637afdb41",
+        "rev": "54d60d191aa8ba0629f662d8873a892cbe3d65ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                           |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------- |
| [`02a45958`](https://github.com/cachix/pre-commit-hooks.nix/commit/02a459585885f57c3fd93bb4e0b9b573a62a1ee5) | `` Add args to prettier hook ``   |
| [`b568e6d3`](https://github.com/cachix/pre-commit-hooks.nix/commit/b568e6d3b8866f1256977fa49fefd12c4a806e86) | `` typos: unset pass_filenames `` |