### PR TITLE
chore(flake/nur): `27e450f5` -> `c91eaea9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707882200,
-        "narHash": "sha256-a/npCDRzRudYP4z+hj2W9dCdy8jC0TNyDLytXJE52is=",
+        "lastModified": 1707883577,
+        "narHash": "sha256-oyONVK/00fIWC9YwfLISkKwvGvfFTOrV2z5OgK7aqyQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "27e450f536763feaf4bfe41ff3f0a83a2804cf5c",
+        "rev": "c91eaea9542b47725232e008fd0b7d762f852286",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c91eaea9`](https://github.com/nix-community/NUR/commit/c91eaea9542b47725232e008fd0b7d762f852286) | `` automatic update `` |