### PR TITLE
chore(flake/nur): `075357ea` -> `b98d0401`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705110884,
-        "narHash": "sha256-8t8C+vYVoNsG7uv1cH/vkUHM84EkxGRoPuwk1TMXBZE=",
+        "lastModified": 1705124508,
+        "narHash": "sha256-jnk864T0S0jErl4jaYycnfSgS+gW0XuqhwnBDWMN5So=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "075357ead2dbaf5c64120371f6a1e57d1ee23a02",
+        "rev": "b98d04014dee60c87f31df0dc6bf62733dc6ee24",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b98d0401`](https://github.com/nix-community/NUR/commit/b98d04014dee60c87f31df0dc6bf62733dc6ee24) | `` automatic update `` |
| [`11db5fb0`](https://github.com/nix-community/NUR/commit/11db5fb0923cc0fccd62b7372abef632cde18388) | `` automatic update `` |