### PR TITLE
chore(flake/nur): `3154dd20` -> `aa75d9f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707365339,
-        "narHash": "sha256-ygz/g98S5oVrD3NiDxzGjQ8YnvoE+XTXtx8GG1G2lwc=",
+        "lastModified": 1707370884,
+        "narHash": "sha256-OuAhTqxJEi2fTO2hUuKVbLML+HNXCWYSXXX/uTRc6bI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3154dd2013a4a0f19cd62df84d344dff91ec88ae",
+        "rev": "aa75d9f3084a6c17dd0e4bef38be65df390a50b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aa75d9f3`](https://github.com/nix-community/NUR/commit/aa75d9f3084a6c17dd0e4bef38be65df390a50b9) | `` automatic update `` |
| [`cd811be5`](https://github.com/nix-community/NUR/commit/cd811be5d7985403afd5728ab6905d6ab3c5e15e) | `` automatic update `` |