### PR TITLE
chore(flake/nur): `0696e958` -> `81077cea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713152776,
-        "narHash": "sha256-2UaJv/QxXAFLBz0SabhSYPlJZ4Nkrcg194eN3Wqb1IE=",
+        "lastModified": 1713154014,
+        "narHash": "sha256-BpXKuSIkb6J3ie+4Otngi6pfDYfDtiSJMi9hwaFCWG4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0696e958410b29969da73549ca9bd5759a98ca11",
+        "rev": "81077cea6c14a22361f8b8f5f46e614a4bb43a1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`81077cea`](https://github.com/nix-community/NUR/commit/81077cea6c14a22361f8b8f5f46e614a4bb43a1f) | `` automatic update `` |