### PR TITLE
chore(flake/agenix): `1381a759` -> `24a7ea39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,11 +16,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712079060,
-        "narHash": "sha256-/JdiT9t+zzjChc5qQiF+jhrVhRt8figYH29rZO7pFe4=",
+        "lastModified": 1714136352,
+        "narHash": "sha256-BtWQ2Th/jamO1SlD+2ASSW5Jaf7JhA/JLpQHk0Goqpg=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "1381a759b205dff7a6818733118d02253340fd5e",
+        "rev": "24a7ea390564ccd5b39b7884f597cfc8d7f6f44e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`2c1d1fb1`](https://github.com/ryantm/agenix/commit/2c1d1fb13467184256e352b00ed2d89046c16cd6) | `` fix: allow for newlines in keys `` |