### PR TITLE
chore(flake/nixos-hardware): `bee2202b` -> `ff16da3a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -666,11 +666,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1705312285,
-        "narHash": "sha256-rd+dY+v61Y8w3u9bukO/hB55Xl4wXv4/yC8rCGVnK5U=",
+        "lastModified": 1706083274,
+        "narHash": "sha256-liTGw5EOOfPIQ0KQkbhbMsicc0WAiCY9dh/9Myncc5A=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "bee2202bec57e521e3bd8acd526884b9767d7fa0",
+        "rev": "ff16da3a6b77941830b1971ef7107a2e7d4da714",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                              |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`ff16da3a`](https://github.com/NixOS/nixos-hardware/commit/ff16da3a6b77941830b1971ef7107a2e7d4da714) | `` starfive visionfive2: update u-boot to 2024.01 `` |