### PR TITLE
chore(flake/nur): `589d8ec7` -> `136efcec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711166128,
-        "narHash": "sha256-dqao7nVSTANkQZXvTo9XpXFjk/9DLsBA6f6wbtIToXM=",
+        "lastModified": 1711169206,
+        "narHash": "sha256-d4rrIWJ08aA/Ds6pQ98fWox1uqRmNrPEKqIcvcjUVhU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "589d8ec7b586c0d83d31f29f3489957a7ad7a81f",
+        "rev": "136efcec84c0acf5c2311b663c8e8e78ed463403",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`136efcec`](https://github.com/nix-community/NUR/commit/136efcec84c0acf5c2311b663c8e8e78ed463403) | `` automatic update `` |