### PR TITLE
chore(flake/nur): `f8b13fd9` -> `3a62196e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712807754,
-        "narHash": "sha256-8vyiX4NRXtnKATCaq9SGC/HRHdLGmuUuBRdnuoqH9Bg=",
+        "lastModified": 1712808728,
+        "narHash": "sha256-r19rlK+CeecbCcerF0qEfme0AFYihqnmkQ0UL2Xf5jI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f8b13fd9789589bc98e9c2e9c8a115cd2fb04881",
+        "rev": "3a62196ec03b5ef2bc491437780d7eddd8854e96",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3a62196e`](https://github.com/nix-community/NUR/commit/3a62196ec03b5ef2bc491437780d7eddd8854e96) | `` automatic update `` |