### PR TITLE
chore(flake/emacs-overlay): `69b18188` -> `4337f34d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708220891,
-        "narHash": "sha256-md3Sx3q6aOKJTmC/UaBmw1c9/ITSEqeFAeq6kTk8S+k=",
+        "lastModified": 1708247084,
+        "narHash": "sha256-8zeIDnhXEfQ7z4EmdsgBzR9gzfqcXbm30W2PvxpbUdM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "69b181888ea72d7c8a769c1b1ff6c5cb49d084ed",
+        "rev": "4337f34dae4a0dc33539852a0e4a52d78605ac81",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1708105575,
-        "narHash": "sha256-sS4AItZeUnAei6v8FqxNlm+/27MPlfoGym/TZP0rmH0=",
+        "lastModified": 1708161998,
+        "narHash": "sha256-6KnemmUorCvlcAvGziFosAVkrlWZGIc6UNT9GUYr0jQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1d1817869c47682a6bee85b5b0a6537b6c0fba26",
+        "rev": "84d981bae8b5e783b3b548de505b22880559515f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4337f34d`](https://github.com/nix-community/emacs-overlay/commit/4337f34dae4a0dc33539852a0e4a52d78605ac81) | `` Updated emacs ``        |
| [`e1d06e86`](https://github.com/nix-community/emacs-overlay/commit/e1d06e86d99e96d1588c291208490c8ee2c08a42) | `` Updated melpa ``        |
| [`9220b65f`](https://github.com/nix-community/emacs-overlay/commit/9220b65fb203554de784267c6a0a9a271888109c) | `` Updated flake inputs `` |