### PR TITLE
chore(flake/pre-commit-hooks): `afe89ba2` -> `e611897d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -881,11 +881,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1710830185,
-        "narHash": "sha256-s34SWPaBnFdkn67+itBFVeXKhJTBlqRwx3jZiZCugUA=",
+        "lastModified": 1710923068,
+        "narHash": "sha256-6hOpUiuxuwpXXc/xfJsBUJeqqgGI+JMJuLo45aG3cKc=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "afe89ba28fae60eb8450b83ca2c93851044fb365",
+        "rev": "e611897ddfdde3ed3eaac4758635d7177ff78673",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
| [`e611897d`](https://github.com/cachix/pre-commit-hooks.nix/commit/e611897ddfdde3ed3eaac4758635d7177ff78673) | `` fix flakes example for enabledPackages ``                           |
| [`543d006f`](https://github.com/cachix/pre-commit-hooks.nix/commit/543d006fef3a86e0887d2f2a213bffa7afbf19d1) | `` fix option ``                                                       |
| [`cf361f56`](https://github.com/cachix/pre-commit-hooks.nix/commit/cf361f562612258d5f6272b0c567aaf2b5ff93df) | `` fix #356: provide a way to access all packages for enabled hooks `` |
| [`21307b20`](https://github.com/cachix/pre-commit-hooks.nix/commit/21307b20b0f24ae8738e1771ac0b4a026756b85c) | `` Rename deprecated flake outputs ``                                  |
| [`8fc4dd7c`](https://github.com/cachix/pre-commit-hooks.nix/commit/8fc4dd7c1f12aeda9b1d001f18e243de563b357c) | `` feat: introduce black flags ``                                      |
| [`cbb3524c`](https://github.com/cachix/pre-commit-hooks.nix/commit/cbb3524cd65a4e71165c77842ac1c5827321cf64) | `` Remove treefmt package in the all-hooks check ``                    |
| [`8a980910`](https://github.com/cachix/pre-commit-hooks.nix/commit/8a9809104fbb6b8c829b95852fdce87a1f5c183a) | `` Fix treefmt flake-parts integration ``                              |
| [`d43e4853`](https://github.com/cachix/pre-commit-hooks.nix/commit/d43e4853f578739ac2264eadcd18faa5aeb41889) | `` rustfmt: Support multi package projects ``                          |
| [`d0589a99`](https://github.com/cachix/pre-commit-hooks.nix/commit/d0589a997c1481c0d4bd31242196054fe18c61f4) | `` fix typstfmt ``                                                     |