### PR TITLE
chore(flake/nur): `56a0f7a0` -> `907d7665`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705406420,
-        "narHash": "sha256-iIV8bwdn+Cabxr1nRkEy/bpo5lB08XCZJcPPKCi716I=",
+        "lastModified": 1705409899,
+        "narHash": "sha256-qgU6s8LQTdNArC2qtPkU0RPGFYe4H3R6/iwnhAx/65w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "56a0f7a0adc8e2ca5a883a4a8a84c60d060cecce",
+        "rev": "907d766528acc15fc250e983076477cc05ba9c9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`907d7665`](https://github.com/nix-community/NUR/commit/907d766528acc15fc250e983076477cc05ba9c9b) | `` automatic update `` |
| [`105dfed1`](https://github.com/nix-community/NUR/commit/105dfed182adde9540b03e86bf804ea5e68a2b47) | `` automatic update `` |
| [`c3552a09`](https://github.com/nix-community/NUR/commit/c3552a0921342253b615412dd6fcb26df4c7f4fe) | `` automatic update `` |