### PR TITLE
chore(flake/nur): `0ebc01a1` -> `0fc60d25`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710056169,
-        "narHash": "sha256-xdoWei0zFVc3LpHWoAce6xGviMPNtW8Z1i2LmPPqqGg=",
+        "lastModified": 1710060343,
+        "narHash": "sha256-63QQVGm3/VoSsnpFeW/zEP//HJ+C1qR9ZOqMguCsqSc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0ebc01a1bf4e1b143b6ddeaa89e2c116ce32a494",
+        "rev": "0fc60d25043f9cda4549e6656fea6787cbdd095f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0fc60d25`](https://github.com/nix-community/NUR/commit/0fc60d25043f9cda4549e6656fea6787cbdd095f) | `` automatic update `` |
| [`cf3f8e86`](https://github.com/nix-community/NUR/commit/cf3f8e868fca09ca61cb70674236aa6b3f86e420) | `` automatic update `` |
| [`f138129f`](https://github.com/nix-community/NUR/commit/f138129fac677792703246532af758dd0edecc6a) | `` automatic update `` |