### PR TITLE
chore(flake/nur): `a5a62f60` -> `3ae216b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713947685,
-        "narHash": "sha256-8faxXE53zBQmr5lsVZvT9Vh8CW7dNSwphIasPP4S1UI=",
+        "lastModified": 1713965716,
+        "narHash": "sha256-utmBQ6p1FKqrWYWGrxx/sitBvB31tgbaN2tEjxn2uP8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a5a62f60303597824baa29266ebf218de266d3d5",
+        "rev": "3ae216b3d67950071428b46a647d31e3ae5c7162",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3ae216b3`](https://github.com/nix-community/NUR/commit/3ae216b3d67950071428b46a647d31e3ae5c7162) | `` automatic update `` |
| [`192ed91d`](https://github.com/nix-community/NUR/commit/192ed91d4c80986d44a2a92b61bf9912b21dc400) | `` automatic update `` |
| [`b75ffb4b`](https://github.com/nix-community/NUR/commit/b75ffb4b56b42ca4185252fbac43e0724458aa77) | `` automatic update `` |
| [`d5ad89a7`](https://github.com/nix-community/NUR/commit/d5ad89a7119a5f6e7d79859f36a51caf5f76cbaa) | `` automatic update `` |
| [`1c623010`](https://github.com/nix-community/NUR/commit/1c62301053428f187d425edd10c913c0bc274457) | `` automatic update `` |
| [`1c36cf79`](https://github.com/nix-community/NUR/commit/1c36cf793dcb8f17cc165cf51ecbfb52c69cbe99) | `` automatic update `` |