### PR TITLE
chore(flake/nur): `538803b1` -> `ae03b5f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706730308,
-        "narHash": "sha256-ZKmQiwePoeyiWg/VsDr6s10CkAu0Sq2AvMmjAR7EQeQ=",
+        "lastModified": 1706737483,
+        "narHash": "sha256-5Zth6Dtl/7S6dt2nBbPPlHh0PSlFJZQg8Ljqy0FUpIM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "538803b10d4986336c30743baa8e4b8b5590e943",
+        "rev": "ae03b5f3fe8cb99cfa26b31c61a3a96fb8e4ad33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ae03b5f3`](https://github.com/nix-community/NUR/commit/ae03b5f3fe8cb99cfa26b31c61a3a96fb8e4ad33) | `` automatic update `` |