### PR TITLE
chore(flake/nur): `da283a91` -> `01e811e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713901553,
-        "narHash": "sha256-f4+VLf7rhjS7fmvnGm+lUlgVIYEagQfEnX2mzJL6wP8=",
+        "lastModified": 1713903158,
+        "narHash": "sha256-dWOrSgYhyuwLcJHa+/VU05i0Qg64TaGXdFJDgXtGELs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "da283a91e2169b6bb45f6e74b1612cf1f8f2436e",
+        "rev": "01e811e23bec13e9ecaed7d64ebbee56c8df9d93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`01e811e2`](https://github.com/nix-community/NUR/commit/01e811e23bec13e9ecaed7d64ebbee56c8df9d93) | `` automatic update `` |