### PR TITLE
chore(flake/nur): `10344bae` -> `84ffbd02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713931794,
-        "narHash": "sha256-W8Si84Fqi/kCPcGh5KnMfHddc39eJ3esmSTzUFL9HEY=",
+        "lastModified": 1713942066,
+        "narHash": "sha256-9gJydU+mqLhI4NMfv5A0GfToEw6/bVwjW5zxLiWpAWg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "10344baebd47c199da92973d7f86f77290997412",
+        "rev": "84ffbd021214820adf6f629e94379b4aac1c25f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`84ffbd02`](https://github.com/nix-community/NUR/commit/84ffbd021214820adf6f629e94379b4aac1c25f4) | `` automatic update `` |
| [`64da7dfc`](https://github.com/nix-community/NUR/commit/64da7dfc2209bb1205da814524f24a2d5589d37b) | `` automatic update `` |
| [`48b802f6`](https://github.com/nix-community/NUR/commit/48b802f6b284c8a7b0750ae41aca56ba6e57876c) | `` automatic update `` |