### PR TITLE
chore(flake/nur): `e0293b12` -> `aad9d1d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706518300,
-        "narHash": "sha256-ZhJTUwpsraxL7Y/rxEXp+2Ws19LSsZbI+8Ho7SQKgdY=",
+        "lastModified": 1706519669,
+        "narHash": "sha256-THY4ByWR7FWNp+egOXq9Gg6Kd6rwcjQ3TubeBTJaVOM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e0293b1268f2f832e0302a2465bf3ec79e1a5d95",
+        "rev": "aad9d1d5df0ba43a33b2b931ea11a7d98fb11927",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aad9d1d5`](https://github.com/nix-community/NUR/commit/aad9d1d5df0ba43a33b2b931ea11a7d98fb11927) | `` automatic update `` |