### PR TITLE
chore(flake/nur): `72e0f158` -> `d425622d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711553441,
-        "narHash": "sha256-0wIjyvunppRWIvZbmNTRvlEZRanSFD1ct96/ahlnw1I=",
+        "lastModified": 1711561468,
+        "narHash": "sha256-DQRNSfcQdDkgY0OzFP1n+856GBe+Bt4KarQo1WALx8E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "72e0f158c73cdd6ba65dc70ef674dd9b8b5da4e8",
+        "rev": "d425622d4f7b4e6cac231e0bd9607a02084d0771",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d425622d`](https://github.com/nix-community/NUR/commit/d425622d4f7b4e6cac231e0bd9607a02084d0771) | `` automatic update `` |
| [`aa8b69fb`](https://github.com/nix-community/NUR/commit/aa8b69fbda7d19757dbe440c72e6150d019d2b75) | `` automatic update `` |
| [`62af7b27`](https://github.com/nix-community/NUR/commit/62af7b2749d930a168147876e3736e1644194472) | `` automatic update `` |