### PR TITLE
chore(flake/nur): `e060d82e` -> `4293c360`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714029133,
-        "narHash": "sha256-06A0OGYpKfqLAYS9bENNMjQzS+eVjG0nTlqT13a5+bM=",
+        "lastModified": 1714029428,
+        "narHash": "sha256-4te/+h5Gz5/0Omnbe8nyq3/W819R/VIUbBP6Ndy2Gdg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e060d82ece644ef33a9ea2f05b71c0c2398347d2",
+        "rev": "4293c3601e052e2ae49b44eba7e27e7739f7ede5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4293c360`](https://github.com/nix-community/NUR/commit/4293c3601e052e2ae49b44eba7e27e7739f7ede5) | `` automatic update `` |