### PR TITLE
chore(flake/emacs-overlay): `03342208` -> `208d00a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713345229,
-        "narHash": "sha256-w+bJEnQfkbLacV4gh1DRu5dAA7pHm4KljYTVY33h4So=",
+        "lastModified": 1713373570,
+        "narHash": "sha256-+ZtrHsUp8vEbQ9FFTj+4ku7byW/ly1JVNqgdiNVBMis=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0334220804cb13f86e1e7ba83b135c9fbffa9d89",
+        "rev": "208d00a7f96d920a153ab90f257357e1aa1d6d77",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`208d00a7`](https://github.com/nix-community/emacs-overlay/commit/208d00a7f96d920a153ab90f257357e1aa1d6d77) | `` Updated emacs `` |
| [`68b08d5c`](https://github.com/nix-community/emacs-overlay/commit/68b08d5cd11d3c005f017ca2199c5164362d26d1) | `` Updated melpa `` |
| [`57295046`](https://github.com/nix-community/emacs-overlay/commit/57295046afe433216a389f73b1bcd351de852842) | `` Updated elpa ``  |