### PR TITLE
chore(flake/emacs-overlay): `a1245ef1` -> `1572bc00`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708073484,
-        "narHash": "sha256-R/R6iEap6ebr2KoyF0mH+BTTxj8+fSVt0gcoFefZ/Eg=",
+        "lastModified": 1708074333,
+        "narHash": "sha256-m3N1qSO3UxHiKHvkAmYid0eVZ/6CH+Z/lxy7Mw40xMw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a1245ef1bb10e332d1353312c058169407145cc7",
+        "rev": "1572bc00e95555e6c4743957103d69c9ec08a336",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`1572bc00`](https://github.com/nix-community/emacs-overlay/commit/1572bc00e95555e6c4743957103d69c9ec08a336) | `` Updated emacs `` |