### PR TITLE
chore(flake/nur): `747db270` -> `df9f4ae0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712262314,
-        "narHash": "sha256-gIQ2PDWWLxv1I811OmM6ZlhSjSINQHM0X4hxl5jhzqE=",
+        "lastModified": 1712270704,
+        "narHash": "sha256-kaXVX//66bJqTXkq0aVn+aJXN277CiV9VQEi+2CtMrk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "747db27055bb338374d1e7ce0817f0f22107e129",
+        "rev": "df9f4ae09236f2417d934992a301687de22ec577",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`df9f4ae0`](https://github.com/nix-community/NUR/commit/df9f4ae09236f2417d934992a301687de22ec577) | `` automatic update `` |
| [`fbb89d6b`](https://github.com/nix-community/NUR/commit/fbb89d6beef3bd6c2781834d4a8a8cfb22ee3e62) | `` automatic update `` |
| [`066d6ff4`](https://github.com/nix-community/NUR/commit/066d6ff4e13ee5c53566cadf384630350dc4d190) | `` automatic update `` |