### PR TITLE
chore(flake/nur): `342e550a` -> `02e10290`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709134953,
-        "narHash": "sha256-E9Ij1nPvb9Gxdd6yxasTenscYJ/75viQ8qgL1/gt9Zw=",
+        "lastModified": 1709139019,
+        "narHash": "sha256-0mQ0J+3RM0DNYFRFz1X9CgD2LNAOcO9nZT65n1va9JM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "342e550a2ca6c50564d30cab76c27fb9342fca9f",
+        "rev": "02e102900bc348f79757dd80154c59cc25d6a790",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`02e10290`](https://github.com/nix-community/NUR/commit/02e102900bc348f79757dd80154c59cc25d6a790) | `` automatic update `` |
| [`c82f190b`](https://github.com/nix-community/NUR/commit/c82f190b6cc61639fce2c4d4b303d7d8ab9f04bc) | `` automatic update `` |