### PR TITLE
chore(flake/nur): `d10584ba` -> `9534dd71`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707237858,
-        "narHash": "sha256-PXptgZ4rC5kC5+kS8qKs4e2USr5gtU3Huf+pvLePdmE=",
+        "lastModified": 1707241543,
+        "narHash": "sha256-Q4wxwWiG1iT3Tu02K88dcQA4M/k2UBclkO3p87EgVmc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d10584ba0ab9f3e9dc2e451cc072a2c6cc2fddec",
+        "rev": "9534dd7152380c152b5a14e646a882de59ea51c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9534dd71`](https://github.com/nix-community/NUR/commit/9534dd7152380c152b5a14e646a882de59ea51c2) | `` automatic update `` |
| [`0dbda58c`](https://github.com/nix-community/NUR/commit/0dbda58cb6ec3a800b15de114669e71a25c134a7) | `` automatic update `` |