### PR TITLE
chore(flake/nur): `2a86b0c0` -> `f0549341`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709927144,
-        "narHash": "sha256-RIJ5Yg0L6iAZX+W5c9yhOTrAQhgmj1NKLoSTg3BZ2vI=",
+        "lastModified": 1709930702,
+        "narHash": "sha256-0gY+pkdLEjRcQ1mZh4i53MUc12biizxbWvRQ4fHa9Bc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2a86b0c093a448ad66cef5a51eff81433a43edb8",
+        "rev": "f0549341806ffe0d50059a2c4cdfd73380cc1800",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f0549341`](https://github.com/nix-community/NUR/commit/f0549341806ffe0d50059a2c4cdfd73380cc1800) | `` automatic update `` |