### PR TITLE
chore(flake/nur): `5571ac76` -> `e65fe342`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711329112,
-        "narHash": "sha256-Q88QjetVa49Wkgl/zx51ZFOkAxdcqO0n0CHjthfGJBg=",
+        "lastModified": 1711339044,
+        "narHash": "sha256-FBl0rD/b0+r+vJaL/Q5xq9jSmPdYG+qVEaX3YgSJAU0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5571ac769a3de8152a10d70ca9544e8a461c77d2",
+        "rev": "e65fe342315ed4fe3201369f7802646eaa40cd8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e65fe342`](https://github.com/nix-community/NUR/commit/e65fe342315ed4fe3201369f7802646eaa40cd8b) | `` automatic update `` |
| [`c1e05715`](https://github.com/nix-community/NUR/commit/c1e05715adf14c227de681002e88ffb2620c56ac) | `` automatic update `` |