### PR TITLE
chore(flake/emacs-overlay): `85535d7e` -> `1e56dc4f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710694137,
-        "narHash": "sha256-/jyzB6HZ+dNrFjUkngpxuFgIkMykSInX94dOyJHqzb8=",
+        "lastModified": 1710695153,
+        "narHash": "sha256-xUQXCEW4xsUb5r/2PS/97ZHOoCTIU6GXZay8byy+nu0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "85535d7e9e9e8ddc934dec61e80575a3f6b93c47",
+        "rev": "1e56dc4fc532f35ac38368e48e1ed607586b5a02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`1e56dc4f`](https://github.com/nix-community/emacs-overlay/commit/1e56dc4fc532f35ac38368e48e1ed607586b5a02) | `` Updated emacs `` |