### PR TITLE
chore(flake/emacs-overlay): `e812fbf7` -> `2876e264`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705683304,
-        "narHash": "sha256-C9Ghs+660LMmAzO16e3pAssXWKcDRQcTorkY72ofaXY=",
+        "lastModified": 1705712499,
+        "narHash": "sha256-dJsq3jvjRLuUCqgugQ4PqQ2DUFuPDz5Q9iJ655lZTIw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e812fbf7ec5c1e9fa44fb74a3f456cdf68fb7a4f",
+        "rev": "2876e264544034fa2f8ac06faec09b87a9a6c916",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1705458851,
-        "narHash": "sha256-uQvEhiv33Zj/Pv364dTvnpPwFSptRZgVedDzoM+HqVg=",
+        "lastModified": 1705641746,
+        "narHash": "sha256-D6c2aH8HQbWc7ZWSV0BUpFpd94ImFyCP8jFIsKQ4Slg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8bf65f17d8070a0a490daf5f1c784b87ee73982c",
+        "rev": "d2003f2223cbb8cd95134e4a0541beea215c1073",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`2876e264`](https://github.com/nix-community/emacs-overlay/commit/2876e264544034fa2f8ac06faec09b87a9a6c916) | `` Updated elpa ``         |
| [`fd002eb7`](https://github.com/nix-community/emacs-overlay/commit/fd002eb789e61b5c213c531f0e5973d98c0a2688) | `` Updated flake inputs `` |