### PR TITLE
chore(flake/nur): `916cd4c4` -> `7d17d2fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712669145,
-        "narHash": "sha256-a2f84spXeiQM13f0K+WRi/bT2C1i44AJddvzfredhfM=",
+        "lastModified": 1712671839,
+        "narHash": "sha256-LjehUc4gAnqGckdck5ul+nWJKAjTodS/Nd+PuO3sIaM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "916cd4c4d5c3e287ff4cc68fef4b86a1ee2c7799",
+        "rev": "7d17d2fa5094e28ddd369ced837f44073b436662",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7d17d2fa`](https://github.com/nix-community/NUR/commit/7d17d2fa5094e28ddd369ced837f44073b436662) | `` automatic update `` |