### PR TITLE
chore(flake/nur): `8f04c52b` -> `80d50c92`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713023153,
-        "narHash": "sha256-gzmlmWtv6S+0mZPOwZAyhM872qThRmcVh3lWnAdIXOY=",
+        "lastModified": 1713032848,
+        "narHash": "sha256-YCV0tgYG/s6Lq28iksdk4LyDF45UShxuCXf0yuiFSBc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8f04c52bbcd09e6ffa5c7173cba7e6e0e8dfb0cd",
+        "rev": "80d50c92b9d514cb18ce828d4c3e4239177728af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`80d50c92`](https://github.com/nix-community/NUR/commit/80d50c92b9d514cb18ce828d4c3e4239177728af) | `` automatic update `` |
| [`2a81d066`](https://github.com/nix-community/NUR/commit/2a81d066ead640c5e0167764ec39b7f07a2a560e) | `` automatic update `` |
| [`bc427174`](https://github.com/nix-community/NUR/commit/bc427174f9abf1dd8ae60db75205d05e47f71280) | `` automatic update `` |