### PR TITLE
chore(flake/nur): `e004fc4f` -> `54adff74`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705636615,
-        "narHash": "sha256-SAxc5twZX4ro2AfF7Aaac4TKtszpVAhevjl6MXL5Tzc=",
+        "lastModified": 1705646672,
+        "narHash": "sha256-Yx/0VhZL5cV57fKEKft7E5chvvCETZHyJ6VgxlJkvek=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e004fc4f6dc5a3016f624e714c6d99460bc84c41",
+        "rev": "54adff742c899c6f7c61420171eb7e5050b21a1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`54adff74`](https://github.com/nix-community/NUR/commit/54adff742c899c6f7c61420171eb7e5050b21a1f) | `` automatic update `` |