### PR TITLE
chore(flake/nur): `202caf5f` -> `4f7da707`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709009106,
-        "narHash": "sha256-aktkbh1qAYjfyH6SZefDDic5rPTCnpUW+9T4icEJ9wk=",
+        "lastModified": 1709016755,
+        "narHash": "sha256-1cro0KJWRlsPoIq5RPYv0TsoSEI2fECjXCwZ3pEOlwc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "202caf5f54797187056eb542841264fdcc69278f",
+        "rev": "4f7da7070f59ac7be0dba7190e36e19cd46ad960",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4f7da707`](https://github.com/nix-community/NUR/commit/4f7da7070f59ac7be0dba7190e36e19cd46ad960) | `` automatic update `` |
| [`db349576`](https://github.com/nix-community/NUR/commit/db349576a93c04796f3ccc86bd2f2102e3b3dfc0) | `` automatic update `` |
| [`6e33d820`](https://github.com/nix-community/NUR/commit/6e33d820cf579ffc04066aeefcb06648ce5e3286) | `` automatic update `` |