### PR TITLE
chore(flake/nur): `298613e6` -> `b9f4941a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706622270,
-        "narHash": "sha256-TFWM+f68Erlohr51497l5rEnxyK3PuNqhw2xDW4mXao=",
+        "lastModified": 1706625187,
+        "narHash": "sha256-5WRFoKWhS615lOfVlDFuwBkCdHpdngP0e6UJLdgBbUQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "298613e6c804d1798096203f7907deee2bde2d5d",
+        "rev": "b9f4941ab6f28d520a056ef139bfd96e4ad9e5f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b9f4941a`](https://github.com/nix-community/NUR/commit/b9f4941ab6f28d520a056ef139bfd96e4ad9e5f6) | `` automatic update `` |