### PR TITLE
chore(flake/nur): `75f39159` -> `9e4b87de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -860,11 +860,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711694356,
-        "narHash": "sha256-Iyr6AhWE4ZtYYbCk4IXtQ7CLrmUhR36shjK/hAKVTfM=",
+        "lastModified": 1711701097,
+        "narHash": "sha256-znOXaDb5XrVHpZ/kEXtUSZio+RkI0P/GFmxtFMkABnw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "75f391598f10b78ea988dcfe5c07c4b3f04f9390",
+        "rev": "9e4b87de57109c8f4c1062e262b4537732607804",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9e4b87de`](https://github.com/nix-community/NUR/commit/9e4b87de57109c8f4c1062e262b4537732607804) | `` automatic update `` |