### PR TITLE
chore(flake/nur): `c41d0b3c` -> `70b93d25`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712849613,
-        "narHash": "sha256-TkZ+WZBmSUp35zdwIjAUD5/boEzlMM4DQMbNwAe/abg=",
+        "lastModified": 1712857484,
+        "narHash": "sha256-GnoXnSt+r/kpva1sqh9Qk2ijfVtN9PVaddLcy/ckDO8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c41d0b3c158ceb8a77085f4a5fd4e2c8c11ce2f4",
+        "rev": "70b93d25e20f1df740051c5f9fc9556e436c67a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`70b93d25`](https://github.com/nix-community/NUR/commit/70b93d25e20f1df740051c5f9fc9556e436c67a5) | `` automatic update `` |
| [`bea305ed`](https://github.com/nix-community/NUR/commit/bea305ed23150d80f17f011a0d1edc5a43dc65d2) | `` automatic update `` |