### PR TITLE
chore(flake/emacs-overlay): `a34163ae` -> `0a9f2206`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708738984,
-        "narHash": "sha256-DtqxEAqjcyw8ppJCBbfxt6xsw6L123sQGIOJd403kzM=",
+        "lastModified": 1708755536,
+        "narHash": "sha256-wtNGi39xz4wGXK5vBieL3mDl2LdkJoWFkjLokA/d4cg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a34163aecd2197823601eadeca2d4f0f2ef1eeb6",
+        "rev": "0a9f2206463dcf4f54d11d2edd98482e7154489d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                     |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
| [`0a9f2206`](https://github.com/nix-community/emacs-overlay/commit/0a9f2206463dcf4f54d11d2edd98482e7154489d) | `` Revert "Use --replace-warn instead of --replace in substituteInPlace" `` |