### PR TITLE
chore(flake/nur): `9ac97db2` -> `08506b97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712320566,
-        "narHash": "sha256-F/NR0Xf/AU21Nbtrni+6i+7C4dBKg9MNg7qrOmPRy6M=",
+        "lastModified": 1712342638,
+        "narHash": "sha256-0yvbIJSRMh09d3BEySpbC+ZNHV7o+nlLH9emLxB6Uq4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ac97db2225dd90fc37c91fb6c91f2a10d331783",
+        "rev": "08506b97dda7b6e5b483885d7bb0f5e6bfdc9b57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                     |
| -------------------------------------------------------------------------------------------------- | --------------------------- |
| [`08506b97`](https://github.com/nix-community/NUR/commit/08506b97dda7b6e5b483885d7bb0f5e6bfdc9b57) | `` automatic update ``      |
| [`108b6f50`](https://github.com/nix-community/NUR/commit/108b6f50d25faac2ced3de26db8b5c3357b0c3f3) | `` automatic update ``      |
| [`a8045c30`](https://github.com/nix-community/NUR/commit/a8045c30841c961b511f9e3793914e4d58bc08ad) | `` automatic update ``      |
| [`85638a5c`](https://github.com/nix-community/NUR/commit/85638a5cd97fabb76f835188a383baa07d4dfb56) | `` automatic update ``      |
| [`b32ce6ce`](https://github.com/nix-community/NUR/commit/b32ce6ce30b5fcc9aabeae2299f0f8bf02d8f346) | `` Add "nikpkgs" repo ``    |
| [`4852787a`](https://github.com/nix-community/NUR/commit/4852787a7d4bf390ee95de255f18aa4f2387b6cf) | `` automatic update ``      |
| [`cc8502de`](https://github.com/nix-community/NUR/commit/cc8502dea19093940cca0274cfff00b3389a64f4) | `` add guoard repository `` |