### PR TITLE
chore(flake/nur): `a7b22dc3` -> `0c358315`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -860,11 +860,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711734298,
-        "narHash": "sha256-w//4QQDBMhjvRrl+leYLKaz+F7hSWMn1RyrZsb3MzIA=",
+        "lastModified": 1711736686,
+        "narHash": "sha256-Y6VJCaRQx75PVuCvMK3F/7Frrbsk4zDvFT96QG06Jdc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a7b22dc34d760f6853b42e673be76c7e67a1030d",
+        "rev": "0c3583158d1fe35d99935c048005ca067353e964",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0c358315`](https://github.com/nix-community/NUR/commit/0c3583158d1fe35d99935c048005ca067353e964) | `` automatic update `` |