### PR TITLE
chore(flake/emacs-overlay): `d7155aaa` -> `2b95246f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709283110,
-        "narHash": "sha256-V3/gFVUB6HwgPTDhcpwe3g4rVOYIe10wdLbztTGeyCU=",
+        "lastModified": 1709312709,
+        "narHash": "sha256-55cDTZXPwcipqBV9MfYTcHEEkIYVLimoAvbm8irOTPg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d7155aaadc98b2c13874f78cc5e00f2dfefd7a6e",
+        "rev": "2b95246fa59e3dd0627e308df545bbd4cc3ce22f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`2b95246f`](https://github.com/nix-community/emacs-overlay/commit/2b95246fa59e3dd0627e308df545bbd4cc3ce22f) | `` Updated emacs ``        |
| [`c2af4557`](https://github.com/nix-community/emacs-overlay/commit/c2af45572b1a63acd56b23f135c5866ff19a7962) | `` Updated melpa ``        |
| [`94bd2c06`](https://github.com/nix-community/emacs-overlay/commit/94bd2c06076fa392ccfcb88f63adf19b2482d5d9) | `` Updated elpa ``         |
| [`514217c9`](https://github.com/nix-community/emacs-overlay/commit/514217c91d0c914a2545a482e6c8bb051edcaa49) | `` Updated flake inputs `` |