### PR TITLE
chore(flake/emacs-overlay): `c114295b` -> `3efb3670`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705368919,
-        "narHash": "sha256-ouEPhGlbi285E04XFsYm8IINFEuDU2Xt0FDA8Vw6uIE=",
+        "lastModified": 1705395196,
+        "narHash": "sha256-6ORCyVxne8ot0iHx9NvVcxLspeI73tzzjKkXwbFItTo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c114295bcec0eb9f036e0d893e09e1bffdf3e84e",
+        "rev": "3efb36706c4c97569002e13d4072640f00a0b14e",
         "type": "github"
       },
       "original": {
@@ -712,11 +712,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1705183652,
-        "narHash": "sha256-rnfkyUH0x72oHfiSDhuCHDHg3gFgF+lF8zkkg5Zihsw=",
+        "lastModified": 1705331948,
+        "narHash": "sha256-qjQXfvrAT1/RKDFAMdl8Hw3m4tLVvMCc8fMqzJv0pP4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "428544ae95eec077c7f823b422afae5f174dee4b",
+        "rev": "b8dd8be3c790215716e7c12b247f45ca525867e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`3efb3670`](https://github.com/nix-community/emacs-overlay/commit/3efb36706c4c97569002e13d4072640f00a0b14e) | `` Updated melpa ``        |
| [`bd632887`](https://github.com/nix-community/emacs-overlay/commit/bd632887992dea09e08244c2f7c632c3590ab9dc) | `` Updated flake inputs `` |