### PR TITLE
chore(flake/nur): `11ffc0e4` -> `f444c64b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710348293,
-        "narHash": "sha256-0HOpOrqPuGTc1SFJkU3aC9MRzshFQ5ESJxmNy94MpOg=",
+        "lastModified": 1710350617,
+        "narHash": "sha256-6Qep6jSOMmp7z9ARf7pB6/5RgT/uoJ3QhGm9OGJz1cc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "11ffc0e4b7b007f1a73c52f8af157044897509d1",
+        "rev": "f444c64b3f5343be91f36c76fa599ab1948e7a3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f444c64b`](https://github.com/nix-community/NUR/commit/f444c64b3f5343be91f36c76fa599ab1948e7a3a) | `` automatic update `` |