### PR TITLE
chore(flake/nur): `2d22add6` -> `0db6af6b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711597179,
-        "narHash": "sha256-k3TekWyk8RH7Td9xS3sHIrvDXmO/OBoNC770Oec25q4=",
+        "lastModified": 1711599567,
+        "narHash": "sha256-OShSLFN7j8gewhJJmV7e76jGV2WSexaKHMdfl5im24g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2d22add691c4187f5d629c2c42b7cb602d37d156",
+        "rev": "0db6af6b579793873d1ff41157ece797b741f691",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0db6af6b`](https://github.com/nix-community/NUR/commit/0db6af6b579793873d1ff41157ece797b741f691) | `` automatic update `` |