### PR TITLE
chore(flake/nur): `f66ad1a3` -> `abe9eb6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707060527,
-        "narHash": "sha256-85kLh6Pu3DHsZCSZTb4tXSNa36nrRBA63T/2CxGBmdo=",
+        "lastModified": 1707071465,
+        "narHash": "sha256-sp+lgTl440Ex3v8rB6hspMJhg5uuGVfO1LRba/a8kSY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f66ad1a3a3aedd1862bc5dc1885ec348fa23f897",
+        "rev": "abe9eb6d605d624e121d4f84749b47f7816f1686",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`abe9eb6d`](https://github.com/nix-community/NUR/commit/abe9eb6d605d624e121d4f84749b47f7816f1686) | `` automatic update `` |