### PR TITLE
chore(flake/nur): `33b9e46b` -> `6214db25`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708519222,
-        "narHash": "sha256-Ehk+Z7vUqtQveiisAZs59o7fTSMnaiXZJcxiOPdz53w=",
+        "lastModified": 1708534347,
+        "narHash": "sha256-lgzszm/rnE/TWBjd4oAOysvvCKhZTB7Hrj9oo/wDHcI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "33b9e46b02305aaf6572c72888e2deee21c920f8",
+        "rev": "6214db25480d8cb2ffbb54718c871509c206467e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6214db25`](https://github.com/nix-community/NUR/commit/6214db25480d8cb2ffbb54718c871509c206467e) | `` automatic update `` |
| [`cf9b05d5`](https://github.com/nix-community/NUR/commit/cf9b05d5f39c764ed41b1a92d332c3e6b1fd733a) | `` automatic update `` |