### PR TITLE
chore(flake/nur): `bd44e26a` -> `8f04c52b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713018776,
-        "narHash": "sha256-bp2EecMby8a6X6EYZgXzi9sucMK8ZoLs/rpTPP/v7VU=",
+        "lastModified": 1713023153,
+        "narHash": "sha256-gzmlmWtv6S+0mZPOwZAyhM872qThRmcVh3lWnAdIXOY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bd44e26a5bda921917e2e4fdfe5c4c84633d427e",
+        "rev": "8f04c52bbcd09e6ffa5c7173cba7e6e0e8dfb0cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8f04c52b`](https://github.com/nix-community/NUR/commit/8f04c52bbcd09e6ffa5c7173cba7e6e0e8dfb0cd) | `` automatic update `` |