### PR TITLE
chore(flake/emacs-overlay): `d08457d4` -> `d940c775`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712713563,
-        "narHash": "sha256-y703Dcj6RS51iO5xFDorkyIGZD8/hQDkwaHJsB6uI80=",
+        "lastModified": 1712739312,
+        "narHash": "sha256-mCYQAljssFDgPjrvhrKcWMYJfnnOI79gYCNGJaZYVUE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d08457d425b0a1f15f44f6d9faa17240f2bd29a6",
+        "rev": "d940c775557a9fb4d9586dfa3f7d9b734f7c0b20",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`d940c775`](https://github.com/nix-community/emacs-overlay/commit/d940c775557a9fb4d9586dfa3f7d9b734f7c0b20) | `` Updated melpa `` |