### PR TITLE
chore(flake/nur): `93b2f73b` -> `d94f513b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707943450,
-        "narHash": "sha256-7lS1d7vOtdFiAHDNeJ5mHEQFDeG6/pD3A5LMm1+9sGU=",
+        "lastModified": 1707948729,
+        "narHash": "sha256-KfRQEqvqd8KqjReVDQS9i7F/aDMm9jPZpFziT8od4SQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "93b2f73bfc0eba78d3e4e22aac849a4c6f8f1114",
+        "rev": "d94f513be3a2156cf8644d45665cf00355c3eb9c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d94f513b`](https://github.com/nix-community/NUR/commit/d94f513be3a2156cf8644d45665cf00355c3eb9c) | `` automatic update `` |
| [`dcdcdf48`](https://github.com/nix-community/NUR/commit/dcdcdf48d0327f1af728c30f641ff64d8ae72db9) | `` automatic update `` |
| [`b4c6cee9`](https://github.com/nix-community/NUR/commit/b4c6cee90275b67d9533a1149893a73a0874b9fe) | `` automatic update `` |