### PR TITLE
chore(flake/emacs-overlay): `c1da8cd5` -> `a9db0bff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709168194,
-        "narHash": "sha256-vE4CD01HZGGn6JwK1rSZvNXzjbKc8D+3C5qV6wbnu7I=",
+        "lastModified": 1709171133,
+        "narHash": "sha256-Q47jPqMW47AOX8HNLBnF0/oSUhKMLbOX57HFF0y9sm0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c1da8cd5719b0ef18fec8deea705cc77504f9217",
+        "rev": "a9db0bffddf142648d9fc5be615dbc246d589296",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`a9db0bff`](https://github.com/nix-community/emacs-overlay/commit/a9db0bffddf142648d9fc5be615dbc246d589296) | `` Updated emacs `` |
| [`7854b1de`](https://github.com/nix-community/emacs-overlay/commit/7854b1dee71f6bab443ed2b96c962f63cc409cdb) | `` Updated melpa `` |