### PR TITLE
chore(flake/srvos): `0a0f4f44` -> `9a147c48`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1011,11 +1011,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706210007,
-        "narHash": "sha256-jplmuOV5vl8Tww8RF2RZ9cv2m8vHkPvDrX1/FGhJtd0=",
+        "lastModified": 1706489267,
+        "narHash": "sha256-EsP4XnW9xGlZ2tuxSL8XAp+8u+N0Kp0+otLI+2QdURk=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "0a0f4f441b7bd014e523de33a810badda546e862",
+        "rev": "9a147c4884c3573837bbd1ac73b3d7b50370efd7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`9a147c48`](https://github.com/nix-community/srvos/commit/9a147c4884c3573837bbd1ac73b3d7b50370efd7) | `` dev/private/flake.lock: Update `` |
| [`2a767c05`](https://github.com/nix-community/srvos/commit/2a767c05d84c472d8ef4df8bbdacd2cfd1667a9e) | `` flake.lock: Update ``             |