### PR TITLE
chore(flake/emacs-overlay): `488f22c2` -> `ad0b9834`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706806355,
-        "narHash": "sha256-v3VCHfIPeUbV81U6WNLzzW/MsY1njRXQDg8EKzOobBw=",
+        "lastModified": 1706807251,
+        "narHash": "sha256-FIQFLSw/5s6Urs9RtZP7FzXCyyBCrmFEc2N0iwmgYe8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "488f22c2eb3bc6a1cf0b4378afc7f331be67fc00",
+        "rev": "ad0b983479cb072cb0e97c9609c11d9e5aeced34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`ad0b9834`](https://github.com/nix-community/emacs-overlay/commit/ad0b983479cb072cb0e97c9609c11d9e5aeced34) | `` Updated emacs `` |