### PR TITLE
chore(flake/nur): `9b059055` -> `31ba97e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708087991,
-        "narHash": "sha256-av90oK1WM8Tf1YQwbgUT4UgjN1c1VT5COPBOCBvScFM=",
+        "lastModified": 1708098276,
+        "narHash": "sha256-2pWhrmQhxUSrkflbupPKG6hjSQzDTzebq5QyIO/HYWI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9b059055da534e79bd6205893d716e85a7945fda",
+        "rev": "31ba97e37ec8c14f8ec2f2baea1a31f0c9abfb3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                        |
| -------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`31ba97e3`](https://github.com/nix-community/NUR/commit/31ba97e37ec8c14f8ec2f2baea1a31f0c9abfb3f) | `` automatic update ``         |
| [`339713c9`](https://github.com/nix-community/NUR/commit/339713c9f42013858739ea18aac30220f22dde08) | `` automatic update ``         |
| [`af0850f5`](https://github.com/nix-community/NUR/commit/af0850f5cf31764f16dd991fa75912ca707ee64d) | `` automatic update ``         |
| [`de895fa0`](https://github.com/nix-community/NUR/commit/de895fa08375ed930028216e925b88e98bea09a9) | `` automatic update ``         |
| [`c68cd1d1`](https://github.com/nix-community/NUR/commit/c68cd1d133108fe9d897fae6bd76bd17e2d9e7a4) | `` add ihaveamac repository `` |
| [`6e10656f`](https://github.com/nix-community/NUR/commit/6e10656f87dbdcb622c81147b209c3ac14a2a3a5) | `` automatic update ``         |