### PR TITLE
chore(flake/srvos): `7c02fb00` -> `8d159ac5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1028,11 +1028,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708303807,
-        "narHash": "sha256-T3ywY/VPlG0n7P7Rhm/GJ+hLXtUmEETJUGRfvaYQ0OM=",
+        "lastModified": 1708676872,
+        "narHash": "sha256-q7UU7tcLlSw0rbHSqm8NHLkNtg+7Egdx5GhII1tgXtA=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "7c02fb006bdd70474853e6395bd5916ba2404fa2",
+        "rev": "8d159ac5bb67368509861cf1a94717402d8d216e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message              |
| ---------------------------------------------------------------------------------------------------- | -------------------- |
| [`8d159ac5`](https://github.com/nix-community/srvos/commit/8d159ac5bb67368509861cf1a94717402d8d216e) | `` no stub (#387) `` |