### PR TITLE
chore(flake/nur): `8252030c` -> `d17d5f64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711369635,
-        "narHash": "sha256-4Z7O66RjOJQD5kBkC0mdr3kcXbGv6NbTTuHRV/cX3BA=",
+        "lastModified": 1711375271,
+        "narHash": "sha256-eCjObd7yAmTJBftJpy76mD8wRSizS77ZZ/+aECRt8tM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8252030c815034f49133b9325f924a75754eedd9",
+        "rev": "d17d5f6411b9c6ef36dd4936652531d692618625",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d17d5f64`](https://github.com/nix-community/NUR/commit/d17d5f6411b9c6ef36dd4936652531d692618625) | `` automatic update `` |
| [`906301be`](https://github.com/nix-community/NUR/commit/906301be75ee865f17cb6fc52720df9dcb49b93f) | `` automatic update `` |
| [`bae5d589`](https://github.com/nix-community/NUR/commit/bae5d589b7c3256a15cfd6372dbd59120cf35192) | `` automatic update `` |