### PR TITLE
chore(flake/nur): `5f94eaed` -> `08227871`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712298922,
-        "narHash": "sha256-gkgjsxjX2SBk5L7qCI5RY7wmNgQhRw+9piOaqYchDzA=",
+        "lastModified": 1712304090,
+        "narHash": "sha256-YtTtsDNXz5/Tq4oinIALXrLkU3N9Z3FRjOUC1yiqGzs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5f94eaedb34a904e89ef71c820f45524d2b1bad3",
+        "rev": "08227871e50c2a42f9cf8187ee4581ca97900a50",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`08227871`](https://github.com/nix-community/NUR/commit/08227871e50c2a42f9cf8187ee4581ca97900a50) | `` automatic update `` |
| [`142dc772`](https://github.com/nix-community/NUR/commit/142dc77248b88f626e1c72da32f50e2b94aaba3f) | `` automatic update `` |
| [`491d2194`](https://github.com/nix-community/NUR/commit/491d2194fd697d608b1bf56af13670b4a9a3f4c7) | `` automatic update `` |