### PR TITLE
chore(flake/nur): `907d7665` -> `63ffe98d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705409899,
-        "narHash": "sha256-qgU6s8LQTdNArC2qtPkU0RPGFYe4H3R6/iwnhAx/65w=",
+        "lastModified": 1705412701,
+        "narHash": "sha256-C+xOfQHcc2eB2iq6qyFzReoDJSUYv513FFuluVu4Lr4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "907d766528acc15fc250e983076477cc05ba9c9b",
+        "rev": "63ffe98d833ec01b51ea43204a4e844e2fa39a5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`63ffe98d`](https://github.com/nix-community/NUR/commit/63ffe98d833ec01b51ea43204a4e844e2fa39a5e) | `` automatic update `` |
| [`60b27d18`](https://github.com/nix-community/NUR/commit/60b27d183fb0b7f4e9de2b7ac1d74d018f590c22) | `` automatic update `` |