### PR TITLE
chore(flake/emacs-overlay): `b0df43bf` -> `4887a3bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708102268,
-        "narHash": "sha256-U79jcTgljeJGiPCatc6hf+l3NHTOAvk0QZ3xd0Bb1Og=",
+        "lastModified": 1708103144,
+        "narHash": "sha256-+HWM66eCCeok8tA1IF4lpSvrreYPcZjayo0i2Vn1RyI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b0df43bf17931a6b870194770340d268fe7412c2",
+        "rev": "4887a3bf368f7ba9fe2640c23ce08646918d4414",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`4887a3bf`](https://github.com/nix-community/emacs-overlay/commit/4887a3bf368f7ba9fe2640c23ce08646918d4414) | `` Updated emacs `` |