### PR TITLE
chore(flake/nur): `b2531250` -> `d90d3e49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706039065,
-        "narHash": "sha256-qowYTHHeb49NvCABGsuqtmLAPs4Os5bNYDixRcWLNaQ=",
+        "lastModified": 1706042735,
+        "narHash": "sha256-phb+YYGT71tuExJE8w2tVpzvZgOtxmkg4RK/fiLALyA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b2531250cbba8a46a60dbcb2166f2024eeb6d194",
+        "rev": "d90d3e49f27dacc9238a7a37e5e27be6719867a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d90d3e49`](https://github.com/nix-community/NUR/commit/d90d3e49f27dacc9238a7a37e5e27be6719867a7) | `` automatic update `` |