### PR TITLE
chore(flake/nur): `3a7285ac` -> `a87b0011`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705391541,
-        "narHash": "sha256-94oAh+Y/0SttY88/r8JJdbxeI0F9Syoa/9IwvYGycZw=",
+        "lastModified": 1705394733,
+        "narHash": "sha256-3cb3uGFgF3Xdn/TOySunrzoyb5ccQhIbTCQNQUKfXwM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3a7285ac0deaff25a1ad5abac097166aa4a3d2a6",
+        "rev": "a87b0011e1e1cf9e0e861078db582081cf97796f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a87b0011`](https://github.com/nix-community/NUR/commit/a87b0011e1e1cf9e0e861078db582081cf97796f) | `` automatic update `` |
| [`17addbaf`](https://github.com/nix-community/NUR/commit/17addbafe01d214ffa2d609070e629d5b98950f2) | `` automatic update `` |
| [`2615497d`](https://github.com/nix-community/NUR/commit/2615497d0919954c5b8fa13cc444a0e1f21af370) | `` automatic update `` |