### PR TITLE
chore(flake/nur): `49ee80a3` -> `f28bee7b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705472837,
-        "narHash": "sha256-h5FAtZwCWcC0/ktcQSUCDZi1l8fU7MeuP/MJpHz4+FQ=",
+        "lastModified": 1705478284,
+        "narHash": "sha256-j0bZUBHz43dO+27yTmfD7rSRjlv6GXEthcPbxAC3I6g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "49ee80a37d8a3a75b501e077de2115a062af0701",
+        "rev": "f28bee7b100aa6b96631eb433f0fcb7f2653be40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f28bee7b`](https://github.com/nix-community/NUR/commit/f28bee7b100aa6b96631eb433f0fcb7f2653be40) | `` automatic update `` |
| [`48c3d556`](https://github.com/nix-community/NUR/commit/48c3d5565365dbaac5d2919d9f7cb754da79f8cc) | `` automatic update `` |
| [`36cb0efe`](https://github.com/nix-community/NUR/commit/36cb0efea3adab06eff2639babdbb24d0c059630) | `` automatic update `` |
| [`579de42a`](https://github.com/nix-community/NUR/commit/579de42a9893e57bc5020dbdddf35473c9cda15a) | `` automatic update `` |