### PR TITLE
chore(flake/nur): `95082a57` -> `a7d5f1e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709753689,
-        "narHash": "sha256-6HQJQ+LFmqqHukeGSq0d/NeA7dSsPQGcfaXc/kRkNDI=",
+        "lastModified": 1709757987,
+        "narHash": "sha256-NEWyao1FX6MOirDKtKN5ceOhbxpDNUoHZPOjQOA+jFE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "95082a571b70231e56db5070dcdf675356da7b52",
+        "rev": "a7d5f1e07e7883c3e064ec87470e7e9c3840f762",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a7d5f1e0`](https://github.com/nix-community/NUR/commit/a7d5f1e07e7883c3e064ec87470e7e9c3840f762) | `` automatic update `` |