### PR TITLE
chore(flake/nur): `69712f23` -> `83e47151`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712285582,
-        "narHash": "sha256-WXvVubSNd1ga0NuTuN05Iy0UKLscQQYc9ppt+DS0H+U=",
+        "lastModified": 1712288688,
+        "narHash": "sha256-53EWSIScwsw0uhO3jMlkp9DqpA+hnngxSN8FCVWCx5A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "69712f23d65f7820bdeb77138d30927e3ada45da",
+        "rev": "83e47151fb7ff30123352c77f37a9d8aca3dec21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`83e47151`](https://github.com/nix-community/NUR/commit/83e47151fb7ff30123352c77f37a9d8aca3dec21) | `` automatic update `` |
| [`be5e8f58`](https://github.com/nix-community/NUR/commit/be5e8f58c1bf713d1aef9cbb88b1892681918c7b) | `` automatic update `` |
| [`e37ef27a`](https://github.com/nix-community/NUR/commit/e37ef27ad542f080a7250b2fe0bbbeb924a52274) | `` automatic update `` |