### PR TITLE
chore(flake/nur): `03919f39` -> `3dcbe5cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710293912,
-        "narHash": "sha256-Bhxi3UMA4DIa7i9VJ0onrbhaKZGKulkz9sVd4pSqiXo=",
+        "lastModified": 1710301061,
+        "narHash": "sha256-rCrmUvOkQi45yiTFYIwxYvN272TZ+9wcjuxDOT/ShqI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "03919f394bdf8cb0ab1c545be65e61dfaa66272d",
+        "rev": "3dcbe5cc318d14ca1813632214492ad97d24dcc4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3dcbe5cc`](https://github.com/nix-community/NUR/commit/3dcbe5cc318d14ca1813632214492ad97d24dcc4) | `` automatic update `` |
| [`80a03134`](https://github.com/nix-community/NUR/commit/80a03134ec813df4ebefabe9e7116c97bb12d978) | `` automatic update `` |
| [`50f12d30`](https://github.com/nix-community/NUR/commit/50f12d30938fff4ed6f782247576fa265400d145) | `` automatic update `` |
| [`f2345cff`](https://github.com/nix-community/NUR/commit/f2345cfffd7a2c319c70702b9c561bb8b7bfb94e) | `` automatic update `` |