### PR TITLE
chore(flake/nur): `710b3dbf` -> `c43f3884`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707354351,
-        "narHash": "sha256-OJ6u8j9tU1I31YlvthvW7bYQSHlmEYq9XUVL+2yPrxE=",
+        "lastModified": 1707364539,
+        "narHash": "sha256-SrtMQ0RNqFBej6Tn/NNvd9XeI+d24PwWC2EeoIQPgEw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "710b3dbf99f137ced15844fc87ac403f8b2f7211",
+        "rev": "c43f38848aa78cc2e649cf0232589a4e25958773",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c43f3884`](https://github.com/nix-community/NUR/commit/c43f38848aa78cc2e649cf0232589a4e25958773) | `` automatic update `` |
| [`eb12e2c5`](https://github.com/nix-community/NUR/commit/eb12e2c5e8b9c099eff2098924c760ad941a573c) | `` automatic update `` |