### PR TITLE
chore(flake/nix-index-database): `e76ff2df` -> `8284ac38`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -591,11 +591,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710120787,
-        "narHash": "sha256-tlLuB73OCOKtU2j83bQzSYFyzjJo3rjpITZE5MoofG8=",
+        "lastModified": 1710644923,
+        "narHash": "sha256-0fjbN5GYYDKPyPay0l8gYoH+tFfNqPPwP5sxxBreeA4=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "e76ff2df6bfd2abe06abd8e7b9f217df941c1b07",
+        "rev": "e25efda85e39fcdc845e371971ac4384989c4295",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                  |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`8284ac38`](https://github.com/nix-community/nix-index-database/commit/8284ac380c1a11806a7bf7ef84eb3d2428e14630) | `` flake.lock: Update `` |