### PR TITLE
chore(flake/nur): `b1858530` -> `8097ddfa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707633935,
-        "narHash": "sha256-k7yox206JvOwOZwCcsk9qfgjO9A4+61+YYaf278ICs4=",
+        "lastModified": 1707637525,
+        "narHash": "sha256-lGAF0DFNpozP8k2GplHkNrOayP/tpRMCYzVnVDE9XKk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b1858530c4ecc35c6b6f29319d69aab2948a8912",
+        "rev": "8097ddfab1b83c26b2f828c069803e3ee6159bd8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8097ddfa`](https://github.com/nix-community/NUR/commit/8097ddfab1b83c26b2f828c069803e3ee6159bd8) | `` automatic update `` |
| [`7efd32ca`](https://github.com/nix-community/NUR/commit/7efd32ca3874101a3f16c06e5aade38153ca4fc7) | `` automatic update `` |