### PR TITLE
chore(flake/nur): `4091dc60` -> `568cd159`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713681356,
-        "narHash": "sha256-XwKxLkVZ77DP8OPL89+InMdOWvkstQ/vZR6h36qT2Zo=",
+        "lastModified": 1713683463,
+        "narHash": "sha256-4byae6EewzcPs1C1JGOts1PLVr+PlR7+FOOqJGNSBIQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4091dc60dea6150d4b961cfe7c9aaab5b9e3ee2b",
+        "rev": "568cd159bad8d8a2e3c2f3f7b71dd27a3d553b45",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`568cd159`](https://github.com/nix-community/NUR/commit/568cd159bad8d8a2e3c2f3f7b71dd27a3d553b45) | `` automatic update `` |
| [`8c487300`](https://github.com/nix-community/NUR/commit/8c487300f9f92f9c1d1e5567fcfa61b024399110) | `` automatic update `` |