### PR TITLE
chore(flake/emacs-overlay): `53b4803d` -> `7d39cb04`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705164639,
-        "narHash": "sha256-CYXxAkMSacPK+inxWKrcdL/FdJODa8WQVk8GnqkmS8s=",
+        "lastModified": 1705194398,
+        "narHash": "sha256-JpL6wpn00fR6M3ZRQ9vpfPmOv57iOxvbiLFUGnpUeYw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "53b4803d6cb623b5b4e3540af99e1b356bbc7f30",
+        "rev": "7d39cb04455e9f6335409f30aff5b4fd058357bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`7d39cb04`](https://github.com/nix-community/emacs-overlay/commit/7d39cb04455e9f6335409f30aff5b4fd058357bb) | `` Updated elpa `` |