### PR TITLE
chore(flake/nur): `68b210c7` -> `d5fea764`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706643926,
-        "narHash": "sha256-GOBRsUCZ3a9GgaLvbm2wpmsnZGY41IvEp9C3rQLXaTI=",
+        "lastModified": 1706647935,
+        "narHash": "sha256-g+bhFHmLkgYukFhbal0v9L6HY9PFkaNYCMSjinc448k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "68b210c7240de86b3639cf9542df9dcb9c504914",
+        "rev": "d5fea7648ed92a859cb837e5b2331fabe802c0a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d5fea764`](https://github.com/nix-community/NUR/commit/d5fea7648ed92a859cb837e5b2331fabe802c0a5) | `` automatic update `` |
| [`f241c228`](https://github.com/nix-community/NUR/commit/f241c228a76c4be5adbfd532760a427aaadf7a90) | `` automatic update `` |