### PR TITLE
chore(flake/nur): `d7b81a30` -> `b5b87b28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709341511,
-        "narHash": "sha256-ZonYkQVpF2jXa4645gyFOTr2XNLK68uvgeljiiyPqdg=",
+        "lastModified": 1709344419,
+        "narHash": "sha256-L+eUbeajoQRQovsU8jj8ytMZcnF2+bDN3NMHrn5eMl8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d7b81a30d06405b2b6ba17698dffe6215e219409",
+        "rev": "b5b87b2880e3091ad286fddd4464caab2e4558f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b5b87b28`](https://github.com/nix-community/NUR/commit/b5b87b2880e3091ad286fddd4464caab2e4558f8) | `` automatic update `` |