### PR TITLE
chore(flake/nur): `f7ce5b8a` -> `68f9962b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713246771,
-        "narHash": "sha256-PFI5lnPZWkQ+uFRdNc6gV8oUdUStMVtgkwWMnEF0Zqk=",
+        "lastModified": 1713248271,
+        "narHash": "sha256-WxLkyL0mcjn4L8nAuk1J3xj4ahQi4WZ059wXKYGjAVQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f7ce5b8a7905c09faf7f5373fa8c3accfe2d80e9",
+        "rev": "68f9962bf0c4f4086cff04e79515c833ac63ab6e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`68f9962b`](https://github.com/nix-community/NUR/commit/68f9962bf0c4f4086cff04e79515c833ac63ab6e) | `` automatic update `` |
| [`cccffdb3`](https://github.com/nix-community/NUR/commit/cccffdb3116b50b77a6860a42ec9b4cb344512ee) | `` automatic update `` |