### PR TITLE
chore(flake/nur): `70ac3c0d` -> `95439c61`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,11 +675,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714021881,
-        "narHash": "sha256-1PCS+QSjMJW0ve7/czqo6XK8aI844Vf1I45Ilw0GzOQ=",
+        "lastModified": 1714026494,
+        "narHash": "sha256-4eGcrACxaKNFwQXFJfzHCcqm2m1vnfTxg+aP0sjdxcs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "70ac3c0d904dbcf825e13f1639fda317a884acbc",
+        "rev": "95439c61f5a5792eadd98cdcf472404af68246d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`95439c61`](https://github.com/nix-community/NUR/commit/95439c61f5a5792eadd98cdcf472404af68246d1) | `` automatic update `` |