### PR TITLE
chore(flake/nur): `91813318` -> `b438dc14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713829550,
-        "narHash": "sha256-fFUjWBiJhm+AxgKSGkbUSyLOiL8UcAv4Ed1KYEPy7N0=",
+        "lastModified": 1713837867,
+        "narHash": "sha256-R1rAEvwYFJvvhR5/KmGA0sQxjXN5t6Vcg6e9kD+mdTI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "918133185f9c984f40e7fbf05c8563140b35e44a",
+        "rev": "b438dc14b20fa06c7925d55911a16d10f61e6074",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b438dc14`](https://github.com/nix-community/NUR/commit/b438dc14b20fa06c7925d55911a16d10f61e6074) | `` automatic update `` |
| [`b3fa6614`](https://github.com/nix-community/NUR/commit/b3fa661458c7f7d18680523101f35d9140042d4b) | `` automatic update `` |
| [`d259431e`](https://github.com/nix-community/NUR/commit/d259431eb5c5526d46d4bcccb9bbfe56ef0bfd16) | `` automatic update `` |