### PR TITLE
chore(flake/nur): `dcf16e00` -> `d7b81a30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709329546,
-        "narHash": "sha256-UHxn5ljW4cMYY3bslY+wSGi3BZ/DqRhWdKILT//63Cs=",
+        "lastModified": 1709341511,
+        "narHash": "sha256-ZonYkQVpF2jXa4645gyFOTr2XNLK68uvgeljiiyPqdg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dcf16e00e8bdfd336dd7e8a9c8e133133d0af959",
+        "rev": "d7b81a30d06405b2b6ba17698dffe6215e219409",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d7b81a30`](https://github.com/nix-community/NUR/commit/d7b81a30d06405b2b6ba17698dffe6215e219409) | `` automatic update `` |
| [`407972e6`](https://github.com/nix-community/NUR/commit/407972e64109cbe67992a754c09fdff96df8c19c) | `` automatic update `` |
| [`b79b14e8`](https://github.com/nix-community/NUR/commit/b79b14e80708477d8cf7c269bd6a5e62121da0cd) | `` automatic update `` |