### PR TITLE
chore(flake/nur): `39082696` -> `eb257a2f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705135171,
-        "narHash": "sha256-FTkVXBKX+7UoIDJJgdSbtStmZEeGMTHsFV95L8bqz3o=",
+        "lastModified": 1705142735,
+        "narHash": "sha256-RA4nC6WFaMj62bdJHLW9idSD18g78dNS94Jy0R2DpU4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "390826968d682186e2672e6834b899463f10e9d5",
+        "rev": "eb257a2f64d88dd14eaaf112822160496f6a916f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                       |
| -------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`eb257a2f`](https://github.com/nix-community/NUR/commit/eb257a2f64d88dd14eaaf112822160496f6a916f) | `` automatic update ``        |
| [`6b80120e`](https://github.com/nix-community/NUR/commit/6b80120ef1e2758e2b2b6650cb3c54925e46e207) | `` automatic update ``        |
| [`3f38ea75`](https://github.com/nix-community/NUR/commit/3f38ea75d4cd1ce66562e61284e9bd45384d6d59) | `` automatic update ``        |
| [`dce2f751`](https://github.com/nix-community/NUR/commit/dce2f751fb6446b345bcdbee2a89663be4ee89e3) | `` add skiletro repository `` |
| [`025c03cd`](https://github.com/nix-community/NUR/commit/025c03cde3c672df87e508b3844f3992562e053c) | `` automatic update ``        |