### PR TITLE
chore(flake/nur): `0ab6855d` -> `c13d359d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705328925,
-        "narHash": "sha256-GSuDQlgjiJRLVbODXlC+vlkYACltIUgv/cLrLSGp3wU=",
+        "lastModified": 1705334264,
+        "narHash": "sha256-/0qC3PwhbN8Ti1tf2/HLrjRULe01uiISI+91S7WNj1g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0ab6855d6a38d57b7094945940de74cadba9b978",
+        "rev": "c13d359df7e56f6733a7d7f55e0acc5ee93ef3f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c13d359d`](https://github.com/nix-community/NUR/commit/c13d359df7e56f6733a7d7f55e0acc5ee93ef3f8) | `` automatic update `` |
| [`551d3c90`](https://github.com/nix-community/NUR/commit/551d3c902a9034cf2d11771034b04bd8c93825da) | `` automatic update `` |
| [`c7d66a45`](https://github.com/nix-community/NUR/commit/c7d66a4510ab346b0c08fd78bdffc6440b857886) | `` automatic update `` |