### PR TITLE
chore(flake/nur): `f9e33021` -> `4144314d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711124939,
-        "narHash": "sha256-IBXc/O+T5ZLBrC6ognGgaDDVOkN0rXHYk2DXmy6OP6o=",
+        "lastModified": 1711132234,
+        "narHash": "sha256-NTmhpyFgzbHwAEwf6j9IvR6zZZuW0R1L0mPSh1IBe8Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f9e330219c525b46c8bdf71996a5f45310c741bc",
+        "rev": "4144314d7b2c929dadec0e9c81759c5909e3d2b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4144314d`](https://github.com/nix-community/NUR/commit/4144314d7b2c929dadec0e9c81759c5909e3d2b3) | `` automatic update `` |
| [`7cd27d65`](https://github.com/nix-community/NUR/commit/7cd27d65c653c418ae8bf452f9389247d154a094) | `` automatic update `` |