### PR TITLE
chore(flake/nur): `056feb1c` -> `be990e92`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707816531,
-        "narHash": "sha256-Jt2ebbDWLCqZD1L4gZMZYnvNcKeWoS1zYWRfOVKt74k=",
+        "lastModified": 1707828757,
+        "narHash": "sha256-CipfbcHon7SM2kc8DBk66EpxSjjC+C5XF/m60q2ofM0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "056feb1c831d61bf6635824876828e56a7fe81ab",
+        "rev": "be990e92c190dc8390897b98c1dfc13274a5321d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`be990e92`](https://github.com/nix-community/NUR/commit/be990e92c190dc8390897b98c1dfc13274a5321d) | `` automatic update `` |
| [`c8a49afe`](https://github.com/nix-community/NUR/commit/c8a49afeed5ab5ee819e10b53ed46dbda5516aa8) | `` automatic update `` |
| [`202b1d62`](https://github.com/nix-community/NUR/commit/202b1d62a55d01aa3e1eb474a989df291718fd71) | `` automatic update `` |