### PR TITLE
chore(flake/nur): `89668a5c` -> `2019468c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713303955,
-        "narHash": "sha256-sVlPheZtFbvEIU4lTKaQ1MNAfe6RSmqhQN6nk0rQmvc=",
+        "lastModified": 1713318798,
+        "narHash": "sha256-0EU70UNeskvfpiyht66HMO52FLpEyi4mMCTNoXOwCJo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "89668a5c7afbef83112a154f587eb07b8dfc0c0c",
+        "rev": "2019468cdfc6d4a3ffc7627c06e2c0cae010d6d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2019468c`](https://github.com/nix-community/NUR/commit/2019468cdfc6d4a3ffc7627c06e2c0cae010d6d8) | `` automatic update `` |
| [`a81f21de`](https://github.com/nix-community/NUR/commit/a81f21de77d933c9f93d7d530486ed1d49192058) | `` automatic update `` |