### PR TITLE
chore(flake/nixpkgs): `9099616b` -> `b8697e57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -774,11 +774,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1709479366,
-        "narHash": "sha256-n6F0n8UV6lnTZbYPl1A9q1BS0p4hduAv1mGAP17CVd0=",
+        "lastModified": 1709703039,
+        "narHash": "sha256-6hqgQ8OK6gsMu1VtcGKBxKQInRLHtzulDo9Z5jxHEFY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b8697e57f10292a6165a20f03d2f42920dfaf973",
+        "rev": "9df3e30ce24fd28c7b3e2de0d986769db5d6225d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`b7e6dda0`](https://github.com/NixOS/nixpkgs/commit/b7e6dda0482f7af257948fedce1e46a2f1eb83a1) | `` wvkbd: 0.14.3 -> 0.14.4 ``                                                        |
| [`f13d9489`](https://github.com/NixOS/nixpkgs/commit/f13d94892c90a105f363ff9ba5930cbe3df52c16) | `` ssh-to-age: 1.1.6 -> 1.1.7 ``                                                     |
| [`55e649c5`](https://github.com/NixOS/nixpkgs/commit/55e649c554fa3d8643b5a589cd123218f8c1ccdf) | `` shopware-cli: 0.4.24 -> 0.4.25 ``                                                 |
| [`61efe8f5`](https://github.com/NixOS/nixpkgs/commit/61efe8f544d3e346a6666b22f3853f2d7d89b85d) | `` python312Packages.teslajsonpy: 3.10.0 -> 3.10.1 ``                                |
| [`0f8027e1`](https://github.com/NixOS/nixpkgs/commit/0f8027e11afd25d553aec94b847f48b08454f54a) | `` openscad: add wrapGAppsHook ``                                                    |
| [`0fabf7e8`](https://github.com/NixOS/nixpkgs/commit/0fabf7e8e1a2907a8400be64d7cce52ae541480a) | `` checkov: 3.2.28 -> 3.2.29 ``                                                      |
| [`dfdd8fc8`](https://github.com/NixOS/nixpkgs/commit/dfdd8fc83a7906cfe30137efe077af933d97d28b) | `` github-commenter: 0.19.0 -> 0.27.0 ``                                             |
| [`6b8b18b3`](https://github.com/NixOS/nixpkgs/commit/6b8b18b3220296ca6e2d74259f545a85ce521e93) | `` fit-trackee: 0.7.29 -> 0.7.31 ``                                                  |
| [`ab0b41f4`](https://github.com/NixOS/nixpkgs/commit/ab0b41f416f0cb9b5eb58f9384af3bdad74f541d) | `` python3.pkgs.inkex: Fix build with lxml 5 ``                                      |
| [`5cb92fd7`](https://github.com/NixOS/nixpkgs/commit/5cb92fd712e859518cd17f2e230a013ded5dabb7) | `` blahaj: enable mt by default and add static (#270608) ``                          |
| [`b34af2d6`](https://github.com/NixOS/nixpkgs/commit/b34af2d675b8ae33f2fa783e5786e79bd7f11902) | `` presenterm: 0.6.1 -> 0.7.0 ``                                                     |
| [`d0dd9626`](https://github.com/NixOS/nixpkgs/commit/d0dd9626dd114955bf599484591a28f761ebfb93) | `` twitch-tui: 2.6.4 -> 2.6.5 ``                                                     |
| [`7305821c`](https://github.com/NixOS/nixpkgs/commit/7305821c58b9d7dbd493e7fb847a0480ffa5cb08) | `` tests/minio: fix broken minio test ``                                             |
| [`286977c0`](https://github.com/NixOS/nixpkgs/commit/286977c08ddf540b4c6bebd8cd96fe30070bcb46) | `` cartridges: 2.7.2 -> 2.7.3 ``                                                     |
| [`e3f64c6d`](https://github.com/NixOS/nixpkgs/commit/e3f64c6d9fd006b812add806d9bef6297c5ced42) | `` sgt-puzzles: 20240103.7a93ae5 -> 20240302.80aac31 ``                              |
| [`f91289a7`](https://github.com/NixOS/nixpkgs/commit/f91289a787d68944ae0d2d4dd543425489d29f1b) | `` python311Packages.asyncstdlib: 3.12.0 -> 3.12.1 ``                                |
| [`ee090eea`](https://github.com/NixOS/nixpkgs/commit/ee090eeac704a0919db821edb5ac7cabdb005aa8) | `` flake-checker: 0.1.16 -> 0.1.17 ``                                                |
| [`70d55953`](https://github.com/NixOS/nixpkgs/commit/70d559530756b3e4a7fb72b3f30c4a162a01062f) | `` python311Packages.unifi-discovery: 1.1.7 -> 1.1.8 ``                              |
| [`d3cb1658`](https://github.com/NixOS/nixpkgs/commit/d3cb165872a3cea3e94a0da640bac6d4505b0864) | `` python311Packages.pydrawise: 2024.2.0 -> 2024.3.0 ``                              |
| [`7bfb794b`](https://github.com/NixOS/nixpkgs/commit/7bfb794b100cfa6fb8a07a6055dd792a82d3492c) | `` python311Packages.pyp: 1.1.0 -> 1.2.0 ``                                          |
| [`3599d230`](https://github.com/NixOS/nixpkgs/commit/3599d230e9d8fc79c993d622575981bdbad44ec8) | `` netease-music-tui: remove ``                                                      |
| [`c6e485da`](https://github.com/NixOS/nixpkgs/commit/c6e485da0c20b402188f40b7565cc7d3abd7c112) | `` blackfire: 2.25.0 -> 2.26.0 ``                                                    |
| [`2b7d1a05`](https://github.com/NixOS/nixpkgs/commit/2b7d1a052453b53962ab88bc30f611533c8926d3) | `` minio-client: 2024-02-16T11-05-48Z -> 2024-02-24T01-33-20Z ``                     |
| [`612c8673`](https://github.com/NixOS/nixpkgs/commit/612c8673be7067e21d57c08af11a4ab4e2277ca6) | `` dracula-theme: unstable-2024-02-16 -> unstable-2024-03-02 ``                      |
| [`336a3a4d`](https://github.com/NixOS/nixpkgs/commit/336a3a4d4e43c8eb29f2be74a74aebd4a3fdc720) | `` typos-lsp: 0.1.13 -> 0.1.14 ``                                                    |
| [`5f26d9fd`](https://github.com/NixOS/nixpkgs/commit/5f26d9fd93fb3403d1fcc5372403dd2128e35dc0) | `` magicrescue: init at 1.1.10-unstable-2021-09-12 ``                                |
| [`a3ba1cbd`](https://github.com/NixOS/nixpkgs/commit/a3ba1cbdd699d8ac77c323376af23f6300e3c4b8) | `` python312Packages.iteration-utilities: 0.12.0 -> 0.12.1 ``                        |
| [`8575d0b2`](https://github.com/NixOS/nixpkgs/commit/8575d0b2dc7bd76bdec69b06a9953269b85fe830) | `` tgt: 1.0.90 -> 1.0.91 ``                                                          |
| [`bde24cef`](https://github.com/NixOS/nixpkgs/commit/bde24cef3314b6e787642bbc49906884b940843f) | `` python311Packages.yalexs: 1.11.4 -> 2.0.0 ``                                      |
| [`e878ba5f`](https://github.com/NixOS/nixpkgs/commit/e878ba5ff7dfbdd56096bbc8bc05199c4f4fccdb) | `` python311Packages.langchain-core: 0.1.27 -> 0.1.28 ``                             |
| [`a40a5350`](https://github.com/NixOS/nixpkgs/commit/a40a53505b059fa875bf0f29c96cee89c33d2bb4) | `` python311Packages.python-cinderclient: 9.4.0 -> 9.5.0 ``                          |
| [`bd84aa21`](https://github.com/NixOS/nixpkgs/commit/bd84aa21a08ef3dc2f699de2cbd8b7e64430a79e) | `` undbx: init at 0.21-unstable-2019-02-11 ``                                        |
| [`a0a754e1`](https://github.com/NixOS/nixpkgs/commit/a0a754e1dfc3e9a063b117c0139e5627bb2aa480) | `` ardour: 8.2 -> 8.4 ``                                                             |
| [`83231482`](https://github.com/NixOS/nixpkgs/commit/8323148284e8d51d0f0b1e88357b14b9a4808e32) | `` prusa-slicer: 2.7.1 -> 2.7.2 ``                                                   |
| [`8f7eb087`](https://github.com/NixOS/nixpkgs/commit/8f7eb087ede82b7a25c1ed528851855eca5ad110) | `` partio: 1.17.1 -> 1.17.3 ``                                                       |
| [`babbddc8`](https://github.com/NixOS/nixpkgs/commit/babbddc88ab2407b4a2fab18c11f7e0fad91f6d1) | `` cargo-cyclonedx: 0.4.1 -> 0.5.0 ``                                                |
| [`54c6cd1e`](https://github.com/NixOS/nixpkgs/commit/54c6cd1e51e18af4d1e696b5c69bb80f8f356fc3) | `` terragrunt: 0.55.10 -> 0.55.11 ``                                                 |
| [`83d145e5`](https://github.com/NixOS/nixpkgs/commit/83d145e5596149346fdab90900b335be7e5befd2) | `` yamlscript: 0.1.38 -> 0.1.39 ``                                                   |
| [`d9d3c32f`](https://github.com/NixOS/nixpkgs/commit/d9d3c32fb66d5e0764c3cf3eded1f744e609d7a3) | `` vhdl-ls: 0.77.0 -> 0.78.0 ``                                                      |
| [`42e98887`](https://github.com/NixOS/nixpkgs/commit/42e98887ba5aa46ed8b9670fd8ae9e7593c10629) | `` rippled: drop redundant `disable-warnings-if-gcc13` ``                            |
| [`76efa481`](https://github.com/NixOS/nixpkgs/commit/76efa481513f9f965ad30b0cc14aa9724c680087) | `` python312Packages.pydrawise: 2024.2.0 -> 2024.3.0 ``                              |
| [`d60c032f`](https://github.com/NixOS/nixpkgs/commit/d60c032f93757c2f5179029ab63cfc291be9f15b) | `` python312Packages.unifi-discovery: 1.1.7 -> 1.1.8 ``                              |
| [`8ebbd46c`](https://github.com/NixOS/nixpkgs/commit/8ebbd46c138896de5e31de82f4d9fb3d8f1b896b) | `` python312Packages.bthome-ble: 3.5.0 -> 3.6.0 ``                                   |
| [`61791cf4`](https://github.com/NixOS/nixpkgs/commit/61791cf4be4912ab38eece0d73c5673a3e642c0b) | `` python311Packages.spacy: 3.7.3 -> 3.7.4 ``                                        |
| [`036a5ca0`](https://github.com/NixOS/nixpkgs/commit/036a5ca059048e3c0f573358b071cad3ef86be37) | `` sequoia-sq: fix darwin test failure ``                                            |
| [`8d8dbeea`](https://github.com/NixOS/nixpkgs/commit/8d8dbeea4e6af811a8ab10ac195549dc76b57730) | `` neoload: remove ``                                                                |
| [`0c52de62`](https://github.com/NixOS/nixpkgs/commit/0c52de62aaa04ed9190ff8743fca280a7e226d24) | `` python311Packages.clickgen: 2.2.0 -> 2.2.1 ``                                     |
| [`f68646c7`](https://github.com/NixOS/nixpkgs/commit/f68646c7b9dbedfb0558c8790656cffe214f295a) | `` process-compose: 0.85.0 -> 0.88.0 ``                                              |
| [`a26b7a4a`](https://github.com/NixOS/nixpkgs/commit/a26b7a4abd74f87c12f30bda835c929be3d6abb3) | `` obs-studio-plugins.obs-shaderfilter: 2.2.2 -> 2.3.0 ``                            |
| [`848f5533`](https://github.com/NixOS/nixpkgs/commit/848f5533fa638d7097ead7a9af5f5537f3721528) | `` python311Packages.crate: 0.34.0 -> 0.35.2 ``                                      |
| [`7a1b9782`](https://github.com/NixOS/nixpkgs/commit/7a1b97825badd102a583b4ef11c86451177859ac) | `` python311Packages.pueblo: init at 0.0.8 ``                                        |
| [`8a2ad954`](https://github.com/NixOS/nixpkgs/commit/8a2ad95413206da58345a744b8cd3ccc868cfa6f) | `` python311Packages.verlib2: init at 0.2.0 ``                                       |
| [`91cbabe9`](https://github.com/NixOS/nixpkgs/commit/91cbabe994af83cfcd2e02025d3297983e1d731c) | `` deploy-rs: unstable-2023-12-20 -> unstable-2024-02-16 ``                          |
| [`7d96b872`](https://github.com/NixOS/nixpkgs/commit/7d96b872b430bb694fdad2fc1d8e801e0500e897) | `` metabigor: 1.12.1 -> 2.0.0 ``                                                     |
| [`16d5b925`](https://github.com/NixOS/nixpkgs/commit/16d5b925a863984018cf0d622b074d78614a6973) | `` lammps-mpi: 2Aug2023_update2 -> 2Aug2023_update3 ``                               |
| [`aa266e89`](https://github.com/NixOS/nixpkgs/commit/aa266e89429e1b3f997bc363671e5c724cb3384f) | `` gobgp: 3.23.0 -> 3.24.0 ``                                                        |
| [`6b100dcc`](https://github.com/NixOS/nixpkgs/commit/6b100dcc5d7d221760936903d0443e4121b010cd) | `` gobgpd: 3.23.0 -> 3.24.0 ``                                                       |
| [`bd456c39`](https://github.com/NixOS/nixpkgs/commit/bd456c39788658892080f6ddc1722abe3ee7bbd9) | `` home-assistant-custom-components.auth-header: init at 1.10-unstable-2024-02-26 `` |
| [`9fefe225`](https://github.com/NixOS/nixpkgs/commit/9fefe225244c737414af613ab199e3da3f93a7a5) | `` poac: remove ken-matsui from maintainers ``                                       |
| [`2037f3e4`](https://github.com/NixOS/nixpkgs/commit/2037f3e480ec4f8e261b449ad8f06e59451874e6) | `` texlive.bin.dvisvgm: use mupdf-headless instead of mupdf (#292803) ``             |
| [`aafa54a1`](https://github.com/NixOS/nixpkgs/commit/aafa54a1a8df54213dce1cb8ae727cdc2fd795a8) | `` nixos/llama-cpp: add to module-list ``                                            |
| [`db884840`](https://github.com/NixOS/nixpkgs/commit/db88484093a36833df9b48c1bd06f29487e38468) | `` vault-bin: 1.15.5 -> 1.15.6 ``                                                    |
| [`7584eeba`](https://github.com/NixOS/nixpkgs/commit/7584eeba20d78de39b1a132896d1f1e8281df1d4) | `` vault: 1.15.5 -> 1.15.6 ``                                                        |
| [`a64e7fc4`](https://github.com/NixOS/nixpkgs/commit/a64e7fc41681b6abd3de9e8d88a3e068e68aec16) | `` lubelogger: 1.2.3 -> 1.2.4 ``                                                     |
| [`87af287f`](https://github.com/NixOS/nixpkgs/commit/87af287f565ca89887378d90b1a5b3deff68735e) | `` python311Packages.oslo-context: 5.4.0 -> 5.5.0 ``                                 |
| [`62c6d7f9`](https://github.com/NixOS/nixpkgs/commit/62c6d7f9387fc77a0e69a203f9a68cde4a167890) | `` ijq: 0.4.1 -> 1.0.1 ``                                                            |
| [`9c8cdfde`](https://github.com/NixOS/nixpkgs/commit/9c8cdfde17d675c9bb3975d0a0bca26bdbbe6683) | `` bngblaster: 0.8.35 -> 0.8.39 (#290294) ``                                         |
| [`5df10e90`](https://github.com/NixOS/nixpkgs/commit/5df10e9029b3beae05c046220165502e374bbaec) | `` qt-6: fix meta.position ``                                                        |
| [`a385846e`](https://github.com/NixOS/nixpkgs/commit/a385846eca36d386ab93a25f881aca580b231058) | `` storj-uplink: 1.98.2 -> 1.99.1 ``                                                 |
| [`907b5ebc`](https://github.com/NixOS/nixpkgs/commit/907b5ebcee65bd1a28419f4e81b3f63fc6cf6510) | `` nixos/nextcloud: build with-apps local ``                                         |
| [`da1ccb62`](https://github.com/NixOS/nixpkgs/commit/da1ccb628fc614625dc44fee52330257bb31e496) | `` nixos/paperless: fix too many open files ``                                       |
| [`bc910886`](https://github.com/NixOS/nixpkgs/commit/bc910886a1cced465b788459001cbb892482e2be) | `` programs/kdeconnect: install sshfs ``                                             |
| [`3ac86e83`](https://github.com/NixOS/nixpkgs/commit/3ac86e83287c001224e9925592bf4ee6f812ce5c) | `` tree-wide: remove flexagoon from maintainers ``                                   |
| [`885d57f6`](https://github.com/NixOS/nixpkgs/commit/885d57f6d2d4028d4a41f194d9757bf5c48f8906) | `` netbird-ui: 0.26.1 -> 0.26.2 ``                                                   |
| [`dfef819d`](https://github.com/NixOS/nixpkgs/commit/dfef819d515bbdc8444305c5458bbab7fc7b1512) | `` python312Packages.langsmith: 0.1.10 -> 0.1.13 ``                                  |
| [`b178a7ef`](https://github.com/NixOS/nixpkgs/commit/b178a7efa12e9052fecaa70f3d8aa44ebb793697) | `` ssb-patchwork: refactor ``                                                        |
| [`935ee8ea`](https://github.com/NixOS/nixpkgs/commit/935ee8eae59bc40750c2b708d36e075837cf3120) | `` colloid-icon-theme: 2023-07-01 -> 2024-02-28 ``                                   |
| [`bc20b671`](https://github.com/NixOS/nixpkgs/commit/bc20b6717ad3cd4370dcbc943f67cbadf6d6b7f5) | `` bpftop: 0.2.2 -> 0.2.3 ``                                                         |
| [`1b4558c4`](https://github.com/NixOS/nixpkgs/commit/1b4558c4cf5f465f3752ac81abb70359afc0e2ff) | `` yara-python: 4.4.0 -> 4.5.0 ``                                                    |
| [`d9b3a34a`](https://github.com/NixOS/nixpkgs/commit/d9b3a34a5f29eff52debc955ea0c45fff0fda8b7) | `` python312Packages.ytmusicapi: 1.5.3 -> 1.5.4 ``                                   |
| [`4c1d7349`](https://github.com/NixOS/nixpkgs/commit/4c1d7349ea2f64b256f1ca130baa48e17411ff8f) | `` python3Packages.pymatgen: enable tests ``                                         |
| [`1d79f89f`](https://github.com/NixOS/nixpkgs/commit/1d79f89ff75cf2f2e94403725c1129819aea0c2b) | `` unixODBCDrivers.mariadb: fix build on darwin ``                                   |
| [`a8675fb2`](https://github.com/NixOS/nixpkgs/commit/a8675fb29b25b4ea87f92bef5a026c41984c1169) | `` python-matter-server: 5.7.0b2 -> 5.8.0 ``                                         |
| [`6f6cb320`](https://github.com/NixOS/nixpkgs/commit/6f6cb3206b0eac0da492deca8bcebab1bc1638a5) | `` python3Packages.vllm: 0.3.2 -> 0.3.3 ``                                           |
| [`dbb0736b`](https://github.com/NixOS/nixpkgs/commit/dbb0736b87a1d7f4280e4b3f57f18b038ad63f83) | `` python3Packages.outlines: init at 0.0.34 ``                                       |
| [`bc438f11`](https://github.com/NixOS/nixpkgs/commit/bc438f11c3a31abe7b37dd919173d2fdcd86eb1e) | `` python3Packages.interegular: init at 0.3.3 ``                                     |
| [`ac4441fa`](https://github.com/NixOS/nixpkgs/commit/ac4441fabd4d276ba43e1f6aa110f3b803ba7a57) | `` Add missing closing parens. ``                                                    |
| [`79813b3b`](https://github.com/NixOS/nixpkgs/commit/79813b3bd838d84eee84f73ae26a7299fdb5a046) | `` fastfetch: 2.8.6 -> 2.8.7 ``                                                      |
| [`7d15e810`](https://github.com/NixOS/nixpkgs/commit/7d15e810d7600d9b7a1ad269174eb444482e1309) | `` treewide: remove unpackCmd involving 7zz ``                                       |