### PR TITLE
chore(flake/nur): `0117ec46` -> `e7d31799`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708635949,
-        "narHash": "sha256-b/lwnHF/VKvxcTFkgREjmip5DZxoGEScWGcxQCDV5Y8=",
+        "lastModified": 1708640132,
+        "narHash": "sha256-w1h/s7LwjqYLUyspIuKankX6qHHeNWVhm3Oe+cvPIS8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0117ec463a196a476752e07200d853d9841fea6a",
+        "rev": "e7d3179956f6054b12efb01f3a998474b48007df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e7d31799`](https://github.com/nix-community/NUR/commit/e7d3179956f6054b12efb01f3a998474b48007df) | `` automatic update `` |