### PR TITLE
chore(flake/nix-index-database): `34519f3b` -> `2844b5f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -591,11 +591,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711249705,
-        "narHash": "sha256-h/NQECj6mIzF4XR6AQoSpkCnwqAM+ol4+qOdYi2ykmQ=",
+        "lastModified": 1711854532,
+        "narHash": "sha256-JPStavwlT7TfxxiXHk6Q7sbNxtnXAIjXQJMLO0KB6M0=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "34519f3bb678a5abbddf7b200ac5347263ee781b",
+        "rev": "2844b5f3ad3b478468151bd101370b9d8ef8a3a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`2844b5f3`](https://github.com/nix-community/nix-index-database/commit/2844b5f3ad3b478468151bd101370b9d8ef8a3a7) | `` update packages.nix to release 2024-03-31-030752 `` |
| [`784ca729`](https://github.com/nix-community/nix-index-database/commit/784ca7299336509ebcfb3702be28fcb0015e99cd) | `` flake.lock: Update ``                               |