### PR TITLE
chore(flake/pre-commit-hooks): `e611897d` -> `db656fc3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -881,11 +881,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1710923068,
-        "narHash": "sha256-6hOpUiuxuwpXXc/xfJsBUJeqqgGI+JMJuLo45aG3cKc=",
+        "lastModified": 1711409088,
+        "narHash": "sha256-+rTCra8TY4vuSNTtQ0tcex1syCRPoKyb8vyHmoxkga4=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "e611897ddfdde3ed3eaac4758635d7177ff78673",
+        "rev": "db656fc3e34907000df26e8bc5cc3c94fb27f353",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`b54aac8e`](https://github.com/cachix/pre-commit-hooks.nix/commit/b54aac8e39a0a0f2ccf8cd95aa747f4b3489bcf8) | `` Add ripsecrets hook `` |