### PR TITLE
chore(flake/nur): `4144314d` -> `5fd75616`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711132234,
-        "narHash": "sha256-NTmhpyFgzbHwAEwf6j9IvR6zZZuW0R1L0mPSh1IBe8Q=",
+        "lastModified": 1711143998,
+        "narHash": "sha256-8Pk4h6Quez3GzxKaA0hIn1a7kPQ2Nl0KtFby/Hbcsrs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4144314d7b2c929dadec0e9c81759c5909e3d2b3",
+        "rev": "5fd756165fa3ce903c8bd9e8dfd7667a2b0c4978",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5fd75616`](https://github.com/nix-community/NUR/commit/5fd756165fa3ce903c8bd9e8dfd7667a2b0c4978) | `` automatic update `` |