### PR TITLE
chore(flake/nixpkgs): `97b17f32` -> `b8b232ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -777,11 +777,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1706550542,
-        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "lastModified": 1706732774,
+        "narHash": "sha256-hqJlyJk4MRpcItGYMF+3uHe8HvxNETWvlGtLuVpqLU0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "rev": "b8b232ae7b8b144397fdb12d20f592e5e7c1a64d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                     |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| [`f125235a`](https://github.com/NixOS/nixpkgs/commit/f125235a38e49a152d5f45c08254b4cb2f325fd6) | `` root: 6.30.02 -> 6.30.04 (#285339) ``                                                                    |
| [`21570187`](https://github.com/NixOS/nixpkgs/commit/215701875d8468071fecfbca276ff5b757dcf297) | `` dex-oidc: Fix embedded version string, add test (#285104) ``                                             |
| [`1b391ffb`](https://github.com/NixOS/nixpkgs/commit/1b391ffbd548dc76d53859b62ec285ffc9e2b94e) | `` testers.hasPkgConfigModules: use PKG_CONFIG envvar instead of hardcoding ``                              |
| [`6c9f27ab`](https://github.com/NixOS/nixpkgs/commit/6c9f27ab9aa717ead9a988dece2ab40862458113) | `` koka: 2.4.2 -> 3.0.4 ``                                                                                  |
| [`15f31376`](https://github.com/NixOS/nixpkgs/commit/15f31376b5746613aa1d1214928b5cab79921d5f) | `` nixos/pretalx: add 24.05 "new service" release note ``                                                   |
| [`b8175385`](https://github.com/NixOS/nixpkgs/commit/b817538514c914ce5c8cfa63751a4b5b331ac942) | `` python311Packages.jq: remove unused patch ``                                                             |
| [`b37344b7`](https://github.com/NixOS/nixpkgs/commit/b37344b7a0d537be2bb408cefdf364bee178a6cc) | `` ruby-modules/gem-config: prometheus-client-mmap 1.1.0 support ``                                         |
| [`dd65d0c6`](https://github.com/NixOS/nixpkgs/commit/dd65d0c67edff6b26e00084f6dbc909a60c266bc) | `` gitlab: 16.7.4 -> 16.8.1 ``                                                                              |
| [`9cbf12b2`](https://github.com/NixOS/nixpkgs/commit/9cbf12b2f0ffe84b32236b6883fa0896f819451c) | `` terraform: 1.7.1 -> 1.7.2 ``                                                                             |
| [`b7bc082d`](https://github.com/NixOS/nixpkgs/commit/b7bc082d084340ede1a164e94dc235720c388707) | `` matrix-synapse-unwrapped: 1.99.0 -> 1.100.0 ``                                                           |
| [`b688bda7`](https://github.com/NixOS/nixpkgs/commit/b688bda73b893c205cce020a5a7fb31e352db64f) | `` gnuradio3_8Minimal: fix build on Linux by using gcc 12 libraries ``                                      |
| [`18463794`](https://github.com/NixOS/nixpkgs/commit/184637940b32ed628bcdbe45a8a0b17bec57dedd) | `` lxc: fix aarch64 build failure ``                                                                        |
| [`7788da7a`](https://github.com/NixOS/nixpkgs/commit/7788da7a55b4d688a9c139df1fb4330d65a89c60) | `` balena-cli: 17.5.0 -> 17.5.1 ``                                                                          |
| [`8c335258`](https://github.com/NixOS/nixpkgs/commit/8c335258bdb9a9bfcc80bb9245bc1285f67a52fa) | `` authentik-outposts.ldap: init at 2023.10.7 ``                                                            |
| [`3d9a9b12`](https://github.com/NixOS/nixpkgs/commit/3d9a9b12aba3cf57f3b42e411f08a6bcdba8850d) | `` authentik: init at 2023.10.7 ``                                                                          |
| [`9cf8b8ba`](https://github.com/NixOS/nixpkgs/commit/9cf8b8bab36f0574fdb455812ccfe6f7c28f7f9b) | `` doc: clarify python.sitePackages ``                                                                      |
| [`1e485531`](https://github.com/NixOS/nixpkgs/commit/1e485531ad5abcbe46db05ab0ccd2ee7c5d621e6) | `` cinnamon.cinnamon-session: 6.0.2 -> 6.0.3 ``                                                             |
| [`9edc23ad`](https://github.com/NixOS/nixpkgs/commit/9edc23ad99a19b347569ff9f53debf33ef8c4f3a) | `` deck: 1.32.0 -> 1.32.1 ``                                                                                |
| [`2a21e2a3`](https://github.com/NixOS/nixpkgs/commit/2a21e2a32d23000cd2859dffb6dff8f551a0700e) | `` gramps: 5.1.4 -> 5.1.6 (#250953) ``                                                                      |
| [`fe89d4bf`](https://github.com/NixOS/nixpkgs/commit/fe89d4bf2575f56273a070a52925576ffa132dc9) | `` python311Packages.git-annex-adapter: disable failing tests ``                                            |
| [`ee3db79b`](https://github.com/NixOS/nixpkgs/commit/ee3db79b07912f63d38d2777e8ac2c5f0685444c) | `` python311Packages.git-annex-adapter: refactor ``                                                         |
| [`18c389b7`](https://github.com/NixOS/nixpkgs/commit/18c389b7a9c334482cb7d604106ca77fcd648134) | `` python311Packages.gentools: 1.2.1 -> 1.2.2 ``                                                            |
| [`9d3034e4`](https://github.com/NixOS/nixpkgs/commit/9d3034e4baa8517e8ad0224efbae5135cae21bc9) | `` minify: 2.20.15 -> 2.20.16 ``                                                                            |
| [`04159da1`](https://github.com/NixOS/nixpkgs/commit/04159da1bb247b46707a5f71da244d52dbb65ffe) | `` capnproto-java: 0.1.15 -> 0.1.16 ``                                                                      |
| [`6a07c59c`](https://github.com/NixOS/nixpkgs/commit/6a07c59cbfec8617177cde2dad1ecafbf978d8fa) | `` hyprland-per-window-layout: 2.6 -> 2.7 ``                                                                |
| [`a1771f17`](https://github.com/NixOS/nixpkgs/commit/a1771f17f40a5772cfba6fc2dba6ac9c8b0ba48d) | `` _0xproto: 1.500 -> 1.601 ``                                                                              |
| [`175ee131`](https://github.com/NixOS/nixpkgs/commit/175ee13140bd77a74d37d96e415e27527acdfd85) | `` netease-music-tui: add mainProgram ``                                                                    |
| [`c3d65c7a`](https://github.com/NixOS/nixpkgs/commit/c3d65c7a634327e5f6f2fcb155482a24a1ba35bb) | `` anytype: 0.37.3 -> 0.38.0 (#284895) ``                                                                   |
| [`b3dcbf62`](https://github.com/NixOS/nixpkgs/commit/b3dcbf626077942fb1c1d87d8a78c1d79a045950) | `` python311Packages.types-aiobotocore: 2.11.0 -> 2.11.1 ``                                                 |
| [`630cbdf5`](https://github.com/NixOS/nixpkgs/commit/630cbdf5bba35adb0699beede40b2a4a89a21455) | `` rustdesk-server: 1.1.9 -> 1.1.10-3 ``                                                                    |
| [`c3321382`](https://github.com/NixOS/nixpkgs/commit/c33213823590ca56d8c7aadb125dd62ab3d139ac) | `` littlefs-fuse: 2.7.4 -> 2.7.5 ``                                                                         |
| [`8636b76e`](https://github.com/NixOS/nixpkgs/commit/8636b76e2011ba6efd8ca08c6c24e4c5c10e2e7b) | `` packer: 1.10.0 -> 1.10.1 (#285184) ``                                                                    |
| [`70e1c722`](https://github.com/NixOS/nixpkgs/commit/70e1c722cd3c9dec28fb0169b5ed524eb006888f) | `` apx: 2.3.0 -> 2.4.0 ``                                                                                   |
| [`3f570fbf`](https://github.com/NixOS/nixpkgs/commit/3f570fbf070ed8757fe9e11f3c58839abfbf85ce) | `` codeium: 1.6.26 -> 1.6.28 ``                                                                             |
| [`80fcccbb`](https://github.com/NixOS/nixpkgs/commit/80fcccbbd682c2eb8b83d22bfb5d1eb770a5b420) | `` twilio-cli: 5.17.0 -> 5.17.1 ``                                                                          |
| [`1cd1df5c`](https://github.com/NixOS/nixpkgs/commit/1cd1df5c954d06bb975b5ce9d6644cf1241dca49) | `` pysqlrecon: init at 0.1.3 ``                                                                             |
| [`1d4c5564`](https://github.com/NixOS/nixpkgs/commit/1d4c5564881e5e45405a69c4e705580e70275d8c) | `` xdp-tools: 1.4.1 -> 1.4.2 ``                                                                             |
| [`ed0bd6bb`](https://github.com/NixOS/nixpkgs/commit/ed0bd6bb553ecea665d312769d0978ce18560530) | `` python312Packages.pycaption: 2.2.1 -> 2.2.2 ``                                                           |
| [`dafd2945`](https://github.com/NixOS/nixpkgs/commit/dafd294592fdaa41557e812c8b084c41cdb3bcbd) | `` sentry-cli: 2.26.0 -> 2.27.0 ``                                                                          |
| [`8e92c16c`](https://github.com/NixOS/nixpkgs/commit/8e92c16cac727a3a211a0691bf78638a91c376c1) | `` prometheus-unbound-exporter: 0.4.4 -> 0.4.5 ``                                                           |
| [`b586e8c8`](https://github.com/NixOS/nixpkgs/commit/b586e8c85387bde955fcb28c5e3b3bf3ddf41c84) | `` prometheus-sql-exporter: 0.5.2 -> 0.5.3 ``                                                               |
| [`584dab49`](https://github.com/NixOS/nixpkgs/commit/584dab4989e812833c2e545f0e904a33009805cd) | `` mympd: 13.0.6 -> 14.0.0 ``                                                                               |
| [`3e945302`](https://github.com/NixOS/nixpkgs/commit/3e9453026e1815b41ef1f94ef018b8e95bcee69f) | `` hwi: 2.3.1 -> 2.4.0 ``                                                                                   |
| [`4490d707`](https://github.com/NixOS/nixpkgs/commit/4490d707c1c370717d5b15727b90787a276fb4c9) | `` flarectl: 0.86.0 -> 0.87.0 ``                                                                            |
| [`8370d30d`](https://github.com/NixOS/nixpkgs/commit/8370d30dbdd393c5bbf7e28256f82ef2758ffec7) | `` copilot-cli: 1.33.0 -> 1.33.1 ``                                                                         |
| [`61492b65`](https://github.com/NixOS/nixpkgs/commit/61492b6567923dbf3b3da6282a26f23c21c5ed03) | `` twm: 0.8.2 -> 0.9.0 ``                                                                                   |
| [`d2951b16`](https://github.com/NixOS/nixpkgs/commit/d2951b16e0d28a738502c9c9c6270900f7f8d4d4) | `` python311Packages.py-sonic: 1.0.0 -> 1.0.1 ``                                                            |
| [`fdcdc832`](https://github.com/NixOS/nixpkgs/commit/fdcdc832ff57c3bd3c181cad202fcc9da0c0539d) | `` nuclei: 3.1.7 -> 3.1.8 ``                                                                                |
| [`28776374`](https://github.com/NixOS/nixpkgs/commit/2877637450f46d5c9757dd491af1932b19b78279) | `` qownnotes: 24.1.4 -> 24.1.5 ``                                                                           |
| [`f3ed4acf`](https://github.com/NixOS/nixpkgs/commit/f3ed4acfb74f186696aa59ffe791b6c13284503d) | `` vale: 3.0.5 -> 3.0.6 ``                                                                                  |
| [`15024e0c`](https://github.com/NixOS/nixpkgs/commit/15024e0c398f1daa8911acd985fbfc75e34cf104) | `` crowdin-cli: 3.16.1 -> 3.17.0 ``                                                                         |
| [`81b7f029`](https://github.com/NixOS/nixpkgs/commit/81b7f0299465d78dd954af9b98406b79ad544e3b) | `` ferium: 4.4.1 -> 4.5.0 ``                                                                                |
| [`d163def2`](https://github.com/NixOS/nixpkgs/commit/d163def2902b8b263d90ec5aeae770fa710bac5c) | `` opengrok: 1.13.1 -> 1.13.2 ``                                                                            |
| [`9c5f3ba9`](https://github.com/NixOS/nixpkgs/commit/9c5f3ba92fd26bd3ad60e35d7485398ce03462b1) | `` rambox: 2.2.3 -> 2.3.0 ``                                                                                |
| [`202e6972`](https://github.com/NixOS/nixpkgs/commit/202e69723315ec54546bea5751ba5f93e0b5fc1f) | `` nixos/systemd-boot: fix editor option ``                                                                 |
| [`b816be18`](https://github.com/NixOS/nixpkgs/commit/b816be1872c8d7a39d0434d2da4f438e0e927ece) | `` python312Packages.influxdb-client: 1.39.0 -> 1.40.0 ``                                                   |
| [`956d39c4`](https://github.com/NixOS/nixpkgs/commit/956d39c4a735236640699d553fc066468dbb41ff) | `` cyclonedx-gomod: 1.5.0 -> 1.6.0 ``                                                                       |
| [`d3380b18`](https://github.com/NixOS/nixpkgs/commit/d3380b18a9380a6d64a50d8ebb919cc01d0c696a) | `` clickhouse-backup: 2.4.22 -> 2.4.23 ``                                                                   |
| [`7e24500c`](https://github.com/NixOS/nixpkgs/commit/7e24500c787f1bf6f5705dd61063283eebb2d864) | `` spglib: 2.2.0 -> 2.3.0 ``                                                                                |
| [`db2c6d42`](https://github.com/NixOS/nixpkgs/commit/db2c6d4203ee184403c3e0311418cb5bbabaf483) | `` pscale: 0.178.0 -> 0.181.0 ``                                                                            |
| [`6e5fdc1e`](https://github.com/NixOS/nixpkgs/commit/6e5fdc1ecf4ecb98a7f71ab6d8c226b8f1ac39d1) | `` ledfx: 2.0.89 -> 2.0.90 ``                                                                               |
| [`29f5ac51`](https://github.com/NixOS/nixpkgs/commit/29f5ac51babb86818216f356dc5dee1bdf54bd99) | `` fastfetch: 2.7.0 -> 2.7.1 ``                                                                             |
| [`e518462e`](https://github.com/NixOS/nixpkgs/commit/e518462e6f119671b06a18f809df6de70ec2f175) | `` buildMozillaMach: use fixed build date ``                                                                |
| [`b1c8402d`](https://github.com/NixOS/nixpkgs/commit/b1c8402d71da3a61035b05d6f60b423e74a38b74) | `` vscode-extensions.serayuzgur.crates: 0.6.5 -> 0.6.6 ``                                                   |
| [`d4402e12`](https://github.com/NixOS/nixpkgs/commit/d4402e12586079c4fa530d703e5c1628382e9387) | `` texlab: 5.12.2 -> 5.12.3 ``                                                                              |
| [`b2c07d4a`](https://github.com/NixOS/nixpkgs/commit/b2c07d4a3487248b3e712f4434e50904e16eda06) | `` minizincide: 2.5.5 -> 2.8.2 ``                                                                           |
| [`049bc131`](https://github.com/NixOS/nixpkgs/commit/049bc131425bc59272d8d25b0594ee1706485f8b) | `` moon: 1.20.0 -> 1.20.1 ``                                                                                |
| [`72d9186f`](https://github.com/NixOS/nixpkgs/commit/72d9186fcc4b44426cca1186ec37d04b4a548bc4) | `` lomiri.lomiri-ui-toolkit: Fix compatibility with versioned QML import paths ``                           |
| [`8b706616`](https://github.com/NixOS/nixpkgs/commit/8b706616ca34bd1c1228fba9a4beeafb17333ee5) | `` offpunk: convert to buildPythonApplication ``                                                            |
| [`cd5a7a3a`](https://github.com/NixOS/nixpkgs/commit/cd5a7a3ac9594456c63150e5d2fb43f7f4dd3073) | `` python311Packages.types-pyopenssl: 23.3.0.20240106 -> 24.0.0.20240130 ``                                 |
| [`e337ee10`](https://github.com/NixOS/nixpkgs/commit/e337ee108859b6fbca662dded419f09bd00abf6f) | `` python3Packages.uamqp: 1.6.5 -> 1.6.8 ``                                                                 |
| [`34ecc6d3`](https://github.com/NixOS/nixpkgs/commit/34ecc6d3219da1b7bd1aa4fb6e0291ed2a54f985) | `` python311Packages.langchain-community: 0.0.13 -> 0.0.16 ``                                               |
| [`241fca1e`](https://github.com/NixOS/nixpkgs/commit/241fca1ecee7a023be5aa1ee77c1df11319cd49d) | `` dex-oidc: 2.37.0 -> 2.38.0 (#283991) ``                                                                  |
| [`5b5e6f99`](https://github.com/NixOS/nixpkgs/commit/5b5e6f990070ec0c5c343ff9160554866ecd23c2) | `` bcachefs-tools: fix fuseSupport option ``                                                                |
| [`ca7640c3`](https://github.com/NixOS/nixpkgs/commit/ca7640c30e53d0a8784cb7c2ffac16a4d29d5acb) | `` git-cinnabar: 0.6.2 -> 0.6.3 ``                                                                          |
| [`c1afcd1c`](https://github.com/NixOS/nixpkgs/commit/c1afcd1c8c677bd0c5146b2f89c55233e3aa9421) | `` Revert "acpid: Disable network access" ``                                                                |
| [`14180d27`](https://github.com/NixOS/nixpkgs/commit/14180d27f97a808457ef82e2b5adf9d3d3ca2f29) | `` xxHash: set meta.mainProgram ``                                                                          |
| [`0be5fc98`](https://github.com/NixOS/nixpkgs/commit/0be5fc9802fe24b93cdde0dd5e0b2fb30fda5ce0) | `` yuzuPackages.compat-list: unstable-2024-01-27 -> unstable-2024-01-30 ``                                  |
| [`f7b31dd5`](https://github.com/NixOS/nixpkgs/commit/f7b31dd5a425a6d98b1906b7d63b615ad8237b55) | `` docfd: init at 2.1.0 ``                                                                                  |
| [`1899b5cd`](https://github.com/NixOS/nixpkgs/commit/1899b5cdcc0e4f2563c160652aec8d636493681e) | `` nile: unstable-2024-01-25 -> unstable-2024-01-27 ``                                                      |
| [`19b3ab3f`](https://github.com/NixOS/nixpkgs/commit/19b3ab3fe467bc1ec5cb06f7e5ca4b6bcdea548b) | `` packagekit: use test_nop backend by default ``                                                           |
| [`c0ae2ef2`](https://github.com/NixOS/nixpkgs/commit/c0ae2ef263397ffa565e6de1929b27d200cc69fb) | `` python311Packages.appthreat-vulnerability-db: 5.5.10 -> 5.6.0 ``                                         |
| [`899edf6b`](https://github.com/NixOS/nixpkgs/commit/899edf6b4dd0db4c78f71acbccd29eeed9e2fc01) | `` yubikey-manager: 5.2.1 -> 5.3.0 ``                                                                       |
| [`b17a81b5`](https://github.com/NixOS/nixpkgs/commit/b17a81b5d7a00f41f63b91fd344e78284ab3b849) | `` python311Packages.aioelectricitymaps: 0.1.6 -> 0.2.0 ``                                                  |
| [`4d0c263f`](https://github.com/NixOS/nixpkgs/commit/4d0c263f8077e9198e9076fcce64d2ac0b2d71e6) | `` python311Packages.griffe: 0.39.1 -> 0.40.0 ``                                                            |
| [`79a02c82`](https://github.com/NixOS/nixpkgs/commit/79a02c82ec8b101749fd1d46176917d42b068a2c) | `` qovery-cli: 0.81.1 -> 0.82.0 ``                                                                          |
| [`597a0c8e`](https://github.com/NixOS/nixpkgs/commit/597a0c8e438b9bc0faf35b5028a3657a54719d65) | `` python311Packages.subarulink: 0.7.9 -> 0.7.10 ``                                                         |
| [`a54b213d`](https://github.com/NixOS/nixpkgs/commit/a54b213de0700f770116440235207cd6556130bf) | `` trufflehog: 3.65.0 -> 3.66.1 ``                                                                          |
| [`a42b3557`](https://github.com/NixOS/nixpkgs/commit/a42b3557abd8a8ded64e51d619284747d11066f9) | `` python311Packages.stdlibs: 2023.12.15 -> 2024.1.28 ``                                                    |
| [`2add75a2`](https://github.com/NixOS/nixpkgs/commit/2add75a2cf3377f175926088c8e5156f44c4e7d9) | `` python311Packages.pygit2: refactor ``                                                                    |
| [`6ec9c731`](https://github.com/NixOS/nixpkgs/commit/6ec9c7318deb9c508fcf753f6d4b95ea9f62287e) | `` python311Packages.pygit2: 1.13.3 -> 1.14.0 ``                                                            |
| [`a180dfb0`](https://github.com/NixOS/nixpkgs/commit/a180dfb061db015477fcaadd2deacff7ab7c0a07) | `` python311Packages.rokuecp: 0.18.2 -> 0.19.0 ``                                                           |
| [`5204fe15`](https://github.com/NixOS/nixpkgs/commit/5204fe158175a1af3d197df1f0e5a695f6df1761) | `` python311Packages.requests-pkcs12: 1.22 -> 1.24 ``                                                       |
| [`4449cd9f`](https://github.com/NixOS/nixpkgs/commit/4449cd9f0c3bb72511a6d92e95b737cbb9b75e77) | `` python311Packages.reconplogger: 4.13.0 -> 4.14.0 ``                                                      |
| [`d32813db`](https://github.com/NixOS/nixpkgs/commit/d32813db52afbdd5b7de79dd25936b30aebd161f) | `` python311Packages.regenmaschine: 2023.12.0 -> 2024.01.0 ``                                               |
| [`7158c4ef`](https://github.com/NixOS/nixpkgs/commit/7158c4efeb33008f3122ef2b3d83acdb05082012) | `` python311Packages.pysnmplib: 5.0.23 -> 5.0.24 ``                                                         |
| [`6ba1fe02`](https://github.com/NixOS/nixpkgs/commit/6ba1fe02d91fd971dba3084a399010c19c902534) | `` python311Packages.oras: 0.1.26 -> 0.1.27 ``                                                              |
| [`951aac17`](https://github.com/NixOS/nixpkgs/commit/951aac17f75bb1008bd567b874b865453d4b9701) | `` checkov: 3.2.1 -> 3.2.2 ``                                                                               |
| [`4ea60f6a`](https://github.com/NixOS/nixpkgs/commit/4ea60f6ae42960ade3456c80bbd5f4ac7d9ea774) | `` python311Packages.neo4j: 5.16.0 -> 5.17.0 ``                                                             |
| [`e62b24c8`](https://github.com/NixOS/nixpkgs/commit/e62b24c8dd4dfcc174598c5d6f6c7b47ee11f9b2) | `` python311Packages.ldfparser: 0.21.0 -> 0.22.0 ``                                                         |
| [`766300ba`](https://github.com/NixOS/nixpkgs/commit/766300ba3d423717a98c49933fa290ba8d2d3ce0) | `` python311Packages.cyclonedx-python-lib: 6.4.0 -> 6.4.1 ``                                                |
| [`8cbeee9a`](https://github.com/NixOS/nixpkgs/commit/8cbeee9a796f8b3b6ae716499678026151dd8c31) | `` python311Packages.boto3-stubs: 1.34.29 -> 1.34.30 ``                                                     |
| [`84bbcf7f`](https://github.com/NixOS/nixpkgs/commit/84bbcf7f6996a4a76962990f5ab445c6c347d571) | `` python311Packages.botocore-stubs: 1.34.29 -> 1.34.30 ``                                                  |
| [`36a00242`](https://github.com/NixOS/nixpkgs/commit/36a00242a108f69fad600d599cac43c65db2baa6) | `` python311Packages.dissect-target: refactor ``                                                            |
| [`c3d57efe`](https://github.com/NixOS/nixpkgs/commit/c3d57efe3b424b9b84811c6c92a2745c43f435cb) | `` python311Packages.dissect-cstruct: update disabled ``                                                    |
| [`65383788`](https://github.com/NixOS/nixpkgs/commit/653837881ed2a27a12c7bf662be4abe9db9b7cc5) | `` treewide: replace `lib/${python.libPrefix}/site-packages` with its shorthand `${python.sitePackages}` `` |
| [`d1d8df0b`](https://github.com/NixOS/nixpkgs/commit/d1d8df0bd9ca006408cf4403fce6f1c9cbe0827e) | `` nextpnr: 0.6 -> 0.7 ``                                                                                   |