### PR TITLE
chore(flake/nur): `ce9c09fb` -> `0d59dcdf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706613454,
-        "narHash": "sha256-oekBAKlWhNgs4MCORSrZnswYTwD5h7HQkDDFf6INAZs=",
+        "lastModified": 1706619148,
+        "narHash": "sha256-hxvNVo8OjUS8yaVy3LHX44hNxxkhBcuViYhhcHD7Umo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ce9c09fbd09d8cccb7353fe32bdfbd39ff3cb7be",
+        "rev": "0d59dcdfdbaf840996b4240295cf93342590e316",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0d59dcdf`](https://github.com/nix-community/NUR/commit/0d59dcdfdbaf840996b4240295cf93342590e316) | `` automatic update `` |
| [`d1333968`](https://github.com/nix-community/NUR/commit/d133396849f86db1ddeb3e32ddd01181aaee8e3c) | `` automatic update `` |