### PR TITLE
chore(flake/nur): `b59a09d1` -> `e2be520b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707450673,
-        "narHash": "sha256-/78GQ68VGDYvdzQ5LjcV1lV7BAJc8sFLbZwswVFExco=",
+        "lastModified": 1707451900,
+        "narHash": "sha256-CBHMdyRdfpyKvx5QIcQhshG2mO+lJT07BBuyhOscY1Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b59a09d1e4fbfdbfb420580a83ed560b21a44a89",
+        "rev": "e2be520b7c9df9d71525661c33d32ca8e4012fcb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e2be520b`](https://github.com/nix-community/NUR/commit/e2be520b7c9df9d71525661c33d32ca8e4012fcb) | `` automatic update `` |
| [`50edc276`](https://github.com/nix-community/NUR/commit/50edc276d561d0df01a3375f5a2d8e16eb1b2cf6) | `` automatic update `` |