### PR TITLE
chore(flake/srvos): `11fcfaa5` -> `0a0f4f44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1011,11 +1011,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706185290,
-        "narHash": "sha256-NtdXAFyldacSjUv/fneq/3iPLWBPyPZvRDK57DwpF4g=",
+        "lastModified": 1706210007,
+        "narHash": "sha256-jplmuOV5vl8Tww8RF2RZ9cv2m8vHkPvDrX1/FGhJtd0=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "11fcfaa50bb1e2335e7313c0751c179c1ea5d6be",
+        "rev": "0a0f4f441b7bd014e523de33a810badda546e862",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                           |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`0a0f4f44`](https://github.com/nix-community/srvos/commit/0a0f4f441b7bd014e523de33a810badda546e862) | `` cloud-init: don't flush the host's ssh keys `` |