### PR TITLE
chore(flake/emacs-overlay): `a31b5c4d` -> `dc68b375`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708911953,
-        "narHash": "sha256-3GjgXt+3UriCQF78v2q0nJEKCb3Qr+TpX7ahDx92fNM=",
+        "lastModified": 1708938386,
+        "narHash": "sha256-WTSScoG1LhH+PBo3l4+Fcl1oGNuISmRzkYDrASPWefk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a31b5c4d51ff2e400453aceea4b81a4a066eca79",
+        "rev": "dc68b375c2733198f642804a3cfacab5ede99761",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`dc68b375`](https://github.com/nix-community/emacs-overlay/commit/dc68b375c2733198f642804a3cfacab5ede99761) | `` Updated emacs `` |
| [`091bfb2b`](https://github.com/nix-community/emacs-overlay/commit/091bfb2bf49d1c4aa31ff070ba17ed0cebca7f94) | `` Updated melpa `` |