### PR TITLE
chore(flake/emacs-overlay): `1c772b55` -> `71596f24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712367860,
-        "narHash": "sha256-OqabNuHSXMYeugAwBIrJ6uNW9HXI02gC3SaarhLDCsw=",
+        "lastModified": 1712393555,
+        "narHash": "sha256-boJbpRlBCQLLeznt1TicryOfdwjd0/an/s76V8mO+Ug=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1c772b55c22f91a1b26c4318671deb1788628f24",
+        "rev": "71596f248d13b1d0f5a1b22851c4cb56bf79f9a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`71596f24`](https://github.com/nix-community/emacs-overlay/commit/71596f248d13b1d0f5a1b22851c4cb56bf79f9a3) | `` Updated melpa `` |