### PR TITLE
chore(flake/nur): `707903b4` -> `f5c83b47`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713763264,
-        "narHash": "sha256-mUK2TyUpS/yTtN3ml2rt2eAYaa+nplrFRbWdgugOn0o=",
+        "lastModified": 1713769261,
+        "narHash": "sha256-MrIrgBO17tpKaRtaiqswhqqzKRzwUI3+danbno6WbPE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "707903b469fe2c1423f58a21e864fe7388bdf86d",
+        "rev": "f5c83b47117524bbe3be63b42ac166a1e74f8689",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f5c83b47`](https://github.com/nix-community/NUR/commit/f5c83b47117524bbe3be63b42ac166a1e74f8689) | `` automatic update `` |
| [`1d04355c`](https://github.com/nix-community/NUR/commit/1d04355c97c79caf7302197b70c78e1c0f4a2d63) | `` automatic update `` |