### PR TITLE
chore(flake/emacs-overlay): `9f440671` -> `6436aa6e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712941527,
-        "narHash": "sha256-wD9XQFGW0qzRW1YHj6oklCHzgKNxjwS0tZ/hFGgiHX4=",
+        "lastModified": 1712972172,
+        "narHash": "sha256-MQHbXC3kNbaeKig8qF8eNSvNrnTyJ1KSfrJB6jkcJPQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9f4406718ada7af83892e17355ef7fd202c20897",
+        "rev": "6436aa6e70126e1cc401eec83a5ab9c909cf1708",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`6436aa6e`](https://github.com/nix-community/emacs-overlay/commit/6436aa6e70126e1cc401eec83a5ab9c909cf1708) | `` Updated emacs `` |
| [`3b76a907`](https://github.com/nix-community/emacs-overlay/commit/3b76a907042b19ec237fe870f65a3e3595e47383) | `` Updated melpa `` |
| [`a27b0ec3`](https://github.com/nix-community/emacs-overlay/commit/a27b0ec305e09e9de940b37a2eec44eb764adeac) | `` Updated elpa ``  |