### PR TITLE
chore(flake/nur): `4350cd5e` -> `056feb1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707806658,
-        "narHash": "sha256-Lh4hqUt47vFipedNBdv+JGoIGhJT5Ls7l2Dqf1QnF3A=",
+        "lastModified": 1707816531,
+        "narHash": "sha256-Jt2ebbDWLCqZD1L4gZMZYnvNcKeWoS1zYWRfOVKt74k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4350cd5ea70e50e041ce61bd67cb04b43dc514a3",
+        "rev": "056feb1c831d61bf6635824876828e56a7fe81ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`056feb1c`](https://github.com/nix-community/NUR/commit/056feb1c831d61bf6635824876828e56a7fe81ab) | `` automatic update `` |