### PR TITLE
chore(flake/emacs-overlay): `95e75afe` -> `a230393b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710089373,
-        "narHash": "sha256-Eo5bhhJnktkXFgh+2XiL2I+5YuiUFJoR59Cvkqv+nuw=",
+        "lastModified": 1710091554,
+        "narHash": "sha256-p4CFIo9dAIgL6KMp1woJxVISoqYKblPGjAgTPkzeOWI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "95e75afe4014460546943a683c33ad06af2b35e6",
+        "rev": "a230393bb7e2db667c63c3f5c279a6e26d8b1c5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`a230393b`](https://github.com/nix-community/emacs-overlay/commit/a230393bb7e2db667c63c3f5c279a6e26d8b1c5a) | `` Updated emacs `` |