### PR TITLE
chore(flake/nur): `b221a8e8` -> `4830333e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710276687,
-        "narHash": "sha256-S53VF0PA1pTz87oi3NKID7BnOqUFrKOflLXA/9DL46M=",
+        "lastModified": 1710280846,
+        "narHash": "sha256-/AkmEniFdMNic22FBW73yKIuPTfm8R76KDOyeUe1OAY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b221a8e8493458bf33a754d86970bc656fdc43cc",
+        "rev": "4830333e7fede2aaa910079a50a9fe60ba6a836b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4830333e`](https://github.com/nix-community/NUR/commit/4830333e7fede2aaa910079a50a9fe60ba6a836b) | `` automatic update `` |