### PR TITLE
chore(flake/nur): `85790ea8` -> `4f87bd82`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709567103,
-        "narHash": "sha256-1obAvL87qIhQUxHacf7aoGKzn2P+2oL/uOzhoEIj1Ds=",
+        "lastModified": 1709578742,
+        "narHash": "sha256-t3E5kpNNeTYawBS3Y2IW0PSLX22GA3WW2yc8Q1W5qaw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "85790ea8d4a609075f0af8b9ff56cf181c33048f",
+        "rev": "4f87bd82e6deac8fbb0388b9712846efa9b58fc9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4f87bd82`](https://github.com/nix-community/NUR/commit/4f87bd82e6deac8fbb0388b9712846efa9b58fc9) | `` automatic update `` |
| [`5a4678cb`](https://github.com/nix-community/NUR/commit/5a4678cb0cd8df0129cc3f11d577a2c11c57a152) | `` automatic update `` |
| [`d90fe3f0`](https://github.com/nix-community/NUR/commit/d90fe3f06e6521c01b496b47abb21832f7af7a38) | `` automatic update `` |
| [`322ce94b`](https://github.com/nix-community/NUR/commit/322ce94b4782f825857b26cb504a1211c33b12be) | `` automatic update `` |