### PR TITLE
chore(flake/home-manager): `8b07ca54` -> `bfc438e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -491,11 +491,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709904018,
-        "narHash": "sha256-fVp/89wNjWg7OQ/Gj3eSK2IXKDk9mXSj5ltOz98Ce2w=",
+        "lastModified": 1709938482,
+        "narHash": "sha256-2Vw2WOFmEXWQH8ziFNOr0U48Guh5FacuD6BOEIcE99s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8b07ca541939211d3cc437ddfd74ebdef3d72471",
+        "rev": "17431970b4ebc75a92657101ccffcfc9e1f9d8f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`bfc438e9`](https://github.com/nix-community/home-manager/commit/bfc438e9b707502dce0474738eff562a38046dc1) | `` ranger: add module `` |
| [`b550d074`](https://github.com/nix-community/home-manager/commit/b550d074fbcd31ac90012596c4d3f5b775dcaddd) | `` zk: add module ``     |