### PR TITLE
chore(flake/nur): `68c68e53` -> `d6c5b607`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705981452,
-        "narHash": "sha256-7UyR/U3f6Yhe6IkosIY/ad3l9EhiyBSWUhRwS6NYyvg=",
+        "lastModified": 1705982724,
+        "narHash": "sha256-gIySjI6ENrIqHs7RZmVRTENa22Wws0XLbxycpUvdQXU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "68c68e53ba4095644cb111d310a9daedb2dbf7fa",
+        "rev": "d6c5b6079d730f1b4588ea22b0ed008c245cb818",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d6c5b607`](https://github.com/nix-community/NUR/commit/d6c5b6079d730f1b4588ea22b0ed008c245cb818) | `` automatic update `` |