### PR TITLE
chore(flake/emacs-overlay): `a5e600b3` -> `a8983cd1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712047901,
-        "narHash": "sha256-EkhrsRtRjS8vgoL57lWU3CpWkyZ1zjWccRnEmzwIIQY=",
+        "lastModified": 1712076734,
+        "narHash": "sha256-HUmIHHMJy2uuhnyappTfhXGwaL9VATkxbDEvILGqhoQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a5e600b3947b736643670367d8380317420f3b33",
+        "rev": "a8983cd18bcca841368f2c56aae4d7efd0bc049e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`a8983cd1`](https://github.com/nix-community/emacs-overlay/commit/a8983cd18bcca841368f2c56aae4d7efd0bc049e) | `` Updated melpa `` |
| [`66655d2a`](https://github.com/nix-community/emacs-overlay/commit/66655d2a1b6faf4a354722bf8f6ef8df80f7524c) | `` Updated elpa ``  |