### PR TITLE
chore(flake/nur): `b615de6a` -> `cd8875b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707962215,
-        "narHash": "sha256-JqlV5Lp3yNcoz/LwcGGrJPz4CCEO8TySzJ6ZNb56G3o=",
+        "lastModified": 1707968512,
+        "narHash": "sha256-5+orSFut1ZSNc5OCmYYVjx9VQLqzSSi4KnP/2/vXJDo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b615de6a536e385b08627ae2e0d92a338c95819f",
+        "rev": "cd8875b09f4842e15b31e9034ca93dab5d715464",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cd8875b0`](https://github.com/nix-community/NUR/commit/cd8875b09f4842e15b31e9034ca93dab5d715464) | `` automatic update `` |
| [`59a17cf7`](https://github.com/nix-community/NUR/commit/59a17cf7763df662667440487b80d68156252c7c) | `` automatic update `` |
| [`ef01ccac`](https://github.com/nix-community/NUR/commit/ef01ccac6e75ad3ed7d4d05c74d6e53378d9ca69) | `` automatic update `` |
| [`1a0101aa`](https://github.com/nix-community/NUR/commit/1a0101aa6227bd06175dcdf33e1ae228e53fcd3e) | `` automatic update `` |