### PR TITLE
chore(flake/emacs-overlay): `b0277cb5` -> `b7e580bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711357602,
-        "narHash": "sha256-Y/B63A2iJd/TN3FVruNVjgQT934cYZDGXNEAKIkGqIc=",
+        "lastModified": 1711386356,
+        "narHash": "sha256-BkvtIgIEgaeM77oAb7QtwCUm8lHCywxOTCgU7zVYuo4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b0277cb505f1ab0e5ea4b1ed22128f31aaec294a",
+        "rev": "b7e580bd8e698b784a02a20071007930f993de99",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`b7e580bd`](https://github.com/nix-community/emacs-overlay/commit/b7e580bd8e698b784a02a20071007930f993de99) | `` Updated emacs `` |
| [`86bba67a`](https://github.com/nix-community/emacs-overlay/commit/86bba67a652c066cae1fb53ef0f23c96b721d2c4) | `` Updated melpa `` |
| [`e9baa59a`](https://github.com/nix-community/emacs-overlay/commit/e9baa59a453ec4e833f708ce1e9b75ee525e9845) | `` Updated elpa ``  |