### PR TITLE
chore(flake/nur): `e3d440d5` -> `89c17529`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707767060,
-        "narHash": "sha256-Tqq2XNGLlcPs0zdCJScBMPvisNoV1TwKJNy/B2Nakl8=",
+        "lastModified": 1707774347,
+        "narHash": "sha256-Z/RjZ6WCO/ZKhxN5Lz6Pb9cIoJWqxcHixttbnPssVzw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e3d440d55073b3fcf5003b4ef27241f668e4a972",
+        "rev": "89c1752919eb4615b35db22557a10b3ac5aedc00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`89c17529`](https://github.com/nix-community/NUR/commit/89c1752919eb4615b35db22557a10b3ac5aedc00) | `` automatic update `` |
| [`c82ebd04`](https://github.com/nix-community/NUR/commit/c82ebd0408ea922b3ac48961cbad797319e2b9e5) | `` automatic update `` |
| [`e2395575`](https://github.com/nix-community/NUR/commit/e2395575d2912b95a27d116e527a1ee2812d8692) | `` automatic update `` |