### PR TITLE
chore(flake/nur): `78ba4a9a` -> `2004e022`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710236998,
-        "narHash": "sha256-3AoOoBL2byA1u3NS6pfOLn9XO0CiEecQsjNej/sovWg=",
+        "lastModified": 1710248086,
+        "narHash": "sha256-fD3JB80kJ6oGt5ensxoL9UYRZ7BrkKi+sfCvKLJfWKM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "78ba4a9ab94f16f6431426fb2509f6a876300024",
+        "rev": "825b348f07d89830d945cfe9a7a37f26d39db2ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2004e022`](https://github.com/nix-community/NUR/commit/2004e022f22629ab1bb4056bf02f1e7cd46e9463) | `` automatic update `` |