### PR TITLE
chore(flake/nur): `23b9ff0c` -> `26eee509`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709790027,
-        "narHash": "sha256-Q2471ZEtzchBTR6FK4Lly9X+hnnfCdWWj1N7BqkbELI=",
+        "lastModified": 1709793202,
+        "narHash": "sha256-hYPotRv6/0mvPScaMBu9YoqKerci9XdJjEnf5ZNkcDY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "23b9ff0c834c893cae94f5ba60efeebe8c5fecc9",
+        "rev": "26eee509e64c2e8412dab1a16c3b4b33157e27f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`26eee509`](https://github.com/nix-community/NUR/commit/26eee509e64c2e8412dab1a16c3b4b33157e27f2) | `` automatic update `` |