### PR TITLE
chore(flake/nur): `b438dc14` -> `6bce03a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713837867,
-        "narHash": "sha256-R1rAEvwYFJvvhR5/KmGA0sQxjXN5t6Vcg6e9kD+mdTI=",
+        "lastModified": 1713844515,
+        "narHash": "sha256-EAxSmwJ0hncSWRcB3chJM90xBpLhjvqzqaaWnWridY0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b438dc14b20fa06c7925d55911a16d10f61e6074",
+        "rev": "6bce03a1ef375589d9acc2313063ea4e662eddb6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6bce03a1`](https://github.com/nix-community/NUR/commit/6bce03a1ef375589d9acc2313063ea4e662eddb6) | `` automatic update `` |
| [`86a4ae26`](https://github.com/nix-community/NUR/commit/86a4ae26269a46cbeac7ef1e36c70ee7262aa378) | `` automatic update `` |
| [`389b341a`](https://github.com/nix-community/NUR/commit/389b341aaa7f5ac1da4b069dc5c34c8c1ca23585) | `` automatic update `` |
| [`9d450ce3`](https://github.com/nix-community/NUR/commit/9d450ce343581e3506eaa809df8e1f6a112d4465) | `` automatic update `` |
| [`b5d2a96a`](https://github.com/nix-community/NUR/commit/b5d2a96a95143b370ffc4a834810d07b7fdba2de) | `` automatic update `` |
| [`1a45a8cd`](https://github.com/nix-community/NUR/commit/1a45a8cd5ac7793b635a27f66b2910d7162a8f78) | `` automatic update `` |
| [`e41e170b`](https://github.com/nix-community/NUR/commit/e41e170ba84ecf750530ef6450fef0a2a14829f4) | `` automatic update `` |
| [`0d070139`](https://github.com/nix-community/NUR/commit/0d07013980365ae552ed98b6b986416fce3ae54f) | `` automatic update `` |