### PR TITLE
chore(flake/nur): `111f701e` -> `0f0e4963`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707335096,
-        "narHash": "sha256-gRy/tMIRUtLXDxIcbYR+UF3AQBpHhFfBhEmuW1sz/js=",
+        "lastModified": 1707338730,
+        "narHash": "sha256-tGG+miyRgSZN1kIOL4Yffj0gVcMU0+SYyHTDY5PN280=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "111f701e9a6ab1612e561397c66310772370d909",
+        "rev": "0f0e49633ad3752a05c8e92864f013efc7c3c8bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0f0e4963`](https://github.com/nix-community/NUR/commit/0f0e49633ad3752a05c8e92864f013efc7c3c8bc) | `` automatic update `` |
| [`9c188633`](https://github.com/nix-community/NUR/commit/9c188633a9cbfd0c1c81b0a8212c8486a3f10a30) | `` automatic update `` |