### PR TITLE
chore(flake/emacs-overlay): `bfd3b792` -> `46140cd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706741822,
-        "narHash": "sha256-mU1aU2SSv70H6TNEzWFnPkOZOEJWNwC8I1HbsPkAS8k=",
+        "lastModified": 1706749249,
+        "narHash": "sha256-RLzdL9rRF14RNfGSBovS0i/iJHmHiGJbiMwde+5PtgA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bfd3b792ef19d8dbe826c7c8e17cdaccd2f82f20",
+        "rev": "46140cd6aea038eb370d01095f12d5da4f656a43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`46140cd6`](https://github.com/nix-community/emacs-overlay/commit/46140cd6aea038eb370d01095f12d5da4f656a43) | `` Updated elpa ``   |
| [`bc072d9c`](https://github.com/nix-community/emacs-overlay/commit/bc072d9cca7c696b5167d352e20728515938f677) | `` Updated nongnu `` |