### PR TITLE
chore(flake/nur): `96b0e9d3` -> `c62ee958`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706910257,
-        "narHash": "sha256-w0EN3LJS+4HlkTBb3rgImSWCkzNdFWxsIbgsYpKh09E=",
+        "lastModified": 1706913851,
+        "narHash": "sha256-vnAPJCPKLb/ym966s1mV6CZi/gs8VrY6EFNOJUVzs1E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "96b0e9d38890afb8e4af6d6a556ee27e79fd6e22",
+        "rev": "c62ee9580c8a875f53e8456c391efa2ee8143620",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c62ee958`](https://github.com/nix-community/NUR/commit/c62ee9580c8a875f53e8456c391efa2ee8143620) | `` automatic update `` |