### PR TITLE
chore(flake/nur): `3871405d` -> `1538059e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711396879,
-        "narHash": "sha256-YZNNY8TH6diuLYHGc2tJCqP49GOwk0UOs9FH+37vRnw=",
+        "lastModified": 1711399488,
+        "narHash": "sha256-vdIJpgLHMgcOMrQR4Jz26mV/1EdySuSTciSAXk1RCCI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3871405d402bfd5e8cb0f2a907b657d84069523f",
+        "rev": "1538059ec8aeac3a01186f63e24c23eb7c2f4cbd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1538059e`](https://github.com/nix-community/NUR/commit/1538059ec8aeac3a01186f63e24c23eb7c2f4cbd) | `` automatic update `` |