### PR TITLE
chore(flake/nur): `f67ac59a` -> `f2af010f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708590064,
-        "narHash": "sha256-Jmw2NGYcSkrC/mOzXeFUBsZXPsDzrqxVO5GeK2OPrFo=",
+        "lastModified": 1708597774,
+        "narHash": "sha256-dofnVMqnuLFiVUGl5l3J27byhnWehd3QvFhLZWczqBc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f67ac59acc731fbc4e584b6d5e319d084bb876e0",
+        "rev": "f2af010f46a7eb25cbeef01f6942eb3b14fbd1da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f2af010f`](https://github.com/nix-community/NUR/commit/f2af010f46a7eb25cbeef01f6942eb3b14fbd1da) | `` automatic update `` |
| [`6330f5ae`](https://github.com/nix-community/NUR/commit/6330f5ae13c404643d7f2ff83f45e8b6e7952370) | `` automatic update `` |
| [`a2c086ff`](https://github.com/nix-community/NUR/commit/a2c086ffc6cd61ded1e6979fd425e08074e3d7ea) | `` automatic update `` |