### PR TITLE
chore(flake/nur): `6fd1b8f8` -> `fe6ef1b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709462771,
-        "narHash": "sha256-Tpo6+O6ySqoBuKzbc7x8h2O4I2qOjrFhhHn/sJZeKtk=",
+        "lastModified": 1709472899,
+        "narHash": "sha256-pb2xmDAYeUrLVx3i/N/X8JxyVWwATMPSURB1HpfDPgs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6fd1b8f81b816ee397a3e1cccd6d0049f83465b3",
+        "rev": "fe6ef1b76a2b590756026ac35df73eebc8104ab6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fe6ef1b7`](https://github.com/nix-community/NUR/commit/fe6ef1b76a2b590756026ac35df73eebc8104ab6) | `` automatic update `` |