### PR TITLE
chore(flake/nixpkgs): `c75037bb` -> `20f77aa0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -758,11 +758,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1710631334,
-        "narHash": "sha256-rL5LSYd85kplL5othxK5lmAtjyMOBg390sGBTb3LRMM=",
+        "lastModified": 1711001935,
+        "narHash": "sha256-URtGpHue7HHZK0mrHnSf8wJ6OmMKYSsoLmJybrOLFSQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c75037bbf9093a2acb617804ee46320d6d1fea5a",
+        "rev": "20f77aa09916374aa3141cbc605c955626762c9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                        |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`a6b670ed`](https://github.com/NixOS/nixpkgs/commit/a6b670edaa6d3d9ca66e04deb0415ca17ff3138f) | `` doc: document name binding for buildPythonPackage ``                                        |
| [`b2f29564`](https://github.com/NixOS/nixpkgs/commit/b2f29564730e757d24d154272e8e50fc2a831980) | `` texlive.withPackages: do not override output attributes (#296751) ``                        |
| [`226958e2`](https://github.com/NixOS/nixpkgs/commit/226958e284160e04c3caf4279ea2350ff7f1e1e5) | `` rofimoji: 6.1.0 -> 6.2.0 ``                                                                 |
| [`1060333f`](https://github.com/NixOS/nixpkgs/commit/1060333f83ca367d4209c31e782800e1e9a8ed5b) | `` cargo-mobile2: 0.10.4 -> 0.11.0 ``                                                          |
| [`040c54ea`](https://github.com/NixOS/nixpkgs/commit/040c54ea5d4cfa1f3fe3103359740cf00fc266ce) | `` sweethome3d.{application,textures-editor,furniture-editor}: fix build for latest jdk ``     |
| [`7135c155`](https://github.com/NixOS/nixpkgs/commit/7135c1559374376936210aa1d6e4aaac262e2640) | `` python311Packages.prometheus-client: 0.19.0 -> 0.20.0 ``                                    |
| [`b0fbf617`](https://github.com/NixOS/nixpkgs/commit/b0fbf6176207d72c96016c47d2ad3f98dd94c4cd) | `` python311Packages.mypy-boto3-savingsplans: 1.34.0 -> 1.34.67 ``                             |
| [`9e7dbb6d`](https://github.com/NixOS/nixpkgs/commit/9e7dbb6d1161e1b498b1e2db3c344a8826b02a2b) | `` python311Packages.mypy-boto3-managedblockchain-query: 1.34.33 -> 1.34.67 ``                 |
| [`ec59df15`](https://github.com/NixOS/nixpkgs/commit/ec59df156f11033ab1ced4820075b1083d328081) | `` python311Packages.mypy-boto3-logs: 1.34.36 -> 1.34.66 ``                                    |
| [`40387fa9`](https://github.com/NixOS/nixpkgs/commit/40387fa9517a03e8505a3dca6e2226afa37b3b2a) | `` python311Packages.mypy-boto3-finspace: 1.34.24 -> 1.34.66 ``                                |
| [`4865cfdd`](https://github.com/NixOS/nixpkgs/commit/4865cfddbc1e163080e85da37adbb0206981940b) | `` python311Packages.mypy-boto3-ec2: 1.34.64 -> 1.34.66 ``                                     |
| [`e9ac05b8`](https://github.com/NixOS/nixpkgs/commit/e9ac05b8a31830dd5f01fdd7dc944958e1d732c6) | `` python311Packages.mypy-boto3-dynamodb: 1.34.57 -> 1.34.67 ``                                |
| [`2e1a35f2`](https://github.com/NixOS/nixpkgs/commit/2e1a35f204a7fd900e2c83609c1508e1ce7b1b9a) | `` python311Packages.mypy-boto3-connect: 1.34.64 -> 1.34.67 ``                                 |
| [`bf2e1979`](https://github.com/NixOS/nixpkgs/commit/bf2e19793fff0976495b504b03b776bd08e6c19c) | `` python311Packages.mypy-boto3-codebuild: 1.34.64 -> 1.34.67 ``                               |
| [`e2426eb3`](https://github.com/NixOS/nixpkgs/commit/e2426eb3ee99eacaca07a85e79fd3111c6eb5c05) | `` python311Packages.mypy-boto3-cloudformation: 1.34.65 -> 1.34.66 ``                          |
| [`4901e0ff`](https://github.com/NixOS/nixpkgs/commit/4901e0ffe1291546a7ceb5a538756c48b529f95d) | `` python311Packages.mypy-boto3-accessanalyzer: 1.34.54 -> 1.34.67 ``                          |
| [`4b92cf45`](https://github.com/NixOS/nixpkgs/commit/4b92cf45709d10cf3b668f2683ce2d66ee5ae990) | `` python311Packages.botocore-stubs: 1.34.66 -> 1.34.67 ``                                     |
| [`e1a0425f`](https://github.com/NixOS/nixpkgs/commit/e1a0425fbdc3f0dcf1bd9e42876c6c642fb7e91b) | `` python311Packages.extract-msg: 0.48.2 -> 0.48.3 ``                                          |
| [`e91b378f`](https://github.com/NixOS/nixpkgs/commit/e91b378f173c139958ead1ddb5082eb4a5f52a22) | `` owmods-cli: fix build on darwin ``                                                          |
| [`6a34e873`](https://github.com/NixOS/nixpkgs/commit/6a34e873ae472ca131d5e6ecedb48467e0a341cd) | `` python311Packages.botocore-stubs: 1.34.66 -> 1.34.67 ``                                     |
| [`0fee5136`](https://github.com/NixOS/nixpkgs/commit/0fee513688acc64ff7767822373da0480a82cdb6) | `` python311Packages.boto3-stubs: 1.34.66 -> 1.34.67 ``                                        |
| [`e62b7d78`](https://github.com/NixOS/nixpkgs/commit/e62b7d78caa3d15ba230b44982595dd97a3c6bd2) | `` python311Packages.pyprosegur: refactor ``                                                   |
| [`3243b276`](https://github.com/NixOS/nixpkgs/commit/3243b276e76b8d9e9af7ee465109f61f3ded772c) | `` cups-printers: init at 1.0.0 ``                                                             |
| [`8f721625`](https://github.com/NixOS/nixpkgs/commit/8f721625be20e191673afe5332ee53d1729c9e67) | `` python311Packages.pyprosegur: 0.0.9 -> 0.0.10 ``                                            |
| [`3c57e346`](https://github.com/NixOS/nixpkgs/commit/3c57e34690730b89b8b576860d0eac28290e107e) | `` conglomerate: change license to hpndUc ``                                                   |
| [`18f02dd2`](https://github.com/NixOS/nixpkgs/commit/18f02dd2b2f57b366cd1e78179057ebc51ee2c79) | `` chez-srfi: change license to x11 ``                                                         |
| [`d44938cf`](https://github.com/NixOS/nixpkgs/commit/d44938cf9fb5554ef3b83a953fb73ae773135760) | `` chez-mit: change license to gpl3Plus ``                                                     |
| [`178c7f61`](https://github.com/NixOS/nixpkgs/commit/178c7f61da4e1271a00de5b41354ad5489293332) | `` bront_fonts: change license to bitstreamVera and ufl ``                                     |
| [`4de5cc5a`](https://github.com/NixOS/nixpkgs/commit/4de5cc5aab113e9d01455abb5c565a75c1f5ee18) | `` bicpl: change license to hpndUc ``                                                          |
| [`a4fabce5`](https://github.com/NixOS/nixpkgs/commit/a4fabce54bd0c5d700b6811ffdd2789974ff5253) | `` bicgl: change license to hpndUc ``                                                          |
| [`58e1eb3b`](https://github.com/NixOS/nixpkgs/commit/58e1eb3b78fbb8a4f1d8247940bf4e0183d0a591) | `` lib/license: add hpndUc ``                                                                  |
| [`2fabb7f9`](https://github.com/NixOS/nixpkgs/commit/2fabb7f99b06757e23b99fb1e98f1ae3afbaeb55) | `` babelstone-han: change license to Arphic-1999 ``                                            |
| [`d5482f93`](https://github.com/NixOS/nixpkgs/commit/d5482f9313e91beddc8143642a7289580cc8c194) | `` b43FirmwareCutter: change license to bsd2 ``                                                |
| [`4534862f`](https://github.com/NixOS/nixpkgs/commit/4534862f7c5afcbeb363e811f7d1b7e32c3bc2f2) | `` arguments: change license to gpl2Plus ``                                                    |
| [`8a060c14`](https://github.com/NixOS/nixpkgs/commit/8a060c14d37487afdaed75b06338658e41a7e2c4) | `` antsimulator: change license to mit ``                                                      |
| [`0eef23bd`](https://github.com/NixOS/nixpkgs/commit/0eef23bd9b6cf5584a2f05f6d53fe29347939288) | `` allegro: change license to giftware ``                                                      |
| [`3f16499c`](https://github.com/NixOS/nixpkgs/commit/3f16499c48b5b0ba7a16cf8d2751a8cbff8f4def) | `` lib/license: add giftware ``                                                                |
| [`857437e9`](https://github.com/NixOS/nixpkgs/commit/857437e930e1917526c759bb4b4bbcb7d2547382) | `` alephone-apotheosis-x: change license to unfree ``                                          |
| [`647e3983`](https://github.com/NixOS/nixpkgs/commit/647e3983cd740ef513d11a9d268536167c4dcb10) | `` 90secondportraits: change license to zlib cc-by-sa-40 cc-by-sa-30 x11 ``                    |
| [`2bd23474`](https://github.com/NixOS/nixpkgs/commit/2bd2347470384860f4a420c0aefe7604e7c3e1e5) | `` lib/license: add NIST-Software ``                                                           |
| [`6e11881e`](https://github.com/NixOS/nixpkgs/commit/6e11881ea164ffa3e2a70ecc346f277b3d6540cd) | `` owmods-cli: add bwc9876 and spoonbaker as maintainers ``                                    |
| [`c958512b`](https://github.com/NixOS/nixpkgs/commit/c958512b32bc082f017baccc6059c65b8c3a1528) | `` maintainers: add spoonbaker ``                                                              |
| [`0ae30c08`](https://github.com/NixOS/nixpkgs/commit/0ae30c08a463d7adf743308f17171ab7ab09cb80) | `` maintainers: add bwc9876 ``                                                                 |
| [`fbc71541`](https://github.com/NixOS/nixpkgs/commit/fbc71541101a9e700a34daba07306015c065e105) | `` kodiPackages.jellycon: init at 0.8.0 ``                                                     |
| [`147344ca`](https://github.com/NixOS/nixpkgs/commit/147344ca8d32d4a28229d6427435291a2d7443b8) | `` owmods-cli: move to pkgs/by-name/ow/owmods-cli ``                                           |
| [`e504a5da`](https://github.com/NixOS/nixpkgs/commit/e504a5da339a472a02fe463966763f370a12309c) | `` alire: 1.2.2 -> 2.0.0 ``                                                                    |
| [`a7ec4177`](https://github.com/NixOS/nixpkgs/commit/a7ec4177ba1591e34822d90b5aa43dfae911bb68) | `` azure-cli: 2.56.0 -> 2.58.0 ``                                                              |
| [`5e9b1938`](https://github.com/NixOS/nixpkgs/commit/5e9b193815d82f3113d8bf7c6e25ad56f395df72) | `` perl538Packages.ParallelLoops: 0.10 -> 0.12 ``                                              |
| [`321d71bd`](https://github.com/NixOS/nixpkgs/commit/321d71bd40bc24e195b2d439ef952eeed2e3cb8f) | `` perl538Packages.FFICStat: 0.02 -> 0.03 ``                                                   |
| [`cc5e99fb`](https://github.com/NixOS/nixpkgs/commit/cc5e99fb282f7212182ac6896138563adae12ac2) | `` owmods-cli: 0.12.2 -> 0.13.0 ``                                                             |
| [`fe90f520`](https://github.com/NixOS/nixpkgs/commit/fe90f520aa3ae7505958dc382d5d0b2656cfd0bd) | `` owmods-cli: Add mono wrap and fix man pages install ``                                      |
| [`74f31366`](https://github.com/NixOS/nixpkgs/commit/74f31366cfa9bcdf1fb1b064a3dd06ebb09cf6ba) | `` androidStudioPackages.stable: 2023.2.1.23 -> 2023.2.1.24 ``                                 |
| [`568623d0`](https://github.com/NixOS/nixpkgs/commit/568623d0c73da032ce8d8904a3c2cc8a3d90be0a) | `` androidStudioPackages.canary: 2023.3.1.12 -> 2023.3.2.1 ``                                  |
| [`1357b820`](https://github.com/NixOS/nixpkgs/commit/1357b820aac78044f911e2638cf1ba40fff8d230) | `` obinskit: remove (#296146) ``                                                               |
| [`ea251072`](https://github.com/NixOS/nixpkgs/commit/ea2510720ea9bcbe1a29d0e41cc06c95480256d5) | `` sl1-to-photon: move to cab404 fork (#290362) ``                                             |
| [`31f1a5b6`](https://github.com/NixOS/nixpkgs/commit/31f1a5b6755636d42b5f34b9f36b88caf224a705) | `` maintainers: update chito.email ``                                                          |
| [`80ab3315`](https://github.com/NixOS/nixpkgs/commit/80ab3315ced8daa380e73d78ca2d0225c29f4d15) | `` eigenlayer: 0.6.2 -> 0.6.3 ``                                                               |
| [`da490968`](https://github.com/NixOS/nixpkgs/commit/da49096833ff1b039c1fcd11228db6f184bf727d) | `` python311Packages.litellm: 1.32.4 -> 1.32.7 ``                                              |
| [`e871fcf8`](https://github.com/NixOS/nixpkgs/commit/e871fcf859651a54d83e87d554aadf578a889503) | `` stdenvAdapters.useLibsFrom: use targetStdenv.cc.override ``                                 |
| [`5bb92281`](https://github.com/NixOS/nixpkgs/commit/5bb92281f50cc692aba94af7fe877092c7f0f9b3) | `` nixos/dnscache: Provide explicit group for "dnscache" user ``                               |
| [`5393cc5d`](https://github.com/NixOS/nixpkgs/commit/5393cc5dc278c5595036025051003084a6d1336e) | `` soupault: mv to by-name ``                                                                  |
| [`bde81af2`](https://github.com/NixOS/nixpkgs/commit/bde81af2418c785a93160c7113b368d217c00caa) | `` soupault: support both code forge mirrors ``                                                |
| [`b03eafd6`](https://github.com/NixOS/nixpkgs/commit/b03eafd6b9622b78bcb65a18e1ae8f70234cc1fb) | `` soupault: 4.8.0 → 4.9.0 ``                                                                  |
| [`306be6af`](https://github.com/NixOS/nixpkgs/commit/306be6af9fc0777f0b2b4bd3917766a805e96f0e) | `` Apply suggestions from code review ``                                                       |
| [`318332f5`](https://github.com/NixOS/nixpkgs/commit/318332f5b6ea41ea9683cbb5890def89258f357f) | `` marimo: init at 0.3.3 ``                                                                    |
| [`ae3aa417`](https://github.com/NixOS/nixpkgs/commit/ae3aa417e366011abf7557690326ab685c1fd57b) | `` chromium: 122.0.6261.128 -> 123.0.6312.58 ``                                                |
| [`19dc69ae`](https://github.com/NixOS/nixpkgs/commit/19dc69aec751487f2654bd5ab51412282b292a3a) | `` chromedriver: 122.0.6261.128 -> 123.0.6312.58 ``                                            |
| [`9db07baf`](https://github.com/NixOS/nixpkgs/commit/9db07bafd1dceae991efb193cad72b7eae43054e) | `` klipper: unstable-2024-03-15 -> unstable-2024-03-19 ``                                      |
| [`155be2eb`](https://github.com/NixOS/nixpkgs/commit/155be2eb13821dddd9099cc78c9adbe3b26d664d) | `` tftui: 0.12.4 -> 0.12.6 ``                                                                  |
| [`5cffd60b`](https://github.com/NixOS/nixpkgs/commit/5cffd60bedf9f5de59f665064b9b9c033dd9d342) | `` pythonPackages.asyncpg: fix build on older Python, bump minimum Python version (#294645) `` |
| [`f3a20533`](https://github.com/NixOS/nixpkgs/commit/f3a20533b7f75b03f350ef3b4d51b0b829b1d33d) | `` fish: fix passthru tests for darwin ``                                                      |
| [`2f7f71ea`](https://github.com/NixOS/nixpkgs/commit/2f7f71ea58687ca173ef6b972027e22e09542437) | `` doc: Add troubleshooting for Cythonized code and pytest (#293069) ``                        |
| [`86950a9c`](https://github.com/NixOS/nixpkgs/commit/86950a9c050afab2f84542c75309c45b46517324) | `` upiano: allow later textual releases ``                                                     |
| [`f54aaa5b`](https://github.com/NixOS/nixpkgs/commit/f54aaa5ba85f98857ac58028f746ec484c3c4ea4) | `` rs-tftpd: init at 0.2.12 ``                                                                 |
| [`b2f79605`](https://github.com/NixOS/nixpkgs/commit/b2f79605c3ca8298697d191d29729bc060a774c6) | `` slimserver: Logitech -> LMS-Community ``                                                    |
| [`e6605620`](https://github.com/NixOS/nixpkgs/commit/e660562087ea3aae56b3b490f683d7a184be00a3) | `` slimserver: 8.4.0 -> 8.5.0 ``                                                               |
| [`b6cb2687`](https://github.com/NixOS/nixpkgs/commit/b6cb26876d8e9e9a02030568df827c3c9580e781) | `` slimserver: add updatescript, move to by-name ``                                            |
| [`86deeaca`](https://github.com/NixOS/nixpkgs/commit/86deeaca82f745d3037b9fa6555d13ccbf8926ba) | `` python312Packages.tesla-fleet-api: 0.4.9 -> 0.5.0 ``                                        |
| [`704daf59`](https://github.com/NixOS/nixpkgs/commit/704daf5961dcd4a2164e1c19d8600cd768e058db) | `` python312Packages.gurobipy: 7.5.2 -> 11.0.1 (darwin) ``                                     |
| [`e0f09135`](https://github.com/NixOS/nixpkgs/commit/e0f091354852825bdb859855b07a53ec095b73ba) | `` uxn: unstable-2024-03-16 -> unstable-2024-03-18 ``                                          |
| [`11fc7cb8`](https://github.com/NixOS/nixpkgs/commit/11fc7cb8d9d429c06710de725ff893b873b9cd22) | `` luaPackages.mimetypes: init at 1.0.0-3 ``                                                   |
| [`6f8d5811`](https://github.com/NixOS/nixpkgs/commit/6f8d5811de4ac06ad7dbcb38337cc5081a7f95fb) | `` bluefish: 2.2.14 -> 2.2.15 ``                                                               |
| [`62ef6473`](https://github.com/NixOS/nixpkgs/commit/62ef647346faf34e7f48c32009a966893a56db39) | `` python312Packages.tree-sitter: add patch to replace distutils ``                            |
| [`f3d1410e`](https://github.com/NixOS/nixpkgs/commit/f3d1410e08859e31bc91463e08666b9642bc9fa4) | `` try to fix ca-derivations firefox ``                                                        |
| [`df4ffc95`](https://github.com/NixOS/nixpkgs/commit/df4ffc959dda485ed0f81d2fdd1c8525f6034b19) | `` protonmail-bridge-gui: init at 3.9.1 ``                                                     |
| [`d403e1be`](https://github.com/NixOS/nixpkgs/commit/d403e1be7a231c353f4b3246f3ad0b36b6b6fcb5) | `` sage, sageWithDoc: 10.2 -> 10.3 ``                                                          |
| [`39f84ba8`](https://github.com/NixOS/nixpkgs/commit/39f84ba837cfd13b79d9d252628f68421e80dd2b) | `` structorizer: 3.32-17 -> 3.32-18 ``                                                         |
| [`94d91e99`](https://github.com/NixOS/nixpkgs/commit/94d91e996b2db90ce02e4dda70effda28fe47be0) | `` displaycal: mv → by-name/ ``                                                                |
| [`1f7e3343`](https://github.com/NixOS/nixpkgs/commit/1f7e3343e3de9e8d05d8316262a95409a390c83b) | `` metals: 1.2.1 -> 1.2.2 ``                                                                   |
| [`debb9277`](https://github.com/NixOS/nixpkgs/commit/debb92775eb516af1fa0c42d2db51a15ee889d70) | `` nixos/starship: cleanup ``                                                                  |
| [`4f9d91e2`](https://github.com/NixOS/nixpkgs/commit/4f9d91e276539428a20bcb47d781778e152a67ee) | `` nixos/starship: allow setting package ``                                                    |
| [`a84c66e9`](https://github.com/NixOS/nixpkgs/commit/a84c66e910c4a500d582c9cfc540c077da530f7e) | `` displaycal: 3.9.11 → 3.9.12 ``                                                              |
| [`724c3309`](https://github.com/NixOS/nixpkgs/commit/724c33094ee275f1774c5e9b8af1006c97f22bb5) | `` chatty: 0.8.1 -> 0.8.2 ``                                                                   |
| [`0cb0e9ab`](https://github.com/NixOS/nixpkgs/commit/0cb0e9ab0c3438a9375d80642e647f3a93f771ee) | `` strictdoc: 0.0.40 -> 0.0.49 ``                                                              |
| [`b2e6139e`](https://github.com/NixOS/nixpkgs/commit/b2e6139e42ae065699ba8fb22371b742a2f7e816) | `` python311Packages.py-tree-sitter: remove ``                                                 |
| [`2e2df990`](https://github.com/NixOS/nixpkgs/commit/2e2df99001cf5f216e6381ada798311feab83792) | `` python311Packages.ollama: init at 0.1.7 ``                                                  |
| [`e5dc7872`](https://github.com/NixOS/nixpkgs/commit/e5dc7872aac7ca2614543344389a1e933f687b1d) | `` exiftool: 12.70 -> 12.80 ``                                                                 |
| [`0dfa6864`](https://github.com/NixOS/nixpkgs/commit/0dfa68647420b93080a04508dda41476cccc0cd0) | `` exiftool: add passthru.tests.version ``                                                     |
| [`74194ca5`](https://github.com/NixOS/nixpkgs/commit/74194ca56376df5ace0e55effcdb47a1a43afd4e) | `` exiftool: add passthru.updateScript ``                                                      |
| [`9e0b98c3`](https://github.com/NixOS/nixpkgs/commit/9e0b98c30994d350c4705deb66abce632e2e44ee) | `` exiftool: move to pkgs/development/perl-modules ``                                          |
| [`09484b3b`](https://github.com/NixOS/nixpkgs/commit/09484b3b3712653c9365da2366da18a9dc4cf99e) | `` python311Packages.tree-sitter: 0.20.4 -> 0.21.1 ``                                          |
| [`ea012e17`](https://github.com/NixOS/nixpkgs/commit/ea012e17f7c3b4d06d45bdc21574635f6a0c92d3) | `` maloader: unstable-2014-02-25 -> 0-unstable-2018-05-02 ``                                   |
| [`199a2140`](https://github.com/NixOS/nixpkgs/commit/199a2140384d54d7a875fa6ad7f8c85b24c8d5a1) | `` python3Packages.bip32: loosen dependency requirements ``                                    |
| [`ac480bad`](https://github.com/NixOS/nixpkgs/commit/ac480bad28b90100de520c0c6787c40371b8cfd1) | `` python312Packages.whoosh: refactor ``                                                       |
| [`e6b54890`](https://github.com/NixOS/nixpkgs/commit/e6b54890095c2ed4467511276d26ecbd68ae48d8) | `` satty: 0.11.2 -> 0.11.3 ``                                                                  |
| [`6d80d02b`](https://github.com/NixOS/nixpkgs/commit/6d80d02b4d72b0945828083a9a908b46ab466a99) | `` signalbackup-tools: 20240318 -> 20240319 ``                                                 |
| [`5c0f7fbd`](https://github.com/NixOS/nixpkgs/commit/5c0f7fbdf8328f3db2769d4dc656b9568ef790cb) | `` kuro: bump electron version and do clean up (#296483) ``                                    |
| [`877e34cb`](https://github.com/NixOS/nixpkgs/commit/877e34cbd09328dbc7833f6a88b8beccb4d91958) | `` passky-desktop: bump electron version (#296603) ``                                          |
| [`109010a8`](https://github.com/NixOS/nixpkgs/commit/109010a866ae9a11061214e2a920a15049c0382a) | `` python311Packages.managesieve: refactor ``                                                  |
| [`f5f9c5be`](https://github.com/NixOS/nixpkgs/commit/f5f9c5bee7948ec3eb37076e8e6acbbb0eb865d3) | `` werf: 1.2.296 -> 1.2.297 ``                                                                 |
| [`5f570c1f`](https://github.com/NixOS/nixpkgs/commit/5f570c1fb9f709819bd308f73c81f2a6ae5d2ebb) | `` spicedb: 1.29.5 -> 1.30.0 ``                                                                |
| [`6f9e7fe7`](https://github.com/NixOS/nixpkgs/commit/6f9e7fe71b979e8136989fb1d69c112b235cf88d) | `` python311Packages.optuna: refactor ``                                                       |
| [`b6ab0527`](https://github.com/NixOS/nixpkgs/commit/b6ab052728de1a7d24164ce8adfb721a7fb5aa02) | `` python311Packages.django-anymail: refactor ``                                               |
| [`1f3a7e41`](https://github.com/NixOS/nixpkgs/commit/1f3a7e4192264ed273f4ea07f61761f4c0d69dfc) | `` python312Packages.toml-adapt: refactor ``                                                   |
| [`dcd58184`](https://github.com/NixOS/nixpkgs/commit/dcd58184988766566769b78b47d66c8712657ba1) | `` python312Packages.pyformlang: update homepage ``                                            |
| [`2852b404`](https://github.com/NixOS/nixpkgs/commit/2852b4041215723fdf0ffc0b5355af6fd076423c) | `` spicedb-zed: 0.16.4 -> 0.17.0 ``                                                            |