### PR TITLE
chore(flake/nur): `0fb8bcca` -> `dea43290`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712906890,
-        "narHash": "sha256-MkhmSqGqQ5cDa1VzqkA76h6+9rYCY2IJzSRglNV+Vr4=",
+        "lastModified": 1712915104,
+        "narHash": "sha256-tixewiijmZp+cd9d3KCEQmWe1r8PpxbqlSHZlt+XKXk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0fb8bccadea16d13d87210c21fbae09b26c28e07",
+        "rev": "dea43290555eac51d3c39153d4530cfa69aa7315",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dea43290`](https://github.com/nix-community/NUR/commit/dea43290555eac51d3c39153d4530cfa69aa7315) | `` automatic update `` |
| [`ff7ff7ab`](https://github.com/nix-community/NUR/commit/ff7ff7aba72bebe001cc1652c7a0e0045898a8c6) | `` automatic update `` |
| [`e915ee3b`](https://github.com/nix-community/NUR/commit/e915ee3ba640c0fe185e6997a4c6e9cea9fe1d80) | `` automatic update `` |