### PR TITLE
chore(flake/emacs-overlay): `4baba64e` -> `68ce1f4f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705579015,
-        "narHash": "sha256-osKcl4saYzbcVUJLdunSyfEBz2OODLckhBuhp4wf4P0=",
+        "lastModified": 1705596796,
+        "narHash": "sha256-PrHtvMCyWhGU2pGdKREkuct1LtH9f9B/WHut3hYRobg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4baba64e8088c2cdbde661d6697d1fff3ba59f6d",
+        "rev": "68ce1f4f6c8d1c0fc9ee3d9febac9fd62e527647",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`68ce1f4f`](https://github.com/nix-community/emacs-overlay/commit/68ce1f4f6c8d1c0fc9ee3d9febac9fd62e527647) | `` Updated melpa ``        |
| [`4e2567af`](https://github.com/nix-community/emacs-overlay/commit/4e2567af3a540d4c9e5512b3f70589b9d7ec181b) | `` Updated elpa ``         |
| [`10ebdcc9`](https://github.com/nix-community/emacs-overlay/commit/10ebdcc9777f3accf780ff2a66da3052445a05b6) | `` Updated flake inputs `` |