### PR TITLE
chore(flake/emacs-overlay): `7da709f5` -> `2426b41b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713949624,
-        "narHash": "sha256-Er2cq+QeylfOs0KWKn0pA0v/3+pYLZN+sdrcl9DSQo8=",
+        "lastModified": 1713978400,
+        "narHash": "sha256-Q/sRS7bKVuaqJWtVwQl3DcjNdW8KikSYx/khPvbgFbc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7da709f57affaa4367e192a4ab4d70e44234a77e",
+        "rev": "2426b41b8b6be7ccac87159476b109c81894d0bf",
         "type": "github"
       },
       "original": {
@@ -627,11 +627,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1713725259,
-        "narHash": "sha256-9ZR/Rbx5/Z/JZf5ehVNMoz/s5xjpP0a22tL6qNvLt5E=",
+        "lastModified": 1713828541,
+        "narHash": "sha256-KtvQeE12MSkCOhvVmnmcZCjnx7t31zWin2XVSDOwBDE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a5e4bbcb4780c63c79c87d29ea409abf097de3f7",
+        "rev": "b500489fd3cf653eafc075f9362423ad5cdd8676",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`2426b41b`](https://github.com/nix-community/emacs-overlay/commit/2426b41b8b6be7ccac87159476b109c81894d0bf) | `` Updated emacs ``        |
| [`735a40ab`](https://github.com/nix-community/emacs-overlay/commit/735a40ab43a9e362c8437986460bf13d38277791) | `` Updated melpa ``        |
| [`64203264`](https://github.com/nix-community/emacs-overlay/commit/642032648deb48237ac587fc8d7c7b3e21ddaff8) | `` Updated elpa ``         |
| [`fda03f22`](https://github.com/nix-community/emacs-overlay/commit/fda03f226ba263c589289f61d0389266b6f5dcae) | `` Updated nongnu ``       |
| [`faa7885d`](https://github.com/nix-community/emacs-overlay/commit/faa7885de7e62e0812b9a3319766014e5021fa40) | `` Updated flake inputs `` |