### PR TITLE
chore(flake/nur): `e7e77ef5` -> `83fe45c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708469069,
-        "narHash": "sha256-h0ZqDHGuRIv+GZeZkQh9RwyAO5F01fQCCKPeRUQwNtc=",
+        "lastModified": 1708477908,
+        "narHash": "sha256-qTDBvWy03FNIVhvG+rSLlkyff2J9Mbhol4ZoGHDjNU4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e7e77ef5ce40a07feebc646ccb1a5e209e14691f",
+        "rev": "83fe45c89d0a6d1ce3df11288d89280ce2ff6c67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`83fe45c8`](https://github.com/nix-community/NUR/commit/83fe45c89d0a6d1ce3df11288d89280ce2ff6c67) | `` automatic update `` |
| [`b9d06197`](https://github.com/nix-community/NUR/commit/b9d061979fdd29a24e263b20f314d84e7d5cd61e) | `` automatic update `` |