### PR TITLE
chore(flake/org-tufte): `acdfde9a` -> `c60056cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -690,11 +690,11 @@
     "org-tufte": {
       "flake": false,
       "locked": {
-        "lastModified": 1713100705,
-        "narHash": "sha256-ZSR3seL+EO929JN7rHtrzgShecHN3fWJCk+z7tnL75o=",
+        "lastModified": 1713629455,
+        "narHash": "sha256-3TtvodyrzQh70Z07KBpl8Y1H5SXd0iAwuo+bUEH12Mg=",
         "owner": "Zilong-Li",
         "repo": "org-tufte",
-        "rev": "acdfde9a3bbbd6c4aa83c960670f804dddbfbbf0",
+        "rev": "c60056cbb7b1a16b6dc04d076fed48b917cc9dea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                   |
| ---------------------------------------------------------------------------------------------------- | ------------------------- |
| [`c60056cb`](https://github.com/Zilong-Li/org-tufte/commit/c60056cbb7b1a16b6dc04d076fed48b917cc9dea) | `` fix potential issue `` |