### PR TITLE
chore(flake/nur): `2b881bb2` -> `1fe352ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708857881,
-        "narHash": "sha256-Teg7subdiw0q6xlEDXWuMZ9Qv92j++gpeEaYHtGz8a8=",
+        "lastModified": 1708864816,
+        "narHash": "sha256-SM1zlHhoZf20lhp0v7ss52MYEWux/j+jfqfxUp8yqW8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2b881bb2d0853c61f207f9486099d923dae10a75",
+        "rev": "1fe352ab8a7560c8bbd793852c52979894a7705e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1fe352ab`](https://github.com/nix-community/NUR/commit/1fe352ab8a7560c8bbd793852c52979894a7705e) | `` automatic update `` |
| [`78c9459d`](https://github.com/nix-community/NUR/commit/78c9459d2ca2194a6f9a7d676390c6912a7e0704) | `` automatic update `` |