### PR TITLE
chore(flake/nur): `07c41ed0` -> `8bdb7c0e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708055801,
-        "narHash": "sha256-eRjogFKJ8ZVaPAHb9Zlr3Y+auVeg3QOpoZ4sOUEqfDo=",
+        "lastModified": 1708058739,
+        "narHash": "sha256-UE88FRpPwza5IWfs+NE8Yyy/MCWycwxKOOAoh6JKGUY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "07c41ed015189e0c6aa0a8795120484f6e0eb090",
+        "rev": "8bdb7c0e1c22262e8fcd66aacab96afa8969ce74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8bdb7c0e`](https://github.com/nix-community/NUR/commit/8bdb7c0e1c22262e8fcd66aacab96afa8969ce74) | `` automatic update `` |
| [`26add158`](https://github.com/nix-community/NUR/commit/26add158a316e1c5b091c8970943704ebec670e4) | `` automatic update `` |
| [`96deee2a`](https://github.com/nix-community/NUR/commit/96deee2a5a19f00b6103b49075db66fe6f785aa1) | `` automatic update `` |