### PR TITLE
chore(flake/nur): `2a027ba6` -> `a59de117`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713417627,
-        "narHash": "sha256-hi4gBe6dJaKXoZ9f+39DibLzStmIxtTLrR7c1Ig8kYE=",
+        "lastModified": 1713423647,
+        "narHash": "sha256-PUU+doAMmL1dLYFEr53XpbVZa+CcxXzmtH+LIu9BZ3w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2a027ba6953bc4109b35360721509a3252011f30",
+        "rev": "a59de1172904d5c159eec3a8e94e2fe48e59e08e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a59de117`](https://github.com/nix-community/NUR/commit/a59de1172904d5c159eec3a8e94e2fe48e59e08e) | `` automatic update `` |
| [`3e25043f`](https://github.com/nix-community/NUR/commit/3e25043f372e21c2d0f8ee9b0e0b1b6c6b5bfe0b) | `` automatic update `` |
| [`45eb9426`](https://github.com/nix-community/NUR/commit/45eb9426545a7fdb1f3dbf3119b3a6fb3a52fbed) | `` automatic update `` |