### PR TITLE
chore(flake/nur): `f2658342` -> `659c1809`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710517509,
-        "narHash": "sha256-RaRu+RRoT3ceuvikpENHg7887jy0wg3LnzlUp9/Q8qM=",
+        "lastModified": 1710529010,
+        "narHash": "sha256-fSOWNOe5rH9JfwA5Yzo9z8YyFJl0pG5IpLk1bhGPuVA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f2658342d8cbd43499d4fc0181b79db93dd839c6",
+        "rev": "659c1809ed5fd88aa78cf7595b787d213a1d45ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`659c1809`](https://github.com/nix-community/NUR/commit/659c1809ed5fd88aa78cf7595b787d213a1d45ac) | `` automatic update `` |
| [`3de07065`](https://github.com/nix-community/NUR/commit/3de07065e6ede890f919dcf34d5ea9b04ea64bdf) | `` automatic update `` |
| [`d944d93b`](https://github.com/nix-community/NUR/commit/d944d93b0aa3057d898b7b9041b0070227076de3) | `` automatic update `` |