### PR TITLE
chore(flake/emacs-overlay): `31aaa030` -> `a4e4766e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710639218,
-        "narHash": "sha256-A/4zUgcEBVXtiMQwJeScB3RoGA80hd53wL4aQs93CWY=",
+        "lastModified": 1710666186,
+        "narHash": "sha256-Kf43lS6UzaOiEYLm4AkWTqIcFOjLKJqfX5oKCJbQ35E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "31aaa0306208e29f9d83bd31e3cbe870d625b92d",
+        "rev": "15f5f7d5eb82b1d2e7a4f754b11480b91aea9e91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`a4e4766e`](https://github.com/nix-community/emacs-overlay/commit/a4e4766e170c7ab715ebadcd0e7cb87c54bddd8b) | `` Updated melpa `` |