### PR TITLE
chore(flake/nur): `cffaf8c8` -> `7ccf5f72`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708287602,
-        "narHash": "sha256-vtRPnAwR0s/ubOOb3jm0K/aSiFQ7DVcIZmKLk8k+tbU=",
+        "lastModified": 1708293570,
+        "narHash": "sha256-S8qH9mIUma122q9Wboh+5u+dJmZC2lnnG4MkOGteFwo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cffaf8c87a877a77f790cfef31e2ad916939a708",
+        "rev": "7ccf5f725834f28e908780ffdacc744319f2834b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7ccf5f72`](https://github.com/nix-community/NUR/commit/7ccf5f725834f28e908780ffdacc744319f2834b) | `` automatic update `` |
| [`4bf696bd`](https://github.com/nix-community/NUR/commit/4bf696bd6382375d823656324ccd33c2037c20f9) | `` automatic update `` |