### PR TITLE
chore(flake/emacs-overlay): `9414446d` -> `9f440671`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712912831,
-        "narHash": "sha256-f+jHNX0q8HLf2zO/TYz19Lg3jIpnpE3yaQemQOZ5zL4=",
+        "lastModified": 1712941527,
+        "narHash": "sha256-wD9XQFGW0qzRW1YHj6oklCHzgKNxjwS0tZ/hFGgiHX4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9414446dfdc600c060284afc74d8dd5aa78208d1",
+        "rev": "9f4406718ada7af83892e17355ef7fd202c20897",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`9f440671`](https://github.com/nix-community/emacs-overlay/commit/9f4406718ada7af83892e17355ef7fd202c20897) | `` Updated emacs ``  |
| [`e84bd87d`](https://github.com/nix-community/emacs-overlay/commit/e84bd87de2cf761c359dc6931c76326cde33e8d2) | `` Updated melpa ``  |
| [`aa451ac0`](https://github.com/nix-community/emacs-overlay/commit/aa451ac08eb3330749f75c4aa33c26e90d0362b2) | `` Updated elpa ``   |
| [`2c7ff266`](https://github.com/nix-community/emacs-overlay/commit/2c7ff266de758a5fd1a29685ff2d6f299ec632d4) | `` Updated nongnu `` |