### PR TITLE
chore(flake/org-tufte): `404ab128` -> `b4c48849`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     "org-tufte": {
       "flake": false,
       "locked": {
-        "lastModified": 1679003984,
-        "narHash": "sha256-KUkhayF8fB4g9nIJeY4lmBJARFooe3JlX0Y6oTMqwPE=",
+        "lastModified": 1710064933,
+        "narHash": "sha256-d2r33oedgUclebJIRk1zgzQoOvICp0sqvZyIklH/aww=",
         "owner": "Zilong-Li",
         "repo": "org-tufte",
-        "rev": "404ab1286139ea6cbdc00bb1fb50a0afd9d067de",
+        "rev": "b4c488492f02a399f1c0a06ce0acf3184d8e0290",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message      |
| ---------------------------------------------------------------------------------------------------- | ------------ |
| [`b4c48849`](https://github.com/Zilong-Li/org-tufte/commit/b4c488492f02a399f1c0a06ce0acf3184d8e0290) | `` v0.3.0 `` |