### PR TITLE
chore(flake/nur): `fab803d7` -> `b8cec179`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706686049,
-        "narHash": "sha256-TCuYU/F5uuMDIBcFSm1xi2fYHt1Bit8fYPzIzB7T6HY=",
+        "lastModified": 1706696373,
+        "narHash": "sha256-Aaz0vYi/7/ob9MlKt8ZCfVqds/0Gm0lg/ovab3F0w6M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fab803d7fa7e066ff6193fe40ba29d2e322835e1",
+        "rev": "b8cec1790834718d4381bcca40340365aefc2195",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b8cec179`](https://github.com/nix-community/NUR/commit/b8cec1790834718d4381bcca40340365aefc2195) | `` automatic update `` |