### PR TITLE
chore(flake/nur): `0422ac6b` -> `c290e9ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706837818,
-        "narHash": "sha256-0lU4OYhqXjoR0S46EPXWC/sohvWEs+zfWFTau0EjpBU=",
+        "lastModified": 1706845226,
+        "narHash": "sha256-q4y9qNVDEuVo49Gly2YHUu72K9UFGN8AW7DnIzCaFPo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0422ac6b6eb0ed71487041fec6b2bf11edc62503",
+        "rev": "c290e9ada7a920be104e37c3052b0c142eb3157d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c290e9ad`](https://github.com/nix-community/NUR/commit/c290e9ada7a920be104e37c3052b0c142eb3157d) | `` automatic update `` |
| [`55de3834`](https://github.com/nix-community/NUR/commit/55de3834d91a4fe68ba2b54253827546d20de133) | `` automatic update `` |
| [`76510831`](https://github.com/nix-community/NUR/commit/765108312dd833802189d15f93c9883b2ca776ab) | `` automatic update `` |