### PR TITLE
chore(flake/templates): `259699d9` -> `0bd10471`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1090,11 +1090,11 @@
     },
     "templates": {
       "locked": {
-        "lastModified": 1708484632,
-        "narHash": "sha256-6UD350MflALvXNkcnZ6VtkuD41mW15NZ7wM+/65uQGY=",
+        "lastModified": 1711620241,
+        "narHash": "sha256-ShA0aiGis+jczMZxjdMlL8EKlVfRAgXupJEGe5dg3bM=",
         "owner": "NixOS",
         "repo": "templates",
-        "rev": "259699d91baef738c5826106b3aa46ddfcd4da51",
+        "rev": "0bd1047151b5dc5733ece2645751acc277228c52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                           |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
| [`560fbb6a`](https://github.com/NixOS/templates/commit/560fbb6a6a041b21fec2225db98fae78fa875a9e) | `` Use vendorHash instead of deprecated sha256 `` |