### PR TITLE
chore(flake/nur): `631e68ef` -> `b4925573`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707991191,
-        "narHash": "sha256-au3iq53h5vcXvItoaHPDpGKnUdrmWeIYnCw7qdsKx5o=",
+        "lastModified": 1707995185,
+        "narHash": "sha256-EZEloWq14yCTy3X6uBOTDxgC4bIKUcxzVfdKnfQau/0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "631e68ef632edf20bd67809815d8b21a4fa949ee",
+        "rev": "b49255739b185560e4025ed905b76e12bd73ba40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b4925573`](https://github.com/nix-community/NUR/commit/b49255739b185560e4025ed905b76e12bd73ba40) | `` automatic update `` |
| [`5342023b`](https://github.com/nix-community/NUR/commit/5342023b455909ebb7c53a1319036f42d7077c62) | `` automatic update `` |
| [`a066606c`](https://github.com/nix-community/NUR/commit/a066606c2a8f27c2b8cec06583bf84c86da81d1a) | `` automatic update `` |