### PR TITLE
chore(flake/nur): `7944446e` -> `b2f8bdcb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708663087,
-        "narHash": "sha256-Ckp8pSkhY+lr9/HxZotE8U4gZy3d8A1R0QH6tx2A9P4=",
+        "lastModified": 1708668033,
+        "narHash": "sha256-+34/+Y3raxieR9dSOmE/cBr1EjeC49PlPd0j9io3KIU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7944446e0031abeb3151dc750672b757088d5220",
+        "rev": "b2f8bdcb64f1cde8848fa6f22848d36c472e8290",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b2f8bdcb`](https://github.com/nix-community/NUR/commit/b2f8bdcb64f1cde8848fa6f22848d36c472e8290) | `` automatic update `` |