### PR TITLE
chore(flake/nur): `faa50628` -> `81994912`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712402821,
-        "narHash": "sha256-hOa+bSGcot5GIJ3Sxh6U2GLYsk5d1kXFUqRza/KWGbk=",
+        "lastModified": 1712408391,
+        "narHash": "sha256-Di3ROGaheWWgX4AlklbpJzfuHvOQl0noBrKDCJzRw5o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "faa50628ecb607767ba6a18c7f8892ef9371a593",
+        "rev": "8199491296e8e0ddf320d112676114c3db7b6d45",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`81994912`](https://github.com/nix-community/NUR/commit/8199491296e8e0ddf320d112676114c3db7b6d45) | `` automatic update `` |
| [`9dfab4c3`](https://github.com/nix-community/NUR/commit/9dfab4c3653fdd62c13ff7e5146b6925ea1943c0) | `` automatic update `` |