### PR TITLE
chore(flake/stylix): `fdf8fd26` -> `a0bdd9c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1030,11 +1030,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711797803,
-        "narHash": "sha256-7CVR/L+sXNNuQtNG6djzgoaMlP1acFIn8p/gImlDwI4=",
+        "lastModified": 1711979457,
+        "narHash": "sha256-gIJNq0eIdddmEfiKoMS/5nl0Uk84uQ2qnHTwjmtnNGc=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "fdf8fd261eba972e23e8926caeb3aa41c5e3ac68",
+        "rev": "a0bdd9c15b23a5db48d29afe3b238333605c357c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                              |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`a0bdd9c1`](https://github.com/danth/stylix/commit/a0bdd9c15b23a5db48d29afe3b238333605c357c) | `` stylix: escape spaces in wallpaper path (#317) `` |
| [`3c6b34fb`](https://github.com/danth/stylix/commit/3c6b34fbc29c57b741f848df77f3072041fd19c3) | `` kde: apply Bash best practices (#314) ``          |