### PR TITLE
chore(flake/emacs-overlay): `e8fd7616` -> `433c5449`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713257603,
-        "narHash": "sha256-kDG9p0XU9GlFj7mEwujfdDsVz8VA1dy7cMFlk6Cb9P8=",
+        "lastModified": 1713258374,
+        "narHash": "sha256-Zi/Iu6uKH9KR1wnd1Ll+5nNQch4Vo2rSaoEJ3oObnv8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e8fd7616e8b998a5835755dbc7c963fe66967565",
+        "rev": "433c54490f99473a5fb9d41e857044a62ffa9baf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`433c5449`](https://github.com/nix-community/emacs-overlay/commit/433c54490f99473a5fb9d41e857044a62ffa9baf) | `` Updated emacs `` |