### PR TITLE
chore(flake/emacs-overlay): `2c532ba6` -> `6cc67062`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709546806,
-        "narHash": "sha256-RtLRpp/GtypAcB2UiX4ArfOuYrb2n6zG3/vExuzWjVM=",
+        "lastModified": 1709549628,
+        "narHash": "sha256-zoOrM8bQ1h0l23G+X3P3W4jQxVvNUn4PhJCutB81U0c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2c532ba61d7313c62d30f3f9cbb71d5e377ab57c",
+        "rev": "6cc67062226eae7feb728b6bfe4246ebc801f028",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`6cc67062`](https://github.com/nix-community/emacs-overlay/commit/6cc67062226eae7feb728b6bfe4246ebc801f028) | `` Updated emacs `` |
| [`57da8acf`](https://github.com/nix-community/emacs-overlay/commit/57da8acf16de0ec858445dabe43f523ad676335d) | `` Updated melpa `` |