### PR TITLE
chore(flake/nur): `a6dbfcbf` -> `b59a09d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707440758,
-        "narHash": "sha256-S2nx5HQvhwuVuSQNKR7eFSMG1julLfsZfmgci8CUMhM=",
+        "lastModified": 1707450673,
+        "narHash": "sha256-/78GQ68VGDYvdzQ5LjcV1lV7BAJc8sFLbZwswVFExco=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a6dbfcbf002cf6309002bef91f61f39fcf0bba73",
+        "rev": "b59a09d1e4fbfdbfb420580a83ed560b21a44a89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b59a09d1`](https://github.com/nix-community/NUR/commit/b59a09d1e4fbfdbfb420580a83ed560b21a44a89) | `` automatic update `` |
| [`44f236b5`](https://github.com/nix-community/NUR/commit/44f236b58e87ca17585ad066c5f21ee945e7d93a) | `` automatic update `` |