### PR TITLE
chore(flake/nur): `3df6f3a2` -> `1ddf1e24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -860,11 +860,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711677643,
-        "narHash": "sha256-bwLuOZwsL8kRt5w7iYCiWVVbQd4epA7jYPyX8CjieBM=",
+        "lastModified": 1711683088,
+        "narHash": "sha256-961l8hvIa3hGHLUpWApRFWKAWSvWKV+/abnBzjYoigk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3df6f3a2ff303c1c7d07a9a6dd5c705789f0e7a8",
+        "rev": "1ddf1e24088777bb36c37fa126ff280216968b20",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1ddf1e24`](https://github.com/nix-community/NUR/commit/1ddf1e24088777bb36c37fa126ff280216968b20) | `` automatic update `` |