### PR TITLE
chore(flake/srvos): `9501896e` -> `29a48ae2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1011,11 +1011,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709301784,
-        "narHash": "sha256-Yf7HeS2VZCD8kD/wEgnToyt9YqQhCle/9TazmFYnjsE=",
+        "lastModified": 1709513456,
+        "narHash": "sha256-mehEGbnj5hwouZz2TcadneZq1Lf6V45mgK5NrxVYsGA=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "9501896e0edf01d2cbd5fa6f0dbb3aafc00dae81",
+        "rev": "29a48ae201fbd69b6b71acdae5e19fa2ceaa8181",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`29a48ae2`](https://github.com/nix-community/srvos/commit/29a48ae201fbd69b6b71acdae5e19fa2ceaa8181) | `` dev/private/flake.lock: Update `` |
| [`78826713`](https://github.com/nix-community/srvos/commit/78826713413430526e4410405d8ddc88d23e35b1) | `` flake.lock: Update ``             |