### PR TITLE
chore(flake/nur): `12814bd0` -> `09e2401f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712723437,
-        "narHash": "sha256-HOX0SPN0wvkNkviAzIESBRvPfuXSXjaiIGMkoImxO2M=",
+        "lastModified": 1712732229,
+        "narHash": "sha256-zfjJPLkZ/YU4hVUGXU0ibhLFdGfWDDFOq+QNkrfOO88=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "12814bd04d7a0b1c412f9de8f013c60d1f92c215",
+        "rev": "09e2401fbbde404f2cf979111cf61c58767e9578",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                         |
| -------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`09e2401f`](https://github.com/nix-community/NUR/commit/09e2401fbbde404f2cf979111cf61c58767e9578) | `` add jpyke3 repository ``     |
| [`13e86741`](https://github.com/nix-community/NUR/commit/13e8674142b65256aa352a1de3936769fc640989) | `` automatic update ``          |
| [`bd127a85`](https://github.com/nix-community/NUR/commit/bd127a85e088fd713d6170fffc71f0b2cd200739) | `` automatic update ``          |
| [`61aa105a`](https://github.com/nix-community/NUR/commit/61aa105ab6fb86138086468ca3783c0f4cbb85ab) | `` remove baduhai repository `` |