### PR TITLE
chore(flake/nur): `f1ac582e` -> `63bd457d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707324405,
-        "narHash": "sha256-I1P9QZ2Vzlwq4AoOALEd21Es6T5PB5hjzq4jyh8IZ/k=",
+        "lastModified": 1707327949,
+        "narHash": "sha256-u7TQhJwoF5SFKw2ZJxN7RRDYdzDcMuswSEMEp7Sa2ic=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f1ac582e2c7bcaa1e9b7e5e7d96e546391ca9bca",
+        "rev": "63bd457df8b0a9e3dd32350ce908b411a8b548e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`63bd457d`](https://github.com/nix-community/NUR/commit/63bd457df8b0a9e3dd32350ce908b411a8b548e2) | `` automatic update `` |