### PR TITLE
chore(flake/nur): `c52b1eae` -> `207b646e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713454509,
-        "narHash": "sha256-aCey0Tc3HkyrLkHcje4qdhhgs1Q/+FvKKImcTMvgQ8Y=",
+        "lastModified": 1713458666,
+        "narHash": "sha256-Ci8/V9g8VGxLvOJEz9aljdT9T4kMBBPr2X3irV3+BuU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c52b1eaed7949111d926e3b4c111358a84b14ea2",
+        "rev": "207b646e74ca8a2f588b63b424d0bf6fc586defd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`207b646e`](https://github.com/nix-community/NUR/commit/207b646e74ca8a2f588b63b424d0bf6fc586defd) | `` automatic update `` |