### PR TITLE
chore(flake/nur): `b95649ad` -> `efc31fac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710992459,
-        "narHash": "sha256-0dz1E5f5KKvNehXQymdPW799FqVIW3XHO5cAupkEYzo=",
+        "lastModified": 1710994322,
+        "narHash": "sha256-8WsHFN5DfnvT2wcEa7Q9TO1V+o0flHHfS/002/q2ECw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b95649adb9ec87be73707568f48d19266eef4215",
+        "rev": "efc31fac5a7eb81f14d604ee1559da82142661a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`efc31fac`](https://github.com/nix-community/NUR/commit/efc31fac5a7eb81f14d604ee1559da82142661a6) | `` automatic update `` |