### PR TITLE
chore(flake/nix-on-droid): `7b3cc6e3` -> `2d93311c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -616,11 +616,11 @@
         "nmd": "nmd_2"
       },
       "locked": {
-        "lastModified": 1709879753,
-        "narHash": "sha256-zEpy3eweBus/cW/oRMBINps6Bnlazpa7TadonwWibHA=",
+        "lastModified": 1710434231,
+        "narHash": "sha256-yrWnsG28518tbIapJWiluweHORuuIwAQrA8lga0Sqlw=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "7b3cc6e3f9919b2d23003cfafb60c146c3f45793",
+        "rev": "2d93311c4f3f300154d2085e4b4b1d550237da92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`2d93311c`](https://github.com/nix-community/nix-on-droid/commit/2d93311c4f3f300154d2085e4b4b1d550237da92) | `` add a few more useful commands for easier onboarding `` |