### PR TITLE
chore(flake/sops-nix): `f88661c9` -> `acfcce2a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1008,11 +1008,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1708447565,
-        "narHash": "sha256-N2oVVguBU2ueGRoYEynedunF+xOKv6X3ZS43YnB9pbg=",
+        "lastModified": 1708456161,
+        "narHash": "sha256-Rh5kJvLZySEPkOxCIX1XA0SpDnYjjXSvixLwKsrcpVE=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "f88661c9a9f4ff10b6a5aca18d5caf7d537e3923",
+        "rev": "acfcce2a36da17ebb724d2e100d47881880c2e48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`acfcce2a`](https://github.com/Mic92/sops-nix/commit/acfcce2a36da17ebb724d2e100d47881880c2e48) | `` update vendorHash ``                                           |
| [`a13fc353`](https://github.com/Mic92/sops-nix/commit/a13fc353cabcc3eea3c76ee6fc726ec2713ff76e) | `` build(deps): bump golang.org/x/crypto from 0.18.0 to 0.19.0 `` |
| [`a5932c85`](https://github.com/Mic92/sops-nix/commit/a5932c85e1b3060440b717b59d4a1125e4cd94de) | `` update vendorHash ``                                           |
| [`203f3fd6`](https://github.com/Mic92/sops-nix/commit/203f3fd65519d384720d9269296ae2021f0a22a2) | `` build(deps): bump golang.org/x/sys from 0.16.0 to 0.17.0 ``    |
| [`5611ba15`](https://github.com/Mic92/sops-nix/commit/5611ba15f13f218f0d540df9f3a5e01486ab7c8c) | `` add nix config snippet to restart sops-nix service ``          |