### PR TITLE
chore(flake/nur): `6e301223` -> `5efd4d39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705916665,
-        "narHash": "sha256-yiZ8oRi6bDMmAw2lQTtKL/dIedBuiTwyC0pjqKaWqLA=",
+        "lastModified": 1705931061,
+        "narHash": "sha256-wFvkFAmIT9hacR6nSwHwu/JrkSfMqFGhYym1Ta3vRFI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6e3012237f99313423d356e18ac6dfda289d8cfb",
+        "rev": "5efd4d39154107ae73b27e917666707ae940f104",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5efd4d39`](https://github.com/nix-community/NUR/commit/5efd4d39154107ae73b27e917666707ae940f104) | `` automatic update `` |
| [`a29c6f71`](https://github.com/nix-community/NUR/commit/a29c6f71063d0ce903e927fa7885651c00abd33b) | `` automatic update `` |
| [`3b71df0e`](https://github.com/nix-community/NUR/commit/3b71df0e3e90c32554154d608db507c4f6d6fd13) | `` automatic update `` |