### PR TITLE
chore(flake/home-manager): `8ff7bb3f` -> `dc906b19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -471,11 +471,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713519169,
-        "narHash": "sha256-tfZMYmny9B5vDaDWaeelhbs7rVZ23cvX+JKDYxpUjbY=",
+        "lastModified": 1713529352,
+        "narHash": "sha256-gg4OWSysmjbuqfY9uTjQnhu1yKrRAv4Jxuz8jdyiK04=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8ff7bb3f4d82a05a52d5242ec454bba14f5d6cc6",
+        "rev": "dc906b197bc20c518e497fb040bb8240543fa634",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`dc906b19`](https://github.com/nix-community/home-manager/commit/dc906b197bc20c518e497fb040bb8240543fa634) | `` kdeconnect: require "tray.target" for kdeconnect ``        |
| [`0184c818`](https://github.com/nix-community/home-manager/commit/0184c8180f5cbb8e3a54a239b874fe849d3073cb) | `` neomutt: add some options ``                               |
| [`b1a5b3d6`](https://github.com/nix-community/home-manager/commit/b1a5b3d6a524c80c7dd20888bff227d52adf5f03) | `` vdirsyncer: set `postHook` to null when not set (#5294) `` |
| [`b62cad68`](https://github.com/nix-community/home-manager/commit/b62cad68b754224caec1e3b0dbadf86821b0b255) | `` spotify-player: add module ``                              |
| [`b5b2b1ac`](https://github.com/nix-community/home-manager/commit/b5b2b1ac63458357e205bcb2df2d0840a2acca13) | `` helix: add ignores option ``                               |