### PR TITLE
chore(flake/nur): `6cc56197` -> `91262c64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705213024,
-        "narHash": "sha256-0apTR7uIVBlvdtzA/VjfSmG1stYnL1TmhQUDu/+pNl4=",
+        "lastModified": 1705226420,
+        "narHash": "sha256-Dl/FgtiJAf19CyHDBawZY5GU4jmleWu03kqUhCj3/+8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6cc5619717b9e2b930d6632bd4a0b4235c84d710",
+        "rev": "91262c64a5aae06d91dd5690261d17b8a54d22b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`91262c64`](https://github.com/nix-community/NUR/commit/91262c64a5aae06d91dd5690261d17b8a54d22b7) | `` automatic update `` |
| [`22e2a7dc`](https://github.com/nix-community/NUR/commit/22e2a7dcbc976a3d719ae7389edd9579bbbac472) | `` automatic update `` |