### PR TITLE
chore(flake/nur): `62244671` -> `73216284`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709307967,
-        "narHash": "sha256-PyDnQzZL/aBogcRS9Tq5oFqopsqG3L9NO3kOAyGkTzg=",
+        "lastModified": 1709315176,
+        "narHash": "sha256-/cFJkQc1M9/UxeEM4kci5jM/uUU8BdGz3Y2wfDvTH+Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "622446714ffabe84c4e007ad8d14be1a44d051a3",
+        "rev": "73216284e7eebc9b5c34b9ce05f220e7e2168e20",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`73216284`](https://github.com/nix-community/NUR/commit/73216284e7eebc9b5c34b9ce05f220e7e2168e20) | `` automatic update `` |
| [`c4456ad5`](https://github.com/nix-community/NUR/commit/c4456ad5a0982c8d37429125b106bf287f0296e4) | `` automatic update `` |
| [`aef6b1d5`](https://github.com/nix-community/NUR/commit/aef6b1d5c2c4adb830eddf478c0f418cb5d4032c) | `` automatic update `` |