### PR TITLE
chore(flake/nur): `ab92c5c6` -> `7c776517`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708850682,
-        "narHash": "sha256-NE9tbU4eqYf1gK5FIGx7yGHfKgZzMNEERQCS2GmdlAc=",
+        "lastModified": 1708852278,
+        "narHash": "sha256-wbp7ZHvnfTu5EcNrwzVvt+sw0EL62X8M30SZ7tMAjfM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ab92c5c64ef62f5e80144fe681dc1e97d54cac60",
+        "rev": "7c77651728ecfa2188e8c7eec34a1646567362d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7c776517`](https://github.com/nix-community/NUR/commit/7c77651728ecfa2188e8c7eec34a1646567362d2) | `` automatic update `` |