### PR TITLE
chore(flake/nur): `1bdfe262` -> `53dbc358`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711088879,
-        "narHash": "sha256-aW3tHHVGfRh+fLuddhVO2vvlgxQF/jA3u2xPhKzOXgU=",
+        "lastModified": 1711094125,
+        "narHash": "sha256-0k9qFutsinEH8KGbndl/9SYpEeOVeC0yCqgzkUj6Mqs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1bdfe2626390909f086504c36edc0adfd462e6ed",
+        "rev": "53dbc358c36b66e1b3396c71d7112ef81f2ff436",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`53dbc358`](https://github.com/nix-community/NUR/commit/53dbc358c36b66e1b3396c71d7112ef81f2ff436) | `` automatic update `` |
| [`9f089669`](https://github.com/nix-community/NUR/commit/9f089669076311a9645caa01ab5c103a916bf33e) | `` automatic update `` |