### PR TITLE
chore(flake/nur): `20df301a` -> `31ddfee2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707932925,
-        "narHash": "sha256-o1XWEc8gOHijkNYnUB39VFWlArsikw4jZGzMXBcxR9g=",
+        "lastModified": 1707940784,
+        "narHash": "sha256-5RxdbwiPK9S2nWwKgCnlhw8ZNvSHHBtpdr/54lI1ruU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "20df301a3354bdb93e10b05ff38bcc9b4d13744d",
+        "rev": "31ddfee271a852372d2c86883c01702ffdb71894",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`31ddfee2`](https://github.com/nix-community/NUR/commit/31ddfee271a852372d2c86883c01702ffdb71894) | `` automatic update `` |
| [`a7a4edf2`](https://github.com/nix-community/NUR/commit/a7a4edf2773f836746db68bc426a5d12bab2faa9) | `` automatic update `` |
| [`0a0af4ae`](https://github.com/nix-community/NUR/commit/0a0af4ae70f79b5c68cf3f706b9e465ed40fbee6) | `` automatic update `` |