### PR TITLE
chore(flake/nur): `49928a2a` -> `f1e570f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706751699,
-        "narHash": "sha256-ILfIMhyVorRqyraJjXB9unaDyctVHZRTd9UDugh3nKA=",
+        "lastModified": 1706759147,
+        "narHash": "sha256-g7Qk+r52YIbJiLsbLPtYndEkUYrBJe39kH+xmNKwFkw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "49928a2aa14988820a75f123004e6ee638b54f0d",
+        "rev": "f1e570f71db5e465d2cc0ddccbdc4b3934c34dbb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f1e570f7`](https://github.com/nix-community/NUR/commit/f1e570f71db5e465d2cc0ddccbdc4b3934c34dbb) | `` automatic update `` |
| [`996662cd`](https://github.com/nix-community/NUR/commit/996662cd85aa302a29a2229d4a21b825c4e30ee0) | `` automatic update `` |