### PR TITLE
chore(flake/nur): `0cf18870` -> `d302acd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713861172,
-        "narHash": "sha256-pnNnt7FzRNe2S9zJ+MF2uvy4M1B2YFRUFE4+49+D/8w=",
+        "lastModified": 1713865711,
+        "narHash": "sha256-dlvwQUsfptlgOFsO7X/Wu57iRTfow3XU+kxzuOTiu0k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0cf1887038e1fe505fda4292862cf35bb6e8417e",
+        "rev": "d302acd64b2f50631629eacf7a88c39eba92d340",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                         |
| -------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`d302acd6`](https://github.com/nix-community/NUR/commit/d302acd64b2f50631629eacf7a88c39eba92d340) | `` add kokakiwi repository ``   |
| [`7de4ce36`](https://github.com/nix-community/NUR/commit/7de4ce362d2d1d04b0aa9cba782cb7a9d794b6b5) | `` automatic update ``          |
| [`61ed7cb8`](https://github.com/nix-community/NUR/commit/61ed7cb81e2331b46cc0e356cfcca79d324f1b32) | `` add jdpkgs repository ``     |
| [`f5ad8942`](https://github.com/nix-community/NUR/commit/f5ad89420d8d6977da20a81d13beaaf76f2a553a) | `` automatic update ``          |
| [`408561c2`](https://github.com/nix-community/NUR/commit/408561c2d40c6ecba3848ab4077e28cd3cc3e70f) | `` Add glostis/nur-packages ``  |
| [`fcf28777`](https://github.com/nix-community/NUR/commit/fcf287771f7a357b57396e2402149d5426617a3d) | `` automatic update ``          |
| [`1fccb01d`](https://github.com/nix-community/NUR/commit/1fccb01d01cc1a91e46a3a54cf773f289c25d77d) | `` add iuricarras repository `` |
| [`44a6c391`](https://github.com/nix-community/NUR/commit/44a6c3911ff6644e57929d26c01bbe5f73de7208) | `` fix mergify configuration `` |