### PR TITLE
chore(flake/nur): `83e47151` -> `f22b81ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712288688,
-        "narHash": "sha256-53EWSIScwsw0uhO3jMlkp9DqpA+hnngxSN8FCVWCx5A=",
+        "lastModified": 1712291656,
+        "narHash": "sha256-rwUFpmtjTBtcsPqWaEuQCbahgihuFdSN3qxxr3G3Mqw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "83e47151fb7ff30123352c77f37a9d8aca3dec21",
+        "rev": "f22b81aebfb5fb5863509783430639187a45da9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f22b81ae`](https://github.com/nix-community/NUR/commit/f22b81aebfb5fb5863509783430639187a45da9a) | `` automatic update `` |
| [`25d3715d`](https://github.com/nix-community/NUR/commit/25d3715db63dee55088d6796b4150510a215a224) | `` automatic update `` |