### PR TITLE
chore(flake/nur): `eac4d04d` -> `e9c855dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708178431,
-        "narHash": "sha256-j2YK6/6oLF3nc5Pxs5sPHsjoiCTr3QjvUr3SiQWU+WI=",
+        "lastModified": 1708181823,
+        "narHash": "sha256-RfIJHRy1eiWxj37wv+oyyqys5PwiDRnKjn/hZjmeQeA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eac4d04d8d02703dafa012540209ad34a0bff559",
+        "rev": "e9c855dd90924f6a0e072ebe22660b36e84a2b54",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e9c855dd`](https://github.com/nix-community/NUR/commit/e9c855dd90924f6a0e072ebe22660b36e84a2b54) | `` automatic update `` |
| [`0799ad07`](https://github.com/nix-community/NUR/commit/0799ad071162f5b534cc55722491f94b61832993) | `` automatic update `` |