### PR TITLE
chore(flake/nur): `843a09cf` -> `1f0b37a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712357109,
-        "narHash": "sha256-9T6xhKRppVjJQFi7z1SNzpbG8cjYU4cuvk8iI/aSrls=",
+        "lastModified": 1712360699,
+        "narHash": "sha256-QEPOGtvowv3X0cVJbm+0Z9RKE+4ftbVv3eJACy9smcQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "843a09cf389cae308eb4ba4e6adc3e14127b29f4",
+        "rev": "1f0b37a2631a99495e0efc6f96285992f74fd358",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1f0b37a2`](https://github.com/nix-community/NUR/commit/1f0b37a2631a99495e0efc6f96285992f74fd358) | `` automatic update `` |