### PR TITLE
chore(flake/emacs-overlay): `66f48ac7` -> `38d5a672`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712653802,
-        "narHash": "sha256-8lhL1auFSvJN0U33/LhaTbRQwJfoHHzMc3AuLmYkhmU=",
+        "lastModified": 1712682492,
+        "narHash": "sha256-gBImC/IcMfZAYL4swTr/sNX27dzFD/rJBHjDqYpOjsU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "66f48ac73046a9dab5f896f0bfa5c618b94417cb",
+        "rev": "38d5a6724f4ad6bbc1d8a92850c9cc9573be8959",
         "type": "github"
       },
       "original": {
@@ -710,11 +710,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1712437997,
-        "narHash": "sha256-g0whLLwRvgO2FsyhY8fNk+TWenS3jg5UdlWL4uqgFeo=",
+        "lastModified": 1712588820,
+        "narHash": "sha256-y31s5idk3jMJMAVE4Ud9AdI7HT3CgTAeMTJ0StqKN7Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e38d7cb66ea4f7a0eb6681920615dfcc30fc2920",
+        "rev": "d272ca50d1f7424fbfcd1e6f1c9e01d92f6da167",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`38d5a672`](https://github.com/nix-community/emacs-overlay/commit/38d5a6724f4ad6bbc1d8a92850c9cc9573be8959) | `` Updated emacs ``        |
| [`88af7104`](https://github.com/nix-community/emacs-overlay/commit/88af7104915a697de774d33cf178e175c5294931) | `` Updated melpa ``        |
| [`e77c9b29`](https://github.com/nix-community/emacs-overlay/commit/e77c9b29da7b9f2684858c5a6f8a25ddb4540f01) | `` Updated elpa ``         |
| [`f4051448`](https://github.com/nix-community/emacs-overlay/commit/f4051448dfea5f3b4559c90f979ef5021cef69c2) | `` Updated flake inputs `` |