### PR TITLE
chore(flake/srvos): `e4ea2626` -> `918e2ad3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -994,11 +994,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710955745,
-        "narHash": "sha256-wQzc7nTgu7EfXFUelXVebavrSYQw9w8XJZ7e0ZXqqTk=",
+        "lastModified": 1710982111,
+        "narHash": "sha256-IKcJnJwLnNXcnTZY4vxhQ0zEkZvr7srhXSZpxa3IiHA=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "e4ea26262b3c40611bfd7fe1f652af73aed47637",
+        "rev": "918e2ad35a9ce4071e9bc72e82ad97a65c8b861b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`918e2ad3`](https://github.com/nix-community/srvos/commit/918e2ad35a9ce4071e9bc72e82ad97a65c8b861b) | `` dev/private/flake.lock: Update `` |
| [`58bccebb`](https://github.com/nix-community/srvos/commit/58bccebb050c4d404c7edd417ae56aee623f8bd4) | `` flake.lock: Update ``             |