### PR TITLE
chore(flake/nur): `516c74d4` -> `e312882c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705571074,
-        "narHash": "sha256-yPV1K5DP7GQZbXL8sGn7RNGJOBEwkAKyhEz5ReP5bJo=",
+        "lastModified": 1705574747,
+        "narHash": "sha256-7efoWGU280kYJfefji85AG2iVFI7RjSGSWqOJWN3yw8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "516c74d45d21debcb58ee3da0570d80d68278ab4",
+        "rev": "e312882c07d2cbc289e5c60c34a23b2a8cd1c880",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e312882c`](https://github.com/nix-community/NUR/commit/e312882c07d2cbc289e5c60c34a23b2a8cd1c880) | `` automatic update `` |