### PR TITLE
chore(flake/nur): `a5a4532b` -> `bfb075d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711254688,
-        "narHash": "sha256-SRVaAGt3I26ZbmwZQa7pueZkToGKS1tVVxvihON2C3Y=",
+        "lastModified": 1711261672,
+        "narHash": "sha256-cunLshFqtSeqpqP1Wb5QPT2F6LYssWaoZxUJCVJ8pZo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a5a4532bb8923fd29a7a313b60d577211a16cf3a",
+        "rev": "bfb075d8578037260b80a69203a1d9fd391f3e34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bfb075d8`](https://github.com/nix-community/NUR/commit/bfb075d8578037260b80a69203a1d9fd391f3e34) | `` automatic update `` |