### PR TITLE
chore(flake/nur): `091efa6b` -> `5da2163c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708396902,
-        "narHash": "sha256-s+NM7TwLWeCJfl4T/w0SL6uUX0J/Kfgg1oLpI7wbgvc=",
+        "lastModified": 1708402266,
+        "narHash": "sha256-b7G8btZ90EYTwOofJvqdXWM5pZMnN04YWW1tK7jf0YM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "091efa6b9f2b766b3032a3abab55fdb4c5fac775",
+        "rev": "5da2163c458a41bb23912371c3590f2e979e7b34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5da2163c`](https://github.com/nix-community/NUR/commit/5da2163c458a41bb23912371c3590f2e979e7b34) | `` automatic update `` |
| [`9424846e`](https://github.com/nix-community/NUR/commit/9424846e1a01bedbb67cb032237d4c59d5d298c4) | `` automatic update `` |