### PR TITLE
chore(flake/nur): `81b0577b` -> `cecb5546`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -860,11 +860,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711724241,
-        "narHash": "sha256-JiclJSBzebtmWevi7TcqYTO/GcDGzzHU0r2FOKNxMas=",
+        "lastModified": 1711726158,
+        "narHash": "sha256-kYOZhk82YTJRYIKpimG3a228/c6L2FNnM2HDZL88ESA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "81b0577bd5a676cc7c4e29aeaa1886f284a0675d",
+        "rev": "cecb55466ea9ae0c8af8ca2bd69c1e4b037352f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cecb5546`](https://github.com/nix-community/NUR/commit/cecb55466ea9ae0c8af8ca2bd69c1e4b037352f1) | `` automatic update `` |