### PR TITLE
chore(flake/nur): `213b98be` -> `dc3adf0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708883898,
-        "narHash": "sha256-ikylhoLwSQx9NIN1jamDxW8MdLGHwxmczzhl0udNw9A=",
+        "lastModified": 1708886747,
+        "narHash": "sha256-EKnrnSngXDqALHSYNtECxpE1jxPhHssLk3TVt2BwOjY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "213b98be1ba8adb0ac3b89efd1bf7ec571301a32",
+        "rev": "dc3adf0b8f3d2df76fe0b500901b2f24ebc0039e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dc3adf0b`](https://github.com/nix-community/NUR/commit/dc3adf0b8f3d2df76fe0b500901b2f24ebc0039e) | `` automatic update `` |