### PR TITLE
chore(flake/emacs-overlay): `8402fc02` -> `74c67bc2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712596176,
-        "narHash": "sha256-4R6djdmLUrNljR1GH1yDXlOx7ufjOcAqmvYqBEgNooE=",
+        "lastModified": 1712624301,
+        "narHash": "sha256-3BL5vkkeDXMDxQ3u4wUasgXpucwkvOQBXBHF9Dyxg3Q=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8402fc022dcde86acf1865fea82dcbe9c74ddf88",
+        "rev": "74c67bc2840f3db59755d6e71f19184bdd710f79",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`74c67bc2`](https://github.com/nix-community/emacs-overlay/commit/74c67bc2840f3db59755d6e71f19184bdd710f79) | `` Updated elpa ``   |
| [`33e32b3d`](https://github.com/nix-community/emacs-overlay/commit/33e32b3d576a04293e02a13e311bbc904d9be32e) | `` Updated nongnu `` |