### PR TITLE
chore(flake/nur): `15cecdfa` -> `21151d82`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705987215,
-        "narHash": "sha256-O678kxNXhOafpnOFxMZ2dbY8ctQKebOpcNntMNyGBcA=",
+        "lastModified": 1705992285,
+        "narHash": "sha256-XhcrvhPaqlZ8bCZKHxYneSXQcdPAPN0pu7dMlEHK5+M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "15cecdfaa9c56d0e3460a80e2672fe9789b94302",
+        "rev": "21151d82b1c2156080bb453b935ecc61dab134b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`21151d82`](https://github.com/nix-community/NUR/commit/21151d82b1c2156080bb453b935ecc61dab134b4) | `` automatic update `` |