### PR TITLE
chore(flake/nur): `14de3286` -> `55aa32e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709248623,
-        "narHash": "sha256-Zmo187XIeCGlGHRcczf5tboirJghYesHmX2Eug8CQRY=",
+        "lastModified": 1709258292,
+        "narHash": "sha256-0MNlpBmWEE+67ZyHvbvin6mRmc7vEfIij4oHfMWcLeA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "14de3286e2081dbffaa7ebb595363227b6af2a74",
+        "rev": "55aa32e99d1a780ff593f667aab845c76ba9ac07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`55aa32e9`](https://github.com/nix-community/NUR/commit/55aa32e99d1a780ff593f667aab845c76ba9ac07) | `` automatic update `` |
| [`66ec9b1c`](https://github.com/nix-community/NUR/commit/66ec9b1cbbb72b79d7d6d5b5d219713f7b4af888) | `` automatic update `` |
| [`7fa3452d`](https://github.com/nix-community/NUR/commit/7fa3452ddbcf35f1a1e9c8153a6734db81e1ae85) | `` automatic update `` |
| [`334b28aa`](https://github.com/nix-community/NUR/commit/334b28aa542a238f3ad41d10fec8d5ebeab15506) | `` automatic update `` |