### PR TITLE
chore(flake/nixpkgs): `73de017e` -> `13aff9b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -757,11 +757,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1708807242,
-        "narHash": "sha256-sRTRkhMD4delO/hPxxi+XwLqPn8BuUq6nnj4JqLwOu0=",
+        "lastModified": 1708984720,
+        "narHash": "sha256-gJctErLbXx4QZBBbGp78PxtOOzsDaQ+yw1ylNQBuSUY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "73de017ef2d18a04ac4bfd0c02650007ccb31c2a",
+        "rev": "13aff9b34cc32e59d35c62ac9356e4a41198a538",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`e6732335`](https://github.com/NixOS/nixpkgs/commit/e6732335fff9abfbe8e74050b82a1d20944c6baa) | `` swaynotificationcenter: 0.9.0 -> 0.10.0 (#290627) ``                             |
| [`a2554b6d`](https://github.com/NixOS/nixpkgs/commit/a2554b6dae6342dc64f83bb1cfeadfd43380c333) | `` SDL2: improve mingw support ``                                                   |
| [`842148eb`](https://github.com/NixOS/nixpkgs/commit/842148eb5b86571e9f0bf4690094fb7c0f4fd565) | `` SDL2: run nixpkgs-fmt ``                                                         |
| [`e3a6e380`](https://github.com/NixOS/nixpkgs/commit/e3a6e380337820d17c154c54eaf50ab95bba5c0d) | `` lib.fileset.toList: init ``                                                      |
| [`3b418eb4`](https://github.com/NixOS/nixpkgs/commit/3b418eb47a203323a481cee3e428d8daec9d43df) | `` python311Packages.mplhep: 0.3.34 -> 0.3.35 ``                                    |
| [`238b975d`](https://github.com/NixOS/nixpkgs/commit/238b975dabf9f1830e70ef0ff24b84eef504554b) | `` atuin: 18.0.1 -> 18.0.2 ``                                                       |
| [`c9cfe85c`](https://github.com/NixOS/nixpkgs/commit/c9cfe85c5104825c5be48777da0220eab1dfa82c) | `` python312Packages.pontos: 24.2.1 -> 24.2.2 ``                                    |
| [`277963b1`](https://github.com/NixOS/nixpkgs/commit/277963b1ba78ace1159e01342312aeebd0f55697) | `` python312Packages.pubnub: 7.4.0 -> 7.4.1 ``                                      |
| [`5b6d5069`](https://github.com/NixOS/nixpkgs/commit/5b6d5069ce925049e742f8ac42dd068d6a75c056) | `` lefthook: 1.6.1 -> 1.6.2 ``                                                      |
| [`a916a91a`](https://github.com/NixOS/nixpkgs/commit/a916a91ab2c8393e070b4f1f1fa7be0539da5218) | `` python312Packages.pygitguardian: 1.13.0 -> 1.14.0 ``                             |
| [`abdd5504`](https://github.com/NixOS/nixpkgs/commit/abdd5504381c22d54b87ea309f23af536b127b39) | `` python312Packages.python-roborock: 0.39.1 -> 0.39.2 ``                           |
| [`1cb3656c`](https://github.com/NixOS/nixpkgs/commit/1cb3656cf3f3fbbf1628f38652723d605a4299d4) | `` jan: 0.4.6 -> 0.4.7 ``                                                           |
| [`cd2ec848`](https://github.com/NixOS/nixpkgs/commit/cd2ec848a90ffdbe716c8829e6c4f75406c5b1a3) | `` kubernetes-helmPlugins.helm-unittest: 0.4.1 -> 0.4.2 ``                          |
| [`e2db77a9`](https://github.com/NixOS/nixpkgs/commit/e2db77a986a5da16e664cc630376a03d4fae99fb) | `` python311Packages.google-cloud-dataproc: 5.9.1 -> 5.9.2 ``                       |
| [`86145b95`](https://github.com/NixOS/nixpkgs/commit/86145b9573f98f671828d6f553c4a1229beefac9) | `` python312Packages.myuplink: 0.4.1 -> 0.5.0 ``                                    |
| [`e426a8f0`](https://github.com/NixOS/nixpkgs/commit/e426a8f09740106e2944be4c583894edcb04830c) | `` lib: export attrsets.mergeAttrsList ``                                           |
| [`19d5c154`](https://github.com/NixOS/nixpkgs/commit/19d5c1544b546af519771c13c09a17280c122506) | `` wttrbar: 0.8.0 -> 0.8.2 ``                                                       |
| [`c786e63c`](https://github.com/NixOS/nixpkgs/commit/c786e63c704fb13cdfff7ac93285710baf76a603) | `` doc: Fix typo resulting in broken link in manual ``                              |
| [`6edee624`](https://github.com/NixOS/nixpkgs/commit/6edee624d05dc5b6fe938f35b90ff1359e047107) | `` OVMF: Restore installation of OVMF.fd. ``                                        |
| [`6f1ce510`](https://github.com/NixOS/nixpkgs/commit/6f1ce51034f93ab9a2e113405c7748da42faa7ec) | `` hyprshade: 3.0.2 -> 3.0.3 ``                                                     |
| [`46f6edbd`](https://github.com/NixOS/nixpkgs/commit/46f6edbd79ad46b4435c7fb1aa2a344d6530f63b) | `` python311Packages.oslo-serialization: 5.3.0 -> 5.4.0 ``                          |
| [`7e1aec7a`](https://github.com/NixOS/nixpkgs/commit/7e1aec7ad2b09ddd65e4e4d3ae27b000e81de18f) | `` python311Packages.litellm: 1.26.8 -> 1.27.4 ``                                   |
| [`106c4ac6`](https://github.com/NixOS/nixpkgs/commit/106c4ac6aa6e325263b740fd30bdda3b430178ef) | `` mongodb-4_4: 4.4.27 -> 4.4.28 ``                                                 |
| [`ce15c39c`](https://github.com/NixOS/nixpkgs/commit/ce15c39c7b3cc3c1fd49cedcee43310b2d893c95) | `` python311Packages.oslo-db: 14.1.0 -> 15.0.0 ``                                   |
| [`04abc678`](https://github.com/NixOS/nixpkgs/commit/04abc6788bf4ba3cd536c38a1483538a887da22d) | `` libkiwix: 12.1.1 -> 13.1.0 ``                                                    |
| [`ff3ce791`](https://github.com/NixOS/nixpkgs/commit/ff3ce7917ca1c312fe47fa24188710a4db7a7764) | `` python311Packages.ldfparser: 0.23.0 -> 0.24.0 ``                                 |
| [`94cf4ea2`](https://github.com/NixOS/nixpkgs/commit/94cf4ea2ee3516607ff46f94bccd9b5a39c53b7a) | `` searxng: unstable-2023-10-31 -> 0-unstable-2024-02-24 (#290962) ``               |
| [`b5468e9a`](https://github.com/NixOS/nixpkgs/commit/b5468e9ac3e667aee45e1d205620e1fd96b7c985) | `` wiremock: 3.4.1 -> 3.4.2 ``                                                      |
| [`d47dea2e`](https://github.com/NixOS/nixpkgs/commit/d47dea2ed2f116e6304b0f6dceadd1f95b4dcd8c) | `` alacritty-theme: unstable-2024-02-11 -> unstable-2024-02-25 ``                   |
| [`8566d1b8`](https://github.com/NixOS/nixpkgs/commit/8566d1b8c6a6d862b7644c5ccf02d2d9fcd0435e) | `` linux/hardened/patches/6.7: 6.7.5-hardened1 -> 6.7.6-hardened1 ``                |
| [`5fcfd0a8`](https://github.com/NixOS/nixpkgs/commit/5fcfd0a8aec6324d2e8e68530561606ada441375) | `` linux/hardened/patches/6.6: 6.6.17-hardened1 -> 6.6.18-hardened1 ``              |
| [`aff1004f`](https://github.com/NixOS/nixpkgs/commit/aff1004f12c81f4b4be9e119ef0c2bc8b28fa744) | `` linux/hardened/patches/6.1: 6.1.78-hardened1 -> 6.1.79-hardened1 ``              |
| [`b833fc37`](https://github.com/NixOS/nixpkgs/commit/b833fc37a86d43f2439f5140c50dff8e7a7e75dc) | `` linux/hardened/patches/5.4: 5.4.268-hardened1 -> 5.4.269-hardened1 ``            |
| [`e04df474`](https://github.com/NixOS/nixpkgs/commit/e04df4742b02e10ae9fe95765b9646ad2b842d9e) | `` linux/hardened/patches/5.15: 5.15.148-hardened1 -> 5.15.149-hardened1 ``         |
| [`ba1ea346`](https://github.com/NixOS/nixpkgs/commit/ba1ea346e08eef4aa90a81880a3b5dad36cae97c) | `` linux/hardened/patches/5.10: 5.10.209-hardened1 -> 5.10.210-hardened1 ``         |
| [`b00c53e4`](https://github.com/NixOS/nixpkgs/commit/b00c53e4cae1ad821cc682497f4b047fd2e36e01) | `` linux/hardened/patches/4.19: 4.19.306-hardened1 -> 4.19.307-hardened1 ``         |
| [`a8bdc1dd`](https://github.com/NixOS/nixpkgs/commit/a8bdc1ddf68e7e7db7fb927259b66ddc4f1a6e63) | `` gitea: 1.21.6 -> 1.21.7 ``                                                       |
| [`66129d5e`](https://github.com/NixOS/nixpkgs/commit/66129d5e24575468ad8feca2f035e33c7374e14a) | `` tests/lomiri-system-settings: init ``                                            |
| [`08ef9001`](https://github.com/NixOS/nixpkgs/commit/08ef9001677d64c88739cbeaa34879901e959ad4) | `` lomiri.lomiri-system-settings: init at 1.0.2 ``                                  |
| [`429be394`](https://github.com/NixOS/nixpkgs/commit/429be39416b921a5af31eb76698956cfd9e95fba) | `` lomiri.lomiri-system-settings-security-privacy: init at 1.0.2 ``                 |
| [`53bb990c`](https://github.com/NixOS/nixpkgs/commit/53bb990cd02e921857d9c1fd6f6e6434f3758dbe) | `` lomiri.lomiri-system-settings-unwrapped: init at 1.0.2 ``                        |
| [`14c955a7`](https://github.com/NixOS/nixpkgs/commit/14c955a77ee5adf5a45f6107afffd41b20fdaca2) | `` vscode-extensions.uloco.theme-bluloco-light: init at 3.7.3 ``                    |
| [`51c9129b`](https://github.com/NixOS/nixpkgs/commit/51c9129bcf61f8c7341c575d095c4224f48bdc53) | `` quaternion: 0.0.96-beta4 -> 0.0.96.1 ``                                          |
| [`586f528d`](https://github.com/NixOS/nixpkgs/commit/586f528d1568ecbe74683878a931d726e2faf4ac) | `` micropython: 1.22.1 -> 1.22.2 ``                                                 |
| [`0bd4cef2`](https://github.com/NixOS/nixpkgs/commit/0bd4cef20a4255800a36927e1d6f02a2c21c1633) | `` python311Packages.yalexs: refactor ``                                            |
| [`eb74747f`](https://github.com/NixOS/nixpkgs/commit/eb74747f38d83f83aa6aace76e3f76a76194b081) | `` nixos/pipewire: add LV2 plugins option ``                                        |
| [`09a92121`](https://github.com/NixOS/nixpkgs/commit/09a92121c53efa0071f3a02456c4f7ef674c1102) | `` python311Packages.yalexs: 1.11.2 -> 1.11.3 ``                                    |
| [`bc97cf46`](https://github.com/NixOS/nixpkgs/commit/bc97cf467b38a3668fe96df3c70cb6a624ef4c1f) | `` python311Packages.appthreat-vulnerability-db: 5.6.3 -> 5.6.4 ``                  |
| [`c508803c`](https://github.com/NixOS/nixpkgs/commit/c508803c4d0d2bcec254890154f89d48c7651d1c) | `` yq-go: 4.41.1 -> 4.42.1 ``                                                       |
| [`6bfbeaf6`](https://github.com/NixOS/nixpkgs/commit/6bfbeaf6aa460428a8d49c77c581886e41b57eaa) | `` brev-cli: 0.6.273 -> 0.6.276 ``                                                  |
| [`34c105aa`](https://github.com/NixOS/nixpkgs/commit/34c105aa3091ea3f79e4b4088f2087f8b856f122) | `` supersonic-wayland: 0.9.0 -> 0.9.1 ``                                            |
| [`eb5a11dd`](https://github.com/NixOS/nixpkgs/commit/eb5a11dd2910ebce53ee7a06eb96a4aa1a3154ac) | `` hyprland-per-window-layout: 2.7 -> 2.8.1 ``                                      |
| [`1021e65f`](https://github.com/NixOS/nixpkgs/commit/1021e65f2575fb699779f3475c30941973b580e1) | `` hcxtools: 6.3.2 -> 6.3.4 ``                                                      |
| [`9df84e4c`](https://github.com/NixOS/nixpkgs/commit/9df84e4c3d9d2efbd581bbd72a6f8ffbdf5754d4) | `` python312Packages.systembridgeconnector: 4.0.1 -> 4.0.2 ``                       |
| [`e6a6af3b`](https://github.com/NixOS/nixpkgs/commit/e6a6af3bec35ccbdc6f459703608050a83c4a34c) | `` xmrig: 6.21.0 -> 6.21.1 ``                                                       |
| [`dbff1bf4`](https://github.com/NixOS/nixpkgs/commit/dbff1bf4de1787051259db1aecf92b669fefb49b) | `` legit-web: 0.2.1 -> 0.2.2 ``                                                     |
| [`c7604322`](https://github.com/NixOS/nixpkgs/commit/c76043228eb33e0b737a4177e1b0b759c3d23705) | `` lightgbm: 4.1.0 -> 4.3.0 ``                                                      |
| [`e4dd0692`](https://github.com/NixOS/nixpkgs/commit/e4dd06921f048a0cf389a6f15a69a6f3beb001e7) | `` wlogout: 1.1.1 -> 1.2 ``                                                         |
| [`6d5db91a`](https://github.com/NixOS/nixpkgs/commit/6d5db91a7f633661e454c50ec40cfb76acf90b10) | `` wpsoffice{-cn}: 11.1.0.11711 -> 11.1.0.11719 ``                                  |
| [`d70c353c`](https://github.com/NixOS/nixpkgs/commit/d70c353c1646a35fc5e586c06cd6d1b78f67e839) | `` nixos/switcherooControl: add package option ``                                   |
| [`5e721403`](https://github.com/NixOS/nixpkgs/commit/5e721403ec713b20a3e7e4c17d7adeadb6f4cb95) | `` packet-sd: fix chmod application order ``                                        |
| [`9ae5e2dc`](https://github.com/NixOS/nixpkgs/commit/9ae5e2dc3901a97f3302bb3adad69b0e52334608) | `` switcheroo-control: fix build ``                                                 |
| [`26c37fca`](https://github.com/NixOS/nixpkgs/commit/26c37fca28c97d0431b403f4d6ba2bbdc39c0b3c) | `` whois: 5.5.20 -> 5.5.21 ``                                                       |
| [`da252015`](https://github.com/NixOS/nixpkgs/commit/da25201532310b8f8c660ac20ff412ed8cd2d0d6) | `` dqlite: 1.16.2 -> 1.16.4 ``                                                      |
| [`b4728c47`](https://github.com/NixOS/nixpkgs/commit/b4728c471861953c1c845c15512df5fba0cf020d) | `` yubioath-flutter: substituteInPlace replace to replace-fail ``                   |
| [`f43811ab`](https://github.com/NixOS/nixpkgs/commit/f43811ab19d925aea81c2de0959c79454b70062d) | `` yubioath-flutter: 6.3.1 -> 6.4.0 ``                                              |
| [`c2563bc1`](https://github.com/NixOS/nixpkgs/commit/c2563bc1ec2837e7fced3bbe78708a20f7466bd3) | `` python312Packages.pillow-heif: fix build with clang ``                           |
| [`b79beadd`](https://github.com/NixOS/nixpkgs/commit/b79beadd1e07f196e082321b321aa46ce2a271d7) | `` opencv4: 4.7.0 -> 4.9.0 ``                                                       |
| [`dcee7e76`](https://github.com/NixOS/nixpkgs/commit/dcee7e76e91609f17cb16bccff8a3b50ba5df8cb) | `` python312Packages.sphinxcontrib-apidoc: 0.4.0 -> 0.5.0 ``                        |
| [`b660c6fd`](https://github.com/NixOS/nixpkgs/commit/b660c6fdb96fed8794f7430bca888e3cfa554aa9) | `` cargo-audit: 0.19.0 -> 0.20.0 ``                                                 |
| [`74cfb74b`](https://github.com/NixOS/nixpkgs/commit/74cfb74bb2d7c062294962093bb5727a3b556f9e) | `` cmctl: 1.14.2 -> 1.14.3 ``                                                       |
| [`8adf6e8c`](https://github.com/NixOS/nixpkgs/commit/8adf6e8c4fc2e72bb2c50335fcbe11a5fe65ee39) | `` python311Packages.enamlx: 0.6.2 -> 0.6.4 ``                                      |
| [`cac6cb1f`](https://github.com/NixOS/nixpkgs/commit/cac6cb1f1354668eb70b1078398feeaed92f87a7) | `` zapzap: 5.2 -> 5.2.1 ``                                                          |
| [`0600791f`](https://github.com/NixOS/nixpkgs/commit/0600791f3ef36e36d702984e275f114295714d58) | `` maintainers: add sentientmonkey ``                                               |
| [`7b7cebb5`](https://github.com/NixOS/nixpkgs/commit/7b7cebb5650ede702116a0370c1265180f4ceed1) | `` git-together: init at 0.1.0-alpha.26 ``                                          |
| [`4836d98c`](https://github.com/NixOS/nixpkgs/commit/4836d98cfd6a45e261515b1506d763970d60e985) | `` python311Packages.azure-eventhub: refactor ``                                    |
| [`bc616640`](https://github.com/NixOS/nixpkgs/commit/bc61664025b59162719e23d110a82fec7efc7530) | `` python311Packages.google-cloud-securitycenter: 1.26.1 -> 1.27.0 ``               |
| [`59a24057`](https://github.com/NixOS/nixpkgs/commit/59a240579c40ab80d299e30bf84b24b2892095c7) | `` ollama: test that rocm and cuda build successfully ``                            |
| [`b8d8c1f2`](https://github.com/NixOS/nixpkgs/commit/b8d8c1f207a8c80f7267920efa70db785e5d441e) | `` nixos/ollama: add option for hardware acceleration ``                            |
| [`70e834c1`](https://github.com/NixOS/nixpkgs/commit/70e834c19b24957546e5e54c9ffbe33ace422d27) | `` ollama: refactor ``                                                              |
| [`a00e878c`](https://github.com/NixOS/nixpkgs/commit/a00e878cb349df2837f4c746f61aeb5ddf4905ca) | `` vscode-extensions.equinusocio.vsc-material-theme: fix user-settings ``           |
| [`682f958f`](https://github.com/NixOS/nixpkgs/commit/682f958f762d767670b1cdbc5a5f3f6a1d1de57a) | `` vscode-extensions.equinusocio.vsc-material-theme: 33.8.0 -> 34.3.1 ``            |
| [`a9466871`](https://github.com/NixOS/nixpkgs/commit/a946687141af3618ec9edf81d17b16546edf2d80) | `` python311Packages.bottleneck: 1.3.7 -> 1.3.8 ``                                  |
| [`d21d21ca`](https://github.com/NixOS/nixpkgs/commit/d21d21ca253413ad72e00998218b77b7cd925bbf) | `` esphome: 2024.2.0 -> 2024.2.1 ``                                                 |
| [`30982c16`](https://github.com/NixOS/nixpkgs/commit/30982c16ea5badfe8eab5c2269f717e09e71c02d) | `` discordo: unstable-2024-02-21 -> unstable-2024-02-25 ``                          |
| [`e34df654`](https://github.com/NixOS/nixpkgs/commit/e34df65424774e1a66b8a534332bc2f2101871b1) | `` wttrbar: 0.7.1 -> 0.8.0 ``                                                       |
| [`6bef3517`](https://github.com/NixOS/nixpkgs/commit/6bef3517593e1782c9877b6b1dfa13ce530ead21) | `` snapcast: compile with opus codec support (#291014) ``                           |
| [`29a30806`](https://github.com/NixOS/nixpkgs/commit/29a30806ca78e6fcffa52c9453e7e5907d247b63) | `` re-isearch: fix `gcc-13` build ``                                                |
| [`2ed1ebcb`](https://github.com/NixOS/nixpkgs/commit/2ed1ebcb1cb62ac3df2fccc2262c36f6265cbd6b) | `` bun: 1.0.28 -> 1.0.29 ``                                                         |
| [`ac85b4b6`](https://github.com/NixOS/nixpkgs/commit/ac85b4b653439b3ad491748a36c6d2bde1f5fa77) | `` python311Packages.dask-awkward: adjust inputs (#291337) ``                       |
| [`c75dd8bf`](https://github.com/NixOS/nixpkgs/commit/c75dd8bff734836bee446f35265c1584acc3ca0b) | `` ollama: 0.1.24 -> 0.1.26 ``                                                      |
| [`a52e27d4`](https://github.com/NixOS/nixpkgs/commit/a52e27d4f637854e81dfd51da3b29627f7374513) | `` nixos/hardware/printers: fix empty ppdOptions ``                                 |
| [`aad08e1a`](https://github.com/NixOS/nixpkgs/commit/aad08e1a548ff57fa0774a8508c35f2eb2ba4c44) | `` homepage-dashboard: support local icons ``                                       |
| [`3aa1a64b`](https://github.com/NixOS/nixpkgs/commit/3aa1a64bd26b09346ee2229ebda6b528f7a1e605) | `` homepage-dashboard: move assets to share folder ``                               |
| [`84e89be7`](https://github.com/NixOS/nixpkgs/commit/84e89be710698cf68c06ab97ce296e2f9eaf3e12) | `` sbcl: set source provenance on binary bootstrap ``                               |
| [`8c5a4cfa`](https://github.com/NixOS/nixpkgs/commit/8c5a4cfa43d6d493ea12d25aca7025ce25293557) | `` gprbuild: prevent cross compiled gprbuild-boot being pulled in ``                |
| [`92718905`](https://github.com/NixOS/nixpkgs/commit/92718905bb39a0b98ad6289980f9a3fe14e88ab5) | `` release-notes: Add Ada / gnatPackages changes ``                                 |
| [`467c84e2`](https://github.com/NixOS/nixpkgs/commit/467c84e2c68d3b16b2b70187d9dbbdd565840640) | `` gnatPackages: Build all ada-modules with gnat12 and gnat13 ``                    |
| [`f2a14272`](https://github.com/NixOS/nixpkgs/commit/f2a142727cc0fbc92a9b420567418df9dd36e568) | `` gnatPackages: Add scope for all ada packages ``                                  |
| [`c02503b5`](https://github.com/NixOS/nixpkgs/commit/c02503b58237072965308415f87e709af128516c) | `` gnatprove: Expose SPARKlib through gpr ``                                        |
| [`d22ba0a2`](https://github.com/NixOS/nixpkgs/commit/d22ba0a2a71cb6136115ca91999409d6498c9936) | `` gnatprove: Make src dependend on gcc version ``                                  |
| [`c1b5933e`](https://github.com/NixOS/nixpkgs/commit/c1b5933e79e45dd7f75075075f6248af8362da08) | `` gnatprove: Rename spark2014 ``                                                   |
| [`63e129f7`](https://github.com/NixOS/nixpkgs/commit/63e129f793ccf07bad4631309812a6f8ba33e234) | `` buildNeovimPlugin: set version accordingly to the manual guidelines (#289008) `` |
| [`ddb92f07`](https://github.com/NixOS/nixpkgs/commit/ddb92f079f20a7d67c018ae3dd0a38fd1318753f) | `` phpExtensions.relay: remove obsolete `inherit` ``                                |
| [`6addd082`](https://github.com/NixOS/nixpkgs/commit/6addd0822026c2d1f406d8c9b5d0398c6ec382d9) | `` phpExtensions.blackfire: remove obsolete `inherit` ``                            |
| [`7e3f284f`](https://github.com/NixOS/nixpkgs/commit/7e3f284f13d90495963017c4b9d333b7440256c1) | `` drush: removed, standalone installation are no more supported ``                 |
| [`b453c845`](https://github.com/NixOS/nixpkgs/commit/b453c845f6fbf9053a046d44406d987bc1613c7e) | `` n98-magerun2: use `buildComposerProject` builder ``                              |
| [`42be235e`](https://github.com/NixOS/nixpkgs/commit/42be235ec004c9fe3579ca9ef3ea29f47e92f673) | `` n98-magerun: use `buildComposerProject` builder ``                               |
| [`ee4ecc33`](https://github.com/NixOS/nixpkgs/commit/ee4ecc331b0b691500ec293959a88da9d5e2873a) | `` phpPackages.phpmd: use `buildComposerProject` builder ``                         |
| [`68866194`](https://github.com/NixOS/nixpkgs/commit/68866194354da5cc7cf69914049c30b57c93f02b) | `` phpPackages.php-cs-fixer: use `buildComposerProject` builder ``                  |
| [`dae4e32f`](https://github.com/NixOS/nixpkgs/commit/dae4e32f4b046943e3913f9dde7bebbcc2b1821b) | `` phpPackages.phive: use `buildComposerProject` builder ``                         |
| [`b7f3d0df`](https://github.com/NixOS/nixpkgs/commit/b7f3d0df8fb5cc7994aa04ca7552dff6dcd98cf1) | `` phpPackages.phing: 2.17.4 -> 3.0.0-rc6 ``                                        |
| [`d653d780`](https://github.com/NixOS/nixpkgs/commit/d653d7800fef3b6b43aa695bdb7382eebb9990d2) | `` phpPackages.phan: use `buildComposerProject` builder ``                          |
| [`7491aa43`](https://github.com/NixOS/nixpkgs/commit/7491aa43a777881766e02f32c0e42b263d0a2469) | `` phpPackages.deployer: 6.8.0 -> 7.3.3 ``                                          |