### PR TITLE
chore(flake/emacs-overlay): `aea1e8e4` -> `cad98a25`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711069030,
-        "narHash": "sha256-jTdGhtHnuVVhRiHsJub+zH528TDSJVdItc97Tk8/04g=",
+        "lastModified": 1711071818,
+        "narHash": "sha256-9SmpbzwNL5m3pIqWrT+7PnQDfYBQAp8EoKcJCFyRITI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "aea1e8e4ee210154ce4b3b2cf1d922577eb18adb",
+        "rev": "cad98a253dc7b22fb12db42ccac3d04402e63dd0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`cad98a25`](https://github.com/nix-community/emacs-overlay/commit/cad98a253dc7b22fb12db42ccac3d04402e63dd0) | `` Updated emacs `` |
| [`e6da5554`](https://github.com/nix-community/emacs-overlay/commit/e6da5554f4f7396f22499a8b87eb05b487e034c1) | `` Updated melpa `` |