### PR TITLE
chore(flake/nur): `4806f72e` -> `974b64aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709869145,
-        "narHash": "sha256-OZw4BmONtrBE2XdnzxBFxgmcZQXk814kee89tXw5y/8=",
+        "lastModified": 1709872661,
+        "narHash": "sha256-jZf1OEQ6VIrR0bU4dboZ9y5iYAiMGMFDBt+zaL+hAfw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4806f72ee2cc5da76160fc4f003bbb777011876a",
+        "rev": "974b64aacff650ec2e9b6d71e6c86a48ff9216e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`974b64aa`](https://github.com/nix-community/NUR/commit/974b64aacff650ec2e9b6d71e6c86a48ff9216e5) | `` automatic update `` |
| [`7f0e6093`](https://github.com/nix-community/NUR/commit/7f0e6093eb1b84e71889ba2c3763ed55ce1bb817) | `` automatic update `` |