### PR TITLE
chore(flake/nur): `ba8d6464` -> `7ad26a18`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709082620,
-        "narHash": "sha256-st6LgKgiw1KSXyIVIUw3ksOkBfuIC33zsoo9hRjbPZo=",
+        "lastModified": 1709084289,
+        "narHash": "sha256-S4tQmPM9U4oBdEdkGbHww9Jo0L9tPwT2yzf7sTSuBZU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ba8d6464499d8a05b91c715ba850e1b3ca2b3a2c",
+        "rev": "7ad26a18580a690e3e0c71d023520bbc1e06f0b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7ad26a18`](https://github.com/nix-community/NUR/commit/7ad26a18580a690e3e0c71d023520bbc1e06f0b0) | `` automatic update `` |