### PR TITLE
chore(flake/srvos): `a1bbd4ab` -> `71a8e8ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -605,11 +605,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714006362,
-        "narHash": "sha256-Wp7eWCLmDHI+sfAergoKluNWPyeAyG8ePfeXsUGJZ6c=",
+        "lastModified": 1714143163,
+        "narHash": "sha256-WMAziIBkwX//WUGxH49ZSm0yaPS6/PvNWUMMut8unm0=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "a1bbd4ab45c065bb2583f6344f9f72663c683fcb",
+        "rev": "71a8e8ab6e4763714d20c22f42ba8860369a1508",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                    |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`71a8e8ab`](https://github.com/nix-community/srvos/commit/71a8e8ab6e4763714d20c22f42ba8860369a1508) | `` update comment for boot.growPartition and boot.initrd.systemd.enable `` |