### PR TITLE
chore(flake/deploy-rs): `0a018779` -> `88b3059b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -260,11 +260,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708091384,
-        "narHash": "sha256-dTGGw2y8wvfjr+J9CjQbfdulOq72hUG17HXVNxpH1yE=",
+        "lastModified": 1711973905,
+        "narHash": "sha256-UFKME/N1pbUtn+2Aqnk+agUt8CekbpuqwzljivfIme8=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "0a0187794ac7f7a1e62cda3dabf8dc041f868790",
+        "rev": "88b3059b020da69cbe16526b8d639bd5e0b51c8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                   |
| --------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`f10a3aa1`](https://github.com/serokell/deploy-rs/commit/f10a3aa17c9cbb1d217ab03369909af6fc29e1d0) | `` [Chore] Fix overlay ``                 |
| [`a9283526`](https://github.com/serokell/deploy-rs/commit/a92835264100583903dc408abe43d461ff7d4dca) | `` [OPS-1384] Introduce NixOS VM tests `` |