### PR TITLE
chore(flake/emacs-overlay): `9ba8ea91` -> `98442aa3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713577601,
-        "narHash": "sha256-DrWeKdiU8F0euJexG1wgyhZnlwwdghhB3FvMk96F5tY=",
+        "lastModified": 1713605220,
+        "narHash": "sha256-PvIdCIep2kZwQqpJesgiUAe+HW8Iy/NCMZ/d6/V+d3I=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9ba8ea91b7d79baf8ced9723abc06d0217acace5",
+        "rev": "98442aa32bbe5f20c0065d9c81257cfe79959972",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`98442aa3`](https://github.com/nix-community/emacs-overlay/commit/98442aa32bbe5f20c0065d9c81257cfe79959972) | `` Updated emacs ``        |
| [`917a11da`](https://github.com/nix-community/emacs-overlay/commit/917a11da8f010b4881d654967214a536b6cab2ba) | `` Updated melpa ``        |
| [`ddb89e84`](https://github.com/nix-community/emacs-overlay/commit/ddb89e842095c88b82b5334e0c87bde1875e7e01) | `` Updated flake inputs `` |