### PR TITLE
chore(flake/nur): `fc2ebc82` -> `92db5d04`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712455599,
-        "narHash": "sha256-jYnNyYN14Kx+7f/4/HfvQn6DshZeB1phhX0AKr3/Y5Y=",
+        "lastModified": 1712457759,
+        "narHash": "sha256-HtvpTNXHabUjWjq8d+WGO0vpZDeGwjxQp0CGha494BA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc2ebc82249d4875fe181d1b0244c681f3729742",
+        "rev": "92db5d0410d291fb534248cb0d78536c38d5036f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`92db5d04`](https://github.com/nix-community/NUR/commit/92db5d0410d291fb534248cb0d78536c38d5036f) | `` automatic update `` |