### PR TITLE
chore(flake/emacs-overlay): `6436aa6e` -> `f3745199`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712972172,
-        "narHash": "sha256-MQHbXC3kNbaeKig8qF8eNSvNrnTyJ1KSfrJB6jkcJPQ=",
+        "lastModified": 1712998906,
+        "narHash": "sha256-PxfZPGgQeXNAFLY9qjR/Wa1CHISPwc16upyE/dB7Qfc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6436aa6e70126e1cc401eec83a5ab9c909cf1708",
+        "rev": "f3745199a37f2a6196d1d98a7912cd70e318aa7d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`f3745199`](https://github.com/nix-community/emacs-overlay/commit/f3745199a37f2a6196d1d98a7912cd70e318aa7d) | `` Updated emacs `` |
| [`6c6d6be1`](https://github.com/nix-community/emacs-overlay/commit/6c6d6be17dbbe0204d9c3b32f458b2658be64d57) | `` Updated melpa `` |