### PR TITLE
chore(flake/sops-nix): `acfcce2a` -> `f6b80ab6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1008,11 +1008,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1708456161,
-        "narHash": "sha256-Rh5kJvLZySEPkOxCIX1XA0SpDnYjjXSvixLwKsrcpVE=",
+        "lastModified": 1708500294,
+        "narHash": "sha256-mvJIecY3tDKZh7297mqOtOuAvP7U1rqjfLNfmfkjFpU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "acfcce2a36da17ebb724d2e100d47881880c2e48",
+        "rev": "f6b80ab6cd25e57f297fe466ad689d8a77057c11",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`f6b80ab6`](https://github.com/Mic92/sops-nix/commit/f6b80ab6cd25e57f297fe466ad689d8a77057c11) | `` Address review comments ``                                          |
| [`fbec5536`](https://github.com/Mic92/sops-nix/commit/fbec55367fda331120416d6ceb99b376d92eb0f9) | `` modules/sops/templates: Support custom files as secret templates `` |