### PR TITLE
chore(flake/nur): `e312882c` -> `9a4b285d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705574747,
-        "narHash": "sha256-7efoWGU280kYJfefji85AG2iVFI7RjSGSWqOJWN3yw8=",
+        "lastModified": 1705579103,
+        "narHash": "sha256-UFJDA73AWrg82QQq1MOZC2madN3B7yMARRLa/Cem7is=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e312882c07d2cbc289e5c60c34a23b2a8cd1c880",
+        "rev": "9a4b285d2da183fad6a7fefa5cd54dc68a20adf0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9a4b285d`](https://github.com/nix-community/NUR/commit/9a4b285d2da183fad6a7fefa5cd54dc68a20adf0) | `` automatic update `` |