### PR TITLE
chore(flake/org-tufte): `b4c48849` -> `cefa7796`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     "org-tufte": {
       "flake": false,
       "locked": {
-        "lastModified": 1710064933,
-        "narHash": "sha256-d2r33oedgUclebJIRk1zgzQoOvICp0sqvZyIklH/aww=",
+        "lastModified": 1710919713,
+        "narHash": "sha256-/dYILTBOutwD78Hmp3NXoTrZknjMp7X8hEp7DmQDF1g=",
         "owner": "Zilong-Li",
         "repo": "org-tufte",
-        "rev": "b4c488492f02a399f1c0a06ce0acf3184d8e0290",
+        "rev": "cefa7796cd11a33c9bd871a1cf514dd1953b879b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message      |
| ---------------------------------------------------------------------------------------------------- | ------------ |
| [`cefa7796`](https://github.com/Zilong-Li/org-tufte/commit/cefa7796cd11a33c9bd871a1cf514dd1953b879b) | `` v0.4.0 `` |