### PR TITLE
chore(flake/emacs-overlay): `bcd935f9` -> `0eb7c2ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713229100,
-        "narHash": "sha256-g32puJ6BxWx4wbJVPn3O9gBCLAW4cfpBSMy/PHJMRAk=",
+        "lastModified": 1713232069,
+        "narHash": "sha256-kDZm1y2PGoH5WTUspKiPT+QTHyRNXxLEkXLY3KzK9Z8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bcd935f930b6b673170331e484426cfeefc06e0d",
+        "rev": "0eb7c2ed361b74817364818fc0289eb44208e76a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`0eb7c2ed`](https://github.com/nix-community/emacs-overlay/commit/0eb7c2ed361b74817364818fc0289eb44208e76a) | `` Updated emacs `` |
| [`35f1a712`](https://github.com/nix-community/emacs-overlay/commit/35f1a712b49b07233a8aa29823ca9f0bf1adb11e) | `` Updated melpa `` |