### PR TITLE
chore(flake/nur): `2c2fa034` -> `18ee9e8c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709538641,
-        "narHash": "sha256-+GNbI082e/Vz2PvYRyAyBItyHxS8br+utPBad8VC2CM=",
+        "lastModified": 1709563953,
+        "narHash": "sha256-s9XwGDKkqWHmORCX5/wtFWDa1Nlk7BrLQN/oXHw3ukM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2c2fa0341ee77b50505363cafd273d3d80b0fe85",
+        "rev": "18ee9e8c537f6bc9d6b435c389bf30b9dc48958f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`18ee9e8c`](https://github.com/nix-community/NUR/commit/18ee9e8c537f6bc9d6b435c389bf30b9dc48958f) | `` automatic update `` |
| [`65f9bf8b`](https://github.com/nix-community/NUR/commit/65f9bf8bfd08ea9106ca14d192391b4f7ab4cd57) | `` automatic update `` |
| [`a21779b3`](https://github.com/nix-community/NUR/commit/a21779b3182ee5566a6bb5d9e851dfd8c79852da) | `` automatic update `` |