### PR TITLE
chore(flake/emacs-overlay): `f3745199` -> `ea70f9df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712998906,
-        "narHash": "sha256-PxfZPGgQeXNAFLY9qjR/Wa1CHISPwc16upyE/dB7Qfc=",
+        "lastModified": 1713027173,
+        "narHash": "sha256-DY+Xldj7rvQIjuCthMIzWI+P0Vv5g5d5B46lBp1vwUo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f3745199a37f2a6196d1d98a7912cd70e318aa7d",
+        "rev": "ea70f9df1ff67d1b37abd0893959ff315a599517",
         "type": "github"
       },
       "original": {
@@ -710,11 +710,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1712741485,
-        "narHash": "sha256-bCs0+MSTra80oXAsnM6Oq62WsirOIaijQ/BbUY59tR4=",
+        "lastModified": 1712867921,
+        "narHash": "sha256-edTFV4KldkCMdViC/rmpJa7oLIU8SE/S35lh/ukC7bg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b2cf36f43f9ef2ded5711b30b1f393ac423d8f72",
+        "rev": "51651a540816273b67bc4dedea2d37d116c5f7fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ea70f9df`](https://github.com/nix-community/emacs-overlay/commit/ea70f9df1ff67d1b37abd0893959ff315a599517) | `` Updated melpa ``        |
| [`86e121f2`](https://github.com/nix-community/emacs-overlay/commit/86e121f22763f18336d18980dd5d9a1d554a6874) | `` Updated elpa ``         |
| [`4163cf55`](https://github.com/nix-community/emacs-overlay/commit/4163cf558682e33b06b3ceaada03161d687edaf7) | `` Updated nongnu ``       |
| [`cedcee8e`](https://github.com/nix-community/emacs-overlay/commit/cedcee8ed57f4f715e487c1a35b06745f7f54cf8) | `` Updated flake inputs `` |