### PR TITLE
chore(flake/nur): `d4076b8f` -> `6f83e0d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710639603,
-        "narHash": "sha256-n2XnsmO856p/tUez0eMwwLkEOvAUDgZ2PmMN8E/KuF4=",
+        "lastModified": 1710647794,
+        "narHash": "sha256-A9xyiXZ87kTLRUDLtydeOE8BeUIY10pKTyvwPBXfHos=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d4076b8ffb0711225d8773238c2a92198a9804df",
+        "rev": "6f83e0d19f2d74aed71ecfefc92c58cc9f8a7de5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6f83e0d1`](https://github.com/nix-community/NUR/commit/6f83e0d19f2d74aed71ecfefc92c58cc9f8a7de5) | `` automatic update `` |