### PR TITLE
chore(flake/nur): `aa75d9f3` -> `6cb13d15`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707370884,
-        "narHash": "sha256-OuAhTqxJEi2fTO2hUuKVbLML+HNXCWYSXXX/uTRc6bI=",
+        "lastModified": 1707374651,
+        "narHash": "sha256-DuSbzsvTPqU9pn07TsgJ2ZYyFRactFgV5IEazYdiuJo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aa75d9f3084a6c17dd0e4bef38be65df390a50b9",
+        "rev": "6cb13d15dd9b2b9ffb10e9d570233d3dcc36a71e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6cb13d15`](https://github.com/nix-community/NUR/commit/6cb13d15dd9b2b9ffb10e9d570233d3dcc36a71e) | `` automatic update `` |