### PR TITLE
chore(flake/nur): `5a7aaebb` -> `350786d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713184705,
-        "narHash": "sha256-1trMJty4RsRsqqWPzIA+IXGLwb/cPdBDGviAPeWKOXA=",
+        "lastModified": 1713191582,
+        "narHash": "sha256-EVQFfDGs90kmfRSx0TJTG9dkIOowcPnLUv4r6CnGrhs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5a7aaebb2fa6569366e789a0252f33ba13bb7373",
+        "rev": "350786d9b873228ca1ccdcefd0354f8d7bed5999",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`350786d9`](https://github.com/nix-community/NUR/commit/350786d9b873228ca1ccdcefd0354f8d7bed5999) | `` automatic update `` |