### PR TITLE
chore(flake/nur): `2482e298` -> `0d37a32e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705939891,
-        "narHash": "sha256-a6zelyVE1Vh0jDR4EI88vdM1NHl7yenHyI041L+xkZk=",
+        "lastModified": 1705945480,
+        "narHash": "sha256-XOG3tjqdOw5072MuH1GSeYSrM2wdxeXKp+HUqVMYBIs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2482e298332a435100483a35e17d50bcbd9a5325",
+        "rev": "0d37a32ebadba95810740b3a44f4dd96eae41587",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0d37a32e`](https://github.com/nix-community/NUR/commit/0d37a32ebadba95810740b3a44f4dd96eae41587) | `` automatic update `` |