### PR TITLE
chore(flake/nur): `df9f4ae0` -> `c1520570`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712270704,
-        "narHash": "sha256-kaXVX//66bJqTXkq0aVn+aJXN277CiV9VQEi+2CtMrk=",
+        "lastModified": 1712279867,
+        "narHash": "sha256-L4Y0RAsD/y7Jkel0v1Lc5gME2/WzzwbwY81uk3isnpU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "df9f4ae09236f2417d934992a301687de22ec577",
+        "rev": "c1520570bc22959081fb20f34a8595f0f8bf716f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c1520570`](https://github.com/nix-community/NUR/commit/c1520570bc22959081fb20f34a8595f0f8bf716f) | `` automatic update `` |
| [`e0cfdeac`](https://github.com/nix-community/NUR/commit/e0cfdeaccee0cee75f81a808929624b76399b441) | `` automatic update `` |