### PR TITLE
chore(flake/nur): `1cb2ea37` -> `7d11a87b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -860,11 +860,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711655291,
-        "narHash": "sha256-0B4kown/dR9PG2ZgYfI9RJJx25q5uvrRoiyHWQsKzYU=",
+        "lastModified": 1711657659,
+        "narHash": "sha256-kdMlKb5nWzi+EUNdpyEBKjKL/ZY75T2cngH+zfKN+Vo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1cb2ea37d0c04c46e9a0bf7eafd937cc1c6d998b",
+        "rev": "7d11a87bb73d00d9fd5829b9eac36107bcdc2e28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7d11a87b`](https://github.com/nix-community/NUR/commit/7d11a87bb73d00d9fd5829b9eac36107bcdc2e28) | `` automatic update `` |