### PR TITLE
chore(flake/nur): `1593636f` -> `516c158f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710940845,
-        "narHash": "sha256-hDL4J2VgG0fmCuq+X1M6e7nVp2a5xHl05PfQZlANhkQ=",
+        "lastModified": 1710945276,
+        "narHash": "sha256-HQJqyeTNmfpk5JRW1P3xY2D3XDjTaHjuSzW4ITIM+OY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1593636f37dc0b788e75fb843916ce1afd21fcd0",
+        "rev": "516c158fc921eca336f05f8f62218a37a547042b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`516c158f`](https://github.com/nix-community/NUR/commit/516c158fc921eca336f05f8f62218a37a547042b) | `` automatic update `` |