### PR TITLE
chore(flake/home-manager): `fb0196ad` -> `d1d6ca9b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -512,11 +512,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707602461,
-        "narHash": "sha256-bcorq66MMPqkrTwk25ywn4Q2I2jDeUAExL9ASH6I6mE=",
+        "lastModified": 1707605127,
+        "narHash": "sha256-H9IVX1ou6MugdLG7pDDc++UfFCvHUjdADpwvyFN4sh8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fb0196ad9d18554e035de27d4f2a906ba050b407",
+        "rev": "d1d6ca9b6552fc93032b76661c83061f1cd4e6e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`d1d6ca9b`](https://github.com/nix-community/home-manager/commit/d1d6ca9b6552fc93032b76661c83061f1cd4e6e8) | `` flake.lock: Update `` |