### PR TITLE
chore(flake/nur): `529739ac` -> `8f3afff4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710439513,
-        "narHash": "sha256-G6P1keng/uIlpqbjwuZl4Z0QJzNv8k7c0PXT8p6rtVE=",
+        "lastModified": 1710447917,
+        "narHash": "sha256-JWz0FzTeXEs6GgxsPDAysCWEZdrp/ln4T/NU9MHF3BM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "529739acaedfa22ee119b902c3b82f93ad68abee",
+        "rev": "8f3afff4f434c7d8547c837bf94b173e2c22b25e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8f3afff4`](https://github.com/nix-community/NUR/commit/8f3afff4f434c7d8547c837bf94b173e2c22b25e) | `` automatic update `` |
| [`96aae2a0`](https://github.com/nix-community/NUR/commit/96aae2a09c8d3ba0981124b06a7a39773e63c9e0) | `` automatic update `` |