### PR TITLE
chore(flake/nur): `ce82c42c` -> `1cb2ea37`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -860,11 +860,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711650964,
-        "narHash": "sha256-tGPMkwlxZuSb4u10c7MxZYPXNF1UkehfaqbqvTe9/c8=",
+        "lastModified": 1711655291,
+        "narHash": "sha256-0B4kown/dR9PG2ZgYfI9RJJx25q5uvrRoiyHWQsKzYU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ce82c42cf4b85a10c5a8052e032b665b02d36d70",
+        "rev": "1cb2ea37d0c04c46e9a0bf7eafd937cc1c6d998b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1cb2ea37`](https://github.com/nix-community/NUR/commit/1cb2ea37d0c04c46e9a0bf7eafd937cc1c6d998b) | `` automatic update `` |