### PR TITLE
chore(flake/nur): `e3f20950` -> `1f700259`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712376330,
-        "narHash": "sha256-r3cGJ70/d8xebhnHsxM4PhhYv2N5b+1mbQxaTpEh6AI=",
+        "lastModified": 1712380838,
+        "narHash": "sha256-X3a7wb0TbcFrEOhPluOM1Ri5w2enPb1WCuv8KjOquQo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e3f209507ba2725b5ba27e39af6f2ee1a454332b",
+        "rev": "1f700259f9c1f572dd14d9d4d361376e6a942fe5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1f700259`](https://github.com/nix-community/NUR/commit/1f700259f9c1f572dd14d9d4d361376e6a942fe5) | `` automatic update `` |