### PR TITLE
chore(flake/emacs-overlay): `b58ea7d9` -> `40c0f10c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711846974,
-        "narHash": "sha256-VJR6ddmMPdLTHwPsyiO3Ua60ZhuBc4PdHDyXTplRH4U=",
+        "lastModified": 1711849715,
+        "narHash": "sha256-eyajQTcI+46/DLa+96GU3ICdsJQv+mJ2XvtFGEf0BWQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b58ea7d9c253d9eea3bbf4d5153a9f1f7bc21722",
+        "rev": "40c0f10c423a5031eccac9cf61410cc7c266de29",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`40c0f10c`](https://github.com/nix-community/emacs-overlay/commit/40c0f10c423a5031eccac9cf61410cc7c266de29) | `` Updated emacs `` |
| [`9dd27fd6`](https://github.com/nix-community/emacs-overlay/commit/9dd27fd6abfe59bab0b99a403f9f2d9caccfeb49) | `` Updated melpa `` |