### PR TITLE
chore(flake/nur): `9e4b87de` -> `e382a814`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -860,11 +860,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711701097,
-        "narHash": "sha256-znOXaDb5XrVHpZ/kEXtUSZio+RkI0P/GFmxtFMkABnw=",
+        "lastModified": 1711709064,
+        "narHash": "sha256-pDDm2YGrUzqDY2YE7ZyRkylaGfVHwZS8x9vd+UcRI6M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9e4b87de57109c8f4c1062e262b4537732607804",
+        "rev": "e382a81485eb5f5b08a28a06878b8939421b98c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e382a814`](https://github.com/nix-community/NUR/commit/e382a81485eb5f5b08a28a06878b8939421b98c9) | `` automatic update `` |
| [`745e95b9`](https://github.com/nix-community/NUR/commit/745e95b92e60a3fb10a9cec105dfe14ec01b7e34) | `` automatic update `` |
| [`ef6a3024`](https://github.com/nix-community/NUR/commit/ef6a30241c071fc16e0aaf935cda7451bcf8f112) | `` automatic update `` |
| [`2701441e`](https://github.com/nix-community/NUR/commit/2701441e446b3d1ec07a59ffaf274ab07d3bd1fd) | `` automatic update `` |