### PR TITLE
chore(flake/home-manager): `21b07830` -> `354643e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -512,11 +512,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707683400,
-        "narHash": "sha256-Zc+J3UO1Xpx+NL8UB6woPHyttEy9cXXtm+0uWwzuYDc=",
+        "lastModified": 1707918247,
+        "narHash": "sha256-DtbG6B0834ItVWfyleP/vSam+PkK9Ve1c7bWyC8IWmk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "21b078306a2ab68748abf72650db313d646cf2ca",
+        "rev": "354643e6c1ce0762d498e5e676e7970922c89208",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                               |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`354643e6`](https://github.com/nix-community/home-manager/commit/354643e6c1ce0762d498e5e676e7970922c89208) | `` neomutt: fix tests ``              |
| [`157bf712`](https://github.com/nix-community/home-manager/commit/157bf71277c92dfc4691e5e1eb88db94043e3865) | `` mpv: create doc output in tests `` |