### PR TITLE
chore(flake/nur): `892517d7` -> `136f332e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706532826,
-        "narHash": "sha256-aMbtt2vJx1XeTRaVzBSWnTxOerb59YKqLWJCvcUfXPM=",
+        "lastModified": 1706540385,
+        "narHash": "sha256-5Rv1vNzTpahjcPXfFIRvCYXUIjtmSNFEPZfkecrs1L4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "892517d79c1ddbedaa21f9f204cdfb4a12321360",
+        "rev": "136f332e3bc7aa6920afec573417e684452c3a6d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`136f332e`](https://github.com/nix-community/NUR/commit/136f332e3bc7aa6920afec573417e684452c3a6d) | `` automatic update `` |