### PR TITLE
chore(flake/nur): `f46d29de` -> `5ead0c85`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713743078,
-        "narHash": "sha256-kOCOPkZXp9zy6b3sDIMjtKgLHmYA3hRKZnkFYTbKp48=",
+        "lastModified": 1713757464,
+        "narHash": "sha256-4Dzr1sbMFrbElfptGhs9PX1Dl5GpJyeXYiXY8Bhs0Io=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f46d29dee964bf467c32a6c5c02ca7da3b1fab97",
+        "rev": "5ead0c858e8ac0b5acdf28bd8e48df7513bb6640",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5ead0c85`](https://github.com/nix-community/NUR/commit/5ead0c858e8ac0b5acdf28bd8e48df7513bb6640) | `` automatic update `` |
| [`48772816`](https://github.com/nix-community/NUR/commit/487728165a3334f420ea44b89426ca6a9fd2e290) | `` automatic update `` |
| [`7473c25c`](https://github.com/nix-community/NUR/commit/7473c25c4bf29b83da8e0a33076a8b540c614d33) | `` automatic update `` |
| [`2bf68998`](https://github.com/nix-community/NUR/commit/2bf689987361a3aded427483cc6cc218eed7ba80) | `` automatic update `` |