### PR TITLE
chore(flake/nur): `b54e6ceb` -> `7d6c7813`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708888440,
-        "narHash": "sha256-aXicgxLGE4nu0B8XtPbxeLLhIbMZ9uoxvu1nJ4mT/cA=",
+        "lastModified": 1708890337,
+        "narHash": "sha256-LzXHAwPA3kjl0ChIbm1bOzrYo9GtOA6JGZhnnt5vYCQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b54e6ceb1036361636218767115d204c06799aca",
+        "rev": "7d6c781342f58e0d8fdb281f2abc238b1aa38e5c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7d6c7813`](https://github.com/nix-community/NUR/commit/7d6c781342f58e0d8fdb281f2abc238b1aa38e5c) | `` automatic update `` |