### PR TITLE
chore(flake/nur): `762cc781` -> `97529887`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710303092,
-        "narHash": "sha256-SZ+WcNc1PpCl4OYEKCss1Nahv45SigYx2BLP4mEbZH8=",
+        "lastModified": 1710312022,
+        "narHash": "sha256-sQFQFO38V2lUMVKEY7bHBveb/nWxjVhD6wmnE6zIOus=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "762cc7811c582d5d8adcc13430c1f443e3ac6a0f",
+        "rev": "975298874399cb1b519af4abf178e5c388eae149",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`97529887`](https://github.com/nix-community/NUR/commit/975298874399cb1b519af4abf178e5c388eae149) | `` automatic update `` |