### PR TITLE
chore(flake/emacs-overlay): `b7ec159f` -> `f8ec23ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710147897,
-        "narHash": "sha256-i/XeOaqudz7jTi9VIz5EGd1BmWZEcJ81x8JLDgljvBs=",
+        "lastModified": 1710176745,
+        "narHash": "sha256-3Av9cY2xw8Lbq56o23uKwYbbrjH4We0SqveKNejlHpU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b7ec159f704bf8b55accd190dc7d0e84182f9a45",
+        "rev": "30fdb303a64d5fcbbaf0609b75d3c9c783af7869",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`f8ec23ab`](https://github.com/nix-community/emacs-overlay/commit/f8ec23ab79ad9f5c9d75eeca35f672ccf8b31c40) | `` Updated melpa ``        |
| [`5bd6ccde`](https://github.com/nix-community/emacs-overlay/commit/5bd6ccdea4d7f4672de5922c7eaf791adc928eed) | `` Updated elpa ``         |
| [`38821439`](https://github.com/nix-community/emacs-overlay/commit/388214396e9868ecd648bce9ccfc4d6074e6aee5) | `` Updated flake inputs `` |