### PR TITLE
chore(flake/nur): `5c5049bf` -> `a1a35629`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707029134,
-        "narHash": "sha256-jCsAUiJRJ27xSdlMwqh18SlFMnAEQ97HkPYZImRW0mQ=",
+        "lastModified": 1707036977,
+        "narHash": "sha256-o7k7PZ4RXWSDnKuDIB/Zr6mqmZMuFhXXRbq4/BTLPXU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5c5049bf7c0054ac395bb5e1bc3ec6b105c196ec",
+        "rev": "a1a35629e1836822cf67a2c555d0110d9784a4f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a1a35629`](https://github.com/nix-community/NUR/commit/a1a35629e1836822cf67a2c555d0110d9784a4f9) | `` automatic update `` |
| [`3029217b`](https://github.com/nix-community/NUR/commit/3029217b493a7f90093439a45c1bd2e1821e8f0e) | `` automatic update `` |