### PR TITLE
chore(flake/nur): `c893a063` -> `94ca1687`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707279052,
-        "narHash": "sha256-gkgzQk/J92fXb6TVS+SqcEctGPVxyLd8ELoQuc+8z/Q=",
+        "lastModified": 1707284699,
+        "narHash": "sha256-tt2ZM+I23cEdYwqF0TgkttmgJytNfYbm4iguWuTYeEY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c893a063986c235396a6baca94a747bb879c1f5d",
+        "rev": "94ca168756e90b856bb94a40b0c4cbc403ec4c10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`94ca1687`](https://github.com/nix-community/NUR/commit/94ca168756e90b856bb94a40b0c4cbc403ec4c10) | `` automatic update `` |