### PR TITLE
chore(flake/nur): `8aed89d9` -> `202caf5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708997700,
-        "narHash": "sha256-UQwCnDu9z2jPEBfBA27xBvSf3oYU1Oq0OKYq7WVVKtM=",
+        "lastModified": 1709009106,
+        "narHash": "sha256-aktkbh1qAYjfyH6SZefDDic5rPTCnpUW+9T4icEJ9wk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8aed89d9ee195307e8b62f7b1ac169b0b5f13899",
+        "rev": "202caf5f54797187056eb542841264fdcc69278f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`202caf5f`](https://github.com/nix-community/NUR/commit/202caf5f54797187056eb542841264fdcc69278f) | `` automatic update `` |
| [`8370645b`](https://github.com/nix-community/NUR/commit/8370645b84697e2bfe7fbb917f7346e553beb2b6) | `` automatic update `` |
| [`c21175ec`](https://github.com/nix-community/NUR/commit/c21175ecb82aa84a5714547b30106f70ac11efaf) | `` automatic update `` |