### PR TITLE
chore(flake/nur): `0d37a32e` -> `ad710d13`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705945480,
-        "narHash": "sha256-XOG3tjqdOw5072MuH1GSeYSrM2wdxeXKp+HUqVMYBIs=",
+        "lastModified": 1705952672,
+        "narHash": "sha256-ERHS2xHDcVIxSVsyzI5C0J6TUxR99hJMYlakbhN116k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0d37a32ebadba95810740b3a44f4dd96eae41587",
+        "rev": "ad710d139b3d033144386445e1dcdbe833fa0f04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ad710d13`](https://github.com/nix-community/NUR/commit/ad710d139b3d033144386445e1dcdbe833fa0f04) | `` automatic update `` |
| [`0d0d7dbf`](https://github.com/nix-community/NUR/commit/0d0d7dbf9317a4e2aaee94c1bd098387262c3256) | `` automatic update `` |