### PR TITLE
chore(flake/nur): `677476e9` -> `23b9ff0c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709786377,
-        "narHash": "sha256-lZCXJLmYFAzrwhE7g4tDpfi0Ti4Ui4azzhWkyLb4QXw=",
+        "lastModified": 1709790027,
+        "narHash": "sha256-Q2471ZEtzchBTR6FK4Lly9X+hnnfCdWWj1N7BqkbELI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "677476e90a9b33bf552d0b5669ee5234daa6f313",
+        "rev": "23b9ff0c834c893cae94f5ba60efeebe8c5fecc9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`23b9ff0c`](https://github.com/nix-community/NUR/commit/23b9ff0c834c893cae94f5ba60efeebe8c5fecc9) | `` automatic update `` |
| [`9602b22e`](https://github.com/nix-community/NUR/commit/9602b22e2be274462244655685f98bc3a0954cc4) | `` automatic update `` |