### PR TITLE
chore(flake/emacs-overlay): `13612d96` -> `0ecb38ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711472751,
-        "narHash": "sha256-MZ81c3n8hbzZJL22rPjy+aMiz06ZOylxgmv4wE1G7hQ=",
+        "lastModified": 1711642640,
+        "narHash": "sha256-sgOjTsGAityIoUxXPYyRrzZzH4O2yg+NvM1X2fah0C4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "13612d96aa95d84cdea6fe0c8fef8117e98ef256",
+        "rev": "0ecb38ec45621eaacffb62fcbf9595d7bc200c7f",
         "type": "github"
       },
       "original": {
@@ -710,11 +710,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1711124224,
-        "narHash": "sha256-l0zlN/3CiodvWDtfBOVxeTwYSRz93muVbXWSpaMjXxM=",
+        "lastModified": 1711460390,
+        "narHash": "sha256-akSgjDZL6pVHEfSE6sz1DNSXuYX6hq+P/1Z5IoYWs7E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "56528ee42526794d413d6f244648aaee4a7b56c0",
+        "rev": "44733514b72e732bd49f5511bd0203dea9b9a434",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                         |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
| [`0ecb38ec`](https://github.com/nix-community/emacs-overlay/commit/0ecb38ec45621eaacffb62fcbf9595d7bc200c7f) | `` Updated elpa ``                                              |
| [`619dd15c`](https://github.com/nix-community/emacs-overlay/commit/619dd15c78edea5b3236c841f25a03d77f260154) | `` Updated emacs ``                                             |
| [`89b9788c`](https://github.com/nix-community/emacs-overlay/commit/89b9788ca819ee2f25606c2df4825612bdc8d9ac) | `` Updated melpa ``                                             |
| [`57bef37f`](https://github.com/nix-community/emacs-overlay/commit/57bef37f7da3ab0f1c5924aa7e19fdf09d6d9618) | `` Updated flake inputs ``                                      |
| [`02a3dbf2`](https://github.com/nix-community/emacs-overlay/commit/02a3dbf25ff3e2d14c3eb5e03b2f80c7c2b0573b) | `` Updated melpa ``                                             |
| [`31f8f393`](https://github.com/nix-community/emacs-overlay/commit/31f8f3937b359e6be3c6d547c7546c2e5d426d93) | `` Updated elpa ``                                              |
| [`f187c8ee`](https://github.com/nix-community/emacs-overlay/commit/f187c8eeef74acb227cf5c3a2fae34c6e1a7dac5) | `` Updated melpa ``                                             |
| [`eae4e64c`](https://github.com/nix-community/emacs-overlay/commit/eae4e64cf625ebad08f65c5c46cb53ad369ec8fb) | `` Updated emacs ``                                             |
| [`c49d537b`](https://github.com/nix-community/emacs-overlay/commit/c49d537b62bf547ea62f6f5e2a7ae54ff7710d4e) | `` Updated elpa ``                                              |
| [`d2d0ea13`](https://github.com/nix-community/emacs-overlay/commit/d2d0ea1363528e8584f3b20158470ffe64fc3208) | `` Updated flake inputs ``                                      |
| [`9f6f38ce`](https://github.com/nix-community/emacs-overlay/commit/9f6f38ce57d29b78cc6db45cf87813ae631641ec) | `` Updated emacs ``                                             |
| [`ccdff575`](https://github.com/nix-community/emacs-overlay/commit/ccdff5758d380ae55c5fef7c7dd6d992e7fe64b2) | `` Updated melpa ``                                             |
| [`9a108561`](https://github.com/nix-community/emacs-overlay/commit/9a108561c43448933272f8709e3936f2242c2abc) | `` README: emacsGit is deprecated, replace it with emacs-git `` |
| [`945d1bb0`](https://github.com/nix-community/emacs-overlay/commit/945d1bb0aa1424fce01b7107fbb6ec7254bbde55) | `` Updated emacs ``                                             |
| [`e81dca95`](https://github.com/nix-community/emacs-overlay/commit/e81dca95f5e2c41606cbe9f8dbe2829912698c7a) | `` Updated melpa ``                                             |
| [`63eeb71d`](https://github.com/nix-community/emacs-overlay/commit/63eeb71dc0537e29dcb2136d9c3514b77d4f1a82) | `` Updated elpa ``                                              |
| [`03e4eb5d`](https://github.com/nix-community/emacs-overlay/commit/03e4eb5d359e86d3e0cc0a44997bba91fd66b75f) | `` Updated nongnu ``                                            |
| [`4070a9eb`](https://github.com/nix-community/emacs-overlay/commit/4070a9eb413f0a7a5501148eb47faf493122b807) | `` Updated flake inputs ``                                      |