### PR TITLE
chore(flake/nur): `86be2f15` -> `055eeb2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707259456,
-        "narHash": "sha256-Q7GlZsC/kBh1Qr7n/cYwwpSvb9LV1no0LQwVOS8/n8M=",
+        "lastModified": 1707267959,
+        "narHash": "sha256-cArpkEwSH2Fagy3LvuPafKlRBOfKeACwXnju+siZOF4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "86be2f150dfce413d8d3a1bc782a2baea7f427e2",
+        "rev": "055eeb2d3c8f6c63c170b3b709478921e973c2fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`055eeb2d`](https://github.com/nix-community/NUR/commit/055eeb2d3c8f6c63c170b3b709478921e973c2fb) | `` automatic update `` |