### PR TITLE
chore(flake/emacs-overlay): `fe8db2c0` -> `3ca8fd85`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1707958644,
-        "narHash": "sha256-MwVh3v5Evuu6bOOlds7GqLnSrKnoXo2LraxcbDQqxR8=",
+        "lastModified": 1707961509,
+        "narHash": "sha256-ux65xSnbGnMDpNYSfnBbMFrE8xHYVm3wnXXeEeLo0ic=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fe8db2c01aa9a1cf77a9bb9346081e21090b8890",
+        "rev": "3ca8fd85438bf9e717628f519044b56d54e56911",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`3ca8fd85`](https://github.com/nix-community/emacs-overlay/commit/3ca8fd85438bf9e717628f519044b56d54e56911) | `` Updated emacs `` |
| [`645894d1`](https://github.com/nix-community/emacs-overlay/commit/645894d1da1ee1987d58149910440a3856d04f79) | `` Updated melpa `` |