### PR TITLE
chore(flake/emacs-overlay): `380a2b90` -> `bf073f54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706519192,
-        "narHash": "sha256-xnlbEJxtRR6hjmRJopRe2TBAWIvEB/S/w1V6613u9Nk=",
+        "lastModified": 1706547981,
+        "narHash": "sha256-gaFfQqXN2SxjUIh8/gDGmQard6nQ1J8ChgH+KP77jBg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "380a2b909774bc47385dfa9556f28f243ea87c71",
+        "rev": "bf073f540fd96d1c5f3faf56a7f4664c8bb49ede",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`bf073f54`](https://github.com/nix-community/emacs-overlay/commit/bf073f540fd96d1c5f3faf56a7f4664c8bb49ede) | `` Updated emacs ``        |
| [`9f6d6ca6`](https://github.com/nix-community/emacs-overlay/commit/9f6d6ca61c8cf8cc39c2436d538a39d64720f4f7) | `` Updated melpa ``        |
| [`a9a8e422`](https://github.com/nix-community/emacs-overlay/commit/a9a8e422dffc94c697fb2f5495fbc83b6c64de59) | `` Updated elpa ``         |
| [`b22256e6`](https://github.com/nix-community/emacs-overlay/commit/b22256e6623d78a850143a4f381a3175432b7388) | `` Updated nongnu ``       |
| [`bc9d133f`](https://github.com/nix-community/emacs-overlay/commit/bc9d133ffbbcd1e3fe0ed78016deb1345912890b) | `` Updated flake inputs `` |