### PR TITLE
chore(flake/srvos): `fbd27899` -> `640f83f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -994,11 +994,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710229638,
-        "narHash": "sha256-9ulYA+afBuWoRizUHJlX90wFHmByMLd0wnjKIaG5sfQ=",
+        "lastModified": 1710324536,
+        "narHash": "sha256-51Lyisz7k2zssV/H63MLdRAfpOpxvJynaYvhg+qoalo=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "fbd27899482c1b61861b96b31e299bf0027c820f",
+        "rev": "640f83f6eb110cc51b75b93a9e36edb0713f64e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                               |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`640f83f6`](https://github.com/nix-community/srvos/commit/640f83f6eb110cc51b75b93a9e36edb0713f64e3) | `` docs: advise bare metal or KVM support for Github Runner (#397) `` |