### PR TITLE
chore(flake/srvos): `905cdf07` -> `8c9b9b1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -989,11 +989,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705009679,
-        "narHash": "sha256-oAq7o8QQ6/raGaKUF+IYYs2752CzfFPxw3KFBOW3Q48=",
+        "lastModified": 1705141646,
+        "narHash": "sha256-EAV6bBQq6Ry5tsOLLImSpFd/o8NtZY01S+6rMdqryBM=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "905cdf0751894d23ff4d6cb3c0235099a3f2cdf2",
+        "rev": "8c9b9b1d27e929a4907f05b310b66389d6cf25a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                        |
| ---------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`8c9b9b1d`](https://github.com/nix-community/srvos/commit/8c9b9b1d27e929a4907f05b310b66389d6cf25a5) | `` telegraf: ignore efivars `` |