### PR TITLE
chore(flake/nur): `d744fce5` -> `7a15e8db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707594277,
-        "narHash": "sha256-cKmzWJWq3Jdb65cHNJBIkVNq/xws3XA1jbGRwg5Nn+I=",
+        "lastModified": 1707613500,
+        "narHash": "sha256-CglD2ca6VXD5hIHXHoCdWeOZDd0c92RV6KI/HOvyHp0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d744fce52b50d53a3bc77720125f281d6c682f37",
+        "rev": "7a15e8dbdfb1b70a28e8d549e2747a4e1242d895",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7a15e8db`](https://github.com/nix-community/NUR/commit/7a15e8dbdfb1b70a28e8d549e2747a4e1242d895) | `` automatic update `` |
| [`3a315bbd`](https://github.com/nix-community/NUR/commit/3a315bbd42ead8a1bafa90e8c3d14c43c80db912) | `` automatic update `` |
| [`a0e18535`](https://github.com/nix-community/NUR/commit/a0e185354efd1ef8701224bbe1fc68c532436dc1) | `` automatic update `` |