### PR TITLE
chore(flake/emacs-overlay): `34775297` -> `c83e29d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708393467,
-        "narHash": "sha256-QZUIl1pNWqR9jzXw4txm9oXrTWs03J/8IAudJeEBNV8=",
+        "lastModified": 1708419083,
+        "narHash": "sha256-6mvpooX+T27/rRBuCcpxOr+kx+RwBoclU8bGyuo9oL4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "347752976096227aed7d06226e1045b5f0112386",
+        "rev": "c83e29d619b19fea300c93cb506bbc99c6599b98",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`c83e29d6`](https://github.com/nix-community/emacs-overlay/commit/c83e29d619b19fea300c93cb506bbc99c6599b98) | `` Updated melpa `` |