### PR TITLE
chore(flake/nur): `d080c30d` -> `bb211faf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708490325,
-        "narHash": "sha256-DGHWfk4nNZMja9lC3xRt49/ABvPp0xc6/TOgB77VqRI=",
+        "lastModified": 1708494335,
+        "narHash": "sha256-EfdXnNN1+h6TKf/XhN6/ZrfU54GRJwijCXIgadcBMD0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d080c30d6c656d1bc59abb3f511b32d41f5486e9",
+        "rev": "bb211faf55e7a4ffaeb25ffbf77cf38df84f4446",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bb211faf`](https://github.com/nix-community/NUR/commit/bb211faf55e7a4ffaeb25ffbf77cf38df84f4446) | `` automatic update `` |
| [`99386fd5`](https://github.com/nix-community/NUR/commit/99386fd535955464e910b33d75c83d3ddb0d6d42) | `` automatic update `` |