### PR TITLE
chore(flake/nur): `a21632ce` -> `921e579a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708317928,
-        "narHash": "sha256-imac6tW+CU64YDKCmpQvSkMO+0RYxtmT19to2hp6FI0=",
+        "lastModified": 1708322436,
+        "narHash": "sha256-3OrZ2jlwbiN9NWM4Dxv9RoCZVfJbEDwmJbw/OkRr/uQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a21632ce1fbd608f389449948024a902dc4328b4",
+        "rev": "921e579ab60c27430d7216a7572e8ad44d8e108b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`921e579a`](https://github.com/nix-community/NUR/commit/921e579ab60c27430d7216a7572e8ad44d8e108b) | `` automatic update `` |
| [`fd43dfae`](https://github.com/nix-community/NUR/commit/fd43dfae1582df05931053e5890cb8aa03a2f492) | `` automatic update `` |
| [`a8d1fb94`](https://github.com/nix-community/NUR/commit/a8d1fb94a4cdca7ac79b16456fefa9609b5bce4a) | `` automatic update `` |