### PR TITLE
chore(flake/emacs-overlay): `6af908b1` -> `c9764e76`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709571173,
-        "narHash": "sha256-8Dpk3WtdhlrvhmocUwky/f3Ruq9JwMyvWjcUJWhkssg=",
+        "lastModified": 1709572030,
+        "narHash": "sha256-UMDxq9roK5I0C8O5/KtfCmR/2DHgu6aHIiyHOEDtUUA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6af908b15dc06f1d8a804e7d0c874cc2d0323857",
+        "rev": "c9764e76968428e466a9c4c5f11f48f510fb5c75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`c9764e76`](https://github.com/nix-community/emacs-overlay/commit/c9764e76968428e466a9c4c5f11f48f510fb5c75) | `` Updated emacs `` |