### PR TITLE
chore(flake/nixos-hardware): `42d7e506` -> `cc65e276`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -666,11 +666,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1706767243,
-        "narHash": "sha256-0Am7wcB4Tt4t6IZLRWv9fivfgyKmVoMczigoetKeuiQ=",
+        "lastModified": 1706782449,
+        "narHash": "sha256-8hEkOJDqR+7gJvXzwIM/VhR9iQzZyrNeh68u+Et2TzA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "42d7e506777436d5e98ca02bd4a5f2da451cf485",
+        "rev": "cc65e27670abccced5997d4a93c4c930aef6fd0b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`cc65e276`](https://github.com/NixOS/nixos-hardware/commit/cc65e27670abccced5997d4a93c4c930aef6fd0b) | `` Better default for amdgpuBusId ``                        |
| [`ed01236e`](https://github.com/NixOS/nixos-hardware/commit/ed01236ece433b5fe96ebd7fe104f18f790aa066) | `` 16ach6h: Comment out failing edid line ``                |
| [`07e43b05`](https://github.com/NixOS/nixos-hardware/commit/07e43b0530503b6034eb82f47bb9ae4af34f9f93) | `` 16ach6h: Fix X11 setup ``                                |
| [`58b17dc2`](https://github.com/NixOS/nixos-hardware/commit/58b17dc23452c1827a38660c44db16ea6f599f2c) | `` 16ach6h: Do not duplicate nvidia config ``               |
| [`3b54f86b`](https://github.com/NixOS/nixos-hardware/commit/3b54f86b535735d22f2f18ec90a8c0c9ba508f6e) | `` dell inspiron 5515: add early kms ``                     |
| [`83ce5906`](https://github.com/NixOS/nixos-hardware/commit/83ce5906a5b9a798ef2e653ddc12491c1b9e9929) | `` ga401: disable hardware.nvidia.powerManagement.enable `` |
| [`80223acd`](https://github.com/NixOS/nixos-hardware/commit/80223acd7f2cfe4ea103bc7e0d671f8a23b35990) | `` ga401: enable nvidia.dynamicBoost ``                     |