### PR TITLE
chore(flake/nur): `b4925573` -> `f5dce867`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707995185,
-        "narHash": "sha256-EZEloWq14yCTy3X6uBOTDxgC4bIKUcxzVfdKnfQau/0=",
+        "lastModified": 1708004700,
+        "narHash": "sha256-pN4Sqh6KpbuH2job+kaYBKIR47fhEnDee9r1wfnFD88=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b49255739b185560e4025ed905b76e12bd73ba40",
+        "rev": "f5dce8671a2ab93efd7dff51fa51aeaef9f0fefe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f5dce867`](https://github.com/nix-community/NUR/commit/f5dce8671a2ab93efd7dff51fa51aeaef9f0fefe) | `` automatic update `` |