### PR TITLE
chore(flake/home-manager): `e8481103` -> `b2f56952`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706099765,
-        "narHash": "sha256-pt98CX+WkTwtnDdu+9kGnuia/3s5krsUqYOSGOYbuHk=",
+        "lastModified": 1706306660,
+        "narHash": "sha256-lZvgkHtVeduGByPb0Tz9LpAi4olfkEm8XPgv0o7GRsk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e84811035d7c8ec79ed6c687a97e19e2a22123c1",
+        "rev": "b2f56952074cb46e93902ecaabfb04dd93733434",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`b2f56952`](https://github.com/nix-community/home-manager/commit/b2f56952074cb46e93902ecaabfb04dd93733434) | `` network-manager-applet: add XDG data directory `` |
| [`690764d2`](https://github.com/nix-community/home-manager/commit/690764d2dcfccf01ddfc9f19220c88182339f40f) | `` firefox: Reimplement FF native messaging ``       |
| [`c7ce343d`](https://github.com/nix-community/home-manager/commit/c7ce343d9bf1a329056a4dd5b32ea8cc43b55e15) | `` home-manager: add extendModules attribute ``      |
| [`c82e52b0`](https://github.com/nix-community/home-manager/commit/c82e52b0d96eb9f1c8334add871dce8e837d043b) | `` flake.lock: Update ``                             |
| [`03958aff`](https://github.com/nix-community/home-manager/commit/03958aff4415a5278d0ea462db370e9d770e904e) | `` firefox: add default containers ``                |
| [`70688f19`](https://github.com/nix-community/home-manager/commit/70688f195a294a09d31d6bfe339bb090d443e949) | `` keepassx: remove module ``                        |
| [`6359d40f`](https://github.com/nix-community/home-manager/commit/6359d40f6ec0b72a38e02b333f343c3d4929ec10) | `` firefox: implement native messaging hosts ``      |