### PR TITLE
chore(flake/nur): `f476d4f5` -> `747db270`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712259874,
-        "narHash": "sha256-R8+qYoRlAcQ/18S8hzw19y02zT83HMdgL/ka5ZWJo0k=",
+        "lastModified": 1712262314,
+        "narHash": "sha256-gIQ2PDWWLxv1I811OmM6ZlhSjSINQHM0X4hxl5jhzqE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f476d4f504ea3f10f2c074a4d3c2af5654cd4bf3",
+        "rev": "747db27055bb338374d1e7ce0817f0f22107e129",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`747db270`](https://github.com/nix-community/NUR/commit/747db27055bb338374d1e7ce0817f0f22107e129) | `` automatic update `` |