### PR TITLE
chore(flake/emacs-overlay): `8057607a` -> `93c49f34`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1707987076,
-        "narHash": "sha256-nYtj3iLahhFe5wOEX4XMQbIqJpPQmsn3U/q2Cs0WLHU=",
+        "lastModified": 1707989266,
+        "narHash": "sha256-7sSvK7Eq7Bg7w5dOEYD9GGx3ZEsrBOEM0dL8hOm0+aA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8057607aec6360988e4a1951fedbfb4fe7552ddf",
+        "rev": "93c49f3479f3abb5e0ed2c62387af0a83e5d59dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`93c49f34`](https://github.com/nix-community/emacs-overlay/commit/93c49f3479f3abb5e0ed2c62387af0a83e5d59dc) | `` Updated emacs `` |