### PR TITLE
chore(flake/nur): `28c9f59f` -> `ac0efe9d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707976813,
-        "narHash": "sha256-64W0Cl7YwZUk2N7SwYzMS7ouhobUOEkIvzy1+Am5Re8=",
+        "lastModified": 1707979458,
+        "narHash": "sha256-fb3Wp638kePhWmwp47rjdTElgfIMrmehdZnrMamPFiI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "28c9f59f9ca9cca4c8e20ecc37d6cc03c815422a",
+        "rev": "ac0efe9df31e79cb14a88103ebe9aaa97a6f595a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ac0efe9d`](https://github.com/nix-community/NUR/commit/ac0efe9df31e79cb14a88103ebe9aaa97a6f595a) | `` automatic update `` |