### PR TITLE
chore(flake/nur): `b96516cb` -> `deba01c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709497459,
-        "narHash": "sha256-dimQgWCTyv4SJz5dqJWPpKq6HdSzz8JtHzDMKrfCl4w=",
+        "lastModified": 1709516387,
+        "narHash": "sha256-gnyNaJIU+hIdkMVcXFhB8nxI8u7n70GWSn420LOoPEk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b96516cba51b3468f7adfd48ae3d2af35056d28f",
+        "rev": "deba01c2e870f16c5528af94984f21437e545606",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`deba01c2`](https://github.com/nix-community/NUR/commit/deba01c2e870f16c5528af94984f21437e545606) | `` automatic update `` |
| [`475eed5b`](https://github.com/nix-community/NUR/commit/475eed5bbf0ce02b084706ccef47fda3eb7ab29e) | `` automatic update `` |
| [`8f779219`](https://github.com/nix-community/NUR/commit/8f779219911c4e1329e4684c2e522c93d4346387) | `` automatic update `` |
| [`632c9344`](https://github.com/nix-community/NUR/commit/632c93448d8aee4e0807a3dd8f042be50e3d2a73) | `` automatic update `` |