### PR TITLE
chore(flake/emacs-overlay): `78207864` -> `bf9f1098`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1707757580,
-        "narHash": "sha256-kBOoyBu5Z9ip/iRUFmzGhEy1RIfwxiPRv3HkHOD75Oc=",
+        "lastModified": 1707788819,
+        "narHash": "sha256-BmQusFAhA+XUcETzgJg0MxksKjtSdkpNxRlMfSRHZG8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "78207864349fb13b7ffd9445d2e0566376e3b738",
+        "rev": "bf9f1098a348303e6eee96f02fc965531d86d984",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`bf9f1098`](https://github.com/nix-community/emacs-overlay/commit/bf9f1098a348303e6eee96f02fc965531d86d984) | `` Updated emacs ``  |
| [`b33b514d`](https://github.com/nix-community/emacs-overlay/commit/b33b514df08dfc133f2ca5d43fcfbdb67f85fc1c) | `` Updated melpa ``  |
| [`ab891678`](https://github.com/nix-community/emacs-overlay/commit/ab89167867bba167b6e6c4f545952a7f74410bb2) | `` Updated elpa ``   |
| [`5e48f3ea`](https://github.com/nix-community/emacs-overlay/commit/5e48f3eafb4cccf45c30047bb2f27b6a4a02b52f) | `` Updated nongnu `` |