### PR TITLE
chore(flake/nur): `d9743aa6` -> `bacaa8bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708138737,
-        "narHash": "sha256-CPV1CcnclwvHduquIhjHtpeV2RdQ8om6iQCtLG3lnxA=",
+        "lastModified": 1708144369,
+        "narHash": "sha256-onHY3CJXCg3rSpIcdffBCjnJiJj07f14CSvEVH3Gr/w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d9743aa636d30c6cdcd2f1c7ab7f0e23af3cb1d8",
+        "rev": "bacaa8bc5fd5a6b8c22004ea3851d7485c9c40b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bacaa8bc`](https://github.com/nix-community/NUR/commit/bacaa8bc5fd5a6b8c22004ea3851d7485c9c40b6) | `` automatic update `` |
| [`8098cc42`](https://github.com/nix-community/NUR/commit/8098cc42a61d691ec6226b4df2915d720895e0af) | `` automatic update `` |
| [`d966121a`](https://github.com/nix-community/NUR/commit/d966121a8014132fc567dcc058f614a478b6826f) | `` automatic update `` |
| [`9b37d872`](https://github.com/nix-community/NUR/commit/9b37d872c4e92ded39283bfa5984eb51a6b3a3a9) | `` automatic update `` |
| [`9853e8d0`](https://github.com/nix-community/NUR/commit/9853e8d036ef4c4e40bb27d59c3bc4e7a270d090) | `` automatic update `` |