### PR TITLE
chore(flake/nur): `7ad26a18` -> `2aa19247`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709084289,
-        "narHash": "sha256-S4tQmPM9U4oBdEdkGbHww9Jo0L9tPwT2yzf7sTSuBZU=",
+        "lastModified": 1709091521,
+        "narHash": "sha256-tkt88zIkEHCW7BlOcPgcbOEiR5t8Zu1OMWaBSVJxTQw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7ad26a18580a690e3e0c71d023520bbc1e06f0b0",
+        "rev": "2aa19247aeafc2a24c6900bdb7d717624f3d123d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2aa19247`](https://github.com/nix-community/NUR/commit/2aa19247aeafc2a24c6900bdb7d717624f3d123d) | `` automatic update `` |