### PR TITLE
chore(flake/nur): `6b4006be` -> `12814bd0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712721366,
-        "narHash": "sha256-YTxlRU33EGlX37YnaMKYa9AOrYTlbjOb6cI4td0YBsQ=",
+        "lastModified": 1712723437,
+        "narHash": "sha256-HOX0SPN0wvkNkviAzIESBRvPfuXSXjaiIGMkoImxO2M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6b4006bee780dbcc9b91f859c3ea2be4b0d15c92",
+        "rev": "12814bd04d7a0b1c412f9de8f013c60d1f92c215",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`12814bd0`](https://github.com/nix-community/NUR/commit/12814bd04d7a0b1c412f9de8f013c60d1f92c215) | `` automatic update `` |
| [`1e33bb8c`](https://github.com/nix-community/NUR/commit/1e33bb8ccff8041a5ace7094d90c2f0a182af170) | `` automatic update `` |