### PR TITLE
chore(flake/emacs-overlay): `af307726` -> `f8ad90d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711788691,
-        "narHash": "sha256-NZH/CMpjUOpoN0TGlZFFkuoogDzDPybFIFsU6tKelI4=",
+        "lastModified": 1711789603,
+        "narHash": "sha256-5c8prZYLBFgMDoBrBTMuAu6F33HHF9kfK+i4d39gUDA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "af307726ea14d3be3627790a40ab6d6b2ae1938f",
+        "rev": "f8ad90d467e2a48cf91aa0b3b75ac7929dc07425",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`f8ad90d4`](https://github.com/nix-community/emacs-overlay/commit/f8ad90d467e2a48cf91aa0b3b75ac7929dc07425) | `` Updated emacs `` |