### PR TITLE
chore(flake/nur): `e08206f6` -> `ed0ac081`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708706671,
-        "narHash": "sha256-7Om8sUhA/v+nMr1ryDJdmd6NPf99ustAr2IAWqwJK3Y=",
+        "lastModified": 1708713911,
+        "narHash": "sha256-Xll/ymLUt+ikR0B/k3IMMqOk8Pt9Mnc2//vGHpdlMhc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e08206f667fa053add91c69ca52770a67732c5fc",
+        "rev": "ed0ac081d4a5f97dd31a01810593ba483433b020",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ed0ac081`](https://github.com/nix-community/NUR/commit/ed0ac081d4a5f97dd31a01810593ba483433b020) | `` automatic update `` |
| [`0efe7096`](https://github.com/nix-community/NUR/commit/0efe7096d93ee45892e478c32fd5ee58bb815948) | `` automatic update `` |
| [`d5d88ce2`](https://github.com/nix-community/NUR/commit/d5d88ce2b91a5a3344901620f718899468d33ba7) | `` automatic update `` |
| [`f910d8ab`](https://github.com/nix-community/NUR/commit/f910d8ab283889f9eae8985ab79cec99faf54ee5) | `` automatic update `` |