### PR TITLE
chore(flake/nur): `09aa177e` -> `3896e559`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709484257,
-        "narHash": "sha256-KhrKzjppVgPwd+rBtM+Ikr9SBv1ZQAQJ85kAm3fFD+A=",
+        "lastModified": 1709492333,
+        "narHash": "sha256-yYjL/HcTnwesM+zWdvDKEGdLDZmrl6P91nr9ilWSLlo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "09aa177e064a885d0ee6ce3d8a790e4433072147",
+        "rev": "3896e559f74591f9ab27791d4e56080e241de319",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3896e559`](https://github.com/nix-community/NUR/commit/3896e559f74591f9ab27791d4e56080e241de319) | `` automatic update `` |
| [`554b583c`](https://github.com/nix-community/NUR/commit/554b583c992084b560f879e44b5159bb7b8c277b) | `` automatic update `` |