### PR TITLE
chore(flake/emacs-overlay): `68ce1f4f` -> `eaf998b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705596796,
-        "narHash": "sha256-PrHtvMCyWhGU2pGdKREkuct1LtH9f9B/WHut3hYRobg=",
+        "lastModified": 1705626181,
+        "narHash": "sha256-NsNOHNjK1Xl0KhVpDvMgT3FkZxMqyRwOqYSQA0sS+Zo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "68ce1f4f6c8d1c0fc9ee3d9febac9fd62e527647",
+        "rev": "eaf998b4ab1397000afeeced036fcb55e61750dd",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1705331948,
-        "narHash": "sha256-qjQXfvrAT1/RKDFAMdl8Hw3m4tLVvMCc8fMqzJv0pP4=",
+        "lastModified": 1705458851,
+        "narHash": "sha256-uQvEhiv33Zj/Pv364dTvnpPwFSptRZgVedDzoM+HqVg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b8dd8be3c790215716e7c12b247f45ca525867e2",
+        "rev": "8bf65f17d8070a0a490daf5f1c784b87ee73982c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`eaf998b4`](https://github.com/nix-community/emacs-overlay/commit/eaf998b4ab1397000afeeced036fcb55e61750dd) | `` Updated elpa ``         |
| [`eeb8da16`](https://github.com/nix-community/emacs-overlay/commit/eeb8da168b6882e54d66b960a2ee9490663b6a7d) | `` Updated flake inputs `` |