### PR TITLE
chore(flake/nur): `8ab9654c` -> `51b44c67`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707038883,
-        "narHash": "sha256-FE5+ZdKhDkLBF6mwuALYuhIUKwjmeZHYzyzVacJKA74=",
+        "lastModified": 1707043111,
+        "narHash": "sha256-d3tdmq/3+SE4mJ4STVlInkAdQ64wz4V4jVEr78AEoak=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8ab9654cc85c8b415660b98c942f4a7e6bf1bf7b",
+        "rev": "51b44c67a6d45183f55b79a5d691d2093b2a046e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`51b44c67`](https://github.com/nix-community/NUR/commit/51b44c67a6d45183f55b79a5d691d2093b2a046e) | `` automatic update `` |