### PR TITLE
chore(flake/emacs-overlay): `33414e0b` -> `c00e6807`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710407148,
-        "narHash": "sha256-NLvfHkuk2owV8NUcOVd6FjL2sebn/lFVpMwGKRJ2AVo=",
+        "lastModified": 1710435979,
+        "narHash": "sha256-XZAhasQ1JnBxItSdzyBe+DGodG6+GGue1llIX7g8KK8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "33414e0b88fe7408884b4542b86818397d9fe44c",
+        "rev": "c1b23815c2e28419e9fadbd254c5bdd47cc6707d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`c00e6807`](https://github.com/nix-community/emacs-overlay/commit/c00e68074c8782f2e7befe496a7c5e0fbf9ce76b) | `` Updated melpa `` |
| [`5bad4af0`](https://github.com/nix-community/emacs-overlay/commit/5bad4af097f771c2329f4806a4828cac76dcb444) | `` Updated elpa ``  |