### PR TITLE
chore(flake/nur): `6b42f9fe` -> `35fbc488`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710923589,
-        "narHash": "sha256-lKYSsx0BQbcXVZf14vpf2yD7r7pakHQ7173pxXmgvk4=",
+        "lastModified": 1710931549,
+        "narHash": "sha256-jyXyiUx5VVUtss0OzlLKt5OY/fLVkLRW6iEiQbeDP4g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6b42f9fe3099d436ada62d4e41a36673caa10bbf",
+        "rev": "35fbc48809c0251085ec8c90dd74e8679a98b20b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`35fbc488`](https://github.com/nix-community/NUR/commit/35fbc48809c0251085ec8c90dd74e8679a98b20b) | `` automatic update `` |