### PR TITLE
chore(flake/emacs-overlay): `70d8a682` -> `ab8d51e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710349542,
-        "narHash": "sha256-3UAFrBdH3RnceKO1dUPpZio7oO0NIl88o0XyMoBcqz8=",
+        "lastModified": 1710380673,
+        "narHash": "sha256-skyx88rHqdUjK2tkIlDUbpIAoXYKPZl/WjOQzGcmGOM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "70d8a682934e97ef4a76630678ecf76ab9b08380",
+        "rev": "2be142e8ad86fd395ad4738e2aa66886592db930",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`ab8d51e7`](https://github.com/nix-community/emacs-overlay/commit/ab8d51e727e7b1caafb11dc378ec9c3ec417dc15) | `` Updated elpa ``   |
| [`2587b8bc`](https://github.com/nix-community/emacs-overlay/commit/2587b8bcc1c54aa24452d2280364d10099109725) | `` Updated nongnu `` |