### PR TITLE
chore(flake/emacs-overlay): `8363635c` -> `53b4803d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705135842,
-        "narHash": "sha256-ua/7SiOdMzyM/0Avx8YOgc7K9m7zrOjIE2slEXP+Ecc=",
+        "lastModified": 1705164639,
+        "narHash": "sha256-CYXxAkMSacPK+inxWKrcdL/FdJODa8WQVk8GnqkmS8s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8363635cc3d70d8869e3ead707eb01e03a203f78",
+        "rev": "53b4803d6cb623b5b4e3540af99e1b356bbc7f30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`53b4803d`](https://github.com/nix-community/emacs-overlay/commit/53b4803d6cb623b5b4e3540af99e1b356bbc7f30) | `` Updated melpa `` |
| [`c11eac23`](https://github.com/nix-community/emacs-overlay/commit/c11eac23245ed3571df6eef40831422a3d49ad18) | `` Updated elpa ``  |