### PR TITLE
chore(flake/nur): `1155ba6a` -> `9b059055`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708076655,
-        "narHash": "sha256-KNRfg2szpJ19/NgXXB4s9r2+CCM90nq0MVUuvdQI+Ws=",
+        "lastModified": 1708087991,
+        "narHash": "sha256-av90oK1WM8Tf1YQwbgUT4UgjN1c1VT5COPBOCBvScFM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1155ba6a69b8a69d7edda02321a21ff993d9300e",
+        "rev": "9b059055da534e79bd6205893d716e85a7945fda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9b059055`](https://github.com/nix-community/NUR/commit/9b059055da534e79bd6205893d716e85a7945fda) | `` automatic update `` |
| [`3de7e3a4`](https://github.com/nix-community/NUR/commit/3de7e3a40d340581b14415448cf18d26587d134f) | `` automatic update `` |