### PR TITLE
chore(flake/nur): `bd2a5ebb` -> `4ad8d319`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713390335,
-        "narHash": "sha256-QLbpgSuLhYDA6fUkq8feipjXNl1PhYpJHTExbeWhAbw=",
+        "lastModified": 1713397476,
+        "narHash": "sha256-diQgHHp5CqyeWgSP0ZkZsI2JoL/bC5ThpgzoniciBd4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bd2a5ebb231e088faed528665725fedad97ded60",
+        "rev": "4ad8d3196f10b99306bac75c29fae4d204fef580",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4ad8d319`](https://github.com/nix-community/NUR/commit/4ad8d3196f10b99306bac75c29fae4d204fef580) | `` automatic update `` |
| [`d503d88d`](https://github.com/nix-community/NUR/commit/d503d88d5029ad94b6ed8832efcd38f5332279b8) | `` automatic update `` |