### PR TITLE
chore(flake/nur): `44508429` -> `3635ceab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709389076,
-        "narHash": "sha256-9x0F2HSgSQJL68ybWnCrIyZt8gBzSE6hvZdwbQBjHvk=",
+        "lastModified": 1709397861,
+        "narHash": "sha256-sB7GQ2mb+b0hwGCUaYNlFUmvg3OsmKnx2xtDs/hOkHA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "445084298133120908fbc286fd6e50bf1aab390a",
+        "rev": "3635ceabe30c7434fd847edc466e41b45c3149e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3635ceab`](https://github.com/nix-community/NUR/commit/3635ceabe30c7434fd847edc466e41b45c3149e4) | `` automatic update `` |