### PR TITLE
chore(flake/nur): `6b338c8b` -> `37429213`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707680740,
-        "narHash": "sha256-+qM/nh6Opv8K7YOu5B4ZXpNxAdM0WjC5cmiqiYnSwQg=",
+        "lastModified": 1707687884,
+        "narHash": "sha256-rtMX1nJEw/SYYIbY6zAN6++GwZlMOUD24eOWovnD1Dk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6b338c8b0e0631d77b18d2535078c837264227a9",
+        "rev": "37429213accf748b9ccaaac4af5674119d9171b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`37429213`](https://github.com/nix-community/NUR/commit/37429213accf748b9ccaaac4af5674119d9171b6) | `` automatic update `` |
| [`73479b37`](https://github.com/nix-community/NUR/commit/73479b37282accecfc7f3f91e56a0b709f104ad2) | `` automatic update `` |