### PR TITLE
chore(flake/emacs-overlay): `433c5449` -> `502906af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713258374,
-        "narHash": "sha256-Zi/Iu6uKH9KR1wnd1Ll+5nNQch4Vo2rSaoEJ3oObnv8=",
+        "lastModified": 1713287188,
+        "narHash": "sha256-LpbYsViVHQ19Qyjw4FxlTWcZNSbiagMfPMrUBuDVTBk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "433c54490f99473a5fb9d41e857044a62ffa9baf",
+        "rev": "502906af674eae890790ec48cad959d42dc2f040",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`502906af`](https://github.com/nix-community/emacs-overlay/commit/502906af674eae890790ec48cad959d42dc2f040) | `` Updated emacs `` |
| [`10b148d3`](https://github.com/nix-community/emacs-overlay/commit/10b148d3b245cd8abf3064c9ed4470125b0d5816) | `` Updated melpa `` |
| [`63221ee3`](https://github.com/nix-community/emacs-overlay/commit/63221ee331da17e5c14e6682224218573bdc3951) | `` Updated elpa ``  |