### PR TITLE
chore(flake/nur): `49341904` -> `b1c8505d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709902347,
-        "narHash": "sha256-J3xnpkNe8HsdLIT1jYMc2fFameJBbGNEJRK0HigMzGE=",
+        "lastModified": 1709905074,
+        "narHash": "sha256-nI74pyhE8i8vfbmvb8Nwv94VpbJlG4/mZmk0583Dp1I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4934190443e3ef3cd172c789c1315635df133486",
+        "rev": "b1c8505d06299a4b6ef3ad332a5d59d10a2e9077",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b1c8505d`](https://github.com/nix-community/NUR/commit/b1c8505d06299a4b6ef3ad332a5d59d10a2e9077) | `` automatic update `` |