### PR TITLE
chore(flake/nur): `61c04b2e` -> `a6655b30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706211899,
-        "narHash": "sha256-gedJjTowTi71oxbYiMXRvzlbMthu2knSmvpuqe7QO4Y=",
+        "lastModified": 1706214858,
+        "narHash": "sha256-RQVCk0YkYLPCCwFtetHqGEHVhNaUPF+0Syi45BYAwKo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "61c04b2e2cc15d505cab5c959df9388fde20525f",
+        "rev": "a6655b30ba4d1ed92eaf67ee3b2aba51a0ca485d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a6655b30`](https://github.com/nix-community/NUR/commit/a6655b30ba4d1ed92eaf67ee3b2aba51a0ca485d) | `` automatic update `` |
| [`32d815ea`](https://github.com/nix-community/NUR/commit/32d815ea486df9070d19cf4276b7d8568236494a) | `` automatic update `` |