### PR TITLE
chore(flake/nur): `7bae6312` -> `e659138c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711858794,
-        "narHash": "sha256-ad+sFxu8NOcBAb5OQa1qIycT/Q7oGYuVSjlKu3KHp80=",
+        "lastModified": 1711864846,
+        "narHash": "sha256-31nrn15ReRnJUXmDkNQskC1ufhJeAzqpe8+1MLRe1yQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7bae6312a92dddd288da938bc07b1932b02c63d4",
+        "rev": "e659138ced33d9a8a08f08b981830ce67a44b7e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e659138c`](https://github.com/nix-community/NUR/commit/e659138ced33d9a8a08f08b981830ce67a44b7e0) | `` automatic update `` |
| [`99f03581`](https://github.com/nix-community/NUR/commit/99f035810fe74bd97ddfb60ac334192d41c38ce6) | `` automatic update `` |
| [`2661a2c1`](https://github.com/nix-community/NUR/commit/2661a2c1070c4784ad88830dcc932c1add2d1ef4) | `` automatic update `` |
| [`b0790c32`](https://github.com/nix-community/NUR/commit/b0790c328e0cd4264faf48a17ba6d89f5d0dcfdb) | `` automatic update `` |