### PR TITLE
chore(flake/nur): `3254e29d` -> `39082696`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705128113,
-        "narHash": "sha256-jKqgtL2qKN7/9xdSrQemX6uwBqn1+GWh8fZ4nplnTbc=",
+        "lastModified": 1705135171,
+        "narHash": "sha256-FTkVXBKX+7UoIDJJgdSbtStmZEeGMTHsFV95L8bqz3o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3254e29ddcd7bb07b85630144200c1aaad73de33",
+        "rev": "390826968d682186e2672e6834b899463f10e9d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`39082696`](https://github.com/nix-community/NUR/commit/390826968d682186e2672e6834b899463f10e9d5) | `` automatic update `` |