### PR TITLE
chore(flake/nur): `b51d28a7` -> `b870db41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710601132,
-        "narHash": "sha256-OZa1Ff80l4t71xl+HVGP77vQIct6qAagGqcXtvZRch0=",
+        "lastModified": 1710607749,
+        "narHash": "sha256-TRgxM7sOiWF8cea73OzDnmfhyYnN8+vDHUUJlkDDZ/U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b51d28a744558df0e8472b2eb1aeffd0209708d7",
+        "rev": "b870db4117d587a8c5c2c8c9e2d311d7fa4befe2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b870db41`](https://github.com/nix-community/NUR/commit/b870db4117d587a8c5c2c8c9e2d311d7fa4befe2) | `` automatic update `` |
| [`bd5a1fd4`](https://github.com/nix-community/NUR/commit/bd5a1fd48fd7e897dac1e9489d6b967ce2901191) | `` automatic update `` |