### PR TITLE
chore(flake/nur): `5edf97f8` -> `5476714a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713692778,
-        "narHash": "sha256-F5rAsavZtY2epAl4DAz2KmYWii4gQ39uB8sqrLSWuO8=",
+        "lastModified": 1713700243,
+        "narHash": "sha256-PmvvUmHRtuEkEXqpEqy55JJgI3j+pmcPhAvxGiIBL1s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5edf97f8cb76f16b6d7f3a53cfac7d2e3f40c510",
+        "rev": "5476714a6c29c82a2e17717a6c9a22addac13c18",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5476714a`](https://github.com/nix-community/NUR/commit/5476714a6c29c82a2e17717a6c9a22addac13c18) | `` automatic update `` |