### PR TITLE
chore(flake/pre-commit-hooks): `e35aed5f` -> `70f50401`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -881,11 +881,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1712055707,
-        "narHash": "sha256-4XLvuSIDZJGS17xEwSrNuJLL7UjDYKGJSbK1WWX2AK8=",
+        "lastModified": 1712579741,
+        "narHash": "sha256-igpsH+pa6yFwYOdah3cFciCk8gw+ytniG9quf5f/q84=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "e35aed5fda3cc79f88ed7f1795021e559582093a",
+        "rev": "70f504012f0a132ac33e56988e1028d88a48855c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                     |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`6c2316d1`](https://github.com/cachix/git-hooks.nix/commit/6c2316d1b2903cecc3692b6b75fdf078e735ebcd) | `` Filter out nulls from enabledPackages `` |
| [`eb9778d3`](https://github.com/cachix/git-hooks.nix/commit/eb9778d3a17b192708d2c8da2ce0f22be5e465b3) | `` Set the default hook package to null ``  |