### PR TITLE
chore(flake/nur): `247debea` -> `b5010cd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705305513,
-        "narHash": "sha256-PJAstEuuiPfu0j4OuwZQLIVOIDCoWknEMdVcovHQprI=",
+        "lastModified": 1705322270,
+        "narHash": "sha256-odjEbykw0cTZxKpfY6fkFxifiR6l0zJpI7kbhJlQW+k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "247debea9f8c68d8bc4696b0a35cdb410cf5ff30",
+        "rev": "b5010cd6f7e15241ac9efb4db940413dda5a2c60",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                 |
| -------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`b5010cd6`](https://github.com/nix-community/NUR/commit/b5010cd6f7e15241ac9efb4db940413dda5a2c60) | `` automatic update ``                  |
| [`9058f755`](https://github.com/nix-community/NUR/commit/9058f75574deccae78e99c35fbf788d40e61cd24) | `` automatic update ``                  |
| [`eaaf9a1c`](https://github.com/nix-community/NUR/commit/eaaf9a1ce64aa4136d9c240238c3715707fc21b2) | `` automatic update ``                  |
| [`96337543`](https://github.com/nix-community/NUR/commit/96337543f95887f8b5498291b543fbc593fb8dc9) | `` automatic update ``                  |
| [`65f13275`](https://github.com/nix-community/NUR/commit/65f132754a4e03680d734db5906b00da42383e0e) | `` automatic update ``                  |
| [`4de48e38`](https://github.com/nix-community/NUR/commit/4de48e384c3d8007c995819117020f0b667fee5c) | `` automatic update ``                  |
| [`4f1dc65d`](https://github.com/nix-community/NUR/commit/4f1dc65d3966cd2e009a5fe6ff464ef464217cce) | `` automatic update ``                  |
| [`d99ee1d0`](https://github.com/nix-community/NUR/commit/d99ee1d0ff43865e2481f764bf380de4a15e0d4c) | ``  add friendsofshopware repository `` |
| [`01702291`](https://github.com/nix-community/NUR/commit/017022911ca6448c54e566a1f6d0984f20022ce8) | `` automatic update ``                  |
| [`64cb7f2c`](https://github.com/nix-community/NUR/commit/64cb7f2ca16c997e86ebbdf2559e210acecf0014) | `` automatic update ``                  |
| [`69bfaede`](https://github.com/nix-community/NUR/commit/69bfaedeab3a050e9855af8842dd775c20fc76b8) | `` automatic update ``                  |