### PR TITLE
chore(flake/nur): `1afb6fba` -> `62869a31`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710355483,
-        "narHash": "sha256-MGYdTEctVmP19adfwmRQ6MrYLdkZIDsZq9pb7yD6dGc=",
+        "lastModified": 1710366270,
+        "narHash": "sha256-6XBd8zoz2oR5ooymyHudSuS0lWq9dDwJdkp9PAkBY04=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1afb6fbae070378ea90fcb289a5e13e355a172a1",
+        "rev": "62869a318b06e1205996b321ab70e570c38bc846",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`62869a31`](https://github.com/nix-community/NUR/commit/62869a318b06e1205996b321ab70e570c38bc846) | `` automatic update `` |