### PR TITLE
chore(flake/nur): `02f08008` -> `ad4663ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711212258,
-        "narHash": "sha256-/YqMeny1WS/UTIH25k/nJwfpfAknbnHhKk6JurfyJYY=",
+        "lastModified": 1711214198,
+        "narHash": "sha256-oDIIckJPfWXK/O5gFFHTtc7f7T0FFEVFYY7QMGvw0g4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "02f080084ab18347fea8842e91c6180c9f0f9d99",
+        "rev": "ad4663ba863f5e7a09c70811ed9abddea238bcbf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ad4663ba`](https://github.com/nix-community/NUR/commit/ad4663ba863f5e7a09c70811ed9abddea238bcbf) | `` automatic update `` |