### PR TITLE
chore(flake/nur): `8023efed` -> `d09f7faa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713358435,
-        "narHash": "sha256-dRS2ZdEc6AePUtoBSx+TE3hEPVz5AA3lMGAWsgHxpEg=",
+        "lastModified": 1713360407,
+        "narHash": "sha256-xsKZVa8vGFAtx2aj0qo27QTWFOkge7a2MS0rZadugEE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8023efed4279d77656e4da3520541521acfd68a7",
+        "rev": "d09f7faa1286e9f64afeeebb9f917783baa3218b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d09f7faa`](https://github.com/nix-community/NUR/commit/d09f7faa1286e9f64afeeebb9f917783baa3218b) | `` automatic update `` |