### PR TITLE
chore(flake/nur): `baa58eff` -> `57df71bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714095576,
-        "narHash": "sha256-rHcBqEf6m8YUTWMH0aIbBOq5NqkaUUOp4t7ODwtFkOw=",
+        "lastModified": 1714103217,
+        "narHash": "sha256-JP+/84IXcRx2dTDZJj9afQOtswgB2VqkNQ6XgIuAybY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "baa58effb3f7f7653ea59960f8791064650a254a",
+        "rev": "57df71bb2a5494ccf4ad26ac1bdf89038dd97355",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`57df71bb`](https://github.com/nix-community/NUR/commit/57df71bb2a5494ccf4ad26ac1bdf89038dd97355) | `` automatic update `` |
| [`5616e4a7`](https://github.com/nix-community/NUR/commit/5616e4a75438a49498d10fd34048a7c9dc335fdb) | `` automatic update `` |