### PR TITLE
chore(flake/nur): `616b45bb` -> `aeff6caf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710204499,
-        "narHash": "sha256-CZQMWQgE7Z8PEXzXanx4Zn30mQPMGhVQUqXSAnAMe9w=",
+        "lastModified": 1710213932,
+        "narHash": "sha256-wLVlSzFd51BaRTIDPYHLEVY5gIRISe/LRKV6Qcf+Ft8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "616b45bbd00efb0812409a8669c43d32cebf3f42",
+        "rev": "c5602255b1627dd68f69fc4c75ccf06f7be6e81c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aeff6caf`](https://github.com/nix-community/NUR/commit/aeff6caf894d6d11936d1c12bf8454e33a1bed7a) | `` automatic update `` |