### PR TITLE
chore(flake/nur): `dcfdf5e5` -> `48bbc63e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706594460,
-        "narHash": "sha256-QHhokpeNb/zRxDUjkVWn0XJj4VnMK5hg69XyxMSb3Pg=",
+        "lastModified": 1706596157,
+        "narHash": "sha256-JxQ1TvmF+vybLkYQn7p1p7Jsy9AUdCtT9AjPLDrV9AE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dcfdf5e57688fcd44ab72d921f8a4986dc4d6d23",
+        "rev": "48bbc63ea14b02c77723aff536d0785036d85e1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`48bbc63e`](https://github.com/nix-community/NUR/commit/48bbc63ea14b02c77723aff536d0785036d85e1f) | `` automatic update `` |