### PR TITLE
chore(flake/nur): `b5010cd6` -> `1d36efec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705322270,
-        "narHash": "sha256-odjEbykw0cTZxKpfY6fkFxifiR6l0zJpI7kbhJlQW+k=",
+        "lastModified": 1705327137,
+        "narHash": "sha256-ok52flSg8kQddLLYSk9mA2vj6WOl+RLRIcxUflvNmdk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b5010cd6f7e15241ac9efb4db940413dda5a2c60",
+        "rev": "1d36efec0d0dae52ba9dffd51fc4d5d9a300453d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1d36efec`](https://github.com/nix-community/NUR/commit/1d36efec0d0dae52ba9dffd51fc4d5d9a300453d) | `` automatic update `` |
| [`d9648fce`](https://github.com/nix-community/NUR/commit/d9648fce710649740589bba6d5602985db663521) | `` automatic update `` |
| [`417dd4ce`](https://github.com/nix-community/NUR/commit/417dd4ce676a05e85fa4c2ad69bde9ffe634790d) | `` automatic update `` |