### PR TITLE
chore(flake/nur): `48be829c` -> `80032740`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713606280,
-        "narHash": "sha256-V4ufpPfk4Gc+xP3rfzOFJLq3tZEW35QQYNOKL13J8tE=",
+        "lastModified": 1713607712,
+        "narHash": "sha256-B4+hiDGLPoL2TOuP7Wr+VqG+9kGu1RUzBR1JU24cfmw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "48be829c3fe20b0226b95677ec8ff73a8e346125",
+        "rev": "800327409d11460386c0f3c757abc7e2beb2900e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`80032740`](https://github.com/nix-community/NUR/commit/800327409d11460386c0f3c757abc7e2beb2900e) | `` automatic update `` |