### PR TITLE
chore(flake/nur): `b17ad9a5` -> `e6ef43d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705340809,
-        "narHash": "sha256-sUbyHANeaYd0LwP0vbL+b/dcdO9pWR0XHrxLMzL2CO8=",
+        "lastModified": 1705353982,
+        "narHash": "sha256-rLiQldW6i9Lb/QkMl5Bik/t0juitVjhLyt0O9kvT7Ok=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b17ad9a57762de5afeccc36db11114061b414a0e",
+        "rev": "e6ef43d07669e28147ce5b502031c16fd6ef48b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e6ef43d0`](https://github.com/nix-community/NUR/commit/e6ef43d07669e28147ce5b502031c16fd6ef48b6) | `` automatic update `` |
| [`ec97b3e2`](https://github.com/nix-community/NUR/commit/ec97b3e21ab3140eee5c53ad40f4802769d7c5a5) | `` automatic update `` |
| [`f2ab53ea`](https://github.com/nix-community/NUR/commit/f2ab53ea1962a48e364e367a69bf9fb89e0acdab) | `` automatic update `` |
| [`ceedd616`](https://github.com/nix-community/NUR/commit/ceedd616fb20b47717a861add2d2e5af6898e75c) | `` automatic update `` |
| [`6de70945`](https://github.com/nix-community/NUR/commit/6de70945c429f5cad826df19fde7c0a50de2e50f) | `` automatic update `` |
| [`4116fef6`](https://github.com/nix-community/NUR/commit/4116fef6bbabeefc9421344d1953634f14eea472) | `` automatic update `` |
| [`969dafda`](https://github.com/nix-community/NUR/commit/969dafdaa6f7ebba85630d51b1a833af5481b4ab) | `` automatic update `` |
| [`d141e18a`](https://github.com/nix-community/NUR/commit/d141e18a0fb92fdefe9b601157dc3a065fff9306) | `` automatic update `` |