### PR TITLE
chore(flake/nur): `9067a232` -> `e4f401a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711943738,
-        "narHash": "sha256-ecxdVHEDNhcfaWlCnJ23yiYTl9IoZxUjFbMdVTbygc8=",
+        "lastModified": 1711946221,
+        "narHash": "sha256-Ba7wf5sRvWy5q390PVUjmU3HlPWcxKW03GqhUiSjWIA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9067a23284a26339f5196faafcbed6b5773ed0b0",
+        "rev": "e4f401a895618fe76b00d9843cec396212d92af3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e4f401a8`](https://github.com/nix-community/NUR/commit/e4f401a895618fe76b00d9843cec396212d92af3) | `` automatic update `` |
| [`0b3081d5`](https://github.com/nix-community/NUR/commit/0b3081d55ed7666363ca9a73aae54e34b9791a44) | `` automatic update `` |