### PR TITLE
chore(flake/nur): `6cbec5ec` -> `af9064a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707198079,
-        "narHash": "sha256-TVhC/Grfa//rhLJCfR+IhiWtBFltYDlBtn+8xycL7fI=",
+        "lastModified": 1707204419,
+        "narHash": "sha256-RUwB/3Sbh2eeQQUl/UtvUVyUeQapmL+vMY3bGECAhuA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6cbec5ec7a282a1ef4dc683ad739ef309a356c18",
+        "rev": "af9064a549d5f89d4a85d651b0b94ac4a3c2ea23",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`af9064a5`](https://github.com/nix-community/NUR/commit/af9064a549d5f89d4a85d651b0b94ac4a3c2ea23) | `` automatic update `` |
| [`69c5afb8`](https://github.com/nix-community/NUR/commit/69c5afb84f142bdbe9079c048941d03aefad9d10) | `` automatic update `` |
| [`28a61f1b`](https://github.com/nix-community/NUR/commit/28a61f1b42334baba1fc179b632852845fb5a9c0) | `` automatic update `` |