### PR TITLE
chore(flake/emacs-overlay): `65f195e9` -> `e60b2a8b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710121508,
-        "narHash": "sha256-lOfYN1BMBNarx3Nvcro6EEXq+ZSUHyhc2WJJdWACwoA=",
+        "lastModified": 1710147897,
+        "narHash": "sha256-i/XeOaqudz7jTi9VIz5EGd1BmWZEcJ81x8JLDgljvBs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "65f195e937a170adac199b12eab303b8488bf38b",
+        "rev": "b7ec159f704bf8b55accd190dc7d0e84182f9a45",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`e60b2a8b`](https://github.com/nix-community/emacs-overlay/commit/e60b2a8b58cc767057fb5daf0d7d5fd305fe4999) | `` Updated melpa `` |