### PR TITLE
chore(flake/emacs-overlay): `74c67bc2` -> `6491d496`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712624301,
-        "narHash": "sha256-3BL5vkkeDXMDxQ3u4wUasgXpucwkvOQBXBHF9Dyxg3Q=",
+        "lastModified": 1712627150,
+        "narHash": "sha256-em9SPxozjE+QL5LwbbhRya/plxT0yGQTV8fbuenVs1Q=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "74c67bc2840f3db59755d6e71f19184bdd710f79",
+        "rev": "6491d49607ebece99d6118780e194ec1941ad389",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`6491d496`](https://github.com/nix-community/emacs-overlay/commit/6491d49607ebece99d6118780e194ec1941ad389) | `` Updated emacs `` |
| [`76e82143`](https://github.com/nix-community/emacs-overlay/commit/76e82143c93b4e9584a4f44a2f9d7a248e8aafd3) | `` Updated melpa `` |