### PR TITLE
chore(flake/nur): `a5db12f1` -> `832d6c6a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713462367,
-        "narHash": "sha256-kFs8J0xgdNMPjn6AxsMct6xOqCmqzpM50ok35qYSzec=",
+        "lastModified": 1713470487,
+        "narHash": "sha256-2aQfyH7DvmL49miGg7mYIQ751w/dvSwUfD/lKgolFw0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a5db12f1288b1147a44459380a829ab2fda792b0",
+        "rev": "832d6c6ae0cad32d1ec6088b66a7a089e78852c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`832d6c6a`](https://github.com/nix-community/NUR/commit/832d6c6ae0cad32d1ec6088b66a7a089e78852c3) | `` automatic update `` |
| [`b586468d`](https://github.com/nix-community/NUR/commit/b586468d13dffcdcbea58df461b91f47d5dfff5a) | `` automatic update `` |
| [`b316075b`](https://github.com/nix-community/NUR/commit/b316075b3373774cdc434e61d08ae16eb05dde14) | `` automatic update `` |
| [`f2d9bb6c`](https://github.com/nix-community/NUR/commit/f2d9bb6ccc759a2347711a544c87f799d3f1067d) | `` automatic update `` |
| [`0a00b61a`](https://github.com/nix-community/NUR/commit/0a00b61ab902d74ce5d9876e49870f6e6e50bea3) | `` automatic update `` |