### PR TITLE
chore(flake/emacs-overlay): `1cdd60ae` -> `95e75afe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710061621,
-        "narHash": "sha256-C9+Yw5pxK1+0a5KxMoKocVZOfkj+V/6TSHasS2h6Zgg=",
+        "lastModified": 1710089373,
+        "narHash": "sha256-Eo5bhhJnktkXFgh+2XiL2I+5YuiUFJoR59Cvkqv+nuw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1cdd60ae31faea0bc68251429f64589978415b4b",
+        "rev": "95e75afe4014460546943a683c33ad06af2b35e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`95e75afe`](https://github.com/nix-community/emacs-overlay/commit/95e75afe4014460546943a683c33ad06af2b35e6) | `` Updated melpa ``        |
| [`f8e768e5`](https://github.com/nix-community/emacs-overlay/commit/f8e768e5f64035f969537827191bd1983afd7635) | `` Updated elpa ``         |
| [`75b53fa5`](https://github.com/nix-community/emacs-overlay/commit/75b53fa59de9baac0f2506c27fb8f0fa4e840778) | `` Updated flake inputs `` |