### PR TITLE
chore(flake/nur): `3ded5d19` -> `9621e2bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707399986,
-        "narHash": "sha256-bYG5VumgkDREZ98iXQOPzi79w0DX9WgO1cFr+dayeLo=",
+        "lastModified": 1707403461,
+        "narHash": "sha256-obSWLYqen4I/jArO04QLAKT2DZSLksCiskmeDRgS3bM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3ded5d1998d41ae456d6ff35238643205293ae3d",
+        "rev": "9621e2bfc47bbfe644c0f9f64b1aa44dec1f3afc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9621e2bf`](https://github.com/nix-community/NUR/commit/9621e2bfc47bbfe644c0f9f64b1aa44dec1f3afc) | `` automatic update `` |
| [`419d998d`](https://github.com/nix-community/NUR/commit/419d998dbab5c36dfc528dccffd6e53b55f9707a) | `` automatic update `` |