### PR TITLE
chore(flake/nur): `6a31ec36` -> `91ae5ad5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706897763,
-        "narHash": "sha256-ZY1GUpy8bZjnU1oU2+IEfbnF6yIttHPuwrffIl0KSAo=",
+        "lastModified": 1706903127,
+        "narHash": "sha256-fGYjT7u3s6b9PKdtDFE6J+kYfIfIcXJSFmSutumfHv4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6a31ec36961e3c3da30aa1dbbdcb654ba9c513b5",
+        "rev": "91ae5ad5a5578726ada9a98f2c839040b93ab03a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`91ae5ad5`](https://github.com/nix-community/NUR/commit/91ae5ad5a5578726ada9a98f2c839040b93ab03a) | `` automatic update `` |
| [`cc8e0246`](https://github.com/nix-community/NUR/commit/cc8e0246cfaf80298f17da838f70b1d492e17ea6) | `` automatic update `` |
| [`97ffd0a3`](https://github.com/nix-community/NUR/commit/97ffd0a361d591ca708d3552c0f70a99f0a06430) | `` automatic update `` |
| [`f579af61`](https://github.com/nix-community/NUR/commit/f579af614747e1aacb4426dfded1c6f5d9b70592) | `` automatic update `` |
| [`87beeb72`](https://github.com/nix-community/NUR/commit/87beeb7278639b639d2e2789f531a586da11c295) | `` automatic update `` |