### PR TITLE
chore(flake/nur): `725550ba` -> `5571ac76`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711317209,
-        "narHash": "sha256-aVnzNYohn26ZubTCwSEnZBRZi7zDMGZsHm9TSjmQFMc=",
+        "lastModified": 1711329112,
+        "narHash": "sha256-Q88QjetVa49Wkgl/zx51ZFOkAxdcqO0n0CHjthfGJBg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "725550ba4278e1dec4b79960a53d0f98dc3822e8",
+        "rev": "5571ac769a3de8152a10d70ca9544e8a461c77d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5571ac76`](https://github.com/nix-community/NUR/commit/5571ac769a3de8152a10d70ca9544e8a461c77d2) | `` automatic update `` |
| [`c58d5684`](https://github.com/nix-community/NUR/commit/c58d5684752ab9141652f7f9b54bdb5c605162ee) | `` automatic update `` |