### PR TITLE
chore(flake/nur): `d4e19206` -> `51437703`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707086744,
-        "narHash": "sha256-iA9V62K9DYwDkw4EBieSxaVrj5+5sQKChyXWuBzw6BY=",
+        "lastModified": 1707090259,
+        "narHash": "sha256-ZZEQCpPohb2KbaRK3ijp+fbuAISevFp9FpADjFjq5bc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d4e19206de96f8c824314ff9b6cbbc00ac9337b9",
+        "rev": "51437703b754e4be55f604c6cfb8eee8f8874ab8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`51437703`](https://github.com/nix-community/NUR/commit/51437703b754e4be55f604c6cfb8eee8f8874ab8) | `` automatic update `` |
| [`a3141350`](https://github.com/nix-community/NUR/commit/a31413502022e9f157a46570bbc34b7dce1a80da) | `` automatic update `` |