### PR TITLE
chore(flake/nur): `0d5e8c37` -> `07501c23`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706240686,
-        "narHash": "sha256-GtTx9TUrnep/oE9lEWGbcZuaW77AX1Q0Pas1UVjr58s=",
+        "lastModified": 1706242084,
+        "narHash": "sha256-gKURnfuuw+4cqM3xSkWqBeaIumxNF81Xs8ZV+XkJwa4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0d5e8c3721350659d1d7c81c938c9b4854907d5c",
+        "rev": "07501c238ab0ad1b2ab8e30d9c9edfa4a8e500e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`07501c23`](https://github.com/nix-community/NUR/commit/07501c238ab0ad1b2ab8e30d9c9edfa4a8e500e0) | `` automatic update `` |