### PR TITLE
chore(flake/nur): `d4a9ca59` -> `f4befb15`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709415900,
-        "narHash": "sha256-e9OGY4nHIFYvAiVAB+ZBl6hfAudEI8XtjOgGCS6Jp9A=",
+        "lastModified": 1709419486,
+        "narHash": "sha256-q0TrZdfP1HHsD+BMweVv67l/WOhXaj4q8VRytFOupTw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d4a9ca59599c0e4f5acfb079a55fe0578ecfc4de",
+        "rev": "f4befb1532ff62f5c542928d1a03a9e2b2465f5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f4befb15`](https://github.com/nix-community/NUR/commit/f4befb1532ff62f5c542928d1a03a9e2b2465f5d) | `` automatic update `` |