### PR TITLE
chore(flake/nur): `0416c890` -> `e0293b12`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706515086,
-        "narHash": "sha256-tjWRh6hv2kNGFRV8ESjg3TZDuA6B4Ls1fnru5z89SNA=",
+        "lastModified": 1706518300,
+        "narHash": "sha256-ZhJTUwpsraxL7Y/rxEXp+2Ws19LSsZbI+8Ho7SQKgdY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0416c8902949ad6fcfe91af8d9f9efa66bce8bef",
+        "rev": "e0293b1268f2f832e0302a2465bf3ec79e1a5d95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e0293b12`](https://github.com/nix-community/NUR/commit/e0293b1268f2f832e0302a2465bf3ec79e1a5d95) | `` automatic update `` |
| [`44cc6d28`](https://github.com/nix-community/NUR/commit/44cc6d28900b3561343793ed40e2f61922267a9a) | `` automatic update `` |
| [`1e782d1d`](https://github.com/nix-community/NUR/commit/1e782d1db5b712e00436d9237a426b4d6ac51615) | `` automatic update `` |