### PR TITLE
chore(flake/emacs-overlay): `7e74ec81` -> `78207864`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1707728884,
-        "narHash": "sha256-xkTiZifF9gO7FLmGQ9jmiTScPyc7Oy+xs7DktKpEfM4=",
+        "lastModified": 1707757580,
+        "narHash": "sha256-kBOoyBu5Z9ip/iRUFmzGhEy1RIfwxiPRv3HkHOD75Oc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7e74ec81680fff91bf07330c0e23d1b4c7aeb6af",
+        "rev": "78207864349fb13b7ffd9445d2e0566376e3b738",
         "type": "github"
       },
       "original": {
@@ -746,11 +746,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1707514827,
-        "narHash": "sha256-Y+wqFkvikpE1epCx57PsGw+M1hX5aY5q/xgk+ebDwxI=",
+        "lastModified": 1707650010,
+        "narHash": "sha256-dOhphIA4MGrH4ElNCy/OlwmN24MsnEqFjRR6+RY7jZw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "20f65b86b6485decb43c5498780c223571dd56ef",
+        "rev": "809cca784b9f72a5ad4b991e0e7bcf8890f9c3a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`78207864`](https://github.com/nix-community/emacs-overlay/commit/78207864349fb13b7ffd9445d2e0566376e3b738) | `` Updated emacs ``        |
| [`dd946433`](https://github.com/nix-community/emacs-overlay/commit/dd946433ce801fab90088ceb499c2490ec97417c) | `` Updated melpa ``        |
| [`e830065f`](https://github.com/nix-community/emacs-overlay/commit/e830065f1f726fe3d8fffe641939ad66b9237f89) | `` Updated elpa ``         |
| [`12f6e2ea`](https://github.com/nix-community/emacs-overlay/commit/12f6e2ea14f50b96ff1de2d0e4e5d809f014a924) | `` Updated flake inputs `` |