### PR TITLE
chore(flake/nur): `abf00e1c` -> `ee536d7c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714181914,
-        "narHash": "sha256-mCPKcxyjmFaY/j1D9fSq6Tb7s/AGfBwd6TOfTap9QOw=",
+        "lastModified": 1714190145,
+        "narHash": "sha256-ByGqF+wRFFUginEX4V4CqoocYKptM+GvAPc2X127hIs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "abf00e1c47d5e792dbde85caeeac42c807945a71",
+        "rev": "ee536d7c63bbfc5a3dfd0f76e32bcd582efe4f7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ee536d7c`](https://github.com/nix-community/NUR/commit/ee536d7c63bbfc5a3dfd0f76e32bcd582efe4f7c) | `` automatic update `` |
| [`63db8d6c`](https://github.com/nix-community/NUR/commit/63db8d6cfd2821b94bb3eb7da2b9842f9621a398) | `` automatic update `` |