### PR TITLE
chore(flake/nur): `634a80da` -> `0416c890`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706509961,
-        "narHash": "sha256-ivQaJm9rSzbnp0iOvQGg6fe7D6X5Gs4oPBR7ZaGEgiM=",
+        "lastModified": 1706515086,
+        "narHash": "sha256-tjWRh6hv2kNGFRV8ESjg3TZDuA6B4Ls1fnru5z89SNA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "634a80daf064af9c76b4c3693744df1d20665194",
+        "rev": "0416c8902949ad6fcfe91af8d9f9efa66bce8bef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0416c890`](https://github.com/nix-community/NUR/commit/0416c8902949ad6fcfe91af8d9f9efa66bce8bef) | `` automatic update `` |