### PR TITLE
chore(flake/nur): `071d505b` -> `98930fb5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706654647,
-        "narHash": "sha256-QWi3Ho25r8jDUbo7iZrOxLKWk01nyfQrp5l2h0RzxYw=",
+        "lastModified": 1706665018,
+        "narHash": "sha256-NtvxIQhRxavrL7PQ1ZURqWr15XM1Dc98yv4U5gTbJhk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "071d505b63297d5b3e358326c00e58ee39c18341",
+        "rev": "98930fb5cf79e652111ed531e6ce777618b1c898",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`98930fb5`](https://github.com/nix-community/NUR/commit/98930fb5cf79e652111ed531e6ce777618b1c898) | `` automatic update `` |
| [`93218f25`](https://github.com/nix-community/NUR/commit/93218f250e2d949cecf4efce55c8d4423852aae5) | `` automatic update `` |
| [`152b28e6`](https://github.com/nix-community/NUR/commit/152b28e6796be0de8b2c45876e5692f0746948c6) | `` automatic update `` |