### PR TITLE
chore(flake/emacs-overlay): `2cd9606b` -> `fbbffc93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714179537,
-        "narHash": "sha256-cQGigYZJwMxA8c6WLL8NLSy8PuA3jso8fd7nnAy5JG4=",
+        "lastModified": 1714181635,
+        "narHash": "sha256-Mt1x1KEkNP7IvhFNjvCiYVbsesEiLIOoLyBpGHPYRSs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2cd9606b3a736f1523fd2cceb30a1b603ebfadb7",
+        "rev": "fbbffc93fc04ca59b01f23ffac35eef284d5770b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`fbbffc93`](https://github.com/nix-community/emacs-overlay/commit/fbbffc93fc04ca59b01f23ffac35eef284d5770b) | `` Updated melpa `` |