### PR TITLE
chore(flake/pre-commit-hooks): `f56597d5` -> `7c54e08a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -910,11 +910,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1705757126,
-        "narHash": "sha256-Eksr+n4Q8EYZKAN0Scef5JK4H6FcHc+TKNHb95CWm+c=",
+        "lastModified": 1706424699,
+        "narHash": "sha256-Q3RBuOpZNH2eFA1e+IHgZLAOqDD9SKhJ/sszrL8bQD4=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "f56597d53fd174f796b5a7d3ee0b494f9e2285cc",
+        "rev": "7c54e08a689b53c8a1e5d70169f2ec9e2a68ffaf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                        |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
| [`9aa03c74`](https://github.com/cachix/pre-commit-hooks.nix/commit/9aa03c749e0f550fd6e807e64c911faf6018e007) | `` docs: use formal capitalization of JavaScript/TypeScript `` |