### PR TITLE
chore(flake/org-tufte): `cefa7796` -> `954ab3bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     "org-tufte": {
       "flake": false,
       "locked": {
-        "lastModified": 1710919713,
-        "narHash": "sha256-/dYILTBOutwD78Hmp3NXoTrZknjMp7X8hEp7DmQDF1g=",
+        "lastModified": 1711061468,
+        "narHash": "sha256-so/3YuIerXMVBgO5FfWrkMYj6u7OXTL56ZsrO23Vtpo=",
         "owner": "Zilong-Li",
         "repo": "org-tufte",
-        "rev": "cefa7796cd11a33c9bd871a1cf514dd1953b879b",
+        "rev": "954ab3bcb87747f62926aa6e15f9a12441751e88",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`954ab3bc`](https://github.com/Zilong-Li/org-tufte/commit/954ab3bcb87747f62926aa6e15f9a12441751e88) | `` update button's color and size `` |