### PR TITLE
chore(flake/nur): `597c8934` -> `d57cb6ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707104683,
-        "narHash": "sha256-XC42Ute5wAejF1iS/6/qNoLO03bxP1lx1xaWyiaOIwQ=",
+        "lastModified": 1707106022,
+        "narHash": "sha256-qJ509gXPrekLYD8dhw+ktpYw52Y6w3VBluyK4GOXk8w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "597c89346ff30536c9923d964893110213dd975c",
+        "rev": "d57cb6ba576b907f4abe41dcf16e99620242eccf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d57cb6ba`](https://github.com/nix-community/NUR/commit/d57cb6ba576b907f4abe41dcf16e99620242eccf) | `` automatic update `` |