### PR TITLE
chore(flake/emacs-overlay): `bdc43452` -> `d82554b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706838389,
-        "narHash": "sha256-dLVRvAPSZAlgVBEXGEAaaJWSsVs9LScTADmPOBu90FI=",
+        "lastModified": 1706863941,
+        "narHash": "sha256-syzBvTVXyFF5LOJGyiiNpjWikAKVb7yeolumAbLSMts=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bdc43452fa833f8ea0c78cb6e2bb67e4642e58ca",
+        "rev": "d82554b44a986ca44c0c533b6f0c8109ffe69dec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`d82554b4`](https://github.com/nix-community/emacs-overlay/commit/d82554b44a986ca44c0c533b6f0c8109ffe69dec) | `` Updated melpa `` |
| [`e4f17c81`](https://github.com/nix-community/emacs-overlay/commit/e4f17c81782040f23958ed74f1ab3a56b53df197) | `` Updated emacs `` |