### PR TITLE
chore(flake/emacs-overlay): `31b87a76` -> `97d761e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1707872254,
-        "narHash": "sha256-af+h/H5wPYDLI0wvs2VzlGnotzXSD6VZZJrEqWvKQuQ=",
+        "lastModified": 1707875136,
+        "narHash": "sha256-yAr93pKdsWThVcgtXOw1/wRAKBfMrijEMLCHSTccSsc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "31b87a760714d848938827be5d53d6bf79d2caaa",
+        "rev": "97d761e40d1f82a982274fcdbef90c4316669052",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`97d761e4`](https://github.com/nix-community/emacs-overlay/commit/97d761e40d1f82a982274fcdbef90c4316669052) | `` Updated emacs `` |
| [`385de3ad`](https://github.com/nix-community/emacs-overlay/commit/385de3ad948bc01498b692a809f589a158bde91f) | `` Updated melpa `` |