### PR TITLE
chore(flake/nur): `68f9962b` -> `075f47a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713248271,
-        "narHash": "sha256-WxLkyL0mcjn4L8nAuk1J3xj4ahQi4WZ059wXKYGjAVQ=",
+        "lastModified": 1713253866,
+        "narHash": "sha256-l8VIEmu7DQ8out+kRApgi3OLq1Su/IZzMu0YNU6ROjk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "68f9962bf0c4f4086cff04e79515c833ac63ab6e",
+        "rev": "075f47a2e6c1c71597aa7c6fc0d70de89237be5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                             |
| -------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`075f47a2`](https://github.com/nix-community/NUR/commit/075f47a2e6c1c71597aa7c6fc0d70de89237be5e) | `` automatic update ``              |
| [`a1074678`](https://github.com/nix-community/NUR/commit/a1074678fa508cbf9c8d638921ebe0857c368106) | `` automatic update ``              |
| [`48fcfae3`](https://github.com/nix-community/NUR/commit/48fcfae33d072445a1d6b8fa209fa8565da697b3) | `` cleanup repos that return 404 `` |
| [`eaba6e5c`](https://github.com/nix-community/NUR/commit/eaba6e5cf25c323bf1c9cff29cf8d5a79933bbdc) | `` automatic update ``              |
| [`f2104959`](https://github.com/nix-community/NUR/commit/f21049590799c3270727ee76756b3cd75ff9c2d9) | `` automatic update ``              |
| [`cdf9509b`](https://github.com/nix-community/NUR/commit/cdf9509b5b1483c9bac582539ed11957ea8a8096) | `` add whs repository ``            |
| [`3f4a1154`](https://github.com/nix-community/NUR/commit/3f4a1154bd9cdf491620c74ce6658a07a9e55904) | `` automatic update ``              |
| [`d8a1a63f`](https://github.com/nix-community/NUR/commit/d8a1a63fe665fe2ab4fd39fc41e750bd6373e532) | `` automatic update ``              |