### PR TITLE
chore(flake/nur): `6ed757d5` -> `5b284306`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711424667,
-        "narHash": "sha256-KWoHkYSLNIG3p+f86i4KMnDA69TtLtYWsIirT6xKtJ8=",
+        "lastModified": 1711428566,
+        "narHash": "sha256-ns01HYTd9RhOqxaGVSDxeQuQVngOeP1Rpuh0Du4JblY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6ed757d52c37f6a75ad2c17ee221d297a3953bed",
+        "rev": "5b284306b24af67544d75b69d16d0dbe2f2f6c1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5b284306`](https://github.com/nix-community/NUR/commit/5b284306b24af67544d75b69d16d0dbe2f2f6c1a) | `` automatic update `` |
| [`56d4ab39`](https://github.com/nix-community/NUR/commit/56d4ab39f5296f3a3be6f33a9b2f05db57f8326f) | `` automatic update `` |
| [`d983516c`](https://github.com/nix-community/NUR/commit/d983516cb75fa48e46e181a81dc89c0316acc344) | `` automatic update `` |
| [`eb9ae3cd`](https://github.com/nix-community/NUR/commit/eb9ae3cd0c019dd06df7d90701dcea2b343b8c5c) | `` automatic update `` |