### PR TITLE
chore(flake/emacs-overlay): `ad4a3a32` -> `3c0112ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1707641519,
-        "narHash": "sha256-cZ7IwukSoufYGwFWrREgpQv3ucCfkKfGhYywCdLwDVs=",
+        "lastModified": 1707642416,
+        "narHash": "sha256-8bnjLSZbLOLQrPX4dWsf+BEX1UhN2SlCYM9CbIF0LE4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ad4a3a3271d161eedf9e85f851be60b8a361bcf2",
+        "rev": "3c0112ec21770085a50d24a899d1644bb238cfef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`3c0112ec`](https://github.com/nix-community/emacs-overlay/commit/3c0112ec21770085a50d24a899d1644bb238cfef) | `` Updated emacs `` |