### PR TITLE
chore(flake/srvos): `bd28160b` -> `6ec75e65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -994,11 +994,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705191232,
-        "narHash": "sha256-eaEN3l9JTq5py2T/jVE0pi/vAqw6kVOHGylmpWWJa4U=",
+        "lastModified": 1705279877,
+        "narHash": "sha256-C5PiMib9AZ4StOzOzb1Nemj8R2Hm0I2c3cRg5zC+hng=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "bd28160bd011354edcca7f29614f6fcb848a9661",
+        "rev": "6ec75e651dce6fb8f894214655d025eae50e8eb0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`6ec75e65`](https://github.com/nix-community/srvos/commit/6ec75e651dce6fb8f894214655d025eae50e8eb0) | `` dev/private/flake.lock: Update `` |
| [`10101a3c`](https://github.com/nix-community/srvos/commit/10101a3c53bb0a30a199cb01c6d7a9cc5732fe94) | `` flake.lock: Update ``             |