### PR TITLE
chore(flake/emacs-overlay): `fcd7c360` -> `7931d882`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705049510,
-        "narHash": "sha256-+r3i5b9QsQX5lew62aHvPWw9cf02Mzf/d0n4URhPBV8=",
+        "lastModified": 1705078385,
+        "narHash": "sha256-ox7zfG2cwBMH8TEw2Z5lO/C1QKWHbBjl+kcFiUUr7XU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fcd7c360c3f73ec91da70155df6d9a413e4bd128",
+        "rev": "7931d882cdb5ce330571f583e989117fdfa808f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`7931d882`](https://github.com/nix-community/emacs-overlay/commit/7931d882cdb5ce330571f583e989117fdfa808f1) | `` Updated melpa `` |
| [`9a5b785e`](https://github.com/nix-community/emacs-overlay/commit/9a5b785e55d35fcbbb50c5098cc78917c1a924d4) | `` Updated elpa ``  |