### PR TITLE
chore(flake/nur): `cc2cac41` -> `e6708f99`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707795929,
-        "narHash": "sha256-B+/2gIL8PMz9oLSduyJzDZsk+4WIXwDFpr9l37WqOWo=",
+        "lastModified": 1707799474,
+        "narHash": "sha256-kvn6J8CxdmnfHkkjhD2ZdyZ9GyiXSykieRj9ToWycNo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cc2cac415909790218b873720a74d7e95fa4e0ea",
+        "rev": "e6708f99c724920c27a9a8ebefa277ab8669aab2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e6708f99`](https://github.com/nix-community/NUR/commit/e6708f99c724920c27a9a8ebefa277ab8669aab2) | `` automatic update `` |
| [`8e791f2d`](https://github.com/nix-community/NUR/commit/8e791f2d764320a89a651ca78ad0dbbaeaca144f) | `` automatic update `` |