### PR TITLE
chore(flake/nur): `c985f1fe` -> `616b45bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710200659,
-        "narHash": "sha256-6hAD7+r9hQOFeeNRd5xIHoF7b/K2n3ns97f5c6QdYiQ=",
+        "lastModified": 1710204499,
+        "narHash": "sha256-CZQMWQgE7Z8PEXzXanx4Zn30mQPMGhVQUqXSAnAMe9w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c985f1fe15821fe58e9a2f82393e2eb9da5c1dea",
+        "rev": "616b45bbd00efb0812409a8669c43d32cebf3f42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`616b45bb`](https://github.com/nix-community/NUR/commit/616b45bbd00efb0812409a8669c43d32cebf3f42) | `` automatic update `` |
| [`862a50af`](https://github.com/nix-community/NUR/commit/862a50af0d86c34d4c6c96ef11f6c325f6c94363) | `` automatic update `` |