### PR TITLE
chore(flake/nur): `bc9bf64c` -> `d4b2d617`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711976084,
-        "narHash": "sha256-uKlDrNyUPWUuswIR7QUstjP0wltZGgNCKG5KSHKtaME=",
+        "lastModified": 1711979987,
+        "narHash": "sha256-zlxP7Z+tJoJwv4X9dXXs7J5Du9SoYbpOEWBKf06e2X4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bc9bf64c4f88bd1fbc6b806999482d2da2a93dff",
+        "rev": "d4b2d617721d968a7811b03ae2095af0d32a8180",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d4b2d617`](https://github.com/nix-community/NUR/commit/d4b2d617721d968a7811b03ae2095af0d32a8180) | `` automatic update `` |