### PR TITLE
chore(flake/emacs-overlay): `3c0112ec` -> `d33b7a3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1707642416,
-        "narHash": "sha256-8bnjLSZbLOLQrPX4dWsf+BEX1UhN2SlCYM9CbIF0LE4=",
+        "lastModified": 1707670278,
+        "narHash": "sha256-htqAl4xLUywKPOfeg0bLT3gL7AGZxXY5EP9w/KofpFo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3c0112ec21770085a50d24a899d1644bb238cfef",
+        "rev": "d33b7a3d9b9b12e4da69f5539845cf872cc0f8b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d33b7a3d`](https://github.com/nix-community/emacs-overlay/commit/d33b7a3d9b9b12e4da69f5539845cf872cc0f8b3) | `` Updated melpa ``        |
| [`9a84e691`](https://github.com/nix-community/emacs-overlay/commit/9a84e691ce4df35ba795b2bbb1945d3139f45a9e) | `` Updated elpa ``         |
| [`d67fd9c9`](https://github.com/nix-community/emacs-overlay/commit/d67fd9c98f2694d771fb6b4f9390678683ccc064) | `` Updated flake inputs `` |