### PR TITLE
chore(flake/nur): `a6655b30` -> `55a782f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706214858,
-        "narHash": "sha256-RQVCk0YkYLPCCwFtetHqGEHVhNaUPF+0Syi45BYAwKo=",
+        "lastModified": 1706221719,
+        "narHash": "sha256-0YszPLswzv7A3tl5OG62sO2xHsDTBI7yDynqDlOQrzk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a6655b30ba4d1ed92eaf67ee3b2aba51a0ca485d",
+        "rev": "55a782f5bc073e9c0b2a8e4d979fbf077063da4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`55a782f5`](https://github.com/nix-community/NUR/commit/55a782f5bc073e9c0b2a8e4d979fbf077063da4f) | `` automatic update `` |
| [`e9c56cdc`](https://github.com/nix-community/NUR/commit/e9c56cdc0a8353823be16a7dd1f419febdfba84f) | `` automatic update `` |