### PR TITLE
chore(flake/nur): `a2756748` -> `6f1371fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706672696,
-        "narHash": "sha256-b5QttzGqf4wKwAGA7vJ5k3Ywtgwa56cF+lv7GUo5cK0=",
+        "lastModified": 1706675850,
+        "narHash": "sha256-urezy8FRe3B9j3C06Zv93N2fiX6LMm06qeaKCykqjxs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a2756748687453a23348c7d9ee46a11f79403398",
+        "rev": "6f1371fef7cd2f64e6a9f191350649417c595e44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6f1371fe`](https://github.com/nix-community/NUR/commit/6f1371fef7cd2f64e6a9f191350649417c595e44) | `` automatic update `` |