### PR TITLE
chore(flake/nur): `e1d526df` -> `5a2cb69a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710494722,
-        "narHash": "sha256-rjYCRxjuNJYH8/YJ3G3fQsdq17pVIdyH5yMSNDQznBg=",
+        "lastModified": 1710501760,
+        "narHash": "sha256-lU15Z+FB68wDzKAxTRfLYgfs1gqdJSEVSIhdlhpjcOs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e1d526df83b9ef104150b67d89afb4d4c20975d7",
+        "rev": "cab51d43cda0e69f1f385b1755c589e017e236e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5a2cb69a`](https://github.com/nix-community/NUR/commit/5a2cb69a0486e645c3cfc52c9d6ec29b407446c1) | `` automatic update `` |