### PR TITLE
chore(flake/nur): `95e5727f` -> `eefe3b11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708501658,
-        "narHash": "sha256-e3zB+Bx1fX80vRm5nMn0DQvtLLCBS4EDA515O3QsFDA=",
+        "lastModified": 1708508651,
+        "narHash": "sha256-45nTgbJL5znsOINtOjI6U76/msNanegoLL9iN84fjdQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "95e5727f7d65efbb7627706c3bb68d7247d2710c",
+        "rev": "eefe3b1192a4040e4cd1216ec4929eb21bd3376e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eefe3b11`](https://github.com/nix-community/NUR/commit/eefe3b1192a4040e4cd1216ec4929eb21bd3376e) | `` automatic update `` |
| [`536a4578`](https://github.com/nix-community/NUR/commit/536a4578760fff9a34274190a19f896087cec1b5) | `` automatic update `` |
| [`47174021`](https://github.com/nix-community/NUR/commit/4717402142372efd49c892d4311dee94c0816295) | `` automatic update `` |