### PR TITLE
chore(flake/nur): `e4039d98` -> `529316cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710580279,
-        "narHash": "sha256-zPgzHeBCiel18uXaqb9enfJqe+BVLkt1QtZZddrSk5s=",
+        "lastModified": 1710585864,
+        "narHash": "sha256-S72KUsuZOV4AnecojtPhjC+fk9BrEOEhdKdazRi4yO4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e4039d98858a4df66adbf7ee887ca05700a831e6",
+        "rev": "529316cbfebac4d81ada47c2b0fb597cbd252e1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`529316cb`](https://github.com/nix-community/NUR/commit/529316cbfebac4d81ada47c2b0fb597cbd252e1e) | `` automatic update `` |