### PR TITLE
chore(flake/nur): `d0869493` -> `be8f2a41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708041837,
-        "narHash": "sha256-x7kuIR3qi0+9A8p9W3D1es/GtGrnEF/x8tQnQDY7ljQ=",
+        "lastModified": 1708047106,
+        "narHash": "sha256-X0tWOFTarbjnrhVxeSyMEIjUVgZHgfgbBpEedoAJFO8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d0869493d7569fcfcc439273ca96e36acca35717",
+        "rev": "be8f2a4105bf8ea7b6a6d3b20a9197b22fab530c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`be8f2a41`](https://github.com/nix-community/NUR/commit/be8f2a4105bf8ea7b6a6d3b20a9197b22fab530c) | `` automatic update `` |