### PR TITLE
chore(flake/nur): `6ece651b` -> `d7e286c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706600668,
-        "narHash": "sha256-AlTzxgQ4noQ6VQbbqSx4Q/IMLCukRi3A95O20tW4EmQ=",
+        "lastModified": 1706607970,
+        "narHash": "sha256-q5W32qx3HhozhAT75AerVqOnhgvNrSyFrjAlu4qNYCU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6ece651b79e370a0f872c0c9628b84a790d73f88",
+        "rev": "d7e286c21530da5d6da54424d64e15de14f7c07a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d7e286c2`](https://github.com/nix-community/NUR/commit/d7e286c21530da5d6da54424d64e15de14f7c07a) | `` automatic update `` |
| [`7256ff5d`](https://github.com/nix-community/NUR/commit/7256ff5dd278dfaf675de442839b51b5b94347c3) | `` automatic update `` |