### PR TITLE
chore(flake/nur): `25091d2c` -> `014a3b4d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712166152,
-        "narHash": "sha256-jo9o03xBb4dCK8luVZh20UO/95qDLidj2oUWLfxDuH8=",
+        "lastModified": 1712177070,
+        "narHash": "sha256-1A05/x5jk0/+WROi4gPCD1ApxXZUH8arjFenrWS6gYw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "25091d2c63de0bbb1826f70b6e967fb356fbdac0",
+        "rev": "014a3b4d03bb62b2a5ab0fbba4af8c2a488eabe5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`014a3b4d`](https://github.com/nix-community/NUR/commit/014a3b4d03bb62b2a5ab0fbba4af8c2a488eabe5) | `` automatic update `` |
| [`bee98b2b`](https://github.com/nix-community/NUR/commit/bee98b2bf5c3cbfb63c9d584e914b6bcc4a03a26) | `` automatic update `` |