### PR TITLE
chore(flake/nur): `55770332` -> `082e6f72`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706438670,
-        "narHash": "sha256-trU250ktAhyqnbq3CulgbXso1nRL3bK9blWVr0Jdj1U=",
+        "lastModified": 1706449462,
+        "narHash": "sha256-Rudhy/zg1Bk0fLnCeCgmmIDj7K4w3pRRV5EJ10p5Hl4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5577033269154484a3194a9efb82b8f5137e2292",
+        "rev": "082e6f72dc501e9d01df29b5241f3a182476a945",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`082e6f72`](https://github.com/nix-community/NUR/commit/082e6f72dc501e9d01df29b5241f3a182476a945) | `` automatic update `` |
| [`0a68de7b`](https://github.com/nix-community/NUR/commit/0a68de7bb6a21eb68d6c58d715532825645e396b) | `` automatic update `` |
| [`36c9f9c3`](https://github.com/nix-community/NUR/commit/36c9f9c3571a7d3f34885bdebff1959d1ff2c97f) | `` automatic update `` |
| [`488b84b3`](https://github.com/nix-community/NUR/commit/488b84b36347304e6408381636eea97c9392af26) | `` automatic update `` |