### PR TITLE
chore(flake/nur): `67ce73ba` -> `2325b08a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705265654,
-        "narHash": "sha256-gQCFQP9KWl/EgU7whB0bS/GRkXt+06rX/JI8rcuBACU=",
+        "lastModified": 1705268677,
+        "narHash": "sha256-1afjXJbO/8t26iE2bYNx4Yi0oN0wJAUU5TwCd273EcE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "67ce73ba2f41b2b711738e5fd2974f35acf87acb",
+        "rev": "2325b08a002c0f745f6a2e292faa82f2e6557bab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2325b08a`](https://github.com/nix-community/NUR/commit/2325b08a002c0f745f6a2e292faa82f2e6557bab) | `` automatic update `` |