### PR TITLE
chore(flake/nur): `50338be2` -> `4c1f5594`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713590342,
-        "narHash": "sha256-E8SPpNzM81XFAdCrudweaIs3RaMRzFq0DkZKHMDRKfA=",
+        "lastModified": 1713595547,
+        "narHash": "sha256-JX5P3noPUB56hlHbLzvhdhiE0qGj78XmE1/7FWqREd0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "50338be2d63f537d251277fbeff0c679b381191a",
+        "rev": "4c1f5594db0d6b4c1b96bb03073918ca3fd7927d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4c1f5594`](https://github.com/nix-community/NUR/commit/4c1f5594db0d6b4c1b96bb03073918ca3fd7927d) | `` automatic update `` |
| [`a62bbc2e`](https://github.com/nix-community/NUR/commit/a62bbc2e8904153c6f2714bba882108b57224dd6) | `` automatic update `` |
| [`2f30cb55`](https://github.com/nix-community/NUR/commit/2f30cb55083a368e9bb86c23a2e406f379bcd573) | `` automatic update `` |