### PR TITLE
chore(flake/nur): `1d6ab131` -> `b2531250`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706035507,
-        "narHash": "sha256-wRg9hdy+vMOH1kI1so4lf0kq7XruNQxBi7ovDJOwk+U=",
+        "lastModified": 1706039065,
+        "narHash": "sha256-qowYTHHeb49NvCABGsuqtmLAPs4Os5bNYDixRcWLNaQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1d6ab131468b2d800cea27d7f153e2827bd7dbea",
+        "rev": "b2531250cbba8a46a60dbcb2166f2024eeb6d194",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b2531250`](https://github.com/nix-community/NUR/commit/b2531250cbba8a46a60dbcb2166f2024eeb6d194) | `` automatic update `` |