### PR TITLE
chore(flake/emacs-overlay): `76b6a3e6` -> `a9216f7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710925487,
-        "narHash": "sha256-CblgCrRQ2NeBPd2mouvAlTNLw4A1lPnJEeD1fs0JlMY=",
+        "lastModified": 1710954378,
+        "narHash": "sha256-IbidJZykfjyGZ9totyhUIPHcDSqW1B3Pepgo3c9tDHI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "76b6a3e62b790f56cb0707ce91bbe111c56cbcb7",
+        "rev": "a9216f7a1ec216e36e31c7d2ed42de4df89d918a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`a9216f7a`](https://github.com/nix-community/emacs-overlay/commit/a9216f7a1ec216e36e31c7d2ed42de4df89d918a) | `` Updated emacs ``  |
| [`4a3172d9`](https://github.com/nix-community/emacs-overlay/commit/4a3172d9c3d385a9ef1e7e309c9afaf44a55b8c7) | `` Updated melpa ``  |
| [`a665e7c3`](https://github.com/nix-community/emacs-overlay/commit/a665e7c30e6f86bc9cb7848f75d8fa856956df22) | `` Updated elpa ``   |
| [`e3379452`](https://github.com/nix-community/emacs-overlay/commit/e33794521c009a603063be601b9485bf76e22a04) | `` Updated nongnu `` |