### PR TITLE
chore(flake/nur): `03be1d05` -> `c20f2911`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713577105,
-        "narHash": "sha256-tQQ3cWnr5MhX/FHsYXrreA9FgHca29uwAFlBxUoBpu4=",
+        "lastModified": 1713580831,
+        "narHash": "sha256-4r9KjBOl13banceGt/j/KJbmETUFBSM6TZPxA9vg6SY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "03be1d05c563e494cc8f67e9fb14c1c91f857b29",
+        "rev": "c20f2911723f440c1291e5ba4b94cef102f4e8ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c20f2911`](https://github.com/nix-community/NUR/commit/c20f2911723f440c1291e5ba4b94cef102f4e8ff) | `` automatic update `` |