### PR TITLE
chore(flake/nur): `48bbc63e` -> `6ece651b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706596157,
-        "narHash": "sha256-JxQ1TvmF+vybLkYQn7p1p7Jsy9AUdCtT9AjPLDrV9AE=",
+        "lastModified": 1706600668,
+        "narHash": "sha256-AlTzxgQ4noQ6VQbbqSx4Q/IMLCukRi3A95O20tW4EmQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "48bbc63ea14b02c77723aff536d0785036d85e1f",
+        "rev": "6ece651b79e370a0f872c0c9628b84a790d73f88",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6ece651b`](https://github.com/nix-community/NUR/commit/6ece651b79e370a0f872c0c9628b84a790d73f88) | `` automatic update `` |
| [`c9046b98`](https://github.com/nix-community/NUR/commit/c9046b986e29d7f0f2c9c4c2575260ee8544403f) | `` automatic update `` |