### PR TITLE
chore(flake/srvos): `e00e4214` -> `a1bbd4ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -787,11 +787,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713747325,
-        "narHash": "sha256-3Rh1372yHv7TYA8yJqSCcKeVsHdhmDa4veN9kb3fNx8=",
+        "lastModified": 1714006362,
+        "narHash": "sha256-Wp7eWCLmDHI+sfAergoKluNWPyeAyG8ePfeXsUGJZ6c=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "e00e421468806a7a245bc76f0a23eb9e91593918",
+        "rev": "a1bbd4ab45c065bb2583f6344f9f72663c683fcb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`a1bbd4ab`](https://github.com/nix-community/srvos/commit/a1bbd4ab45c065bb2583f6344f9f72663c683fcb) | `` dev/private/flake.lock: Update `` |
| [`89847c5d`](https://github.com/nix-community/srvos/commit/89847c5dadd856dae5f1024e1f5b5c74aeb2d598) | `` flake.lock: Update ``             |