### PR TITLE
chore(flake/home-manager): `dc906b19` -> `938357cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -471,11 +471,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713529352,
-        "narHash": "sha256-gg4OWSysmjbuqfY9uTjQnhu1yKrRAv4Jxuz8jdyiK04=",
+        "lastModified": 1713547559,
+        "narHash": "sha256-zju60y4pyYQoRmqhbgkw+jwmKZReVsCNvb8mZxID2Do=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "dc906b197bc20c518e497fb040bb8240543fa634",
+        "rev": "938357cb234e85da37109df2cdd9cc59ab9c1cc0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`938357cb`](https://github.com/nix-community/home-manager/commit/938357cb234e85da37109df2cdd9cc59ab9c1cc0) | `` hyprland: remove enableNvidiaPatches option ``        |
| [`6a171bfd`](https://github.com/nix-community/home-manager/commit/6a171bfd84ee9b3df83f6eb76dab042219978439) | `` kconfig: add module ``                                |
| [`1f305c36`](https://github.com/nix-community/home-manager/commit/1f305c363ecd7c6505f03fc7baba15505f3aa630) | `` remmina: add module ``                                |
| [`31c77dcc`](https://github.com/nix-community/home-manager/commit/31c77dcc2e4b6b9f73df0e7eaa89536f175954e8) | `` sway: systemd customization ``                        |
| [`068dd4ae`](https://github.com/nix-community/home-manager/commit/068dd4ae292b5bf64bda18a48bcd80f39dd76257) | `` alacritty: cleanup after 0.13 merge in nixpkgs ``     |
| [`7ca7025c`](https://github.com/nix-community/home-manager/commit/7ca7025cf2fa88bebc2190955c44263c3989b706) | `` alacritty: fix escape sequence in example and test `` |