### PR TITLE
chore(flake/nur): `419b9c04` -> `a04e8bf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709235865,
-        "narHash": "sha256-6vtvq4C0VVd6Loa2hsusjG+tbdPejlDSZTGKeZtct3w=",
+        "lastModified": 1709240301,
+        "narHash": "sha256-O/IAJcIUB7ZQTXsnmuqOnHbM5oIypIh15T944zXwA54=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "419b9c04478cf09efce7635cee0e0c14ec1d9cfd",
+        "rev": "a04e8bf56f7cc3fc05a117733ede8d7a38e50eac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a04e8bf5`](https://github.com/nix-community/NUR/commit/a04e8bf56f7cc3fc05a117733ede8d7a38e50eac) | `` automatic update `` |
| [`04faed2b`](https://github.com/nix-community/NUR/commit/04faed2bbb45869890824deb06ab315228ffe7b1) | `` automatic update `` |