### PR TITLE
chore(flake/emacs-overlay): `f42e044d` -> `42b8b4a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708825735,
-        "narHash": "sha256-R7Hoofk9AsO7i2OHlXe6sZSHhKcbwHxbt8G17BLvWNw=",
+        "lastModified": 1708851887,
+        "narHash": "sha256-gMzpMV8sYuhuPniw/Yef7Sx0MOkP/QGCblm3CRI24EQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f42e044d8eae9e0da1a00afa79d411765c757648",
+        "rev": "42b8b4a59edbd70550ebc96e95c9258dbdefd753",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`42b8b4a5`](https://github.com/nix-community/emacs-overlay/commit/42b8b4a59edbd70550ebc96e95c9258dbdefd753) | `` Updated emacs `` |
| [`0a1a15af`](https://github.com/nix-community/emacs-overlay/commit/0a1a15afc03b1a48662ac62879b1918ec11289e2) | `` Updated melpa `` |