### PR TITLE
chore(flake/nur): `2019468c` -> `6c5c3b4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713318798,
-        "narHash": "sha256-0EU70UNeskvfpiyht66HMO52FLpEyi4mMCTNoXOwCJo=",
+        "lastModified": 1713325534,
+        "narHash": "sha256-FSzhe0WbYT9IFGNIQfcc/uA/1yjXZ8szq2/aO9hs7Vs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2019468cdfc6d4a3ffc7627c06e2c0cae010d6d8",
+        "rev": "6c5c3b4aec06a820f73bfeb52e3fa29870aa9294",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6c5c3b4a`](https://github.com/nix-community/NUR/commit/6c5c3b4aec06a820f73bfeb52e3fa29870aa9294) | `` automatic update `` |
| [`f86100e9`](https://github.com/nix-community/NUR/commit/f86100e96e7af3fe73294b9cd85bcaa1598687ae) | `` automatic update `` |
| [`f5c12729`](https://github.com/nix-community/NUR/commit/f5c127294e93ed97bd6d3cdd3c8b7ad61b923651) | `` automatic update `` |