### PR TITLE
chore(flake/nur): `7d1f369d` -> `01e63128`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709972233,
-        "narHash": "sha256-T8XE8bPNK2WvROra4RCQVJks9QAb0rhxSoOUz0CGx2A=",
+        "lastModified": 1709977451,
+        "narHash": "sha256-zQSSG0wSd9ZW2u96bucB/LlWW0oCilx9pPBO8ub2X3o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7d1f369d01ee0eb3e05fd1b9fb25e73992df625b",
+        "rev": "01e631284d5ad81e58fc332086f435f0a57bb00d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`01e63128`](https://github.com/nix-community/NUR/commit/01e631284d5ad81e58fc332086f435f0a57bb00d) | `` automatic update `` |