### PR TITLE
chore(flake/emacs-overlay): `c2e5f187` -> `6be3f18f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711414652,
-        "narHash": "sha256-Cf16PDtyBW9CJX/pzFIaBydx6uI9SyEprxAUaavMCHk=",
+        "lastModified": 1711416635,
+        "narHash": "sha256-mhqtVG7gZC5Dvi6WUZeT33muqZYNOXiye7FEauXGNBA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c2e5f187f0efa2668c08e228152f7b561c5b65bd",
+        "rev": "6be3f18f4547b7e16b914a3e1e55baa1e775a3e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`6be3f18f`](https://github.com/nix-community/emacs-overlay/commit/6be3f18f4547b7e16b914a3e1e55baa1e775a3e3) | `` Updated melpa `` |