### PR TITLE
chore(flake/nur): `b1c8505d` -> `16940537`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709905074,
-        "narHash": "sha256-nI74pyhE8i8vfbmvb8Nwv94VpbJlG4/mZmk0583Dp1I=",
+        "lastModified": 1709912094,
+        "narHash": "sha256-OfXTMLxNkGtXKAIYt7VgmpDkl310/zl1Vx4BOZQyp48=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b1c8505d06299a4b6ef3ad332a5d59d10a2e9077",
+        "rev": "16940537af952d8d2cf870eda0d2f355addcaba6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`16940537`](https://github.com/nix-community/NUR/commit/16940537af952d8d2cf870eda0d2f355addcaba6) | `` automatic update `` |