### PR TITLE
chore(flake/srvos): `8e03bea7` -> `1d742203`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1011,11 +1011,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705346686,
-        "narHash": "sha256-lTf1b2I6wwNDhV5eEKIAMT5DOa43bK5KaPqDWH2yfek=",
+        "lastModified": 1705543670,
+        "narHash": "sha256-ipXBn/jPzpOn138ckp9Zm+ZzHkBVj3R04mJumGeTjAo=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "8e03bea707212a7225b0ab02a8186af8b1e98e0a",
+        "rev": "1d742203e3818f11522ba3eba2b0919f739445ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                 |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`1d742203`](https://github.com/nix-community/srvos/commit/1d742203e3818f11522ba3eba2b0919f739445ce) | `` dev/private/flake: add nix-darwin `` |
| [`faee6e92`](https://github.com/nix-community/srvos/commit/faee6e92c583fdbb6301946dc99246f967831dc7) | `` ci: re-enable automerge ``           |
| [`38253086`](https://github.com/nix-community/srvos/commit/38253086738db782b8ea2b32f502627fe959a461) | `` dev/private/flake.lock: Update ``    |
| [`d4b14169`](https://github.com/nix-community/srvos/commit/d4b1416945bf84fb0e0be507ceb758206f748e04) | `` flake.lock: Update ``                |