### PR TITLE
chore(flake/nur): `910a98f9` -> `247debea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705301670,
-        "narHash": "sha256-n24Fe0M6gWOAyvg1VQqQ2hW7Rcss5mBS+UyrFJwbfmM=",
+        "lastModified": 1705305513,
+        "narHash": "sha256-PJAstEuuiPfu0j4OuwZQLIVOIDCoWknEMdVcovHQprI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "910a98f9d07d4b51e75541916c518e465dee579b",
+        "rev": "247debea9f8c68d8bc4696b0a35cdb410cf5ff30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                            |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`247debea`](https://github.com/nix-community/NUR/commit/247debea9f8c68d8bc4696b0a35cdb410cf5ff30) | `` automatic update ``                             |
| [`cd142482`](https://github.com/nix-community/NUR/commit/cd142482b349e5ca6b2943232e94c765b98e26c8) | `` automatic update ``                             |
| [`bca84172`](https://github.com/nix-community/NUR/commit/bca84172dea8d3dbe6d4e324ddf8616d728b0137) | `` Bump cachix/install-nix-action from 24 to 25 `` |
| [`c8b814d6`](https://github.com/nix-community/NUR/commit/c8b814d68931b23783a169e6bde55b337e4a2e7b) | `` automatic update ``                             |