### PR TITLE
chore(flake/nur): `c4d4b7ff` -> `d4e19206`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707079475,
-        "narHash": "sha256-8qANBFbQw8vbxHJVeyfIJeo8P/BeE1m1/hPwIf5egTQ=",
+        "lastModified": 1707086744,
+        "narHash": "sha256-iA9V62K9DYwDkw4EBieSxaVrj5+5sQKChyXWuBzw6BY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c4d4b7ffa0166e69d45491ffa1bf53b58d8579f8",
+        "rev": "d4e19206de96f8c824314ff9b6cbbc00ac9337b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d4e19206`](https://github.com/nix-community/NUR/commit/d4e19206de96f8c824314ff9b6cbbc00ac9337b9) | `` automatic update `` |