### PR TITLE
chore(flake/nur): `843061db` -> `0afaeedc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712022164,
-        "narHash": "sha256-yx1kMMxqlDavIfAIVibbmWQYeQd1OprXtk1x+atNwXc=",
+        "lastModified": 1712030020,
+        "narHash": "sha256-f/xM1UvjVptyEABLMreBSYW3idZ3WXJ7WfRYs7Wbp1Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "843061db485b07c7582730f2d22c1e6a03320bec",
+        "rev": "0afaeedcd5a03f7c195b970645b960e1cb8da8cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0afaeedc`](https://github.com/nix-community/NUR/commit/0afaeedcd5a03f7c195b970645b960e1cb8da8cf) | `` automatic update `` |
| [`1af66552`](https://github.com/nix-community/NUR/commit/1af66552a5ab318cbcd78c2fa2fdb8fcc93c4ee2) | `` automatic update `` |
| [`662f1ccc`](https://github.com/nix-community/NUR/commit/662f1cccfd7530808bf12e8de17af208b5a1580a) | `` automatic update `` |
| [`5a81c315`](https://github.com/nix-community/NUR/commit/5a81c315a055feddb75f15d94ac5eaab704e3fb9) | `` automatic update `` |