### PR TITLE
chore(flake/nur): `02d07e54` -> `2fd6d20b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707147875,
-        "narHash": "sha256-/on633fQUfpZYOHgVdprKNLlHv6psNRla+7XokAtcrI=",
+        "lastModified": 1707151471,
+        "narHash": "sha256-1au4c4EKRPNT8zx7sJ1vamevyA0EPjF1938Naz9af/8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "02d07e54807dada0f00b8f297c872d5ecb9cf65d",
+        "rev": "2fd6d20bb00f05fc91321c2eebd497c2e5247d74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2fd6d20b`](https://github.com/nix-community/NUR/commit/2fd6d20bb00f05fc91321c2eebd497c2e5247d74) | `` automatic update `` |