### PR TITLE
chore(flake/nur): `1dd57a39` -> `397ef4d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707302670,
-        "narHash": "sha256-0lGQHRfZiQRVTGURGmCmq/3s1Q2FRFE01R2t/yFXliI=",
+        "lastModified": 1707313542,
+        "narHash": "sha256-iSBYrruik+1I2KtYX+h1m58lsQCHIcXJho4esc2m9po=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1dd57a39f8db7ca6cff9696c9ccf543df15bc263",
+        "rev": "397ef4d149c587b19977209b0fbaaaf1c41edfb4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`397ef4d1`](https://github.com/nix-community/NUR/commit/397ef4d149c587b19977209b0fbaaaf1c41edfb4) | `` automatic update `` |
| [`4054c7e0`](https://github.com/nix-community/NUR/commit/4054c7e07150bac189d786c02d3cae13db151f56) | `` automatic update `` |
| [`b9b75c71`](https://github.com/nix-community/NUR/commit/b9b75c71c0f520d644a07be8bb9deb33a6129927) | `` automatic update `` |
| [`d47dbf43`](https://github.com/nix-community/NUR/commit/d47dbf43ced4485a2b05eb3430e85358b43f8dd1) | `` automatic update `` |