### PR TITLE
chore(flake/nur): `f3b602d5` -> `39942185`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711968388,
-        "narHash": "sha256-Eoza7CxmVaIe6J47krsSX5e/7WH+RqtIQFX422plFdQ=",
+        "lastModified": 1711971896,
+        "narHash": "sha256-AISS9Z0YDKdhvep+ZEYVAfgoo7yMU1kGP1Zk/n2wiEc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f3b602d58ca5d7359c46e2d2129ba633de15cf3e",
+        "rev": "3994218574cb3a1bd6f1effa838315f43eea6840",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`39942185`](https://github.com/nix-community/NUR/commit/3994218574cb3a1bd6f1effa838315f43eea6840) | `` automatic update `` |