### PR TITLE
chore(flake/srvos): `8d159ac5` -> `b54e462b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1028,11 +1028,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708676872,
-        "narHash": "sha256-q7UU7tcLlSw0rbHSqm8NHLkNtg+7Egdx5GhII1tgXtA=",
+        "lastModified": 1708908680,
+        "narHash": "sha256-/ZVHI0KviV/DtZRneFinXrfHEeAhAT1mnx3+vNFKBx8=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "8d159ac5bb67368509861cf1a94717402d8d216e",
+        "rev": "b54e462b834d6c95721382a3fdb90411b0642220",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`b54e462b`](https://github.com/nix-community/srvos/commit/b54e462b834d6c95721382a3fdb90411b0642220) | `` dev/private/flake.lock: Update `` |
| [`ec0b66b6`](https://github.com/nix-community/srvos/commit/ec0b66b61d3fbd45d97d384070beb4c60b5d930c) | `` flake.lock: Update ``             |