### PR TITLE
chore(flake/nur): `28a70527` -> `5a7eaad5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713815481,
-        "narHash": "sha256-WyJ2WR9GCkw3cNCTp7Xe/nbeAINPLqmlEQYBVzwnq54=",
+        "lastModified": 1713822266,
+        "narHash": "sha256-sTj3Bl2snlgJsH8VaFjIykjXlMxd6SNjlaNb9uucR94=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "28a705279a74e75b4f8beeba08efc22606346585",
+        "rev": "5a7eaad55879eaa58fc62d357781a8ed2a708bc0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5a7eaad5`](https://github.com/nix-community/NUR/commit/5a7eaad55879eaa58fc62d357781a8ed2a708bc0) | `` automatic update `` |