### PR TITLE
chore(flake/nur): `6fd7cbdc` -> `77c735e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710816034,
-        "narHash": "sha256-xIW7RHoq1xU9nXJzPQGC7BabMc6YJ4XXH6UD61VLkyw=",
+        "lastModified": 1710818712,
+        "narHash": "sha256-SjLYV1OqOj5Bo73+QtXPp84V0yQG62ksyfzhzWB82vs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6fd7cbdc18374e81b98e7d4895df013123d120c6",
+        "rev": "77c735e5fe3c06d5f7dbb1c513c9b610c7779eff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`77c735e5`](https://github.com/nix-community/NUR/commit/77c735e5fe3c06d5f7dbb1c513c9b610c7779eff) | `` automatic update `` |