### PR TITLE
chore(flake/nur): `8d6e8a7a` -> `c210daf7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709690156,
-        "narHash": "sha256-+J7QyZAoK8zcdfVpYGdgasEoInvRgGIabWBX0UGRH+0=",
+        "lastModified": 1709696452,
+        "narHash": "sha256-nWV3TH7doTUhDyiTZe6TjFxlI9skxp8IgBvCrPIYVFQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8d6e8a7a64fa1bef1c662a84d9643f58598eb2a7",
+        "rev": "c210daf7d5e72fe0807ed5c7fde52a0e8b8dc026",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c210daf7`](https://github.com/nix-community/NUR/commit/c210daf7d5e72fe0807ed5c7fde52a0e8b8dc026) | `` automatic update `` |
| [`53103057`](https://github.com/nix-community/NUR/commit/5310305765d5347d5d078838f541a3f74f74fa1e) | `` automatic update `` |