### PR TITLE
chore(flake/nur): `453c7203` -> `574b1608`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711803146,
-        "narHash": "sha256-7WvEbsBV4AYZhuRkOvyZMXAAeNEPIkKQQsx2VXD9PnI=",
+        "lastModified": 1711806271,
+        "narHash": "sha256-yE+aMbxIlxdcAsZpnG2BLYgJb53+w0Y3vN1srp/fhKQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "453c7203a263436d0cce7f2035b3203a1dc98bc3",
+        "rev": "574b16081bd491d66f3810cb842142a153db8a85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`574b1608`](https://github.com/nix-community/NUR/commit/574b16081bd491d66f3810cb842142a153db8a85) | `` automatic update `` |