### PR TITLE
chore(flake/nur): `4293c360` -> `ff96ec8c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714029428,
-        "narHash": "sha256-4te/+h5Gz5/0Omnbe8nyq3/W819R/VIUbBP6Ndy2Gdg=",
+        "lastModified": 1714034345,
+        "narHash": "sha256-YXX9tWYUcnwjog2f9XfonLdMO1BvxvsBzrLZNLkzT3E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4293c3601e052e2ae49b44eba7e27e7739f7ede5",
+        "rev": "ff96ec8c57f5ff270240ebb948ce754beaff67bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ff96ec8c`](https://github.com/nix-community/NUR/commit/ff96ec8c57f5ff270240ebb948ce754beaff67bb) | `` automatic update `` |
| [`94f82949`](https://github.com/nix-community/NUR/commit/94f82949814f038f3c4f3a7f43d812bf3120c9c6) | `` automatic update `` |