### PR TITLE
chore(flake/nur): `6823c94a` -> `fca09fec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709199804,
-        "narHash": "sha256-6+GYVYwYsHpnm/xF968OTJhAWHJFs/7clZFwC2+tWXo=",
+        "lastModified": 1709214303,
+        "narHash": "sha256-fh7WCJVaxEULOmRh1vnXudkCf964nq3WqXY43MnmUIg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6823c94afb3a35e71414c6fcab276b1b5a3662a7",
+        "rev": "fca09fec01533adaaaaa3ddc3eb6f351913af615",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fca09fec`](https://github.com/nix-community/NUR/commit/fca09fec01533adaaaaa3ddc3eb6f351913af615) | `` automatic update `` |
| [`74be1009`](https://github.com/nix-community/NUR/commit/74be1009198dc18d3c974d85f7660e6e6c1c8184) | `` automatic update `` |
| [`0168a848`](https://github.com/nix-community/NUR/commit/0168a84850c8770adb26fd4bf8a3b4bf9103932a) | `` automatic update `` |
| [`fbe8df1c`](https://github.com/nix-community/NUR/commit/fbe8df1c13fd8e63e35c2c4654104661eb1fbbed) | `` automatic update `` |
| [`2b3b8752`](https://github.com/nix-community/NUR/commit/2b3b8752d1bd83b66b38163685f686ba8f3d1924) | `` automatic update `` |
| [`7975ad51`](https://github.com/nix-community/NUR/commit/7975ad514763c1f05ff4f61dda641adaf1efbab0) | `` automatic update `` |