### PR TITLE
chore(flake/nur): `8ffb7d2f` -> `835bffd3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707742500,
-        "narHash": "sha256-KuL//Ml0h+IWlcuOce4HPJ4O/qexdAJbN2dBPmGBJck=",
+        "lastModified": 1707744338,
+        "narHash": "sha256-giOjQA0hAjAWtDcqHHhHGHr5JxEhVBOy6PeA7voqWYQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8ffb7d2fe51b383e3c844d38cf48c4de8a35742f",
+        "rev": "835bffd3ca5761f73a60cee4fe0a328b81bbbd7d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`835bffd3`](https://github.com/nix-community/NUR/commit/835bffd3ca5761f73a60cee4fe0a328b81bbbd7d) | `` automatic update `` |