### PR TITLE
chore(flake/nur): `98930fb5` -> `a2756748`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706665018,
-        "narHash": "sha256-NtvxIQhRxavrL7PQ1ZURqWr15XM1Dc98yv4U5gTbJhk=",
+        "lastModified": 1706672696,
+        "narHash": "sha256-b5QttzGqf4wKwAGA7vJ5k3Ywtgwa56cF+lv7GUo5cK0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "98930fb5cf79e652111ed531e6ce777618b1c898",
+        "rev": "a2756748687453a23348c7d9ee46a11f79403398",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a2756748`](https://github.com/nix-community/NUR/commit/a2756748687453a23348c7d9ee46a11f79403398) | `` automatic update `` |