### PR TITLE
chore(flake/emacs-overlay): `46a2877d` -> `ea1a2b4b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713719238,
-        "narHash": "sha256-1++fqKoVrDrOm8+ODkazxqWj6B6aw4Al4rUD9rKkZGk=",
+        "lastModified": 1713747651,
+        "narHash": "sha256-e83NorrQkUGjF33jux9kAPwEYfzjHrbvcWPJO4PUnb0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "46a2877d1f0f661627d1d104cbf4963e97391e95",
+        "rev": "ea1a2b4b74c0fb2d8b73ca48d289b540827dd913",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`ea1a2b4b`](https://github.com/nix-community/emacs-overlay/commit/ea1a2b4b74c0fb2d8b73ca48d289b540827dd913) | `` Updated elpa `` |