### PR TITLE
chore(flake/nur): `8765dcbc` -> `8f0f28c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714141885,
-        "narHash": "sha256-hiGQbV4b59L5SXpvuX4OLNBusxRq6hanjpOw2O9RoH8=",
+        "lastModified": 1714153552,
+        "narHash": "sha256-+3CdMPm0E4fExxj3xZ8nZY/TW/Tc0BczK4DopNdr6gY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8765dcbc18b2bda9fc6c73ec8bcc4ed94e012bea",
+        "rev": "8f0f28c3bf4fb66368ecf10fd742a44c7f816d35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8f0f28c3`](https://github.com/nix-community/NUR/commit/8f0f28c3bf4fb66368ecf10fd742a44c7f816d35) | `` automatic update `` |
| [`b7b280aa`](https://github.com/nix-community/NUR/commit/b7b280aa74e2bbfa214cef3112ce7a80b56a6b89) | `` automatic update `` |