### PR TITLE
chore(flake/emacs-overlay): `3efb3670` -> `0272f041`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705395196,
-        "narHash": "sha256-6ORCyVxne8ot0iHx9NvVcxLspeI73tzzjKkXwbFItTo=",
+        "lastModified": 1705423993,
+        "narHash": "sha256-kZtmuGdBzKT6vFbzVZqe9vm7ckkowSQz1Ln1ItvU3+A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3efb36706c4c97569002e13d4072640f00a0b14e",
+        "rev": "0272f04189d187055b300c77178cce855382cc55",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`0272f041`](https://github.com/nix-community/emacs-overlay/commit/0272f04189d187055b300c77178cce855382cc55) | `` Updated melpa `` |
| [`bb990abe`](https://github.com/nix-community/emacs-overlay/commit/bb990abe0aec2f288bbd547b872d95c70fa5b2eb) | `` Updated elpa ``  |