### PR TITLE
chore(flake/nur): `c126d72d` -> `44f86a7b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710428301,
-        "narHash": "sha256-cFOOucrx9WKI5unN3fBJhsQ8fsWA+iZPjPNYWcMWarY=",
+        "lastModified": 1710435416,
+        "narHash": "sha256-kKDcKvwFFMDiz5LYc6OCYlRqIgqw9iReuYGW1HnTI+g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c126d72dfedc7ea419cb382a5411c16dd20a5e18",
+        "rev": "44f86a7b47bdc0aeb631b1949f3021103589e416",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`44f86a7b`](https://github.com/nix-community/NUR/commit/44f86a7b47bdc0aeb631b1949f3021103589e416) | `` automatic update `` |
| [`534deb27`](https://github.com/nix-community/NUR/commit/534deb270631282d7e56be3141ff71286ec7928f) | `` automatic update `` |
| [`18cdbd1f`](https://github.com/nix-community/NUR/commit/18cdbd1f8243d841d818bef2e6b86cf9d8122faa) | `` automatic update `` |