### PR TITLE
chore(flake/darwin): `1e706ef3` -> `bdbae6ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705915768,
-        "narHash": "sha256-+Jlz8OAqkOwJlioac9wtpsCnjgGYUhvLpgJR/5tP9po=",
+        "lastModified": 1706833576,
+        "narHash": "sha256-w7BL0EWRts+nD1lbLECIuz6fRzmmV+z8oWwoY7womR0=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "1e706ef323de76236eb183d7784f3bd57255ec0b",
+        "rev": "bdbae6ecff8fcc322bf6b9053c0b984912378af7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                              |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
| [`4363d3b4`](https://github.com/LnL7/nix-darwin/commit/4363d3b42f71156c5de80c3cf9ff998ff0a5681a) | `` services/yabai: Remove IFD ``                                     |
| [`492944b0`](https://github.com/LnL7/nix-darwin/commit/492944b0f2c539240dc99392eb07f9064cb93c93) | `` Update darwin-rebuild.zsh-completions ``                          |
| [`0f0478ef`](https://github.com/LnL7/nix-darwin/commit/0f0478efa68e442dd46fc64d46889da7c0859ad5) | `` Add zsh completions to darwin-rebuld by default ``                |
| [`3a9755f9`](https://github.com/LnL7/nix-darwin/commit/3a9755f98dfc0589890ea54a870d9475e10b064f) | `` Use nixpkgs generators.toPlist for launchd service generation. `` |
| [`30311b6f`](https://github.com/LnL7/nix-darwin/commit/30311b6f90b333fcef1967a5fd139340c301b6f0) | `` services/yabai: Remove --check-sa and --install-sa flags ``       |