### PR TITLE
chore(flake/emacs-overlay): `5d141af6` -> `de404693`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712451792,
-        "narHash": "sha256-vJKBs9YdwyoSFNynYZkTW1SwSRJ99tSotjX4JtSGwYU=",
+        "lastModified": 1712454648,
+        "narHash": "sha256-GZCEJ3i6XLGqo2NH83DJX5pSwamoU/BTPSanCiRUxsw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5d141af64a57b0cfdf12a4c4156ecd44ae802057",
+        "rev": "de404693eaa05689a237f3fd5d4fce4f15ef9a07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`de404693`](https://github.com/nix-community/emacs-overlay/commit/de404693eaa05689a237f3fd5d4fce4f15ef9a07) | `` Updated emacs `` |
| [`9024c37e`](https://github.com/nix-community/emacs-overlay/commit/9024c37e24119939f2d2ac49bcaf6cd7a98d666a) | `` Updated melpa `` |