### PR TITLE
chore(flake/nur): `f5dce867` -> `f5f31894`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708004700,
-        "narHash": "sha256-pN4Sqh6KpbuH2job+kaYBKIR47fhEnDee9r1wfnFD88=",
+        "lastModified": 1708007560,
+        "narHash": "sha256-bTqS086dNvy5B1Wt/Yb2+EslprKGu1wxKui/76p4tzw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f5dce8671a2ab93efd7dff51fa51aeaef9f0fefe",
+        "rev": "f5f31894eb886506cbc0e850f78340cd21d7fb18",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f5f31894`](https://github.com/nix-community/NUR/commit/f5f31894eb886506cbc0e850f78340cd21d7fb18) | `` automatic update `` |