### PR TITLE
chore(flake/nur): `77c735e5` -> `98f805c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710818712,
-        "narHash": "sha256-SjLYV1OqOj5Bo73+QtXPp84V0yQG62ksyfzhzWB82vs=",
+        "lastModified": 1710821402,
+        "narHash": "sha256-viBWlQNJOh9N08oVNzkOgI7qYBpMX2ANo6fAF4mPqG4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "77c735e5fe3c06d5f7dbb1c513c9b610c7779eff",
+        "rev": "98f805c5070045296f94557a27e8ad3e04212294",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`98f805c5`](https://github.com/nix-community/NUR/commit/98f805c5070045296f94557a27e8ad3e04212294) | `` automatic update `` |