### PR TITLE
chore(flake/nur): `fe2a92e5` -> `5e8adec2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708152229,
-        "narHash": "sha256-5jNCuY0xrHvYhgFrXC+upSO2OhL07VUT9mVbvVOEFtk=",
+        "lastModified": 1708154803,
+        "narHash": "sha256-0UivvfxrHJQZXIY+J8+uQ/NKF+qgu/zlxDBeo+LO/4E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fe2a92e50ae1f324551eb240b89d71baee10ce38",
+        "rev": "5e8adec22987489f1a0c94529559ba1af24426dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5e8adec2`](https://github.com/nix-community/NUR/commit/5e8adec22987489f1a0c94529559ba1af24426dd) | `` automatic update `` |