### PR TITLE
chore(flake/nur): `2a8b3d0f` -> `516c74d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705564330,
-        "narHash": "sha256-GR7yTEETo0CMWDIQJ18kyupPF+2GSMr9mBnzCVMOrhc=",
+        "lastModified": 1705571074,
+        "narHash": "sha256-yPV1K5DP7GQZbXL8sGn7RNGJOBEwkAKyhEz5ReP5bJo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2a8b3d0f05e087ab9c38165d826946a97ab45c5e",
+        "rev": "516c74d45d21debcb58ee3da0570d80d68278ab4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`516c74d4`](https://github.com/nix-community/NUR/commit/516c74d45d21debcb58ee3da0570d80d68278ab4) | `` automatic update `` |
| [`3bc7e5ff`](https://github.com/nix-community/NUR/commit/3bc7e5ff2c0eaf2c20bf91bedb1b32683c58582c) | `` automatic update `` |
| [`51ae7d4b`](https://github.com/nix-community/NUR/commit/51ae7d4b33927abfde437cf08f125bb2e26e891d) | `` automatic update `` |