### PR TITLE
chore(flake/nur): `76f8da45` -> `17c9e04c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709957470,
-        "narHash": "sha256-tA4neD+PA9gEzaBLogsXs66Q7lgghmSknLp9RmejoXg=",
+        "lastModified": 1709966697,
+        "narHash": "sha256-n131yVNfru/IsoIZHb8MbAaetIP61T0bZ4WxFC0SViw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "76f8da4574c89286569aa292316ea3843227a8eb",
+        "rev": "17c9e04c8053f5722a5c8a1239108294fa6764e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`17c9e04c`](https://github.com/nix-community/NUR/commit/17c9e04c8053f5722a5c8a1239108294fa6764e1) | `` automatic update `` |