### PR TITLE
chore(flake/nur): `2e13570e` -> `9d786404`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707500742,
-        "narHash": "sha256-rdJOiKeJfTD5iaJ/KVksDBo5lDUSvjcdxp/F/9Kzyvw=",
+        "lastModified": 1707503097,
+        "narHash": "sha256-Q4jk8SNl7FZyXYpBRzi0WdskBvgYobqj3w/WjW3aEFE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2e13570e2eb9164eae348f806bc6493c5d194a1a",
+        "rev": "9d78640429eedaffca63bf0b196bbc452e95523f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9d786404`](https://github.com/nix-community/NUR/commit/9d78640429eedaffca63bf0b196bbc452e95523f) | `` automatic update `` |