### PR TITLE
chore(flake/nur): `f33b8119` -> `30083548`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708443313,
-        "narHash": "sha256-9PR7f2Fy0jY8AVB4VJcXGacG6nixiyN69xA24ZXAi+s=",
+        "lastModified": 1708450392,
+        "narHash": "sha256-MkAamIeaJdgC8XB02Mc3q4EWL39TimEyFBVgY1cn/kA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f33b8119a722cc1f017cb46f2dfb2c69a2fbe319",
+        "rev": "30083548b4ac11731dee0d101c4717bd6005fa9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`30083548`](https://github.com/nix-community/NUR/commit/30083548b4ac11731dee0d101c4717bd6005fa9e) | `` automatic update `` |
| [`1b9b8c8d`](https://github.com/nix-community/NUR/commit/1b9b8c8d29f7327e3adf76f9a0d413b2fced9e81) | `` automatic update `` |