### PR TITLE
chore(flake/nur): `38340847` -> `1cef2d36`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707170335,
-        "narHash": "sha256-mL1hsn1YuGG8JOYHPiLwxya57RvsuvyPaGvsn+fJams=",
+        "lastModified": 1707173438,
+        "narHash": "sha256-En3ICNAc6qn+lhWNiC7CXqEGtZGVaSBSEFGoa7gLYhk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "383408470fd7375c874c697df9e0eb151a74e276",
+        "rev": "1cef2d364b4b4ff28fde06483b4cf5df9fee8a97",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1cef2d36`](https://github.com/nix-community/NUR/commit/1cef2d364b4b4ff28fde06483b4cf5df9fee8a97) | `` automatic update `` |
| [`4f568381`](https://github.com/nix-community/NUR/commit/4f5683815bec121ca33ca76c3b3513ca6bdd47ad) | `` automatic update `` |
| [`3ad87700`](https://github.com/nix-community/NUR/commit/3ad877008a525772f7a1162b825e72a224c00632) | `` automatic update `` |