### PR TITLE
chore(flake/nur): `8f557dfa` -> `9982d9ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713728331,
-        "narHash": "sha256-SqG/zCZlhSdfJGS2EooRLr+5me4z2ekQMrqT2YXSuMM=",
+        "lastModified": 1713732355,
+        "narHash": "sha256-7dtWxV9O1ujFcZcYmaiBVdL3Snk0Y7AFL6pufM31alk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8f557dfa37b430807d1e4d001930896d23c04cec",
+        "rev": "9982d9ed76f4b0335d8e016fe7c71f21fd4ef5eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9982d9ed`](https://github.com/nix-community/NUR/commit/9982d9ed76f4b0335d8e016fe7c71f21fd4ef5eb) | `` automatic update `` |