### PR TITLE
chore(flake/nur): `ac0ade06` -> `b417bdc5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705588933,
-        "narHash": "sha256-W47+gUkJ4TW4jhYegKPjLIocead23smTW+yz64DrE1A=",
+        "lastModified": 1705600534,
+        "narHash": "sha256-b+koVDd9CsPovaHX32sUhXn8iLfQYWDCNI5SFSR/9vU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ac0ade06f6ef7b095567c58b2a62c62837358480",
+        "rev": "b417bdc500787ba21935e34c676f0eb009b7a9a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                              |
| -------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`b417bdc5`](https://github.com/nix-community/NUR/commit/b417bdc500787ba21935e34c676f0eb009b7a9a3) | `` automatic update ``               |
| [`ec2cb59e`](https://github.com/nix-community/NUR/commit/ec2cb59e4d9da7c7c4cb0882de698ba7633fc539) | `` added Ex-32 repo to repos.json `` |
| [`56e9a4c0`](https://github.com/nix-community/NUR/commit/56e9a4c0e034499dbf48ef58a9555fc4b0d5333f) | `` automatic update ``               |