### PR TITLE
chore(flake/sops-nix): `23f61b89` -> `2168851d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -778,16 +778,16 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1705957679,
-        "narHash": "sha256-Q8LJaVZGJ9wo33wBafvZSzapYsjOaNjP/pOnSiKVGHY=",
+        "lastModified": 1707391491,
+        "narHash": "sha256-TyDXcq8Z3slMNeyeF+ke0BzISWuM6NrBklr7XyiRbZA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9a333eaa80901efe01df07eade2c16d183761fa3",
+        "rev": "bc6cb3d59b7aab88e967264254f8c1aa4c0284e9",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-23.05",
+        "ref": "release-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1007,11 +1007,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1707015547,
-        "narHash": "sha256-YZr0OrqWPdbwBhxpBu69D32ngJZw8AMgZtJeaJn0e94=",
+        "lastModified": 1707397511,
+        "narHash": "sha256-pYqXcTjcPC/go3FzT1dYtYsbmzAjO1MHhT/xgiI6J7o=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "23f61b897c00b66855074db471ba016e0cda20dd",
+        "rev": "2168851d58595431ee11ebfc3a49d60d318b7312",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                        |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`2168851d`](https://github.com/Mic92/sops-nix/commit/2168851d58595431ee11ebfc3a49d60d318b7312) | `` nixos-tests: drop < 23.11 compat code ``    |
| [`98aa76b7`](https://github.com/Mic92/sops-nix/commit/98aa76b72e06ce748e7498949e88d8d583b1b2de) | `` bump nixos-stable release ``                |
| [`00071af8`](https://github.com/Mic92/sops-nix/commit/00071af896e4e196bff530b2ed6aa9d22cc76825) | `` move secrets-fo-users to it's own module `` |