### PR TITLE
chore(flake/templates): `bfc872ca` -> `c57ac1ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1090,11 +1090,11 @@
     },
     "templates": {
       "locked": {
-        "lastModified": 1712072577,
-        "narHash": "sha256-V5IH+i+VXHe0cEqIDkfKeISEZppOIF7Ys1dba84FJMA=",
+        "lastModified": 1712660171,
+        "narHash": "sha256-VEBWAf0RRoTu5zCQgivoEHW0kUJEbGndp9jaz4XWa4k=",
         "owner": "NixOS",
         "repo": "templates",
-        "rev": "bfc872cab560e3c0852bd073a52eff8093cfeaa6",
+        "rev": "c57ac1ea60ef97bdce2f13e12b849f0ca5eaffe9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message              |
| ------------------------------------------------------------------------------------------------ | -------------------- |
| [`30a6f188`](https://github.com/NixOS/templates/commit/30a6f188056a4c252626e19f6de81c06f79b4490) | `` minor refactor `` |