### PR TITLE
chore(flake/home-manager): `938357cb` -> `2f072c12`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -471,11 +471,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713547559,
-        "narHash": "sha256-zju60y4pyYQoRmqhbgkw+jwmKZReVsCNvb8mZxID2Do=",
+        "lastModified": 1713992342,
+        "narHash": "sha256-bW7K4WPo6jhYMo4ZUGoJfog6xJV0XZh8adXqZKunRoc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "938357cb234e85da37109df2cdd9cc59ab9c1cc0",
+        "rev": "2f072c127c041eec36621b8e38a531fe0fe07961",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`2f072c12`](https://github.com/nix-community/home-manager/commit/2f072c127c041eec36621b8e38a531fe0fe07961) | `` zsh: use correct autosuggestion color variable (#5320) `` |
| [`bfa7c064`](https://github.com/nix-community/home-manager/commit/bfa7c06436771e3a0c666ccc6ee01e815d4c33aa) | `` swayosd: add custom style option ``                       |
| [`33a20182`](https://github.com/nix-community/home-manager/commit/33a20182e3164f451b6a4ac2ecadcab5c2c36703) | `` home-manager: improve session variables comment ``        |
| [`67de98ae`](https://github.com/nix-community/home-manager/commit/67de98ae6eed5ad6f91b1142356d71a87ba97f21) | `` tealdeer: documentation typo ``                           |
| [`e866aae5`](https://github.com/nix-community/home-manager/commit/e866aae5bbbcfe6798ca05d3004a4e62f1828954) | `` amberol: add module ``                                    |
| [`1451d286`](https://github.com/nix-community/home-manager/commit/1451d2866d9ef3739c20f964c9c8bd6db39cc373) | `` foot: unset PATH in server's systemd unit file ``         |
| [`e2e7ea9b`](https://github.com/nix-community/home-manager/commit/e2e7ea9b8f3de1e6a09f4fc512eae75f6e413a10) | `` kconfig: fix missing quoting ``                           |
| [`2ad154bd`](https://github.com/nix-community/home-manager/commit/2ad154bd1be2441ac8c624704587734dddb9f41a) | `` Translate using Weblate (Swedish) ``                      |
| [`46833c31`](https://github.com/nix-community/home-manager/commit/46833c3115e8858370880d892748f0927d8193c3) | `` bat: allow overriding package (#5301) ``                  |
| [`670d9ecc`](https://github.com/nix-community/home-manager/commit/670d9ecc3e46a6e3265c203c2d136031a3d3548e) | `` poetry: add module ``                                     |
| [`2846d523`](https://github.com/nix-community/home-manager/commit/2846d5230a3c3923618eabb367deaf8885df580f) | `` joplin-desktop: allow undefined options ``                |
| [`ad83c154`](https://github.com/nix-community/home-manager/commit/ad83c154bdfedad9807e86dd0633729ea3b116c5) | `` qt: fix `qt.platformTheme = "gtk3"` ``                    |
| [`147b5a5e`](https://github.com/nix-community/home-manager/commit/147b5a5e1c04e1f27e30b6df720966422fb4bc09) | `` qt: fix platform theme package install ``                 |
| [`4cec20db`](https://github.com/nix-community/home-manager/commit/4cec20dbf5c0a716115745ae32531e34816ecbbe) | `` flake.lock: Update ``                                     |
| [`057117a4`](https://github.com/nix-community/home-manager/commit/057117a401a34259c9615ce62218aea7afdee4d3) | `` kdeconnect: fix "tray.target" requires ``                 |
| [`a2040822`](https://github.com/nix-community/home-manager/commit/a20408227466032a16e73893b09a67092258cf67) | `` firefox: fix test ``                                      |
| [`3a435342`](https://github.com/nix-community/home-manager/commit/3a435342e2e5e2bff1d3331c2bd9e70f25693ea2) | `` sway: check config file validity ``                       |
| [`95888b15`](https://github.com/nix-community/home-manager/commit/95888b153c24c36971c4b4b66beecf32593064fb) | `` sway: writeText -> writeTextFile ``                       |
| [`7c61e400`](https://github.com/nix-community/home-manager/commit/7c61e400a99f33cdff3118c1e4032bcb049e1a30) | `` Translate using Weblate (Turkish) ``                      |
| [`991f6faf`](https://github.com/nix-community/home-manager/commit/991f6fafce729e6d7d64107a66e445114194b778) | `` Translate using Weblate (Portuguese) ``                   |
| [`5682ccdc`](https://github.com/nix-community/home-manager/commit/5682ccdcaf72aef74be97e4b683545a9de27c386) | `` Translate using Weblate (Spanish) ``                      |