### PR TITLE
chore(flake/nur): `0e46a94c` -> `53747802`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707889273,
-        "narHash": "sha256-SwGuNmBCwWDgKYfpOTJBr0L+Debnfqk/J65f5pBB6dg=",
+        "lastModified": 1707893073,
+        "narHash": "sha256-t9paHowMi3BAnB8vLVy49xOZQuBSDc2GfnJjD33bP0Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0e46a94c5b5e29ff1f62d78bcb595a3fcba4ecf3",
+        "rev": "537478022fa6267cc9dc6d5b25a2a1e3fa06f48d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`53747802`](https://github.com/nix-community/NUR/commit/537478022fa6267cc9dc6d5b25a2a1e3fa06f48d) | `` automatic update `` |
| [`aa59c0f6`](https://github.com/nix-community/NUR/commit/aa59c0f62204dedf092ee8a46311a659ea010ea2) | `` automatic update `` |