### PR TITLE
chore(flake/home-manager): `cf111d1a` -> `417015af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -491,11 +491,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709764752,
-        "narHash": "sha256-+lM4J4JoJeiN8V+3WSWndPHj1pJ9Jc1UMikGbXLqCTk=",
+        "lastModified": 1709904018,
+        "narHash": "sha256-fVp/89wNjWg7OQ/Gj3eSK2IXKDk9mXSj5ltOz98Ce2w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cf111d1a849ddfc38e9155be029519b0e2329615",
+        "rev": "8b07ca541939211d3cc437ddfd74ebdef3d72471",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`417015af`](https://github.com/nix-community/home-manager/commit/417015af0dc2525557ab36528643c2d519ca4334) | `` himalaya: adjust code for v1.0.0-beta.3 ``          |
| [`0c65bfa3`](https://github.com/nix-community/home-manager/commit/0c65bfa3cf7e8621a6cd3da500f591e2e92a6259) | `` git-sync: allow passing extraPackages to service `` |
| [`1283bf6e`](https://github.com/nix-community/home-manager/commit/1283bf6ebbdee4d980b7551bed4c6596805e812c) | `` xdg-user-dirs: check for existing symlink ``        |