### PR TITLE
chore(flake/nur): `8f3afff4` -> `f3e47f0f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710447917,
-        "narHash": "sha256-JWz0FzTeXEs6GgxsPDAysCWEZdrp/ln4T/NU9MHF3BM=",
+        "lastModified": 1710453512,
+        "narHash": "sha256-GZQ2BBdAuYlf9GtxuKvoLG7LiUR97hggvsHwWzKBOyo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8f3afff4f434c7d8547c837bf94b173e2c22b25e",
+        "rev": "f3e47f0f8bb71175b7474aae6318efb61a0d4701",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f3e47f0f`](https://github.com/nix-community/NUR/commit/f3e47f0f8bb71175b7474aae6318efb61a0d4701) | `` automatic update `` |
| [`1888dde6`](https://github.com/nix-community/NUR/commit/1888dde60893b98cf95c5e51c53c9571294dbf06) | `` automatic update `` |