### PR TITLE
chore(flake/nur): `37c8d3a4` -> `d9743aa6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708134894,
-        "narHash": "sha256-yOEkCBE62tg61YrrLeWzpwXrXqPwrLGIuMj7P38ZWfQ=",
+        "lastModified": 1708138737,
+        "narHash": "sha256-CPV1CcnclwvHduquIhjHtpeV2RdQ8om6iQCtLG3lnxA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "37c8d3a4bf5c9e871e76c124c89d8d7a35bd7c5b",
+        "rev": "d9743aa636d30c6cdcd2f1c7ab7f0e23af3cb1d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d9743aa6`](https://github.com/nix-community/NUR/commit/d9743aa636d30c6cdcd2f1c7ab7f0e23af3cb1d8) | `` automatic update `` |