### PR TITLE
chore(flake/emacs-overlay): `6e1f5e6d` -> `9657a4d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708566204,
-        "narHash": "sha256-U3OC4ObjTzBrGUs8Zx3y/po4q5Cihu7jRzl5brcySFA=",
+        "lastModified": 1708596385,
+        "narHash": "sha256-Qub4NbZZwXr3dOltzIO729NW+aHlN56Cycs+WjvmVi4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6e1f5e6da33486d1f56d98f97949f961dd621479",
+        "rev": "9657a4d41b7efd275488613a3c408765b4d55e5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                            |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
| [`9657a4d4`](https://github.com/nix-community/emacs-overlay/commit/9657a4d41b7efd275488613a3c408765b4d55e5b) | `` Use --replace-warn instead of --replace in substituteInPlace `` |
| [`7f463b6a`](https://github.com/nix-community/emacs-overlay/commit/7f463b6ae783990b87a2821491df823f75f89f9c) | `` Updated emacs ``                                                |
| [`1e5be0a6`](https://github.com/nix-community/emacs-overlay/commit/1e5be0a6a9e14ece938f8882f670eb44428db059) | `` Updated melpa ``                                                |