### PR TITLE
chore(flake/nur): `b7d7b0d4` -> `a3ebe7a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711186400,
-        "narHash": "sha256-TBMtD0NGVZrfOYvfqPyCZjzZfqTjvyxL2X7rPPScq14=",
+        "lastModified": 1711194268,
+        "narHash": "sha256-u79VWp3ID9sebue9wz2oXA5M2AnjFzG77DjWDjXA9Ic=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b7d7b0d4013c0b8b0d31f3381df0a27269ebc4e0",
+        "rev": "a3ebe7a031d71dd3c979a6d4c99d53958631acd8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a3ebe7a0`](https://github.com/nix-community/NUR/commit/a3ebe7a031d71dd3c979a6d4c99d53958631acd8) | `` automatic update `` |
| [`8f5e05e5`](https://github.com/nix-community/NUR/commit/8f5e05e50ced9197fc6fc21d73f53276eed05eeb) | `` automatic update `` |
| [`6d28d52c`](https://github.com/nix-community/NUR/commit/6d28d52cad64e309e0ba0d8ab6bcf080b0570e67) | `` automatic update `` |