### PR TITLE
chore(flake/nur): `4f7da707` -> `8860cc9b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -875,11 +875,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709016755,
-        "narHash": "sha256-1cro0KJWRlsPoIq5RPYv0TsoSEI2fECjXCwZ3pEOlwc=",
+        "lastModified": 1709020581,
+        "narHash": "sha256-MXYbnsD71iTCem3/hZwMvmAQq/7uRGsLoaNn/nbWv04=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4f7da7070f59ac7be0dba7190e36e19cd46ad960",
+        "rev": "8860cc9b5dfc855f648c5b8d47f23a0d456d4869",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8860cc9b`](https://github.com/nix-community/NUR/commit/8860cc9b5dfc855f648c5b8d47f23a0d456d4869) | `` automatic update `` |
| [`050fba32`](https://github.com/nix-community/NUR/commit/050fba3242dfec4f41ce7942b75100b84cb48247) | `` automatic update `` |