### PR TITLE
chore(flake/nur): `6e4abe63` -> `dd9df9e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713638122,
-        "narHash": "sha256-cOXl7NPEaSVszzp493hjdHUZm/sHwF8/Elxf5ykv2OI=",
+        "lastModified": 1713644644,
+        "narHash": "sha256-MPx/45dnoBiNZbBp93pUmRHXhiWt1jj/Rd/Uu/WQp+Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6e4abe6333c4bff2b4521f7e5fdaf1c11af655e4",
+        "rev": "dd9df9e038e40aa8cf054435ee022fea228ea03e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dd9df9e0`](https://github.com/nix-community/NUR/commit/dd9df9e038e40aa8cf054435ee022fea228ea03e) | `` automatic update `` |