### PR TITLE
chore(flake/nur): `fec4a0f5` -> `8b5e0025`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711896271,
-        "narHash": "sha256-KY49OkcG0w04AHza1tDzWJ6/kjWX7EW/QZ1M4RfG+bA=",
+        "lastModified": 1711899970,
+        "narHash": "sha256-NZg9Avu4UC3BjYbDFZGfDHgEPXOhYPVYVHIeAKYONSY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fec4a0f5021ece60ecf44f1f97b9702a5ea48f8c",
+        "rev": "8b5e0025b22da9df1efeafbd8b84e594c670c8a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8b5e0025`](https://github.com/nix-community/NUR/commit/8b5e0025b22da9df1efeafbd8b84e594c670c8a7) | `` automatic update `` |