### PR TITLE
chore(flake/nur): `d94a031e` -> `45e99e80`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705607056,
-        "narHash": "sha256-UTBLGHKCyPcXnVVAry3JazKTPuuQz4uzDZQrie0H8Z4=",
+        "lastModified": 1705617906,
+        "narHash": "sha256-KPsZU00iPK6+XpUbTTHvIRWrsLAt0jfi367Gcxyxpto=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d94a031eb1ca4d4aa34eb49b4916f8d0e82dd089",
+        "rev": "45e99e80a0f25e50905f9da6153048136c4c7f64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`45e99e80`](https://github.com/nix-community/NUR/commit/45e99e80a0f25e50905f9da6153048136c4c7f64) | `` automatic update `` |