### PR TITLE
chore(flake/srvos): `72956bfc` -> `8e1328f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1011,11 +1011,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709158468,
-        "narHash": "sha256-It4Ir3xOKBvYZB42uvjruK8DGlg7mTgjzwA/vuhkw2g=",
+        "lastModified": 1709290688,
+        "narHash": "sha256-uGOqZffYg3mNS43MI6yhYB5tE8QYXgvCzO8dg5lC9TA=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "72956bfcd1a1e08f7202592751afc80eceaaf217",
+        "rev": "8e1328f734bff51198c44facd064b257756343c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                               |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`8e1328f7`](https://github.com/nix-community/srvos/commit/8e1328f734bff51198c44facd064b257756343c5) | `` zfs: remove udev scheduler rule `` |