### PR TITLE
chore(flake/nur): `59b19303` -> `39c492ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705049972,
-        "narHash": "sha256-dQDF/YP2BZ4yxsUBPlkQdKnM/XAlA9CSexxyEboBs4I=",
+        "lastModified": 1705057155,
+        "narHash": "sha256-0RqlKHIg1cZxiHhawRd1TNyAiYM7PD9tG+gqVkJ+at8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "59b193033007f646cdd9dbf1e9f8696a04f53d5f",
+        "rev": "39c492ef77c88b1c50fea7c5755f515a66f828cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`39c492ef`](https://github.com/nix-community/NUR/commit/39c492ef77c88b1c50fea7c5755f515a66f828cc) | `` automatic update `` |