### PR TITLE
chore(flake/nur): `03a8f31d` -> `2b655318`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712089483,
-        "narHash": "sha256-JfZBRoe75yTcm5QjvfbIrkB63pBOF7FHaqsfbelGeoI=",
+        "lastModified": 1712097892,
+        "narHash": "sha256-YEROpZs8saHffMKmSisTwhYdF/G3VMHgka4MAhz7Q9A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "03a8f31da963d044ea91cb420b20a284522d8c69",
+        "rev": "2b655318c106193f6ffa11f6f7b778dc74688a3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2b655318`](https://github.com/nix-community/NUR/commit/2b655318c106193f6ffa11f6f7b778dc74688a3b) | `` automatic update `` |
| [`d7666601`](https://github.com/nix-community/NUR/commit/d7666601c0054c9150a2152da0cfc007c1de3948) | `` automatic update `` |
| [`78196fda`](https://github.com/nix-community/NUR/commit/78196fda79cdc5a1561473d6512634ab5926e254) | `` automatic update `` |
| [`7459067a`](https://github.com/nix-community/NUR/commit/7459067abfbd7888a63d24849e4c77ed316bc889) | `` automatic update `` |