### PR TITLE
chore(flake/nur): `17c9e04c` -> `2f11b175`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709966697,
-        "narHash": "sha256-n131yVNfru/IsoIZHb8MbAaetIP61T0bZ4WxFC0SViw=",
+        "lastModified": 1709970970,
+        "narHash": "sha256-wY9AWHW3o8b2YWRR478tVrFlli4lE6AHkt7S7soTovQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "17c9e04c8053f5722a5c8a1239108294fa6764e1",
+        "rev": "2f11b175650fb864efa620aa1db5f47eb9408d52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2f11b175`](https://github.com/nix-community/NUR/commit/2f11b175650fb864efa620aa1db5f47eb9408d52) | `` automatic update `` |
| [`760b9ced`](https://github.com/nix-community/NUR/commit/760b9ced75917fd0b7d80765511b70c1fbb0ae6e) | `` automatic update `` |
| [`3f83e9c6`](https://github.com/nix-community/NUR/commit/3f83e9c6d97104c5b87563784d1b25edf1c2b952) | `` automatic update `` |
| [`79e75953`](https://github.com/nix-community/NUR/commit/79e7595387c63174a948c951a580eecad498384c) | `` automatic update `` |