### PR TITLE
chore(flake/nur): `fe333c1e` -> `f7a87cff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711528413,
-        "narHash": "sha256-KUT4InuxPkP0nRAHW95utttSMvr1nML94C5vUTVkujI=",
+        "lastModified": 1711532663,
+        "narHash": "sha256-Y0I1/ENnkXvrgK3xLKaRkPZSfbgQkcWu2ctqbwU4Fb0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fe333c1ef76228778b5e69e0336fbda31db9ef19",
+        "rev": "f7a87cffaf22af88cfeda2951de842aa919e2fdd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f7a87cff`](https://github.com/nix-community/NUR/commit/f7a87cffaf22af88cfeda2951de842aa919e2fdd) | `` automatic update `` |
| [`dc2eea60`](https://github.com/nix-community/NUR/commit/dc2eea604c3835ea69b06967f6323fcd3cdb5f71) | `` automatic update `` |