### PR TITLE
chore(flake/emacs-overlay): `1cbf4672` -> `6e8f627b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713833979,
-        "narHash": "sha256-S4oUzhscDvzYKt7AvVf4lgAJaCnBHIoKIR439vCPPuA=",
+        "lastModified": 1713836896,
+        "narHash": "sha256-kkWa/BbZcJSJbo4X2ZARbA/TJnM6abj9RXtIM5gDRi4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1cbf4672adc9c1a26f76da384d0f0685d2c2f561",
+        "rev": "6e8f627bd82b5885e1808b772fcaebe4ebd40967",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`6e8f627b`](https://github.com/nix-community/emacs-overlay/commit/6e8f627bd82b5885e1808b772fcaebe4ebd40967) | `` Updated emacs `` |
| [`cb7b4758`](https://github.com/nix-community/emacs-overlay/commit/cb7b475812320db2263340c11b4edf484011ba33) | `` Updated melpa `` |