### PR TITLE
chore(flake/nur): `be8f2a41` -> `07c41ed0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708047106,
-        "narHash": "sha256-X0tWOFTarbjnrhVxeSyMEIjUVgZHgfgbBpEedoAJFO8=",
+        "lastModified": 1708055801,
+        "narHash": "sha256-eRjogFKJ8ZVaPAHb9Zlr3Y+auVeg3QOpoZ4sOUEqfDo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "be8f2a4105bf8ea7b6a6d3b20a9197b22fab530c",
+        "rev": "07c41ed015189e0c6aa0a8795120484f6e0eb090",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`07c41ed0`](https://github.com/nix-community/NUR/commit/07c41ed015189e0c6aa0a8795120484f6e0eb090) | `` automatic update `` |
| [`9ddce2d4`](https://github.com/nix-community/NUR/commit/9ddce2d418e29d5e51509d35a8f607087298fdaf) | `` automatic update `` |
| [`e9c90796`](https://github.com/nix-community/NUR/commit/e9c90796f7a60ee60a34c4e4e98382d56abe4b55) | `` automatic update `` |