### PR TITLE
chore(flake/nur): `ccc244cf` -> `149248e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708213449,
-        "narHash": "sha256-m1H5SvWlIldAzQrvzOSxhoxNJjodIZZBY34F/Iu7id4=",
+        "lastModified": 1708221555,
+        "narHash": "sha256-UAn3O/xQvH24AwBG8UW7tZzQoZIcCHvtDqGKHlY2DxU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ccc244cf9a517cdfccfd6a7a8b47083a5f926a0e",
+        "rev": "149248e3c6ed196b6c67b7d8542d54dbee62c86f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`149248e3`](https://github.com/nix-community/NUR/commit/149248e3c6ed196b6c67b7d8542d54dbee62c86f) | `` automatic update `` |
| [`8d232f6a`](https://github.com/nix-community/NUR/commit/8d232f6aee3d466492104a4c27b2f23827549bab) | `` automatic update `` |
| [`47ce279b`](https://github.com/nix-community/NUR/commit/47ce279ba92857948eb790ee2e29c2498bad5819) | `` automatic update `` |
| [`9758b25f`](https://github.com/nix-community/NUR/commit/9758b25ffc7b95025d9530a3a833563210ad1206) | `` automatic update `` |