### PR TITLE
chore(flake/nur): `576dc6b3` -> `ed1845e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710401724,
-        "narHash": "sha256-B+iWYyO7R0uTu+3hKBgVLeJNFhkZZfGsWd1EwKvxHHw=",
+        "lastModified": 1710405935,
+        "narHash": "sha256-6UtlVbu/AmxQBaLpxhwNmottoQsAqcr9Jr6xy/3dbic=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "576dc6b324b2f9188fdfd3197d0622fcde5f27ee",
+        "rev": "ed1845e43a6f2b25ec16895f92678832e7f2cf17",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ed1845e4`](https://github.com/nix-community/NUR/commit/ed1845e43a6f2b25ec16895f92678832e7f2cf17) | `` automatic update `` |
| [`4e1bacc8`](https://github.com/nix-community/NUR/commit/4e1bacc872c6a06fe5952c95486423181492e815) | `` automatic update `` |
| [`a8081266`](https://github.com/nix-community/NUR/commit/a808126641d571ed5fe8c95f78cfa4fff18ac60f) | `` automatic update `` |
| [`4c5351b2`](https://github.com/nix-community/NUR/commit/4c5351b2ea90ccf55c3b6ef5d37c6eb2ccf30ae3) | `` automatic update `` |