### PR TITLE
chore(flake/nur): `7718aa5b` -> `6cc56197`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705210559,
-        "narHash": "sha256-1FsKdLhdj1qOwa0Xnv4ayrYJaF3hM9vZTldGOTHE0ZY=",
+        "lastModified": 1705213024,
+        "narHash": "sha256-0apTR7uIVBlvdtzA/VjfSmG1stYnL1TmhQUDu/+pNl4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7718aa5b12644569b793d72ef305d7c3186bae50",
+        "rev": "6cc5619717b9e2b930d6632bd4a0b4235c84d710",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6cc56197`](https://github.com/nix-community/NUR/commit/6cc5619717b9e2b930d6632bd4a0b4235c84d710) | `` automatic update `` |