### PR TITLE
chore(flake/nur): `751ff5df` -> `9ea82ef9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708580424,
-        "narHash": "sha256-jLqeg10+fzkuV/WIeteygpEiM3E4mIl8L3O/Rntnz4I=",
+        "lastModified": 1708583973,
+        "narHash": "sha256-BTOan9V+OZCh9rCUD+8Efn8Ua54dmUHP3vvxaVFRFqk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "751ff5dfb26711c9977ed4cd6f42c8a2d66d2625",
+        "rev": "9ea82ef92cd9ec9e532ad4e4e081a9136890d2a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ea82ef9`](https://github.com/nix-community/NUR/commit/9ea82ef92cd9ec9e532ad4e4e081a9136890d2a4) | `` automatic update `` |