### PR TITLE
chore(flake/emacs-overlay): `ca072922` -> `5dee04f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711991227,
-        "narHash": "sha256-fnJhMTzMTmCauYrcm4Swzhk/2imWfi/hyIE28dZVvfM=",
+        "lastModified": 1712021653,
+        "narHash": "sha256-Yr+cDDESdm2E9C/nj1nlhrMpyYt1/Va9yXvlRYD9SyA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ca072922f5ccde8a5deb9bc3a8307b95ce37f971",
+        "rev": "5dee04f5269dffad92faf3a8210c03e639d86db2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`5dee04f5`](https://github.com/nix-community/emacs-overlay/commit/5dee04f5269dffad92faf3a8210c03e639d86db2) | `` Updated melpa `` |
| [`fb64abf8`](https://github.com/nix-community/emacs-overlay/commit/fb64abf84f49dc419caa9f5545afe597382bb30e) | `` Updated emacs `` |
| [`664dac1c`](https://github.com/nix-community/emacs-overlay/commit/664dac1cc0f5308f5ec6c673c2d0e0d41bcd6407) | `` Updated elpa ``  |