### PR TITLE
chore(flake/srvos): `c490c19a` -> `b3af8aed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -994,11 +994,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711327968,
-        "narHash": "sha256-L8UatcwpSi7KSn6+f2ULPdt/1XTPdZirX+K+cwo4mv0=",
+        "lastModified": 1711586987,
+        "narHash": "sha256-/8LbB2JCme+RQekVcXaeQisfqIMBI8uLp0BvzxqdHk8=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "c490c19a959d406c87ae1c1481a4608d41a83597",
+        "rev": "b3af8aed091d85e180a861695f2d57b3b2d24ba1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`b3af8aed`](https://github.com/nix-community/srvos/commit/b3af8aed091d85e180a861695f2d57b3b2d24ba1) | `` dev/private/flake.lock: Update `` |
| [`895fe37b`](https://github.com/nix-community/srvos/commit/895fe37bd1826daf3400f3f2fc1d8bb11df98908) | `` flake.lock: Update ``             |