### PR TITLE
chore(flake/nur): `8307c8c0` -> `c5677797`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711568684,
-        "narHash": "sha256-zCOzrY4cG16wsi6wLNGQMZQyWjbtj2LMrH8BVYKpv8k=",
+        "lastModified": 1711573267,
+        "narHash": "sha256-GZkrAP2a0aGfQ9ZsaWGJ3MkbzdFlsjoZULaTbpi3zlk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8307c8c0772270ee4d7184151e40b6d2dc83139c",
+        "rev": "c5677797c395f81d17330f3cb0d9ef994d37c397",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c5677797`](https://github.com/nix-community/NUR/commit/c5677797c395f81d17330f3cb0d9ef994d37c397) | `` automatic update `` |
| [`e9553def`](https://github.com/nix-community/NUR/commit/e9553def713796172d23c3c80b30c75ba2e84d6c) | `` automatic update `` |
| [`affe0870`](https://github.com/nix-community/NUR/commit/affe0870fe26a0c7395a9b156b340fbc20c32e08) | `` automatic update `` |