### PR TITLE
chore(flake/nur): `8e272415` -> `f4f1274b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713791714,
-        "narHash": "sha256-feZckq2tCi1mqwqfJoh+DigSKVhh9rTq3uW3khfUzFc=",
+        "lastModified": 1713797199,
+        "narHash": "sha256-+0MmgVgD31MFhzvqrqU7+/b2J+JJeEPxThtnLfwfOLk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8e2724159d1bbc41d6365f53782e0c9602f8f721",
+        "rev": "f4f1274b9d8d277c5dc6dd9ba451e81486ff8f98",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f4f1274b`](https://github.com/nix-community/NUR/commit/f4f1274b9d8d277c5dc6dd9ba451e81486ff8f98) | `` automatic update `` |