### PR TITLE
chore(flake/emacs-overlay): `c69f2e48` -> `845e9cba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710723496,
-        "narHash": "sha256-laBq6lKOCw59iAgl3MAElzZmaiEMQDD/qMcvDVQWduw=",
+        "lastModified": 1710726387,
+        "narHash": "sha256-cI1/Z0EV+0wu0oPa3PY9OYUWce7O8fZgWct82laul1A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c69f2e48abb2fd0958be8f44037c717d673e5f37",
+        "rev": "845e9cbad448ab23a4c2a19705af2e1f380256b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`845e9cba`](https://github.com/nix-community/emacs-overlay/commit/845e9cbad448ab23a4c2a19705af2e1f380256b1) | `` Updated emacs `` |
| [`558bde4f`](https://github.com/nix-community/emacs-overlay/commit/558bde4f14b4d167520b3591b65f502b94589769) | `` Updated melpa `` |