### PR TITLE
chore(flake/home-manager): `1d717f58` -> `613384a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -491,11 +491,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709722441,
-        "narHash": "sha256-OdkGhZ+OrOEZWsLyGLNVWS0sQF0adPXCkkwhy8vlEuo=",
+        "lastModified": 1709726282,
+        "narHash": "sha256-4S5EFTLeI90XzOT4MdEC+3emCdR8B7/OPSiwC6/3cKg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1d717f581b7b001b2a1293277a1d3386fca5b87e",
+        "rev": "613384a51119ea34af58eb5e611e7f31dd3970d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`613384a5`](https://github.com/nix-community/home-manager/commit/613384a51119ea34af58eb5e611e7f31dd3970d6) | `` tests: include a service in integration tests `` |
| [`950673ce`](https://github.com/nix-community/home-manager/commit/950673cec79298d9a1072499e0181849545376e2) | `` pueue: always write configuration file ``        |
| [`47717650`](https://github.com/nix-community/home-manager/commit/477176502a6e099192da61984cd5be896d0b5659) | `` flake.lock: Update ``                            |