### PR TITLE
chore(flake/srvos): `e4252aa7` -> `4f89af16`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -994,11 +994,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712704648,
-        "narHash": "sha256-HlFVUnjLyEIyTQegmOtPD8k8VKP71/3Pyf5Zux+f9BY=",
+        "lastModified": 1712882618,
+        "narHash": "sha256-TnVDEMpOrOEKhgVMQmkamKVRkQWz3Q4lYgtTnD8G0CQ=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "e4252aa777482dc9d4cacd779ae29115de69b7ba",
+        "rev": "4f89af165fde1454cb917a5f23e1f82d32541d38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                           |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`4f89af16`](https://github.com/nix-community/srvos/commit/4f89af165fde1454cb917a5f23e1f82d32541d38) | `` flake: only build devShells on x86_64-linux `` |
| [`3e21e187`](https://github.com/nix-community/srvos/commit/3e21e1873b5bff22eb3d87636d38c6b81713c217) | `` dev/private/flake.lock: Update ``              |
| [`c3cc6618`](https://github.com/nix-community/srvos/commit/c3cc66181e0fc943cc453bf7afbbca48a399f43b) | `` flake.lock: Update ``                          |