### PR TITLE
chore(flake/nur): `4d853e68` -> `55770332`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706435139,
-        "narHash": "sha256-JWcKQoarr4dzsMVsXV+u00rRPuQ9NQFs/JVeSZiVEbg=",
+        "lastModified": 1706438670,
+        "narHash": "sha256-trU250ktAhyqnbq3CulgbXso1nRL3bK9blWVr0Jdj1U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4d853e68ed04ff32af7a53b97fdc5ae9244f040e",
+        "rev": "5577033269154484a3194a9efb82b8f5137e2292",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`55770332`](https://github.com/nix-community/NUR/commit/5577033269154484a3194a9efb82b8f5137e2292) | `` automatic update `` |