### PR TITLE
chore(flake/nur): `e2083b88` -> `975323e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709271691,
-        "narHash": "sha256-b5kOUYqWohybzjYl2mJsGvzkK0rTOz8rFe1CzQD74yQ=",
+        "lastModified": 1709278039,
+        "narHash": "sha256-+NW+df4TSznF0QFumSH0be17W1e0ONWILqw/IYKpFDs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e2083b8865f5427a5f178766e5241ecc49e87507",
+        "rev": "975323e2a56dde3ed8879469091a830ca8b2f3cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`975323e2`](https://github.com/nix-community/NUR/commit/975323e2a56dde3ed8879469091a830ca8b2f3cd) | `` automatic update `` |