### PR TITLE
chore(flake/nur): `84a71ce3` -> `52d030ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713008697,
-        "narHash": "sha256-kzU87X3x4JJty4pPexRrDbl2JYBYq9b77NT61WcSLms=",
+        "lastModified": 1713010025,
+        "narHash": "sha256-+I7xiUv+gr8oBEHf/gwpBiFtW86CcnUOgX6ltZixu7w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "84a71ce3c4c37b218d4aab0b2ef1b36bf32fa38d",
+        "rev": "52d030ad7c9de4e1d978eced02c1b09b1a17d5a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`52d030ad`](https://github.com/nix-community/NUR/commit/52d030ad7c9de4e1d978eced02c1b09b1a17d5a7) | `` automatic update `` |