### PR TITLE
chore(flake/nixos-hardware): `f84eaffc` -> `42d7e506`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -666,11 +666,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1706182238,
-        "narHash": "sha256-Ti7CerGydU7xyrP/ow85lHsOpf+XMx98kQnPoQCSi1g=",
+        "lastModified": 1706767243,
+        "narHash": "sha256-0Am7wcB4Tt4t6IZLRWv9fivfgyKmVoMczigoetKeuiQ=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f84eaffc35d1a655e84749228cde19922fcf55f1",
+        "rev": "42d7e506777436d5e98ca02bd4a5f2da451cf485",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`42d7e506`](https://github.com/NixOS/nixos-hardware/commit/42d7e506777436d5e98ca02bd4a5f2da451cf485) | `` starfive visionfive2: update kernel to 6.6.0 `` |