### PR TITLE
chore(flake/nur): `03d5417f` -> `ae3bac27`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713489381,
-        "narHash": "sha256-AU8AH8ZWVQYOA8H6S9yfHWyvRFdmlENSNFGHJc8nudw=",
+        "lastModified": 1713498342,
+        "narHash": "sha256-TB699eOW0bKFLenFDPUgV5nBr1bUkz6RRBVCITIje4w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "03d5417f8e59fd0adec838ca191bbd6265fd406b",
+        "rev": "ae3bac2732e982a9ef929c2a8b45f703c5008976",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ae3bac27`](https://github.com/nix-community/NUR/commit/ae3bac2732e982a9ef929c2a8b45f703c5008976) | `` automatic update `` |
| [`b94ce662`](https://github.com/nix-community/NUR/commit/b94ce662bb30272bd5c5640c234da02cdf109568) | `` automatic update `` |
| [`7aabdaa4`](https://github.com/nix-community/NUR/commit/7aabdaa4dcd88163e2556adfadecb86fc643bb2a) | `` automatic update `` |
| [`d0fb1a60`](https://github.com/nix-community/NUR/commit/d0fb1a6096b179fb1a56a8332b12ca6e6e77fed1) | `` automatic update `` |
| [`fe4733de`](https://github.com/nix-community/NUR/commit/fe4733de9e9d2754729ca9cf27400b200ab50665) | `` automatic update `` |
| [`75c54c0e`](https://github.com/nix-community/NUR/commit/75c54c0e695b78219aafed211858b02cfb885fc5) | `` automatic update `` |
| [`93c15283`](https://github.com/nix-community/NUR/commit/93c15283a14a9dfb25739b5fd9c81aeecddbe378) | `` automatic update `` |