### PR TITLE
chore(flake/nur): `c736b740` -> `916cd4c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712667161,
-        "narHash": "sha256-h4D1dM44WlyUnVw20i3YZDT2PKZUdy9MyCG/Y+i9aHs=",
+        "lastModified": 1712669145,
+        "narHash": "sha256-a2f84spXeiQM13f0K+WRi/bT2C1i44AJddvzfredhfM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c736b7408f2afb11096a0c5425551f10b4e46586",
+        "rev": "916cd4c4d5c3e287ff4cc68fef4b86a1ee2c7799",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`916cd4c4`](https://github.com/nix-community/NUR/commit/916cd4c4d5c3e287ff4cc68fef4b86a1ee2c7799) | `` automatic update `` |
| [`9a8e067d`](https://github.com/nix-community/NUR/commit/9a8e067d53fd86241ec42acfa3d59e1c11fe2c75) | `` automatic update `` |