### PR TITLE
chore(flake/nur): `4ac24e33` -> `b94873af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710593481,
-        "narHash": "sha256-/8+wKOSQg/Z5I8lshnPrKjnxhTTQqmY+kQ9iZa/maNI=",
+        "lastModified": 1710596736,
+        "narHash": "sha256-820vaWXJhu+H4KigceuTTn/5ufZDNKujo1HBAB1JddA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ac24e3329bc69f3c6dff959e6a23496a27eba99",
+        "rev": "b94873af47d357463c71e894736becf6c345cfd5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b94873af`](https://github.com/nix-community/NUR/commit/b94873af47d357463c71e894736becf6c345cfd5) | `` automatic update `` |