### PR TITLE
chore(flake/nixpkgs_tmux): `d4143f3b` -> `9404f2ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -809,11 +809,11 @@
     },
     "nixpkgs_tmux": {
       "locked": {
-        "lastModified": 1703265355,
-        "narHash": "sha256-4gqBqOBNTKhAtEg173MgH+/pMjhigUHaiGkWE90RrmE=",
+        "lastModified": 1706182073,
+        "narHash": "sha256-H0UahPm40gM4e+vsy4Rnt/QMtjcho43i9PdQABdOTjk=",
         "owner": "hmajid2301",
         "repo": "nixpkgs",
-        "rev": "d4143f3b9f1c0054c459e8215ca8f07d3956d79a",
+        "rev": "9404f2ac4345612840350b2b70b63650d472dd33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                                          |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`9404f2ac`](https://github.com/hmajid2301/nixpkgs/commit/9404f2ac4345612840350b2b70b63650d472dd33) | `` tmuxPlugins.t-smart-tmux-session-manager: init at 2.8.0 ``                    |
| [`5e579401`](https://github.com/hmajid2301/nixpkgs/commit/5e5794015fcf48afbf26d586d9067d3d20448b64) | `` pikopixel: unpin llvm9 ``                                                     |
| [`d436ff6b`](https://github.com/hmajid2301/nixpkgs/commit/d436ff6b7a8b3c96c0c2a58c7c8a4b719905a2e4) | `` path-of-building.data: 2.39.0 -> 2.39.1 ``                                    |
| [`a83e82c4`](https://github.com/hmajid2301/nixpkgs/commit/a83e82c4e9b02f3686b66701915cd35ef1a5e358) | `` yanic: init at 1.5.0 ``                                                       |
| [`5c4784cd`](https://github.com/hmajid2301/nixpkgs/commit/5c4784cd2f2a54288108019bb8f7466d7ca3171f) | `` marvin: pin openjdk17 ``                                                      |
| [`aaaa1aaa`](https://github.com/hmajid2301/nixpkgs/commit/aaaa1aaa767d767379e274dae38505a25b886ad6) | `` maintainers: add herbetom ``                                                  |
| [`8deb9a06`](https://github.com/hmajid2301/nixpkgs/commit/8deb9a06798b426169aba7a7342affe787ab5dd5) | `` marvin: 23.12.0 -> 23.17.0 ``                                                 |
| [`af2562d9`](https://github.com/hmajid2301/nixpkgs/commit/af2562d930d7888812f39fc565df5b11084fdaff) | `` cargo-deny: add SystemConfiguration framework on darwin ``                    |
| [`ab2ba74e`](https://github.com/hmajid2301/nixpkgs/commit/ab2ba74e90a7ad10f82dac4d77a8ccadbfa32b9d) | `` wander: 1.0.1 -> 1.0.2 ``                                                     |
| [`c847e364`](https://github.com/hmajid2301/nixpkgs/commit/c847e364eacd9b0ae888b7fcdc235a321d1de52a) | `` nixos/hyprland: move to programs/wayland ``                                   |
| [`cdb08106`](https://github.com/hmajid2301/nixpkgs/commit/cdb081065109ef6873c107be1594a4ceab3f6d7a) | `` fritzing: unstable-2022-07-01 -> 1.0.1 ``                                     |
| [`644ee68b`](https://github.com/hmajid2301/nixpkgs/commit/644ee68b9605fa581e56bf092ad1b601d1288354) | `` trueseeing: 2.1.9 -> 2.1.10 ``                                                |
| [`5faf086c`](https://github.com/hmajid2301/nixpkgs/commit/5faf086cad787328c813eba440e5b7bfbdf242d1) | `` magma: unbreak for cudaPackages_12 ``                                         |
| [`88c2708f`](https://github.com/hmajid2301/nixpkgs/commit/88c2708f0e70bfbadc969a3de29df989068e6f7e) | `` pdm: 2.12.1 -> 2.12.2 ``                                                      |
| [`ee8267f6`](https://github.com/hmajid2301/nixpkgs/commit/ee8267f6a225a1dc7571302640cef2418d54f4c6) | `` cargo-show-asm: 0.2.28 -> 0.2.29 ``                                           |
| [`8916302f`](https://github.com/hmajid2301/nixpkgs/commit/8916302f6b5b3e4c17f3a0f53210d8683d1c7c98) | `` llvmPackages: 14.0.6 -> 17.0.6 for other platforms ``                         |
| [`3353a928`](https://github.com/hmajid2301/nixpkgs/commit/3353a928afe371e02555b8a2f7734139952304a2) | `` go_1_22: 1.22rc1 -> 1.22rc2 ``                                                |
| [`944f1672`](https://github.com/hmajid2301/nixpkgs/commit/944f16727f6ffcc5bda5efce5e2dee46e8d880bb) | `` go_1_22: init at 1.22rc1 ``                                                   |
| [`214229b2`](https://github.com/hmajid2301/nixpkgs/commit/214229b26dbf2c05bf0cfa679bbd0c06c479bb76) | `` retroarch: Fix wrapper arguments in mkLibretroCore ``                         |
| [`1d1d938b`](https://github.com/hmajid2301/nixpkgs/commit/1d1d938bf03b89a9fc8c1d905d64bdd915213391) | `` tests.cc-wrapper: fix error ``                                                |
| [`2a302a6c`](https://github.com/hmajid2301/nixpkgs/commit/2a302a6c90cc885c4057a3ea7689c41865522a04) | `` gpxsee: 13.14 -> 13.15 ``                                                     |
| [`680c93e8`](https://github.com/hmajid2301/nixpkgs/commit/680c93e8086322edb5306680e15b4db997259ba4) | `` php81Extensions.amqp: 2.1.1 -> 2.1.2 ``                                       |
| [`d6aef928`](https://github.com/hmajid2301/nixpkgs/commit/d6aef9282e31236758bae8ca81f7c185cb732fb5) | `` python311Packages.aiocomelit: 0.7.3 -> 0.7.4 ``                               |
| [`24855168`](https://github.com/hmajid2301/nixpkgs/commit/248551683d396462feabd373b2eae773779d28fa) | `` python311Packages.appthreat-vulnerability-db: 5.5.8 -> 5.5.10 ``              |
| [`cef2022e`](https://github.com/hmajid2301/nixpkgs/commit/cef2022ef69eae2e0b695deccea4bd6105c2fcce) | `` python311Packages.dvc: 3.41.0 -> 3.42.0 ``                                    |
| [`577376ca`](https://github.com/hmajid2301/nixpkgs/commit/577376cab3cce235a7e131e6efceaf85c9572c8c) | `` httpx: 1.3.8 -> 1.3.9 ``                                                      |
| [`49136bdc`](https://github.com/hmajid2301/nixpkgs/commit/49136bdc58b79b7b0a522b85e4abf216d508d629) | `` python311Packages.reptor: 0.7 -> 0.8 ``                                       |
| [`aa10a2ae`](https://github.com/hmajid2301/nixpkgs/commit/aa10a2ae5727532ef96eb4f309b1704899ea4e34) | `` python311Packages.blurhash-python: 1.2.1 -> 1.2.2 ``                          |
| [`eb81a153`](https://github.com/hmajid2301/nixpkgs/commit/eb81a1530f183dcb65456aae2287872044aa10c1) | `` python311Packages.cvss: 2.6 -> 3.0 ``                                         |
| [`643b6647`](https://github.com/hmajid2301/nixpkgs/commit/643b6647fbc3a5103ee3eb526c177aa9b6194cff) | `` fwupd: move to by-name ``                                                     |
| [`28ea07d4`](https://github.com/hmajid2301/nixpkgs/commit/28ea07d4e33c63447e699562d0085f6eeefd6ee0) | `` fwupd: 1.9.11 -> 1.9.12 ``                                                    |
| [`8561e189`](https://github.com/hmajid2301/nixpkgs/commit/8561e189245cc572aedeed1dedd35ec5ab317bef) | `` symfony-cli: 5.8.2 -> 5.8.4 ``                                                |
| [`aab29f6c`](https://github.com/hmajid2301/nixpkgs/commit/aab29f6cffd34acda5dae22715105088610e8b90) | `` python311Packages.dvc-data: 3.7.0 -> 3.8.0 ``                                 |
| [`93f9595c`](https://github.com/hmajid2301/nixpkgs/commit/93f9595c36676fbfece20ae64c00008c85ec8d07) | `` kdash: 0.4.7 -> 0.5.0 ``                                                      |
| [`4c1fda7d`](https://github.com/hmajid2301/nixpkgs/commit/4c1fda7d4bd05ad6371636e36a51b5692a3ac521) | `` python311Packages.hahomematic: 2024.1.7 -> 2024.1.8 ``                        |
| [`bafa35ab`](https://github.com/hmajid2301/nixpkgs/commit/bafa35ab4300ab45b18d45f865d532cc896df6f2) | `` rclone: 1.65.1 -> 1.65.2 ``                                                   |
| [`d4f3c661`](https://github.com/hmajid2301/nixpkgs/commit/d4f3c6611b5a354454491e53cb042c0051f858f3) | `` fzf-make: 0.21.0 -> 0.22.0 ``                                                 |
| [`f863c227`](https://github.com/hmajid2301/nixpkgs/commit/f863c227fe1d633a615af33861c166d9dca8ad0b) | `` mullvad-browser: 13.0.7 -> 13.0.9 ``                                          |
| [`dfe6be12`](https://github.com/hmajid2301/nixpkgs/commit/dfe6be1209bb7b9ac0382c2543692e0747230fd3) | `` tor-browser: 13.0.8 -> 13.0.9 ``                                              |
| [`648314b2`](https://github.com/hmajid2301/nixpkgs/commit/648314b200cd677e19081bcd805338f46d02637a) | `` mullvad-browser: fix desktop item name ``                                     |
| [`dc8293a5`](https://github.com/hmajid2301/nixpkgs/commit/dc8293a53082fb3e1c306cb369e073dfc71ce78c) | `` meshcentral: take over maintainership ``                                      |
| [`fbc1452b`](https://github.com/hmajid2301/nixpkgs/commit/fbc1452b83737ded618e56d3537d4ba9edb47595) | `` nnpdf: 4.0.7 -> 4.0.8 ``                                                      |
| [`6b19a1f3`](https://github.com/hmajid2301/nixpkgs/commit/6b19a1f3fe225c495bceeba8d2b773e3e2442e0c) | `` jdt-language-server: set `passthru.updateScript` ``                           |
| [`af0589b0`](https://github.com/hmajid2301/nixpkgs/commit/af0589b0e61fd316443b92860df1e87dee2ffc1f) | `` jdt-language-server: move to `pkgs/by-name` ``                                |
| [`851e2fee`](https://github.com/hmajid2301/nixpkgs/commit/851e2fee6b2b68b4e47c6de9b0132828f81c2a11) | `` python311Packages.transformers: 4.37.0 -> 4.37.1 ``                           |
| [`16bcff92`](https://github.com/hmajid2301/nixpkgs/commit/16bcff9241e62aa8942d006ec631aa2b0009e7de) | `` grafana-loki,promtail: 2.9.3 -> 2.9.4 ``                                      |
| [`b8767be1`](https://github.com/hmajid2301/nixpkgs/commit/b8767be1b8fcb70cfb350325d7cf721ee7a90615) | `` mastodon: 4.2.3 -> 4.2.4 ``                                                   |
| [`3c4477c3`](https://github.com/hmajid2301/nixpkgs/commit/3c4477c32ea39abe21eb7ce0025b17f80f66e3b4) | `` kops: 1.28.2 -> 1.28.3 ``                                                     |
| [`8a3a274c`](https://github.com/hmajid2301/nixpkgs/commit/8a3a274c24669c1ecbdafd2aa89dfe809d09898f) | `` google-chrome: unbreak build in M121 ``                                       |
| [`29eb2579`](https://github.com/hmajid2301/nixpkgs/commit/29eb257997bc6e41258b8334db6485868fe705e6) | `` python311Packages.botocore-stubs: 1.34.25 -> 1.34.26 ``                       |
| [`ea77c587`](https://github.com/hmajid2301/nixpkgs/commit/ea77c587e1b49900a4a660f999b8075bebaeeb32) | `` cppcheck: 2.13.1 -> 2.13.2 ``                                                 |
| [`73f6621a`](https://github.com/hmajid2301/nixpkgs/commit/73f6621a3713fc01c09d2e237bf1cc877be45cfe) | `` mesa: make libunwind optional ``                                              |
| [`cb97e261`](https://github.com/hmajid2301/nixpkgs/commit/cb97e26158c6b894a95ccf03fbd82eca77f185cc) | `` libunwind: populate bad platforms ``                                          |
| [`4380881c`](https://github.com/hmajid2301/nixpkgs/commit/4380881c20c13727efb966d13ab76b772de50aee) | `` libunwind: fix build on aarch64-musl ``                                       |
| [`df844bb3`](https://github.com/hmajid2301/nixpkgs/commit/df844bb3f52640c22fae24ccd77596f754f71d3b) | `` opentofu: 1.6.0 -> 1.6.1 ``                                                   |
| [`ca744ae6`](https://github.com/hmajid2301/nixpkgs/commit/ca744ae6d691d3a4b17668695561e1999d33f815) | `` firefox-esr-unwrapped: 115.6.0esr -> 115.7.0esr ``                            |
| [`4475f50a`](https://github.com/hmajid2301/nixpkgs/commit/4475f50ae9a3bfa043d5728cc1c7dc7e1f28df3b) | `` firefox-bin-unwrapped: 121.0.1 -> 122.0 ``                                    |
| [`3b64fdba`](https://github.com/hmajid2301/nixpkgs/commit/3b64fdbae9648eae53a15499d3df3c250a83e84f) | `` firefox-unwrapped: 121.0.1 -> 122.0 ``                                        |
| [`506b2151`](https://github.com/hmajid2301/nixpkgs/commit/506b21518dfaa747b022ff1850de86b8e5dc44d5) | `` ceph: Fix tests by adding back old required python libs. See #281858. ``      |
| [`d37074d8`](https://github.com/hmajid2301/nixpkgs/commit/d37074d8b405553fb829821cc8ccb4f85d1e6378) | `` sage, sageWithDoc: 10.0 -> 10.2 ``                                            |
| [`69edce0c`](https://github.com/hmajid2301/nixpkgs/commit/69edce0c66f88f111beb4f491960fa01bffe85f0) | `` python311Packages.memory-allocator: use cython_3 ``                           |
| [`2ca72170`](https://github.com/hmajid2301/nixpkgs/commit/2ca721709aa14ba072f2e4d2be318198b42cb7c8) | `` python311Packages.primecountpy: use cython_3 ``                               |
| [`16aef004`](https://github.com/hmajid2301/nixpkgs/commit/16aef004f30f22228a2d9642535651f6de34d8bb) | `` python311Packages.pplpy: use cython_3 ``                                      |
| [`2266324e`](https://github.com/hmajid2301/nixpkgs/commit/2266324e20bb482e49819dff54dc00e43adc8075) | `` python311Packages.cypari2: 2.1.3 -> 2.1.4 ``                                  |
| [`824d91a5`](https://github.com/hmajid2301/nixpkgs/commit/824d91a532d084fd6cdae333ae9f7a765d7c746c) | `` Revert "python311Packages.cysignals: revert to cython 0.29 for the moment" `` |
| [`5b93b83b`](https://github.com/hmajid2301/nixpkgs/commit/5b93b83bcba9b03da23ed0c002555bcefe58b031) | `` Revert "python311Packages.fpylll: revert to cython 0.29 for the moment" ``    |
| [`a8154b77`](https://github.com/hmajid2301/nixpkgs/commit/a8154b773386c87ded47257c6f89116d26cb3202) | `` mpvScripts.mpv-cheatsheet: init at 0.30.0.2 ``                                |
| [`04b7a280`](https://github.com/hmajid2301/nixpkgs/commit/04b7a2803dbc5973cf5fcc0b0ebce00ec15d8f4b) | `` djhtml: 3.0.5 -> 3.0.6 ``                                                     |
| [`f03470fe`](https://github.com/hmajid2301/nixpkgs/commit/f03470fe9a19579f55ac1db67a8724395efc8d35) | `` lune: mark as broken on darwin ``                                             |
| [`7bb7c307`](https://github.com/hmajid2301/nixpkgs/commit/7bb7c3079b9e7fa376a3faabf9b62026b7a1bad6) | `` btop: enable nvidia gpu support ``                                            |
| [`27971014`](https://github.com/hmajid2301/nixpkgs/commit/279710140a1ba327a73add25856ad8379b15f561) | `` cargo-crev: 0.25.4 -> 0.25.6 ``                                               |
| [`6c25130f`](https://github.com/hmajid2301/nixpkgs/commit/6c25130f8552d4a6ea6ee43db7abe42280e752f5) | `` anyk: init at 3.26.0 ``                                                       |
| [`bf2c85fa`](https://github.com/hmajid2301/nixpkgs/commit/bf2c85fa691c0908740e1a1bc16435351f7bde2c) | `` ceph: Fix build with GCC 13 by using fmt_8 -> fmt_9. Fixes #281027 ``         |
| [`c332a23b`](https://github.com/hmajid2301/nixpkgs/commit/c332a23b7b6111e3106f46495ef4c40ce85797f9) | `` python311Packages.linien-common: fix build by using rpyc4 ``                  |
| [`ebb7b9b7`](https://github.com/hmajid2301/nixpkgs/commit/ebb7b9b772cf1bbb4a436d57e39e3741f29e10dc) | `` python311Packages.rpyc4: init at 4.1.5 ``                                     |
| [`a64fba24`](https://github.com/hmajid2301/nixpkgs/commit/a64fba242ea1712800dc3b95f58c507ff1eca6aa) | `` mysql-workbench: 8.0.34 -> 8.0.36 ``                                          |
| [`9fcbb8e4`](https://github.com/hmajid2301/nixpkgs/commit/9fcbb8e48d06f2975761986f0cfdafcf1b4a2652) | `` polkadot: 1.5.0 -> 1.6.0 ``                                                   |
| [`9106a352`](https://github.com/hmajid2301/nixpkgs/commit/9106a35231ee2e47e1cc96f73424b84368825f12) | `` minesweep-rs: 6.0.47 -> 6.0.50 ``                                             |
| [`001dfac4`](https://github.com/hmajid2301/nixpkgs/commit/001dfac4c86599a31412c0cc318f6f91ccb2f710) | `` khal: override urwid ``                                                       |
| [`90386982`](https://github.com/hmajid2301/nixpkgs/commit/903869821357fa836ccbd54ac806de184049c35d) | `` khal: refactor ``                                                             |
| [`36a7359e`](https://github.com/hmajid2301/nixpkgs/commit/36a7359ea472919010b5feb5eda88b6fd578334b) | `` python311Packages.schwifty: 2023.11.2 -> 2024.1.1.post0 ``                    |
| [`60809c4d`](https://github.com/hmajid2301/nixpkgs/commit/60809c4d28cfc81380a81a7fbf0f6d191c47f867) | `` python311Packages.lupupy: refactor ``                                         |
| [`7045f27c`](https://github.com/hmajid2301/nixpkgs/commit/7045f27ce787865c21130fe7f991573e41634638) | `` automatic-timezoned: 1.0.139 -> 1.0.146 ``                                    |
| [`d6c2574c`](https://github.com/hmajid2301/nixpkgs/commit/d6c2574c63929274e3fe72734d7c54e9f3452249) | `` pass2csv: 1.0.0 -> 1.1.0 ``                                                   |
| [`c2716fd4`](https://github.com/hmajid2301/nixpkgs/commit/c2716fd4163ad920e0ac4c41408699e3d04ed22d) | `` zeekscript: refactor ``                                                       |
| [`724f7d79`](https://github.com/hmajid2301/nixpkgs/commit/724f7d79b1ed972a5314a582be185d8f9ccbb5b4) | `` ddrescue: 1.27 -> 1.28 ``                                                     |
| [`8609cc8a`](https://github.com/hmajid2301/nixpkgs/commit/8609cc8a437164125fe2888c39f4bf35aa218245) | `` m33-linux: fix the build against `gcc-13` ``                                  |
| [`dbc5b625`](https://github.com/hmajid2301/nixpkgs/commit/dbc5b62594a1b69ba307ef83b059da15d2812764) | `` musescore: 4.2.0 -> 4.2.1 ``                                                  |
| [`d7b970c4`](https://github.com/hmajid2301/nixpkgs/commit/d7b970c4ee9da0c7288560c4901391587c51606e) | `` m17-cxx-demod: fix the build against `gcc-13` ``                              |
| [`05a57af1`](https://github.com/hmajid2301/nixpkgs/commit/05a57af1258eaf12f4996d82ea59531f710fe58a) | `` lzwolf: fix the build against `gcc-13` ``                                     |
| [`9f4fd889`](https://github.com/hmajid2301/nixpkgs/commit/9f4fd8893fb6d3d525e26c06b7ca47e04598b7a6) | `` remote-touchpad: 1.4.3 -> 1.4.4 ``                                            |
| [`cb5cd3f5`](https://github.com/hmajid2301/nixpkgs/commit/cb5cd3f59c883e5072fb9a5cf1b8c9c72c8ad28c) | `` sbclPackages.nyxt: 3.11.0 -> 3.11.1 ``                                        |
| [`a33e3d60`](https://github.com/hmajid2301/nixpkgs/commit/a33e3d607c7eb9a9146a3a356800fd27994a1445) | `` paraview: include missing header ``                                           |
| [`c2e081fe`](https://github.com/hmajid2301/nixpkgs/commit/c2e081fe1815fd63e25472c86c7b2975f5f45459) | `` paraview: 5.11.1 -> 5.11.2 ``                                                 |
| [`3f066cda`](https://github.com/hmajid2301/nixpkgs/commit/3f066cdafd961a22638fc3891cedbd62d26b2f17) | `` sish: 2.11.0 -> 2.12.0 ``                                                     |
| [`9c839356`](https://github.com/hmajid2301/nixpkgs/commit/9c839356d936709be3053a6fc7ba7e25e8d51ed5) | `` man-pages: Install in parallel ``                                             |