### PR TITLE
chore(flake/nur): `b2cbb8f2` -> `f3b602d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711964698,
-        "narHash": "sha256-AQ2iVm4UJqEMJ433hjZT+c6reb68VVc4RABkFSnA18w=",
+        "lastModified": 1711968388,
+        "narHash": "sha256-Eoza7CxmVaIe6J47krsSX5e/7WH+RqtIQFX422plFdQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b2cbb8f23ba0b106710090b3e6782b9553bc3e64",
+        "rev": "f3b602d58ca5d7359c46e2d2129ba633de15cf3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f3b602d5`](https://github.com/nix-community/NUR/commit/f3b602d58ca5d7359c46e2d2129ba633de15cf3e) | `` automatic update `` |
| [`088ba0f7`](https://github.com/nix-community/NUR/commit/088ba0f79fd578a5bd91703e99281715bd83fbba) | `` automatic update `` |