### PR TITLE
chore(flake/nur): `572fa5e5` -> `169962b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710953147,
-        "narHash": "sha256-sqja0/7Gi2K3WEVc/Q9UKlgOmQ530qcmNmRt8H/nb2Y=",
+        "lastModified": 1710956215,
+        "narHash": "sha256-VRg1o2LW2SdcmjwQLr2+9UZWd0gz6FmmvCnEbywPfEk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "572fa5e564e2150a1247ba5b7079b824f6a13c41",
+        "rev": "169962b8afd4340a10df5116f743d1482250089f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`169962b8`](https://github.com/nix-community/NUR/commit/169962b8afd4340a10df5116f743d1482250089f) | `` automatic update `` |