### PR TITLE
chore(flake/emacs-overlay): `7bfcd741` -> `5d0a1093`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712105839,
-        "narHash": "sha256-f8n6GxZa5IOP2f7MnL4+LM/wS2i+UgNjTUKuls2zQnY=",
+        "lastModified": 1712108714,
+        "narHash": "sha256-QzrcwGuuAP1octIcUw/d+Yi5BEXYt1NOwNLpeUrqKTk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7bfcd7412b5b0c0677d41444ff3c4f5d23ee74d8",
+        "rev": "5d0a10938c32f3cb95d1f1f18127948d239c6720",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`5d0a1093`](https://github.com/nix-community/emacs-overlay/commit/5d0a10938c32f3cb95d1f1f18127948d239c6720) | `` Updated emacs `` |
| [`d20dbcb7`](https://github.com/nix-community/emacs-overlay/commit/d20dbcb705e84848953212db68d5067d5bb99b05) | `` Updated melpa `` |