### PR TITLE
chore(flake/nur): `91ae5ad5` -> `96b0e9d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706903127,
-        "narHash": "sha256-fGYjT7u3s6b9PKdtDFE6J+kYfIfIcXJSFmSutumfHv4=",
+        "lastModified": 1706910257,
+        "narHash": "sha256-w0EN3LJS+4HlkTBb3rgImSWCkzNdFWxsIbgsYpKh09E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "91ae5ad5a5578726ada9a98f2c839040b93ab03a",
+        "rev": "96b0e9d38890afb8e4af6d6a556ee27e79fd6e22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`96b0e9d3`](https://github.com/nix-community/NUR/commit/96b0e9d38890afb8e4af6d6a556ee27e79fd6e22) | `` automatic update `` |