### PR TITLE
chore(flake/emacs-overlay): `cc3baade` -> `84fdcde6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709053684,
-        "narHash": "sha256-2n0raWWfmi7xhWhMksILmchMHi3naPLujrcchQ9RfdU=",
+        "lastModified": 1709083815,
+        "narHash": "sha256-oCjFBWqKfnBkFvffnLKx5mQ8GvVBym/FH27t9PPNAbE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cc3baadef2a6e417cff991253f741b7726836649",
+        "rev": "84fdcde68b7b07761b69d5a416b66ed61dcfb23c",
         "type": "github"
       },
       "original": {
@@ -709,11 +709,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1708831307,
-        "narHash": "sha256-0iL/DuGjiUeck1zEaL+aIe2WvA3/cVhp/SlmTcOZXH4=",
+        "lastModified": 1708979614,
+        "narHash": "sha256-FWLWmYojIg6TeqxSnHkKpHu5SGnFP5um1uUjH+wRV6g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5bf1cadb72ab4e77cb0b700dab76bcdaf88f706b",
+        "rev": "b7ee09cf5614b02d289cd86fcfa6f24d4e078c2a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`84fdcde6`](https://github.com/nix-community/emacs-overlay/commit/84fdcde68b7b07761b69d5a416b66ed61dcfb23c) | `` Updated melpa ``        |
| [`d220ffb9`](https://github.com/nix-community/emacs-overlay/commit/d220ffb9f6ae2708cfd6179f7dd9d6502f220a39) | `` Updated elpa ``         |
| [`fb25df62`](https://github.com/nix-community/emacs-overlay/commit/fb25df62dc98426dd4d97f871332ab579db70a02) | `` Updated flake inputs `` |