### PR TITLE
chore(flake/emacs-overlay): `b82c7765` -> `d33745f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712336909,
-        "narHash": "sha256-tpmLGa9l2cwsf/1g4tPFOQDOeDrEgAsKHFhKabd0nyo=",
+        "lastModified": 1712365008,
+        "narHash": "sha256-DtELM005n4/hBZkbZAziubfR/M5L5LeEiFX5NvePDTk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b82c77652e4191f41842c6ae39853490f0cc1e13",
+        "rev": "d33745f85f5b61bbe4cd48e81d9abe0083b677a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`d33745f8`](https://github.com/nix-community/emacs-overlay/commit/d33745f85f5b61bbe4cd48e81d9abe0083b677a1) | `` Updated elpa ``   |
| [`9c47d498`](https://github.com/nix-community/emacs-overlay/commit/9c47d498651720aff2f63b3876f4cce56053ee53) | `` Updated nongnu `` |