### PR TITLE
chore(flake/nur): `c716ac54` -> `618009f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713922938,
-        "narHash": "sha256-f3aDBK2c9D4Kfe59RlbPdiuGbhsQ0tjNYUyCDvx6Bxk=",
+        "lastModified": 1713931048,
+        "narHash": "sha256-7twe+T37zsOddswZ9zUDdQGzk5KCaJGKlmFa5naqQnQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c716ac543b77c8f3737961ed8a5395ef76bfa29d",
+        "rev": "618009f3fa72c6ec6fcaf6fdd9150569c996ca8a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`618009f3`](https://github.com/nix-community/NUR/commit/618009f3fa72c6ec6fcaf6fdd9150569c996ca8a) | `` automatic update `` |
| [`d60fb97f`](https://github.com/nix-community/NUR/commit/d60fb97f7da36b29b03f14f0353dbda975800b48) | `` automatic update `` |
| [`f20d28c5`](https://github.com/nix-community/NUR/commit/f20d28c5aef98ace8ed8b8525de4a82be65f5288) | `` automatic update `` |
| [`21e49cc3`](https://github.com/nix-community/NUR/commit/21e49cc307cbe8a134f83a09705eccd002162394) | `` automatic update `` |