### PR TITLE
chore(flake/nur): `587df369` -> `7bea34bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706345472,
-        "narHash": "sha256-n70KMr2alXCWHGZcLn1zlyk9XlCFVeqP9qiLnzbgC64=",
+        "lastModified": 1706346956,
+        "narHash": "sha256-jrjCKpztrxQk1kOFbRRXzxvv/sKfVLboKaYNHI9UYmo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "587df369fd2023582e267beddc2bfc9600f76207",
+        "rev": "7bea34bc73790b0a2c3798a8c6a25296e6566219",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7bea34bc`](https://github.com/nix-community/NUR/commit/7bea34bc73790b0a2c3798a8c6a25296e6566219) | `` automatic update `` |