### PR TITLE
chore(flake/nur): `3324c298` -> `12015b20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706946929,
-        "narHash": "sha256-aASJGUmOzorebMnlXmFDKFWJ4uMCvXOwd74hZ2xnlJ0=",
+        "lastModified": 1706947796,
+        "narHash": "sha256-JQ6Vp2ZbulrGzLb8aOAbgPGiTukS+xGo7N3ujqHeJew=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3324c298a423c2eef03488b6f9a2ef0d82e42083",
+        "rev": "12015b208a5f627aafc9fd8a3b93b8487f5774ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`12015b20`](https://github.com/nix-community/NUR/commit/12015b208a5f627aafc9fd8a3b93b8487f5774ed) | `` automatic update `` |
| [`bd5c490c`](https://github.com/nix-community/NUR/commit/bd5c490c6073077f14ca8570b0aac1fc741470ad) | `` automatic update `` |