### PR TITLE
chore(flake/nur): `c91eaea9` -> `0e46a94c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707883577,
-        "narHash": "sha256-oyONVK/00fIWC9YwfLISkKwvGvfFTOrV2z5OgK7aqyQ=",
+        "lastModified": 1707889273,
+        "narHash": "sha256-SwGuNmBCwWDgKYfpOTJBr0L+Debnfqk/J65f5pBB6dg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c91eaea9542b47725232e008fd0b7d762f852286",
+        "rev": "0e46a94c5b5e29ff1f62d78bcb595a3fcba4ecf3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0e46a94c`](https://github.com/nix-community/NUR/commit/0e46a94c5b5e29ff1f62d78bcb595a3fcba4ecf3) | `` automatic update `` |