### PR TITLE
chore(flake/nur): `b8a6ba0f` -> `538803b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706723641,
-        "narHash": "sha256-H6+8h6f6lTTr9kKeunuiWvOlHRjbLs6sgCctgH1HzSc=",
+        "lastModified": 1706730308,
+        "narHash": "sha256-ZKmQiwePoeyiWg/VsDr6s10CkAu0Sq2AvMmjAR7EQeQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b8a6ba0f01c785b0240e306e765e71850c1943e8",
+        "rev": "538803b10d4986336c30743baa8e4b8b5590e943",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`538803b1`](https://github.com/nix-community/NUR/commit/538803b10d4986336c30743baa8e4b8b5590e943) | `` automatic update `` |
| [`c8974169`](https://github.com/nix-community/NUR/commit/c89741693418dc01bc1d01df5cee04abdfd53a47) | `` automatic update `` |
| [`97236a74`](https://github.com/nix-community/NUR/commit/97236a744ef30a8e928555844ec0654ec7569d2a) | `` automatic update `` |