### PR TITLE
chore(flake/nur): `24eb65ac` -> `3428e6cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709778977,
-        "narHash": "sha256-IQHvSipruiJZ6dTj0a7kNbu1IAkeaMPUor4RqMVuvd8=",
+        "lastModified": 1709786377,
+        "narHash": "sha256-lZCXJLmYFAzrwhE7g4tDpfi0Ti4Ui4azzhWkyLb4QXw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "24eb65ac74dbc70f963567ae4e88b598ce76129c",
+        "rev": "677476e90a9b33bf552d0b5669ee5234daa6f313",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3428e6cf`](https://github.com/nix-community/NUR/commit/3428e6cf4521df6254ff5b8bcf31df84fc1dd0d2) | `` automatic update `` |