### PR TITLE
chore(flake/nur): `f8b08a29` -> `627d5706`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712894742,
-        "narHash": "sha256-g14y6ynb6EC8ZPE9Mh76KbmgR8oJfGIudaT3ozTDOdw=",
+        "lastModified": 1712903918,
+        "narHash": "sha256-ludd2VsqKgue64wGt+0NhTZShc5rMdX0XYb7VpYRiIA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f8b08a29ede1eaac78d359d6339142c14df22c0a",
+        "rev": "627d5706d44cb34b510615e927cb27c9887f9367",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`627d5706`](https://github.com/nix-community/NUR/commit/627d5706d44cb34b510615e927cb27c9887f9367) | `` automatic update `` |
| [`dcb2d11e`](https://github.com/nix-community/NUR/commit/dcb2d11e181b1f48b6a1c068123600194b973218) | `` automatic update `` |
| [`f39b1c6d`](https://github.com/nix-community/NUR/commit/f39b1c6d6c301823f6ff283331c8ff24c51a9160) | `` automatic update `` |