### PR TITLE
chore(flake/sops-nix): `ac538092` -> `b94c6edb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -767,11 +767,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1713439347,
-        "narHash": "sha256-bSCdPIzLadg4eHPt1CB9HQnqJ/SWG82y8A6wBGp8CQw=",
+        "lastModified": 1713457024,
+        "narHash": "sha256-31MpStyXedDL1fvuOvn6iz3JURSVShDtDVMyP1PTjtc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "ac538092be2723b68fd4ff75eba7684480451c8f",
+        "rev": "b94c6edbb8355756c53efc8ca3874c63622f287a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                  |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`b94c6edb`](https://github.com/Mic92/sops-nix/commit/b94c6edbb8355756c53efc8ca3874c63622f287a) | `` fix symlink directory not existing `` |
| [`6b259336`](https://github.com/Mic92/sops-nix/commit/6b259336bd009e8a056ea740e75e6ac95e0f0c1f) | `` Lint fixes (#539) ``                  |