### PR TITLE
chore(flake/nur): `d5fea764` -> `117de70f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706647935,
-        "narHash": "sha256-g+bhFHmLkgYukFhbal0v9L6HY9PFkaNYCMSjinc448k=",
+        "lastModified": 1706649596,
+        "narHash": "sha256-KE0xTu27Ib5dpFJQRLRQ6xblgVrIhfH7HKVA/mX5Tv8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d5fea7648ed92a859cb837e5b2331fabe802c0a5",
+        "rev": "117de70feb65cfdd62f855d8093aacdc51ea930e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`117de70f`](https://github.com/nix-community/NUR/commit/117de70feb65cfdd62f855d8093aacdc51ea930e) | `` automatic update `` |