### PR TITLE
chore(flake/emacs-overlay): `9f7f7f3e` -> `bf2ab188`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714006900,
-        "narHash": "sha256-afxLU2fMveyqJbicV/PHTCBGfeZAd/zbY3UzoeAi0ms=",
+        "lastModified": 1714012795,
+        "narHash": "sha256-UCst+RoX67NhDgfCcJwOk94ZEjDg09wh1i0gs83Nrvc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9f7f7f3ec123281ecb01e525dcf716b35e8769d2",
+        "rev": "bf2ab188e525dd20cdd9448e270fd442cea56949",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                         |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------- |
| [`9b6590d9`](https://github.com/nix-community/emacs-overlay/commit/9b6590d9fb34872137e09585c853e6960dd22c30) | `` Updated melpa ``             |
| [`8bb3595c`](https://github.com/nix-community/emacs-overlay/commit/8bb3595ccc40b0ab2a60fbbf715887c855edea95) | `` Correct Smart Parens hash `` |