### PR TITLE
chore(flake/nur): `0f53fded` -> `07574526`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708544649,
-        "narHash": "sha256-hMdUmMqVVPPixnXvkRe4ZxEzXT5h8NPzPYMGHuTqpzo=",
+        "lastModified": 1708551955,
+        "narHash": "sha256-BI7+0KO4OfxzsEukk8Js1ce4ysJ4BS141ps07MNhO0s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0f53fdedb89a2a062f8f10c5de534300277d2ca2",
+        "rev": "0757452695e0d82544e47312e64b2f7a6211abde",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`07574526`](https://github.com/nix-community/NUR/commit/0757452695e0d82544e47312e64b2f7a6211abde) | `` automatic update `` |