### PR TITLE
chore(flake/nur): `a9c30564` -> `72e0f158`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711548918,
-        "narHash": "sha256-Hmw/ZW9XbPExeWBghfTk/YFjI/Tj4w1it2S2UJgexP8=",
+        "lastModified": 1711553441,
+        "narHash": "sha256-0wIjyvunppRWIvZbmNTRvlEZRanSFD1ct96/ahlnw1I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a9c30564f01160a8e2ee023e36e22f0e5776218b",
+        "rev": "72e0f158c73cdd6ba65dc70ef674dd9b8b5da4e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`72e0f158`](https://github.com/nix-community/NUR/commit/72e0f158c73cdd6ba65dc70ef674dd9b8b5da4e8) | `` automatic update `` |