### PR TITLE
chore(flake/nur): `7da4a8a9` -> `4f131f19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707121924,
-        "narHash": "sha256-eeFSNid3MuGouOM3OgxtiZEtxOpX0Ckln80AhTk93Yo=",
+        "lastModified": 1707126301,
+        "narHash": "sha256-fzYJfTdd3I6YsWIY2FTya+asDoSWTVwxmVgIJjmvn8Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7da4a8a9a76d5b62aba41fe9063341829f7e5707",
+        "rev": "4f131f190ff362b8cadca9d063ac8e16207c7af7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4f131f19`](https://github.com/nix-community/NUR/commit/4f131f190ff362b8cadca9d063ac8e16207c7af7) | `` automatic update `` |