### PR TITLE
chore(flake/emacs-overlay): `86055b72` -> `d97f4109`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712883560,
-        "narHash": "sha256-fnTdksGHWz3q3y2zW5XGSGfAGh/8EgchKhQL3M9oYZc=",
+        "lastModified": 1712886378,
+        "narHash": "sha256-UrRX+PbrU8nBZRhK5SUnoCEGgS0+Hn0Lq+lLVJKAU3g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "86055b7247d4b9192ae3bb4c087de5786c9789ba",
+        "rev": "d97f41093894dd5e2d2548fe1e67e0b556a4f250",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`d97f4109`](https://github.com/nix-community/emacs-overlay/commit/d97f41093894dd5e2d2548fe1e67e0b556a4f250) | `` Updated emacs `` |
| [`39dc9983`](https://github.com/nix-community/emacs-overlay/commit/39dc9983ae9a65f12b4cbb7a80f4586aa6c78b51) | `` Updated melpa `` |