### PR TITLE
chore(flake/home-manager): `1d085ea4` -> `2f336776`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -491,11 +491,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708988456,
-        "narHash": "sha256-RCz7Xe64tN2zgWk+MVHkzg224znwqknJ1RnB7rVqUWw=",
+        "lastModified": 1709204054,
+        "narHash": "sha256-U1idK0JHs1XOfSI1APYuXi4AEADf+B+ZU4Wifc0pBHk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1d085ea4444d26aa52297758b333b449b2aa6fca",
+        "rev": "2f3367769a93b226c467551315e9e270c3f78b15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`2f336776`](https://github.com/nix-community/home-manager/commit/2f3367769a93b226c467551315e9e270c3f78b15) | `` Translate using Weblate (Portuguese (Brazil)) `` |
| [`ecfffe36`](https://github.com/nix-community/home-manager/commit/ecfffe363102f2c95bed6576465504c6a57bf8fe) | `` river: fix systemd activation (#5055) ``         |