### PR TITLE
chore(flake/emacs-overlay): `68478abb` -> `7e07cbc3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710204993,
-        "narHash": "sha256-r17NKPl3mea+HzSY3+zm1CzLM6fMXDhsyevwNAq4OLM=",
+        "lastModified": 1710206972,
+        "narHash": "sha256-W0W7meJTRzcbocv0eZXvnSHoGUGl13eSJQH8KkhI0Cs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "68478abbc2484dc059e797de119bebe46910aa32",
+        "rev": "7e07cbc381897f0090e12cb9f442cedb10d94360",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`7e07cbc3`](https://github.com/nix-community/emacs-overlay/commit/7e07cbc381897f0090e12cb9f442cedb10d94360) | `` Updated melpa `` |