### PR TITLE
chore(flake/nur): `c791e8be` -> `3324c298`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706942735,
-        "narHash": "sha256-AfbvR9+7o/Fed+rkRqKK1Qk+bWJ2iO/xdjyb9aC4NCA=",
+        "lastModified": 1706946929,
+        "narHash": "sha256-aASJGUmOzorebMnlXmFDKFWJ4uMCvXOwd74hZ2xnlJ0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c791e8becc5137946cf40e86bdb0e7f64e80a280",
+        "rev": "3324c298a423c2eef03488b6f9a2ef0d82e42083",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3324c298`](https://github.com/nix-community/NUR/commit/3324c298a423c2eef03488b6f9a2ef0d82e42083) | `` automatic update `` |
| [`2f0cb902`](https://github.com/nix-community/NUR/commit/2f0cb902c5888a434c24746fd5b4f2d4494d3c14) | `` automatic update `` |
| [`b7feb2f4`](https://github.com/nix-community/NUR/commit/b7feb2f4f95f208044e5be1f4bb5080cfd8f3652) | `` automatic update `` |