### PR TITLE
chore(flake/nur): `855a9fe4` -> `433f7612`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710675859,
-        "narHash": "sha256-faOjYmiTnWFIrda3yFmrEHeuoF4cSy5yD/LGRhodNcU=",
+        "lastModified": 1710678566,
+        "narHash": "sha256-pAhPyKz1MUkxk4f1pqYTGDbtWfxpHgO7v8Ro5bsSCe0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "855a9fe4dd2a48cf61ba8e489b8aae9f720663c5",
+        "rev": "433f76122d83946cf0640f0b4cb719b972021554",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`433f7612`](https://github.com/nix-community/NUR/commit/433f76122d83946cf0640f0b4cb719b972021554) | `` automatic update `` |