### PR TITLE
chore(flake/nur): `d52b9e3d` -> `4c94f025`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707565398,
-        "narHash": "sha256-cuNdIPwqo2LaOWxvmCeUb1I0UAGFavT8bvUf2O7eJVo=",
+        "lastModified": 1707576133,
+        "narHash": "sha256-+J9DNHvUfD+sVQ5j7sX+7YvOQbrtVPUUdcD+i5wHdJA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d52b9e3d55a8ec67a0fd08dce7a511a670d5d99a",
+        "rev": "4c94f0253e60c9071064ff23ad880a1cbeaff704",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4c94f025`](https://github.com/nix-community/NUR/commit/4c94f0253e60c9071064ff23ad880a1cbeaff704) | `` automatic update `` |