### PR TITLE
chore(flake/nur): `1ecfd53f` -> `5434c62e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709049270,
-        "narHash": "sha256-d/1F6SYEJYJsDkX2uqkhDR7OrqBoZysLHFKdAtMMZ+0=",
+        "lastModified": 1709058305,
+        "narHash": "sha256-MDUmf4+aeSDuVGeu2EeOVBopjsGsfdr/a5Z6fwf+ODA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1ecfd53fed16ad1ac971cf4cbfa89f44a7683fbd",
+        "rev": "5434c62e9f06f38a1b60affe7012dc4498bb6c94",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5434c62e`](https://github.com/nix-community/NUR/commit/5434c62e9f06f38a1b60affe7012dc4498bb6c94) | `` automatic update `` |