### PR TITLE
chore(flake/nur): `a64e9d1d` -> `214e8a38`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710898620,
-        "narHash": "sha256-sTCWEtyFHC4g6SZ50Yj/V39PMQb6DgAIzf3SgRe8eXc=",
+        "lastModified": 1710902443,
+        "narHash": "sha256-WWO7eTfmebp7nHWA+N2Us7LMz885COkgGBPs6CLDiXo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a64e9d1d40f14eb1902d1e62b9f3ecbbc4a255bf",
+        "rev": "214e8a38599880c887950cac318f6aa30c73d979",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`214e8a38`](https://github.com/nix-community/NUR/commit/214e8a38599880c887950cac318f6aa30c73d979) | `` automatic update `` |