### PR TITLE
chore(flake/nur): `3881be4b` -> `05918303`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712227568,
-        "narHash": "sha256-fySksp8RxCJRLsdlscLxsWBGPQ6GyzHPKeHL9MhYj3E=",
+        "lastModified": 1712241281,
+        "narHash": "sha256-UWrJQfrrQ9nOHC39KI51wtdAiR3WWnK+tjvJ2OPmc9A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3881be4b7511a48d762a34c4b2b303608211972a",
+        "rev": "05918303de325e7af117803730114f74a8275667",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`05918303`](https://github.com/nix-community/NUR/commit/05918303de325e7af117803730114f74a8275667) | `` automatic update `` |
| [`681c10a0`](https://github.com/nix-community/NUR/commit/681c10a0ac07ae53c4991224d1eddd877cdc69d4) | `` automatic update `` |
| [`4dd276e9`](https://github.com/nix-community/NUR/commit/4dd276e98e13308a0967eaa199abc76d28296f65) | `` automatic update `` |