### PR TITLE
chore(flake/nur): `141b6000` -> `a5a4532b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711251386,
-        "narHash": "sha256-MCquUbbED9gk0YfB+Zfp1VImmpNV4LpoR0YaN5pjNIQ=",
+        "lastModified": 1711254688,
+        "narHash": "sha256-SRVaAGt3I26ZbmwZQa7pueZkToGKS1tVVxvihON2C3Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "141b6000ce386f29ce15c890f5b6e35c2238f4ab",
+        "rev": "a5a4532bb8923fd29a7a313b60d577211a16cf3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a5a4532b`](https://github.com/nix-community/NUR/commit/a5a4532bb8923fd29a7a313b60d577211a16cf3a) | `` automatic update `` |
| [`fe8fe34f`](https://github.com/nix-community/NUR/commit/fe8fe34f4bdb35c35f50e8e419ec1d4d51ad7028) | `` automatic update `` |