### PR TITLE
chore(flake/srvos): `918e2ad3` -> `c490c19a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -994,11 +994,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710982111,
-        "narHash": "sha256-IKcJnJwLnNXcnTZY4vxhQ0zEkZvr7srhXSZpxa3IiHA=",
+        "lastModified": 1711327968,
+        "narHash": "sha256-L8UatcwpSi7KSn6+f2ULPdt/1XTPdZirX+K+cwo4mv0=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "918e2ad35a9ce4071e9bc72e82ad97a65c8b861b",
+        "rev": "c490c19a959d406c87ae1c1481a4608d41a83597",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`c490c19a`](https://github.com/nix-community/srvos/commit/c490c19a959d406c87ae1c1481a4608d41a83597) | `` dev/private/flake.lock: Update `` |
| [`f21cb13c`](https://github.com/nix-community/srvos/commit/f21cb13c8e3511f3766f0e954b83031efb07b974) | `` flake.lock: Update ``             |