### PR TITLE
chore(flake/nur): `cab51d43` -> `90155b22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710501760,
-        "narHash": "sha256-lU15Z+FB68wDzKAxTRfLYgfs1gqdJSEVSIhdlhpjcOs=",
+        "lastModified": 1710506669,
+        "narHash": "sha256-9m+oWHbBZi3c7YyiMs5hiOIqCG+WgP1sMA+s60AtWOU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cab51d43cda0e69f1f385b1755c589e017e236e9",
+        "rev": "90155b2212a941712b74575db564c6afd24492b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`90155b22`](https://github.com/nix-community/NUR/commit/90155b2212a941712b74575db564c6afd24492b5) | `` automatic update `` |
| [`caf6f6af`](https://github.com/nix-community/NUR/commit/caf6f6af0f956ade8bf6a17f07b71261c8ed6a62) | `` automatic update `` |
| [`877afca4`](https://github.com/nix-community/NUR/commit/877afca400d31a802be5f0778f66e628eaa7a879) | `` automatic update `` |