### PR TITLE
chore(flake/emacs-overlay): `88685372` -> `883f0161`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710899046,
-        "narHash": "sha256-cX/RWdP1eoLBR92TOLHVivqSYbWjSD2XQ2i6XXFn4Cw=",
+        "lastModified": 1710925487,
+        "narHash": "sha256-CblgCrRQ2NeBPd2mouvAlTNLw4A1lPnJEeD1fs0JlMY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "88685372ad906c0b12b541806a5fcdad9857681f",
+        "rev": "76b6a3e62b790f56cb0707ce91bbe111c56cbcb7",
         "type": "github"
       },
       "original": {
@@ -710,11 +710,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1710695816,
-        "narHash": "sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84=",
+        "lastModified": 1710838473,
+        "narHash": "sha256-RLvwdQSENKOaLdKhNie8XqHmTXzNm00/M/THj6zplQo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "614b4613980a522ba49f0d194531beddbb7220d3",
+        "rev": "fa9f817df522ac294016af3d40ccff82f5fd3a63",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`883f0161`](https://github.com/nix-community/emacs-overlay/commit/883f01615dd52d12aa2309c5d70fadc93153c81e) | `` Updated melpa ``        |
| [`44817d1f`](https://github.com/nix-community/emacs-overlay/commit/44817d1f0a8150bafa1b5516d7896234ea867236) | `` Updated flake inputs `` |