### PR TITLE
chore(flake/templates): `6ca9b8b0` -> `259699d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1124,11 +1124,11 @@
     },
     "templates": {
       "locked": {
-        "lastModified": 1707966994,
-        "narHash": "sha256-1gdZ2owbx1jv/T+PjD/IU5YSCQJnpFECjJB7dHoFUu0=",
+        "lastModified": 1708484632,
+        "narHash": "sha256-6UD350MflALvXNkcnZ6VtkuD41mW15NZ7wM+/65uQGY=",
         "owner": "NixOS",
         "repo": "templates",
-        "rev": "6ca9b8b02e3c0e14ad2fffd812febbde5797bf07",
+        "rev": "259699d91baef738c5826106b3aa46ddfcd4da51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                   |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------- |
| [`1c160025`](https://github.com/NixOS/templates/commit/1c160025a3137d9109f51939bd2473520040ff8f) | `` clarify `haskell-flake` description `` |
| [`192f1d96`](https://github.com/NixOS/templates/commit/192f1d969b91e258e6b637bf9ab3203449063c3f) | `` add `haskell-flake` to list ``         |