### PR TITLE
chore(flake/nur): `fba4ee3b` -> `6a31ec36`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706890648,
-        "narHash": "sha256-bMohGiBZMHw1QxovKenSt7cGMXBqA3c+a2zqdoe01Cs=",
+        "lastModified": 1706897763,
+        "narHash": "sha256-ZY1GUpy8bZjnU1oU2+IEfbnF6yIttHPuwrffIl0KSAo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fba4ee3ba82ddef9cfcc183af9b5e9cb7ae15277",
+        "rev": "6a31ec36961e3c3da30aa1dbbdcb654ba9c513b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6a31ec36`](https://github.com/nix-community/NUR/commit/6a31ec36961e3c3da30aa1dbbdcb654ba9c513b5) | `` automatic update `` |
| [`04a91253`](https://github.com/nix-community/NUR/commit/04a91253344796e363f4938ff9b1f7e15a943f80) | `` automatic update `` |