### PR TITLE
chore(flake/nur): `61796609` -> `9c12d8c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708030772,
-        "narHash": "sha256-K9qfwL0/VuBNO3Au+Gfj3l4kBwQ8mPPsxPgQsAfRl5Q=",
+        "lastModified": 1708034410,
+        "narHash": "sha256-2dRePJc3JcnU2R5KbgpBSM4t+ZMh40jlPmg3FSnJV6Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "61796609aafd62b5bfc51557243a4c10fa8ef1e9",
+        "rev": "9c12d8c55be1297d0cdedd6591d4319aab80b4b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9c12d8c5`](https://github.com/nix-community/NUR/commit/9c12d8c55be1297d0cdedd6591d4319aab80b4b0) | `` automatic update `` |
| [`fe5e0fea`](https://github.com/nix-community/NUR/commit/fe5e0fea416cf5c2bb35253366d3d8ca5ab551ea) | `` automatic update `` |