### PR TITLE
chore(flake/nur): `447fcf57` -> `7bae6312`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711853594,
-        "narHash": "sha256-kT2NJk2kF2Ulqrh4JLlRVocCF1HqaBWtPjfYd54xLB4=",
+        "lastModified": 1711858794,
+        "narHash": "sha256-ad+sFxu8NOcBAb5OQa1qIycT/Q7oGYuVSjlKu3KHp80=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "447fcf5781117eebf1fed773e1b6c45549a89a78",
+        "rev": "7bae6312a92dddd288da938bc07b1932b02c63d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7bae6312`](https://github.com/nix-community/NUR/commit/7bae6312a92dddd288da938bc07b1932b02c63d4) | `` automatic update `` |
| [`e757a928`](https://github.com/nix-community/NUR/commit/e757a9282ecc7e38679d130f3f97eaeaaee348cd) | `` automatic update `` |
| [`4cee435a`](https://github.com/nix-community/NUR/commit/4cee435ace9b508eb4a108d3b795461fc7d8b11b) | `` automatic update `` |