### PR TITLE
chore(flake/nur): `6cb13d15` -> `20260b5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707374651,
-        "narHash": "sha256-DuSbzsvTPqU9pn07TsgJ2ZYyFRactFgV5IEazYdiuJo=",
+        "lastModified": 1707381565,
+        "narHash": "sha256-uvIk890e7TsYhenORzqKAfIMmJ2QNpTX6WL79rl5+Xk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6cb13d15dd9b2b9ffb10e9d570233d3dcc36a71e",
+        "rev": "20260b5a03e74c6d624e4b983e5b482a8ec1a0c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`20260b5a`](https://github.com/nix-community/NUR/commit/20260b5a03e74c6d624e4b983e5b482a8ec1a0c0) | `` automatic update `` |