### PR TITLE
chore(flake/nur): `b7566341` -> `e4533588`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710067451,
-        "narHash": "sha256-W/E29aurg2vfvdiJ9sBFIgo8PuqRxUyAooWa+XB3mCA=",
+        "lastModified": 1710075630,
+        "narHash": "sha256-ZqiRLmz7otOkIbOdY2mlB+zTze8kjSgsaKM6DPoU5ng=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b756634158c608a7741d3c9aeaed586cab58966c",
+        "rev": "e453358844c3307e73c0e67fcc3bdd258c3080d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e4533588`](https://github.com/nix-community/NUR/commit/e453358844c3307e73c0e67fcc3bdd258c3080d5) | `` automatic update `` |
| [`e7dbfe21`](https://github.com/nix-community/NUR/commit/e7dbfe2166ae91b36011848ce6b8ca48447b7129) | `` automatic update `` |