### PR TITLE
chore(flake/nur): `2fde9f92` -> `50f8d668`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706298359,
-        "narHash": "sha256-Akibmb69MTDTZ+sSbRngKROKPqbAFVwI+GD8git9qLY=",
+        "lastModified": 1706307192,
+        "narHash": "sha256-u7tmHc3T/NZSaB+SgNMr9jllfvRH/EQ5JywkNwbuAR0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2fde9f9248e2dea3c2534ade2e4a9c3ea079a025",
+        "rev": "50f8d6686ad6d6591c1c09e2168e2b296d0fd845",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`50f8d668`](https://github.com/nix-community/NUR/commit/50f8d6686ad6d6591c1c09e2168e2b296d0fd845) | `` automatic update `` |