### PR TITLE
chore(flake/emacs-overlay): `dc68b375` -> `f6a1a96f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708938386,
-        "narHash": "sha256-WTSScoG1LhH+PBo3l4+Fcl1oGNuISmRzkYDrASPWefk=",
+        "lastModified": 1708966353,
+        "narHash": "sha256-HugVgj0tzfrT3KL3NwqcZOwvsRlXjebzaJ6ptn3hx88=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dc68b375c2733198f642804a3cfacab5ede99761",
+        "rev": "f6a1a96f834d3d7936a768472d09006cc18d62d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`f6a1a96f`](https://github.com/nix-community/emacs-overlay/commit/f6a1a96f834d3d7936a768472d09006cc18d62d2) | `` Updated melpa `` |
| [`fd86f754`](https://github.com/nix-community/emacs-overlay/commit/fd86f7540e1b446f3646906b7ee3cfdb4d8702d1) | `` Updated emacs `` |
| [`17580f47`](https://github.com/nix-community/emacs-overlay/commit/17580f47433324e6e0a7a136103a3da9fd1c4749) | `` Updated elpa ``  |