### PR TITLE
chore(flake/nur): `fc4eb8c4` -> `ee4ce451`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712684690,
-        "narHash": "sha256-sTiG9QN5gI5iXL/KKdXatJDJ+s/hfrlJN/P6oCOrlrM=",
+        "lastModified": 1712692796,
+        "narHash": "sha256-q3Tx4kS+nH4IDcEsZSv8o2IuCn475mGhCYBXxfxZ2gY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc4eb8c45137fd24158739cf23aa119c69d54a39",
+        "rev": "ee4ce451f46a08778d1a9f9837eff0750714b08b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ee4ce451`](https://github.com/nix-community/NUR/commit/ee4ce451f46a08778d1a9f9837eff0750714b08b) | `` automatic update `` |
| [`f09396de`](https://github.com/nix-community/NUR/commit/f09396de0fa0259bf562d026ca639dfbf3ccfa41) | `` automatic update `` |
| [`228a36fe`](https://github.com/nix-community/NUR/commit/228a36fecc0ac131c4f93ee2836f1158c5884dad) | `` automatic update `` |
| [`1b2675be`](https://github.com/nix-community/NUR/commit/1b2675bed07b63fb0d4c88b94e46f14286fb7e59) | `` automatic update `` |