### PR TITLE
chore(flake/emacs-overlay): `015c96d0` -> `1f8c4bc8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713920413,
-        "narHash": "sha256-+qrZ+Kgc3JNxk+32fUTZeCOdOTHhUMpGU9pIldCa+uM=",
+        "lastModified": 1713923369,
+        "narHash": "sha256-XHWD4/bX5UYtNxDTEwD3WVWhehR6IgDaR5T7QyqPc5s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "015c96d07f171ae7f9061648b4a492d193ebe20d",
+        "rev": "1f8c4bc8b3d395ff65844930b562e775fd18fc23",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`1f8c4bc8`](https://github.com/nix-community/emacs-overlay/commit/1f8c4bc8b3d395ff65844930b562e775fd18fc23) | `` Updated emacs `` |
| [`c72d8b8b`](https://github.com/nix-community/emacs-overlay/commit/c72d8b8b670309f06f9e24432ea0f1de67ec3aae) | `` Updated melpa `` |