### PR TITLE
chore(flake/nur): `e9d9c03f` -> `81b0577b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -860,11 +860,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711719877,
-        "narHash": "sha256-mTjODsSfGnyD/y2gTUYpfhe3zTkswM4RG+WDcBFkLok=",
+        "lastModified": 1711724241,
+        "narHash": "sha256-JiclJSBzebtmWevi7TcqYTO/GcDGzzHU0r2FOKNxMas=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e9d9c03f6958f2b783d58339615129cee07466d6",
+        "rev": "81b0577bd5a676cc7c4e29aeaa1886f284a0675d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`81b0577b`](https://github.com/nix-community/NUR/commit/81b0577bd5a676cc7c4e29aeaa1886f284a0675d) | `` automatic update `` |