### PR TITLE
chore(flake/nur): `20f64c71` -> `4197afd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706174248,
-        "narHash": "sha256-VNN7md+kJhBvl5bINEXybSG4jHavrQIlXdywpcaEEwc=",
+        "lastModified": 1706197487,
+        "narHash": "sha256-6lXv3BRE9risuMO9C1l7mL+/peT/gMJWE6H1D228PMM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "20f64c7125413fc19372f11b45db99363bea7c1f",
+        "rev": "4197afd79efd78aa30199db35dbdad6af5c53e48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4197afd7`](https://github.com/nix-community/NUR/commit/4197afd79efd78aa30199db35dbdad6af5c53e48) | `` automatic update `` |