### PR TITLE
chore(flake/nur): `d74371d2` -> `c7a2f8c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713217470,
-        "narHash": "sha256-fsDAxXSacvYwtvT55tT7MVZzudsBcf/mtSVBfbl6Zjc=",
+        "lastModified": 1713232370,
+        "narHash": "sha256-/NNIjHyK8q9LQaxm2TstyYCTvcjFdSW2zzJx5l8qLM8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d74371d2183243d37aa711a6cbdb33375398b9ad",
+        "rev": "c7a2f8c9ad3a6abcc43359bfcf609e9e0ae3a6bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c7a2f8c9`](https://github.com/nix-community/NUR/commit/c7a2f8c9ad3a6abcc43359bfcf609e9e0ae3a6bb) | `` automatic update `` |
| [`12973923`](https://github.com/nix-community/NUR/commit/129739236c7c077de5b0080aaf3559e432cfdc11) | `` automatic update `` |