### PR TITLE
chore(flake/nur): `a30b8d63` -> `5b2e8b3c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707003862,
-        "narHash": "sha256-XYstV4DLkO60Gxr7y9IWiz8XENWmvy2svwlvpf700xw=",
+        "lastModified": 1707018236,
+        "narHash": "sha256-TUZVZURywivViXdC+nRhWh9/UUZ8IXnrDv1wRKPjUiM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a30b8d6366e36e256e803c14f81da4068bd134c2",
+        "rev": "5b2e8b3cb4404e60da0c4f64f9c17feae02132e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5b2e8b3c`](https://github.com/nix-community/NUR/commit/5b2e8b3cb4404e60da0c4f64f9c17feae02132e8) | `` automatic update `` |
| [`ab432ace`](https://github.com/nix-community/NUR/commit/ab432acea15134873882610c0e936a882319bc8a) | `` automatic update `` |