### PR TITLE
chore(flake/nur): `f2cc2c37` -> `6c3f4640`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713061232,
-        "narHash": "sha256-vmMlO1WUGDmuRG5cx/HZ2Rcf+9e0V5diWq8cl0kBzFM=",
+        "lastModified": 1713067493,
+        "narHash": "sha256-jLI7D9jTK24SQKHBxEfRqy6uHHQDMtzzeslGv38qnK8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f2cc2c377f041c182e5495a1204fe5028de1ac54",
+        "rev": "6c3f46407ec70895b3e0b3e10fd9490e3b54e089",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6c3f4640`](https://github.com/nix-community/NUR/commit/6c3f46407ec70895b3e0b3e10fd9490e3b54e089) | `` automatic update `` |