### PR TITLE
chore(flake/nur): `ad1aacea` -> `05351320`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710743281,
-        "narHash": "sha256-jAkeYF6arapCdJFFxwHN5jYTr/29YEOIF+ttj7itZas=",
+        "lastModified": 1710750753,
+        "narHash": "sha256-MQ5haKyTNKAFTw3oDaShLHiECiD5DVV4HfmzN3l77Yk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ad1aacea16a2af3e0cc96686e09edd177dda8cd5",
+        "rev": "05351320d5ece2eb43cbd991edd4d1f56f5ca17f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`05351320`](https://github.com/nix-community/NUR/commit/05351320d5ece2eb43cbd991edd4d1f56f5ca17f) | `` automatic update `` |
| [`a45b7fa3`](https://github.com/nix-community/NUR/commit/a45b7fa3e52f2f820d6d71b67b411d5798d7ffd4) | `` automatic update `` |