### PR TITLE
chore(flake/nur): `37b670b3` -> `520e25b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712980545,
-        "narHash": "sha256-Qkb2VjtjHDXr0YN4fx739sTDnAeD/ec6p+FzodKIZdY=",
+        "lastModified": 1712983839,
+        "narHash": "sha256-LNhvnC7UioC8c49FVBWxkZeCZDp+Seb66tjX8y//h+A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "37b670b3d14bc559d9cdaf1641e9b0a984404f36",
+        "rev": "520e25b0725a313cd029e581ea5fe86c43524661",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`520e25b0`](https://github.com/nix-community/NUR/commit/520e25b0725a313cd029e581ea5fe86c43524661) | `` automatic update `` |
| [`0be2dd33`](https://github.com/nix-community/NUR/commit/0be2dd33ff1216720bc19282e56079271732dfe0) | `` automatic update `` |
| [`87a91dee`](https://github.com/nix-community/NUR/commit/87a91dee17ba8c1c7b34e77059da33a367ce9d68) | `` automatic update `` |