### PR TITLE
chore(flake/nur): `5476714a` -> `e558232e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713700243,
-        "narHash": "sha256-PmvvUmHRtuEkEXqpEqy55JJgI3j+pmcPhAvxGiIBL1s=",
+        "lastModified": 1713707886,
+        "narHash": "sha256-eixmKYCzDqq0II8yOiuoQNmTE/lNCiIt71lh7V4PSvk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5476714a6c29c82a2e17717a6c9a22addac13c18",
+        "rev": "e558232e47b407866c8e2974739fac7ccc17e452",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e558232e`](https://github.com/nix-community/NUR/commit/e558232e47b407866c8e2974739fac7ccc17e452) | `` automatic update `` |
| [`baec08bb`](https://github.com/nix-community/NUR/commit/baec08bbdf244ba132aa6ed1ee3f0406228a2ae4) | `` automatic update `` |