### PR TITLE
chore(flake/nur): `699643a5` -> `76f8da45`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709956549,
-        "narHash": "sha256-mI3gN1R8BFM+nmrFFFT4GFVcgENFtdIN9x1/lsoWz14=",
+        "lastModified": 1709957470,
+        "narHash": "sha256-tA4neD+PA9gEzaBLogsXs66Q7lgghmSknLp9RmejoXg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "699643a50ddd0a758c3d73af3cd52afb270a2f0e",
+        "rev": "76f8da4574c89286569aa292316ea3843227a8eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`76f8da45`](https://github.com/nix-community/NUR/commit/76f8da4574c89286569aa292316ea3843227a8eb) | `` automatic update `` |