### PR TITLE
chore(flake/nix-index-database): `2844b5f3` -> `4676d72d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -591,11 +591,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711854532,
-        "narHash": "sha256-JPStavwlT7TfxxiXHk6Q7sbNxtnXAIjXQJMLO0KB6M0=",
+        "lastModified": 1712459390,
+        "narHash": "sha256-e12bNDottaGoBgd0AdH/bQvk854xunlWAdZwr/oHO1c=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "2844b5f3ad3b478468151bd101370b9d8ef8a3a7",
+        "rev": "4676d72d872459e1e3a248d049609f110c570e9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`4676d72d`](https://github.com/nix-community/nix-index-database/commit/4676d72d872459e1e3a248d049609f110c570e9a) | `` update packages.nix to release 2024-04-07-030847 `` |
| [`373c00eb`](https://github.com/nix-community/nix-index-database/commit/373c00eb260c976fb13c886c0a6235818125f388) | `` flake.lock: Update ``                               |