### PR TITLE
chore(flake/emacs-overlay): `db67dedb` -> `803135be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711011893,
-        "narHash": "sha256-2sLnDxfQMD5HaLsRunHKtgBxq493hgud/Skdlf0L4zA=",
+        "lastModified": 1711040829,
+        "narHash": "sha256-1cz3Abamghj9xDpTFd4fLCDa75CPqqWqQnfoYnAf6d0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "db67dedba21b1e119c7f835662e80934f0882c1e",
+        "rev": "803135bef04c3e58301ae422922e486223f526c0",
         "type": "github"
       },
       "original": {
@@ -710,11 +710,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1710838473,
-        "narHash": "sha256-RLvwdQSENKOaLdKhNie8XqHmTXzNm00/M/THj6zplQo=",
+        "lastModified": 1710951922,
+        "narHash": "sha256-FOOBJ3DQenLpTNdxMHR2CpGZmYuctb92gF0lpiirZ30=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fa9f817df522ac294016af3d40ccff82f5fd3a63",
+        "rev": "f091af045dff8347d66d186a62d42aceff159456",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`803135be`](https://github.com/nix-community/emacs-overlay/commit/803135bef04c3e58301ae422922e486223f526c0) | `` Updated emacs ``        |
| [`9bcc2419`](https://github.com/nix-community/emacs-overlay/commit/9bcc24197b1ef9bcc336246c72aa0ae8e56d23ca) | `` Updated melpa ``        |
| [`0eda17b4`](https://github.com/nix-community/emacs-overlay/commit/0eda17b4424345a0f3e26eaf966439a3f32a5dd6) | `` Updated elpa ``         |
| [`4313d82e`](https://github.com/nix-community/emacs-overlay/commit/4313d82e2440ed3118a7eefd7e1ebd42ed9bed30) | `` Updated flake inputs `` |