### PR TITLE
chore(flake/nur): `81994912` -> `ade3664e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712408391,
-        "narHash": "sha256-Di3ROGaheWWgX4AlklbpJzfuHvOQl0noBrKDCJzRw5o=",
+        "lastModified": 1712418268,
+        "narHash": "sha256-ada/cxhkwk0D7/iuklXUv/EOx7ooYIn27LYAyYuoQ3o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8199491296e8e0ddf320d112676114c3db7b6d45",
+        "rev": "ade3664ee297f453ea7f31945af6b751cf800b84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ade3664e`](https://github.com/nix-community/NUR/commit/ade3664ee297f453ea7f31945af6b751cf800b84) | `` automatic update `` |