### PR TITLE
chore(flake/emacs-overlay): `89ef4839` -> `27805cce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706288758,
-        "narHash": "sha256-4JFpDpkna1DKcZNuUkFUCM2W/4tBGXHbzRYNhyFqpkE=",
+        "lastModified": 1706317077,
+        "narHash": "sha256-5v4BipPkaejjF6Viu52l4AlZ1sCZKZrSjDk2o3+i30g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "89ef483952c2f5d1a4d8e52be846a6c20fd6be64",
+        "rev": "27805ccec0cd57b4dd2e6768f9df769d3e62ca77",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`27805cce`](https://github.com/nix-community/emacs-overlay/commit/27805ccec0cd57b4dd2e6768f9df769d3e62ca77) | `` Updated elpa ``         |
| [`77ab1e5b`](https://github.com/nix-community/emacs-overlay/commit/77ab1e5b58f46c48b78e47bcd3d727459740cb57) | `` Updated flake inputs `` |