### PR TITLE
chore(flake/nur): `f968a0cc` -> `edb6a29c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712305171,
-        "narHash": "sha256-YFm/Qsdb+0PJN0QYEhOSWSWvbhKCALFA9TyaH9UGWo4=",
+        "lastModified": 1712309630,
+        "narHash": "sha256-yAREHJZHGrd5OtjI1d7Z9w/Qpxw3uPQVLajinXRVrhE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f968a0cce761c8aa8560b372422067c0b3dd6416",
+        "rev": "edb6a29c376df88468e871d07e71db552f3e54cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`edb6a29c`](https://github.com/nix-community/NUR/commit/edb6a29c376df88468e871d07e71db552f3e54cb) | `` automatic update `` |
| [`c3a64e14`](https://github.com/nix-community/NUR/commit/c3a64e140cd1fdca30ccf8b582d7231fcc2f2035) | `` automatic update `` |