### PR TITLE
chore(flake/lanzaboote): `73fec693` -> `cd0acfcd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -540,11 +540,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1708388174,
-        "narHash": "sha256-mLROAGNyOykYwWOLga24BX05GnRE+acms0Ru10tye2o=",
+        "lastModified": 1709038808,
+        "narHash": "sha256-Vc4awLLoC+Frc8TVVuoPQmqLaOf6AErPYiq/vCuOmFo=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "73fec69386e8005911e15f3abe6bb6cee7fd9711",
+        "rev": "cd0acfcdb7cc4ce630d1752ad8187ce3156342fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                  |
| --------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`1933be30`](https://github.com/nix-community/lanzaboote/commit/1933be309626e1dd906cb5aaac1eb90bf687bf8e) | `` fix(deps): update all dependencies `` |