### PR TITLE
chore(flake/nur): `4505aa08` -> `eac4d04d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708166739,
-        "narHash": "sha256-Hc+umnBPkFN5GdO8CAuvkdZ9CQmWXCjludtpH4VNwnE=",
+        "lastModified": 1708178431,
+        "narHash": "sha256-j2YK6/6oLF3nc5Pxs5sPHsjoiCTr3QjvUr3SiQWU+WI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4505aa081f915ea31046fed4b10014b740c219c0",
+        "rev": "eac4d04d8d02703dafa012540209ad34a0bff559",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eac4d04d`](https://github.com/nix-community/NUR/commit/eac4d04d8d02703dafa012540209ad34a0bff559) | `` automatic update `` |