### PR TITLE
chore(flake/srvos): `88014ded` -> `e19a0dc5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -378,27 +378,6 @@
         "type": "github"
       }
     },
-    "flake-parts_2": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "srvos",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1706830856,
-        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems_2"
@@ -1022,17 +1001,16 @@
     },
     "srvos": {
       "inputs": {
-        "flake-parts": "flake-parts_2",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1707957968,
-        "narHash": "sha256-2iLIl6ZsNKYz2jtRe/uFX9NabR+0WQxP1D+3DAnucNY=",
+        "lastModified": 1708003942,
+        "narHash": "sha256-M0d1ouJUVCDiorvuAXifrR03geHGAf+3ELD7kuayWfI=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "88014ded851a318af0ddc3ff2cf337d375d3a24d",
+        "rev": "e19a0dc562b1df371772d90613f91c2a6b1839b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                     |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`e19a0dc5`](https://github.com/nix-community/srvos/commit/e19a0dc562b1df371772d90613f91c2a6b1839b3) | `` flake: distill the private flake input pattern (#376) `` |
| [`c26b531a`](https://github.com/nix-community/srvos/commit/c26b531a3c4f568c22588983781eb308b615f6ce) | `` no stub: <insert TLC song> (#383) ``                     |