### PR TITLE
chore(flake/srvos): `640f83f6` -> `224e1cff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -994,11 +994,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710324536,
-        "narHash": "sha256-51Lyisz7k2zssV/H63MLdRAfpOpxvJynaYvhg+qoalo=",
+        "lastModified": 1710377268,
+        "narHash": "sha256-pQohZXgvVPhogkTOGUIGegWdHCXHFTh4xRkrpyZ6kLs=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "640f83f6eb110cc51b75b93a9e36edb0713f64e3",
+        "rev": "224e1cff5e392d15c5f9d9b6fbcf7ea687144b29",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`224e1cff`](https://github.com/nix-community/srvos/commit/224e1cff5e392d15c5f9d9b6fbcf7ea687144b29) | `` dev/private/flake.lock: Update `` |
| [`12a233c8`](https://github.com/nix-community/srvos/commit/12a233c8352ff2ad3aaffc7a7f697b202d05aa1d) | `` flake.lock: Update ``             |