### PR TITLE
chore(flake/nur): `49ed1c11` -> `b5f8982b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708408824,
-        "narHash": "sha256-wgx4wBCl11lyrIU/SCbsZ5MR0f4tXkPYV3FMidu1AOw=",
+        "lastModified": 1708411950,
+        "narHash": "sha256-PJ80T2+QtkiFdNIsu630DUqQ9Zs3HzfPyPYAP0HDrrI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "49ed1c11041345b7b6e98492701b751cfc864ee3",
+        "rev": "b5f8982bb3e4adbd328fcc5113f72daa308183d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b5f8982b`](https://github.com/nix-community/NUR/commit/b5f8982bb3e4adbd328fcc5113f72daa308183d2) | `` automatic update `` |
| [`65134bef`](https://github.com/nix-community/NUR/commit/65134beff1e6963fdd20c5f7188fc547a2243519) | `` automatic update `` |