### PR TITLE
chore(flake/nur): `8913066d` -> `d4a9ca59`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709408738,
-        "narHash": "sha256-VHRTlpUd3xnqCI5FnYKrrdYvUU6b2PoqapXUpKcfGjI=",
+        "lastModified": 1709415900,
+        "narHash": "sha256-e9OGY4nHIFYvAiVAB+ZBl6hfAudEI8XtjOgGCS6Jp9A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8913066dbc3d389d2a26354c30753ceb1acb6e32",
+        "rev": "d4a9ca59599c0e4f5acfb079a55fe0578ecfc4de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d4a9ca59`](https://github.com/nix-community/NUR/commit/d4a9ca59599c0e4f5acfb079a55fe0578ecfc4de) | `` automatic update `` |
| [`38334efa`](https://github.com/nix-community/NUR/commit/38334efa320e3981afe86f37d816059b4dbe6978) | `` automatic update `` |