### PR TITLE
chore(flake/nur): `75d51fd1` -> `c10daa69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709668364,
-        "narHash": "sha256-eq2NecyZiU8b8A+LiM933KiOf2xRWE7vjt7Q+Go0n9c=",
+        "lastModified": 1709670325,
+        "narHash": "sha256-8kaRyki/vK0dQeH6tRxy/xW9Ocq2jF5rwEsH5iLFbzM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "75d51fd11b69588ab0e6d80628fa505847e15c5c",
+        "rev": "c10daa69f6a06c5743ab07c111ee546ce6698098",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c10daa69`](https://github.com/nix-community/NUR/commit/c10daa69f6a06c5743ab07c111ee546ce6698098) | `` automatic update `` |