### PR TITLE
chore(flake/nixos-hardware): `6e5cc385` -> `2b68ccd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -683,11 +683,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1707211557,
-        "narHash": "sha256-LTKTzZ6fM5j8XWXf51IMBzDaOaJg9kYWLUZxoIhzRN8=",
+        "lastModified": 1707821782,
+        "narHash": "sha256-j5fSpKvEUNkELEQXnQbJHGa5QI7ChbMqWMsyUjc/Bo8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "6e5cc385fc8cf5ca6495d70243074ccdea9f64c7",
+        "rev": "2b68ccd7475362b8c8d6a1805b403033ba6273a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`2b68ccd7`](https://github.com/NixOS/nixos-hardware/commit/2b68ccd7475362b8c8d6a1805b403033ba6273a8) | `` gpd-win-max-2-2023: enable iio subsystem ``                           |
| [`c1db24a1`](https://github.com/NixOS/nixos-hardware/commit/c1db24a14b17b49d0d57096831ed6b469ea2ab4a) | `` gpd-win-max-2-2023: init BMI260  driver ``                            |
| [`d1117dcf`](https://github.com/NixOS/nixos-hardware/commit/d1117dcf09907ffc92b49a2db2bc5bad2bb95076) | `` gpd-win-man-2-2023: init README ``                                    |
| [`61d602f4`](https://github.com/NixOS/nixos-hardware/commit/61d602f428c28208a91d3c1ff00e60576fc40e3f) | `` gpd-win-max-2-2023: remove udev rule disabling PCI wakeup ``          |
| [`7220f26a`](https://github.com/NixOS/nixos-hardware/commit/7220f26a7c09c8b9c18a3703e4724d7c9ab32fea) | `` Missed a curly bracket ``                                             |
| [`8be74baa`](https://github.com/NixOS/nixos-hardware/commit/8be74baad009dde11fd70b0d0e9d390331c2adbe) | `` Fix audio interference in headphone jack on Thinkpad x1 Nano Gen 1 `` |