### PR TITLE
chore(flake/nur): `832d6c6a` -> `13455a25`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713470487,
-        "narHash": "sha256-2aQfyH7DvmL49miGg7mYIQ751w/dvSwUfD/lKgolFw0=",
+        "lastModified": 1713471880,
+        "narHash": "sha256-LANZ2NK/5OlSbwjNuLaqd+Q0iCxAN5vBUt/+g0qLHvg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "832d6c6ae0cad32d1ec6088b66a7a089e78852c3",
+        "rev": "13455a253b4e890ae69925a7b554c660f63da85d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`13455a25`](https://github.com/nix-community/NUR/commit/13455a253b4e890ae69925a7b554c660f63da85d) | `` automatic update `` |