### PR TITLE
chore(flake/emacs-overlay): `cd78b29e` -> `d925614f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713401880,
-        "narHash": "sha256-0q5KCiKBIHYQxk1tpv408gcJljE9nMiXm38Am+L7ufI=",
+        "lastModified": 1713404731,
+        "narHash": "sha256-8OEArL56tmnLTX5Zqt/I7xm3xfcjdZAbsOworvcy8Aw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cd78b29e11bd11d9569eb51d857e43b144deaf9d",
+        "rev": "d925614faac9750fcdba7072576b0ce366dd7229",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`d925614f`](https://github.com/nix-community/emacs-overlay/commit/d925614faac9750fcdba7072576b0ce366dd7229) | `` Updated emacs `` |
| [`d40c0689`](https://github.com/nix-community/emacs-overlay/commit/d40c0689b14e99cc930671008913e81bf7b73e62) | `` Updated melpa `` |