### PR TITLE
chore(flake/nur): `01e811e2` -> `4b1ce762`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713903158,
-        "narHash": "sha256-dWOrSgYhyuwLcJHa+/VU05i0Qg64TaGXdFJDgXtGELs=",
+        "lastModified": 1713908742,
+        "narHash": "sha256-iDH0/wF3H37auDHCf9FxFDL2DJaOZbvSkXbbGyTmk68=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "01e811e23bec13e9ecaed7d64ebbee56c8df9d93",
+        "rev": "4b1ce7625c123b2e33eb122c46543a50c625ef73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4b1ce762`](https://github.com/nix-community/NUR/commit/4b1ce7625c123b2e33eb122c46543a50c625ef73) | `` automatic update `` |
| [`f9df2fa9`](https://github.com/nix-community/NUR/commit/f9df2fa9da3b358f4606aa12d8b967598db81015) | `` automatic update `` |