### PR TITLE
chore(flake/nur): `c098cf85` -> `1bdfe262`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711080615,
-        "narHash": "sha256-0jbDy3AN5JgVqZxfUYliGQKEtXIcLFaB0krYfg/lUz0=",
+        "lastModified": 1711088879,
+        "narHash": "sha256-aW3tHHVGfRh+fLuddhVO2vvlgxQF/jA3u2xPhKzOXgU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c098cf85b6a8fe7b90566c2f06c1b1253d28d498",
+        "rev": "1bdfe2626390909f086504c36edc0adfd462e6ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1bdfe262`](https://github.com/nix-community/NUR/commit/1bdfe2626390909f086504c36edc0adfd462e6ed) | `` automatic update `` |