### PR TITLE
chore(flake/emacs-overlay): `bf073f54` -> `392cb00f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706547981,
-        "narHash": "sha256-gaFfQqXN2SxjUIh8/gDGmQard6nQ1J8ChgH+KP77jBg=",
+        "lastModified": 1706579126,
+        "narHash": "sha256-DEaYvguh4/zhLg/9LQZYOZLehAS93sKBheWW4Dh5xDA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bf073f540fd96d1c5f3faf56a7f4664c8bb49ede",
+        "rev": "392cb00f9e019b9ec1ef4eb530ac0cfb2ddd32e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`392cb00f`](https://github.com/nix-community/emacs-overlay/commit/392cb00f9e019b9ec1ef4eb530ac0cfb2ddd32e3) | `` Updated emacs ``  |
| [`b7295450`](https://github.com/nix-community/emacs-overlay/commit/b7295450764fe32f3e478e31c4121bf05a6bc8a5) | `` Updated melpa ``  |
| [`de3f66c6`](https://github.com/nix-community/emacs-overlay/commit/de3f66c6abccf36c44a642b4dfa48d6326d0292e) | `` Updated elpa ``   |
| [`248e2664`](https://github.com/nix-community/emacs-overlay/commit/248e26643010de9f5dd61d4c4d592b72c6f2d16f) | `` Updated nongnu `` |