### PR TITLE
chore(flake/nur): `63ffe98d` -> `85319dec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705412701,
-        "narHash": "sha256-C+xOfQHcc2eB2iq6qyFzReoDJSUYv513FFuluVu4Lr4=",
+        "lastModified": 1705419891,
+        "narHash": "sha256-aPbUyn22kkWOBaeIqf+H3VdtpQhvZKi/yCqEVFFuu84=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "63ffe98d833ec01b51ea43204a4e844e2fa39a5e",
+        "rev": "85319dece798bf5542a09b20cf2d60c1b13dbd48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`85319dec`](https://github.com/nix-community/NUR/commit/85319dece798bf5542a09b20cf2d60c1b13dbd48) | `` automatic update `` |