### PR TITLE
chore(flake/nur): `c81f994e` -> `9a2b1af6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711875273,
-        "narHash": "sha256-IcWnTxZH0aY8WqYki1POVPajTUU+o17MBZRXbSrWoi0=",
+        "lastModified": 1711889542,
+        "narHash": "sha256-MTlwGha4ukHdq4HiwTWSqUImeJdddxj3QXfqgPlfrXc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c81f994ee66090cf56543f06d5d5e40ba1564db4",
+        "rev": "9a2b1af65cd813316bd718be1e7e809e3451b7f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9a2b1af6`](https://github.com/nix-community/NUR/commit/9a2b1af65cd813316bd718be1e7e809e3451b7f7) | `` automatic update `` |
| [`9c8ba168`](https://github.com/nix-community/NUR/commit/9c8ba168159281644f751bc29bf8a9c00c61de88) | `` automatic update `` |