### PR TITLE
chore(flake/nur): `130da755` -> `aa095efe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706319301,
-        "narHash": "sha256-gSMSBoD08JjbFLUeH6Sk+ZoiC39ldwLFy48g8R6lRh8=",
+        "lastModified": 1706334124,
+        "narHash": "sha256-bDoXDDqN/olkLB3U9x2GmMRWildo+2WrK/icOnW1C2s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "130da75573f9e1aac9599eb763113fd3faa7919c",
+        "rev": "aa095efecbf4da50d57d1e02d4729c8e9c299158",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aa095efe`](https://github.com/nix-community/NUR/commit/aa095efecbf4da50d57d1e02d4729c8e9c299158) | `` automatic update `` |