### PR TITLE
chore(flake/nur): `5501b1db` -> `31f53499`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709635743,
-        "narHash": "sha256-vjhHdcG/uEHFSsZSQuE/yBRk9dljsw9JFwdpEi7060M=",
+        "lastModified": 1709643287,
+        "narHash": "sha256-QiB2S3ujzBiu9WfNY4h3MqNfQEbmyyd8Z2HBKIj5VaI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5501b1db6763f09b9e0afa0a75285bd1e3390ecc",
+        "rev": "31f53499a212b6cd07cad5fc4f6e26f6f12ee1b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`31f53499`](https://github.com/nix-community/NUR/commit/31f53499a212b6cd07cad5fc4f6e26f6f12ee1b9) | `` automatic update `` |
| [`1ef60da4`](https://github.com/nix-community/NUR/commit/1ef60da4324f4c8024899a00228657571d7d250d) | `` automatic update `` |