### PR TITLE
chore(flake/nixos-hardware): `f1b2f71c` -> `106d3fec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -662,11 +662,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1707842204,
-        "narHash": "sha256-M+HAq1qWQBi/gywaMZwX0odU+Qb/XeqVeANGKRBDOwU=",
+        "lastModified": 1708091350,
+        "narHash": "sha256-o28BJYi68qqvHipT7V2jkWxDiMS1LF9nxUsou+eFUPQ=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f1b2f71c86a5b1941d20608db0b1e88a07d31303",
+        "rev": "106d3fec43bcea19cb2e061ca02531d54b542ce3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`106d3fec`](https://github.com/NixOS/nixos-hardware/commit/106d3fec43bcea19cb2e061ca02531d54b542ce3) | `` framework AMD 7040: work around white screen / flickering issue on newer kernels `` |
| [`a377fb23`](https://github.com/NixOS/nixos-hardware/commit/a377fb23dc22097a120f10a281074ef0f678901b) | `` cpu/amd/igpu: change condition to check actually used kernel version ``             |