### PR TITLE
chore(flake/nur): `b878d82e` -> `8c7e9635`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708453610,
-        "narHash": "sha256-xKd53jAJVQi0rMUFMEJAegxnGLBABF8dHHwggCQbVlw=",
+        "lastModified": 1708461156,
+        "narHash": "sha256-ft6Y4foeLkJg2ZlAzt6IsjNxg+fgo9fNVRJbnlvKwGc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b878d82e0bee71857863aab9e94a95d6ba3cfa00",
+        "rev": "8c7e9635c81242c42d3cf729ccc7cfc40dcee01d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8c7e9635`](https://github.com/nix-community/NUR/commit/8c7e9635c81242c42d3cf729ccc7cfc40dcee01d) | `` automatic update `` |
| [`3bf1f64e`](https://github.com/nix-community/NUR/commit/3bf1f64e4827a42ec3423f7b77ba654f63525a00) | `` automatic update `` |
| [`f8fd9ce3`](https://github.com/nix-community/NUR/commit/f8fd9ce3260d1a759e0e167fec4cbce67c0240bc) | `` automatic update `` |