### PR TITLE
chore(flake/emacs-overlay): `1bff8265` -> `d4d9c62d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712740132,
-        "narHash": "sha256-8N5QS7MS94oJHo4EjlW+cR0Y8tP2/UpVYMAn89XFJf8=",
+        "lastModified": 1712768907,
+        "narHash": "sha256-o3yQ8ZWR4AOoLPk3+If1F0xmm65LsszDLvC7iUqWVG0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1bff826527840aefa0234d7a381a02fd74ad6868",
+        "rev": "d4d9c62d5e11ad212aee995ad56b8885067179e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`d4d9c62d`](https://github.com/nix-community/emacs-overlay/commit/d4d9c62d5e11ad212aee995ad56b8885067179e7) | `` Updated emacs `` |
| [`5ed94cc2`](https://github.com/nix-community/emacs-overlay/commit/5ed94cc242bd12c516b2f79e73f10a6ecdd78b7b) | `` Updated melpa `` |
| [`5fe8b6dd`](https://github.com/nix-community/emacs-overlay/commit/5fe8b6ddd77f1536e41a72a1785e2894a79af5bf) | `` Updated elpa ``  |