### PR TITLE
chore(flake/nur): `ddb584e9` -> `bb957277`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712136626,
-        "narHash": "sha256-vjRmTShaLTmtoJhz3JYAvacyhT0z71lRh+hLpvN7Vpg=",
+        "lastModified": 1712141198,
+        "narHash": "sha256-AAnrGN3AiXN2GxzU5k6SjtGS49gPIF3fJx5rczurLd8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ddb584e9cee8a446b01ad47905579346e1ecb78c",
+        "rev": "bb95727716587b17d9829fac6312467594fc79c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bb957277`](https://github.com/nix-community/NUR/commit/bb95727716587b17d9829fac6312467594fc79c1) | `` automatic update `` |
| [`27f9f2f3`](https://github.com/nix-community/NUR/commit/27f9f2f3a3561cf04fc34f746fdc2682343febad) | `` automatic update `` |