### PR TITLE
chore(flake/nur): `4f24de20` -> `6eb03949`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708789503,
-        "narHash": "sha256-vcSC8zW2csv1HUSXUZGG0cqZJFsnFwHdNqTu2+CtNlY=",
+        "lastModified": 1708793180,
+        "narHash": "sha256-TCu1L+Msied0BLUDXStChcz3e1yvd2no/DxLjyffYVI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4f24de20bff7a1b2ccd6f1212756392a09c8f5dd",
+        "rev": "6eb0394958661a7b8a16e7e670170d1908631d8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6eb03949`](https://github.com/nix-community/NUR/commit/6eb0394958661a7b8a16e7e670170d1908631d8f) | `` automatic update `` |