### PR TITLE
chore(flake/emacs-overlay): `babae500` -> `fe9774e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706260016,
-        "narHash": "sha256-tNq/IZhAezmzxZvR53NA1TSp4YD9EJs4AsLecSKsAEw=",
+        "lastModified": 1706285927,
+        "narHash": "sha256-E1Et+ZXP0viAm6epO7sqMoaMA1bmWwkK3bTgPYCq2F0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "babae500c2bca610eb38e17a1ef1bf0f70beb29e",
+        "rev": "fe9774e2308a9efbfb83c1f1c0b69d9db3581649",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`fe9774e2`](https://github.com/nix-community/emacs-overlay/commit/fe9774e2308a9efbfb83c1f1c0b69d9db3581649) | `` Updated elpa `` |