### PR TITLE
chore(flake/nur): `f5ee95b1` -> `f1bc89bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711104278,
-        "narHash": "sha256-RNGTDnDQIZWN86ujldIeExVFlgU8GhHkPumoeyhYiUo=",
+        "lastModified": 1711107873,
+        "narHash": "sha256-FVPBC9sVWpO+OiSGwaYk6g/5Wa0+7G8DtJveuywrbbg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f5ee95b131630a3bb053c3e3e3c8a39595974ab4",
+        "rev": "f1bc89bdccbfcddfac73e7a3e28028b3baf48f66",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f1bc89bd`](https://github.com/nix-community/NUR/commit/f1bc89bdccbfcddfac73e7a3e28028b3baf48f66) | `` automatic update `` |