### PR TITLE
chore(flake/nur): `01f00b3e` -> `058c9183`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711109287,
-        "narHash": "sha256-n82y2qP/UpdK0UNDIixTk7MFpMHMmuyLwkmaIHMhq+k=",
+        "lastModified": 1711114923,
+        "narHash": "sha256-fX5g4ZNlTNGSW6dzUkfzKCQTacIVgLGAovhsA3nbRPs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "01f00b3e261f8bd3fde89f3274e4b707b8e9734b",
+        "rev": "058c918315ecbc64295046d2e81227be92ea9595",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`058c9183`](https://github.com/nix-community/NUR/commit/058c918315ecbc64295046d2e81227be92ea9595) | `` automatic update `` |
| [`00e8f787`](https://github.com/nix-community/NUR/commit/00e8f787a8f4f51e0e1f13bbf340ae496ab1e52a) | `` automatic update `` |
| [`ab42515f`](https://github.com/nix-community/NUR/commit/ab42515f42f5ea5b88425e553b26ecd0d4238112) | `` automatic update `` |