### PR TITLE
chore(flake/nur): `44f751f3` -> `d6309b93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706363048,
-        "narHash": "sha256-woyGT/QR4XYtmXzrnqgVosB6vxWdj5qbfYq89J9B3og=",
+        "lastModified": 1706366610,
+        "narHash": "sha256-nQysJOK8oAk7PlHDn9SHeCAZSXqhD3OoN3Wo6Y37TM8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "44f751f3434cb8a4ae82aa4e05c11bddbc8be8ea",
+        "rev": "d6309b93218b980f77a67d5521b37f963a5de361",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d6309b93`](https://github.com/nix-community/NUR/commit/d6309b93218b980f77a67d5521b37f963a5de361) | `` automatic update `` |
| [`183839d1`](https://github.com/nix-community/NUR/commit/183839d1ff0eaf2ba684f2e0647d38747a6ee100) | `` automatic update `` |