### PR TITLE
chore(flake/nur): `e16514a5` -> `fba4ee3b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706888714,
-        "narHash": "sha256-F7N74OFgsRZ3JmRljfGyYmSSOsb7aln2/XCSNNmE0DM=",
+        "lastModified": 1706890648,
+        "narHash": "sha256-bMohGiBZMHw1QxovKenSt7cGMXBqA3c+a2zqdoe01Cs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e16514a57faf7092aa9e7d54dd134453bebeca2c",
+        "rev": "fba4ee3ba82ddef9cfcc183af9b5e9cb7ae15277",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fba4ee3b`](https://github.com/nix-community/NUR/commit/fba4ee3ba82ddef9cfcc183af9b5e9cb7ae15277) | `` automatic update `` |