### PR TITLE
chore(flake/nur): `45e99e80` -> `e004fc4f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705617906,
-        "narHash": "sha256-KPsZU00iPK6+XpUbTTHvIRWrsLAt0jfi367Gcxyxpto=",
+        "lastModified": 1705636615,
+        "narHash": "sha256-SAxc5twZX4ro2AfF7Aaac4TKtszpVAhevjl6MXL5Tzc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "45e99e80a0f25e50905f9da6153048136c4c7f64",
+        "rev": "e004fc4f6dc5a3016f624e714c6d99460bc84c41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e004fc4f`](https://github.com/nix-community/NUR/commit/e004fc4f6dc5a3016f624e714c6d99460bc84c41) | `` automatic update `` |
| [`fbdc1ba8`](https://github.com/nix-community/NUR/commit/fbdc1ba81e9a5121386e64f54a1eff41dc47e8bc) | `` automatic update `` |