### PR TITLE
chore(flake/nur): `384ac71f` -> `b69cb83b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705888149,
-        "narHash": "sha256-+Lsx+x+2GEM53M6hnD8OY7kHBkRVKQGGX3C12LnbcOc=",
+        "lastModified": 1705895048,
+        "narHash": "sha256-AtTF7vYa6avfaZw8HRCWSBsE/ojKlhs9SHhnqqKrSKQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "384ac71f725e53d3e2acf3a86cdd8d25ca7e2ae4",
+        "rev": "b69cb83b2bbf8ff89384718258da18f3a6a3c024",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b69cb83b`](https://github.com/nix-community/NUR/commit/b69cb83b2bbf8ff89384718258da18f3a6a3c024) | `` automatic update `` |