### PR TITLE
chore(flake/nur): `7bea34bc` -> `3c5fedcf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706346956,
-        "narHash": "sha256-jrjCKpztrxQk1kOFbRRXzxvv/sKfVLboKaYNHI9UYmo=",
+        "lastModified": 1706355938,
+        "narHash": "sha256-jnHi0cbb307/pUOXdkvGtCzeNM8688TT7bhPnisYnyQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7bea34bc73790b0a2c3798a8c6a25296e6566219",
+        "rev": "3c5fedcf5bb8f566a15c3f59a05ec0591d4925b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3c5fedcf`](https://github.com/nix-community/NUR/commit/3c5fedcf5bb8f566a15c3f59a05ec0591d4925b1) | `` automatic update `` |
| [`f6e87f1b`](https://github.com/nix-community/NUR/commit/f6e87f1b10a7d8625ff77c6fb84bbfba8355ce2e) | `` automatic update `` |
| [`8c0cfe8f`](https://github.com/nix-community/NUR/commit/8c0cfe8f6a9a8f3f5581a678fdf5cbcf26940cb4) | `` automatic update `` |