### PR TITLE
chore(flake/nixpkgs): `ae5c332c` -> `c002c6aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -777,11 +777,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1706191920,
-        "narHash": "sha256-eLihrZAPZX0R6RyM5fYAWeKVNuQPYjAkCUBr+JNvtdE=",
+        "lastModified": 1706371002,
+        "narHash": "sha256-dwuorKimqSYgyu8Cw6ncKhyQjUDOyuXoxDTVmAXq88s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ae5c332cbb5827f6b1f02572496b141021de335f",
+        "rev": "c002c6aa977ad22c60398daaa9be52f2203d0006",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`6e4b590d`](https://github.com/NixOS/nixpkgs/commit/6e4b590ddd04d6c5d9da86451ce21c8967fa11b5) | `` prettyping: set meta.mainProgram ``                                             |
| [`8b1a8efe`](https://github.com/NixOS/nixpkgs/commit/8b1a8efe45cc80c931dda2e7fbf51bd86806d492) | `` pydf: set meta.mainProgram ``                                                   |
| [`ec66ff78`](https://github.com/NixOS/nixpkgs/commit/ec66ff787ec6db7ca83516055f16faa007edd8d9) | `` snakemake: 8.2.1 -> 8.3.2 (#284218) ``                                          |
| [`c01d3cb4`](https://github.com/NixOS/nixpkgs/commit/c01d3cb4185acbe9b1653d7332dc193d92355c52) | `` pkgs/README.md: Fix formatting (#284244) ``                                     |
| [`4b12819a`](https://github.com/NixOS/nixpkgs/commit/4b12819aae6c22ff8b756b79b18f5509a631faf0) | `` qq: 3.2.5-20979 -> 3.2.5-21159 ``                                               |
| [`a8c6acb7`](https://github.com/NixOS/nixpkgs/commit/a8c6acb721d675638d91f4d7ae405366d1324c63) | `` python311Packages.pymilvus: 2.3.5 -> 2.3.6 ``                                   |
| [`c8d69218`](https://github.com/NixOS/nixpkgs/commit/c8d69218d7cbd51eb926b2b5c7cab01cea068fa2) | `` moon: 1.19.3 -> 1.20.0 ``                                                       |
| [`514abba9`](https://github.com/NixOS/nixpkgs/commit/514abba95dedf568b4cfaa8baa449aa56e714037) | `` python312Packages.types-requests: 2.31.0.20240106 -> 2.31.0.20240125 ``         |
| [`b19c0e84`](https://github.com/NixOS/nixpkgs/commit/b19c0e84e472a74a974a636105857e81237bac7a) | `` igir: use autoPatchelfHook ``                                                   |
| [`e103c5cf`](https://github.com/NixOS/nixpkgs/commit/e103c5cfcf6347f51636c758f372b720803bc8f8) | `` nixos/systemd-lock-handler: init ``                                             |
| [`28f40adf`](https://github.com/NixOS/nixpkgs/commit/28f40adf8c7b2802ac8a2331203f9130a8be9a0a) | `` systemd-lock-handler: init at 2.4.2 ``                                          |
| [`0f8d0f82`](https://github.com/NixOS/nixpkgs/commit/0f8d0f826ab534587cfde08c35adf8de4e7ee724) | `` govulncheck: 1.0.2 -> 1.0.3 ``                                                  |
| [`1bcc7a10`](https://github.com/NixOS/nixpkgs/commit/1bcc7a10083479af313bed8eee5bf407a3a2ad99) | `` steampipe: 0.21.3 -> 0.21.4 ``                                                  |
| [`bc4a93e7`](https://github.com/NixOS/nixpkgs/commit/bc4a93e7447bf8c71f4868b66767802beeb3e9c2) | `` metasploit: 6.3.48 -> 6.3.53 ``                                                 |
| [`c3e68874`](https://github.com/NixOS/nixpkgs/commit/c3e68874090339fde83e68d4bd74ef6940b5f7a1) | `` python311Packages.napari-svg: 0.1.6 -> 0.1.10 ``                                |
| [`269dcb68`](https://github.com/NixOS/nixpkgs/commit/269dcb681278fce0e8d6ecffcca02cb6ff565af3) | `` python311Packages.cx-freeze: 6.15.12 -> 6.15.13 ``                              |
| [`68459bd6`](https://github.com/NixOS/nixpkgs/commit/68459bd6d0e2211cb55a488708f984c79d5c2ceb) | `` minify: 2.20.14 -> 2.20.15 ``                                                   |
| [`6d974716`](https://github.com/NixOS/nixpkgs/commit/6d974716629d3bf8a31b519952c6a5754a41bd38) | `` terraform-providers.cloudfoundry: 0.51.3 -> 0.52.0 ``                           |
| [`66ec4f95`](https://github.com/NixOS/nixpkgs/commit/66ec4f95876f7366e3cc0419431fc277982b57f9) | `` terraform-providers.baiducloud: 1.19.26 -> 1.19.31 ``                           |
| [`cd5a9f8b`](https://github.com/NixOS/nixpkgs/commit/cd5a9f8b7e1543e55ecafca6b45c1a3d43122351) | `` terraform-providers.yandex: 0.104.0 -> 0.106.0 ``                               |
| [`90793efa`](https://github.com/NixOS/nixpkgs/commit/90793efa1d4412ba1da4e763e9fcb413ec6601f4) | `` terraform-providers.vault: 3.23.0 -> 3.24.0 ``                                  |
| [`0c41f48e`](https://github.com/NixOS/nixpkgs/commit/0c41f48e58263c46f8cf104d7de64a8d1826fa38) | `` terraform-providers.utils: 1.14.0 -> 1.15.0 ``                                  |
| [`5faccfe0`](https://github.com/NixOS/nixpkgs/commit/5faccfe0df282275bfdb9bf1d98f04372255b1d1) | `` terraform-providers.thunder: 1.3.0 -> 1.4.1 ``                                  |
| [`f94ff549`](https://github.com/NixOS/nixpkgs/commit/f94ff5497c5e87715d6fd7ab060b77963dabb2c7) | `` terraform-providers.tencentcloud: 1.81.64 -> 1.81.71 ``                         |
| [`441c20ea`](https://github.com/NixOS/nixpkgs/commit/441c20ea88e4e8bde03466558f3fe7cd7fd2edd6) | `` terraform-providers.sumologic: 2.28.0 -> 2.28.1 ``                              |
| [`0623e49d`](https://github.com/NixOS/nixpkgs/commit/0623e49da664c3a65ce63febf8f73dd5780fee15) | `` terraform-providers.spotinst: 1.158.0 -> 1.160.0 ``                             |
| [`06c49ac5`](https://github.com/NixOS/nixpkgs/commit/06c49ac54e09047abfa6509cceb33c1922698ce1) | `` terraform-providers.snowflake: 0.82.0 -> 0.84.1 ``                              |
| [`1e7a209a`](https://github.com/NixOS/nixpkgs/commit/1e7a209a0aed908eee2ef6476b94e5fca17e0bdb) | `` terraform-providers.signalfx: 9.0.0 -> 9.0.1 ``                                 |
| [`d04b6122`](https://github.com/NixOS/nixpkgs/commit/d04b612220bbb392c7fffeb8793beea882b44e6d) | `` terraform-providers.scaleway: 2.35.0 -> 2.36.0 ``                               |
| [`13b9fb45`](https://github.com/NixOS/nixpkgs/commit/13b9fb45e23e210a8f55eca7f657c1efeea1c690) | `` terraform-providers.sentry: 0.12.1 -> 0.12.2 ``                                 |
| [`6d6fcbf2`](https://github.com/NixOS/nixpkgs/commit/6d6fcbf2c869af612410d1792e720e9d1630921e) | `` terraform-providers.pagerduty: 3.4.0 -> 3.6.0 ``                                |
| [`9465d6b2`](https://github.com/NixOS/nixpkgs/commit/9465d6b23be9f8d39791aee14d3303ceedbfddf3) | `` terraform-providers.oci: 5.23.0 -> 5.26.0 ``                                    |
| [`8c5b288c`](https://github.com/NixOS/nixpkgs/commit/8c5b288c7ecf427c0b3bf9845f9abf7383d9ef62) | `` terraform-providers.opentelekomcloud: 1.35.15 -> 1.36.0 ``                      |
| [`149a2c34`](https://github.com/NixOS/nixpkgs/commit/149a2c34a6d173eb0867073892c6d934a195e09f) | `` terraform-providers.opennebula: 1.3.1 -> 1.4.0 ``                               |
| [`b438f8de`](https://github.com/NixOS/nixpkgs/commit/b438f8deeaf80cae59aa65ad43c9323a05eb024c) | `` terraform-providers.nutanix: 1.9.4 -> 1.9.5 ``                                  |
| [`b3f8e99d`](https://github.com/NixOS/nixpkgs/commit/b3f8e99dfea055465c665e4dfbd9e230a35d65cc) | `` terraform-providers.newrelic: 3.28.1 -> 3.29.0 ``                               |
| [`b74cee76`](https://github.com/NixOS/nixpkgs/commit/b74cee763d08da944bc350f856e54184199ac94f) | `` terraform-providers.migadu: 2023.12.21 -> 2024.1.25 ``                          |
| [`af62f91d`](https://github.com/NixOS/nixpkgs/commit/af62f91d04ce0abb71d932ef8dbb7fde82456dfc) | `` terraform-providers.lxd: 1.10.4 -> 2.0.0 ``                                     |
| [`9039e0e6`](https://github.com/NixOS/nixpkgs/commit/9039e0e62fa665f871633597b1dcb298b8253dc7) | `` terraform-providers.hcloud: 1.44.1 -> 1.45.0 ``                                 |
| [`d5b3b220`](https://github.com/NixOS/nixpkgs/commit/d5b3b220d38e4e5bf510b0aca858d06e74d3746a) | `` terraform-providers.heroku: 5.2.7 -> 5.2.8 ``                                   |
| [`647d91b6`](https://github.com/NixOS/nixpkgs/commit/647d91b66f31d84ec7a7477fd5146b9fa13fb908) | `` terraform-providers.grafana: 2.8.1 -> 2.10.0 ``                                 |
| [`4757e3a8`](https://github.com/NixOS/nixpkgs/commit/4757e3a89093a796bbc4f52676d762d2c18415d7) | `` terraform-providers.google-beta: 5.11.0 -> 5.13.0 ``                            |
| [`a8910abe`](https://github.com/NixOS/nixpkgs/commit/a8910abe84b36e69a92881f63537bb943b4c9a7b) | `` terraform-providers.google: 5.11.0 -> 5.13.0 ``                                 |
| [`e29841b0`](https://github.com/NixOS/nixpkgs/commit/e29841b032ea168c41b8cbc0b03b7979c6ae4bb4) | `` terraform-providers.gitlab: 16.7.0 -> 16.8.1 ``                                 |
| [`0c152281`](https://github.com/NixOS/nixpkgs/commit/0c1522818bfbdb1a3c14b67883f2574a8ac95a84) | `` terraform-providers.equinix: 1.22.0 -> 1.26.0 ``                                |
| [`2b394afa`](https://github.com/NixOS/nixpkgs/commit/2b394afadbdd5211ff57f9e485a70ddf298e4bc9) | `` terraform-providers.exoscale: 0.54.1 -> 0.55.0 ``                               |
| [`4bcc96f5`](https://github.com/NixOS/nixpkgs/commit/4bcc96f55e59d2f5462e714a3c2ce19f58293589) | `` terraform-providers.doppler: 1.3.0 -> 1.4.0 ``                                  |
| [`e7b00715`](https://github.com/NixOS/nixpkgs/commit/e7b007151d58b7cf5ab23a67227fbcef81decff6) | `` terraform-providers.datadog: 3.34.0 -> 3.35.0 ``                                |
| [`137719de`](https://github.com/NixOS/nixpkgs/commit/137719def939217da742957f152f49095be1348a) | `` terraform-providers.dnsimple: 1.3.1 -> 1.4.0 ``                                 |
| [`d5c01e7f`](https://github.com/NixOS/nixpkgs/commit/d5c01e7fa69d5c23c015b105c40f1b2c46c995f9) | `` terraform-providers.cloudflare: 4.21.0 -> 4.23.0 ``                             |
| [`e61e2303`](https://github.com/NixOS/nixpkgs/commit/e61e2303d5b4421c4ddd591d7c37a766e59ccbf6) | `` terraform-providers.aws: 5.31.0 -> 5.34.0 ``                                    |
| [`ca0a40d0`](https://github.com/NixOS/nixpkgs/commit/ca0a40d0e9142c5fdd7268157c11c74791dbeff9) | `` terraform-providers.cloudamqp: 1.29.1 -> 1.29.3 ``                              |
| [`e550c1e3`](https://github.com/NixOS/nixpkgs/commit/e550c1e38e849d8587f81cf001e7880f836033a7) | `` terraform-providers.azurerm: 3.86.0 -> 3.89.0 ``                                |
| [`793c88e9`](https://github.com/NixOS/nixpkgs/commit/793c88e991a04e4db7e01ff67ce16d6bd95c198d) | `` terraform-providers.aviatrix: 3.1.3 -> 3.1.4 ``                                 |
| [`441cc7f3`](https://github.com/NixOS/nixpkgs/commit/441cc7f3356397497436ece719857cb9944c55a0) | `` terraform-providers.alicloud: 1.214.1 -> 1.215.0 ``                             |
| [`e5f9cd26`](https://github.com/NixOS/nixpkgs/commit/e5f9cd26dd72bee445056dcf95a563fc43f5c953) | `` terraform-providers.auth0: 1.1.1 -> 1.1.2 ``                                    |
| [`0086fb8b`](https://github.com/NixOS/nixpkgs/commit/0086fb8b2ba1733a7d3368bcfc26128fa9d778d2) | `` terraform-providers.artifactory: 10.0.2 -> 10.1.2 ``                            |
| [`e90977d5`](https://github.com/NixOS/nixpkgs/commit/e90977d512f5f15ecce97790fab0f9a362b6fff4) | `` terraform-providers.archive: 2.4.1 -> 2.4.2 ``                                  |
| [`a0a4d9aa`](https://github.com/NixOS/nixpkgs/commit/a0a4d9aa61103eec9e8d0fd40f2bc60f7e054b53) | `` terraform-providers.acme: 2.19.0 -> 2.19.1 ``                                   |
| [`c4f3b75a`](https://github.com/NixOS/nixpkgs/commit/c4f3b75adc97cd4b4ab2b539ee78a18fb9653b5c) | `` terraform-providers.aiven: 4.12.1 -> 4.13.2 ``                                  |
| [`fafa9d2f`](https://github.com/NixOS/nixpkgs/commit/fafa9d2f3c03d57596fa02f68186ac10198d9c45) | `` terraform-providers.aci: 2.12.0 -> 2.13.0 ``                                    |
| [`2f330f48`](https://github.com/NixOS/nixpkgs/commit/2f330f48c6529cd273038b581421c9459a9c5d30) | `` cloudfox: add ldflags ``                                                        |
| [`5697a99a`](https://github.com/NixOS/nixpkgs/commit/5697a99a87a3d9abf5ffb3eda7ea2bc14dcf92d6) | `` grype: 0.74.2 -> 0.74.3 ``                                                      |
| [`db26c17e`](https://github.com/NixOS/nixpkgs/commit/db26c17e05063fabc844c7da1597982d04984806) | `` fly: 7.11.0 -> 7.11.1 ``                                                        |
| [`e66dd6b8`](https://github.com/NixOS/nixpkgs/commit/e66dd6b81e94d1f7235d3a5f25a0de0ccd4c7f17) | `` hysteria: 2.2.3 -> 2.2.4 ``                                                     |
| [`594c6f9a`](https://github.com/NixOS/nixpkgs/commit/594c6f9aa1b90ba372e33a9df0fc02fd314f16d1) | `` python312Packages.types-awscrt: 0.20.2 -> 0.20.3 ``                             |
| [`27656b61`](https://github.com/NixOS/nixpkgs/commit/27656b614fde92b904aca0b9e2c07c8a22002822) | `` doge: 3.6.0 -> 3.7.0 ``                                                         |
| [`83aef02b`](https://github.com/NixOS/nixpkgs/commit/83aef02b9a7c10cd8b48546099cc7c9c52fd79c3) | `` libbgcode: set meta.platforms ``                                                |
| [`ceeddc5b`](https://github.com/NixOS/nixpkgs/commit/ceeddc5b159fe20d4c186bf43e0c8e1c534db9ab) | `` nixos/systemd-boot: move builder script in bin folder ``                        |
| [`d9c8f947`](https://github.com/NixOS/nixpkgs/commit/d9c8f947942f3262bbaf7bb3be4c24fdfbc45160) | `` digikam: add maintainer ``                                                      |
| [`ae78df7a`](https://github.com/NixOS/nixpkgs/commit/ae78df7a69130f67511eb9ad98a92b7bd7a86eb2) | `` python311Packages.uproot: 5.2.1 -> 5.2.2 (#284112) ``                           |
| [`05a4bb42`](https://github.com/NixOS/nixpkgs/commit/05a4bb42c32e1a6f39307c4c824e34d8cca824e4) | `` python311Packages.mypy-boto3-builder: 7.21.0 -> 7.23.1 ``                       |
| [`78efc5b3`](https://github.com/NixOS/nixpkgs/commit/78efc5b39cb503449e8aee705c42e7f56373cd7b) | `` python311Packages.niaarm: 0.3.5 -> 0.3.6 ``                                     |
| [`edc49b2e`](https://github.com/NixOS/nixpkgs/commit/edc49b2e8318fb3c0f729c99fe6aaf01d7a6d2d7) | `` nixos/plasma5: fix plasmaMobileGear path ``                                     |
| [`4411a297`](https://github.com/NixOS/nixpkgs/commit/4411a29705030c836735c82fbeddc065202b0e3a) | `` xsct: 2.1 -> 2.2 ``                                                             |
| [`d7f16753`](https://github.com/NixOS/nixpkgs/commit/d7f16753e46801fd5b8ad8de63245209708f77c9) | `` trufflehog: 3.64.0 -> 3.65.0 ``                                                 |
| [`555fd301`](https://github.com/NixOS/nixpkgs/commit/555fd3010022de0e2bccbbc98e62066270ef8645) | `` nethack: add desktop icon ``                                                    |
| [`41766616`](https://github.com/NixOS/nixpkgs/commit/417666166e2c6ccc75703e8d47cdcf4c3437656d) | `` redpanda-client: 23.3.2 -> 23.3.4 ``                                            |
| [`76ad039b`](https://github.com/NixOS/nixpkgs/commit/76ad039bc3afeb2096d58c166b0e7730f0ad45bd) | `` _1password-gui: 8.10.23 → 8.10.24, 8.10.24-35 → 8.10.26-1 ``                    |
| [`d0825562`](https://github.com/NixOS/nixpkgs/commit/d0825562a5604c2dd1c8b091a02e6c4368a37205) | `` worker: 5.0.0 -> 5.0.1 ``                                                       |
| [`944aef9f`](https://github.com/NixOS/nixpkgs/commit/944aef9fb7170e0b8e6b29adcc85f7d8f0bb2b48) | `` linuxKernel.kernels.linux_lqx: 6.7.1-lqx1 -> 6.7.2-lqx1 ``                      |
| [`3390aa1a`](https://github.com/NixOS/nixpkgs/commit/3390aa1aed9600e82e4d32d48631214583c20879) | `` linuxKernel.kernels.linux_zen: 6.7.1-zen1 -> 6.7.2-zen1 ``                      |
| [`1b3cbb70`](https://github.com/NixOS/nixpkgs/commit/1b3cbb70f3ed76bbbf5a66b2f45ea07ebef6b29b) | `` fit-trackee: 0.7.22 -> 0.7.29 ``                                                |
| [`ccb6245f`](https://github.com/NixOS/nixpkgs/commit/ccb6245ff10bee89565ec66bcad880148d3b27a8) | `` python311Packages.qcs-api-client: adjust inputs ``                              |
| [`a3cdc83d`](https://github.com/NixOS/nixpkgs/commit/a3cdc83dbfd414531113a43fd8b1eee26537e48f) | `` python311Packages.cirq-google: disable time-consuming tests ``                  |
| [`8f34299f`](https://github.com/NixOS/nixpkgs/commit/8f34299f1b30e095daa7361e9472c518acd83235) | `` ocamlPackages.type_eq: Fix build failure due to source tarball change ``        |
| [`318667d8`](https://github.com/NixOS/nixpkgs/commit/318667d8d913bf5f62dd6a9a2fec72185aba3511) | `` pkgs/top-level/release.nix: expose `.build` as a direct jobset for hydra ``     |
| [`04932484`](https://github.com/NixOS/nixpkgs/commit/04932484262a0a5e20eaced071433e1535a8275a) | `` python311Packages.cirq-ft: disable failing test ``                              |
| [`92dc7685`](https://github.com/NixOS/nixpkgs/commit/92dc768511f1d5884814cdd9e0af90f98835a74f) | `` python311Packages.cirq-ft: refactor ``                                          |
| [`1ee8e728`](https://github.com/NixOS/nixpkgs/commit/1ee8e72834880c4859666c501dbbeef896c0d127) | `` livebook: Set KillMode=mixed ``                                                 |
| [`897d5670`](https://github.com/NixOS/nixpkgs/commit/897d5670a3da4166ad87b115770ad7d587d7238d) | `` livebook: Use `mix release` to build instead of escript ``                      |
| [`89712ab5`](https://github.com/NixOS/nixpkgs/commit/89712ab58b5ca3b50a89f1a045bc8cefe51be206) | `` rust-analyzer-unwrapped: 2024-01-15 -> 2024-01-22 ``                            |
| [`17243e6a`](https://github.com/NixOS/nixpkgs/commit/17243e6a84f3efe2b2b0d8d6eea9de16baff5046) | `` nixos/esphome: add option to use ping to check online status of devices ``      |
| [`145b4298`](https://github.com/NixOS/nixpkgs/commit/145b42985179dbbd4827c898de5c67ae95fcc1c1) | `` coqPackages_8_19.mathcomp-real-closed ``                                        |
| [`2114214e`](https://github.com/NixOS/nixpkgs/commit/2114214e504a780a107526014ede05d60450db16) | `` coqPackages_8_19.multinomials ``                                                |
| [`d25c59be`](https://github.com/NixOS/nixpkgs/commit/d25c59bebb9fd4971bd25f30d55dd7d28134c6d8) | `` coqPackages_8_19.extructures ``                                                 |
| [`523c0935`](https://github.com/NixOS/nixpkgs/commit/523c093518c3ce5a7d7981e979f2bef0fed39de9) | `` coqPackages_8_19.mathcomp-algebra-tactics ``                                    |
| [`aad90cd3`](https://github.com/NixOS/nixpkgs/commit/aad90cd395b7d8b53e9445df830cf5ed9fcb03e9) | `` coqPackages_8_19.reglang ``                                                     |
| [`a7c7c0b6`](https://github.com/NixOS/nixpkgs/commit/a7c7c0b6e48fa1242253bd981c70e8facd3e1287) | `` coqPackages_8_19.coqprime ``                                                    |
| [`9a393840`](https://github.com/NixOS/nixpkgs/commit/9a393840652fe6983ccc40cad90a6421818e951d) | `` coqPackages.coquelicot: 3.4.0 -> 3.4.1 ``                                       |
| [`5cc532b3`](https://github.com/NixOS/nixpkgs/commit/5cc532b336d189b4401dfc48b6456d7e64f07c28) | `` coqPackages_8_19.QuickChick ``                                                  |
| [`9e6484a3`](https://github.com/NixOS/nixpkgs/commit/9e6484a32d5f7b7596b122894bc6a398e933c9de) | `` coqPackages_8_19.ITree ``                                                       |
| [`b57a1c69`](https://github.com/NixOS/nixpkgs/commit/b57a1c69343dc8f693bc89514b0bbf6321234ef3) | `` coqPackages_8_19.paco ``                                                        |
| [`c61980d9`](https://github.com/NixOS/nixpkgs/commit/c61980d92bbde58bdbe10a4753c208114c33d1f7) | `` coqPackages.flocq: 4.1.3 -> 4.1.4 ``                                            |
| [`4ce414bb`](https://github.com/NixOS/nixpkgs/commit/4ce414bbe414bcf79ac229bf3a17f9c6ccbd3c56) | `` coq: 8.19+rc1 -> 8.19.0 ``                                                      |
| [`8177c1ca`](https://github.com/NixOS/nixpkgs/commit/8177c1ca90c8dda289d1234ab05b5a2096365480) | `` json-schema-for-humans: 0.46 -> 0.47 ``                                         |
| [`36ca5eda`](https://github.com/NixOS/nixpkgs/commit/36ca5eda5912391e80cd2b71620e36010a75b485) | `` mountpoint-s3: 1.3.2 -> 1.4.0 ``                                                |
| [`5734f2e4`](https://github.com/NixOS/nixpkgs/commit/5734f2e486b0f7ec3a57112d7035d19e259faeea) | `` python311Packages.pinecone-client: 2.2.5 -> 3.0.2 ``                            |
| [`f0faed2b`](https://github.com/NixOS/nixpkgs/commit/f0faed2bca4ca5adedcf5abd13fdc08ff7478dd2) | `` esphome: add missing dependency for discovery with ping ``                      |
| [`2817ffc8`](https://github.com/NixOS/nixpkgs/commit/2817ffc8e1440e705f9c92b88dd522fe00ddee42) | `` linuxPackages_latest.nvidiaPackages.{latest,vulkan_beta}.open: broken on 6.7 `` |
| [`fedc949f`](https://github.com/NixOS/nixpkgs/commit/fedc949f84f081c671cb15f8cbb52fc944f2e767) | `` python311Packages.mplhep: 0.3.31 -> 0.3.32 (#283966) ``                         |
| [`ce689654`](https://github.com/NixOS/nixpkgs/commit/ce689654cf9bb6d0c44c7561b5f77121892f99b0) | `` tlmi-auth: init at 1.0.1 ``                                                     |
| [`ea45edf0`](https://github.com/NixOS/nixpkgs/commit/ea45edf0633ca0c53d8871daa992f2373697551a) | `` rure: 0.2.2 -> 0.2.2 ``                                                         |
| [`de9d0ca7`](https://github.com/NixOS/nixpkgs/commit/de9d0ca71a75ef0137f437360f73c3d1c0f7d4b7) | `` virtiofsd: 1.10.0 -> 1.10.1 ``                                                  |
| [`0ae5f8f3`](https://github.com/NixOS/nixpkgs/commit/0ae5f8f348ed7fb00c8cc4135760b6babf787ba9) | `` nextcloud-notify_push: set platforms to linux, add ``                           |
| [`92f44f90`](https://github.com/NixOS/nixpkgs/commit/92f44f90bd1c6f47fd25cd5a1a7f8a59a72f89fa) | `` nextcloud: set platforms to linux ``                                            |
| [`327f5566`](https://github.com/NixOS/nixpkgs/commit/327f5566b9962c4d31d701b9976f8a9cb3557484) | `` cloud-init: 23.4.1 -> 23.4.2 ``                                                 |
| [`6bad2ad4`](https://github.com/NixOS/nixpkgs/commit/6bad2ad4de1e71d96296208e14cc3e2fa97a0dda) | `` eksctl: 0.168.0 -> 0.169.0 ``                                                   |
| [`67702f10`](https://github.com/NixOS/nixpkgs/commit/67702f10747a0c7bdeceffd35b0ce127c75805b6) | `` fable: 4.9.0 -> 4.10.0 ``                                                       |
| [`8a3600b8`](https://github.com/NixOS/nixpkgs/commit/8a3600b8a835308389bb35a905b5acaa68094a8f) | `` trunk-io: 1.2.7 -> 1.3.0 ``                                                     |
| [`bf15de8c`](https://github.com/NixOS/nixpkgs/commit/bf15de8c3bc13bb07d3a5f0cca117084e4ce90cd) | `` eid-mw: 5.1.11 -> 5.1.15 ``                                                     |
| [`3fe363f6`](https://github.com/NixOS/nixpkgs/commit/3fe363f6336f98e8ffb9f901f4cd6f948e352763) | `` vcmi: 1.4.4 -> 1.4.5 ``                                                         |
| [`8f6ef974`](https://github.com/NixOS/nixpkgs/commit/8f6ef9742a6e5c23f810e05f8742eac65600bedf) | `` sozu: 0.15.18 -> 0.15.19 ``                                                     |
| [`0f93b3f9`](https://github.com/NixOS/nixpkgs/commit/0f93b3f9b4b3a22afbaeec05014d4f7de23e1228) | `` wallust: 2.9.0 -> 2.10.0 ``                                                     |
| [`6dccc3ad`](https://github.com/NixOS/nixpkgs/commit/6dccc3adeeeaf218bfa994c689303780a24eab33) | `` pyprland: 1.7.0 -> 1.7.1 ``                                                     |
| [`3f5f020d`](https://github.com/NixOS/nixpkgs/commit/3f5f020da58150abec90208d04defa8ed9d9d4cb) | `` pcm: 202311 -> 202401 ``                                                        |
| [`48965449`](https://github.com/NixOS/nixpkgs/commit/489654493fd8c4310fb14ebd06a134f767624223) | `` opencomposite: unstable-2023-09-11 -> unstable-2024-01-14 ``                    |
| [`ba4d345c`](https://github.com/NixOS/nixpkgs/commit/ba4d345c160d6f8037e1d1a12dfd2b4382e209ac) | `` topgrade: 14.0.0 -> 14.0.1 ``                                                   |
| [`6081df26`](https://github.com/NixOS/nixpkgs/commit/6081df2649d246e60d9d0165c79bea8ac3a97816) | `` super-slicer-beta: 2.5.59.3 -> 2.5.59.6 (#283789) ``                            |
| [`8ee5cbc8`](https://github.com/NixOS/nixpkgs/commit/8ee5cbc89950c516e33ecc31449076170437d825) | `` extism-cli: 1.0.1 -> 1.0.3 ``                                                   |
| [`d65c9a63`](https://github.com/NixOS/nixpkgs/commit/d65c9a63201dd2537ac98a03eeb9eb104ba877dd) | `` centrifugo: 5.2.1 -> 5.2.2 ``                                                   |