### PR TITLE
chore(flake/nur): `d8183104` -> `c791e8be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706938866,
-        "narHash": "sha256-iMgX+sv6dCrSjISBCbpuWKsUF3oPAeVJxaQMyOcr3n4=",
+        "lastModified": 1706942735,
+        "narHash": "sha256-AfbvR9+7o/Fed+rkRqKK1Qk+bWJ2iO/xdjyb9aC4NCA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d81831044d87718c4ce4d268b0528dddb7758a68",
+        "rev": "c791e8becc5137946cf40e86bdb0e7f64e80a280",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c791e8be`](https://github.com/nix-community/NUR/commit/c791e8becc5137946cf40e86bdb0e7f64e80a280) | `` automatic update `` |
| [`23f628ec`](https://github.com/nix-community/NUR/commit/23f628ec120e128b5ed0dcccb68d788b52839d4e) | `` automatic update `` |