### PR TITLE
chore(flake/nur): `c1daa1fc` -> `50e3c14c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712885997,
-        "narHash": "sha256-kWgX1RJQjMk8ddd+stxfNgFMRQZlVHh95l87n0b4AsM=",
+        "lastModified": 1712894002,
+        "narHash": "sha256-0JuDjspaC804J0y5VzCJ/37vt+lxFyv/ejoKK76dxfw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c1daa1fc9927444798c24df3e7a06d848f08af28",
+        "rev": "50e3c14cbc0acaf0cfafdb1018205817a6f4cd66",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`50e3c14c`](https://github.com/nix-community/NUR/commit/50e3c14cbc0acaf0cfafdb1018205817a6f4cd66) | `` automatic update `` |
| [`80a33380`](https://github.com/nix-community/NUR/commit/80a3338038be59cd7cc09590de463b7e858fdbe0) | `` automatic update `` |
| [`bdddb52c`](https://github.com/nix-community/NUR/commit/bdddb52ca59560b9be1f8c1324d3853a4e6f5bf8) | `` automatic update `` |
| [`ddcf6a54`](https://github.com/nix-community/NUR/commit/ddcf6a5488b0448c4a5b6d77f885ff2c0e989230) | `` automatic update `` |
| [`70589469`](https://github.com/nix-community/NUR/commit/70589469fe21c1d0e01f28611d21912463e2cbfe) | `` automatic update `` |