### PR TITLE
chore(flake/srvos): `c5df91dd` -> `e6f41dfe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1028,11 +1028,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707353089,
-        "narHash": "sha256-4Y3K21dwnhJCJdo6b2W9Sbs2My4bTpiuHsAIEkz3Eac=",
+        "lastModified": 1707699075,
+        "narHash": "sha256-Zzj9ZtnqgwRV9VjBYIAtfq315v3cXn+Cq6bgNB1ZjLQ=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "c5df91ddcc76abfefe4adcda30a25ede8b761156",
+        "rev": "e6f41dfe31ab8ae4cb1271ddd20d38c02f2222f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`e6f41dfe`](https://github.com/nix-community/srvos/commit/e6f41dfe31ab8ae4cb1271ddd20d38c02f2222f7) | `` dev/private/flake.lock: Update `` |
| [`b9f015dd`](https://github.com/nix-community/srvos/commit/b9f015ddbec81daf1ce09f9f204feab96c2fc6da) | `` flake.lock: Update ``             |