### PR TITLE
chore(flake/emacs-overlay): `553f68ee` -> `28c564cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710521468,
-        "narHash": "sha256-i6eCBHvyXWn0XPF2TJ/9vMvhEPhXc/fVMTMG78Ajs1s=",
+        "lastModified": 1710522300,
+        "narHash": "sha256-9PYmC6X8qQiUExjkRmJp5d1B+cPYglvHuIg80Virvuo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "553f68ee98a5d36c188f563f4e0851adbc132eda",
+        "rev": "28c564ccf915615c65c4c1334504f1535192dee2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`28c564cc`](https://github.com/nix-community/emacs-overlay/commit/28c564ccf915615c65c4c1334504f1535192dee2) | `` Updated emacs `` |