### PR TITLE
chore(flake/nur): `bcaef5f9` -> `c21b0244`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706982194,
-        "narHash": "sha256-7xTi+5aqKem7jFuC0j2MO3K04Sz1lCoC+kys0k4iy7w=",
+        "lastModified": 1706989523,
+        "narHash": "sha256-Ci+Fgu7ngo+WRvHXJWEBpCHL560hbHsDFz28H1CwUkI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bcaef5f9f718b523117ad5a3798d7ed072bfa6bb",
+        "rev": "c21b0244a519085f2597ec75854ce3671e68e32d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c21b0244`](https://github.com/nix-community/NUR/commit/c21b0244a519085f2597ec75854ce3671e68e32d) | `` automatic update `` |
| [`2550466d`](https://github.com/nix-community/NUR/commit/2550466d4a700a11b4b1d37f0803eac56a5355a3) | `` automatic update `` |
| [`1932c503`](https://github.com/nix-community/NUR/commit/1932c50322b1c6e191a88da3436c6da6b18eca88) | `` automatic update `` |