### PR TITLE
chore(flake/nur): `27e795dc` -> `34dd0b90`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713071825,
-        "narHash": "sha256-u0/ZKumF7I6QHpqXsKqF7reeBSdxg1UdMMWmsyq0e3I=",
+        "lastModified": 1713081784,
+        "narHash": "sha256-t0RoW0DTQQ8MaQ6DXbkOZtPapv9rNZa5UYwOan5Th/k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "27e795dc1684cc205f6af769aa3d8c395d867416",
+        "rev": "34dd0b90d8075657d7816e31f3955fcc958e22f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`34dd0b90`](https://github.com/nix-community/NUR/commit/34dd0b90d8075657d7816e31f3955fcc958e22f7) | `` automatic update `` |
| [`d97e32e6`](https://github.com/nix-community/NUR/commit/d97e32e6a989752e2e19833a8b1dd263f8dcaef5) | `` automatic update `` |
| [`c07e1067`](https://github.com/nix-community/NUR/commit/c07e1067a4de9e6b985565bbeb4933026014eddd) | `` automatic update `` |