### PR TITLE
chore(flake/nur): `1fe46d61` -> `37b670b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712971442,
-        "narHash": "sha256-dHtmiSKPKgxPxiWJIRYQt8KftfyJXMey9RFaVFyBw/E=",
+        "lastModified": 1712980545,
+        "narHash": "sha256-Qkb2VjtjHDXr0YN4fx739sTDnAeD/ec6p+FzodKIZdY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1fe46d61040d98d9ac69c9d23231d9068a168241",
+        "rev": "37b670b3d14bc559d9cdaf1641e9b0a984404f36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`37b670b3`](https://github.com/nix-community/NUR/commit/37b670b3d14bc559d9cdaf1641e9b0a984404f36) | `` automatic update `` |