### PR TITLE
chore(flake/emacs-overlay): `383aeb1b` -> `ca5deb0f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710263223,
-        "narHash": "sha256-Z19hPhLUwF5M8FQdBuSH+/GDCdWzr5FPDHN+Cbk1/0Q=",
+        "lastModified": 1710294321,
+        "narHash": "sha256-h24aWEjBi1VqC+XsCsP7dEd8+uZP380zDZjHgMV8aa8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "383aeb1bf3e2fdf14e7b1b66a35123228d7a0edb",
+        "rev": "69e03a148e6c604aed3579d81989aabccbba4d67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`ca5deb0f`](https://github.com/nix-community/emacs-overlay/commit/ca5deb0fc98adf4dfcb9ca0dfdb6ca203ac7f95e) | `` Updated elpa `` |