### PR TITLE
chore(flake/emacs-overlay): `61264683` -> `cf218237`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713171039,
-        "narHash": "sha256-9QrWi1VqMafXPAWw126uWRn56MtwzokNxDevSTjeQ/U=",
+        "lastModified": 1713200735,
+        "narHash": "sha256-6qPfZsYW3BvyJq+BahgygLdFd5bdqrFue8QGat4lSQo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "612646835968f663fd0e8f1a21ef52b5d0b88c57",
+        "rev": "cf218237d0d80f1ec8109677ebc82ded2ca84c43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`cf218237`](https://github.com/nix-community/emacs-overlay/commit/cf218237d0d80f1ec8109677ebc82ded2ca84c43) | `` Updated emacs `` |
| [`ef7430cd`](https://github.com/nix-community/emacs-overlay/commit/ef7430cdf20c9d82d75ca9331ecc0f8f3115da3c) | `` Updated melpa `` |
| [`5e8cb839`](https://github.com/nix-community/emacs-overlay/commit/5e8cb83995ca355ebed239e66ec4b078f595a1b3) | `` Updated elpa ``  |