### PR TITLE
chore(flake/nur): `fb3db4fd` -> `448de75b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710475858,
-        "narHash": "sha256-ZQcYTr86dSykgeG/iriagcuQrd50Vkg9IbPRizgPwkQ=",
+        "lastModified": 1710481065,
+        "narHash": "sha256-QnqWdUXkv/3y+7ZDf9s/xMHDI1mKGYKqv6j62+0Tc0E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fb3db4fd9d03fda520760dbcf7d13c0b2c5513ea",
+        "rev": "448de75b31ae4a3ac14aaab5e820833eb2c13fe4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`448de75b`](https://github.com/nix-community/NUR/commit/448de75b31ae4a3ac14aaab5e820833eb2c13fe4) | `` automatic update `` |
| [`01c13d5c`](https://github.com/nix-community/NUR/commit/01c13d5c0da63680ed84fa534655395e64df5e0a) | `` automatic update `` |