### PR TITLE
chore(flake/emacs-overlay): `e42410cb` -> `9327b7e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1707929524,
-        "narHash": "sha256-2162f6C6UKHbhyokH4Z5uTyPmJ35oAM7Tm7+mVzq6PY=",
+        "lastModified": 1707930447,
+        "narHash": "sha256-NDkHiMa4+DfLwLo28D9nxNzCVYBitwLZzlcSTUua5JY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e42410cb62a21e0f39051ea76beaac7175ef8ede",
+        "rev": "9327b7e16a991c8a2efbad729ac28452d7c40bf0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`9327b7e1`](https://github.com/nix-community/emacs-overlay/commit/9327b7e16a991c8a2efbad729ac28452d7c40bf0) | `` Updated emacs `` |