### PR TITLE
chore(flake/nur): `b865e0a9` -> `8d563c34`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713037556,
-        "narHash": "sha256-bGMexO/ZW8ox0u/InJ1F+SH0t0rZNQNgQxDKvJgR/D8=",
+        "lastModified": 1713044713,
+        "narHash": "sha256-yvuOE6QiuTJYyRIfeAda5qsZdMwD7ry5rR/5HtvbvlM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b865e0a9799e757c24baa95c389beb4a0d4736d1",
+        "rev": "8d563c34f15b20cba7c8fbcb8558325e722dd094",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8d563c34`](https://github.com/nix-community/NUR/commit/8d563c34f15b20cba7c8fbcb8558325e722dd094) | `` automatic update `` |
| [`db42f8e1`](https://github.com/nix-community/NUR/commit/db42f8e1e9693cc94cbf46458a5d305615ecd0ed) | `` automatic update `` |