### PR TITLE
chore(flake/nur): `07574526` -> `e7bd3c60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708551955,
-        "narHash": "sha256-BI7+0KO4OfxzsEukk8Js1ce4ysJ4BS141ps07MNhO0s=",
+        "lastModified": 1708559587,
+        "narHash": "sha256-LVyCfkRZlPU2B3qqSY2tDGNvh6nuFSV+LgNfB6Evas8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0757452695e0d82544e47312e64b2f7a6211abde",
+        "rev": "e7bd3c6040c831aaf6c0fbcfab17f42420129c17",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e7bd3c60`](https://github.com/nix-community/NUR/commit/e7bd3c6040c831aaf6c0fbcfab17f42420129c17) | `` automatic update `` |
| [`4ddaee82`](https://github.com/nix-community/NUR/commit/4ddaee829a77882406085d9c82d972a8a44ca7bd) | `` automatic update `` |