### PR TITLE
chore(flake/nur): `ca498223` -> `837d2cf0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710153753,
-        "narHash": "sha256-oILsW7rFrH1AknlW8GVh7GmQoJyYsDB31QVJV1oGXWs=",
+        "lastModified": 1710168943,
+        "narHash": "sha256-lVes2OOaw6Yxsql6+9srQ35xEoKxIrQY10zoi7hJP7c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ca4982238c58ad2fb44a4a5e10b203bb1b6524f1",
+        "rev": "4482fd07dcc20d92b680a2f115a9c92a24092749",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`837d2cf0`](https://github.com/nix-community/NUR/commit/837d2cf049b8fc727584a6e610c4af8f0e496f0e) | `` automatic update `` |
| [`cbd208ba`](https://github.com/nix-community/NUR/commit/cbd208bab281a2754515b352dc5ac888f004198a) | `` automatic update `` |
| [`88a98b97`](https://github.com/nix-community/NUR/commit/88a98b97721f1e530868ec325d7ab8342aa1e9bb) | `` automatic update `` |
| [`ff19513c`](https://github.com/nix-community/NUR/commit/ff19513c66ec904c1380afb85e81f8213d79f515) | `` automatic update `` |