### PR TITLE
chore(flake/nur): `1d25c04a` -> `0d92c8de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713714751,
-        "narHash": "sha256-LkxyITl9iOdldT3XOfQcJz5giJmtrAl3PSCmo/wuRQk=",
+        "lastModified": 1713717876,
+        "narHash": "sha256-pJfwkI3sUMI/5J9rvJc15ZvKvlIlAO3YIfL6EJ1pmXQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1d25c04aee29f3b37ae0b9531e149ba53f8b5783",
+        "rev": "0d92c8dec19b7cd840867e64f4b024f41f9dd5ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0d92c8de`](https://github.com/nix-community/NUR/commit/0d92c8dec19b7cd840867e64f4b024f41f9dd5ab) | `` automatic update `` |