### PR TITLE
chore(flake/nur): `d903efee` -> `e624e8d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705434341,
-        "narHash": "sha256-fa9QNItGGp4l7LvkReXBrbNHRCxkQBpIlJp1oCHcezU=",
+        "lastModified": 1705438232,
+        "narHash": "sha256-QNzH7vSpJmlSYh8UKbNgh9+9k0+c/dYoX2DUg9iW/UQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d903efee82490af2b5307eb0717f9de623a53195",
+        "rev": "e624e8d167a7376b1ea715cf218c547d11bb4d28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e624e8d1`](https://github.com/nix-community/NUR/commit/e624e8d167a7376b1ea715cf218c547d11bb4d28) | `` automatic update `` |
| [`69bb2258`](https://github.com/nix-community/NUR/commit/69bb22580340859ff3b1fcb477010f7c5ab755cb) | `` automatic update `` |