### PR TITLE
chore(flake/nur): `80d50c92` -> `b865e0a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713032848,
-        "narHash": "sha256-YCV0tgYG/s6Lq28iksdk4LyDF45UShxuCXf0yuiFSBc=",
+        "lastModified": 1713037556,
+        "narHash": "sha256-bGMexO/ZW8ox0u/InJ1F+SH0t0rZNQNgQxDKvJgR/D8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "80d50c92b9d514cb18ce828d4c3e4239177728af",
+        "rev": "b865e0a9799e757c24baa95c389beb4a0d4736d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b865e0a9`](https://github.com/nix-community/NUR/commit/b865e0a9799e757c24baa95c389beb4a0d4736d1) | `` automatic update `` |
| [`b6e57f2b`](https://github.com/nix-community/NUR/commit/b6e57f2b20a480d4c047f20fbfbf60e2fff24e9b) | `` automatic update `` |