### PR TITLE
chore(flake/nur): `dabf5222` -> `cfcdba22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706577237,
-        "narHash": "sha256-NRwSu6yxYcoDP/17XFMcVTgVwpGGON0tQhsP2j1ANks=",
+        "lastModified": 1706580165,
+        "narHash": "sha256-7vcwXQutF35yNvDDPzMbnJ7UIgO6Lc136hx6tKsNqxA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dabf5222e6467876462328871860e16a4ccf53ed",
+        "rev": "cfcdba22aacb9150ecd7347a4c8576a01a600bb2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cfcdba22`](https://github.com/nix-community/NUR/commit/cfcdba22aacb9150ecd7347a4c8576a01a600bb2) | `` automatic update `` |