### PR TITLE
chore(flake/nur): `cb959eeb` -> `f8f65fbd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707389964,
-        "narHash": "sha256-1wGwfFJDwPZ4tUvp8SO4TWntf4O8IzuO/aRsbRAeCIE=",
+        "lastModified": 1707392692,
+        "narHash": "sha256-LrCqwg3E+dU+8ar52FeklgD28qLkLJAf3OMxWQGnJ3M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cb959eeba711ab3fc17a388b572d64c5f193f1f7",
+        "rev": "f8f65fbd2e6fbf663f14f2f46c250f22bd86f3e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f8f65fbd`](https://github.com/nix-community/NUR/commit/f8f65fbd2e6fbf663f14f2f46c250f22bd86f3e9) | `` automatic update `` |