### PR TITLE
chore(flake/nur): `805e40f6` -> `63095761`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712635515,
-        "narHash": "sha256-vhWWhQk//y7AgYrBvYn3v7yKzOUFz/TouJLONsQLTfY=",
+        "lastModified": 1712639971,
+        "narHash": "sha256-U/6OU1nzKJtFD/mh7zyQzmcojpUYm2Gx/DxQvG4m+20=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "805e40f634a3cd444a221d03092cafc4365798f7",
+        "rev": "630957610d0bb497370137efaf98e63dff8a71b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`63095761`](https://github.com/nix-community/NUR/commit/630957610d0bb497370137efaf98e63dff8a71b1) | `` automatic update `` |