### PR TITLE
chore(flake/nur): `1c51a38f` -> `b3df65ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707291887,
-        "narHash": "sha256-Jls62X+S2qMGdDOa5tUSwqXiIdYENARq1vC6qODohPA=",
+        "lastModified": 1707299136,
+        "narHash": "sha256-xDBdVDg6AwtLtgzeUMWW9PqMywtZ7wnvv6eFcoktOLs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1c51a38f6bb8297ffdcd4d203fed1154b8523361",
+        "rev": "b3df65ab7e7aef08b1204efce768b577c5f48034",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b3df65ab`](https://github.com/nix-community/NUR/commit/b3df65ab7e7aef08b1204efce768b577c5f48034) | `` automatic update `` |