### PR TITLE
chore(flake/nur): `208f26d4` -> `2a8b3d0f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705560345,
-        "narHash": "sha256-QzYWwmS8kw1pzI/MEQpw6KTlIjSeqFvR2i6LXFM3xrE=",
+        "lastModified": 1705564330,
+        "narHash": "sha256-GR7yTEETo0CMWDIQJ18kyupPF+2GSMr9mBnzCVMOrhc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "208f26d4d1c4b8e951a51357e20190a24cd3f304",
+        "rev": "2a8b3d0f05e087ab9c38165d826946a97ab45c5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2a8b3d0f`](https://github.com/nix-community/NUR/commit/2a8b3d0f05e087ab9c38165d826946a97ab45c5e) | `` automatic update `` |
| [`45fe6e3a`](https://github.com/nix-community/NUR/commit/45fe6e3a6888a1a7666936038ded021ce1206325) | `` automatic update `` |