### PR TITLE
chore(flake/nur): `925328c6` -> `76d8eda2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711953887,
-        "narHash": "sha256-cv5y2w2Olg/QVxEQKqDJorxk+f18faiX6QzXJvRj7HM=",
+        "lastModified": 1711957030,
+        "narHash": "sha256-DAyqa3vl1v+0HswB6AcdsCTasulmacI9dGdyCZcvnGE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "925328c635fbe0826bf090b8cb1f2c8007e0c0c5",
+        "rev": "76d8eda21e3e19da0716c3ac9f8e02b66337ee37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`76d8eda2`](https://github.com/nix-community/NUR/commit/76d8eda21e3e19da0716c3ac9f8e02b66337ee37) | `` automatic update `` |