### PR TITLE
chore(flake/nur): `ae3bac27` -> `6d4165c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713498342,
-        "narHash": "sha256-TB699eOW0bKFLenFDPUgV5nBr1bUkz6RRBVCITIje4w=",
+        "lastModified": 1713548116,
+        "narHash": "sha256-H/80JPGAkXvZSHd9RkL2p9jIHzWdZILkFCzq8AqnJ9c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ae3bac2732e982a9ef929c2a8b45f703c5008976",
+        "rev": "6d4165c4306a4166ce0cb39393fa9152f876840c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6d4165c4`](https://github.com/nix-community/NUR/commit/6d4165c4306a4166ce0cb39393fa9152f876840c) | `` automatic update `` |
| [`51331af1`](https://github.com/nix-community/NUR/commit/51331af1e52853d9a58e740f186b379230214c7e) | `` automatic update `` |
| [`c4428fb5`](https://github.com/nix-community/NUR/commit/c4428fb53f4532c42c0355deda2a41cd25155381) | `` automatic update `` |
| [`e16ee8a6`](https://github.com/nix-community/NUR/commit/e16ee8a64f1ab6bfbd54f24985141a0bd1243c29) | `` automatic update `` |
| [`d45c1e7e`](https://github.com/nix-community/NUR/commit/d45c1e7ed73dd6d3a8964b50ae2d047aa59a134e) | `` automatic update `` |
| [`488a54ce`](https://github.com/nix-community/NUR/commit/488a54ce2bd202390272f6a93cf282454b4a8c7b) | `` automatic update `` |
| [`09a84079`](https://github.com/nix-community/NUR/commit/09a8407960fdab24db6ee7aa8d3c4d2db7bd8e34) | `` automatic update `` |
| [`dcd51fcb`](https://github.com/nix-community/NUR/commit/dcd51fcb12e4c174165d5f6d8820fe815e9a7202) | `` automatic update `` |
| [`c7b78714`](https://github.com/nix-community/NUR/commit/c7b7871428af0cd10812cc68e2109ee4ad7d2857) | `` automatic update `` |
| [`7970cd0c`](https://github.com/nix-community/NUR/commit/7970cd0cf03c06634e965eba10d5702403d95687) | `` automatic update `` |
| [`a097cd74`](https://github.com/nix-community/NUR/commit/a097cd7439d5e5f1df066ae5cd2fbbbf01c605a1) | `` automatic update `` |
| [`4a6a14e3`](https://github.com/nix-community/NUR/commit/4a6a14e35f0b0f53470078452bbfdc1458de3f76) | `` automatic update `` |
| [`51746023`](https://github.com/nix-community/NUR/commit/517460237a8886a0b0b6f4b5782baa7bb5492c52) | `` automatic update `` |
| [`f1b49553`](https://github.com/nix-community/NUR/commit/f1b49553e38de35de77bf273f8531a0d7099566b) | `` automatic update `` |
| [`53be2a38`](https://github.com/nix-community/NUR/commit/53be2a38fe6b7eff84f216df1c9b17f88fa1eaa0) | `` automatic update `` |
| [`6bca0c9f`](https://github.com/nix-community/NUR/commit/6bca0c9f0da8fbc6ee69fca70c48fb0a993b855d) | `` automatic update `` |
| [`dbe5a2f2`](https://github.com/nix-community/NUR/commit/dbe5a2f2ada4ecde4c68b1bd8d6297676a231350) | `` automatic update `` |
| [`b373ce8d`](https://github.com/nix-community/NUR/commit/b373ce8d23b626e01271aaa059e27392d5bbef17) | `` automatic update `` |
| [`98acbd7c`](https://github.com/nix-community/NUR/commit/98acbd7c0168e21fb73dd3a45deee411f70ff678) | `` automatic update `` |
| [`6ea05593`](https://github.com/nix-community/NUR/commit/6ea055935bdf9ef1505ece3f42a4d92e42280e7b) | `` automatic update `` |