### PR TITLE
chore(flake/nur): `9a2b1af6` -> `fec4a0f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711889542,
-        "narHash": "sha256-MTlwGha4ukHdq4HiwTWSqUImeJdddxj3QXfqgPlfrXc=",
+        "lastModified": 1711896271,
+        "narHash": "sha256-KY49OkcG0w04AHza1tDzWJ6/kjWX7EW/QZ1M4RfG+bA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9a2b1af65cd813316bd718be1e7e809e3451b7f7",
+        "rev": "fec4a0f5021ece60ecf44f1f97b9702a5ea48f8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fec4a0f5`](https://github.com/nix-community/NUR/commit/fec4a0f5021ece60ecf44f1f97b9702a5ea48f8c) | `` automatic update `` |