### PR TITLE
chore(flake/nur): `57df71bb` -> `8769701a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714103217,
-        "narHash": "sha256-JP+/84IXcRx2dTDZJj9afQOtswgB2VqkNQ6XgIuAybY=",
+        "lastModified": 1714107458,
+        "narHash": "sha256-65rKSdQfnSQcosAR/+dUIc8AzPX+kfGr36+HxdEknBI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "57df71bb2a5494ccf4ad26ac1bdf89038dd97355",
+        "rev": "8769701a1c42070c566288d42607893de78a2cbc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8769701a`](https://github.com/nix-community/NUR/commit/8769701a1c42070c566288d42607893de78a2cbc) | `` automatic update `` |
| [`79037549`](https://github.com/nix-community/NUR/commit/7903754982f243ab0773285aa2ee79a0a03f1536) | `` automatic update `` |
| [`a598529b`](https://github.com/nix-community/NUR/commit/a598529ba69b8fdc2aa03778d1e0d32aea6e9c77) | `` automatic update `` |