### PR TITLE
chore(flake/emacs-overlay): `98442aa3` -> `557a6976`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713605220,
-        "narHash": "sha256-PvIdCIep2kZwQqpJesgiUAe+HW8Iy/NCMZ/d6/V+d3I=",
+        "lastModified": 1713632759,
+        "narHash": "sha256-iEEDprzTYWa8ZV/OolHfGo3ThNxqOtuxfh6ld6uYods=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "98442aa32bbe5f20c0065d9c81257cfe79959972",
+        "rev": "557a69764e1aeb16c3d0f7d53ff4c3001a4ccafc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`557a6976`](https://github.com/nix-community/emacs-overlay/commit/557a69764e1aeb16c3d0f7d53ff4c3001a4ccafc) | `` Updated emacs `` |
| [`832a762e`](https://github.com/nix-community/emacs-overlay/commit/832a762e2789007887ab0720a14bbd03e6798f03) | `` Updated melpa `` |
| [`7028dd82`](https://github.com/nix-community/emacs-overlay/commit/7028dd8249bb1306dfb7250d70bd9333dd056401) | `` Updated elpa ``  |