### PR TITLE
chore(flake/emacs-overlay): `f2d21ce0` -> `42f2c32d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706752080,
-        "narHash": "sha256-7FEcuds8vl+4IFDGyqoCSsEc+oEDfHNYihehcgS4nbQ=",
+        "lastModified": 1706777546,
+        "narHash": "sha256-ZOsu6wxxNXm5o6RfXTcsDHiTtXf6fxCeEEpu73RJVh0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f2d21ce04546fe3120c1670f06e5f7598592ecd0",
+        "rev": "42f2c32d615b145ab47faeca4d9cfb48f7909052",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`42f2c32d`](https://github.com/nix-community/emacs-overlay/commit/42f2c32d615b145ab47faeca4d9cfb48f7909052) | `` Updated melpa `` |
| [`7130fb6c`](https://github.com/nix-community/emacs-overlay/commit/7130fb6cae4492784d282f005cfc3e43afc9ebb4) | `` Updated emacs `` |