### PR TITLE
chore(flake/nur): `159cb3c3` -> `25cca100`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713851141,
-        "narHash": "sha256-paLfwAqrvy+qEhQNfwnhCb808CenuRL9/oBWk6Hsirc=",
+        "lastModified": 1713854073,
+        "narHash": "sha256-r7r01yd6/oZ18XvtCy9dvonH7aRKEcW+t24iqUUblnw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "159cb3c3f074726858cd0957650c9f8105e8fd37",
+        "rev": "25cca1001d9e88bd12cdadc36d07142b9fa25f16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`25cca100`](https://github.com/nix-community/NUR/commit/25cca1001d9e88bd12cdadc36d07142b9fa25f16) | `` automatic update `` |
| [`e568dbd8`](https://github.com/nix-community/NUR/commit/e568dbd83ed0437bb8947a8af2c16b62ec9d6e13) | `` automatic update `` |