### PR TITLE
chore(flake/nur): `0e4f7b6b` -> `b794dac6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711177229,
-        "narHash": "sha256-DIyLN/PSA4q/Lw9kvzu1FMx4lqDRZSA50kgMendwyHw=",
+        "lastModified": 1711179097,
+        "narHash": "sha256-VGCP0OIhsMc1hujOCyikKgZiqk5yFizNsML3KiWdfOM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0e4f7b6bf7693f0e24550c0886ea2725965ef68b",
+        "rev": "b794dac6911750b57f1b191f1c60fadd044b7516",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b794dac6`](https://github.com/nix-community/NUR/commit/b794dac6911750b57f1b191f1c60fadd044b7516) | `` automatic update `` |
| [`09b41e18`](https://github.com/nix-community/NUR/commit/09b41e185625f208d04074331b2ca422d4f06d70) | `` automatic update `` |