### PR TITLE
chore(flake/nur): `669c888b` -> `ca498223`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710148609,
-        "narHash": "sha256-9Px+bZMJxafCeqDGOh4IZXu2W96Pmd1sgDxHCxUFDGs=",
+        "lastModified": 1710153753,
+        "narHash": "sha256-oILsW7rFrH1AknlW8GVh7GmQoJyYsDB31QVJV1oGXWs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "669c888b0a869cf1c122afe5352d01fa1960f5e2",
+        "rev": "ca4982238c58ad2fb44a4a5e10b203bb1b6524f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ca498223`](https://github.com/nix-community/NUR/commit/ca4982238c58ad2fb44a4a5e10b203bb1b6524f1) | `` automatic update `` |