### PR TITLE
chore(flake/nur): `ed1f1d3d` -> `d1216824`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712760283,
-        "narHash": "sha256-VJJ7fF11x0HikBjYcMs03AP/CJNG3rxx+AKUPBSljzE=",
+        "lastModified": 1712778319,
+        "narHash": "sha256-aDImeUTAOHao9kDElg3Aqz42+mEowulAnVAhSy7p0uM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed1f1d3d737e25a33e9b6a638e9820e87f44c6aa",
+        "rev": "d12168241efa646818ad3f9451e13c51b34e7e00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d1216824`](https://github.com/nix-community/NUR/commit/d12168241efa646818ad3f9451e13c51b34e7e00) | `` automatic update `` |
| [`be5e4188`](https://github.com/nix-community/NUR/commit/be5e418830e3b3649d83702c7d31a48eeaecaa50) | `` automatic update `` |