### PR TITLE
chore(flake/emacs-overlay): `70266acb` -> `0f7f3b39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1707814433,
-        "narHash": "sha256-bgHVG2RLIK8VjnleL/vtWvnhzIcWGZaDKSh8jC1PqYs=",
+        "lastModified": 1707815184,
+        "narHash": "sha256-WFoDXgaPdhjgQB3ut+ZN+VT7e60Yw+KUyvUkOSu5Wto=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "70266acb2bbfd9be21988aee89efab767d00913d",
+        "rev": "0f7f3b39157419f3035a2dad39fbaf8a4ba0448d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`0f7f3b39`](https://github.com/nix-community/emacs-overlay/commit/0f7f3b39157419f3035a2dad39fbaf8a4ba0448d) | `` Updated emacs `` |