### PR TITLE
chore(flake/emacs-overlay): `ad0b9834` -> `bdc43452`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706807251,
-        "narHash": "sha256-FIQFLSw/5s6Urs9RtZP7FzXCyyBCrmFEc2N0iwmgYe8=",
+        "lastModified": 1706838389,
+        "narHash": "sha256-dLVRvAPSZAlgVBEXGEAaaJWSsVs9LScTADmPOBu90FI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ad0b983479cb072cb0e97c9609c11d9e5aeced34",
+        "rev": "bdc43452fa833f8ea0c78cb6e2bb67e4642e58ca",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1706515015,
-        "narHash": "sha256-eFfY5A7wlYy3jD/75lx6IJRueg4noE+jowl0a8lIlVo=",
+        "lastModified": 1706718339,
+        "narHash": "sha256-S+S97c/HzkO2A/YsU7ZmNF9w2s7Xk6P8dzmfDdckzLs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f4a8d6d5324c327dcc2d863eb7f3cc06ad630df4",
+        "rev": "53fbe41cf76b6a685004194e38e889bc8857e8c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`bdc43452`](https://github.com/nix-community/emacs-overlay/commit/bdc43452fa833f8ea0c78cb6e2bb67e4642e58ca) | `` Updated emacs ``        |
| [`28256189`](https://github.com/nix-community/emacs-overlay/commit/282561890cbd396a3da4a494cd17f71d111f35bf) | `` Updated melpa ``        |
| [`3756fc6f`](https://github.com/nix-community/emacs-overlay/commit/3756fc6fdf12c19fa36bfd8cf912bf59a9de19b6) | `` Updated elpa ``         |
| [`e7d08abf`](https://github.com/nix-community/emacs-overlay/commit/e7d08abf067abc211df72a0300bc24713105bad2) | `` Updated nongnu ``       |
| [`4e6805bd`](https://github.com/nix-community/emacs-overlay/commit/4e6805bd2930052e49344faf10f7e32f1bc2e34c) | `` Updated flake inputs `` |