### PR TITLE
chore(flake/home-manager): `2f072c12` -> `6864ca2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -290,11 +290,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713992342,
-        "narHash": "sha256-bW7K4WPo6jhYMo4ZUGoJfog6xJV0XZh8adXqZKunRoc=",
+        "lastModified": 1714039456,
+        "narHash": "sha256-EAjkeoa/0Mdi6KlPVt4E4WZAWuk6EqtZX3cGvNkO0CU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f072c127c041eec36621b8e38a531fe0fe07961",
+        "rev": "6864ca2d2657d57a041110dcaf8be0c4b71346c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`6864ca2d`](https://github.com/nix-community/home-manager/commit/6864ca2d2657d57a041110dcaf8be0c4b71346c0) | `` Add translation using Weblate (Icelandic) `` |
| [`3ebcff8d`](https://github.com/nix-community/home-manager/commit/3ebcff8d1219c9e0fb3c880ef7959feca7ea2c4a) | `` Translate using Weblate (Icelandic) ``       |
| [`4c157f84`](https://github.com/nix-community/home-manager/commit/4c157f84e8fbd6a0fd1688b458c6ce04d047a165) | `` flake.lock: Update ``                        |