### PR TITLE
chore(flake/nur): `3ae216b3` -> `ea29248d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713965716,
-        "narHash": "sha256-utmBQ6p1FKqrWYWGrxx/sitBvB31tgbaN2tEjxn2uP8=",
+        "lastModified": 1713973934,
+        "narHash": "sha256-JmSBVRR0iWT2JeYSB+UOH5fIVdiWFDZmZ//t/GfCTtA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3ae216b3d67950071428b46a647d31e3ae5c7162",
+        "rev": "ea29248d3e1a1c1efea6edaefbe3b0e0102b9458",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ea29248d`](https://github.com/nix-community/NUR/commit/ea29248d3e1a1c1efea6edaefbe3b0e0102b9458) | `` automatic update `` |
| [`d8dd5ed5`](https://github.com/nix-community/NUR/commit/d8dd5ed5900b1417212c03f8d2075cb3e668dd0e) | `` automatic update `` |
| [`15b9b1b1`](https://github.com/nix-community/NUR/commit/15b9b1b1ea8d780175e0cb4297485a04c597174b) | `` automatic update `` |