### PR TITLE
chore(flake/emacs-overlay): `2d69eefb` -> `512b3890`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706691967,
-        "narHash": "sha256-ADKh/Vss8ITblcLDl/LUM6GqJOahBktu4EXzhv7Uxbs=",
+        "lastModified": 1706719893,
+        "narHash": "sha256-XkBuHmEJoSJ+FhXzZ/at+5UoGzlOA6BlDodp1Ve6jT4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2d69eefbcadbac97bda477477cd53c0ef815f436",
+        "rev": "512b3890a5bc20a6d9996dfdda4ca2276194eba8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`512b3890`](https://github.com/nix-community/emacs-overlay/commit/512b3890a5bc20a6d9996dfdda4ca2276194eba8) | `` Updated melpa `` |
| [`8db120f2`](https://github.com/nix-community/emacs-overlay/commit/8db120f2369ed54f570dcc146b244559468a2f6e) | `` Updated elpa ``  |