### PR TITLE
chore(flake/emacs-overlay): `276530c6` -> `4224d726`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706604734,
-        "narHash": "sha256-eYWGpam2zTlLoTH2XinmmFhhbEYFwBbtTQ4MAhOfRHY=",
+        "lastModified": 1706605572,
+        "narHash": "sha256-1F0+sqHovq4baop6eO0SQC8YD1k6wxL6VUZrfCylzLc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "276530c68ca828bf33d2af230f73fe8a49778209",
+        "rev": "4224d7269955e4cab294384f7ba8daed73810946",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`4224d726`](https://github.com/nix-community/emacs-overlay/commit/4224d7269955e4cab294384f7ba8daed73810946) | `` Updated emacs `` |