### PR TITLE
chore(flake/nur): `1c932dbf` -> `910a98f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705297199,
-        "narHash": "sha256-V7MiI/vFAG/fEbgOMX8hxGP3lguIh0/XSP4gT20MXVQ=",
+        "lastModified": 1705301670,
+        "narHash": "sha256-n24Fe0M6gWOAyvg1VQqQ2hW7Rcss5mBS+UyrFJwbfmM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1c932dbfc5de2bbb14d8a941abb2d0caae1cf73b",
+        "rev": "910a98f9d07d4b51e75541916c518e465dee579b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`910a98f9`](https://github.com/nix-community/NUR/commit/910a98f9d07d4b51e75541916c518e465dee579b) | `` automatic update `` |
| [`346b03be`](https://github.com/nix-community/NUR/commit/346b03be198c160e0587cebee799c937ffbb4ec9) | `` automatic update `` |
| [`787201ac`](https://github.com/nix-community/NUR/commit/787201ac2a55ede4b2da012467f408c1b08190a3) | `` automatic update `` |