### PR TITLE
chore(flake/srvos): `b3af8aed` -> `e5a5f15a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -994,11 +994,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711586987,
-        "narHash": "sha256-/8LbB2JCme+RQekVcXaeQisfqIMBI8uLp0BvzxqdHk8=",
+        "lastModified": 1711932894,
+        "narHash": "sha256-aiMc4JHJU72cbkeHPDBE8pQEOel/RrW8YkGXelRvFn8=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "b3af8aed091d85e180a861695f2d57b3b2d24ba1",
+        "rev": "e5a5f15acaff9daa69e7ef5596f6985ec695685f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`e5a5f15a`](https://github.com/nix-community/srvos/commit/e5a5f15acaff9daa69e7ef5596f6985ec695685f) | `` dev/private/flake.lock: Update `` |
| [`4b5df9bc`](https://github.com/nix-community/srvos/commit/4b5df9bcc588e36261781e47b4df9bc5fcffa9f0) | `` flake.lock: Update ``             |