### PR TITLE
chore(flake/sops-nix): `695275c3` -> `48afd326`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1007,11 +1007,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1707748232,
-        "narHash": "sha256-o9L8jrOemQl/5cYp++0cWdfMLzVljCdHwPFF4N0KZeQ=",
+        "lastModified": 1707842202,
+        "narHash": "sha256-3dTBbCzHJBinwhsisGJHW1HLBsLbj91+a5ZDXt7ttW0=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "695275c349bb27f91b2b06cb742510899c887b81",
+        "rev": "48afd3264ec52bee85231a7122612e2c5202fa74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                    |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`48afd326`](https://github.com/Mic92/sops-nix/commit/48afd3264ec52bee85231a7122612e2c5202fa74) | `` home-manager/darwin: run sops-nix-user _once_ on login or activation `` |