### PR TITLE
chore(flake/nur): `18ee9e8c` -> `85790ea8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709563953,
-        "narHash": "sha256-s9XwGDKkqWHmORCX5/wtFWDa1Nlk7BrLQN/oXHw3ukM=",
+        "lastModified": 1709567103,
+        "narHash": "sha256-1obAvL87qIhQUxHacf7aoGKzn2P+2oL/uOzhoEIj1Ds=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "18ee9e8c537f6bc9d6b435c389bf30b9dc48958f",
+        "rev": "85790ea8d4a609075f0af8b9ff56cf181c33048f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`85790ea8`](https://github.com/nix-community/NUR/commit/85790ea8d4a609075f0af8b9ff56cf181c33048f) | `` automatic update `` |
| [`96940f9c`](https://github.com/nix-community/NUR/commit/96940f9cc0c81c63fa42000859255a6772c6ce6e) | `` automatic update `` |