### PR TITLE
chore(flake/nur): `055eeb2d` -> `b3207b9c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707267959,
-        "narHash": "sha256-cArpkEwSH2Fagy3LvuPafKlRBOfKeACwXnju+siZOF4=",
+        "lastModified": 1707269663,
+        "narHash": "sha256-5pWv86hpGNcA0ob8h3i+qX+4t5VNEacHjoC+HlHj5f4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "055eeb2d3c8f6c63c170b3b709478921e973c2fb",
+        "rev": "b3207b9cd0cfc0074645375bce1c90e6159458e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b3207b9c`](https://github.com/nix-community/NUR/commit/b3207b9cd0cfc0074645375bce1c90e6159458e9) | `` automatic update `` |