### PR TITLE
chore(flake/emacs-overlay): `c83e29d6` -> `0b46b54c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708419083,
-        "narHash": "sha256-6mvpooX+T27/rRBuCcpxOr+kx+RwBoclU8bGyuo9oL4=",
+        "lastModified": 1708535184,
+        "narHash": "sha256-Duz/yAWiSaDo+zRMszQtaU9v5kDsi80Utyp4TfYJVXU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c83e29d619b19fea300c93cb506bbc99c6599b98",
+        "rev": "0b46b54cbbf135a1e6924b0a7ca22dcfd98f0cc6",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1708294118,
-        "narHash": "sha256-evZzmLW7qoHXf76VCepvun1esZDxHfVRFUJtumD7L2M=",
+        "lastModified": 1708440434,
+        "narHash": "sha256-XY+B9mbhL/i+Q6fP6gBQ6P76rv9rWtpjQiUJ+DGtaUg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e0da498ad77ac8909a980f07eff060862417ccf7",
+        "rev": "526d051b128b82ae045a70e5ff1adf8e6dafa560",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`0b46b54c`](https://github.com/nix-community/emacs-overlay/commit/0b46b54cbbf135a1e6924b0a7ca22dcfd98f0cc6) | `` Updated emacs ``        |
| [`243457f5`](https://github.com/nix-community/emacs-overlay/commit/243457f5cf17fd1c3723889b474924afbe0789bf) | `` Updated melpa ``        |
| [`5bcb462a`](https://github.com/nix-community/emacs-overlay/commit/5bcb462ac3c818ca56389bf0c47346ee6b77cb6c) | `` Updated elpa ``         |
| [`acbcd811`](https://github.com/nix-community/emacs-overlay/commit/acbcd8110648411631b60b633b5d0c77bb61b20a) | `` Updated flake inputs `` |
| [`39a63475`](https://github.com/nix-community/emacs-overlay/commit/39a63475945fea0d8b4e4aeb351f392c1c3beeab) | `` Updated emacs ``        |
| [`cf4080f0`](https://github.com/nix-community/emacs-overlay/commit/cf4080f0f4e0e7eb3223b723b7617e34d6a1239c) | `` Updated melpa ``        |
| [`965e4460`](https://github.com/nix-community/emacs-overlay/commit/965e446000282dda9bce8fc5fcf65a5ef038f396) | `` Updated emacs ``        |
| [`7523288d`](https://github.com/nix-community/emacs-overlay/commit/7523288d4a7691c719d168f74bf88404cded497f) | `` Updated melpa ``        |
| [`46a27ccf`](https://github.com/nix-community/emacs-overlay/commit/46a27ccfdce3c14f8cc79250c6a27b5abc75832d) | `` Updated elpa ``         |
| [`0a5f33bc`](https://github.com/nix-community/emacs-overlay/commit/0a5f33bc21d5a2b594208da4d41cad7e19f29366) | `` Updated nongnu ``       |
| [`eca18f04`](https://github.com/nix-community/emacs-overlay/commit/eca18f048a96d077a72881ced8949e1e8dcee4b5) | `` Updated emacs ``        |
| [`7b175193`](https://github.com/nix-community/emacs-overlay/commit/7b1751931dee4af2f8ca14c3958b45c2704ba4ee) | `` Updated melpa ``        |
| [`6879e098`](https://github.com/nix-community/emacs-overlay/commit/6879e098c576b2e386fe84a464a5a4bad5bff41e) | `` Updated elpa ``         |
| [`db8898a6`](https://github.com/nix-community/emacs-overlay/commit/db8898a6db80f8dc07056fd1f449f3a4b65c45f9) | `` Updated nongnu ``       |