### PR TITLE
chore(flake/nur): `7779309e` -> `1e00872a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706247663,
-        "narHash": "sha256-t0oCsnQoAaXx+rt0vhqn2qdHGf+0Fz2gM5WlEXEShmE=",
+        "lastModified": 1706251467,
+        "narHash": "sha256-uR6TEvf0PNFgIKLTImc4mt00qS7H5op9r7B++vdj2Io=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7779309e590d19c6f742baa6fb098a359375e65e",
+        "rev": "1e00872abadba03e57c74975b05527e418620986",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1e00872a`](https://github.com/nix-community/NUR/commit/1e00872abadba03e57c74975b05527e418620986) | `` automatic update `` |