### PR TITLE
chore(flake/nur): `4a6bf969` -> `e16514a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706884401,
-        "narHash": "sha256-4nIODIKJEYHnosQsXdl7KmdEMJ6R9WNiaJrLzflSmDU=",
+        "lastModified": 1706888714,
+        "narHash": "sha256-F7N74OFgsRZ3JmRljfGyYmSSOsb7aln2/XCSNNmE0DM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4a6bf969ebd7383e60aacd1e7d251f0d45ac7372",
+        "rev": "e16514a57faf7092aa9e7d54dd134453bebeca2c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e16514a5`](https://github.com/nix-community/NUR/commit/e16514a57faf7092aa9e7d54dd134453bebeca2c) | `` automatic update `` |
| [`2f898c47`](https://github.com/nix-community/NUR/commit/2f898c47cb6d8954ab021ee8593f3a5f5bdcf062) | `` automatic update `` |