### PR TITLE
chore(flake/emacs-overlay): `fb0b8273` -> `4ad65bb1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711242161,
-        "narHash": "sha256-L8FR1w4DaoBBTh4shRRf8vdeRPQzXl5X0O81UI8E0Bw=",
+        "lastModified": 1711244990,
+        "narHash": "sha256-nIULDbyLcZIJbNNQwIliYWqSG3xTP9uLPAncflBMgvU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fb0b8273fdbb853c97dcfb9d0c02f3581a23d92a",
+        "rev": "4ad65bb18dc1b6e9bd62a9375986025ef9beb488",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`4ad65bb1`](https://github.com/nix-community/emacs-overlay/commit/4ad65bb18dc1b6e9bd62a9375986025ef9beb488) | `` Updated emacs `` |
| [`80a28966`](https://github.com/nix-community/emacs-overlay/commit/80a289667716a29aef3f0f4ba6b5bfba118e2657) | `` Updated melpa `` |