### PR TITLE
chore(flake/emacs-overlay): `8c56baa0` -> `c1da8cd5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709140068,
-        "narHash": "sha256-lvRBx3t6wF4crVlHko6Rm7rV2bSES4rgPC8a2zoaic8=",
+        "lastModified": 1709168194,
+        "narHash": "sha256-vE4CD01HZGGn6JwK1rSZvNXzjbKc8D+3C5qV6wbnu7I=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8c56baa0e5ba4bbf9947605a31672e2f4735b1a9",
+        "rev": "c1da8cd5719b0ef18fec8deea705cc77504f9217",
         "type": "github"
       },
       "original": {
@@ -709,11 +709,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1708979614,
-        "narHash": "sha256-FWLWmYojIg6TeqxSnHkKpHu5SGnFP5um1uUjH+wRV6g=",
+        "lastModified": 1709128929,
+        "narHash": "sha256-GWrv9a+AgGhG4/eI/CyVVIIygia7cEy68Huv3P8oyaw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b7ee09cf5614b02d289cd86fcfa6f24d4e078c2a",
+        "rev": "c8e74c2f83fe12b4e5a8bd1abbc090575b0f7611",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c1da8cd5`](https://github.com/nix-community/emacs-overlay/commit/c1da8cd5719b0ef18fec8deea705cc77504f9217) | `` Updated elpa ``         |
| [`d80b2213`](https://github.com/nix-community/emacs-overlay/commit/d80b22132b8ea17707f87220b3518d9de200b599) | `` Updated flake inputs `` |