### PR TITLE
chore(flake/nur): `b872338e` -> `8061785e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710912007,
-        "narHash": "sha256-AC5nz3ZN3jpxqWWGv18SVGNXOQ/Q0mzrema05WUaqXI=",
+        "lastModified": 1710917082,
+        "narHash": "sha256-fAYP9x6LPaj4Oeo01eIlxZM4s9e4LCgSUnmjKEZDHiQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b872338eababdfe454d62c3cfda27b4796e6875c",
+        "rev": "8061785e6bde33629623c4ab16c68585d72b8bc7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8061785e`](https://github.com/nix-community/NUR/commit/8061785e6bde33629623c4ab16c68585d72b8bc7) | `` automatic update `` |