### PR TITLE
chore(flake/nur): `36535e10` -> `8252c4a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705147303,
-        "narHash": "sha256-BMmqbpzY8CFe1EcKtHdlQKF4Og7thjgGSGptQIyEz6I=",
+        "lastModified": 1705147390,
+        "narHash": "sha256-0lVryWXzjEk0SbUMY/aRkewzb5zglaykdpWh2gExrHs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "36535e104e2aa0735d7e8e054a7a49ceec073793",
+        "rev": "8252c4a2edad482d170c4006a680d4e441f90ff6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8252c4a2`](https://github.com/nix-community/NUR/commit/8252c4a2edad482d170c4006a680d4e441f90ff6) | `` automatic update `` |