### PR TITLE
chore(flake/nur): `97d7ae67` -> `f3257281`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709698293,
-        "narHash": "sha256-oIXHGCxT7fBWnHCyCBYi7dIfm3tMrM/26m9Gh/Bc0cE=",
+        "lastModified": 1709702309,
+        "narHash": "sha256-NcnMRkx/fzH70V/maNEf4fgSOxwvHBPxksG+ai78l84=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "97d7ae675bb9261e8ea9036433467d7f6fc8cf57",
+        "rev": "f325728186437fe1dbe732d40fe22b0d4cc13fc4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f3257281`](https://github.com/nix-community/NUR/commit/f325728186437fe1dbe732d40fe22b0d4cc13fc4) | `` automatic update `` |