### PR TITLE
chore(flake/nur): `a1a35629` -> `8ab9654c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707036977,
-        "narHash": "sha256-o7k7PZ4RXWSDnKuDIB/Zr6mqmZMuFhXXRbq4/BTLPXU=",
+        "lastModified": 1707038883,
+        "narHash": "sha256-FE5+ZdKhDkLBF6mwuALYuhIUKwjmeZHYzyzVacJKA74=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a1a35629e1836822cf67a2c555d0110d9784a4f9",
+        "rev": "8ab9654cc85c8b415660b98c942f4a7e6bf1bf7b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8ab9654c`](https://github.com/nix-community/NUR/commit/8ab9654cc85c8b415660b98c942f4a7e6bf1bf7b) | `` automatic update `` |