### PR TITLE
chore(flake/nur): `863657f6` -> `1393242e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711306740,
-        "narHash": "sha256-oG92pJ/SdEbb+utwhWhz/KGxlHyxpP/369NkDbp7i9Q=",
+        "lastModified": 1711310052,
+        "narHash": "sha256-x2uMh3JFblIZ+uLsSQY1Px1/II4sKk07qvvxbOQ7V+k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "863657f6d96b045a506a53c709703a4eca7868a6",
+        "rev": "1393242e65123b8752087e0f997626071e1f8656",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1393242e`](https://github.com/nix-community/NUR/commit/1393242e65123b8752087e0f997626071e1f8656) | `` automatic update `` |
| [`835f0ddd`](https://github.com/nix-community/NUR/commit/835f0ddd8270463ae3d7be720c67e03c6d047889) | `` automatic update `` |