### PR TITLE
chore(flake/stylix): `f9b9bc7c` -> `c630a7d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1030,11 +1030,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712154372,
-        "narHash": "sha256-2HFQm/gpmxtMokn6pInHlTlU7mBONLb3Y1aN8SlY0tc=",
+        "lastModified": 1712765163,
+        "narHash": "sha256-lFNTiwp8rkLrjatLP/J2YfzoXKInPaHVRtQxDUitgeE=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f9b9bc7c8e69942cd2583a3309f86fc5260f1275",
+        "rev": "c630a7d3ee4530e6a0e20ddf45ad813fc8b6da1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                       |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`c630a7d3`](https://github.com/danth/stylix/commit/c630a7d3ee4530e6a0e20ddf45ad813fc8b6da1b) | `` plymouth: lock URL version (#335) ``                       |
| [`58761b51`](https://github.com/danth/stylix/commit/58761b51f86be18a4638ba59ba1debd01d71323a) | `` doc: add mention of `lib.stylix.pixel` to tricks (#327) `` |