### PR TITLE
chore(flake/nur): `add24022` -> `9410133c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714048553,
-        "narHash": "sha256-yF7BHH1NbmY6D/aFk6K+iHlGA/eqnMwOiw6WQM172aQ=",
+        "lastModified": 1714056679,
+        "narHash": "sha256-RKilQQQiuVVeRTRjJkZSmhsG60MG0ln9d9eSn07Zbt0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "add24022473f9c66e23a59f95b9b1cbdd4582498",
+        "rev": "9410133c3f453de8074e16f06926a5302bc19b29",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9410133c`](https://github.com/nix-community/NUR/commit/9410133c3f453de8074e16f06926a5302bc19b29) | `` automatic update `` |
| [`662f31ae`](https://github.com/nix-community/NUR/commit/662f31ae2bca65b75e4dfadce4cbf0f0018800df) | `` automatic update `` |