### PR TITLE
chore(flake/nur): `9566b92d` -> `5e12fd0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709743609,
-        "narHash": "sha256-nsBQOdhZ0VFUxByUoj1ovBbkk0s5/nfXEdfM1XPPBUY=",
+        "lastModified": 1709753689,
+        "narHash": "sha256-6HQJQ+LFmqqHukeGSq0d/NeA7dSsPQGcfaXc/kRkNDI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9566b92d9be6a7e13b9381c728ef0642449a8fca",
+        "rev": "95082a571b70231e56db5070dcdf675356da7b52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5e12fd0b`](https://github.com/nix-community/NUR/commit/5e12fd0b31670e7f51da6be185f2a7c44bedfb76) | `` automatic update `` |