### PR TITLE
chore(flake/nur): `835bffd3` -> `4990bd96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707744338,
-        "narHash": "sha256-giOjQA0hAjAWtDcqHHhHGHr5JxEhVBOy6PeA7voqWYQ=",
+        "lastModified": 1707748413,
+        "narHash": "sha256-9N3yzStRJxEwli/2uV3gQcVSD+hXOF4T6MkL3DGQCus=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "835bffd3ca5761f73a60cee4fe0a328b81bbbd7d",
+        "rev": "4990bd96a1e0102ff1354f317cd19cc4b4c08c42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4990bd96`](https://github.com/nix-community/NUR/commit/4990bd96a1e0102ff1354f317cd19cc4b4c08c42) | `` automatic update `` |