### PR TITLE
chore(flake/nur): `7318fa6c` -> `0ccb1899`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711629854,
-        "narHash": "sha256-HOurkUE5QBv7s57d/BLolvjQCi8Ts84UJrAQfiMGdjU=",
+        "lastModified": 1711635893,
+        "narHash": "sha256-ULay7PLILr2BEdySdctFKTsfV4fmI1/hNiZPKEVuvWo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7318fa6cc074072af60122a046c14371d1f8a9d0",
+        "rev": "0ccb18994cca45444b862482fe4197717ea2cff4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0ccb1899`](https://github.com/nix-community/NUR/commit/0ccb18994cca45444b862482fe4197717ea2cff4) | `` automatic update `` |
| [`e4f98a7d`](https://github.com/nix-community/NUR/commit/e4f98a7d1a2fe8c92e809e9f254481e16afb92c7) | `` automatic update `` |