### PR TITLE
chore(flake/nur): `8769701a` -> `f7b882d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714107458,
-        "narHash": "sha256-65rKSdQfnSQcosAR/+dUIc8AzPX+kfGr36+HxdEknBI=",
+        "lastModified": 1714109449,
+        "narHash": "sha256-0Sa4WhyEX0ow5cLq9yFLM8UKyEwBltoUZRxtU2H299M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8769701a1c42070c566288d42607893de78a2cbc",
+        "rev": "f7b882d41103084f28cb2b5c8a6c85c472eb38b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f7b882d4`](https://github.com/nix-community/NUR/commit/f7b882d41103084f28cb2b5c8a6c85c472eb38b7) | `` automatic update `` |
| [`f99fc680`](https://github.com/nix-community/NUR/commit/f99fc680734ee21c48243f6fe55740d4b9a9b4a7) | `` automatic update `` |