### PR TITLE
chore(flake/emacs-overlay): `d8c28bca` -> `4b1e5663`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712196574,
-        "narHash": "sha256-wiA16ORjj6VSRzUlhgKio9eIoqt86c/56fAkdmcBrOk=",
+        "lastModified": 1712221601,
+        "narHash": "sha256-98XsXO6uK8EA9Oz1d/+8FTuTxzwmqhOcxTjf7RE0DKo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d8c28bca43275f1503a029cc73629cd1aa585af7",
+        "rev": "4b1e5663bb9c6754d72c722bc2c3acf2dc460066",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`4b1e5663`](https://github.com/nix-community/emacs-overlay/commit/4b1e5663bb9c6754d72c722bc2c3acf2dc460066) | `` Updated emacs `` |
| [`56cbce1f`](https://github.com/nix-community/emacs-overlay/commit/56cbce1f396f9c98dd899cbc0bd7105d8eace6c5) | `` Updated melpa `` |