### PR TITLE
chore(flake/emacs-overlay): `b234c1f8` -> `45b3e94d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708015876,
-        "narHash": "sha256-2AUDicWH0rBteuVpasrK5++2Pe26f+WNsDBYW1Po4w0=",
+        "lastModified": 1708016732,
+        "narHash": "sha256-X+QgTGLzXtN9wlP5Dll82ou5zdLk3zaANsR+l+igHLM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b234c1f87824418a6c6effcf3f9ad805221d1d5c",
+        "rev": "45b3e94dfd35aa81f150d293089ed8c28f602f5f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`45b3e94d`](https://github.com/nix-community/emacs-overlay/commit/45b3e94dfd35aa81f150d293089ed8c28f602f5f) | `` Updated emacs `` |