### PR TITLE
chore(flake/nur): `8097ddfa` -> `c7fa9c6c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707637525,
-        "narHash": "sha256-lGAF0DFNpozP8k2GplHkNrOayP/tpRMCYzVnVDE9XKk=",
+        "lastModified": 1707648276,
+        "narHash": "sha256-KOU9ae22fglOXsOHCGYW25iFXnfnz2fSrUy75qfDyuA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8097ddfab1b83c26b2f828c069803e3ee6159bd8",
+        "rev": "c7fa9c6c3becdb8a330bf1202e009494a381ef32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c7fa9c6c`](https://github.com/nix-community/NUR/commit/c7fa9c6c3becdb8a330bf1202e009494a381ef32) | `` automatic update `` |