### PR TITLE
chore(flake/srvos): `e1c34f2d` -> `937ddb11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -787,11 +787,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713373578,
-        "narHash": "sha256-z0kgb26kvd+VCTyfFkI1ZVE2VGnSfr4KZ6Bo9bKBi1E=",
+        "lastModified": 1713401155,
+        "narHash": "sha256-OCk2pEINp0/ixFi5yncvEWuG7wj+JFT85/wsZGhOU1A=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "e1c34f2d9f826054a1ba002dfa4332e7e80a3f56",
+        "rev": "937ddb11d81d9706b26dc583cf41e65de771c346",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`937ddb11`](https://github.com/nix-community/srvos/commit/937ddb11d81d9706b26dc583cf41e65de771c346) | `` dev/private/flake.lock: Update `` |
| [`5e64806f`](https://github.com/nix-community/srvos/commit/5e64806f15efd8fb968d2730bc7410d259ad6b1e) | `` flake.lock: Update ``             |