### PR TITLE
chore(flake/nur): `586f8853` -> `501887fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711496743,
-        "narHash": "sha256-ps3WYPIAHPFhmSneR8+002/qeF9/UL08sq7fOyAJUvE=",
+        "lastModified": 1711502101,
+        "narHash": "sha256-UH4sqHdokBl3R/LtIZi3cLHPOMddQUkLry76w4f1z0c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "586f8853518e8bc46198f58e3d440c140414e1cb",
+        "rev": "501887fef86208b731f6deaba4f15cd36c619973",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`501887fe`](https://github.com/nix-community/NUR/commit/501887fef86208b731f6deaba4f15cd36c619973) | `` automatic update `` |
| [`b809f1f2`](https://github.com/nix-community/NUR/commit/b809f1f2bffffd6500705cc7b6267d0ad2073e78) | `` automatic update `` |