### PR TITLE
chore(flake/nur): `a725b78c` -> `ffe51132`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709980490,
-        "narHash": "sha256-JEz01axJNybS2DSZoEkv0G8x/aOIXKv8Eo/zRWFdXYM=",
+        "lastModified": 1709988251,
+        "narHash": "sha256-qGIQ1oFmRcGP5Xn6facMlAE3DYItBTUrHcQ7rYmP8no=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a725b78cdcdefe02dc4de9ba32f270d16d32628f",
+        "rev": "ffe511324b8e9853e6fda172d033b6de2897c941",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ffe51132`](https://github.com/nix-community/NUR/commit/ffe511324b8e9853e6fda172d033b6de2897c941) | `` automatic update `` |
| [`b8dc242a`](https://github.com/nix-community/NUR/commit/b8dc242a9cf5b85b798ac1ba235e7ced8323b760) | `` automatic update `` |