### PR TITLE
chore(flake/nur): `0777a688` -> `4229f5a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706492153,
-        "narHash": "sha256-0nAuIGI6DaOhDt3JGEFwOgdrCbqFv7vSBmTziZRK5qE=",
+        "lastModified": 1706500560,
+        "narHash": "sha256-c6jHa/QahPkyMKvEEsXVYlKeUScKPP/NSjLsJyTXkBE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0777a6886749d6a726d5a3fab0156d5f92969fe6",
+        "rev": "4229f5a8f0c00b374b991c6617a4f36fd915f0a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4229f5a8`](https://github.com/nix-community/NUR/commit/4229f5a8f0c00b374b991c6617a4f36fd915f0a1) | `` automatic update `` |