### PR TITLE
chore(flake/nur): `47ff97d9` -> `2a045537`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707111670,
-        "narHash": "sha256-EWmWjdypBAeey5b0PhxiJSfijJX1tz8jK7Gazt+G1a8=",
+        "lastModified": 1707115526,
+        "narHash": "sha256-BaKzXxR0M+FZeXMqFe0xEu653CmhtGVSKPlrUpyVdjU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "47ff97d9b90f9f2c19022f12582fce59a45b504c",
+        "rev": "2a0455372ab43453f4a7260bfa1aa64813f63933",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2a045537`](https://github.com/nix-community/NUR/commit/2a0455372ab43453f4a7260bfa1aa64813f63933) | `` automatic update `` |
| [`d697b6b0`](https://github.com/nix-community/NUR/commit/d697b6b0de1829b872c4a16e4d1c596699e9ea03) | `` automatic update `` |