### PR TITLE
chore(flake/nur): `6eb03949` -> `b36b8de8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708793180,
-        "narHash": "sha256-TCu1L+Msied0BLUDXStChcz3e1yvd2no/DxLjyffYVI=",
+        "lastModified": 1708799159,
+        "narHash": "sha256-yWqq7bc2YGZrKBDgQTcf0C1PPXTNOsi+UNxzFO2LglE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6eb0394958661a7b8a16e7e670170d1908631d8f",
+        "rev": "b36b8de81d0ae9e20f2c5c190559987ce875884d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b36b8de8`](https://github.com/nix-community/NUR/commit/b36b8de81d0ae9e20f2c5c190559987ce875884d) | `` automatic update `` |