### PR TITLE
chore(flake/home-manager): `30f2ec39` -> `820be197`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711868868,
-        "narHash": "sha256-QpZanlbVu6Gb2K96u3vgu0F2BvZD74+fOsIFWcYEXoY=",
+        "lastModified": 1711915616,
+        "narHash": "sha256-co6LoFA+j6BZEeJNSR8nZ4oOort5qYPskjrDHBaJgmo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "30f2ec39519f4f5a8a96af808c439e730c15aeab",
+        "rev": "820be197ccf3adaad9a8856ef255c13b6cc561a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`820be197`](https://github.com/nix-community/home-manager/commit/820be197ccf3adaad9a8856ef255c13b6cc561a6) | `` programs.khal: ability to set RGB color (#5192) `` |