### PR TITLE
chore(flake/emacs-overlay): `caa3f53e` -> `d8c28bca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712163912,
-        "narHash": "sha256-8GoqX+rXuzNII4OPdCvkLihNCGerN2EIP/rc37wymas=",
+        "lastModified": 1712196574,
+        "narHash": "sha256-wiA16ORjj6VSRzUlhgKio9eIoqt86c/56fAkdmcBrOk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "caa3f53e460e97f0499f1006de35cf3f898a66d9",
+        "rev": "d8c28bca43275f1503a029cc73629cd1aa585af7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d8c28bca`](https://github.com/nix-community/emacs-overlay/commit/d8c28bca43275f1503a029cc73629cd1aa585af7) | `` Updated emacs ``        |
| [`3a2a6fd5`](https://github.com/nix-community/emacs-overlay/commit/3a2a6fd5bbfe5066377afcae6e001698e5dcdf81) | `` Updated melpa ``        |
| [`46294460`](https://github.com/nix-community/emacs-overlay/commit/462944602d2eaa43bf51b958e7f453887e9ba3c1) | `` Updated elpa ``         |
| [`7480617f`](https://github.com/nix-community/emacs-overlay/commit/7480617fd05f6ed921ee879af6948bbbda53f731) | `` Updated flake inputs `` |