### PR TITLE
chore(flake/nur): `e659138c` -> `5d3026de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711864846,
-        "narHash": "sha256-31nrn15ReRnJUXmDkNQskC1ufhJeAzqpe8+1MLRe1yQ=",
+        "lastModified": 1711869794,
+        "narHash": "sha256-3rtSpHe+rMxFX3ftox+CBs9imr8t7BZX2N2nNBHAj/A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e659138ced33d9a8a08f08b981830ce67a44b7e0",
+        "rev": "5d3026de3ca64dadc0a6a2d077c211d5278aa9b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5d3026de`](https://github.com/nix-community/NUR/commit/5d3026de3ca64dadc0a6a2d077c211d5278aa9b3) | `` automatic update `` |
| [`774cad07`](https://github.com/nix-community/NUR/commit/774cad077fc6e44710e879261b7b63ce510b91c4) | `` automatic update `` |
| [`d800525a`](https://github.com/nix-community/NUR/commit/d800525a8563741091dd1407bfa5e4562b0595f2) | `` automatic update `` |
| [`353553a9`](https://github.com/nix-community/NUR/commit/353553a9c1311f34f515c2d54c5465ae496262c9) | `` automatic update `` |