### PR TITLE
chore(flake/nur): `29baed9c` -> `4bd6f5cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709163935,
-        "narHash": "sha256-Mh7GpqklderqcpMYK/vyalIRkJAKF4UImbF0nJ7QuoA=",
+        "lastModified": 1709175202,
+        "narHash": "sha256-fc5xSV2qkUPrIt8gtWlkxLmp/aqtKhdPO5KTi+xNWGU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "29baed9ccb889e9bb0eaf51dab3a5fcdd247d3e7",
+        "rev": "4bd6f5cb15e23013cd8cdc6aa10dcf8ce3dc8609",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4bd6f5cb`](https://github.com/nix-community/NUR/commit/4bd6f5cb15e23013cd8cdc6aa10dcf8ce3dc8609) | `` automatic update `` |
| [`2779c60a`](https://github.com/nix-community/NUR/commit/2779c60a9cb1188359ae97ec0c1c8042d04eb20f) | `` automatic update `` |
| [`23341250`](https://github.com/nix-community/NUR/commit/23341250077c28dd4c0cdc83a4cf59dd3a27d9ac) | `` automatic update `` |