### PR TITLE
chore(flake/nur): `76d8eda2` -> `59d5865e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711957030,
-        "narHash": "sha256-DAyqa3vl1v+0HswB6AcdsCTasulmacI9dGdyCZcvnGE=",
+        "lastModified": 1711960880,
+        "narHash": "sha256-7h0HJPBEEeayHV/gkZRNwBEDzS/ZeolMGq5zC8k2OR0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "76d8eda21e3e19da0716c3ac9f8e02b66337ee37",
+        "rev": "59d5865e54f42c34a17b17df5749e2adb224ce57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`59d5865e`](https://github.com/nix-community/NUR/commit/59d5865e54f42c34a17b17df5749e2adb224ce57) | `` automatic update `` |