### PR TITLE
chore(flake/nur): `c5677797` -> `43913243`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711573267,
-        "narHash": "sha256-GZkrAP2a0aGfQ9ZsaWGJ3MkbzdFlsjoZULaTbpi3zlk=",
+        "lastModified": 1711581287,
+        "narHash": "sha256-168mSQ0RvuLDa8CeVfjZpfT6GE/Yh309jD4UnvpaGUY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c5677797c395f81d17330f3cb0d9ef994d37c397",
+        "rev": "439132433acf7a45c24ed30bf0578a6da4a8808e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                     |
| -------------------------------------------------------------------------------------------------- | --------------------------- |
| [`43913243`](https://github.com/nix-community/NUR/commit/439132433acf7a45c24ed30bf0578a6da4a8808e) | `` automatic update ``      |
| [`5b8120de`](https://github.com/nix-community/NUR/commit/5b8120deee9634b453941034f8c9c2e53afd83ef) | `` add nim65s repository `` |