### PR TITLE
chore(flake/emacs-overlay): `46d30fde` -> `cefc21a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706086435,
-        "narHash": "sha256-e+BqXkquFW7LtC+LCbVrVWTXXr/dCEfNAN9wmdyVJ8k=",
+        "lastModified": 1706146600,
+        "narHash": "sha256-LQ9eyJO9n8oTHArgYp7VQ2YUpEZGoFX5aFa40zflCrU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "46d30fdef02008e5f1856d4039a0b48d20a3bca6",
+        "rev": "cefc21a743a96cf996c4f09e141317e74e7ae794",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`cefc21a7`](https://github.com/nix-community/emacs-overlay/commit/cefc21a743a96cf996c4f09e141317e74e7ae794) | `` Updated melpa ``  |
| [`fdd86a5e`](https://github.com/nix-community/emacs-overlay/commit/fdd86a5eb908203d3bac9f694960508a8182b601) | `` Updated elpa ``   |
| [`5b427ea1`](https://github.com/nix-community/emacs-overlay/commit/5b427ea16e8c0e9510d1afcd98bb1e7f51ef8f07) | `` Updated emacs ``  |
| [`fca275c0`](https://github.com/nix-community/emacs-overlay/commit/fca275c0dad55e519073df9552ccb34dd1fc08fc) | `` Updated nongnu `` |
| [`697e5806`](https://github.com/nix-community/emacs-overlay/commit/697e580696334fa0d85276b98f484e03fa88dc83) | `` Updated melpa ``  |
| [`e3b7bb7f`](https://github.com/nix-community/emacs-overlay/commit/e3b7bb7fffddec090d20fc805aa9717a550b7d5a) | `` Updated elpa ``   |
| [`0d6e23e8`](https://github.com/nix-community/emacs-overlay/commit/0d6e23e87da95a64b1f4aa871bddd1640708c767) | `` Updated emacs ``  |