### PR TITLE
chore(flake/nur): `43913243` -> `e9fb0618`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711581287,
-        "narHash": "sha256-168mSQ0RvuLDa8CeVfjZpfT6GE/Yh309jD4UnvpaGUY=",
+        "lastModified": 1711588014,
+        "narHash": "sha256-ZCtnt4Lfb4ZKddsT16grnKhCtBFIpuwdETNORNbAUFI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "439132433acf7a45c24ed30bf0578a6da4a8808e",
+        "rev": "e9fb06187654059328b8a266ea9a6d2f36cf1cf6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e9fb0618`](https://github.com/nix-community/NUR/commit/e9fb06187654059328b8a266ea9a6d2f36cf1cf6) | `` automatic update `` |
| [`f9162e54`](https://github.com/nix-community/NUR/commit/f9162e54520cf952033ca894fd27864ea1bd19c6) | `` automatic update `` |