### PR TITLE
chore(flake/nur): `bc9a0c94` -> `4cdb0ded`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712930451,
-        "narHash": "sha256-TEOsV8n9XgPAZaoRzSJ2/fS0qc2I6Q8n2yCvT7wRaBA=",
+        "lastModified": 1712936795,
+        "narHash": "sha256-HIBTo4GjLKpjVtUK7hgJf0pvkXLUU0QANWQU3fQtOIs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bc9a0c948c4e87bb812f9f6a4117e617b7ca7a05",
+        "rev": "4cdb0dedbb61e2ddb69749f5e440187436842936",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4cdb0ded`](https://github.com/nix-community/NUR/commit/4cdb0dedbb61e2ddb69749f5e440187436842936) | `` automatic update `` |
| [`e5d72887`](https://github.com/nix-community/NUR/commit/e5d7288700dab849d2f2261b4a4ef383df1adbb5) | `` automatic update `` |