### PR TITLE
chore(flake/srvos): `acf84aca` -> `11fcfaa5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1011,11 +1011,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705884983,
-        "narHash": "sha256-cVzXizWdkmJQ5xwe/6S+cam8fyxTN4emkdmB8LKJGCY=",
+        "lastModified": 1706185290,
+        "narHash": "sha256-NtdXAFyldacSjUv/fneq/3iPLWBPyPZvRDK57DwpF4g=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "acf84acad906a1886ee36adc2353ac685e63466f",
+        "rev": "11fcfaa50bb1e2335e7313c0751c179c1ea5d6be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`11fcfaa5`](https://github.com/nix-community/srvos/commit/11fcfaa50bb1e2335e7313c0751c179c1ea5d6be) | `` dev/private/flake.lock: Update `` |
| [`c65391f9`](https://github.com/nix-community/srvos/commit/c65391f97de4a500cc7f6c3055805e09600f98fe) | `` flake.lock: Update ``             |