### PR TITLE
chore(flake/nur): `f4befb15` -> `7dece497`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709419486,
-        "narHash": "sha256-q0TrZdfP1HHsD+BMweVv67l/WOhXaj4q8VRytFOupTw=",
+        "lastModified": 1709423131,
+        "narHash": "sha256-IC6JS+Rk6MKg7jl6C9gHHl2StLvwnzDkN3cjU5SQ+ig=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f4befb1532ff62f5c542928d1a03a9e2b2465f5d",
+        "rev": "7dece49714e9c3dd6b7395ac789099b82ab40104",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7dece497`](https://github.com/nix-community/NUR/commit/7dece49714e9c3dd6b7395ac789099b82ab40104) | `` automatic update `` |