### PR TITLE
chore(flake/nur): `85bb76d4` -> `43c8ffcd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706420453,
-        "narHash": "sha256-yY2QL7lCUHW7GGE6GYp6gj4igq0lrC6xwUR5x4QaC+g=",
+        "lastModified": 1706429505,
+        "narHash": "sha256-U/GczbmVazpcrsf8mwpdiO9eTf6FXTg1TxK6Nsv0auY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "85bb76d48f81dba7a21dfefbc6cbfcddae8988f6",
+        "rev": "43c8ffcd58bd718302cbb7ae719ac6e65aac5fae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`43c8ffcd`](https://github.com/nix-community/NUR/commit/43c8ffcd58bd718302cbb7ae719ac6e65aac5fae) | `` automatic update `` |
| [`f778c917`](https://github.com/nix-community/NUR/commit/f778c917fc46d2e038ad4645756a132b46b37884) | `` automatic update `` |
| [`f3b2c8dc`](https://github.com/nix-community/NUR/commit/f3b2c8dcff020cb7670bbc597a27a791e3f625fb) | `` automatic update `` |