### PR TITLE
chore(flake/emacs-overlay): `6a9992d6` -> `b82c7765`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712336043,
-        "narHash": "sha256-w3O8LXdYHvasqtJHjUqbFuC3pQWmXdhojjmOmhMwIjM=",
+        "lastModified": 1712336909,
+        "narHash": "sha256-tpmLGa9l2cwsf/1g4tPFOQDOeDrEgAsKHFhKabd0nyo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6a9992d6bc959bab580c98aeeed371f75c2c77c7",
+        "rev": "b82c77652e4191f41842c6ae39853490f0cc1e13",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`b82c7765`](https://github.com/nix-community/emacs-overlay/commit/b82c77652e4191f41842c6ae39853490f0cc1e13) | `` Updated emacs `` |