### PR TITLE
chore(flake/emacs-overlay): `38ae419b` -> `973347e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709456759,
-        "narHash": "sha256-FX+zO1z70chrQBs6ocxPTU1DHimRpvRf7DHqigh4MSE=",
+        "lastModified": 1709484588,
+        "narHash": "sha256-ZNKcArWa9oMdR2KGP86ttpMOl96qwNZPNDsCgWa8UMo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "38ae419b3aa286f48b323adf97bb12738b1d7b1e",
+        "rev": "973347e0c130fde703cfb631dcf9c81ece588c36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`973347e0`](https://github.com/nix-community/emacs-overlay/commit/973347e0c130fde703cfb631dcf9c81ece588c36) | `` Updated melpa `` |
| [`5e24cd86`](https://github.com/nix-community/emacs-overlay/commit/5e24cd86f616933e95467ff198b9101a8a7f8e65) | `` Updated elpa ``  |