### PR TITLE
chore(flake/nur): `f9922340` -> `691d245e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705552804,
-        "narHash": "sha256-BP2tnJdbPhIqqjkbWri5A7xFVA6Nk+9V7cHBLEmXe2g=",
+        "lastModified": 1705556493,
+        "narHash": "sha256-DjU5tegm54GfUwqeQFCqGCtok9HhujWpRv1HM+x0jkY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f99223402ec756b3f9f54666029c87edb78b2502",
+        "rev": "691d245e369dfc04c1a60e3b98f564503758e098",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`691d245e`](https://github.com/nix-community/NUR/commit/691d245e369dfc04c1a60e3b98f564503758e098) | `` automatic update `` |