### PR TITLE
chore(flake/emacs-overlay): `e4f883ea` -> `404b72d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713863221,
-        "narHash": "sha256-/7G+gmGHObRYGUOJl8UWizW4GXAWSLqpTg4Dhxaj5F8=",
+        "lastModified": 1713892023,
+        "narHash": "sha256-Db02rcyvMSjHlOu/xPX4kvc8HDOUxTX0MldcUcAe/zM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e4f883ea9d8314280968f460709f1df31c2801a3",
+        "rev": "404b72d67877f73f029ddc77848a85e7d0f6edd0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`404b72d6`](https://github.com/nix-community/emacs-overlay/commit/404b72d67877f73f029ddc77848a85e7d0f6edd0) | `` Updated emacs ``  |
| [`5de71851`](https://github.com/nix-community/emacs-overlay/commit/5de71851e1cde4e80a0babfa7ea6fd537952b12f) | `` Updated melpa ``  |
| [`17920802`](https://github.com/nix-community/emacs-overlay/commit/1792080299ec0204c3472e6a782b5e472c568ce8) | `` Updated elpa ``   |
| [`1ecf1d71`](https://github.com/nix-community/emacs-overlay/commit/1ecf1d7150a6e8c313092dace9bb6eed36de80c2) | `` Updated nongnu `` |