### PR TITLE
chore(flake/darwin): `36524adc` -> `eb25dc61`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -220,11 +220,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711763326,
-        "narHash": "sha256-sXcesZWKXFlEQ8oyGHnfk4xc9f2Ip0X/+YZOq3sKviI=",
+        "lastModified": 1713492497,
+        "narHash": "sha256-FifiHvYmHL7BEOaQorHjHRaW3SJj2qYCdxUmCETAQl4=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "36524adc31566655f2f4d55ad6b875fb5c1a4083",
+        "rev": "eb25dc61a62efcdf47efce6cb17cd5cb3c8f2719",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                          |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`1098e60e`](https://github.com/LnL7/nix-darwin/commit/1098e60e92afc5e30611a3933ad783d99e198734) | `` ci, readme: update stable nixpkgs to 23.11 `` |
| [`81f7aab5`](https://github.com/LnL7/nix-darwin/commit/81f7aab5edf705d851415762d1bfe4fa836bbce7) | `` Update ShowDate in menuExtraClock ``          |