### PR TITLE
chore(flake/nur): `bf3465e3` -> `407fbafd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709281923,
-        "narHash": "sha256-aHxiig/3uORX/keRsNLCs7yLP8GBogmwcGBaLKMdMJ8=",
+        "lastModified": 1709289863,
+        "narHash": "sha256-AjkKqC5HaQLSGR/4UivLaLxUJSbx0xUIv25n961aNac=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bf3465e366e868b9d91f78e54d55566ebd2aa03e",
+        "rev": "407fbafde51bdab6e1b43ac0ea1c51d6f448ca41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`407fbafd`](https://github.com/nix-community/NUR/commit/407fbafde51bdab6e1b43ac0ea1c51d6f448ca41) | `` automatic update `` |
| [`8e82d078`](https://github.com/nix-community/NUR/commit/8e82d0789dab6faf0abe94def7b8bc9cab2996bc) | `` automatic update `` |