### PR TITLE
chore(flake/emacs-overlay): `c663a0f8` -> `46a2877d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713689526,
-        "narHash": "sha256-Wp97GTE1D2w9Yyk7SGM0Tt3gH4drO5HZmgvmv+seuTA=",
+        "lastModified": 1713719238,
+        "narHash": "sha256-1++fqKoVrDrOm8+ODkazxqWj6B6aw4Al4rUD9rKkZGk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c663a0f86514516f717479075a07b31f93f31e75",
+        "rev": "46a2877d1f0f661627d1d104cbf4963e97391e95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`46a2877d`](https://github.com/nix-community/emacs-overlay/commit/46a2877d1f0f661627d1d104cbf4963e97391e95) | `` Updated emacs `` |
| [`9fa2385d`](https://github.com/nix-community/emacs-overlay/commit/9fa2385df7c4d8ccf8727b74f2edccc1dea7a914) | `` Updated melpa `` |
| [`89247aa1`](https://github.com/nix-community/emacs-overlay/commit/89247aa1a7d6d113c859f2f3b2e6674066369aa1) | `` Updated elpa ``  |