### PR TITLE
chore(flake/nur): `4387a223` -> `83e8ff3a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710329715,
-        "narHash": "sha256-IJTQMXs/cX85T7zceYNv0A2bNacvj+ETwW5CRCa2P+w=",
+        "lastModified": 1710337555,
+        "narHash": "sha256-42PBwWzEf4PfCEMSg5AOFs1OiC4ZMCvSeoS82OAt6Z0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4387a223e07e14658c654056cbe101623b17f79a",
+        "rev": "83e8ff3a4bb59a6bc5ea7cb565b49ed363f1054a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`83e8ff3a`](https://github.com/nix-community/NUR/commit/83e8ff3a4bb59a6bc5ea7cb565b49ed363f1054a) | `` automatic update `` |
| [`54a5aaaf`](https://github.com/nix-community/NUR/commit/54a5aaaf6f92201300fa548ff04de492b53e5fdb) | `` automatic update `` |