### PR TITLE
chore(flake/nur): `3c773fa3` -> `f9922340`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705539966,
-        "narHash": "sha256-RkNylawOa36vNRfmJpTcOHZ5g2drQ1s1zTqaGzNMd/o=",
+        "lastModified": 1705552804,
+        "narHash": "sha256-BP2tnJdbPhIqqjkbWri5A7xFVA6Nk+9V7cHBLEmXe2g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3c773fa3b438b5b06261f69167b609543caa8701",
+        "rev": "f99223402ec756b3f9f54666029c87edb78b2502",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f9922340`](https://github.com/nix-community/NUR/commit/f99223402ec756b3f9f54666029c87edb78b2502) | `` automatic update `` |
| [`5d4a5a69`](https://github.com/nix-community/NUR/commit/5d4a5a69aefe71df9860948364143f6b41171ddc) | `` automatic update `` |
| [`cc3f814b`](https://github.com/nix-community/NUR/commit/cc3f814b1ed18c0763ed781b48f0ccd59ac2e8e6) | `` automatic update `` |
| [`20d8d3c3`](https://github.com/nix-community/NUR/commit/20d8d3c30b4440dd5bbf0ac328ba2bf5cba1fc3d) | `` automatic update `` |
| [`04601475`](https://github.com/nix-community/NUR/commit/04601475300f553c98c6768bbba456d63840d044) | `` automatic update `` |
| [`6076a79b`](https://github.com/nix-community/NUR/commit/6076a79b8d26bc47091fe635760d958bc313fd94) | `` automatic update `` |