### PR TITLE
chore(flake/nur): `e4f401a8` -> `925328c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711946221,
-        "narHash": "sha256-Ba7wf5sRvWy5q390PVUjmU3HlPWcxKW03GqhUiSjWIA=",
+        "lastModified": 1711953887,
+        "narHash": "sha256-cv5y2w2Olg/QVxEQKqDJorxk+f18faiX6QzXJvRj7HM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e4f401a895618fe76b00d9843cec396212d92af3",
+        "rev": "925328c635fbe0826bf090b8cb1f2c8007e0c0c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`925328c6`](https://github.com/nix-community/NUR/commit/925328c635fbe0826bf090b8cb1f2c8007e0c0c5) | `` automatic update `` |