### PR TITLE
chore(flake/nur): `68729fe4` -> `445e7ee7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707406464,
-        "narHash": "sha256-/5l+pRJXUPGBpuANr2yBllyt6O3Kjxyema+7rHlrSTI=",
+        "lastModified": 1707417882,
+        "narHash": "sha256-p4i+PwyX1W5jZVhrbJgClkcbs+nD5bW/JOxfMUICc28=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "68729fe4b2511d27ad04e24148febca527ab9605",
+        "rev": "445e7ee7627e87a51fd1ba42f0407db8b2268d53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`445e7ee7`](https://github.com/nix-community/NUR/commit/445e7ee7627e87a51fd1ba42f0407db8b2268d53) | `` automatic update `` |
| [`ea7d727e`](https://github.com/nix-community/NUR/commit/ea7d727e716d983bc9fcace2f712dd86b08edc47) | `` automatic update `` |