### PR TITLE
chore(flake/nur): `b8f58824` -> `bb1b8093`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707864306,
-        "narHash": "sha256-Z7+NvNX48QEZ4ubmxvy+RYYG8x/Axow1FAn3pmbudOU=",
+        "lastModified": 1707874634,
+        "narHash": "sha256-JVj91PhZVTxp39SgZekFrzFIFXxjws0+MedXliCzXPw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b8f58824a8b5e2c4e4d5ffa51739f23e021935a5",
+        "rev": "bb1b80932f0d5d34624d4d1260071cc9ef88dedc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bb1b8093`](https://github.com/nix-community/NUR/commit/bb1b80932f0d5d34624d4d1260071cc9ef88dedc) | `` automatic update `` |
| [`8eebb200`](https://github.com/nix-community/NUR/commit/8eebb20097ee19431d6ac6b2c36a95e38ed57188) | `` automatic update `` |