### PR TITLE
chore(flake/emacs-overlay): `734cfa5f` -> `b2b55327`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711729067,
-        "narHash": "sha256-RVoWO3ZxBk5zBiJhStWcwnDnBFDZLQlz7v58mQv5lGo=",
+        "lastModified": 1711746486,
+        "narHash": "sha256-MPDK45AjopUUmwHfEarvcKiXqLrtLOb3dqbDx/HSxOo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "734cfa5f4f5183076552cb14497768f768be9904",
+        "rev": "b2b55327ffdc55cbc873f86335503ca65a489034",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                     |
| ------------------------------------------------------------------------------------------------------------ | --------------------------- |
| [`b2b55327`](https://github.com/nix-community/emacs-overlay/commit/b2b55327ffdc55cbc873f86335503ca65a489034) | `` Updated melpa ``         |
| [`825ea7a5`](https://github.com/nix-community/emacs-overlay/commit/825ea7a501bae55ceea334b3e83a0ac740b137ac) | `` Manually update Emacs `` |
| [`63c6ebdb`](https://github.com/nix-community/emacs-overlay/commit/63c6ebdb1426947d8e5f3daa3f29f247f8eac218) | `` Update patch ``          |