### PR TITLE
chore(flake/nur): `83e8ff3a` -> `17d59e26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710337555,
-        "narHash": "sha256-42PBwWzEf4PfCEMSg5AOFs1OiC4ZMCvSeoS82OAt6Z0=",
+        "lastModified": 1710340943,
+        "narHash": "sha256-rrZ/5DITmeqHelwROyhVP7i1BWoIeVM+DJzFTax/xwE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "83e8ff3a4bb59a6bc5ea7cb565b49ed363f1054a",
+        "rev": "17d59e267fdb5c4047a908fc3ec3c34a85f205eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`17d59e26`](https://github.com/nix-community/NUR/commit/17d59e267fdb5c4047a908fc3ec3c34a85f205eb) | `` automatic update `` |
| [`3e6d2707`](https://github.com/nix-community/NUR/commit/3e6d2707d6335cc79cf2970c5f340da695efc0f7) | `` automatic update `` |