### PR TITLE
chore(flake/nur): `30a884dc` -> `db715586`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712111942,
-        "narHash": "sha256-Te1B7/Gnyjhc+bKdu2XDTRN4hzR/Wbk8GBijt/bA5/g=",
+        "lastModified": 1712119826,
+        "narHash": "sha256-v21NswnOtBnWKjgHNZGkzPAyAjGX+hMdLrnaxLCaEgo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "30a884dcaa94ea5fda2848716e85d77913f1285f",
+        "rev": "db715586e65fb99150521812501e4cefc7d0a197",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`db715586`](https://github.com/nix-community/NUR/commit/db715586e65fb99150521812501e4cefc7d0a197) | `` automatic update `` |
| [`ae9cd564`](https://github.com/nix-community/NUR/commit/ae9cd564060f00b61e8b05b10794dd08d5c73117) | `` automatic update `` |