### PR TITLE
chore(flake/nur): `9356aa54` -> `0422ac6b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706820262,
-        "narHash": "sha256-Xe4kJypV9JYjgFQFnLuQ6/JPZo9d/ricCAo+9CeMNd0=",
+        "lastModified": 1706837818,
+        "narHash": "sha256-0lU4OYhqXjoR0S46EPXWC/sohvWEs+zfWFTau0EjpBU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9356aa54aaae959f0770dc9a24cb7a64fba70bda",
+        "rev": "0422ac6b6eb0ed71487041fec6b2bf11edc62503",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0422ac6b`](https://github.com/nix-community/NUR/commit/0422ac6b6eb0ed71487041fec6b2bf11edc62503) | `` automatic update `` |
| [`cccf44e0`](https://github.com/nix-community/NUR/commit/cccf44e078fcc9e3d797d8be9ad34a27a6a0629a) | `` automatic update `` |