### PR TITLE
chore(flake/nur): `fbfc9b74` -> `4b323bfa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711986269,
-        "narHash": "sha256-2P3LmeDijOQXGuJ/Rxubuu+8UGf7lJhpFGvzaU+dpDU=",
+        "lastModified": 1711990191,
+        "narHash": "sha256-jNFBz0Py24GNURY9RSc2D1XyZZxzx5rvDOgZwVpni08=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fbfc9b742a6349690acd5923a02a214930d34baf",
+        "rev": "4b323bfaf8ef40973e78317ed1e0e2b0c2fd2ee2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4b323bfa`](https://github.com/nix-community/NUR/commit/4b323bfaf8ef40973e78317ed1e0e2b0c2fd2ee2) | `` automatic update `` |