### PR TITLE
chore(flake/nur): `b68b7cf3` -> `7d8494cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705668878,
-        "narHash": "sha256-avadoMOXwHeMpo3o1inLgksQWP4D49IDuv3KOwQSP1Y=",
+        "lastModified": 1705880023,
+        "narHash": "sha256-ygbL2ewxuoOvPQ9VDaf31nigmkwc0jbwFIqoJyYJ/sA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b68b7cf37a4d34c12c4b7d76d8ac6cedca6817ed",
+        "rev": "7d8494cbcbcc26d90d87e77a0f3a62459fbbf05c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7d8494cb`](https://github.com/nix-community/NUR/commit/7d8494cbcbcc26d90d87e77a0f3a62459fbbf05c) | `` automatic update `` |
| [`f0a4f546`](https://github.com/nix-community/NUR/commit/f0a4f546d8aaa4ee0ccf9e907ee12ce9121fffc4) | `` automatic update `` |
| [`1b6ca600`](https://github.com/nix-community/NUR/commit/1b6ca600ff9357fa500a9e636bb15e59b2599e5f) | `` automatic update `` |
| [`2072630f`](https://github.com/nix-community/NUR/commit/2072630fec40fe24c905f508f7b8a2cf27b3f277) | `` automatic update `` |
| [`43740fb4`](https://github.com/nix-community/NUR/commit/43740fb42099d9814c6d290c15722feedc2f9ce1) | `` automatic update `` |
| [`906a8697`](https://github.com/nix-community/NUR/commit/906a86978c205e6043a1ad11692f9766c2774880) | `` automatic update `` |
| [`15971653`](https://github.com/nix-community/NUR/commit/15971653a2e5ed1d67c01d0c00c4e3e3b84bea0c) | `` automatic update `` |
| [`2b4a30cd`](https://github.com/nix-community/NUR/commit/2b4a30cde35eb5b7813c731aa26fc475a27c723e) | `` automatic update `` |
| [`bfd7ae8f`](https://github.com/nix-community/NUR/commit/bfd7ae8fd550bbae107547934fdb9d3dd04bb592) | `` automatic update `` |
| [`2fe90f24`](https://github.com/nix-community/NUR/commit/2fe90f24673e65191c8c9c7f5207a7d936decf51) | `` automatic update `` |
| [`6364d3aa`](https://github.com/nix-community/NUR/commit/6364d3aa72c8f16787a187a0a3967cd83911dd76) | `` automatic update `` |
| [`0f826a07`](https://github.com/nix-community/NUR/commit/0f826a07b9f2b7110fd811d334357461734df579) | `` automatic update `` |
| [`d798727f`](https://github.com/nix-community/NUR/commit/d798727f69dd62b67b17dc99d35691f9c6b44b96) | `` automatic update `` |
| [`035838c4`](https://github.com/nix-community/NUR/commit/035838c4b3844d36c399df306b7d537f905cfda4) | `` automatic update `` |
| [`246a0315`](https://github.com/nix-community/NUR/commit/246a031505b2c9043e82fcabd551f5dcded77c2d) | `` automatic update `` |
| [`907ca905`](https://github.com/nix-community/NUR/commit/907ca905eab246a08be6f652cb94e2e7ef81e9d0) | `` automatic update `` |
| [`caa9ee7b`](https://github.com/nix-community/NUR/commit/caa9ee7ba5c583ad1e46199ebcaad0ff57ed3992) | `` automatic update `` |
| [`ff6497ef`](https://github.com/nix-community/NUR/commit/ff6497ef576a1d88ef7ecb7e40e3a7cd9a410b2b) | `` automatic update `` |
| [`3c0ac654`](https://github.com/nix-community/NUR/commit/3c0ac654b9ef21a3dc6960cd2b311e458ff9b48d) | `` automatic update `` |
| [`c39b293f`](https://github.com/nix-community/NUR/commit/c39b293ff897568c488372823230ec46b5b1b841) | `` automatic update `` |
| [`26884905`](https://github.com/nix-community/NUR/commit/26884905e6e16577275d60f3985861eec185afa4) | `` automatic update `` |
| [`65380eec`](https://github.com/nix-community/NUR/commit/65380eec6e39c81a064b44d43d706599c9d8320d) | `` automatic update `` |
| [`eee17bb6`](https://github.com/nix-community/NUR/commit/eee17bb61f9a6dff151a595cbc2d75e6918768fe) | `` automatic update `` |
| [`09a43e5c`](https://github.com/nix-community/NUR/commit/09a43e5cb3c252dccd2ef00e7f3607a9573f4d05) | `` automatic update `` |
| [`93a3c398`](https://github.com/nix-community/NUR/commit/93a3c3987677fc28e66b8876f9e5a2712d79b918) | `` automatic update `` |
| [`8cf1886e`](https://github.com/nix-community/NUR/commit/8cf1886e854410b982ace2f2263cf570d5f6b730) | `` automatic update `` |
| [`4a37f776`](https://github.com/nix-community/NUR/commit/4a37f7768e7c0d2a1a6bb21bb1568f1fe4c7c66a) | `` automatic update `` |
| [`313c3c10`](https://github.com/nix-community/NUR/commit/313c3c1063318216b51b9691902fc285f5b1b7ae) | `` automatic update `` |
| [`5600a7b7`](https://github.com/nix-community/NUR/commit/5600a7b720cc0ba8134d64c88d132d94fcc3ae78) | `` automatic update `` |
| [`43c32d3b`](https://github.com/nix-community/NUR/commit/43c32d3bc27361bbdba050977fe6a40dc7fce128) | `` automatic update `` |
| [`ce4b47f0`](https://github.com/nix-community/NUR/commit/ce4b47f0d290e2f5b8f088a82a9b810cbe90afa3) | `` automatic update `` |
| [`d57a0ad1`](https://github.com/nix-community/NUR/commit/d57a0ad143f0f42883a1ff824344a06995157c9f) | `` automatic update `` |
| [`883f061d`](https://github.com/nix-community/NUR/commit/883f061dd30e40bb06f1ed490ab073cb18c41a41) | `` automatic update `` |
| [`238f73f6`](https://github.com/nix-community/NUR/commit/238f73f63e2c0a0fd894d95ebeb09c3daddc5801) | `` automatic update `` |
| [`eca40357`](https://github.com/nix-community/NUR/commit/eca403570fcf05edcbcfd6142d25d4f7a5f55e32) | `` automatic update `` |
| [`74f84f4b`](https://github.com/nix-community/NUR/commit/74f84f4bb3b36de03f205a75609eca91fe7332e2) | `` automatic update `` |
| [`f8acdb36`](https://github.com/nix-community/NUR/commit/f8acdb369de0846742840c1b19026f81df6af24b) | `` automatic update `` |
| [`5ee948b8`](https://github.com/nix-community/NUR/commit/5ee948b8a5f654ad91a1d6db22ab2f89e928ae1e) | `` automatic update `` |
| [`48b3de8c`](https://github.com/nix-community/NUR/commit/48b3de8c458d1b144b183cace158edfae75391c6) | `` automatic update `` |
| [`4a497e24`](https://github.com/nix-community/NUR/commit/4a497e248db739c85191bed691acd969db1cb881) | `` automatic update `` |
| [`c821534e`](https://github.com/nix-community/NUR/commit/c821534eb6202e0a2af60ddf47dc1e487db03b0a) | `` automatic update `` |
| [`a4f012ac`](https://github.com/nix-community/NUR/commit/a4f012ac71386b639a8e1a15dc1679ca0c49ff3e) | `` automatic update `` |
| [`de4ee222`](https://github.com/nix-community/NUR/commit/de4ee22210e14df8bc1c91cb517701a1e91aa92c) | `` automatic update `` |
| [`d1f5ecf8`](https://github.com/nix-community/NUR/commit/d1f5ecf8f123124af3977d3010a2d4bcc42af18b) | `` automatic update `` |
| [`868aa9b5`](https://github.com/nix-community/NUR/commit/868aa9b52241ad7c8cb89cdd207f8d0149ebf95b) | `` automatic update `` |
| [`fa77eaf6`](https://github.com/nix-community/NUR/commit/fa77eaf6c407aa48ce8da0212ea0c752189bf87d) | `` automatic update `` |
| [`9270a293`](https://github.com/nix-community/NUR/commit/9270a293f01ae7748ec42b903c7b92123cb24ec0) | `` automatic update `` |
| [`750734b3`](https://github.com/nix-community/NUR/commit/750734b35cbc48450a8bfa04586fbe3610e2f2c3) | `` automatic update `` |