### PR TITLE
chore(flake/nur): `d5c04f64` -> `75cca9f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705161658,
-        "narHash": "sha256-IyMW3rjKdRkHRtF5yuca1QeEkCkUZ4besJCkjDkoRc0=",
+        "lastModified": 1705164127,
+        "narHash": "sha256-rot970TtIphE/bq65tj/pyyxSo4aILPbP81uN3JM3sc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d5c04f64c74370d924fc9a838896f50b8b2c27be",
+        "rev": "75cca9f7b3298ded7044811f5929399f819d9529",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`75cca9f7`](https://github.com/nix-community/NUR/commit/75cca9f7b3298ded7044811f5929399f819d9529) | `` automatic update `` |