### PR TITLE
chore(flake/nur): `e4d1d884` -> `61796609`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708022687,
-        "narHash": "sha256-5G9my5clYX58cNtZ1dGnEquGr/rixCxRBk7IzcJS2qo=",
+        "lastModified": 1708030772,
+        "narHash": "sha256-K9qfwL0/VuBNO3Au+Gfj3l4kBwQ8mPPsxPgQsAfRl5Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e4d1d8843b4c65fca13143755f6744aa7f0ed41a",
+        "rev": "61796609aafd62b5bfc51557243a4c10fa8ef1e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`61796609`](https://github.com/nix-community/NUR/commit/61796609aafd62b5bfc51557243a4c10fa8ef1e9) | `` automatic update `` |
| [`e0c222bf`](https://github.com/nix-community/NUR/commit/e0c222bf9aaf27f225fd7e1f61a97722eec18aa2) | `` automatic update `` |
| [`0ff60c10`](https://github.com/nix-community/NUR/commit/0ff60c109e6a0882b9b77c1d9fa2940a406a9735) | `` automatic update `` |
| [`4f80eef9`](https://github.com/nix-community/NUR/commit/4f80eef9d04a980c8a75ac943640e2a2d64b348b) | `` automatic update `` |
| [`62c3c670`](https://github.com/nix-community/NUR/commit/62c3c670366a5a0d9f1dfd0d9bd55bfb4395f46a) | `` rename bbjubjub ``  |