### PR TITLE
chore(flake/nur): `26eee509` -> `895e0855`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709793202,
-        "narHash": "sha256-hYPotRv6/0mvPScaMBu9YoqKerci9XdJjEnf5ZNkcDY=",
+        "lastModified": 1709800027,
+        "narHash": "sha256-iyCUV3wbl+3kYpi5mJZQJRjFo/8YuuVR0UF3Ql5wLFw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "26eee509e64c2e8412dab1a16c3b4b33157e27f2",
+        "rev": "895e0855655804508fbeb90ed38bc82b6139c9bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`895e0855`](https://github.com/nix-community/NUR/commit/895e0855655804508fbeb90ed38bc82b6139c9bc) | `` automatic update `` |