### PR TITLE
chore(flake/nur): `1fe0820e` -> `11da1f8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711360026,
-        "narHash": "sha256-1MyDu65b7hECwOtvgWTDZ+NodGdPdpYkFqGT22TB6yk=",
+        "lastModified": 1711367244,
+        "narHash": "sha256-VayOuXyAKPTb4x2UbDtq3+QPfGHRsVhHwRKh3mbCiHA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1fe0820e8caaa45a2d686141c72c44c0a14e71cc",
+        "rev": "11da1f8d50f4cceb49acfda174be161ddfee4bf3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`11da1f8d`](https://github.com/nix-community/NUR/commit/11da1f8d50f4cceb49acfda174be161ddfee4bf3) | `` automatic update `` |
| [`f03b54df`](https://github.com/nix-community/NUR/commit/f03b54df0edde4d19fa8bc825a55724669714149) | `` automatic update `` |