### PR TITLE
chore(flake/emacs-overlay): `0b46b54c` -> `6e1f5e6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708535184,
-        "narHash": "sha256-Duz/yAWiSaDo+zRMszQtaU9v5kDsi80Utyp4TfYJVXU=",
+        "lastModified": 1708566204,
+        "narHash": "sha256-U3OC4ObjTzBrGUs8Zx3y/po4q5Cihu7jRzl5brcySFA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0b46b54cbbf135a1e6924b0a7ca22dcfd98f0cc6",
+        "rev": "6e1f5e6da33486d1f56d98f97949f961dd621479",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`6e1f5e6d`](https://github.com/nix-community/emacs-overlay/commit/6e1f5e6da33486d1f56d98f97949f961dd621479) | `` Updated emacs `` |
| [`4735a15b`](https://github.com/nix-community/emacs-overlay/commit/4735a15b5329c87554a8d54873acddbc846e8753) | `` Updated melpa `` |
| [`54d05956`](https://github.com/nix-community/emacs-overlay/commit/54d0595648c17dd7e782eef6242ccb2295a2a054) | `` Updated elpa ``  |