### PR TITLE
chore(flake/darwin): `bcc8afd0` -> `f0dd0838`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -218,11 +218,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710717205,
-        "narHash": "sha256-Wf3gHh5uV6W1TV/A8X8QJf99a5ypDSugY4sNtdJDe0A=",
+        "lastModified": 1711591334,
+        "narHash": "sha256-9d5ilxxq4CXw44eFw8VFrRneAKex7D8xjn95mwZjgf4=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "bcc8afd06e237df060c85bad6af7128e05fd61a3",
+        "rev": "f0dd0838c3558b59dc3b726d8ab89f5b5e35c297",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                    |
| ------------------------------------------------------------------------------------------------ | -------------------------- |
| [`83a9a41f`](https://github.com/LnL7/nix-darwin/commit/83a9a41f1bc62ffedd147df4584501b6bdb992b0) | `` Use valid maintainer `` |