### PR TITLE
chore(flake/srvos): `bed9cfce` -> `e1c34f2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -787,11 +787,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712943026,
-        "narHash": "sha256-x2PaFsoZjqm2mC8dbUbv93to8H7wAruauluOH81lzA8=",
+        "lastModified": 1713373578,
+        "narHash": "sha256-z0kgb26kvd+VCTyfFkI1ZVE2VGnSfr4KZ6Bo9bKBi1E=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "bed9cfce2adc4c72de9bc90656d5cfe66e4371f3",
+        "rev": "e1c34f2d9f826054a1ba002dfa4332e7e80a3f56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                         |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`a5cc8d86`](https://github.com/nix-community/srvos/commit/a5cc8d86c4d64d546d962d25869801919a7a5a3f) | `` enable multicast dns for desktop machines `` |