### PR TITLE
chore(flake/nur): `08227871` -> `f968a0cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712304090,
-        "narHash": "sha256-YtTtsDNXz5/Tq4oinIALXrLkU3N9Z3FRjOUC1yiqGzs=",
+        "lastModified": 1712305171,
+        "narHash": "sha256-YFm/Qsdb+0PJN0QYEhOSWSWvbhKCALFA9TyaH9UGWo4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "08227871e50c2a42f9cf8187ee4581ca97900a50",
+        "rev": "f968a0cce761c8aa8560b372422067c0b3dd6416",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                    |
| -------------------------------------------------------------------------------------------------- | -------------------------- |
| [`f968a0cc`](https://github.com/nix-community/NUR/commit/f968a0cce761c8aa8560b372422067c0b3dd6416) | `` automatic update ``     |
| [`2bf0a4ca`](https://github.com/nix-community/NUR/commit/2bf0a4ca15a4531817b79f488a495094c03c8fad) | `` add nykma repository `` |