### PR TITLE
chore(flake/nur): `1bab2e33` -> `2fde9f92`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706279458,
-        "narHash": "sha256-ErYk1jxwtsyJum8q6HNrmpUTqZFc0MzZjQyEwMOwC0I=",
+        "lastModified": 1706298359,
+        "narHash": "sha256-Akibmb69MTDTZ+sSbRngKROKPqbAFVwI+GD8git9qLY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1bab2e33bbc766aab100ad647e5d24e9d705e968",
+        "rev": "2fde9f9248e2dea3c2534ade2e4a9c3ea079a025",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2fde9f92`](https://github.com/nix-community/NUR/commit/2fde9f9248e2dea3c2534ade2e4a9c3ea079a025) | `` automatic update `` |
| [`e7859e6a`](https://github.com/nix-community/NUR/commit/e7859e6a08a3668e3c5a573949e9e1b18174b5f9) | `` automatic update `` |
| [`d5ae4728`](https://github.com/nix-community/NUR/commit/d5ae4728235dccaec5c20b3118430dc92349dc47) | `` automatic update `` |