### PR TITLE
chore(flake/nur): `4d0f41b9` -> `747cb01a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706069182,
-        "narHash": "sha256-9XpBDEcpKjD1fXei4qB8NZe3AWK/Xp/Y4EWvCXP6+Z4=",
+        "lastModified": 1706074956,
+        "narHash": "sha256-Pcd1U4IiLcR9KX1emVES+hu82iNLrwjTK9KYUiGF/vI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4d0f41b9d3d9497fbee183e0e2a6f75b5c59140a",
+        "rev": "747cb01a39816a204654894739b9849b2f341d78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`747cb01a`](https://github.com/nix-community/NUR/commit/747cb01a39816a204654894739b9849b2f341d78) | `` automatic update `` |