### PR TITLE
chore(flake/nur): `f3e47f0f` -> `25e2f672`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710453512,
-        "narHash": "sha256-GZQ2BBdAuYlf9GtxuKvoLG7LiUR97hggvsHwWzKBOyo=",
+        "lastModified": 1710454985,
+        "narHash": "sha256-7BjB5Bco+btNQA6fsZCoT+m04np1XJQtgrgY/dD0cBM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f3e47f0f8bb71175b7474aae6318efb61a0d4701",
+        "rev": "25e2f6726e0bc6bd9c08a89453713abcba3459f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`25e2f672`](https://github.com/nix-community/NUR/commit/25e2f6726e0bc6bd9c08a89453713abcba3459f1) | `` automatic update `` |
| [`b3769d16`](https://github.com/nix-community/NUR/commit/b3769d169eb67ef396044a10bc685c54facdf00a) | `` automatic update `` |