### PR TITLE
chore(flake/nur): `af5d41d2` -> `33b9e46b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708512253,
-        "narHash": "sha256-4dbfZlNo6pL9fJ+kLsYOjKtGAh0lRB2fmf2lySojaEI=",
+        "lastModified": 1708519222,
+        "narHash": "sha256-Ehk+Z7vUqtQveiisAZs59o7fTSMnaiXZJcxiOPdz53w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "af5d41d230662b1988aca30e3fc2e9e92bdc95dd",
+        "rev": "33b9e46b02305aaf6572c72888e2deee21c920f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`33b9e46b`](https://github.com/nix-community/NUR/commit/33b9e46b02305aaf6572c72888e2deee21c920f8) | `` automatic update `` |
| [`ad7aef8a`](https://github.com/nix-community/NUR/commit/ad7aef8a39597c7de4c5daf1c8578584e7a55f8a) | `` automatic update `` |