### PR TITLE
chore(flake/nur): `aaf38150` -> `d52b9e3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707562602,
-        "narHash": "sha256-/2Kwa1Evk7U3QdPYaBNkkkoJA5FYQ526UVBAlg/f5dI=",
+        "lastModified": 1707565398,
+        "narHash": "sha256-cuNdIPwqo2LaOWxvmCeUb1I0UAGFavT8bvUf2O7eJVo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aaf38150714d016ade37f5f38112819ebb75c9a2",
+        "rev": "d52b9e3d55a8ec67a0fd08dce7a511a670d5d99a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d52b9e3d`](https://github.com/nix-community/NUR/commit/d52b9e3d55a8ec67a0fd08dce7a511a670d5d99a) | `` automatic update `` |