### PR TITLE
chore(flake/nur): `9029b6ce` -> `09aa177e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709476973,
-        "narHash": "sha256-VBL/iUSsoosRawEaQdNsY+Cld+F+Hxbynfg62/aVc0I=",
+        "lastModified": 1709484257,
+        "narHash": "sha256-KhrKzjppVgPwd+rBtM+Ikr9SBv1ZQAQJ85kAm3fFD+A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9029b6ce991c4beabbfe3c9e39a901a6f8a4a213",
+        "rev": "09aa177e064a885d0ee6ce3d8a790e4433072147",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`09aa177e`](https://github.com/nix-community/NUR/commit/09aa177e064a885d0ee6ce3d8a790e4433072147) | `` automatic update `` |