### PR TITLE
chore(flake/emacs-overlay): `fb22d2ec` -> `9ae82c10`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709657478,
-        "narHash": "sha256-EsC1qEMGfJo+oosdgMdmgKLKXZXIzTEc2PEQ26EofpQ=",
+        "lastModified": 1709689484,
+        "narHash": "sha256-hLfsGBUFYTV5pPhPdhHdryC0s3cSqKN8psHTba9D5es=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fb22d2ecf6d4741221eba1950d5fb6b1702b9a26",
+        "rev": "9ae82c10a7065080516fb7665a143ff6f8a57136",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`9ae82c10`](https://github.com/nix-community/emacs-overlay/commit/9ae82c10a7065080516fb7665a143ff6f8a57136) | `` Updated emacs `` |
| [`efdcd87f`](https://github.com/nix-community/emacs-overlay/commit/efdcd87f425e4c37a7053b0466100bb0cba74889) | `` Updated melpa `` |
| [`c61a9a41`](https://github.com/nix-community/emacs-overlay/commit/c61a9a413d4423c2c08ed0fa740e9d124db316a3) | `` Updated elpa ``  |