### PR TITLE
chore(flake/nur): `b1ef58aa` -> `4bbc9c64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711269179,
-        "narHash": "sha256-ZgFCaZwJbGSAsA6kddebRLuUU9oli94oopKhE5wMr6U=",
+        "lastModified": 1711284997,
+        "narHash": "sha256-AWrSU67HMatCrv/CKWuPSKpO69aRtweQzDUmOg4PXdQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b1ef58aad1eee7dfcbb361bff39d60b216a74508",
+        "rev": "4bbc9c64a7326b39494af8fe19095abc0054760b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4bbc9c64`](https://github.com/nix-community/NUR/commit/4bbc9c64a7326b39494af8fe19095abc0054760b) | `` automatic update `` |
| [`4331ae5c`](https://github.com/nix-community/NUR/commit/4331ae5ce1f4132be4cd1cb97c23637358d32a13) | `` automatic update `` |
| [`24cb68fc`](https://github.com/nix-community/NUR/commit/24cb68fc561a21128c8fa94b5f7638025399c41d) | `` automatic update `` |
| [`8ef4be78`](https://github.com/nix-community/NUR/commit/8ef4be789b09122a98de08ef3496c65511b3b35d) | `` automatic update `` |