### PR TITLE
chore(flake/nur): `e7d31799` -> `e076e631`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708640132,
-        "narHash": "sha256-w1h/s7LwjqYLUyspIuKankX6qHHeNWVhm3Oe+cvPIS8=",
+        "lastModified": 1708653636,
+        "narHash": "sha256-KN1bamwUhamvCx+udkEFcDnzo9mniPbjy8QT9f2O71Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e7d3179956f6054b12efb01f3a998474b48007df",
+        "rev": "e076e631f5aec5e3ecc8a9d932199095462a10f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e076e631`](https://github.com/nix-community/NUR/commit/e076e631f5aec5e3ecc8a9d932199095462a10f0) | `` automatic update `` |
| [`3fac564e`](https://github.com/nix-community/NUR/commit/3fac564efbd1224fdebea052380fc64307cb311f) | `` automatic update `` |
| [`52422d24`](https://github.com/nix-community/NUR/commit/52422d2443f60feb5a426ef698c6ab6b544f0e6d) | `` automatic update `` |