### PR TITLE
chore(flake/emacs-overlay): `661ffb2c` -> `75440e56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711128460,
-        "narHash": "sha256-tRkfFEfjuhP2it/C20eL6rwnsiEAPworFPc0EN8eBHE=",
+        "lastModified": 1711158193,
+        "narHash": "sha256-ocLl8sf9/RrA30oew/vRR0MqVyA09FZmtqCAYOaWugg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "661ffb2c8fa3a7f8d032df474d035b33aa50a4b9",
+        "rev": "75440e565fe138f169389e1a65cc21f7ec5f0a30",
         "type": "github"
       },
       "original": {
@@ -710,11 +710,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1710951922,
-        "narHash": "sha256-FOOBJ3DQenLpTNdxMHR2CpGZmYuctb92gF0lpiirZ30=",
+        "lastModified": 1711124224,
+        "narHash": "sha256-l0zlN/3CiodvWDtfBOVxeTwYSRz93muVbXWSpaMjXxM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f091af045dff8347d66d186a62d42aceff159456",
+        "rev": "56528ee42526794d413d6f244648aaee4a7b56c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`75440e56`](https://github.com/nix-community/emacs-overlay/commit/75440e565fe138f169389e1a65cc21f7ec5f0a30) | `` Updated emacs ``        |
| [`e3f8066b`](https://github.com/nix-community/emacs-overlay/commit/e3f8066b900c949dfb4b485be36d5704f9a112dc) | `` Updated melpa ``        |
| [`a79977ec`](https://github.com/nix-community/emacs-overlay/commit/a79977ec536fa8d57ff193710131a2b662bcbc85) | `` Updated elpa ``         |
| [`c97beff9`](https://github.com/nix-community/emacs-overlay/commit/c97beff978530311380ccd8698ede4c409e20a3f) | `` Updated flake inputs `` |