### PR TITLE
chore(flake/nur): `9aebb2fd` -> `4baa2c95`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712990206,
-        "narHash": "sha256-yQblp6dXqy8/dgqtXTPPyoz5c1u35L7xAVbtDidgmjE=",
+        "lastModified": 1712997882,
+        "narHash": "sha256-zLXaXJGyWujX1nJQTHBoljEpc2G8JYX1SgsSFLuXeLM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9aebb2fd194d95452f1952f28a5164e20a451a0e",
+        "rev": "4baa2c9502a8568421ab0fcb21514b5cfdc9d8e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4baa2c95`](https://github.com/nix-community/NUR/commit/4baa2c9502a8568421ab0fcb21514b5cfdc9d8e3) | `` automatic update `` |
| [`75f44a9f`](https://github.com/nix-community/NUR/commit/75f44a9f935f708e9cb92a115f32d62a487847c4) | `` automatic update `` |
| [`f79c4638`](https://github.com/nix-community/NUR/commit/f79c4638eb2b3f9e9dbb6241d9ffe05584e3e43c) | `` automatic update `` |
| [`85055c20`](https://github.com/nix-community/NUR/commit/85055c20dac3157cfdb93e76411727c698794766) | `` automatic update `` |
| [`22d9f692`](https://github.com/nix-community/NUR/commit/22d9f6929621663fbad4cce0e6e2058b05d23439) | `` automatic update `` |