### PR TITLE
chore(flake/nur): `3db12e68` -> `e1f626f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712249469,
-        "narHash": "sha256-0dQqSn+c32scKFg3fCZDaoLuhw4C97bl3xWN/YB6Nxo=",
+        "lastModified": 1712256362,
+        "narHash": "sha256-IslY+brMHxXgWaaNo7pzIMs+pi7xiFbQFsWEr1WdnhI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3db12e68914428aa6711bfc8ab27fda2660832ff",
+        "rev": "e1f626f42d403ad5022cbec58471332a9f43cba9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e1f626f4`](https://github.com/nix-community/NUR/commit/e1f626f42d403ad5022cbec58471332a9f43cba9) | `` automatic update `` |