### PR TITLE
chore(flake/emacs-overlay): `1da43661` -> `ac7a6bb9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706194426,
-        "narHash": "sha256-GyRzoplHQ+05WPKSWipl5Y1HJsOwjoNQZP/IDslCHIE=",
+        "lastModified": 1706199638,
+        "narHash": "sha256-W+2oI91mU+tkT47SFKPidyL/BAtJnRY198Z2LhM8/s0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1da43661dec36a276fbae4c4c78f79c3a084328d",
+        "rev": "ac7a6bb962205862337d8034b04c98d6059f604d",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1705916986,
-        "narHash": "sha256-iBpfltu6QvN4xMpen6jGGEb6jOqmmVQKUrXdOJ32u8w=",
+        "lastModified": 1706098335,
+        "narHash": "sha256-r3dWjT8P9/Ah5m5ul4WqIWD8muj5F+/gbCdjiNVBKmU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d7f206b723e42edb09d9d753020a84b3061a79d8",
+        "rev": "a77ab169a83a4175169d78684ddd2e54486ac651",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ac7a6bb9`](https://github.com/nix-community/emacs-overlay/commit/ac7a6bb962205862337d8034b04c98d6059f604d) | `` Updated elpa ``         |
| [`b141adfd`](https://github.com/nix-community/emacs-overlay/commit/b141adfd12559af3a9fb73f9ba6a70703e4abc25) | `` Updated flake inputs `` |