### PR TITLE
chore(flake/nur): `66564edd` -> `4843ee0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706370289,
-        "narHash": "sha256-fLVGtfXOQYkX34lqk3iUJFImyFHNrBA7yvvc6fTXwH0=",
+        "lastModified": 1706377249,
+        "narHash": "sha256-Yexs/FRVheTzHNMbFr4/ogsfq0x35FoTK6a4MOhjSko=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "66564edd76394d5ddd285144564e57ce2c558eb0",
+        "rev": "4843ee0bf2cfd4cce6ed4b325ceddd7691df8435",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4843ee0b`](https://github.com/nix-community/NUR/commit/4843ee0bf2cfd4cce6ed4b325ceddd7691df8435) | `` automatic update `` |
| [`84cb8996`](https://github.com/nix-community/NUR/commit/84cb8996e17777f663003cf34de1761397e4f8fb) | `` automatic update `` |