### PR TITLE
chore(flake/emacs-overlay): `71596f24` -> `149186b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712393555,
-        "narHash": "sha256-boJbpRlBCQLLeznt1TicryOfdwjd0/an/s76V8mO+Ug=",
+        "lastModified": 1712394300,
+        "narHash": "sha256-fXRfo7BSdKBtA5ome5BLOk7+rRNWUcPfPWBFE2GuXyk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "71596f248d13b1d0f5a1b22851c4cb56bf79f9a3",
+        "rev": "149186b1156c0da8d9624bde981d2e5c02aa1376",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`149186b1`](https://github.com/nix-community/emacs-overlay/commit/149186b1156c0da8d9624bde981d2e5c02aa1376) | `` Updated emacs `` |