### PR TITLE
chore(flake/emacs-overlay): `68ed87aa` -> `03342208`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713318396,
-        "narHash": "sha256-AgT6tQGmbAeF2AqnkYtwks1i6o2Z+cQz8WLd0DVfsEs=",
+        "lastModified": 1713345229,
+        "narHash": "sha256-w+bJEnQfkbLacV4gh1DRu5dAA7pHm4KljYTVY33h4So=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "68ed87aa28ef073f9e6a482977f07591aae61639",
+        "rev": "0334220804cb13f86e1e7ba83b135c9fbffa9d89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`03342208`](https://github.com/nix-community/emacs-overlay/commit/0334220804cb13f86e1e7ba83b135c9fbffa9d89) | `` Updated emacs `` |
| [`50b2646a`](https://github.com/nix-community/emacs-overlay/commit/50b2646a6560eeb9119e66b22da87a3dce1e272a) | `` Updated melpa `` |