### PR TITLE
chore(flake/emacs-overlay): `42f2c32d` -> `488f22c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706777546,
-        "narHash": "sha256-ZOsu6wxxNXm5o6RfXTcsDHiTtXf6fxCeEEpu73RJVh0=",
+        "lastModified": 1706806355,
+        "narHash": "sha256-v3VCHfIPeUbV81U6WNLzzW/MsY1njRXQDg8EKzOobBw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "42f2c32d615b145ab47faeca4d9cfb48f7909052",
+        "rev": "488f22c2eb3bc6a1cf0b4378afc7f331be67fc00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`488f22c2`](https://github.com/nix-community/emacs-overlay/commit/488f22c2eb3bc6a1cf0b4378afc7f331be67fc00) | `` Updated melpa `` |
| [`fabe4b75`](https://github.com/nix-community/emacs-overlay/commit/fabe4b7550aaaf6e1fdc31cffe9164153a1e492c) | `` Updated elpa ``  |