### PR TITLE
chore(flake/srvos): `6f5c52bc` -> `e4ea2626`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -994,11 +994,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710722976,
-        "narHash": "sha256-tAQvMzQ3pB4O7C0WJqvewlywEpJQRTdu2om5bgKV3L8=",
+        "lastModified": 1710955745,
+        "narHash": "sha256-wQzc7nTgu7EfXFUelXVebavrSYQw9w8XJZ7e0ZXqqTk=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "6f5c52bcd3b9e7c0e88907a75d284d11b609a36c",
+        "rev": "e4ea26262b3c40611bfd7fe1f652af73aed47637",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                     |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`e4ea2626`](https://github.com/nix-community/srvos/commit/e4ea26262b3c40611bfd7fe1f652af73aed47637) | `` treewide: fix typo using typos (#400) `` |