### PR TITLE
chore(flake/home-manager): `afcedcf2` -> `f99eace7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707114923,
-        "narHash": "sha256-LDYPWa+BgxHSNEye93SyIPgz5u3RAfh78P9KyO+rQzI=",
+        "lastModified": 1707175763,
+        "narHash": "sha256-0MKHC6tQ4KEuM5rui6DjKZ/VNiSANB4E+DJ/+wPS1PU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "afcedcf2c8e424d0465e823cf833eb3adebe1db7",
+        "rev": "f99eace7c167b8a6a0871849493b1c613d0f1b80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`f99eace7`](https://github.com/nix-community/home-manager/commit/f99eace7c167b8a6a0871849493b1c613d0f1b80) | `` jetbrains-remote: add module ``                        |
| [`f65dcd6c`](https://github.com/nix-community/home-manager/commit/f65dcd6c15db0fc2045d56ef8fdf4a03aa52e81f) | `` neomutt: fix crypt_use_gpgme in newer versions ``      |
| [`7b4ea8d8`](https://github.com/nix-community/home-manager/commit/7b4ea8d82fdeaa71ab942a8a8f6f8add8afdfad0) | `` arrpc: add module ``                                   |
| [`13dbf262`](https://github.com/nix-community/home-manager/commit/13dbf2623d6465d5c4db54ce8a5a630dce79c3e9) | `` swayosd: update executable ``                          |
| [`b319781e`](https://github.com/nix-community/home-manager/commit/b319781e304c668da0ef144b1b4ee48977d4877d) | `` home-manager: Check VISUAL before EDITOR for editor `` |
| [`3c6f2dd5`](https://github.com/nix-community/home-manager/commit/3c6f2dd59cb8c0b06ed1fe01f297e75bbaec3003) | `` himalaya: adjust module for v1.0.0-beta ``             |
| [`274bd470`](https://github.com/nix-community/home-manager/commit/274bd470a544647d90d7491037fdf8af61b7d8d0) | `` nix-gc: add service ``                                 |