### PR TITLE
chore(flake/nur): `9418abb1` -> `589d8ec7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711159264,
-        "narHash": "sha256-N9kVDjz0tA72qHkXhEQANsUfQ3YJ8OrUuHcUky1mVxY=",
+        "lastModified": 1711166128,
+        "narHash": "sha256-dqao7nVSTANkQZXvTo9XpXFjk/9DLsBA6f6wbtIToXM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9418abb1a0d6bad766f155a0404fe57534a3b963",
+        "rev": "589d8ec7b586c0d83d31f29f3489957a7ad7a81f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`589d8ec7`](https://github.com/nix-community/NUR/commit/589d8ec7b586c0d83d31f29f3489957a7ad7a81f) | `` automatic update `` |
| [`1f796ebf`](https://github.com/nix-community/NUR/commit/1f796ebf69861edde0b5ce9059c0958cf8947bee) | `` automatic update `` |
| [`552371c0`](https://github.com/nix-community/NUR/commit/552371c0415870f09b94e24d37165f877154d80f) | `` automatic update `` |
| [`297f2e70`](https://github.com/nix-community/NUR/commit/297f2e70a07072e35601611905d87670b10dffe0) | `` automatic update `` |