### PR TITLE
chore(flake/nur): `4ff476f2` -> `5209d1f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706388274,
-        "narHash": "sha256-2jwl+TttR/1z3G28Ye92I05dBXBaCAxUtOQYEiY73sA=",
+        "lastModified": 1706392862,
+        "narHash": "sha256-B42uOkwM2eykZPssttYKxF2B2B+3pwSMOk1Co+RWjpM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ff476f2a8497a909ab190969197680a83558548",
+        "rev": "5209d1f058c7f5c062dd1e9f7c6c6c923ad4f70f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5209d1f0`](https://github.com/nix-community/NUR/commit/5209d1f058c7f5c062dd1e9f7c6c6c923ad4f70f) | `` automatic update `` |
| [`b12db5b1`](https://github.com/nix-community/NUR/commit/b12db5b1190acde0eb9ecc60367486e920a44aa7) | `` automatic update `` |