### PR TITLE
chore(flake/emacs-overlay): `2dee8f65` -> `c94a9019`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708998344,
-        "narHash": "sha256-x0OUh9OiQ6xd/pJQl1E2pL6YQDHidBAi9E8eRMweXVg=",
+        "lastModified": 1709024751,
+        "narHash": "sha256-G6ZB1QsFzGgcYQNjOSLYRKmhXf/4b6ldY+1oCGQc3I4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2dee8f65405e0445d7178531e79a45b6fecfab92",
+        "rev": "c94a9019370b0d719621e1478d5bb317223ec15b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`c94a9019`](https://github.com/nix-community/emacs-overlay/commit/c94a9019370b0d719621e1478d5bb317223ec15b) | `` Updated emacs `` |
| [`c70c2e2a`](https://github.com/nix-community/emacs-overlay/commit/c70c2e2ac3b0b8f4f194cbd34115c65a033adefd) | `` Updated melpa `` |