### PR TITLE
chore(flake/nur): `e57de8f3` -> `d9ddb7e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708699965,
-        "narHash": "sha256-+nEU8x+VuA3ArsZzSkh8EI625TvEO7QtOWUu5e3nXXo=",
+        "lastModified": 1708703175,
+        "narHash": "sha256-RjXygWqRt4HQaD2fBnhPC7+x1HlGny03BVCrx6E0ou8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e57de8f3b903d09d56b763a02f659ddd29413564",
+        "rev": "d9ddb7e1b789fea42f136a2f04ee20b6edf1cd55",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d9ddb7e1`](https://github.com/nix-community/NUR/commit/d9ddb7e1b789fea42f136a2f04ee20b6edf1cd55) | `` automatic update `` |