### PR TITLE
chore(flake/nur): `d83fd2f4` -> `1e826931`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706060722,
-        "narHash": "sha256-qhWoTeKD+tecX69OnM2H46PVh3PGIBIp9Ah48E5PYrM=",
+        "lastModified": 1706067919,
+        "narHash": "sha256-F2pr7Y7jePQPUmYdrmPsi7bPNVTdSsLuLx4NMiCvr7k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d83fd2f4513610abbafa9e67e97518e5923977e3",
+        "rev": "1e8269316f3bb7c1ccc97660bc50ee876fb5c68d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1e826931`](https://github.com/nix-community/NUR/commit/1e8269316f3bb7c1ccc97660bc50ee876fb5c68d) | `` automatic update `` |
| [`457cc9f9`](https://github.com/nix-community/NUR/commit/457cc9f9524fa195e82e4a3c787d66586d4eeb48) | `` automatic update `` |