### PR TITLE
chore(flake/nur): `c462af68` -> `88061a9d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706702864,
-        "narHash": "sha256-KEPCWJFaaUUnU92C36QMlXYHqTrBnh687ctwgsSSsSA=",
+        "lastModified": 1706708674,
+        "narHash": "sha256-CRKrAQf0zUzT//ajWbuP8QPZxcs8nSux5nbXc6NQ0z4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c462af68ad7740ed50079d2b6be2dadfaf0e211c",
+        "rev": "88061a9d6cfd09617228d66fade1ac8ab46dea02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`88061a9d`](https://github.com/nix-community/NUR/commit/88061a9d6cfd09617228d66fade1ac8ab46dea02) | `` automatic update `` |