### PR TITLE
chore(flake/nur): `55a782f5` -> `d4d60da6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706221719,
-        "narHash": "sha256-0YszPLswzv7A3tl5OG62sO2xHsDTBI7yDynqDlOQrzk=",
+        "lastModified": 1706224280,
+        "narHash": "sha256-NjNVRbhfqLcQ1mbv4p8sJWUykdVS1K1+kvOFYCcjL/o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "55a782f5bc073e9c0b2a8e4d979fbf077063da4f",
+        "rev": "d4d60da6551ad5425b2456f7e7081364fd17d7dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d4d60da6`](https://github.com/nix-community/NUR/commit/d4d60da6551ad5425b2456f7e7081364fd17d7dd) | `` automatic update `` |