### PR TITLE
chore(flake/nur): `f4f1274b` -> `ef628778`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713797199,
-        "narHash": "sha256-+0MmgVgD31MFhzvqrqU7+/b2J+JJeEPxThtnLfwfOLk=",
+        "lastModified": 1713800726,
+        "narHash": "sha256-gUuf7LrPqMyQuXP8SkKpRR7LEsLq9prdlSXUvVP4DX4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f4f1274b9d8d277c5dc6dd9ba451e81486ff8f98",
+        "rev": "ef628778ec8a405ddc62beb848c8ff961afe022c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ef628778`](https://github.com/nix-community/NUR/commit/ef628778ec8a405ddc62beb848c8ff961afe022c) | `` automatic update `` |