### PR TITLE
chore(flake/nur): `438fbf45` -> `f33b8119`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708440276,
-        "narHash": "sha256-ii3ONuTga+Y7sMaZxYOq2E2bsGRFmI3lsddyBiCd+Bo=",
+        "lastModified": 1708443313,
+        "narHash": "sha256-9PR7f2Fy0jY8AVB4VJcXGacG6nixiyN69xA24ZXAi+s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "438fbf450419f20d98855f863b1808cd058239f2",
+        "rev": "f33b8119a722cc1f017cb46f2dfb2c69a2fbe319",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f33b8119`](https://github.com/nix-community/NUR/commit/f33b8119a722cc1f017cb46f2dfb2c69a2fbe319) | `` automatic update `` |