### PR TITLE
chore(flake/nur): `691addfb` -> `8765dcbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714139621,
-        "narHash": "sha256-TOIzPdWLpfznNX94E+E1GjtJuFVKMzYqtSRb8AVnJN0=",
+        "lastModified": 1714141885,
+        "narHash": "sha256-hiGQbV4b59L5SXpvuX4OLNBusxRq6hanjpOw2O9RoH8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "691addfbb8f8e549ff83c55d2115a79f0c98782c",
+        "rev": "8765dcbc18b2bda9fc6c73ec8bcc4ed94e012bea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8765dcbc`](https://github.com/nix-community/NUR/commit/8765dcbc18b2bda9fc6c73ec8bcc4ed94e012bea) | `` automatic update `` |