### PR TITLE
chore(flake/nur): `944f7d5b` -> `01d67f73`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710378825,
-        "narHash": "sha256-OWiv8dIP7kboyWsR50Ir9aMgQXS2Q7sNbv2Rk0zUf5g=",
+        "lastModified": 1710381124,
+        "narHash": "sha256-Gcmkki3WO7wjaK6bsLR5XI2cfdjLAHedGq2mKldBYZg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "944f7d5bddfdc0187c22de62fbabd23cad431190",
+        "rev": "01d67f7387055d9652e2d605dc75e56b35441f9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`01d67f73`](https://github.com/nix-community/NUR/commit/01d67f7387055d9652e2d605dc75e56b35441f9a) | `` automatic update `` |
| [`02423677`](https://github.com/nix-community/NUR/commit/02423677fb1a9e03d498d01f4d68529babb38ba4) | `` automatic update `` |