### PR TITLE
chore(flake/nur): `921e579a` -> `119ba100`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708322436,
-        "narHash": "sha256-3OrZ2jlwbiN9NWM4Dxv9RoCZVfJbEDwmJbw/OkRr/uQ=",
+        "lastModified": 1708322991,
+        "narHash": "sha256-faAddXI8xOjs3u5TcMvGLkcWVjaFVWJjG9G3lsvIVwU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "921e579ab60c27430d7216a7572e8ad44d8e108b",
+        "rev": "119ba100d25078d371915db9b8598a5e68cd874f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`119ba100`](https://github.com/nix-community/NUR/commit/119ba100d25078d371915db9b8598a5e68cd874f) | `` automatic update `` |