### PR TITLE
chore(flake/nur): `2a045537` -> `7da4a8a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707115526,
-        "narHash": "sha256-BaKzXxR0M+FZeXMqFe0xEu653CmhtGVSKPlrUpyVdjU=",
+        "lastModified": 1707121924,
+        "narHash": "sha256-eeFSNid3MuGouOM3OgxtiZEtxOpX0Ckln80AhTk93Yo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2a0455372ab43453f4a7260bfa1aa64813f63933",
+        "rev": "7da4a8a9a76d5b62aba41fe9063341829f7e5707",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7da4a8a9`](https://github.com/nix-community/NUR/commit/7da4a8a9a76d5b62aba41fe9063341829f7e5707) | `` automatic update `` |
| [`3c8e9a89`](https://github.com/nix-community/NUR/commit/3c8e9a897ca4e705c7dea1303b79830d06cb09f7) | `` automatic update `` |