### PR TITLE
chore(flake/emacs-overlay): `97d761e4` -> `b40877f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1707875136,
-        "narHash": "sha256-yAr93pKdsWThVcgtXOw1/wRAKBfMrijEMLCHSTccSsc=",
+        "lastModified": 1707898540,
+        "narHash": "sha256-jbcSmuJSiI6DMR91w8VbVYZUUi/Fujv/ZZiguwD2Wqc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "97d761e40d1f82a982274fcdbef90c4316669052",
+        "rev": "b40877f8ce5a3c4720e6d1e965bd65d9e9e1be3c",
         "type": "github"
       },
       "original": {
@@ -746,11 +746,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1707650010,
-        "narHash": "sha256-dOhphIA4MGrH4ElNCy/OlwmN24MsnEqFjRR6+RY7jZw=",
+        "lastModified": 1707786466,
+        "narHash": "sha256-yLPfrmW87M2qt+8bAmwopJawa+MJLh3M9rUbXtpUc1o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "809cca784b9f72a5ad4b991e0e7bcf8890f9c3a6",
+        "rev": "01885a071465e223f8f68971f864b15829988504",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b40877f8`](https://github.com/nix-community/emacs-overlay/commit/b40877f8ce5a3c4720e6d1e965bd65d9e9e1be3c) | `` Updated flake inputs `` |