### PR TITLE
chore(flake/home-manager): `043ba285` -> `3d6791b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -491,11 +491,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707919853,
-        "narHash": "sha256-qxmBGDzutuJ/tsX4gp+Mr7fjxOZBbeT9ixhS5o4iFOw=",
+        "lastModified": 1708031129,
+        "narHash": "sha256-EH20hJfNnc1/ODdDVat9B7aKm0B95L3YtkIRwKLvQG8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "043ba285c6dc20f36441d48525402bcb9743c498",
+        "rev": "3d6791b3897b526c82920a2ab5f61d71985b3cf8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`3d6791b3`](https://github.com/nix-community/home-manager/commit/3d6791b3897b526c82920a2ab5f61d71985b3cf8) | `` home-manager: add Nix sanity check ``      |
| [`07fd4117`](https://github.com/nix-community/home-manager/commit/07fd41171ff8f263a9e4a95e17a3db1ff8a000c9) | `` home-manager: fix incorrect log message `` |