### PR TITLE
chore(flake/nur): `82564768` -> `a15c4ca3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712345133,
-        "narHash": "sha256-H5MOMPeO2iC3fv5O5nKd1+JobxbfKsj4sFFc79rS/PI=",
+        "lastModified": 1712349863,
+        "narHash": "sha256-vtv4pz/JxFU3aW5oQntzFb2fDzDG8GkaKG9titlIIiY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8256476866b051013b54ecff8788b623546c2537",
+        "rev": "a15c4ca371bf58642197818c3629e634b40e12c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a15c4ca3`](https://github.com/nix-community/NUR/commit/a15c4ca371bf58642197818c3629e634b40e12c3) | `` automatic update `` |
| [`8c368a6f`](https://github.com/nix-community/NUR/commit/8c368a6f2ef66ae290ad918f9f9cca81fbbaa458) | `` automatic update `` |
| [`e7bc2eda`](https://github.com/nix-community/NUR/commit/e7bc2eda4eec67fddcf68cac0b2156b7f9a4a6cb) | `` automatic update `` |