### PR TITLE
chore(flake/nur): `a4291b2f` -> `aa378fc7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712051077,
-        "narHash": "sha256-eM/LTDd/2zwcizYEvuV/8BRX03Hfsjxp7ZXnparG6nw=",
+        "lastModified": 1712054766,
+        "narHash": "sha256-3UyalgybRCgEq/5PZ6e0qjOULNba9QPKOYmPEi6sqZs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a4291b2fa3c6d7edbc07f7e49dcf207173c754c0",
+        "rev": "aa378fc7283e64adaafe8006b97f27c913575c7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aa378fc7`](https://github.com/nix-community/NUR/commit/aa378fc7283e64adaafe8006b97f27c913575c7c) | `` automatic update `` |