### PR TITLE
chore(flake/emacs-overlay): `4afdb9d4` -> `69b18188`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708218016,
-        "narHash": "sha256-5EgDoMFvB4ynLoSM4e1wnqE5Ln//cjImOPyyGAewl3k=",
+        "lastModified": 1708220891,
+        "narHash": "sha256-md3Sx3q6aOKJTmC/UaBmw1c9/ITSEqeFAeq6kTk8S+k=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4afdb9d4384f7e18faf385552899ad948f2601da",
+        "rev": "69b181888ea72d7c8a769c1b1ff6c5cb49d084ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`69b18188`](https://github.com/nix-community/emacs-overlay/commit/69b181888ea72d7c8a769c1b1ff6c5cb49d084ed) | `` Updated emacs `` |
| [`4d106338`](https://github.com/nix-community/emacs-overlay/commit/4d106338574dfb66e16ebb9b8a53b7693da2a787) | `` Updated melpa `` |