### PR TITLE
chore(flake/nur): `058c9183` -> `a7694244`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711114923,
-        "narHash": "sha256-fX5g4ZNlTNGSW6dzUkfzKCQTacIVgLGAovhsA3nbRPs=",
+        "lastModified": 1711119007,
+        "narHash": "sha256-eEzlS2ANXnqVZtzq9AWDoBWYnFj8D/NzvDEYuESXxsQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "058c918315ecbc64295046d2e81227be92ea9595",
+        "rev": "a769424490d67c40f3dbd72da70ff2b6ba0912a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a7694244`](https://github.com/nix-community/NUR/commit/a769424490d67c40f3dbd72da70ff2b6ba0912a4) | `` automatic update `` |
| [`ed992dc9`](https://github.com/nix-community/NUR/commit/ed992dc9c1058fed6f6d8b14c624ba9e139658ad) | `` automatic update `` |