### PR TITLE
chore(flake/nur): `3de7657e` -> `3c45f6cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709376345,
-        "narHash": "sha256-C4IvZxPx0qObH0iqIruubQM9EfL0H0Iwp4Ytdg6o/zI=",
+        "lastModified": 1709379866,
+        "narHash": "sha256-wRP/vLoTz9qZ5iHMTqWCMfe2DuSJxy0sdI23Ix6MN0g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3de7657e6ea4ed20f9b4076f1dd33a5e91a43ab7",
+        "rev": "3c45f6cd9a2520013c5aa946c00307132b236262",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3c45f6cd`](https://github.com/nix-community/NUR/commit/3c45f6cd9a2520013c5aa946c00307132b236262) | `` automatic update `` |