### PR TITLE
chore(flake/nur): `91b1dd67` -> `4db887e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713340772,
-        "narHash": "sha256-47z29AhUnazawOxDSfRlpx+wm1Z3FLa3jNwSpXseQZE=",
+        "lastModified": 1713342586,
+        "narHash": "sha256-W+6xjlqwJ6ec4BrYsz+rU+S46CimL/yWgsztOzt1GKY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "91b1dd671486773d31ef137904bdac5fbf02e0f0",
+        "rev": "4db887e475761d3e04aabce861d147b0d0e928e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4db887e4`](https://github.com/nix-community/NUR/commit/4db887e475761d3e04aabce861d147b0d0e928e5) | `` automatic update `` |
| [`6bb5fc99`](https://github.com/nix-community/NUR/commit/6bb5fc99b448bb7d2dd9bd3e9fc94facba074592) | `` automatic update `` |