### PR TITLE
chore(flake/nur): `8dc68058` -> `2d513974`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713427292,
-        "narHash": "sha256-IrkDVF7aFhXPpXcXwK0SokG8TS7X38SvQgLzT80VtKc=",
+        "lastModified": 1713447875,
+        "narHash": "sha256-Rt0atfugUthSe80Q7lZarPBZ3PUWrf+hYBccnag9OVw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8dc68058f0336cf9b0e589dae88114a75cf18ef0",
+        "rev": "2d5139740cf17b30b1a720d5b9e482005b36468e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2d513974`](https://github.com/nix-community/NUR/commit/2d5139740cf17b30b1a720d5b9e482005b36468e) | `` automatic update `` |
| [`8113691b`](https://github.com/nix-community/NUR/commit/8113691be04acba67b05ff6e387f7098aedb63dc) | `` automatic update `` |
| [`c1e287ba`](https://github.com/nix-community/NUR/commit/c1e287ba6b80d4a991f691b0bd64e05e74d5666b) | `` automatic update `` |
| [`3d973d4b`](https://github.com/nix-community/NUR/commit/3d973d4b8bf53bbb4089c170fd81dd7d46e5d40d) | `` automatic update `` |
| [`263715fe`](https://github.com/nix-community/NUR/commit/263715fe80866783b4158994de294e10cdc94d40) | `` automatic update `` |