### PR TITLE
chore(flake/nur): `5ee15db6` -> `3f5b0d2b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710967499,
-        "narHash": "sha256-f5Ro10NEDq+aZPrSO5f+Hg40iD4BOx2U8NJGomnCqi8=",
+        "lastModified": 1710977109,
+        "narHash": "sha256-PIVzBf+SWNfccSo57Gb1xWXHKIDTudO/USW9nxUHnz8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5ee15db66832970cf391e0c18392779a57a79605",
+        "rev": "3f5b0d2b63c7596602539d7ffdb5ce00bc81b404",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3f5b0d2b`](https://github.com/nix-community/NUR/commit/3f5b0d2b63c7596602539d7ffdb5ce00bc81b404) | `` automatic update `` |
| [`71e7b0e6`](https://github.com/nix-community/NUR/commit/71e7b0e6971b26c14756d96642568ac9c1a9380d) | `` automatic update `` |
| [`9561d520`](https://github.com/nix-community/NUR/commit/9561d520d037e4939a8f2d7c49df350d672b57a9) | `` automatic update `` |