### PR TITLE
chore(flake/nur): `1c024d94` -> `03a8f31d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712087101,
-        "narHash": "sha256-yaGe1cyIORTh7HCtGmMK8ZYhGeBs//Y8H+G71Q3ZSVM=",
+        "lastModified": 1712089483,
+        "narHash": "sha256-JfZBRoe75yTcm5QjvfbIrkB63pBOF7FHaqsfbelGeoI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1c024d942e16494b10038d7f2ef4b20e385718a8",
+        "rev": "03a8f31da963d044ea91cb420b20a284522d8c69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`03a8f31d`](https://github.com/nix-community/NUR/commit/03a8f31da963d044ea91cb420b20a284522d8c69) | `` automatic update `` |