### PR TITLE
chore(flake/nur): `8c204036` -> `ec581e84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711484723,
-        "narHash": "sha256-YdX9qnD6zzY7LCGn83TgS7CKTr4RxYUoNfI6UJ39Rx4=",
+        "lastModified": 1711490584,
+        "narHash": "sha256-Vwjtj5neN86VxKcSXItYVcJ3JHCmXHlhnYuEfVZ4fSw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8c2040365b527dc716729dc8b4f0003f4ba1e236",
+        "rev": "ec581e843bbe09899e54745dc6753893b37f36db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ec581e84`](https://github.com/nix-community/NUR/commit/ec581e843bbe09899e54745dc6753893b37f36db) | `` automatic update `` |