### PR TITLE
chore(flake/nixpkgs): `b8b232ae` -> `faf912b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -777,11 +777,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1706732774,
-        "narHash": "sha256-hqJlyJk4MRpcItGYMF+3uHe8HvxNETWvlGtLuVpqLU0=",
+        "lastModified": 1707092692,
+        "narHash": "sha256-ZbHsm+mGk/izkWtT4xwwqz38fdlwu7nUUKXTOmm4SyE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b8b232ae7b8b144397fdb12d20f592e5e7c1a64d",
+        "rev": "faf912b086576fd1a15fca610166c98d47bc667e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                    |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`8b0d333f`](https://github.com/NixOS/nixpkgs/commit/8b0d333f546d6247c0c846ffbc9f7e89b4d06022) | `` nixos/archisteamfarm: allow bots.*.passwordFile to be null (#284978) `` |
| [`eaefae19`](https://github.com/NixOS/nixpkgs/commit/eaefae19673e8737f55fa61544876d645847a854) | `` moonraker: unstable-2023-12-16 -> unstable-2023-12-27 (#277239) ``      |
| [`3b71558f`](https://github.com/NixOS/nixpkgs/commit/3b71558f3e2db297197bf6c8e7c8ac0b7e83a4b8) | `` pritunl-client: 1.3.3584.5 -> 1.3.3785.81 (#283218) ``                  |
| [`0bf2c590`](https://github.com/NixOS/nixpkgs/commit/0bf2c59003ef6ab726b7d38410490fae07faaf4e) | `` himalaya: 1.0.0-beta -> 1.0.0-beta.2 (#284358) ``                       |
| [`2280e919`](https://github.com/NixOS/nixpkgs/commit/2280e9192a6f9f96cb6dd2a1321bb6c219eed578) | `` neo4j: 5.9.0 -> 5.16.0 ``                                               |
| [`65d27708`](https://github.com/NixOS/nixpkgs/commit/65d2770885cca56e2607bd2f1be24780c1a00b94) | `` csvkit: 1.1.1 -> 1.3.0 (#282340) ``                                     |
| [`a30ae784`](https://github.com/NixOS/nixpkgs/commit/a30ae78435b7c481233601eea523b9340ca0760f) | `` xonsh: 0.14.0 -> 0.14.4 (#282368) ``                                    |
| [`340654ad`](https://github.com/NixOS/nixpkgs/commit/340654adda3f0a74d3dfa1abf16d314d78891e52) | `` rustic-rs: 0.6.1 -> 0.7.0 ``                                            |
| [`2b6423fa`](https://github.com/NixOS/nixpkgs/commit/2b6423fa14df280b2776508ea3bef70a76b6b2f6) | `` python311Packages.jenkins-job-builder: cleanup ``                       |
| [`22f81d9c`](https://github.com/NixOS/nixpkgs/commit/22f81d9c886be7ce3652b5dbde2c81ba01fef7a0) | `` python311Packages.jenkins-job-builder: 5.0.4 -> 6.0.0 ``                |
| [`2ed00dbb`](https://github.com/NixOS/nixpkgs/commit/2ed00dbbd671072ad6d20930b6fcfeab52e9eb05) | `` fangfrisch: 1.6.1 -> 1.7.0 ``                                           |
| [`901de021`](https://github.com/NixOS/nixpkgs/commit/901de021f46302e26ea12ec7b898018ca436184b) | `` dbip-country-lite: 2024-01 -> 2024-02 ``                                |