### PR TITLE
chore(flake/nur): `165b0b3e` -> `14ef22fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711835027,
-        "narHash": "sha256-aDPDznV5FnUAmwfzuDPpgD6oM2mgZpO91xUUjC6nPE0=",
+        "lastModified": 1711849502,
+        "narHash": "sha256-OULGZgAwK6jQCu2JQtOU+XcnpY6fSQdLNM7SmSML3bI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "165b0b3ec702d1eef16074d09f5db730d926c1af",
+        "rev": "14ef22fa480dfbc3afadbc712d97bcf28f442378",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`14ef22fa`](https://github.com/nix-community/NUR/commit/14ef22fa480dfbc3afadbc712d97bcf28f442378) | `` automatic update `` |
| [`2bd2a7a4`](https://github.com/nix-community/NUR/commit/2bd2a7a47647490f1e6ee1ea65730a61f62c702c) | `` automatic update `` |
| [`75036f5d`](https://github.com/nix-community/NUR/commit/75036f5d218b9c3383a8a121d318cf8283c6caff) | `` automatic update `` |
| [`ecc0dbe2`](https://github.com/nix-community/NUR/commit/ecc0dbe2ada612369edc342c47533b71e2073d67) | `` automatic update `` |