### PR TITLE
chore(flake/nur): `4483245d` -> `d8183104`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706934613,
-        "narHash": "sha256-O57Q8pUs/8hZ0C8z0AcmgGsvpW9PFs9uO3Bqbh8B+kw=",
+        "lastModified": 1706938866,
+        "narHash": "sha256-iMgX+sv6dCrSjISBCbpuWKsUF3oPAeVJxaQMyOcr3n4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4483245d746ce8e67073af4d4f819b9e5cc1c617",
+        "rev": "d81831044d87718c4ce4d268b0528dddb7758a68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d8183104`](https://github.com/nix-community/NUR/commit/d81831044d87718c4ce4d268b0528dddb7758a68) | `` automatic update `` |