### PR TITLE
chore(flake/nur): `7e39029b` -> `c7d6638c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708338823,
-        "narHash": "sha256-YtkY05G4lf4qXilV36F2lJpfyuAgBilkUHgihid9p3k=",
+        "lastModified": 1708350267,
+        "narHash": "sha256-Eb80PPhF2vML6vMT2LKc6B+R2NVN87BkZZIUnuz/fdY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7e39029bd978da19b84621faec3d129fe8475de9",
+        "rev": "c7d6638ca9e5bd42a4dfc7aa3992a2b655e616d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c7d6638c`](https://github.com/nix-community/NUR/commit/c7d6638ca9e5bd42a4dfc7aa3992a2b655e616d0) | `` automatic update `` |
| [`b2b511e7`](https://github.com/nix-community/NUR/commit/b2b511e7ee918392ce4c40cecb19e29e76ad15f5) | `` automatic update `` |
| [`5b8eb19f`](https://github.com/nix-community/NUR/commit/5b8eb19f8db38405e9e1a12ee08737249950609b) | `` automatic update `` |