### PR TITLE
chore(flake/nur): `e55ccb49` -> `02d07e54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707143578,
-        "narHash": "sha256-Ve4kq9p31fXJjfvVRqB6JCkkV4ajJwaAjPY4kUwNNfk=",
+        "lastModified": 1707147875,
+        "narHash": "sha256-/on633fQUfpZYOHgVdprKNLlHv6psNRla+7XokAtcrI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e55ccb495ff1c39fb600db4ba5b92e477e01213e",
+        "rev": "02d07e54807dada0f00b8f297c872d5ecb9cf65d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`02d07e54`](https://github.com/nix-community/NUR/commit/02d07e54807dada0f00b8f297c872d5ecb9cf65d) | `` automatic update `` |
| [`efe7184e`](https://github.com/nix-community/NUR/commit/efe7184e100553bbe6dfcbbd5911cb40f26c4564) | `` automatic update `` |