### PR TITLE
chore(flake/nur): `9e7d2d75` -> `30a884dc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712109110,
-        "narHash": "sha256-FeDBF6DWBtEy34Vooajoaedrf1DO1gPO+p3Xw8Q6vQY=",
+        "lastModified": 1712111942,
+        "narHash": "sha256-Te1B7/Gnyjhc+bKdu2XDTRN4hzR/Wbk8GBijt/bA5/g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9e7d2d75bd55ae79941ef44f58dd396e5ac2dc00",
+        "rev": "30a884dcaa94ea5fda2848716e85d77913f1285f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`30a884dc`](https://github.com/nix-community/NUR/commit/30a884dcaa94ea5fda2848716e85d77913f1285f) | `` automatic update `` |
| [`a9d4e5a7`](https://github.com/nix-community/NUR/commit/a9d4e5a73956be514c8fa11bfa4476fd4c0ba4c6) | `` automatic update `` |