### PR TITLE
chore(flake/emacs-overlay): `7931d882` -> `3ad4e810`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705078385,
-        "narHash": "sha256-ox7zfG2cwBMH8TEw2Z5lO/C1QKWHbBjl+kcFiUUr7XU=",
+        "lastModified": 1705107696,
+        "narHash": "sha256-1WaDBp8Vm326eA8dDzT3rdLcaDyJMWqD2tillvlUlnM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7931d882cdb5ce330571f583e989117fdfa808f1",
+        "rev": "3ad4e8104948385481e9d1cc37405818f46d9ab4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`3ad4e810`](https://github.com/nix-community/emacs-overlay/commit/3ad4e8104948385481e9d1cc37405818f46d9ab4) | `` Updated elpa ``   |
| [`f7a9453d`](https://github.com/nix-community/emacs-overlay/commit/f7a9453dc2173a9cf64fd59ae7a11d9c0aa8ac8b) | `` Updated nongnu `` |