### PR TITLE
chore(flake/nur): `a8545f84` -> `25091d2c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712163067,
-        "narHash": "sha256-pzkemn3QHFydb7GHIOyhG2ECEZg3R++lADnSNBKsC4o=",
+        "lastModified": 1712166152,
+        "narHash": "sha256-jo9o03xBb4dCK8luVZh20UO/95qDLidj2oUWLfxDuH8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a8545f8498458bea294878b3ce5e239cd9d6616e",
+        "rev": "25091d2c63de0bbb1826f70b6e967fb356fbdac0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`25091d2c`](https://github.com/nix-community/NUR/commit/25091d2c63de0bbb1826f70b6e967fb356fbdac0) | `` automatic update `` |