### PR TITLE
chore(flake/emacs-overlay): `d97f4109` -> `9414446d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712886378,
-        "narHash": "sha256-UrRX+PbrU8nBZRhK5SUnoCEGgS0+Hn0Lq+lLVJKAU3g=",
+        "lastModified": 1712912831,
+        "narHash": "sha256-f+jHNX0q8HLf2zO/TYz19Lg3jIpnpE3yaQemQOZ5zL4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d97f41093894dd5e2d2548fe1e67e0b556a4f250",
+        "rev": "9414446dfdc600c060284afc74d8dd5aa78208d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`9414446d`](https://github.com/nix-community/emacs-overlay/commit/9414446dfdc600c060284afc74d8dd5aa78208d1) | `` Updated emacs ``        |
| [`8de63fb7`](https://github.com/nix-community/emacs-overlay/commit/8de63fb7fbddaec406db99adc302174ec6b4016d) | `` Updated melpa ``        |
| [`9a6b212e`](https://github.com/nix-community/emacs-overlay/commit/9a6b212ead9f4b57809493369c412f79e833ea17) | `` Updated flake inputs `` |