### PR TITLE
chore(flake/emacs-overlay): `763c614a` -> `e42410cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1707901582,
-        "narHash": "sha256-/u7TGrMRoT/h360iHThg1cumIJ9l2+xw51w4qi+cgFA=",
+        "lastModified": 1707929524,
+        "narHash": "sha256-2162f6C6UKHbhyokH4Z5uTyPmJ35oAM7Tm7+mVzq6PY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "763c614a4cce4296941b44dece54390dd108b781",
+        "rev": "e42410cb62a21e0f39051ea76beaac7175ef8ede",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`e42410cb`](https://github.com/nix-community/emacs-overlay/commit/e42410cb62a21e0f39051ea76beaac7175ef8ede) | `` Updated melpa ``  |
| [`b69808ce`](https://github.com/nix-community/emacs-overlay/commit/b69808ceea4367b7826d4045958d3e556365d3f4) | `` Updated elpa ``   |
| [`7e59721f`](https://github.com/nix-community/emacs-overlay/commit/7e59721f8aef4297683eae683c6883ca08957d0a) | `` Updated nongnu `` |