### PR TITLE
chore(flake/nur): `9eec0266` -> `38340847`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707165876,
-        "narHash": "sha256-dhmE05oI68jY4UzhgTijn4qqRlMVaoLVbVt5/fPRVjc=",
+        "lastModified": 1707170335,
+        "narHash": "sha256-mL1hsn1YuGG8JOYHPiLwxya57RvsuvyPaGvsn+fJams=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9eec02662a79129ddd96e8027ede1c513aa4a18d",
+        "rev": "383408470fd7375c874c697df9e0eb151a74e276",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`38340847`](https://github.com/nix-community/NUR/commit/383408470fd7375c874c697df9e0eb151a74e276) | `` automatic update `` |
| [`91b05f05`](https://github.com/nix-community/NUR/commit/91b05f0568aed3c03a602755f1457a228c73aa07) | `` automatic update `` |