### PR TITLE
chore(flake/nixos-hardware): `805adee8` -> `e1c4bac1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -631,11 +631,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1712739139,
-        "narHash": "sha256-I8fw3ot29H9TXClIJHmPfQXaq2dEXHs2VmZeMEw7sb4=",
+        "lastModified": 1712760404,
+        "narHash": "sha256-4zhaEW1nB+nGbCNMjOggWeY5nXs/H0Y71q0+h+jdxoU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "805adee81c82efbe50cac7398c4de05769488ed9",
+        "rev": "e1c4bac14beb8c409d0534382cf967171706b9d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                 |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`e1c4bac1`](https://github.com/NixOS/nixos-hardware/commit/e1c4bac14beb8c409d0534382cf967171706b9d9) | `` Lenovo ThinkPad Z13 Gen 2 (#844) ``  |
| [`79a20e2a`](https://github.com/NixOS/nixos-hardware/commit/79a20e2ac0dddeaf6a482a547181361f061f7955) | `` common/pc: remove libinput.enable `` |