### PR TITLE
chore(flake/emacs-overlay): `d33745f8` -> `1c772b55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712365008,
-        "narHash": "sha256-DtELM005n4/hBZkbZAziubfR/M5L5LeEiFX5NvePDTk=",
+        "lastModified": 1712367860,
+        "narHash": "sha256-OqabNuHSXMYeugAwBIrJ6uNW9HXI02gC3SaarhLDCsw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d33745f85f5b61bbe4cd48e81d9abe0083b677a1",
+        "rev": "1c772b55c22f91a1b26c4318671deb1788628f24",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`1c772b55`](https://github.com/nix-community/emacs-overlay/commit/1c772b55c22f91a1b26c4318671deb1788628f24) | `` Updated emacs `` |
| [`dce01fc2`](https://github.com/nix-community/emacs-overlay/commit/dce01fc2a65d23815a026e946114009b81d21f45) | `` Updated melpa `` |