### PR TITLE
chore(flake/nur): `6cb6d34c` -> `5bf8f828`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712965531,
-        "narHash": "sha256-qSOJWWc+mCK7oR9D+w/ZCe9FapLZT85j3HIjoq80Uxk=",
+        "lastModified": 1712966807,
+        "narHash": "sha256-95DfA5bKPHf81S2fklcSrMqAn28WfZHoMTTOOI9NBBs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6cb6d34cd4db4e7ea09ff3e8bea0e2b11773292b",
+        "rev": "5bf8f828db922f6787e0f7a26432c39bfbd39dac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5bf8f828`](https://github.com/nix-community/NUR/commit/5bf8f828db922f6787e0f7a26432c39bfbd39dac) | `` automatic update `` |