### PR TITLE
chore(flake/emacs-overlay): `de404693` -> `e6b7c7ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712454648,
-        "narHash": "sha256-GZCEJ3i6XLGqo2NH83DJX5pSwamoU/BTPSanCiRUxsw=",
+        "lastModified": 1712480668,
+        "narHash": "sha256-2qr3MzZxhk8Ew++TDOZciJBJk9eRCcdZiLebuw1dUlo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "de404693eaa05689a237f3fd5d4fce4f15ef9a07",
+        "rev": "e6b7c7ee1429b7569e1b6c5c833d0c3dd8806633",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`e6b7c7ee`](https://github.com/nix-community/emacs-overlay/commit/e6b7c7ee1429b7569e1b6c5c833d0c3dd8806633) | `` Updated emacs ``        |
| [`97f33a07`](https://github.com/nix-community/emacs-overlay/commit/97f33a07d97911da5c41858e083236e7bcea994f) | `` Updated melpa ``        |
| [`e085f947`](https://github.com/nix-community/emacs-overlay/commit/e085f9471491c9385ef9c719149432ebbafa855b) | `` Updated flake inputs `` |