### PR TITLE
chore(flake/nur): `17d59e26` -> `11ffc0e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710340943,
-        "narHash": "sha256-rrZ/5DITmeqHelwROyhVP7i1BWoIeVM+DJzFTax/xwE=",
+        "lastModified": 1710348293,
+        "narHash": "sha256-0HOpOrqPuGTc1SFJkU3aC9MRzshFQ5ESJxmNy94MpOg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "17d59e267fdb5c4047a908fc3ec3c34a85f205eb",
+        "rev": "11ffc0e4b7b007f1a73c52f8af157044897509d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`11ffc0e4`](https://github.com/nix-community/NUR/commit/11ffc0e4b7b007f1a73c52f8af157044897509d1) | `` automatic update `` |