### PR TITLE
chore(flake/stylix): `aca2d28f` -> `50cae37c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1064,11 +1064,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707685931,
-        "narHash": "sha256-Zjdfj7FUkA50yOyy9ZQDqrwHmiCEbQN9gyeriGB6078=",
+        "lastModified": 1707757489,
+        "narHash": "sha256-YyqHbxtDGB3OIITPQ3XtkM20fh9/t4CXkYXKzg9DuP8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "aca2d28f08e71bdd14192c3b20fb4df768ae1240",
+        "rev": "50cae37cfe23e5ad202ed53f48529139dfa0d008",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                 |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`50cae37c`](https://github.com/danth/stylix/commit/50cae37cfe23e5ad202ed53f48529139dfa0d008) | `` gnome: rename `overrideScope'` to `overrideScope` `` |