### PR TITLE
chore(flake/nixpkgs): `c3e128f3` -> `842d9d80`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -777,11 +777,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1705316053,
-        "narHash": "sha256-J2Ey5mPFT8gdfL2XC0JTZvKaBw/b2pnyudEXFvl+dQM=",
+        "lastModified": 1705496572,
+        "narHash": "sha256-rPIe9G5EBLXdBdn9ilGc0nq082lzQd0xGGe092R/5QE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c3e128f3c0ecc1fb04aef9f72b3dcc2f6cecf370",
+        "rev": "842d9d80cfd4560648c785f8a4e6f3b096790e19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`e862ac6b`](https://github.com/NixOS/nixpkgs/commit/e862ac6b5ca280d3e41db71467f129839e47ee45) | `` element-{web,desktop}: 1.11.53 -> 1.11.54 (#281458) ``                    |
| [`01acbe0f`](https://github.com/NixOS/nixpkgs/commit/01acbe0fba4d0c5fb52fa6b86538750fa58e86fa) | `` libphonenumber: fix reproducible builds patch ``                          |
| [`c7f615d8`](https://github.com/NixOS/nixpkgs/commit/c7f615d8ab15c23961fd885123201f01321273f6) | `` prevo: adjust wrapper, loosen platforms ``                                |
| [`6c900ea1`](https://github.com/NixOS/nixpkgs/commit/6c900ea19a74aad802cadc1941a5fc907f36a645) | `` prevo*: move to pkgs/by-name ``                                           |
| [`7ec60593`](https://github.com/NixOS/nixpkgs/commit/7ec605930b289b9ca75817afe386103df7fe3a92) | `` pkgsMusl.systemd: fix build (#281323) ``                                  |
| [`2dca255f`](https://github.com/NixOS/nixpkgs/commit/2dca255f5e7cc4d4640b9f7b9186be1dba2bf5b5) | `` ocamlPackages.cmarkit: 0.2.0 -> 0.3.0 ``                                  |
| [`509fa455`](https://github.com/NixOS/nixpkgs/commit/509fa4552c92ef77491c92d1a96cb796fc94ee5b) | `` python311Packages.icalevents: relax deps ``                               |
| [`023a55f8`](https://github.com/NixOS/nixpkgs/commit/023a55f825a38a1bd939b4d8300c4b86a3f3c7fa) | `` yazi: 0.1.5 -> 0.2.1 ``                                                   |
| [`148cff9b`](https://github.com/NixOS/nixpkgs/commit/148cff9bff0f859b46ad5622d157ebaa95a1737d) | `` slskd: 0.18.2 -> 0.19.5 ``                                                |
| [`053e365c`](https://github.com/NixOS/nixpkgs/commit/053e365c0b4da1be7aa32632073438b1f886ccdc) | `` aws-sso-cli: 1.14.2 -> 1.14.3 ``                                          |
| [`7c3ecbdc`](https://github.com/NixOS/nixpkgs/commit/7c3ecbdce9e5f054e32e5d58c86399d5f2375a6b) | `` nixos/invoiceplane: add nginx as a webserver option for invoiceplane ``   |
| [`d09e4541`](https://github.com/NixOS/nixpkgs/commit/d09e454114b2930f847ea9337f7e0b12a8103fdf) | `` fix: tmux-plugins binary path ``                                          |
| [`d9097c0a`](https://github.com/NixOS/nixpkgs/commit/d9097c0a2b8dc510901ff7428868fb6ebeebdbc1) | `` typst-preview: 0.9.2 -> 0.10.5 ``                                         |
| [`ffe76ea5`](https://github.com/NixOS/nixpkgs/commit/ffe76ea5e23e80c4ea79cf8beba6e59fae975f5b) | `` likwid: init at 5.3.0 ``                                                  |
| [`05b06094`](https://github.com/NixOS/nixpkgs/commit/05b060948bb846e2c6be0e98d5bed3c5cfed801d) | `` python311Packages.pyatag: exclude from bulk updates ``                    |
| [`d7a396b3`](https://github.com/NixOS/nixpkgs/commit/d7a396b3c4f805bbb498a9cbffeac1d7eb833a88) | `` python311Packages.securetar: refactor ``                                  |
| [`d34e1df8`](https://github.com/NixOS/nixpkgs/commit/d34e1df8e83c956340d5aae372b7ce77a09f790b) | `` python311Packages.securetar: 2023.3.0 -> 2023.12.0 ``                     |
| [`c2c0bb75`](https://github.com/NixOS/nixpkgs/commit/c2c0bb756546a1cb1fe24ac3a0d3b38555839bd6) | `` python311Packages.freebox-api: relax urllib3 constraint ``                |
| [`3c98d743`](https://github.com/NixOS/nixpkgs/commit/3c98d74363717419729c98bb58366923bf963ccf) | `` python311Packages.meteofrance-api: relax urllib3 constraint ``            |
| [`bdcc187a`](https://github.com/NixOS/nixpkgs/commit/bdcc187afa745557c860478f1590e230506fcf0a) | `` python311Packages.xiaomi-ble: relax pycryptodomex constraint ``           |
| [`40929299`](https://github.com/NixOS/nixpkgs/commit/40929299ec130308e0bec1aa45f1edba079dc6ba) | `` zapzap: 4.5.5.2 -> 5.1.3 ``                                               |
| [`f7704151`](https://github.com/NixOS/nixpkgs/commit/f770415172caff1f0a00630d0414237d8dd0c5e9) | `` python311Packages.miauth: 0.9.1 -> 0.9.7 ``                               |
| [`0ecd7c6e`](https://github.com/NixOS/nixpkgs/commit/0ecd7c6eaf771632607f48f8da424a83dc2ac07b) | `` ungit: 1.5.24 -> 1.5.25 ``                                                |
| [`22c1c3ce`](https://github.com/NixOS/nixpkgs/commit/22c1c3ce37201039f18a28a33f4802d3fefb2460) | `` octodns-providers.powerdns: remove wheel ``                               |
| [`6e52aa8d`](https://github.com/NixOS/nixpkgs/commit/6e52aa8d5645cee744d8d299d51551be5556db72) | `` octodns-providers.hetzner: remove wheel ``                                |
| [`97150e38`](https://github.com/NixOS/nixpkgs/commit/97150e381a6757ed92e33bd02ce78f406b85db74) | `` octodns-providers.gandi: remove wheel ``                                  |
| [`41f479b9`](https://github.com/NixOS/nixpkgs/commit/41f479b9ef9e36831f7baba2b25cb32f99607d1f) | `` octodns-providers.bind: remove wheel ``                                   |
| [`92833041`](https://github.com/NixOS/nixpkgs/commit/92833041e3e47448f075fd00eea66240729a3377) | `` octodns: remove wheel ``                                                  |
| [`0dc128c6`](https://github.com/NixOS/nixpkgs/commit/0dc128c6fc4b0e222212bde385be05a030ee5c2f) | `` CODEOWNERS: add janik to octodns ``                                       |
| [`2316bf39`](https://github.com/NixOS/nixpkgs/commit/2316bf39cd0c89ab31aee49067f9457801a723cc) | `` xdg-desktop-portal-hyprland: 1.2.6 -> 1.3.1 ``                            |
| [`065e614c`](https://github.com/NixOS/nixpkgs/commit/065e614cde0ae042f11a9b87edbcdcb1dec01828) | `` fwupd-efi: 1.3 → 1.4 ``                                                   |
| [`0351ba00`](https://github.com/NixOS/nixpkgs/commit/0351ba003f4933edb3035edff0a798a2a4290152) | `` pythonPackages.pyosmium: fix build ``                                     |
| [`3b5fd3ff`](https://github.com/NixOS/nixpkgs/commit/3b5fd3ff818b0ebafed1dbb937bef6dd945e7553) | `` poetry: fix tests on Darwin ``                                            |
| [`84f81517`](https://github.com/NixOS/nixpkgs/commit/84f815170f6761af5aacbf43c783fb226488fffa) | `` electrum: 4.4.6 -> 4.5.0 ``                                               |
| [`2c35131a`](https://github.com/NixOS/nixpkgs/commit/2c35131a7caafcfd192f3b29d0435e51957466d5) | `` tilemaker: 2.4.0 -> 3.0.0 ``                                              |
| [`8cfd22b8`](https://github.com/NixOS/nixpkgs/commit/8cfd22b876c51ad048284ee7697574bfd855431e) | `` reproc: fix build, add upstream patches for gcc-13 ``                     |
| [`6d5f575f`](https://github.com/NixOS/nixpkgs/commit/6d5f575fd0bc6bb9abc953354cc67eac025f0517) | `` check-by-name: Remove legacy script ``                                    |
| [`82f17760`](https://github.com/NixOS/nixpkgs/commit/82f177603566265d6d37218e40110378e101f10c) | `` licensee: 9.16.0 -> 9.16.1 ``                                             |
| [`c86b13ed`](https://github.com/NixOS/nixpkgs/commit/c86b13ed6db7fe1ea3325218e30a3d9fa9705e71) | `` cudaPackages: __structuredAttrs works with autoPatchelf since #272752 ``  |
| [`35d3a70a`](https://github.com/NixOS/nixpkgs/commit/35d3a70aa46f5f8f242ccfedb73822eaa70f303f) | `` matrix-synapse-unwrapped: 1.98.0 -> 1.99.0 ``                             |
| [`b799c25f`](https://github.com/NixOS/nixpkgs/commit/b799c25fe85008cb9bba7a04ff216d740cf574ff) | `` hyprlang: init at 0.2.1 ``                                                |
| [`0f27917d`](https://github.com/NixOS/nixpkgs/commit/0f27917d9afb22106362942c30cb4547bd0a1142) | `` tests.nixpkgs-check-by-name: Don't error for pkgs/by-name aliases ``      |
| [`3ebd239c`](https://github.com/NixOS/nixpkgs/commit/3ebd239cd5645f679b45f7f843fc4cc67a281ea4) | `` tests.nixpkgs-check-by-name: Test on the current Nixpkgs ``               |
| [`91b754ed`](https://github.com/NixOS/nixpkgs/commit/91b754edff9120b6dd868e61b2f50348f465a0d1) | `` tests.nixpkgs-check-by-name: Minor Nix build refactor ``                  |
| [`479ea66d`](https://github.com/NixOS/nixpkgs/commit/479ea66d213f40e056a1f425ff3c871b854351b6) | `` surrealdb: 1.0.2 -> 1.1.1 ``                                              |
| [`0c2a29ec`](https://github.com/NixOS/nixpkgs/commit/0c2a29ecd4e4a5c37aaa28a85864175438c2bea2) | `` cutemaze: 1.3.2 -> 1.3.3 ``                                               |
| [`5ec01e69`](https://github.com/NixOS/nixpkgs/commit/5ec01e69b48345d32cf8f2a6e02782a727167451) | `` scalpel: init at 2.1 ``                                                   |
| [`cc422e32`](https://github.com/NixOS/nixpkgs/commit/cc422e321e33f0e0f9fa085df71efbfd089bd914) | `` workflows/check-by-name: Pin nixpkgs-check-by-name tool ``                |
| [`9264d7f3`](https://github.com/NixOS/nixpkgs/commit/9264d7f30a053d55f5975484e6d65437e0eae9fe) | `` clairvoyant: init at 3.1.2 ``                                             |
| [`a4c7cc9b`](https://github.com/NixOS/nixpkgs/commit/a4c7cc9b69c97f97e9a0b4a389cfb9ddf7f23637) | `` chess-clock: init at 0.6.0 ``                                             |
| [`0c41a38c`](https://github.com/NixOS/nixpkgs/commit/0c41a38ced0de9abff3bb000be0fd44326b12f08) | `` formatjson5: init at 0.2.6 ``                                             |
| [`2ccf45ee`](https://github.com/NixOS/nixpkgs/commit/2ccf45ee95e4ceba8365837d773e284030e28d6f) | `` ci: Fix nix-parse workflow ``                                             |
| [`732296bb`](https://github.com/NixOS/nixpkgs/commit/732296bb50c1683400b990ba286ae89ea77cc485) | `` linuxPackages.nvidiaPackages.production: 535.146.02 -> 535.154.05 ``      |
| [`94368076`](https://github.com/NixOS/nixpkgs/commit/94368076f77f9d393c7082c4b785a1ff6330b7c8) | `` vice: 3.7.1 -> 3.8 ``                                                     |
| [`8705b093`](https://github.com/NixOS/nixpkgs/commit/8705b09357af1806bc51a0301c79ea5b2fa51a3d) | `` oh-my-posh: 18.26.1 -> 19.6.0 ``                                          |
| [`ecb201b9`](https://github.com/NixOS/nixpkgs/commit/ecb201b99ee6ddac2869ea6e3a9e4d9e36105ec4) | `` unifi-protect-backup: add aiolimiter ``                                   |
| [`319aff8d`](https://github.com/NixOS/nixpkgs/commit/319aff8d5b06fe5fe87a68d41ef99bedaa4352ad) | `` prometheus-nats-exporter: 0.13.0 -> 0.14.0 ``                             |
| [`3b22cec4`](https://github.com/NixOS/nixpkgs/commit/3b22cec4600677335e32a6956abf0af7bf3302cc) | `` xwayland: 23.2.3 -> 23.2.4 ``                                             |
| [`a3b999b1`](https://github.com/NixOS/nixpkgs/commit/a3b999b17ff44a3a5bd25cb7fbaa3a2034f667df) | `` xorg.xserver: 21.1.10 -> 21.1.11 ``                                       |
| [`fa83d552`](https://github.com/NixOS/nixpkgs/commit/fa83d552b8eaa16bcc058a0b3be0c3eae76dc0bd) | `` x11: sort pkg-config modules ``                                           |
| [`495b938c`](https://github.com/NixOS/nixpkgs/commit/495b938c3b1c5fe6c753705a60b2c673f8f41c6f) | `` electrum: add QtWayland and certifi ``                                    |
| [`f45863e4`](https://github.com/NixOS/nixpkgs/commit/f45863e49e8dc19458c0a843492f14025deb1983) | `` xfce.xfce4-notes-plugin: 1.10.0 -> 1.11.0 ``                              |
| [`03649bfd`](https://github.com/NixOS/nixpkgs/commit/03649bfdf23866ecfdf373d259615a60adfd0239) | `` python3Packages.flask-security-too: fix for webauth 2 ``                  |
| [`ea5285c1`](https://github.com/NixOS/nixpkgs/commit/ea5285c15d7bc68c2673a1721cf07783e1322eee) | `` python311Packages.syncedlyrics: 0.7.0 -> 0.8.0 ``                         |
| [`d6c1cdcc`](https://github.com/NixOS/nixpkgs/commit/d6c1cdcc30cbe00c7e7fd691446f0436dce8c2eb) | `` mdcat: add changelog to meta ``                                           |
| [`e0ed4302`](https://github.com/NixOS/nixpkgs/commit/e0ed43027e6aa228f006e4a70a77f7f7baf93bf6) | `` python311Packages.twilio: 8.11.0 -> 8.11.1 ``                             |
| [`f5f34e91`](https://github.com/NixOS/nixpkgs/commit/f5f34e91d79ccfd07a0eecb17d35a39aeabbe96d) | `` python3Packages.libagent: 0.14.5 -> 0.14.8 ``                             |
| [`e75479d0`](https://github.com/NixOS/nixpkgs/commit/e75479d0a63c28ea099c7aea51ff8bbbb3d68cbe) | `` python3Packages.ledgerblue: enable build on darwin ``                     |
| [`fbb61615`](https://github.com/NixOS/nixpkgs/commit/fbb6161527665e3788a9cfdea145489ca383ef0a) | `` cloudlist: refactor ``                                                    |
| [`1d026627`](https://github.com/NixOS/nixpkgs/commit/1d026627702bf8a2654d904f8c4bef133a7207c7) | `` cloudlist: 1.0.4 -> 1.0.6 ``                                              |
| [`b0209635`](https://github.com/NixOS/nixpkgs/commit/b0209635c0494482f910a699f8b671029863c4cc) | `` linux_4_19: 4.19.304 -> 4.19.305 ``                                       |
| [`34b2bea9`](https://github.com/NixOS/nixpkgs/commit/34b2bea9f7962261fd21930d645d1b3fb09bc63b) | `` linux_5_4: 5.4.266 -> 5.4.267 ``                                          |
| [`8140229b`](https://github.com/NixOS/nixpkgs/commit/8140229b0bb0e8e2c6adf616f576545d3ffbee9d) | `` linux_5_10: 5.10.207 -> 5.10.208 ``                                       |
| [`98c3e64d`](https://github.com/NixOS/nixpkgs/commit/98c3e64d968ec1500b7e4396574a77362a17dea9) | `` linux_5_15: 5.15.146 -> 5.15.147 ``                                       |
| [`2a0eb313`](https://github.com/NixOS/nixpkgs/commit/2a0eb3136163209040fe57cf6b7edb5fca728bd5) | `` linux_6_1: 6.1.72 -> 6.1.73 ``                                            |
| [`4c7712d2`](https://github.com/NixOS/nixpkgs/commit/4c7712d2f542f8a1898d0dda0980bd7bcf83c51e) | `` linux_6_6: 6.6.11 -> 6.6.12 ``                                            |
| [`c5974d0e`](https://github.com/NixOS/nixpkgs/commit/c5974d0e1600c205678655e0df68a5bc9032ef62) | `` checkov: 3.1.60 -> 3.1.62 ``                                              |
| [`b5ccd620`](https://github.com/NixOS/nixpkgs/commit/b5ccd620cc07eea03b6304a0fa857a66b5a8e1fc) | `` mdcat: 2.1.0 -> 2.1.1 ``                                                  |
| [`b5acb600`](https://github.com/NixOS/nixpkgs/commit/b5acb600cc565ee6464bad70f5cd49aa169831f2) | `` octodns-providers.gandi: init at 0.0.2 ``                                 |
| [`35ff104e`](https://github.com/NixOS/nixpkgs/commit/35ff104e602c67390943e24878030f681dc4ab7a) | `` python311Packages.brother: migrate to lextudio pysnmp flavor ``           |
| [`45a67b4d`](https://github.com/NixOS/nixpkgs/commit/45a67b4d930e8849bd990f268cfb7065f835e84e) | `` python311Packages.pysnmp-lextudio: init at 5.0.33 ``                      |
| [`b86c5299`](https://github.com/NixOS/nixpkgs/commit/b86c5299ccae478e5ad6aaf2a1c3d20b20db745a) | `` python311Packages.pysnmpcrypto: init at 0.0.4 ``                          |
| [`ed829b9e`](https://github.com/NixOS/nixpkgs/commit/ed829b9ed8e32e69c274dee79518525960e5f6d6) | `` python311Packages.asn1tools: add pytest-xdist ``                          |
| [`c143177e`](https://github.com/NixOS/nixpkgs/commit/c143177e25c0574ed3e28954f4f7677c7b803700) | `` python311Packages.pyasyncore: init at 1.0.2 ``                            |
| [`69181403`](https://github.com/NixOS/nixpkgs/commit/69181403dc5f7ec622ea6c9af125117c93fd371b) | `` python311Packages.homeassistant-stubs: 2024.1.2 -> 2024.1.3 ``            |
| [`d1ccaa43`](https://github.com/NixOS/nixpkgs/commit/d1ccaa431bbbde1c7207529d685d53acdc5fc4d8) | `` python311Packages.aio-geojson-generic-client: relax geojson constraint `` |
| [`c4977750`](https://github.com/NixOS/nixpkgs/commit/c4977750ef439c409206cd55346f0fa445fa0ec6) | `` python311Packages.aio-geojson-client: 0.19 -> 0.20 ``                     |
| [`d8d70ae5`](https://github.com/NixOS/nixpkgs/commit/d8d70ae5425c5b171ef603bf56500b269f64a508) | `` home-assistant: 2024.1.2 -> 2024.1.3 ``                                   |
| [`92bb0e55`](https://github.com/NixOS/nixpkgs/commit/92bb0e55e7be4f8a5d07f78e781ae9e669e230cb) | `` python311Packages.asn1tools: disable failing tests ``                     |
| [`8a38f6f6`](https://github.com/NixOS/nixpkgs/commit/8a38f6f6f27d229936e35ade4e3c5263b3a12441) | `` python311Packages.mcstatus: 11.1.0 -> 11.1.1 ``                           |
| [`6b08b527`](https://github.com/NixOS/nixpkgs/commit/6b08b527485d57064b29c54b1c32471a366b56c0) | `` python311Packages.bluetooth-adapters: 0.16.2 -> 0.17.0 ``                 |
| [`5ba6e0cb`](https://github.com/NixOS/nixpkgs/commit/5ba6e0cbb747a9457ce6caf94ccb3227f991bbed) | `` python311Packages.bluetooth-auto-recovery: 1.2.3 -> 1.3.0 ``              |
| [`f03c8a03`](https://github.com/NixOS/nixpkgs/commit/f03c8a036d1af7d4059a4b0ab8f3dfa4273dbc65) | `` python311Packages.home-assistant-bluetooth: 1.11.0 -> 1.12.0 ``           |
| [`c7cd3a3a`](https://github.com/NixOS/nixpkgs/commit/c7cd3a3aff47a5af9da1141ee6f99c54d3e3e5a9) | `` python311Packages.habluetooth: 2.0.2 -> 2.1.0 ``                          |
| [`f6bb6c22`](https://github.com/NixOS/nixpkgs/commit/f6bb6c22c3891ec2377ad73bbf5ed9f8621d2e34) | `` python311Packages.aioshelly: 7.0.0 -> 7.1.0 ``                            |
| [`e8500af5`](https://github.com/NixOS/nixpkgs/commit/e8500af5c57c4b3c458b7bef0fa31d925ae06ae4) | `` edusong: update http url to https ``                                      |
| [`ae8abf36`](https://github.com/NixOS/nixpkgs/commit/ae8abf36cfcdad2ccc3bf3e9c4ca7089021c51e7) | `` anydesk: fix desktop file ``                                              |
| [`e31d14b5`](https://github.com/NixOS/nixpkgs/commit/e31d14b5e540f919a6a817f308023f88ed186100) | `` meilisearch: 1.5.0 -> 1.6.0 ``                                            |
| [`ffe06954`](https://github.com/NixOS/nixpkgs/commit/ffe069543444f8b9b409d09b292486cd344a13b0) | `` lnd: 0.17.0-beta -> 0.17.3-beta ``                                        |
| [`e62550ba`](https://github.com/NixOS/nixpkgs/commit/e62550bad0bd89cff09da766d1e2a116bb45566a) | `` theharvester: add mainProgram ``                                          |
| [`27804ebd`](https://github.com/NixOS/nixpkgs/commit/27804ebd4af145beef37cc18ec392143b493ce56) | `` theharvester: relax dependencies ``                                       |
| [`9344875c`](https://github.com/NixOS/nixpkgs/commit/9344875c7c187106de4cf6bdac427efb55a03e51) | `` ircdog: 0.5.1 -> 0.5.2 ``                                                 |
| [`59ed7cae`](https://github.com/NixOS/nixpkgs/commit/59ed7caeedcd5b775b3a09a3c421a103306bfe43) | `` opencv3: build with openexr 3 (#279918) ``                                |