### PR TITLE
chore(flake/nur): `7d8717af` -> `69d76ed5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711760784,
-        "narHash": "sha256-ik/IgTK21BSnAdvF16lDMdFrEdoCj20AKRIAEyHiW4o=",
+        "lastModified": 1711766549,
+        "narHash": "sha256-Ufur5/ldgTigMzTqEqztSHfClPhO7V1bfy0CBdc/7Gw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7d8717afcc55c8c2bb1a35d4be118e731f99be2f",
+        "rev": "69d76ed5fad814adb96ad9598b9217337a5e424b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`69d76ed5`](https://github.com/nix-community/NUR/commit/69d76ed5fad814adb96ad9598b9217337a5e424b) | `` automatic update `` |
| [`e35ae653`](https://github.com/nix-community/NUR/commit/e35ae653cb0166b92132d2f99bbcd3e6d90f54fc) | `` automatic update `` |
| [`0a0e4bd3`](https://github.com/nix-community/NUR/commit/0a0e4bd3ea105c29e31f16d1802065a93ee12e39) | `` automatic update `` |