### PR TITLE
chore(flake/nur): `da946be8` -> `5ffe4611`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709627553,
-        "narHash": "sha256-aLRiyDWEZDilspug51/DnXF4fuGpNK1s7NJN5sXTYSg=",
+        "lastModified": 1709632022,
+        "narHash": "sha256-LkAicutWhc8isd8q+s602NklRYssWN3SCGHqpKdd+EI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "da946be895ab71faca938e7bb92c1ce3dd08de8c",
+        "rev": "5ffe461198c89239e214fde652145988afcfe603",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5ffe4611`](https://github.com/nix-community/NUR/commit/5ffe461198c89239e214fde652145988afcfe603) | `` automatic update `` |