### PR TITLE
chore(flake/nur): `3e8c42ab` -> `1155ba6a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708065949,
-        "narHash": "sha256-MDloc0EX5eqGfh4ZIur6APN8s6BYZRwz5vU42bsoAac=",
+        "lastModified": 1708076655,
+        "narHash": "sha256-KNRfg2szpJ19/NgXXB4s9r2+CCM90nq0MVUuvdQI+Ws=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3e8c42ab5f6dc1db57c5eac7f88892e479093525",
+        "rev": "1155ba6a69b8a69d7edda02321a21ff993d9300e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1155ba6a`](https://github.com/nix-community/NUR/commit/1155ba6a69b8a69d7edda02321a21ff993d9300e) | `` automatic update `` |
| [`bc1ef9ea`](https://github.com/nix-community/NUR/commit/bc1ef9eadcb51c6ec28ead4bd0b10d1ef0cde763) | `` automatic update `` |