### PR TITLE
chore(flake/home-manager): `b84191db` -> `2064348e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705535278,
-        "narHash": "sha256-V5+XKfNbiY0bLKLQlH+AXyhHttEL7XcZBH9iSbxxexA=",
+        "lastModified": 1705660020,
+        "narHash": "sha256-1tOuNh+UbiZlaC8RrpQzzypgnLBC67eRlBunfkE4sbQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b84191db127c16a92cbdf7f7b9969d58bb456699",
+        "rev": "2064348e555b6aa963da6372a8f14e6acb80a176",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`2064348e`](https://github.com/nix-community/home-manager/commit/2064348e555b6aa963da6372a8f14e6acb80a176) | `` hyprland: do not override existing plugins settings in config `` |
| [`d6185e83`](https://github.com/nix-community/home-manager/commit/d6185e83d864a4a73d5e6655ab7410c074c0657c) | `` docs, tests: revert to fetchTarball for nmd and nmt ``           |