### PR TITLE
chore(flake/srvos): `ddafe2fd` -> `ea19f15c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -994,11 +994,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712191870,
-        "narHash": "sha256-+MzSZ4IuZNT4QJS8b+gM48thfWkrJ7vL4NV5zG8Lqx8=",
+        "lastModified": 1712537533,
+        "narHash": "sha256-7am1D7k7xn0q7VfRgS9lFBaBFSFLiiQilCRQagPjQHE=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "ddafe2fd3547f63e6bf75b6e1a99ecfa61c59687",
+        "rev": "ea19f15cf66d334f9a20a8b0bd0a260aff8919a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`ea19f15c`](https://github.com/nix-community/srvos/commit/ea19f15cf66d334f9a20a8b0bd0a260aff8919a6) | `` dev/private/flake.lock: Update `` |
| [`248b2203`](https://github.com/nix-community/srvos/commit/248b220345537c0aa826f374db7a81474b12ddb8) | `` flake.lock: Update ``             |