### PR TITLE
chore(flake/nur): `4229f5a8` -> `3b667f15`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706500560,
-        "narHash": "sha256-c6jHa/QahPkyMKvEEsXVYlKeUScKPP/NSjLsJyTXkBE=",
+        "lastModified": 1706501155,
+        "narHash": "sha256-n2pnpxxa5AQUJa3IS/yBsx61/REswCOX6zrRxOD/MaU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4229f5a8f0c00b374b991c6617a4f36fd915f0a1",
+        "rev": "3b667f154e01d9c01298be604804f4f9f63c9795",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3b667f15`](https://github.com/nix-community/NUR/commit/3b667f154e01d9c01298be604804f4f9f63c9795) | `` automatic update `` |