### PR TITLE
chore(flake/nur): `75cca9f7` -> `81f76b7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705164127,
-        "narHash": "sha256-rot970TtIphE/bq65tj/pyyxSo4aILPbP81uN3JM3sc=",
+        "lastModified": 1705175999,
+        "narHash": "sha256-Pxogq2LAEkrHvomKfmCEtOKdRe/9HpueZC4vYZuie1c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "75cca9f7b3298ded7044811f5929399f819d9529",
+        "rev": "81f76b7a734327e184886537c0138a5f7259e604",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`81f76b7a`](https://github.com/nix-community/NUR/commit/81f76b7a734327e184886537c0138a5f7259e604) | `` automatic update `` |
| [`fa51fa6e`](https://github.com/nix-community/NUR/commit/fa51fa6e5130fd056673355eadd724361871ba74) | `` automatic update `` |
| [`1644e8f5`](https://github.com/nix-community/NUR/commit/1644e8f5bd74b42409fcfe272dfda1d9dd0b1ed1) | `` automatic update `` |
| [`0de635d9`](https://github.com/nix-community/NUR/commit/0de635d9bc8833a431638f59897abae066ed7719) | `` automatic update `` |
| [`ed4cff73`](https://github.com/nix-community/NUR/commit/ed4cff7351c0f7f4ed4273da70c5219d9ef055d4) | `` automatic update `` |