### PR TITLE
chore(flake/nur): `189f1eb5` -> `d5c04f64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705157818,
-        "narHash": "sha256-tmnVt75I03QxWjAITgIEPAqVBk6Mi0AqHuf/f+GhC/Q=",
+        "lastModified": 1705161658,
+        "narHash": "sha256-IyMW3rjKdRkHRtF5yuca1QeEkCkUZ4besJCkjDkoRc0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "189f1eb56201c5c252d5c762b6eba690fdc6f0c7",
+        "rev": "d5c04f64c74370d924fc9a838896f50b8b2c27be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d5c04f64`](https://github.com/nix-community/NUR/commit/d5c04f64c74370d924fc9a838896f50b8b2c27be) | `` automatic update `` |