### PR TITLE
chore(flake/nur): `3b8fdc2d` -> `2dc6c5f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706760464,
-        "narHash": "sha256-rhyuyUbJPShCiIwDhNM88aFuVQNUnGsGlEL0YSeC6Iw=",
+        "lastModified": 1706769860,
+        "narHash": "sha256-DyRGKj847sU14wUhf5VKfS537mJXeg2KIpemWve4lN0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3b8fdc2dfa3fd900578fdc99b58764b4b2a2da2b",
+        "rev": "2dc6c5f06e6323699a6fa713f65793ee4d493917",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2dc6c5f0`](https://github.com/nix-community/NUR/commit/2dc6c5f06e6323699a6fa713f65793ee4d493917) | `` automatic update `` |
| [`f21ac749`](https://github.com/nix-community/NUR/commit/f21ac7498b17300be04a2ceffc623c94678211d9) | `` automatic update `` |