### PR TITLE
chore(flake/nur): `94ca1687` -> `3d28563e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707284699,
-        "narHash": "sha256-tt2ZM+I23cEdYwqF0TgkttmgJytNfYbm4iguWuTYeEY=",
+        "lastModified": 1707287803,
+        "narHash": "sha256-PFGxFmzePhgG/Iz8gAwSxLyEqpiZtVjdFLBnobwMOSA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "94ca168756e90b856bb94a40b0c4cbc403ec4c10",
+        "rev": "3d28563eb8c950868143f0b2bd98e6aefcbf53a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3d28563e`](https://github.com/nix-community/NUR/commit/3d28563eb8c950868143f0b2bd98e6aefcbf53a2) | `` automatic update `` |
| [`1221ce16`](https://github.com/nix-community/NUR/commit/1221ce16e52f7ccb909b8a6970d792989f90aba7) | `` automatic update `` |