### PR TITLE
chore(flake/srvos): `4f89af16` -> `bed9cfce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -994,11 +994,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712882618,
-        "narHash": "sha256-TnVDEMpOrOEKhgVMQmkamKVRkQWz3Q4lYgtTnD8G0CQ=",
+        "lastModified": 1712943026,
+        "narHash": "sha256-x2PaFsoZjqm2mC8dbUbv93to8H7wAruauluOH81lzA8=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "4f89af165fde1454cb917a5f23e1f82d32541d38",
+        "rev": "bed9cfce2adc4c72de9bc90656d5cfe66e4371f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                             |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`bed9cfce`](https://github.com/nix-community/srvos/commit/bed9cfce2adc4c72de9bc90656d5cfe66e4371f3) | `` Update docs/nixos/hardware.md ``                 |
| [`e663d189`](https://github.com/nix-community/srvos/commit/e663d1890e388b901f95e63359b5f06192bd4999) | `` add digitalocean ``                              |
| [`8a4c3ea6`](https://github.com/nix-community/srvos/commit/8a4c3ea6458228fdadbd81ce27521702eeb92973) | `` hetzner-cloud/arm: remove boot.loader.timeout `` |
| [`3e8526c5`](https://github.com/nix-community/srvos/commit/3e8526c54a3a24fecd58e913a445a50ddc2e4b82) | `` telegraf: use list for inputs.prometheus ``      |