### PR TITLE
chore(flake/nur): `169962b8` -> `5ee15db6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710956215,
-        "narHash": "sha256-VRg1o2LW2SdcmjwQLr2+9UZWd0gz6FmmvCnEbywPfEk=",
+        "lastModified": 1710967499,
+        "narHash": "sha256-f5Ro10NEDq+aZPrSO5f+Hg40iD4BOx2U8NJGomnCqi8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "169962b8afd4340a10df5116f743d1482250089f",
+        "rev": "5ee15db66832970cf391e0c18392779a57a79605",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5ee15db6`](https://github.com/nix-community/NUR/commit/5ee15db66832970cf391e0c18392779a57a79605) | `` automatic update `` |
| [`cf4c8b49`](https://github.com/nix-community/NUR/commit/cf4c8b49ff7227ab8ebdab294e5a97682e5d09e3) | `` automatic update `` |
| [`4db96b61`](https://github.com/nix-community/NUR/commit/4db96b6123115a9bec6c6cc03a4c43287eb38abf) | `` automatic update `` |
| [`77cee904`](https://github.com/nix-community/NUR/commit/77cee9047998a26254edc7d62b113c09dc215484) | `` automatic update `` |
| [`873b757c`](https://github.com/nix-community/NUR/commit/873b757cad067db38491ca334d2dc88fcc7513df) | `` automatic update `` |
| [`c4c25ef9`](https://github.com/nix-community/NUR/commit/c4c25ef9cc14546f4b05e5ea552c87ca58b4dc58) | `` automatic update `` |