### PR TITLE
chore(flake/srvos): `977371a1` -> `c5df91dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1028,11 +1028,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707160670,
-        "narHash": "sha256-svt/yQB8l/edU9yhYB78lIGKiaO7mXzUQvu/uJLZAVs=",
+        "lastModified": 1707353089,
+        "narHash": "sha256-4Y3K21dwnhJCJdo6b2W9Sbs2My4bTpiuHsAIEkz3Eac=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "977371a151fc3c96d6fac923b3032d07000e9490",
+        "rev": "c5df91ddcc76abfefe4adcda30a25ede8b761156",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`c5df91dd`](https://github.com/nix-community/srvos/commit/c5df91ddcc76abfefe4adcda30a25ede8b761156) | `` dev/private/flake.lock: Update `` |
| [`5f94856c`](https://github.com/nix-community/srvos/commit/5f94856ce20699a9aac971566172fb64f455b9ab) | `` flake.lock: Update ``             |