### PR TITLE
chore(flake/nur): `7dece497` -> `17421bac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709423131,
-        "narHash": "sha256-IC6JS+Rk6MKg7jl6C9gHHl2StLvwnzDkN3cjU5SQ+ig=",
+        "lastModified": 1709427911,
+        "narHash": "sha256-Rm6u5IEVMltB3VIetx1ELQPZSuitG5KqUe3+EBl22hE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7dece49714e9c3dd6b7395ac789099b82ab40104",
+        "rev": "17421bac8e3a1663fbcc935f3b685794a89b6999",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`17421bac`](https://github.com/nix-community/NUR/commit/17421bac8e3a1663fbcc935f3b685794a89b6999) | `` automatic update `` |