### PR TITLE
chore(flake/nur): `1159b3d5` -> `2d70d084`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712000692,
-        "narHash": "sha256-RPxjUll/KKhF/DUL/2ws8UK3cyLYO2WCdX0uHsIn1A4=",
+        "lastModified": 1712011498,
+        "narHash": "sha256-bASAtLec+HjSDcWy3n3SkfDWaFfl3yIg3hjWQC52ubs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1159b3d58c4ee82ebf09fc7107b126dde17c482a",
+        "rev": "2d70d084ce6118c5c7f9891746b8508badf02957",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2d70d084`](https://github.com/nix-community/NUR/commit/2d70d084ce6118c5c7f9891746b8508badf02957) | `` automatic update `` |
| [`c7eea5a5`](https://github.com/nix-community/NUR/commit/c7eea5a5b9b48769de2b72d402323478ca6325b8) | `` automatic update `` |
| [`f1fae246`](https://github.com/nix-community/NUR/commit/f1fae246d6a2d3fe2c220121cd47686a00b38e16) | `` automatic update `` |