### PR TITLE
chore(flake/nur): `6c5c3b4a` -> `8e56e24e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713325534,
-        "narHash": "sha256-FSzhe0WbYT9IFGNIQfcc/uA/1yjXZ8szq2/aO9hs7Vs=",
+        "lastModified": 1713327032,
+        "narHash": "sha256-4nObrbvhDDB3PmrmvZDD4SGPTqFsrmWcnIv4pI182zo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6c5c3b4aec06a820f73bfeb52e3fa29870aa9294",
+        "rev": "8e56e24e032317cce8683e4dc953f2eb9c9bb81e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8e56e24e`](https://github.com/nix-community/NUR/commit/8e56e24e032317cce8683e4dc953f2eb9c9bb81e) | `` automatic update `` |