### PR TITLE
chore(flake/nur): `5fd75616` -> `618e21ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711143998,
-        "narHash": "sha256-8Pk4h6Quez3GzxKaA0hIn1a7kPQ2Nl0KtFby/Hbcsrs=",
+        "lastModified": 1711147863,
+        "narHash": "sha256-EbFEQqZJIRcTLTfl1XEK6V9ULNGKhTyD4SOaNpekteY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5fd756165fa3ce903c8bd9e8dfd7667a2b0c4978",
+        "rev": "618e21ba8e21383b5cdf199c8609ba19d5a60c99",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`618e21ba`](https://github.com/nix-community/NUR/commit/618e21ba8e21383b5cdf199c8609ba19d5a60c99) | `` automatic update `` |
| [`570ed586`](https://github.com/nix-community/NUR/commit/570ed586943cb9614ca46fb3607afba41672d8d2) | `` automatic update `` |