### PR TITLE
chore(flake/nur): `f8d65afc` -> `e2083b88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709266767,
-        "narHash": "sha256-D2lO9ZCAhYvljqADQ7Zf3ywZyrE4sda7VYghVEKwxjo=",
+        "lastModified": 1709271691,
+        "narHash": "sha256-b5kOUYqWohybzjYl2mJsGvzkK0rTOz8rFe1CzQD74yQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f8d65afc4806c6541bf5f516a8319c31c7386ede",
+        "rev": "e2083b8865f5427a5f178766e5241ecc49e87507",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e2083b88`](https://github.com/nix-community/NUR/commit/e2083b8865f5427a5f178766e5241ecc49e87507) | `` automatic update `` |