### PR TITLE
chore(flake/nur): `c10daa69` -> `8d6e8a7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709670325,
-        "narHash": "sha256-8kaRyki/vK0dQeH6tRxy/xW9Ocq2jF5rwEsH5iLFbzM=",
+        "lastModified": 1709690156,
+        "narHash": "sha256-+J7QyZAoK8zcdfVpYGdgasEoInvRgGIabWBX0UGRH+0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c10daa69f6a06c5743ab07c111ee546ce6698098",
+        "rev": "8d6e8a7a64fa1bef1c662a84d9643f58598eb2a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8d6e8a7a`](https://github.com/nix-community/NUR/commit/8d6e8a7a64fa1bef1c662a84d9643f58598eb2a7) | `` automatic update `` |
| [`fe40949e`](https://github.com/nix-community/NUR/commit/fe40949ea87f14665b7139ae414e395e58fa0b43) | `` automatic update `` |
| [`d6580e52`](https://github.com/nix-community/NUR/commit/d6580e52fa6582bd490f2b5014b505129891419f) | `` automatic update `` |
| [`9b766455`](https://github.com/nix-community/NUR/commit/9b766455d1b07a2042a14c39902728c2529174c2) | `` automatic update `` |
| [`d92ff072`](https://github.com/nix-community/NUR/commit/d92ff072d96bcbdf4eae2481f6d5bf7f55d6d312) | `` automatic update `` |
| [`73761ba8`](https://github.com/nix-community/NUR/commit/73761ba861f07b13d9717c13fbd500eec0a5ab0a) | `` automatic update `` |
| [`db764ae1`](https://github.com/nix-community/NUR/commit/db764ae1d6a0a43676d67bcb7d122338f466c377) | `` automatic update `` |
| [`94cc427b`](https://github.com/nix-community/NUR/commit/94cc427bb87caa8d954e3e80c72e39e078c93dca) | `` automatic update `` |
| [`8a98fb18`](https://github.com/nix-community/NUR/commit/8a98fb18f7884c796fccac5a4a0cc5ffb7cb47e4) | `` automatic update `` |