### PR TITLE
chore(flake/nur): `2e171de7` -> `4b831266`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708920684,
-        "narHash": "sha256-of/WWbxGm9L++3FJw2yFmKyvvLK/BfEaZp9j6V5VoQc=",
+        "lastModified": 1708929950,
+        "narHash": "sha256-30VrShwM5ymOR1EAqa+slihLAtYzyKQMldrDjFn8hY0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2e171de74cc6b1eba87485afd001dc37a5fbb3b7",
+        "rev": "4b8312664c01d20da6b27627b3690a99ee2b6d86",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4b831266`](https://github.com/nix-community/NUR/commit/4b8312664c01d20da6b27627b3690a99ee2b6d86) | `` automatic update `` |