### PR TITLE
chore(flake/nur): `89d6a89f` -> `c59a6ea0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713647689,
-        "narHash": "sha256-WdNJwfyesw2uQtQ4Jzt3k+I70pSNR7cdADa+QwWDjPc=",
+        "lastModified": 1713653076,
+        "narHash": "sha256-uhYM+VFxlwj6WDpO/+59uLRDSX1Nt1pylNxmLw/B1Sc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "89d6a89f1e59b5d27719212ef23e1c452dc6666e",
+        "rev": "c59a6ea0043f7030cdf3ddbd560580814a4923f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c59a6ea0`](https://github.com/nix-community/NUR/commit/c59a6ea0043f7030cdf3ddbd560580814a4923f9) | `` automatic update `` |