### PR TITLE
chore(flake/nur): `9410133c` -> `d46b9a40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714056679,
-        "narHash": "sha256-RKilQQQiuVVeRTRjJkZSmhsG60MG0ln9d9eSn07Zbt0=",
+        "lastModified": 1714063494,
+        "narHash": "sha256-Eq1+4qzT60GfkUX/38W0xokhNn1+t+cAaV5TJ9zxJo0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9410133c3f453de8074e16f06926a5302bc19b29",
+        "rev": "d46b9a407fdb5f324e7bb9a8795baffdf23a1e51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d46b9a40`](https://github.com/nix-community/NUR/commit/d46b9a407fdb5f324e7bb9a8795baffdf23a1e51) | `` automatic update `` |
| [`23ec6b3c`](https://github.com/nix-community/NUR/commit/23ec6b3cf4882a7b39685837368af00744d8cb6e) | `` automatic update `` |
| [`2a60daad`](https://github.com/nix-community/NUR/commit/2a60daad9ff4f9333c1253079aaa742bcacbad36) | `` automatic update `` |