### PR TITLE
chore(flake/nur): `2fd6d20b` -> `aa997413`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707151471,
-        "narHash": "sha256-1au4c4EKRPNT8zx7sJ1vamevyA0EPjF1938Naz9af/8=",
+        "lastModified": 1707158739,
+        "narHash": "sha256-XwI9ib3rbVDEUUTzW823IIvwRhImsWlK8sQn/xQxQ8M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2fd6d20bb00f05fc91321c2eebd497c2e5247d74",
+        "rev": "aa997413d7772f3ab5d12b45f44ccb8a9fa03420",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aa997413`](https://github.com/nix-community/NUR/commit/aa997413d7772f3ab5d12b45f44ccb8a9fa03420) | `` automatic update `` |
| [`e496b0a1`](https://github.com/nix-community/NUR/commit/e496b0a16f125fcbb1f613065eb6d61564b1acce) | `` automatic update `` |