### PR TITLE
chore(flake/nur): `12d272c1` -> `c716ac54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713912298,
-        "narHash": "sha256-r0xi+Sso/4z6r3un+dloRXcOJHnQkv5fybKJTI//wA8=",
+        "lastModified": 1713922938,
+        "narHash": "sha256-f3aDBK2c9D4Kfe59RlbPdiuGbhsQ0tjNYUyCDvx6Bxk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "12d272c11768b65067f621034eaf507932e2fc2e",
+        "rev": "c716ac543b77c8f3737961ed8a5395ef76bfa29d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c716ac54`](https://github.com/nix-community/NUR/commit/c716ac543b77c8f3737961ed8a5395ef76bfa29d) | `` automatic update `` |