### PR TITLE
chore(flake/nur): `ed6250ce` -> `43bab0ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711462639,
-        "narHash": "sha256-HmvhZIFTnGZKcaCK95lbdiw9FlEDfc84bjg1K/U+T3Y=",
+        "lastModified": 1711471517,
+        "narHash": "sha256-ffGkKm0aUBZrwgbngUU1ydiQsSER48LMYl8/OEoaD9E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed6250ce6000c12d59a2159a67159d45780538a1",
+        "rev": "43bab0ae75bfaa39d64b0183c533b4cbe680d6af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`43bab0ae`](https://github.com/nix-community/NUR/commit/43bab0ae75bfaa39d64b0183c533b4cbe680d6af) | `` automatic update `` |