### PR TITLE
chore(flake/nur): `28a25efe` -> `6c35acd5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711780022,
-        "narHash": "sha256-tYJ1IzmHwDOtClIFPR+wv0q0TSEEhuV2RIro0Nbxi08=",
+        "lastModified": 1711784196,
+        "narHash": "sha256-tfUwfQPqljtXd4+nQiGe2zMHZA/I2cn+GvIIaYgqPBs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "28a25efe01cca82451e705112c30278057be9605",
+        "rev": "6c35acd5fee9ae16e84459c520d5e5072704da8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6c35acd5`](https://github.com/nix-community/NUR/commit/6c35acd5fee9ae16e84459c520d5e5072704da8c) | `` automatic update `` |
| [`f9f6256c`](https://github.com/nix-community/NUR/commit/f9f6256cb055fb436f22b799b6ffa3ca09d7194a) | `` automatic update `` |
| [`adf66d4f`](https://github.com/nix-community/NUR/commit/adf66d4f4de2fdd80240ccf9c3e4828df30fd0c1) | `` automatic update `` |