### PR TITLE
chore(flake/emacs-overlay): `2b46008a` -> `9b79fd13`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712797128,
-        "narHash": "sha256-ZnJelZwDFTlmrRlSuKPdkUIsaSzT53eDsm8c4buuZzA=",
+        "lastModified": 1712800011,
+        "narHash": "sha256-mEL4y1N/aQrI+OeYHm6Sol8lpDVsceCc2TJF8+uMv6Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2b46008a2a346141d38fb57a87cb22f9219f75dd",
+        "rev": "9b79fd139ff55062e46191bd5dd42fcb79696328",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`9b79fd13`](https://github.com/nix-community/emacs-overlay/commit/9b79fd139ff55062e46191bd5dd42fcb79696328) | `` Updated emacs `` |
| [`0a2c51c5`](https://github.com/nix-community/emacs-overlay/commit/0a2c51c571bf98fcb8b219bcd0b26a942c3ae7de) | `` Updated melpa `` |