### PR TITLE
chore(flake/nur): `67f12457` -> `cdb259ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708932525,
-        "narHash": "sha256-eMwNrfYhALhWuvdkctLv65bRS/2kB8qnlONW++RZsTE=",
+        "lastModified": 1708935806,
+        "narHash": "sha256-gboyUpnICFCIJ7rfijoAjJguezMj2rikstb5n4LDKIM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "67f124575c14b4aa0d565d5f248d82350625209c",
+        "rev": "cdb259ad397fa9e087bbe75c180b11972504b508",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cdb259ad`](https://github.com/nix-community/NUR/commit/cdb259ad397fa9e087bbe75c180b11972504b508) | `` automatic update `` |