### PR TITLE
chore(flake/emacs-overlay): `40463aaa` -> `e641ac10`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714121587,
-        "narHash": "sha256-mXwE5H5JJxi1c2c8nwjiyMRGy9UYgNPSJ2caJDxbGgk=",
+        "lastModified": 1714151396,
+        "narHash": "sha256-ZA8puHVEMhd8xdq1u+WEfiddWnG4aZLep0Gzmg0NeZc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "40463aaa81fc44a2908716ca79d29c16c5fef81b",
+        "rev": "e641ac1008eb11b0b0bb0a07f507061eed1690a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`e641ac10`](https://github.com/nix-community/emacs-overlay/commit/e641ac1008eb11b0b0bb0a07f507061eed1690a8) | `` Updated emacs ``        |
| [`f0ee04fd`](https://github.com/nix-community/emacs-overlay/commit/f0ee04fd09a388ada67b93cd72493df0c93a67e2) | `` Updated melpa ``        |
| [`67b49d43`](https://github.com/nix-community/emacs-overlay/commit/67b49d4343f33e624d610b2ce1f8fb023504df95) | `` Updated elpa ``         |
| [`c6f3c11c`](https://github.com/nix-community/emacs-overlay/commit/c6f3c11c47d674116a9fa6526ff9d703fd491151) | `` Updated flake inputs `` |