### PR TITLE
chore(flake/nur): `c0e385dd` -> `de949cf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711384832,
-        "narHash": "sha256-X/HitvznpziQu3GYr5FoBp5rSV1R3T5xgQnKfmlGGf4=",
+        "lastModified": 1711391150,
+        "narHash": "sha256-JxZjYgddO/OfkNMYs4K1sZFC8KlSLCn6OWF2W/QStiI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c0e385ddfb79a073f945890d66a0c1e4c24ea9dd",
+        "rev": "de949cf5f7456d62398d2d5ee2cf235e1a1df0b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`de949cf5`](https://github.com/nix-community/NUR/commit/de949cf5f7456d62398d2d5ee2cf235e1a1df0b7) | `` automatic update `` |