### PR TITLE
chore(flake/nur): `d8f26b89` -> `9960edd0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708191906,
-        "narHash": "sha256-JfwBEkHaIVq4We2rT/1WqD5zdR511ALhsu+CmynPp8s=",
+        "lastModified": 1708199059,
+        "narHash": "sha256-ru1Qvrjcq+XR70yDJFZTzbDRDAhHvBCHFkrZGbEn2aI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d8f26b89cb7e1a4a893f5bc9d4878e2190d30d4d",
+        "rev": "9960edd041c77e7041f2016abfc9ed9e44f32166",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9960edd0`](https://github.com/nix-community/NUR/commit/9960edd041c77e7041f2016abfc9ed9e44f32166) | `` automatic update `` |
| [`59988ea4`](https://github.com/nix-community/NUR/commit/59988ea4f710e875f025914d6de2afe5dab79647) | `` automatic update `` |