### PR TITLE
chore(flake/nur): `9c524d0f` -> `b872338e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710909178,
-        "narHash": "sha256-3uaUxTGngNy1exMZMYwjUlV8ueaAoOktgDZUenhKrAg=",
+        "lastModified": 1710912007,
+        "narHash": "sha256-AC5nz3ZN3jpxqWWGv18SVGNXOQ/Q0mzrema05WUaqXI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9c524d0f6070131a0eb512c35a58bedb17cd31c4",
+        "rev": "b872338eababdfe454d62c3cfda27b4796e6875c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b872338e`](https://github.com/nix-community/NUR/commit/b872338eababdfe454d62c3cfda27b4796e6875c) | `` automatic update `` |