### PR TITLE
chore(flake/nur): `bcd9e5ca` -> `69712f23`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712281052,
-        "narHash": "sha256-XTGV58YTBVIUwdYpR/mR7w84Pr4DCUc1CI6+NyqUt6k=",
+        "lastModified": 1712285582,
+        "narHash": "sha256-WXvVubSNd1ga0NuTuN05Iy0UKLscQQYc9ppt+DS0H+U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bcd9e5ca5ff515d216a6dd339f8ee8ac8c0956ad",
+        "rev": "69712f23d65f7820bdeb77138d30927e3ada45da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`69712f23`](https://github.com/nix-community/NUR/commit/69712f23d65f7820bdeb77138d30927e3ada45da) | `` automatic update `` |