### PR TITLE
chore(flake/nur): `f26313a6` -> `a539b9e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709361986,
-        "narHash": "sha256-SqZN3Vd8ncAMKDiK8ml0blTMANt8u9/qT33InsIU0fs=",
+        "lastModified": 1709366185,
+        "narHash": "sha256-K8CZc7mWQ2p2UiCzi9WVuzuUgG4nZe+BwTb3S6AYAsg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f26313a67e4c6f4bd0e31ffef9f60bfca1948cf2",
+        "rev": "a539b9e38cd2604dae50937d80f181cca533a462",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a539b9e3`](https://github.com/nix-community/NUR/commit/a539b9e38cd2604dae50937d80f181cca533a462) | `` automatic update `` |