### PR TITLE
chore(flake/nur): `cc8b423d` -> `649a2532`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712197840,
-        "narHash": "sha256-Wh5C4oaqIACSQrZiQkVyBJDoxurXTcoTalZONuqGM6A=",
+        "lastModified": 1712203845,
+        "narHash": "sha256-aLd+s9I6NrecXORHG82LuBkOJG15iXXsYjDszBXV5xQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cc8b423d3b54181dee4e7a40b51100a91bb9aa0a",
+        "rev": "649a2532ef17e30bcc4c8addd67215f6ea6d7043",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`649a2532`](https://github.com/nix-community/NUR/commit/649a2532ef17e30bcc4c8addd67215f6ea6d7043) | `` automatic update `` |
| [`aebf3f6d`](https://github.com/nix-community/NUR/commit/aebf3f6d2b3e27c697f9d88ef1db16f61166a58a) | `` automatic update `` |
| [`c124dd85`](https://github.com/nix-community/NUR/commit/c124dd85c2b5f57a31c169d3a4327dc33bf1e36d) | `` automatic update `` |