### PR TITLE
chore(flake/nur): `c4296c55` -> `fc843cb9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708261229,
-        "narHash": "sha256-mC9gMz4E7Dm9nvCE6oqNMmZLMdoJ3Pjik2oqEZDVrgU=",
+        "lastModified": 1708276853,
+        "narHash": "sha256-X1uSQVHl/4yosiAhIWV61lVDL/520LKfDGt3eC+YAQY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c4296c55625e5394c142d5c07c00cddb76d5241b",
+        "rev": "fc843cb9767ccbd850aa3a823d071874e6f8a4f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fc843cb9`](https://github.com/nix-community/NUR/commit/fc843cb9767ccbd850aa3a823d071874e6f8a4f2) | `` automatic update `` |
| [`78167236`](https://github.com/nix-community/NUR/commit/781672361ff1a08f668b1f31dfa571735c964ca8) | `` automatic update `` |