### PR TITLE
chore(flake/nur): `e25e13d3` -> `e3ca1bd4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710314185,
-        "narHash": "sha256-jRWuUk4F0ux7U2U1HwO24TyheNlBWAzMPm6tJKtiRd0=",
+        "lastModified": 1710317965,
+        "narHash": "sha256-XsumRdRnryHdyzKMxXFhI7FXp0JCksDr19S96jG5fCI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e25e13d3c010e9e1e55df9e7756df9ab06a67ece",
+        "rev": "e3ca1bd405762320da4c8808acc724b89dbe5edd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e3ca1bd4`](https://github.com/nix-community/NUR/commit/e3ca1bd405762320da4c8808acc724b89dbe5edd) | `` automatic update `` |
| [`3371977b`](https://github.com/nix-community/NUR/commit/3371977b16b3e5afdef48a9fa15edb7b0c3c96a2) | `` automatic update `` |