### PR TITLE
chore(flake/nur): `72aec480` -> `7f970ae3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706679692,
-        "narHash": "sha256-ZBuyVqBUrCqNGU7rsNomQ+KBwcbKrWPFxQigekJMkxA=",
+        "lastModified": 1706683558,
+        "narHash": "sha256-Rz8mjD3GTVP5HQweR4GA23I9Nl+mH6GokyaOohpyfMk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "72aec4801b982219a2f4b98c41b1b97131917ce0",
+        "rev": "7f970ae3b784af7e4505ae09780a56a13300a1be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7f970ae3`](https://github.com/nix-community/NUR/commit/7f970ae3b784af7e4505ae09780a56a13300a1be) | `` automatic update `` |
| [`9bc44fec`](https://github.com/nix-community/NUR/commit/9bc44feccbc86196b9b6d15e31d4a85efe1abcca) | `` automatic update `` |