### PR TITLE
chore(flake/nur): `66c3aec5` -> `d94a031e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705602701,
-        "narHash": "sha256-FkR40ElbG1pW3f/mpSzbRON9Tjx5pkT2IBWNtd3YKDQ=",
+        "lastModified": 1705607056,
+        "narHash": "sha256-UTBLGHKCyPcXnVVAry3JazKTPuuQz4uzDZQrie0H8Z4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "66c3aec51e9d40381a053798de41b5e477d4b665",
+        "rev": "d94a031eb1ca4d4aa34eb49b4916f8d0e82dd089",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d94a031e`](https://github.com/nix-community/NUR/commit/d94a031eb1ca4d4aa34eb49b4916f8d0e82dd089) | `` automatic update `` |
| [`67bd5c7e`](https://github.com/nix-community/NUR/commit/67bd5c7e6189cbc8134756754b6ec8a19222cde2) | `` automatic update `` |