### PR TITLE
chore(flake/nur): `b9478b89` -> `14de3286`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709246668,
-        "narHash": "sha256-pwxjUEMNKuUk8tt77w8fXovuFoZViJlKRrxvH7h80rw=",
+        "lastModified": 1709248623,
+        "narHash": "sha256-Zmo187XIeCGlGHRcczf5tboirJghYesHmX2Eug8CQRY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b9478b89c4fb5e2d0d6b1717b5278d3d748daad2",
+        "rev": "14de3286e2081dbffaa7ebb595363227b6af2a74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`14de3286`](https://github.com/nix-community/NUR/commit/14de3286e2081dbffaa7ebb595363227b6af2a74) | `` automatic update `` |