### PR TITLE
chore(flake/nur): `b3bb0dca` -> `8c204036`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711477522,
-        "narHash": "sha256-WcImWmfhIKsFfBKt5ofi1mZAI7QGGUu930+8jTHeOYs=",
+        "lastModified": 1711484723,
+        "narHash": "sha256-YdX9qnD6zzY7LCGn83TgS7CKTr4RxYUoNfI6UJ39Rx4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b3bb0dca0d2943ec192cefcf4d15ba7532c377e4",
+        "rev": "8c2040365b527dc716729dc8b4f0003f4ba1e236",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8c204036`](https://github.com/nix-community/NUR/commit/8c2040365b527dc716729dc8b4f0003f4ba1e236) | `` automatic update `` |