### PR TITLE
chore(flake/nur): `d4cff0d9` -> `d7d9902a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708823083,
-        "narHash": "sha256-iNBuglL+gKLhZcC7BY8MTyEBXKi1e3EsdaV1ZXUZD44=",
+        "lastModified": 1708832498,
+        "narHash": "sha256-FoTRzVRP1KFuIgaF0RLUSegERw/v/xWfIBM7Z0CN58E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d4cff0d91d9e8bc38c0d2446a0617eea68ea0d17",
+        "rev": "d7d9902aeda4c7c46ecd8978fb5aec59dcd12d34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d7d9902a`](https://github.com/nix-community/NUR/commit/d7d9902aeda4c7c46ecd8978fb5aec59dcd12d34) | `` automatic update `` |
| [`442c6e5b`](https://github.com/nix-community/NUR/commit/442c6e5b2038f4abd4e89fa6bb46c9122e75be7b) | `` automatic update `` |
| [`9549d87f`](https://github.com/nix-community/NUR/commit/9549d87f2cddc0579c67443e4ee6a95ea1da6380) | `` automatic update `` |
| [`4a78ac86`](https://github.com/nix-community/NUR/commit/4a78ac8656d2461d8873554950b53f698c2a6cb6) | `` automatic update `` |