### PR TITLE
chore(flake/emacs-overlay): `da023f67` -> `6cd7ddb6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709859399,
-        "narHash": "sha256-/2wnEJV9qE3ftsoexdg2R7cKEmRVOXYvF0kzijt3riE=",
+        "lastModified": 1709862236,
+        "narHash": "sha256-i/0IUNU2q11tTTYK6HCdJn+YV2vly08PMCRiN2Ksjr4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "da023f67f164e5571faeac7feec565f211a1b27b",
+        "rev": "6cd7ddb6c8a8ac4b2bfb35ca3261d3e689740c8e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`6cd7ddb6`](https://github.com/nix-community/emacs-overlay/commit/6cd7ddb6c8a8ac4b2bfb35ca3261d3e689740c8e) | `` Updated emacs `` |
| [`306bf8bb`](https://github.com/nix-community/emacs-overlay/commit/306bf8bbce411033bbef90fd29018b468cb988a3) | `` Updated melpa `` |