### PR TITLE
chore(flake/nur): `f9356ad3` -> `fe333c1e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711524974,
-        "narHash": "sha256-RSnNj0WP15Sl/+wAj8T1bBK8b0XGQerJxtdF+t+xJVY=",
+        "lastModified": 1711528413,
+        "narHash": "sha256-KUT4InuxPkP0nRAHW95utttSMvr1nML94C5vUTVkujI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f9356ad3c42686b74a74e334f27a1f805abb706e",
+        "rev": "fe333c1ef76228778b5e69e0336fbda31db9ef19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fe333c1e`](https://github.com/nix-community/NUR/commit/fe333c1ef76228778b5e69e0336fbda31db9ef19) | `` automatic update `` |