### PR TITLE
chore(flake/nix-on-droid): `3aab6a9e` -> `11e98b01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -587,11 +587,11 @@
         "nmt": "nmt"
       },
       "locked": {
-        "lastModified": 1666720474,
-        "narHash": "sha256-iWojjDS1D19zpeZXbBdjWb9MiKmVVFQCqtJmtTXgPx8=",
+        "lastModified": 1705252799,
+        "narHash": "sha256-HgSTREh7VoXjGgNDwKQUYcYo13rPkltW7IitHrTPA5c=",
         "owner": "Gerschtli",
         "repo": "nix-formatter-pack",
-        "rev": "14876cc8fe94a3d329964ecb073b4c988c7b61f5",
+        "rev": "2de39dedd79aab14c01b9e2934842051a160ffa5",
         "type": "github"
       },
       "original": {
@@ -631,11 +631,11 @@
         "nmd": "nmd_2"
       },
       "locked": {
-        "lastModified": 1708167934,
-        "narHash": "sha256-6OYqVcniyeU5c9GpedeWN7JQbi0Lcaa5Pf/Qsbyv/vA=",
+        "lastModified": 1709676965,
+        "narHash": "sha256-BOMqEShw82JRbdEBY3T5i9PId8Ri1OB78MSOQHvf0ag=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "3aab6a9ec47c644f9ef132fc6450ede3c380837f",
+        "rev": "11e98b0140e094919258028b05db0efe6e83977e",
         "type": "github"
       },
       "original": {
@@ -660,11 +660,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664019863,
-        "narHash": "sha256-nXRRSPr2Jntx2hdZZMkds1fSDNUyw9N/wMtdcQ8VElU=",
+        "lastModified": 1708172716,
+        "narHash": "sha256-3M94oln0b61m3dUmLyECCA9hYAHXZEszM4saE3CmQO4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9c64b91d14268cf20ea07ea7930479a75325af9f",
+        "rev": "5d874ac46894c896119bce68e758e9e80bdb28f1",
         "type": "github"
       },
       "original": {
@@ -675,17 +675,17 @@
     },
     "nixpkgs-for-bootstrap": {
       "locked": {
-        "lastModified": 1686921029,
-        "narHash": "sha256-J1bX9plPCFhTSh6E3TWn9XSxggBh/zDD4xigyaIQBy8=",
+        "lastModified": 1708105575,
+        "narHash": "sha256-sS4AItZeUnAei6v8FqxNlm+/27MPlfoGym/TZP0rmH0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c7ff1b9b95620ce8728c0d7bd501c458e6da9e04",
+        "rev": "1d1817869c47682a6bee85b5b0a6537b6c0fba26",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c7ff1b9b95620ce8728c0d7bd501c458e6da9e04",
+        "rev": "1d1817869c47682a6bee85b5b0a6537b6c0fba26",
         "type": "github"
       }
     },
@@ -970,11 +970,11 @@
     "scss-reset": {
       "flake": false,
       "locked": {
-        "lastModified": 1683906868,
-        "narHash": "sha256-cif5Sx8Ca5vxdw/mNAgpulLH15TwmzyJFNM7JURpoaE=",
+        "lastModified": 1631450058,
+        "narHash": "sha256-muDlZJPtXDIGevSEWkicPP0HQ6VtucbkMNygpGlBEUM=",
         "owner": "andreymatin",
         "repo": "scss-reset",
-        "rev": "5a7bd491ac82441e6283fb0d5d54644b913b30c7",
+        "rev": "0cf50e27a4e95e9bb5b1715eedf9c54dee1a5a91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                              |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`11e98b01`](https://github.com/nix-community/nix-on-droid/commit/11e98b0140e094919258028b05db0efe6e83977e) | `` .github/workflows/docs: fixup upload-pages-artifact version ``    |
| [`8bcabf2f`](https://github.com/nix-community/nix-on-droid/commit/8bcabf2f5ac65f3108cb12d9d0a9e7460f57e0b4) | `` .github/workflows: update action versions ``                      |
| [`c33e2497`](https://github.com/nix-community/nix-on-droid/commit/c33e249719536312cffc82267cde632eef4b143b) | `` nix-on-droid: warn on switching with flake.nix w/o --flake ``     |
| [`94bf554e`](https://github.com/nix-community/nix-on-droid/commit/94bf554ee96ed8a127a7e11931436ab2d585d6b6) | `` flake.lock: update more inputs ``                                 |
| [`53f89666`](https://github.com/nix-community/nix-on-droid/commit/53f8966627efafe24c3705ef0bab4d319dc8465c) | `` pkgs: update proot and talloc ``                                  |
| [`6daee587`](https://github.com/nix-community/nix-on-droid/commit/6daee587912bb596597c0b71879b8e31a91bf2b3) | `` update nixpkgs; applyPatches to fix toolchain (nixpkgs!269077) `` |
| [`970a735f`](https://github.com/nix-community/nix-on-droid/commit/970a735f567e5a7859ad5433eadd7f2cae44e812) | `` pkgs/nix-directory: update nix to 2.20.4 ``                       |
| [`be783dd2`](https://github.com/nix-community/nix-on-droid/commit/be783dd251454fc873c344e90056998760f2af59) | `` set stable version to 23.11 ``                                    |
| [`4b1a6ebc`](https://github.com/nix-community/nix-on-droid/commit/4b1a6ebcc7cef2c76e046b4d60227f1277a43780) | `` home-manager: Extend `lib` instead of `pkgs.lib` ``               |
| [`78349e4a`](https://github.com/nix-community/nix-on-droid/commit/78349e4a8104646943279ceb5467413bb2551eb1) | `` nix-on-droid: allow passing args to on-device-test ``             |