### PR TITLE
chore(flake/nur): `16940537` -> `1cc9f2fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709912094,
-        "narHash": "sha256-OfXTMLxNkGtXKAIYt7VgmpDkl310/zl1Vx4BOZQyp48=",
+        "lastModified": 1709919849,
+        "narHash": "sha256-eTLTDD2tixEOKFPipKBC8Ty9vcVBfiVzDdAwiHRBcnI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "16940537af952d8d2cf870eda0d2f355addcaba6",
+        "rev": "abf0979b47bd2c9746e552f43cb99a9f714fcd8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1cc9f2fb`](https://github.com/nix-community/NUR/commit/1cc9f2fb404ca1d261338ba0ebde17cfe6155def) | `` automatic update `` |