### PR TITLE
chore(flake/nur): `30efcadc` -> `c03f6fde`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710180069,
-        "narHash": "sha256-vDqzjlagiHJDe5u5cn3TdbeWjRSWi2Pqyas+xYVEkaE=",
+        "lastModified": 1710186250,
+        "narHash": "sha256-j3yNHXTcgCiTtPq/61nkqXIqggEx0Rr33BILCBOC7QQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "30efcadc4df76f9ca181a1586d0cbb6f669c64d8",
+        "rev": "e3a0f99335866b0020f6720e4f02b5b7a4da05f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c03f6fde`](https://github.com/nix-community/NUR/commit/c03f6fde2dcef20584e97b25ea64b83e2b52baf4) | `` automatic update `` |
| [`7a7f5d32`](https://github.com/nix-community/NUR/commit/7a7f5d323d6820fa4fc883569329600de4ed6338) | `` automatic update `` |
| [`1f7d0731`](https://github.com/nix-community/NUR/commit/1f7d0731ac829e082fe5dcecefd13d93a5a5b6e0) | `` automatic update `` |
| [`03852205`](https://github.com/nix-community/NUR/commit/03852205c3c13251c4a1efc176d53b3c18d0bc64) | `` automatic update `` |