### PR TITLE
chore(flake/darwin): `3ac7acd3` -> `91c19ab2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705796049,
-        "narHash": "sha256-zkqbujNu3ixEar79QJTpJeOG5MYse1uJdcjl9f96uBg=",
+        "lastModified": 1705833550,
+        "narHash": "sha256-CyzbM1mw5xUG4rV5G6FIRM44EvdOgRdWR3joqswyuIU=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "3ac7acd32db4f7111015e8d5349ff6067df01bf6",
+        "rev": "91c19ab206b4b8af72f3f34a947969964ad45908",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                         |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`a3be68d1`](https://github.com/LnL7/nix-darwin/commit/a3be68d105ebb640f7dc4be615f84fe00288e5d3) | `` Add option to disable zsh global compinit `` |