### PR TITLE
chore(flake/nur): `4c166e42` -> `0481d33c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712033433,
-        "narHash": "sha256-iHEU6YnoQAA7odXmUjKzRBVh9Dwa/k9ptCDo4b0wQL8=",
+        "lastModified": 1712037404,
+        "narHash": "sha256-w8H/4XTR38rV+RjiyOPRZIenjEswZtm1Ir1Lmc3uUgI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4c166e425d61650861a412af9afaae5b749d5781",
+        "rev": "0481d33cdbc73ec5b4bcdc4040f9fc29447604d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0481d33c`](https://github.com/nix-community/NUR/commit/0481d33cdbc73ec5b4bcdc4040f9fc29447604d0) | `` automatic update `` |