### PR TITLE
chore(flake/nur): `20260b5a` -> `ba3d65ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707381565,
-        "narHash": "sha256-uvIk890e7TsYhenORzqKAfIMmJ2QNpTX6WL79rl5+Xk=",
+        "lastModified": 1707384186,
+        "narHash": "sha256-BhSK4Re5oHTsmu46n5K5lwhxQJu8coaXBPA/WPhSLss=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "20260b5a03e74c6d624e4b983e5b482a8ec1a0c0",
+        "rev": "ba3d65eeda258c1aa84ffdf897234e90cbbab47a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ba3d65ee`](https://github.com/nix-community/NUR/commit/ba3d65eeda258c1aa84ffdf897234e90cbbab47a) | `` automatic update `` |
| [`43365ed8`](https://github.com/nix-community/NUR/commit/43365ed82d355ed9d5578897c1a99652c5b09ad4) | `` automatic update `` |