### PR TITLE
chore(flake/home-manager): `4be04644` -> `80546b22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712016346,
-        "narHash": "sha256-O2nO7pD+krq+4HgkLB4VThRtAucIPfXDs/jJqCGlK1w=",
+        "lastModified": 1712093955,
+        "narHash": "sha256-94I0sXz6fiVBvUAk2tg6t3UpM5rOImj4JTSTNFbg64s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4be0464472675212654dedf3e021bd5f1d58b92f",
+        "rev": "80546b220e95a575c66c213af1b09fe255299438",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`80546b22`](https://github.com/nix-community/home-manager/commit/80546b220e95a575c66c213af1b09fe255299438) | `` Translate using Weblate (Norwegian Bokmål) `` |
| [`58e5ae81`](https://github.com/nix-community/home-manager/commit/58e5ae81ceb274a249ae69659f3150419673f14c) | `` Translate using Weblate (Romanian) ``         |
| [`aca33e99`](https://github.com/nix-community/home-manager/commit/aca33e99551250cfb23f384789d9fecea0254ac4) | `` Translate using Weblate (Russian) ``          |
| [`81cd7199`](https://github.com/nix-community/home-manager/commit/81cd71995ade24333017e7930802040363ce1946) | `` hyprland: fix systemd variables example ``    |
| [`e429a609`](https://github.com/nix-community/home-manager/commit/e429a60900c1c8f6c07bbd4926b79f05a98544c9) | `` bacon: add default value for settings ``      |
| [`6396954c`](https://github.com/nix-community/home-manager/commit/6396954c0d26ffd7601c478c11443f454926bf27) | `` bacon: add package option ``                  |