### PR TITLE
chore(flake/nur): `a4df8795` -> `785c5c00`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711346013,
-        "narHash": "sha256-CCzWq1iOdlJHsAGDfptedmnysttJAyonl8+N8+d4blQ=",
+        "lastModified": 1711348004,
+        "narHash": "sha256-/dmMqjGh/Iv/F1vJCPq8pWtoGRhjq9J66k9FsKSrLCo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a4df8795e4b0171f620853b878b57e230c8ce885",
+        "rev": "785c5c00b489e69773bcac0c28a46eee990dd12b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`785c5c00`](https://github.com/nix-community/NUR/commit/785c5c00b489e69773bcac0c28a46eee990dd12b) | `` automatic update `` |
| [`8c2e26d0`](https://github.com/nix-community/NUR/commit/8c2e26d0ab2663132b1e43eab890cc53da3cac14) | `` automatic update `` |