### PR TITLE
chore(flake/nur): `bc9055dd` -> `30dcc214`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705455956,
-        "narHash": "sha256-d6P2UJYQzxrMmF+WotmN99ASTLmYcJNbuIE979ye5OI=",
+        "lastModified": 1705463825,
+        "narHash": "sha256-Fq1afoLHKvYTAnDtdJLMKPYh3mmqtFUFf+txz85tbfo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bc9055dd280a5c8c1e9a8e0b7f10608cf3915b0b",
+        "rev": "30dcc214b3ca38fb769b289399cc6b486921457b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`30dcc214`](https://github.com/nix-community/NUR/commit/30dcc214b3ca38fb769b289399cc6b486921457b) | `` automatic update `` |
| [`b7672ac6`](https://github.com/nix-community/NUR/commit/b7672ac60e52dc5804d07079eaca31dc4a0854eb) | `` automatic update `` |