### PR TITLE
chore(flake/lanzaboote): `f0039ede` -> `f143c542`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1710149224,
-        "narHash": "sha256-Ysw6x1VgeLOZHuyJ0UjON/ms8tzCjkcKCZ85A9O016U=",
+        "lastModified": 1710171982,
+        "narHash": "sha256-WFMB+Yohcvego1/vOtaq+MJ8Wvp5meOANfNifg26Ie4=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "f0039ede99adf0027b796065350566a1ef9e4a78",
+        "rev": "19ad7fd5724f30868748b8156ff25be838cd2bc5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                          |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`674773cf`](https://github.com/nix-community/lanzaboote/commit/674773cf74cf0ebe62ee230b28e3533286db5b55) | `` docs: add more framework-specific hints ``    |
| [`e92f808e`](https://github.com/nix-community/lanzaboote/commit/e92f808ea1c180fb182da201ecbb530b6e2d4454) | `` fix(deps): update rust crate clap to 4.5.2 `` |