### PR TITLE
chore(flake/nur): `bf5a5250` -> `e060d82e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714028524,
-        "narHash": "sha256-AnaW3WPtm6p3lT3np6YwVUc9S0c+wUAzqDf3wWlQvck=",
+        "lastModified": 1714029133,
+        "narHash": "sha256-06A0OGYpKfqLAYS9bENNMjQzS+eVjG0nTlqT13a5+bM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bf5a5250fb2618aa8693800bfc1ede879faa291b",
+        "rev": "e060d82ece644ef33a9ea2f05b71c0c2398347d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e060d82e`](https://github.com/nix-community/NUR/commit/e060d82ece644ef33a9ea2f05b71c0c2398347d2) | `` automatic update `` |