### PR TITLE
chore(flake/emacs-overlay): `bf2ab188` -> `4db70e79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714012795,
-        "narHash": "sha256-UCst+RoX67NhDgfCcJwOk94ZEjDg09wh1i0gs83Nrvc=",
+        "lastModified": 1714036088,
+        "narHash": "sha256-fNWTexdJX3BJKcbLD2J8Oy4EtygZcC5Kdk5UOu2f4UU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bf2ab188e525dd20cdd9448e270fd442cea56949",
+        "rev": "4db70e7955dee1ed9446a2f910144c560f704f9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`4db70e79`](https://github.com/nix-community/emacs-overlay/commit/4db70e7955dee1ed9446a2f910144c560f704f9d) | `` Updated emacs `` |
| [`788512ea`](https://github.com/nix-community/emacs-overlay/commit/788512ea00d4bd46740a283125aa0853ff10ce8a) | `` Updated melpa `` |