### PR TITLE
chore(flake/nur): `d24540b6` -> `77bc2584`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708779111,
-        "narHash": "sha256-2CD3RFLqKGcRPRmdVQWc8yRPoUrHg+OpNlCjZq2ZewM=",
+        "lastModified": 1708783103,
+        "narHash": "sha256-+4lGvcDW0BXWJuERR/z2cpOewQqKcTj3Mqdg91Jxayo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d24540b60bc7f22d530d4f68bc53fab227180b16",
+        "rev": "77bc25848d0279f03bdfdf3f428750bd04caf4e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`77bc2584`](https://github.com/nix-community/NUR/commit/77bc25848d0279f03bdfdf3f428750bd04caf4e1) | `` automatic update `` |