### PR TITLE
chore(flake/home-manager): `ce4b88c4` -> `9b378afa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705708511,
-        "narHash": "sha256-3f4BkRY70Fj7yvuo87c4QQPAjnt571g2wJ50jY7hnYc=",
+        "lastModified": 1705794055,
+        "narHash": "sha256-mv/KrxEAZNhpPJcDqdQ709If9p2DTEYIDPo2r9xchlg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ce4b88c465d928f4f8b75d0920f1788d5b65ca94",
+        "rev": "9b378afae72cb07471e19aefc30e8e05ef2d7a61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`9b378afa`](https://github.com/nix-community/home-manager/commit/9b378afae72cb07471e19aefc30e8e05ef2d7a61) | `` hyprland: change plugins settings generation `` |