### PR TITLE
chore(flake/nur): `bf2583cd` -> `b9dbb375`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713981939,
-        "narHash": "sha256-pOzz6IZc1pGAyYVa3cql8cYMgH0ps7/1BqBG03r7iSo=",
+        "lastModified": 1713988419,
+        "narHash": "sha256-wJqzudiiJ8lwxc3JlFJlGYTAvGObumw1ifgechzUuEM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bf2583cd22c8cb98dc07b617a77dff13c565c28d",
+        "rev": "b9dbb37557ddb95abd4bf780651c16e3d1923069",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b9dbb375`](https://github.com/nix-community/NUR/commit/b9dbb37557ddb95abd4bf780651c16e3d1923069) | `` automatic update `` |
| [`8d8f94ba`](https://github.com/nix-community/NUR/commit/8d8f94bab3305be5fcbf0302fe40be0b3c8ca77b) | `` automatic update `` |