### PR TITLE
chore(flake/nur): `cf48318b` -> `e3f20950`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712375059,
-        "narHash": "sha256-E3uEUOom6I5BSaI3RmVBE2KjNOz0/O14rPcl2VZVjAs=",
+        "lastModified": 1712376330,
+        "narHash": "sha256-r3cGJ70/d8xebhnHsxM4PhhYv2N5b+1mbQxaTpEh6AI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cf48318b52af63d28a9c31d3cc787247c2cbc28e",
+        "rev": "e3f209507ba2725b5ba27e39af6f2ee1a454332b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e3f20950`](https://github.com/nix-community/NUR/commit/e3f209507ba2725b5ba27e39af6f2ee1a454332b) | `` automatic update `` |