### PR TITLE
chore(flake/nur): `08b53a97` -> `e55ccb49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707140664,
-        "narHash": "sha256-unrfjvRrju3CHGCtSzFiiFQNwErwZ2IXVTbiENYReWM=",
+        "lastModified": 1707143578,
+        "narHash": "sha256-Ve4kq9p31fXJjfvVRqB6JCkkV4ajJwaAjPY4kUwNNfk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "08b53a973f9fc702f90a5be56b7d9f47bb5aaa41",
+        "rev": "e55ccb495ff1c39fb600db4ba5b92e477e01213e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e55ccb49`](https://github.com/nix-community/NUR/commit/e55ccb495ff1c39fb600db4ba5b92e477e01213e) | `` automatic update `` |