### PR TITLE
chore(flake/nur): `e6fb1165` -> `1e1da751`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713672231,
-        "narHash": "sha256-RbElVkjytKbPOA9VqNvS0kEM6dNd+mT7c5CUJQr0yEo=",
+        "lastModified": 1713678856,
+        "narHash": "sha256-jV/I2mFfUL5njdKbmAJhfW+wNuinxa7//iyeGB6Kd4w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e6fb11656afee0b63cdba03f7c15db9e5d8d0f9a",
+        "rev": "1e1da751686f428e6e4ed239092f01df09d72917",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1e1da751`](https://github.com/nix-community/NUR/commit/1e1da751686f428e6e4ed239092f01df09d72917) | `` automatic update `` |
| [`aa26802d`](https://github.com/nix-community/NUR/commit/aa26802d950f90a315932fe1b3b657c28de3f1dc) | `` automatic update `` |