### PR TITLE
chore(flake/nur): `61aac25a` -> `67ce73ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705261349,
-        "narHash": "sha256-d9GcEDWQ7paQkYOT3gfVO2+41gCCjdhYtqyp3PYQAgc=",
+        "lastModified": 1705265654,
+        "narHash": "sha256-gQCFQP9KWl/EgU7whB0bS/GRkXt+06rX/JI8rcuBACU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "61aac25a690e53aada655c4eb288daa05f7acb39",
+        "rev": "67ce73ba2f41b2b711738e5fd2974f35acf87acb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`67ce73ba`](https://github.com/nix-community/NUR/commit/67ce73ba2f41b2b711738e5fd2974f35acf87acb) | `` automatic update `` |
| [`ed40df65`](https://github.com/nix-community/NUR/commit/ed40df65f59cb6f2ce8b42f4c7e9839592197023) | `` automatic update `` |
| [`e29cbed5`](https://github.com/nix-community/NUR/commit/e29cbed55ca5a2cf117662bd9179a85476184ff6) | `` automatic update `` |