### PR TITLE
chore(flake/nur): `7401f125` -> `2e13570e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707488227,
-        "narHash": "sha256-CJavI6VIk12u8mntxepDDinX2TX5et1I2phRm9mObtI=",
+        "lastModified": 1707500742,
+        "narHash": "sha256-rdJOiKeJfTD5iaJ/KVksDBo5lDUSvjcdxp/F/9Kzyvw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7401f12518027ed8ea1d8f7634a446ac3269c3c4",
+        "rev": "2e13570e2eb9164eae348f806bc6493c5d194a1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2e13570e`](https://github.com/nix-community/NUR/commit/2e13570e2eb9164eae348f806bc6493c5d194a1a) | `` automatic update `` |
| [`c5f8f80e`](https://github.com/nix-community/NUR/commit/c5f8f80e14293e269fe0f7aa98f04329eedfbe69) | `` automatic update `` |