### PR TITLE
chore(flake/nur): `4ee46320` -> `56d2b554`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710139026,
-        "narHash": "sha256-1dDwfcJ7JeLq1Q47ftS6aAKOhf1exXiph4Te4O2P5Lk=",
+        "lastModified": 1710143211,
+        "narHash": "sha256-paaSfdeiBddwGRh5bmiCRiAo8Itby3yNCUcmRUa3k/4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ee463208e545d6a1cba7b970c6da9fc08b4fa88",
+        "rev": "56d2b554a63e74c1ca7ebcf719640d3af67b816f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                            |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`56d2b554`](https://github.com/nix-community/NUR/commit/56d2b554a63e74c1ca7ebcf719640d3af67b816f) | `` automatic update ``                             |
| [`3d9195d5`](https://github.com/nix-community/NUR/commit/3d9195d53f3ce3d494b3ed3c24da1cdafe20e617) | `` add kugland repository ``                       |
| [`e6b25cf4`](https://github.com/nix-community/NUR/commit/e6b25cf4e114b2f01ce51d2cbaa8306d49be50ab) | `` automatic update ``                             |
| [`99312ca1`](https://github.com/nix-community/NUR/commit/99312ca114f44f54d69889900894d0a267c5dbde) | `` automatic update ``                             |
| [`77738d69`](https://github.com/nix-community/NUR/commit/77738d692710289b189ecf48e2c295177fa70fd4) | `` Bump cachix/install-nix-action from 25 to 26 `` |
| [`2a36348c`](https://github.com/nix-community/NUR/commit/2a36348c01c84e5641a2d20b67123ed918046418) | `` add chigyutendies ``                            |