### PR TITLE
chore(flake/nur): `1e339672` -> `63247f76`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712481828,
-        "narHash": "sha256-K+62NrYhyceMjfHezEMQPYRCnfJEJ5wVgQtn4ZzKJqE=",
+        "lastModified": 1712489679,
+        "narHash": "sha256-kZx6jLrtLrXHjuvQe2u3G5AuuwLKvHl0DjAsiBsxIC8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1e3396729b411d6ed9aa5fb9418b8c4e6a09a814",
+        "rev": "63247f7619902dab6ac2d8f4203feb03faa70f3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`63247f76`](https://github.com/nix-community/NUR/commit/63247f7619902dab6ac2d8f4203feb03faa70f3b) | `` automatic update `` |
| [`e4dfbd7e`](https://github.com/nix-community/NUR/commit/e4dfbd7eb86b3ac1bf5b7d5c4ca200dba5cbb5a9) | `` automatic update `` |
| [`d380a644`](https://github.com/nix-community/NUR/commit/d380a6442e9847a87bf71b6c9e87658f6bf22980) | `` automatic update `` |
| [`4504b447`](https://github.com/nix-community/NUR/commit/4504b447d7ac89246eef99f1363635434b595d46) | `` automatic update `` |