### PR TITLE
chore(flake/nur): `ca477a06` -> `20f64c71`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706165097,
-        "narHash": "sha256-k4DDMdP4WJji/GlSJX5tcJIASZ5XrOlMSmiYWY4KkPM=",
+        "lastModified": 1706174248,
+        "narHash": "sha256-VNN7md+kJhBvl5bINEXybSG4jHavrQIlXdywpcaEEwc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ca477a06ac06163e1a7b888f8a358f5c64a7cbc2",
+        "rev": "20f64c7125413fc19372f11b45db99363bea7c1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`20f64c71`](https://github.com/nix-community/NUR/commit/20f64c7125413fc19372f11b45db99363bea7c1f) | `` automatic update `` |