### PR TITLE
chore(flake/emacs-overlay): `9327b7e1` -> `fe8db2c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1707930447,
-        "narHash": "sha256-NDkHiMa4+DfLwLo28D9nxNzCVYBitwLZzlcSTUua5JY=",
+        "lastModified": 1707958644,
+        "narHash": "sha256-MwVh3v5Evuu6bOOlds7GqLnSrKnoXo2LraxcbDQqxR8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9327b7e16a991c8a2efbad729ac28452d7c40bf0",
+        "rev": "fe8db2c01aa9a1cf77a9bb9346081e21090b8890",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`fe8db2c0`](https://github.com/nix-community/emacs-overlay/commit/fe8db2c01aa9a1cf77a9bb9346081e21090b8890) | `` Updated elpa ``   |
| [`8ceb0a35`](https://github.com/nix-community/emacs-overlay/commit/8ceb0a355b70a76ca3e4aad4584c7be55e0ad0e1) | `` Updated nongnu `` |