### PR TITLE
chore(flake/nur): `dd9df9e0` -> `89d6a89f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713644644,
-        "narHash": "sha256-MPx/45dnoBiNZbBp93pUmRHXhiWt1jj/Rd/Uu/WQp+Y=",
+        "lastModified": 1713647689,
+        "narHash": "sha256-WdNJwfyesw2uQtQ4Jzt3k+I70pSNR7cdADa+QwWDjPc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd9df9e038e40aa8cf054435ee022fea228ea03e",
+        "rev": "89d6a89f1e59b5d27719212ef23e1c452dc6666e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`89d6a89f`](https://github.com/nix-community/NUR/commit/89d6a89f1e59b5d27719212ef23e1c452dc6666e) | `` automatic update `` |