### PR TITLE
chore(flake/emacs-overlay): `42b8b4a5` -> `8bd96b59`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708851887,
-        "narHash": "sha256-gMzpMV8sYuhuPniw/Yef7Sx0MOkP/QGCblm3CRI24EQ=",
+        "lastModified": 1708879861,
+        "narHash": "sha256-Uw6YY4HHkjoDb+1PihpCYgTuKSTimo9vgXLdhOg+sEY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "42b8b4a59edbd70550ebc96e95c9258dbdefd753",
+        "rev": "8bd96b59c634cb8fd2cf7528a81be84d0779b0df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`8bd96b59`](https://github.com/nix-community/emacs-overlay/commit/8bd96b59c634cb8fd2cf7528a81be84d0779b0df) | `` Updated melpa ``        |
| [`fd78fc83`](https://github.com/nix-community/emacs-overlay/commit/fd78fc83959ee842d637871a046027ec4c69f194) | `` Updated elpa ``         |
| [`16b8c77f`](https://github.com/nix-community/emacs-overlay/commit/16b8c77f0c2f8ba9acdb1284b784aa0490e4d86e) | `` Updated flake inputs `` |