### PR TITLE
chore(flake/nur): `db2db947` -> `4cfda477`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705182040,
-        "narHash": "sha256-sKqPxt8IcgQESwbW+XGTiqWjuwSUMwnluaZabxJQl3A=",
+        "lastModified": 1705186832,
+        "narHash": "sha256-4aAU0tjmHSLd+676ju0FqWwB2gL+bR0OW1C0gh+1DOA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "db2db947af6421fade9fd94c20986e1c95e0b41f",
+        "rev": "4cfda477728a6c1ad73237c4554701a6ee4efe6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4cfda477`](https://github.com/nix-community/NUR/commit/4cfda477728a6c1ad73237c4554701a6ee4efe6c) | `` automatic update `` |