### PR TITLE
chore(flake/nur): `e077a3a5` -> `366dbc5c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710866717,
-        "narHash": "sha256-bbEQ1Q8yzrnFhOhXjgCBzabClEbXvqGglSjZAIiMDzs=",
+        "lastModified": 1710872681,
+        "narHash": "sha256-huvjoZI189K8tZuFRDKUpvCwrFmH1avONKcS2ikGRU8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e077a3a5979b888f33508b861feed0a2e7f3a859",
+        "rev": "366dbc5ccc6c1e1b62abe71a92dae8af74d00e35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`366dbc5c`](https://github.com/nix-community/NUR/commit/366dbc5ccc6c1e1b62abe71a92dae8af74d00e35) | `` automatic update `` |