### PR TITLE
chore(flake/home-manager): `93e804e7` -> `0912d26b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -457,11 +457,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704980804,
-        "narHash": "sha256-lPNNKdPqIYcjhhYIVwlajNt/HqVWbMOoSdNnwCvOP04=",
+        "lastModified": 1705104164,
+        "narHash": "sha256-pllCu3Hcm1wP/B0SUxgUXvHeEd4w8s2aVrEQRdIL1yo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "93e804e7f8a1eb88bde6117cd5046501e66aa4bd",
+        "rev": "0912d26b30332ae6a90e1b321ff88e80492127dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`0912d26b`](https://github.com/nix-community/home-manager/commit/0912d26b30332ae6a90e1b321ff88e80492127dd) | `` gh: only run migration when required `` |
| [`7403ed49`](https://github.com/nix-community/home-manager/commit/7403ed49801e1a30ed0ffdec5b60c17f0cbf7bd5) | `` home-manager: internalize uninstall ``  |