### PR TITLE
chore(flake/nur): `9982d9ed` -> `6781117e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713732355,
-        "narHash": "sha256-7dtWxV9O1ujFcZcYmaiBVdL3Snk0Y7AFL6pufM31alk=",
+        "lastModified": 1713735861,
+        "narHash": "sha256-CwhWG2KkcF2pa/PNY0gSLCMKFqaXw9AwQUYSZOo5C3s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9982d9ed76f4b0335d8e016fe7c71f21fd4ef5eb",
+        "rev": "6781117e1f3a70c026b7006ae51d559b4f1942c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6781117e`](https://github.com/nix-community/NUR/commit/6781117e1f3a70c026b7006ae51d559b4f1942c2) | `` automatic update `` |