### PR TITLE
chore(flake/nix-index-database): `07ece11b` -> `dcb6ac44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -564,11 +564,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713668931,
-        "narHash": "sha256-rVlwWQlgFGGK3aPVcKmtYqWgjYnPah5FOIsYAqrMN2w=",
+        "lastModified": 1713869268,
+        "narHash": "sha256-o3CMQeu/S8/4zU0pMtYg51rd1FWdJsI2Xohzng1Ysdg=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "07ece11b22217b8459df589f858e92212b74f1a1",
+        "rev": "dcb6ac44922858ce3a5b46f77a36d6030181460c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                      |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`dcb6ac44`](https://github.com/nix-community/nix-index-database/commit/dcb6ac44922858ce3a5b46f77a36d6030181460c) | `` hm: Symlink per default only if needed `` |
| [`622b16b7`](https://github.com/nix-community/nix-index-database/commit/622b16b7d8b8697e40cb2e1d10e37188df02bfc2) | `` update to new merge configuration ``      |
| [`ed94c127`](https://github.com/nix-community/nix-index-database/commit/ed94c127153dccb088aa1a6c47d01cfdbdd07bc7) | `` mergify: also merge dependabot ``         |