### PR TITLE
chore(flake/nixpkgs): `317484b1` -> `9b19f5e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -760,11 +760,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1704722960,
-        "narHash": "sha256-mKGJ3sPsT6//s+Knglai5YflJUF2DGj7Ai6Ynopz0kI=",
+        "lastModified": 1705133751,
+        "narHash": "sha256-rCIsyE80jgiOU78gCWN3A0wE0tR2GI5nH6MlS+HaaSQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "317484b1ead87b9c1b8ac5261a8d2dd748a0492d",
+        "rev": "9b19f5e77dd906cb52dade0b7bd280339d2a1f3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                           |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`2de745f1`](https://github.com/NixOS/nixpkgs/commit/2de745f11dbc413e747d5c2f41445db4d282e9a1) | `` mesa: 23.3.2 -> 23.3.3 ``                                      |
| [`13a6f426`](https://github.com/NixOS/nixpkgs/commit/13a6f4268742c16273ca8db92780a3fb504a4639) | `` virtualbox: fix build with libxml 2.12 + gcc 13 ``             |
| [`2c3dd4a4`](https://github.com/NixOS/nixpkgs/commit/2c3dd4a4f03ff284c0b5d3c5dc345d8ead745b1c) | `` mommy: 1.2.6 -> 1.3.0 ``                                       |
| [`28330aa2`](https://github.com/NixOS/nixpkgs/commit/28330aa2040cb412315ea884f2864b17cade222e) | `` keep-sorted: init at 0.2.0 ``                                  |
| [`c36ba0e4`](https://github.com/NixOS/nixpkgs/commit/c36ba0e449548d092a19f03e23665e2bc1605eb9) | `` pegasus: unstable-2023-05-22 -> unstable-2023-12-05 ``         |
| [`dbc598a3`](https://github.com/NixOS/nixpkgs/commit/dbc598a3c83383f2508f05cd349585cbe33b917c) | `` python311Packages.pysmi-lextudio: init at 1.1.13 ``            |
| [`77e5fa5e`](https://github.com/NixOS/nixpkgs/commit/77e5fa5ea6f11617e5852eb82dfd39b4f2df8a94) | `` nixos/libvirtd: support out-of-tree vhost-user drivers ``      |
| [`62c8b51c`](https://github.com/NixOS/nixpkgs/commit/62c8b51c2720b31c76dda52626b6d914597b18d9) | `` virtiofsd: include vhost-user configuration file ``            |
| [`52c3d54b`](https://github.com/NixOS/nixpkgs/commit/52c3d54be78d9d9e15326ab24e41a216e50450a5) | `` mod_tile: 0.6.1+unstable=2023-03-09 -> 0.7.0 ``                |
| [`280b6d8d`](https://github.com/NixOS/nixpkgs/commit/280b6d8d65f4d5aaaa82c0c23925a309118fff57) | `` cartridges: 2.3 -> 2.7.2 ``                                    |
| [`6a5ee95e`](https://github.com/NixOS/nixpkgs/commit/6a5ee95e7899b7e7bcf76014998c388d75130461) | `` garmin-plugin: remove ``                                       |
| [`ab22a877`](https://github.com/NixOS/nixpkgs/commit/ab22a877c47acc6933c83653c5bacec8cbcd2e65) | `` docker-buildx: 0.12.0 -> 0.12.1 ``                             |
| [`476e51ad`](https://github.com/NixOS/nixpkgs/commit/476e51ad719b4f7bfe883af2878334bf5ce14800) | `` cozette: 1.23.1 -> 1.23.2 ``                                   |
| [`a9a99b39`](https://github.com/NixOS/nixpkgs/commit/a9a99b390550ab481a769cae2e5f05d5e624aa89) | `` astc-encoder: 4.6.1 -> 4.7.0 ``                                |
| [`d1236a45`](https://github.com/NixOS/nixpkgs/commit/d1236a45f1ff171bb42e2acb6ad0adac26da910f) | `` tailwindcss-language-server: 0.0.14 -> 0.0.16 ``               |
| [`d690f454`](https://github.com/NixOS/nixpkgs/commit/d690f4546e9b9902fa9737e4bcb6c6f83eaeef65) | `` tailwindcss: 3.4.0 -> 3.4.1 ``                                 |
| [`09aa366e`](https://github.com/NixOS/nixpkgs/commit/09aa366e5616ccbbb127021379d4ffa90aa39db4) | `` cosmic-settings: unstable-2023-10-26 -> unstable-2024-01-09 `` |
| [`aabf6422`](https://github.com/NixOS/nixpkgs/commit/aabf642251f0f5db3ba4680af8ab1e61815c5e01) | `` cosmic-files: init at unstable-2024-01-12 ``                   |
| [`f86a8266`](https://github.com/NixOS/nixpkgs/commit/f86a8266a2ac4dc497c532f45a78bc85d0ef1ab1) | `` svd2rust: 0.31.4 -> 0.31.5 ``                                  |
| [`e5472720`](https://github.com/NixOS/nixpkgs/commit/e5472720170f41d24394cde7fe10396bd33e35f4) | `` apx: 2.1.2 -> 2.2.0 ``                                         |
| [`577cf0f8`](https://github.com/NixOS/nixpkgs/commit/577cf0f895fbb5c27c7b626fbdb10b9b8faf7e1a) | `` multipass: 1.12.2 -> 1.13.0 ``                                 |
| [`8b5217b6`](https://github.com/NixOS/nixpkgs/commit/8b5217b6deabc37b0114552cfce8c445e7567cc5) | `` iortcw: add rjpcasalino as maintainer ``                       |
| [`4e614fa1`](https://github.com/NixOS/nixpkgs/commit/4e614fa1be54962bf83c143b4d642ff9cb7c73f4) | `` dnf-plugins-core: 4.4.3 -> 4.4.4 ``                            |
| [`b28200aa`](https://github.com/NixOS/nixpkgs/commit/b28200aa23db05fe6ac29e8828b8119e6a4cd6ff) | `` texlive: document LuaLaTeX font cache (#280080) ``             |
| [`ea423335`](https://github.com/NixOS/nixpkgs/commit/ea42333590a909ced8a58febf584b75788fa7d75) | `` sssd: 2.9.3 -> 2.9.4 ``                                        |
| [`391d29cb`](https://github.com/NixOS/nixpkgs/commit/391d29cb04fe2ca9a4744c10d6b8a7783f6b0f6d) | `` nixos/tests/installer: fix eval ``                             |
| [`8c947d17`](https://github.com/NixOS/nixpkgs/commit/8c947d1782e6a8905b950ce61eedc738c51d6c59) | `` i2p: enable aarch64-linux platform ``                          |
| [`07f2cd9a`](https://github.com/NixOS/nixpkgs/commit/07f2cd9ac2e5a5596c6ada00b9eabcc915f414bb) | `` linux_zen, linux_lqx: add missing top-level attributes. ``     |
| [`68bfb1d2`](https://github.com/NixOS/nixpkgs/commit/68bfb1d2e5965df8f355bf6fbbe238b8925827d1) | `` maintainers: add rjpcasalino. ``                               |
| [`72525b80`](https://github.com/NixOS/nixpkgs/commit/72525b80be362f78d25ca651e4283e2d0e1db3d7) | `` crosvm: 119.0 -> 120.0 ``                                      |
| [`47e473ac`](https://github.com/NixOS/nixpkgs/commit/47e473acca92717d3eb44358ed8298e9115a49ec) | `` java-service-wrapper: enable aarch64-linux platform ``         |
| [`b1eff5ae`](https://github.com/NixOS/nixpkgs/commit/b1eff5aeabf2466e005eb55b8458dea966f6dc9f) | `` snac2: 2.43 -> 2.44 ``                                         |
| [`293fe1cf`](https://github.com/NixOS/nixpkgs/commit/293fe1cf1ad57f79d851bdf04f2ac81430143363) | `` smbmap: 1.9.2 -> 1.10.2 ``                                     |
| [`adb78d94`](https://github.com/NixOS/nixpkgs/commit/adb78d94434065c684e2d1817ed5fcb01c82fede) | `` nix-lib-nmd: init at 0.5.0 ``                                  |
| [`1a502c91`](https://github.com/NixOS/nixpkgs/commit/1a502c91a77e0c8bbc379f5b4097e31b9507ef59) | `` nix-lib-nmt: init at 0.5.0 ``                                  |
| [`cc22b678`](https://github.com/NixOS/nixpkgs/commit/cc22b678b14bf008b10e973c8d48ff4fad326022) | `` skytemple: 1.6.0 -> 1.6.3 ``                                   |
| [`182eac4c`](https://github.com/NixOS/nixpkgs/commit/182eac4c19488a830f87327b536b480bde0ddd09) | `` remnote: 1.13.0 -> 1.13.34 ``                                  |
| [`dc237ef7`](https://github.com/NixOS/nixpkgs/commit/dc237ef7f577bada0022109bed5727d7f74effa6) | `` dftd4: enable shared builds on !isStatic platforms ``          |
| [`00713edc`](https://github.com/NixOS/nixpkgs/commit/00713edc7bc763a268a6b5b39df202bdfca258e0) | `` mstore: enable shared builds on !isStatic platforms ``         |
| [`0138d805`](https://github.com/NixOS/nixpkgs/commit/0138d805ddce32a6327e562d132236a4310423e9) | `` multicharge: enable shared builds on !isStatic platforms ``    |
| [`66317989`](https://github.com/NixOS/nixpkgs/commit/6631798926b430943266bf844a8ae5a27f7d7e69) | `` simple-dftd3: enable shared builds on !isStatic platforms ``   |
| [`a3f4b8c7`](https://github.com/NixOS/nixpkgs/commit/a3f4b8c7da2b8707205041f9144024a983886e98) | `` tblite: enable shared builds on !isStatic platforms ``         |
| [`9250befb`](https://github.com/NixOS/nixpkgs/commit/9250befb66367bb67cca3101f7464d7ded05e953) | `` toml-f: enable shared builds on !isStatic platforms ``         |
| [`71e47e8a`](https://github.com/NixOS/nixpkgs/commit/71e47e8a232fc3a4fd1817d33028194ada8d3554) | `` mctc-lib: enable shared builds on !isStatic platforms ``       |
| [`330cf660`](https://github.com/NixOS/nixpkgs/commit/330cf66034eb53b790da6f757a9b28ef67ea163f) | `` sidplayfp: 2.6.0 -> 2.6.2 ``                                   |
| [`02fb23a5`](https://github.com/NixOS/nixpkgs/commit/02fb23a53fb92ffc0023fd61c6d101dcac9100cb) | `` shot-scraper: 1.1.1 -> 1.3 ``                                  |
| [`9490738b`](https://github.com/NixOS/nixpkgs/commit/9490738be7b6a33844e4faf192f168bb755539e6) | `` nixos/lib/test-driver: add setuptools build dep ``             |
| [`96478c43`](https://github.com/NixOS/nixpkgs/commit/96478c43ec80609cd6da1385560eb0bf0a4e27ea) | `` gitlab: 16.7.0 -> 16.7.2 (#280369) ``                          |
| [`a1aae1ff`](https://github.com/NixOS/nixpkgs/commit/a1aae1ffb16464d7483b579434a72e6141e4d047) | `` gamescope: 3.12.5 -> 3.13.19, refactor ``                      |
| [`3973eb92`](https://github.com/NixOS/nixpkgs/commit/3973eb9259cfeb9b09d001c9537e36319314c6c5) | `` semiphemeral: 0.6 -> 0.7 ``                                    |
| [`b58b9d10`](https://github.com/NixOS/nixpkgs/commit/b58b9d1002080fe7bdc36f9f013ade14ab3baf18) | `` pharo: 10.0.8 -> 10.0.9-de76067 ``                             |
| [`a2d2b1a6`](https://github.com/NixOS/nixpkgs/commit/a2d2b1a66544eb4dfec25b78636af344831c2ac1) | `` pharo: cleanup, add more library paths to wrapper ``           |
| [`b6d82435`](https://github.com/NixOS/nixpkgs/commit/b6d824354397c702b56e7c827598207781d215c5) | `` eurofurence: init at 2000-04-21 ``                             |
| [`c9ac7782`](https://github.com/NixOS/nixpkgs/commit/c9ac778259b985725277734df7c5cf493ce95a31) | `` katana: add ldflags ``                                         |
| [`6f992b0d`](https://github.com/NixOS/nixpkgs/commit/6f992b0d9a0c00375ca3ce81ab99bed555ff7015) | `` scriv: 1.5.0 -> 1.5.1 ``                                       |
| [`b9335f6e`](https://github.com/NixOS/nixpkgs/commit/b9335f6e08ec35a08e192457355f6b9b43f83f0b) | `` scli: 0.7.2 -> 0.7.3 ``                                        |
| [`feab8379`](https://github.com/NixOS/nixpkgs/commit/feab83792948416260d13fee7cc6b0b95f182014) | `` tmux-fingers: 1.0.1 -> 2.1.1 (#280173) ``                      |
| [`3674fb5d`](https://github.com/NixOS/nixpkgs/commit/3674fb5de53d4618bea80463f53399141eacac53) | `` python311Packages.adafruit-platformdetect: 3.57.0 -> 3.58.0 `` |
| [`f0ac7d21`](https://github.com/NixOS/nixpkgs/commit/f0ac7d218935b588d85c64232de944ed25f72ccb) | `` python311Packages.vulcan-api: 2.3.1 -> 2.3.2 ``                |
| [`0b0b228b`](https://github.com/NixOS/nixpkgs/commit/0b0b228ba8d6fea64e8156a12e753451dd9f54da) | `` rust-analyzer-unwrapped: 2024-01-01 -> 2024-01-08 ``           |
| [`e8731386`](https://github.com/NixOS/nixpkgs/commit/e873138649d62340bdbac7ab3066af936b922d67) | `` rure: 0.2.2 -> 0.2.2 ``                                        |
| [`cc2a3d39`](https://github.com/NixOS/nixpkgs/commit/cc2a3d3904b56eda92c3e500b59010d5c5ec749a) | `` release-checks: remove unnecessary escape ``                   |
| [`8ef54ae9`](https://github.com/NixOS/nixpkgs/commit/8ef54ae956f2d82475700c362583531ed4014d4e) | `` pkgs/release: don't interpolate store paths unnecessarily ``   |
| [`57f2e786`](https://github.com/NixOS/nixpkgs/commit/57f2e7869eb9cc5bc05f7685126888415998976f) | `` rofi-rbw: 1.2.0 -> 1.3.0 ``                                    |
| [`9a3c7c1a`](https://github.com/NixOS/nixpkgs/commit/9a3c7c1aef6d70bb1da7975db84cd9fb2accd9cb) | `` python311Packages.textual-dev: 1.3.0 -> 1.4.0 ``               |
| [`24dc9521`](https://github.com/NixOS/nixpkgs/commit/24dc95214b05fc074f916e24d24244b0dcce6bfc) | `` python311Packages.pyswitchbot: 0.43.0 -> 0.44.0 ``             |
| [`92b06884`](https://github.com/NixOS/nixpkgs/commit/92b06884df13a0615b9fd3dc2ee35aa176d54e11) | `` cadical: 1.9.3 -> 1.9.4 ``                                     |
| [`0a3759e3`](https://github.com/NixOS/nixpkgs/commit/0a3759e38a89cb24ecbbec4c964f983628c1c692) | `` pygame-sdl2: update hash ``                                    |
| [`1d833f7b`](https://github.com/NixOS/nixpkgs/commit/1d833f7bba9efb9ec570cb1c95694a775dbc108c) | `` terragrunt: 0.54.12 -> 0.54.16 ``                              |