### PR TITLE
chore(flake/nur): `0c358315` -> `91164785`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -860,11 +860,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711736686,
-        "narHash": "sha256-Y6VJCaRQx75PVuCvMK3F/7Frrbsk4zDvFT96QG06Jdc=",
+        "lastModified": 1711741576,
+        "narHash": "sha256-NWhmYK2jTlDqPQIiwEfEJUYP2xNgWO6nwltor80+YGU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0c3583158d1fe35d99935c048005ca067353e964",
+        "rev": "91164785f810add20b1de18354fd2ce1d8b63f9c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`91164785`](https://github.com/nix-community/NUR/commit/91164785f810add20b1de18354fd2ce1d8b63f9c) | `` automatic update `` |