### PR TITLE
chore(flake/stylix): `14d24033` -> `daddbb14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1030,11 +1030,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710759032,
-        "narHash": "sha256-xFJVsELNlZcjZG2DHY6wOAO6JlG2Swe0Dnfa/KoHCmQ=",
+        "lastModified": 1710774666,
+        "narHash": "sha256-ZkaYqxHcSBlSpehz7PTO8KP47YoLuUU4/4RfDm3VR1Y=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "14d240334719b15d9adab127e9bd34cfe0f03098",
+        "rev": "2221c7d61b2e10b17df6c6795b4678fb59a0a92a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                    |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`daddbb14`](https://github.com/danth/stylix/commit/daddbb141b1ea353942d0d1070b8a03a7128fa05) | `` plymouth: fail if substitution does not apply (#293) `` |