### PR TITLE
chore(flake/nur): `50e3c14c` -> `f8b08a29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712894002,
-        "narHash": "sha256-0JuDjspaC804J0y5VzCJ/37vt+lxFyv/ejoKK76dxfw=",
+        "lastModified": 1712894742,
+        "narHash": "sha256-g14y6ynb6EC8ZPE9Mh76KbmgR8oJfGIudaT3ozTDOdw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "50e3c14cbc0acaf0cfafdb1018205817a6f4cd66",
+        "rev": "f8b08a29ede1eaac78d359d6339142c14df22c0a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f8b08a29`](https://github.com/nix-community/NUR/commit/f8b08a29ede1eaac78d359d6339142c14df22c0a) | `` automatic update `` |