### PR TITLE
chore(flake/nur): `af0ee065` -> `24478b9e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706548190,
-        "narHash": "sha256-AECukQgQujRdTkTzlquV8oYGD7q2AwTzaKYNJDZqWVo=",
+        "lastModified": 1706559951,
+        "narHash": "sha256-yfez9ZnYWsm3m3K8HvN3bGEdWe8aO0ni9r82bAq+q9k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "af0ee065b9b7f3415c7ce792078574c9e1b9b307",
+        "rev": "24478b9e556e4366ef0a2ff58590d8cf24c77267",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`24478b9e`](https://github.com/nix-community/NUR/commit/24478b9e556e4366ef0a2ff58590d8cf24c77267) | `` automatic update `` |
| [`e08169f2`](https://github.com/nix-community/NUR/commit/e08169f28b322bc3ba164aa2c837bd68475d24ea) | `` automatic update `` |
| [`60358a68`](https://github.com/nix-community/NUR/commit/60358a68c155b8a91d729fb50171f2e29723cfd8) | `` automatic update `` |