### PR TITLE
chore(flake/nur): `acb503f1` -> `76abf534`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711195696,
-        "narHash": "sha256-i2pHhQFpNzlMB+9uCai8jGSmjY7/XMAs9AiCE+g6gYk=",
+        "lastModified": 1711199179,
+        "narHash": "sha256-pBVqbCTrZAla7wImf0Lfj08DqCzbk+B/21y5WpPLYXo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "acb503f120503349d81e2c8791b0b6d6fb9485be",
+        "rev": "76abf5345942cfc59c85905d3ae32187fbc6a85e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`76abf534`](https://github.com/nix-community/NUR/commit/76abf5345942cfc59c85905d3ae32187fbc6a85e) | `` automatic update `` |