### PR TITLE
chore(flake/nur): `4c94f025` -> `2f014699`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707576133,
-        "narHash": "sha256-+J9DNHvUfD+sVQ5j7sX+7YvOQbrtVPUUdcD+i5wHdJA=",
+        "lastModified": 1707583450,
+        "narHash": "sha256-HEaczyxNnsjFPtoWZr/odx4jFRR/HQVpsYtIKokPQt4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4c94f0253e60c9071064ff23ad880a1cbeaff704",
+        "rev": "2f014699cc4a8b9f42b48c9d79f3a69654ae3501",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2f014699`](https://github.com/nix-community/NUR/commit/2f014699cc4a8b9f42b48c9d79f3a69654ae3501) | `` automatic update `` |