### PR TITLE
chore(flake/nur): `2d513974` -> `c52b1eae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713447875,
-        "narHash": "sha256-Rt0atfugUthSe80Q7lZarPBZ3PUWrf+hYBccnag9OVw=",
+        "lastModified": 1713454509,
+        "narHash": "sha256-aCey0Tc3HkyrLkHcje4qdhhgs1Q/+FvKKImcTMvgQ8Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2d5139740cf17b30b1a720d5b9e482005b36468e",
+        "rev": "c52b1eaed7949111d926e3b4c111358a84b14ea2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c52b1eae`](https://github.com/nix-community/NUR/commit/c52b1eaed7949111d926e3b4c111358a84b14ea2) | `` automatic update `` |