### PR TITLE
chore(flake/nur): `cd8875b0` -> `28c9f59f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707968512,
-        "narHash": "sha256-5+orSFut1ZSNc5OCmYYVjx9VQLqzSSi4KnP/2/vXJDo=",
+        "lastModified": 1707976813,
+        "narHash": "sha256-64W0Cl7YwZUk2N7SwYzMS7ouhobUOEkIvzy1+Am5Re8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cd8875b09f4842e15b31e9034ca93dab5d715464",
+        "rev": "28c9f59f9ca9cca4c8e20ecc37d6cc03c815422a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`28c9f59f`](https://github.com/nix-community/NUR/commit/28c9f59f9ca9cca4c8e20ecc37d6cc03c815422a) | `` automatic update `` |
| [`671ca010`](https://github.com/nix-community/NUR/commit/671ca0107fb45ae50d72d20ea963c8a2c20b8d1c) | `` automatic update `` |
| [`56e8d835`](https://github.com/nix-community/NUR/commit/56e8d835ee623651ba211d0486b34f0db10a4d47) | `` automatic update `` |