### PR TITLE
chore(flake/emacs-overlay): `89541209` -> `1e6301ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709370247,
-        "narHash": "sha256-X0D8+Mk9ROxMfoetZDeBm3LU9jUC5ouEA3aVzinc0J8=",
+        "lastModified": 1709399032,
+        "narHash": "sha256-4LUxOtqa4PDyHbgqDPM9M23S5Q1gg47rAflE+qhclm8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "89541209151acb287bfb71659e738038521b0bcb",
+        "rev": "1e6301ed0b30f7601ab4cf85cabc086385ce3618",
         "type": "github"
       },
       "original": {
@@ -709,11 +709,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1709218635,
-        "narHash": "sha256-nytX/MkfqeTD4z7bMq4QRXcHxO9B3vRo9tM6fMtPFA8=",
+        "lastModified": 1709309926,
+        "narHash": "sha256-VZFBtXGVD9LWTecGi6eXrE0hJ/mVB3zGUlHImUs2Qak=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "068d4db604958d05d0b46c47f79b507d84dbc069",
+        "rev": "79baff8812a0d68e24a836df0a364c678089e2c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`1e6301ed`](https://github.com/nix-community/emacs-overlay/commit/1e6301ed0b30f7601ab4cf85cabc086385ce3618) | `` Updated emacs ``        |
| [`bde7c369`](https://github.com/nix-community/emacs-overlay/commit/bde7c369f548e93febee51d1bc38ecbac644c308) | `` Updated melpa ``        |
| [`d8b62d7b`](https://github.com/nix-community/emacs-overlay/commit/d8b62d7bf5edf5d14ba03a904c9c9c4f3b719e81) | `` Updated elpa ``         |
| [`bab54c41`](https://github.com/nix-community/emacs-overlay/commit/bab54c414822538a2275bd32d546f87192ae1576) | `` Updated flake inputs `` |