### PR TITLE
chore(flake/emacs-overlay): `57048e83` -> `5d141af6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712423135,
-        "narHash": "sha256-KMclzJzAbt1P6O3xqaRy36VmW/Fyyh+Qg/q1bD1LXwc=",
+        "lastModified": 1712451792,
+        "narHash": "sha256-vJKBs9YdwyoSFNynYZkTW1SwSRJ99tSotjX4JtSGwYU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "57048e832be022087f098c998f9b4d3481a1ccf5",
+        "rev": "5d141af64a57b0cfdf12a4c4156ecd44ae802057",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`5d141af6`](https://github.com/nix-community/emacs-overlay/commit/5d141af64a57b0cfdf12a4c4156ecd44ae802057) | `` Updated elpa `` |