### PR TITLE
chore(flake/nur): `34dd0b90` -> `1e6e9f41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713081784,
-        "narHash": "sha256-t0RoW0DTQQ8MaQ6DXbkOZtPapv9rNZa5UYwOan5Th/k=",
+        "lastModified": 1713093341,
+        "narHash": "sha256-zON2LEPO98NiUtOItgu+Vz1uWkrUbt5zJbzf5XCm71Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "34dd0b90d8075657d7816e31f3955fcc958e22f7",
+        "rev": "1e6e9f41f0fbdcba7ca505a7d54128bc2f1053d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1e6e9f41`](https://github.com/nix-community/NUR/commit/1e6e9f41f0fbdcba7ca505a7d54128bc2f1053d6) | `` automatic update `` |
| [`2b092358`](https://github.com/nix-community/NUR/commit/2b0923586913a4a8c6cf78423ac82557aba8f554) | `` automatic update `` |