### PR TITLE
chore(flake/nur): `697a6d1e` -> `bd2a5ebb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713378668,
-        "narHash": "sha256-bVAtjhMGtb5GNIFOeYxJ+svisaqRmDjNYK1EfOqPNnE=",
+        "lastModified": 1713390335,
+        "narHash": "sha256-QLbpgSuLhYDA6fUkq8feipjXNl1PhYpJHTExbeWhAbw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "697a6d1e583326d1f3ba1b1cf3f168c1ea6c68ee",
+        "rev": "bd2a5ebb231e088faed528665725fedad97ded60",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bd2a5ebb`](https://github.com/nix-community/NUR/commit/bd2a5ebb231e088faed528665725fedad97ded60) | `` automatic update `` |
| [`a95d3d24`](https://github.com/nix-community/NUR/commit/a95d3d2483ec724733e6b2e7116e05f689218d8a) | `` automatic update `` |
| [`ef29b23b`](https://github.com/nix-community/NUR/commit/ef29b23b1f7d8ee5da5c020d38782ba9b7543ddc) | `` automatic update `` |