### PR TITLE
chore(flake/emacs-overlay): `4b1e5663` -> `2abacaa0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712221601,
-        "narHash": "sha256-98XsXO6uK8EA9Oz1d/+8FTuTxzwmqhOcxTjf7RE0DKo=",
+        "lastModified": 1712250442,
+        "narHash": "sha256-yfr/dxiHrS1MNbumiX+7imIwpMGvbycwOJkIgQfa3VU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4b1e5663bb9c6754d72c722bc2c3acf2dc460066",
+        "rev": "2abacaa07d19f6bddd832d451478c95663792da6",
         "type": "github"
       },
       "original": {
@@ -710,11 +710,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1711668574,
-        "narHash": "sha256-u1dfs0ASQIEr1icTVrsKwg2xToIpn7ZXxW3RHfHxshg=",
+        "lastModified": 1712168706,
+        "narHash": "sha256-XP24tOobf6GGElMd0ux90FEBalUtw6NkBSVh/RlA6ik=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "219951b495fc2eac67b1456824cc1ec1fd2ee659",
+        "rev": "1487bdea619e4a7a53a4590c475deabb5a9d1bfb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`2abacaa0`](https://github.com/nix-community/emacs-overlay/commit/2abacaa07d19f6bddd832d451478c95663792da6) | `` Updated emacs ``        |
| [`ac67d5fc`](https://github.com/nix-community/emacs-overlay/commit/ac67d5fc4081a29e7baaafd9bd9bce85f0a3477b) | `` Updated melpa ``        |
| [`cbecad87`](https://github.com/nix-community/emacs-overlay/commit/cbecad879e445e56788ae41cc0133721e69110d4) | `` Updated elpa ``         |
| [`07a1b83c`](https://github.com/nix-community/emacs-overlay/commit/07a1b83c60f69503cf2bca8de5d4de26da3e5d8d) | `` Updated flake inputs `` |