### PR TITLE
chore(flake/nur): `832d3fe6` -> `839733a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712149118,
-        "narHash": "sha256-DKzOREeEEVl/fR1OwTns6wFZ43/OXBKZob6+bJ+n5CM=",
+        "lastModified": 1712159103,
+        "narHash": "sha256-jbVMGl4TePM6faeW9SXWsOsn7KOn7TB6OWKsI148qB0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "832d3fe6d9dd4dfcad0ed6d886372beed72818dc",
+        "rev": "839733a1d390b4450cd509f7e6c0b5966bd03798",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`839733a1`](https://github.com/nix-community/NUR/commit/839733a1d390b4450cd509f7e6c0b5966bd03798) | `` automatic update `` |
| [`ddfca238`](https://github.com/nix-community/NUR/commit/ddfca238450636d8eb531885841f3d3ee72bfbd5) | `` automatic update `` |
| [`d8ebfd35`](https://github.com/nix-community/NUR/commit/d8ebfd35449514393ece50ae51f9bdb44b7994d9) | `` automatic update `` |
| [`1f0386de`](https://github.com/nix-community/NUR/commit/1f0386de6fd6f2cd2ec3652c07332f16a97fb4e1) | `` automatic update `` |
| [`0d874fb6`](https://github.com/nix-community/NUR/commit/0d874fb60918cf49bc8fadf3b911ba52a30bf006) | `` automatic update `` |