### PR TITLE
chore(flake/nur): `bb211faf` -> `b88fac58`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708494335,
-        "narHash": "sha256-EfdXnNN1+h6TKf/XhN6/ZrfU54GRJwijCXIgadcBMD0=",
+        "lastModified": 1708497504,
+        "narHash": "sha256-o/f6YXfF46WlTqlszrpnuuZSZQl671GqZbSobmO+hrQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bb211faf55e7a4ffaeb25ffbf77cf38df84f4446",
+        "rev": "b88fac587b86f3cc96d031b423bda61d65fe3ff9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b88fac58`](https://github.com/nix-community/NUR/commit/b88fac587b86f3cc96d031b423bda61d65fe3ff9) | `` automatic update `` |