### PR TITLE
chore(flake/nur): `1f626d2e` -> `8f8aaec2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711034660,
-        "narHash": "sha256-AURgOJFzS+k+Sj9Aif198WM5dDyLJ1GMLaa9ge1NETY=",
+        "lastModified": 1711039682,
+        "narHash": "sha256-Eb171c8J7j2UlX4yvbMsH2EcqYze+UkFl+OCK1ytn7s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1f626d2e2e780e5ba0fe203a7e74f79b57f1af67",
+        "rev": "8f8aaec2b768c738f4273f0536de61f419df5d6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8f8aaec2`](https://github.com/nix-community/NUR/commit/8f8aaec2b768c738f4273f0536de61f419df5d6b) | `` automatic update `` |