### PR TITLE
chore(flake/nur): `822636f0` -> `d6145a9d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714128377,
-        "narHash": "sha256-rwD8jIlSn0Km519hBkjjrng1RTrsWA+682cu6NnRjX4=",
+        "lastModified": 1714131820,
+        "narHash": "sha256-XcTvldxKGKMQnzZ3WYg2zaxI0HJsF6qShItv9o73iPw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "822636f03e7eb1f26de00b9851db777b0aa7e775",
+        "rev": "d6145a9d31692f2960aab6c3c229c37ba20dd8cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d6145a9d`](https://github.com/nix-community/NUR/commit/d6145a9d31692f2960aab6c3c229c37ba20dd8cb) | `` automatic update `` |