### PR TITLE
chore(flake/nixpkgs): `612f9723` -> `ae5c332c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -777,11 +777,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1705856552,
-        "narHash": "sha256-JXfnuEf5Yd6bhMs/uvM67/joxYKoysyE3M2k6T3eWbg=",
+        "lastModified": 1706191920,
+        "narHash": "sha256-eLihrZAPZX0R6RyM5fYAWeKVNuQPYjAkCUBr+JNvtdE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "612f97239e2cc474c13c9dafa0df378058c5ad8d",
+        "rev": "ae5c332cbb5827f6b1f02572496b141021de335f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                  |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`d7d7e123`](https://github.com/NixOS/nixpkgs/commit/d7d7e123b332b4da5008fdcc56253c437e1387ff) | `` nodePackages.volar: add meta.mainProgram ``                                           |
| [`354d2267`](https://github.com/NixOS/nixpkgs/commit/354d2267d2d84d88ae4ecf17b4c155f905523c10) | `` terraform: 1.7.0 -> 1.7.1 (#283693) ``                                                |
| [`4e4f86fb`](https://github.com/NixOS/nixpkgs/commit/4e4f86fbccfc6c2bfe0dbd1219048b245f9712f6) | `` protege-distribution: set meta.mainProgram ``                                         |
| [`35906439`](https://github.com/NixOS/nixpkgs/commit/359064396f556da8552ce3437668bd6b732894d5) | `` vimPlugins.haskell-scope-highlighting-nvim: init at 2023-04-29 ``                     |
| [`703c3208`](https://github.com/NixOS/nixpkgs/commit/703c3208defc72625553ecaae1e3f948adbf339e) | `` pkgsStatic.libunwind: don't -mno-outline-atomics ``                                   |
| [`9b2f4b16`](https://github.com/NixOS/nixpkgs/commit/9b2f4b164b2cadc37cb588d8bc3da7715a06d61c) | `` lscolors: 0.16.0 -> 0.17.0 ``                                                         |
| [`39b0be0d`](https://github.com/NixOS/nixpkgs/commit/39b0be0d82e2fa40ec181615c0dbff4e77914e41) | `` corrscope: relax ruamel.yaml dependency; fix build ``                                 |
| [`e4a8ae54`](https://github.com/NixOS/nixpkgs/commit/e4a8ae547c7cd2875116767c4c952c491213c1df) | `` jellyfin-ffmpeg: clobber patches ``                                                   |
| [`4567be8a`](https://github.com/NixOS/nixpkgs/commit/4567be8aa5a29e4489e601326820d0ae4b1a16cb) | `` ffmpeg: always use version from finalAttrs ``                                         |
| [`3f258b8e`](https://github.com/NixOS/nixpkgs/commit/3f258b8e445577ad47b566bceeb40c1a89d98b05) | `` catch2_3: fix build on i686 ``                                                        |
| [`1f37e33a`](https://github.com/NixOS/nixpkgs/commit/1f37e33af51568e615afc93e5d4047bc52b92358) | `` llvmPackages_12: pin to gcc12 to fix builds ``                                        |
| [`c5ac684a`](https://github.com/NixOS/nixpkgs/commit/c5ac684ad8eff90e45f1459844604114c121d096) | `` python311Packages.ale-py: change GitHub repo owner according to migration ``          |
| [`0c10ec9d`](https://github.com/NixOS/nixpkgs/commit/0c10ec9d2c0e1993798f70ad58e18a62352f3b21) | `` flashmq: 1.4.5 -> 1.8.4 ``                                                            |
| [`b2ee4908`](https://github.com/NixOS/nixpkgs/commit/b2ee4908adafc02c36975fb65d2618ed04d182ab) | `` nvidia-x11: revert "add an assert that `useSettings` implies more than `libsOnly`" `` |
| [`b9b58d1c`](https://github.com/NixOS/nixpkgs/commit/b9b58d1c46ca234dd18102cdc1222f383554189f) | `` libreswan: patch build after gcc upgrade ``                                           |
| [`0d4760b5`](https://github.com/NixOS/nixpkgs/commit/0d4760b5c4b40f6ecdf322ae7eb507e9de51c7f0) | `` dnscontrol: 4.8.1 -> 4.8.2 ``                                                         |
| [`8a2f9b24`](https://github.com/NixOS/nixpkgs/commit/8a2f9b24143cd5e0ef7aaf7d2f38ba8174e87b4d) | `` python311Packages.levenshtein: fetch submodules ``                                    |
| [`efe7c87c`](https://github.com/NixOS/nixpkgs/commit/efe7c87c4de672603442fe4755c5e76c4bec6cb4) | `` llvmPackages_11: pin to gcc12 to fix builds ``                                        |
| [`a082c256`](https://github.com/NixOS/nixpkgs/commit/a082c256ae3b8e2c1ecc5832f5f1224ffc2d6340) | `` hobbes: unpin stdenv llvm ``                                                          |
| [`5e579401`](https://github.com/NixOS/nixpkgs/commit/5e5794015fcf48afbf26d586d9067d3d20448b64) | `` pikopixel: unpin llvm9 ``                                                             |
| [`d436ff6b`](https://github.com/NixOS/nixpkgs/commit/d436ff6b7a8b3c96c0c2a58c7c8a4b719905a2e4) | `` path-of-building.data: 2.39.0 -> 2.39.1 ``                                            |
| [`a7630267`](https://github.com/NixOS/nixpkgs/commit/a7630267808ebd4116c0823327ae56d51aabab26) | `` linux-pam: fixup build on musl ``                                                     |
| [`24db4fbc`](https://github.com/NixOS/nixpkgs/commit/24db4fbcb81d80e8e74b3580736dedebada317cf) | `` octopus: fixup build by adding `which` ``                                             |
| [`a83e82c4`](https://github.com/NixOS/nixpkgs/commit/a83e82c4e9b02f3686b66701915cd35ef1a5e358) | `` yanic: init at 1.5.0 ``                                                               |
| [`5c4784cd`](https://github.com/NixOS/nixpkgs/commit/5c4784cd2f2a54288108019bb8f7466d7ca3171f) | `` marvin: pin openjdk17 ``                                                              |
| [`aaaa1aaa`](https://github.com/NixOS/nixpkgs/commit/aaaa1aaa767d767379e274dae38505a25b886ad6) | `` maintainers: add herbetom ``                                                          |
| [`e8a9c8e8`](https://github.com/NixOS/nixpkgs/commit/e8a9c8e821eeca631f7b553ffbe817219e4a74c5) | `` ruff-lsp: 0.0.49 -> 0.0.50 ``                                                         |
| [`8deb9a06`](https://github.com/NixOS/nixpkgs/commit/8deb9a06798b426169aba7a7342affe787ab5dd5) | `` marvin: 23.12.0 -> 23.17.0 ``                                                         |
| [`6882fc49`](https://github.com/NixOS/nixpkgs/commit/6882fc4950e392831ea76fd645fd095608958a42) | `` python311Packages.scikit-learn: 1.3.2 -> 1.4.0 ``                                     |
| [`af2562d9`](https://github.com/NixOS/nixpkgs/commit/af2562d930d7888812f39fc565df5b11084fdaff) | `` cargo-deny: add SystemConfiguration framework on darwin ``                            |
| [`ab2ba74e`](https://github.com/NixOS/nixpkgs/commit/ab2ba74e90a7ad10f82dac4d77a8ccadbfa32b9d) | `` wander: 1.0.1 -> 1.0.2 ``                                                             |
| [`c847e364`](https://github.com/NixOS/nixpkgs/commit/c847e364eacd9b0ae888b7fcdc235a321d1de52a) | `` nixos/hyprland: move to programs/wayland ``                                           |
| [`cdb08106`](https://github.com/NixOS/nixpkgs/commit/cdb081065109ef6873c107be1594a4ceab3f6d7a) | `` fritzing: unstable-2022-07-01 -> 1.0.1 ``                                             |
| [`644ee68b`](https://github.com/NixOS/nixpkgs/commit/644ee68b9605fa581e56bf092ad1b601d1288354) | `` trueseeing: 2.1.9 -> 2.1.10 ``                                                        |
| [`32f3172e`](https://github.com/NixOS/nixpkgs/commit/32f3172e93f1a02a0cf911677b43722b637f69bd) | `` thunderbird-unwrapped: 115.6.1 -> 115.7.0 ``                                          |
| [`5faf086c`](https://github.com/NixOS/nixpkgs/commit/5faf086cad787328c813eba440e5b7bfbdf242d1) | `` magma: unbreak for cudaPackages_12 ``                                                 |
| [`88c2708f`](https://github.com/NixOS/nixpkgs/commit/88c2708f0e70bfbadc969a3de29df989068e6f7e) | `` pdm: 2.12.1 -> 2.12.2 ``                                                              |
| [`79bfd335`](https://github.com/NixOS/nixpkgs/commit/79bfd335bd2ea94d4033966343e161e31263f3a7) | `` zram-generator: 1.1.2 -> 1.1.2 ``                                                     |
| [`ee8267f6`](https://github.com/NixOS/nixpkgs/commit/ee8267f6a225a1dc7571302640cef2418d54f4c6) | `` cargo-show-asm: 0.2.28 -> 0.2.29 ``                                                   |
| [`8916302f`](https://github.com/NixOS/nixpkgs/commit/8916302f6b5b3e4c17f3a0f53210d8683d1c7c98) | `` llvmPackages: 14.0.6 -> 17.0.6 for other platforms ``                                 |
| [`3353a928`](https://github.com/NixOS/nixpkgs/commit/3353a928afe371e02555b8a2f7734139952304a2) | `` go_1_22: 1.22rc1 -> 1.22rc2 ``                                                        |
| [`944f1672`](https://github.com/NixOS/nixpkgs/commit/944f16727f6ffcc5bda5efce5e2dee46e8d880bb) | `` go_1_22: init at 1.22rc1 ``                                                           |
| [`efa0f7d5`](https://github.com/NixOS/nixpkgs/commit/efa0f7d58cf1fe3a83d73930d1f5006fc614f6bd) | `` python311Packages.ale-py: fix build ``                                                |
| [`22f14055`](https://github.com/NixOS/nixpkgs/commit/22f14055afdf1b86dc37b3fee386248f2cbc3df0) | `` python311Packages.torchrl: init at 0.2.1 ``                                           |
| [`1642ca6f`](https://github.com/NixOS/nixpkgs/commit/1642ca6fc6f0b9eeaedc7b830d5b54cc35d5c84e) | `` python311Packages.tensordict: init at 0.2.1 ``                                        |
| [`214229b2`](https://github.com/NixOS/nixpkgs/commit/214229b26dbf2c05bf0cfa679bbd0c06c479bb76) | `` retroarch: Fix wrapper arguments in mkLibretroCore ``                                 |
| [`50259190`](https://github.com/NixOS/nixpkgs/commit/502591907cf51e009922c5aaf6c7d9be9e261193) | `` androidStudioPackages.canary: 2023.3.1.4 -> 2023.3.1.5 ``                             |
| [`15701258`](https://github.com/NixOS/nixpkgs/commit/1570125877e428b62bcb238734f9408cf8ea3570) | `` androidStudioPackages.stable: 2023.1.1.27 -> 2023.1.1.28 ``                           |
| [`1d1d938b`](https://github.com/NixOS/nixpkgs/commit/1d1d938bf03b89a9fc8c1d905d64bdd915213391) | `` tests.cc-wrapper: fix error ``                                                        |
| [`2a302a6c`](https://github.com/NixOS/nixpkgs/commit/2a302a6c90cc885c4057a3ea7689c41865522a04) | `` gpxsee: 13.14 -> 13.15 ``                                                             |
| [`680c93e8`](https://github.com/NixOS/nixpkgs/commit/680c93e8086322edb5306680e15b4db997259ba4) | `` php81Extensions.amqp: 2.1.1 -> 2.1.2 ``                                               |
| [`d6aef928`](https://github.com/NixOS/nixpkgs/commit/d6aef9282e31236758bae8ca81f7c185cb732fb5) | `` python311Packages.aiocomelit: 0.7.3 -> 0.7.4 ``                                       |
| [`24855168`](https://github.com/NixOS/nixpkgs/commit/248551683d396462feabd373b2eae773779d28fa) | `` python311Packages.appthreat-vulnerability-db: 5.5.8 -> 5.5.10 ``                      |
| [`cef2022e`](https://github.com/NixOS/nixpkgs/commit/cef2022ef69eae2e0b695deccea4bd6105c2fcce) | `` python311Packages.dvc: 3.41.0 -> 3.42.0 ``                                            |
| [`577376ca`](https://github.com/NixOS/nixpkgs/commit/577376cab3cce235a7e131e6efceaf85c9572c8c) | `` httpx: 1.3.8 -> 1.3.9 ``                                                              |
| [`49136bdc`](https://github.com/NixOS/nixpkgs/commit/49136bdc58b79b7b0a522b85e4abf216d508d629) | `` python311Packages.reptor: 0.7 -> 0.8 ``                                               |
| [`aa10a2ae`](https://github.com/NixOS/nixpkgs/commit/aa10a2ae5727532ef96eb4f309b1704899ea4e34) | `` python311Packages.blurhash-python: 1.2.1 -> 1.2.2 ``                                  |
| [`80823874`](https://github.com/NixOS/nixpkgs/commit/80823874927a60e0712c247aae0cb861dd81c53f) | `` sniffglue: enable darwin support ``                                                   |
| [`eb81a153`](https://github.com/NixOS/nixpkgs/commit/eb81a1530f183dcb65456aae2287872044aa10c1) | `` python311Packages.cvss: 2.6 -> 3.0 ``                                                 |
| [`81294f9c`](https://github.com/NixOS/nixpkgs/commit/81294f9c6c76a91df9210684b6d7bd29fc7e308c) | `` uhk-agent: 3.2.2 -> 3.3.0 ``                                                          |
| [`643b6647`](https://github.com/NixOS/nixpkgs/commit/643b6647fbc3a5103ee3eb526c177aa9b6194cff) | `` fwupd: move to by-name ``                                                             |
| [`28ea07d4`](https://github.com/NixOS/nixpkgs/commit/28ea07d4e33c63447e699562d0085f6eeefd6ee0) | `` fwupd: 1.9.11 -> 1.9.12 ``                                                            |
| [`8561e189`](https://github.com/NixOS/nixpkgs/commit/8561e189245cc572aedeed1dedd35ec5ab317bef) | `` symfony-cli: 5.8.2 -> 5.8.4 ``                                                        |
| [`aab29f6c`](https://github.com/NixOS/nixpkgs/commit/aab29f6cffd34acda5dae22715105088610e8b90) | `` python311Packages.dvc-data: 3.7.0 -> 3.8.0 ``                                         |
| [`0f71ad20`](https://github.com/NixOS/nixpkgs/commit/0f71ad2021d8d8daa1c99256213051138488d6ff) | `` linuxPackages.nvidiaPackages.beta: 545.23.06 -> 550.40.07 ``                          |
| [`93f9595c`](https://github.com/NixOS/nixpkgs/commit/93f9595c36676fbfece20ae64c00008c85ec8d07) | `` kdash: 0.4.7 -> 0.5.0 ``                                                              |
| [`4c1fda7d`](https://github.com/NixOS/nixpkgs/commit/4c1fda7d4bd05ad6371636e36a51b5692a3ac521) | `` python311Packages.hahomematic: 2024.1.7 -> 2024.1.8 ``                                |
| [`bafa35ab`](https://github.com/NixOS/nixpkgs/commit/bafa35ab4300ab45b18d45f865d532cc896df6f2) | `` rclone: 1.65.1 -> 1.65.2 ``                                                           |
| [`d4f3c661`](https://github.com/NixOS/nixpkgs/commit/d4f3c6611b5a354454491e53cb042c0051f858f3) | `` fzf-make: 0.21.0 -> 0.22.0 ``                                                         |
| [`f863c227`](https://github.com/NixOS/nixpkgs/commit/f863c227fe1d633a615af33861c166d9dca8ad0b) | `` mullvad-browser: 13.0.7 -> 13.0.9 ``                                                  |
| [`dfe6be12`](https://github.com/NixOS/nixpkgs/commit/dfe6be1209bb7b9ac0382c2543692e0747230fd3) | `` tor-browser: 13.0.8 -> 13.0.9 ``                                                      |
| [`648314b2`](https://github.com/NixOS/nixpkgs/commit/648314b200cd677e19081bcd805338f46d02637a) | `` mullvad-browser: fix desktop item name ``                                             |
| [`dc8293a5`](https://github.com/NixOS/nixpkgs/commit/dc8293a53082fb3e1c306cb369e073dfc71ce78c) | `` meshcentral: take over maintainership ``                                              |
| [`fbc1452b`](https://github.com/NixOS/nixpkgs/commit/fbc1452b83737ded618e56d3537d4ba9edb47595) | `` nnpdf: 4.0.7 -> 4.0.8 ``                                                              |
| [`6b19a1f3`](https://github.com/NixOS/nixpkgs/commit/6b19a1f3fe225c495bceeba8d2b773e3e2442e0c) | `` jdt-language-server: set `passthru.updateScript` ``                                   |
| [`af0589b0`](https://github.com/NixOS/nixpkgs/commit/af0589b0e61fd316443b92860df1e87dee2ffc1f) | `` jdt-language-server: move to `pkgs/by-name` ``                                        |
| [`851e2fee`](https://github.com/NixOS/nixpkgs/commit/851e2fee6b2b68b4e47c6de9b0132828f81c2a11) | `` python311Packages.transformers: 4.37.0 -> 4.37.1 ``                                   |
| [`16bcff92`](https://github.com/NixOS/nixpkgs/commit/16bcff9241e62aa8942d006ec631aa2b0009e7de) | `` grafana-loki,promtail: 2.9.3 -> 2.9.4 ``                                              |
| [`b8767be1`](https://github.com/NixOS/nixpkgs/commit/b8767be1b8fcb70cfb350325d7cf721ee7a90615) | `` mastodon: 4.2.3 -> 4.2.4 ``                                                           |
| [`3c4477c3`](https://github.com/NixOS/nixpkgs/commit/3c4477c32ea39abe21eb7ce0025b17f80f66e3b4) | `` kops: 1.28.2 -> 1.28.3 ``                                                             |
| [`8a3a274c`](https://github.com/NixOS/nixpkgs/commit/8a3a274c24669c1ecbdafd2aa89dfe809d09898f) | `` google-chrome: unbreak build in M121 ``                                               |
| [`29eb2579`](https://github.com/NixOS/nixpkgs/commit/29eb257997bc6e41258b8334db6485868fe705e6) | `` python311Packages.botocore-stubs: 1.34.25 -> 1.34.26 ``                               |
| [`ea77c587`](https://github.com/NixOS/nixpkgs/commit/ea77c587e1b49900a4a660f999b8075bebaeeb32) | `` cppcheck: 2.13.1 -> 2.13.2 ``                                                         |
| [`73f6621a`](https://github.com/NixOS/nixpkgs/commit/73f6621a3713fc01c09d2e237bf1cc877be45cfe) | `` mesa: make libunwind optional ``                                                      |
| [`cb97e261`](https://github.com/NixOS/nixpkgs/commit/cb97e26158c6b894a95ccf03fbd82eca77f185cc) | `` libunwind: populate bad platforms ``                                                  |
| [`4380881c`](https://github.com/NixOS/nixpkgs/commit/4380881c20c13727efb966d13ab76b772de50aee) | `` libunwind: fix build on aarch64-musl ``                                               |
| [`df844bb3`](https://github.com/NixOS/nixpkgs/commit/df844bb3f52640c22fae24ccd77596f754f71d3b) | `` opentofu: 1.6.0 -> 1.6.1 ``                                                           |
| [`ca744ae6`](https://github.com/NixOS/nixpkgs/commit/ca744ae6d691d3a4b17668695561e1999d33f815) | `` firefox-esr-unwrapped: 115.6.0esr -> 115.7.0esr ``                                    |
| [`4475f50a`](https://github.com/NixOS/nixpkgs/commit/4475f50ae9a3bfa043d5728cc1c7dc7e1f28df3b) | `` firefox-bin-unwrapped: 121.0.1 -> 122.0 ``                                            |
| [`3b64fdba`](https://github.com/NixOS/nixpkgs/commit/3b64fdbae9648eae53a15499d3df3c250a83e84f) | `` firefox-unwrapped: 121.0.1 -> 122.0 ``                                                |
| [`506b2151`](https://github.com/NixOS/nixpkgs/commit/506b21518dfaa747b022ff1850de86b8e5dc44d5) | `` ceph: Fix tests by adding back old required python libs. See #281858. ``              |
| [`d37074d8`](https://github.com/NixOS/nixpkgs/commit/d37074d8b405553fb829821cc8ccb4f85d1e6378) | `` sage, sageWithDoc: 10.0 -> 10.2 ``                                                    |
| [`69edce0c`](https://github.com/NixOS/nixpkgs/commit/69edce0c66f88f111beb4f491960fa01bffe85f0) | `` python311Packages.memory-allocator: use cython_3 ``                                   |
| [`2ca72170`](https://github.com/NixOS/nixpkgs/commit/2ca721709aa14ba072f2e4d2be318198b42cb7c8) | `` python311Packages.primecountpy: use cython_3 ``                                       |
| [`16aef004`](https://github.com/NixOS/nixpkgs/commit/16aef004f30f22228a2d9642535651f6de34d8bb) | `` python311Packages.pplpy: use cython_3 ``                                              |
| [`2266324e`](https://github.com/NixOS/nixpkgs/commit/2266324e20bb482e49819dff54dc00e43adc8075) | `` python311Packages.cypari2: 2.1.3 -> 2.1.4 ``                                          |
| [`824d91a5`](https://github.com/NixOS/nixpkgs/commit/824d91a532d084fd6cdae333ae9f7a765d7c746c) | `` Revert "python311Packages.cysignals: revert to cython 0.29 for the moment" ``         |
| [`5b93b83b`](https://github.com/NixOS/nixpkgs/commit/5b93b83bcba9b03da23ed0c002555bcefe58b031) | `` Revert "python311Packages.fpylll: revert to cython 0.29 for the moment" ``            |