### PR TITLE
chore(flake/emacs-overlay): `803135be` -> `aea1e8e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711040829,
-        "narHash": "sha256-1cz3Abamghj9xDpTFd4fLCDa75CPqqWqQnfoYnAf6d0=",
+        "lastModified": 1711069030,
+        "narHash": "sha256-jTdGhtHnuVVhRiHsJub+zH528TDSJVdItc97Tk8/04g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "803135bef04c3e58301ae422922e486223f526c0",
+        "rev": "aea1e8e4ee210154ce4b3b2cf1d922577eb18adb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`aea1e8e4`](https://github.com/nix-community/emacs-overlay/commit/aea1e8e4ee210154ce4b3b2cf1d922577eb18adb) | `` Updated elpa `` |