### PR TITLE
chore(flake/emacs-overlay): `4ad65bb1` -> `d6bbd32e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711244990,
-        "narHash": "sha256-nIULDbyLcZIJbNNQwIliYWqSG3xTP9uLPAncflBMgvU=",
+        "lastModified": 1711271005,
+        "narHash": "sha256-JrhnnutZvHowEJFIrA/rQAFgGAc83WOx+BVy97teqKM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4ad65bb18dc1b6e9bd62a9375986025ef9beb488",
+        "rev": "d6bbd32eb3e0f167f312e1031c1beee452dc9174",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`d6bbd32e`](https://github.com/nix-community/emacs-overlay/commit/d6bbd32eb3e0f167f312e1031c1beee452dc9174) | `` Updated emacs `` |
| [`d3a94d43`](https://github.com/nix-community/emacs-overlay/commit/d3a94d43373ad928335853223470503d46cbf827) | `` Updated melpa `` |