### PR TITLE
chore(flake/home-manager): `d1d6ca9b` -> `bfd0ae29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -512,11 +512,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707605127,
-        "narHash": "sha256-H9IVX1ou6MugdLG7pDDc++UfFCvHUjdADpwvyFN4sh8=",
+        "lastModified": 1707607386,
+        "narHash": "sha256-hj/RgQMTvCWQVInkZwiMMieumkfOjHXhtWhfuXHop/8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d1d6ca9b6552fc93032b76661c83061f1cd4e6e8",
+        "rev": "bfd0ae29a86eff4603098683b516c67e22184511",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`bfd0ae29`](https://github.com/nix-community/home-manager/commit/bfd0ae29a86eff4603098683b516c67e22184511) | `` emacs: use `overrideScope` instead of `overrideScope'` `` |