### PR TITLE
chore(flake/nur): `8c7e9635` -> `e7e77ef5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708461156,
-        "narHash": "sha256-ft6Y4foeLkJg2ZlAzt6IsjNxg+fgo9fNVRJbnlvKwGc=",
+        "lastModified": 1708469069,
+        "narHash": "sha256-h0ZqDHGuRIv+GZeZkQh9RwyAO5F01fQCCKPeRUQwNtc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8c7e9635c81242c42d3cf729ccc7cfc40dcee01d",
+        "rev": "e7e77ef5ce40a07feebc646ccb1a5e209e14691f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e7e77ef5`](https://github.com/nix-community/NUR/commit/e7e77ef5ce40a07feebc646ccb1a5e209e14691f) | `` automatic update `` |