### PR TITLE
chore(flake/emacs-overlay): `f92b1cf3` -> `1cc0a115`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713133980,
-        "narHash": "sha256-fGpgQoMyuLbS/r3FkZ59ISNI3Oo148tEMlKJpnmCI7w=",
+        "lastModified": 1713136826,
+        "narHash": "sha256-BDcBWsluWFUyyb40MP7F7qkO7X3O0mas5Sh9Fz0hyVo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f92b1cf3105eb9eab992e585861a762ad8cb0037",
+        "rev": "1cc0a11542f4feba8430a001b20c2c0151978706",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`1cc0a115`](https://github.com/nix-community/emacs-overlay/commit/1cc0a11542f4feba8430a001b20c2c0151978706) | `` Updated emacs `` |
| [`3b158dc7`](https://github.com/nix-community/emacs-overlay/commit/3b158dc76f3bb67ee9f32bb9bb15571d7ea2074c) | `` Updated melpa `` |