### PR TITLE
chore(flake/nur): `f28bee7b` -> `b574577f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705478284,
-        "narHash": "sha256-j0bZUBHz43dO+27yTmfD7rSRjlv6GXEthcPbxAC3I6g=",
+        "lastModified": 1705481485,
+        "narHash": "sha256-4raq9KXsKYp2Ci0Cblyu0Fj71dIjsEgaLh0O3Fwibqw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f28bee7b100aa6b96631eb433f0fcb7f2653be40",
+        "rev": "b574577f6d3c5b9fab849ddacc0ad7d05cc08847",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b574577f`](https://github.com/nix-community/NUR/commit/b574577f6d3c5b9fab849ddacc0ad7d05cc08847) | `` automatic update `` |
| [`e6ef947a`](https://github.com/nix-community/NUR/commit/e6ef947a377d529b33796a9e05c1e9138f3bc192) | `` automatic update `` |
| [`1566b4e1`](https://github.com/nix-community/NUR/commit/1566b4e117d0cc8b9336f2dd6fade51089b9453b) | `` automatic update `` |
| [`fc514e83`](https://github.com/nix-community/NUR/commit/fc514e835def8cf67e63eb8a4f06eb6c52e05cb8) | `` automatic update `` |