### PR TITLE
chore(flake/nur): `2e50b152` -> `f9356ad3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711513914,
-        "narHash": "sha256-6VDSIRuql5d3qk5Jc4dzBH2fecCHWv5wj4CHEzF1BpE=",
+        "lastModified": 1711524974,
+        "narHash": "sha256-RSnNj0WP15Sl/+wAj8T1bBK8b0XGQerJxtdF+t+xJVY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2e50b152b804b3cd46346dc5ff4bbdb86264af7f",
+        "rev": "f9356ad3c42686b74a74e334f27a1f805abb706e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f9356ad3`](https://github.com/nix-community/NUR/commit/f9356ad3c42686b74a74e334f27a1f805abb706e) | `` automatic update `` |