### PR TITLE
chore(flake/nixos-hardware): `7559df1e` -> `9a763a7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -631,11 +631,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1711274671,
-        "narHash": "sha256-19KQXya5VERUXOdeEJJN+zOqtvuE6MV3qTk9Gr4J9Uo=",
+        "lastModified": 1711352745,
+        "narHash": "sha256-luvqik+i3HTvCbXQZgB6uggvEcxI9uae0nmrgtXJ17U=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "7559df1e4af972d5f1de87975b5ef6a8d7559db2",
+        "rev": "9a763a7acc4cfbb8603bb0231fec3eda864f81c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                 |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`474549f8`](https://github.com/NixOS/nixos-hardware/commit/474549f84151ceaed1c4ef0465192c7b0952f161) | `` gigabyte b550: suspend fix (#884) `` |
| [`19e5d3c9`](https://github.com/NixOS/nixos-hardware/commit/19e5d3c9d984d35edfd6ed1700c67d25b5030ed0) | `` Add Thinkpad X13 Gen1 AMD variant `` |