### PR TITLE
chore(flake/nur): `a1d530ae` -> `e6fb1165`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713671128,
-        "narHash": "sha256-Kak1m0BOWkf9KdBaZqeVgyv+pp5eRXXb0xGL7zicl00=",
+        "lastModified": 1713672231,
+        "narHash": "sha256-RbElVkjytKbPOA9VqNvS0kEM6dNd+mT7c5CUJQr0yEo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a1d530ae065008ef50901d17386de22f82cdc1da",
+        "rev": "e6fb11656afee0b63cdba03f7c15db9e5d8d0f9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e6fb1165`](https://github.com/nix-community/NUR/commit/e6fb11656afee0b63cdba03f7c15db9e5d8d0f9a) | `` automatic update `` |