### PR TITLE
chore(flake/nur): `4b2ff742` -> `72a299e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712750092,
-        "narHash": "sha256-FQl3VMjkmaGNwYCw1Tn+lCR4+mQgi/fq7ZqUeftljeM=",
+        "lastModified": 1712753744,
+        "narHash": "sha256-gmw5cWa/+K78CDkx1o5RlwPPgYTRaIhoF5bI4LI6HuQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4b2ff742fe4eeb1f6157304034874e2da906ad8b",
+        "rev": "72a299e9362607acd61c99c1858d0b4d1e6d2aef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`72a299e9`](https://github.com/nix-community/NUR/commit/72a299e9362607acd61c99c1858d0b4d1e6d2aef) | `` automatic update `` |
| [`aecad459`](https://github.com/nix-community/NUR/commit/aecad4591e813fdb57bdfe030050ca88a8659018) | `` automatic update `` |
| [`f278eeb9`](https://github.com/nix-community/NUR/commit/f278eeb9c2893b7d17b277bdf9b1d764e3668956) | `` automatic update `` |