### PR TITLE
chore(flake/nur): `cda46f8b` -> `a143c335`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709093414,
-        "narHash": "sha256-KJHhOQoDXPmx6fap3o5g9CNe4a2NuEVUAI3ftm7pcuk=",
+        "lastModified": 1709102729,
+        "narHash": "sha256-NIrUWhmXOT4rlHGTBorgeRCUdugCRlWXzNioSaEXup0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cda46f8ba81f533ebff2a90db89364c6237fbc52",
+        "rev": "a143c335d8516e7fb7536e98b38944b9d337167f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a143c335`](https://github.com/nix-community/NUR/commit/a143c335d8516e7fb7536e98b38944b9d337167f) | `` automatic update `` |