### PR TITLE
chore(flake/nur): `a61bebc1` -> `a6dbfcbf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707430654,
-        "narHash": "sha256-98/HBsqc8Nmpe5Va4BWhb0fTAqdvEFoWyDTq+/WqFRc=",
+        "lastModified": 1707440758,
+        "narHash": "sha256-S2nx5HQvhwuVuSQNKR7eFSMG1julLfsZfmgci8CUMhM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a61bebc12b20c4ed92df1dd8b479c6f91ee40188",
+        "rev": "a6dbfcbf002cf6309002bef91f61f39fcf0bba73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a6dbfcbf`](https://github.com/nix-community/NUR/commit/a6dbfcbf002cf6309002bef91f61f39fcf0bba73) | `` automatic update `` |
| [`059c6787`](https://github.com/nix-community/NUR/commit/059c6787012ba8a4f48b2c621bcc88ea72997017) | `` automatic update `` |