### PR TITLE
chore(flake/nur): `ed454059` -> `f76da9a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712501617,
-        "narHash": "sha256-ipzJlgEAURIUIIDvpSDWtF4DiS0ANvkmQodB9BZ5BDA=",
+        "lastModified": 1712618213,
+        "narHash": "sha256-72SqUCVrovvN+U0vJEOsSpHer+X5rbjhmOtvyhDkORg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed45405982bdd65ce2eb7341a42ea18fb5958d76",
+        "rev": "f76da9a924dc46ae71ea1694b290e6309fe5fb8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f76da9a9`](https://github.com/nix-community/NUR/commit/f76da9a924dc46ae71ea1694b290e6309fe5fb8c) | `` automatic update `` |
| [`1db8af43`](https://github.com/nix-community/NUR/commit/1db8af43c9b75768461a01d84e17596e331df77f) | `` automatic update `` |
| [`4c315f60`](https://github.com/nix-community/NUR/commit/4c315f60bc1aba629ae7e429e53d490e5a42eca8) | `` automatic update `` |
| [`5e41c8d1`](https://github.com/nix-community/NUR/commit/5e41c8d18e2ee4826060a03f1a4048319c46620d) | `` automatic update `` |
| [`b00f8495`](https://github.com/nix-community/NUR/commit/b00f84950da1a1664193a762ad7d8ce6fd389a06) | `` automatic update `` |
| [`8216f524`](https://github.com/nix-community/NUR/commit/8216f5247f695e7648f9735177870071061700f8) | `` automatic update `` |
| [`41a02781`](https://github.com/nix-community/NUR/commit/41a02781a370613aa045dbc34f42b0d616dcb200) | `` automatic update `` |
| [`ee1298c0`](https://github.com/nix-community/NUR/commit/ee1298c063ac6b77332f29cb362a8d581e80e186) | `` automatic update `` |
| [`8dffa757`](https://github.com/nix-community/NUR/commit/8dffa757764ed34514fcf78c711de3064014087f) | `` automatic update `` |
| [`cfffcc7b`](https://github.com/nix-community/NUR/commit/cfffcc7b1953a11dcb505073155d7e593ace06ed) | `` automatic update `` |
| [`47a8f374`](https://github.com/nix-community/NUR/commit/47a8f374c33c567f9b0c63f6a953f38e3b6eb921) | `` automatic update `` |
| [`96b9a930`](https://github.com/nix-community/NUR/commit/96b9a930341019d17ff4d58f4209ad69a3eb162d) | `` automatic update `` |
| [`90422a0b`](https://github.com/nix-community/NUR/commit/90422a0ba97dcc2c9b6ea1425afe6ee6e639caa5) | `` automatic update `` |
| [`682da86e`](https://github.com/nix-community/NUR/commit/682da86ec3c67228ba4ed8e036f9fd6a2d53f172) | `` automatic update `` |
| [`4a09dacd`](https://github.com/nix-community/NUR/commit/4a09dacd4328cf6c476ef3c612915e5a57fb2f93) | `` automatic update `` |
| [`b2a491ae`](https://github.com/nix-community/NUR/commit/b2a491ae32346d3113374cd206cc17334b13cde4) | `` automatic update `` |
| [`13515688`](https://github.com/nix-community/NUR/commit/1351568877a720ecd8180d57541e9edd39aac389) | `` automatic update `` |
| [`53925aaa`](https://github.com/nix-community/NUR/commit/53925aaa986b319b2acfe016a562b9420e6b6529) | `` automatic update `` |
| [`a4d41c12`](https://github.com/nix-community/NUR/commit/a4d41c12e51159c3d8d7c6be0e87183f84be7207) | `` automatic update `` |
| [`ea542198`](https://github.com/nix-community/NUR/commit/ea5421984347a2a7abcf67e6dfa3973e0608b052) | `` automatic update `` |
| [`e8e78499`](https://github.com/nix-community/NUR/commit/e8e78499b3140c67c90bcf2d04c4dcfd504b2fd2) | `` automatic update `` |
| [`7d5c7621`](https://github.com/nix-community/NUR/commit/7d5c7621604a46368951da049503b8ec3bc34422) | `` automatic update `` |
| [`77c8115a`](https://github.com/nix-community/NUR/commit/77c8115aa553f43a25538b3a78a39bbce0fbc8d2) | `` automatic update `` |
| [`e595a5eb`](https://github.com/nix-community/NUR/commit/e595a5eb3863acb4e310b9ee2a8be81a75bc2949) | `` automatic update `` |
| [`706a34d9`](https://github.com/nix-community/NUR/commit/706a34d9c7158448b7be6f74f66172bbd7f26318) | `` automatic update `` |
| [`498e425b`](https://github.com/nix-community/NUR/commit/498e425b17e64f5aa4f7b81828db759b3d41b6f2) | `` automatic update `` |
| [`8ad0390e`](https://github.com/nix-community/NUR/commit/8ad0390ed38f6f6536bb20b044af001f2cc120b7) | `` automatic update `` |