### PR TITLE
chore(flake/home-manager): `354643e6` -> `043ba285`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -512,11 +512,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707918247,
-        "narHash": "sha256-DtbG6B0834ItVWfyleP/vSam+PkK9Ve1c7bWyC8IWmk=",
+        "lastModified": 1707919853,
+        "narHash": "sha256-qxmBGDzutuJ/tsX4gp+Mr7fjxOZBbeT9ixhS5o4iFOw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "354643e6c1ce0762d498e5e676e7970922c89208",
+        "rev": "043ba285c6dc20f36441d48525402bcb9743c498",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`043ba285`](https://github.com/nix-community/home-manager/commit/043ba285c6dc20f36441d48525402bcb9743c498) | `` tests: add basic integration tests ``                 |
| [`7889bfb4`](https://github.com/nix-community/home-manager/commit/7889bfb4752b27c83c8ae9ca45f63b77fff7ef7b) | `` home-manager: overrideable URLs in generated flake `` |