### PR TITLE
chore(flake/lanzaboote): `e761c7ee` -> `614b538f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -540,11 +540,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1709051793,
-        "narHash": "sha256-4FXFBq5mN1IwN18Fd2OEF1iCZV5PC40gP2L64oyq3xQ=",
+        "lastModified": 1709281447,
+        "narHash": "sha256-YUC12DAhE5RJtGVg0CDXyHBycccjp82HP99t7AViJFU=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "e761c7ee47b64debc687d8bff7599d702c893dcc",
+        "rev": "614b538f0fcd4eda423abc36819a57eb4b241b1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                               |
| --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`7df500bd`](https://github.com/nix-community/lanzaboote/commit/7df500bd1cc911932f9c3a7cd2eb6c071764f0c4) | `` readme: add mention of "Window UEFI Mode" needed on some boards `` |
| [`e2e8059d`](https://github.com/nix-community/lanzaboote/commit/e2e8059df26a70a43796c60da25d3f4c6b2eb4a5) | `` stub(*): merge dynamically initrds ``                              |
| [`88bcd99c`](https://github.com/nix-community/lanzaboote/commit/88bcd99ca8dc13e67670e601f94a6c9f623b426a) | `` stub(*): support dynamic initrds ``                                |