### PR TITLE
chore(flake/nur): `c7a2f8c9` -> `64f646e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713232370,
-        "narHash": "sha256-/NNIjHyK8q9LQaxm2TstyYCTvcjFdSW2zzJx5l8qLM8=",
+        "lastModified": 1713236082,
+        "narHash": "sha256-8GizEKw2fFqldXqzJQYFYQKc8uc6grdcYS2aPwnA/yo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c7a2f8c9ad3a6abcc43359bfcf609e9e0ae3a6bb",
+        "rev": "64f646e5906905dea956ef7a25b59fd74af375e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`64f646e5`](https://github.com/nix-community/NUR/commit/64f646e5906905dea956ef7a25b59fd74af375e7) | `` automatic update `` |
| [`b29a23dc`](https://github.com/nix-community/NUR/commit/b29a23dcde8f72366ed363609384f57080e87170) | `` automatic update `` |