### PR TITLE
chore(flake/nur): `4830333e` -> `3ded995b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710280846,
-        "narHash": "sha256-/AkmEniFdMNic22FBW73yKIuPTfm8R76KDOyeUe1OAY=",
+        "lastModified": 1710283548,
+        "narHash": "sha256-8Zh4mgDCHrIK9K+D2AHhIsoGdnSbEAWKJVQW9UE1VMI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4830333e7fede2aaa910079a50a9fe60ba6a836b",
+        "rev": "3ded995b7d4963ac49052e13e339623df1ad5406",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3ded995b`](https://github.com/nix-community/NUR/commit/3ded995b7d4963ac49052e13e339623df1ad5406) | `` automatic update `` |
| [`f1e91448`](https://github.com/nix-community/NUR/commit/f1e914489134d8c8b2b8d7e80bed62ad85337d11) | `` automatic update `` |
| [`5f319cc0`](https://github.com/nix-community/NUR/commit/5f319cc0adcc7f843cd436bd19a5bee8271915d4) | `` automatic update `` |
| [`e62c095b`](https://github.com/nix-community/NUR/commit/e62c095b1a0e2dac3df7628414bd3032bedf130d) | `` automatic update `` |