### PR TITLE
chore(flake/nur): `5d874529` -> `7f0cad37`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708761275,
-        "narHash": "sha256-Wua+wwcAOeoEmB8LJcP6Rp55StXOBwyPJbFc1LqS01k=",
+        "lastModified": 1708771490,
+        "narHash": "sha256-HYFlXYMWDHZmwazXGNu0DT5M/ZNkYTOMtUxh40onEGA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5d874529e3006e19f9928b8a988115af40631554",
+        "rev": "7f0cad37958f31e19255fcc50683c638caa3149e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7f0cad37`](https://github.com/nix-community/NUR/commit/7f0cad37958f31e19255fcc50683c638caa3149e) | `` automatic update `` |
| [`91985622`](https://github.com/nix-community/NUR/commit/919856228550477509e5a64e0f5bc8303f5103f6) | `` automatic update `` |