### PR TITLE
chore(flake/nur): `d6c5b607` -> `15cecdfa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705982724,
-        "narHash": "sha256-gIySjI6ENrIqHs7RZmVRTENa22Wws0XLbxycpUvdQXU=",
+        "lastModified": 1705987215,
+        "narHash": "sha256-O678kxNXhOafpnOFxMZ2dbY8ctQKebOpcNntMNyGBcA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d6c5b6079d730f1b4588ea22b0ed008c245cb818",
+        "rev": "15cecdfaa9c56d0e3460a80e2672fe9789b94302",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`15cecdfa`](https://github.com/nix-community/NUR/commit/15cecdfaa9c56d0e3460a80e2672fe9789b94302) | `` automatic update `` |