### PR TITLE
chore(flake/nur): `c3641e09` -> `38d6c257`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707729478,
-        "narHash": "sha256-2HMTWJIwsL6kvt53Jfi/35eliXt9UCSl87cmwxuMbGM=",
+        "lastModified": 1707738334,
+        "narHash": "sha256-t9XjL0oF+ioe0JuX9cA96uXYchiPjmS0Rzbg2haf18c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c3641e09dbea9b64a331d5d8b5345dbda14ed42b",
+        "rev": "38d6c25795837df0476e7c3e940a3da595a50067",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`38d6c257`](https://github.com/nix-community/NUR/commit/38d6c25795837df0476e7c3e940a3da595a50067) | `` automatic update `` |
| [`c3a14371`](https://github.com/nix-community/NUR/commit/c3a1437116c490fa7b2d47253ac5d862005ba5db) | `` automatic update `` |