### PR TITLE
chore(flake/home-manager): `bdea159f` -> `3c7bacf1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -491,11 +491,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709677162,
-        "narHash": "sha256-nIXa0KM3FOVjD3XDDigW12qktQvLG+uKuPg00rjIX/8=",
+        "lastModified": 1709710941,
+        "narHash": "sha256-4FjuX5kGQhvrxkwuB3tAcA7cqNgNW10eZ7qzePfl+kM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bdea159ffab9865f808b8d92fd2bef33521867b2",
+        "rev": "3c7bacf1d42e533299c5e3baf74556a0e0ac3d0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                               |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`3c7bacf1`](https://github.com/nix-community/home-manager/commit/3c7bacf1d42e533299c5e3baf74556a0e0ac3d0e) | `` ci: remove cachix action ``        |
| [`9daee941`](https://github.com/nix-community/home-manager/commit/9daee941ab013b057df34ebb7f1c41cafabfea95) | `` gpg: fix immutable keyfile test `` |
| [`c386fde5`](https://github.com/nix-community/home-manager/commit/c386fde594c016865ecc98235a0454bea782ecc7) | `` bemenu: stub package in tests ``   |