### PR TITLE
chore(flake/nur): `6214db25` -> `99f4a808`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708534347,
-        "narHash": "sha256-lgzszm/rnE/TWBjd4oAOysvvCKhZTB7Hrj9oo/wDHcI=",
+        "lastModified": 1708537484,
+        "narHash": "sha256-btt9aF1Q6xLGMYL2pfAlT0FWnFUbqfNYQfY2vxdNRp4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6214db25480d8cb2ffbb54718c871509c206467e",
+        "rev": "99f4a8084773e933558f2bb1452e3ade1768e087",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`99f4a808`](https://github.com/nix-community/NUR/commit/99f4a8084773e933558f2bb1452e3ade1768e087) | `` automatic update `` |