### PR TITLE
chore(flake/emacs-overlay): `1e56dc4f` -> `c69f2e48`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710695153,
-        "narHash": "sha256-xUQXCEW4xsUb5r/2PS/97ZHOoCTIU6GXZay8byy+nu0=",
+        "lastModified": 1710723496,
+        "narHash": "sha256-laBq6lKOCw59iAgl3MAElzZmaiEMQDD/qMcvDVQWduw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1e56dc4fc532f35ac38368e48e1ed607586b5a02",
+        "rev": "c69f2e48abb2fd0958be8f44037c717d673e5f37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`c69f2e48`](https://github.com/nix-community/emacs-overlay/commit/c69f2e48abb2fd0958be8f44037c717d673e5f37) | `` Updated elpa `` |