### PR TITLE
chore(flake/emacs-overlay): `cad98a25` -> `661ffb2c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711071818,
-        "narHash": "sha256-9SmpbzwNL5m3pIqWrT+7PnQDfYBQAp8EoKcJCFyRITI=",
+        "lastModified": 1711128460,
+        "narHash": "sha256-tRkfFEfjuhP2it/C20eL6rwnsiEAPworFPc0EN8eBHE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cad98a253dc7b22fb12db42ccac3d04402e63dd0",
+        "rev": "661ffb2c8fa3a7f8d032df474d035b33aa50a4b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`661ffb2c`](https://github.com/nix-community/emacs-overlay/commit/661ffb2c8fa3a7f8d032df474d035b33aa50a4b9) | `` Updated emacs ``        |
| [`3e0e49b0`](https://github.com/nix-community/emacs-overlay/commit/3e0e49b059f7f3aa66688c85b38f9ab2e8410da6) | `` Updated melpa ``        |
| [`5a166e0a`](https://github.com/nix-community/emacs-overlay/commit/5a166e0a7a750ec08f18d61d627134d7a2948e28) | `` Updated elpa ``         |
| [`c0ccc0cc`](https://github.com/nix-community/emacs-overlay/commit/c0ccc0cc430b18b766c51942f16cd2d071fd9a90) | `` Updated nongnu ``       |
| [`b6aff5c0`](https://github.com/nix-community/emacs-overlay/commit/b6aff5c0c41400f511b689f3896a3571e8f5b1f2) | `` Updated flake inputs `` |
| [`4dc3e8eb`](https://github.com/nix-community/emacs-overlay/commit/4dc3e8ebdfbe18cf0a1dcacac242ae3f3fb878b9) | `` Updated emacs ``        |
| [`b211a25f`](https://github.com/nix-community/emacs-overlay/commit/b211a25ffa4f6938243612b63c0d59e3d2ca0259) | `` Updated melpa ``        |