### PR TITLE
chore(flake/nur): `3569087c` -> `5d874529`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708757092,
-        "narHash": "sha256-d3gKOfyJeBt8BXKOy0VPmU/Ex+13JMgesiIBw0C5dGY=",
+        "lastModified": 1708761275,
+        "narHash": "sha256-Wua+wwcAOeoEmB8LJcP6Rp55StXOBwyPJbFc1LqS01k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3569087c73e3a145c6c7d9b7791c64c1e56f9317",
+        "rev": "5d874529e3006e19f9928b8a988115af40631554",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5d874529`](https://github.com/nix-community/NUR/commit/5d874529e3006e19f9928b8a988115af40631554) | `` automatic update `` |