### PR TITLE
chore(flake/emacs-overlay): `8bcb0f18` -> `8c960d16`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708652664,
-        "narHash": "sha256-bTObNjlIvxOmTct0LBm0WkxrtOy2/wWAfxT1a03HpB4=",
+        "lastModified": 1708678318,
+        "narHash": "sha256-MPQIcOdmy1mPp61Pu7owPrYKQuxOYPu3LJhItb93m54=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8bcb0f18ef0e77012d8ade7cdb97e897774a179c",
+        "rev": "8c960d16f0397375d706757635a6b1c437d75fdb",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1708440434,
-        "narHash": "sha256-XY+B9mbhL/i+Q6fP6gBQ6P76rv9rWtpjQiUJ+DGtaUg=",
+        "lastModified": 1708566995,
+        "narHash": "sha256-e/THimsoxxMAHSbwMKov5f5Yg+utTj6XVGEo24Lhx+0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "526d051b128b82ae045a70e5ff1adf8e6dafa560",
+        "rev": "3cb4ae6689d2aa3f363516234572613b31212b78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`8c960d16`](https://github.com/nix-community/emacs-overlay/commit/8c960d16f0397375d706757635a6b1c437d75fdb) | `` Updated melpa ``        |
| [`eab05784`](https://github.com/nix-community/emacs-overlay/commit/eab0578469312efc175332bc8ec405d6d7a765a0) | `` Updated flake inputs `` |