### PR TITLE
chore(flake/nur): `b8d6b7a4` -> `03919f39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710289680,
-        "narHash": "sha256-MaoIQ0Anvh7cX5MJMYZYS16ymGF7l9lJyaekLV0nL4s=",
+        "lastModified": 1710293912,
+        "narHash": "sha256-Bhxi3UMA4DIa7i9VJ0onrbhaKZGKulkz9sVd4pSqiXo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b8d6b7a4de536ccfede2c447f21e2f951aa288ba",
+        "rev": "03919f394bdf8cb0ab1c545be65e61dfaa66272d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`03919f39`](https://github.com/nix-community/NUR/commit/03919f394bdf8cb0ab1c545be65e61dfaa66272d) | `` automatic update `` |