### PR TITLE
chore(flake/nur): `25cca100` -> `302fcd88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713854073,
-        "narHash": "sha256-r7r01yd6/oZ18XvtCy9dvonH7aRKEcW+t24iqUUblnw=",
+        "lastModified": 1713858341,
+        "narHash": "sha256-mUYdPD6p5zrv0EkdfXsJ0+/DSz4Br/SjW2G3eMWPv3w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "25cca1001d9e88bd12cdadc36d07142b9fa25f16",
+        "rev": "302fcd882d97fcdf2b230e6c11c1a34a341af475",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`302fcd88`](https://github.com/nix-community/NUR/commit/302fcd882d97fcdf2b230e6c11c1a34a341af475) | `` automatic update `` |