### PR TITLE
chore(flake/nix-index-database): `f8e04fbc` -> `2c1a58ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -627,11 +627,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705806513,
-        "narHash": "sha256-FcOmNjhHFfPz2udZbRpZ1sfyhVMr+C2O8kOxPj+HDDk=",
+        "lastModified": 1706410643,
+        "narHash": "sha256-L7ebEULKK8ZWkMfuZJQgxYIYx3+V7SXm0mE8EM8ZRJo=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "f8e04fbcebcc24cebc91989981bd45f69b963ed7",
+        "rev": "2c1a58ea29af0bd3da947c6bb3e7a7704a2f972b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                  |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`2c1a58ea`](https://github.com/nix-community/nix-index-database/commit/2c1a58ea29af0bd3da947c6bb3e7a7704a2f972b) | `` flake.lock: Update `` |