### PR TITLE
chore(flake/nur): `651abfb4` -> `9c02deda`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706917546,
-        "narHash": "sha256-6tK05tNcAFD/qJu33P7TbvAWPM9TCivrmtY60Jw8P0s=",
+        "lastModified": 1706925150,
+        "narHash": "sha256-DHgpDkm1SyhC0Nfa2btvlR88obKndXaNUaAPIYwIVGs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "651abfb46a238ffb0d71bee02c368a18aa528b35",
+        "rev": "9c02dedaf63decb814dabd377b22b40735287488",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9c02deda`](https://github.com/nix-community/NUR/commit/9c02dedaf63decb814dabd377b22b40735287488) | `` automatic update `` |
| [`492bf04e`](https://github.com/nix-community/NUR/commit/492bf04e19a98008c0fae15baa0bccbf8d3adb91) | `` automatic update `` |