### PR TITLE
chore(flake/nur): `5da1d036` -> `2d550df1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705063377,
-        "narHash": "sha256-nCjsfNVxEh+HBzYRRzDLU/4uUTLPWuQbd60oCpuRxmM=",
+        "lastModified": 1705066623,
+        "narHash": "sha256-+bPQZxIhUYUgdjoDLihXsQfA+trzXtJSPUlHncOWOfw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5da1d036dcd69a0f5dddd3845b0ce94f34d2ff3b",
+        "rev": "2d550df1e76d9c1b095feb24fb3eee786d36a9d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2d550df1`](https://github.com/nix-community/NUR/commit/2d550df1e76d9c1b095feb24fb3eee786d36a9d1) | `` automatic update `` |