### PR TITLE
chore(flake/srvos): `c46f7d9b` -> `e4252aa7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -994,11 +994,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712604985,
-        "narHash": "sha256-V/0bzoxSwPIy6s1+hUc2XAprtv/YzSjwfDiF9bQi5X8=",
+        "lastModified": 1712704648,
+        "narHash": "sha256-HlFVUnjLyEIyTQegmOtPD8k8VKP71/3Pyf5Zux+f9BY=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "c46f7d9b5a3e9e246d90f7ddfb76461a80b7b27a",
+        "rev": "e4252aa777482dc9d4cacd779ae29115de69b7ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                           |
| ---------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`e4252aa7`](https://github.com/nix-community/srvos/commit/e4252aa777482dc9d4cacd779ae29115de69b7ba) | `` docs: fix wiki links (#411) `` |