### PR TITLE
chore(flake/nur): `bea3201f` -> `9356aa54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706816673,
-        "narHash": "sha256-VO1Z7dS9Z+bw97WWAQtAX361U2YyHJfYsqu7kYWdPhU=",
+        "lastModified": 1706820262,
+        "narHash": "sha256-Xe4kJypV9JYjgFQFnLuQ6/JPZo9d/ricCAo+9CeMNd0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bea3201f4f38f83e83079a5bddc7c587ec91162a",
+        "rev": "9356aa54aaae959f0770dc9a24cb7a64fba70bda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9356aa54`](https://github.com/nix-community/NUR/commit/9356aa54aaae959f0770dc9a24cb7a64fba70bda) | `` automatic update `` |