### PR TITLE
chore(flake/emacs-overlay): `88cb60b6` -> `5e278b16`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709197479,
-        "narHash": "sha256-2+Mu5f6sru7wfAXTo21EfYlTGEo4j8ddl4LrsBiv/6A=",
+        "lastModified": 1709226281,
+        "narHash": "sha256-lqIEcsfb1p3bVyTLE1mrRbrQnHTYUxDUBW+wpkNvC7o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "88cb60b6c44861e422302371c0761a89377cf2c7",
+        "rev": "5e278b16d982831f1b81669d26649454c1a37981",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`5e278b16`](https://github.com/nix-community/emacs-overlay/commit/5e278b16d982831f1b81669d26649454c1a37981) | `` Updated emacs `` |
| [`187e5acf`](https://github.com/nix-community/emacs-overlay/commit/187e5acf9468f9403e7ce4d7876d682d4c347596) | `` Updated melpa `` |
| [`24c73905`](https://github.com/nix-community/emacs-overlay/commit/24c73905454662533a7a4295787d6e241632bb01) | `` Updated elpa ``  |