### PR TITLE
chore(flake/nur): `d6145a9d` -> `691addfb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714131820,
-        "narHash": "sha256-XcTvldxKGKMQnzZ3WYg2zaxI0HJsF6qShItv9o73iPw=",
+        "lastModified": 1714139621,
+        "narHash": "sha256-TOIzPdWLpfznNX94E+E1GjtJuFVKMzYqtSRb8AVnJN0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d6145a9d31692f2960aab6c3c229c37ba20dd8cb",
+        "rev": "691addfbb8f8e549ff83c55d2115a79f0c98782c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`691addfb`](https://github.com/nix-community/NUR/commit/691addfbb8f8e549ff83c55d2115a79f0c98782c) | `` automatic update `` |
| [`86c9fa8c`](https://github.com/nix-community/NUR/commit/86c9fa8c229fc66b3949c832e5532dffd91625a3) | `` automatic update `` |
| [`c22ca102`](https://github.com/nix-community/NUR/commit/c22ca102a828803425cccc97bab35ee3287499b3) | `` automatic update `` |
| [`528a0e78`](https://github.com/nix-community/NUR/commit/528a0e7860796e6ab62b197c9dba93346ed90ac1) | `` automatic update `` |
| [`580c6ab6`](https://github.com/nix-community/NUR/commit/580c6ab64a5fbe99fe5f23cfbfa24ed35b31c3f7) | `` automatic update `` |