### PR TITLE
chore(flake/nur): `c43f3884` -> `3154dd20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707364539,
-        "narHash": "sha256-SrtMQ0RNqFBej6Tn/NNvd9XeI+d24PwWC2EeoIQPgEw=",
+        "lastModified": 1707365339,
+        "narHash": "sha256-ygz/g98S5oVrD3NiDxzGjQ8YnvoE+XTXtx8GG1G2lwc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c43f38848aa78cc2e649cf0232589a4e25958773",
+        "rev": "3154dd2013a4a0f19cd62df84d344dff91ec88ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3154dd20`](https://github.com/nix-community/NUR/commit/3154dd2013a4a0f19cd62df84d344dff91ec88ae) | `` automatic update `` |