### PR TITLE
chore(flake/nur): `54adff74` -> `4fb9a66e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705646672,
-        "narHash": "sha256-Yx/0VhZL5cV57fKEKft7E5chvvCETZHyJ6VgxlJkvek=",
+        "lastModified": 1705650738,
+        "narHash": "sha256-5mAUrfIdnxlFv2llDjIhGiJLixW3plcBp8B2+xuIUV0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "54adff742c899c6f7c61420171eb7e5050b21a1f",
+        "rev": "4fb9a66e564c5d0b8e2393473e225a2827579bcf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4fb9a66e`](https://github.com/nix-community/NUR/commit/4fb9a66e564c5d0b8e2393473e225a2827579bcf) | `` automatic update `` |