### PR TITLE
chore(flake/emacs-overlay): `a9db0bff` -> `b0ff39b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709171133,
-        "narHash": "sha256-Q47jPqMW47AOX8HNLBnF0/oSUhKMLbOX57HFF0y9sm0=",
+        "lastModified": 1709196651,
+        "narHash": "sha256-+D2ws0j52RjTlcu2f+fSuhX2xP6F9ofFBpEoOKjhz4g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a9db0bffddf142648d9fc5be615dbc246d589296",
+        "rev": "b0ff39b2ecfd233a8117dd95dd1b1bfd926714ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b0ff39b2`](https://github.com/nix-community/emacs-overlay/commit/b0ff39b2ecfd233a8117dd95dd1b1bfd926714ae) | `` Updated melpa ``        |
| [`f0b399a4`](https://github.com/nix-community/emacs-overlay/commit/f0b399a48ad970fbaabb0a171b103b066285054c) | `` Updated flake inputs `` |