### PR TITLE
chore(flake/nur): `4bd6f5cb` -> `c908e030`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709175202,
-        "narHash": "sha256-fc5xSV2qkUPrIt8gtWlkxLmp/aqtKhdPO5KTi+xNWGU=",
+        "lastModified": 1709178929,
+        "narHash": "sha256-D4HjrDGjedFQ3h6luRWOJ93CuBaw1uaQSti6A5NwpvA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4bd6f5cb15e23013cd8cdc6aa10dcf8ce3dc8609",
+        "rev": "c908e0303b21d92daf63c3a4241126fd9d93d01d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c908e030`](https://github.com/nix-community/NUR/commit/c908e0303b21d92daf63c3a4241126fd9d93d01d) | `` automatic update `` |
| [`ca5f207f`](https://github.com/nix-community/NUR/commit/ca5f207f80b8782de0552e7182f76414c5cd7c23) | `` automatic update `` |
| [`fa6c40d5`](https://github.com/nix-community/NUR/commit/fa6c40d5b94adc81bb61c5561d188c5866f8bce8) | `` automatic update `` |
| [`8495ff48`](https://github.com/nix-community/NUR/commit/8495ff48e2699a6b679878774396092f37e0e331) | `` automatic update `` |
| [`d8a664be`](https://github.com/nix-community/NUR/commit/d8a664bee9fbd87836e983e301d0513dd9f279c1) | `` automatic update `` |