### PR TITLE
chore(flake/nur): `ee94df42` -> `ccbf2aaf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711018521,
-        "narHash": "sha256-92oocIAsoplQayUC8vsVimnHZUPqvKxMb2F7Kk3DwGM=",
+        "lastModified": 1711025101,
+        "narHash": "sha256-bKxsDE1b3JsT2PasbDZVCp8Q+Vr8Xy1c+pAN07kj5VY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ee94df4241bb6c2930aec3f4e29eebbe0338f656",
+        "rev": "ccbf2aafeb68a1ae9f67d3052a5b6b9bc2159511",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ccbf2aaf`](https://github.com/nix-community/NUR/commit/ccbf2aafeb68a1ae9f67d3052a5b6b9bc2159511) | `` automatic update `` |