### PR TITLE
chore(flake/nur): `dd0c7591` -> `2625e25d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711809066,
-        "narHash": "sha256-jJqVP4MBRzRrlVCytMO6EIojjN012Ynsv7u7gSKWRtc=",
+        "lastModified": 1711827888,
+        "narHash": "sha256-LuXpc/SL6qLpxMD5Qide4/Su824qzi/Mb1DUHDCLLCc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd0c7591edf10dbe65223bb7353927b2a1f1b41e",
+        "rev": "2625e25d5572159ba4cd8a648663e91d1dee09f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2625e25d`](https://github.com/nix-community/NUR/commit/2625e25d5572159ba4cd8a648663e91d1dee09f5) | `` automatic update `` |