### PR TITLE
chore(flake/nur): `d7d9902a` -> `408fe763`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708832498,
-        "narHash": "sha256-FoTRzVRP1KFuIgaF0RLUSegERw/v/xWfIBM7Z0CN58E=",
+        "lastModified": 1708844373,
+        "narHash": "sha256-WnPWb13KlqygqA8Wgr2a5pq/KzsVNtka+falIqB02uA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d7d9902aeda4c7c46ecd8978fb5aec59dcd12d34",
+        "rev": "408fe76319f64a9395291e71879b85f34428d46c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`408fe763`](https://github.com/nix-community/NUR/commit/408fe76319f64a9395291e71879b85f34428d46c) | `` automatic update `` |
| [`d0aeb622`](https://github.com/nix-community/NUR/commit/d0aeb622bd4baa0d645abb68930eec2b88654a01) | `` automatic update `` |
| [`e38c20f5`](https://github.com/nix-community/NUR/commit/e38c20f50c537690d8e40c22eab80c65ad6f634a) | `` automatic update `` |
| [`46eb23f6`](https://github.com/nix-community/NUR/commit/46eb23f6c3724da2c4fc62968663b3063987be3d) | `` automatic update `` |
| [`be8e5dc5`](https://github.com/nix-community/NUR/commit/be8e5dc50940ca6a2e94a7edaf151ef056816df9) | `` automatic update `` |
| [`d825643f`](https://github.com/nix-community/NUR/commit/d825643f7c47eedc0e27abe716df7d3fe7a9182b) | `` automatic update `` |
| [`a1b32783`](https://github.com/nix-community/NUR/commit/a1b327833d80c8210e03a8ca20a53ee7fc5e676a) | `` automatic update `` |
| [`51b5dfc6`](https://github.com/nix-community/NUR/commit/51b5dfc67df3a2815c354d8faeadc872f2d7ee9d) | `` automatic update `` |
| [`6298f9ef`](https://github.com/nix-community/NUR/commit/6298f9ef11374cd702f19e989eaed2f088066e4f) | `` automatic update `` |
| [`373f4c4b`](https://github.com/nix-community/NUR/commit/373f4c4b272bbfdfa1bfd74dc9b3fdaa36801033) | `` automatic update `` |
| [`e87cad65`](https://github.com/nix-community/NUR/commit/e87cad65ed138017180bb0d0b9164d2cdca80585) | `` automatic update `` |