### PR TITLE
chore(flake/nur): `f662fa27` -> `3df6f3a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -860,11 +860,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711669582,
-        "narHash": "sha256-kLDfK0ZZmV1pNqiUq9IZNO8JjN6I4uDTd0dWjw4O/M0=",
+        "lastModified": 1711677643,
+        "narHash": "sha256-bwLuOZwsL8kRt5w7iYCiWVVbQd4epA7jYPyX8CjieBM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f662fa278c7856b487b2dd11a6fcc7aaf13a75b6",
+        "rev": "3df6f3a2ff303c1c7d07a9a6dd5c705789f0e7a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3df6f3a2`](https://github.com/nix-community/NUR/commit/3df6f3a2ff303c1c7d07a9a6dd5c705789f0e7a8) | `` automatic update `` |
| [`9b443384`](https://github.com/nix-community/NUR/commit/9b443384339d9f7bd7ee02f6bb5cbf377fcfb1f2) | `` automatic update `` |
| [`e84c1392`](https://github.com/nix-community/NUR/commit/e84c13927c810e1d7958f2ec329d4a1107d33742) | `` automatic update `` |