### PR TITLE
chore(flake/nur): `b69cb83b` -> `d1821b6a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705895048,
-        "narHash": "sha256-AtTF7vYa6avfaZw8HRCWSBsE/ojKlhs9SHhnqqKrSKQ=",
+        "lastModified": 1705896442,
+        "narHash": "sha256-ex7B7+C8DBwgqStxJvu8XmWTXZhSbRV4eLnAIO6XGso=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b69cb83b2bbf8ff89384718258da18f3a6a3c024",
+        "rev": "d1821b6a0206e931d42c22da4654162abebcf4d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d1821b6a`](https://github.com/nix-community/NUR/commit/d1821b6a0206e931d42c22da4654162abebcf4d9) | `` automatic update `` |