### PR TITLE
chore(flake/nur): `be990e92` -> `38411021`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707828757,
-        "narHash": "sha256-CipfbcHon7SM2kc8DBk66EpxSjjC+C5XF/m60q2ofM0=",
+        "lastModified": 1707835305,
+        "narHash": "sha256-kfIM9MCvanWTgyThNp9jDrFYzeK2mqP2GC7lTO4VoQQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "be990e92c190dc8390897b98c1dfc13274a5321d",
+        "rev": "38411021532bd70fb7b761d3485d3fae0d30d559",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`38411021`](https://github.com/nix-community/NUR/commit/38411021532bd70fb7b761d3485d3fae0d30d559) | `` automatic update `` |
| [`f17a0504`](https://github.com/nix-community/NUR/commit/f17a0504887729ba9a1f2871db8f6b35e937d17c) | `` automatic update `` |