### PR TITLE
chore(flake/nur): `59c3ac9c` -> `dee5c587`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707422362,
-        "narHash": "sha256-M6indfMkjEw6zwlps6rJtgfvVx1r/GZuH6PGMrZnoSs=",
+        "lastModified": 1707425147,
+        "narHash": "sha256-fEbvk8EOVFhby7Z8hgfoWhfKhmpRHLtYVPtQSf3U4jY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "59c3ac9c9a0b8f34772ff32c2237c0524896f6c3",
+        "rev": "dee5c58753ebd74bf7434afc890689776ec2feee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dee5c587`](https://github.com/nix-community/NUR/commit/dee5c58753ebd74bf7434afc890689776ec2feee) | `` automatic update `` |