### PR TITLE
chore(flake/nur): `d8ad7ae7` -> `4fa33164`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708573448,
-        "narHash": "sha256-l/icd3WBnkpTd19oYiJMVETOw8CWYaqgg60K52pxk1c=",
+        "lastModified": 1708574976,
+        "narHash": "sha256-xsS6aJlfm77d9eLRPVkeJtmQqPY5S5lMvRIvXt0vdhQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d8ad7ae793a9e20bc52fc440659c36405f531af1",
+        "rev": "4fa331649d6f6f2f41fa5410f97cdea0462ed27c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4fa33164`](https://github.com/nix-community/NUR/commit/4fa331649d6f6f2f41fa5410f97cdea0462ed27c) | `` automatic update `` |