### PR TITLE
chore(flake/nur): `74865ce6` -> `0117ec46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708633445,
-        "narHash": "sha256-K8qjcprq4g6TCaf0sc5QISLpj8sNJ53PuqvzxITTHuo=",
+        "lastModified": 1708635949,
+        "narHash": "sha256-b/lwnHF/VKvxcTFkgREjmip5DZxoGEScWGcxQCDV5Y8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "74865ce680458a3b48338ab7251de9eae21bd504",
+        "rev": "0117ec463a196a476752e07200d853d9841fea6a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0117ec46`](https://github.com/nix-community/NUR/commit/0117ec463a196a476752e07200d853d9841fea6a) | `` automatic update `` |