### PR TITLE
chore(flake/nur): `d3d6e432` -> `b726b335`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713876129,
-        "narHash": "sha256-eBk9qIC3PiCkgBiOb0bF0kAazUhw1iGyemMrVTFlCWs=",
+        "lastModified": 1713887057,
+        "narHash": "sha256-pX6VU9zWJQlgNS61UmPEssY12zGkc3l6AexYDfI0AWk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d3d6e43263575684f804701bebb9739885e6cc0d",
+        "rev": "b726b33500beb5c1be583d32bce126fbe50558c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                       |
| -------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`b726b335`](https://github.com/nix-community/NUR/commit/b726b33500beb5c1be583d32bce126fbe50558c7) | `` automatic update ``        |
| [`98867008`](https://github.com/nix-community/NUR/commit/9886700897e289f55cbd94922510e0490cf43a8c) | `` automatic update ``        |
| [`110ba450`](https://github.com/nix-community/NUR/commit/110ba4503f5f7feeb3843b00dbe948a637a07db5) | `` automatic update ``        |
| [`8b1df61b`](https://github.com/nix-community/NUR/commit/8b1df61bf878b4598e5ea643bb046a915443c7f5) | `` Fix kokakiwi's repo URL `` |