### PR TITLE
chore(flake/nur): `53dbc358` -> `c03e4bfa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711094125,
-        "narHash": "sha256-0k9qFutsinEH8KGbndl/9SYpEeOVeC0yCqgzkUj6Mqs=",
+        "lastModified": 1711095683,
+        "narHash": "sha256-mLxazCxRu18EUFAAgQroruM83rdPH1mQvIaCAUtv/DQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "53dbc358c36b66e1b3396c71d7112ef81f2ff436",
+        "rev": "c03e4bfa0dbd731210226d2b406c6b512107ed9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c03e4bfa`](https://github.com/nix-community/NUR/commit/c03e4bfa0dbd731210226d2b406c6b512107ed9e) | `` automatic update `` |
| [`f5696518`](https://github.com/nix-community/NUR/commit/f5696518847b1584a95b68c5439d4886fd775302) | `` automatic update `` |