### PR TITLE
chore(flake/nur): `14ef22fa` -> `447fcf57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711849502,
-        "narHash": "sha256-OULGZgAwK6jQCu2JQtOU+XcnpY6fSQdLNM7SmSML3bI=",
+        "lastModified": 1711853594,
+        "narHash": "sha256-kT2NJk2kF2Ulqrh4JLlRVocCF1HqaBWtPjfYd54xLB4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "14ef22fa480dfbc3afadbc712d97bcf28f442378",
+        "rev": "447fcf5781117eebf1fed773e1b6c45549a89a78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`447fcf57`](https://github.com/nix-community/NUR/commit/447fcf5781117eebf1fed773e1b6c45549a89a78) | `` automatic update `` |