### PR TITLE
chore(flake/emacs-overlay): `50c3a1f7` -> `cea4619a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711298983,
-        "narHash": "sha256-VvsZWBjLubjClKHcHl+eirBy8wdX0UuxhHxWrv5cnXk=",
+        "lastModified": 1711301146,
+        "narHash": "sha256-q74EoQ3bnf0nCUz26QBjcRJ76CJgS7mcpOq2FeYfS3o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "50c3a1f7ffc6b9e85e5b74c1a15fd7d5780dd817",
+        "rev": "cea4619a3f9026cb4d805c81a70280c05ace512a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`cea4619a`](https://github.com/nix-community/emacs-overlay/commit/cea4619a3f9026cb4d805c81a70280c05ace512a) | `` Updated emacs `` |