### PR TITLE
chore(flake/nur): `1cef2d36` -> `65a74c3f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707173438,
-        "narHash": "sha256-En3ICNAc6qn+lhWNiC7CXqEGtZGVaSBSEFGoa7gLYhk=",
+        "lastModified": 1707176267,
+        "narHash": "sha256-noAIpR+ZjVRdDcZ/pgboe37q3div1b3Ygw16ISNpAkY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1cef2d364b4b4ff28fde06483b4cf5df9fee8a97",
+        "rev": "65a74c3f40d3e60ba1b7c04c63c371208ba88657",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`65a74c3f`](https://github.com/nix-community/NUR/commit/65a74c3f40d3e60ba1b7c04c63c371208ba88657) | `` automatic update `` |
| [`25e43919`](https://github.com/nix-community/NUR/commit/25e4391947cc2bb53de6f2277893b5339207d41f) | `` automatic update `` |