### PR TITLE
chore(flake/nur): `4b1ce762` -> `12d272c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713908742,
-        "narHash": "sha256-iDH0/wF3H37auDHCf9FxFDL2DJaOZbvSkXbbGyTmk68=",
+        "lastModified": 1713912298,
+        "narHash": "sha256-r0xi+Sso/4z6r3un+dloRXcOJHnQkv5fybKJTI//wA8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4b1ce7625c123b2e33eb122c46543a50c625ef73",
+        "rev": "12d272c11768b65067f621034eaf507932e2fc2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`12d272c1`](https://github.com/nix-community/NUR/commit/12d272c11768b65067f621034eaf507932e2fc2e) | `` automatic update `` |