### PR TITLE
chore(flake/nur): `520e25b0` -> `9aebb2fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712983839,
-        "narHash": "sha256-LNhvnC7UioC8c49FVBWxkZeCZDp+Seb66tjX8y//h+A=",
+        "lastModified": 1712990206,
+        "narHash": "sha256-yQblp6dXqy8/dgqtXTPPyoz5c1u35L7xAVbtDidgmjE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "520e25b0725a313cd029e581ea5fe86c43524661",
+        "rev": "9aebb2fd194d95452f1952f28a5164e20a451a0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9aebb2fd`](https://github.com/nix-community/NUR/commit/9aebb2fd194d95452f1952f28a5164e20a451a0e) | `` automatic update `` |
| [`08434b57`](https://github.com/nix-community/NUR/commit/08434b57af00c7497c6abdce434a065343aa3269) | `` automatic update `` |