### PR TITLE
chore(flake/nur): `c6522270` -> `c02d4f15`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705275933,
-        "narHash": "sha256-0xiaHr3InXCx1XOmbAc5puyi+QzTr7AUT8z9jwve64s=",
+        "lastModified": 1705286953,
+        "narHash": "sha256-k5llnMa/ohUHIQN9c35GPf4KnOfmDyEEtD1SojsdRPc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c6522270eb2d1fb97f78ddb3ed5756e37764fcd2",
+        "rev": "c02d4f15e41c615641377101e8791d4c7e0de542",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c02d4f15`](https://github.com/nix-community/NUR/commit/c02d4f15e41c615641377101e8791d4c7e0de542) | `` automatic update `` |
| [`375b9a94`](https://github.com/nix-community/NUR/commit/375b9a949232cd1e31bd89d197a5605a17d2aeb3) | `` automatic update `` |
| [`18aadee7`](https://github.com/nix-community/NUR/commit/18aadee796c4ca7e2de75ff5f25b533d7b2802d5) | `` automatic update `` |
| [`902398e3`](https://github.com/nix-community/NUR/commit/902398e334b8e93403ab3ecb7b25d3c59f054224) | `` automatic update `` |