### PR TITLE
chore(flake/nur): `d2c468ae` -> `80c86b64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707249572,
-        "narHash": "sha256-I4iLd10K+gnhesJuVZeh7LOI8xYLr0BYXHxUkpn+DQU=",
+        "lastModified": 1707251143,
+        "narHash": "sha256-YaZvoW3SpDYUwIx0079oZxEsY1Xevj7VOHmXnArExm0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d2c468ae02e54593b1d83537429853873b93abd0",
+        "rev": "80c86b649fcc2b97d978379a271d344ac79fcf46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`80c86b64`](https://github.com/nix-community/NUR/commit/80c86b649fcc2b97d978379a271d344ac79fcf46) | `` automatic update `` |