### PR TITLE
chore(flake/nur): `70b93d25` -> `b43d77a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712857484,
-        "narHash": "sha256-GnoXnSt+r/kpva1sqh9Qk2ijfVtN9PVaddLcy/ckDO8=",
+        "lastModified": 1712860238,
+        "narHash": "sha256-Zu3uZomOIw5Vo1eNqLPBrmpa9XnOP/r/kMwj6bWAyq0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "70b93d25e20f1df740051c5f9fc9556e436c67a5",
+        "rev": "b43d77a7737ee3b4b1628a149bb457cb8fcafbf5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b43d77a7`](https://github.com/nix-community/NUR/commit/b43d77a7737ee3b4b1628a149bb457cb8fcafbf5) | `` automatic update `` |