### PR TITLE
chore(flake/nur): `0ff6d565` -> `870c1879`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708955058,
-        "narHash": "sha256-ebVXjIILpjWWYGTSFuKI0A0DUwpfZn5ktcQFeIZ5Kvk=",
+        "lastModified": 1708961810,
+        "narHash": "sha256-Axcae8beLP3cDn4b+zX+EgA3Ar/OXQqZYetsfSlt+uQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0ff6d565aa7b176c964777e0675df38f2b66a2e9",
+        "rev": "870c1879a3b277c16b7ed483edbce8e9fc6f1b80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`870c1879`](https://github.com/nix-community/NUR/commit/870c1879a3b277c16b7ed483edbce8e9fc6f1b80) | `` automatic update `` |