### PR TITLE
chore(flake/nur): `b9dbb375` -> `699351c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713988419,
-        "narHash": "sha256-wJqzudiiJ8lwxc3JlFJlGYTAvGObumw1ifgechzUuEM=",
+        "lastModified": 1713990402,
+        "narHash": "sha256-xEZrk9YjKrZamtlvEfmEGhubN+ZVJ2VGSUgW5yOQ8go=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b9dbb37557ddb95abd4bf780651c16e3d1923069",
+        "rev": "699351c41c7611493e4cc4fa85f372d00c1aead5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`699351c4`](https://github.com/nix-community/NUR/commit/699351c41c7611493e4cc4fa85f372d00c1aead5) | `` automatic update `` |