### PR TITLE
chore(flake/emacs-overlay): `af746c7a` -> `4d36a831`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710550578,
-        "narHash": "sha256-3G+CIzZy6YK9go4odRpj6r6WjKO8Oh+D3S0AUgPRrMQ=",
+        "lastModified": 1710553346,
+        "narHash": "sha256-YHDgW5dnt55Z9DhXOKHhyDL6m6BbsRMyAucRxmNOMvo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "af746c7a293f90504c96f16dc821ca18038801db",
+        "rev": "4d36a8316894dbfc9af4364a1d869b9212f778eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`4d36a831`](https://github.com/nix-community/emacs-overlay/commit/4d36a8316894dbfc9af4364a1d869b9212f778eb) | `` Updated emacs `` |
| [`35ae865e`](https://github.com/nix-community/emacs-overlay/commit/35ae865e6482b8446f2dc5edeb5ebac35c26b5cc) | `` Updated melpa `` |