### PR TITLE
chore(flake/nur): `fc48817f` -> `62aa1985`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709117554,
-        "narHash": "sha256-DhGnfXqmR+ATDTkVnkeVAobPizh0WUG4CQWp2XpUozo=",
+        "lastModified": 1709121438,
+        "narHash": "sha256-Oepo4KQD2a+hux2fe0JfjegHFg4KtZHtj8X/wmi4ScI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc48817f24a90cc4bfece1f70252051b028368ff",
+        "rev": "62aa1985c7e5fe6f2246eabd345619c288dd30f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`62aa1985`](https://github.com/nix-community/NUR/commit/62aa1985c7e5fe6f2246eabd345619c288dd30f7) | `` automatic update `` |