### PR TITLE
chore(flake/nur): `be49b9e1` -> `6b4006be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712712480,
-        "narHash": "sha256-1HGUhh7lBpuhZHl+OzOBD4UJY7qItZ95O7iInGLVTBg=",
+        "lastModified": 1712721366,
+        "narHash": "sha256-YTxlRU33EGlX37YnaMKYa9AOrYTlbjOb6cI4td0YBsQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "be49b9e1f77748b15fcfbd9ceedfd679005fa681",
+        "rev": "6b4006bee780dbcc9b91f859c3ea2be4b0d15c92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6b4006be`](https://github.com/nix-community/NUR/commit/6b4006bee780dbcc9b91f859c3ea2be4b0d15c92) | `` automatic update `` |
| [`b3bea27f`](https://github.com/nix-community/NUR/commit/b3bea27fa1dcb10a07174bf975b11bbab7ef25fc) | `` automatic update `` |
| [`29b6f7f0`](https://github.com/nix-community/NUR/commit/29b6f7f081f6b7ea2143c3bc39d1d95db6c0b612) | `` automatic update `` |
| [`3f77a205`](https://github.com/nix-community/NUR/commit/3f77a205beafe14a7cc9748547b8672e1fffe44c) | `` automatic update `` |