### PR TITLE
chore(flake/emacs-overlay): `f6a1a96f` -> `2dee8f65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708966353,
-        "narHash": "sha256-HugVgj0tzfrT3KL3NwqcZOwvsRlXjebzaJ6ptn3hx88=",
+        "lastModified": 1708998344,
+        "narHash": "sha256-x0OUh9OiQ6xd/pJQl1E2pL6YQDHidBAi9E8eRMweXVg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f6a1a96f834d3d7936a768472d09006cc18d62d2",
+        "rev": "2dee8f65405e0445d7178531e79a45b6fecfab92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`2dee8f65`](https://github.com/nix-community/emacs-overlay/commit/2dee8f65405e0445d7178531e79a45b6fecfab92) | `` Updated emacs ``  |
| [`759e91c6`](https://github.com/nix-community/emacs-overlay/commit/759e91c65bad01974b7514a2905365bc04a115b4) | `` Updated melpa ``  |
| [`fdc34eab`](https://github.com/nix-community/emacs-overlay/commit/fdc34eabbe59ffe5e935fcb53a40996fc4e46958) | `` Updated elpa ``   |
| [`25081a86`](https://github.com/nix-community/emacs-overlay/commit/25081a866d8e2efeaa5407ee658051c140a63dd1) | `` Updated nongnu `` |