### PR TITLE
chore(flake/nur): `9ce1c995` -> `92151b1e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710261592,
-        "narHash": "sha256-hqKA5jN911VQU/Z6ssK+g802L4W/MUU6YJD8NVAAChg=",
+        "lastModified": 1710265496,
+        "narHash": "sha256-E+zrgtnKpFan7TvIdPS+pGn2Qb42bXlKDn66DpUPjQo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ce1c9956cbb50e4e753accc062251508e6c1dc9",
+        "rev": "92151b1ee2b0e717c66e26c54adc9258145f6992",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`92151b1e`](https://github.com/nix-community/NUR/commit/92151b1ee2b0e717c66e26c54adc9258145f6992) | `` automatic update `` |