### PR TITLE
chore(flake/nur): `07246215` -> `b2a437c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708990413,
-        "narHash": "sha256-zwDB1k2ELdKyLwLflBRqFqECV8gEIiD5C9E5fBbcYkA=",
+        "lastModified": 1708995898,
+        "narHash": "sha256-xdf0qykEP1QcGWzoAi3NvU9NR0IDyrJwAQsEDrNgHYk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0724621598e2a1849b934f4f38f64519bb1cf0ec",
+        "rev": "b2a437c84e7af787459ced8d94737f20456f42a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b2a437c8`](https://github.com/nix-community/NUR/commit/b2a437c84e7af787459ced8d94737f20456f42a6) | `` automatic update `` |
| [`4d6b3ba0`](https://github.com/nix-community/NUR/commit/4d6b3ba0fee3c75f8842e4e1c8945aaa24ca1823) | `` automatic update `` |