### PR TITLE
chore(flake/nur): `b36b8de8` -> `deb67c14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708799159,
-        "narHash": "sha256-yWqq7bc2YGZrKBDgQTcf0C1PPXTNOsi+UNxzFO2LglE=",
+        "lastModified": 1708806201,
+        "narHash": "sha256-kZv5LWZaR1N1Jz+3S3OBWadCXyOAdmi2heKfCmjmkYw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b36b8de81d0ae9e20f2c5c190559987ce875884d",
+        "rev": "deb67c142317827d32256bb0df1fc96be237a177",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`deb67c14`](https://github.com/nix-community/NUR/commit/deb67c142317827d32256bb0df1fc96be237a177) | `` automatic update `` |
| [`63862fa4`](https://github.com/nix-community/NUR/commit/63862fa406a392b70265a065269d0f5bb9126050) | `` automatic update `` |
| [`78834d86`](https://github.com/nix-community/NUR/commit/78834d86e59d74af591676eeb519f73c2fb1a81c) | `` automatic update `` |