### PR TITLE
chore(flake/nur): `5d99ce2d` -> `a9c30564`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711547074,
-        "narHash": "sha256-MhlvPHvMkY/rIWuy+eHYxvinZ28kjp/T3Sjk4QSGEFA=",
+        "lastModified": 1711548918,
+        "narHash": "sha256-Hmw/ZW9XbPExeWBghfTk/YFjI/Tj4w1it2S2UJgexP8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5d99ce2d0d6fe50698da64d8c460418d3fe8bdd7",
+        "rev": "a9c30564f01160a8e2ee023e36e22f0e5776218b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a9c30564`](https://github.com/nix-community/NUR/commit/a9c30564f01160a8e2ee023e36e22f0e5776218b) | `` automatic update `` |