### PR TITLE
chore(flake/nur): `e17ac139` -> `8df08698`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708329376,
-        "narHash": "sha256-E5LJjNT6dMD2r6m93CdOccQmW3+YT7Pr2lHMMmr5pXs=",
+        "lastModified": 1708334453,
+        "narHash": "sha256-dzy9CBKhQ/mPapRhZOhRNPNIzYv9R3sc/M7tsKTe4cs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e17ac139d5903c021aff79b52d659bf90145cbb2",
+        "rev": "8df08698ebbd2486e420f0c809f7be1a49898959",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8df08698`](https://github.com/nix-community/NUR/commit/8df08698ebbd2486e420f0c809f7be1a49898959) | `` automatic update `` |
| [`23f3523d`](https://github.com/nix-community/NUR/commit/23f3523da4d2617ed37a3175362fc8f62b550af5) | `` automatic update `` |