### PR TITLE
chore(flake/nur): `d57ddfeb` -> `aaf38150`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707558329,
-        "narHash": "sha256-2y5G3E4fU3vzwWPhQjhy+JaSf3uJZoifq1dC5InNxUs=",
+        "lastModified": 1707562602,
+        "narHash": "sha256-/2Kwa1Evk7U3QdPYaBNkkkoJA5FYQ526UVBAlg/f5dI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d57ddfebbc4a97ff6b054f06d066020a4455f7e9",
+        "rev": "aaf38150714d016ade37f5f38112819ebb75c9a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aaf38150`](https://github.com/nix-community/NUR/commit/aaf38150714d016ade37f5f38112819ebb75c9a2) | `` automatic update `` |