### PR TITLE
chore(flake/nur): `81077cea` -> `92535740`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713154014,
-        "narHash": "sha256-BpXKuSIkb6J3ie+4Otngi6pfDYfDtiSJMi9hwaFCWG4=",
+        "lastModified": 1713155537,
+        "narHash": "sha256-PRq9nCMwkR1JXH7Lalj0HtKD6xmirKcYX1I6/bn4u4A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "81077cea6c14a22361f8b8f5f46e614a4bb43a1f",
+        "rev": "925357404770acfe89fb96e5fa52b3bc7d56fd99",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`92535740`](https://github.com/nix-community/NUR/commit/925357404770acfe89fb96e5fa52b3bc7d56fd99) | `` automatic update `` |
| [`62eb19e9`](https://github.com/nix-community/NUR/commit/62eb19e9635beb1baca846d1f04c2d9579382466) | `` automatic update `` |