### PR TITLE
chore(flake/nur): `8d5e9636` -> `a64e9d1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710896818,
-        "narHash": "sha256-8iTpNJv0FmTjfBN6Y1GZW6O7Jqx+J2F4pibeyVaF6y8=",
+        "lastModified": 1710898620,
+        "narHash": "sha256-sTCWEtyFHC4g6SZ50Yj/V39PMQb6DgAIzf3SgRe8eXc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8d5e9636916fa5f95572fceffa6f82dadaf63b83",
+        "rev": "a64e9d1d40f14eb1902d1e62b9f3ecbbc4a255bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a64e9d1d`](https://github.com/nix-community/NUR/commit/a64e9d1d40f14eb1902d1e62b9f3ecbbc4a255bf) | `` automatic update `` |