### PR TITLE
chore(flake/srvos): `b54e462b` -> `72956bfc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1011,11 +1011,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708908680,
-        "narHash": "sha256-/ZVHI0KviV/DtZRneFinXrfHEeAhAT1mnx3+vNFKBx8=",
+        "lastModified": 1709158468,
+        "narHash": "sha256-It4Ir3xOKBvYZB42uvjruK8DGlg7mTgjzwA/vuhkw2g=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "b54e462b834d6c95721382a3fdb90411b0642220",
+        "rev": "72956bfcd1a1e08f7202592751afc80eceaaf217",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                          |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`72956bfc`](https://github.com/nix-community/srvos/commit/72956bfcd1a1e08f7202592751afc80eceaaf217) | `` update SATA HDDs comment on kernel modules `` |