### PR TITLE
chore(flake/nur): `f532e0f7` -> `141b6000`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711247211,
-        "narHash": "sha256-5zb1hOx4dd+IJCSiL3DQt5cNjcIIFzn6Nbku904QCEI=",
+        "lastModified": 1711251386,
+        "narHash": "sha256-MCquUbbED9gk0YfB+Zfp1VImmpNV4LpoR0YaN5pjNIQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f532e0f7404fa4899348ccc472b62c401ba91bc7",
+        "rev": "141b6000ce386f29ce15c890f5b6e35c2238f4ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`141b6000`](https://github.com/nix-community/NUR/commit/141b6000ce386f29ce15c890f5b6e35c2238f4ab) | `` automatic update `` |
| [`fd0df72f`](https://github.com/nix-community/NUR/commit/fd0df72f269fb747aa312452377f014a75f05d3d) | `` automatic update `` |
| [`2c51591d`](https://github.com/nix-community/NUR/commit/2c51591d403544d53733e33fcd2b84d0ab0b4a5e) | `` automatic update `` |