### PR TITLE
chore(flake/emacs-overlay): `83731bc2` -> `6474bb55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705913685,
-        "narHash": "sha256-Npj1tB5lkYTAAQ0QAQMm505sluFJaX9ZBCM0SksZZ/Q=",
+        "lastModified": 1705942392,
+        "narHash": "sha256-pSajr0eF0noWeX+HJImMlwGco5ZkQ/TQtU0CX1RcOcM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "83731bc2f68f485e843534da607f374f75b4f0bd",
+        "rev": "6474bb55cdc31790ce7911a501689b3099985c09",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`6474bb55`](https://github.com/nix-community/emacs-overlay/commit/6474bb55cdc31790ce7911a501689b3099985c09) | `` Updated melpa ``        |
| [`90b1750b`](https://github.com/nix-community/emacs-overlay/commit/90b1750b38194c49eb99a9074b6fc7f24956fd4b) | `` Updated emacs ``        |
| [`207d3343`](https://github.com/nix-community/emacs-overlay/commit/207d3343f36c098cefab8c920a67309e436b3243) | `` Updated elpa ``         |
| [`7906c257`](https://github.com/nix-community/emacs-overlay/commit/7906c2578426d2f0dfc42d4a585896f38f5f8731) | `` Updated flake inputs `` |