### PR TITLE
chore(flake/nur): `04e8a50a` -> `832d3fe6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712144685,
-        "narHash": "sha256-UGymPNg0pxnAHiR9hM0RuVB4wNcSh6V8SHe/RXd0Ey8=",
+        "lastModified": 1712149118,
+        "narHash": "sha256-DKzOREeEEVl/fR1OwTns6wFZ43/OXBKZob6+bJ+n5CM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "04e8a50af48979dd2c43ae6b588387d9134f2a98",
+        "rev": "832d3fe6d9dd4dfcad0ed6d886372beed72818dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`832d3fe6`](https://github.com/nix-community/NUR/commit/832d3fe6d9dd4dfcad0ed6d886372beed72818dc) | `` automatic update `` |
| [`8a7a0fe1`](https://github.com/nix-community/NUR/commit/8a7a0fe16f7d8e88e1b5c4348d253cc864784b96) | `` automatic update `` |