### PR TITLE
chore(flake/emacs-overlay): `3566704a` -> `340aa2c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705783124,
-        "narHash": "sha256-OK9WJGd/b4VSZ/d5v3xm9E2YoVwJx/PDN26EHrQv5Ic=",
+        "lastModified": 1705801241,
+        "narHash": "sha256-VK2AC5DnriGpLGiwHxcp/L8UsedaAkXMqzsCtGNsvYM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3566704a6769341e5a84c49a28b545b26759e23f",
+        "rev": "340aa2c0aa86961ed4cc818885e245660d6bc611",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`340aa2c0`](https://github.com/nix-community/emacs-overlay/commit/340aa2c0aa86961ed4cc818885e245660d6bc611) | `` Updated melpa ``        |
| [`eb1e63bf`](https://github.com/nix-community/emacs-overlay/commit/eb1e63bfb52352f35edc63d39b70ad4a186e132c) | `` Updated elpa ``         |
| [`19aeab9b`](https://github.com/nix-community/emacs-overlay/commit/19aeab9b06a80467836db74d673421027f29bf3f) | `` Updated emacs ``        |
| [`446a8bee`](https://github.com/nix-community/emacs-overlay/commit/446a8bee5f191ec899ba7eb33c507a3187146d2a) | `` Updated nongnu ``       |
| [`c4615217`](https://github.com/nix-community/emacs-overlay/commit/c4615217bce56ec45cff6be1a91bba17ac4b4de0) | `` Updated flake inputs `` |