### PR TITLE
chore(flake/emacs-overlay): `502906af` -> `32256276`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713287188,
-        "narHash": "sha256-LpbYsViVHQ19Qyjw4FxlTWcZNSbiagMfPMrUBuDVTBk=",
+        "lastModified": 1713315550,
+        "narHash": "sha256-V3mZtrlXso9H71Dbd+6j2CarVh/k2f9z6Z3TWbG5vH8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "502906af674eae890790ec48cad959d42dc2f040",
+        "rev": "32256276525e8cdc4e9ec285660acd5e7e26e4e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`32256276`](https://github.com/nix-community/emacs-overlay/commit/32256276525e8cdc4e9ec285660acd5e7e26e4e1) | `` Updated elpa ``         |
| [`d3c01e02`](https://github.com/nix-community/emacs-overlay/commit/d3c01e025103a7fc9a1946775e191a82cf3af4fa) | `` Updated nongnu ``       |
| [`dd5697cf`](https://github.com/nix-community/emacs-overlay/commit/dd5697cf3687ddc010b66b8eeecd43a144f5ed88) | `` Updated flake inputs `` |