### PR TITLE
chore(flake/nix-index-database): `4676d72d` -> `93aed672`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -591,11 +591,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712459390,
-        "narHash": "sha256-e12bNDottaGoBgd0AdH/bQvk854xunlWAdZwr/oHO1c=",
+        "lastModified": 1713067146,
+        "narHash": "sha256-9D20xjblGKEVRVCnM3qWhiizEa9i6OpK6xQJajwcwOQ=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "4676d72d872459e1e3a248d049609f110c570e9a",
+        "rev": "93aed67288be60c9ef6133ba2f8de128f4ef265c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`93aed672`](https://github.com/nix-community/nix-index-database/commit/93aed67288be60c9ef6133ba2f8de128f4ef265c) | `` update packages.nix to release 2024-04-14-035802 `` |
| [`1b4ef0a7`](https://github.com/nix-community/nix-index-database/commit/1b4ef0a7b7481b7b8ad7a1962e4e090718075947) | `` flake.lock: Update ``                               |