### PR TITLE
chore(flake/emacs-overlay): `e2953343` -> `b47e82db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706000038,
-        "narHash": "sha256-QytIgkH0wEV2SlW0qttfINEyXPuD7o22W6ZzUceT6z4=",
+        "lastModified": 1706028863,
+        "narHash": "sha256-7AUDN/Eo/YioUd2wbzacau5cEsEzi+MOUEQCT4vAA9I=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e2953343aa80377bb1f486f46ef5553b5570753e",
+        "rev": "b47e82dbcfdfa4b6ce844565707b51fde1b58988",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1705774713,
-        "narHash": "sha256-j6ADaDH9XiumUzkTPlFyCBcoWYhO83lfgiSqEJF2zcs=",
+        "lastModified": 1705916986,
+        "narHash": "sha256-iBpfltu6QvN4xMpen6jGGEb6jOqmmVQKUrXdOJ32u8w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1b64fc1287991a9cce717a01c1973ef86cb1af0b",
+        "rev": "d7f206b723e42edb09d9d753020a84b3061a79d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b47e82db`](https://github.com/nix-community/emacs-overlay/commit/b47e82dbcfdfa4b6ce844565707b51fde1b58988) | `` Updated melpa ``        |
| [`1060b97c`](https://github.com/nix-community/emacs-overlay/commit/1060b97c199bf5abff50bf09c7983250e749d884) | `` Updated elpa ``         |
| [`cfbcb6f4`](https://github.com/nix-community/emacs-overlay/commit/cfbcb6f4cdf4a206bc3bf51abb6b5c7f27700932) | `` Updated emacs ``        |
| [`667d22e0`](https://github.com/nix-community/emacs-overlay/commit/667d22e0dd361093efa024dfe30fd1b3334676b3) | `` Updated flake inputs `` |