### PR TITLE
chore(flake/nur): `f5f31894` -> `55420932`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708007560,
-        "narHash": "sha256-bTqS086dNvy5B1Wt/Yb2+EslprKGu1wxKui/76p4tzw=",
+        "lastModified": 1708012199,
+        "narHash": "sha256-sOoLF8aXooEI1ET2m0lhwT0kFlzj4gdwUP1xY/GQOHs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f5f31894eb886506cbc0e850f78340cd21d7fb18",
+        "rev": "55420932ef6b5822a332b8617de623447549bb91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`55420932`](https://github.com/nix-community/NUR/commit/55420932ef6b5822a332b8617de623447549bb91) | `` automatic update `` |
| [`765457f4`](https://github.com/nix-community/NUR/commit/765457f4b9375772a86e34314a03ca29d080159e) | `` automatic update `` |