### PR TITLE
chore(flake/emacs-overlay): `7f898abe` -> `e2953343`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705973842,
-        "narHash": "sha256-QgmJfo5LyrWsYaNSEapTN5xPr1xtRMRMUj830lrEC9Y=",
+        "lastModified": 1706000038,
+        "narHash": "sha256-QytIgkH0wEV2SlW0qttfINEyXPuD7o22W6ZzUceT6z4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7f898abe4a56b56b9f5b13dec1af0132b1950642",
+        "rev": "e2953343aa80377bb1f486f46ef5553b5570753e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`e2953343`](https://github.com/nix-community/emacs-overlay/commit/e2953343aa80377bb1f486f46ef5553b5570753e) | `` Updated melpa `` |
| [`0ba82576`](https://github.com/nix-community/emacs-overlay/commit/0ba825768579730f1db48b74245e9948df3875db) | `` Updated emacs `` |