### PR TITLE
chore(flake/nur): `176a8703` -> `ec0543fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710468289,
-        "narHash": "sha256-y6qFdM9ROS6ikrK02aO0WtVbHslSS8j3wg5kRfcE+Uk=",
+        "lastModified": 1710474097,
+        "narHash": "sha256-qZWfh9imuGEMhbLtt9UuTsVLbHafH+AJ0Zzn1YkahVs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "176a87039b3519b079a26fef5cb4d66ffe406840",
+        "rev": "9d592c1a20924d2df81b5adcc2fb7eeabee6ab6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ec0543fc`](https://github.com/nix-community/NUR/commit/ec0543fc9635cf9b178b7cb88b7c9fba3f701ee5) | `` automatic update `` |