### PR TITLE
chore(flake/nur): `135a48ba` -> `c0a0251b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713561483,
-        "narHash": "sha256-70b71bY2erMeqiJm3M5lK90z6NbAzk47XslnTPbOkrc=",
+        "lastModified": 1713567460,
+        "narHash": "sha256-rUtH8IO0dObR5EfoQroH+u1VQ1TPnUUo+uF3oNE0GIk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "135a48ba31b1e3d7f7f9429e4b244f0f2a1f8682",
+        "rev": "c0a0251b2482b5d978e770404d59dbf2259bac23",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c0a0251b`](https://github.com/nix-community/NUR/commit/c0a0251b2482b5d978e770404d59dbf2259bac23) | `` automatic update `` |
| [`346ad9af`](https://github.com/nix-community/NUR/commit/346ad9af75cb5662eef047043c8229fea690025f) | `` automatic update `` |