### PR TITLE
chore(flake/emacs-overlay): `93c49f34` -> `b234c1f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1707989266,
-        "narHash": "sha256-7sSvK7Eq7Bg7w5dOEYD9GGx3ZEsrBOEM0dL8hOm0+aA=",
+        "lastModified": 1708015876,
+        "narHash": "sha256-2AUDicWH0rBteuVpasrK5++2Pe26f+WNsDBYW1Po4w0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "93c49f3479f3abb5e0ed2c62387af0a83e5d59dc",
+        "rev": "b234c1f87824418a6c6effcf3f9ad805221d1d5c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b234c1f8`](https://github.com/nix-community/emacs-overlay/commit/b234c1f87824418a6c6effcf3f9ad805221d1d5c) | `` Updated melpa ``        |
| [`f9ac504d`](https://github.com/nix-community/emacs-overlay/commit/f9ac504d6dceac20600690ec40b2774ce98a6b7f) | `` Updated elpa ``         |
| [`f2566442`](https://github.com/nix-community/emacs-overlay/commit/f2566442d6ff7837f89dc962d0bce70c68a7d6a3) | `` Updated flake inputs `` |