### PR TITLE
chore(flake/nur): `d86d5d1c` -> `2cd3bd2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705370778,
-        "narHash": "sha256-T3SoFKTT9px5LjoJuDA/0aEsyPhyVwYyqPIK807nTgE=",
+        "lastModified": 1705374852,
+        "narHash": "sha256-8YQwz9Rwc43HRI8YrBKw1/IV3XGKo5LaW0Dcmtt5KTI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d86d5d1cb02545338e0e51debbf6fb707e399f4f",
+        "rev": "2cd3bd2d5367983339ffa40175be1c44f8042e27",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2cd3bd2d`](https://github.com/nix-community/NUR/commit/2cd3bd2d5367983339ffa40175be1c44f8042e27) | `` automatic update `` |
| [`8a9dca3b`](https://github.com/nix-community/NUR/commit/8a9dca3bf5a2e0832ab04e69a081efb1217d2e08) | `` automatic update `` |
| [`852fcb0f`](https://github.com/nix-community/NUR/commit/852fcb0fa38b3e3252d5d9548791ef038e40c758) | `` automatic update `` |