### PR TITLE
chore(flake/nur): `dd44295a` -> `ed1f1d3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712756700,
-        "narHash": "sha256-TFAn3eG1JnibDPcPigMb6PJSbEafTGjQ4s4zg+dDkYs=",
+        "lastModified": 1712760283,
+        "narHash": "sha256-VJJ7fF11x0HikBjYcMs03AP/CJNG3rxx+AKUPBSljzE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd44295ab789c4115fefa2b33a12d41a661ee382",
+        "rev": "ed1f1d3d737e25a33e9b6a638e9820e87f44c6aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ed1f1d3d`](https://github.com/nix-community/NUR/commit/ed1f1d3d737e25a33e9b6a638e9820e87f44c6aa) | `` automatic update `` |