### PR TITLE
chore(flake/nur): `e6a9c811` -> `ee94df42`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711014405,
-        "narHash": "sha256-6vH25xWy/jthelzXyG8hhajQVLLuq2wF/WkEtGu43Yc=",
+        "lastModified": 1711018521,
+        "narHash": "sha256-92oocIAsoplQayUC8vsVimnHZUPqvKxMb2F7Kk3DwGM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e6a9c811a480fa0cb154569bfde3270926bb1104",
+        "rev": "ee94df4241bb6c2930aec3f4e29eebbe0338f656",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ee94df42`](https://github.com/nix-community/NUR/commit/ee94df4241bb6c2930aec3f4e29eebbe0338f656) | `` automatic update `` |
| [`b826deca`](https://github.com/nix-community/NUR/commit/b826decadd4e5d1aa9ca90972c9bb64f246e72a4) | `` automatic update `` |