### PR TITLE
chore(flake/nur): `2625e25d` -> `f15e5975`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711827888,
-        "narHash": "sha256-LuXpc/SL6qLpxMD5Qide4/Su824qzi/Mb1DUHDCLLCc=",
+        "lastModified": 1711828914,
+        "narHash": "sha256-AVNXWWyTKmN+zCNzjD/4YciwL4bVkPHH/mGC4+w2w04=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2625e25d5572159ba4cd8a648663e91d1dee09f5",
+        "rev": "f15e597505c1d6a0c3d6560067ecfda57ee511d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f15e5975`](https://github.com/nix-community/NUR/commit/f15e597505c1d6a0c3d6560067ecfda57ee511d6) | `` automatic update `` |