### PR TITLE
chore(flake/nur): `747cb01a` -> `83afbadd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706074956,
-        "narHash": "sha256-Pcd1U4IiLcR9KX1emVES+hu82iNLrwjTK9KYUiGF/vI=",
+        "lastModified": 1706078696,
+        "narHash": "sha256-F5IXtCJAQaCYu42gRu6waSj9bGP14jNrzP7Ohm2xibs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "747cb01a39816a204654894739b9849b2f341d78",
+        "rev": "83afbadd1e06f46afa1ff6de75abfbeb3a4cf19e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`83afbadd`](https://github.com/nix-community/NUR/commit/83afbadd1e06f46afa1ff6de75abfbeb3a4cf19e) | `` automatic update `` |