### PR TITLE
chore(flake/nur): `5ec9be8a` -> `60ef97da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707659083,
-        "narHash": "sha256-AACVGpkK3iPTKu2cPGD7Vdyx7UxwDZM+Ik//czpOuPk=",
+        "lastModified": 1707674071,
+        "narHash": "sha256-FazuDvMieRQnIUyaFosG3O38bCuNoqzshBM3wjxGDTw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5ec9be8abec9ab008486961c1c49f05774b8458c",
+        "rev": "60ef97da55cb8640cc646b66e6a51fac452c7202",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`60ef97da`](https://github.com/nix-community/NUR/commit/60ef97da55cb8640cc646b66e6a51fac452c7202) | `` automatic update `` |
| [`e8455970`](https://github.com/nix-community/NUR/commit/e84559701c5ad9e914a378cefbfbf7118c7e3666) | `` automatic update `` |
| [`4dca2c63`](https://github.com/nix-community/NUR/commit/4dca2c63b91e5f93bbdd62afb2860a35725b2a67) | `` automatic update `` |