### PR TITLE
chore(flake/nur): `52078524` -> `15db5a23`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707475479,
-        "narHash": "sha256-Ap2w/tDqnJd61gSRCYDaDKNua7pgWluygVryuGHB0tI=",
+        "lastModified": 1707482166,
+        "narHash": "sha256-UO3Sh88CGwY9Aw7kcCZZ+RdFLRsYyX5atNYp3+7Vj+E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "52078524325fd8473f872cfb387b37d5790d318f",
+        "rev": "15db5a2314372dde84a47f016c22c5cc4c47082a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`15db5a23`](https://github.com/nix-community/NUR/commit/15db5a2314372dde84a47f016c22c5cc4c47082a) | `` automatic update `` |
| [`7ca8beef`](https://github.com/nix-community/NUR/commit/7ca8beef3ee2c0c7bde39375c4a4a478eebf782f) | `` automatic update `` |