### PR TITLE
chore(flake/nur): `a143c335` -> `fc48817f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709102729,
-        "narHash": "sha256-NIrUWhmXOT4rlHGTBorgeRCUdugCRlWXzNioSaEXup0=",
+        "lastModified": 1709117554,
+        "narHash": "sha256-DhGnfXqmR+ATDTkVnkeVAobPizh0WUG4CQWp2XpUozo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a143c335d8516e7fb7536e98b38944b9d337167f",
+        "rev": "fc48817f24a90cc4bfece1f70252051b028368ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fc48817f`](https://github.com/nix-community/NUR/commit/fc48817f24a90cc4bfece1f70252051b028368ff) | `` automatic update `` |
| [`369aad59`](https://github.com/nix-community/NUR/commit/369aad59c996fe9de023d0f7d9e462c85da65339) | `` automatic update `` |
| [`01d877e5`](https://github.com/nix-community/NUR/commit/01d877e55d2113ab72bb5fbb66dc9c53c80c1024) | `` automatic update `` |