### PR TITLE
chore(flake/nur): `cd8b4844` -> `e077a3a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710860658,
-        "narHash": "sha256-bdC8a70B/wpjBzpXXFNZfLnXYeL5WIaQ8MnBOVGwbY0=",
+        "lastModified": 1710866717,
+        "narHash": "sha256-bbEQ1Q8yzrnFhOhXjgCBzabClEbXvqGglSjZAIiMDzs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cd8b48448ba1ded38528605711c5ee6402ecd934",
+        "rev": "e077a3a5979b888f33508b861feed0a2e7f3a859",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e077a3a5`](https://github.com/nix-community/NUR/commit/e077a3a5979b888f33508b861feed0a2e7f3a859) | `` automatic update `` |