### PR TITLE
chore(flake/nur): `36e01542` -> `61c04b2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706204716,
-        "narHash": "sha256-MwpaBG9QuXdCzC4otFxTJrdIW6DRAe64I0nvyZp9Tco=",
+        "lastModified": 1706211899,
+        "narHash": "sha256-gedJjTowTi71oxbYiMXRvzlbMthu2knSmvpuqe7QO4Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "36e01542664b2435defe362505880629dabd1b55",
+        "rev": "61c04b2e2cc15d505cab5c959df9388fde20525f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`61c04b2e`](https://github.com/nix-community/NUR/commit/61c04b2e2cc15d505cab5c959df9388fde20525f) | `` automatic update `` |
| [`b26add5d`](https://github.com/nix-community/NUR/commit/b26add5df68fd25df8b873d25f74b61b4d22ac7c) | `` automatic update `` |