### PR TITLE
chore(flake/nur): `5b2e8b3c` -> `5c5049bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707018236,
-        "narHash": "sha256-TUZVZURywivViXdC+nRhWh9/UUZ8IXnrDv1wRKPjUiM=",
+        "lastModified": 1707029134,
+        "narHash": "sha256-jCsAUiJRJ27xSdlMwqh18SlFMnAEQ97HkPYZImRW0mQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5b2e8b3cb4404e60da0c4f64f9c17feae02132e8",
+        "rev": "5c5049bf7c0054ac395bb5e1bc3ec6b105c196ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5c5049bf`](https://github.com/nix-community/NUR/commit/5c5049bf7c0054ac395bb5e1bc3ec6b105c196ec) | `` automatic update `` |
| [`8b7fb422`](https://github.com/nix-community/NUR/commit/8b7fb42266d566a47777426dce429373cf68542d) | `` automatic update `` |