### PR TITLE
chore(flake/emacs-overlay): `1ec32758` -> `0c36a0d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713057554,
-        "narHash": "sha256-wn/wbEz1PaW7kPIE4cwrJKxKomTnnJwsEWh2gVVc4VM=",
+        "lastModified": 1713060447,
+        "narHash": "sha256-1kJdTTyeRvNQVjhFYFRoYW9I5sQT1NDT7hl188v6Gf0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1ec327581332f85fb273487226b102ee1af3d6db",
+        "rev": "0c36a0d16b7ca94731eee246d00238885d22490f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`0c36a0d1`](https://github.com/nix-community/emacs-overlay/commit/0c36a0d16b7ca94731eee246d00238885d22490f) | `` Updated emacs `` |
| [`8b543264`](https://github.com/nix-community/emacs-overlay/commit/8b543264eb28d8953911bcf1bc0d94d7e89c2d7a) | `` Updated melpa `` |