### PR TITLE
chore(flake/nur): `7a15e8db` -> `4acc83ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707613500,
-        "narHash": "sha256-CglD2ca6VXD5hIHXHoCdWeOZDd0c92RV6KI/HOvyHp0=",
+        "lastModified": 1707623086,
+        "narHash": "sha256-vM5/HYQQMib8HY/XvQwemozRPBrWPzjaXeTFWGiMLgs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7a15e8dbdfb1b70a28e8d549e2747a4e1242d895",
+        "rev": "4acc83adfbe8844fdab0b3cc916394c4391379ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4acc83ad`](https://github.com/nix-community/NUR/commit/4acc83adfbe8844fdab0b3cc916394c4391379ea) | `` automatic update `` |
| [`c4278232`](https://github.com/nix-community/NUR/commit/c4278232d6c9ca6db2e278fbb30eea245c429fa0) | `` automatic update `` |
| [`6238b1b1`](https://github.com/nix-community/NUR/commit/6238b1b15a953d7bdc10be948551610e297cceb1) | `` automatic update `` |