### PR TITLE
chore(flake/nur): `07f80cd6` -> `7d66edbb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706634014,
-        "narHash": "sha256-ap2TGXGqFB0ga5MLJjpp992me+SHnGbXLiBH/yb3yU0=",
+        "lastModified": 1706634602,
+        "narHash": "sha256-tl5wLIccwQaUYASKFv3bLcsRfnp2U6UnsAg/6G70VBM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "07f80cd6480e31b8bbe4ed8be90d100af453d750",
+        "rev": "7d66edbb4817023b9bef059d3aeefcd0585c777c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7d66edbb`](https://github.com/nix-community/NUR/commit/7d66edbb4817023b9bef059d3aeefcd0585c777c) | `` automatic update `` |