### PR TITLE
chore(flake/nur): `1a8f1350` -> `ab92c5c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708846068,
-        "narHash": "sha256-DLO8wGGBsveni/D2MABfrMrMM0zzRHA0Mh2508UoKTY=",
+        "lastModified": 1708850682,
+        "narHash": "sha256-NE9tbU4eqYf1gK5FIGx7yGHfKgZzMNEERQCS2GmdlAc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1a8f13501baaa98a17387c742bf0a13e53ae974c",
+        "rev": "ab92c5c64ef62f5e80144fe681dc1e97d54cac60",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ab92c5c6`](https://github.com/nix-community/NUR/commit/ab92c5c64ef62f5e80144fe681dc1e97d54cac60) | `` automatic update `` |
| [`834687f6`](https://github.com/nix-community/NUR/commit/834687f661d7083626a2481ba1c7f8eeae98244c) | `` automatic update `` |
| [`02f95dc0`](https://github.com/nix-community/NUR/commit/02f95dc07523e444691aca63243ce1660c1937fa) | `` automatic update `` |