### PR TITLE
chore(flake/emacs-overlay): `482ea123` -> `a31b5c4d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708882023,
-        "narHash": "sha256-kGUpmwdfR4wTrlLUNzR6NFGpwlzrVRtnVaxHm4yTlCE=",
+        "lastModified": 1708911953,
+        "narHash": "sha256-3GjgXt+3UriCQF78v2q0nJEKCb3Qr+TpX7ahDx92fNM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "482ea12373e83482e9a37113908cb947980cf8aa",
+        "rev": "a31b5c4d51ff2e400453aceea4b81a4a066eca79",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1708702655,
-        "narHash": "sha256-qxT5jSLhelfLhQ07+AUxSTm1VnVH+hQxDkQSZ/m/Smo=",
+        "lastModified": 1708831307,
+        "narHash": "sha256-0iL/DuGjiUeck1zEaL+aIe2WvA3/cVhp/SlmTcOZXH4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c5101e457206dd437330d283d6626944e28794b3",
+        "rev": "5bf1cadb72ab4e77cb0b700dab76bcdaf88f706b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`a31b5c4d`](https://github.com/nix-community/emacs-overlay/commit/a31b5c4d51ff2e400453aceea4b81a4a066eca79) | `` Updated emacs ``        |
| [`255453a9`](https://github.com/nix-community/emacs-overlay/commit/255453a988380977c0df4eb2149434ee26151aaf) | `` Updated melpa ``        |
| [`a33b5055`](https://github.com/nix-community/emacs-overlay/commit/a33b5055039d7e575203ea63f9e194b141bf1231) | `` Updated elpa ``         |
| [`5f4a570f`](https://github.com/nix-community/emacs-overlay/commit/5f4a570f269fc26a704eccb796f5c59e4aaa96d3) | `` Updated flake inputs `` |