### PR TITLE
chore(flake/nur): `b41ad07a` -> `26ae54f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707842751,
-        "narHash": "sha256-MBXtmsWqkBiThMMASebc1l6JrqgZ8E8cx13FyOxNBUM=",
+        "lastModified": 1707853532,
+        "narHash": "sha256-ioduK+UsEs8YGYB/ZvVObvBXJHU5dgk1wEf5XPgxzsE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b41ad07abb6e0b062bbb12d14a5bf0b0d7ffb6c8",
+        "rev": "26ae54f21cacae653cf9561c9afe5ba9496e80b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`26ae54f2`](https://github.com/nix-community/NUR/commit/26ae54f21cacae653cf9561c9afe5ba9496e80b6) | `` automatic update `` |
| [`9c0e71b2`](https://github.com/nix-community/NUR/commit/9c0e71b2416828e1305b4846e51011d88e6551e5) | `` automatic update `` |