### PR TITLE
chore(flake/nur): `ff29c606` -> `0d5e8c37`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706236853,
-        "narHash": "sha256-UCB3DHy2kwBVPzHTCi+OqZS/fmdxK1V7ANCDbLtw9Rg=",
+        "lastModified": 1706240686,
+        "narHash": "sha256-GtTx9TUrnep/oE9lEWGbcZuaW77AX1Q0Pas1UVjr58s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ff29c6068eecf79a60accc29db1fd12a2a78af22",
+        "rev": "0d5e8c3721350659d1d7c81c938c9b4854907d5c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0d5e8c37`](https://github.com/nix-community/NUR/commit/0d5e8c3721350659d1d7c81c938c9b4854907d5c) | `` automatic update `` |