### PR TITLE
chore(flake/nur): `d70c2a18` -> `68c68e53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705978869,
-        "narHash": "sha256-CcwcxApCuKVjwzlsEWJFaSmpof/1FOoAeiCGipuaViw=",
+        "lastModified": 1705981452,
+        "narHash": "sha256-7UyR/U3f6Yhe6IkosIY/ad3l9EhiyBSWUhRwS6NYyvg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d70c2a18ef5df36804bb87537063b2d15baf9292",
+        "rev": "68c68e53ba4095644cb111d310a9daedb2dbf7fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`68c68e53`](https://github.com/nix-community/NUR/commit/68c68e53ba4095644cb111d310a9daedb2dbf7fa) | `` automatic update `` |