### PR TITLE
chore(flake/nur): `5c70fdaf` -> `dc353b85`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709879657,
-        "narHash": "sha256-pb2qyDfjmdCIh/HwHj0LAIKBOGcKL22KSYt1BKIrgvU=",
+        "lastModified": 1709887655,
+        "narHash": "sha256-tOdMwgPOGXcH5Q2tA/ucnE32yRSB/73/vCDA7j5zWAs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5c70fdaf1205fa010f458b6a2f3835f14e32e3b4",
+        "rev": "8803df6e3a9b825ad7979184f25471719e7040bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dc353b85`](https://github.com/nix-community/NUR/commit/dc353b8596452bc4ecd7cdb6ed1d64314cf87981) | `` automatic update `` |