### PR TITLE
chore(flake/nur): `4a06dbfc` -> `d080c30d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708483231,
-        "narHash": "sha256-nEt81dQBylCvBYrnnyqy4Fxh34HoXewnfJRf1cBb86Q=",
+        "lastModified": 1708490325,
+        "narHash": "sha256-DGHWfk4nNZMja9lC3xRt49/ABvPp0xc6/TOgB77VqRI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4a06dbfc56df098148d311fd37c74e0363019863",
+        "rev": "d080c30d6c656d1bc59abb3f511b32d41f5486e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d080c30d`](https://github.com/nix-community/NUR/commit/d080c30d6c656d1bc59abb3f511b32d41f5486e9) | `` automatic update `` |
| [`fe99d068`](https://github.com/nix-community/NUR/commit/fe99d068026b02046a9aae34fe60b4063d457d20) | `` automatic update `` |
| [`ba788ed3`](https://github.com/nix-community/NUR/commit/ba788ed38fa45a8c7fb7f3a2c051e5670c758c97) | `` automatic update `` |
| [`377837e1`](https://github.com/nix-community/NUR/commit/377837e1766b7867d0012f4c88b9858548bbdcda) | `` automatic update `` |