### PR TITLE
chore(flake/nur): `1e826931` -> `4d0f41b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706067919,
-        "narHash": "sha256-F2pr7Y7jePQPUmYdrmPsi7bPNVTdSsLuLx4NMiCvr7k=",
+        "lastModified": 1706069182,
+        "narHash": "sha256-9XpBDEcpKjD1fXei4qB8NZe3AWK/Xp/Y4EWvCXP6+Z4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1e8269316f3bb7c1ccc97660bc50ee876fb5c68d",
+        "rev": "4d0f41b9d3d9497fbee183e0e2a6f75b5c59140a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4d0f41b9`](https://github.com/nix-community/NUR/commit/4d0f41b9d3d9497fbee183e0e2a6f75b5c59140a) | `` automatic update `` |