### PR TITLE
chore(flake/nur): `42d465eb` -> `597c8934`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707099544,
-        "narHash": "sha256-ZFEVPGPG4S4q6Wnr91vqG+KTFRQXV8ZslU8sL47gp7U=",
+        "lastModified": 1707104683,
+        "narHash": "sha256-XC42Ute5wAejF1iS/6/qNoLO03bxP1lx1xaWyiaOIwQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "42d465ebd6db46f3f03c9bbeeebb562f7cb4a023",
+        "rev": "597c89346ff30536c9923d964893110213dd975c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`597c8934`](https://github.com/nix-community/NUR/commit/597c89346ff30536c9923d964893110213dd975c) | `` automatic update `` |