### PR TITLE
chore(flake/nur): `7bba799f` -> `eed80d9c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707465312,
-        "narHash": "sha256-w00s/Ynan1mDOhNm2pGw9bqq/Vqm2qCjRyTN4aB1Efo=",
+        "lastModified": 1707468342,
+        "narHash": "sha256-iFnqobyChNcBzBtlh2CqwblQzF0qWVu2kO5n4vnPzFk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7bba799fc1b49a73d24e92b7ac559de9d34929e4",
+        "rev": "eed80d9c52a5b0c8c49ebe4a4cce8ca1803b56f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eed80d9c`](https://github.com/nix-community/NUR/commit/eed80d9c52a5b0c8c49ebe4a4cce8ca1803b56f1) | `` automatic update `` |