### PR TITLE
chore(flake/emacs-overlay): `b2b55327` -> `082f1fc8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711746486,
-        "narHash": "sha256-MPDK45AjopUUmwHfEarvcKiXqLrtLOb3dqbDx/HSxOo=",
+        "lastModified": 1711762142,
+        "narHash": "sha256-J/kwKuoyTrMZ/BkgbYScGUH9YtUU4Z5tun5WEfoZhmg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b2b55327ffdc55cbc873f86335503ca65a489034",
+        "rev": "082f1fc8593b304c201439d700c4d89bf08d9a03",
         "type": "github"
       },
       "original": {
@@ -710,11 +710,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1711460390,
-        "narHash": "sha256-akSgjDZL6pVHEfSE6sz1DNSXuYX6hq+P/1Z5IoYWs7E=",
+        "lastModified": 1711668574,
+        "narHash": "sha256-u1dfs0ASQIEr1icTVrsKwg2xToIpn7ZXxW3RHfHxshg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "44733514b72e732bd49f5511bd0203dea9b9a434",
+        "rev": "219951b495fc2eac67b1456824cc1ec1fd2ee659",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`082f1fc8`](https://github.com/nix-community/emacs-overlay/commit/082f1fc8593b304c201439d700c4d89bf08d9a03) | `` Updated melpa ``        |
| [`0986a439`](https://github.com/nix-community/emacs-overlay/commit/0986a439e17fadf35e618f049f48722c3bc46557) | `` Updated elpa ``         |
| [`ac7d8c8a`](https://github.com/nix-community/emacs-overlay/commit/ac7d8c8afeb66f66cd1e72194de52f9fb00de25b) | `` Updated nongnu ``       |
| [`307fe8bd`](https://github.com/nix-community/emacs-overlay/commit/307fe8bd8599c228f6062e37dd70c10d981434f2) | `` Updated flake inputs `` |