### PR TITLE
chore(flake/nur): `05351320` -> `fc4f9acb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710750753,
-        "narHash": "sha256-MQ5haKyTNKAFTw3oDaShLHiECiD5DVV4HfmzN3l77Yk=",
+        "lastModified": 1710758009,
+        "narHash": "sha256-E60fc4liidYWo+0FKGwDFndhcmV40ZNwfDbROTwaInA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "05351320d5ece2eb43cbd991edd4d1f56f5ca17f",
+        "rev": "fc4f9acb61749a12a7ff7ac4020142b121a5dd25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fc4f9acb`](https://github.com/nix-community/NUR/commit/fc4f9acb61749a12a7ff7ac4020142b121a5dd25) | `` automatic update `` |
| [`ecc1ee87`](https://github.com/nix-community/NUR/commit/ecc1ee870395551e365623071a2a12d3e26ed90e) | `` automatic update `` |