### PR TITLE
chore(flake/nur): `c65ad4eb` -> `6cbec5ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707194339,
-        "narHash": "sha256-r/qRtrd34bBbtmsGRTj2HKuU6ly4RVAHmoZ6dZu3PLA=",
+        "lastModified": 1707198079,
+        "narHash": "sha256-TVhC/Grfa//rhLJCfR+IhiWtBFltYDlBtn+8xycL7fI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c65ad4eb0467ed7cf3dd8b9f0c1e1369aa1fb2af",
+        "rev": "6cbec5ec7a282a1ef4dc683ad739ef309a356c18",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6cbec5ec`](https://github.com/nix-community/NUR/commit/6cbec5ec7a282a1ef4dc683ad739ef309a356c18) | `` automatic update `` |
| [`4b2a4b0a`](https://github.com/nix-community/NUR/commit/4b2a4b0aba080fa079e371125d5d0c84236727ee) | `` automatic update `` |