### PR TITLE
chore(flake/nur): `1538059e` -> `d4c1a20d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711399488,
-        "narHash": "sha256-vdIJpgLHMgcOMrQR4Jz26mV/1EdySuSTciSAXk1RCCI=",
+        "lastModified": 1711403229,
+        "narHash": "sha256-XVaXVp5KbW2yL6aiL+21PMBWrglIJEDvGmXTPMtZYZw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1538059ec8aeac3a01186f63e24c23eb7c2f4cbd",
+        "rev": "d4c1a20daebafce67d767b6139b36c7115a10405",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d4c1a20d`](https://github.com/nix-community/NUR/commit/d4c1a20daebafce67d767b6139b36c7115a10405) | `` automatic update `` |
| [`4256fed0`](https://github.com/nix-community/NUR/commit/4256fed0d833bd34f343d5786bc0901d706b767d) | `` automatic update `` |