### PR TITLE
chore(flake/home-manager): `16cefa78` -> `b84191db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705446327,
-        "narHash": "sha256-n7FCuAR2BI1SvLjF6eFc8VE6WLZCMlbToyfqU2ihbkU=",
+        "lastModified": 1705535278,
+        "narHash": "sha256-V5+XKfNbiY0bLKLQlH+AXyhHttEL7XcZBH9iSbxxexA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "16cefa78cc801911ebd4ff1faddc6280ab3c9228",
+        "rev": "b84191db127c16a92cbdf7f7b9969d58bb456699",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`b84191db`](https://github.com/nix-community/home-manager/commit/b84191db127c16a92cbdf7f7b9969d58bb456699) | `` gh: add github gist to default credential hosts `` |
| [`d9c86968`](https://github.com/nix-community/home-manager/commit/d9c869681db7171a1ffb6f88489e4a5170fd0fb5) | `` sway: include cursor environment variables ``      |
| [`62856932`](https://github.com/nix-community/home-manager/commit/62856932af0c75c5be7a5ba23441e16a305423b3) | `` gradle: Don't enable programs.java ``              |
| [`9fed3282`](https://github.com/nix-community/home-manager/commit/9fed3282e9d5fdc106001a20a84d4e3d8c86dd13) | `` gradle: re-add britter as maintainer ``            |
| [`646c243e`](https://github.com/nix-community/home-manager/commit/646c243e6f8426b37e45cbd6263f607fe046808a) | `` flake.lock: Update ``                              |