### PR TITLE
chore(flake/emacs-overlay): `c9764e76` -> `79d5576e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709572030,
-        "narHash": "sha256-UMDxq9roK5I0C8O5/KtfCmR/2DHgu6aHIiyHOEDtUUA=",
+        "lastModified": 1709600203,
+        "narHash": "sha256-U6BWVtCGuRG4HuXMOqF9mgxKjB2m8ZOMhxF4HspssP8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c9764e76968428e466a9c4c5f11f48f510fb5c75",
+        "rev": "79d5576efbed2e33eab26688fa0816a1872c8e01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`79d5576e`](https://github.com/nix-community/emacs-overlay/commit/79d5576efbed2e33eab26688fa0816a1872c8e01) | `` Updated elpa ``         |
| [`ca5a359a`](https://github.com/nix-community/emacs-overlay/commit/ca5a359a1303a14567b4c3aed43134412fbe4382) | `` Updated flake inputs `` |