### PR TITLE
chore(flake/emacs-overlay): `4887a3bf` -> `33751916`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708103144,
-        "narHash": "sha256-+HWM66eCCeok8tA1IF4lpSvrreYPcZjayo0i2Vn1RyI=",
+        "lastModified": 1708131381,
+        "narHash": "sha256-KNXq3ir/8gW0UsZ4dB7dTWQTGdntjesudFGJYO2iQDc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4887a3bf368f7ba9fe2640c23ce08646918d4414",
+        "rev": "337519167c4ef503a9617a35e95322b10e756f6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`33751916`](https://github.com/nix-community/emacs-overlay/commit/337519167c4ef503a9617a35e95322b10e756f6c) | `` Updated elpa ``   |
| [`c7090a11`](https://github.com/nix-community/emacs-overlay/commit/c7090a11f393071dcfd8a14ef5d803d30f477016) | `` Updated nongnu `` |