### PR TITLE
chore(flake/nur): `be1fa0de` -> `f02a048d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706860355,
-        "narHash": "sha256-BzZsITtwil+4sYVBDyT3r+zmIELspzKM9Gc6+4+W0oE=",
+        "lastModified": 1706870652,
+        "narHash": "sha256-HMdc7iXVRGF8l+Li9RXEX78VRuCgi+llSsjPJ0eSZhI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "be1fa0de949b3cb8b79be80dd4cd10f7869bca45",
+        "rev": "f02a048d5950e81e1e1254f4617448cfe323058d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f02a048d`](https://github.com/nix-community/NUR/commit/f02a048d5950e81e1e1254f4617448cfe323058d) | `` automatic update `` |
| [`b059a4cc`](https://github.com/nix-community/NUR/commit/b059a4cc6638f3be13c710dbbf1ee537eeb37359) | `` automatic update `` |
| [`bfb80b4b`](https://github.com/nix-community/NUR/commit/bfb80b4b69abcdab9f09e83637fb88de3c5c890c) | `` automatic update `` |
| [`1059ebf9`](https://github.com/nix-community/NUR/commit/1059ebf9a4a6ba47180c1616195ec807ecef6702) | `` automatic update `` |