### PR TITLE
chore(flake/nur): `5bcb1e79` -> `7c521252`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709063146,
-        "narHash": "sha256-Y8TNyZp/7NVHzbkes/7oi+2czpJVwujhq3p7z+fQPgk=",
+        "lastModified": 1709073950,
+        "narHash": "sha256-nEg+Mvc6MjlmVp3O77U/WZkZLrDv5I2Eowh0rWm0SmI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5bcb1e798d578b41ad62b86416b574ca97454d79",
+        "rev": "7c5212524ec49bf659dd8e5b7de572f03f27fc9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7c521252`](https://github.com/nix-community/NUR/commit/7c5212524ec49bf659dd8e5b7de572f03f27fc9f) | `` automatic update `` |