### PR TITLE
chore(flake/nur): `e4e53d5f` -> `6f5910d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714010743,
-        "narHash": "sha256-fYlMwpyUbWTIGUAJh3cyfaMFEWEvTfFFfeezNVG7tNE=",
+        "lastModified": 1714013020,
+        "narHash": "sha256-wCy0/MvyN1Ad0UpBTfAuNJzwYD4JK+1BzlIh0gfA7hc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e4e53d5f42d74b69320404fa73d9bb72c260b95c",
+        "rev": "6f5910d017e8beb495076fece7039831b9d98f52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6f5910d0`](https://github.com/nix-community/NUR/commit/6f5910d017e8beb495076fece7039831b9d98f52) | `` automatic update `` |