### PR TITLE
chore(flake/nur): `f0549341` -> `0e308c95`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709930702,
-        "narHash": "sha256-0gY+pkdLEjRcQ1mZh4i53MUc12biizxbWvRQ4fHa9Bc=",
+        "lastModified": 1709938874,
+        "narHash": "sha256-1TGZ8kWod3g/w2l1Wt9NgqKA7NIc8u6zSXNNyC0I86c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f0549341806ffe0d50059a2c4cdfd73380cc1800",
+        "rev": "0e308c9589e11470660afed7c69f530ae6253c15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0e308c95`](https://github.com/nix-community/NUR/commit/0e308c9589e11470660afed7c69f530ae6253c15) | `` automatic update `` |
| [`aa86c655`](https://github.com/nix-community/NUR/commit/aa86c6552aa736aa9f1ec2121d2d745d0f113521) | `` automatic update `` |