### PR TITLE
chore(flake/stylix): `50cae37c` -> `32fe070b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1064,11 +1064,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707757489,
-        "narHash": "sha256-YyqHbxtDGB3OIITPQ3XtkM20fh9/t4CXkYXKzg9DuP8=",
+        "lastModified": 1708691286,
+        "narHash": "sha256-murghW5kgE4fE1tqZdXiMeeUXbyM4qrwKX0SUZTrEKg=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "50cae37cfe23e5ad202ed53f48529139dfa0d008",
+        "rev": "32fe070be53d7d6891e21dcb2b1ebbfe45c3cf1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                     |
| --------------------------------------------------------------------------------------------- | --------------------------- |
| [`32fe070b`](https://github.com/danth/stylix/commit/32fe070be53d7d6891e21dcb2b1ebbfe45c3cf1e) | `` btop: init (#259) ``     |
| [`a38d900d`](https://github.com/danth/stylix/commit/a38d900ddf2c65658cd242afdee90c3ec2d6b810) | `` mangohud: init (#260) `` |