### PR TITLE
chore(flake/emacs-overlay): `b7e580bd` -> `c2e5f187`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711386356,
-        "narHash": "sha256-BkvtIgIEgaeM77oAb7QtwCUm8lHCywxOTCgU7zVYuo4=",
+        "lastModified": 1711414652,
+        "narHash": "sha256-Cf16PDtyBW9CJX/pzFIaBydx6uI9SyEprxAUaavMCHk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b7e580bd8e698b784a02a20071007930f993de99",
+        "rev": "c2e5f187f0efa2668c08e228152f7b561c5b65bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`c2e5f187`](https://github.com/nix-community/emacs-overlay/commit/c2e5f187f0efa2668c08e228152f7b561c5b65bd) | `` Updated elpa `` |