### PR TITLE
chore(flake/srvos): `d8945920` -> `e00e4214`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -787,11 +787,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713533513,
-        "narHash": "sha256-nv5GmWaGryyZU8ihQIYLZWasqaXTZKGTjsypG0TRw9Q=",
+        "lastModified": 1713747325,
+        "narHash": "sha256-3Rh1372yHv7TYA8yJqSCcKeVsHdhmDa4veN9kb3fNx8=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "d8945920cb8e98dc737d1fc2d42607f5916c34cf",
+        "rev": "e00e421468806a7a245bc76f0a23eb9e91593918",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`e00e4214`](https://github.com/nix-community/srvos/commit/e00e421468806a7a245bc76f0a23eb9e91593918) | `` dev/private/flake.lock: Update `` |
| [`6c01bfa2`](https://github.com/nix-community/srvos/commit/6c01bfa289c8d3aaa4afcc897616bbe127c1a38e) | `` flake.lock: Update ``             |