### PR TITLE
chore(flake/nix-on-droid): `039379ab` -> `82b4cd68`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -668,11 +668,11 @@
         "nmd": "nmd_2"
       },
       "locked": {
-        "lastModified": 1694604941,
-        "narHash": "sha256-KsoRStRs8dNRRMWQhuB3eUOpzQhOc4dcBQB85tEq3wY=",
+        "lastModified": 1707944604,
+        "narHash": "sha256-WDWbfzOfvau5AlkfMlv1li2Fx3siYdVUN0IxWZCD07g=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "039379abeee67144d4094d80bbdaf183fb2eabe5",
+        "rev": "82b4cd68fc6f354c2003e68e937e683dd5159ec1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                              |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`82b4cd68`](https://github.com/nix-community/nix-on-droid/commit/82b4cd68fc6f354c2003e68e937e683dd5159ec1) | `` nix-on-droid.nix.default: switch to nix-community/home-manager `` |
| [`7390acee`](https://github.com/nix-community/nix-on-droid/commit/7390acee6dad869a2d2d17aa75466232365274c5) | `` Update README.md ``                                               |