### PR TITLE
chore(flake/nur): `b9208a06` -> `bc9a0c94`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712926429,
-        "narHash": "sha256-WmwbUCUZc5RjQIy4RXzeIHe0upQYBZ4EpzsHG5ekjtU=",
+        "lastModified": 1712930451,
+        "narHash": "sha256-TEOsV8n9XgPAZaoRzSJ2/fS0qc2I6Q8n2yCvT7wRaBA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b9208a06751daf35263796bc3b1a92ec82aff59c",
+        "rev": "bc9a0c948c4e87bb812f9f6a4117e617b7ca7a05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bc9a0c94`](https://github.com/nix-community/NUR/commit/bc9a0c948c4e87bb812f9f6a4117e617b7ca7a05) | `` automatic update `` |
| [`256d4e53`](https://github.com/nix-community/NUR/commit/256d4e53bdf16a95dee7534525d314a1f5d1a718) | `` automatic update `` |