### PR TITLE
chore(flake/nur): `31ddfee2` -> `93b2f73b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707940784,
-        "narHash": "sha256-5RxdbwiPK9S2nWwKgCnlhw8ZNvSHHBtpdr/54lI1ruU=",
+        "lastModified": 1707943450,
+        "narHash": "sha256-7lS1d7vOtdFiAHDNeJ5mHEQFDeG6/pD3A5LMm1+9sGU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "31ddfee271a852372d2c86883c01702ffdb71894",
+        "rev": "93b2f73bfc0eba78d3e4e22aac849a4c6f8f1114",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`93b2f73b`](https://github.com/nix-community/NUR/commit/93b2f73bfc0eba78d3e4e22aac849a4c6f8f1114) | `` automatic update `` |