### PR TITLE
chore(flake/emacs-overlay): `15f5f7d5` -> `85535d7e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710666186,
-        "narHash": "sha256-Kf43lS6UzaOiEYLm4AkWTqIcFOjLKJqfX5oKCJbQ35E=",
+        "lastModified": 1710694137,
+        "narHash": "sha256-/jyzB6HZ+dNrFjUkngpxuFgIkMykSInX94dOyJHqzb8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "15f5f7d5eb82b1d2e7a4f754b11480b91aea9e91",
+        "rev": "85535d7e9e9e8ddc934dec61e80575a3f6b93c47",
         "type": "github"
       },
       "original": {
@@ -710,11 +710,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1710420202,
-        "narHash": "sha256-MvFKESbq4rUWuaf2RKPNYENaSZEw/jaCLo2gU6oREcM=",
+        "lastModified": 1710565619,
+        "narHash": "sha256-xu/EnZCNdIj7m/QjCNIG5vrCA4TYg5uwFReb9XDxET0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "878ef7d9721bee9f81f8a80819f9211ad1f993da",
+        "rev": "8ac30a39abc5ea67037dfbf090d6e89f187c6e50",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`85535d7e`](https://github.com/nix-community/emacs-overlay/commit/85535d7e9e9e8ddc934dec61e80575a3f6b93c47) | `` Updated melpa ``        |
| [`d07b2d28`](https://github.com/nix-community/emacs-overlay/commit/d07b2d2813bac1dac913e8d2f58b9e5f735d855c) | `` Updated elpa ``         |
| [`d5956593`](https://github.com/nix-community/emacs-overlay/commit/d5956593e73501dd88a12412a4638fb48300a3c0) | `` Updated nongnu ``       |
| [`ae6b39da`](https://github.com/nix-community/emacs-overlay/commit/ae6b39daa8c758813f0671c23839483d9ff6e20b) | `` Updated flake inputs `` |