### PR TITLE
chore(flake/nixpkgs): `c002c6aa` -> `97b17f32`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -777,11 +777,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1706371002,
-        "narHash": "sha256-dwuorKimqSYgyu8Cw6ncKhyQjUDOyuXoxDTVmAXq88s=",
+        "lastModified": 1706550542,
+        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c002c6aa977ad22c60398daaa9be52f2203d0006",
+        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`b1e30d76`](https://github.com/NixOS/nixpkgs/commit/b1e30d76d4a8821783d94be6f6d6d91a5f7a7033) | `` fahclient: 8.1.18 -> 8.3.1 (#281830) ``                                           |
| [`7ba3caea`](https://github.com/NixOS/nixpkgs/commit/7ba3caea70556bb6691f0ed0792c2ac89393018b) | `` neovide: 0.12.1 -> 0.12.2 ``                                                      |
| [`45e6764d`](https://github.com/NixOS/nixpkgs/commit/45e6764d05df7c3f04e1e2ae89f070e974a3c161) | `` armcord: makeWrapper -> makeBinaryWrapper ``                                      |
| [`c4ff7f4c`](https://github.com/NixOS/nixpkgs/commit/c4ff7f4c1690a6bf2091a3d1aadda07592ffd59a) | `` cook-cli: init at 0.7.1 ``                                                        |
| [`bee5a980`](https://github.com/NixOS/nixpkgs/commit/bee5a980c13655d13b63c035d495608656c52a1a) | `` linux_latest-libre: 19473 -> 19482 ``                                             |
| [`92d90fd5`](https://github.com/NixOS/nixpkgs/commit/92d90fd5b16be9d6286729c0166f8fa664a96122) | `` linux_testing: 6.8-rc1 -> 6.8-rc2 ``                                              |
| [`8b534637`](https://github.com/NixOS/nixpkgs/commit/8b53463731de41306d53cbc38aa0cc65e359d5df) | `` vikunja-frontend: 0.22.0 -> 0.22.1 ``                                             |
| [`c954d246`](https://github.com/NixOS/nixpkgs/commit/c954d246dd03b5d136bb7216004668ffdeb52514) | `` vikunja-api: 0.22.0 -> 0.22.1 ``                                                  |
| [`46ab2388`](https://github.com/NixOS/nixpkgs/commit/46ab2388ca0ab6b6a7d6294da84afa54a7dc239f) | `` earthly: 0.8.0 -> 0.8.2 ``                                                        |
| [`f4d61276`](https://github.com/NixOS/nixpkgs/commit/f4d61276b1d9a7a5fe9647f165647d2b8b2f2290) | `` cargo-make: 0.37.7 -> 0.37.8 ``                                                   |
| [`a8e6acef`](https://github.com/NixOS/nixpkgs/commit/a8e6acefc56dd02f66cbac39aafa726a5fd1381c) | `` github-backup: 0.44.1 -> 0.45.0 ``                                                |
| [`63da56ea`](https://github.com/NixOS/nixpkgs/commit/63da56ea6974c938b8c243462a40423b8bdcce8f) | `` python311Packages.json-stream-rs-tokenizer: 0.4.22 -> 0.4.25 ``                   |
| [`8700612e`](https://github.com/NixOS/nixpkgs/commit/8700612e7e7ec263998c6d4e00649498be70221e) | `` maintainers: drop inactive scubed2 ``                                             |
| [`2cf6db07`](https://github.com/NixOS/nixpkgs/commit/2cf6db07ee287652ca9d52671cd5aefce8e436f0) | `` risor: 1.1.2 -> 1.3.2 ``                                                          |
| [`c65f6820`](https://github.com/NixOS/nixpkgs/commit/c65f6820b279d439570ddb226c4eae15d42c95e2) | `` paperless-ngx: 2.4.0 -> 2.4.3 ``                                                  |
| [`20cb4f70`](https://github.com/NixOS/nixpkgs/commit/20cb4f705d9de6e140a3941f54e218dce7452f60) | `` Revert "python3Packages.preshed: 3.0.9 -> 4.0.0" ``                               |
| [`6b5dd064`](https://github.com/NixOS/nixpkgs/commit/6b5dd0640b58ec457291573acffce19bd1211656) | `` nixosTests.budgie: Fix login subtest ``                                           |
| [`c7443adb`](https://github.com/NixOS/nixpkgs/commit/c7443adb155d54d1c0fe81762181e27fd8d56df2) | `` budgie.budgie-desktop: 10.8.2 -> 10.9 ``                                          |
| [`75cd6e49`](https://github.com/NixOS/nixpkgs/commit/75cd6e49a90751c1bbe19fe9e39b160597710ecb) | `` python311Packages.bip-utils: 2.9.0 -> 2.9.1 ``                                    |
| [`7371b0a3`](https://github.com/NixOS/nixpkgs/commit/7371b0a3bb54cb056b549834e243043593fe4a35) | `` python311Packages.gitlike-commands: remove patch ``                               |
| [`b0438a43`](https://github.com/NixOS/nixpkgs/commit/b0438a433f11bcf33f56d371a08af52282b9ed7c) | `` python311Packages.gitlike-commands: 0.2.1 -> 0.3.0 ``                             |
| [`c570e449`](https://github.com/NixOS/nixpkgs/commit/c570e449716a1e29290e26469104710a074c2e0d) | `` jitsi-meet: 1.0.7712 -> 1.0.7762 ``                                               |
| [`d5762179`](https://github.com/NixOS/nixpkgs/commit/d5762179dfbf798510cd8e7be709a20ff0418352) | `` spotube: init at 3.4.1 ``                                                         |
| [`e48bdfb7`](https://github.com/NixOS/nixpkgs/commit/e48bdfb7f4197d3866c724f343be0153ee8d182f) | `` bandwhich: 0.21.1 -> 0.22.2 ``                                                    |
| [`ec79a038`](https://github.com/NixOS/nixpkgs/commit/ec79a038c4d4077261cc9fcdb07d3bcdeef59670) | `` ocamlPackages.riot: 0.0.5 -> 0.0.7 ``                                             |
| [`7a12b26f`](https://github.com/NixOS/nixpkgs/commit/7a12b26fb2a9360a2de103ccea8d009c811f5be2) | `` python311Packages.frigidaire: refactor ``                                         |
| [`55aa3629`](https://github.com/NixOS/nixpkgs/commit/55aa3629277347a8aca1fa4f2692e1498b42dbd7) | `` build(deps): bump peter-evans/create-or-update-comment ``                         |
| [`d72adfb5`](https://github.com/NixOS/nixpkgs/commit/d72adfb5a178b1f50a4a69a09687c445e4e46ed6) | `` python311Packages.frigidaire: 0.18.13 -> 0.18.15 ``                               |
| [`3b365cc8`](https://github.com/NixOS/nixpkgs/commit/3b365cc8461ed55525f6d075bd1fe32c6d43531f) | `` bitmagnet: 0.4.1 -> 0.5.1 ``                                                      |
| [`e46203c6`](https://github.com/NixOS/nixpkgs/commit/e46203c6e28f455a5f386202b2e7fbc204dfbf30) | `` jira-cli-go: 1.5.0 -> 1.5.1 ``                                                    |
| [`bd13f994`](https://github.com/NixOS/nixpkgs/commit/bd13f9943491e04affdc6ff9c293fe941768bd7f) | `` python311Packages.hahomematic: 2024.1.8 -> 2024.1.10 ``                           |
| [`c1d3b6b7`](https://github.com/NixOS/nixpkgs/commit/c1d3b6b7ba087096a5d1b57773aba7eaa09ba7b0) | `` build-support/testers: don't fail the test on empty list of pkg-config modules `` |
| [`cb603f1b`](https://github.com/NixOS/nixpkgs/commit/cb603f1b5bf2451b18d9a155193154f5768aa73a) | `` python311Packages.django-cleanup: 8.0.0 -> 8.1.0 ``                               |
| [`df2f1a85`](https://github.com/NixOS/nixpkgs/commit/df2f1a85106a52596eaf152dfcd9225bf674dcf2) | `` openvpn: cleanup unnecessary generic function ``                                  |
| [`0d5ad472`](https://github.com/NixOS/nixpkgs/commit/0d5ad472690745f479e63fdc2772383072b54ff7) | `` python311Packages.python-docs-theme: 2023.9 -> 2024.1 ``                          |
| [`50cf3e31`](https://github.com/NixOS/nixpkgs/commit/50cf3e310b3f3c963af507e4252d33e3eb362d86) | `` homepage-dashboard: 0.8.6 -> 0.8.7 ``                                             |
| [`45fad890`](https://github.com/NixOS/nixpkgs/commit/45fad8902ff1c49f1f3af282c7f12f2e09651fd0) | `` linux/hardened/patches/6.7: init at 6.7.2-hardened1 ``                            |
| [`018def54`](https://github.com/NixOS/nixpkgs/commit/018def54e4d459cbdf74df5cdc47bd3cd190d4c5) | `` linux/hardened/patches/6.6: 6.6.13-hardened1 -> 6.6.14-hardened1 ``               |
| [`b3f3397b`](https://github.com/NixOS/nixpkgs/commit/b3f3397b4b30ba163fb20a4c8ed732a5e5a3951c) | `` linux/hardened/patches/6.1: 6.1.74-hardened1 -> 6.1.75-hardened1 ``               |
| [`33dd8598`](https://github.com/NixOS/nixpkgs/commit/33dd85989dca85bcc19c08969e19c58ad491c6a5) | `` linux/hardened/patches/5.4: 5.4.267-hardened1 -> 5.4.268-hardened1 ``             |
| [`503d0f65`](https://github.com/NixOS/nixpkgs/commit/503d0f65a7723caba27052ada52a0e921229021b) | `` linux/hardened/patches/5.15: 5.15.147-hardened1 -> 5.15.148-hardened1 ``          |
| [`ed540a7c`](https://github.com/NixOS/nixpkgs/commit/ed540a7c8e7e1c66a7e6485235a0a1b4a856a3df) | `` linux/hardened/patches/5.10: 5.10.208-hardened1 -> 5.10.209-hardened1 ``          |
| [`114b7a4a`](https://github.com/NixOS/nixpkgs/commit/114b7a4a3b9a8ab065ee421dc4d15753d8dfc45a) | `` linux/hardened/patches/4.19: 4.19.305-hardened1 -> 4.19.306-hardened1 ``          |
| [`8370f142`](https://github.com/NixOS/nixpkgs/commit/8370f142be754f52921c37f315b429c8a8d484e7) | `` vscode-extensions.davidanson.vscode-markdownlint: 0.53.0 -> 0.54.0 ``             |
| [`d0cdb657`](https://github.com/NixOS/nixpkgs/commit/d0cdb657c2f6a87e5089ba33c0a58fd52edddf10) | `` why3: move the OCaml library to its own dev output ``                             |
| [`b4c95394`](https://github.com/NixOS/nixpkgs/commit/b4c953947f562a144b70bd1461a82df125f654e4) | `` ocamlPackages.lambdapi: use why3 built with the same version of OCaml ``          |
| [`e997629c`](https://github.com/NixOS/nixpkgs/commit/e997629cea8885bb4b00c5998eb0adfb8bf5ae39) | `` why3: make it easy to disable IDE support ``                                      |
| [`c4f01b3b`](https://github.com/NixOS/nixpkgs/commit/c4f01b3b73caa8c86f026bdccfd9c61282dbfb0e) | `` why3: 1.7.0 → 1.7.1 ``                                                            |
| [`6a53d150`](https://github.com/NixOS/nixpkgs/commit/6a53d1509399bf897c8cf6859713513148a97243) | `` dalfox: add ldflags ``                                                            |
| [`8754a9d3`](https://github.com/NixOS/nixpkgs/commit/8754a9d37e2e63a9fe4c3491ae821b03e2026c90) | `` python311Packages.aiortm: 0.8.7 -> 0.8.9 ``                                       |
| [`a9fbf4d8`](https://github.com/NixOS/nixpkgs/commit/a9fbf4d8a0bd6b7ff34b510ff08065667dfec53a) | `` teams-for-linux: 1.4.5 -> 1.4.6 ``                                                |
| [`0cae536a`](https://github.com/NixOS/nixpkgs/commit/0cae536a2fd73b4f22a8bb1ea5dc580e39750192) | `` python311Packages.aioopenexchangerates: 0.4.6 -> 0.4.7 ``                         |
| [`83591dbb`](https://github.com/NixOS/nixpkgs/commit/83591dbbe548364f567a8d692e911921fb7b0ccb) | `` nixosTests.netbird: fix after module update ``                                    |
| [`40d570d1`](https://github.com/NixOS/nixpkgs/commit/40d570d13a354f117287191005b299f7592dec88) | `` protobuf_25: 25.1 -> 25.2 ``                                                      |
| [`786bf7fd`](https://github.com/NixOS/nixpkgs/commit/786bf7fd00eb4ea47d07c885bff358e09197fa30) | `` python311Packages.glfw: 2.6.4 -> 2.6.5 ``                                         |
| [`0e6d8212`](https://github.com/NixOS/nixpkgs/commit/0e6d821272b9b492224c15446c810f67a9a3539d) | `` libhwy: disable RVV ``                                                            |
| [`26e39126`](https://github.com/NixOS/nixpkgs/commit/26e3912653a744691e5e66e6ebe4c27410fdd207) | `` ocamlPackages.tiny_httpd: 0.12 -> 0.16 ``                                         |
| [`1acd69a0`](https://github.com/NixOS/nixpkgs/commit/1acd69a00837c9407b02fbba6146bbd0d88286f6) | `` j: 904-beta-c -> 9.5.1 ``                                                         |
| [`61d95a93`](https://github.com/NixOS/nixpkgs/commit/61d95a93f3c3ec1c5cfdc223ca3479012c21a0ba) | `` audiowaveform: 1.10.0 -> 1.10.1 ``                                                |
| [`6f6aaac3`](https://github.com/NixOS/nixpkgs/commit/6f6aaac3296b076937fbf3d51907d3263619af98) | `` okteto: 2.24.1 -> 2.24.2 ``                                                       |
| [`5ae3e3cd`](https://github.com/NixOS/nixpkgs/commit/5ae3e3cdc1b3017c6c0329da1270e651030ef0d9) | `` snazy: 0.52.7 -> 0.52.17 ``                                                       |
| [`2d632d2e`](https://github.com/NixOS/nixpkgs/commit/2d632d2e46fcce8a7eb3e8144c4833b9a518df94) | `` discordo: unstable-2023-12-12 -> unstable-2024-01-25 ``                           |
| [`3be0f4c1`](https://github.com/NixOS/nixpkgs/commit/3be0f4c18aae0e174fe57160029060642d12a107) | `` buildbot-plugins.react-wsgi-dashboards: init at 3.11.0 ``                         |
| [`59ba51d2`](https://github.com/NixOS/nixpkgs/commit/59ba51d251f310fb3dda6c7c3aaef80b410e76c0) | `` buildbot: 3.10.1 -> 3.11.0 ``                                                     |
| [`c1bd7160`](https://github.com/NixOS/nixpkgs/commit/c1bd71605c7a397f04b674890eb4a1564a2f7385) | `` minio: 2024-01-18T22-51-28Z -> 2024-01-28T22-35-53Z ``                            |
| [`cc274ed1`](https://github.com/NixOS/nixpkgs/commit/cc274ed15ebf48466e9989e7dc2a9423aad18a9d) | `` process-compose: 0.80.0 -> 0.81.4 ``                                              |
| [`49e9e6ed`](https://github.com/NixOS/nixpkgs/commit/49e9e6ed075d458f494f68b4f861b515bad5a051) | `` pmtiles: 1.13.0 -> 1.14.0 ``                                                      |
| [`1c89ce8c`](https://github.com/NixOS/nixpkgs/commit/1c89ce8c777a7f18df53b7d78c3c8a9685be2cb6) | `` ytcast: 1.3.0 -> 1.4.0 ``                                                         |
| [`be92f8b5`](https://github.com/NixOS/nixpkgs/commit/be92f8b518dbd2a58bf79977ece920c1cfba2b73) | `` pgweb: 0.14.2 -> 0.14.3 ``                                                        |
| [`2617d44d`](https://github.com/NixOS/nixpkgs/commit/2617d44d529c153c0ee535f1e71021e61442dc7d) | `` nwg-look: 0.2.5 -> 0.2.6 ``                                                       |
| [`04d11161`](https://github.com/NixOS/nixpkgs/commit/04d1116128c6e2a3c4228d4aebe45096f7396001) | `` nwg-bar: 0.1.5 -> 0.1.6 ``                                                        |
| [`851cdd07`](https://github.com/NixOS/nixpkgs/commit/851cdd07b210e0b3995505084fe197d33daf2563) | `` sigtop: 0.7.0 -> 0.8.0 ``                                                         |
| [`d699183b`](https://github.com/NixOS/nixpkgs/commit/d699183b260416ce0d339edca688bdc09890ae9b) | `` markdownlint-cli: 0.38.0 -> 0.39.0 ``                                             |
| [`014d9298`](https://github.com/NixOS/nixpkgs/commit/014d92981109df57e963b10a6e03648dbfaff6ea) | `` maskromtool: 2024-01-1 -> 2024-01-28 ``                                           |
| [`6a0b7afd`](https://github.com/NixOS/nixpkgs/commit/6a0b7afdaaa67684643b91676d1d5723271e569f) | `` dalfox: 2.9.1 -> 2.9.2 ``                                                         |
| [`450e082a`](https://github.com/NixOS/nixpkgs/commit/450e082a81caa5569e07d2c2de63dd6ea7fc8993) | `` rapidfuzz-cpp: add passthru.tests.levenshtein ``                                  |
| [`a9a3f6d6`](https://github.com/NixOS/nixpkgs/commit/a9a3f6d6317de9c311e1e8a3b5c11199987ee308) | `` pulldown-cmark: 0.9.4 -> 0.9.5 ``                                                 |
| [`57db427b`](https://github.com/NixOS/nixpkgs/commit/57db427b6d898377b7341653c9987be9ab47fe9d) | `` dpp: init at 10.0.29 ``                                                           |
| [`5e4df916`](https://github.com/NixOS/nixpkgs/commit/5e4df916ab40c03a76bc9ac2dd103716a6638958) | `` mantainers: add xbz ``                                                            |
| [`5b284c5c`](https://github.com/NixOS/nixpkgs/commit/5b284c5cfe37906d9cef0670874b20a312f7384f) | `` monkeysAudio: 10.43 -> 10.44 ``                                                   |
| [`d8fdaffa`](https://github.com/NixOS/nixpkgs/commit/d8fdaffa4821298a17c581d3d41dc40319461eb8) | `` python311Packages.sagemaker: 2.204.0 -> 2.205.0 ``                                |
| [`4540dd58`](https://github.com/NixOS/nixpkgs/commit/4540dd587265cefdd18eb8903a831e9c83db5a5c) | `` python311Packages.pytrafikverket: 0.3.9.2 -> 0.3.10 ``                            |
| [`50acbada`](https://github.com/NixOS/nixpkgs/commit/50acbada81e3b47cd495bee38884c5bf453c71c8) | `` virt-viewer: add GStreamer in buildInputs ``                                      |
| [`773d09d9`](https://github.com/NixOS/nixpkgs/commit/773d09d9200df7a7724013aab6fb9b932b697631) | `` python311Packages.nibabel: 5.1.0 -> 5.2.0 ``                                      |
| [`1a7c8f44`](https://github.com/NixOS/nixpkgs/commit/1a7c8f44509b47006f3e21ea4b87f2189fba1dba) | `` checkov: 3.1.70 -> 3.2.0 ``                                                       |
| [`93aa0025`](https://github.com/NixOS/nixpkgs/commit/93aa00253e724c803b1a3f413200ddc8042b4514) | `` xfce.libxfce4windowing: init at 4.19.2 ``                                         |
| [`4dd4cdf0`](https://github.com/NixOS/nixpkgs/commit/4dd4cdf07a865f21b711e36ca35fb86edea1daff) | `` python311Packages.robotframework-seleniumlibrary: fix tests ``                    |
| [`c0079344`](https://github.com/NixOS/nixpkgs/commit/c0079344adae8a8eeb7ac8aae9247ce6001af9f5) | `` python311Packages.approvaltests: 10.2.0 -> 10.3.0 ``                              |
| [`6e1cbcd3`](https://github.com/NixOS/nixpkgs/commit/6e1cbcd3c228eae9b7d4c94e425b685159295557) | `` prometheus-knot-exporter: 3.3.3 -> 3.3.4 ``                                       |
| [`0e7efe59`](https://github.com/NixOS/nixpkgs/commit/0e7efe59de3518ca0da1429b6ce8e859811f1da7) | `` v2ray-domain-list-community: 20240105034708 -> 20240123112230 ``                  |
| [`a35fedb6`](https://github.com/NixOS/nixpkgs/commit/a35fedb6a628775ee810f5e053d3e458e0e99053) | `` python311Packages.tilequant: relax pillow constraint ``                           |
| [`96101568`](https://github.com/NixOS/nixpkgs/commit/961015684e9924076248e1366f963a51f48164ec) | `` uftrace: 0.15.1 -> 0.15.2 ``                                                      |
| [`e0331ec3`](https://github.com/NixOS/nixpkgs/commit/e0331ec3e4861c3eb929c687eceab2db8526f656) | `` terraform-compliance: 1.3.46 -> 1.3.47 ``                                         |
| [`348fc113`](https://github.com/NixOS/nixpkgs/commit/348fc113a21622069307d7f2ff2759b6154ae899) | `` python311Packages.anthropic: 0.11.0 -> 0.12.0 ``                                  |
| [`9e67b430`](https://github.com/NixOS/nixpkgs/commit/9e67b4305cd96ce9d278b80a0c401700d87f7fdc) | `` intel-compute-runtime: 23.43.27642.18 -> 23.48.27912.11 ``                        |
| [`610d056c`](https://github.com/NixOS/nixpkgs/commit/610d056ce8dda52266acca3a9987700e4b13afc2) | `` python311Packages.nose2: 0.14.0 -> 0.14.1 ``                                      |
| [`6025aee0`](https://github.com/NixOS/nixpkgs/commit/6025aee055ada55c99459e6e07b76e5fea9fde63) | `` python311Packages.ring-doorbell: 0.8.5 -> 0.8.6 ``                                |
| [`cccf38f8`](https://github.com/NixOS/nixpkgs/commit/cccf38f8f85a87bc97a02d6b8511a3b7c872f4f2) | `` gnmic: 0.35.0 -> 0.35.1 ``                                                        |
| [`0d209c66`](https://github.com/NixOS/nixpkgs/commit/0d209c66415a8a751c8f6e34888729a2c13b64b8) | `` nixos/budgie: Replace gnome-session with budgie-session ``                        |
| [`a58775cf`](https://github.com/NixOS/nixpkgs/commit/a58775cfde259c2dc550b52a9805a4884c047c8f) | `` gnome.gnome-session: Drop gnomeShellSupport option ``                             |
| [`230eb916`](https://github.com/NixOS/nixpkgs/commit/230eb916d394f64c16e184a2398e0050bde8e3e6) | `` budgie.budgie-session: init at 0.9.1 ``                                           |
| [`bbabd9b6`](https://github.com/NixOS/nixpkgs/commit/bbabd9b6cbbc16841cb9d03949175ca0fd8548a0) | `` obs-studio-plugins.obs-composite-blur: fix ``                                     |
| [`b2b16180`](https://github.com/NixOS/nixpkgs/commit/b2b16180e20047f80e04dac3774b4f77fed78bd1) | `` presenterm: 0.4.1 -> 0.5.0 ``                                                     |
| [`a0d71869`](https://github.com/NixOS/nixpkgs/commit/a0d718692a373c4a1a9b8e6a3fd41445174a4dc8) | `` mcaselector: 2.2.2 -> 2.3 ``                                                      |
| [`c6944dff`](https://github.com/NixOS/nixpkgs/commit/c6944dffd3db5c3584e2d98d59cc74e4e71cd89c) | `` portfolio: 0.67.1 -> 0.67.2 ``                                                    |