### PR TITLE
chore(flake/nur): `5ead0c85` -> `7b1c63ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713757464,
-        "narHash": "sha256-4Dzr1sbMFrbElfptGhs9PX1Dl5GpJyeXYiXY8Bhs0Io=",
+        "lastModified": 1713761486,
+        "narHash": "sha256-EgH8y7dgsUGcZ7wsC4f6Zxf0v0fsrTyFXzIquDxbbII=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5ead0c858e8ac0b5acdf28bd8e48df7513bb6640",
+        "rev": "7b1c63ed73916ebe6b3d9255f39d0dca3960f79c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7b1c63ed`](https://github.com/nix-community/NUR/commit/7b1c63ed73916ebe6b3d9255f39d0dca3960f79c) | `` automatic update `` |
| [`0d090daf`](https://github.com/nix-community/NUR/commit/0d090dafdbab32c079cd431915159d186cb92054) | `` automatic update `` |
| [`a424cf5a`](https://github.com/nix-community/NUR/commit/a424cf5a4330b0d3aee09d012cea57bb73d7cd60) | `` automatic update `` |