### PR TITLE
chore(flake/nur): `e9fb0618` -> `2d22add6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711588014,
-        "narHash": "sha256-ZCtnt4Lfb4ZKddsT16grnKhCtBFIpuwdETNORNbAUFI=",
+        "lastModified": 1711597179,
+        "narHash": "sha256-k3TekWyk8RH7Td9xS3sHIrvDXmO/OBoNC770Oec25q4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e9fb06187654059328b8a266ea9a6d2f36cf1cf6",
+        "rev": "2d22add691c4187f5d629c2c42b7cb602d37d156",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2d22add6`](https://github.com/nix-community/NUR/commit/2d22add691c4187f5d629c2c42b7cb602d37d156) | `` automatic update `` |
| [`2ad7d4e2`](https://github.com/nix-community/NUR/commit/2ad7d4e26e0d63eff5bbf327887d6cf598a55b73) | `` automatic update `` |