### PR TITLE
chore(flake/nur): `5dc2f93e` -> `28cb99d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706953443,
-        "narHash": "sha256-LY8dwDRACfWLEWNTicWOzgspfhtOIloteILwFYbf7bM=",
+        "lastModified": 1706960163,
+        "narHash": "sha256-Vabzb9tPMdQMDcGnA3oBlhsxTI6fbScs5RokPJixRLc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5dc2f93e4a5965e2d50da740bee8aa3d661cb079",
+        "rev": "28cb99d30a99625796619b525a5e69aec1058368",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`28cb99d3`](https://github.com/nix-community/NUR/commit/28cb99d30a99625796619b525a5e69aec1058368) | `` automatic update `` |
| [`b1011120`](https://github.com/nix-community/NUR/commit/b10111201b4064d90e42db525b2648aa9d0f754b) | `` automatic update `` |
| [`88c97939`](https://github.com/nix-community/NUR/commit/88c97939e93769bb00312ff612489ceaffdaa5a0) | `` automatic update `` |