### PR TITLE
chore(flake/nur): `42b2f038` -> `cc2cac41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707788142,
-        "narHash": "sha256-gJV6EjKByRNPujG9ks20cnyW8M/HoxCPYoOdfBpQP+Q=",
+        "lastModified": 1707795929,
+        "narHash": "sha256-B+/2gIL8PMz9oLSduyJzDZsk+4WIXwDFpr9l37WqOWo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "42b2f0389e0f4fe9e41c20528e9afff8f0124e41",
+        "rev": "cc2cac415909790218b873720a74d7e95fa4e0ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cc2cac41`](https://github.com/nix-community/NUR/commit/cc2cac415909790218b873720a74d7e95fa4e0ea) | `` automatic update `` |