### PR TITLE
chore(flake/nur): `fe6ef1b7` -> `9029b6ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709472899,
-        "narHash": "sha256-pb2xmDAYeUrLVx3i/N/X8JxyVWwATMPSURB1HpfDPgs=",
+        "lastModified": 1709476973,
+        "narHash": "sha256-VBL/iUSsoosRawEaQdNsY+Cld+F+Hxbynfg62/aVc0I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fe6ef1b76a2b590756026ac35df73eebc8104ab6",
+        "rev": "9029b6ce991c4beabbfe3c9e39a901a6f8a4a213",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9029b6ce`](https://github.com/nix-community/NUR/commit/9029b6ce991c4beabbfe3c9e39a901a6f8a4a213) | `` automatic update `` |