### PR TITLE
chore(flake/nur): `2d550df1` -> `0b832792`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705066623,
-        "narHash": "sha256-+bPQZxIhUYUgdjoDLihXsQfA+trzXtJSPUlHncOWOfw=",
+        "lastModified": 1705071520,
+        "narHash": "sha256-qxlyZ0cmHOSRcYypzUQmhyIdauG7OEThmQj4ZGbuM1s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2d550df1e76d9c1b095feb24fb3eee786d36a9d1",
+        "rev": "0b83279250ed154a1bb92978bbce7a17296a5355",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0b832792`](https://github.com/nix-community/NUR/commit/0b83279250ed154a1bb92978bbce7a17296a5355) | `` automatic update `` |