### PR TITLE
chore(flake/nur): `7ac3be9d` -> `48be829c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713601859,
-        "narHash": "sha256-1N+I4+UoasNJtDGwXT56JMbJHj+l39Rp1gqmSGJ7bgU=",
+        "lastModified": 1713606280,
+        "narHash": "sha256-V4ufpPfk4Gc+xP3rfzOFJLq3tZEW35QQYNOKL13J8tE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7ac3be9d0dd057f8ecf45463776bcccac1e2262e",
+        "rev": "48be829c3fe20b0226b95677ec8ff73a8e346125",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`48be829c`](https://github.com/nix-community/NUR/commit/48be829c3fe20b0226b95677ec8ff73a8e346125) | `` automatic update `` |