### PR TITLE
chore(flake/emacs-overlay): `a9216f7a` -> `3ceaaf96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710954378,
-        "narHash": "sha256-IbidJZykfjyGZ9totyhUIPHcDSqW1B3Pepgo3c9tDHI=",
+        "lastModified": 1710984731,
+        "narHash": "sha256-my6J7w+KUfciORMZJEA9vBivWmSt7W/1opVCMZ2LvTI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a9216f7a1ec216e36e31c7d2ed42de4df89d918a",
+        "rev": "3ceaaf96fb4ee8f81cf5e381322d6d071950b55d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`3ceaaf96`](https://github.com/nix-community/emacs-overlay/commit/3ceaaf96fb4ee8f81cf5e381322d6d071950b55d) | `` Updated melpa ``  |
| [`7270f36a`](https://github.com/nix-community/emacs-overlay/commit/7270f36aa2ef94fba91cc20abc1e70552669b4c9) | `` Updated emacs ``  |
| [`6dac2d37`](https://github.com/nix-community/emacs-overlay/commit/6dac2d374a457a1e117271a9b547c0628e1607bc) | `` Updated elpa ``   |
| [`8d22154b`](https://github.com/nix-community/emacs-overlay/commit/8d22154b02c319d07662f6eaab61da54f58778c6) | `` Updated nongnu `` |