### PR TITLE
chore(flake/emacs-overlay): `0bd7189c` -> `b0277cb5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711356788,
-        "narHash": "sha256-Epwi57p1lDJvwYFoOu9A7z2eOhjXH26J4HtrzEX5wGg=",
+        "lastModified": 1711357602,
+        "narHash": "sha256-Y/B63A2iJd/TN3FVruNVjgQT934cYZDGXNEAKIkGqIc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0bd7189c98161c469713f03a42fe599c53fcf98d",
+        "rev": "b0277cb505f1ab0e5ea4b1ed22128f31aaec294a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`b0277cb5`](https://github.com/nix-community/emacs-overlay/commit/b0277cb505f1ab0e5ea4b1ed22128f31aaec294a) | `` Updated emacs `` |