### PR TITLE
chore(flake/nur): `43df15e3` -> `b68b7cf3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705663615,
-        "narHash": "sha256-dR+zPH3q8vVhliYM3W152RqT0YlFO8Nt421wdva53hk=",
+        "lastModified": 1705668878,
+        "narHash": "sha256-avadoMOXwHeMpo3o1inLgksQWP4D49IDuv3KOwQSP1Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "43df15e3feb5ef80aa41d49876fbf5bd860b355a",
+        "rev": "b68b7cf37a4d34c12c4b7d76d8ac6cedca6817ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b68b7cf3`](https://github.com/nix-community/NUR/commit/b68b7cf37a4d34c12c4b7d76d8ac6cedca6817ed) | `` automatic update `` |
| [`a00a6151`](https://github.com/nix-community/NUR/commit/a00a61515a07be0cb55e76c981ef3fbfe875fbe0) | `` automatic update `` |