### PR TITLE
chore(flake/nur): `4c1f5594` -> `642134c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713595547,
-        "narHash": "sha256-JX5P3noPUB56hlHbLzvhdhiE0qGj78XmE1/7FWqREd0=",
+        "lastModified": 1713600062,
+        "narHash": "sha256-oTCYFFCPyM9FskbmYLZuF409i5/1o7f5DqeqAiQ+wgk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4c1f5594db0d6b4c1b96bb03073918ca3fd7927d",
+        "rev": "642134c9cc78ba43fab0986effa5c584d28bc4fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`642134c9`](https://github.com/nix-community/NUR/commit/642134c9cc78ba43fab0986effa5c584d28bc4fe) | `` automatic update `` |
| [`7d0eeea4`](https://github.com/nix-community/NUR/commit/7d0eeea45c300c2f97d77dcdbbefb7e9c85e6061) | `` automatic update `` |
| [`ff4cc8ed`](https://github.com/nix-community/NUR/commit/ff4cc8ed94a223e86b385bf4fb878fa1090407ba) | `` automatic update `` |