### PR TITLE
chore(flake/sops-nix): `cc535d07` -> `a9795d19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -767,11 +767,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1713174909,
-        "narHash": "sha256-APoDs2GtzVrsE+Z9w72qpHzEtEDfuinWcNTN7zhwLxg=",
+        "lastModified": 1713428550,
+        "narHash": "sha256-bHWNcnnlVzd1ek7uHoQQzFEM5lqscijCOgcz1uU766w=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "cc535d07cbcdd562bcca418e475c7b1959cefa4b",
+        "rev": "a9795d1959fe17a38bc901323d25f4e70acef511",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                               |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`a9795d19`](https://github.com/Mic92/sops-nix/commit/a9795d1959fe17a38bc901323d25f4e70acef511) | `` home-manager: Change defaultSymlinkPath to "<xdg-config-home>/sops-nix/secrets" `` |
| [`74f03c1a`](https://github.com/Mic92/sops-nix/commit/74f03c1a517ed437da1c00c4ede2aee8bd337ea8) | `` Refuse age keyfile paths that are in the nix store ``                              |
| [`7f491112`](https://github.com/Mic92/sops-nix/commit/7f49111254333bda6881b0dfa8cf7d82fe305f93) | `` update vendorHash ``                                                               |
| [`3a30a388`](https://github.com/Mic92/sops-nix/commit/3a30a38816fbd79f9c2f3fcf9fb7904cf5b5d951) | `` Bump github.com/ProtonMail/go-crypto ``                                            |
| [`dacc9519`](https://github.com/Mic92/sops-nix/commit/dacc9519f5a45a8a32d64fe91ef13cb3f97b9f48) | `` home-manager: Include home.activation-script for linux similar to macos ``         |