### PR TITLE
chore(flake/nur): `a15c4ca3` -> `62139fc3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712349863,
-        "narHash": "sha256-vtv4pz/JxFU3aW5oQntzFb2fDzDG8GkaKG9titlIIiY=",
+        "lastModified": 1712351537,
+        "narHash": "sha256-T668vitz6AmktJIzuac7P286syeLL+kUqMuEC+vvYoM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a15c4ca371bf58642197818c3629e634b40e12c3",
+        "rev": "62139fc3f520d2b4550b2531317ceb0ccae9f969",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`62139fc3`](https://github.com/nix-community/NUR/commit/62139fc3f520d2b4550b2531317ceb0ccae9f969) | `` automatic update `` |