### PR TITLE
chore(flake/nur): `8b05bbd9` -> `8f557dfa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713721479,
-        "narHash": "sha256-HfmkPAtMyU794rzBGsSS089qsv7MIwcTy/rrlST4Ta0=",
+        "lastModified": 1713728331,
+        "narHash": "sha256-SqG/zCZlhSdfJGS2EooRLr+5me4z2ekQMrqT2YXSuMM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8b05bbd9f0ef32148e81a6dc7e794b977687125a",
+        "rev": "8f557dfa37b430807d1e4d001930896d23c04cec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8f557dfa`](https://github.com/nix-community/NUR/commit/8f557dfa37b430807d1e4d001930896d23c04cec) | `` automatic update `` |
| [`b680c7e4`](https://github.com/nix-community/NUR/commit/b680c7e42aec726462d823797e3055ce4e68f54f) | `` automatic update `` |
| [`7eaf2026`](https://github.com/nix-community/NUR/commit/7eaf2026a28f27e8cc93fbef2f4313920e0f637e) | `` automatic update `` |