### PR TITLE
chore(flake/nur): `abf0979b` -> `2a86b0c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709919849,
-        "narHash": "sha256-eTLTDD2tixEOKFPipKBC8Ty9vcVBfiVzDdAwiHRBcnI=",
+        "lastModified": 1709927144,
+        "narHash": "sha256-RIJ5Yg0L6iAZX+W5c9yhOTrAQhgmj1NKLoSTg3BZ2vI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "abf0979b47bd2c9746e552f43cb99a9f714fcd8b",
+        "rev": "2a86b0c093a448ad66cef5a51eff81433a43edb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2a86b0c0`](https://github.com/nix-community/NUR/commit/2a86b0c093a448ad66cef5a51eff81433a43edb8) | `` automatic update `` |