### PR TITLE
chore(flake/nur): `f68a4897` -> `1bab2e33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706276690,
-        "narHash": "sha256-BVQ2POHWwc6uTwrqgOVWONtQKwYFeJztdY5FcEhbqMg=",
+        "lastModified": 1706279458,
+        "narHash": "sha256-ErYk1jxwtsyJum8q6HNrmpUTqZFc0MzZjQyEwMOwC0I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f68a48971bd33ff845dc5d6734f6a77d0d7a0967",
+        "rev": "1bab2e33bbc766aab100ad647e5d24e9d705e968",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1bab2e33`](https://github.com/nix-community/NUR/commit/1bab2e33bbc766aab100ad647e5d24e9d705e968) | `` automatic update `` |