### PR TITLE
chore(flake/nur): `44ca5feb` -> `61aac25a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705255898,
-        "narHash": "sha256-b72VLlCj+QzESXMQrSPSul7CplIJ5I3Z3CFBegxLHsc=",
+        "lastModified": 1705261349,
+        "narHash": "sha256-d9GcEDWQ7paQkYOT3gfVO2+41gCCjdhYtqyp3PYQAgc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "44ca5feb9001e010f1cb80e2d62c3d3f7af0e2fe",
+        "rev": "61aac25a690e53aada655c4eb288daa05f7acb39",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`61aac25a`](https://github.com/nix-community/NUR/commit/61aac25a690e53aada655c4eb288daa05f7acb39) | `` automatic update `` |
| [`08e422ac`](https://github.com/nix-community/NUR/commit/08e422ac8dc316cd0d13cf6042a5f7e9be5f35d1) | `` automatic update `` |