### PR TITLE
chore(flake/nur): `b5f8982b` -> `b3847d02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708411950,
-        "narHash": "sha256-PJ80T2+QtkiFdNIsu630DUqQ9Zs3HzfPyPYAP0HDrrI=",
+        "lastModified": 1708415643,
+        "narHash": "sha256-NSdkkyM7Cjr315i8YUOFgx0WOtsMF/dEAqOUv4xOfRI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b5f8982bb3e4adbd328fcc5113f72daa308183d2",
+        "rev": "b3847d02db51d11a0dfaf9c9460a58bcbdc124f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b3847d02`](https://github.com/nix-community/NUR/commit/b3847d02db51d11a0dfaf9c9460a58bcbdc124f9) | `` automatic update `` |
| [`5b6a3b89`](https://github.com/nix-community/NUR/commit/5b6a3b89bf6be167401f0c3e840e0f34dd1c0e11) | `` automatic update `` |
| [`a8a56419`](https://github.com/nix-community/NUR/commit/a8a5641924c0f1c803beb3063b6cadc3698492d2) | `` automatic update `` |