### PR TITLE
chore(flake/nur): `0bff3c35` -> `af731823`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713267893,
-        "narHash": "sha256-HMHYHrQRCOVhYSfKbIpa3fLNcTjE6mH2jO2xnSHrTQw=",
+        "lastModified": 1713274099,
+        "narHash": "sha256-7Y/0iVsaswxW4YTn8s5kuIQzuPq7Q/JWiQJbonW3CpA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0bff3c351235a87ea3e9b1d271cb6abbc6b82216",
+        "rev": "af731823f6b440f86e4229ecbaedb887db53a1d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`af731823`](https://github.com/nix-community/NUR/commit/af731823f6b440f86e4229ecbaedb887db53a1d8) | `` automatic update `` |