### PR TITLE
chore(flake/emacs-overlay): `a26ccf07` -> `87bfbcd2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706432702,
-        "narHash": "sha256-zjBaFgm7Tv+hpWI8lgddSktZtpHywSTEDVPfmLzqX78=",
+        "lastModified": 1706461459,
+        "narHash": "sha256-xUgM+E0gtSAgl8VCwLgZ3qCLuZA2bdExN0AwGGFVYJ0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a26ccf07b81aa26a4e7ee4c58f4a0f9d919e642a",
+        "rev": "87bfbcd248f3f17040db47b2cc8542033b12d051",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`87bfbcd2`](https://github.com/nix-community/emacs-overlay/commit/87bfbcd248f3f17040db47b2cc8542033b12d051) | `` Updated emacs ``  |
| [`eff17f93`](https://github.com/nix-community/emacs-overlay/commit/eff17f93e92eaa9ff77c79c1783d36267ce88450) | `` Updated elpa ``   |
| [`7c2ab8b3`](https://github.com/nix-community/emacs-overlay/commit/7c2ab8b3dc60b7f2d0d492472d0b6f1444712a21) | `` Updated nongnu `` |