### PR TITLE
chore(flake/nur): `481c3d7c` -> `713b918b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706962088,
-        "narHash": "sha256-pKHdsnoRP+wgy0bu36Fs+8iGZEBmQ8vNltYjtiMsrVA=",
+        "lastModified": 1706970787,
+        "narHash": "sha256-fxRS38zykN8/5268VNHBv2gO3hlH6mpE9WTw7BwUKs0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "481c3d7ce8fbee0de1e4375a2e86d862b0c3de2d",
+        "rev": "713b918bf04438463f7587fe23a092648a863d26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`713b918b`](https://github.com/nix-community/NUR/commit/713b918bf04438463f7587fe23a092648a863d26) | `` automatic update `` |