### PR TITLE
chore(flake/emacs-overlay): `3ef9acae` -> `2b5885f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712567166,
-        "narHash": "sha256-IHc8IfVjWnlET894jWyDVqwFnT95p7vBgiK5GRzJ5P4=",
+        "lastModified": 1712595326,
+        "narHash": "sha256-Dzi9Sm82uj0HU7w1LFXt5uY/yppI1mJfSLCqANPl1RY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3ef9acae671e1eab0a71ee982ef9097a9707b665",
+        "rev": "2b5885f25d2242820c3e54f8a4c787ce07dccdd5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`2b5885f2`](https://github.com/nix-community/emacs-overlay/commit/2b5885f25d2242820c3e54f8a4c787ce07dccdd5) | `` Updated melpa `` |
| [`ab785fd3`](https://github.com/nix-community/emacs-overlay/commit/ab785fd3e0d1d2751eba53510637cdf7f5e5bb9f) | `` Updated elpa ``  |