### PR TITLE
chore(flake/nur): `6443c52d` -> `896df0e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707540330,
-        "narHash": "sha256-g0ve9sueLOJaYHt8JUvtKpOo0+HGCvoZkiQnj5MkDR4=",
+        "lastModified": 1707543678,
+        "narHash": "sha256-sfflu+pBMQAru5ComWfZaUd87AZvE3iAIJ+Nw70fCHI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6443c52d5f126822b872442b43b7eb5efa13411b",
+        "rev": "896df0e4f5bbfc619c11d88881cc691a153b75b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`896df0e4`](https://github.com/nix-community/NUR/commit/896df0e4f5bbfc619c11d88881cc691a153b75b0) | `` automatic update `` |
| [`72e84ed7`](https://github.com/nix-community/NUR/commit/72e84ed764782d61c5cd6f08ef221f1e59cf50db) | `` automatic update `` |