### PR TITLE
chore(flake/nur): `6a05d29a` -> `8c189fc4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711508011,
-        "narHash": "sha256-xK7y1bNLn5TuGToP3amq5XSkSZP/GDcpLFDmThQpZUU=",
+        "lastModified": 1711511050,
+        "narHash": "sha256-+AYUgwYwBTThXE+hf7zxxkU/iC5jWttPIbdv1Jlbe1M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6a05d29adfdf3024a775203a51e273a952d63201",
+        "rev": "8c189fc4588150376a1537c63892054094e72ed5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8c189fc4`](https://github.com/nix-community/NUR/commit/8c189fc4588150376a1537c63892054094e72ed5) | `` automatic update `` |
| [`489fba29`](https://github.com/nix-community/NUR/commit/489fba29be4a0a5eeddeca8182e505feabd90192) | `` automatic update `` |
| [`bab9f2a4`](https://github.com/nix-community/NUR/commit/bab9f2a43b643cf49f23790e3ad7b32d1dca72f1) | `` automatic update `` |