### PR TITLE
chore(flake/nur): `435c03ee` -> `c0e385dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711377844,
-        "narHash": "sha256-E5jsUyR5UQY5slFiCO+QtGOFj56UWPNgKoKgnW4eZnM=",
+        "lastModified": 1711384832,
+        "narHash": "sha256-X/HitvznpziQu3GYr5FoBp5rSV1R3T5xgQnKfmlGGf4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "435c03ee817cba44dd394383b0f7a9a33216d649",
+        "rev": "c0e385ddfb79a073f945890d66a0c1e4c24ea9dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c0e385dd`](https://github.com/nix-community/NUR/commit/c0e385ddfb79a073f945890d66a0c1e4c24ea9dd) | `` automatic update `` |
| [`9353835b`](https://github.com/nix-community/NUR/commit/9353835b1818b9e7593272e637827b5781de8fd5) | `` automatic update `` |