### PR TITLE
chore(flake/nur): `2bf7c7d0` -> `159cb3c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713848119,
-        "narHash": "sha256-2CBX2V+fYVt6cy3WMJfKCVjdOINQViWq2RhYk5xNuIc=",
+        "lastModified": 1713851141,
+        "narHash": "sha256-paLfwAqrvy+qEhQNfwnhCb808CenuRL9/oBWk6Hsirc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2bf7c7d08d3b147a42fdc7ad710d9e1cfcbdeb2a",
+        "rev": "159cb3c3f074726858cd0957650c9f8105e8fd37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`159cb3c3`](https://github.com/nix-community/NUR/commit/159cb3c3f074726858cd0957650c9f8105e8fd37) | `` automatic update `` |