### PR TITLE
chore(flake/nur): `f2251c97` -> `c887bb06`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708671626,
-        "narHash": "sha256-DW3Dg/AgdWZxBmawlAmxIUH0lbkdx5XRBbskrQ7CT0c=",
+        "lastModified": 1708673415,
+        "narHash": "sha256-HzhtFIu27pv1/Qaq5oLGaVtmEAO14WrxsB7utEP7aew=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f2251c9702b4152b8a5ea519c28b0a3af00046a2",
+        "rev": "c887bb0661d6e67f42feed9480f968305bc7dcb1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c887bb06`](https://github.com/nix-community/NUR/commit/c887bb0661d6e67f42feed9480f968305bc7dcb1) | `` automatic update `` |