### PR TITLE
chore(flake/nur): `99da0539` -> `d83fd2f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706059416,
-        "narHash": "sha256-n2cqO7Xm8qk2kqE3QNQROl1ro3MuUS3jfMaDC1QM/dM=",
+        "lastModified": 1706060722,
+        "narHash": "sha256-qhWoTeKD+tecX69OnM2H46PVh3PGIBIp9Ah48E5PYrM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "99da053948394b5dd76f70c88d4295755ca27a67",
+        "rev": "d83fd2f4513610abbafa9e67e97518e5923977e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d83fd2f4`](https://github.com/nix-community/NUR/commit/d83fd2f4513610abbafa9e67e97518e5923977e3) | `` automatic update `` |