### PR TITLE
chore(flake/emacs-overlay): `3ad4e810` -> `9e423719`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705107696,
-        "narHash": "sha256-1WaDBp8Vm326eA8dDzT3rdLcaDyJMWqD2tillvlUlnM=",
+        "lastModified": 1705109607,
+        "narHash": "sha256-JCwZRYaef6io0R+SxDN9l2HnyqLSBRYIfaBk4uwjMqQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3ad4e8104948385481e9d1cc37405818f46d9ab4",
+        "rev": "9e423719e0c85a4624813489080636f4d696fa3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`9e423719`](https://github.com/nix-community/emacs-overlay/commit/9e423719e0c85a4624813489080636f4d696fa3e) | `` Updated melpa `` |