### PR TITLE
chore(flake/org-tufte): `5251cdb7` -> `acdfde9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -859,11 +859,11 @@
     "org-tufte": {
       "flake": false,
       "locked": {
-        "lastModified": 1713081912,
-        "narHash": "sha256-gbFmqZC29eICiN6DfJeH0yH0r13UhpCK/iI9SyERzqo=",
+        "lastModified": 1713100705,
+        "narHash": "sha256-ZSR3seL+EO929JN7rHtrzgShecHN3fWJCk+z7tnL75o=",
         "owner": "Zilong-Li",
         "repo": "org-tufte",
-        "rev": "5251cdb7badacd90c6ba1bff7dd89847754053a7",
+        "rev": "acdfde9a3bbbd6c4aa83c960670f804dddbfbbf0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                           |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`acdfde9a`](https://github.com/Zilong-Li/org-tufte/commit/acdfde9a3bbbd6c4aa83c960670f804dddbfbbf0) | `` figure caption with margin-toggle on mobile `` |