### PR TITLE
chore(flake/nur): `5ade29e2` -> `8d5e9636`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710877502,
-        "narHash": "sha256-qpP8pmtC6Fr825Sm0Ci2GXMRBuqcufxEW+kmJkuQu0A=",
+        "lastModified": 1710896818,
+        "narHash": "sha256-8iTpNJv0FmTjfBN6Y1GZW6O7Jqx+J2F4pibeyVaF6y8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5ade29e20e32a6a3cdcb713851f1c620635b46e9",
+        "rev": "8d5e9636916fa5f95572fceffa6f82dadaf63b83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8d5e9636`](https://github.com/nix-community/NUR/commit/8d5e9636916fa5f95572fceffa6f82dadaf63b83) | `` automatic update `` |