### PR TITLE
chore(flake/nur): `cdb259ad` -> `36121729`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708935806,
-        "narHash": "sha256-gboyUpnICFCIJ7rfijoAjJguezMj2rikstb5n4LDKIM=",
+        "lastModified": 1708938863,
+        "narHash": "sha256-RwqyijFuO+O6T4IX3eQk64j3zHQHBjNWlP57Mc2wyvY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cdb259ad397fa9e087bbe75c180b11972504b508",
+        "rev": "3612172937c01525cc14646aea107cc764ed5cb2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`36121729`](https://github.com/nix-community/NUR/commit/3612172937c01525cc14646aea107cc764ed5cb2) | `` automatic update `` |