### PR TITLE
chore(flake/nur): `02e10290` -> `1bf10717`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709139019,
-        "narHash": "sha256-0mQ0J+3RM0DNYFRFz1X9CgD2LNAOcO9nZT65n1va9JM=",
+        "lastModified": 1709140809,
+        "narHash": "sha256-bJKS1pEQWnp/OHPtGJbSfXLzJS82XgC+oxhJ2Nrk5Yk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "02e102900bc348f79757dd80154c59cc25d6a790",
+        "rev": "1bf10717adfd557fe76165fcc7be830398f859e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1bf10717`](https://github.com/nix-community/NUR/commit/1bf10717adfd557fe76165fcc7be830398f859e3) | `` automatic update `` |