### PR TITLE
chore(flake/nur): `7565d27f` -> `1f626d2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711031142,
-        "narHash": "sha256-y6swZcyef/hGgLEtwY9RfINuvOulaDeIMQN0xU4d5Ok=",
+        "lastModified": 1711034660,
+        "narHash": "sha256-AURgOJFzS+k+Sj9Aif198WM5dDyLJ1GMLaa9ge1NETY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7565d27ff55171eeab73cd67c70cd1728ccb8d0a",
+        "rev": "1f626d2e2e780e5ba0fe203a7e74f79b57f1af67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1f626d2e`](https://github.com/nix-community/NUR/commit/1f626d2e2e780e5ba0fe203a7e74f79b57f1af67) | `` automatic update `` |