### PR TITLE
chore(flake/emacs-overlay): `0f1fd52b` -> `012c7047`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710579943,
-        "narHash": "sha256-8pchjDXadDAOdDS6OxeCJDYrOm2uBLg2c1MELcW4wL0=",
+        "lastModified": 1710608587,
+        "narHash": "sha256-7to4df2dUDd2LhPSp/XeH9rpONb2MtYDn1uFeVMolVc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0f1fd52b4ea652c7e8d983ceefe3a298848d0c1a",
+        "rev": "895a56e7294c2e5be4f84aa8e1cbc9e53e91307e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`012c7047`](https://github.com/nix-community/emacs-overlay/commit/012c70470e2bc0430ecd878453fa01b070efd2a0) | `` Updated melpa ``  |
| [`e500adcc`](https://github.com/nix-community/emacs-overlay/commit/e500adcc051336f222f28b144bdea5e2a5384a0b) | `` Updated elpa ``   |
| [`3fbacadd`](https://github.com/nix-community/emacs-overlay/commit/3fbacaddcf3ba1055780517c817d4b0e3b99b47a) | `` Updated nongnu `` |