### PR TITLE
chore(flake/nur): `9eab660e` -> `37c8d3a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708123471,
-        "narHash": "sha256-oLVR1/4320M6V3WoDx25YYrwY9INZCz0jJSofPZqXdE=",
+        "lastModified": 1708134894,
+        "narHash": "sha256-yOEkCBE62tg61YrrLeWzpwXrXqPwrLGIuMj7P38ZWfQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9eab660e8f9fe1b41bca3e198ba96c23270659ab",
+        "rev": "37c8d3a4bf5c9e871e76c124c89d8d7a35bd7c5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`37c8d3a4`](https://github.com/nix-community/NUR/commit/37c8d3a4bf5c9e871e76c124c89d8d7a35bd7c5b) | `` automatic update `` |
| [`630c0d00`](https://github.com/nix-community/NUR/commit/630c0d00d4db58867724d4be569f648a4eed730b) | `` automatic update `` |
| [`d717360b`](https://github.com/nix-community/NUR/commit/d717360bac05db6c76907bf8fd822ced1bb32b64) | `` automatic update `` |