### PR TITLE
chore(flake/emacs-overlay): `69e03a14` -> `9b66dbef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710294321,
-        "narHash": "sha256-h24aWEjBi1VqC+XsCsP7dEd8+uZP380zDZjHgMV8aa8=",
+        "lastModified": 1710320774,
+        "narHash": "sha256-TrLaYznIzUGy4vIRw4hDDlOKuF/vDD1J49cLtkxvgAI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "69e03a148e6c604aed3579d81989aabccbba4d67",
+        "rev": "c68aeff603f1b5c4cc7a57b876cf5e7101f2f21c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`9b66dbef`](https://github.com/nix-community/emacs-overlay/commit/9b66dbef5285b09ceebc337c76dc498e077c6a1f) | `` Updated melpa ``        |
| [`cfb8d4a7`](https://github.com/nix-community/emacs-overlay/commit/cfb8d4a721073302d61539010ff04b91d5031689) | `` Updated flake inputs `` |