### PR TITLE
chore(flake/nur): `08fbc188` -> `3e8c42ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708063242,
-        "narHash": "sha256-R7S962xCIJ2LTfbASSh0D7BwwGqTTNWKf8DT7RE7yhc=",
+        "lastModified": 1708065949,
+        "narHash": "sha256-MDloc0EX5eqGfh4ZIur6APN8s6BYZRwz5vU42bsoAac=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "08fbc18862d206b58976b9baa25f4ecf48b71e39",
+        "rev": "3e8c42ab5f6dc1db57c5eac7f88892e479093525",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3e8c42ab`](https://github.com/nix-community/NUR/commit/3e8c42ab5f6dc1db57c5eac7f88892e479093525) | `` automatic update `` |