### PR TITLE
chore(flake/nur): `4b323bfa` -> `1159b3d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711990191,
-        "narHash": "sha256-jNFBz0Py24GNURY9RSc2D1XyZZxzx5rvDOgZwVpni08=",
+        "lastModified": 1712000692,
+        "narHash": "sha256-RPxjUll/KKhF/DUL/2ws8UK3cyLYO2WCdX0uHsIn1A4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4b323bfaf8ef40973e78317ed1e0e2b0c2fd2ee2",
+        "rev": "1159b3d58c4ee82ebf09fc7107b126dde17c482a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1159b3d5`](https://github.com/nix-community/NUR/commit/1159b3d58c4ee82ebf09fc7107b126dde17c482a) | `` automatic update `` |