### PR TITLE
chore(flake/nur): `99f4a808` -> `15d82702`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708537484,
-        "narHash": "sha256-btt9aF1Q6xLGMYL2pfAlT0FWnFUbqfNYQfY2vxdNRp4=",
+        "lastModified": 1708540341,
+        "narHash": "sha256-x0HP+cyB5YZSKiHLawfoDf41RVfZtLJ+8nrZhIuYIH8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "99f4a8084773e933558f2bb1452e3ade1768e087",
+        "rev": "15d82702d15e1c9f6a861ed62a72dfa592918a0b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`15d82702`](https://github.com/nix-community/NUR/commit/15d82702d15e1c9f6a861ed62a72dfa592918a0b) | `` automatic update `` |
| [`90663063`](https://github.com/nix-community/NUR/commit/90663063a0a99e2d27a6f3b9c894fe3810fa6b87) | `` automatic update `` |