### PR TITLE
chore(flake/emacs-overlay): `2db8934d` -> `d3944caa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705741831,
-        "narHash": "sha256-IVkdenfJ9FFRrXHY03hCveXZXSEbpmEZQfAY7HrHzlQ=",
+        "lastModified": 1705767550,
+        "narHash": "sha256-lQhd6+jUHqd7OPDRrVpa1ePOH/aNtN6dLZpdFcCEbf0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2db8934d6ec0a50effad0cf4dfbcdd496d0d2fdc",
+        "rev": "d3944caa140aa7ee67b0238ec3a19a910e4a4050",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`d3944caa`](https://github.com/nix-community/emacs-overlay/commit/d3944caa140aa7ee67b0238ec3a19a910e4a4050) | `` Updated emacs `` |