### PR TITLE
chore(flake/emacs-overlay): `4283007a` -> `3ef9acae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712540794,
-        "narHash": "sha256-XHveC/2idiH2Z2qvuZf455nprl5LaONyWBTSnk4GyrU=",
+        "lastModified": 1712567166,
+        "narHash": "sha256-IHc8IfVjWnlET894jWyDVqwFnT95p7vBgiK5GRzJ5P4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4283007a03481a77a83d1be97c728fd8abf2128d",
+        "rev": "3ef9acae671e1eab0a71ee982ef9097a9707b665",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`3ef9acae`](https://github.com/nix-community/emacs-overlay/commit/3ef9acae671e1eab0a71ee982ef9097a9707b665) | `` Updated emacs `` |
| [`b0dbb78d`](https://github.com/nix-community/emacs-overlay/commit/b0dbb78d0327813a105dbf06ad13f6fce6199f0f) | `` Updated melpa `` |