### PR TITLE
chore(flake/nur): `e0a81dd9` -> `6e7382a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709821974,
-        "narHash": "sha256-u0QmqQg90nbV1UinZZYBwJWgEvPByc+q1stxAMazjeA=",
+        "lastModified": 1709826373,
+        "narHash": "sha256-pxiQu+2OIlAkozwX7Vn3zwFZebVL3YyoOfeHXpCL/mQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e0a81dd9f1bac574b4c760ee087995c03c00e351",
+        "rev": "6e7382a8bb7d7f3920d4ff37ecad5f53bdfe11a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6e7382a8`](https://github.com/nix-community/NUR/commit/6e7382a8bb7d7f3920d4ff37ecad5f53bdfe11a5) | `` automatic update `` |