### PR TITLE
chore(flake/nur): `4bb4d7c9` -> `de8ad2d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710230162,
-        "narHash": "sha256-LpJB6eSTqfzFuaCYFiXRzsQ5V/Ji7L7LTToHiCKTcwM=",
+        "lastModified": 1710232777,
+        "narHash": "sha256-VrgKQf6q3R6J8t0nl69lKfJTS3/KC9oBGdlessfFuXA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4bb4d7c96eb12e7d107737ed77576c119d99b73d",
+        "rev": "de8ad2d078986ba191d2c4f91e5a46061dd8d76a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`de8ad2d0`](https://github.com/nix-community/NUR/commit/de8ad2d078986ba191d2c4f91e5a46061dd8d76a) | `` automatic update `` |
| [`40d05422`](https://github.com/nix-community/NUR/commit/40d054225eb08223c24d9a8e67f17ee2f731bf73) | `` automatic update `` |
| [`df62a02c`](https://github.com/nix-community/NUR/commit/df62a02c9ce8eceaf59eb995db99fd721187ea24) | `` automatic update `` |