### PR TITLE
chore(flake/org-tufte): `954ab3bc` -> `5251cdb7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     "org-tufte": {
       "flake": false,
       "locked": {
-        "lastModified": 1711061468,
-        "narHash": "sha256-so/3YuIerXMVBgO5FfWrkMYj6u7OXTL56ZsrO23Vtpo=",
+        "lastModified": 1713081912,
+        "narHash": "sha256-gbFmqZC29eICiN6DfJeH0yH0r13UhpCK/iI9SyERzqo=",
         "owner": "Zilong-Li",
         "repo": "org-tufte",
-        "rev": "954ab3bcb87747f62926aa6e15f9a12441751e88",
+        "rev": "5251cdb7badacd90c6ba1bff7dd89847754053a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                    |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`5251cdb7`](https://github.com/Zilong-Li/org-tufte/commit/5251cdb7badacd90c6ba1bff7dd89847754053a7) | `` v0.5.0 ``                               |
| [`b703dd12`](https://github.com/Zilong-Li/org-tufte/commit/b703dd129d577bd1abf6b6da2bc0d46e8e8c7a98) | `` Unify naming of new function better. `` |
| [`84d4b7ca`](https://github.com/Zilong-Li/org-tufte/commit/84d4b7ca191dea75eb370a9767fbe9a8f9346a77) | `` Modify `wrap-inline` ``                 |
| [`e6b4bb3f`](https://github.com/Zilong-Li/org-tufte/commit/e6b4bb3f501a5865a251b46861062bbd8e256e5a) | `` Make "Posted on" string optional. ``    |