### PR TITLE
chore(flake/darwin): `70d162d4` -> `8a15cb36`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709292216,
-        "narHash": "sha256-DwC4ASXZpssI7ZOJADOtQ7PhVV1mrEEXQdML/0gLPGo=",
+        "lastModified": 1709348262,
+        "narHash": "sha256-eYTA1uZtYGFKrDOKiAz1wlE6aIC9WSdBNF8bSS818zM=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "70d162d4684f738761ab4251c0cee05b5f5d4d53",
+        "rev": "8a15cb36fffa0b5fbe31ef16ede0a479bef4b365",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                               |
| ------------------------------------------------------------------------------------------------ | ------------------------------------- |
| [`ee53e578`](https://github.com/LnL7/nix-darwin/commit/ee53e5785c437aa2e836c6ce3b9fbf3936bf511e) | `` `system.startup.chime`: init ``    |
| [`0363c18c`](https://github.com/LnL7/nix-darwin/commit/0363c18c3704c44d4a282ecbd1455b325bc37a77) | `` `system.nvram`: init (internal) `` |