### PR TITLE
chore(flake/emacs-overlay): `973347e0` -> `dcb6c5cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709484588,
-        "narHash": "sha256-ZNKcArWa9oMdR2KGP86ttpMOl96qwNZPNDsCgWa8UMo=",
+        "lastModified": 1709516695,
+        "narHash": "sha256-oymuRjQUhUx71xb4N1P9QFx+OmpnSF3pJKU1tsZBlE8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "973347e0c130fde703cfb631dcf9c81ece588c36",
+        "rev": "dcb6c5cc11efa3ab804960537242217cf335b230",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`dcb6c5cc`](https://github.com/nix-community/emacs-overlay/commit/dcb6c5cc11efa3ab804960537242217cf335b230) | `` Updated emacs `` |
| [`6bd7020b`](https://github.com/nix-community/emacs-overlay/commit/6bd7020b3f194c67a517722c9e48ece36118581c) | `` Updated melpa `` |
| [`944910d3`](https://github.com/nix-community/emacs-overlay/commit/944910d3bf4ea98fbd7f0bfe95fe0f590b75bf83) | `` Updated elpa ``  |