### PR TITLE
chore(flake/nur): `ddc28098` -> `59c2f310`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707457460,
-        "narHash": "sha256-RO86kmBKUFl7dLfoI4aKx7zc3ZixF+NbB2oxdr2s5TQ=",
+        "lastModified": 1707461058,
+        "narHash": "sha256-kLGokdS+Gcv/soj96FB1g1CV7JVIrwdRmU+zTIjlQ0g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ddc28098837535e1204cf101f958680fb84aeffc",
+        "rev": "59c2f31018b7064bcb5634312dcc56dd94683adf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`59c2f310`](https://github.com/nix-community/NUR/commit/59c2f31018b7064bcb5634312dcc56dd94683adf) | `` automatic update `` |