### PR TITLE
chore(flake/srvos): `e6f41dfe` -> `88014ded`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1028,11 +1028,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707699075,
-        "narHash": "sha256-Zzj9ZtnqgwRV9VjBYIAtfq315v3cXn+Cq6bgNB1ZjLQ=",
+        "lastModified": 1707957968,
+        "narHash": "sha256-2iLIl6ZsNKYz2jtRe/uFX9NabR+0WQxP1D+3DAnucNY=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "e6f41dfe31ab8ae4cb1271ddd20d38c02f2222f7",
+        "rev": "88014ded851a318af0ddc3ff2cf337d375d3a24d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`88014ded`](https://github.com/nix-community/srvos/commit/88014ded851a318af0ddc3ff2cf337d375d3a24d) | `` dev/private/flake.lock: Update `` |
| [`3251a881`](https://github.com/nix-community/srvos/commit/3251a881a5e4ca242cd0ec2a239f113f7b5c47eb) | `` flake.lock: Update ``             |