### PR TITLE
chore(flake/nur): `319e516a` -> `ddb584e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712133822,
-        "narHash": "sha256-MMoHOnX4GSzFTsUb/0FGEHWcduz4K/Vx7yHB+6vGarI=",
+        "lastModified": 1712136626,
+        "narHash": "sha256-vjRmTShaLTmtoJhz3JYAvacyhT0z71lRh+hLpvN7Vpg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "319e516a81bb0bd5187487710394b3f5c4f96600",
+        "rev": "ddb584e9cee8a446b01ad47905579346e1ecb78c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                     |
| -------------------------------------------------------------------------------------------------- | --------------------------- |
| [`ddb584e9`](https://github.com/nix-community/NUR/commit/ddb584e9cee8a446b01ad47905579346e1ecb78c) | `` automatic update ``      |
| [`24492e63`](https://github.com/nix-community/NUR/commit/24492e6349a27e24ad998ad52f8b2e4e95d0eb62) | `` add c2vi repository ``   |
| [`aef16250`](https://github.com/nix-community/NUR/commit/aef162508cfc57527d84c41466ae5df16ab3b254) | `` automatic update ``      |
| [`c972da03`](https://github.com/nix-community/NUR/commit/c972da033da227d7c729a488fe2a8e068733f152) | `` nur format-manifest ``   |
| [`9f39b8cb`](https://github.com/nix-community/NUR/commit/9f39b8cbf7b169d8cf73128de05e1b4f860efe0f) | `` Added "spitzeqc" repo `` |