### PR TITLE
chore(flake/emacs-overlay): `32256276` -> `68ed87aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713315550,
-        "narHash": "sha256-V3mZtrlXso9H71Dbd+6j2CarVh/k2f9z6Z3TWbG5vH8=",
+        "lastModified": 1713318396,
+        "narHash": "sha256-AgT6tQGmbAeF2AqnkYtwks1i6o2Z+cQz8WLd0DVfsEs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "32256276525e8cdc4e9ec285660acd5e7e26e4e1",
+        "rev": "68ed87aa28ef073f9e6a482977f07591aae61639",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`68ed87aa`](https://github.com/nix-community/emacs-overlay/commit/68ed87aa28ef073f9e6a482977f07591aae61639) | `` Updated emacs `` |
| [`b40ce49e`](https://github.com/nix-community/emacs-overlay/commit/b40ce49e63df574d5de122796e60ab8089e6ea78) | `` Updated melpa `` |