### PR TITLE
chore(flake/nur): `a9d8891e` -> `04042bd1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713774295,
-        "narHash": "sha256-Z/evp2msYDi0mul2km7femF11ilgKOWT1u0neNIGcZ0=",
+        "lastModified": 1713782755,
+        "narHash": "sha256-dgBYUKgItCPC8N8OlJegAXEE2nrQcjNcgtSbKnW3u44=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a9d8891ee925e450f1e94cdf0f8004ea2aa698a9",
+        "rev": "04042bd1c1ce9dccad5a1a07d84811f58dea9826",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`04042bd1`](https://github.com/nix-community/NUR/commit/04042bd1c1ce9dccad5a1a07d84811f58dea9826) | `` automatic update `` |