### PR TITLE
chore(flake/nur): `ee6b56a3` -> `9056cab1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710555771,
-        "narHash": "sha256-qrcuGpyDpgRzrn0qbv8IoQqOo1xO6SO6uPbonn82614=",
+        "lastModified": 1710560511,
+        "narHash": "sha256-+l0eMWAZgydwakdTYI9Q7ZzH+HDoAN9iGDdpe5IMPYU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ee6b56a34c6f526c8d40fd7ecf471f7758eb38f5",
+        "rev": "9056cab1d18a352c7187a03fe4ef788e9e7117d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9056cab1`](https://github.com/nix-community/NUR/commit/9056cab1d18a352c7187a03fe4ef788e9e7117d0) | `` automatic update `` |