### PR TITLE
chore(flake/emacs-overlay): `c4d37df2` -> `dbf1f7fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711875924,
-        "narHash": "sha256-xhT772p1RCH4KLkHJref333U0i08y85cUbUptIMLgJo=",
+        "lastModified": 1711904644,
+        "narHash": "sha256-RknDeaZHTi/HV89L41XcomfW+R0pEaHqieCLnzESwAE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c4d37df2341ca6ed9269e3bff81984fde865aa70",
+        "rev": "dbf1f7fdcc2fa15cb60ed0ec6ee84fb75646ed92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`dbf1f7fd`](https://github.com/nix-community/emacs-overlay/commit/dbf1f7fdcc2fa15cb60ed0ec6ee84fb75646ed92) | `` Updated emacs ``  |
| [`95915c61`](https://github.com/nix-community/emacs-overlay/commit/95915c61f4d578c77380f2f8b3d3ee986c5abaee) | `` Updated melpa ``  |
| [`3bfb56ed`](https://github.com/nix-community/emacs-overlay/commit/3bfb56ed6e9c26b13828ccff013578575141c5e9) | `` Updated elpa ``   |
| [`98f098ea`](https://github.com/nix-community/emacs-overlay/commit/98f098ead66cd01b7eda6877c506882d6ddb6ee1) | `` Updated nongnu `` |