### PR TITLE
chore(flake/nur): `72a299e9` -> `dd44295a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712753744,
-        "narHash": "sha256-gmw5cWa/+K78CDkx1o5RlwPPgYTRaIhoF5bI4LI6HuQ=",
+        "lastModified": 1712756700,
+        "narHash": "sha256-TFAn3eG1JnibDPcPigMb6PJSbEafTGjQ4s4zg+dDkYs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "72a299e9362607acd61c99c1858d0b4d1e6d2aef",
+        "rev": "dd44295ab789c4115fefa2b33a12d41a661ee382",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dd44295a`](https://github.com/nix-community/NUR/commit/dd44295ab789c4115fefa2b33a12d41a661ee382) | `` automatic update `` |