### PR TITLE
chore(flake/nur): `4f8031ee` -> `9311c905`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711614342,
-        "narHash": "sha256-nvHhquj4ZZ1y+EEF4a1Xha+NE7+zLufJ8sIkhh/rMfY=",
+        "lastModified": 1711619542,
+        "narHash": "sha256-6EblMFuCc/H3NXsWQ2MhQtXJ0/gYwL46vQT7waxvc+I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4f8031eeb2f61e40026fa12c40f9952bbec727f1",
+        "rev": "9311c905af1e658b44850429c97003beb9910820",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9311c905`](https://github.com/nix-community/NUR/commit/9311c905af1e658b44850429c97003beb9910820) | `` automatic update `` |