### PR TITLE
chore(flake/srvos): `e5a5f15a` -> `ddafe2fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -994,11 +994,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711932894,
-        "narHash": "sha256-aiMc4JHJU72cbkeHPDBE8pQEOel/RrW8YkGXelRvFn8=",
+        "lastModified": 1712191870,
+        "narHash": "sha256-+MzSZ4IuZNT4QJS8b+gM48thfWkrJ7vL4NV5zG8Lqx8=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "e5a5f15acaff9daa69e7ef5596f6985ec695685f",
+        "rev": "ddafe2fd3547f63e6bf75b6e1a99ecfa61c59687",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`ddafe2fd`](https://github.com/nix-community/srvos/commit/ddafe2fd3547f63e6bf75b6e1a99ecfa61c59687) | `` dev/private/flake.lock: Update `` |
| [`4e0bf7f1`](https://github.com/nix-community/srvos/commit/4e0bf7f1cecc2f38f2052c45d6f0ecbfcfe7cf95) | `` flake.lock: Update ``             |