### PR TITLE
chore(flake/nur): `ce722ba5` -> `815fcbe5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709525373,
-        "narHash": "sha256-oulxxPR2kcWnkfYzpaM4xQykBds3T2g5EGP0OSuA3R4=",
+        "lastModified": 1709535876,
+        "narHash": "sha256-gG182jr6/M3UNugkkGetq0tLCz6zg5vrKOHW44Jf3uU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ce722ba5a6dcc92c3e5fde0dcb9b8408491e3469",
+        "rev": "815fcbe53191416c49898f6ea1ec95639a7cabf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`815fcbe5`](https://github.com/nix-community/NUR/commit/815fcbe53191416c49898f6ea1ec95639a7cabf2) | `` automatic update `` |
| [`3e681f45`](https://github.com/nix-community/NUR/commit/3e681f45139dbc893bae716bc01a974e8474c984) | `` automatic update `` |