### PR TITLE
chore(flake/nur): `9c29bd89` -> `c0285ab2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706792013,
-        "narHash": "sha256-GNtaljvhc2DviPq+h4I8IuYMbiQf9hKUyHpO+Sd7YNM=",
+        "lastModified": 1706803130,
+        "narHash": "sha256-BDemrVSiKE0aWGwAa2R0/S9XjfyxlR5oDlYv9XKsk2Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9c29bd8955e64ea7aec76de7e1a6541ac40e3f4d",
+        "rev": "c0285ab2aea80da369c0d2f56ebdbcd95fce9f9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c0285ab2`](https://github.com/nix-community/NUR/commit/c0285ab2aea80da369c0d2f56ebdbcd95fce9f9a) | `` automatic update `` |
| [`d36360d3`](https://github.com/nix-community/NUR/commit/d36360d3bc247b7b7f08f53d21dd727196f1f0e8) | `` automatic update `` |
| [`d656e0cf`](https://github.com/nix-community/NUR/commit/d656e0cfb6d38df52f93a3e3c31f9231fcc7d794) | `` automatic update `` |
| [`c8afc5fb`](https://github.com/nix-community/NUR/commit/c8afc5fb671e272af825d979ce60f70b647aa035) | `` automatic update `` |