### PR TITLE
chore(flake/nur): `d0150de0` -> `06bae44c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711907167,
-        "narHash": "sha256-+xQqJ/j+EpxSymMcZnkkIptvKFeWApsz3DdGuMlOzIo=",
+        "lastModified": 1711910193,
+        "narHash": "sha256-6SDYiSpDJYxhvsiLfQCLgrofNitsh3+ZJK8zgT0IyGg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d0150de0df485538d2c6f7c92b71f93dda3ef493",
+        "rev": "06bae44ce969281c826fb127fc94280a68912fb2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`06bae44c`](https://github.com/nix-community/NUR/commit/06bae44ce969281c826fb127fc94280a68912fb2) | `` automatic update `` |
| [`265a1d75`](https://github.com/nix-community/NUR/commit/265a1d75fc3ec1b9a1b555d1661f0e222eefa181) | `` automatic update `` |