### PR TITLE
chore(flake/nur): `327169ed` -> `e8898635`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711914285,
-        "narHash": "sha256-n7Bm62/s+t/S3xiZz33gp4HWgKfSOgYG5JzmT0gJoQ8=",
+        "lastModified": 1711936474,
+        "narHash": "sha256-YlaNwbY/J9NuOEXIP0q79UwXUHa0NLaCh2dQlU32IvE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "327169ed2b4766f8112d4fb144bc8f8a7cebf8bd",
+        "rev": "e8898635343424f8c9de3142ec9b22e3b586af6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e8898635`](https://github.com/nix-community/NUR/commit/e8898635343424f8c9de3142ec9b22e3b586af6c) | `` automatic update `` |
| [`da279ff7`](https://github.com/nix-community/NUR/commit/da279ff77d70d76da9dbbab7c87e25c0ecacd48a) | `` automatic update `` |