### PR TITLE
chore(flake/nur): `d8dc453e` -> `a1d530ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713663606,
-        "narHash": "sha256-365cMOgQ4IKZsyK4HZ//NuwcYJA/BfC09IBDAcai7yk=",
+        "lastModified": 1713671128,
+        "narHash": "sha256-Kak1m0BOWkf9KdBaZqeVgyv+pp5eRXXb0xGL7zicl00=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d8dc453e681d331ec241f2d8ea5a5b64f21ca44a",
+        "rev": "a1d530ae065008ef50901d17386de22f82cdc1da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a1d530ae`](https://github.com/nix-community/NUR/commit/a1d530ae065008ef50901d17386de22f82cdc1da) | `` automatic update `` |
| [`97ae352c`](https://github.com/nix-community/NUR/commit/97ae352cdfa80c51b05565edc0f313e7b50ddd97) | `` automatic update `` |
| [`cde481a5`](https://github.com/nix-community/NUR/commit/cde481a529746f811ae2a75e2a2cdec973ba29e4) | `` automatic update `` |