### PR TITLE
chore(flake/nur): `445e7ee7` -> `59c3ac9c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707417882,
-        "narHash": "sha256-p4i+PwyX1W5jZVhrbJgClkcbs+nD5bW/JOxfMUICc28=",
+        "lastModified": 1707422362,
+        "narHash": "sha256-M6indfMkjEw6zwlps6rJtgfvVx1r/GZuH6PGMrZnoSs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "445e7ee7627e87a51fd1ba42f0407db8b2268d53",
+        "rev": "59c3ac9c9a0b8f34772ff32c2237c0524896f6c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`59c3ac9c`](https://github.com/nix-community/NUR/commit/59c3ac9c9a0b8f34772ff32c2237c0524896f6c3) | `` automatic update `` |