### PR TITLE
chore(flake/nur): `f7b882d4` -> `10fc1b8b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714109449,
-        "narHash": "sha256-0Sa4WhyEX0ow5cLq9yFLM8UKyEwBltoUZRxtU2H299M=",
+        "lastModified": 1714114197,
+        "narHash": "sha256-f1kMNBUgbY+2/N0YkeouGNYdL7HVsRgcQLf5zL/ayd0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f7b882d41103084f28cb2b5c8a6c85c472eb38b7",
+        "rev": "10fc1b8b048fe797ada9302f700590afb457dde2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`10fc1b8b`](https://github.com/nix-community/NUR/commit/10fc1b8b048fe797ada9302f700590afb457dde2) | `` automatic update `` |
| [`88096204`](https://github.com/nix-community/NUR/commit/88096204052509bccb056ca92fbc7bbec189078f) | `` automatic update `` |