### PR TITLE
chore(flake/nur): `e9c855dd` -> `55ddee9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708181823,
-        "narHash": "sha256-RfIJHRy1eiWxj37wv+oyyqys5PwiDRnKjn/hZjmeQeA=",
+        "lastModified": 1708188268,
+        "narHash": "sha256-GMeOZ0gExvHH/KgBKq0K4U49GwB8OR78SgLR+PrKVnQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e9c855dd90924f6a0e072ebe22660b36e84a2b54",
+        "rev": "55ddee9a45eb054748d85b4db2185d25d7fe0409",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`55ddee9a`](https://github.com/nix-community/NUR/commit/55ddee9a45eb054748d85b4db2185d25d7fe0409) | `` automatic update `` |
| [`a0543345`](https://github.com/nix-community/NUR/commit/a0543345ddda9db58d930675085c9d1a52af4ca1) | `` automatic update `` |