### PR TITLE
chore(flake/nur): `e1f626f4` -> `f476d4f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712256362,
-        "narHash": "sha256-IslY+brMHxXgWaaNo7pzIMs+pi7xiFbQFsWEr1WdnhI=",
+        "lastModified": 1712259874,
+        "narHash": "sha256-R8+qYoRlAcQ/18S8hzw19y02zT83HMdgL/ka5ZWJo0k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e1f626f42d403ad5022cbec58471332a9f43cba9",
+        "rev": "f476d4f504ea3f10f2c074a4d3c2af5654cd4bf3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f476d4f5`](https://github.com/nix-community/NUR/commit/f476d4f504ea3f10f2c074a4d3c2af5654cd4bf3) | `` automatic update `` |
| [`45eca1d9`](https://github.com/nix-community/NUR/commit/45eca1d9ee380f60340380a174f286a73d857bc6) | `` automatic update `` |