### PR TITLE
chore(flake/nur): `80d3dc02` -> `a03fe83a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711003479,
-        "narHash": "sha256-m2wty8CnE7S9somBQXCdV9OAHxpIfOOXM/n8AR1ZwLY=",
+        "lastModified": 1711008087,
+        "narHash": "sha256-mqChoZfE6fjba1sGVH/1IACUFna9O98vMuXlJ+bKMSc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "80d3dc0275b917561145cfb5e6d62a04e1d77993",
+        "rev": "a03fe83a8821969622fb32fe9df09f68e4fac5f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a03fe83a`](https://github.com/nix-community/NUR/commit/a03fe83a8821969622fb32fe9df09f68e4fac5f0) | `` automatic update `` |
| [`2c1ca91a`](https://github.com/nix-community/NUR/commit/2c1ca91a2df16c35273d979c34a8310e890fd516) | `` automatic update `` |