### PR TITLE
chore(flake/nur): `56d2b554` -> `70a07f18`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710143211,
-        "narHash": "sha256-paaSfdeiBddwGRh5bmiCRiAo8Itby3yNCUcmRUa3k/4=",
+        "lastModified": 1710145961,
+        "narHash": "sha256-a5s8Gxu2SY5jfBgfmLRcIg3D+JGFfJau3pWcOcX4Hkc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "56d2b554a63e74c1ca7ebcf719640d3af67b816f",
+        "rev": "70a07f18d94fc0da882345eafd6facbe8a781cad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`70a07f18`](https://github.com/nix-community/NUR/commit/70a07f18d94fc0da882345eafd6facbe8a781cad) | `` automatic update `` |
| [`9b1b18a9`](https://github.com/nix-community/NUR/commit/9b1b18a9681d030a1ceded5fa418d074ef70e690) | `` automatic update `` |