### PR TITLE
chore(flake/emacs-overlay): `fc571589` -> `7e74ec81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1707728018,
-        "narHash": "sha256-gmvPj0UCgkaTOfW3DGCKmr4VTnIcRAtk8MLpjR61Lmw=",
+        "lastModified": 1707728884,
+        "narHash": "sha256-xkTiZifF9gO7FLmGQ9jmiTScPyc7Oy+xs7DktKpEfM4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fc57158935b23b709de7d74e023084ce6332e86d",
+        "rev": "7e74ec81680fff91bf07330c0e23d1b4c7aeb6af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`7e74ec81`](https://github.com/nix-community/emacs-overlay/commit/7e74ec81680fff91bf07330c0e23d1b4c7aeb6af) | `` Updated emacs `` |