### PR TITLE
chore(flake/nur): `a87b0011` -> `56a0f7a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705394733,
-        "narHash": "sha256-3cb3uGFgF3Xdn/TOySunrzoyb5ccQhIbTCQNQUKfXwM=",
+        "lastModified": 1705406420,
+        "narHash": "sha256-iIV8bwdn+Cabxr1nRkEy/bpo5lB08XCZJcPPKCi716I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a87b0011e1e1cf9e0e861078db582081cf97796f",
+        "rev": "56a0f7a0adc8e2ca5a883a4a8a84c60d060cecce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`56a0f7a0`](https://github.com/nix-community/NUR/commit/56a0f7a0adc8e2ca5a883a4a8a84c60d060cecce) | `` automatic update `` |
| [`68bb618a`](https://github.com/nix-community/NUR/commit/68bb618a0bfb1c0ec49f62e8053a0e9c26498427) | `` automatic update `` |
| [`fc6a7968`](https://github.com/nix-community/NUR/commit/fc6a7968946381bbd658ff8a85afa1697b884b27) | `` automatic update `` |
| [`b84acff4`](https://github.com/nix-community/NUR/commit/b84acff443bea19dad8f2308773cef3a1c2595cf) | `` automatic update `` |
| [`355d7d1b`](https://github.com/nix-community/NUR/commit/355d7d1bd60e263ee67cb5ebc00eb1078af144f3) | `` automatic update `` |