### PR TITLE
chore(flake/nur): `08506b97` -> `82564768`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712342638,
-        "narHash": "sha256-0yvbIJSRMh09d3BEySpbC+ZNHV7o+nlLH9emLxB6Uq4=",
+        "lastModified": 1712345133,
+        "narHash": "sha256-H5MOMPeO2iC3fv5O5nKd1+JobxbfKsj4sFFc79rS/PI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "08506b97dda7b6e5b483885d7bb0f5e6bfdc9b57",
+        "rev": "8256476866b051013b54ecff8788b623546c2537",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`82564768`](https://github.com/nix-community/NUR/commit/8256476866b051013b54ecff8788b623546c2537) | `` automatic update `` |
| [`cc255af2`](https://github.com/nix-community/NUR/commit/cc255af21f1d06f3a8282bd4ab3250f5ab778dbf) | `` automatic update `` |