### PR TITLE
chore(flake/nur): `4baa2c95` -> `f2d42483`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1712997882,
-        "narHash": "sha256-zLXaXJGyWujX1nJQTHBoljEpc2G8JYX1SgsSFLuXeLM=",
+        "lastModified": 1713001499,
+        "narHash": "sha256-K+vpy3KL79P2iegNoUc65o0FWIahXh5aDoPgJLmQGtc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4baa2c9502a8568421ab0fcb21514b5cfdc9d8e3",
+        "rev": "f2d42483bf8cf8c3ccd6e5a039d23104540db22d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f2d42483`](https://github.com/nix-community/NUR/commit/f2d42483bf8cf8c3ccd6e5a039d23104540db22d) | `` automatic update `` |
| [`4d70f51a`](https://github.com/nix-community/NUR/commit/4d70f51a8ae25050156b6fde7f528ece078a3788) | `` automatic update `` |