### PR TITLE
chore(flake/nur): `975323e2` -> `bf3465e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709278039,
-        "narHash": "sha256-+NW+df4TSznF0QFumSH0be17W1e0ONWILqw/IYKpFDs=",
+        "lastModified": 1709281923,
+        "narHash": "sha256-aHxiig/3uORX/keRsNLCs7yLP8GBogmwcGBaLKMdMJ8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "975323e2a56dde3ed8879469091a830ca8b2f3cd",
+        "rev": "bf3465e366e868b9d91f78e54d55566ebd2aa03e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bf3465e3`](https://github.com/nix-community/NUR/commit/bf3465e366e868b9d91f78e54d55566ebd2aa03e) | `` automatic update `` |