### PR TITLE
chore(flake/nur): `7c776517` -> `2b881bb2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708852278,
-        "narHash": "sha256-wbp7ZHvnfTu5EcNrwzVvt+sw0EL62X8M30SZ7tMAjfM=",
+        "lastModified": 1708857881,
+        "narHash": "sha256-Teg7subdiw0q6xlEDXWuMZ9Qv92j++gpeEaYHtGz8a8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7c77651728ecfa2188e8c7eec34a1646567362d2",
+        "rev": "2b881bb2d0853c61f207f9486099d923dae10a75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2b881bb2`](https://github.com/nix-community/NUR/commit/2b881bb2d0853c61f207f9486099d923dae10a75) | `` automatic update `` |