### PR TITLE
chore(flake/nur): `e6ef43d0` -> `414094f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705353982,
-        "narHash": "sha256-rLiQldW6i9Lb/QkMl5Bik/t0juitVjhLyt0O9kvT7Ok=",
+        "lastModified": 1705366858,
+        "narHash": "sha256-0DVY/jQbjxs8i5O5Po2yOy7EYSMbhqk8jOR+yPtrlHc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e6ef43d07669e28147ce5b502031c16fd6ef48b6",
+        "rev": "414094f0d8951e65fffbbeb4c1f0d2409ca272a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`414094f0`](https://github.com/nix-community/NUR/commit/414094f0d8951e65fffbbeb4c1f0d2409ca272a3) | `` automatic update `` |
| [`9835acbb`](https://github.com/nix-community/NUR/commit/9835acbbd10eca5641fd9545bb6bcbbe539e4ee5) | `` automatic update `` |
| [`141ec3a8`](https://github.com/nix-community/NUR/commit/141ec3a84bf0c5ec8d9da95b3fed24c76386f7f8) | `` automatic update `` |
| [`ddbf326e`](https://github.com/nix-community/NUR/commit/ddbf326ec8f83884c64b4834542d6c833d78c930) | `` automatic update `` |
| [`c7f551e3`](https://github.com/nix-community/NUR/commit/c7f551e3bc9d1d5390ef5fb34124141504419454) | `` automatic update `` |