### PR TITLE
chore(flake/emacs-overlay): `404b72d6` -> `015c96d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713892023,
-        "narHash": "sha256-Db02rcyvMSjHlOu/xPX4kvc8HDOUxTX0MldcUcAe/zM=",
+        "lastModified": 1713920413,
+        "narHash": "sha256-+qrZ+Kgc3JNxk+32fUTZeCOdOTHhUMpGU9pIldCa+uM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "404b72d67877f73f029ddc77848a85e7d0f6edd0",
+        "rev": "015c96d07f171ae7f9061648b4a492d193ebe20d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`015c96d0`](https://github.com/nix-community/emacs-overlay/commit/015c96d07f171ae7f9061648b4a492d193ebe20d) | `` Updated elpa `` |