### PR TITLE
chore(flake/nur): `9519c9c5` -> `8ef331b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713174335,
-        "narHash": "sha256-19d549SdSw+zxRkwRH8LvzVYUndSoY+cPm6W1sSeK48=",
+        "lastModified": 1713181542,
+        "narHash": "sha256-Q7T+eTTVpwVkStBWM0swCfpuEInA0w7Nf8jSiqqSb/I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9519c9c5b0d44206b7b4fc07e33c8e8a528e00ee",
+        "rev": "8ef331b6e34f122df5930947280bdd153bab48de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8ef331b6`](https://github.com/nix-community/NUR/commit/8ef331b6e34f122df5930947280bdd153bab48de) | `` automatic update `` |
| [`8abf694d`](https://github.com/nix-community/NUR/commit/8abf694d334a030ac65b20f0257ce70fb46fde8b) | `` automatic update `` |
| [`45df440d`](https://github.com/nix-community/NUR/commit/45df440d252b32dbce56cf46f2b4ca024a1f00a5) | `` automatic update `` |