### PR TITLE
chore(flake/emacs-overlay): `6a029558` -> `f797cc93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1707672469,
-        "narHash": "sha256-VhbhOOI9P9TMMc/xjdPCvuU90fYN7v6flqPAJZjewUk=",
+        "lastModified": 1707702406,
+        "narHash": "sha256-7ez40hfgNhcrZr9EnG2U9twbjG6oiofc7bGzLLifBdA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6a029558e537f597a436ba36a7ffc28730ecb27e",
+        "rev": "f797cc93d86b19e5e007f6df584a12ce6a3cc7e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`f797cc93`](https://github.com/nix-community/emacs-overlay/commit/f797cc93d86b19e5e007f6df584a12ce6a3cc7e4) | `` Updated emacs `` |
| [`6bf6a11f`](https://github.com/nix-community/emacs-overlay/commit/6bf6a11f29c04046a7a60795a90ac4932b70caba) | `` Updated melpa `` |
| [`7cdc51cc`](https://github.com/nix-community/emacs-overlay/commit/7cdc51cc725dbbf25173d0a5517448572cf041fe) | `` Updated elpa ``  |