### PR TITLE
chore(flake/nur): `dacaa989` -> `c65ad4eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707188759,
-        "narHash": "sha256-2FEaBzOIFAqCgIWSn6GeSEJh+GNosK2tqh6reDiyWjM=",
+        "lastModified": 1707194339,
+        "narHash": "sha256-r/qRtrd34bBbtmsGRTj2HKuU6ly4RVAHmoZ6dZu3PLA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dacaa989fba8c5bb3efa3d5d1964f99407a11ae2",
+        "rev": "c65ad4eb0467ed7cf3dd8b9f0c1e1369aa1fb2af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c65ad4eb`](https://github.com/nix-community/NUR/commit/c65ad4eb0467ed7cf3dd8b9f0c1e1369aa1fb2af) | `` automatic update `` |
| [`e0bec738`](https://github.com/nix-community/NUR/commit/e0bec73865d244c1c4479112daf36c5b0e8078c1) | `` automatic update `` |