### PR TITLE
chore(flake/nur): `219c8acc` -> `f1ac582e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707316923,
-        "narHash": "sha256-YQ6xkQxUmU8WU0p8sXqTg6cQQUCPE35OJSbd3cTYStY=",
+        "lastModified": 1707324405,
+        "narHash": "sha256-I1P9QZ2Vzlwq4AoOALEd21Es6T5PB5hjzq4jyh8IZ/k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "219c8accacaaed12989564d4bf2f6b9a39532944",
+        "rev": "f1ac582e2c7bcaa1e9b7e5e7d96e546391ca9bca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f1ac582e`](https://github.com/nix-community/NUR/commit/f1ac582e2c7bcaa1e9b7e5e7d96e546391ca9bca) | `` automatic update `` |