### PR TITLE
chore(flake/nur): `60e99743` -> `114a0572`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712651583,
-        "narHash": "sha256-ay/PkT9BXOAWqiom3X4HPmEvMc0LfAJ/8dPhTWx19Bg=",
+        "lastModified": 1712655300,
+        "narHash": "sha256-fhZkaczniHTV5pu4CFi/nvSrmwtiaI+Ndx4Zxp30lo0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "60e9974382f3d49aedf9ff07c179faebb1203f73",
+        "rev": "114a0572a712475b71523c61014d8f9224d719ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`114a0572`](https://github.com/nix-community/NUR/commit/114a0572a712475b71523c61014d8f9224d719ee) | `` automatic update `` |