### PR TITLE
chore(flake/emacs-overlay): `2b95246f` -> `16fc59cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709312709,
-        "narHash": "sha256-55cDTZXPwcipqBV9MfYTcHEEkIYVLimoAvbm8irOTPg=",
+        "lastModified": 1709343803,
+        "narHash": "sha256-seXqExZkSwnE3V2uDNeEQmA4IrkP0teCGoTfngXkFUI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2b95246fa59e3dd0627e308df545bbd4cc3ce22f",
+        "rev": "16fc59cc0a5882b60dbd7d5665363d743b3d95c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`16fc59cc`](https://github.com/nix-community/emacs-overlay/commit/16fc59cc0a5882b60dbd7d5665363d743b3d95c1) | `` Updated emacs ``  |
| [`ba8ee81a`](https://github.com/nix-community/emacs-overlay/commit/ba8ee81a90e1019be55f950dffb4b75099691a3e) | `` Updated elpa ``   |
| [`d909a8b4`](https://github.com/nix-community/emacs-overlay/commit/d909a8b4f5b332a8086ce2fbe7f30b91957c229b) | `` Updated nongnu `` |