### PR TITLE
chore(flake/nur): `a77498e0` -> `5095f759`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705506374,
-        "narHash": "sha256-pXE6NbFiitsKvt5hqUU+94mZKzghZWrhAZUOcwuRjWo=",
+        "lastModified": 1705513563,
+        "narHash": "sha256-EbSEAPIcAbbZ6+w3nMMbHKfNVf+owyrV+bdVzdQ/nkc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a77498e0017ac7512002828b7e02337cf6928e1c",
+        "rev": "5095f759261809f4e5eaec878e767a673b922184",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5095f759`](https://github.com/nix-community/NUR/commit/5095f759261809f4e5eaec878e767a673b922184) | `` automatic update `` |
| [`76b08c50`](https://github.com/nix-community/NUR/commit/76b08c50a95288f4100ebabc9f4d3a825a35ee68) | `` automatic update `` |
| [`1b54a4c3`](https://github.com/nix-community/NUR/commit/1b54a4c32111f486ae0e39771eab7f40f1f1d51a) | `` automatic update `` |