### PR TITLE
chore(flake/nur): `1e1da751` -> `4091dc60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713678856,
-        "narHash": "sha256-jV/I2mFfUL5njdKbmAJhfW+wNuinxa7//iyeGB6Kd4w=",
+        "lastModified": 1713681356,
+        "narHash": "sha256-XwKxLkVZ77DP8OPL89+InMdOWvkstQ/vZR6h36qT2Zo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1e1da751686f428e6e4ed239092f01df09d72917",
+        "rev": "4091dc60dea6150d4b961cfe7c9aaab5b9e3ee2b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4091dc60`](https://github.com/nix-community/NUR/commit/4091dc60dea6150d4b961cfe7c9aaab5b9e3ee2b) | `` automatic update `` |
| [`6e2a2daa`](https://github.com/nix-community/NUR/commit/6e2a2daac5224b9c0988ce2e22a7277e456a3614) | `` automatic update `` |