### PR TITLE
chore(flake/nur): `691d245e` -> `208f26d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705556493,
-        "narHash": "sha256-DjU5tegm54GfUwqeQFCqGCtok9HhujWpRv1HM+x0jkY=",
+        "lastModified": 1705560345,
+        "narHash": "sha256-QzYWwmS8kw1pzI/MEQpw6KTlIjSeqFvR2i6LXFM3xrE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "691d245e369dfc04c1a60e3b98f564503758e098",
+        "rev": "208f26d4d1c4b8e951a51357e20190a24cd3f304",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`208f26d4`](https://github.com/nix-community/NUR/commit/208f26d4d1c4b8e951a51357e20190a24cd3f304) | `` automatic update `` |