### PR TITLE
chore(flake/nur): `59d5865e` -> `b2cbb8f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711960880,
-        "narHash": "sha256-7h0HJPBEEeayHV/gkZRNwBEDzS/ZeolMGq5zC8k2OR0=",
+        "lastModified": 1711964698,
+        "narHash": "sha256-AQ2iVm4UJqEMJ433hjZT+c6reb68VVc4RABkFSnA18w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "59d5865e54f42c34a17b17df5749e2adb224ce57",
+        "rev": "b2cbb8f23ba0b106710090b3e6782b9553bc3e64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b2cbb8f2`](https://github.com/nix-community/NUR/commit/b2cbb8f23ba0b106710090b3e6782b9553bc3e64) | `` automatic update `` |
| [`3f66b75f`](https://github.com/nix-community/NUR/commit/3f66b75f0eee328a51df1b76bcaa1978e48c0a48) | `` automatic update `` |