### PR TITLE
chore(flake/nur): `2a44896d` -> `6f10c0c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710488667,
-        "narHash": "sha256-/OXg3154w8bTnwllYoHb9frNr13PwviMpmO8kcIiJ4E=",
+        "lastModified": 1710491619,
+        "narHash": "sha256-vtMw8iV3jl1LPVFmmZ7AZE8ifqqSTMPG1+FbL32dcEM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2a44896d85da3f9f5909db483796169debf16863",
+        "rev": "6f10c0c70d20b3d3e2824fcfa581a705f0c81d8a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6f10c0c7`](https://github.com/nix-community/NUR/commit/6f10c0c70d20b3d3e2824fcfa581a705f0c81d8a) | `` automatic update `` |