### PR TITLE
chore(flake/nur): `3c5fedcf` -> `9fb6d3cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706355938,
-        "narHash": "sha256-jnHi0cbb307/pUOXdkvGtCzeNM8688TT7bhPnisYnyQ=",
+        "lastModified": 1706360221,
+        "narHash": "sha256-wCMQcLn45gsbFlnv+zQmXvBJ8K4D4JrOpROcNleQ22w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3c5fedcf5bb8f566a15c3f59a05ec0591d4925b1",
+        "rev": "9fb6d3cc0fd4a3a66dca5108e85626b8bbbbdcd4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9fb6d3cc`](https://github.com/nix-community/NUR/commit/9fb6d3cc0fd4a3a66dca5108e85626b8bbbbdcd4) | `` automatic update `` |
| [`0c2280a7`](https://github.com/nix-community/NUR/commit/0c2280a788d441edfb82b81f9475f1aea17c8756) | `` automatic update `` |
| [`63467f6a`](https://github.com/nix-community/NUR/commit/63467f6aa6726390d7901ba8d84c5bdf3305d02b) | `` automatic update `` |