### PR TITLE
chore(flake/emacs-overlay): `705fbd14` -> `86055b72`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712855032,
-        "narHash": "sha256-FrlJ7F6568TIj4uTmP2vXhF5cOEsY+w3voxMNMwvchI=",
+        "lastModified": 1712883560,
+        "narHash": "sha256-fnTdksGHWz3q3y2zW5XGSGfAGh/8EgchKhQL3M9oYZc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "705fbd143cc7ee5899525003feda2267e23b4bd6",
+        "rev": "86055b7247d4b9192ae3bb4c087de5786c9789ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`86055b72`](https://github.com/nix-community/emacs-overlay/commit/86055b7247d4b9192ae3bb4c087de5786c9789ba) | `` Updated elpa ``   |
| [`c0172f74`](https://github.com/nix-community/emacs-overlay/commit/c0172f7428f7b594721351c394471b4c45dbee8e) | `` Updated nongnu `` |