### PR TITLE
chore(flake/nur): `6bce03a1` -> `2bf7c7d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713844515,
-        "narHash": "sha256-EAxSmwJ0hncSWRcB3chJM90xBpLhjvqzqaaWnWridY0=",
+        "lastModified": 1713848119,
+        "narHash": "sha256-2CBX2V+fYVt6cy3WMJfKCVjdOINQViWq2RhYk5xNuIc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6bce03a1ef375589d9acc2313063ea4e662eddb6",
+        "rev": "2bf7c7d08d3b147a42fdc7ad710d9e1cfcbdeb2a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2bf7c7d0`](https://github.com/nix-community/NUR/commit/2bf7c7d08d3b147a42fdc7ad710d9e1cfcbdeb2a) | `` automatic update `` |
| [`0d918871`](https://github.com/nix-community/NUR/commit/0d918871ed3b90175fab29b7b3283907bdf0d183) | `` automatic update `` |
| [`a0c5e399`](https://github.com/nix-community/NUR/commit/a0c5e39987a7563eea26c88c5a7208b868ff198f) | `` automatic update `` |