### PR TITLE
chore(flake/nur): `b6eb0f41` -> `e57de8f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708691991,
-        "narHash": "sha256-AIJCuZXyHtF0yXw4jQXlXkvW+VmL3/Y7GO5MTSL0y7o=",
+        "lastModified": 1708699965,
+        "narHash": "sha256-+nEU8x+VuA3ArsZzSkh8EI625TvEO7QtOWUu5e3nXXo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b6eb0f41fc7f5f9aba88af8b30d98fb9617da4b7",
+        "rev": "e57de8f3b903d09d56b763a02f659ddd29413564",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e57de8f3`](https://github.com/nix-community/NUR/commit/e57de8f3b903d09d56b763a02f659ddd29413564) | `` automatic update `` |
| [`f36586c0`](https://github.com/nix-community/NUR/commit/f36586c075aadb508c09066261f73ca888cdef4b) | `` automatic update `` |
| [`e2fe470b`](https://github.com/nix-community/NUR/commit/e2fe470ba0e468355422fc639f84f0d94dd28422) | `` automatic update `` |