### PR TITLE
chore(flake/nur): `c1a0966d` -> `62244671`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709296225,
-        "narHash": "sha256-VJURrEZAht+YEPSZanCD2E0eZv8hLEAAho+FAVByXYs=",
+        "lastModified": 1709307967,
+        "narHash": "sha256-PyDnQzZL/aBogcRS9Tq5oFqopsqG3L9NO3kOAyGkTzg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c1a0966dac356909a9dfd8c161e08f3ac10e003b",
+        "rev": "622446714ffabe84c4e007ad8d14be1a44d051a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`62244671`](https://github.com/nix-community/NUR/commit/622446714ffabe84c4e007ad8d14be1a44d051a3) | `` automatic update `` |
| [`9338d6c7`](https://github.com/nix-community/NUR/commit/9338d6c7c4115a8c7fe17fc887919204a9635545) | `` automatic update `` |
| [`f272567e`](https://github.com/nix-community/NUR/commit/f272567edc7cb4c72cc11d045e4db2660a9dd126) | `` automatic update `` |
| [`c14e838f`](https://github.com/nix-community/NUR/commit/c14e838f7baab6f5ddce63082f79d129446bd20a) | `` automatic update `` |
| [`6ad856f5`](https://github.com/nix-community/NUR/commit/6ad856f58f1da6cbd6e003f1b5245fd4232d821a) | `` automatic update `` |