### PR TITLE
chore(flake/emacs-overlay): `da95bd8d` -> `34775297`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708390592,
-        "narHash": "sha256-sT88Ps5tpLvzUP+ChjRs7mvvpWjYHYuHVIMWT/1ry+A=",
+        "lastModified": 1708393467,
+        "narHash": "sha256-QZUIl1pNWqR9jzXw4txm9oXrTWs03J/8IAudJeEBNV8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "da95bd8d883d0e2a4bd5bdc7aad18a7cd2becb9f",
+        "rev": "347752976096227aed7d06226e1045b5f0112386",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`34775297`](https://github.com/nix-community/emacs-overlay/commit/347752976096227aed7d06226e1045b5f0112386) | `` Updated emacs `` |
| [`5c1b7b8a`](https://github.com/nix-community/emacs-overlay/commit/5c1b7b8aafcb9e98a7244e5b2d1490844537045b) | `` Updated melpa `` |