### PR TITLE
chore(flake/nur): `cba5754b` -> `cc8b423d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712190931,
-        "narHash": "sha256-vaOtI+0sK5S3cvF7FxEOV2EpNPs8B8yO1n5eWSi6DxI=",
+        "lastModified": 1712197840,
+        "narHash": "sha256-Wh5C4oaqIACSQrZiQkVyBJDoxurXTcoTalZONuqGM6A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cba5754bf474f13e47fbbea736f473357aac7907",
+        "rev": "cc8b423d3b54181dee4e7a40b51100a91bb9aa0a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cc8b423d`](https://github.com/nix-community/NUR/commit/cc8b423d3b54181dee4e7a40b51100a91bb9aa0a) | `` automatic update `` |
| [`d28540aa`](https://github.com/nix-community/NUR/commit/d28540aa3a2c98a4486892ed54709859a8e5be16) | `` automatic update `` |