### PR TITLE
chore(flake/nur): `ff96ec8c` -> `add24022`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714034345,
-        "narHash": "sha256-YXX9tWYUcnwjog2f9XfonLdMO1BvxvsBzrLZNLkzT3E=",
+        "lastModified": 1714048553,
+        "narHash": "sha256-yF7BHH1NbmY6D/aFk6K+iHlGA/eqnMwOiw6WQM172aQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ff96ec8c57f5ff270240ebb948ce754beaff67bb",
+        "rev": "add24022473f9c66e23a59f95b9b1cbdd4582498",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`add24022`](https://github.com/nix-community/NUR/commit/add24022473f9c66e23a59f95b9b1cbdd4582498) | `` automatic update `` |
| [`eee7cc5c`](https://github.com/nix-community/NUR/commit/eee7cc5c18e3ec1d59badc86e80c8b5e8acc0729) | `` automatic update `` |
| [`794795ff`](https://github.com/nix-community/NUR/commit/794795ff49332e801755f91dd9c23372c2d5f5e5) | `` automatic update `` |
| [`8475fdc0`](https://github.com/nix-community/NUR/commit/8475fdc0d601452de1eec0cfdc66cf73e9edc4ca) | `` automatic update `` |