### PR TITLE
chore(flake/darwin): `17c2ca3c` -> `e7d7a7f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709434167,
-        "narHash": "sha256-2VLj0k4GNZCISN/1uf02GSaLwM1iBbTwWRLJWbjh/fw=",
+        "lastModified": 1709529951,
+        "narHash": "sha256-KVqN0Dvf4bg87XYQCHdd1kuJkjA23y5wlTTSOnilLIU=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "17c2ca3c7537a2512224242b84e1ea3c08e79b92",
+        "rev": "e7d7a7f0c5a184c67b6bff56f95436d83d05fba5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                          |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`b620e32a`](https://github.com/LnL7/nix-darwin/commit/b620e32a761ef6376c1097e73b3f8283604e4982) | `` fix writing values with containers ``         |
| [`0b638a97`](https://github.com/LnL7/nix-darwin/commit/0b638a97c069ca331daf657eab2c47ce44aae916) | `` users: fix `forceRecreate` bash comparison `` |
| [`8e102a99`](https://github.com/LnL7/nix-darwin/commit/8e102a9991822b7688a2d7438483923941062257) | `` a few fixes for ipfs module ``                |