### PR TITLE
chore(flake/nur): `9056cab1` -> `7412501b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710560511,
-        "narHash": "sha256-+l0eMWAZgydwakdTYI9Q7ZzH+HDoAN9iGDdpe5IMPYU=",
+        "lastModified": 1710562769,
+        "narHash": "sha256-USwSNqYG5FbZSJZzcpmwwZRNPb5A3m2bkST5+sI2QV8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9056cab1d18a352c7187a03fe4ef788e9e7117d0",
+        "rev": "7412501b811a9b6e9349763f4914152c71cb6068",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7412501b`](https://github.com/nix-community/NUR/commit/7412501b811a9b6e9349763f4914152c71cb6068) | `` automatic update `` |
| [`339c47d3`](https://github.com/nix-community/NUR/commit/339c47d3995e8d2870163272a9ee4f2ea0d267d4) | `` automatic update `` |