### PR TITLE
chore(flake/nur): `119c7ad8` -> `6d45433d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709431145,
-        "narHash": "sha256-8ksJ8FeD1cNtMBWB7YAorBm6toZyTJ/07ufGSn86VoQ=",
+        "lastModified": 1709451872,
+        "narHash": "sha256-1YoU6ac9eUIOM5fUPCfczv1Ub9TTooK5XRrmrq5+W+c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "119c7ad8d9c65e89bc69b6657f2edc43584158cb",
+        "rev": "6d45433dfe902663544a0ba341f637ecdbf8a3e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6d45433d`](https://github.com/nix-community/NUR/commit/6d45433dfe902663544a0ba341f637ecdbf8a3e9) | `` automatic update `` |
| [`ab4e2daa`](https://github.com/nix-community/NUR/commit/ab4e2daa6cb49be32366a487a3484c6fe82bc026) | `` automatic update `` |
| [`9ae561d9`](https://github.com/nix-community/NUR/commit/9ae561d96a2a08ae0409d887a10d7cb517eddef4) | `` automatic update `` |
| [`a9879485`](https://github.com/nix-community/NUR/commit/a98794856dfd98d95f518ff3381e3372e6f6fb05) | `` automatic update `` |
| [`075c3094`](https://github.com/nix-community/NUR/commit/075c3094d6c6c3fae0e107de41e2367d17341ac4) | `` automatic update `` |
| [`8f797f74`](https://github.com/nix-community/NUR/commit/8f797f74c787ea46e207357afa18f3ba523c4ae0) | `` automatic update `` |
| [`468520fc`](https://github.com/nix-community/NUR/commit/468520fc9249021033a70c0fc8580e37e0b0ceec) | `` automatic update `` |
| [`2199ffdc`](https://github.com/nix-community/NUR/commit/2199ffdcb1068395f6018112aefc6a849dc91d7d) | `` automatic update `` |
| [`7cf254f2`](https://github.com/nix-community/NUR/commit/7cf254f2153f2d0cde346c6ea3ff158acf6a6609) | `` automatic update `` |
| [`d0e7c872`](https://github.com/nix-community/NUR/commit/d0e7c87274c040ed3635789b45fabce03fe05b92) | `` automatic update `` |
| [`e73e2b5b`](https://github.com/nix-community/NUR/commit/e73e2b5bd3eee6263ffce5ad8579acbafcc5709b) | `` automatic update `` |
| [`440e8de5`](https://github.com/nix-community/NUR/commit/440e8de53fc7e6d069e735d0201ab3d82edd9911) | `` automatic update `` |
| [`b1652a75`](https://github.com/nix-community/NUR/commit/b1652a75f13f6e0853b5511aa41dd129ba53893f) | `` automatic update `` |