### PR TITLE
chore(flake/emacs-overlay): `0ecb38ec` -> `04518449`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711642640,
-        "narHash": "sha256-sgOjTsGAityIoUxXPYyRrzZzH4O2yg+NvM1X2fah0C4=",
+        "lastModified": 1711673880,
+        "narHash": "sha256-0Vg/1lkAR3OXdzLYo12LKW8it2Ln6HIRPh7LF9Fee0o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0ecb38ec45621eaacffb62fcbf9595d7bc200c7f",
+        "rev": "04518449b13898684d17bb14baf5213e66cbf602",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`04518449`](https://github.com/nix-community/emacs-overlay/commit/04518449b13898684d17bb14baf5213e66cbf602) | `` Updated elpa `` |