### PR TITLE
chore(flake/lanzaboote): `96181a46` -> `098f0194`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -540,11 +540,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1707777617,
-        "narHash": "sha256-gU2TLJuSNENQ8e61YayDcBUyWwAKbyO8VCosAklxuGc=",
+        "lastModified": 1708119716,
+        "narHash": "sha256-vw0MS7qMmNP6ch0LU8KR8mgvUXy6LU9DJytr+FlfDP4=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "96181a4667a811e4408cbc45092ac42a17a46d74",
+        "rev": "098f019407b020f808cf4acecb6f58c6ac12e0ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                                        |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`5a88b898`](https://github.com/nix-community/lanzaboote/commit/5a88b8987f3513a1a725776dce44d48cf44172e1) | `` feat(cpio): introduce `pio`, a library to write CPIO in `alloc` contexts `` |