### PR TITLE
chore(flake/emacs-overlay): `6474bb55` -> `e58b822a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705942392,
-        "narHash": "sha256-pSajr0eF0noWeX+HJImMlwGco5ZkQ/TQtU0CX1RcOcM=",
+        "lastModified": 1705971828,
+        "narHash": "sha256-adgk2m2FChlTCNHddb2QLE3iHTd02hnRt0Dqd/O7vJI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6474bb55cdc31790ce7911a501689b3099985c09",
+        "rev": "e58b822a7c3de3e2445982da0630eb5dbd58e72d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`e58b822a`](https://github.com/nix-community/emacs-overlay/commit/e58b822a7c3de3e2445982da0630eb5dbd58e72d) | `` Updated elpa ``   |
| [`d87c4688`](https://github.com/nix-community/emacs-overlay/commit/d87c4688208b04e4c1d49090ce19a46eb6031209) | `` Updated emacs ``  |
| [`f2304fe5`](https://github.com/nix-community/emacs-overlay/commit/f2304fe5b19fd1554a977eaf905cd82bd6186f0e) | `` Updated nongnu `` |