### PR TITLE
chore(flake/nixos-hardware): `f2d364de` -> `6f976e53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -579,11 +579,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1713377320,
-        "narHash": "sha256-OrBm62B+X9jylr6cPgKc+5OSgF2PRW9IY0ARCOtURMY=",
+        "lastModified": 1713441075,
+        "narHash": "sha256-3GGeFsEO8ivD+TcDEqe4s/d0VLvMYGNDGtx0ZnBxkUs=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f2d364de6589f7a029624983593eafc3c4dac726",
+        "rev": "6f976e53752e5b9ab08f9a3b1b0b9c67815c9754",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                               |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`6f976e53`](https://github.com/NixOS/nixos-hardware/commit/6f976e53752e5b9ab08f9a3b1b0b9c67815c9754) | `` surface: linux-surface to 6.8.6 `` |
| [`699723a7`](https://github.com/NixOS/nixos-hardware/commit/699723a72878912a7f8ae4b18d57eea68836c0fa) | `` surface: linux-surface to 6.8.1 `` |