### PR TITLE
chore(flake/nur): `513ce65a` -> `23f0c5dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709707477,
-        "narHash": "sha256-Bxs/XeJtAmXOTsCK5XK5MEXG2WihvxlkJYMpcugQhUo=",
+        "lastModified": 1709736994,
+        "narHash": "sha256-N456fn55ESRC6i9QCF33FBcxuvUpby818rIyn/T81F4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "513ce65ad8cb152f03f88081e80892eaadc83ea2",
+        "rev": "23f0c5dd985819bd159215cf2e602b7daa2268cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`23f0c5dd`](https://github.com/nix-community/NUR/commit/23f0c5dd985819bd159215cf2e602b7daa2268cc) | `` automatic update `` |
| [`7316bcec`](https://github.com/nix-community/NUR/commit/7316bcece06f7b9d7fd4b4c4b2e2b4f78432942d) | `` automatic update `` |
| [`81142813`](https://github.com/nix-community/NUR/commit/81142813d61a934d2f5c9080295d18a9f3417e4d) | `` automatic update `` |
| [`e75e8885`](https://github.com/nix-community/NUR/commit/e75e8885efb15f254aebf64ec33e338ffe551ee0) | `` automatic update `` |
| [`f8f9912a`](https://github.com/nix-community/NUR/commit/f8f9912a9f678c521e4a2e061d52311844b27724) | `` automatic update `` |
| [`e4ea33b9`](https://github.com/nix-community/NUR/commit/e4ea33b9aa652e2871fbc604d1d611e6f5940a66) | `` automatic update `` |
| [`466d739c`](https://github.com/nix-community/NUR/commit/466d739cfde240577a1e201889e489f55bbda6c7) | `` automatic update `` |
| [`43d0d0b8`](https://github.com/nix-community/NUR/commit/43d0d0b8a4b5a56b53851858a5e8dce27b14381f) | `` automatic update `` |
| [`b9f3efde`](https://github.com/nix-community/NUR/commit/b9f3efdee1b6242f67dc46b782b2a27247ae0a35) | `` automatic update `` |
| [`eff97899`](https://github.com/nix-community/NUR/commit/eff97899a55520915041fc278e5f4094a89d8a49) | `` automatic update `` |
| [`12859d6d`](https://github.com/nix-community/NUR/commit/12859d6d480786d515a6b5b4ea749b194330c896) | `` automatic update `` |