### PR TITLE
chore(flake/nur): `67bde509` -> `3a7285ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705388041,
-        "narHash": "sha256-cUMNm50nMPxDum03IQwkYhvzVflZFIiWk+Um4lxKs0Q=",
+        "lastModified": 1705391541,
+        "narHash": "sha256-94oAh+Y/0SttY88/r8JJdbxeI0F9Syoa/9IwvYGycZw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "67bde509383c2db1c1e9a3906f3b78234e2edf7b",
+        "rev": "3a7285ac0deaff25a1ad5abac097166aa4a3d2a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3a7285ac`](https://github.com/nix-community/NUR/commit/3a7285ac0deaff25a1ad5abac097166aa4a3d2a6) | `` automatic update `` |