### PR TITLE
chore(flake/nur): `29fb3ba3` -> `d98b152c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711441864,
-        "narHash": "sha256-IydTkm5qYJRNkH/D7TNw2AJs/4CkWLNvkHIU7zRJq4E=",
+        "lastModified": 1711453554,
+        "narHash": "sha256-f6rwDTE7V9m55yoqytA+EXMs8axFhpPQvjX8L81EJHQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "29fb3ba317fe519e65bbd2a176bb5581a61025cd",
+        "rev": "d98b152c918bfdda27524a6ed492f5f6884f04ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d98b152c`](https://github.com/nix-community/NUR/commit/d98b152c918bfdda27524a6ed492f5f6884f04ae) | `` automatic update `` |
| [`45add4b9`](https://github.com/nix-community/NUR/commit/45add4b9962011f0e988619d61f930a7cc5195f0) | `` automatic update `` |