### PR TITLE
chore(flake/emacs-overlay): `368f873d` -> `50ac0adb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709830299,
-        "narHash": "sha256-od1MC+WnDH04GGjFCo9joYGypr8DL3w9QoWCn79wDVY=",
+        "lastModified": 1709831328,
+        "narHash": "sha256-z5B6+3y4WJBGgbdi/AOGQb2EvaHzWVJDjsmvuaNgdBs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "368f873d4066da95159c2095a847f6c36d74af83",
+        "rev": "50ac0adb684bcde50574db50f814960545620730",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`50ac0adb`](https://github.com/nix-community/emacs-overlay/commit/50ac0adb684bcde50574db50f814960545620730) | `` Updated emacs `` |