### PR TITLE
chore(flake/nur): `9ef12405` -> `5c70fdaf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709876523,
-        "narHash": "sha256-0PTUu6ZKAf19/B5gt/aJpllSjeas2pu6W6kfBeVRgS0=",
+        "lastModified": 1709879657,
+        "narHash": "sha256-pb2qyDfjmdCIh/HwHj0LAIKBOGcKL22KSYt1BKIrgvU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ef124059b9f2fb675ae3a6ae68e62a3ef8f7b6a",
+        "rev": "5c70fdaf1205fa010f458b6a2f3835f14e32e3b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5c70fdaf`](https://github.com/nix-community/NUR/commit/5c70fdaf1205fa010f458b6a2f3835f14e32e3b4) | `` automatic update `` |