### PR TITLE
chore(flake/nur): `fde0f4f3` -> `6823c94a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709182221,
-        "narHash": "sha256-NX2VXh/9yx2eB+co5si/482KO7EoMXgqDd2tIT3lsgU=",
+        "lastModified": 1709199804,
+        "narHash": "sha256-6+GYVYwYsHpnm/xF968OTJhAWHJFs/7clZFwC2+tWXo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fde0f4f35ebf2ed4d0308d84087f875f913e97a6",
+        "rev": "6823c94afb3a35e71414c6fcab276b1b5a3662a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6823c94a`](https://github.com/nix-community/NUR/commit/6823c94afb3a35e71414c6fcab276b1b5a3662a7) | `` automatic update `` |
| [`40f4664d`](https://github.com/nix-community/NUR/commit/40f4664dfa27f5b5c938a01660d63a1bdecde35f) | `` automatic update `` |