### PR TITLE
chore(flake/nur): `55420932` -> `e4d1d884`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708012199,
-        "narHash": "sha256-sOoLF8aXooEI1ET2m0lhwT0kFlzj4gdwUP1xY/GQOHs=",
+        "lastModified": 1708022687,
+        "narHash": "sha256-5G9my5clYX58cNtZ1dGnEquGr/rixCxRBk7IzcJS2qo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "55420932ef6b5822a332b8617de623447549bb91",
+        "rev": "e4d1d8843b4c65fca13143755f6744aa7f0ed41a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e4d1d884`](https://github.com/nix-community/NUR/commit/e4d1d8843b4c65fca13143755f6744aa7f0ed41a) | `` automatic update `` |
| [`f093b8a5`](https://github.com/nix-community/NUR/commit/f093b8a537d1b226a85352c03883175174b29da3) | `` automatic update `` |
| [`1497e2d0`](https://github.com/nix-community/NUR/commit/1497e2d00a3dfef017c5ceff1da886b7032e1e6a) | `` automatic update `` |
| [`80519ce1`](https://github.com/nix-community/NUR/commit/80519ce11b5ccd1c66cd39c412eb0fd500d4a799) | `` automatic update `` |
| [`c189c2ff`](https://github.com/nix-community/NUR/commit/c189c2ffb9f8f5d7e1c37cb088dc90d68e3a2fd7) | `` automatic update `` |