### PR TITLE
chore(flake/emacs-overlay): `d6bbd32e` -> `50c3a1f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711271005,
-        "narHash": "sha256-JrhnnutZvHowEJFIrA/rQAFgGAc83WOx+BVy97teqKM=",
+        "lastModified": 1711298983,
+        "narHash": "sha256-VvsZWBjLubjClKHcHl+eirBy8wdX0UuxhHxWrv5cnXk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d6bbd32eb3e0f167f312e1031c1beee452dc9174",
+        "rev": "50c3a1f7ffc6b9e85e5b74c1a15fd7d5780dd817",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`50c3a1f7`](https://github.com/nix-community/emacs-overlay/commit/50c3a1f7ffc6b9e85e5b74c1a15fd7d5780dd817) | `` Updated melpa `` |
| [`422f326f`](https://github.com/nix-community/emacs-overlay/commit/422f326f7a2786d4454d2a942cac81fe0a835d43) | `` Updated elpa ``  |