### PR TITLE
chore(flake/nur): `b5d3e0fa` -> `6f4ec711`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709607860,
-        "narHash": "sha256-eM6R3gCfI2XuJ0tlX+vKL/kISSNHkhMoiqHWmn3fBIw=",
+        "lastModified": 1709613079,
+        "narHash": "sha256-EBEHGEQ2Lo5EU5YMd7QnvzlU5fQLORRj6XTOhaC3EXc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b5d3e0fa26fb7a82a4c985c37e66cf8fe4f99889",
+        "rev": "6f4ec711e1c95598658b41c2125ae354ff1379cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6f4ec711`](https://github.com/nix-community/NUR/commit/6f4ec711e1c95598658b41c2125ae354ff1379cb) | `` automatic update `` |
| [`37d92b3e`](https://github.com/nix-community/NUR/commit/37d92b3ef869226fa9dd1fce28b9e128a552dcfd) | `` automatic update `` |
| [`7d440232`](https://github.com/nix-community/NUR/commit/7d440232f1dfbea9a85f88cc6052b2d61ec2931e) | `` automatic update `` |