### PR TITLE
chore(flake/nur): `ccbf2aaf` -> `974805b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711025101,
-        "narHash": "sha256-bKxsDE1b3JsT2PasbDZVCp8Q+Vr8Xy1c+pAN07kj5VY=",
+        "lastModified": 1711026792,
+        "narHash": "sha256-xGr1qq8yckEKYw28bUO5rODef/kmbuEW70JiHTERxPA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ccbf2aafeb68a1ae9f67d3052a5b6b9bc2159511",
+        "rev": "974805b3b75e7606dde6fa97a56f3e87a3a59ef7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`974805b3`](https://github.com/nix-community/NUR/commit/974805b3b75e7606dde6fa97a56f3e87a3a59ef7) | `` automatic update `` |