### PR TITLE
chore(flake/nur): `8d1c62ba` -> `cb8b51f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705490880,
-        "narHash": "sha256-JfC6ZMF/BWWIzzqYNswF/WTtIbjaF8MKkpdhl1YPyN8=",
+        "lastModified": 1705495488,
+        "narHash": "sha256-AHTY7s+ijwY9PiRTgJUqItqitbc1siQ44FxYcMJvCts=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8d1c62baf47e465e0732ebf7336d2443add7e3ec",
+        "rev": "cb8b51f32f9587369857ee5cb6331b3fca0fb10b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cb8b51f3`](https://github.com/nix-community/NUR/commit/cb8b51f32f9587369857ee5cb6331b3fca0fb10b) | `` automatic update `` |
| [`61c58aa4`](https://github.com/nix-community/NUR/commit/61c58aa4fe5ec33003a9fe51de7799539fac1473) | `` automatic update `` |