### PR TITLE
chore(flake/emacs-overlay): `d82554b4` -> `e33ffe03`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706863941,
-        "narHash": "sha256-syzBvTVXyFF5LOJGyiiNpjWikAKVb7yeolumAbLSMts=",
+        "lastModified": 1706893533,
+        "narHash": "sha256-GvbueGSKJW4YmOepz7gTaNyVrluRhRW0doLfpAWw8mc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d82554b44a986ca44c0c533b6f0c8109ffe69dec",
+        "rev": "e33ffe039bf46a8d10d3e73e48dd7e298f0232e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`e33ffe03`](https://github.com/nix-community/emacs-overlay/commit/e33ffe039bf46a8d10d3e73e48dd7e298f0232e7) | `` Updated emacs ``        |
| [`5cdd16c0`](https://github.com/nix-community/emacs-overlay/commit/5cdd16c04c0893ab07d28f6de20a3b7ec6f2f451) | `` Updated melpa ``        |
| [`2e1493b0`](https://github.com/nix-community/emacs-overlay/commit/2e1493b0e8b920d91a3d5c7382746dcd89ca2642) | `` Updated elpa ``         |
| [`a0a3bab9`](https://github.com/nix-community/emacs-overlay/commit/a0a3bab96eaa014edbf9868536f702fd57ac343e) | `` Updated flake inputs `` |