### PR TITLE
chore(flake/nur): `ee536d7c` -> `19f5d750`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714190145,
-        "narHash": "sha256-ByGqF+wRFFUginEX4V4CqoocYKptM+GvAPc2X127hIs=",
+        "lastModified": 1714193998,
+        "narHash": "sha256-bwRxnw75LpPstEWnzKJ9MJ2sd75fmrz60I2AQtYHwvU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ee536d7c63bbfc5a3dfd0f76e32bcd582efe4f7c",
+        "rev": "19f5d75020addffc957b23e67093095b9ac90c7e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`19f5d750`](https://github.com/nix-community/NUR/commit/19f5d75020addffc957b23e67093095b9ac90c7e) | `` automatic update `` |