### PR TITLE
chore(flake/nur): `691000ac` -> `d66f3002`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710080370,
-        "narHash": "sha256-pIbyQ0a/FUW1uRn2YyHnZm4Fi8tT3FmH9M0CjGMVUHM=",
+        "lastModified": 1710092659,
+        "narHash": "sha256-EaWWwi6DXUzMMV4S5IQmBdTrhh+pTGGzeF1wsRojoEw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "691000ac2025ae3e089966e8191410f778f7fa23",
+        "rev": "d66f300255c8973d295c896fabd531fdcddcf28a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d66f3002`](https://github.com/nix-community/NUR/commit/d66f300255c8973d295c896fabd531fdcddcf28a) | `` automatic update `` |
| [`46c97c01`](https://github.com/nix-community/NUR/commit/46c97c0164c869a48dbaaa6fa20b30b4fcbac814) | `` automatic update `` |