### PR TITLE
chore(flake/nur): `c03e4bfa` -> `151fe92d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711095683,
-        "narHash": "sha256-mLxazCxRu18EUFAAgQroruM83rdPH1mQvIaCAUtv/DQ=",
+        "lastModified": 1711101576,
+        "narHash": "sha256-1DoVRksecbLSIkgBQKYy2pGhPeEZb4NfQkQ1o5qPb8o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c03e4bfa0dbd731210226d2b406c6b512107ed9e",
+        "rev": "151fe92dbfd47c0f536be8e5f747e7c4c21ea573",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                 |
| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`151fe92d`](https://github.com/nix-community/NUR/commit/151fe92dbfd47c0f536be8e5f747e7c4c21ea573) | `` automatic update ``                                  |
| [`6482897e`](https://github.com/nix-community/NUR/commit/6482897ed87de3782f8956ed4c906438b8f7ce8e) | `` add ona-li-toki-e-jan-Epiphany-tawa-mi repository `` |