### PR TITLE
chore(flake/emacs-overlay): `fd04cba8` -> `2db8934d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705740707,
-        "narHash": "sha256-wF1SjdysS+eiKWNrFzyO0IQQkYiacz0c4Su1gxc1fFs=",
+        "lastModified": 1705741831,
+        "narHash": "sha256-IVkdenfJ9FFRrXHY03hCveXZXSEbpmEZQfAY7HrHzlQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fd04cba897ffc741d08eceee8cb4d4058177eb5d",
+        "rev": "2db8934d6ec0a50effad0cf4dfbcdd496d0d2fdc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                       |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
| [`2db8934d`](https://github.com/nix-community/emacs-overlay/commit/2db8934d6ec0a50effad0cf4dfbcdd496d0d2fdc) | `` Update emacs ``                                                            |
| [`7744578a`](https://github.com/nix-community/emacs-overlay/commit/7744578ae998127cef9002949f84778e6775a2c8) | `` Revert "Revert "Revert "Revert "fixup! Update bytecomp-revert.patch"""" `` |
| [`ceacea3b`](https://github.com/nix-community/emacs-overlay/commit/ceacea3bc70890c816cd616ec2a7af5ff93d6f4c) | `` Revert "Revert "Revert "Revert "Update bytecomp-revert.patch"""" ``        |
| [`90dfac9d`](https://github.com/nix-community/emacs-overlay/commit/90dfac9d46c86246b7fac16c689b5e5492bf9b2c) | `` Revert "Temporarily disable "emacs" update" ``                             |