### PR TITLE
chore(flake/nur): `13aef887` -> `b7566341`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710064700,
-        "narHash": "sha256-J6YVRyDpt4brzkceUPeZ7wvt846/sL+igL6hOdXiVAA=",
+        "lastModified": 1710067451,
+        "narHash": "sha256-W/E29aurg2vfvdiJ9sBFIgo8PuqRxUyAooWa+XB3mCA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "13aef887a9cb355c9bc4f2306f9362c31ee2b18a",
+        "rev": "b756634158c608a7741d3c9aeaed586cab58966c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b7566341`](https://github.com/nix-community/NUR/commit/b756634158c608a7741d3c9aeaed586cab58966c) | `` automatic update `` |
| [`611f72b1`](https://github.com/nix-community/NUR/commit/611f72b1ea69624152e81f86fc24ec9fc0cf3031) | `` automatic update `` |