### PR TITLE
chore(flake/nur): `bacaa8bc` -> `fe2a92e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708144369,
-        "narHash": "sha256-onHY3CJXCg3rSpIcdffBCjnJiJj07f14CSvEVH3Gr/w=",
+        "lastModified": 1708152229,
+        "narHash": "sha256-5jNCuY0xrHvYhgFrXC+upSO2OhL07VUT9mVbvVOEFtk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bacaa8bc5fd5a6b8c22004ea3851d7485c9c40b6",
+        "rev": "fe2a92e50ae1f324551eb240b89d71baee10ce38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fe2a92e5`](https://github.com/nix-community/NUR/commit/fe2a92e50ae1f324551eb240b89d71baee10ce38) | `` automatic update `` |