### PR TITLE
chore(flake/nur): `dc3adf0b` -> `b54e6ceb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708886747,
-        "narHash": "sha256-EKnrnSngXDqALHSYNtECxpE1jxPhHssLk3TVt2BwOjY=",
+        "lastModified": 1708888440,
+        "narHash": "sha256-aXicgxLGE4nu0B8XtPbxeLLhIbMZ9uoxvu1nJ4mT/cA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dc3adf0b8f3d2df76fe0b500901b2f24ebc0039e",
+        "rev": "b54e6ceb1036361636218767115d204c06799aca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b54e6ceb`](https://github.com/nix-community/NUR/commit/b54e6ceb1036361636218767115d204c06799aca) | `` automatic update `` |