### PR TITLE
chore(flake/nur): `895e0855` -> `33bc9053`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709800027,
-        "narHash": "sha256-iyCUV3wbl+3kYpi5mJZQJRjFo/8YuuVR0UF3Ql5wLFw=",
+        "lastModified": 1709808264,
+        "narHash": "sha256-vFrGHdiTcSk4QoxhMQXCEXUBQUEQ5o8dHKTSnD9x6sc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "895e0855655804508fbeb90ed38bc82b6139c9bc",
+        "rev": "33bc905322ad38466b503a3e756c60d9e8356350",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`33bc9053`](https://github.com/nix-community/NUR/commit/33bc905322ad38466b503a3e756c60d9e8356350) | `` automatic update `` |