### PR TITLE
chore(flake/nur): `65a74c3f` -> `3247ef77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707176267,
-        "narHash": "sha256-noAIpR+ZjVRdDcZ/pgboe37q3div1b3Ygw16ISNpAkY=",
+        "lastModified": 1707184575,
+        "narHash": "sha256-MzQaqNeeAnGrAv94tX08Me+sCY0Uf1PD/bTWdZyXCqY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "65a74c3f40d3e60ba1b7c04c63c371208ba88657",
+        "rev": "3247ef77c09dd3f8138660dda48fac8b2d2a429d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3247ef77`](https://github.com/nix-community/NUR/commit/3247ef77c09dd3f8138660dda48fac8b2d2a429d) | `` automatic update `` |
| [`ff750f0d`](https://github.com/nix-community/NUR/commit/ff750f0d827f95ab132046d0d01e82c37b7a1c5c) | `` automatic update `` |