### PR TITLE
chore(flake/nur): `b574577f` -> `d8cb8b7b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705481485,
-        "narHash": "sha256-4raq9KXsKYp2Ci0Cblyu0Fj71dIjsEgaLh0O3Fwibqw=",
+        "lastModified": 1705486356,
+        "narHash": "sha256-L3jttQvRGNx85oxzt/Uyyfzf0KQnOQfCB0dHUErtcLs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b574577f6d3c5b9fab849ddacc0ad7d05cc08847",
+        "rev": "d8cb8b7bc09cf704831caa4cec54d2ab6e5756cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d8cb8b7b`](https://github.com/nix-community/NUR/commit/d8cb8b7bc09cf704831caa4cec54d2ab6e5756cd) | `` automatic update `` |
| [`5124d9b9`](https://github.com/nix-community/NUR/commit/5124d9b94d3ffd632864d07c1a31bf0d2e568c42) | `` automatic update `` |