### PR TITLE
chore(flake/nur): `ad8cd957` -> `07246215`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708983459,
-        "narHash": "sha256-j8JEqCU+bPNpe6J3WQQ+Aw52rLaef26qEk35lXtVfFc=",
+        "lastModified": 1708990413,
+        "narHash": "sha256-zwDB1k2ELdKyLwLflBRqFqECV8gEIiD5C9E5fBbcYkA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ad8cd957b3a11da615e092e517c22be0179966b1",
+        "rev": "0724621598e2a1849b934f4f38f64519bb1cf0ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`07246215`](https://github.com/nix-community/NUR/commit/0724621598e2a1849b934f4f38f64519bb1cf0ec) | `` automatic update `` |
| [`1a8c4eda`](https://github.com/nix-community/NUR/commit/1a8c4eda55d24a097271d89ba9eb8681e650c029) | `` automatic update `` |