### PR TITLE
chore(flake/sops-nix): `075df9d8` -> `291aad29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -991,11 +991,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1709434911,
-        "narHash": "sha256-UN47hQPM9ijwoz7cYq10xl19hvlSP/232+M5vZDOMs4=",
+        "lastModified": 1709591996,
+        "narHash": "sha256-0sQcalXSgqlO6mnxBTXkSQChBHy2GQsokB1XY8r+LpQ=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "075df9d85ee70cfb53e598058045e1738f05e273",
+        "rev": "291aad29b59ceda517a06e59809f35cb0bb17c6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                    |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`291aad29`](https://github.com/Mic92/sops-nix/commit/291aad29b59ceda517a06e59809f35cb0bb17c6b) | `` build(deps): bump DeterminateSystems/update-flake-lock from 20 to 21 `` |