### PR TITLE
chore(flake/emacs-overlay): `d6d5dd09` -> `a26ccf07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706406538,
-        "narHash": "sha256-VmeZ0iaGJWkzYepUpkzHPz6vFvdB3YAPguZjwKPGueE=",
+        "lastModified": 1706432702,
+        "narHash": "sha256-zjBaFgm7Tv+hpWI8lgddSktZtpHywSTEDVPfmLzqX78=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d6d5dd09b6533a30e3b312f0f225bd3475733f23",
+        "rev": "a26ccf07b81aa26a4e7ee4c58f4a0f9d919e642a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`a26ccf07`](https://github.com/nix-community/emacs-overlay/commit/a26ccf07b81aa26a4e7ee4c58f4a0f9d919e642a) | `` Updated emacs `` |