### PR TITLE
chore(flake/darwin): `0e6857fa` -> `314a36d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708231718,
-        "narHash": "sha256-IZdieFWvhBkxoOFMDejqLUYqD94WN6k0YSpw0DFy+4g=",
+        "lastModified": 1708655464,
+        "narHash": "sha256-dhi3XXT662o1FtP/Li2dIwcQCco6nhT+Yv71dptTlSw=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "0e6857fa1d632637488666c08e7b02c08e3178f8",
+        "rev": "314a36d99b507892b598da72d0f9d78db084cec9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                                |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
| [`27e6a022`](https://github.com/LnL7/nix-darwin/commit/27e6a022f25b94010fdb8e5fbbb79608dc589397) | `` apply feedback, fix merge goof ``                                                                   |
| [`61c5879b`](https://github.com/LnL7/nix-darwin/commit/61c5879b5a326874f6be7c8c9a4c377b693098f4) | `` linux-builder: default pass through protocol to nix.buildMachines ``                                |
| [`94558e7e`](https://github.com/LnL7/nix-darwin/commit/94558e7e8b3acb1ac8fe2b65042b49b488fe0678) | `` linux-builder: Pass through more options to nix.buildMachines ``                                    |
| [`72dd60bf`](https://github.com/LnL7/nix-darwin/commit/72dd60bfc98c128149d84213b17d1b8a68863055) | `` Add default system to `systems` option ``                                                           |
| [`6a3a683d`](https://github.com/LnL7/nix-darwin/commit/6a3a683d4351e68d746a5aea6953395cedf921bf) | `` Use `nix.buildMachines.*.systems` instead of `nix.buildMachines.*.system` ``                        |
| [`a5812ff8`](https://github.com/LnL7/nix-darwin/commit/a5812ff83c0d5e8b5af40cf188929a5a393d77c6) | `` Add `nix.linux-builder.systems` option to set corresponding `nix.buildMachines.*.systems` option `` |