### PR TITLE
chore(flake/nur): `dee5c587` -> `c61e24b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707425147,
-        "narHash": "sha256-fEbvk8EOVFhby7Z8hgfoWhfKhmpRHLtYVPtQSf3U4jY=",
+        "lastModified": 1707426601,
+        "narHash": "sha256-+2rhVWgO8UhpIUY/qlPHH4aRIP0QpRZGidlBoCWwICI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dee5c58753ebd74bf7434afc890689776ec2feee",
+        "rev": "c61e24b9c003ca9db760173787e43927c8d87030",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c61e24b9`](https://github.com/nix-community/NUR/commit/c61e24b9c003ca9db760173787e43927c8d87030) | `` automatic update `` |