### PR TITLE
chore(flake/emacs-overlay): `925e7b36` -> `65297336`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713460029,
-        "narHash": "sha256-UwM5DAeSKEeGDT0vog2GspvVEmK2fsj6+K52XBIRTFY=",
+        "lastModified": 1713491175,
+        "narHash": "sha256-6fXEcCAzhWrouGPJeAmV7oN/Ur0XJtUgQKfA+TofoXU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "925e7b367814ff67e1e8cbf96835c0c68534a4ed",
+        "rev": "65297336c6db39d94adb8156d811d800b253fded",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`65297336`](https://github.com/nix-community/emacs-overlay/commit/65297336c6db39d94adb8156d811d800b253fded) | `` Updated emacs ``        |
| [`d2d351a8`](https://github.com/nix-community/emacs-overlay/commit/d2d351a80e5487cd45269ff5dfc6247c7478948c) | `` Updated melpa ``        |
| [`1457c4eb`](https://github.com/nix-community/emacs-overlay/commit/1457c4ebe76260189cd021766876b17ef13eadf3) | `` Updated elpa ``         |
| [`380de855`](https://github.com/nix-community/emacs-overlay/commit/380de855a8d44f009c50306ec9585c60a12371f8) | `` Updated nongnu ``       |
| [`e63c323f`](https://github.com/nix-community/emacs-overlay/commit/e63c323fdd81ca2a50542ed02eb3870a0f95c415) | `` Updated flake inputs `` |