### PR TITLE
chore(flake/nur): `e0c1ab7b` -> `9ad94435`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708909787,
-        "narHash": "sha256-mCt3amVqvJNv2H8BEd8gBwqcmMQM6FlJwBbpQQeJobE=",
+        "lastModified": 1708918783,
+        "narHash": "sha256-B8ZWYMEVHHK6+YvunYeLVAkmLr2uowIcmBz0Nl5NSAg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e0c1ab7bea5b4cc584de7fc0073000a1fc5079dd",
+        "rev": "9ad944357c8e4af38264c99bd8d988a48cdf7597",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ad94435`](https://github.com/nix-community/NUR/commit/9ad944357c8e4af38264c99bd8d988a48cdf7597) | `` automatic update `` |