### PR TITLE
chore(flake/lanzaboote): `44b88813` -> `7b91a7a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -544,11 +544,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1705839853,
-        "narHash": "sha256-2GiwtuSRZY3ctvH72GMzCo+G2giLYTI0okVJLy7i5/E=",
+        "lastModified": 1705855210,
+        "narHash": "sha256-RDDGKrN4VupdWfUHImFFH8/nmO6Z5NjtSSl743GWGsQ=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "44b8881301008ec9b0405043fa0ea9e2e0050952",
+        "rev": "7b91a7a352483cf4c26d62dd194f49b344c94717",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                     |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`234e4da1`](https://github.com/nix-community/lanzaboote/commit/234e4da1f35da45fcd91fe4c589edae88883da07) | `` rust-toolchain: 1.70 -> 1.75 ``          |
| [`50247a68`](https://github.com/nix-community/lanzaboote/commit/50247a6890a3e2f80f5474ba99b143c0dfb16083) | `` flake: remove custom sbctl from shell `` |