### PR TITLE
chore(flake/nur): `b726b335` -> `da283a91`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713887057,
-        "narHash": "sha256-pX6VU9zWJQlgNS61UmPEssY12zGkc3l6AexYDfI0AWk=",
+        "lastModified": 1713901553,
+        "narHash": "sha256-f4+VLf7rhjS7fmvnGm+lUlgVIYEagQfEnX2mzJL6wP8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b726b33500beb5c1be583d32bce126fbe50558c7",
+        "rev": "da283a91e2169b6bb45f6e74b1612cf1f8f2436e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`da283a91`](https://github.com/nix-community/NUR/commit/da283a91e2169b6bb45f6e74b1612cf1f8f2436e) | `` automatic update `` |
| [`b787dfe1`](https://github.com/nix-community/NUR/commit/b787dfe124b542c342d29c510b53c22fcfd708c8) | `` automatic update `` |
| [`62ce2f5c`](https://github.com/nix-community/NUR/commit/62ce2f5cfff530af86421b68a84babdbb0c71023) | `` automatic update `` |
| [`bd7acd72`](https://github.com/nix-community/NUR/commit/bd7acd72156a162b511d9ab2d1508b11edd6da0c) | `` automatic update `` |
| [`47948d07`](https://github.com/nix-community/NUR/commit/47948d07d138a4f746f8b42abb7db07f8b0f92a4) | `` automatic update `` |