### PR TITLE
chore(flake/nur): `5ffd5845` -> `185b26aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706144728,
-        "narHash": "sha256-ZJM/MUnOEyQMmIhnLB6K7quGwhNPX5i4rLAapW6uehc=",
+        "lastModified": 1706157678,
+        "narHash": "sha256-kTf+2V14+TpaPn7L5H54RXfSvDdkwFa7PkhU9ZysCxg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5ffd5845388d4a4289edeb315366e36acfb0872d",
+        "rev": "185b26aa505f3df079807891a55be1d197826eeb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`185b26aa`](https://github.com/nix-community/NUR/commit/185b26aa505f3df079807891a55be1d197826eeb) | `` automatic update `` |
| [`0b762679`](https://github.com/nix-community/NUR/commit/0b7626799f2d9c0a6d8bd951e9d4fca46ae39b4f) | `` automatic update `` |