### PR TITLE
chore(flake/emacs-overlay): `ddc0d1e4` -> `561994a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710752732,
-        "narHash": "sha256-G4sFKirxi49JaYi90Aq5Lo0jVSCJfYwYVTPhIt8zBT8=",
+        "lastModified": 1710781559,
+        "narHash": "sha256-JYaqWCeSD/qrUsWuCvZO3HM9x0I4lSC66rfhwINdHnk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ddc0d1e406566b0389f4e7f25d4b6aa59f98114e",
+        "rev": "f6166eecac653b5ed815feacdf17aa2e797a0578",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`561994a3`](https://github.com/nix-community/emacs-overlay/commit/561994a3c87ecfc8ddb1159c0153a15ce29deacd) | `` Updated melpa `` |
| [`3cf84387`](https://github.com/nix-community/emacs-overlay/commit/3cf8438736eb28dcbcde868f71fdd31c19ea830d) | `` Updated elpa ``  |