### PR TITLE
chore(flake/nur): `21151d82` -> `ca9d5533`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705992285,
-        "narHash": "sha256-XhcrvhPaqlZ8bCZKHxYneSXQcdPAPN0pu7dMlEHK5+M=",
+        "lastModified": 1705996618,
+        "narHash": "sha256-RZ0Oa5s96JULebjuxGfcebJU6Kv9zj1L8z4cvB+tYWM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "21151d82b1c2156080bb453b935ecc61dab134b4",
+        "rev": "ca9d55332782e1ac0ac263596cd4d48b4a429dab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ca9d5533`](https://github.com/nix-community/NUR/commit/ca9d55332782e1ac0ac263596cd4d48b4a429dab) | `` automatic update `` |
| [`0069433d`](https://github.com/nix-community/NUR/commit/0069433daa260b20302ee5b501888828ba4e4dbc) | `` automatic update `` |
| [`7fa73649`](https://github.com/nix-community/NUR/commit/7fa73649f77307a61836cbd5a0b95703223a9a86) | `` automatic update `` |
| [`42cf459f`](https://github.com/nix-community/NUR/commit/42cf459f61ab038beadd4da7867c46203cb941c9) | `` automatic update `` |