### PR TITLE
chore(flake/nur): `71ff7f65` -> `699643a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709945051,
-        "narHash": "sha256-/BLi/xCFBN+OWeUvfPt8sFF6xd6jRV9lGxmGPJT3aCA=",
+        "lastModified": 1709956549,
+        "narHash": "sha256-mI3gN1R8BFM+nmrFFFT4GFVcgENFtdIN9x1/lsoWz14=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "71ff7f65c103361e170371351d742dc42bf4ff2f",
+        "rev": "699643a50ddd0a758c3d73af3cd52afb270a2f0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`699643a5`](https://github.com/nix-community/NUR/commit/699643a50ddd0a758c3d73af3cd52afb270a2f0e) | `` automatic update `` |
| [`3a6e31e6`](https://github.com/nix-community/NUR/commit/3a6e31e637e8bb05567741cf98b914c41400b1d0) | `` automatic update `` |