### PR TITLE
chore(flake/nur): `3d28563e` -> `1c51a38f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707287803,
-        "narHash": "sha256-PFGxFmzePhgG/Iz8gAwSxLyEqpiZtVjdFLBnobwMOSA=",
+        "lastModified": 1707291887,
+        "narHash": "sha256-Jls62X+S2qMGdDOa5tUSwqXiIdYENARq1vC6qODohPA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3d28563eb8c950868143f0b2bd98e6aefcbf53a2",
+        "rev": "1c51a38f6bb8297ffdcd4d203fed1154b8523361",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1c51a38f`](https://github.com/nix-community/NUR/commit/1c51a38f6bb8297ffdcd4d203fed1154b8523361) | `` automatic update `` |