### PR TITLE
chore(flake/home-manager): `4740f2cc` -> `afcedcf2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707088232,
-        "narHash": "sha256-nxPBAZ//BwKkBcjwLE5g9zTq29g7gccTnH5+CeMTxpA=",
+        "lastModified": 1707114923,
+        "narHash": "sha256-LDYPWa+BgxHSNEye93SyIPgz5u3RAfh78P9KyO+rQzI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4740f2ccda184e9cc509d7a82b26d7271e0c79d9",
+        "rev": "afcedcf2c8e424d0465e823cf833eb3adebe1db7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                               |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`afcedcf2`](https://github.com/nix-community/home-manager/commit/afcedcf2c8e424d0465e823cf833eb3adebe1db7) | `` mcfly: add interfaceView option `` |
| [`a28b12d7`](https://github.com/nix-community/home-manager/commit/a28b12d7412324aa22a5f9df8909672dec33613e) | `` vscode: add openvscode-server ``   |