### PR TITLE
chore(flake/nur): `d46b9a40` -> `489168d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714063494,
-        "narHash": "sha256-Eq1+4qzT60GfkUX/38W0xokhNn1+t+cAaV5TJ9zxJo0=",
+        "lastModified": 1714069768,
+        "narHash": "sha256-6CMK3zVKTmAzpXtyQmTFbWU7lgD1LzXEtgBOApSbW4o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d46b9a407fdb5f324e7bb9a8795baffdf23a1e51",
+        "rev": "489168d7bc73986d9849fea3d26aec5905a1a395",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`489168d7`](https://github.com/nix-community/NUR/commit/489168d7bc73986d9849fea3d26aec5905a1a395) | `` automatic update `` |
| [`a01b40a7`](https://github.com/nix-community/NUR/commit/a01b40a72aa0ee5afb681c537b39c39e6d8cfc08) | `` automatic update `` |
| [`578ac358`](https://github.com/nix-community/NUR/commit/578ac35866e8088ad5312a2a54d5cc5098c3dd6c) | `` automatic update `` |