### PR TITLE
chore(flake/nur): `65b7f961` -> `4483245d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706931807,
-        "narHash": "sha256-0pExor1sr5hV9QgbeugvSyWtWyjgbIHJXMgrgfdRryE=",
+        "lastModified": 1706934613,
+        "narHash": "sha256-O57Q8pUs/8hZ0C8z0AcmgGsvpW9PFs9uO3Bqbh8B+kw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "65b7f961d25c02c750907c9a69972a8eb89e83a3",
+        "rev": "4483245d746ce8e67073af4d4f819b9e5cc1c617",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4483245d`](https://github.com/nix-community/NUR/commit/4483245d746ce8e67073af4d4f819b9e5cc1c617) | `` automatic update `` |
| [`f9ac11b3`](https://github.com/nix-community/NUR/commit/f9ac11b3fb8670bfe7034eaaba8b5abb5bc17322) | `` automatic update `` |