### PR TITLE
chore(flake/nur): `d09f7faa` -> `9b0f500e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713360407,
-        "narHash": "sha256-xsKZVa8vGFAtx2aj0qo27QTWFOkge7a2MS0rZadugEE=",
+        "lastModified": 1713365147,
+        "narHash": "sha256-ZOPpV7NGnY0wd49vAuXWPYyNA+n3XbuAnlZ7NwXHyrU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d09f7faa1286e9f64afeeebb9f917783baa3218b",
+        "rev": "9b0f500e19055bdb94942c5dde758301e8f4ea13",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9b0f500e`](https://github.com/nix-community/NUR/commit/9b0f500e19055bdb94942c5dde758301e8f4ea13) | `` automatic update `` |