### PR TITLE
chore(flake/nur): `658636d2` -> `9d71b5e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712122103,
-        "narHash": "sha256-N8KKrFJkHNjqdL7Z0UthQc8Uz3lZ3tooI76WMXjoC2Q=",
+        "lastModified": 1712127152,
+        "narHash": "sha256-LPFdS9oxJfLsIPn3/59p/n43EgUV3InMZdhlhmMg8WI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "658636d26ccfd0d26e77f8f59abcaa40c6dca0b0",
+        "rev": "9d71b5e8ad6127de490d4715170ce32e767f2d0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9d71b5e8`](https://github.com/nix-community/NUR/commit/9d71b5e8ad6127de490d4715170ce32e767f2d0f) | `` automatic update `` |
| [`f5617512`](https://github.com/nix-community/NUR/commit/f561751241f5e86f893ac37c5c40b48a6af4ca75) | `` automatic update `` |