### PR TITLE
chore(flake/nix-on-droid): `40290511` -> `7b3cc6e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -632,11 +632,11 @@
         "nmd": "nmd_2"
       },
       "locked": {
-        "lastModified": 1709686262,
-        "narHash": "sha256-zSAS1R52CAPc6prc9+EZeUFZmr6hDPhEOU46hZz5aG8=",
+        "lastModified": 1709879753,
+        "narHash": "sha256-zEpy3eweBus/cW/oRMBINps6Bnlazpa7TadonwWibHA=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "40290511094531f2932f7954fd5159861de2ada3",
+        "rev": "7b3cc6e3f9919b2d23003cfafb60c146c3f45793",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`7b3cc6e3`](https://github.com/nix-community/nix-on-droid/commit/7b3cc6e3f9919b2d23003cfafb60c146c3f45793) | `` pkgs/nix-directory: update nix to 2.20.5 `` |