### PR TITLE
chore(flake/emacs-overlay): `0272f041` -> `ed25d979`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705423993,
-        "narHash": "sha256-kZtmuGdBzKT6vFbzVZqe9vm7ckkowSQz1Ln1ItvU3+A=",
+        "lastModified": 1705455365,
+        "narHash": "sha256-OLulju3LkZNyMleeCrGnuPTM4Ry1Rmlgmngs6NdznMY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0272f04189d187055b300c77178cce855382cc55",
+        "rev": "ed25d9799f2251666a0e8749a15f4301ebf37a1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ed25d979`](https://github.com/nix-community/emacs-overlay/commit/ed25d9799f2251666a0e8749a15f4301ebf37a1b) | `` Updated melpa ``        |
| [`d2a68273`](https://github.com/nix-community/emacs-overlay/commit/d2a68273c0a309d78c6e654602bf5c087f401d61) | `` Updated elpa ``         |
| [`9ad02597`](https://github.com/nix-community/emacs-overlay/commit/9ad0259722fd75ed4402d5e8cf1393ddf94a4928) | `` Updated flake inputs `` |