### PR TITLE
chore(flake/home-manager): `782eed8b` -> `b787726a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712317700,
-        "narHash": "sha256-rnkQ6qMhlxfjpCECkTMlFXHU/88QvC5KpdJWq5H6F1E=",
+        "lastModified": 1712390667,
+        "narHash": "sha256-ebq+fJZfobqpsAdGDGpxNWSySbQejRwW9cdiil6krCo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "782eed8bb64b27acaeb7c17be4a095c85e65717f",
+        "rev": "b787726a8413e11b074cde42704b4af32d95545c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`b787726a`](https://github.com/nix-community/home-manager/commit/b787726a8413e11b074cde42704b4af32d95545c) | `` home-manager: extract inline shell script to file `` |