### PR TITLE
chore(flake/nur): `75cb71b2` -> `a01b1fe8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711050282,
-        "narHash": "sha256-pzZWDtsNDM0AXv4R4G+BrQ0/H2Ml65z5o1j7iLzCgok=",
+        "lastModified": 1711052752,
+        "narHash": "sha256-wHgyWnWvjG7P+8PX3E2PZrtpsnIsmzodXt/7r+SyhBk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "75cb71b2ef4de7b34c165a6eec5b0ac33dce484b",
+        "rev": "a01b1fe8e4253ca176ece6733d4e71ab8e65fa9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a01b1fe8`](https://github.com/nix-community/NUR/commit/a01b1fe8e4253ca176ece6733d4e71ab8e65fa9f) | `` automatic update `` |