### PR TITLE
chore(flake/nur): `4986dcbe` -> `892517d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706525068,
-        "narHash": "sha256-Z9PdNtpVTl1bgN8rK2Feh0K7cSr7uuFvl0pSbllX+k0=",
+        "lastModified": 1706532826,
+        "narHash": "sha256-aMbtt2vJx1XeTRaVzBSWnTxOerb59YKqLWJCvcUfXPM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4986dcbe4ed18f9b23ce078d421b7febaa1d9b09",
+        "rev": "892517d79c1ddbedaa21f9f204cdfb4a12321360",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`892517d7`](https://github.com/nix-community/NUR/commit/892517d79c1ddbedaa21f9f204cdfb4a12321360) | `` automatic update `` |
| [`f7d9d8bc`](https://github.com/nix-community/NUR/commit/f7d9d8bc877ab3036ea253dcd50305cc63081bc4) | `` automatic update `` |