### PR TITLE
chore(flake/nur): `a7d5f1e0` -> `cacd071c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709757987,
-        "narHash": "sha256-NEWyao1FX6MOirDKtKN5ceOhbxpDNUoHZPOjQOA+jFE=",
+        "lastModified": 1709763720,
+        "narHash": "sha256-jHBwA64j26CNw2ikFd05jTc3RlJ9akUsmctEsSIXZUE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a7d5f1e07e7883c3e064ec87470e7e9c3840f762",
+        "rev": "922e9ab7245e8d8083cb2e8e61021e27d5f6b2f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cacd071c`](https://github.com/nix-community/NUR/commit/cacd071c8805056e2072163ac115089b7983fb43) | `` automatic update `` |