### PR TITLE
chore(flake/pre-commit-hooks): `f3bb9549` -> `642dce09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -881,11 +881,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1711981679,
-        "narHash": "sha256-pnbHEXJOdGkPrHBdkZLv/a2V09On+V3J4aPE/BfAJC8=",
+        "lastModified": 1712033542,
+        "narHash": "sha256-werD6WtgYo+ZGopbLENP0phwoWyd73CWz01VgrFOSL0=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "f3bb95498eaaa49a93bacaf196cdb6cf8e872cdf",
+        "rev": "642dce09c85b1478b509416f83e72bd59b6b3ac2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------- |
| [`649fb51d`](https://github.com/cachix/git-hooks.nix/commit/649fb51def9772b420737dae9cf7289af80f0a8b) | `` add installation test `` |