### PR TITLE
chore(flake/emacs-overlay): `1f8c4bc8` -> `aabdc120`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713923369,
-        "narHash": "sha256-XHWD4/bX5UYtNxDTEwD3WVWhehR6IgDaR5T7QyqPc5s=",
+        "lastModified": 1713948883,
+        "narHash": "sha256-wjff06fN+Gv3zjoZXNu4HNSBN0y6fF2FHcJvVyz7Lls=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1f8c4bc8b3d395ff65844930b562e775fd18fc23",
+        "rev": "aabdc120398f3bf7d1ba0a95cbe06c7b141c87d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`aabdc120`](https://github.com/nix-community/emacs-overlay/commit/aabdc120398f3bf7d1ba0a95cbe06c7b141c87d5) | `` Updated melpa `` |