### PR TITLE
chore(flake/nur): `9b0f500e` -> `697a6d1e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713365147,
-        "narHash": "sha256-ZOPpV7NGnY0wd49vAuXWPYyNA+n3XbuAnlZ7NwXHyrU=",
+        "lastModified": 1713378668,
+        "narHash": "sha256-bVAtjhMGtb5GNIFOeYxJ+svisaqRmDjNYK1EfOqPNnE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9b0f500e19055bdb94942c5dde758301e8f4ea13",
+        "rev": "697a6d1e583326d1f3ba1b1cf3f168c1ea6c68ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`697a6d1e`](https://github.com/nix-community/NUR/commit/697a6d1e583326d1f3ba1b1cf3f168c1ea6c68ee) | `` automatic update `` |
| [`ef7598dd`](https://github.com/nix-community/NUR/commit/ef7598dd6058fcc906b250271ad8ab37df8e3004) | `` automatic update `` |