### PR TITLE
chore(flake/nur): `5ee4493e` -> `f5156e56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712388155,
-        "narHash": "sha256-kmToMs9TEgIzUBC1TbxEqK1X3HmuGii6THHRejNDKZw=",
+        "lastModified": 1712396677,
+        "narHash": "sha256-0XofzwmWCY3Pu+rjPzQCa0rhcrnAQVypcC0UuJ4L3s0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5ee4493e1ab42b2cba9b25e6e53acae791788043",
+        "rev": "f5156e5620a5c71d87c71e4fa4bfe0327cd6f60f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f5156e56`](https://github.com/nix-community/NUR/commit/f5156e5620a5c71d87c71e4fa4bfe0327cd6f60f) | `` automatic update `` |
| [`d35cac9e`](https://github.com/nix-community/NUR/commit/d35cac9e59a40dd24ecda6848c51c04ca49782b7) | `` automatic update `` |