### PR TITLE
chore(flake/nur): `ed19e9ec` -> `7718aa5b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705203702,
-        "narHash": "sha256-C8rryvCHSgfUdkslZB6m5NW7K8BgI8VQtBO0hPk80iY=",
+        "lastModified": 1705210559,
+        "narHash": "sha256-1FsKdLhdj1qOwa0Xnv4ayrYJaF3hM9vZTldGOTHE0ZY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed19e9ec7a86acf3c1b58cc2f48be55ed490ac9c",
+        "rev": "7718aa5b12644569b793d72ef305d7c3186bae50",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7718aa5b`](https://github.com/nix-community/NUR/commit/7718aa5b12644569b793d72ef305d7c3186bae50) | `` automatic update `` |
| [`dee12121`](https://github.com/nix-community/NUR/commit/dee121215383aaef82188ea25ae82025d8e8de50) | `` automatic update `` |
| [`ac312301`](https://github.com/nix-community/NUR/commit/ac312301911159eab84d310d77d99f9be5b96487) | `` automatic update `` |