### PR TITLE
chore(flake/nur): `09e2401f` -> `4b2ff742`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712732229,
-        "narHash": "sha256-zfjJPLkZ/YU4hVUGXU0ibhLFdGfWDDFOq+QNkrfOO88=",
+        "lastModified": 1712750092,
+        "narHash": "sha256-FQl3VMjkmaGNwYCw1Tn+lCR4+mQgi/fq7ZqUeftljeM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "09e2401fbbde404f2cf979111cf61c58767e9578",
+        "rev": "4b2ff742fe4eeb1f6157304034874e2da906ad8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4b2ff742`](https://github.com/nix-community/NUR/commit/4b2ff742fe4eeb1f6157304034874e2da906ad8b) | `` automatic update `` |
| [`6616fdf0`](https://github.com/nix-community/NUR/commit/6616fdf0af27c838b1adaf077208a5989b7b7e98) | `` automatic update `` |
| [`183b9085`](https://github.com/nix-community/NUR/commit/183b908511f6cd1c1c6efd105fda89195c0ea6d3) | `` automatic update `` |
| [`98277947`](https://github.com/nix-community/NUR/commit/982779476d7971438481903d1eaf7e1e850239a7) | `` automatic update `` |
| [`d5602f3c`](https://github.com/nix-community/NUR/commit/d5602f3c52be97c9b1e50fdac3f8629808d3dcb9) | `` automatic update `` |
| [`d615cad6`](https://github.com/nix-community/NUR/commit/d615cad6019014b1d13d81e9c55ae496dd24855d) | `` automatic update `` |
| [`af0629d7`](https://github.com/nix-community/NUR/commit/af0629d73f2a212da703896d8d3d74770da7687b) | `` automatic update `` |
| [`f8e01e52`](https://github.com/nix-community/NUR/commit/f8e01e52fb1c4007d66d178f0205a9eec9bf54f5) | `` automatic update `` |