### PR TITLE
chore(flake/nur): `7d003db9` -> `6575c91c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709322401,
-        "narHash": "sha256-AUuuklEh6Ph5FYCjh3odZFeqz9ynh+HDDgARbh52rcU=",
+        "lastModified": 1709326940,
+        "narHash": "sha256-88BiXn9PJ5y+BGggqQvn7YvluHzBh2I9ZJglmI/JaS8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7d003db96005f367008a368f5e3ea1b9d073d64f",
+        "rev": "6575c91c724aa12426c49a70bca63a94462f4efd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6575c91c`](https://github.com/nix-community/NUR/commit/6575c91c724aa12426c49a70bca63a94462f4efd) | `` automatic update `` |
| [`6b9b5949`](https://github.com/nix-community/NUR/commit/6b9b59495ff2a7092af2d4c399e0cf9142d50100) | `` automatic update `` |