### PR TITLE
chore(flake/nur): `1a834468` -> `2482e298`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705936814,
-        "narHash": "sha256-5k+3DhgwIAP3SisB6iyb2jnbX6H/KZMe/YSd++k5NKI=",
+        "lastModified": 1705939891,
+        "narHash": "sha256-a6zelyVE1Vh0jDR4EI88vdM1NHl7yenHyI041L+xkZk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1a83446861b58ce409f485016bf66a8d66957e2c",
+        "rev": "2482e298332a435100483a35e17d50bcbd9a5325",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2482e298`](https://github.com/nix-community/NUR/commit/2482e298332a435100483a35e17d50bcbd9a5325) | `` automatic update `` |