### PR TITLE
chore(flake/nur): `31f7e25c` -> `9a1b6e56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711434559,
-        "narHash": "sha256-xKJxWVxml6KAEXthBfTKUp/WPVemH1TneSG27Xgtb+I=",
+        "lastModified": 1711439095,
+        "narHash": "sha256-TEUZ9f6avdpWW25mjxvgXfrEsyL+FAj23IYuK5yto+k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "31f7e25c328833841d91661a2483aa122a4699ae",
+        "rev": "9a1b6e56322c63beda1c3016faf5d584c2c592ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9a1b6e56`](https://github.com/nix-community/NUR/commit/9a1b6e56322c63beda1c3016faf5d584c2c592ac) | `` automatic update `` |
| [`f86670e4`](https://github.com/nix-community/NUR/commit/f86670e4869416a98519e0512cd57fff647fb9e8) | `` automatic update `` |
| [`afa19aae`](https://github.com/nix-community/NUR/commit/afa19aae5fe105b9f120c6fd0ed82332e6b2b0eb) | `` automatic update `` |