### PR TITLE
chore(flake/emacs-overlay): `aed9a9e5` -> `0247f642`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709974977,
-        "narHash": "sha256-h0k0+volnVkG1NB9Iswgqrm5neA+13Ye8tdJiKcVJ0U=",
+        "lastModified": 1710003807,
+        "narHash": "sha256-NVQosZpEz9dDo2f9I84P9NCsVjx2NQy3T9Lpp3TbJJs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "aed9a9e58391a498c2ed2b5bbd0b59ec3d862f6d",
+        "rev": "4dd04421a91873b26f5b4acc8b2c947cb91c7900",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`0247f642`](https://github.com/nix-community/emacs-overlay/commit/0247f6426f346c7ffd575ed938ee835cea1b329e) | `` Updated melpa `` |
| [`74be16c1`](https://github.com/nix-community/emacs-overlay/commit/74be16c1d2aaecc4e3cd19d323e89f528b492a57) | `` Updated elpa ``  |