### PR TITLE
chore(flake/home-manager): `6217b735` -> `f2942f33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -457,11 +457,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705168353,
-        "narHash": "sha256-LRl+CJu2eQMry+PpW3I1CocYM2j+oSKwQAPBo+CkC9M=",
+        "lastModified": 1705169127,
+        "narHash": "sha256-j9OEtNxOIPWZWjbECVMkI1TO17SzlpHMm0LnVWKOR/g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6217b735988ef28fa07d9c4be92d06d5573defa3",
+        "rev": "f2942f3385f1b35cc8a1abb03a45e29c9cb4d3c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`f2942f33`](https://github.com/nix-community/home-manager/commit/f2942f3385f1b35cc8a1abb03a45e29c9cb4d3c8) | `` Remove some formatting exceptions `` |