### PR TITLE
chore(flake/sops-nix): `6ef5c647` -> `a929a011`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -767,11 +767,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1713521745,
-        "narHash": "sha256-GGk7TTOTrw87fF7xPTB94ciqbwuIjcqOygntXgIsO38=",
+        "lastModified": 1713532771,
+        "narHash": "sha256-vfKxhYVMzG2tg48/1rewBoSLCrKIjQsG1j7Nm/Y2gf4=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "6ef5c647a4f38f5608a63fdc80a58bf772b11be8",
+        "rev": "a929a011a09db735abc45a8a45d1ff7fdee62755",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                           |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`a929a011`](https://github.com/Mic92/sops-nix/commit/a929a011a09db735abc45a8a45d1ff7fdee62755) | `` update vendorHash ``                           |
| [`d63d2a0f`](https://github.com/Mic92/sops-nix/commit/d63d2a0fdfcbd5e24d5a19e97cd1ed3d78b6418d) | `` Bump golang.org/x/net from 0.21.0 to 0.23.0 `` |