### PR TITLE
chore(flake/emacs-overlay): `4337f34d` -> `e3b3b271`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708247084,
-        "narHash": "sha256-8zeIDnhXEfQ7z4EmdsgBzR9gzfqcXbm30W2PvxpbUdM=",
+        "lastModified": 1708275037,
+        "narHash": "sha256-KK5oRPLEFfvQf+FKZ9FQwAnihP7C5XrsVtYPAuMKS58=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4337f34dae4a0dc33539852a0e4a52d78605ac81",
+        "rev": "e3b3b271caf7a4664b51e1a25c16e5a69fe70036",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`e3b3b271`](https://github.com/nix-community/emacs-overlay/commit/e3b3b271caf7a4664b51e1a25c16e5a69fe70036) | `` Updated melpa `` |
| [`af022425`](https://github.com/nix-community/emacs-overlay/commit/af02242510319d4dcb895f4de83b74b461b9cbda) | `` Updated elpa ``  |