### PR TITLE
chore(flake/nur): `73216284` -> `7d003db9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709315176,
-        "narHash": "sha256-/cFJkQc1M9/UxeEM4kci5jM/uUU8BdGz3Y2wfDvTH+Q=",
+        "lastModified": 1709322401,
+        "narHash": "sha256-AUuuklEh6Ph5FYCjh3odZFeqz9ynh+HDDgARbh52rcU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "73216284e7eebc9b5c34b9ce05f220e7e2168e20",
+        "rev": "7d003db96005f367008a368f5e3ea1b9d073d64f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7d003db9`](https://github.com/nix-community/NUR/commit/7d003db96005f367008a368f5e3ea1b9d073d64f) | `` automatic update `` |
| [`2bc9cfcb`](https://github.com/nix-community/NUR/commit/2bc9cfcb92c01b8483e1768c39823b36d6077059) | `` automatic update `` |
| [`7cc43767`](https://github.com/nix-community/NUR/commit/7cc43767dba920519939e2a7f0162e8703fb3673) | `` automatic update `` |