### PR TITLE
chore(flake/nur): `b8cec179` -> `9be129c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706696373,
-        "narHash": "sha256-Aaz0vYi/7/ob9MlKt8ZCfVqds/0Gm0lg/ovab3F0w6M=",
+        "lastModified": 1706702331,
+        "narHash": "sha256-ajFdyILjnwe69HEiI2EFVC10o8xzJhJfQsK7p3lEs+I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b8cec1790834718d4381bcca40340365aefc2195",
+        "rev": "9be129c15b400bae1ba97abc14d62c718c660fc2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9be129c1`](https://github.com/nix-community/NUR/commit/9be129c15b400bae1ba97abc14d62c718c660fc2) | `` automatic update `` |
| [`e52bfdd7`](https://github.com/nix-community/NUR/commit/e52bfdd7d331dd32f0f0f8eb430488a36d6e6402) | `` automatic update `` |