### PR TITLE
chore(flake/emacs-overlay): `cf218237` -> `bcd935f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713200735,
-        "narHash": "sha256-6qPfZsYW3BvyJq+BahgygLdFd5bdqrFue8QGat4lSQo=",
+        "lastModified": 1713229100,
+        "narHash": "sha256-g32puJ6BxWx4wbJVPn3O9gBCLAW4cfpBSMy/PHJMRAk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cf218237d0d80f1ec8109677ebc82ded2ca84c43",
+        "rev": "bcd935f930b6b673170331e484426cfeefc06e0d",
         "type": "github"
       },
       "original": {
@@ -710,11 +710,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1713013257,
-        "narHash": "sha256-ZEfGB3YCBVggvk0BQIqVY7J8XF/9jxQ68fCca6nib+8=",
+        "lastModified": 1713145326,
+        "narHash": "sha256-m7+IWM6mkWOg22EC5kRUFCycXsXLSU7hWmHdmBfmC3s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "90055d5e616bd943795d38808c94dbf0dd35abe8",
+        "rev": "53a2c32bc66f5ae41a28d7a9a49d321172af621e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`bcd935f9`](https://github.com/nix-community/emacs-overlay/commit/bcd935f930b6b673170331e484426cfeefc06e0d) | `` Updated elpa ``         |
| [`86d9b02f`](https://github.com/nix-community/emacs-overlay/commit/86d9b02f8d928ea1c27bcf421ec685df5e68c6bb) | `` Updated flake inputs `` |