### PR TITLE
chore(flake/emacs-overlay): `5d0a1093` -> `caa3f53e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712108714,
-        "narHash": "sha256-QzrcwGuuAP1octIcUw/d+Yi5BEXYt1NOwNLpeUrqKTk=",
+        "lastModified": 1712163912,
+        "narHash": "sha256-8GoqX+rXuzNII4OPdCvkLihNCGerN2EIP/rc37wymas=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5d0a10938c32f3cb95d1f1f18127948d239c6720",
+        "rev": "caa3f53e460e97f0499f1006de35cf3f898a66d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`caa3f53e`](https://github.com/nix-community/emacs-overlay/commit/caa3f53e460e97f0499f1006de35cf3f898a66d9) | `` Updated emacs `` |
| [`451efa21`](https://github.com/nix-community/emacs-overlay/commit/451efa21977d503139fa2235de324f99e6d99c05) | `` Updated melpa `` |
| [`9ff3efce`](https://github.com/nix-community/emacs-overlay/commit/9ff3efceeec20ae2b8c3d42d6057cae2f1f55f36) | `` Updated elpa ``  |