### PR TITLE
chore(flake/nur): `c31e6836` -> `4f24de20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708784025,
-        "narHash": "sha256-MiH1+ITLrADLRl9TZcZtFso3FDXFnNph+PS2pPMWd6M=",
+        "lastModified": 1708789503,
+        "narHash": "sha256-vcSC8zW2csv1HUSXUZGG0cqZJFsnFwHdNqTu2+CtNlY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c31e683648bb756993e914698d7da86a981cac79",
+        "rev": "4f24de20bff7a1b2ccd6f1212756392a09c8f5dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4f24de20`](https://github.com/nix-community/NUR/commit/4f24de20bff7a1b2ccd6f1212756392a09c8f5dd) | `` automatic update `` |