### PR TITLE
chore(flake/emacs-overlay): `0c36a0d1` -> `f92b1cf3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713060447,
-        "narHash": "sha256-1kJdTTyeRvNQVjhFYFRoYW9I5sQT1NDT7hl188v6Gf0=",
+        "lastModified": 1713133980,
+        "narHash": "sha256-fGpgQoMyuLbS/r3FkZ59ISNI3Oo148tEMlKJpnmCI7w=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0c36a0d16b7ca94731eee246d00238885d22490f",
+        "rev": "f92b1cf3105eb9eab992e585861a762ad8cb0037",
         "type": "github"
       },
       "original": {
@@ -710,11 +710,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1712867921,
-        "narHash": "sha256-edTFV4KldkCMdViC/rmpJa7oLIU8SE/S35lh/ukC7bg=",
+        "lastModified": 1713013257,
+        "narHash": "sha256-ZEfGB3YCBVggvk0BQIqVY7J8XF/9jxQ68fCca6nib+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "51651a540816273b67bc4dedea2d37d116c5f7fe",
+        "rev": "90055d5e616bd943795d38808c94dbf0dd35abe8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`f92b1cf3`](https://github.com/nix-community/emacs-overlay/commit/f92b1cf3105eb9eab992e585861a762ad8cb0037) | `` Updated elpa ``         |
| [`5b014959`](https://github.com/nix-community/emacs-overlay/commit/5b014959f1634723bfce7bf137a181031b1c6e7c) | `` Updated flake inputs `` |
| [`8a3f1e57`](https://github.com/nix-community/emacs-overlay/commit/8a3f1e574aa11b3f0aee99bcb453b56c8d6f1ac7) | `` Updated emacs ``        |
| [`6cfac69a`](https://github.com/nix-community/emacs-overlay/commit/6cfac69a49d02b98869683e0776857662ae06a39) | `` Updated melpa ``        |
| [`f4bc6d72`](https://github.com/nix-community/emacs-overlay/commit/f4bc6d7272120520122cfef5867d92a92e81bf62) | `` Updated elpa ``         |