### PR TITLE
chore(flake/nur): `aa997413` -> `9eec0266`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707158739,
-        "narHash": "sha256-XwI9ib3rbVDEUUTzW823IIvwRhImsWlK8sQn/xQxQ8M=",
+        "lastModified": 1707165876,
+        "narHash": "sha256-dhmE05oI68jY4UzhgTijn4qqRlMVaoLVbVt5/fPRVjc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aa997413d7772f3ab5d12b45f44ccb8a9fa03420",
+        "rev": "9eec02662a79129ddd96e8027ede1c513aa4a18d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9eec0266`](https://github.com/nix-community/NUR/commit/9eec02662a79129ddd96e8027ede1c513aa4a18d) | `` automatic update `` |
| [`e3d41526`](https://github.com/nix-community/NUR/commit/e3d4152650489edee1282af7a7a7d95e110ef424) | `` automatic update `` |