### PR TITLE
chore(flake/nur): `8c2ca0f7` -> `6af543d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710794701,
-        "narHash": "sha256-NQaXLIVMMWFhpbd4p75xfpWMcMkVXn8fmdSsS4nop7w=",
+        "lastModified": 1710798282,
+        "narHash": "sha256-+cHn+UXh8v5or56Z7+HqO5JP17E+yDpzspQxoGE7/UE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8c2ca0f744b3dd0b616e37239bdb8eef0a3f64a0",
+        "rev": "6af543d8508419c77cb7e77c29c80939abc9a21f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6af543d8`](https://github.com/nix-community/NUR/commit/6af543d8508419c77cb7e77c29c80939abc9a21f) | `` automatic update `` |