### PR TITLE
chore(flake/nur): `62869a31` -> `6f660129`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710366270,
-        "narHash": "sha256-6XBd8zoz2oR5ooymyHudSuS0lWq9dDwJdkp9PAkBY04=",
+        "lastModified": 1710373977,
+        "narHash": "sha256-6HldoE1b8nRRF4EfzbX3iYROi5eCQfbwAN03kP+XFfU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "62869a318b06e1205996b321ab70e570c38bc846",
+        "rev": "6f66012960027795d8ea5e1b9cd5adff9e814de3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6f660129`](https://github.com/nix-community/NUR/commit/6f66012960027795d8ea5e1b9cd5adff9e814de3) | `` automatic update `` |
| [`19c6344e`](https://github.com/nix-community/NUR/commit/19c6344eb398387a6ecf1d62a1526a0664277b43) | `` automatic update `` |
| [`dbc008cf`](https://github.com/nix-community/NUR/commit/dbc008cf8837db599848d1fa3e65500d46fdb7e4) | `` automatic update `` |