### PR TITLE
chore(flake/home-manager): `f2942f33` -> `846200eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -478,11 +478,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705169127,
-        "narHash": "sha256-j9OEtNxOIPWZWjbECVMkI1TO17SzlpHMm0LnVWKOR/g=",
+        "lastModified": 1705269478,
+        "narHash": "sha256-j7Rp8Y3ckBHOlIzqe0g2+/BVce9SU/dVtn4Eb0rMuY4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f2942f3385f1b35cc8a1abb03a45e29c9cb4d3c8",
+        "rev": "846200eb574faa2af808ed02e653c2b8ed51fd71",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                           |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`846200eb`](https://github.com/nix-community/home-manager/commit/846200eb574faa2af808ed02e653c2b8ed51fd71) | `` docs: use nmd from Nixpkgs ``  |
| [`8ae3bfe2`](https://github.com/nix-community/home-manager/commit/8ae3bfe2bffe0b058b3158f83eaa53bf14ca347b) | `` tests: use nmt from Nixpkgs `` |