### PR TITLE
chore(flake/emacs-overlay): `3135b0f4` -> `ee992c3b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705853917,
-        "narHash": "sha256-JmrOXRIJeCZYy0MHu6Tg33SA0aR66tm6jTZwVH7dha8=",
+        "lastModified": 1705887527,
+        "narHash": "sha256-t1CBk4UaBkyCEH6wWY2DQAXWA354ilFcreeQmgnqhP8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3135b0f49fab65ff105d0a6f6eeceae184b335cb",
+        "rev": "ee992c3b9fac56c40e79c958e5241250feccd336",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1705641746,
-        "narHash": "sha256-D6c2aH8HQbWc7ZWSV0BUpFpd94ImFyCP8jFIsKQ4Slg=",
+        "lastModified": 1705774713,
+        "narHash": "sha256-j6ADaDH9XiumUzkTPlFyCBcoWYhO83lfgiSqEJF2zcs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d2003f2223cbb8cd95134e4a0541beea215c1073",
+        "rev": "1b64fc1287991a9cce717a01c1973ef86cb1af0b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ee992c3b`](https://github.com/nix-community/emacs-overlay/commit/ee992c3b9fac56c40e79c958e5241250feccd336) | `` Updated melpa ``        |
| [`7ead5922`](https://github.com/nix-community/emacs-overlay/commit/7ead5922cd7e28b488040ae600ab079578220b3e) | `` Updated elpa ``         |
| [`8f9a6e38`](https://github.com/nix-community/emacs-overlay/commit/8f9a6e38cb3c57dad69656722474f38dd301d898) | `` Updated emacs ``        |
| [`cfc3478a`](https://github.com/nix-community/emacs-overlay/commit/cfc3478a947fd0296e9d834269bb77f9814d9de3) | `` Updated flake inputs `` |