### PR TITLE
chore(flake/emacs-overlay): `cea4619a` -> `3b51a532`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711301146,
-        "narHash": "sha256-q74EoQ3bnf0nCUz26QBjcRJ76CJgS7mcpOq2FeYfS3o=",
+        "lastModified": 1711330304,
+        "narHash": "sha256-ekzWO410axeB8MGFcFbUHjrERMt3WcXaFak4zW4WYtA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cea4619a3f9026cb4d805c81a70280c05ace512a",
+        "rev": "3b51a53286ab12124ddb7e22e037bad2aeb6dc0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`3b51a532`](https://github.com/nix-community/emacs-overlay/commit/3b51a53286ab12124ddb7e22e037bad2aeb6dc0f) | `` Updated melpa ``  |
| [`40c879a7`](https://github.com/nix-community/emacs-overlay/commit/40c879a7212f4ff242fab34d3d604ce3856d1d55) | `` Updated elpa ``   |
| [`e4f201b6`](https://github.com/nix-community/emacs-overlay/commit/e4f201b647af64fd18aaf671fec0ceb8a71d1e0f) | `` Updated nongnu `` |