### PR TITLE
chore(flake/emacs-overlay): `46140cd6` -> `f2d21ce0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706749249,
-        "narHash": "sha256-RLzdL9rRF14RNfGSBovS0i/iJHmHiGJbiMwde+5PtgA=",
+        "lastModified": 1706752080,
+        "narHash": "sha256-7FEcuds8vl+4IFDGyqoCSsEc+oEDfHNYihehcgS4nbQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "46140cd6aea038eb370d01095f12d5da4f656a43",
+        "rev": "f2d21ce04546fe3120c1670f06e5f7598592ecd0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`f2d21ce0`](https://github.com/nix-community/emacs-overlay/commit/f2d21ce04546fe3120c1670f06e5f7598592ecd0) | `` Updated emacs `` |
| [`19fac0e8`](https://github.com/nix-community/emacs-overlay/commit/19fac0e8e98cc770dc960094ff6be4f72f536e7d) | `` Updated melpa `` |