### PR TITLE
chore(flake/nur): `4cfda477` -> `7a24ce86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705186832,
-        "narHash": "sha256-4aAU0tjmHSLd+676ju0FqWwB2gL+bR0OW1C0gh+1DOA=",
+        "lastModified": 1705197850,
+        "narHash": "sha256-WtgOcadsR2/4ArDfYLEezIo99JrvZ0uVpxNwH66dXmM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4cfda477728a6c1ad73237c4554701a6ee4efe6c",
+        "rev": "7a24ce86be38634afc3c82caccefc2059bdf935b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                    |
| -------------------------------------------------------------------------------------------------- | -------------------------- |
| [`7a24ce86`](https://github.com/nix-community/NUR/commit/7a24ce86be38634afc3c82caccefc2059bdf935b) | `` automatic update ``     |
| [`3b9b946d`](https://github.com/nix-community/NUR/commit/3b9b946d36c60c9244b7b5f97c3203a2bfe362fc) | `` automatic update ``     |
| [`f07c5379`](https://github.com/nix-community/NUR/commit/f07c53795b11a0fc780d77ae139c063601564b00) | `` automatic update ``     |
| [`9f8b664c`](https://github.com/nix-community/NUR/commit/9f8b664cca8d229db1d3958fcae35be23752ea52) | `` automatic update ``     |
| [`b1010ee8`](https://github.com/nix-community/NUR/commit/b1010ee867feb9da82e005fa4c991d933c6bf918) | `` automatic update ``     |
| [`265ac8e4`](https://github.com/nix-community/NUR/commit/265ac8e4270ed0b5292b528a7fc6fc5b36e3c729) | `` automatic update ``     |
| [`e088ec55`](https://github.com/nix-community/NUR/commit/e088ec5514d3b98444a75c40139055589c0a23ac) | `` add brpaz repository `` |