### PR TITLE
chore(flake/emacs-overlay): `45b3e94d` -> `512ec36b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708016732,
-        "narHash": "sha256-X+QgTGLzXtN9wlP5Dll82ou5zdLk3zaANsR+l+igHLM=",
+        "lastModified": 1708047895,
+        "narHash": "sha256-1O5Py55HmTOS8L+RUcCjqCJXqn+o9MZcYrPmmc5ldeo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "45b3e94dfd35aa81f150d293089ed8c28f602f5f",
+        "rev": "512ec36be62eaec6ddec1515a2a659029e35de30",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1707786466,
-        "narHash": "sha256-yLPfrmW87M2qt+8bAmwopJawa+MJLh3M9rUbXtpUc1o=",
+        "lastModified": 1707978831,
+        "narHash": "sha256-UblFdWQ2MMZNzD9C/w8+7RjAJ2QIbebbzHUniQ/a44o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "01885a071465e223f8f68971f864b15829988504",
+        "rev": "c68a9fc85c2cb3a313be6ff40511635544dde8da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`512ec36b`](https://github.com/nix-community/emacs-overlay/commit/512ec36be62eaec6ddec1515a2a659029e35de30) | `` Updated emacs ``        |
| [`872e3935`](https://github.com/nix-community/emacs-overlay/commit/872e3935226c183c84707fda203a08ce2358f2b9) | `` Updated melpa ``        |
| [`38e6edaa`](https://github.com/nix-community/emacs-overlay/commit/38e6edaa6d0aa316bd16042c76e5af93287b2512) | `` Updated elpa ``         |
| [`ccf25455`](https://github.com/nix-community/emacs-overlay/commit/ccf254555f8586272e1e50dc11eb9dc82ee51103) | `` Updated flake inputs `` |