### PR TITLE
chore(flake/emacs-overlay): `1e6301ed` -> `349cdc7e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709399032,
-        "narHash": "sha256-4LUxOtqa4PDyHbgqDPM9M23S5Q1gg47rAflE+qhclm8=",
+        "lastModified": 1709430482,
+        "narHash": "sha256-6DuA//PbOEMb3JjhbqYCMaLT6Y86r2TRvVEkKpDbU6Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1e6301ed0b30f7601ab4cf85cabc086385ce3618",
+        "rev": "349cdc7ea8cbb285146a4ce42421ca15c956fb12",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`349cdc7e`](https://github.com/nix-community/emacs-overlay/commit/349cdc7ea8cbb285146a4ce42421ca15c956fb12) | `` Updated emacs `` |
| [`0329a922`](https://github.com/nix-community/emacs-overlay/commit/0329a922bf16ccb1fa77205793f5b06aa82ce5aa) | `` Updated melpa `` |
| [`bc61b276`](https://github.com/nix-community/emacs-overlay/commit/bc61b276a41a9f5bd1a4ff5ac7b7651cd76feb8c) | `` Updated elpa ``  |