### PR TITLE
chore(flake/sops-nix): `0441c0fb` -> `f1b0adc2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -767,11 +767,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1713876234,
-        "narHash": "sha256-Wl0oA7U6y7qzSBX6G5Rw66/AfhK1X1OtvAC5a8P/694=",
+        "lastModified": 1713892811,
+        "narHash": "sha256-uIGmA2xq41vVFETCF1WW4fFWFT2tqBln+aXnWrvjGRE=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "0441c0fb4fdbe5e5e65250039d509f14ca39e212",
+        "rev": "f1b0adc27265274e3b0c9b872a8f476a098679bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                  |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`f1b0adc2`](https://github.com/Mic92/sops-nix/commit/f1b0adc27265274e3b0c9b872a8f476a098679bd) | `` fix mergify configuration ``          |
| [`2733f774`](https://github.com/Mic92/sops-nix/commit/2733f77428a4aa49ec0ab7cea667958e62fc902e) | `` Adds command to update secret keys `` |