### PR TITLE
chore(flake/nur): `0453b074` -> `ccc244cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708208022,
-        "narHash": "sha256-2dq8bTb4UYtGMiK4qXbqbb0BgX82XuDWAAeBAzdtkjk=",
+        "lastModified": 1708213449,
+        "narHash": "sha256-m1H5SvWlIldAzQrvzOSxhoxNJjodIZZBY34F/Iu7id4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0453b0745100cee220ff5b1be71c8806aaa07547",
+        "rev": "ccc244cf9a517cdfccfd6a7a8b47083a5f926a0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ccc244cf`](https://github.com/nix-community/NUR/commit/ccc244cf9a517cdfccfd6a7a8b47083a5f926a0e) | `` automatic update `` |
| [`8199a4b8`](https://github.com/nix-community/NUR/commit/8199a4b8d5d6074db7b10a725d880630e5c37637) | `` automatic update `` |