### PR TITLE
chore(flake/nur): `7a46497a` -> `f532e0f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711243889,
-        "narHash": "sha256-MX9SlY80NyFgGqnifVIMU4KzjNr7qqb8WW58Eu+Clr0=",
+        "lastModified": 1711247211,
+        "narHash": "sha256-5zb1hOx4dd+IJCSiL3DQt5cNjcIIFzn6Nbku904QCEI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7a46497a9a1488036b875c818ee680d753a6e204",
+        "rev": "f532e0f7404fa4899348ccc472b62c401ba91bc7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f532e0f7`](https://github.com/nix-community/NUR/commit/f532e0f7404fa4899348ccc472b62c401ba91bc7) | `` automatic update `` |
| [`9080f296`](https://github.com/nix-community/NUR/commit/9080f2966d3938b0d53de178b940899af8a16273) | `` automatic update `` |