### PR TITLE
chore(flake/nur): `13a7c86f` -> `af0ee065`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706546663,
-        "narHash": "sha256-3ZBlYG6TXPEQshGDCgkP7F9e8yMAAOyxXyGZWWOpat4=",
+        "lastModified": 1706548190,
+        "narHash": "sha256-AECukQgQujRdTkTzlquV8oYGD7q2AwTzaKYNJDZqWVo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "13a7c86f96ae7e8d2a53e7d5e526aaf3b9324821",
+        "rev": "af0ee065b9b7f3415c7ce792078574c9e1b9b307",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`af0ee065`](https://github.com/nix-community/NUR/commit/af0ee065b9b7f3415c7ce792078574c9e1b9b307) | `` automatic update `` |