### PR TITLE
chore(flake/nur): `744d76e1` -> `c3641e09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707724699,
-        "narHash": "sha256-5FT0Q2qXJRWhHYdiQ79jwr2JeeEjETo6NQ5hl0pKCSU=",
+        "lastModified": 1707729478,
+        "narHash": "sha256-2HMTWJIwsL6kvt53Jfi/35eliXt9UCSl87cmwxuMbGM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "744d76e115389e0729c2d5de9a678b4f3d55db53",
+        "rev": "c3641e09dbea9b64a331d5d8b5345dbda14ed42b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c3641e09`](https://github.com/nix-community/NUR/commit/c3641e09dbea9b64a331d5d8b5345dbda14ed42b) | `` automatic update `` |