### PR TITLE
chore(flake/nur): `234fac39` -> `9c29bd89`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706787938,
-        "narHash": "sha256-Wyanm0F0bAtHMxIam+jsRDtCkvrmUdO9V4JrexouEtQ=",
+        "lastModified": 1706792013,
+        "narHash": "sha256-GNtaljvhc2DviPq+h4I8IuYMbiQf9hKUyHpO+Sd7YNM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "234fac39724697dac46e735c514e2c8e33b2082d",
+        "rev": "9c29bd8955e64ea7aec76de7e1a6541ac40e3f4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9c29bd89`](https://github.com/nix-community/NUR/commit/9c29bd8955e64ea7aec76de7e1a6541ac40e3f4d) | `` automatic update `` |
| [`52ebbcb0`](https://github.com/nix-community/NUR/commit/52ebbcb0de8dd0e916211ae8084fafe4ee23650a) | `` automatic update `` |