### PR TITLE
chore(flake/nur): `9e8d4f23` -> `d8dc453e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713654731,
-        "narHash": "sha256-KXf2oFFfwQmmscj9/+FyZ0HT3YDjJFE8e7CGJM/bj0o=",
+        "lastModified": 1713663606,
+        "narHash": "sha256-365cMOgQ4IKZsyK4HZ//NuwcYJA/BfC09IBDAcai7yk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9e8d4f238bac2b21ea8e0c42a8819b0e8560171c",
+        "rev": "d8dc453e681d331ec241f2d8ea5a5b64f21ca44a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d8dc453e`](https://github.com/nix-community/NUR/commit/d8dc453e681d331ec241f2d8ea5a5b64f21ca44a) | `` automatic update `` |
| [`36f8caf8`](https://github.com/nix-community/NUR/commit/36f8caf86c91e57f7b26391c1f29a091e407e600) | `` automatic update `` |
| [`4ec14db7`](https://github.com/nix-community/NUR/commit/4ec14db73e55b8b326b677ae608314518f16c6e8) | `` automatic update `` |
| [`5bf9f2a1`](https://github.com/nix-community/NUR/commit/5bf9f2a1624c2b4d74e7ee06a25c2e473a4ea802) | `` automatic update `` |