### PR TITLE
chore(flake/emacs-overlay): `84fdcde6` -> `8c56baa0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709083815,
-        "narHash": "sha256-oCjFBWqKfnBkFvffnLKx5mQ8GvVBym/FH27t9PPNAbE=",
+        "lastModified": 1709140068,
+        "narHash": "sha256-lvRBx3t6wF4crVlHko6Rm7rV2bSES4rgPC8a2zoaic8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "84fdcde68b7b07761b69d5a416b66ed61dcfb23c",
+        "rev": "8c56baa0e5ba4bbf9947605a31672e2f4735b1a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`8c56baa0`](https://github.com/nix-community/emacs-overlay/commit/8c56baa0e5ba4bbf9947605a31672e2f4735b1a9) | `` Updated emacs ``        |
| [`0e8baab3`](https://github.com/nix-community/emacs-overlay/commit/0e8baab3c80e696600dfcc6a673c399a8c339e68) | `` Updated melpa ``        |
| [`678a4feb`](https://github.com/nix-community/emacs-overlay/commit/678a4febfec7ae6900d54a2bab7db41a55aeacd6) | `` Updated elpa ``         |
| [`4719c864`](https://github.com/nix-community/emacs-overlay/commit/4719c864b381b19dcacf7f720be3ee8a96a62da5) | `` Updated flake inputs `` |
| [`119523b8`](https://github.com/nix-community/emacs-overlay/commit/119523b8931aaad7648e1e42fe653f66a9b5ee21) | `` Updated emacs ``        |
| [`2dc1cb18`](https://github.com/nix-community/emacs-overlay/commit/2dc1cb1830ec2d802a74aa0338fe39fd082b4348) | `` Updated melpa ``        |