### PR TITLE
chore(flake/srvos): `1d742203` -> `acf84aca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1011,11 +1011,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705543670,
-        "narHash": "sha256-ipXBn/jPzpOn138ckp9Zm+ZzHkBVj3R04mJumGeTjAo=",
+        "lastModified": 1705884983,
+        "narHash": "sha256-cVzXizWdkmJQ5xwe/6S+cam8fyxTN4emkdmB8LKJGCY=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "1d742203e3818f11522ba3eba2b0919f739445ce",
+        "rev": "acf84acad906a1886ee36adc2353ac685e63466f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`acf84aca`](https://github.com/nix-community/srvos/commit/acf84acad906a1886ee36adc2353ac685e63466f) | `` dev/private/flake.lock: Update `` |
| [`1bcf0bb8`](https://github.com/nix-community/srvos/commit/1bcf0bb8fb21b52534af95cfb584616ae78117da) | `` flake.lock: Update ``             |