### PR TITLE
chore(flake/nur): `136f332e` -> `13a7c86f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706540385,
-        "narHash": "sha256-5Rv1vNzTpahjcPXfFIRvCYXUIjtmSNFEPZfkecrs1L4=",
+        "lastModified": 1706546663,
+        "narHash": "sha256-3ZBlYG6TXPEQshGDCgkP7F9e8yMAAOyxXyGZWWOpat4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "136f332e3bc7aa6920afec573417e684452c3a6d",
+        "rev": "13a7c86f96ae7e8d2a53e7d5e526aaf3b9324821",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`13a7c86f`](https://github.com/nix-community/NUR/commit/13a7c86f96ae7e8d2a53e7d5e526aaf3b9324821) | `` automatic update `` |
| [`24b087fd`](https://github.com/nix-community/NUR/commit/24b087fde8cbdd8642f394c7da5fd538fadf7c7c) | `` automatic update `` |