### PR TITLE
chore(flake/nur): `e35123da` -> `0bff3c35`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713259065,
-        "narHash": "sha256-I3kPk3HC5lABiqU1RW/GdYWeT71D0Krf67UxWZwTeEE=",
+        "lastModified": 1713267893,
+        "narHash": "sha256-HMHYHrQRCOVhYSfKbIpa3fLNcTjE6mH2jO2xnSHrTQw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e35123dabb4f386c4044555979ef1a1dabc8e56c",
+        "rev": "0bff3c351235a87ea3e9b1d271cb6abbc6b82216",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0bff3c35`](https://github.com/nix-community/NUR/commit/0bff3c351235a87ea3e9b1d271cb6abbc6b82216) | `` automatic update `` |
| [`dd997d3e`](https://github.com/nix-community/NUR/commit/dd997d3e9be7b526b7e567a70b78c0e09db89062) | `` automatic update `` |