### PR TITLE
chore(flake/nur): `d38b6f7c` -> `e826440f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710618267,
-        "narHash": "sha256-MUTaKu3j24c9Ij8DTwL/ymAG1XMT+dxkVp3o6FcOgmc=",
+        "lastModified": 1710626224,
+        "narHash": "sha256-VKdMMY0bR4SEvnoHR/3tO+lWzK8YWxlDmwB/h69pyUo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d38b6f7c4db4fe70123e7c4afaa5d3ef33912166",
+        "rev": "cbb38b5c51960bbc785a85a9ed827104c80b64e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                 |
| -------------------------------------------------------------------------------------------------- | ----------------------- |
| [`e826440f`](https://github.com/nix-community/NUR/commit/e826440f924a69c254ae92a14d0c3c2076f30707) | `` automatic update ``  |
| [`476c8bb0`](https://github.com/nix-community/NUR/commit/476c8bb001802513f934a105544a936e03734941) | `` fix order ``         |
| [`4a31d441`](https://github.com/nix-community/NUR/commit/4a31d44192ea80a130751898e91b8c7b403fa0b0) | `` Update repos.json `` |