### PR TITLE
chore(flake/nur): `3a62196e` -> `359663b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712808728,
-        "narHash": "sha256-r19rlK+CeecbCcerF0qEfme0AFYihqnmkQ0UL2Xf5jI=",
+        "lastModified": 1712825248,
+        "narHash": "sha256-RQKY8ld6Zy+/M1WuCt8+4OWnHKw7OuUC3WemRrDvCrc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3a62196ec03b5ef2bc491437780d7eddd8854e96",
+        "rev": "359663b0c6cb6e9c3ab2805a3bad536014b338fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`359663b0`](https://github.com/nix-community/NUR/commit/359663b0c6cb6e9c3ab2805a3bad536014b338fb) | `` automatic update `` |
| [`cf9d16a8`](https://github.com/nix-community/NUR/commit/cf9d16a8f905efd591a48cd519a8af0bd260f84c) | `` automatic update `` |