### PR TITLE
chore(flake/nur): `f1bc89bd` -> `01f00b3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711107873,
-        "narHash": "sha256-FVPBC9sVWpO+OiSGwaYk6g/5Wa0+7G8DtJveuywrbbg=",
+        "lastModified": 1711109287,
+        "narHash": "sha256-n82y2qP/UpdK0UNDIixTk7MFpMHMmuyLwkmaIHMhq+k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f1bc89bdccbfcddfac73e7a3e28028b3baf48f66",
+        "rev": "01f00b3e261f8bd3fde89f3274e4b707b8e9734b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`01f00b3e`](https://github.com/nix-community/NUR/commit/01f00b3e261f8bd3fde89f3274e4b707b8e9734b) | `` automatic update `` |