### PR TITLE
chore(flake/nur): `9d71b5e8` -> `319e516a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712127152,
-        "narHash": "sha256-LPFdS9oxJfLsIPn3/59p/n43EgUV3InMZdhlhmMg8WI=",
+        "lastModified": 1712133822,
+        "narHash": "sha256-MMoHOnX4GSzFTsUb/0FGEHWcduz4K/Vx7yHB+6vGarI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9d71b5e8ad6127de490d4715170ce32e767f2d0f",
+        "rev": "319e516a81bb0bd5187487710394b3f5c4f96600",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`319e516a`](https://github.com/nix-community/NUR/commit/319e516a81bb0bd5187487710394b3f5c4f96600) | `` automatic update `` |
| [`8b79e51b`](https://github.com/nix-community/NUR/commit/8b79e51b77678fac77da4370666fa7ebb9100304) | `` automatic update `` |