### PR TITLE
chore(flake/emacs-overlay): `a8983cd1` -> `7bfcd741`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712076734,
-        "narHash": "sha256-HUmIHHMJy2uuhnyappTfhXGwaL9VATkxbDEvILGqhoQ=",
+        "lastModified": 1712105839,
+        "narHash": "sha256-f8n6GxZa5IOP2f7MnL4+LM/wS2i+UgNjTUKuls2zQnY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a8983cd18bcca841368f2c56aae4d7efd0bc049e",
+        "rev": "7bfcd7412b5b0c0677d41444ff3c4f5d23ee74d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`7bfcd741`](https://github.com/nix-community/emacs-overlay/commit/7bfcd7412b5b0c0677d41444ff3c4f5d23ee74d8) | `` Updated elpa `` |