### PR TITLE
chore(flake/emacs-overlay): `79d5576e` -> `ceb97396`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709600203,
-        "narHash": "sha256-U6BWVtCGuRG4HuXMOqF9mgxKjB2m8ZOMhxF4HspssP8=",
+        "lastModified": 1709603049,
+        "narHash": "sha256-pw/Lty1T7CDnhJvyVziXQM+nbPSAgwFf4JE3zM0j6bM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "79d5576efbed2e33eab26688fa0816a1872c8e01",
+        "rev": "ceb9739648fff3dea0552003a9a4127191f50cd1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`ceb97396`](https://github.com/nix-community/emacs-overlay/commit/ceb9739648fff3dea0552003a9a4127191f50cd1) | `` Updated emacs `` |
| [`f6880709`](https://github.com/nix-community/emacs-overlay/commit/f6880709cd55f7be74b6fe59eb7dcca4e0b68d94) | `` Updated melpa `` |