### PR TITLE
chore(flake/nur): `05ed926a` -> `4a6bf969`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706877205,
-        "narHash": "sha256-6cwtonCnIDitCP2O71W83G5XTC6/h4awWF2z7Tu4qes=",
+        "lastModified": 1706884401,
+        "narHash": "sha256-4nIODIKJEYHnosQsXdl7KmdEMJ6R9WNiaJrLzflSmDU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "05ed926a9a38779b9dd6b2a0527bb8f83d412fa1",
+        "rev": "4a6bf969ebd7383e60aacd1e7d251f0d45ac7372",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4a6bf969`](https://github.com/nix-community/NUR/commit/4a6bf969ebd7383e60aacd1e7d251f0d45ac7372) | `` automatic update `` |