### PR TITLE
chore(flake/nur): `f80f405a` -> `4f8031ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711607324,
-        "narHash": "sha256-mQ/VKdy2Z4U67ME32sDQR+TghkEEsYrTIGrA3qAr1tQ=",
+        "lastModified": 1711614342,
+        "narHash": "sha256-nvHhquj4ZZ1y+EEF4a1Xha+NE7+zLufJ8sIkhh/rMfY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f80f405a89ee01a029399d3e5afcfa2a47780864",
+        "rev": "4f8031eeb2f61e40026fa12c40f9952bbec727f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4f8031ee`](https://github.com/nix-community/NUR/commit/4f8031eeb2f61e40026fa12c40f9952bbec727f1) | `` automatic update `` |