### PR TITLE
chore(flake/nur): `c59a6ea0` -> `9e8d4f23`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713653076,
-        "narHash": "sha256-uhYM+VFxlwj6WDpO/+59uLRDSX1Nt1pylNxmLw/B1Sc=",
+        "lastModified": 1713654731,
+        "narHash": "sha256-KXf2oFFfwQmmscj9/+FyZ0HT3YDjJFE8e7CGJM/bj0o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c59a6ea0043f7030cdf3ddbd560580814a4923f9",
+        "rev": "9e8d4f238bac2b21ea8e0c42a8819b0e8560171c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9e8d4f23`](https://github.com/nix-community/NUR/commit/9e8d4f238bac2b21ea8e0c42a8819b0e8560171c) | `` automatic update `` |