### PR TITLE
chore(flake/home-manager): `6864ca2d` -> `0c5704ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -290,11 +290,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714039456,
-        "narHash": "sha256-EAjkeoa/0Mdi6KlPVt4E4WZAWuk6EqtZX3cGvNkO0CU=",
+        "lastModified": 1714042918,
+        "narHash": "sha256-4AItZA3EQIiSNAxliuYEJumw/LaVfrMv84gYyrs0r3U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6864ca2d2657d57a041110dcaf8be0c4b71346c0",
+        "rev": "0c5704eceefcb7bb238a958f532a86e3b59d76db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`0c5704ec`](https://github.com/nix-community/home-manager/commit/0c5704eceefcb7bb238a958f532a86e3b59d76db) | `` home-manager: make newsReadIdsFile more reliable `` |