### PR TITLE
chore(flake/nur): `3c45f6cd` -> `c2d6a728`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709379866,
-        "narHash": "sha256-wRP/vLoTz9qZ5iHMTqWCMfe2DuSJxy0sdI23Ix6MN0g=",
+        "lastModified": 1709381237,
+        "narHash": "sha256-otJrgJ5Q4mzNXNYyu4/Qp652OpLzY5/dVNS/xu4PiR4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3c45f6cd9a2520013c5aa946c00307132b236262",
+        "rev": "c2d6a7282138ae32abf50aae5fd2efddb066a6da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c2d6a728`](https://github.com/nix-community/NUR/commit/c2d6a7282138ae32abf50aae5fd2efddb066a6da) | `` automatic update `` |