### PR TITLE
chore(flake/combobulate): `c7e4670a` -> `f220e87c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -193,11 +193,11 @@
     "combobulate": {
       "flake": false,
       "locked": {
-        "lastModified": 1695673560,
-        "narHash": "sha256-oLxJfHN50GWlXZYmZP7ZGqyvwEG3h0HreLAfBqoWfBg=",
+        "lastModified": 1709228400,
+        "narHash": "sha256-jR8XlRAig/lgmaVoM3uPp+Odao0JIGG5x3FTHxnmJRo=",
         "owner": "mickeynp",
         "repo": "combobulate",
-        "rev": "c7e4670a3047c0b58dff3746577a5c8e5832cfba",
+        "rev": "f220e87c7bc1792e5fd46efaa86f75a9f5bcc1d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`d35bb11d`](https://github.com/mickeynp/combobulate/commit/d35bb11dfd7fbcc16cb5002c31bd13d5aff3e23d) | `` Clarify that the table or example code lists the versions. ``                       |
| [`d78aade0`](https://github.com/mickeynp/combobulate/commit/d78aade0deb70f6607b4b87746d4340928c585fe) | `` Fix gif name ``                                                                     |
| [`4d82c68b`](https://github.com/mickeynp/combobulate/commit/4d82c68bc73aaf13dbe76ea206a4941ac8350493) | `` Ensure html-ts-mode is properly loaded in the test harness ``                       |
| [`75fa2334`](https://github.com/mickeynp/combobulate/commit/75fa233467d91d42a6b0ee7965e4b918f18e5104) | `` Wrapping text with a tag is also legal. ``                                          |
| [`8260c3c9`](https://github.com/mickeynp/combobulate/commit/8260c3c9391c9a316d9a6500a7905afa8326a8d2) | `` Update HTML to v0.20.3 and fix the code ``                                          |
| [`bf3336c3`](https://github.com/mickeynp/combobulate/commit/bf3336c33c5054d1dc90e84a9973dcf8a6177570) | `` Fix removed function ``                                                             |
| [`d495630e`](https://github.com/mickeynp/combobulate/commit/d495630ee753404e11368cfa840db41ea4f3a5b6) | `` Do not warn if we install an invalid query ``                                       |
| [`6d49f8d1`](https://github.com/mickeynp/combobulate/commit/6d49f8d146dbf09a41fc764b8c1e34360d55d64c) | `` Upgrade grammars to the latest version ``                                           |
| [`42d04a00`](https://github.com/mickeynp/combobulate/commit/42d04a003b954722e36f39f54d7b278521fe2d0e) | `` README improvements ``                                                              |
| [`65170f85`](https://github.com/mickeynp/combobulate/commit/65170f858f053a3df5285a963c9da2a0cce78d08) | `` Rule should not apply in statement blocks' rules ``                                 |
| [`b7c63c27`](https://github.com/mickeynp/combobulate/commit/b7c63c279004bc960becfb9a5e03d0a20be1fcc1) | `` Fix command names ``                                                                |
| [`b55321e8`](https://github.com/mickeynp/combobulate/commit/b55321e8121d311bebd00797b07f67a14eddc76d) | `` Do not complain by default about missing rules ``                                   |
| [`cb272b35`](https://github.com/mickeynp/combobulate/commit/cb272b357e1f87955fdda07c588ebbc7495d1c64) | `` Fix double t clause in cond ``                                                      |
| [`8d593019`](https://github.com/mickeynp/combobulate/commit/8d593019f3f60584011fadeb53368cb4f6127047) | `` Formatting ``                                                                       |
| [`50212f0a`](https://github.com/mickeynp/combobulate/commit/50212f0ac8349ce5eb25038b4dab4f454b648c49) | `` Use `read-key' in the GUI; read-key-sequence-vector in the terminal ``              |
| [`15586cae`](https://github.com/mickeynp/combobulate/commit/15586caed33fefd658e19df6c26a174d34e7dba2) | `` Indent region after splicing ``                                                     |
| [`d6ad0727`](https://github.com/mickeynp/combobulate/commit/d6ad0727b1a780940b354d8319ad0cd81c776bc9) | `` Rename constructors ``                                                              |
| [`e9ad8e94`](https://github.com/mickeynp/combobulate/commit/e9ad8e94fbfc7bb13bfbb6dcda9f9bde7d77e3bc) | `` Also ignore closing element in the display ``                                       |
| [`05ee4113`](https://github.com/mickeynp/combobulate/commit/05ee41130c4118ffe74cf33d0fefa6c6e3e971da) | `` Show clone outline like we used to do in the good, old days. ``                     |
| [`e40f601f`](https://github.com/mickeynp/combobulate/commit/e40f601f74e59c7122bb3743800be59d8943367c) | `` In debug mode, show matched procedures ``                                           |
| [`1d741133`](https://github.com/mickeynp/combobulate/commit/1d741133f6dd667fd03e2dc59cabf159b10de445) | `` Merge jsx/regular sibling rules ``                                                  |
| [`6b7e8739`](https://github.com/mickeynp/combobulate/commit/6b7e8739f6ee4f46350cdab9b9a4681af3d3fc15) | `` Fix byte compiler issues and tests ``                                               |
| [`e462d4d1`](https://github.com/mickeynp/combobulate/commit/e462d4d1c1385d8acf78a399f4c02f102a7a3cc4) | `` Fix layout issue with clone dwim; add tests. ``                                     |
| [`17492d95`](https://github.com/mickeynp/combobulate/commit/17492d9516a71a8800b436430919e04d01a7775c) | `` Fix tests ``                                                                        |
| [`bd732c26`](https://github.com/mickeynp/combobulate/commit/bd732c268371534c6d6bd09518de2ba744a29fdd) | `` Simplify logical next/prev ``                                                       |
| [`f83291a6`](https://github.com/mickeynp/combobulate/commit/f83291a6133bdb2e6932b7bdcd4f7c8d7421f203) | `` Add missing defvars ``                                                              |
| [`5b7a08b3`](https://github.com/mickeynp/combobulate/commit/5b7a08b36c2bcbd316d5a53e12b2ee7696bcac45) | `` Add a plausible separators value to try and prevent wrongful separator insertion `` |
| [`e947ee8b`](https://github.com/mickeynp/combobulate/commit/e947ee8b89aa58afc990d3b19340af0ed699c121) | `` More tests and commensurate nav tweaks ``                                           |
| [`f68ee0b1`](https://github.com/mickeynp/combobulate/commit/f68ee0b1245c69c886080d91385fdab9779a1bdf) | `` Improvements to navigation ``                                                       |
| [`0d55b658`](https://github.com/mickeynp/combobulate/commit/0d55b658d38e07178a357e6e7b1dbb5f4f36af1d) | `` Turn node into a proxy ``                                                           |
| [`517bc92f`](https://github.com/mickeynp/combobulate/commit/517bc92ff625e9df073d27106fbe658714c35a7d) | `` Fix query builder ``                                                                |
| [`a2abdadd`](https://github.com/mickeynp/combobulate/commit/a2abdadd719d079e2ee030532dfc18f7d6f8c272) | `` Recenter can trigger errors if it's run against a non-selected window ``            |
| [`42ddb0d4`](https://github.com/mickeynp/combobulate/commit/42ddb0d4b86636880c9fa498b4ee1f3111dce03e) | `` Misc. tests for combobulate-refactor ``                                             |
| [`d342694b`](https://github.com/mickeynp/combobulate/commit/d342694b9b067d66e5f1a2f1f37fe7dc4ff138a3) | `` Indent only when the region is in use ``                                            |
| [`da06e90d`](https://github.com/mickeynp/combobulate/commit/da06e90d9f42939bbc3cfcf7115a42816a4baf69) | `` Try to improve the python if envelope ``                                            |
| [`84cd7ec3`](https://github.com/mickeynp/combobulate/commit/84cd7ec3b0970daed13ef70b11469e1ca7da0a47) | `` Get rid of combobulate-manipulation-splicing-procedures ``                          |
| [`07887d56`](https://github.com/mickeynp/combobulate/commit/07887d564d1ccdb15421d1d777eb65f18c85ebc3) | `` `combobulate-make-proxy' now passes through cons cells OK ``                        |
| [`69cb7034`](https://github.com/mickeynp/combobulate/commit/69cb703419c4940ae3f5b9135de476456317a530) | `` Fix display of highlighted node ``                                                  |
| [`8c0f0244`](https://github.com/mickeynp/combobulate/commit/8c0f0244cfe21418f9be4414d97d5061244733ca) | `` Convert more things to procedures ``                                                |
| [`1f801c9c`](https://github.com/mickeynp/combobulate/commit/1f801c9cfcd2be78fbef1735fe1a1509631f51b2) | `` Choice previews should move to the first point ``                                   |
| [`2b0a8ae3`](https://github.com/mickeynp/combobulate/commit/2b0a8ae382e8c27179342f92902f8fd606388764) | `` Fix docstring ``                                                                    |
| [`6285b17c`](https://github.com/mickeynp/combobulate/commit/6285b17ce4a75e474c2d7ccb51bcbe1bbc88375f) | `` Prefer combobulate-navigation-sexp-procedures to ...sexp-nodes ``                   |
| [`7cac1510`](https://github.com/mickeynp/combobulate/commit/7cac15103a6db0d74889387a873005de78f41710) | `` Prefer combobulate-navigation-default-procedures to ...default-nodes ``             |
| [`c1b999c4`](https://github.com/mickeynp/combobulate/commit/c1b999c45858e6bb0d9f51674d872837639aaba0) | `` Switch logical nodes to procedures ``                                               |
| [`654e851b`](https://github.com/mickeynp/combobulate/commit/654e851b83d7941a5fcd1588e8425ad6fa08e4d4) | `` Add key/value distinction to clustered object editing ``                            |
| [`d162a4cd`](https://github.com/mickeynp/combobulate/commit/d162a4cd12effb7df6a2c153fb7db164b53d7a86) | `` Switch defuns to procedures ``                                                      |
| [`fce51464`](https://github.com/mickeynp/combobulate/commit/fce514643415da1aaf2c50c522d7eb28a8a71ba8) | `` Improve parent-child and sibling in HTML ``                                         |
| [`fa1d3cd4`](https://github.com/mickeynp/combobulate/commit/fa1d3cd41ca2085ff62a6cf800a5b1871ba3e05b) | `` Convert parent-child to procedures ``                                               |
| [`e238de8b`](https://github.com/mickeynp/combobulate/commit/e238de8b655ae7d7753a7bce3b7304c8bfc1cfa5) | `` Fix comment ``                                                                      |
| [`a3a2c640`](https://github.com/mickeynp/combobulate/commit/a3a2c640a7d831a35e8706cf8eafec965ee1fc24) | `` Docstring fix ``                                                                    |
| [`ea49ebe0`](https://github.com/mickeynp/combobulate/commit/ea49ebe0c7830b029355c473b6b3081c833a6366) | `` Use combobulate-atomic-change-group ``                                              |
| [`89d15c3b`](https://github.com/mickeynp/combobulate/commit/89d15c3bed82b3239f97273db0d72cbf3b480932) | `` Capitalise the field in useState ``                                                 |
| [`a1e791a4`](https://github.com/mickeynp/combobulate/commit/a1e791a42397ade48a73642a17fa75af478880df) | `` Ensure `end' is passed through correctly ``                                         |
| [`eb840738`](https://github.com/mickeynp/combobulate/commit/eb84073830f964bfb6381b2e7db18a76d0dfb159) | `` Improve test harness generation ``                                                  |
| [`8b862e81`](https://github.com/mickeynp/combobulate/commit/8b862e814f0e23a3e7d1e5fbb689ef5498e58021) | `` Rename block to user ``                                                             |
| [`03ce0d82`](https://github.com/mickeynp/combobulate/commit/03ce0d82dfa6d22cb890bba10a48cda0ef1ca8cb) | `` More documentation improvements ``                                                  |
| [`9c44d57e`](https://github.com/mickeynp/combobulate/commit/9c44d57e4e5238b1ed44642425198b1c7922bb59) | `` Typo ``                                                                             |
| [`2d82dcb7`](https://github.com/mickeynp/combobulate/commit/2d82dcb7729bb403b346001c85ba2896168c4b3d) | `` Use `attr-choice' for enveloping jsx attributes by default ``                       |
| [`8f6c1180`](https://github.com/mickeynp/combobulate/commit/8f6c1180ab75757e0d0adbd8384141b685cbf467) | `` Always rollback whether it is a quit error or not ``                                |
| [`0817be6e`](https://github.com/mickeynp/combobulate/commit/0817be6ee3dae55d95281ef04b348da3bf415b45) | `` Docstring and cleanup ``                                                            |
| [`ad99ded9`](https://github.com/mickeynp/combobulate/commit/ad99ded91da867ffd76dfe8045173a68f9e55d77) | `` Remove message calls ``                                                             |
| [`58dddcd4`](https://github.com/mickeynp/combobulate/commit/58dddcd47eab2ecbf26a5082ce0d7ec39cf060ca) | `` Place a point at the region ``                                                      |
| [`371a6dfc`](https://github.com/mickeynp/combobulate/commit/371a6dfc147563b8cfaee054f5586c04cfe82bda) | `` Further refinements to how prompts and fields interact ``                           |
| [`bee1aa83`](https://github.com/mickeynp/combobulate/commit/bee1aa83419de95b2f4c3506b47523824d262890) | `` Media query envelope improvement ``                                                 |
| [`d3198c21`](https://github.com/mickeynp/combobulate/commit/d3198c21075f997b0e9cfa15756d31648fe9df7d) | `` Make python proffer indentation not use the action for side effects ``              |
| [`22cb64dc`](https://github.com/mickeynp/combobulate/commit/22cb64dcadd164a104de19fca45556cb42105bc5) | `` Fix combobulate-debug breaking pretty printing ``                                   |
| [`e82ff13d`](https://github.com/mickeynp/combobulate/commit/e82ff13d854139905f458b1d59954cee8496634b) | `` Prompts are now rendered last. ``                                                   |
| [`b82dfce0`](https://github.com/mickeynp/combobulate/commit/b82dfce05bdaa483b61ca97936dd4976088776b4) | `` Assert the start index is not outside the node list bounds ``                       |
| [`9dc1dcb6`](https://github.com/mickeynp/combobulate/commit/9dc1dcb692ce708075fb74a9daa478505a22a6f6) | `` Tweaks to < and save-column ``                                                      |
| [`db08ab35`](https://github.com/mickeynp/combobulate/commit/db08ab35cb7dd1ca390bfaeee25c330513cde3ad) | `` Track block instructions from choice expansions ``                                  |
| [`9780ed5c`](https://github.com/mickeynp/combobulate/commit/9780ed5c12bf3a7df96e533c1d06abb6fbff54f0) | `` Remove superfluous change group ``                                                  |
| [`724fa6f2`](https://github.com/mickeynp/combobulate/commit/724fa6f2ff85deca07ced31169b7958b2c158051) | `` Fix indentation/selection/undo problems ``                                          |
| [`af94133e`](https://github.com/mickeynp/combobulate/commit/af94133ef415d9c37b9fadf1a287893f14dd87ee) | `` Block instructions revamp ``                                                        |
| [`c55d84f3`](https://github.com/mickeynp/combobulate/commit/c55d84f361803a9404038744522e9b288fecd717) | `` Improvements to numeric selection ``                                                |
| [`444b21b8`](https://github.com/mickeynp/combobulate/commit/444b21b8c35b292d60512bf69d1515d55a5bf8ac) | `` html-ts-mode is in actual fact released ``                                          |
| [`60869f32`](https://github.com/mickeynp/combobulate/commit/60869f329ac4ca70dfd6ca8bb81f3a0aa56a67d9) | `` Rename variable so its use is more obvious ``                                       |
| [`1f9bbdb9`](https://github.com/mickeynp/combobulate/commit/1f9bbdb9aa5e3c1c83e797197a0e52fc8504e966) | `` Rewrite Python's indentation mechanism ``                                           |
| [`a756b57f`](https://github.com/mickeynp/combobulate/commit/a756b57f1df896a90852a82ebd1270205f83d018) | `` Remove commented code ``                                                            |
| [`b18dc893`](https://github.com/mickeynp/combobulate/commit/b18dc893cd560fae5715117c468a25b2abcdd2f3) | `` Fix a few minor warnings ``                                                         |
| [`82152973`](https://github.com/mickeynp/combobulate/commit/82152973c2758bd802dd1fd09ef09a5ccd6a7225) | `` Merge function ``                                                                   |
| [`cc558888`](https://github.com/mickeynp/combobulate/commit/cc558888a0e0dafff032bbce6c77b4e6f3aa5c59) | `` Move envelope functions to envelope file ``                                         |
| [`41d6d071`](https://github.com/mickeynp/combobulate/commit/41d6d071eda324ffc7a9269659ae0e2555255912) | `` Tweak order to preserve clarity ``                                                  |
| [`bfd25928`](https://github.com/mickeynp/combobulate/commit/bfd259283b93c6828a36999d3cbd2eb1a7342cb3) | `` Also treat argument_list sub-rules as valid parent-children ``                      |
| [`d686fe45`](https://github.com/mickeynp/combobulate/commit/d686fe45062b2d424f3d48d38e5b2c0974a417cf) | `` Add more activation nodes ``                                                        |
| [`f8c8809e`](https://github.com/mickeynp/combobulate/commit/f8c8809e0b5ec486d0f1df6131ae2599855447e6) | `` Use the parent to correctly indicate edit context ``                                |
| [`5d66a297`](https://github.com/mickeynp/combobulate/commit/5d66a29761c054a15cb142cf63908fad3041f3ed) | `` Add before-string support to mark label ``                                          |
| [`5aa4c403`](https://github.com/mickeynp/combobulate/commit/5aa4c403296edc76bf7c67c3912f9a2919b7407d) | `` Use `read-key-sequence-vector' so unread command events work ``                     |
| [`746bcae9`](https://github.com/mickeynp/combobulate/commit/746bcae97bbe77f49cfcc1e4ed6f7e4a77a6a13d) | `` Pass in the correct context-node ``                                                 |
| [`27c73ad9`](https://github.com/mickeynp/combobulate/commit/27c73ad94551b75cafda5f8966703d9dd8ec7a5b) | `` Cleanup and remove disused code ``                                                  |
| [`5069f43b`](https://github.com/mickeynp/combobulate/commit/5069f43ba2d034aaf1287855ddfbbb2f93a659f0) | `` Appease the byte compiler ``                                                        |
| [`ce71130e`](https://github.com/mickeynp/combobulate/commit/ce71130e2df9f144081704367e7f2d792d98cb71) | `` Fix docstring ``                                                                    |
| [`a34aeaa4`](https://github.com/mickeynp/combobulate/commit/a34aeaa42814b441b8e5b502bc8a57f649aac3cd) | `` Centralise cursor messaging logic ``                                                |
| [`8ce9cc85`](https://github.com/mickeynp/combobulate/commit/8ce9cc8517c128c476684ab97214bcf8475e1437) | `` Add basic envelopes to JSON ``                                                      |
| [`745729ed`](https://github.com/mickeynp/combobulate/commit/745729edb3a640d89a90cc41193d8f326b6702bb) | `` Use a single pass and a hash table to speed up uniqueness checks ``                 |
| [`6af8841c`](https://github.com/mickeynp/combobulate/commit/6af8841cd3263be6b822b18d81a7c39f8b35d3c7) | `` Fix navigation so it is more consistent and simpler ``                              |
| [`fa08d5ac`](https://github.com/mickeynp/combobulate/commit/fa08d5ac7b4db481dc0f3ee63863439141cd4162) | `` Do not double quote pp'd JSON strings ``                                            |
| [`b285bd46`](https://github.com/mickeynp/combobulate/commit/b285bd46664088d8b972a0ab497234b458c945a2) | `` Return a cons cell and not a list ``                                                |
| [`0fb2f119`](https://github.com/mickeynp/combobulate/commit/0fb2f1190b6fe19dc820dd79dbc95a68c368a97e) | `` Properly name the thing at point node ``                                            |
| [`3983e97e`](https://github.com/mickeynp/combobulate/commit/3983e97ec5ed898ecf971cb1efe1be6f1a204836) | `` Allow picking proffered nodes by C-1 through C-9 ``                                 |
| [`8e143fb1`](https://github.com/mickeynp/combobulate/commit/8e143fb1b3b0bda49fdb1606b298aa1f85e96aa6) | `` Tweak read key loop in proffer choices so it behaves consistently on a terminal ``  |
| [`e4855f58`](https://github.com/mickeynp/combobulate/commit/e4855f58161f99a2e88b143f11192d523b23b6b3) | `` Also bind prev to <backtab> in combobulate-proffer-map ``                           |
| [`f57da1df`](https://github.com/mickeynp/combobulate/commit/f57da1df57222e04a78028f885f690d8942a6f5d) | `` Formalise deindentation envelope instruction ``                                     |
| [`7886314b`](https://github.com/mickeynp/combobulate/commit/7886314b5ef8a292e9ca9d0f46f094211170d812) | `` Remove hardcoded refactor id ``                                                     |
| [`c4ef1c45`](https://github.com/mickeynp/combobulate/commit/c4ef1c4591977b1455379e9b192a48bfeb3eeef2) | `` Documentation improvements ``                                                       |
| [`457a8b76`](https://github.com/mickeynp/combobulate/commit/457a8b76d0b2e5d9891f535cb8ba35fc63fae4bf) | `` Indentation ``                                                                      |
| [`046c2603`](https://github.com/mickeynp/combobulate/commit/046c2603a79717ad30f463213558dc02d8244e1f) | `` Fix test ``                                                                         |
| [`6ccc92af`](https://github.com/mickeynp/combobulate/commit/6ccc92afda21c2d7d9d7fef30976a1d3dbb89039) | `` Handle a regular node being passed ``                                               |
| [`33125df0`](https://github.com/mickeynp/combobulate/commit/33125df004f73f5f53a4dc496a49eb6370263c76) | `` Fix off-by-one ``                                                                   |
| [`966dbd01`](https://github.com/mickeynp/combobulate/commit/966dbd016ea1cdc112fd4d2daf50a23364361af9) | `` Restore vanish node behaviour to its old self ``                                    |
| [`2a6bc114`](https://github.com/mickeynp/combobulate/commit/2a6bc1145f5f1c0e40a69eacf254329088a68819) | `` Fix naming of diff files ``                                                         |
| [`6af7cd7f`](https://github.com/mickeynp/combobulate/commit/6af7cd7fbf3fa79b7a60c001b66bb18619100eb6) | `` Correct jsx splicing ``                                                             |
| [`a1e6a242`](https://github.com/mickeynp/combobulate/commit/a1e6a2421774a2dafb1183fcd4770b34b5301456) | `` Fix edit jsx attribute ``                                                           |
| [`06a47dec`](https://github.com/mickeynp/combobulate/commit/06a47dec6453843fe798660a6708c0205b7e6c97) | `` Fix combobulate-navigate-up-list-maybe ``                                           |
| [`7881b563`](https://github.com/mickeynp/combobulate/commit/7881b563edf1f61bc075371ddd4402d06c421c41) | `` Add tests for navigate up ``                                                        |
| [`6c4a8c0e`](https://github.com/mickeynp/combobulate/commit/6c4a8c0e8240013dcf1d617d621a503f0f3cfcc8) | `` Layout ``                                                                           |
| [`112202bc`](https://github.com/mickeynp/combobulate/commit/112202bc5f6d4cddc9fd793f6a1f7949b07a97d3) | `` Ensure tag is indented properly ``                                                  |
| [`1ad0d19f`](https://github.com/mickeynp/combobulate/commit/1ad0d19f051ecb3aff7fd3cc35cfd3e0942192ae) | `` Pointer logic is slightly improved ``                                               |
| [`de62e0bf`](https://github.com/mickeynp/combobulate/commit/de62e0bf2fa6c074231e5aa7b26f9f8ade581e6e) | `` Improvements to error handling and recovery. Docstring improvements. ``             |
| [`4687a106`](https://github.com/mickeynp/combobulate/commit/4687a10600f09e5409fa7fe68c71ff7b08689e47) | `` Fix tests ``                                                                        |
| [`f9aa787c`](https://github.com/mickeynp/combobulate/commit/f9aa787ca0bc6eafcc8567dd8a535d9590459b40) | `` Handle python indentation better inside a choice ``                                 |
| [`6d1da189`](https://github.com/mickeynp/combobulate/commit/6d1da189532fbc2374363da73f80d4fd7cd690c3) | `` Give point proxy nodes a pretty printed name ``                                     |
| [`a6dbd21d`](https://github.com/mickeynp/combobulate/commit/a6dbd21d72e79ef8026040b369cd6e11aa2426f7) | `` Choice seems to work way better now. ``                                             |
| [`61943417`](https://github.com/mickeynp/combobulate/commit/61943417dd0608124fa8f8d8736d031e8fb8b082) | `` More in-progress work on choice ``                                                  |
| [`7a486a0a`](https://github.com/mickeynp/combobulate/commit/7a486a0a1006bda24a24b1b978ab367596c78b3e) | `` Ensure point is at the prompt during prompting ``                                   |
| [`76ceb543`](https://github.com/mickeynp/combobulate/commit/76ceb543c115b4a672f9c5cb71d3dd4cf2026b09) | `` More work on choice selection. ``                                                   |
| [`c5a0a940`](https://github.com/mickeynp/combobulate/commit/c5a0a94051ebdb260e5f758621d78c6cf2b58acc) | `` Working `choice' instruction ``                                                     |
| [`fbb37226`](https://github.com/mickeynp/combobulate/commit/fbb3722666ec144d178f5b4ee656ca5f8afc2af6) | `` Preserve prompts across `repeat' blocks in envelopes ``                             |
| [`a7ed31f8`](https://github.com/mickeynp/combobulate/commit/a7ed31f87ee03f604082951dec762d170092ace4) | `` More test work ``                                                                   |
| [`7fbc17bf`](https://github.com/mickeynp/combobulate/commit/7fbc17bff5cc814b6fcd62d34a76600da6a624b9) | `` More refinements to tests ``                                                        |
| [`11cc6467`](https://github.com/mickeynp/combobulate/commit/11cc646740780bdf6a8fd075832c8b5cc6220a0d) | `` Improve indentation handling ``                                                     |
| [`6ebba511`](https://github.com/mickeynp/combobulate/commit/6ebba511ebcb2844a3c525fe8184b786ef4daf80) | `` Rename ``                                                                           |
| [`95390dae`](https://github.com/mickeynp/combobulate/commit/95390dae4d12aac9d08d1d03375dab936aacaeaf) | `` Add dockerised testing ``                                                           |
| [`abb64808`](https://github.com/mickeynp/combobulate/commit/abb6480822ffe2b81ee7806919f09ee29b1891b0) | `` Regenerate rules & reformat buildre-lationships ``                                  |
| [`3ab83c54`](https://github.com/mickeynp/combobulate/commit/3ab83c5463d1bb793dbeedfe9a44a5d97014dd07) | `` Re-generate drag tests ``                                                           |
| [`35506bca`](https://github.com/mickeynp/combobulate/commit/35506bcaf5ed170cdf7eef03bed583462cef1393) | `` Refactor how argument handling for mc edit commands work ``                         |
| [`489d62ab`](https://github.com/mickeynp/combobulate/commit/489d62abb73fa00deafa4ab33c7c125a092661b9) | `` Improve handling of incorrect languages and loading of highlights ``                |
| [`4a5a621d`](https://github.com/mickeynp/combobulate/commit/4a5a621da44d8f213488313e76c0702ad3080fa4) | `` Bind `combobulate-edit-node-siblings-dwim` ``                                       |
| [`6f126120`](https://github.com/mickeynp/combobulate/commit/6f126120e9a8ff434af1b0a8583383ca1f22a1b9) | `` Formatting ``                                                                       |
| [`8a4105c6`](https://github.com/mickeynp/combobulate/commit/8a4105c6f6b9f1da63be30f4946e35632abcd7a7) | `` Clean up mc testing ``                                                              |
| [`9e8e9643`](https://github.com/mickeynp/combobulate/commit/9e8e9643462557738925f207180d1cdcd440979d) | `` Work on testing multiple cursors editing ``                                         |
| [`2b09f7ff`](https://github.com/mickeynp/combobulate/commit/2b09f7ff9c647c855b2edc2ef5c9b9a5099fec18) | `` Fix missing final newline issue ``                                                  |
| [`12081959`](https://github.com/mickeynp/combobulate/commit/12081959255e2c6aa982ebc094fa3c94412ee249) | `` More stability ``                                                                   |
| [`9e839106`](https://github.com/mickeynp/combobulate/commit/9e83910652619d2086bc22bcf834345cf55e8770) | `` More improvements still ``                                                          |
| [`700843fc`](https://github.com/mickeynp/combobulate/commit/700843fccbabd99e8485030e94b5656198043e20) | `` More test improvements ``                                                           |
| [`cec97f24`](https://github.com/mickeynp/combobulate/commit/cec97f247fa18ee423188f0c54e07accb1df61bf) | `` More work on code generating tests ``                                               |
| [`869f741d`](https://github.com/mickeynp/combobulate/commit/869f741d35247387515c5a22bec57641e3714d34) | `` Add sibling navigation tests ``                                                     |
| [`ee3a64ad`](https://github.com/mickeynp/combobulate/commit/ee3a64ad671616e7917480b11ddd80619d45ce36) | `` Formatting ``                                                                       |
| [`18701fcc`](https://github.com/mickeynp/combobulate/commit/18701fcc34324477f399578e6306e6a51349ef3a) | `` Ensure point is placed properly ``                                                  |
| [`07cfb35c`](https://github.com/mickeynp/combobulate/commit/07cfb35c6d1f4dc4b637aeef1d49bdf8948a4b00) | `` Also delete the elc file ``                                                         |
| [`e9cadc88`](https://github.com/mickeynp/combobulate/commit/e9cadc8889fd15d6a1601adf27bc0bb59492b084) | `` Formatting and byte compiler fixes ``                                               |
| [`284be2ac`](https://github.com/mickeynp/combobulate/commit/284be2ac367deb256397128c4cf92351ad348708) | `` Remove dead code ``                                                                 |
| [`02c2a46f`](https://github.com/mickeynp/combobulate/commit/02c2a46fb47026a45346489fa66d4a56e8fd929e) | `` Remove use of combobulate-get-immediate-siblings-of-node ``                         |
| [`e9a394f5`](https://github.com/mickeynp/combobulate/commit/e9a394f5e7da108d5d5bb0d96f43859c9ae708a9) | `` Fix formatting ``                                                                   |
| [`563a43ea`](https://github.com/mickeynp/combobulate/commit/563a43ea8bed9dd43b5a20f3477fbe6447d39305) | `` Remove old-school drag logic and use sibling procedures instead ``                  |
| [`942c31ec`](https://github.com/mickeynp/combobulate/commit/942c31ec2f67241cc0b27f551e87f41dce983b83) | `` `M-H' now also contracts the marked region ``                                       |
| [`1c4e0dd4`](https://github.com/mickeynp/combobulate/commit/1c4e0dd46b6a2ca5bcd84080ebe5a86235064138) | `` Keep point at the top of the region when calling mark dwim ``                       |
| [`97f7a7ea`](https://github.com/mickeynp/combobulate/commit/97f7a7eaa663b4659ed7e6da6f3d9539ab21377b) | `` Correct old combobulate highlighter face group names ``                             |
| [`08010d54`](https://github.com/mickeynp/combobulate/commit/08010d5494adcc281033c9530038ce467603394e) | `` Prefer the point to be at the first multiple cursor ``                              |
| [`a2fdb13e`](https://github.com/mickeynp/combobulate/commit/a2fdb13e46b3df5397db06e888b27946f9840340) | `` Do not include indent unless we're in newline insert mode ``                        |
| [`de5c27e3`](https://github.com/mickeynp/combobulate/commit/de5c27e3bc7941a09a939a35f6e825f3ec41839c) | `` Try to make node cloning a bit more robust ``                                       |
| [`eb4d121d`](https://github.com/mickeynp/combobulate/commit/eb4d121d9bfd22c6a20661093f9676ca154d708e) | `` Add navigation support to classes ``                                                |
| [`d850d001`](https://github.com/mickeynp/combobulate/commit/d850d001f218f13d79346f10e576c80a684d3f3c) | `` Add all nodes to default nodes ``                                                   |
| [`4a129084`](https://github.com/mickeynp/combobulate/commit/4a129084fe1ca60eb732d853751c04c4542e0f14) | `` Fix colours ``                                                                      |
| [`4b035bb0`](https://github.com/mickeynp/combobulate/commit/4b035bb05627586d2f2e3eb0dfad843b419de1c5) | `` Add save & quit to query builder ``                                                 |
| [`636c7fc7`](https://github.com/mickeynp/combobulate/commit/636c7fc7b4dbd882a8e5282342e4b47843993443) | `` If there is no parser in a buffer, query builder will ask for a ``                  |
| [`7aabf178`](https://github.com/mickeynp/combobulate/commit/7aabf1785497e7e7560d3d3ca7c192778ffbfa74) | `` Split sources into its own file, and clean up code a bit. ``                        |