### PR TITLE
chore(flake/nur): `7d8494cb` -> `384ac71f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705880023,
-        "narHash": "sha256-ygbL2ewxuoOvPQ9VDaf31nigmkwc0jbwFIqoJyYJ/sA=",
+        "lastModified": 1705888149,
+        "narHash": "sha256-+Lsx+x+2GEM53M6hnD8OY7kHBkRVKQGGX3C12LnbcOc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7d8494cbcbcc26d90d87e77a0f3a62459fbbf05c",
+        "rev": "384ac71f725e53d3e2acf3a86cdd8d25ca7e2ae4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`384ac71f`](https://github.com/nix-community/NUR/commit/384ac71f725e53d3e2acf3a86cdd8d25ca7e2ae4) | `` automatic update `` |
| [`53b9b646`](https://github.com/nix-community/NUR/commit/53b9b646124543179ff2f63117551599801bf103) | `` automatic update `` |
| [`5e5d9934`](https://github.com/nix-community/NUR/commit/5e5d9934a13055949729770476e640d3e1a1a612) | `` automatic update `` |