### PR TITLE
chore(flake/nur): `bb1b8093` -> `27e450f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707874634,
-        "narHash": "sha256-JVj91PhZVTxp39SgZekFrzFIFXxjws0+MedXliCzXPw=",
+        "lastModified": 1707882200,
+        "narHash": "sha256-a/npCDRzRudYP4z+hj2W9dCdy8jC0TNyDLytXJE52is=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bb1b80932f0d5d34624d4d1260071cc9ef88dedc",
+        "rev": "27e450f536763feaf4bfe41ff3f0a83a2804cf5c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`27e450f5`](https://github.com/nix-community/NUR/commit/27e450f536763feaf4bfe41ff3f0a83a2804cf5c) | `` automatic update `` |