### PR TITLE
chore(flake/sops-nix): `2874fbbe` -> `a1c8de14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1008,11 +1008,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1708830076,
-        "narHash": "sha256-Cjh2xdjxC6S6nW6Whr2dxSeh8vjodzhTmQdI4zPJ4RA=",
+        "lastModified": 1708987867,
+        "narHash": "sha256-k2lDaDWNTU5sBVHanYzjDKVDmk29RHIgdbbXu5sdzBA=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "2874fbbe4a65bd2484b0ad757d27a16107f6bc17",
+        "rev": "a1c8de14f60924fafe13aea66b46157f0150f4cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`a1c8de14`](https://github.com/Mic92/sops-nix/commit/a1c8de14f60924fafe13aea66b46157f0150f4cf) | `` update vendorHash ``                                           |
| [`e386e52a`](https://github.com/Mic92/sops-nix/commit/e386e52abe52e7d764a5fb577a45f67dfd967f01) | `` build(deps): bump golang.org/x/crypto from 0.19.0 to 0.20.0 `` |