### PR TITLE
chore(flake/emacs-overlay): `03b374a3` -> `f46c7855`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709254925,
-        "narHash": "sha256-Z6hJVMlXzVjNUB0ZYVNBWiMRSiH72c2beFB6A6YExSA=",
+        "lastModified": 1709257831,
+        "narHash": "sha256-2fIN5wSy38nfHXTxvyrFu8nu5wHi/nbaG48iGLOShY8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "03b374a38f808b3f42d7a8b59bcc8ba7c20e5ce9",
+        "rev": "f46c7855660fd07e03c4ce68f025b65f22ff95e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`f46c7855`](https://github.com/nix-community/emacs-overlay/commit/f46c7855660fd07e03c4ce68f025b65f22ff95e2) | `` Updated emacs `` |
| [`51d054fd`](https://github.com/nix-community/emacs-overlay/commit/51d054fd379c4bf1bc9df49c98db0a356ffc20f5) | `` Updated melpa `` |