### PR TITLE
chore(flake/nur): `db8b64ad` -> `65d70de5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713203163,
-        "narHash": "sha256-4rlIUvisOlvcTLGFyxOSuL+KAMPOjv7yDSqyuSDsRzI=",
+        "lastModified": 1713210391,
+        "narHash": "sha256-3hCveQPMmr6eW3uz2jCBO/Fgctc2kTYsrGrnpDq6Xps=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "db8b64ad4fe5d393dc7182b0bb0e5ade1a98471d",
+        "rev": "65d70de5b2cf84cbba108422e9b79d8b57c58959",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`65d70de5`](https://github.com/nix-community/NUR/commit/65d70de5b2cf84cbba108422e9b79d8b57c58959) | `` automatic update `` |
| [`92e8f695`](https://github.com/nix-community/NUR/commit/92e8f6959e0d8632f80c84b71849c6fe2bd610fe) | `` automatic update `` |
| [`40cc1ee6`](https://github.com/nix-community/NUR/commit/40cc1ee67ef352673abab33de12adb84110e6d91) | `` automatic update `` |