### PR TITLE
chore(flake/nixpkgs): `9b19f5e7` -> `c3e128f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -760,11 +760,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1705133751,
-        "narHash": "sha256-rCIsyE80jgiOU78gCWN3A0wE0tR2GI5nH6MlS+HaaSQ=",
+        "lastModified": 1705316053,
+        "narHash": "sha256-J2Ey5mPFT8gdfL2XC0JTZvKaBw/b2pnyudEXFvl+dQM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9b19f5e77dd906cb52dade0b7bd280339d2a1f3d",
+        "rev": "c3e128f3c0ecc1fb04aef9f72b3dcc2f6cecf370",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`d6e9e26d`](https://github.com/NixOS/nixpkgs/commit/d6e9e26d2351c4aa26adcd7ec96d2cbe9c7aaf0b) | `` ocamlPackages.js_of_ocaml: 5.5.2 -> 5.6.0 ``                                           |
| [`9b8cffeb`](https://github.com/NixOS/nixpkgs/commit/9b8cffeb6bb5a990381a204dfbd45b98671d981a) | `` python311Packages.agate: 1.7.1 -> 1.9.1 (#280993) ``                                   |
| [`424d85db`](https://github.com/NixOS/nixpkgs/commit/424d85dbb80facc18a70eae5b4070e20828c61de) | `` python3Packages.sqlalchemy_1_4: drop tag_build to fix version ``                       |
| [`9350f6fa`](https://github.com/NixOS/nixpkgs/commit/9350f6fa5a2cb2b2918c90c131d2efd4691064cd) | `` linuxKernel.kernels.linux_zen: 6.7-zen2 -> 6.7-zen3 ``                                 |
| [`77ac10e7`](https://github.com/NixOS/nixpkgs/commit/77ac10e7a52da2baab3089e280fe48e220903cf0) | `` waylock: add adamcstephens as maintainer ``                                            |
| [`2af02d3b`](https://github.com/NixOS/nixpkgs/commit/2af02d3bed657ca858df1cfe2b01130c98f829e3) | `` waylock: upstream moved to codeberg ``                                                 |
| [`ff67c91c`](https://github.com/NixOS/nixpkgs/commit/ff67c91cf88a721a3e9a5ddf75b74c404b8fec0f) | `` freerdp: use latest ffmpeg ``                                                          |
| [`7ff48c20`](https://github.com/NixOS/nixpkgs/commit/7ff48c20eeba8944b8c2f8ce614501144ba82f6a) | `` osu-lazer: 2024.113.0 -> 2023.114.0 ``                                                 |
| [`af146f47`](https://github.com/NixOS/nixpkgs/commit/af146f47b310b695053dd850b5dd7cf638272ade) | `` osu-lazer-bin: 2023.113.0 -> 2023.114.0 ``                                             |
| [`05a21a18`](https://github.com/NixOS/nixpkgs/commit/05a21a1870bdf0b2f6ced6ecd3b7f088e345c77a) | `` python311Packages.python-crontab: disable failing test ``                              |
| [`6b55672b`](https://github.com/NixOS/nixpkgs/commit/6b55672bb521c6d7f4ee69f6d24fe3992f6901b1) | `` outline: 0.73.1 -> 0.74.0 (#275007) ``                                                 |
| [`c35f2b06`](https://github.com/NixOS/nixpkgs/commit/c35f2b069fc59711f2900794c9584b68b2178db6) | `` calcure: refactor ``                                                                   |
| [`8fc50f53`](https://github.com/NixOS/nixpkgs/commit/8fc50f53a3204f494850d1253be59aa72e6ceeae) | `` csvlens: 0.5.1 -> 0.6.0 ``                                                             |
| [`06cbb08c`](https://github.com/NixOS/nixpkgs/commit/06cbb08c1fc1c84dd7c54f92afb725df3b18fa54) | `` python311Packages.ics: refactor ``                                                     |
| [`cac10ee0`](https://github.com/NixOS/nixpkgs/commit/cac10ee05182c5298764a4e623da0a1be8f92f55) | `` tmuxp: add myself as co-maintainer ``                                                  |
| [`3e924be8`](https://github.com/NixOS/nixpkgs/commit/3e924be8a85a134df4fa5169adfb871f54473865) | `` tmuxp: 1.29.0 -> 1.34.0 ``                                                             |
| [`40cd3bcc`](https://github.com/NixOS/nixpkgs/commit/40cd3bcc06d8a9118c26ab905a7d52d672283942) | `` lxqt.obconf-qt: 0.16.3 -> 0.16.4 ``                                                    |
| [`362aba4b`](https://github.com/NixOS/nixpkgs/commit/362aba4b17a3e4ae04c50af4a2ae98a11d81bae6) | `` openxray: Drop freeimage ``                                                            |
| [`99159b6f`](https://github.com/NixOS/nixpkgs/commit/99159b6f7ed2f73baafe07e12cb96b6dd1d18194) | `` top-level: use callPackages where inheriting packages ``                               |
| [`47c63826`](https://github.com/NixOS/nixpkgs/commit/47c638264b9e7564853cf1998128b3b2eb63013b) | `` openxray: Simplify wrapping ``                                                         |
| [`f853628a`](https://github.com/NixOS/nixpkgs/commit/f853628ae5569d40879d77880026935347930a4b) | `` openxray: 2088-august-2023-rc1 -> 2188-november-2023-rc1, add passthru.updateScript `` |
| [`60c8b2e2`](https://github.com/NixOS/nixpkgs/commit/60c8b2e2339e25add195e0cdcc4989f5208726bf) | `` openxray: Enable on Darwin ``                                                          |
| [`1fb2556e`](https://github.com/NixOS/nixpkgs/commit/1fb2556e994c3e549deea0330a2f72373d190a05) | `` openxray: 1747-january-2023-rc3 -> 2088-august-2023-rc1 ``                             |
| [`6605c0da`](https://github.com/NixOS/nixpkgs/commit/6605c0dad80d6399176706cde1893179e058320e) | `` openxray: 1144-december-2021-rc1 -> 1747-january-2023-rc3 ``                           |
| [`083770a4`](https://github.com/NixOS/nixpkgs/commit/083770a4baf1a6fdb21aab8b2546afcd43d60c6b) | `` brscan5: 1.2.9-0 -> 1.3.0-0 ``                                                         |
| [`7d2c5bf4`](https://github.com/NixOS/nixpkgs/commit/7d2c5bf495a113fac493cad733f5bf89e1915b35) | `` python311Packages.logging-journald: 0.6.5 -> 0.6.7 ``                                  |
| [`d81eeb42`](https://github.com/NixOS/nixpkgs/commit/d81eeb426bf1fbf43732929e2dda39b26358585b) | `` genericUpdater: Add support for commit protocol ``                                     |
| [`f557e05b`](https://github.com/NixOS/nixpkgs/commit/f557e05b313c7d7bbf7f82cd3fffd9f6d8cd7899) | `` paperless-ngx: 2.2.1 -> 2.3.3 ``                                                       |
| [`5c44c87c`](https://github.com/NixOS/nixpkgs/commit/5c44c87c8d269ad970a1b8ea8c09e17ec28ddb0d) | `` python3Packages.wandb: fix build ``                                                    |
| [`ec836290`](https://github.com/NixOS/nixpkgs/commit/ec836290b03ac2eef0e083720a6186894c89ffeb) | `` pinentry_mac: add 'meta.mainProgram' ``                                                |
| [`1a76b6cc`](https://github.com/NixOS/nixpkgs/commit/1a76b6cc783c01157372e31fbb768a767e5f7580) | `` pinentry-rofi: add 'meta.mainProgram' ``                                               |
| [`84ac7df0`](https://github.com/NixOS/nixpkgs/commit/84ac7df0a4ece1880769facba66f1a31d525ddae) | `` pinentry-bemenu: add 'meta.mainProgram' ``                                             |
| [`7e223e61`](https://github.com/NixOS/nixpkgs/commit/7e223e610a6a7a7d732c9cc140a9409254bbbeba) | `` python311Packages.aiogram: 3.2.0 -> 3.3.0 ``                                           |
| [`5f0ddd9a`](https://github.com/NixOS/nixpkgs/commit/5f0ddd9aaf86d061a34fc313aeefe396ff33b124) | `` nh: 3.5.1 -> 3.5.2 ``                                                                  |
| [`81db2e7e`](https://github.com/NixOS/nixpkgs/commit/81db2e7e776926762c16734a83fdc7abc486dde3) | `` python311Packages.aiolifx-themes: 0.4.11 -> 0.4.12 ``                                  |
| [`03f4092a`](https://github.com/NixOS/nixpkgs/commit/03f4092aed8c5a33469291609414219af5e1e221) | `` python311Packages.aiolifx: 1.0.0 -> 1.0.1 ``                                           |
| [`6f98d8fd`](https://github.com/NixOS/nixpkgs/commit/6f98d8fdc7cf5ba61d7f9bdfb97fe1c3781b4b30) | `` python311Packages.inquirerpy: refactor ``                                              |
| [`74808f16`](https://github.com/NixOS/nixpkgs/commit/74808f169cf137a632593524672f68dd834251ff) | `` nixos/pcscd: remove noop restartTriggers ``                                            |
| [`6ecb73df`](https://github.com/NixOS/nixpkgs/commit/6ecb73df1b45a5195167512e57b6bd915208b87e) | `` nixos/pcscd: suggest yubikey-personalization for additional udev rules ``              |
| [`c09acaa9`](https://github.com/NixOS/nixpkgs/commit/c09acaa9056975a9a5b52be1703e543151283a91) | `` nixos/pcscd: cleanup code ``                                                           |
| [`57c0c869`](https://github.com/NixOS/nixpkgs/commit/57c0c869dd5a7ec60a466fb25e5737f2fc09b9e5) | `` python311Packages.aiohomekit: 3.1.2 -> 3.1.3 ``                                        |
| [`d3c10deb`](https://github.com/NixOS/nixpkgs/commit/d3c10debffc069315e33f71d5589cd6b83d0d8d1) | `` checkov: 3.1.57 -> 3.1.60 ``                                                           |
| [`155914b6`](https://github.com/NixOS/nixpkgs/commit/155914b6671fe095091e7c61d58872f2894768ca) | `` python311Packages.zamg: 0.3.4 -> 0.3.5 ``                                              |
| [`9707745c`](https://github.com/NixOS/nixpkgs/commit/9707745cf8af50adf2ef2408933be3e7ea0b1912) | `` nixos/ntpd-rs: init ``                                                                 |
| [`a39d50f8`](https://github.com/NixOS/nixpkgs/commit/a39d50f8b3a21ed7f24124198f73f7a7abb47b3d) | `` ntpd-rs: 0.3.7 -> 1.1.0 ``                                                             |
| [`32c72f2c`](https://github.com/NixOS/nixpkgs/commit/32c72f2cf09b31ae75696f0eb3ea82cfdadcc0bc) | `` python311Packages.soco: 0.30.1 -> 0.30.2 ``                                            |
| [`2952f4a5`](https://github.com/NixOS/nixpkgs/commit/2952f4a579e8f32d64ead60bfd7d71f762778b57) | `` pipx: fix test failure ``                                                              |
| [`20760fd9`](https://github.com/NixOS/nixpkgs/commit/20760fd970c33c997fec682485fc70ab6fe91a8f) | `` catppuccin-qt5ct: init at 2023-03-21 ``                                                |
| [`058c8b44`](https://github.com/NixOS/nixpkgs/commit/058c8b442fa76107ab59305a741d62335ba9e524) | `` python311Packages.idasen: 0.11.0 -> 0.11.1 ``                                          |
| [`a005b432`](https://github.com/NixOS/nixpkgs/commit/a005b43238f591552880a385e07a62d3e8382e78) | `` nushellPlugins: hash update for 0.89.0 ``                                              |
| [`d4207e55`](https://github.com/NixOS/nixpkgs/commit/d4207e550aa35d2f88fb8b0667afd3e96b75de5e) | `` folks: Replace finalAttrs.pname with fixed string folks ``                             |
| [`03f54507`](https://github.com/NixOS/nixpkgs/commit/03f54507fa6550f615f1c0219e6b0577584afda4) | `` home-assistant-custom-lovelace-modules.mushroom: 3.2.3 -> 3.2.4 ``                     |
| [`ddbab9f8`](https://github.com/NixOS/nixpkgs/commit/ddbab9f8532be6d2dd415f16482a6839805de6a3) | `` folks: Really disable tests ``                                                         |
| [`a77764f6`](https://github.com/NixOS/nixpkgs/commit/a77764f6c1678bc1ae1f607884181d5333f92fb1) | `` python311Packages.hahomematic: 2024.1.6 -> 2024.1.7 ``                                 |
| [`02266dc6`](https://github.com/NixOS/nixpkgs/commit/02266dc69eb5aa8f33df6b5ccbde1c128f64001c) | `` electron: migrate to fixup-yarn-lock from prefetch-yarn-deps (#269933) ``              |
| [`bfb58157`](https://github.com/NixOS/nixpkgs/commit/bfb58157d580deeaf69a96a71a4e9ddfdd1b997e) | `` xed-editor: Fix typelib path ``                                                        |
| [`8b27ff83`](https://github.com/NixOS/nixpkgs/commit/8b27ff83eca6ee6596cab10f5dc941ba5a6182c3) | `` python311Packages.pydrawise: 2024.1.0 -> 2024.1.1 ``                                   |
| [`eec7a722`](https://github.com/NixOS/nixpkgs/commit/eec7a7225e7e66c04a0e53a24d259b27029c85af) | `` python311Packages.grafanalib: 0.7.0 -> 0.7.1 ``                                        |
| [`02192dde`](https://github.com/NixOS/nixpkgs/commit/02192dde3dbabb645fde26fd358d894fc44ffc9b) | `` python311Packages.gotenberg-client: 0.4.1 -> 0.5.0 ``                                  |
| [`e5fb7f2e`](https://github.com/NixOS/nixpkgs/commit/e5fb7f2ef9f0c826d53339b602d42a4cc1380c76) | `` vdirsyncer: fix build by relaxing aiostream ``                                         |
| [`e0fe0f7d`](https://github.com/NixOS/nixpkgs/commit/e0fe0f7d52cc52e0fe58c93bb33794b3729f84bb) | `` python311Packages.fireflyalgorithm: refactor ``                                        |
| [`3cad2da1`](https://github.com/NixOS/nixpkgs/commit/3cad2da1f8ab5f1941503b9df8b6da8a52cab0cd) | `` python311Packages.epion: add changelog to meta ``                                      |
| [`6d061652`](https://github.com/NixOS/nixpkgs/commit/6d06165273c4d563ac8341baf61e4df9c181d3fc) | `` Revert "python311Packages.gql: 3.4.1 -> 3.6.0b0" ``                                    |
| [`69d191ae`](https://github.com/NixOS/nixpkgs/commit/69d191aeafedfb86d691200357fe1e8c4aa0f51e) | `` amdgpu_top: 0.3.1 -> 0.6.1 ``                                                          |
| [`f5dfc971`](https://github.com/NixOS/nixpkgs/commit/f5dfc9716403cb950f3bdb50de77cf4249b045b4) | `` folks: disable checks ``                                                               |
| [`8dcf8f95`](https://github.com/NixOS/nixpkgs/commit/8dcf8f9572124f18f171d8336ace9862f3daa6dc) | `` python311Packages.garth: add changelog to meta ``                                      |
| [`e467119a`](https://github.com/NixOS/nixpkgs/commit/e467119a1565ccf9ca150820ae82661e7ad331bc) | `` iwd: 2.12 -> 2.13 ``                                                                   |
| [`5a65ef7f`](https://github.com/NixOS/nixpkgs/commit/5a65ef7fc6b1085df94f7e563ad43a892545a735) | `` python311Packages.garth: 0.4.43 -> 0.4.44 ``                                           |
| [`cfa3f2b8`](https://github.com/NixOS/nixpkgs/commit/cfa3f2b8f6956079ee41a843bffad834bbe09448) | `` python311Packages.opower: refactor ``                                                  |
| [`572c9e5a`](https://github.com/NixOS/nixpkgs/commit/572c9e5aa83ba7f2502d88afd785cdda0c52fa80) | `` python311Packages.fireflyalgorithm: 0.3.4 -> 0.4.4 ``                                  |
| [`217cc2b9`](https://github.com/NixOS/nixpkgs/commit/217cc2b9fb5fd7d80e0a9b0c02b18f43d789f0fa) | `` python311Packages.epion: 0.0.2 -> 0.0.3 ``                                             |
| [`1a7e6365`](https://github.com/NixOS/nixpkgs/commit/1a7e63652208c1423c19bcbf9e86103b622a17f5) | `` python311Packages.opower: 0.1.0 -> 0.2.0 ``                                            |
| [`ca904d84`](https://github.com/NixOS/nixpkgs/commit/ca904d847ef0f51fbeafbf1368ead6819ec84d20) | `` python311Packages.aiotractive: refactor ``                                             |
| [`9ab15494`](https://github.com/NixOS/nixpkgs/commit/9ab154949f583c9926fa2ac1aa58564d7c0a4536) | `` python311Packages.aiotractive: 0.5.6 -> 0.5.7 ``                                       |
| [`418eac9f`](https://github.com/NixOS/nixpkgs/commit/418eac9f6d62001f78bb30eefaafc9880c5874cf) | `` python311Packages.ray: 2.7.0 -> 2.9.0 ``                                               |
| [`7790f5ac`](https://github.com/NixOS/nixpkgs/commit/7790f5ac1cf4d14cdd55561ce652a90786256437) | `` python311Packages.dominate: add changelog to meta ``                                   |
| [`d0abf0bc`](https://github.com/NixOS/nixpkgs/commit/d0abf0bca81e188f8c5cc99d3ed2731c6fccb32d) | `` python311Packages.dvc: 3.38.1 -> 3.39.0 ``                                             |
| [`ed147dbb`](https://github.com/NixOS/nixpkgs/commit/ed147dbbd54bfa6a187aff62661261771ca497bf) | `` python311Packages.diffusers: 0.24.0 -> 0.25.0 ``                                       |
| [`1366434b`](https://github.com/NixOS/nixpkgs/commit/1366434ba6878a94b4fdc7764d08625f13c767d9) | `` python311Packages.astropy-healpix: remove patch; fix build ``                          |
| [`ba1518e6`](https://github.com/NixOS/nixpkgs/commit/ba1518e683fb22bd68736bfd28e3a831f1ae63db) | `` python311Packages.langchain: 0.0.344 -> 0.1.0 ``                                       |
| [`0684a7f8`](https://github.com/NixOS/nixpkgs/commit/0684a7f8d032b48123db699f2c096f1a9436069d) | `` python311Packages.langsmith: 0.0.75 -> 0.0.80 ``                                       |
| [`bc4f1f5d`](https://github.com/NixOS/nixpkgs/commit/bc4f1f5d2fa634cc97f26dd7270357eef91929f2) | `` python311Packages.langchain-community: init at 0.0.12 ``                               |
| [`e3f00a4e`](https://github.com/NixOS/nixpkgs/commit/e3f00a4e056407c7b6d7b82e48bb83052450922e) | `` python311Packages.langchain-core: init at 0.1.10 ``                                    |
| [`6ba32e8a`](https://github.com/NixOS/nixpkgs/commit/6ba32e8ad933c2d057f239cf72d174b242108c92) | `` python311Packages.dominate: 2.9.0 -> 2.9.1 ``                                          |
| [`1db693c3`](https://github.com/NixOS/nixpkgs/commit/1db693c304bc5590a1516fcc20b92207dc6f2c5a) | `` python311Packages.django-vite: 3.0.1 -> 3.0.2 ``                                       |
| [`40bec359`](https://github.com/NixOS/nixpkgs/commit/40bec35947ef38fe59ee94f848ddedb9135929c2) | `` nixosTests.pantheon: Extend the test ``                                                |
| [`9c0581d4`](https://github.com/NixOS/nixpkgs/commit/9c0581d47f7a8118d252a2f42e739faf6d541dba) | `` opencolorio: remove ilmbase from inputs (#279925) ``                                   |
| [`89cf670d`](https://github.com/NixOS/nixpkgs/commit/89cf670d33000b587d376621570aa79ccaf9f108) | `` python3Packages.devpi-common: add missing dependency ``                                |
| [`652754ac`](https://github.com/NixOS/nixpkgs/commit/652754ac37567781be911d9dbb091337bb96d42d) | `` python311Packages.cvxpy: add clarabel dependency ``                                    |
| [`2e144895`](https://github.com/NixOS/nixpkgs/commit/2e1448950f1f579e6e8f81ee1ac0579f412801ee) | `` python311Packages.clarabel: init at v0.6.0.post1 ``                                    |
| [`b0ee9915`](https://github.com/NixOS/nixpkgs/commit/b0ee9915ad1fb1db1a72b8db2ee58672a61331ad) | `` typst-live: 0.6.0 -> 0.7.0 ``                                                          |
| [`d9c57e58`](https://github.com/NixOS/nixpkgs/commit/d9c57e581095e12d0e32d81ffb0d4eb8fb374af2) | `` capnproto: 1.0.1.1 -> 1.0.2 ``                                                         |
| [`bd76d59d`](https://github.com/NixOS/nixpkgs/commit/bd76d59d0ed855dd8182e7b38d8bfcd534840b53) | `` typst-lsp: 0.12.0 -> 0.12.1 ``                                                         |
| [`bbe2f639`](https://github.com/NixOS/nixpkgs/commit/bbe2f639b1652f99c8b7440cdf0441fe3c772b4e) | `` flexget: 3.11.2 -> 3.11.8 ``                                                           |