### PR TITLE
chore(flake/emacs-overlay): `9aaefc4e` -> `39f23b18`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705541748,
-        "narHash": "sha256-Vb3ahL5n8X5PnhMdhKYodBfZNrwNYf5mSSFVTVZwQA4=",
+        "lastModified": 1705567980,
+        "narHash": "sha256-++Ryg/WFi2zWbbGbZs/9Sp6FvjNSLmVVvHOpJFzRfS0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9aaefc4e713561e39a642e2a645777528b40fbdb",
+        "rev": "39f23b184ca4b191fbef420ba3f6f63a0895d68b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`39f23b18`](https://github.com/nix-community/emacs-overlay/commit/39f23b184ca4b191fbef420ba3f6f63a0895d68b) | `` Updated melpa `` |