### PR TITLE
chore(flake/nur): `ca9d5533` -> `084c9e5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705996618,
-        "narHash": "sha256-RZ0Oa5s96JULebjuxGfcebJU6Kv9zj1L8z4cvB+tYWM=",
+        "lastModified": 1706005806,
+        "narHash": "sha256-DKzMwoKq7UTsvSv7RELNPfS7xTWqYoHmqcC3KekWTh0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ca9d55332782e1ac0ac263596cd4d48b4a429dab",
+        "rev": "084c9e5ac47b1da166bb485fe1ade830eb525f07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`084c9e5a`](https://github.com/nix-community/NUR/commit/084c9e5ac47b1da166bb485fe1ade830eb525f07) | `` automatic update `` |
| [`dbda804c`](https://github.com/nix-community/NUR/commit/dbda804cf36a64d698b1ef4df35ecabfa45442a6) | `` automatic update `` |
| [`1d21e45d`](https://github.com/nix-community/NUR/commit/1d21e45d0a555e48e3800dfae234c330361bfc08) | `` automatic update `` |