### PR TITLE
chore(flake/emacs-overlay): `984860d0` -> `8bac1264`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709715989,
-        "narHash": "sha256-x8nsKGkLCq+i1pHj+Jr29GpPkYQrVQjrvJ7Kb3ogY30=",
+        "lastModified": 1709744151,
+        "narHash": "sha256-/c8wW50nETga4k5hXJpSvCez2EG3GD69NzTk4j/fkuU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "984860d0f4f5c3a6d1d92d0ac3cd1c081408e138",
+        "rev": "8bac12643777ddcade600de7752615867f7f518f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`8bac1264`](https://github.com/nix-community/emacs-overlay/commit/8bac12643777ddcade600de7752615867f7f518f) | `` Updated melpa `` |
| [`d6fc9ce4`](https://github.com/nix-community/emacs-overlay/commit/d6fc9ce426b1574182f0db5b395386920750a61b) | `` Updated emacs `` |
| [`3f549c3f`](https://github.com/nix-community/emacs-overlay/commit/3f549c3f5f9c4f764779fa161fbe5a245e6fb5c2) | `` Updated elpa ``  |