### PR TITLE
chore(flake/nur): `cb8b51f3` -> `0482c9db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705495488,
-        "narHash": "sha256-AHTY7s+ijwY9PiRTgJUqItqitbc1siQ44FxYcMJvCts=",
+        "lastModified": 1705499802,
+        "narHash": "sha256-zOLnIFP2NUKG9Ny6rw0xmcxLdUGUTtKffW3R0t/TXzw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cb8b51f32f9587369857ee5cb6331b3fca0fb10b",
+        "rev": "0482c9dbc4e0f18340a6efe2c52b77800435fc68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0482c9db`](https://github.com/nix-community/NUR/commit/0482c9dbc4e0f18340a6efe2c52b77800435fc68) | `` automatic update `` |
| [`2afd51ec`](https://github.com/nix-community/NUR/commit/2afd51ec110a41d646272a548fe5a2913f33a918) | `` automatic update `` |
| [`e5a47250`](https://github.com/nix-community/NUR/commit/e5a47250972eb972d108f003fe71babba5b5913c) | `` automatic update `` |