### PR TITLE
chore(flake/nur): `a3ebe7a0` -> `acb503f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711194268,
-        "narHash": "sha256-u79VWp3ID9sebue9wz2oXA5M2AnjFzG77DjWDjXA9Ic=",
+        "lastModified": 1711195696,
+        "narHash": "sha256-i2pHhQFpNzlMB+9uCai8jGSmjY7/XMAs9AiCE+g6gYk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a3ebe7a031d71dd3c979a6d4c99d53958631acd8",
+        "rev": "acb503f120503349d81e2c8791b0b6d6fb9485be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`acb503f1`](https://github.com/nix-community/NUR/commit/acb503f120503349d81e2c8791b0b6d6fb9485be) | `` automatic update `` |