### PR TITLE
chore(flake/nur): `c2d6a728` -> `ffd46da1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709381237,
-        "narHash": "sha256-otJrgJ5Q4mzNXNYyu4/Qp652OpLzY5/dVNS/xu4PiR4=",
+        "lastModified": 1709387082,
+        "narHash": "sha256-dGcJWgYGidP/lS9rQ6nAkJsfy5YvRIdldw8EiQDstjU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c2d6a7282138ae32abf50aae5fd2efddb066a6da",
+        "rev": "ffd46da1c67009bd0272e4faa331ae38c545f3fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ffd46da1`](https://github.com/nix-community/NUR/commit/ffd46da1c67009bd0272e4faa331ae38c545f3fa) | `` automatic update `` |