### PR TITLE
chore(flake/nur): `de949cf5` -> `3871405d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711391150,
-        "narHash": "sha256-JxZjYgddO/OfkNMYs4K1sZFC8KlSLCn6OWF2W/QStiI=",
+        "lastModified": 1711396879,
+        "narHash": "sha256-YZNNY8TH6diuLYHGc2tJCqP49GOwk0UOs9FH+37vRnw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "de949cf5f7456d62398d2d5ee2cf235e1a1df0b7",
+        "rev": "3871405d402bfd5e8cb0f2a907b657d84069523f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3871405d`](https://github.com/nix-community/NUR/commit/3871405d402bfd5e8cb0f2a907b657d84069523f) | `` automatic update `` |
| [`4f822591`](https://github.com/nix-community/NUR/commit/4f822591ad9552c2ed858d90ca0e82846984ceaf) | `` automatic update `` |