### PR TITLE
chore(flake/nix-index-database): `93554c04` -> `94a1e464`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -607,11 +607,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709435391,
-        "narHash": "sha256-s4itTkIVxn5lYeTzwkbAgl99atnjdZv1idI1118vdzA=",
+        "lastModified": 1709708644,
+        "narHash": "sha256-XAFOkZ6yexsqeJrCXWoHxopq0i+7ZqbwATXomMnGmr4=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "93554c04c2f1c02f4a383538e8848d511c3129e9",
+        "rev": "94a1e46434736a40f976a454f8bd3ea2144f349b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                              |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`c46d85da`](https://github.com/nix-community/nix-index-database/commit/c46d85da736e6b2563cf1f284f7e054bd87b9b38) | `` readme: Mic92 -> nix-community `` |