### PR TITLE
chore(flake/nur): `11da1f8d` -> `8252030c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711367244,
-        "narHash": "sha256-VayOuXyAKPTb4x2UbDtq3+QPfGHRsVhHwRKh3mbCiHA=",
+        "lastModified": 1711369635,
+        "narHash": "sha256-4Z7O66RjOJQD5kBkC0mdr3kcXbGv6NbTTuHRV/cX3BA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "11da1f8d50f4cceb49acfda174be161ddfee4bf3",
+        "rev": "8252030c815034f49133b9325f924a75754eedd9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8252030c`](https://github.com/nix-community/NUR/commit/8252030c815034f49133b9325f924a75754eedd9) | `` automatic update `` |