### PR TITLE
chore(flake/templates): `0bd10471` -> `bfc872ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1090,11 +1090,11 @@
     },
     "templates": {
       "locked": {
-        "lastModified": 1711620241,
-        "narHash": "sha256-ShA0aiGis+jczMZxjdMlL8EKlVfRAgXupJEGe5dg3bM=",
+        "lastModified": 1712072577,
+        "narHash": "sha256-V5IH+i+VXHe0cEqIDkfKeISEZppOIF7Ys1dba84FJMA=",
         "owner": "NixOS",
         "repo": "templates",
-        "rev": "0bd1047151b5dc5733ece2645751acc277228c52",
+        "rev": "bfc872cab560e3c0852bd073a52eff8093cfeaa6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                 |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
| [`19d06ec2`](https://github.com/NixOS/templates/commit/19d06ec2511dc912795d2affc82daef490152720) | `` chore: update install-nix-action to latest; fix nix build command `` |