### PR TITLE
chore(flake/nur): `6f5910d0` -> `c16a72c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714013020,
-        "narHash": "sha256-wCy0/MvyN1Ad0UpBTfAuNJzwYD4JK+1BzlIh0gfA7hc=",
+        "lastModified": 1714017342,
+        "narHash": "sha256-9oc+gwuOg9G/Ku4lWy/y4OLgUFD8QbMcwlLesYvdwE8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6f5910d017e8beb495076fece7039831b9d98f52",
+        "rev": "c16a72c1ce23474a47d456820d0a1b84f3d366bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c16a72c1`](https://github.com/nix-community/NUR/commit/c16a72c1ce23474a47d456820d0a1b84f3d366bc) | `` automatic update `` |
| [`319b4f3d`](https://github.com/nix-community/NUR/commit/319b4f3d48e26d45681780eeba411a7f9c27c1b2) | `` automatic update `` |
| [`25cfc60e`](https://github.com/nix-community/NUR/commit/25cfc60ecfdae78209f1f945cd2ffc2ef1425204) | `` automatic update `` |
| [`1b4069d6`](https://github.com/nix-community/NUR/commit/1b4069d613ed7185c72f3604688862b96b7fe53b) | `` automatic update `` |