### PR TITLE
chore(flake/nur): `07501c23` -> `7779309e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706242084,
-        "narHash": "sha256-gKURnfuuw+4cqM3xSkWqBeaIumxNF81Xs8ZV+XkJwa4=",
+        "lastModified": 1706247663,
+        "narHash": "sha256-t0oCsnQoAaXx+rt0vhqn2qdHGf+0Fz2gM5WlEXEShmE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "07501c238ab0ad1b2ab8e30d9c9edfa4a8e500e0",
+        "rev": "7779309e590d19c6f742baa6fb098a359375e65e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7779309e`](https://github.com/nix-community/NUR/commit/7779309e590d19c6f742baa6fb098a359375e65e) | `` automatic update `` |