### PR TITLE
chore(flake/stylix): `406f7930` -> `83866ed8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1030,11 +1030,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712847516,
-        "narHash": "sha256-/b7TZ+PY99e1bRbSGW9FOJExX8tBII5sS1zMqEaUHBo=",
+        "lastModified": 1713025302,
+        "narHash": "sha256-za4w2wYt1fg9EdTv5fYLwEqAyHgPmPq88HmlxirXuEk=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "406f793045ce82689194273cb7e7c4ad0fec530c",
+        "rev": "83866ed8800ed39519a79ea30b18c8eb21f26080",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                              |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`83866ed8`](https://github.com/danth/stylix/commit/83866ed8800ed39519a79ea30b18c8eb21f26080) | `` plymouth: remove substituteInPlace to fix build failure (#338) `` |