### PR TITLE
chore(flake/sops-nix): `39191e8e` -> `538c114c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -974,11 +974,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1712458908,
-        "narHash": "sha256-DMgBS+jNHDg8z3g9GkwqL8xTKXCRQ/0FGsAyrniVonc=",
+        "lastModified": 1712617241,
+        "narHash": "sha256-a4hbls4vlLRMciv62YrYT/Xs/3Cubce8WFHPUDWwzf8=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "39191e8e6265b106c9a2ba0cfd3a4dafe98a31c6",
+        "rev": "538c114cfdf1f0458f507087b1dcf018ce1c0c4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                              |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`538c114c`](https://github.com/Mic92/sops-nix/commit/538c114cfdf1f0458f507087b1dcf018ce1c0c4c) | `` update vendorHash ``                              |
| [`104aabf3`](https://github.com/Mic92/sops-nix/commit/104aabf3247d521b3b66940d73c7dd458145125d) | `` Bump golang.org/x/crypto from 0.21.0 to 0.22.0 `` |