### PR TITLE
chore(flake/nur): `592988f1` -> `5d99ce2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711536331,
-        "narHash": "sha256-XM+v9UVX9MwdZ4IYEq0WdjaaJH+QL8LCInTZGttXKDY=",
+        "lastModified": 1711547074,
+        "narHash": "sha256-MhlvPHvMkY/rIWuy+eHYxvinZ28kjp/T3Sjk4QSGEFA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "592988f111a01b18a78d97fe71f174c1d5a9fced",
+        "rev": "5d99ce2d0d6fe50698da64d8c460418d3fe8bdd7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5d99ce2d`](https://github.com/nix-community/NUR/commit/5d99ce2d0d6fe50698da64d8c460418d3fe8bdd7) | `` automatic update `` |