### PR TITLE
chore(flake/nixos-hardware): `1e3b3a35` -> `05aa46a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -631,11 +631,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1712566108,
-        "narHash": "sha256-c9nT2ZODGqobISP41kUwCQ84Srwg7a/1TmPFQuol2/8=",
+        "lastModified": 1712695607,
+        "narHash": "sha256-rXb3onsPMiv00FrGSpIJyYa8x53W0dlbJ5Ka3xvje/c=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "1e3b3a35b7083f4152f5a516798cf9b21e686465",
+        "rev": "05aa46a1f3b5ac92bfe84807868ba9670d48b031",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                               |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`41e6854d`](https://github.com/NixOS/nixos-hardware/commit/41e6854df791c23e30a91cd48790c647bde28d0d) | `` surface: linux 6.6.13 -> 6.6.25 `` |