### PR TITLE
chore(flake/nur): `14f7736a` -> `b7b9868d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712460626,
-        "narHash": "sha256-h3aBqHFlnQW9JJlo8LMPnLs2+E2XY61LBM5H+9GwG7E=",
+        "lastModified": 1712473264,
+        "narHash": "sha256-5/qp7yaO4TJYDbfHdl3GpGTMwoPCt7zpcYe+r09umnQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "14f7736a89ffa94603db2d0479c0622a80091718",
+        "rev": "b7b9868ddb4cdf762bd4bac66bf3b5efe85b000a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b7b9868d`](https://github.com/nix-community/NUR/commit/b7b9868ddb4cdf762bd4bac66bf3b5efe85b000a) | `` automatic update `` |
| [`c4eb26f0`](https://github.com/nix-community/NUR/commit/c4eb26f0303145d9541e64fe156f5987db474e7f) | `` automatic update `` |
| [`bc560a8a`](https://github.com/nix-community/NUR/commit/bc560a8aa161fc0228e2a438162cb483f2cc916d) | `` automatic update `` |