### PR TITLE
chore(flake/nur): `31ba97e3` -> `2593837c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708098276,
-        "narHash": "sha256-2pWhrmQhxUSrkflbupPKG6hjSQzDTzebq5QyIO/HYWI=",
+        "lastModified": 1708105507,
+        "narHash": "sha256-OLjuwC6g02i9c3IfbOEywOOcnsNZkqei9DcZ5BY1D2Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "31ba97e37ec8c14f8ec2f2baea1a31f0c9abfb3f",
+        "rev": "2593837ca8fc3abd462bac0ac002eec451001418",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2593837c`](https://github.com/nix-community/NUR/commit/2593837ca8fc3abd462bac0ac002eec451001418) | `` automatic update `` |