### PR TITLE
chore(flake/nur): `ffd46da1` -> `44508429`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709387082,
-        "narHash": "sha256-dGcJWgYGidP/lS9rQ6nAkJsfy5YvRIdldw8EiQDstjU=",
+        "lastModified": 1709389076,
+        "narHash": "sha256-9x0F2HSgSQJL68ybWnCrIyZt8gBzSE6hvZdwbQBjHvk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ffd46da1c67009bd0272e4faa331ae38c545f3fa",
+        "rev": "445084298133120908fbc286fd6e50bf1aab390a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`44508429`](https://github.com/nix-community/NUR/commit/445084298133120908fbc286fd6e50bf1aab390a) | `` automatic update `` |