### PR TITLE
chore(flake/emacs-overlay): `b47e82db` -> `24b4024a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706028863,
-        "narHash": "sha256-7AUDN/Eo/YioUd2wbzacau5cEsEzi+MOUEQCT4vAA9I=",
+        "lastModified": 1706060237,
+        "narHash": "sha256-PWO5+AM+2mKegmVxFyilZky/uZQ4pn9E9a96EvzWJbc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b47e82dbcfdfa4b6ce844565707b51fde1b58988",
+        "rev": "24b4024af8327b64067d97dd9d98e635ffd9beca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                               |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`24b4024a`](https://github.com/nix-community/emacs-overlay/commit/24b4024af8327b64067d97dd9d98e635ffd9beca) | `` Updated melpa ``                                   |
| [`71b38b13`](https://github.com/nix-community/emacs-overlay/commit/71b38b1324939cd53b0b3c31d4a82aec238ae1af) | `` Updated elpa ``                                    |
| [`0c3c8702`](https://github.com/nix-community/emacs-overlay/commit/0c3c87020fcca200978143698e85d5846a47bb2c) | `` Updated emacs ``                                   |
| [`ea1f9f60`](https://github.com/nix-community/emacs-overlay/commit/ea1f9f60b6530698e2340c7798229355500bbfb2) | `` Revert "Try removing the bytecomp-revert.patch" `` |
| [`d6772c6c`](https://github.com/nix-community/emacs-overlay/commit/d6772c6c105d28dcd1f7763aa507b9cdddee249c) | `` Try removing the bytecomp-revert.patch ``          |