### PR TITLE
chore(flake/nur): `5a7eaad5` -> `ce671849`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713822266,
-        "narHash": "sha256-sTj3Bl2snlgJsH8VaFjIykjXlMxd6SNjlaNb9uucR94=",
+        "lastModified": 1713825131,
+        "narHash": "sha256-qw0rwULFXKIheW4e8bTL74P4AGz7rLr6M2OUlJ3fNgs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5a7eaad55879eaa58fc62d357781a8ed2a708bc0",
+        "rev": "ce671849e5ef3a56fc2ee3e0bbfa83aa87104e48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ce671849`](https://github.com/nix-community/NUR/commit/ce671849e5ef3a56fc2ee3e0bbfa83aa87104e48) | `` automatic update `` |