### PR TITLE
chore(flake/nur): `da285bde` -> `234fac39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706774233,
-        "narHash": "sha256-zLXsMg9TbjgPR/ppjc7u+skxI87SYziPIT4xVE/Evpc=",
+        "lastModified": 1706787938,
+        "narHash": "sha256-Wyanm0F0bAtHMxIam+jsRDtCkvrmUdO9V4JrexouEtQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "da285bdefd95343608560429b1b223ed5b29fbcb",
+        "rev": "234fac39724697dac46e735c514e2c8e33b2082d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`234fac39`](https://github.com/nix-community/NUR/commit/234fac39724697dac46e735c514e2c8e33b2082d) | `` automatic update `` |
| [`45fb7fa3`](https://github.com/nix-community/NUR/commit/45fb7fa3eeab66b5c7dff1dfeb9817175c96d781) | `` automatic update `` |
| [`22a1c517`](https://github.com/nix-community/NUR/commit/22a1c5173e73320bfbd4cbe31369b3337a913528) | `` automatic update `` |