### PR TITLE
chore(flake/nur): `0b52287d` -> `438fbf45`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708436755,
-        "narHash": "sha256-S8LctGPKKztCbUSH6+o4yQllAi8adWp1xc9Kec113cc=",
+        "lastModified": 1708440276,
+        "narHash": "sha256-ii3ONuTga+Y7sMaZxYOq2E2bsGRFmI3lsddyBiCd+Bo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0b52287d9b265cb18bd303684698f99fb2907772",
+        "rev": "438fbf450419f20d98855f863b1808cd058239f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`438fbf45`](https://github.com/nix-community/NUR/commit/438fbf450419f20d98855f863b1808cd058239f2) | `` automatic update `` |
| [`5ace0fe0`](https://github.com/nix-community/NUR/commit/5ace0fe042e5b86f2dbce82a173ee8d58a3b9107) | `` automatic update `` |