### PR TITLE
chore(flake/nur): `3ded995b` -> `b8d6b7a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710283548,
-        "narHash": "sha256-8Zh4mgDCHrIK9K+D2AHhIsoGdnSbEAWKJVQW9UE1VMI=",
+        "lastModified": 1710289680,
+        "narHash": "sha256-MaoIQ0Anvh7cX5MJMYZYS16ymGF7l9lJyaekLV0nL4s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3ded995b7d4963ac49052e13e339623df1ad5406",
+        "rev": "b8d6b7a4de536ccfede2c447f21e2f951aa288ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b8d6b7a4`](https://github.com/nix-community/NUR/commit/b8d6b7a4de536ccfede2c447f21e2f951aa288ba) | `` automatic update `` |