### PR TITLE
chore(flake/nur): `1e6e9f41` -> `a3a09376`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713093341,
-        "narHash": "sha256-zON2LEPO98NiUtOItgu+Vz1uWkrUbt5zJbzf5XCm71Y=",
+        "lastModified": 1713107623,
+        "narHash": "sha256-dH0J7yp6Tem2VMWU0TYimiiOq6kvlbCTlrUH/z2nZc0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1e6e9f41f0fbdcba7ca505a7d54128bc2f1053d6",
+        "rev": "a3a0937684767c4e16ab63694fa0dfb4007a28ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a3a09376`](https://github.com/nix-community/NUR/commit/a3a0937684767c4e16ab63694fa0dfb4007a28ce) | `` automatic update `` |
| [`91e629fb`](https://github.com/nix-community/NUR/commit/91e629fb636a36357227843a36361fed20a50733) | `` automatic update `` |
| [`909aa52c`](https://github.com/nix-community/NUR/commit/909aa52c9a599dcb6c4587aa8759935ec5450e71) | `` automatic update `` |