### PR TITLE
chore(flake/nur): `f5156e56` -> `faa50628`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712396677,
-        "narHash": "sha256-0XofzwmWCY3Pu+rjPzQCa0rhcrnAQVypcC0UuJ4L3s0=",
+        "lastModified": 1712402821,
+        "narHash": "sha256-hOa+bSGcot5GIJ3Sxh6U2GLYsk5d1kXFUqRza/KWGbk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f5156e5620a5c71d87c71e4fa4bfe0327cd6f60f",
+        "rev": "faa50628ecb607767ba6a18c7f8892ef9371a593",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`faa50628`](https://github.com/nix-community/NUR/commit/faa50628ecb607767ba6a18c7f8892ef9371a593) | `` automatic update `` |
| [`62e9fa51`](https://github.com/nix-community/NUR/commit/62e9fa51fd095b2918c11f6be7c45885edf4cb21) | `` automatic update `` |
| [`76a61ca1`](https://github.com/nix-community/NUR/commit/76a61ca11212abfcc2021521d25a36e312ccb8a5) | `` automatic update `` |