### PR TITLE
chore(flake/sops-nix): `ae171b54` -> `4606d9b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -990,11 +990,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1705805983,
-        "narHash": "sha256-HluB9w7l75I4kK25uO4y6baY4fcDm2Rho0WI1DN2Hmc=",
+        "lastModified": 1706130372,
+        "narHash": "sha256-fHZxKH1DhsXPP36a2vJ91Zy6S+q6+QRIFlpLr9fZHU8=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "ae171b54e76ced88d506245249609f8c87305752",
+        "rev": "4606d9b1595e42ffd9b75b9e69667708c70b1d68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                             |
| ----------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`4606d9b1`](https://github.com/Mic92/sops-nix/commit/4606d9b1595e42ffd9b75b9e69667708c70b1d68) | `` Add info about hash passwords `` |