### PR TITLE
chore(flake/emacs-overlay): `1c3facbb` -> `40463aaa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714096051,
-        "narHash": "sha256-rASn4qwcaXbi3QnITe3e5mzrB/Gd0vwnC6DXsB3CJM0=",
+        "lastModified": 1714121587,
+        "narHash": "sha256-mXwE5H5JJxi1c2c8nwjiyMRGy9UYgNPSJ2caJDxbGgk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1c3facbb9e90bb80e985d7a91138dadd09e9e7f3",
+        "rev": "40463aaa81fc44a2908716ca79d29c16c5fef81b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`40463aaa`](https://github.com/nix-community/emacs-overlay/commit/40463aaa81fc44a2908716ca79d29c16c5fef81b) | `` Updated melpa `` |