### PR TITLE
chore(flake/nur): `a3a09376` -> `90060445`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713107623,
-        "narHash": "sha256-dH0J7yp6Tem2VMWU0TYimiiOq6kvlbCTlrUH/z2nZc0=",
+        "lastModified": 1713113175,
+        "narHash": "sha256-E/WxD3Nh4kd3AYYLk8UyMnkUm9AMT3zUk/rBI4Qjk04=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a3a0937684767c4e16ab63694fa0dfb4007a28ce",
+        "rev": "90060445d9ee7b731c147b2caa53dc45d557bce9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`90060445`](https://github.com/nix-community/NUR/commit/90060445d9ee7b731c147b2caa53dc45d557bce9) | `` automatic update `` |