### PR TITLE
chore(flake/nur): `5bd3123a` -> `8023efed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713352820,
-        "narHash": "sha256-mzb8+b8PVB7NddSQc/t4KkMgTXMpAwSfCS1Zr38jZfY=",
+        "lastModified": 1713358435,
+        "narHash": "sha256-dRS2ZdEc6AePUtoBSx+TE3hEPVz5AA3lMGAWsgHxpEg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5bd3123a7748d23e80a28ca9b16e144f974c4400",
+        "rev": "8023efed4279d77656e4da3520541521acfd68a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8023efed`](https://github.com/nix-community/NUR/commit/8023efed4279d77656e4da3520541521acfd68a7) | `` automatic update `` |
| [`edc3aaeb`](https://github.com/nix-community/NUR/commit/edc3aaeb8e37a1a1e362d1304b5c6ab8a46dd3e6) | `` automatic update `` |
| [`058d482c`](https://github.com/nix-community/NUR/commit/058d482c001f37d47e96d95a7a919515867da0df) | `` automatic update `` |