### PR TITLE
chore(flake/nur): `7412501b` -> `1be7b848`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710562769,
-        "narHash": "sha256-USwSNqYG5FbZSJZzcpmwwZRNPb5A3m2bkST5+sI2QV8=",
+        "lastModified": 1710572368,
+        "narHash": "sha256-Vi2dmUvHQYng9vfYgVFTcVOfjPorUH8DYYdKBnbjz4I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7412501b811a9b6e9349763f4914152c71cb6068",
+        "rev": "1be7b8486af579a66bef032907b287dffb16bcb9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1be7b848`](https://github.com/nix-community/NUR/commit/1be7b8486af579a66bef032907b287dffb16bcb9) | `` automatic update `` |
| [`83d42a3e`](https://github.com/nix-community/NUR/commit/83d42a3e31f6f4bfd88ffd2a89c111d2e193f742) | `` automatic update `` |