### PR TITLE
chore(flake/nur): `ea29248d` -> `b24ab762`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713973934,
-        "narHash": "sha256-JmSBVRR0iWT2JeYSB+UOH5fIVdiWFDZmZ//t/GfCTtA=",
+        "lastModified": 1713977085,
+        "narHash": "sha256-Kqj8OrJRKn6hccYFsM2a1Z60oDVsUxyr6bB0FCAry7Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ea29248d3e1a1c1efea6edaefbe3b0e0102b9458",
+        "rev": "b24ab762a78fcd4b777d0ac95263c73f90af6476",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b24ab762`](https://github.com/nix-community/NUR/commit/b24ab762a78fcd4b777d0ac95263c73f90af6476) | `` automatic update `` |