### PR TITLE
chore(flake/nur): `cdf7b85e` -> `b7d7b0d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711182575,
-        "narHash": "sha256-3qYkDO5tqJd6Kq3pvuEzQgMa59Fj7i9shn+xoH1afXI=",
+        "lastModified": 1711186400,
+        "narHash": "sha256-TBMtD0NGVZrfOYvfqPyCZjzZfqTjvyxL2X7rPPScq14=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cdf7b85e41498d3c1be94b6abb201532679f42a5",
+        "rev": "b7d7b0d4013c0b8b0d31f3381df0a27269ebc4e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b7d7b0d4`](https://github.com/nix-community/NUR/commit/b7d7b0d4013c0b8b0d31f3381df0a27269ebc4e0) | `` automatic update `` |
| [`e54329c2`](https://github.com/nix-community/NUR/commit/e54329c26b6839dc402ccefab4ac292edc18bb56) | `` automatic update `` |