### PR TITLE
chore(flake/nur): `8252c4a2` -> `189f1eb5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705147390,
-        "narHash": "sha256-0lVryWXzjEk0SbUMY/aRkewzb5zglaykdpWh2gExrHs=",
+        "lastModified": 1705157818,
+        "narHash": "sha256-tmnVt75I03QxWjAITgIEPAqVBk6Mi0AqHuf/f+GhC/Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8252c4a2edad482d170c4006a680d4e441f90ff6",
+        "rev": "189f1eb56201c5c252d5c762b6eba690fdc6f0c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`189f1eb5`](https://github.com/nix-community/NUR/commit/189f1eb56201c5c252d5c762b6eba690fdc6f0c7) | `` automatic update `` |
| [`0880c3c0`](https://github.com/nix-community/NUR/commit/0880c3c03c2125b267ae20bbf72eb5bebc5a8470) | `` automatic update `` |