### PR TITLE
chore(flake/nur): `cf1e9b0e` -> `91cc2004`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710013455,
-        "narHash": "sha256-qzOpU4APTso6JLA+/F4zlO/yL8++n/CsUpmxbQAsy/4=",
+        "lastModified": 1710019138,
+        "narHash": "sha256-6v+/OWVboOYiv6Eb75HEDMVXp3kyExgJPOkn3NnpGJE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cf1e9b0e085368cc489c765f285f1d07c2ec8d36",
+        "rev": "91cc200411377bd61e63526d925a82be50dc9d7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`91cc2004`](https://github.com/nix-community/NUR/commit/91cc200411377bd61e63526d925a82be50dc9d7f) | `` automatic update `` |
| [`0fcbd140`](https://github.com/nix-community/NUR/commit/0fcbd140884d31178bfeae69998e7472b53de304) | `` automatic update `` |