### PR TITLE
chore(flake/nur): `d8cb8b7b` -> `8d1c62ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705486356,
-        "narHash": "sha256-L3jttQvRGNx85oxzt/Uyyfzf0KQnOQfCB0dHUErtcLs=",
+        "lastModified": 1705490880,
+        "narHash": "sha256-JfC6ZMF/BWWIzzqYNswF/WTtIbjaF8MKkpdhl1YPyN8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d8cb8b7bc09cf704831caa4cec54d2ab6e5756cd",
+        "rev": "8d1c62baf47e465e0732ebf7336d2443add7e3ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8d1c62ba`](https://github.com/nix-community/NUR/commit/8d1c62baf47e465e0732ebf7336d2443add7e3ec) | `` automatic update `` |