### PR TITLE
chore(flake/nur): `af9064a5` -> `1d5ac4e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707204419,
-        "narHash": "sha256-RUwB/3Sbh2eeQQUl/UtvUVyUeQapmL+vMY3bGECAhuA=",
+        "lastModified": 1707209904,
+        "narHash": "sha256-QpX2oQBPHRFu9v55WnP6wsZ5Eu1P9xcXhpNgkPicz3Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "af9064a549d5f89d4a85d651b0b94ac4a3c2ea23",
+        "rev": "1d5ac4e7212e568f128644e993ac99363be15aa6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                            |
| -------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`1d5ac4e7`](https://github.com/nix-community/NUR/commit/1d5ac4e7212e568f128644e993ac99363be15aa6) | `` automatic update ``             |
| [`f091eff0`](https://github.com/nix-community/NUR/commit/f091eff006378774b654635e115675814f783207) | `` add demivan repository ``       |
| [`c10720db`](https://github.com/nix-community/NUR/commit/c10720db02e241cdf92f0431013ca5c31ceed797) | `` automatic update ``             |
| [`de6bf2f2`](https://github.com/nix-community/NUR/commit/de6bf2f257fe7be5d363fb453884aa927d4528f0) | `` add ggemre repository ``        |
| [`2fa7d477`](https://github.com/nix-community/NUR/commit/2fa7d4770a2013aed3b8c65bf7f0414738813da4) | `` automatic update ``             |
| [`b26259c7`](https://github.com/nix-community/NUR/commit/b26259c7e5a213507c21a404e5eec9b7e40d3183) | `` add twistoy repository ``       |
| [`715b3554`](https://github.com/nix-community/NUR/commit/715b35541008f5b4c1147d42d3d8bbd2ce1c974d) | `` automatic update ``             |
| [`b975c5d3`](https://github.com/nix-community/NUR/commit/b975c5d3c3afa7f52aaad98e1cdcd7eae070bce3) | `` add harukafractus repository `` |