### PR TITLE
chore(flake/nur): `c61e24b9` -> `a61bebc1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707426601,
-        "narHash": "sha256-+2rhVWgO8UhpIUY/qlPHH4aRIP0QpRZGidlBoCWwICI=",
+        "lastModified": 1707430654,
+        "narHash": "sha256-98/HBsqc8Nmpe5Va4BWhb0fTAqdvEFoWyDTq+/WqFRc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c61e24b9c003ca9db760173787e43927c8d87030",
+        "rev": "a61bebc12b20c4ed92df1dd8b479c6f91ee40188",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a61bebc1`](https://github.com/nix-community/NUR/commit/a61bebc12b20c4ed92df1dd8b479c6f91ee40188) | `` automatic update `` |