### PR TITLE
chore(flake/nur): `13455a25` -> `5e4c95de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713471880,
-        "narHash": "sha256-LANZ2NK/5OlSbwjNuLaqd+Q0iCxAN5vBUt/+g0qLHvg=",
+        "lastModified": 1713476130,
+        "narHash": "sha256-MhhsD7sg882csF2gcHXWABjJoS6kxs4LRWbIQzKDBIY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "13455a253b4e890ae69925a7b554c660f63da85d",
+        "rev": "5e4c95dea03ea0b78e477325a16e96e643cae78f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5e4c95de`](https://github.com/nix-community/NUR/commit/5e4c95dea03ea0b78e477325a16e96e643cae78f) | `` automatic update `` |