### PR TITLE
chore(flake/nur): `eed80d9c` -> `52078524`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707468342,
-        "narHash": "sha256-iFnqobyChNcBzBtlh2CqwblQzF0qWVu2kO5n4vnPzFk=",
+        "lastModified": 1707475479,
+        "narHash": "sha256-Ap2w/tDqnJd61gSRCYDaDKNua7pgWluygVryuGHB0tI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eed80d9c52a5b0c8c49ebe4a4cce8ca1803b56f1",
+        "rev": "52078524325fd8473f872cfb387b37d5790d318f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`52078524`](https://github.com/nix-community/NUR/commit/52078524325fd8473f872cfb387b37d5790d318f) | `` automatic update `` |