### PR TITLE
chore(flake/nur): `770c8dd0` -> `b5d3e0fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709601743,
-        "narHash": "sha256-VBV7dVhdLCIjDW2dw94lPulmLOOl1onFS3AsSuuMUXw=",
+        "lastModified": 1709607860,
+        "narHash": "sha256-eM6R3gCfI2XuJ0tlX+vKL/kISSNHkhMoiqHWmn3fBIw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "770c8dd0e0f8a5aa6037a2fa8049ead8a2a7a05f",
+        "rev": "b5d3e0fa26fb7a82a4c985c37e66cf8fe4f99889",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b5d3e0fa`](https://github.com/nix-community/NUR/commit/b5d3e0fa26fb7a82a4c985c37e66cf8fe4f99889) | `` automatic update `` |
| [`2271e922`](https://github.com/nix-community/NUR/commit/2271e92241a8b2562970b5aad5b81de8e201ab25) | `` automatic update `` |
| [`123c91b9`](https://github.com/nix-community/NUR/commit/123c91b94dba01fb69e9dc130c9319d07429be70) | `` automatic update `` |