### PR TITLE
chore(flake/nur): `839733a1` -> `a8545f84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712159103,
-        "narHash": "sha256-jbVMGl4TePM6faeW9SXWsOsn7KOn7TB6OWKsI148qB0=",
+        "lastModified": 1712163067,
+        "narHash": "sha256-pzkemn3QHFydb7GHIOyhG2ECEZg3R++lADnSNBKsC4o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "839733a1d390b4450cd509f7e6c0b5966bd03798",
+        "rev": "a8545f8498458bea294878b3ce5e239cd9d6616e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a8545f84`](https://github.com/nix-community/NUR/commit/a8545f8498458bea294878b3ce5e239cd9d6616e) | `` automatic update `` |