### PR TITLE
chore(flake/nur): `4fb9a66e` -> `0297e17e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705650738,
-        "narHash": "sha256-5mAUrfIdnxlFv2llDjIhGiJLixW3plcBp8B2+xuIUV0=",
+        "lastModified": 1705660485,
+        "narHash": "sha256-+N17fzZAjvQSvLraUnabFpCjv/q6iPOBvpctmvH/vqk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4fb9a66e564c5d0b8e2393473e225a2827579bcf",
+        "rev": "0297e17e7a1c5246cd1fba75c0353c8dae24ad7b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0297e17e`](https://github.com/nix-community/NUR/commit/0297e17e7a1c5246cd1fba75c0353c8dae24ad7b) | `` automatic update `` |