### PR TITLE
chore(flake/nur): `b2f8bdcb` -> `f2251c97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708668033,
-        "narHash": "sha256-+34/+Y3raxieR9dSOmE/cBr1EjeC49PlPd0j9io3KIU=",
+        "lastModified": 1708671626,
+        "narHash": "sha256-DW3Dg/AgdWZxBmawlAmxIUH0lbkdx5XRBbskrQ7CT0c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b2f8bdcb64f1cde8848fa6f22848d36c472e8290",
+        "rev": "f2251c9702b4152b8a5ea519c28b0a3af00046a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f2251c97`](https://github.com/nix-community/NUR/commit/f2251c9702b4152b8a5ea519c28b0a3af00046a2) | `` automatic update `` |
| [`f2dea19f`](https://github.com/nix-community/NUR/commit/f2dea19f00712b55adae54680320368c69303312) | `` automatic update `` |