### PR TITLE
chore(flake/nur): `5e8adec2` -> `96ec1f30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -869,11 +869,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708154803,
-        "narHash": "sha256-0UivvfxrHJQZXIY+J8+uQ/NKF+qgu/zlxDBeo+LO/4E=",
+        "lastModified": 1708158591,
+        "narHash": "sha256-YlfIM95IKgb1g+JyrNMNP3tuho6I8vgc29+cBZwNlP4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5e8adec22987489f1a0c94529559ba1af24426dd",
+        "rev": "96ec1f30b8caf822d50d75ec30f8ad9949d50584",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`96ec1f30`](https://github.com/nix-community/NUR/commit/96ec1f30b8caf822d50d75ec30f8ad9949d50584) | `` automatic update `` |
| [`866edeb7`](https://github.com/nix-community/NUR/commit/866edeb74fbb7b2ebcdc98d394da340f264f2135) | `` automatic update `` |