### PR TITLE
chore(flake/nur): `974b64aa` -> `9ef12405`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709872661,
-        "narHash": "sha256-jZf1OEQ6VIrR0bU4dboZ9y5iYAiMGMFDBt+zaL+hAfw=",
+        "lastModified": 1709876523,
+        "narHash": "sha256-0PTUu6ZKAf19/B5gt/aJpllSjeas2pu6W6kfBeVRgS0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "974b64aacff650ec2e9b6d71e6c86a48ff9216e5",
+        "rev": "9ef124059b9f2fb675ae3a6ae68e62a3ef8f7b6a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ef12405`](https://github.com/nix-community/NUR/commit/9ef124059b9f2fb675ae3a6ae68e62a3ef8f7b6a) | `` automatic update `` |