### PR TITLE
chore(flake/nur): `fece3b48` -> `a9077460`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707701846,
-        "narHash": "sha256-9ItDrTVXw4nJmMlUsl0DsCx4VcIHHnsm0IgfobIB5ME=",
+        "lastModified": 1707716004,
+        "narHash": "sha256-BmzNRarGISAELbphp75yXi5Dma7LrNsXUHiuk5Zk49c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fece3b48c569c4adb1a4e8a8956cf121e2df8437",
+        "rev": "a907746031a38749d38b02987d6ce950ab330bd1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a9077460`](https://github.com/nix-community/NUR/commit/a907746031a38749d38b02987d6ce950ab330bd1) | `` automatic update `` |
| [`34a6ec5d`](https://github.com/nix-community/NUR/commit/34a6ec5d3a223e31298326b5e384044d4aa599cc) | `` automatic update `` |
| [`135827c3`](https://github.com/nix-community/NUR/commit/135827c341c23db57ba6655f89100752c2d637ad) | `` automatic update `` |