### PR TITLE
chore(flake/nur): `46ad8f60` -> `c126d72d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710420799,
-        "narHash": "sha256-P/wnPkUy37kpu4IWLDEGPqhEan+ye863RjT//jM+IC8=",
+        "lastModified": 1710428301,
+        "narHash": "sha256-cFOOucrx9WKI5unN3fBJhsQ8fsWA+iZPjPNYWcMWarY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "46ad8f604d6a7ae9b8ca70ab2a94584e25848b9d",
+        "rev": "c126d72dfedc7ea419cb382a5411c16dd20a5e18",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c126d72d`](https://github.com/nix-community/NUR/commit/c126d72dfedc7ea419cb382a5411c16dd20a5e18) | `` automatic update `` |
| [`ef7f6cb3`](https://github.com/nix-community/NUR/commit/ef7f6cb3b934a7dd9c70d9580346d44cd145fda7) | `` automatic update `` |