### PR TITLE
chore(flake/nur): `e8898635` -> `9067a232`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711936474,
-        "narHash": "sha256-YlaNwbY/J9NuOEXIP0q79UwXUHa0NLaCh2dQlU32IvE=",
+        "lastModified": 1711943738,
+        "narHash": "sha256-ecxdVHEDNhcfaWlCnJ23yiYTl9IoZxUjFbMdVTbygc8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e8898635343424f8c9de3142ec9b22e3b586af6c",
+        "rev": "9067a23284a26339f5196faafcbed6b5773ed0b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9067a232`](https://github.com/nix-community/NUR/commit/9067a23284a26339f5196faafcbed6b5773ed0b0) | `` automatic update `` |
| [`489d683e`](https://github.com/nix-community/NUR/commit/489d683e31480d9c0d81b439ebbe9b8f09827257) | `` automatic update `` |