### PR TITLE
chore(flake/emacs-overlay): `501cc214` -> `22cce99b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706924815,
-        "narHash": "sha256-Lg+QiUJ70Kw6vigCn0rZpk1fO5wSyJ6U+EKru15ul2c=",
+        "lastModified": 1707555888,
+        "narHash": "sha256-opXjVZpavvfMFzv9c+teipFQ2zDs6+CX7KOQE8uhuHc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "501cc2145240ef9e2c4e466dd229350f3a50de4e",
+        "rev": "22cce99b0abb79c5d00583f6f82e823b2bdb131b",
         "type": "github"
       },
       "original": {
@@ -746,11 +746,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1706718339,
-        "narHash": "sha256-S+S97c/HzkO2A/YsU7ZmNF9w2s7Xk6P8dzmfDdckzLs=",
+        "lastModified": 1707347730,
+        "narHash": "sha256-0etC/exQIaqC9vliKhc3eZE2Mm2wgLa0tj93ZF/egvM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "53fbe41cf76b6a685004194e38e889bc8857e8c2",
+        "rev": "6832d0d99649db3d65a0e15fa51471537b2c56a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                            |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------- |
| [`22cce99b`](https://github.com/nix-community/emacs-overlay/commit/22cce99b0abb79c5d00583f6f82e823b2bdb131b) | `` Updated emacs ``                |
| [`98d2b370`](https://github.com/nix-community/emacs-overlay/commit/98d2b3707652c8638046a7578f30924529965b90) | `` Updated melpa ``                |
| [`95acf329`](https://github.com/nix-community/emacs-overlay/commit/95acf3297bda934c1ec5260e18ffea39f05bbf3a) | `` Updated emacs ``                |
| [`06528d90`](https://github.com/nix-community/emacs-overlay/commit/06528d90408b8c86f6d70ad2bb5e7f6fc86441ef) | `` Updated melpa ``                |
| [`5c6b8429`](https://github.com/nix-community/emacs-overlay/commit/5c6b8429c02e6593ee2bab649b28225097893751) | `` Updated elpa ``                 |
| [`45e69044`](https://github.com/nix-community/emacs-overlay/commit/45e690448c8b0c3d3906bab65152f1c7e2e202a4) | `` Updated emacs ``                |
| [`e73eddaa`](https://github.com/nix-community/emacs-overlay/commit/e73eddaaa5ffbdf35bda143a4068115a049f45a0) | `` Updated melpa ``                |
| [`eda89e24`](https://github.com/nix-community/emacs-overlay/commit/eda89e24ee4ceb6e4bfcd00dabb894d6301c36db) | `` Updated emacs ``                |
| [`bc4a6ddc`](https://github.com/nix-community/emacs-overlay/commit/bc4a6ddc986782a49d3bf6cf6af27c6aeca7d8e9) | `` Updated melpa ``                |
| [`3ab30310`](https://github.com/nix-community/emacs-overlay/commit/3ab303101f287c1769f0a0dc4f7ec5473e61f94f) | `` Updated melpa ``                |
| [`2e98b222`](https://github.com/nix-community/emacs-overlay/commit/2e98b222342ad0cc9682d450988b498fb5309772) | `` Updated elpa ``                 |
| [`ae7f86b1`](https://github.com/nix-community/emacs-overlay/commit/ae7f86b13cab5b2e89f6d3e4c121471a59e7980e) | `` Updated flake inputs ``         |
| [`a225b7bb`](https://github.com/nix-community/emacs-overlay/commit/a225b7bbeab6a594a7f3859fef4c3f6898b1fd50) | `` Updated emacs ``                |
| [`64a63365`](https://github.com/nix-community/emacs-overlay/commit/64a633659fab447f12c898a32c451f88b5c3c048) | `` Updated melpa ``                |
| [`fec6062d`](https://github.com/nix-community/emacs-overlay/commit/fec6062d065254ef7a6a288f63ed19c0fee6d6be) | `` Updated elpa ``                 |
| [`4a34b655`](https://github.com/nix-community/emacs-overlay/commit/4a34b655ebc29a22f13b547c1fa3729f7dd42f94) | `` Updated emacs ``                |
| [`08d584a5`](https://github.com/nix-community/emacs-overlay/commit/08d584a52c965ad6cd592750e7e004a2bda0901a) | `` Updated melpa ``                |
| [`ccaf5772`](https://github.com/nix-community/emacs-overlay/commit/ccaf577227e5a64f95c03d66b6ac50879b4a3521) | `` Updated emacs ``                |
| [`b1b55ae0`](https://github.com/nix-community/emacs-overlay/commit/b1b55ae037f900793dcb74d87b18b6ba5d8c5d38) | `` Updated melpa ``                |
| [`d28950bc`](https://github.com/nix-community/emacs-overlay/commit/d28950bce310568129d58b74639e73c7d3e73a78) | `` Updated elpa ``                 |
| [`97ebd2a2`](https://github.com/nix-community/emacs-overlay/commit/97ebd2a2bd3e4fc8ee09940822625654c949a391) | `` Updated nongnu ``               |
| [`97017b23`](https://github.com/nix-community/emacs-overlay/commit/97017b23dad7fe36be291d0b99584ff9f67d9c34) | `` Updated flake inputs ``         |
| [`202c1eec`](https://github.com/nix-community/emacs-overlay/commit/202c1eec521b02ccad6e7bdf32476c0eddb54c2d) | `` Updated emacs ``                |
| [`6ce89b64`](https://github.com/nix-community/emacs-overlay/commit/6ce89b64f94a846b185e9ef1f063099e4e170c86) | `` Updated melpa ``                |
| [`3c16647d`](https://github.com/nix-community/emacs-overlay/commit/3c16647dfd441883e733897e799fd450ebd7f2f3) | `` Updated elpa ``                 |
| [`223c6e9b`](https://github.com/nix-community/emacs-overlay/commit/223c6e9be9ef430d3523ec9c996eb74cb329c42f) | `` Updated emacs ``                |
| [`0db31bf7`](https://github.com/nix-community/emacs-overlay/commit/0db31bf7477ac7c58157aa7d5d7674936b712f47) | `` Updated melpa ``                |
| [`552a5b1f`](https://github.com/nix-community/emacs-overlay/commit/552a5b1fbcde5557b2a011956fa36fdef056fdb7) | `` Updated emacs ``                |
| [`1bb597ae`](https://github.com/nix-community/emacs-overlay/commit/1bb597ae016883152249651ceaaf85b1589d7ab4) | `` Updated melpa ``                |
| [`61b58a1c`](https://github.com/nix-community/emacs-overlay/commit/61b58a1cef89cf6b25fae43671ff33661ef1e6c3) | `` Updated elpa ``                 |
| [`bda20050`](https://github.com/nix-community/emacs-overlay/commit/bda20050fde1908491e9b573430ebc4745cdea58) | `` Updated emacs ``                |
| [`aa0155d1`](https://github.com/nix-community/emacs-overlay/commit/aa0155d148c316cc653476c83f3aac57afbde000) | `` Updated melpa ``                |
| [`5d4ab701`](https://github.com/nix-community/emacs-overlay/commit/5d4ab701c80872226f8dcaf0b494816746cdb738) | `` Updated elpa ``                 |
| [`5106217a`](https://github.com/nix-community/emacs-overlay/commit/5106217a5b0652bcd8f24ebf955aed45d2e7c2ad) | `` Updated emacs ``                |
| [`11c8e196`](https://github.com/nix-community/emacs-overlay/commit/11c8e196c5130ce4f91f9f433ee5067001382df5) | `` Updated melpa ``                |
| [`51d8c9b0`](https://github.com/nix-community/emacs-overlay/commit/51d8c9b0e14c73d3b52e3a5e894caff20337bc6a) | `` Updated flake inputs ``         |
| [`550f226f`](https://github.com/nix-community/emacs-overlay/commit/550f226f99b0e54179a76cf9500468e120def867) | `` Updated emacs ``                |
| [`fab6612e`](https://github.com/nix-community/emacs-overlay/commit/fab6612e70edd3d48993906a7e88c5216ce4c571) | `` Updated melpa ``                |
| [`ae6f9bc8`](https://github.com/nix-community/emacs-overlay/commit/ae6f9bc80ea20d24216b566aecfe8f3eb7b70363) | `` Updated elpa ``                 |
| [`68e08a9a`](https://github.com/nix-community/emacs-overlay/commit/68e08a9ac499542ef473bd5306345cf24a780f50) | `` Updated nongnu ``               |
| [`5531296a`](https://github.com/nix-community/emacs-overlay/commit/5531296a4fd231dee0ad5bb252a47cbd0198b06d) | `` Updated emacs ``                |
| [`6e6e5f78`](https://github.com/nix-community/emacs-overlay/commit/6e6e5f78c7e5edbf7091174a31b35446c3519098) | `` Updated melpa ``                |
| [`b814c602`](https://github.com/nix-community/emacs-overlay/commit/b814c6022b1658d29b0eacd4a1e797946ba2532a) | `` Updated elpa ``                 |
| [`7de6a630`](https://github.com/nix-community/emacs-overlay/commit/7de6a630960f81ab2bf5a12ecdd5678ffaee9f5c) | `` Updated emacs ``                |
| [`c748ebeb`](https://github.com/nix-community/emacs-overlay/commit/c748ebeb27022d6ece8d9bcda28755572f26dc5e) | `` Updated melpa ``                |
| [`b7c67b5f`](https://github.com/nix-community/emacs-overlay/commit/b7c67b5f71db89ec27e1aa4413fbbcdf5bbfa451) | `` Shut up obsolescence warning `` |
| [`72e11f21`](https://github.com/nix-community/emacs-overlay/commit/72e11f211bba2c57c5e646e35a95380fafd0341a) | `` Updated emacs ``                |
| [`f44c8471`](https://github.com/nix-community/emacs-overlay/commit/f44c8471e50df56af9229aa354f3061570dfab0a) | `` Updated melpa ``                |
| [`ac950010`](https://github.com/nix-community/emacs-overlay/commit/ac95001079db6ee5c1e05acf1c7fec33d1cf2f3a) | `` Updated elpa ``                 |
| [`6945b802`](https://github.com/nix-community/emacs-overlay/commit/6945b80223499bba37d46d9a0bc9ce85589df936) | `` Updated emacs ``                |
| [`9b34fbdd`](https://github.com/nix-community/emacs-overlay/commit/9b34fbdd9556dcf635abdd543f71f1d245c8634c) | `` Updated melpa ``                |
| [`8a3ac745`](https://github.com/nix-community/emacs-overlay/commit/8a3ac745eefe247bdb0f3a33e35586d0d41a91f5) | `` Updated elpa ``                 |
| [`77b373a3`](https://github.com/nix-community/emacs-overlay/commit/77b373a3930607022e7678ab30715763c24dfaa3) | `` Updated flake inputs ``         |
| [`f994dc5c`](https://github.com/nix-community/emacs-overlay/commit/f994dc5cd9323dc83968049348858ea7e683f424) | `` Updated emacs ``                |
| [`acdd825f`](https://github.com/nix-community/emacs-overlay/commit/acdd825fbf3127a8a12235c754ec5bd3d447c24d) | `` Updated melpa ``                |
| [`0c9de266`](https://github.com/nix-community/emacs-overlay/commit/0c9de2665a034fbc19782514e32595412cb6a781) | `` Updated emacs ``                |
| [`08ecda2d`](https://github.com/nix-community/emacs-overlay/commit/08ecda2df93d592fc6bf1ac7e9f5bc27ee876c11) | `` Updated melpa ``                |
| [`187befb5`](https://github.com/nix-community/emacs-overlay/commit/187befb50d43371b697cd6233e4caec3e18cd9f3) | `` Updated elpa ``                 |
| [`f2df9741`](https://github.com/nix-community/emacs-overlay/commit/f2df97415de3805c1daa3c14d30357e79943961e) | `` Updated nongnu ``               |
| [`41b0349b`](https://github.com/nix-community/emacs-overlay/commit/41b0349b7219d5128acbf66d753e921f283cf1b2) | `` Updated emacs ``                |
| [`87dec8f9`](https://github.com/nix-community/emacs-overlay/commit/87dec8f92846c69fb17e4bddd66c160bd769cb38) | `` Updated melpa ``                |
| [`4eec5674`](https://github.com/nix-community/emacs-overlay/commit/4eec567404d4f12acd70674cbc3c319cf92fb43f) | `` Updated elpa ``                 |
| [`16ca106d`](https://github.com/nix-community/emacs-overlay/commit/16ca106d2a6efab591b7489d1839b391f660b1b9) | `` Updated flake inputs ``         |
| [`164c11f0`](https://github.com/nix-community/emacs-overlay/commit/164c11f0ddbf47ed5a20272a35b8f24557eaabb1) | `` Updated emacs ``                |
| [`7f585f4a`](https://github.com/nix-community/emacs-overlay/commit/7f585f4ab4a726b3f6f73c2e5c267085bb0a13f2) | `` Updated melpa ``                |