### PR TITLE
chore(flake/sops-nix): `291aad29` -> `25dd60fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1008,11 +1008,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1709591996,
-        "narHash": "sha256-0sQcalXSgqlO6mnxBTXkSQChBHy2GQsokB1XY8r+LpQ=",
+        "lastModified": 1709711091,
+        "narHash": "sha256-L0rSIU9IguTG4YqSj4B/02SyTEz55ACq5t8gXpzteYc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "291aad29b59ceda517a06e59809f35cb0bb17c6b",
+        "rev": "25dd60fdd08fcacee2567a26ba6b91fe098941dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                        |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`25dd60fd`](https://github.com/Mic92/sops-nix/commit/25dd60fdd08fcacee2567a26ba6b91fe098941dc) | `` update vendorHash ``                                        |
| [`e3b396f4`](https://github.com/Mic92/sops-nix/commit/e3b396f42fb887dd6df447fb2e7cc640dc525215) | `` build(deps): bump golang.org/x/sys from 0.17.0 to 0.18.0 `` |