### PR TITLE
chore(flake/emacs-overlay): `8a3a40fd` -> `9fa1fdb2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705222228,
-        "narHash": "sha256-qa3WIBN2+J0VZRId88CatjROob41nyMz4dQ4q82h3xs=",
+        "lastModified": 1705251094,
+        "narHash": "sha256-BrAJHZ2v3BA1maTTc3a619DDQ0pq13zLDLq/V5soj78=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8a3a40fdad4a0fa56f98bf0b53db631a9367680b",
+        "rev": "9fa1fdb259360c2d7b45bb3f4003a83b5f9f809e",
         "type": "github"
       },
       "original": {
@@ -712,11 +712,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1704874635,
-        "narHash": "sha256-YWuCrtsty5vVZvu+7BchAxmcYzTMfolSPP5io8+WYCg=",
+        "lastModified": 1705183652,
+        "narHash": "sha256-rnfkyUH0x72oHfiSDhuCHDHg3gFgF+lF8zkkg5Zihsw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3dc440faeee9e889fe2d1b4d25ad0f430d449356",
+        "rev": "428544ae95eec077c7f823b422afae5f174dee4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`9fa1fdb2`](https://github.com/nix-community/emacs-overlay/commit/9fa1fdb259360c2d7b45bb3f4003a83b5f9f809e) | `` Updated melpa ``        |
| [`adf6870c`](https://github.com/nix-community/emacs-overlay/commit/adf6870cdaf54d033ba7e5954090734c52156480) | `` Updated elpa ``         |
| [`c0376182`](https://github.com/nix-community/emacs-overlay/commit/c0376182b057f1aa71c34075320f3e3309466d8a) | `` Updated flake inputs `` |