### PR TITLE
chore(flake/nur): `9ea82ef9` -> `f67ac59a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708583973,
-        "narHash": "sha256-BTOan9V+OZCh9rCUD+8Efn8Ua54dmUHP3vvxaVFRFqk=",
+        "lastModified": 1708590064,
+        "narHash": "sha256-Jmw2NGYcSkrC/mOzXeFUBsZXPsDzrqxVO5GeK2OPrFo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ea82ef92cd9ec9e532ad4e4e081a9136890d2a4",
+        "rev": "f67ac59acc731fbc4e584b6d5e319d084bb876e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f67ac59a`](https://github.com/nix-community/NUR/commit/f67ac59acc731fbc4e584b6d5e319d084bb876e0) | `` automatic update `` |
| [`5b326fa0`](https://github.com/nix-community/NUR/commit/5b326fa01c53a41ea747e3901941a24581b98b4f) | `` automatic update `` |