### PR TITLE
chore(flake/nur): `03393894` -> `89668a5c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713296703,
-        "narHash": "sha256-D2LrIpCT28CaZkDGmzmbepiaRost1VuXtPAYc/l+ncQ=",
+        "lastModified": 1713303955,
+        "narHash": "sha256-sVlPheZtFbvEIU4lTKaQ1MNAfe6RSmqhQN6nk0rQmvc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "033938945c4c3496fab143e3168fd312e4eecbae",
+        "rev": "89668a5c7afbef83112a154f587eb07b8dfc0c0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`89668a5c`](https://github.com/nix-community/NUR/commit/89668a5c7afbef83112a154f587eb07b8dfc0c0c) | `` automatic update `` |
| [`7a55c815`](https://github.com/nix-community/NUR/commit/7a55c815d8ed61651e416b56e7f9cfc9a539c272) | `` automatic update `` |