### PR TITLE
chore(flake/emacs-overlay): `16a15efb` -> `1c3facbb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714093156,
-        "narHash": "sha256-++je6OQFLEn9N3ZNSdxhuZdwLm2OKVlIDViJ5sjTWgU=",
+        "lastModified": 1714096051,
+        "narHash": "sha256-rASn4qwcaXbi3QnITe3e5mzrB/Gd0vwnC6DXsB3CJM0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "16a15efb0989db2e9b9ffa678f79583ef8817960",
+        "rev": "1c3facbb9e90bb80e985d7a91138dadd09e9e7f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`1c3facbb`](https://github.com/nix-community/emacs-overlay/commit/1c3facbb9e90bb80e985d7a91138dadd09e9e7f3) | `` Updated emacs `` |
| [`25943a54`](https://github.com/nix-community/emacs-overlay/commit/25943a543cccc1348d636a2564037450f67a792e) | `` Updated melpa `` |