### PR TITLE
chore(flake/darwin): `0dd382b7` -> `44a6ec1f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -217,11 +217,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704277720,
-        "narHash": "sha256-meAKNgmh3goankLGWqqpw73pm9IvXjEENJloF0coskE=",
+        "lastModified": 1705356404,
+        "narHash": "sha256-0/WnHU5S9GXOJD2HGe/mFNmGGE+8UGnhwofsyJQVoDA=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "0dd382b70c351f528561f71a0a7df82c9d2be9a4",
+        "rev": "44a6ec1faeff61a6404c25ef1a263fc2d98d081b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                     |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
| [`c4ea346d`](https://github.com/LnL7/nix-darwin/commit/c4ea346d0f74bfaaeb6a0afbc27bbdf5963a153b) | `` Dedupe the WorkingDirectory path of the linux-builder `` |