### PR TITLE
chore(flake/nur): `b43d77a7` -> `57ca57a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712860238,
-        "narHash": "sha256-Zu3uZomOIw5Vo1eNqLPBrmpa9XnOP/r/kMwj6bWAyq0=",
+        "lastModified": 1712869279,
+        "narHash": "sha256-BRPucVYK3mB6TAZxDfDNXA4Gri7ELKJiSAIu38dLHKQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b43d77a7737ee3b4b1628a149bb457cb8fcafbf5",
+        "rev": "57ca57a98453a3c0fd3e59eaf3d0c70bf94943dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`57ca57a9`](https://github.com/nix-community/NUR/commit/57ca57a98453a3c0fd3e59eaf3d0c70bf94943dd) | `` automatic update `` |
| [`967c36de`](https://github.com/nix-community/NUR/commit/967c36de9e82e35be638a55aba24beedcd54022d) | `` automatic update `` |
| [`39c20da0`](https://github.com/nix-community/NUR/commit/39c20da0e08551145993f6c096ecfe1ee2bb336f) | `` automatic update `` |