### PR TITLE
chore(flake/nur): `649a2532` -> `ded87e3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712203845,
-        "narHash": "sha256-aLd+s9I6NrecXORHG82LuBkOJG15iXXsYjDszBXV5xQ=",
+        "lastModified": 1712215405,
+        "narHash": "sha256-WqQKP0zifFgUIW1ZLEsyJTcfh0TojQjpnUZRQA7+W2A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "649a2532ef17e30bcc4c8addd67215f6ea6d7043",
+        "rev": "ded87e3d2f1ffbcb7505991f3b27f3436dafdc3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ded87e3d`](https://github.com/nix-community/NUR/commit/ded87e3d2f1ffbcb7505991f3b27f3436dafdc3e) | `` automatic update `` |
| [`fb11975a`](https://github.com/nix-community/NUR/commit/fb11975a9e0e868dd5cc5fe45b7cc6c5d1589b33) | `` automatic update `` |
| [`e811241d`](https://github.com/nix-community/NUR/commit/e811241d8eb68b1fbd8366ab9cbd6e0781c1cdb8) | `` automatic update `` |
| [`43e8d68b`](https://github.com/nix-community/NUR/commit/43e8d68bf75e30f877a161437d335b90d6f0638f) | `` automatic update `` |
| [`e6a630cb`](https://github.com/nix-community/NUR/commit/e6a630cb501f2d6c4cf173b689db89419bac5ee1) | `` automatic update `` |