### PR TITLE
chore(flake/nur): `b3847d02` -> `034cf7dc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708415643,
-        "narHash": "sha256-NSdkkyM7Cjr315i8YUOFgx0WOtsMF/dEAqOUv4xOfRI=",
+        "lastModified": 1708422279,
+        "narHash": "sha256-WuBt+axaRt0vnUXeMcgPS9ePSvWc4Cv3Q2deYkFL17o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b3847d02db51d11a0dfaf9c9460a58bcbdc124f9",
+        "rev": "034cf7dc073f5d18921016cf9bbfec436b97eff2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`034cf7dc`](https://github.com/nix-community/NUR/commit/034cf7dc073f5d18921016cf9bbfec436b97eff2) | `` automatic update `` |
| [`37e2a583`](https://github.com/nix-community/NUR/commit/37e2a5836ece4dd373530656ec7d41c0aeee3ff1) | `` automatic update `` |