### PR TITLE
chore(flake/nur): `302fcd88` -> `0cf18870`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713858341,
-        "narHash": "sha256-mUYdPD6p5zrv0EkdfXsJ0+/DSz4Br/SjW2G3eMWPv3w=",
+        "lastModified": 1713861172,
+        "narHash": "sha256-pnNnt7FzRNe2S9zJ+MF2uvy4M1B2YFRUFE4+49+D/8w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "302fcd882d97fcdf2b230e6c11c1a34a341af475",
+        "rev": "0cf1887038e1fe505fda4292862cf35bb6e8417e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0cf18870`](https://github.com/nix-community/NUR/commit/0cf1887038e1fe505fda4292862cf35bb6e8417e) | `` automatic update `` |