### PR TITLE
chore(flake/nur): `c20f2911` -> `7802f40f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713580831,
-        "narHash": "sha256-4r9KjBOl13banceGt/j/KJbmETUFBSM6TZPxA9vg6SY=",
+        "lastModified": 1713585875,
+        "narHash": "sha256-/StBrB7gn6B17leuiW7pdExdgb3yQS8MtTyz3EnbOE0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c20f2911723f440c1291e5ba4b94cef102f4e8ff",
+        "rev": "7802f40fc7e0b94c5c60547f07c9175b11112c23",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7802f40f`](https://github.com/nix-community/NUR/commit/7802f40fc7e0b94c5c60547f07c9175b11112c23) | `` automatic update `` |
| [`d7b97514`](https://github.com/nix-community/NUR/commit/d7b9751449b3dfba261e3d3f68fdc7671ad0559c) | `` automatic update `` |
| [`ec82449d`](https://github.com/nix-community/NUR/commit/ec82449d3347ab8a3af518bd03958eede7df82b8) | `` automatic update `` |