### PR TITLE
chore(flake/emacs-overlay): `4db70e79` -> `a1e3efaa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714036088,
-        "narHash": "sha256-fNWTexdJX3BJKcbLD2J8Oy4EtygZcC5Kdk5UOu2f4UU=",
+        "lastModified": 1714064794,
+        "narHash": "sha256-HuSOnSa/+OwJ5+HoTtisHMbbQhLFiUuTa/o/P/6dwRo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4db70e7955dee1ed9446a2f910144c560f704f9d",
+        "rev": "a1e3efaa0ff7cd4e19463d5fcadf4c20380980a8",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1713828541,
-        "narHash": "sha256-KtvQeE12MSkCOhvVmnmcZCjnx7t31zWin2XVSDOwBDE=",
+        "lastModified": 1713995372,
+        "narHash": "sha256-fFE3M0vCoiSwCX02z8VF58jXFRj9enYUSTqjyHAjrds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b500489fd3cf653eafc075f9362423ad5cdd8676",
+        "rev": "dd37924974b9202f8226ed5d74a252a9785aedf8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`a1e3efaa`](https://github.com/nix-community/emacs-overlay/commit/a1e3efaa0ff7cd4e19463d5fcadf4c20380980a8) | `` Updated emacs ``        |
| [`9795b38d`](https://github.com/nix-community/emacs-overlay/commit/9795b38ddf2674def112303e4a3ab7792c776a5b) | `` Updated melpa ``        |
| [`57150222`](https://github.com/nix-community/emacs-overlay/commit/571502222fdaf84c428834167ac1bd9ed41e10be) | `` Updated elpa ``         |
| [`9f647da4`](https://github.com/nix-community/emacs-overlay/commit/9f647da449cfbab30c6b6d0a90e2e8a04cba66e6) | `` Updated flake inputs `` |