### PR TITLE
chore(flake/nur): `896df0e4` -> `27ddd21e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707543678,
-        "narHash": "sha256-sfflu+pBMQAru5ComWfZaUd87AZvE3iAIJ+Nw70fCHI=",
+        "lastModified": 1707547546,
+        "narHash": "sha256-sqwWVBhPCqCYAEI00Jdva6dYwq/Hw+pdlHe1JeNNusc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "896df0e4f5bbfc619c11d88881cc691a153b75b0",
+        "rev": "27ddd21e02b78d7e29da520484745afc26bdc423",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`27ddd21e`](https://github.com/nix-community/NUR/commit/27ddd21e02b78d7e29da520484745afc26bdc423) | `` automatic update `` |