### PR TITLE
chore(flake/nur): `cfcdba22` -> `db25a01d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706580165,
-        "narHash": "sha256-7vcwXQutF35yNvDDPzMbnJ7UIgO6Lc136hx6tKsNqxA=",
+        "lastModified": 1706586923,
+        "narHash": "sha256-JHfZkcSHQBfZOZAXU1/LtZYN03wFsuzc0QrfUJ8CS+E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cfcdba22aacb9150ecd7347a4c8576a01a600bb2",
+        "rev": "db25a01deab2b9e4edadbf19f957ae4649a81b36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`db25a01d`](https://github.com/nix-community/NUR/commit/db25a01deab2b9e4edadbf19f957ae4649a81b36) | `` automatic update `` |
| [`b4d4d180`](https://github.com/nix-community/NUR/commit/b4d4d180c89478e2bf745dc555d8db897e0d3811) | `` automatic update `` |