### PR TITLE
chore(flake/emacs-overlay): `2abacaa0` -> `773d8e0c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712250442,
-        "narHash": "sha256-yfr/dxiHrS1MNbumiX+7imIwpMGvbycwOJkIgQfa3VU=",
+        "lastModified": 1712281765,
+        "narHash": "sha256-xfkgB7cyg1klT95Fe2k60hTW2rCKzBvfYJqvpu130rw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2abacaa07d19f6bddd832d451478c95663792da6",
+        "rev": "773d8e0c4f2d1c7c14081a1973e46da651e9aae6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`773d8e0c`](https://github.com/nix-community/emacs-overlay/commit/773d8e0c4f2d1c7c14081a1973e46da651e9aae6) | `` Updated emacs `` |
| [`68c88287`](https://github.com/nix-community/emacs-overlay/commit/68c882877c24a34b032eae7f0a871c020b0a6095) | `` Updated melpa `` |
| [`c8b9a44b`](https://github.com/nix-community/emacs-overlay/commit/c8b9a44be2d65bc91549b3c3c1fd2c941072411d) | `` Updated elpa ``  |