### PR TITLE
chore(flake/nur): `082e6f72` -> `f271bc81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706449462,
-        "narHash": "sha256-Rudhy/zg1Bk0fLnCeCgmmIDj7K4w3pRRV5EJ10p5Hl4=",
+        "lastModified": 1706452914,
+        "narHash": "sha256-d+uBNhbnsEorlZXYLyNgGZ79PpgfyBqSajTSbQPdKGM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "082e6f72dc501e9d01df29b5241f3a182476a945",
+        "rev": "f271bc81436c96bf40da5100d8c6aa754e5cc403",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f271bc81`](https://github.com/nix-community/NUR/commit/f271bc81436c96bf40da5100d8c6aa754e5cc403) | `` automatic update `` |
| [`b226cd59`](https://github.com/nix-community/NUR/commit/b226cd59852745bce13dd3ce63c0ced9757e9606) | `` automatic update `` |