### PR TITLE
chore(flake/nur): `58f1c69c` -> `076de536`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705527861,
-        "narHash": "sha256-h8X6fmxxmzRYxKE0Ms8LgY0P2szcnueKE+AiPXy8Ido=",
+        "lastModified": 1705534762,
+        "narHash": "sha256-wv0G+H1XK7SaAbB5lch0H3SZ+03NteNvK06E4xByFsQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "58f1c69c63adcaa2fb02697a0f8f3ca9eccca528",
+        "rev": "076de53609ecd728684bde3c0a1d719669a9866c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`076de536`](https://github.com/nix-community/NUR/commit/076de53609ecd728684bde3c0a1d719669a9866c) | `` automatic update `` |
| [`c050a429`](https://github.com/nix-community/NUR/commit/c050a4297f2025516c9dbd6603bab1b218e80764) | `` automatic update `` |
| [`2cb8b307`](https://github.com/nix-community/NUR/commit/2cb8b307e3cd085aacbb4f2c59590e7bdb3f25ae) | `` automatic update `` |