### PR TITLE
chore(flake/emacs-overlay): `04518449` -> `8dbeee1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711673880,
-        "narHash": "sha256-0Vg/1lkAR3OXdzLYo12LKW8it2Ln6HIRPh7LF9Fee0o=",
+        "lastModified": 1711676745,
+        "narHash": "sha256-O5lzeG1CdD7HDO9kg3r//HRT6CY179ZkUfHcvKxVLPA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "04518449b13898684d17bb14baf5213e66cbf602",
+        "rev": "8dbeee1c4befdeb36fbb3a951d5c3bf2b7f1ae05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`8dbeee1c`](https://github.com/nix-community/emacs-overlay/commit/8dbeee1c4befdeb36fbb3a951d5c3bf2b7f1ae05) | `` Updated emacs `` |
| [`8189846d`](https://github.com/nix-community/emacs-overlay/commit/8189846d4d123e9056541088a75c255c6cde3c2d) | `` Updated melpa `` |