### PR TITLE
chore(flake/emacs-overlay): `ceb97396` -> `5a24cf51`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709603049,
-        "narHash": "sha256-pw/Lty1T7CDnhJvyVziXQM+nbPSAgwFf4JE3zM0j6bM=",
+        "lastModified": 1709629551,
+        "narHash": "sha256-G+nZqqGVtMdDNhbaFeT9u2FhjUt7/lh28pB5Grd1WFg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ceb9739648fff3dea0552003a9a4127191f50cd1",
+        "rev": "5a24cf5100cd2584313119d0f4d413417fec949c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`5a24cf51`](https://github.com/nix-community/emacs-overlay/commit/5a24cf5100cd2584313119d0f4d413417fec949c) | `` Updated emacs `` |
| [`f25632fa`](https://github.com/nix-community/emacs-overlay/commit/f25632fa01090713d4f70ae345f2ddff0920d19c) | `` Updated melpa `` |