### PR TITLE
chore(flake/nur): `c1bb3d34` -> `e3c306a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710845145,
-        "narHash": "sha256-BYwh8Oz9uIOtpH5deD0INTJFEBZjIcSUcEcf3+JKDW4=",
+        "lastModified": 1710855882,
+        "narHash": "sha256-upZI3GONOnN1hoXiDsq+ZfhfV9/XDOh0zLDWX6enk+8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c1bb3d347c595c580dd48fc9a47003fd4211dcd1",
+        "rev": "c83bf02689eeaddeefb36611c0bdc52299ab4496",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e3c306a8`](https://github.com/nix-community/NUR/commit/e3c306a8f36a198b9edb03d3bce9ffdb16b0d217) | `` automatic update `` |