### PR TITLE
chore(flake/emacs-overlay): `756bfe12` -> `de274dc5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710839086,
-        "narHash": "sha256-PZd5F7qBdhxMvcYDJhoxVK+QQrmOkoo0y1QOQ6Y71dY=",
+        "lastModified": 1710867991,
+        "narHash": "sha256-DXDC0u2Nrde3687uRiuwLy3lCCRRiymYluOCgj3tAvQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "756bfe12bd21a23d803025dc07c7493bd1948494",
+        "rev": "78da5146ec2bbffc5a31fe08be4bcaf2fd6eeea3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`de274dc5`](https://github.com/nix-community/emacs-overlay/commit/de274dc5d822bf93de2996ab40a98f314d123740) | `` Updated melpa ``        |
| [`2f9ef66d`](https://github.com/nix-community/emacs-overlay/commit/2f9ef66d7d1d55f1ce8deed9f8b7e9f4169760cb) | `` Updated elpa ``         |
| [`b46d002e`](https://github.com/nix-community/emacs-overlay/commit/b46d002e832944a78bfaf431c461187d11f2288c) | `` Updated flake inputs `` |