### PR TITLE
chore(flake/nur): `17421bac` -> `119c7ad8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709427911,
-        "narHash": "sha256-Rm6u5IEVMltB3VIetx1ELQPZSuitG5KqUe3+EBl22hE=",
+        "lastModified": 1709431145,
+        "narHash": "sha256-8ksJ8FeD1cNtMBWB7YAorBm6toZyTJ/07ufGSn86VoQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "17421bac8e3a1663fbcc935f3b685794a89b6999",
+        "rev": "119c7ad8d9c65e89bc69b6657f2edc43584158cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`119c7ad8`](https://github.com/nix-community/NUR/commit/119c7ad8d9c65e89bc69b6657f2edc43584158cb) | `` automatic update `` |