### PR TITLE
chore(flake/emacs-overlay): `e641ac10` -> `2cd9606b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714151396,
-        "narHash": "sha256-ZA8puHVEMhd8xdq1u+WEfiddWnG4aZLep0Gzmg0NeZc=",
+        "lastModified": 1714179537,
+        "narHash": "sha256-cQGigYZJwMxA8c6WLL8NLSy8PuA3jso8fd7nnAy5JG4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e641ac1008eb11b0b0bb0a07f507061eed1690a8",
+        "rev": "2cd9606b3a736f1523fd2cceb30a1b603ebfadb7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`2cd9606b`](https://github.com/nix-community/emacs-overlay/commit/2cd9606b3a736f1523fd2cceb30a1b603ebfadb7) | `` Updated elpa `` |