### PR TITLE
chore(flake/nur): `8b5e0025` -> `956ae342`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711899970,
-        "narHash": "sha256-NZg9Avu4UC3BjYbDFZGfDHgEPXOhYPVYVHIeAKYONSY=",
+        "lastModified": 1711903479,
+        "narHash": "sha256-Rc76s9/+g+XD25cyDeKPahCMCRQeRAj4t1EATxzvXa8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8b5e0025b22da9df1efeafbd8b84e594c670c8a7",
+        "rev": "956ae34206a2521c1fb4b870274963a306a9a695",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`956ae342`](https://github.com/nix-community/NUR/commit/956ae34206a2521c1fb4b870274963a306a9a695) | `` automatic update `` |