### PR TITLE
chore(flake/nur): `d6309b93` -> `66564edd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706366610,
-        "narHash": "sha256-nQysJOK8oAk7PlHDn9SHeCAZSXqhD3OoN3Wo6Y37TM8=",
+        "lastModified": 1706370289,
+        "narHash": "sha256-fLVGtfXOQYkX34lqk3iUJFImyFHNrBA7yvvc6fTXwH0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d6309b93218b980f77a67d5521b37f963a5de361",
+        "rev": "66564edd76394d5ddd285144564e57ce2c558eb0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`66564edd`](https://github.com/nix-community/NUR/commit/66564edd76394d5ddd285144564e57ce2c558eb0) | `` automatic update `` |