### PR TITLE
chore(flake/emacs-overlay): `8bac1264` -> `534e9e5c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709744151,
-        "narHash": "sha256-/c8wW50nETga4k5hXJpSvCez2EG3GD69NzTk4j/fkuU=",
+        "lastModified": 1709775299,
+        "narHash": "sha256-bnOkvXZLmgvDMJvkyP76GnN2UYkZACL/nOoZc+T2GlM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8bac12643777ddcade600de7752615867f7f518f",
+        "rev": "e720d1e442dbdd2ea55cddfe3e918ba2868f2c56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`534e9e5c`](https://github.com/nix-community/emacs-overlay/commit/534e9e5cfacc2231cef91cd8bb566fc913f870e5) | `` Updated elpa ``   |
| [`2f8aaed4`](https://github.com/nix-community/emacs-overlay/commit/2f8aaed4b9cf8b9337af27f887022285d6455cc8) | `` Updated nongnu `` |