### PR TITLE
chore(flake/srvos): `fda52d32` -> `434ad845`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1028,11 +1028,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709727834,
-        "narHash": "sha256-f/bcK8mGcyz+5dxddGDRo9osX/3T3kIziwNddMEKuGk=",
+        "lastModified": 1709894640,
+        "narHash": "sha256-prpcUATCGnIbh2FaHiKBV/sS+agUtzU2IAt+VTdKRVk=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "fda52d3209d79196bb2588ae223591793b163b8b",
+        "rev": "434ad8453dffd81b91fddc0d68fb65d9bc5d5059",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`434ad845`](https://github.com/nix-community/srvos/commit/434ad8453dffd81b91fddc0d68fb65d9bc5d5059) | `` fixup! vultr: disable srvos.boot.consoles (#392) `` |