### PR TITLE
chore(flake/emacs-overlay): `75440e56` -> `5dc85425`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711158193,
-        "narHash": "sha256-ocLl8sf9/RrA30oew/vRR0MqVyA09FZmtqCAYOaWugg=",
+        "lastModified": 1711184681,
+        "narHash": "sha256-528hdf8FGxgM7qANlL+7+Pv5c9MP4obM4dCKAuLsf2s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "75440e565fe138f169389e1a65cc21f7ec5f0a30",
+        "rev": "5dc85425ccc2513d6a843bf58ddd104b5689b6c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`5dc85425`](https://github.com/nix-community/emacs-overlay/commit/5dc85425ccc2513d6a843bf58ddd104b5689b6c6) | `` Updated emacs `` |
| [`2ea50482`](https://github.com/nix-community/emacs-overlay/commit/2ea504825e8512a8ce2ffd43a7827ddac4ed3da0) | `` Updated melpa `` |