### PR TITLE
chore(flake/nur): `e25bcec8` -> `74865ce6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708629801,
-        "narHash": "sha256-oLsGmWvK3ST0jjwb+bnPgKFsv2XMLQRFJKR01yD/+d0=",
+        "lastModified": 1708633445,
+        "narHash": "sha256-K8qjcprq4g6TCaf0sc5QISLpj8sNJ53PuqvzxITTHuo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e25bcec8bfbf285498929d6baaaa615001a1ef10",
+        "rev": "74865ce680458a3b48338ab7251de9eae21bd504",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`74865ce6`](https://github.com/nix-community/NUR/commit/74865ce680458a3b48338ab7251de9eae21bd504) | `` automatic update `` |