### PR TITLE
chore(flake/emacs-overlay): `ee3a92b1` -> `553f68ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710493512,
-        "narHash": "sha256-mqWEpPqxeHYslfmevxx/KwuoZ9uIWjiD+CsdQFW7xsM=",
+        "lastModified": 1710521468,
+        "narHash": "sha256-i6eCBHvyXWn0XPF2TJ/9vMvhEPhXc/fVMTMG78Ajs1s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ee3a92b17a377d2ac2bb8293638f7e87f74953ee",
+        "rev": "553f68ee98a5d36c188f563f4e0851adbc132eda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`553f68ee`](https://github.com/nix-community/emacs-overlay/commit/553f68ee98a5d36c188f563f4e0851adbc132eda) | `` Updated melpa ``        |
| [`7115e70b`](https://github.com/nix-community/emacs-overlay/commit/7115e70bb490c73a00b576b2a7040403e9460a09) | `` Updated elpa ``         |
| [`e32cd426`](https://github.com/nix-community/emacs-overlay/commit/e32cd426fb92d6328a94ce87de87a343ceaac2aa) | `` Updated flake inputs `` |