### PR TITLE
chore(flake/srvos): `ea19f15c` -> `c46f7d9b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -994,11 +994,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712537533,
-        "narHash": "sha256-7am1D7k7xn0q7VfRgS9lFBaBFSFLiiQilCRQagPjQHE=",
+        "lastModified": 1712604985,
+        "narHash": "sha256-V/0bzoxSwPIy6s1+hUc2XAprtv/YzSjwfDiF9bQi5X8=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "ea19f15cf66d334f9a20a8b0bd0a260aff8919a6",
+        "rev": "c46f7d9b5a3e9e246d90f7ddfb76461a80b7b27a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                        |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`c46f7d9b`](https://github.com/nix-community/srvos/commit/c46f7d9b5a3e9e246d90f7ddfb76461a80b7b27a) | `` build(deps): bump peaceiris/actions-gh-pages from 3 to 4 `` |