### PR TITLE
chore(flake/nur): `4fc5b14c` -> `0777a688`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706471093,
-        "narHash": "sha256-BtmD2F/SU7fG822hGYxFK/Yp5hizY3EZdBUqnbuccY8=",
+        "lastModified": 1706492153,
+        "narHash": "sha256-0nAuIGI6DaOhDt3JGEFwOgdrCbqFv7vSBmTziZRK5qE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4fc5b14cae1e1b4fd6f4ef879a552e1d8c6f868a",
+        "rev": "0777a6886749d6a726d5a3fab0156d5f92969fe6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0777a688`](https://github.com/nix-community/NUR/commit/0777a6886749d6a726d5a3fab0156d5f92969fe6) | `` automatic update `` |
| [`ad66156e`](https://github.com/nix-community/NUR/commit/ad66156e8eab6dd59bbbe8ebe630595820dc4ded) | `` automatic update `` |