### PR TITLE
chore(flake/nur): `eefe3b11` -> `af5d41d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708508651,
-        "narHash": "sha256-45nTgbJL5znsOINtOjI6U76/msNanegoLL9iN84fjdQ=",
+        "lastModified": 1708512253,
+        "narHash": "sha256-4dbfZlNo6pL9fJ+kLsYOjKtGAh0lRB2fmf2lySojaEI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eefe3b1192a4040e4cd1216ec4929eb21bd3376e",
+        "rev": "af5d41d230662b1988aca30e3fc2e9e92bdc95dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`af5d41d2`](https://github.com/nix-community/NUR/commit/af5d41d230662b1988aca30e3fc2e9e92bdc95dd) | `` automatic update `` |