### PR TITLE
chore(flake/nur): `83a28718` -> `d15592eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705088644,
-        "narHash": "sha256-dG3Ck5OZZSdJZwokeWsAV5XpYPXIjyrIf9VR5SktjkQ=",
+        "lastModified": 1705091008,
+        "narHash": "sha256-YM8AiknMy4qQ9n1RSQskx52BkzqzjUBaq5AODQijlEE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "83a28718371d3741673cbc587e2e2cb770ff4226",
+        "rev": "d15592ebd519a9d603f76cfae32acbc043bd7147",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d15592eb`](https://github.com/nix-community/NUR/commit/d15592ebd519a9d603f76cfae32acbc043bd7147) | `` automatic update `` |
| [`a8597f56`](https://github.com/nix-community/NUR/commit/a8597f56b71b3d1c92c1989d6e0e27ad9121719a) | `` automatic update `` |