### PR TITLE
chore(flake/nur): `442dba48` -> `4387a223`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710326699,
-        "narHash": "sha256-YPQSBzfHqXpSbgtyJ3z/7vegpYyxW9wvGy/WvRQy1t4=",
+        "lastModified": 1710329715,
+        "narHash": "sha256-IJTQMXs/cX85T7zceYNv0A2bNacvj+ETwW5CRCa2P+w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "442dba488e7def464331fb16a3d06a1a6b50f31b",
+        "rev": "4387a223e07e14658c654056cbe101623b17f79a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4387a223`](https://github.com/nix-community/NUR/commit/4387a223e07e14658c654056cbe101623b17f79a) | `` automatic update `` |