### PR TITLE
chore(flake/nur): `b9fdd3da` -> `ef329c54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709999056,
-        "narHash": "sha256-YZBLyvYRIsT9jSo9rxhFLq4XvE9woduFdxyzTaOwZys=",
+        "lastModified": 1710002672,
+        "narHash": "sha256-Ijim2SZq7Zeu1fodvPqn4+o/GIBApCJGQek78yHU4qI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b9fdd3dace5a629c585a2e137563c2a04fe59e40",
+        "rev": "ef329c544e503cb626c0927c9bd67df7b163bd65",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ef329c54`](https://github.com/nix-community/NUR/commit/ef329c544e503cb626c0927c9bd67df7b163bd65) | `` automatic update `` |