### PR TITLE
chore(flake/emacs-overlay): `082f1fc8` -> `af307726`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711762142,
-        "narHash": "sha256-J/kwKuoyTrMZ/BkgbYScGUH9YtUU4Z5tun5WEfoZhmg=",
+        "lastModified": 1711788691,
+        "narHash": "sha256-NZH/CMpjUOpoN0TGlZFFkuoogDzDPybFIFsU6tKelI4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "082f1fc8593b304c201439d700c4d89bf08d9a03",
+        "rev": "af307726ea14d3be3627790a40ab6d6b2ae1938f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`af307726`](https://github.com/nix-community/emacs-overlay/commit/af307726ea14d3be3627790a40ab6d6b2ae1938f) | `` Updated melpa `` |