### PR TITLE
chore(flake/nur): `a59de117` -> `8dc68058`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713423647,
-        "narHash": "sha256-PUU+doAMmL1dLYFEr53XpbVZa+CcxXzmtH+LIu9BZ3w=",
+        "lastModified": 1713427292,
+        "narHash": "sha256-IrkDVF7aFhXPpXcXwK0SokG8TS7X38SvQgLzT80VtKc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a59de1172904d5c159eec3a8e94e2fe48e59e08e",
+        "rev": "8dc68058f0336cf9b0e589dae88114a75cf18ef0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8dc68058`](https://github.com/nix-community/NUR/commit/8dc68058f0336cf9b0e589dae88114a75cf18ef0) | `` automatic update `` |
| [`1365b3bc`](https://github.com/nix-community/NUR/commit/1365b3bcb71fe55c75e5c0ccb7fb8a11d9ba826d) | `` automatic update `` |