### PR TITLE
chore(flake/nur): `4ad8d319` -> `016ef05d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713397476,
-        "narHash": "sha256-diQgHHp5CqyeWgSP0ZkZsI2JoL/bC5ThpgzoniciBd4=",
+        "lastModified": 1713404236,
+        "narHash": "sha256-zX0Fazk44H0w/znS/5mjgl4zQCLVn9d5iAsBfDw7l6o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ad8d3196f10b99306bac75c29fae4d204fef580",
+        "rev": "016ef05d61660d391c90ec45c764f1899e939de9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`016ef05d`](https://github.com/nix-community/NUR/commit/016ef05d61660d391c90ec45c764f1899e939de9) | `` automatic update `` |
| [`4c311a66`](https://github.com/nix-community/NUR/commit/4c311a66b26d6ada31723e2473b1b67e0631ecb5) | `` automatic update `` |
| [`504a4ff8`](https://github.com/nix-community/NUR/commit/504a4ff8c33d7c846fc52786bb1e4c0c64e6717b) | `` automatic update `` |