### PR TITLE
chore(flake/emacs-overlay): `5dc85425` -> `2d56af52`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711184681,
-        "narHash": "sha256-528hdf8FGxgM7qANlL+7+Pv5c9MP4obM4dCKAuLsf2s=",
+        "lastModified": 1711213350,
+        "narHash": "sha256-UKdhoZkS1I6jemmOpaUgt1qwdsZ6AtizHJx+WXsxRNE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5dc85425ccc2513d6a843bf58ddd104b5689b6c6",
+        "rev": "2d56af526e581cd6af4b28b508dbac970bf2f536",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`2d56af52`](https://github.com/nix-community/emacs-overlay/commit/2d56af526e581cd6af4b28b508dbac970bf2f536) | `` Updated emacs `` |
| [`a3e3e382`](https://github.com/nix-community/emacs-overlay/commit/a3e3e3826b7afd237956c4832cfe6806a1e7e2b5) | `` Updated melpa `` |
| [`b527a992`](https://github.com/nix-community/emacs-overlay/commit/b527a992efa2efc26c446c8b2c22b7e65dfc941d) | `` Updated elpa ``  |