### PR TITLE
chore(flake/nur): `6575c91c` -> `dcf16e00`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709326940,
-        "narHash": "sha256-88BiXn9PJ5y+BGggqQvn7YvluHzBh2I9ZJglmI/JaS8=",
+        "lastModified": 1709329546,
+        "narHash": "sha256-UHxn5ljW4cMYY3bslY+wSGi3BZ/DqRhWdKILT//63Cs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6575c91c724aa12426c49a70bca63a94462f4efd",
+        "rev": "dcf16e00e8bdfd336dd7e8a9c8e133133d0af959",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dcf16e00`](https://github.com/nix-community/NUR/commit/dcf16e00e8bdfd336dd7e8a9c8e133133d0af959) | `` automatic update `` |