### PR TITLE
chore(flake/nur): `78bd9227` -> `dacaa989`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707187522,
-        "narHash": "sha256-aCfCUGuw1aIEEksHgA76m/5XrQApjyqBVghivyd7dq4=",
+        "lastModified": 1707188759,
+        "narHash": "sha256-2FEaBzOIFAqCgIWSn6GeSEJh+GNosK2tqh6reDiyWjM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "78bd9227a16201515082cc5eeb5cad4e842a9616",
+        "rev": "dacaa989fba8c5bb3efa3d5d1964f99407a11ae2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dacaa989`](https://github.com/nix-community/NUR/commit/dacaa989fba8c5bb3efa3d5d1964f99407a11ae2) | `` automatic update `` |