### PR TITLE
chore(flake/nur): `7056fa27` -> `c985f1fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710197080,
-        "narHash": "sha256-OE9EhdJC0RBBojUOEdoBoad5ondDIUHD0wTy64kU908=",
+        "lastModified": 1710200659,
+        "narHash": "sha256-6hAD7+r9hQOFeeNRd5xIHoF7b/K2n3ns97f5c6QdYiQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7056fa2747edbd5652bc570bc3ad913c9871ab4e",
+        "rev": "c985f1fe15821fe58e9a2f82393e2eb9da5c1dea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c985f1fe`](https://github.com/nix-community/NUR/commit/c985f1fe15821fe58e9a2f82393e2eb9da5c1dea) | `` automatic update `` |
| [`75d601b3`](https://github.com/nix-community/NUR/commit/75d601b37460b3e8ded620f983a7113925f36bd4) | `` automatic update `` |