### PR TITLE
chore(flake/emacs-overlay): `78da5146` -> `22fa7038`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710867991,
-        "narHash": "sha256-DXDC0u2Nrde3687uRiuwLy3lCCRRiymYluOCgj3tAvQ=",
+        "lastModified": 1710899046,
+        "narHash": "sha256-cX/RWdP1eoLBR92TOLHVivqSYbWjSD2XQ2i6XXFn4Cw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "78da5146ec2bbffc5a31fe08be4bcaf2fd6eeea3",
+        "rev": "88685372ad906c0b12b541806a5fcdad9857681f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`22fa7038`](https://github.com/nix-community/emacs-overlay/commit/22fa70381601884c5859d21bf6b0fc9ba54c2845) | `` Updated elpa ``   |
| [`871ff869`](https://github.com/nix-community/emacs-overlay/commit/871ff869f459fb6115f66a830cfa5d5421ea9bbd) | `` Updated nongnu `` |