### PR TITLE
chore(flake/nur): `f2d42483` -> `84a71ce3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713001499,
-        "narHash": "sha256-K+vpy3KL79P2iegNoUc65o0FWIahXh5aDoPgJLmQGtc=",
+        "lastModified": 1713008697,
+        "narHash": "sha256-kzU87X3x4JJty4pPexRrDbl2JYBYq9b77NT61WcSLms=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f2d42483bf8cf8c3ccd6e5a039d23104540db22d",
+        "rev": "84a71ce3c4c37b218d4aab0b2ef1b36bf32fa38d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`84a71ce3`](https://github.com/nix-community/NUR/commit/84a71ce3c4c37b218d4aab0b2ef1b36bf32fa38d) | `` automatic update `` |