### PR TITLE
chore(flake/emacs-overlay): `d28ef513` -> `c114295b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705337610,
-        "narHash": "sha256-NmmxENhK/O/uDnpb2pm0r2nSI0A0vC19ir38F8zNCMY=",
+        "lastModified": 1705368919,
+        "narHash": "sha256-ouEPhGlbi285E04XFsYm8IINFEuDU2Xt0FDA8Vw6uIE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d28ef513693ace9f18ffb90948169bfa3c61f6af",
+        "rev": "c114295bcec0eb9f036e0d893e09e1bffdf3e84e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`c114295b`](https://github.com/nix-community/emacs-overlay/commit/c114295bcec0eb9f036e0d893e09e1bffdf3e84e) | `` Updated melpa `` |
| [`3b9c536c`](https://github.com/nix-community/emacs-overlay/commit/3b9c536c66615b8f03ea73c605501eb2bec33e3e) | `` Updated elpa ``  |