### PR TITLE
chore(flake/nur): `5948f511` -> `6cb6d34c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712961963,
-        "narHash": "sha256-fcuo3+dWhKRpWSEfrJxJS4ryKWdc9ygteKe0N7dRNMk=",
+        "lastModified": 1712965531,
+        "narHash": "sha256-qSOJWWc+mCK7oR9D+w/ZCe9FapLZT85j3HIjoq80Uxk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5948f5111581e7fdad49eecaa5999a1088cfa693",
+        "rev": "6cb6d34cd4db4e7ea09ff3e8bea0e2b11773292b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6cb6d34c`](https://github.com/nix-community/NUR/commit/6cb6d34cd4db4e7ea09ff3e8bea0e2b11773292b) | `` automatic update `` |