### PR TITLE
chore(flake/nur): `2325b08a` -> `c6522270`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705268677,
-        "narHash": "sha256-1afjXJbO/8t26iE2bYNx4Yi0oN0wJAUU5TwCd273EcE=",
+        "lastModified": 1705275933,
+        "narHash": "sha256-0xiaHr3InXCx1XOmbAc5puyi+QzTr7AUT8z9jwve64s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2325b08a002c0f745f6a2e292faa82f2e6557bab",
+        "rev": "c6522270eb2d1fb97f78ddb3ed5756e37764fcd2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c6522270`](https://github.com/nix-community/NUR/commit/c6522270eb2d1fb97f78ddb3ed5756e37764fcd2) | `` automatic update `` |