### PR TITLE
chore(flake/emacs-overlay): `9fa1fdb2` -> `6bd9fd95`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705251094,
-        "narHash": "sha256-BrAJHZ2v3BA1maTTc3a619DDQ0pq13zLDLq/V5soj78=",
+        "lastModified": 1705282666,
+        "narHash": "sha256-YQj5jW20yXYHG/5+ExU+ewTVUyQ93kVlpgY4pXEsVys=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9fa1fdb259360c2d7b45bb3f4003a83b5f9f809e",
+        "rev": "6bd9fd951f5306ff81c01c38bc0e5773947aa349",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`6bd9fd95`](https://github.com/nix-community/emacs-overlay/commit/6bd9fd951f5306ff81c01c38bc0e5773947aa349) | `` Updated melpa `` |
| [`9a132afd`](https://github.com/nix-community/emacs-overlay/commit/9a132afd3eb09b2d64b32823019774b73775620c) | `` Updated elpa ``  |