### PR TITLE
chore(flake/nur): `a03fe83a` -> `106588f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711008087,
-        "narHash": "sha256-mqChoZfE6fjba1sGVH/1IACUFna9O98vMuXlJ+bKMSc=",
+        "lastModified": 1711009251,
+        "narHash": "sha256-0i0ojZcUlm/by72+g/GdpegdT0yqxRKyFoQAOr9GAHk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a03fe83a8821969622fb32fe9df09f68e4fac5f0",
+        "rev": "106588f58e7058b88c0558e1f9097baa923369db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`106588f5`](https://github.com/nix-community/NUR/commit/106588f58e7058b88c0558e1f9097baa923369db) | `` automatic update `` |