### PR TITLE
chore(flake/nur): `b94873af` -> `b51d28a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710596736,
-        "narHash": "sha256-820vaWXJhu+H4KigceuTTn/5ufZDNKujo1HBAB1JddA=",
+        "lastModified": 1710601132,
+        "narHash": "sha256-OZa1Ff80l4t71xl+HVGP77vQIct6qAagGqcXtvZRch0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b94873af47d357463c71e894736becf6c345cfd5",
+        "rev": "b51d28a744558df0e8472b2eb1aeffd0209708d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b51d28a7`](https://github.com/nix-community/NUR/commit/b51d28a744558df0e8472b2eb1aeffd0209708d7) | `` automatic update `` |
| [`01f5bb8e`](https://github.com/nix-community/NUR/commit/01f5bb8e5231eaff5b2ffa35bfe32c8348004cee) | `` automatic update `` |