### PR TITLE
chore(flake/nur): `bda1b55d` -> `bfaf2fee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709811865,
-        "narHash": "sha256-GBpBfoem1p0FKWDUDsEloO1KGBeg5jt0wd5WTe6SB3s=",
+        "lastModified": 1709815228,
+        "narHash": "sha256-NhTRACZB6JjfzKYXiUgMLhrT7SXoazUJojl4s0zgczE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bda1b55d8bd4e9f0e906a88ff38b8ae88afced73",
+        "rev": "bfaf2fee0da0b371afd5fa2f6fb4057844a9d70b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bfaf2fee`](https://github.com/nix-community/NUR/commit/bfaf2fee0da0b371afd5fa2f6fb4057844a9d70b) | `` automatic update `` |
| [`6ea67584`](https://github.com/nix-community/NUR/commit/6ea6758424a5feb2997261317e2cfae6c010b646) | `` automatic update `` |
| [`527f1d25`](https://github.com/nix-community/NUR/commit/527f1d2569fbbe1c6db8e44bdfb399242a307d98) | `` automatic update `` |