### PR TITLE
chore(flake/nur): `45e26847` -> `f8d65afc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709264735,
-        "narHash": "sha256-b40AyryjclFbBqyyAFFiFZXTE45t7XD74jZPznHlvRo=",
+        "lastModified": 1709266767,
+        "narHash": "sha256-D2lO9ZCAhYvljqADQ7Zf3ywZyrE4sda7VYghVEKwxjo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "45e268473e501a69fca55cd4c3b362521b2a0312",
+        "rev": "f8d65afc4806c6541bf5f516a8319c31c7386ede",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f8d65afc`](https://github.com/nix-community/NUR/commit/f8d65afc4806c6541bf5f516a8319c31c7386ede) | `` automatic update `` |
| [`f4be25a0`](https://github.com/nix-community/NUR/commit/f4be25a071c35bb099d40bc6be7652c1a17fdf2b) | `` automatic update `` |