### PR TITLE
chore(flake/nur): `82beb090` -> `4fc5b14c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706460269,
-        "narHash": "sha256-oH2SdecBKTD/Cuj6fsvbM2/t5jAZgdHERD6GfJWQCH4=",
+        "lastModified": 1706471093,
+        "narHash": "sha256-BtmD2F/SU7fG822hGYxFK/Yp5hizY3EZdBUqnbuccY8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "82beb09009e4844811e2f35a7e67c04a215e2730",
+        "rev": "4fc5b14cae1e1b4fd6f4ef879a552e1d8c6f868a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4fc5b14c`](https://github.com/nix-community/NUR/commit/4fc5b14cae1e1b4fd6f4ef879a552e1d8c6f868a) | `` automatic update `` |
| [`cba525fe`](https://github.com/nix-community/NUR/commit/cba525fe33906e67fcd872448ba091456cc09f6e) | `` automatic update `` |
| [`183e7b71`](https://github.com/nix-community/NUR/commit/183e7b71b743e6801391e1c86a9529a353768a6b) | `` automatic update `` |