### PR TITLE
chore(flake/emacs-overlay): `a8692d4e` -> `c5caaf3b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713517520,
-        "narHash": "sha256-t59lpRo7EulX9J0/bc5/8cUEo7hl6z9YOYukzg54cyU=",
+        "lastModified": 1713546495,
+        "narHash": "sha256-5I/Nn0ibs16JVU5xLEjPx3AXBQxs86wxrJOWH8iVHTg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a8692d4e570e93061d2bbe10af4a1590afe82e15",
+        "rev": "c5caaf3b6d4f711e5a408ada4dc4c36537a18372",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`c5caaf3b`](https://github.com/nix-community/emacs-overlay/commit/c5caaf3b6d4f711e5a408ada4dc4c36537a18372) | `` Updated emacs `` |
| [`0be1306b`](https://github.com/nix-community/emacs-overlay/commit/0be1306bf44aedaf54642c4dc9bbbc210267dcd7) | `` Updated melpa `` |
| [`7600854b`](https://github.com/nix-community/emacs-overlay/commit/7600854b9d7d7e4a897638a1df6ea2275682a8ab) | `` Updated elpa ``  |