### PR TITLE
chore(flake/nur): `01d67f73` -> `32bab95d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710381124,
-        "narHash": "sha256-Gcmkki3WO7wjaK6bsLR5XI2cfdjLAHedGq2mKldBYZg=",
+        "lastModified": 1710389984,
+        "narHash": "sha256-dgyBPkTmgZwipRrR4s7ZL7AGU+2VUb+SLdWU3nTIFhU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "01d67f7387055d9652e2d605dc75e56b35441f9a",
+        "rev": "a26506f4e86f57d0262cd9603f53d1e2f7ebee64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`32bab95d`](https://github.com/nix-community/NUR/commit/32bab95d15898bbf950e2983ee5acc6091fa3acd) | `` automatic update `` |
| [`91019c27`](https://github.com/nix-community/NUR/commit/91019c27dc0e3e57f5def1c216a8a5da293c901e) | `` automatic update `` |
| [`39728f40`](https://github.com/nix-community/NUR/commit/39728f409462ed9ab6b66444758765d672dcfb3a) | `` automatic update `` |