### PR TITLE
chore(flake/nur): `64f646e5` -> `bb2c4db7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713236082,
-        "narHash": "sha256-8GizEKw2fFqldXqzJQYFYQKc8uc6grdcYS2aPwnA/yo=",
+        "lastModified": 1713243003,
+        "narHash": "sha256-g87AO6jZbZpUATYWlMKKgDkeWdmqTh/sJK3c1sG1IBs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "64f646e5906905dea956ef7a25b59fd74af375e7",
+        "rev": "bb2c4db7251ef19593291f4103b88e05bdc811d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bb2c4db7`](https://github.com/nix-community/NUR/commit/bb2c4db7251ef19593291f4103b88e05bdc811d3) | `` automatic update `` |
| [`a3a5fc55`](https://github.com/nix-community/NUR/commit/a3a5fc555324bfe3a97957eef7eeda68cd31e51d) | `` automatic update `` |
| [`fef08996`](https://github.com/nix-community/NUR/commit/fef089967f04788b7bb24efdc91685c97223f8c1) | `` automatic update `` |
| [`e19d8367`](https://github.com/nix-community/NUR/commit/e19d83674f5e26d3f6e988d22516b74280ebbdef) | `` automatic update `` |
| [`6f0b77ba`](https://github.com/nix-community/NUR/commit/6f0b77baa28cde7694794ae89d3bb039ae616c7b) | `` automatic update `` |
| [`7c5ee9fe`](https://github.com/nix-community/NUR/commit/7c5ee9feb465c754fbd7c779ef150d819c895e33) | `` automatic update `` |
| [`a597cafa`](https://github.com/nix-community/NUR/commit/a597cafafd0085a3bec1f1b8f0b40bfd46cda28f) | `` automatic update `` |
| [`053320ac`](https://github.com/nix-community/NUR/commit/053320ac9dee1176cb1904702d57c6ecf2bfbbcf) | `` automatic update `` |
| [`e586687e`](https://github.com/nix-community/NUR/commit/e586687ee8cac93cb1fa3306b55504a1e4cb401e) | `` automatic update `` |
| [`0106430d`](https://github.com/nix-community/NUR/commit/0106430d7928f9da63fb082364e4d4c416abbf0e) | `` automatic update `` |
| [`d70fb9ee`](https://github.com/nix-community/NUR/commit/d70fb9ee0b8f08e7ca91af16633508bd9ba9dca9) | `` automatic update `` |