### PR TITLE
chore(flake/nur): `47c73cda` -> `60e99743`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712643846,
-        "narHash": "sha256-fFSCYLM8gYgPAgFhphnhoIEi9OBciWHbM+X84GjECwU=",
+        "lastModified": 1712651583,
+        "narHash": "sha256-ay/PkT9BXOAWqiom3X4HPmEvMc0LfAJ/8dPhTWx19Bg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "47c73cdadf4d9533b33fc1609d2d592ab56d5c64",
+        "rev": "60e9974382f3d49aedf9ff07c179faebb1203f73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`60e99743`](https://github.com/nix-community/NUR/commit/60e9974382f3d49aedf9ff07c179faebb1203f73) | `` automatic update `` |