### PR TITLE
chore(flake/nur): `aa095efe` -> `5a9ff024`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706334124,
-        "narHash": "sha256-bDoXDDqN/olkLB3U9x2GmMRWildo+2WrK/icOnW1C2s=",
+        "lastModified": 1706336067,
+        "narHash": "sha256-CK6wCnWSw4nX2TbGL9oPlZyCZoYl+yVUAsGoelfh/5c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aa095efecbf4da50d57d1e02d4729c8e9c299158",
+        "rev": "5a9ff024fd7a50e93ad738ef48e68ca746593489",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5a9ff024`](https://github.com/nix-community/NUR/commit/5a9ff024fd7a50e93ad738ef48e68ca746593489) | `` automatic update `` |