### PR TITLE
chore(flake/nur): `52d030ad` -> `bd44e26a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713010025,
-        "narHash": "sha256-+I7xiUv+gr8oBEHf/gwpBiFtW86CcnUOgX6ltZixu7w=",
+        "lastModified": 1713018776,
+        "narHash": "sha256-bp2EecMby8a6X6EYZgXzi9sucMK8ZoLs/rpTPP/v7VU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "52d030ad7c9de4e1d978eced02c1b09b1a17d5a7",
+        "rev": "bd44e26a5bda921917e2e4fdfe5c4c84633d427e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bd44e26a`](https://github.com/nix-community/NUR/commit/bd44e26a5bda921917e2e4fdfe5c4c84633d427e) | `` automatic update `` |