### PR TITLE
chore(flake/nixos-hardware): `e756ff62` -> `f84eaffc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -666,11 +666,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1706085157,
-        "narHash": "sha256-0pTbYwn9qubaZLtuN0Ouj0neEfrir1wSNyH8gL1BzB0=",
+        "lastModified": 1706182238,
+        "narHash": "sha256-Ti7CerGydU7xyrP/ow85lHsOpf+XMx98kQnPoQCSi1g=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e756ff62c2e9db4f7c197bc1849a02024a7bfb2e",
+        "rev": "f84eaffc35d1a655e84749228cde19922fcf55f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------ |
| [`e57f8c26`](https://github.com/NixOS/nixos-hardware/commit/e57f8c264a4b6c2c8fef65dcd1adc13237004901) | `` Update default.nix `` |
| [`6b5d311c`](https://github.com/NixOS/nixos-hardware/commit/6b5d311cb66a153bffbdf96d5e9b79f1c3656a2e) | `` Fix patches.nix ``    |