### PR TITLE
chore(flake/nur): `9960edd0` -> `d46453dc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708199059,
-        "narHash": "sha256-ru1Qvrjcq+XR70yDJFZTzbDRDAhHvBCHFkrZGbEn2aI=",
+        "lastModified": 1708206268,
+        "narHash": "sha256-x179TuS6oGwBSPF9WtCP2jB6z5qB9fH/Cz2pyZAZgIc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9960edd041c77e7041f2016abfc9ed9e44f32166",
+        "rev": "d46453dcb1bd9aec9ecfa8a0ad8027308c643606",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d46453dc`](https://github.com/nix-community/NUR/commit/d46453dcb1bd9aec9ecfa8a0ad8027308c643606) | `` automatic update `` |
| [`19370e44`](https://github.com/nix-community/NUR/commit/19370e44d2d001f6412b52ca28f5003c7e48a3b1) | `` automatic update `` |