### PR TITLE
chore(flake/nur): `f895192b` -> `1d25c04a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713710647,
-        "narHash": "sha256-5hlLPEF3Pa+lkRhHlg+qBwwRh04GxPv+KivZx2BpSVk=",
+        "lastModified": 1713714751,
+        "narHash": "sha256-LkxyITl9iOdldT3XOfQcJz5giJmtrAl3PSCmo/wuRQk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f895192b572181736d462bf5d9fc04e494c46e38",
+        "rev": "1d25c04aee29f3b37ae0b9531e149ba53f8b5783",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1d25c04a`](https://github.com/nix-community/NUR/commit/1d25c04aee29f3b37ae0b9531e149ba53f8b5783) | `` automatic update `` |