### PR TITLE
chore(flake/nur): `ade3664e` -> `d47aa79f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712418268,
-        "narHash": "sha256-ada/cxhkwk0D7/iuklXUv/EOx7ooYIn27LYAyYuoQ3o=",
+        "lastModified": 1712435091,
+        "narHash": "sha256-Hyn/2goBwkDGxTF6IBcc1HpRscpLg8ErEy+vmQwEqoc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ade3664ee297f453ea7f31945af6b751cf800b84",
+        "rev": "d47aa79f2aae0bea15c6a40b7fca5830fcfe1346",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d47aa79f`](https://github.com/nix-community/NUR/commit/d47aa79f2aae0bea15c6a40b7fca5830fcfe1346) | `` automatic update `` |
| [`a4d91cb8`](https://github.com/nix-community/NUR/commit/a4d91cb8f7ed9663e222dc585b232381668e1bdd) | `` automatic update `` |