### PR TITLE
chore(flake/emacs-overlay): `dcb6c5cc` -> `2c532ba6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709516695,
-        "narHash": "sha256-oymuRjQUhUx71xb4N1P9QFx+OmpnSF3pJKU1tsZBlE8=",
+        "lastModified": 1709546806,
+        "narHash": "sha256-RtLRpp/GtypAcB2UiX4ArfOuYrb2n6zG3/vExuzWjVM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dcb6c5cc11efa3ab804960537242217cf335b230",
+        "rev": "2c532ba61d7313c62d30f3f9cbb71d5e377ab57c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`2c532ba6`](https://github.com/nix-community/emacs-overlay/commit/2c532ba61d7313c62d30f3f9cbb71d5e377ab57c) | `` Updated elpa `` |