### PR TITLE
chore(flake/nur): `51437703` -> `42d465eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707090259,
-        "narHash": "sha256-ZZEQCpPohb2KbaRK3ijp+fbuAISevFp9FpADjFjq5bc=",
+        "lastModified": 1707099544,
+        "narHash": "sha256-ZFEVPGPG4S4q6Wnr91vqG+KTFRQXV8ZslU8sL47gp7U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "51437703b754e4be55f604c6cfb8eee8f8874ab8",
+        "rev": "42d465ebd6db46f3f03c9bbeeebb562f7cb4a023",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`42d465eb`](https://github.com/nix-community/NUR/commit/42d465ebd6db46f3f03c9bbeeebb562f7cb4a023) | `` automatic update `` |
| [`f837023b`](https://github.com/nix-community/NUR/commit/f837023b7dc36bceca1bc4b6becef87802f259a2) | `` automatic update `` |
| [`674996ec`](https://github.com/nix-community/NUR/commit/674996ec4ce4f9c4771d110dd1767ad50390f54b) | `` automatic update `` |
| [`e3d1786d`](https://github.com/nix-community/NUR/commit/e3d1786dc5957e85cf634309c69f00e36f3bd8d6) | `` automatic update `` |