### PR TITLE
chore(flake/nur): `0a7a2c10` -> `e9d9c03f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -860,11 +860,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711716298,
-        "narHash": "sha256-24MNZKd/kBWp1Lks+IeN0MUcNgVtddlwvcb5g/J1bMM=",
+        "lastModified": 1711719877,
+        "narHash": "sha256-mTjODsSfGnyD/y2gTUYpfhe3zTkswM4RG+WDcBFkLok=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0a7a2c10096cae71f40231baf9ba65a409833d7d",
+        "rev": "e9d9c03f6958f2b783d58339615129cee07466d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e9d9c03f`](https://github.com/nix-community/NUR/commit/e9d9c03f6958f2b783d58339615129cee07466d6) | `` automatic update `` |