### PR TITLE
chore(flake/nur): `ef7e3eca` -> `fc2ebc82`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712439993,
-        "narHash": "sha256-dwtJxHYg6EJg5LVfcpRcwlUOxqCGLGlndB7YrbNqcC4=",
+        "lastModified": 1712455599,
+        "narHash": "sha256-jYnNyYN14Kx+7f/4/HfvQn6DshZeB1phhX0AKr3/Y5Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ef7e3ecaf9f58150db1e00d01ea9985b0f8d9756",
+        "rev": "fc2ebc82249d4875fe181d1b0244c681f3729742",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fc2ebc82`](https://github.com/nix-community/NUR/commit/fc2ebc82249d4875fe181d1b0244c681f3729742) | `` automatic update `` |
| [`0c8bcb86`](https://github.com/nix-community/NUR/commit/0c8bcb86546a6c2d1a48c54f758d675f3562731a) | `` automatic update `` |