### PR TITLE
chore(flake/nur): `bc7ae946` -> `1944ea83`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710654680,
-        "narHash": "sha256-GlQoHF1f9s/J3EQsbbokvC85/3y6e4JiVOcAXg35KlY=",
+        "lastModified": 1710672334,
+        "narHash": "sha256-KSGqaTpK35Q8CqmSH8E8d2efR4s/V+TCB7be4AW892Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bc7ae946dd34942dd19079133d6debd35da5a8f0",
+        "rev": "1944ea837f0ee82807a09cd523c1b9ddc11b2706",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1944ea83`](https://github.com/nix-community/NUR/commit/1944ea837f0ee82807a09cd523c1b9ddc11b2706) | `` automatic update `` |