### PR TITLE
chore(flake/nur): `099272d8` -> `3569087c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708749495,
-        "narHash": "sha256-yCCmJIJFy9PMXraVAibkAsrJMEuMInC9gvKsQZz+f8s=",
+        "lastModified": 1708757092,
+        "narHash": "sha256-d3gKOfyJeBt8BXKOy0VPmU/Ex+13JMgesiIBw0C5dGY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "099272d8b84ddafe37e4f451bc27f554e00fca05",
+        "rev": "3569087c73e3a145c6c7d9b7791c64c1e56f9317",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3569087c`](https://github.com/nix-community/NUR/commit/3569087c73e3a145c6c7d9b7791c64c1e56f9317) | `` automatic update `` |