### PR TITLE
chore(flake/emacs-overlay): `b0ff39b2` -> `88cb60b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709196651,
-        "narHash": "sha256-+D2ws0j52RjTlcu2f+fSuhX2xP6F9ofFBpEoOKjhz4g=",
+        "lastModified": 1709197479,
+        "narHash": "sha256-2+Mu5f6sru7wfAXTo21EfYlTGEo4j8ddl4LrsBiv/6A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b0ff39b2ecfd233a8117dd95dd1b1bfd926714ae",
+        "rev": "88cb60b6c44861e422302371c0761a89377cf2c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`88cb60b6`](https://github.com/nix-community/emacs-overlay/commit/88cb60b6c44861e422302371c0761a89377cf2c7) | `` Updated emacs `` |