### PR TITLE
chore(flake/nur): `c210daf7` -> `97d7ae67`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709696452,
-        "narHash": "sha256-nWV3TH7doTUhDyiTZe6TjFxlI9skxp8IgBvCrPIYVFQ=",
+        "lastModified": 1709698293,
+        "narHash": "sha256-oIXHGCxT7fBWnHCyCBYi7dIfm3tMrM/26m9Gh/Bc0cE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c210daf7d5e72fe0807ed5c7fde52a0e8b8dc026",
+        "rev": "97d7ae675bb9261e8ea9036433467d7f6fc8cf57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`97d7ae67`](https://github.com/nix-community/NUR/commit/97d7ae675bb9261e8ea9036433467d7f6fc8cf57) | `` automatic update `` |
| [`8154431d`](https://github.com/nix-community/NUR/commit/8154431d2d636cd43b23a2559dee80bda631ca74) | `` automatic update `` |