### PR TITLE
chore(flake/nur): `70a07f18` -> `669c888b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710145961,
-        "narHash": "sha256-a5s8Gxu2SY5jfBgfmLRcIg3D+JGFfJau3pWcOcX4Hkc=",
+        "lastModified": 1710148609,
+        "narHash": "sha256-9Px+bZMJxafCeqDGOh4IZXu2W96Pmd1sgDxHCxUFDGs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "70a07f18d94fc0da882345eafd6facbe8a781cad",
+        "rev": "669c888b0a869cf1c122afe5352d01fa1960f5e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`669c888b`](https://github.com/nix-community/NUR/commit/669c888b0a869cf1c122afe5352d01fa1960f5e2) | `` automatic update `` |