### PR TITLE
chore(flake/nur): `d90d3e49` -> `99da0539`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706042735,
-        "narHash": "sha256-phb+YYGT71tuExJE8w2tVpzvZgOtxmkg4RK/fiLALyA=",
+        "lastModified": 1706059416,
+        "narHash": "sha256-n2cqO7Xm8qk2kqE3QNQROl1ro3MuUS3jfMaDC1QM/dM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d90d3e49f27dacc9238a7a37e5e27be6719867a7",
+        "rev": "99da053948394b5dd76f70c88d4295755ca27a67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`99da0539`](https://github.com/nix-community/NUR/commit/99da053948394b5dd76f70c88d4295755ca27a67) | `` automatic update `` |
| [`0dd306ef`](https://github.com/nix-community/NUR/commit/0dd306ef5a94a8c5e06be3f5b186b5249bfa7d98) | `` automatic update `` |