### PR TITLE
chore(flake/nur): `1d36efec` -> `0ab6855d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705327137,
-        "narHash": "sha256-ok52flSg8kQddLLYSk9mA2vj6WOl+RLRIcxUflvNmdk=",
+        "lastModified": 1705328925,
+        "narHash": "sha256-GSuDQlgjiJRLVbODXlC+vlkYACltIUgv/cLrLSGp3wU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1d36efec0d0dae52ba9dffd51fc4d5d9a300453d",
+        "rev": "0ab6855d6a38d57b7094945940de74cadba9b978",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0ab6855d`](https://github.com/nix-community/NUR/commit/0ab6855d6a38d57b7094945940de74cadba9b978) | `` automatic update `` |
| [`cffaa1c8`](https://github.com/nix-community/NUR/commit/cffaa1c88cd09c8c87a421ed72029e4bc658b966) | `` automatic update `` |