### PR TITLE
chore(flake/emacs-overlay): `c9356ad5` -> `f42e044d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708822825,
-        "narHash": "sha256-DF6nnDNT2QxE4QC8IayNcxKK8/vD/DqjcJN5Jq8IT4Y=",
+        "lastModified": 1708825735,
+        "narHash": "sha256-R7Hoofk9AsO7i2OHlXe6sZSHhKcbwHxbt8G17BLvWNw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c9356ad50ab78e0ac6eec0505cbdd3685427cee4",
+        "rev": "f42e044d8eae9e0da1a00afa79d411765c757648",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`f42e044d`](https://github.com/nix-community/emacs-overlay/commit/f42e044d8eae9e0da1a00afa79d411765c757648) | `` Updated emacs `` |
| [`47070af1`](https://github.com/nix-community/emacs-overlay/commit/47070af18d262bd7a84f55c8e2b5108eae7d1de9) | `` Updated melpa `` |