### PR TITLE
chore(flake/nur): `3247ef77` -> `78bd9227`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707184575,
-        "narHash": "sha256-MzQaqNeeAnGrAv94tX08Me+sCY0Uf1PD/bTWdZyXCqY=",
+        "lastModified": 1707187522,
+        "narHash": "sha256-aCfCUGuw1aIEEksHgA76m/5XrQApjyqBVghivyd7dq4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3247ef77c09dd3f8138660dda48fac8b2d2a429d",
+        "rev": "78bd9227a16201515082cc5eeb5cad4e842a9616",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`78bd9227`](https://github.com/nix-community/NUR/commit/78bd9227a16201515082cc5eeb5cad4e842a9616) | `` automatic update `` |