### PR TITLE
chore(flake/nur): `149b8a58` -> `4ee46320`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710135633,
-        "narHash": "sha256-CUX5FuzTflZGJOMiI1cJ3Ybc6192lB1wdvT5a7SJKAM=",
+        "lastModified": 1710139026,
+        "narHash": "sha256-1dDwfcJ7JeLq1Q47ftS6aAKOhf1exXiph4Te4O2P5Lk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "149b8a5858ada863bce99df36b7bc78bfaf7160a",
+        "rev": "4ee463208e545d6a1cba7b970c6da9fc08b4fa88",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4ee46320`](https://github.com/nix-community/NUR/commit/4ee463208e545d6a1cba7b970c6da9fc08b4fa88) | `` automatic update `` |