### PR TITLE
chore(flake/emacs-overlay): `218be052` -> `45dcc834`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710464277,
-        "narHash": "sha256-LjOQls6xvqcxdnbgmqDpElrLUmUIOrSqgs0J7cRjSoQ=",
+        "lastModified": 1710467097,
+        "narHash": "sha256-FjrUwzv3wt0W/ekgCgbAdjkShZNUdAEDx/+qLukQFkI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "218be052c69487035e61fea04287da0d17275199",
+        "rev": "45dcc83490fe6befb6c1fd5bacf9ded14cdf0554",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`45dcc834`](https://github.com/nix-community/emacs-overlay/commit/45dcc83490fe6befb6c1fd5bacf9ded14cdf0554) | `` Updated emacs `` |
| [`a257259d`](https://github.com/nix-community/emacs-overlay/commit/a257259d041d08eaa52701a7d4f617d25656ea45) | `` Updated melpa `` |