### PR TITLE
chore(flake/stylix): `ccca01b5` -> `a2d8d6b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,6 +488,23 @@
         "type": "github"
       }
     },
+    "gnome-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1698794309,
+        "narHash": "sha256-/TIkZ8y5Wv3QHLFp79Poao9fINurKs5pa4z0CRe+F8s=",
+        "owner": "GNOME",
+        "repo": "gnome-shell",
+        "rev": "a7c169c6c29cf02a4c392fa0acbbc5f5072823e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "GNOME",
+        "ref": "45.1",
+        "repo": "gnome-shell",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -1038,6 +1055,7 @@
         "flake-compat": [
           "flake-compat"
         ],
+        "gnome-shell": "gnome-shell",
         "home-manager": [
           "home-manager"
         ],
@@ -1046,11 +1064,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706783767,
-        "narHash": "sha256-Rn21YNSa4TgZzTsarghUPQv+fz1dZcfdDKQZS9H79Hg=",
+        "lastModified": 1707303782,
+        "narHash": "sha256-5JHbqDtBpfX0H/WUIXSswMUrOKBkC4TlWS8uZfFTMDo=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ccca01b5b0393119822b1888cb7c68e294fc115b",
+        "rev": "a2d8d6b460bb6c53cb09ce645fd041c0c308c0c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`a2d8d6b4`](https://github.com/danth/stylix/commit/a2d8d6b460bb6c53cb09ce645fd041c0c308c0c8) | `` treewide: remove runtime fetch operations (#224) `` |