### PR TITLE
chore(flake/emacs-overlay): `4224d726` -> `eb3071f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706605572,
-        "narHash": "sha256-1F0+sqHovq4baop6eO0SQC8YD1k6wxL6VUZrfCylzLc=",
+        "lastModified": 1706634414,
+        "narHash": "sha256-lBGkZxNZAZKb08hJkTloq52/lGIg6MiqAFNF6g+YGXg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4224d7269955e4cab294384f7ba8daed73810946",
+        "rev": "eb3071f959d2c4bd6eccd2176d43f33ccfbfb3b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`eb3071f9`](https://github.com/nix-community/emacs-overlay/commit/eb3071f959d2c4bd6eccd2176d43f33ccfbfb3b1) | `` Updated emacs `` |
| [`630458ac`](https://github.com/nix-community/emacs-overlay/commit/630458acbc94c79af0c4eb26dd9ac26532e31d5a) | `` Updated melpa `` |
| [`00418d6b`](https://github.com/nix-community/emacs-overlay/commit/00418d6b797f9cf85245cd014a6df4617961bcfe) | `` Updated elpa ``  |