### PR TITLE
chore(flake/nix-index-database): `94a1e464` -> `2ad5ebce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -607,11 +607,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709708644,
-        "narHash": "sha256-XAFOkZ6yexsqeJrCXWoHxopq0i+7ZqbwATXomMnGmr4=",
+        "lastModified": 1709906691,
+        "narHash": "sha256-206XMy1NGW42bnHukJl5W2F90yHNoJc7+H3i+/8i2Pg=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "94a1e46434736a40f976a454f8bd3ea2144f349b",
+        "rev": "2ad5ebce1e1be47a8cf330d85265ac09ffa15178",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                  |
| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`56335944`](https://github.com/nix-community/nix-index-database/commit/56335944627b7360c31da13c73aa521d996637d8) | `` Document nix-locate usage. Fix #79 `` |