### PR TITLE
chore(flake/nur): `0afaeedc` -> `4c166e42`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712030020,
-        "narHash": "sha256-f/xM1UvjVptyEABLMreBSYW3idZ3WXJ7WfRYs7Wbp1Y=",
+        "lastModified": 1712033433,
+        "narHash": "sha256-iHEU6YnoQAA7odXmUjKzRBVh9Dwa/k9ptCDo4b0wQL8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0afaeedcd5a03f7c195b970645b960e1cb8da8cf",
+        "rev": "4c166e425d61650861a412af9afaae5b749d5781",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4c166e42`](https://github.com/nix-community/NUR/commit/4c166e425d61650861a412af9afaae5b749d5781) | `` automatic update `` |
| [`cede7119`](https://github.com/nix-community/NUR/commit/cede711911c10d34474a2489e8f86b313a5a25c0) | `` automatic update `` |
| [`03d2247b`](https://github.com/nix-community/NUR/commit/03d2247b04de6e3142aa6b600fc549d75366879d) | `` automatic update `` |
| [`58c1ad99`](https://github.com/nix-community/NUR/commit/58c1ad9987a2030b61bcfc2c22268a3028ce8040) | `` automatic update `` |
| [`4dfc696f`](https://github.com/nix-community/NUR/commit/4dfc696fcd573bfdb14a71ab44510d7169fcf847) | `` automatic update `` |