### PR TITLE
chore(flake/nur): `6f83e0d1` -> `3bba19c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710647794,
-        "narHash": "sha256-A9xyiXZ87kTLRUDLtydeOE8BeUIY10pKTyvwPBXfHos=",
+        "lastModified": 1710649154,
+        "narHash": "sha256-XWNzWhllM1C6qwYkQ9d9pugJ2g5c/R1aeHE0BglKHMA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6f83e0d19f2d74aed71ecfefc92c58cc9f8a7de5",
+        "rev": "3bba19c4ac87d2636aa55ade9401a4ea7ea33557",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3bba19c4`](https://github.com/nix-community/NUR/commit/3bba19c4ac87d2636aa55ade9401a4ea7ea33557) | `` automatic update `` |
| [`6067453d`](https://github.com/nix-community/NUR/commit/6067453d1e5a8db5327a250beb34da4a5ecc7cd2) | `` automatic update `` |
| [`4c40ad76`](https://github.com/nix-community/NUR/commit/4c40ad762845ca5748dc230b8f8aadbd5a7e4e67) | `` automatic update `` |