### PR TITLE
chore(flake/nur): `4db887e4` -> `8848aa88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713342586,
-        "narHash": "sha256-W+6xjlqwJ6ec4BrYsz+rU+S46CimL/yWgsztOzt1GKY=",
+        "lastModified": 1713347163,
+        "narHash": "sha256-ElGPXN2CwsBn/f8yQuRx9Xtplnu/xX3gkuc84QhRTtg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4db887e475761d3e04aabce861d147b0d0e928e5",
+        "rev": "8848aa88dc8b9cfe4e9129b7fa06f47f9f2f5dbc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8848aa88`](https://github.com/nix-community/NUR/commit/8848aa88dc8b9cfe4e9129b7fa06f47f9f2f5dbc) | `` automatic update `` |
| [`6a479646`](https://github.com/nix-community/NUR/commit/6a4796465a21ad68f75d57b3b76bceebb66ada59) | `` automatic update `` |