### PR TITLE
chore(flake/nixos-hardware): `83e571bb` -> `6e5cc385`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -666,11 +666,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1706834982,
-        "narHash": "sha256-3CfxA7gZ+DVv/N9Pvw61bV5Oe/mWfxYPyVQGqp9TMJA=",
+        "lastModified": 1707211557,
+        "narHash": "sha256-LTKTzZ6fM5j8XWXf51IMBzDaOaJg9kYWLUZxoIhzRN8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "83e571bb291161682b9c3ccd48318f115143a550",
+        "rev": "6e5cc385fc8cf5ca6495d70243074ccdea9f64c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`6e5cc385`](https://github.com/NixOS/nixos-hardware/commit/6e5cc385fc8cf5ca6495d70243074ccdea9f64c7) | `` Extract AMD-GPU from Nvidia, to make it easier to choose either `` |
| [`5a8ed531`](https://github.com/NixOS/nixos-hardware/commit/5a8ed531f99b52cf5413c724d8f982350d79416e) | `` Initial config. for Lenovo Yoga Slim 7 Pro-X (14ARH7) ``           |
| [`06e919ac`](https://github.com/NixOS/nixos-hardware/commit/06e919ac0791475a4192068fdd7f8ebdd4f0f712) | `` Update README.md and flake.nix ``                                  |
| [`b5c4fb6b`](https://github.com/NixOS/nixos-hardware/commit/b5c4fb6b89e3a3d261110ea79a59122574099b68) | `` Add a config for Asus Zephyrus GA402X* (2023) series ``            |
| [`fc8d1ebb`](https://github.com/NixOS/nixos-hardware/commit/fc8d1ebb82b470e7c315d18f06804f26802afec8) | `` Rename Omen model ``                                               |