### PR TITLE
chore(flake/nur): `b042f04b` -> `f1c50451`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711644301,
-        "narHash": "sha256-D/jn9ZbiAdOdQtUXkYRRQ1IebzwPajMBw3UVFeFi+l4=",
+        "lastModified": 1711648230,
+        "narHash": "sha256-n33cks8ayJoYx8/ls62PGlykoCg9/xgWoxqGsGpPQkg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b042f04b3c95e96b2125f3f691657d6469237c47",
+        "rev": "f1c504519490b64d9748648a6333ec2a43ff3623",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f1c50451`](https://github.com/nix-community/NUR/commit/f1c504519490b64d9748648a6333ec2a43ff3623) | `` automatic update `` |
| [`d9bc55a4`](https://github.com/nix-community/NUR/commit/d9bc55a405addbd6ccf6a6495870c2d277a355de) | `` automatic update `` |