### PR TITLE
chore(flake/nur): `79a69d91` -> `8913066d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709401479,
-        "narHash": "sha256-H+97CRsSX/VJKyXAaKd3FXdTYz3SFzmLdDP8/wswiNk=",
+        "lastModified": 1709408738,
+        "narHash": "sha256-VHRTlpUd3xnqCI5FnYKrrdYvUU6b2PoqapXUpKcfGjI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "79a69d9135886a0a5954c573402b0724b2562d22",
+        "rev": "8913066dbc3d389d2a26354c30753ceb1acb6e32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8913066d`](https://github.com/nix-community/NUR/commit/8913066dbc3d389d2a26354c30753ceb1acb6e32) | `` automatic update `` |
| [`3a467458`](https://github.com/nix-community/NUR/commit/3a4674583d8b69fdc3875c5615046d540ea56a27) | `` automatic update `` |
| [`96180796`](https://github.com/nix-community/NUR/commit/96180796965f828546779a019a38ee6fe769a119) | `` automatic update `` |