### PR TITLE
chore(flake/nur): `36487884` -> `6443c52d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707527174,
-        "narHash": "sha256-6L3ChHvOU/FygiLw2QzM7eFpYW0UDRka62/Ksy4iYU8=",
+        "lastModified": 1707540330,
+        "narHash": "sha256-g0ve9sueLOJaYHt8JUvtKpOo0+HGCvoZkiQnj5MkDR4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3648788428ce6da20158d1c704128bb517a34b4b",
+        "rev": "6443c52d5f126822b872442b43b7eb5efa13411b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6443c52d`](https://github.com/nix-community/NUR/commit/6443c52d5f126822b872442b43b7eb5efa13411b) | `` automatic update `` |
| [`eec3054b`](https://github.com/nix-community/NUR/commit/eec3054bb44714b45c2a89816d194648758dc9ed) | `` automatic update `` |