### PR TITLE
chore(flake/nur): `3896e559` -> `b96516cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709492333,
-        "narHash": "sha256-yYjL/HcTnwesM+zWdvDKEGdLDZmrl6P91nr9ilWSLlo=",
+        "lastModified": 1709497459,
+        "narHash": "sha256-dimQgWCTyv4SJz5dqJWPpKq6HdSzz8JtHzDMKrfCl4w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3896e559f74591f9ab27791d4e56080e241de319",
+        "rev": "b96516cba51b3468f7adfd48ae3d2af35056d28f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b96516cb`](https://github.com/nix-community/NUR/commit/b96516cba51b3468f7adfd48ae3d2af35056d28f) | `` automatic update `` |
| [`74368310`](https://github.com/nix-community/NUR/commit/743683108b9549eea13fcf1307fc3c2682754a3d) | `` automatic update `` |