### PR TITLE
chore(flake/emacs-overlay): `2b3c5813` -> `f7c18159`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710032429,
-        "narHash": "sha256-QYtvB21nqdaytJR94bGvRF7IsMLH9ZNyaU2sK0DW9gc=",
+        "lastModified": 1710034490,
+        "narHash": "sha256-n3pEX8Ji498tu2ht86mL1aaK6mWQSS6hwk7M2SoXh6Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2b3c5813233795dff6c23fc56fbaa85fcf16b55a",
+        "rev": "f7c18159c781e56a74d3352ef2865929fc122c61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`f7c18159`](https://github.com/nix-community/emacs-overlay/commit/f7c18159c781e56a74d3352ef2865929fc122c61) | `` Updated melpa `` |