### PR TITLE
chore(flake/nur): `c853b2bd` -> `5d14d273`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712840159,
-        "narHash": "sha256-IWyQcCfyBW3V1yI1J8DVWwqrbh2mw928Vv3OwW6TEt8=",
+        "lastModified": 1712847053,
+        "narHash": "sha256-pF7ozmHUwOjrVH7jkPxqeIF/zEFrOW5+wrb9pmEMUOU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c853b2bdc1d750a4ba2eef266976127eca4dbcdc",
+        "rev": "5d14d2737394f68208b62c686f91bfa1a301d20a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5d14d273`](https://github.com/nix-community/NUR/commit/5d14d2737394f68208b62c686f91bfa1a301d20a) | `` automatic update `` |
| [`ece3d357`](https://github.com/nix-community/NUR/commit/ece3d357681233442392e985d7748cbbe099fb1f) | `` automatic update `` |