### PR TITLE
chore(flake/nur): `29adde8a` -> `83a28718`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705076498,
-        "narHash": "sha256-eFmcoMHgrAov3bpgG8KzOIS01RXlp/rNV4ZtnYm4Q/w=",
+        "lastModified": 1705088644,
+        "narHash": "sha256-dG3Ck5OZZSdJZwokeWsAV5XpYPXIjyrIf9VR5SktjkQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "29adde8a4441bda17febf534d76218c0584b3618",
+        "rev": "83a28718371d3741673cbc587e2e2cb770ff4226",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`83a28718`](https://github.com/nix-community/NUR/commit/83a28718371d3741673cbc587e2e2cb770ff4226) | `` automatic update `` |
| [`159f2e6f`](https://github.com/nix-community/NUR/commit/159f2e6f40cbf70be977dee501f5b4df641908d9) | `` automatic update `` |
| [`01a98cf0`](https://github.com/nix-community/NUR/commit/01a98cf07b402c69ba640b31a7f2b44ff27c3161) | `` automatic update `` |