### PR TITLE
chore(flake/nur): `bb2c4db7` -> `f7ce5b8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713243003,
-        "narHash": "sha256-g87AO6jZbZpUATYWlMKKgDkeWdmqTh/sJK3c1sG1IBs=",
+        "lastModified": 1713246771,
+        "narHash": "sha256-PFI5lnPZWkQ+uFRdNc6gV8oUdUStMVtgkwWMnEF0Zqk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bb2c4db7251ef19593291f4103b88e05bdc811d3",
+        "rev": "f7ce5b8a7905c09faf7f5373fa8c3accfe2d80e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f7ce5b8a`](https://github.com/nix-community/NUR/commit/f7ce5b8a7905c09faf7f5373fa8c3accfe2d80e9) | `` automatic update `` |
| [`acc080c4`](https://github.com/nix-community/NUR/commit/acc080c46e3d09ec80307ff771e94cdfc239d37a) | `` automatic update `` |