### PR TITLE
chore(flake/nur): `43bab0ae` -> `b3bb0dca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711471517,
-        "narHash": "sha256-ffGkKm0aUBZrwgbngUU1ydiQsSER48LMYl8/OEoaD9E=",
+        "lastModified": 1711477522,
+        "narHash": "sha256-WcImWmfhIKsFfBKt5ofi1mZAI7QGGUu930+8jTHeOYs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "43bab0ae75bfaa39d64b0183c533b4cbe680d6af",
+        "rev": "b3bb0dca0d2943ec192cefcf4d15ba7532c377e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b3bb0dca`](https://github.com/nix-community/NUR/commit/b3bb0dca0d2943ec192cefcf4d15ba7532c377e4) | `` automatic update `` |