### PR TITLE
chore(flake/nur): `a2c8dbc6` -> `b9fdd3da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709994731,
-        "narHash": "sha256-yRFDZtD2+4icvK8htOzFQRC3BQTIwsVSK8CHfDW+FMw=",
+        "lastModified": 1709999056,
+        "narHash": "sha256-YZBLyvYRIsT9jSo9rxhFLq4XvE9woduFdxyzTaOwZys=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a2c8dbc69af439969f96519317880bd1f5b352c8",
+        "rev": "b9fdd3dace5a629c585a2e137563c2a04fe59e40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b9fdd3da`](https://github.com/nix-community/NUR/commit/b9fdd3dace5a629c585a2e137563c2a04fe59e40) | `` automatic update `` |