### PR TITLE
chore(flake/emacs-overlay): `09ef7d5d` -> `d08457d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712710697,
-        "narHash": "sha256-gATBYtZXUGhIt6+GT7wBRQD52vZk5qzA4Rkbuak9ros=",
+        "lastModified": 1712713563,
+        "narHash": "sha256-y703Dcj6RS51iO5xFDorkyIGZD8/hQDkwaHJsB6uI80=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "09ef7d5d9f37fd1193d9c03c0cf97a41db93801f",
+        "rev": "d08457d425b0a1f15f44f6d9faa17240f2bd29a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`d08457d4`](https://github.com/nix-community/emacs-overlay/commit/d08457d425b0a1f15f44f6d9faa17240f2bd29a6) | `` Updated emacs `` |
| [`e90dc8dd`](https://github.com/nix-community/emacs-overlay/commit/e90dc8dd0338420ad78b7c9b7d2e8e22fa290975) | `` Updated melpa `` |