### PR TITLE
chore(flake/nur): `d94f513b` -> `b615de6a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707948729,
-        "narHash": "sha256-KfRQEqvqd8KqjReVDQS9i7F/aDMm9jPZpFziT8od4SQ=",
+        "lastModified": 1707962215,
+        "narHash": "sha256-JqlV5Lp3yNcoz/LwcGGrJPz4CCEO8TySzJ6ZNb56G3o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d94f513be3a2156cf8644d45665cf00355c3eb9c",
+        "rev": "b615de6a536e385b08627ae2e0d92a338c95819f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b615de6a`](https://github.com/nix-community/NUR/commit/b615de6a536e385b08627ae2e0d92a338c95819f) | `` automatic update `` |
| [`5e350241`](https://github.com/nix-community/NUR/commit/5e350241541dfd9f2d5a9ef37653d08957ed12f3) | `` automatic update `` |
| [`ef1f67d7`](https://github.com/nix-community/NUR/commit/ef1f67d787f406be2be12afd7c10346c9c93d650) | `` automatic update `` |