### PR TITLE
chore(flake/nur): `1d5ac4e7` -> `2f1ba0ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707209904,
-        "narHash": "sha256-QpX2oQBPHRFu9v55WnP6wsZ5Eu1P9xcXhpNgkPicz3Y=",
+        "lastModified": 1707214968,
+        "narHash": "sha256-RsccedWkkWBrUJj1dGklWNFaA9oOvVv3RCNpHUm9D18=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1d5ac4e7212e568f128644e993ac99363be15aa6",
+        "rev": "2f1ba0efb756f813843fb4be0a73cd0759852e03",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                         |
| -------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`2f1ba0ef`](https://github.com/nix-community/NUR/commit/2f1ba0efb756f813843fb4be0a73cd0759852e03) | `` automatic update ``          |
| [`c8ca24b1`](https://github.com/nix-community/NUR/commit/c8ca24b1e7a7cafc2788e8da83793eb4c986d00e) | `` automatic update ``          |
| [`a92630ba`](https://github.com/nix-community/NUR/commit/a92630ba5bd35d9f3ea8432ffc8b75a3aa34df04) | `` automatic update ``          |
| [`b3ceff8d`](https://github.com/nix-community/NUR/commit/b3ceff8daa4c475f69de298d9493e0ae9de16002) | `` add eownerdead repository `` |