### PR TITLE
chore(flake/home-manager): `630a0992` -> `9f32c66a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713077896,
-        "narHash": "sha256-Noot8H0EZEAFRQWyGxh9ryvhK96xpIqKbh78X447JWs=",
+        "lastModified": 1713131281,
+        "narHash": "sha256-/Jm1X9MPfLXAxZSCdWmQAFNUQggEfNWHol5jSyyzFzw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "630a0992b3627c64e34f179fab68e3d48c6991c0",
+        "rev": "9f32c66a51d05e6d4ec0dea555bbff9135749ec7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`9f32c66a`](https://github.com/nix-community/home-manager/commit/9f32c66a51d05e6d4ec0dea555bbff9135749ec7) | `` k9s: configuration files in Darwin without XDG `` |
| [`76a1650c`](https://github.com/nix-community/home-manager/commit/76a1650c45df8ed130e66eeeb8275a149562c4c5) | `` k9s: fix typos in configuration file names ``     |