### PR TITLE
chore(flake/nur): `31f53499` -> `c715d34e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709643287,
-        "narHash": "sha256-QiB2S3ujzBiu9WfNY4h3MqNfQEbmyyd8Z2HBKIj5VaI=",
+        "lastModified": 1709649736,
+        "narHash": "sha256-HRrzvBWIRQlSN4joPI+rroqtEPWEcZK/ETY4cAkDwOs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "31f53499a212b6cd07cad5fc4f6e26f6f12ee1b9",
+        "rev": "c715d34e7040f934a2edfa7024a1f04e86536b9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c715d34e`](https://github.com/nix-community/NUR/commit/c715d34e7040f934a2edfa7024a1f04e86536b9e) | `` automatic update `` |
| [`cc0db38a`](https://github.com/nix-community/NUR/commit/cc0db38a5fd0933c644e6dc5d20e09e396642837) | `` automatic update `` |
| [`daa1e8cc`](https://github.com/nix-community/NUR/commit/daa1e8cc0a3b32032745df5a405e3e492aa10d46) | `` automatic update `` |
| [`5149a516`](https://github.com/nix-community/NUR/commit/5149a516fd2a611753dd8f91bf447b2c50be4423) | `` automatic update `` |