### PR TITLE
chore(flake/nur): `15885313` -> `ca93af01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708731959,
-        "narHash": "sha256-zneXL4+jxo1e08rSEOTCFaSHYNQicYeV5t26S+seguc=",
+        "lastModified": 1708736989,
+        "narHash": "sha256-dBm35dyt8aE5X0YwhDKvrR2WV6RvEsTboIvR/yK4T40=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1588531309e9bd3ed51cb280e66e628b53dfb73f",
+        "rev": "ca93af016d87c2f150a96394f4c3d860d41c67a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ca93af01`](https://github.com/nix-community/NUR/commit/ca93af016d87c2f150a96394f4c3d860d41c67a0) | `` automatic update `` |
| [`9ad79fd0`](https://github.com/nix-community/NUR/commit/9ad79fd0bacc6e0b29e476b1226c2257811115c2) | `` automatic update `` |