### PR TITLE
chore(flake/nur): `c5602255` -> `ae0ed8a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710213932,
-        "narHash": "sha256-wLVlSzFd51BaRTIDPYHLEVY5gIRISe/LRKV6Qcf+Ft8=",
+        "lastModified": 1710218311,
+        "narHash": "sha256-pOXlmYFL3fG0jqJmIotlObqMLddgmRtZobrPU9W7/3I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c5602255b1627dd68f69fc4c75ccf06f7be6e81c",
+        "rev": "ae0ed8a370108406593cc386f65a7c9fc7546eb1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ae0ed8a3`](https://github.com/nix-community/NUR/commit/ae0ed8a370108406593cc386f65a7c9fc7546eb1) | `` automatic update `` |
| [`9b397aa5`](https://github.com/nix-community/NUR/commit/9b397aa50605344ca9744236b46792071a88f49e) | `` automatic update `` |