### PR TITLE
chore(flake/nur): `ca93af01` -> `099272d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708736989,
-        "narHash": "sha256-dBm35dyt8aE5X0YwhDKvrR2WV6RvEsTboIvR/yK4T40=",
+        "lastModified": 1708749495,
+        "narHash": "sha256-yCCmJIJFy9PMXraVAibkAsrJMEuMInC9gvKsQZz+f8s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ca93af016d87c2f150a96394f4c3d860d41c67a0",
+        "rev": "099272d8b84ddafe37e4f451bc27f554e00fca05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`099272d8`](https://github.com/nix-community/NUR/commit/099272d8b84ddafe37e4f451bc27f554e00fca05) | `` automatic update `` |
| [`0ec596e0`](https://github.com/nix-community/NUR/commit/0ec596e0c61b136b668a98051d9f530922be7b7c) | `` automatic update `` |
| [`74a7d74e`](https://github.com/nix-community/NUR/commit/74a7d74e28630535779aa6e43d94504660abedc6) | `` automatic update `` |
| [`be54879f`](https://github.com/nix-community/NUR/commit/be54879f8e138501b38985fa56cf8df92ffc5498) | `` automatic update `` |