### PR TITLE
chore(flake/nur): `9c02deda` -> `65b7f961`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706925150,
-        "narHash": "sha256-DHgpDkm1SyhC0Nfa2btvlR88obKndXaNUaAPIYwIVGs=",
+        "lastModified": 1706931807,
+        "narHash": "sha256-0pExor1sr5hV9QgbeugvSyWtWyjgbIHJXMgrgfdRryE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9c02dedaf63decb814dabd377b22b40735287488",
+        "rev": "65b7f961d25c02c750907c9a69972a8eb89e83a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`65b7f961`](https://github.com/nix-community/NUR/commit/65b7f961d25c02c750907c9a69972a8eb89e83a3) | `` automatic update `` |
| [`4cadb9c9`](https://github.com/nix-community/NUR/commit/4cadb9c9a0210fbfb53f3517559877b50eebed1a) | `` automatic update `` |