### PR TITLE
chore(flake/nur): `6f1371fe` -> `72aec480`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706675850,
-        "narHash": "sha256-urezy8FRe3B9j3C06Zv93N2fiX6LMm06qeaKCykqjxs=",
+        "lastModified": 1706679692,
+        "narHash": "sha256-ZBuyVqBUrCqNGU7rsNomQ+KBwcbKrWPFxQigekJMkxA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6f1371fef7cd2f64e6a9f191350649417c595e44",
+        "rev": "72aec4801b982219a2f4b98c41b1b97131917ce0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`72aec480`](https://github.com/nix-community/NUR/commit/72aec4801b982219a2f4b98c41b1b97131917ce0) | `` automatic update `` |