### PR TITLE
chore(flake/emacs-overlay): `79237579` -> `ab74faf9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708613949,
-        "narHash": "sha256-7zOtvdeZuliH77vjvlBGEA7fjJeeGWPCoefihHx/Znc=",
+        "lastModified": 1708620703,
+        "narHash": "sha256-SAbyzvfcQQwDSj9PatYJVkQxA3QdODkTYdue5SEvbAg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "792375796de4ccc00350095ffbe55f049f05143f",
+        "rev": "ab74faf9e9930fa1785f8a6a0005cf2c17188d5c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`ab74faf9`](https://github.com/nix-community/emacs-overlay/commit/ab74faf9e9930fa1785f8a6a0005cf2c17188d5c) | `` Updated melpa `` |
| [`dfe78231`](https://github.com/nix-community/emacs-overlay/commit/dfe78231595f36e4f25aee6a861feff5b077862a) | `` Updated elpa ``  |