### PR TITLE
chore(flake/nur): `6c35acd5` -> `9c84c541`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711784196,
-        "narHash": "sha256-tfUwfQPqljtXd4+nQiGe2zMHZA/I2cn+GvIIaYgqPBs=",
+        "lastModified": 1711789378,
+        "narHash": "sha256-aFHVJ0j7p54FyjpfJ2nVMv5MDXrP4ttL8efcWu1lxf0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6c35acd5fee9ae16e84459c520d5e5072704da8c",
+        "rev": "9c84c5419c332d79fbd2b3644c62f978beccfff9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9c84c541`](https://github.com/nix-community/NUR/commit/9c84c5419c332d79fbd2b3644c62f978beccfff9) | `` automatic update `` |