### PR TITLE
chore(flake/nur): `117de70f` -> `071d505b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706649596,
-        "narHash": "sha256-KE0xTu27Ib5dpFJQRLRQ6xblgVrIhfH7HKVA/mX5Tv8=",
+        "lastModified": 1706654647,
+        "narHash": "sha256-QWi3Ho25r8jDUbo7iZrOxLKWk01nyfQrp5l2h0RzxYw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "117de70feb65cfdd62f855d8093aacdc51ea930e",
+        "rev": "071d505b63297d5b3e358326c00e58ee39c18341",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`071d505b`](https://github.com/nix-community/NUR/commit/071d505b63297d5b3e358326c00e58ee39c18341) | `` automatic update `` |
| [`c1ff1093`](https://github.com/nix-community/NUR/commit/c1ff109362e22cf30ea1f16edd462100e646e7b7) | `` automatic update `` |