### PR TITLE
chore(flake/nur): `3a3f889a` -> `70ac3c0d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714019566,
-        "narHash": "sha256-M1FEQysyUcAA69aS6eYSR5rNPioqbvsFZ5gczbSRMOc=",
+        "lastModified": 1714021881,
+        "narHash": "sha256-1PCS+QSjMJW0ve7/czqo6XK8aI844Vf1I45Ilw0GzOQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3a3f889abe29c106addfb9863d4fb0dc0f15916c",
+        "rev": "70ac3c0d904dbcf825e13f1639fda317a884acbc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`70ac3c0d`](https://github.com/nix-community/NUR/commit/70ac3c0d904dbcf825e13f1639fda317a884acbc) | `` automatic update `` |