### PR TITLE
chore(flake/nur): `97529887` -> `e25e13d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710312022,
-        "narHash": "sha256-sQFQFO38V2lUMVKEY7bHBveb/nWxjVhD6wmnE6zIOus=",
+        "lastModified": 1710314185,
+        "narHash": "sha256-jRWuUk4F0ux7U2U1HwO24TyheNlBWAzMPm6tJKtiRd0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "975298874399cb1b519af4abf178e5c388eae149",
+        "rev": "e25e13d3c010e9e1e55df9e7756df9ab06a67ece",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e25e13d3`](https://github.com/nix-community/NUR/commit/e25e13d3c010e9e1e55df9e7756df9ab06a67ece) | `` automatic update `` |