### PR TITLE
chore(flake/nur): `676caef6` -> `b6eb0f41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708685148,
-        "narHash": "sha256-hkQ1ELaEDG6QCtlABANGXRiQxdPUP6L2m5D1UJtvGck=",
+        "lastModified": 1708691991,
+        "narHash": "sha256-AIJCuZXyHtF0yXw4jQXlXkvW+VmL3/Y7GO5MTSL0y7o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "676caef6be77d3446e94a47a01e0b1253ad818ca",
+        "rev": "b6eb0f41fc7f5f9aba88af8b30d98fb9617da4b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b6eb0f41`](https://github.com/nix-community/NUR/commit/b6eb0f41fc7f5f9aba88af8b30d98fb9617da4b7) | `` automatic update `` |