### PR TITLE
chore(flake/nur): `63bd457d` -> `4d14dfd1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707327949,
-        "narHash": "sha256-u7TQhJwoF5SFKw2ZJxN7RRDYdzDcMuswSEMEp7Sa2ic=",
+        "lastModified": 1707330307,
+        "narHash": "sha256-kR7DeIy4C0XwR36X4O+98cjWK8S3jpPAopNDz+eDSgI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "63bd457df8b0a9e3dd32350ce908b411a8b548e2",
+        "rev": "4d14dfd1ee00acc4e2e38982c4b104dce2e64b30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4d14dfd1`](https://github.com/nix-community/NUR/commit/4d14dfd1ee00acc4e2e38982c4b104dce2e64b30) | `` automatic update `` |