### PR TITLE
chore(flake/nur): `a0471f14` -> `f8b13fd9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712785619,
-        "narHash": "sha256-1RCStMZUGqus3DAl7jivw7XM5jpbecfqWtA1r45Ts90=",
+        "lastModified": 1712807754,
+        "narHash": "sha256-8vyiX4NRXtnKATCaq9SGC/HRHdLGmuUuBRdnuoqH9Bg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a0471f14e0499a66898fc1c7d5aff259a9fa58b9",
+        "rev": "f8b13fd9789589bc98e9c2e9c8a115cd2fb04881",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f8b13fd9`](https://github.com/nix-community/NUR/commit/f8b13fd9789589bc98e9c2e9c8a115cd2fb04881) | `` automatic update `` |
| [`5e2e82fe`](https://github.com/nix-community/NUR/commit/5e2e82feb0747d6177937c719d1745084a141a8f) | `` automatic update `` |