### PR TITLE
chore(flake/nix-index-database): `eea599cf` -> `274a40db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705201042,
-        "narHash": "sha256-JJOaFer4hGPNlCB6LeH23v6kOdNCVHjOF8gK51I7jyw=",
+        "lastModified": 1705201750,
+        "narHash": "sha256-0umjkDiAoXDsIhaFlIIhKFTX/q7sMhfzvhNuY6wFdZo=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "eea599cf923f54149ee7e58d8787d24092a10d21",
+        "rev": "274a40dbf8be212697f3988471a4473987f8a886",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`274a40db`](https://github.com/nix-community/nix-index-database/commit/274a40dbf8be212697f3988471a4473987f8a886) | `` update packages.nix to release 2024-01-14-030810 `` |