### PR TITLE
chore(flake/nur): `7d59ece6` -> `a0471f14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712781926,
-        "narHash": "sha256-3ZzFxTqxfKxWTkJqkU4B7plLzkniXTHSCVKJdPWTI/A=",
+        "lastModified": 1712785619,
+        "narHash": "sha256-1RCStMZUGqus3DAl7jivw7XM5jpbecfqWtA1r45Ts90=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7d59ece64bd81acaae53a0287b9332995ddd3707",
+        "rev": "a0471f14e0499a66898fc1c7d5aff259a9fa58b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a0471f14`](https://github.com/nix-community/NUR/commit/a0471f14e0499a66898fc1c7d5aff259a9fa58b9) | `` automatic update `` |