### PR TITLE
chore(flake/nur): `ecaddbc1` -> `8ee91739`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707549722,
-        "narHash": "sha256-oiUqhy3gUtyOsKljyujuD1qnTcHWyFXGcbIznjyiDSg=",
+        "lastModified": 1707553305,
+        "narHash": "sha256-c/LZCdsmP/V1tYITGk265VYJuFnzDTRCTjTuw6l6tlM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ecaddbc1aacd0f81bd9248a9184d6e1df90d29af",
+        "rev": "8ee9173918959d2f6a080163cce766a831395bfc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8ee91739`](https://github.com/nix-community/NUR/commit/8ee9173918959d2f6a080163cce766a831395bfc) | `` automatic update `` |
| [`9b627fcf`](https://github.com/nix-community/NUR/commit/9b627fcf736577ed07fd3f8294db9c01f64e4863) | `` automatic update `` |
| [`f1bcb540`](https://github.com/nix-community/NUR/commit/f1bcb540b8ae8bd8e6609b8475d8d55f1a57f52e) | `` automatic update `` |