### PR TITLE
chore(flake/nur): `dea43290` -> `67d041f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712915104,
-        "narHash": "sha256-tixewiijmZp+cd9d3KCEQmWe1r8PpxbqlSHZlt+XKXk=",
+        "lastModified": 1712918680,
+        "narHash": "sha256-luYW6W6PQ491E/fIaHwVNhjpgoEZYjyiotWr7p+mtTY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dea43290555eac51d3c39153d4530cfa69aa7315",
+        "rev": "67d041f54e20ba1abf70069400e6637a3655b9b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`67d041f5`](https://github.com/nix-community/NUR/commit/67d041f54e20ba1abf70069400e6637a3655b9b5) | `` automatic update `` |