### PR TITLE
chore(flake/nur): `82d83574` -> `7cf9aa5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708242239,
-        "narHash": "sha256-qvek/eYwR2n0+x0Bs9DzLSdbbhHyLVfsL8LQo2ffUWc=",
+        "lastModified": 1708243971,
+        "narHash": "sha256-BY8GxDugjtqDf8p4f/T/qgOTIMWa4PeZ75Cb4AUMEP0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "82d83574b9eb036f268c6a218f68f3ebbb44c482",
+        "rev": "7cf9aa5a48b01934164cbe28e38b4cb744d9e412",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7cf9aa5a`](https://github.com/nix-community/NUR/commit/7cf9aa5a48b01934164cbe28e38b4cb744d9e412) | `` automatic update `` |