### PR TITLE
chore(flake/nur): `9015f77d` -> `b0662386`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705237125,
-        "narHash": "sha256-esEbSZwNAhQo30Rv1rWRSx5g+wrbNmU6xY+hYJDxClU=",
+        "lastModified": 1705247077,
+        "narHash": "sha256-FQWo+6AEag1RfyWllm6l4lgKoxPY9q5E4ad/TpSCZuw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9015f77d9e1eabf5c06737cd99aacbfcaa38ffc4",
+        "rev": "b066238694b662157e6a0330d2813b1a78ca3aed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b0662386`](https://github.com/nix-community/NUR/commit/b066238694b662157e6a0330d2813b1a78ca3aed) | `` automatic update `` |