### PR TITLE
chore(flake/nur): `e558232e` -> `f895192b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713707886,
-        "narHash": "sha256-eixmKYCzDqq0II8yOiuoQNmTE/lNCiIt71lh7V4PSvk=",
+        "lastModified": 1713710647,
+        "narHash": "sha256-5hlLPEF3Pa+lkRhHlg+qBwwRh04GxPv+KivZx2BpSVk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e558232e47b407866c8e2974739fac7ccc17e452",
+        "rev": "f895192b572181736d462bf5d9fc04e494c46e38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f895192b`](https://github.com/nix-community/NUR/commit/f895192b572181736d462bf5d9fc04e494c46e38) | `` automatic update `` |
| [`346db609`](https://github.com/nix-community/NUR/commit/346db609ac3a44b37d2a9a201aa8344d06a49838) | `` automatic update `` |