### PR TITLE
chore(flake/nur): `04042bd1` -> `8e272415`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713782755,
-        "narHash": "sha256-dgBYUKgItCPC8N8OlJegAXEE2nrQcjNcgtSbKnW3u44=",
+        "lastModified": 1713791714,
+        "narHash": "sha256-feZckq2tCi1mqwqfJoh+DigSKVhh9rTq3uW3khfUzFc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "04042bd1c1ce9dccad5a1a07d84811f58dea9826",
+        "rev": "8e2724159d1bbc41d6365f53782e0c9602f8f721",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8e272415`](https://github.com/nix-community/NUR/commit/8e2724159d1bbc41d6365f53782e0c9602f8f721) | `` automatic update `` |
| [`4a50a5b7`](https://github.com/nix-community/NUR/commit/4a50a5b7cf8d49ec448c016792824c811b6051ae) | `` automatic update `` |
| [`cf97d775`](https://github.com/nix-community/NUR/commit/cf97d775732f6d9a0d7faffebcb4d4775ee94a7b) | `` automatic update `` |