### PR TITLE
chore(flake/nur): `b55f6d5a` -> `30efcadc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710175618,
-        "narHash": "sha256-ORZWIz6cpm9FOcUDPm6iRC1BqIJlJpe+0dcQMg5V3Mg=",
+        "lastModified": 1710180069,
+        "narHash": "sha256-vDqzjlagiHJDe5u5cn3TdbeWjRSWi2Pqyas+xYVEkaE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b55f6d5af86868997152787df8ab980ed73cc8e6",
+        "rev": "30efcadc4df76f9ca181a1586d0cbb6f669c64d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`30efcadc`](https://github.com/nix-community/NUR/commit/30efcadc4df76f9ca181a1586d0cbb6f669c64d8) | `` automatic update `` |
| [`f0997d13`](https://github.com/nix-community/NUR/commit/f0997d139623c1b57ed85ae07d9a3480e43849ce) | `` automatic update `` |
| [`155ff7d6`](https://github.com/nix-community/NUR/commit/155ff7d6787c61827bd7d6e8e806c776e4bc599e) | `` automatic update `` |