### PR TITLE
chore(flake/nur): `7ccf5f72` -> `8abbb121`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708293570,
-        "narHash": "sha256-S8qH9mIUma122q9Wboh+5u+dJmZC2lnnG4MkOGteFwo=",
+        "lastModified": 1708294799,
+        "narHash": "sha256-CXpBIBqeWiarwpJk2DLTEooy0uX7at1mqFNCnho5kRo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7ccf5f725834f28e908780ffdacc744319f2834b",
+        "rev": "8abbb1212ff453b65fe998f01e644584fff79f6d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8abbb121`](https://github.com/nix-community/NUR/commit/8abbb1212ff453b65fe998f01e644584fff79f6d) | `` automatic update `` |