### PR TITLE
chore(flake/nur): `e3ca1bd4` -> `04ef2532`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710317965,
-        "narHash": "sha256-XsumRdRnryHdyzKMxXFhI7FXp0JCksDr19S96jG5fCI=",
+        "lastModified": 1710322390,
+        "narHash": "sha256-1NyfRrZSwoN9LR3Zmg8mCg0Rvz3okzkW1x+1NcHy/ys=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e3ca1bd405762320da4c8808acc724b89dbe5edd",
+        "rev": "04ef253223c652b1ac198e205ef15d94bc7ac44c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`04ef2532`](https://github.com/nix-community/NUR/commit/04ef253223c652b1ac198e205ef15d94bc7ac44c) | `` automatic update `` |