### PR TITLE
chore(flake/nur): `5b284306` -> `770ae6b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711428566,
-        "narHash": "sha256-ns01HYTd9RhOqxaGVSDxeQuQVngOeP1Rpuh0Du4JblY=",
+        "lastModified": 1711430204,
+        "narHash": "sha256-G73YsMO63nXTb5N1Po5a5l1Frbh2bxdzdffs1nAQpTs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5b284306b24af67544d75b69d16d0dbe2f2f6c1a",
+        "rev": "770ae6b12dbb483057c96f3cf8437ce05ee9bacf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`770ae6b1`](https://github.com/nix-community/NUR/commit/770ae6b12dbb483057c96f3cf8437ce05ee9bacf) | `` automatic update `` |