### PR TITLE
chore(flake/nur): `51ec37c0` -> `cadddc01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712313101,
-        "narHash": "sha256-vP6S1aJQQXyHXEmVjvyrqXF9zd158Nm/WaB3xOGrUcg=",
+        "lastModified": 1712318274,
+        "narHash": "sha256-Z/tyNhF1CDF+6K98eSugUrfdRJhOTsUS/ovs1msSflw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "51ec37c0ebc4db136d85b0c59715df9937bd50ad",
+        "rev": "cadddc01a309505230fdea0ef54c6542916e2a93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cadddc01`](https://github.com/nix-community/NUR/commit/cadddc01a309505230fdea0ef54c6542916e2a93) | `` automatic update `` |
| [`4c327307`](https://github.com/nix-community/NUR/commit/4c3273079ce4f8f556c45c3076e0d195caaffc20) | `` automatic update `` |