### PR TITLE
chore(flake/nur): `4fa33164` -> `751ff5df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708574976,
-        "narHash": "sha256-xsS6aJlfm77d9eLRPVkeJtmQqPY5S5lMvRIvXt0vdhQ=",
+        "lastModified": 1708580424,
+        "narHash": "sha256-jLqeg10+fzkuV/WIeteygpEiM3E4mIl8L3O/Rntnz4I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4fa331649d6f6f2f41fa5410f97cdea0462ed27c",
+        "rev": "751ff5dfb26711c9977ed4cd6f42c8a2d66d2625",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`751ff5df`](https://github.com/nix-community/NUR/commit/751ff5dfb26711c9977ed4cd6f42c8a2d66d2625) | `` automatic update `` |