### PR TITLE
chore(flake/nur): `5dfa1588` -> `7056fa27`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710192140,
-        "narHash": "sha256-SkXL3suPyLPmaAOc5YpcxL/4z3BhX1/vmM511sF4sg8=",
+        "lastModified": 1710197080,
+        "narHash": "sha256-OE9EhdJC0RBBojUOEdoBoad5ondDIUHD0wTy64kU908=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5dfa15884c8d74d16e42124b48150461e25cf694",
+        "rev": "7056fa2747edbd5652bc570bc3ad913c9871ab4e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7056fa27`](https://github.com/nix-community/NUR/commit/7056fa2747edbd5652bc570bc3ad913c9871ab4e) | `` automatic update `` |
| [`31827c41`](https://github.com/nix-community/NUR/commit/31827c411943b01542feec69a1924fbbe72f703e) | `` automatic update `` |