### PR TITLE
chore(flake/nur): `eb257a2f` -> `36535e10`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705142735,
-        "narHash": "sha256-RA4nC6WFaMj62bdJHLW9idSD18g78dNS94Jy0R2DpU4=",
+        "lastModified": 1705147303,
+        "narHash": "sha256-BMmqbpzY8CFe1EcKtHdlQKF4Og7thjgGSGptQIyEz6I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eb257a2f64d88dd14eaaf112822160496f6a916f",
+        "rev": "36535e104e2aa0735d7e8e054a7a49ceec073793",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`36535e10`](https://github.com/nix-community/NUR/commit/36535e104e2aa0735d7e8e054a7a49ceec073793) | `` automatic update `` |