### PR TITLE
chore(flake/nur): `2f1ba0ef` -> `c9082c6b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707214968,
-        "narHash": "sha256-RsccedWkkWBrUJj1dGklWNFaA9oOvVv3RCNpHUm9D18=",
+        "lastModified": 1707218108,
+        "narHash": "sha256-Ga8leUFMuuxKIqUS5pz8CwayaW1fOGdretxX2Pg4FTY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2f1ba0efb756f813843fb4be0a73cd0759852e03",
+        "rev": "c9082c6bafa25a4c1ad1b5ca370a063c723d9c21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c9082c6b`](https://github.com/nix-community/NUR/commit/c9082c6bafa25a4c1ad1b5ca370a063c723d9c21) | `` automatic update `` |