### PR TITLE
chore(flake/nur): `7f970ae3` -> `fab803d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706683558,
-        "narHash": "sha256-Rz8mjD3GTVP5HQweR4GA23I9Nl+mH6GokyaOohpyfMk=",
+        "lastModified": 1706686049,
+        "narHash": "sha256-TCuYU/F5uuMDIBcFSm1xi2fYHt1Bit8fYPzIzB7T6HY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7f970ae3b784af7e4505ae09780a56a13300a1be",
+        "rev": "fab803d7fa7e066ff6193fe40ba29d2e322835e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fab803d7`](https://github.com/nix-community/NUR/commit/fab803d7fa7e066ff6193fe40ba29d2e322835e1) | `` automatic update `` |