### PR TITLE
chore(flake/lanzaboote): `e92070f3` -> `5667bbc1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -197,11 +197,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699218802,
-        "narHash": "sha256-5l0W4Q7z7A4BCstaF5JuBqXOVrZ3Vqst5+hUnP7EdUc=",
+        "lastModified": 1704819371,
+        "narHash": "sha256-oFUfPWrWGQTZaCM3byxwYwrMLwshDxVGOrMH5cVP/X8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "2d6c2aaff5a05e443eb15efddc21f9c73720340c",
+        "rev": "5c234301a1277e4cc759c23a2a7a00a06ddd7111",
         "type": "github"
       },
       "original": {
@@ -527,11 +527,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1705313811,
-        "narHash": "sha256-NLpHHriPWwYmkfxnYyYZVDK+ZLB5E/dQNsjG9ScCVT0=",
+        "lastModified": 1705341977,
+        "narHash": "sha256-gDV6qK2yBM6o/m09RVDXiBmwXx5oy3H5dO4vsiHxoaA=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "e92070f3e5a01009bc1355c12b7ef5a955b7a24b",
+        "rev": "5667bbc1f40df129dc093ad73a29e0c39c3dcbee",
         "type": "github"
       },
       "original": {
@@ -952,11 +952,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699409596,
-        "narHash": "sha256-L3g1smIol3dGTxkUQOlNShJtZLvjLzvtbaeTRizwZBU=",
+        "lastModified": 1705285102,
+        "narHash": "sha256-e7uridAdtZOiUZD7fjrWkUB6qr1HM2thQpDRRgJfLNc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "58240e1ac627cef3ea30c7732fedfb4f51afd8e7",
+        "rev": "d681ac8a92a1cce066df1d3a5a7f7c909688f4be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                               |
| --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`d7d63e6b`](https://github.com/nix-community/lanzaboote/commit/d7d63e6b6c58e14ddcab9eb9a26d0e2873f6ba87) | `` disable synthesis test on aarch64-linux ``                         |
| [`65330d81`](https://github.com/nix-community/lanzaboote/commit/65330d8172799ba0baf8dcfc17adb81f795a7b97) | `` fix hardcoded efi arch in tests ``                                 |
| [`1d3f28ac`](https://github.com/nix-community/lanzaboote/commit/1d3f28acef416b6bc2e0333596fa75e4b1e49b35) | `` Revert "feat(flake): perform final fixups to the flake outputs" `` |
| [`7dfc5f07`](https://github.com/nix-community/lanzaboote/commit/7dfc5f07ce0a37254ea1dc4adfc59a189e336924) | `` Revert "flake: remove moving away the `unsupportedChecks`" ``      |
| [`78680cc5`](https://github.com/nix-community/lanzaboote/commit/78680cc51d81799bfd4a4bae818f509d7800764d) | `` chore(deps): lock file maintenance ``                              |
| [`e6df60de`](https://github.com/nix-community/lanzaboote/commit/e6df60debbf654307739e5bf0c6f1b20b9b9e36f) | `` make pre-commit-hooks-nix optional ``                              |