### PR TITLE
chore(flake/nur): `25e2f672` -> `176a8703`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710454985,
-        "narHash": "sha256-7BjB5Bco+btNQA6fsZCoT+m04np1XJQtgrgY/dD0cBM=",
+        "lastModified": 1710468289,
+        "narHash": "sha256-y6qFdM9ROS6ikrK02aO0WtVbHslSS8j3wg5kRfcE+Uk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "25e2f6726e0bc6bd9c08a89453713abcba3459f1",
+        "rev": "176a87039b3519b079a26fef5cb4d66ffe406840",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`176a8703`](https://github.com/nix-community/NUR/commit/176a87039b3519b079a26fef5cb4d66ffe406840) | `` automatic update `` |