### PR TITLE
chore(flake/nur): `a04e8bf5` -> `b9478b89`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709240301,
-        "narHash": "sha256-O/IAJcIUB7ZQTXsnmuqOnHbM5oIypIh15T944zXwA54=",
+        "lastModified": 1709246668,
+        "narHash": "sha256-pwxjUEMNKuUk8tt77w8fXovuFoZViJlKRrxvH7h80rw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a04e8bf56f7cc3fc05a117733ede8d7a38e50eac",
+        "rev": "b9478b89c4fb5e2d0d6b1717b5278d3d748daad2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b9478b89`](https://github.com/nix-community/NUR/commit/b9478b89c4fb5e2d0d6b1717b5278d3d748daad2) | `` automatic update `` |