### PR TITLE
chore(flake/nur): `d46453dc` -> `0453b074`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708206268,
-        "narHash": "sha256-x179TuS6oGwBSPF9WtCP2jB6z5qB9fH/Cz2pyZAZgIc=",
+        "lastModified": 1708208022,
+        "narHash": "sha256-2dq8bTb4UYtGMiK4qXbqbb0BgX82XuDWAAeBAzdtkjk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d46453dcb1bd9aec9ecfa8a0ad8027308c643606",
+        "rev": "0453b0745100cee220ff5b1be71c8806aaa07547",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0453b074`](https://github.com/nix-community/NUR/commit/0453b0745100cee220ff5b1be71c8806aaa07547) | `` automatic update `` |