### PR TITLE
chore(flake/stylix): `1a5dee19` -> `7a7c9001`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1046,11 +1046,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706172305,
-        "narHash": "sha256-9VXEpF+wFyVNmUAMyGFPqXCSTAa+oXEkwm2Fe0Oq/JM=",
+        "lastModified": 1706466685,
+        "narHash": "sha256-R6D+3wBQvn7sCZLbM3WrHbKtVNSflkruGQ/5bHfslhg=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "1a5dee1957dc45e125013ae3919ff284cfb83cdc",
+        "rev": "7a7c90015de7454060e103e94bb4e6010b5aa062",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                        |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`7a7c9001`](https://github.com/danth/stylix/commit/7a7c90015de7454060e103e94bb4e6010b5aa062) | `` k9s: use new name for skin option (#232) `` |