### PR TITLE
chore(flake/nur): `f15e5975` -> `165b0b3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711828914,
-        "narHash": "sha256-AVNXWWyTKmN+zCNzjD/4YciwL4bVkPHH/mGC4+w2w04=",
+        "lastModified": 1711835027,
+        "narHash": "sha256-aDPDznV5FnUAmwfzuDPpgD6oM2mgZpO91xUUjC6nPE0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f15e597505c1d6a0c3d6560067ecfda57ee511d6",
+        "rev": "165b0b3ec702d1eef16074d09f5db730d926c1af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`165b0b3e`](https://github.com/nix-community/NUR/commit/165b0b3ec702d1eef16074d09f5db730d926c1af) | `` automatic update `` |
| [`81f8cfcf`](https://github.com/nix-community/NUR/commit/81f8cfcf740840869a9c2ac3c08152d03323e764) | `` automatic update `` |