### PR TITLE
chore(flake/nur): `b3207b9c` -> `f83a1817`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707269663,
-        "narHash": "sha256-5pWv86hpGNcA0ob8h3i+qX+4t5VNEacHjoC+HlHj5f4=",
+        "lastModified": 1707277796,
+        "narHash": "sha256-SWY/cfEb+QIdAd8XT4ubGC1cl8F06kFZxV2BZaWF088=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b3207b9cd0cfc0074645375bce1c90e6159458e9",
+        "rev": "f83a1817d263a914ca4747fbb9026e8296db28f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f83a1817`](https://github.com/nix-community/NUR/commit/f83a1817d263a914ca4747fbb9026e8296db28f8) | `` automatic update `` |
| [`7e0db0cf`](https://github.com/nix-community/NUR/commit/7e0db0cf2e4fd81fd9171b22c0598b3c10c07b93) | `` automatic update `` |
| [`04cf6773`](https://github.com/nix-community/NUR/commit/04cf6773dda024c1ae0176e158d33c5d54e31975) | `` automatic update `` |