### PR TITLE
chore(flake/nixos-hardware): `01467901` -> `33a97b58`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -646,11 +646,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1709110790,
-        "narHash": "sha256-qUk0G9vWX90beOKB1EtLFdeImXAujNi5SP5zTyIEATc=",
+        "lastModified": 1709147990,
+        "narHash": "sha256-vpXMWoaCtMYJ7lisJedCRhQG9BSsInEyZnnG5GfY9tQ=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "01467901ec51dd92774040f2b3dff4f21f4e1c45",
+        "rev": "33a97b5814d36ddd65ad678ad07ce43b1a67f159",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`33a97b58`](https://github.com/NixOS/nixos-hardware/commit/33a97b5814d36ddd65ad678ad07ce43b1a67f159) | `` add w520 to readme ``        |
| [`ce93797a`](https://github.com/NixOS/nixos-hardware/commit/ce93797a42b8300c3e8bcb550d7659935289eeaf) | `` add w520 ( copy of t520 ) `` |