### PR TITLE
chore(flake/nur): `f22b81ae` -> `5f94eaed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712291656,
-        "narHash": "sha256-rwUFpmtjTBtcsPqWaEuQCbahgihuFdSN3qxxr3G3Mqw=",
+        "lastModified": 1712298922,
+        "narHash": "sha256-gkgjsxjX2SBk5L7qCI5RY7wmNgQhRw+9piOaqYchDzA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f22b81aebfb5fb5863509783430639187a45da9a",
+        "rev": "5f94eaedb34a904e89ef71c820f45524d2b1bad3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5f94eaed`](https://github.com/nix-community/NUR/commit/5f94eaedb34a904e89ef71c820f45524d2b1bad3) | `` automatic update `` |
| [`b405b122`](https://github.com/nix-community/NUR/commit/b405b122d059f836cdffbeb2f22f14ad0795053f) | `` automatic update `` |
| [`6c82c6fc`](https://github.com/nix-community/NUR/commit/6c82c6fc4af8e30b778c9a2f006e3fc4098b33f1) | `` automatic update `` |