### PR TITLE
chore(flake/sops-nix): `e52d8117` -> `804157eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -974,11 +974,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1710195194,
-        "narHash": "sha256-KFxCJp0T6TJOz1IOKlpRdpsCr9xsvlVuWY/VCiAFnTE=",
+        "lastModified": 1710433464,
+        "narHash": "sha256-IXlPoWgIRovZ32mYvqqdBgOQln71LouE/HBhbKc1wcw=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "e52d8117b330f690382f1d16d81ae43daeb4b880",
+        "rev": "6c32d3b9c7593f4b466ec5404e59fc09a803a090",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`804157eb`](https://github.com/Mic92/sops-nix/commit/804157eb75a4312df25a9a144d3807c40ade72b6) | `` update vendorHash ``                                           |
| [`1385b12f`](https://github.com/Mic92/sops-nix/commit/1385b12fb3fe95fcb5bd81c46e9aa0311d466599) | `` build(deps): bump golang.org/x/crypto from 0.20.0 to 0.21.0 `` |
| [`7f015eef`](https://github.com/Mic92/sops-nix/commit/7f015eeff10532b0c3aae1b6fe0c5d348bede5fe) | `` modules/sops: fix typo ``                                      |