### PR TITLE
chore(flake/emacs-overlay): `65297336` -> `a8692d4e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713491175,
-        "narHash": "sha256-6fXEcCAzhWrouGPJeAmV7oN/Ur0XJtUgQKfA+TofoXU=",
+        "lastModified": 1713517520,
+        "narHash": "sha256-t59lpRo7EulX9J0/bc5/8cUEo7hl6z9YOYukzg54cyU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "65297336c6db39d94adb8156d811d800b253fded",
+        "rev": "a8692d4e570e93061d2bbe10af4a1590afe82e15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`a8692d4e`](https://github.com/nix-community/emacs-overlay/commit/a8692d4e570e93061d2bbe10af4a1590afe82e15) | `` Updated emacs `` |
| [`d66e33b9`](https://github.com/nix-community/emacs-overlay/commit/d66e33b94492c5e897729f1aac2094e618a5001a) | `` Updated melpa `` |