### PR TITLE
chore(flake/emacs-overlay): `f7fcac14` -> `4283007a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712509449,
-        "narHash": "sha256-W61ArwUi3gMNEDbAm511ZmtYmopZH23zPq2TJZSdrCQ=",
+        "lastModified": 1712540794,
+        "narHash": "sha256-XHveC/2idiH2Z2qvuZf455nprl5LaONyWBTSnk4GyrU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f7fcac1403356fd09e2320bc3d61ccefe36c1b91",
+        "rev": "4283007a03481a77a83d1be97c728fd8abf2128d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`4283007a`](https://github.com/nix-community/emacs-overlay/commit/4283007a03481a77a83d1be97c728fd8abf2128d) | `` Updated emacs `` |
| [`1e9632f3`](https://github.com/nix-community/emacs-overlay/commit/1e9632f3571c4c3aa910dc4798b68cc736f3ed07) | `` Updated melpa `` |
| [`b7e4986c`](https://github.com/nix-community/emacs-overlay/commit/b7e4986c45397644eeefce8ec5b06b06c689ae49) | `` Updated elpa ``  |