### PR TITLE
chore(flake/srvos): `434ad845` -> `f0688645`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -994,11 +994,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709894640,
-        "narHash": "sha256-prpcUATCGnIbh2FaHiKBV/sS+agUtzU2IAt+VTdKRVk=",
+        "lastModified": 1710229638,
+        "narHash": "sha256-9ulYA+afBuWoRizUHJlX90wFHmByMLd0wnjKIaG5sfQ=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "434ad8453dffd81b91fddc0d68fb65d9bc5d5059",
+        "rev": "fbd27899482c1b61861b96b31e299bf0027c820f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                         |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`f0688645`](https://github.com/nix-community/srvos/commit/f0688645adb8e9e90039e955d6ec750eacfee4cc) | `` build(deps): bump cachix/install-nix-action from 25 to 26 `` |