### PR TITLE
chore(flake/nur): `38d6c257` -> `8ffb7d2f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707738334,
-        "narHash": "sha256-t9XjL0oF+ioe0JuX9cA96uXYchiPjmS0Rzbg2haf18c=",
+        "lastModified": 1707742500,
+        "narHash": "sha256-KuL//Ml0h+IWlcuOce4HPJ4O/qexdAJbN2dBPmGBJck=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "38d6c25795837df0476e7c3e940a3da595a50067",
+        "rev": "8ffb7d2fe51b383e3c844d38cf48c4de8a35742f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8ffb7d2f`](https://github.com/nix-community/NUR/commit/8ffb7d2fe51b383e3c844d38cf48c4de8a35742f) | `` automatic update `` |
| [`26e9a8e4`](https://github.com/nix-community/NUR/commit/26e9a8e46faaf3c55cdfba0a9c7adcf90677d3fa) | `` automatic update `` |