### PR TITLE
chore(flake/nur): `c7cd4210` -> `863657f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711302386,
-        "narHash": "sha256-fwmvXTVnFYiA98rTbSeNKZfv83l57iroT++THM7o0KY=",
+        "lastModified": 1711306740,
+        "narHash": "sha256-oG92pJ/SdEbb+utwhWhz/KGxlHyxpP/369NkDbp7i9Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c7cd421028fab1fd4771ddf89eb9c24a4248f3a2",
+        "rev": "863657f6d96b045a506a53c709703a4eca7868a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`863657f6`](https://github.com/nix-community/NUR/commit/863657f6d96b045a506a53c709703a4eca7868a6) | `` automatic update `` |
| [`c20ec55d`](https://github.com/nix-community/NUR/commit/c20ec55d3b83057e7fe1c3c84c3576ae41628da4) | `` automatic update `` |
| [`775ae3cb`](https://github.com/nix-community/NUR/commit/775ae3cb9a0a68c1ec64c4fd4f0bf45b453c72aa) | `` automatic update `` |