### PR TITLE
chore(flake/emacs-overlay): `0313ac9c` -> `a9c6d1dc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713661385,
-        "narHash": "sha256-cNK7nbDL7o9NIa0YFKT8DTIatc81fTDJPfoaILo31BQ=",
+        "lastModified": 1713664248,
+        "narHash": "sha256-rFIrw1KDFiO1STFE6RaKVBRq1d5Mg6gd1kurBvHNzj4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0313ac9c196ba3a90566b72666a5220b2a841b71",
+        "rev": "a9c6d1dc8ddcf32d9e67ea95761aac0f3f34b4cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`a9c6d1dc`](https://github.com/nix-community/emacs-overlay/commit/a9c6d1dc8ddcf32d9e67ea95761aac0f3f34b4cc) | `` Updated emacs `` |
| [`e4ee7be8`](https://github.com/nix-community/emacs-overlay/commit/e4ee7be879a0300b414d5565602a8b70d38c3467) | `` Updated melpa `` |