### PR TITLE
chore(flake/nur): `50c9ffc8` -> `4e6f7a80`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709038338,
-        "narHash": "sha256-DNaOqpAY+WnoXa4YC38TOQYcpS5YHzxSlRwERaUaRco=",
+        "lastModified": 1709042115,
+        "narHash": "sha256-J7g9rCpHbb7p1xpoG60923U9zOjdJ4xIar8CQCj2UJQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "50c9ffc84902256dc6d095a0dddb0d9cb69b4938",
+        "rev": "4e6f7a809b8efb65c591043923213d82521d3fc5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4e6f7a80`](https://github.com/nix-community/NUR/commit/4e6f7a809b8efb65c591043923213d82521d3fc5) | `` automatic update `` |
| [`8f4c569c`](https://github.com/nix-community/NUR/commit/8f4c569c132e4b20eac909ec30c650e436ac5574) | `` automatic update `` |