### PR TITLE
chore(flake/home-manager): `7e91f2a0` -> `0c73c1b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712212014,
-        "narHash": "sha256-s+lbaf3nLRn1++/X2eXwY9mYCA/m9l8AvyG8beeOaXE=",
+        "lastModified": 1712266167,
+        "narHash": "sha256-gr2CBgT8t+utDqzWSp2vSjX/c39Q0BNtrWE6/cDhhEE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7e91f2a0ba4b62b88591279d54f741a13e36245b",
+        "rev": "0c73c1b8da28a24c4fe842ced3f2548d5828b550",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`0c73c1b8`](https://github.com/nix-community/home-manager/commit/0c73c1b8da28a24c4fe842ced3f2548d5828b550) | `` zoxide: remove obsolete workaround `` |
| [`9de3aab0`](https://github.com/nix-community/home-manager/commit/9de3aab0917914baad72e32023834f9b39e77610) | `` kdeconnect: add package option ``     |