### PR TITLE
chore(flake/nur): `6ec9b716` -> `ad8cd957`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708979125,
-        "narHash": "sha256-HcVmPfbckeO4nMMiLm9ZTzY63Qjzg+7s6deC6Xm6Seg=",
+        "lastModified": 1708983459,
+        "narHash": "sha256-j8JEqCU+bPNpe6J3WQQ+Aw52rLaef26qEk35lXtVfFc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6ec9b716040e4a3701ac1e0807e450ede7606177",
+        "rev": "ad8cd957b3a11da615e092e517c22be0179966b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                            |
| -------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`ad8cd957`](https://github.com/nix-community/NUR/commit/ad8cd957b3a11da615e092e517c22be0179966b1) | `` automatic update ``             |
| [`ba27e577`](https://github.com/nix-community/NUR/commit/ba27e5779f132762e94fb77b598aee0cda693466) | `` add Educorreia932 repository `` |
| [`facd37dc`](https://github.com/nix-community/NUR/commit/facd37dc8ed65a8bda15f8bff223c6bbc8265628) | `` automatic update ``             |
| [`79c79825`](https://github.com/nix-community/NUR/commit/79c7982504e4a36b3e0c9091e60a6241a309dd16) | `` add nousefreak repository ``    |
| [`c086b70f`](https://github.com/nix-community/NUR/commit/c086b70fd169a837cfb17615810b3785540ca298) | `` automatic update ``             |
| [`07b39287`](https://github.com/nix-community/NUR/commit/07b39287302f01fa0f389830e8241dc1f2e7da78) | `` add guanran928 repository ``    |