### PR TITLE
chore(flake/emacs-overlay): `30fdb303` -> `68478abb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710176745,
-        "narHash": "sha256-3Av9cY2xw8Lbq56o23uKwYbbrjH4We0SqveKNejlHpU=",
+        "lastModified": 1710204993,
+        "narHash": "sha256-r17NKPl3mea+HzSY3+zm1CzLM6fMXDhsyevwNAq4OLM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "30fdb303a64d5fcbbaf0609b75d3c9c783af7869",
+        "rev": "68478abbc2484dc059e797de119bebe46910aa32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`68478abb`](https://github.com/nix-community/emacs-overlay/commit/68478abbc2484dc059e797de119bebe46910aa32) | `` Updated elpa `` |