### PR TITLE
chore(flake/nur): `7d17d2fa` -> `b8516927`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712671839,
-        "narHash": "sha256-LjehUc4gAnqGckdck5ul+nWJKAjTodS/Nd+PuO3sIaM=",
+        "lastModified": 1712677672,
+        "narHash": "sha256-/bDMXXtF4rvGkOm6/RQ8OlzQY20+NMxqjEnzJH7H+Uk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7d17d2fa5094e28ddd369ced837f44073b436662",
+        "rev": "b85169271d1df1b9e93709647842df4840dbdc2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b8516927`](https://github.com/nix-community/NUR/commit/b85169271d1df1b9e93709647842df4840dbdc2e) | `` automatic update `` |