### PR TITLE
chore(flake/nur): `54c92e55` -> `9519c9c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713167892,
-        "narHash": "sha256-tRKL0quH3MRi8Y5yCIGveMvOkLCUVL6cbp6jWX9BaEY=",
+        "lastModified": 1713174335,
+        "narHash": "sha256-19d549SdSw+zxRkwRH8LvzVYUndSoY+cPm6W1sSeK48=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "54c92e5501afca7f839de0ff029b8f183b9f76c3",
+        "rev": "9519c9c5b0d44206b7b4fc07e33c8e8a528e00ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9519c9c5`](https://github.com/nix-community/NUR/commit/9519c9c5b0d44206b7b4fc07e33c8e8a528e00ee) | `` automatic update `` |
| [`176d335e`](https://github.com/nix-community/NUR/commit/176d335eaf1562de6dad71af2e850b2897c7a69e) | `` automatic update `` |