### PR TITLE
chore(flake/nur): `91262c64` -> `9015f77d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705226420,
-        "narHash": "sha256-Dl/FgtiJAf19CyHDBawZY5GU4jmleWu03kqUhCj3/+8=",
+        "lastModified": 1705237125,
+        "narHash": "sha256-esEbSZwNAhQo30Rv1rWRSx5g+wrbNmU6xY+hYJDxClU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "91262c64a5aae06d91dd5690261d17b8a54d22b7",
+        "rev": "9015f77d9e1eabf5c06737cd99aacbfcaa38ffc4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                      |
| -------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`9015f77d`](https://github.com/nix-community/NUR/commit/9015f77d9e1eabf5c06737cd99aacbfcaa38ffc4) | `` automatic update ``       |
| [`89326808`](https://github.com/nix-community/NUR/commit/893268083b831e7592653410296ad1585b5502f9) | `` automatic update ``       |
| [`6dfa0e9a`](https://github.com/nix-community/NUR/commit/6dfa0e9ad8bc5da6f34ae8c5ca8583d173145472) | `` add gabr1sr repository `` |