### PR TITLE
chore(flake/srvos): `83eef007` -> `6f5c52bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -994,11 +994,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710664522,
-        "narHash": "sha256-Y2z6Q7V3vjCKTAsn65VNeWoHfr9XE7W9cM7wjq0Yu5w=",
+        "lastModified": 1710722976,
+        "narHash": "sha256-tAQvMzQ3pB4O7C0WJqvewlywEpJQRTdu2om5bgKV3L8=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "83eef007bb039bd5dfd7262a0746d02791ef4b6b",
+        "rev": "6f5c52bcd3b9e7c0e88907a75d284d11b609a36c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`6f5c52bc`](https://github.com/nix-community/srvos/commit/6f5c52bcd3b9e7c0e88907a75d284d11b609a36c) | `` dev/private/flake.lock: Update `` |
| [`435bda70`](https://github.com/nix-community/srvos/commit/435bda7010fcc7a261575ac87fb2c70da196c9c1) | `` flake.lock: Update ``             |