### PR TITLE
chore(flake/nur): `c825ba23` -> `d16ac714`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708425876,
-        "narHash": "sha256-aO0mqF9pZch1gSk/T4kzQrhaI7Zb89IG88U+IkyHscE=",
+        "lastModified": 1708433158,
+        "narHash": "sha256-W/Qkcei+cAZSzprYHPaStA3xiHnC5hVuLXIawM3hjIs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c825ba23aaa2fcb8162a4345dc62058b29f425f6",
+        "rev": "d16ac7142e433fb51cfb23ac579e9efc3d493f6d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d16ac714`](https://github.com/nix-community/NUR/commit/d16ac7142e433fb51cfb23ac579e9efc3d493f6d) | `` automatic update `` |
| [`fc37563c`](https://github.com/nix-community/NUR/commit/fc37563cdb6a232329dd48873449706cab888fa1) | `` automatic update `` |
| [`071a40f7`](https://github.com/nix-community/NUR/commit/071a40f774c8ffb78c97cdceae46403f74974929) | `` automatic update `` |