### PR TITLE
chore(flake/nur): `abe9eb6d` -> `c4d4b7ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707071465,
-        "narHash": "sha256-sp+lgTl440Ex3v8rB6hspMJhg5uuGVfO1LRba/a8kSY=",
+        "lastModified": 1707079475,
+        "narHash": "sha256-8qANBFbQw8vbxHJVeyfIJeo8P/BeE1m1/hPwIf5egTQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "abe9eb6d605d624e121d4f84749b47f7816f1686",
+        "rev": "c4d4b7ffa0166e69d45491ffa1bf53b58d8579f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c4d4b7ff`](https://github.com/nix-community/NUR/commit/c4d4b7ffa0166e69d45491ffa1bf53b58d8579f8) | `` automatic update `` |
| [`51579816`](https://github.com/nix-community/NUR/commit/515798160ecfeef7b533cc772a6711d88f30b89f) | `` automatic update `` |
| [`c4761461`](https://github.com/nix-community/NUR/commit/c4761461667441873565fb41ab947803255b1669) | `` automatic update `` |