### PR TITLE
chore(flake/nur): `3dcbe5cc` -> `762cc781`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710301061,
-        "narHash": "sha256-rCrmUvOkQi45yiTFYIwxYvN272TZ+9wcjuxDOT/ShqI=",
+        "lastModified": 1710303092,
+        "narHash": "sha256-SZ+WcNc1PpCl4OYEKCss1Nahv45SigYx2BLP4mEbZH8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3dcbe5cc318d14ca1813632214492ad97d24dcc4",
+        "rev": "762cc7811c582d5d8adcc13430c1f443e3ac6a0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`762cc781`](https://github.com/nix-community/NUR/commit/762cc7811c582d5d8adcc13430c1f443e3ac6a0f) | `` automatic update `` |