### PR TITLE
chore(flake/nur): `bb957277` -> `04e8a50a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712141198,
-        "narHash": "sha256-AAnrGN3AiXN2GxzU5k6SjtGS49gPIF3fJx5rczurLd8=",
+        "lastModified": 1712144685,
+        "narHash": "sha256-UGymPNg0pxnAHiR9hM0RuVB4wNcSh6V8SHe/RXd0Ey8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bb95727716587b17d9829fac6312467594fc79c1",
+        "rev": "04e8a50af48979dd2c43ae6b588387d9134f2a98",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`04e8a50a`](https://github.com/nix-community/NUR/commit/04e8a50af48979dd2c43ae6b588387d9134f2a98) | `` automatic update `` |