### PR TITLE
chore(flake/emacs-overlay): `2876e264` -> `fcc7bd71`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705712499,
-        "narHash": "sha256-dJsq3jvjRLuUCqgugQ4PqQ2DUFuPDz5Q9iJ655lZTIw=",
+        "lastModified": 1705714490,
+        "narHash": "sha256-Vn2XjmLXOXz4YaWDr1E0YW/Mtl6D+ab4WJAOD9zPFK4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2876e264544034fa2f8ac06faec09b87a9a6c916",
+        "rev": "fcc7bd71eadb8041dab9e97c237ae12873be627a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`fcc7bd71`](https://github.com/nix-community/emacs-overlay/commit/fcc7bd71eadb8041dab9e97c237ae12873be627a) | `` Updated melpa `` |