### PR TITLE
chore(flake/nur): `55ddee9a` -> `d8f26b89`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708188268,
-        "narHash": "sha256-GMeOZ0gExvHH/KgBKq0K4U49GwB8OR78SgLR+PrKVnQ=",
+        "lastModified": 1708191906,
+        "narHash": "sha256-JfwBEkHaIVq4We2rT/1WqD5zdR511ALhsu+CmynPp8s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "55ddee9a45eb054748d85b4db2185d25d7fe0409",
+        "rev": "d8f26b89cb7e1a4a893f5bc9d4878e2190d30d4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d8f26b89`](https://github.com/nix-community/NUR/commit/d8f26b89cb7e1a4a893f5bc9d4878e2190d30d4d) | `` automatic update `` |