### PR TITLE
chore(flake/nur): `014a3b4d` -> `3ffb9a2b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712177070,
-        "narHash": "sha256-1A05/x5jk0/+WROi4gPCD1ApxXZUH8arjFenrWS6gYw=",
+        "lastModified": 1712180592,
+        "narHash": "sha256-8smRh8KCbiyDP8PUW410C6WjA8wuo/BDGiNhn4Dkd3U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "014a3b4d03bb62b2a5ab0fbba4af8c2a488eabe5",
+        "rev": "3ffb9a2b7bbc5576c81ab610875fa22199a1eaaf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3ffb9a2b`](https://github.com/nix-community/NUR/commit/3ffb9a2b7bbc5576c81ab610875fa22199a1eaaf) | `` automatic update `` |