### PR TITLE
chore(flake/treefmt): `49dc4a92` -> `c6aaf729`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -655,11 +655,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711963903,
-        "narHash": "sha256-N3QDhoaX+paWXHbEXZapqd1r95mdshxToGowtjtYkGI=",
+        "lastModified": 1714058656,
+        "narHash": "sha256-Qv4RBm4LKuO4fNOfx9wl40W2rBbv5u5m+whxRYUMiaA=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "49dc4a92b02b8e68798abd99184f228243b6e3ac",
+        "rev": "c6aaf729f34a36c445618580a9f95a48f5e4e03f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                               |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`c6aaf729`](https://github.com/numtide/treefmt-nix/commit/c6aaf729f34a36c445618580a9f95a48f5e4e03f) | `` ruff: allow both checking and formatting (#175) `` |