### PR TITLE
chore(flake/nur): `3ff3675c` -> `c7cd4210`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711295217,
-        "narHash": "sha256-8n1sVXcFNcR/LpZDsWxvvqp+wJYUhqG3lQPsxJv/Eco=",
+        "lastModified": 1711302386,
+        "narHash": "sha256-fwmvXTVnFYiA98rTbSeNKZfv83l57iroT++THM7o0KY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3ff3675c67eb0ce58f8bc47bc796ab8033eff641",
+        "rev": "c7cd421028fab1fd4771ddf89eb9c24a4248f3a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c7cd4210`](https://github.com/nix-community/NUR/commit/c7cd421028fab1fd4771ddf89eb9c24a4248f3a2) | `` automatic update `` |