### PR TITLE
chore(flake/nur): `e076e631` -> `7944446e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708653636,
-        "narHash": "sha256-KN1bamwUhamvCx+udkEFcDnzo9mniPbjy8QT9f2O71Y=",
+        "lastModified": 1708663087,
+        "narHash": "sha256-Ckp8pSkhY+lr9/HxZotE8U4gZy3d8A1R0QH6tx2A9P4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e076e631f5aec5e3ecc8a9d932199095462a10f0",
+        "rev": "7944446e0031abeb3151dc750672b757088d5220",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7944446e`](https://github.com/nix-community/NUR/commit/7944446e0031abeb3151dc750672b757088d5220) | `` automatic update `` |
| [`bba66b71`](https://github.com/nix-community/NUR/commit/bba66b7118eb9466eba8309fa2cbc8bb30677e5b) | `` automatic update `` |
| [`033887f2`](https://github.com/nix-community/NUR/commit/033887f2c8ffeab2abfd3bec23a3386d0cc17e70) | `` automatic update `` |
| [`5c4df059`](https://github.com/nix-community/NUR/commit/5c4df0594289335dbe400664a2771969397e7c7f) | `` automatic update `` |