### PR TITLE
chore(flake/emacs-overlay): `c3d788a4` -> `462042a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708133394,
-        "narHash": "sha256-XjT+2BCA8Ntp0ZguhID7QyPkwKSwE2uqMwJ4PBfeQYg=",
+        "lastModified": 1708160677,
+        "narHash": "sha256-FvjBzvuMQlFpdjZZ3P56swPDi1AWZ3CXeFKltB+GvHQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c3d788a49ce7f930194fa1b8e4afef65a34d6cf3",
+        "rev": "462042a4c13a7f9ca6a2a6c46397945fc4444602",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`462042a4`](https://github.com/nix-community/emacs-overlay/commit/462042a4c13a7f9ca6a2a6c46397945fc4444602) | `` Updated emacs `` |
| [`02231aec`](https://github.com/nix-community/emacs-overlay/commit/02231aec4f9f4d5bd6f8933036faf7b1df5f114f) | `` Updated melpa `` |