### PR TITLE
chore(flake/nur): `b870db41` -> `79bcc2c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710607749,
-        "narHash": "sha256-TRgxM7sOiWF8cea73OzDnmfhyYnN8+vDHUUJlkDDZ/U=",
+        "lastModified": 1710618267,
+        "narHash": "sha256-MUTaKu3j24c9Ij8DTwL/ymAG1XMT+dxkVp3o6FcOgmc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b870db4117d587a8c5c2c8c9e2d311d7fa4befe2",
+        "rev": "d38b6f7c4db4fe70123e7c4afaa5d3ef33912166",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`79bcc2c4`](https://github.com/nix-community/NUR/commit/79bcc2c4379e84adc24275842b4cf64fa74b622f) | `` automatic update `` |
| [`6dc38199`](https://github.com/nix-community/NUR/commit/6dc3819962101fb0448bef49e6969c6477b1bef0) | `` automatic update `` |