### PR TITLE
chore(flake/nur): `b88fac58` -> `95e5727f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708497504,
-        "narHash": "sha256-o/f6YXfF46WlTqlszrpnuuZSZQl671GqZbSobmO+hrQ=",
+        "lastModified": 1708501658,
+        "narHash": "sha256-e3zB+Bx1fX80vRm5nMn0DQvtLLCBS4EDA515O3QsFDA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b88fac587b86f3cc96d031b423bda61d65fe3ff9",
+        "rev": "95e5727f7d65efbb7627706c3bb68d7247d2710c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`95e5727f`](https://github.com/nix-community/NUR/commit/95e5727f7d65efbb7627706c3bb68d7247d2710c) | `` automatic update `` |