### PR TITLE
chore(flake/srvos): `e19a0dc5` -> `7c02fb00`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1028,11 +1028,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708003942,
-        "narHash": "sha256-M0d1ouJUVCDiorvuAXifrR03geHGAf+3ELD7kuayWfI=",
+        "lastModified": 1708303807,
+        "narHash": "sha256-T3ywY/VPlG0n7P7Rhm/GJ+hLXtUmEETJUGRfvaYQ0OM=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "e19a0dc562b1df371772d90613f91c2a6b1839b3",
+        "rev": "7c02fb006bdd70474853e6395bd5916ba2404fa2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`7c02fb00`](https://github.com/nix-community/srvos/commit/7c02fb006bdd70474853e6395bd5916ba2404fa2) | `` dev/private/flake.lock: Update `` |
| [`5d8c21a5`](https://github.com/nix-community/srvos/commit/5d8c21a5747af0613811c73db56e1efb6c90ca75) | `` flake.lock: Update ``             |