### PR TITLE
chore(flake/nur): `59c2f310` -> `7bba799f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707461058,
-        "narHash": "sha256-kLGokdS+Gcv/soj96FB1g1CV7JVIrwdRmU+zTIjlQ0g=",
+        "lastModified": 1707465312,
+        "narHash": "sha256-w00s/Ynan1mDOhNm2pGw9bqq/Vqm2qCjRyTN4aB1Efo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "59c2f31018b7064bcb5634312dcc56dd94683adf",
+        "rev": "7bba799fc1b49a73d24e92b7ac559de9d34929e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7bba799f`](https://github.com/nix-community/NUR/commit/7bba799fc1b49a73d24e92b7ac559de9d34929e4) | `` automatic update `` |