### PR TITLE
chore(flake/emacs-overlay): `c94a9019` -> `cc3baade`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709024751,
-        "narHash": "sha256-G6ZB1QsFzGgcYQNjOSLYRKmhXf/4b6ldY+1oCGQc3I4=",
+        "lastModified": 1709053684,
+        "narHash": "sha256-2n0raWWfmi7xhWhMksILmchMHi3naPLujrcchQ9RfdU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c94a9019370b0d719621e1478d5bb317223ec15b",
+        "rev": "cc3baadef2a6e417cff991253f741b7726836649",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`cc3baade`](https://github.com/nix-community/emacs-overlay/commit/cc3baadef2a6e417cff991253f741b7726836649) | `` Updated emacs ``  |
| [`aa54c73c`](https://github.com/nix-community/emacs-overlay/commit/aa54c73cba1e6fed697f72c6d823df229116be41) | `` Updated melpa ``  |
| [`3e9c83ab`](https://github.com/nix-community/emacs-overlay/commit/3e9c83abe98d2846f96a01afa313010a0f82e775) | `` Updated elpa ``   |
| [`a00d13fb`](https://github.com/nix-community/emacs-overlay/commit/a00d13fb01ea97b39d558bda561955ccf4d0aaee) | `` Updated nongnu `` |