### PR TITLE
chore(flake/emacs-overlay): `0f7f3b39` -> `1c9b038a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1707815184,
-        "narHash": "sha256-WFoDXgaPdhjgQB3ut+ZN+VT7e60Yw+KUyvUkOSu5Wto=",
+        "lastModified": 1707843995,
+        "narHash": "sha256-ZL4J9hZNAYNoh+CaZqmH1spry1HzqzN9FsBobW/yPzM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0f7f3b39157419f3035a2dad39fbaf8a4ba0448d",
+        "rev": "1c9b038a329736e444cabffb0e473642458a9858",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`1c9b038a`](https://github.com/nix-community/emacs-overlay/commit/1c9b038a329736e444cabffb0e473642458a9858) | `` Updated emacs `` |
| [`6af2cc79`](https://github.com/nix-community/emacs-overlay/commit/6af2cc7983267b08387630f0da8eac3b55482bc5) | `` Updated melpa `` |
| [`376f5e10`](https://github.com/nix-community/emacs-overlay/commit/376f5e107de8e95d6decd185682c6deeef6ccbf5) | `` Updated elpa ``  |