### PR TITLE
chore(flake/nur): `f8f65fbd` -> `6a29ce38`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707392692,
-        "narHash": "sha256-LrCqwg3E+dU+8ar52FeklgD28qLkLJAf3OMxWQGnJ3M=",
+        "lastModified": 1707396743,
+        "narHash": "sha256-w3m6sInarmQsfI/WPLULQmxapP/HA8lllNOhsJbYXis=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f8f65fbd2e6fbf663f14f2f46c250f22bd86f3e9",
+        "rev": "6a29ce382fb00c8501c511e5f973199bb58f8f18",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6a29ce38`](https://github.com/nix-community/NUR/commit/6a29ce382fb00c8501c511e5f973199bb58f8f18) | `` automatic update `` |