### PR TITLE
chore(flake/nur): `dc7f899f` -> `6ad802fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706853673,
-        "narHash": "sha256-+zOMMeXXLes00pb0a+7r+jbhM/SpI4vvFDKoeDN6jnk=",
+        "lastModified": 1706855220,
+        "narHash": "sha256-aWQ8INII8FKBesP5Z67+63J30FNtTUNTBPtEjIEx4Ok=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dc7f899faa627af70bab354984ec652275a06af5",
+        "rev": "6ad802fb5e81af60a6ea0c8645aa5a6fa0d7d6dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6ad802fb`](https://github.com/nix-community/NUR/commit/6ad802fb5e81af60a6ea0c8645aa5a6fa0d7d6dd) | `` automatic update `` |