### PR TITLE
chore(flake/nur): `149248e3` -> `82d83574`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708221555,
-        "narHash": "sha256-UAn3O/xQvH24AwBG8UW7tZzQoZIcCHvtDqGKHlY2DxU=",
+        "lastModified": 1708242239,
+        "narHash": "sha256-qvek/eYwR2n0+x0Bs9DzLSdbbhHyLVfsL8LQo2ffUWc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "149248e3c6ed196b6c67b7d8542d54dbee62c86f",
+        "rev": "82d83574b9eb036f268c6a218f68f3ebbb44c482",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`82d83574`](https://github.com/nix-community/NUR/commit/82d83574b9eb036f268c6a218f68f3ebbb44c482) | `` automatic update `` |
| [`507abb80`](https://github.com/nix-community/NUR/commit/507abb80942a552e20305208f9e98208bce01bf1) | `` automatic update `` |
| [`6dde857e`](https://github.com/nix-community/NUR/commit/6dde857e083df1fa28dc7264eab681456fa68430) | `` automatic update `` |
| [`748255c3`](https://github.com/nix-community/NUR/commit/748255c325b79a54b82b7f7e9292ff48f715b908) | `` automatic update `` |
| [`250e8938`](https://github.com/nix-community/NUR/commit/250e893814c620c9a87e5c007751dd98daa594ee) | `` automatic update `` |
| [`ddb349d1`](https://github.com/nix-community/NUR/commit/ddb349d1ed90658ca10da0d2158ff9732c8c635c) | `` automatic update `` |
| [`36b4ceb5`](https://github.com/nix-community/NUR/commit/36b4ceb52a68f5bc5f0cb711b418327e3b127cfa) | `` automatic update `` |
| [`71314f0e`](https://github.com/nix-community/NUR/commit/71314f0e287bb7c7d301f3a5c19f6cc4f5a1f8c1) | `` automatic update `` |
| [`61e4ca30`](https://github.com/nix-community/NUR/commit/61e4ca30feac8b3cbc260a9b4fc0194e9056f0f5) | `` automatic update `` |
| [`acf217e8`](https://github.com/nix-community/NUR/commit/acf217e874c1ad38e0b93290448813ea34cb152c) | `` automatic update `` |