### PR TITLE
chore(flake/nur): `bd73240b` -> `54c92e55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713161802,
-        "narHash": "sha256-jn3liafRwxUlqeimoof+Vz0NPLpUfhMmr+dQSA/lh0U=",
+        "lastModified": 1713167892,
+        "narHash": "sha256-tRKL0quH3MRi8Y5yCIGveMvOkLCUVL6cbp6jWX9BaEY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bd73240bff825d7fa7001eda864265399c6486b1",
+        "rev": "54c92e5501afca7f839de0ff029b8f183b9f76c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`54c92e55`](https://github.com/nix-community/NUR/commit/54c92e5501afca7f839de0ff029b8f183b9f76c3) | `` automatic update `` |
| [`93bc3437`](https://github.com/nix-community/NUR/commit/93bc34375e392358f7b9b5ed0b1434627681d95d) | `` automatic update `` |
| [`55b803d1`](https://github.com/nix-community/NUR/commit/55b803d19b9e7ad8bcc8fa4013d442916099dae2) | `` automatic update `` |