### PR TITLE
chore(flake/nur): `c7d6638c` -> `0746498e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708350267,
-        "narHash": "sha256-Eb80PPhF2vML6vMT2LKc6B+R2NVN87BkZZIUnuz/fdY=",
+        "lastModified": 1708353184,
+        "narHash": "sha256-BdSI+j49fZmMD9to0Har0wRvkN14x2Ipzipu6cQfp2A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c7d6638ca9e5bd42a4dfc7aa3992a2b655e616d0",
+        "rev": "0746498eec8c0a0b2ac98fe835d6af996b719531",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0746498e`](https://github.com/nix-community/NUR/commit/0746498eec8c0a0b2ac98fe835d6af996b719531) | `` automatic update `` |