### PR TITLE
chore(flake/emacs-overlay): `6e8f627b` -> `e4f883ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713836896,
-        "narHash": "sha256-kkWa/BbZcJSJbo4X2ZARbA/TJnM6abj9RXtIM5gDRi4=",
+        "lastModified": 1713863221,
+        "narHash": "sha256-/7G+gmGHObRYGUOJl8UWizW4GXAWSLqpTg4Dhxaj5F8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6e8f627bd82b5885e1808b772fcaebe4ebd40967",
+        "rev": "e4f883ea9d8314280968f460709f1df31c2801a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`e4f883ea`](https://github.com/nix-community/emacs-overlay/commit/e4f883ea9d8314280968f460709f1df31c2801a3) | `` Updated emacs `` |
| [`9b960970`](https://github.com/nix-community/emacs-overlay/commit/9b960970b5d0e7594aae8732d92561b988e3e1f0) | `` Updated melpa `` |