### PR TITLE
chore(flake/stylix): `b36fb34a` -> `0fe277a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,39 +47,6 @@
         "type": "github"
       }
     },
-    "base16-alacritty": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1703982197,
-        "narHash": "sha256-TNxKbwdiUXGi4Z4chT72l3mt3GSvOcz6NZsUH8bQU/k=",
-        "owner": "aarowill",
-        "repo": "base16-alacritty",
-        "rev": "c95c200b3af739708455a03b5d185d3d2d263c6e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "aarowill",
-        "repo": "base16-alacritty",
-        "type": "github"
-      }
-    },
-    "base16-alacritty-yaml": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1674275109,
-        "narHash": "sha256-Adwx9yP70I6mJrjjODOgZJjt4OPPe8gJu7UuBboXO4M=",
-        "owner": "aarowill",
-        "repo": "base16-alacritty",
-        "rev": "63d8ae5dfefe5db825dd4c699d0cdc2fc2c3eaf7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "aarowill",
-        "repo": "base16-alacritty",
-        "rev": "63d8ae5dfefe5db825dd4c699d0cdc2fc2c3eaf7",
-        "type": "github"
-      }
-    },
     "base16-fish": {
       "flake": false,
       "locked": {
@@ -803,8 +770,6 @@
     "stylix": {
       "inputs": {
         "base16": "base16",
-        "base16-alacritty": "base16-alacritty",
-        "base16-alacritty-yaml": "base16-alacritty-yaml",
         "base16-fish": "base16-fish",
         "base16-foot": "base16-foot",
         "base16-helix": "base16-helix",
@@ -823,11 +788,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713427823,
-        "narHash": "sha256-ehqlyBoNi66fptxAEzV/p1uCd16ExxO+n77S/uIMG7o=",
+        "lastModified": 1713821140,
+        "narHash": "sha256-/kGc9R01h8mTmZKhrVyGWaK/w9zgettmHIE3GZW8Khs=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "b36fb34a9c8fb728c7efe5dbbb222bb23dcaa967",
+        "rev": "0fe277a3641a849478a94c7900c2d5a90609a306",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                              |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`0fe277a3`](https://github.com/danth/stylix/commit/0fe277a3641a849478a94c7900c2d5a90609a306) | `` treewide: remove `lib.mdDoc` (#349) ``                            |
| [`267cf91e`](https://github.com/danth/stylix/commit/267cf91e0340076e1057cb14930fa8437f591b5a) | `` doc: add documentation for testbeds (#347) ``                     |
| [`2f29ecd3`](https://github.com/danth/stylix/commit/2f29ecd3e4c0ebf75f46647b4c4fb7261b978aac) | `` alacritty: replace base16-alacritty with a custom theme (#346) `` |
| [`845c6745`](https://github.com/danth/stylix/commit/845c6745108b0ee76361a3d677a2e1df1d3d9487) | `` nixos-icons: remove rendered version of logo (#344) ``            |
| [`5749cf16`](https://github.com/danth/stylix/commit/5749cf162340b230e86fa75571b3cb6ce7f11441) | `` nixos-icons: `white.svg` -> `nix-snowflake-white.svg` (#343) ``   |