### PR TITLE
chore(flake/emacs-overlay): `81d4eb04` -> `13612d96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711443855,
-        "narHash": "sha256-jPEUYELo7ACEiFU7jKDdQ+yC5OkqG2UcHk1/N+N7f3E=",
+        "lastModified": 1711472751,
+        "narHash": "sha256-MZ81c3n8hbzZJL22rPjy+aMiz06ZOylxgmv4wE1G7hQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "81d4eb044fac45daf51281a046d413a40f05d103",
+        "rev": "13612d96aa95d84cdea6fe0c8fef8117e98ef256",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`13612d96`](https://github.com/nix-community/emacs-overlay/commit/13612d96aa95d84cdea6fe0c8fef8117e98ef256) | `` Updated emacs `` |
| [`97092bb3`](https://github.com/nix-community/emacs-overlay/commit/97092bb3498e0a13eac1493d5cb7f5233cc29f8e) | `` Updated melpa `` |
| [`e8388bf6`](https://github.com/nix-community/emacs-overlay/commit/e8388bf6202d0de9f8f8dc04223e1557a5637a45) | `` Updated elpa ``  |