### PR TITLE
chore(flake/nur): `c908e030` -> `fde0f4f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709178929,
-        "narHash": "sha256-D4HjrDGjedFQ3h6luRWOJ93CuBaw1uaQSti6A5NwpvA=",
+        "lastModified": 1709182221,
+        "narHash": "sha256-NX2VXh/9yx2eB+co5si/482KO7EoMXgqDd2tIT3lsgU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c908e0303b21d92daf63c3a4241126fd9d93d01d",
+        "rev": "fde0f4f35ebf2ed4d0308d84087f875f913e97a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fde0f4f3`](https://github.com/nix-community/NUR/commit/fde0f4f35ebf2ed4d0308d84087f875f913e97a6) | `` automatic update `` |
| [`72ee76e3`](https://github.com/nix-community/NUR/commit/72ee76e356013f2ff5516aaa9d7276466bad6aed) | `` automatic update `` |
| [`10c14d98`](https://github.com/nix-community/NUR/commit/10c14d9853b0286711d63fe0ecdeefebd53c5d94) | `` automatic update `` |
| [`390e8cf9`](https://github.com/nix-community/NUR/commit/390e8cf9e5280fec60624737618bb0f6dbf99bb6) | `` automatic update `` |