### PR TITLE
chore(flake/nur): `92151b1e` -> `5b7b25cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710265496,
-        "narHash": "sha256-E+zrgtnKpFan7TvIdPS+pGn2Qb42bXlKDn66DpUPjQo=",
+        "lastModified": 1710268474,
+        "narHash": "sha256-5c+7dcsXd5b3Rw5WTr8pkWhpT4fO0bAjmoz3YLhZor0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "92151b1ee2b0e717c66e26c54adc9258145f6992",
+        "rev": "5b7b25cbbce0e39b692d98eb42bd97d01568c519",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5b7b25cb`](https://github.com/nix-community/NUR/commit/5b7b25cbbce0e39b692d98eb42bd97d01568c519) | `` automatic update `` |
| [`15e85f5d`](https://github.com/nix-community/NUR/commit/15e85f5df6676e15420f5323c953aab6943fa5cf) | `` automatic update `` |