### PR TITLE
chore(flake/nur): `7f0cad37` -> `d24540b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708771490,
-        "narHash": "sha256-HYFlXYMWDHZmwazXGNu0DT5M/ZNkYTOMtUxh40onEGA=",
+        "lastModified": 1708779111,
+        "narHash": "sha256-2CD3RFLqKGcRPRmdVQWc8yRPoUrHg+OpNlCjZq2ZewM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7f0cad37958f31e19255fcc50683c638caa3149e",
+        "rev": "d24540b60bc7f22d530d4f68bc53fab227180b16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d24540b6`](https://github.com/nix-community/NUR/commit/d24540b60bc7f22d530d4f68bc53fab227180b16) | `` automatic update `` |
| [`c535580a`](https://github.com/nix-community/NUR/commit/c535580af90c127bf48d9343fe43518a75e0e233) | `` automatic update `` |