### PR TITLE
chore(flake/emacs-overlay): `a097d639` -> `da95bd8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708362445,
-        "narHash": "sha256-hu6v1PrOmkjd2dkfRqUDjwGINO233EDhruwSJSMBO2s=",
+        "lastModified": 1708390592,
+        "narHash": "sha256-sT88Ps5tpLvzUP+ChjRs7mvvpWjYHYuHVIMWT/1ry+A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a097d6392a1959ed28cdd1717b729437a1e7c4fe",
+        "rev": "da95bd8d883d0e2a4bd5bdc7aad18a7cd2becb9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`da95bd8d`](https://github.com/nix-community/emacs-overlay/commit/da95bd8d883d0e2a4bd5bdc7aad18a7cd2becb9f) | `` Updated elpa ``         |
| [`a1434c43`](https://github.com/nix-community/emacs-overlay/commit/a1434c437d2c9eb4b638918cfb25729f42bf30b4) | `` Updated flake inputs `` |