### PR TITLE
chore(flake/nixos-hardware): `797f8d80` -> `53db5e10`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -398,11 +398,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1713864415,
-        "narHash": "sha256-/BPDMJEkrsFAFOsQWhwm31wezlgshPFlLBn34KEUdVA=",
+        "lastModified": 1714201532,
+        "narHash": "sha256-nk0W4rH7xYdDeS7k1SqqNtBaNrcgIBYNmOVc8P2puEY=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "797f8d8082c7cc3259cba7275c699d4991b09ecc",
+        "rev": "53db5e1070d07e750030bf65f1b9963df8f0c678",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`53db5e10`](https://github.com/NixOS/nixos-hardware/commit/53db5e1070d07e750030bf65f1b9963df8f0c678) | `` protectli/vp4670: add Super I/O kernel module ``                      |
| [`9821d2c5`](https://github.com/NixOS/nixos-hardware/commit/9821d2c5438edbb567190377bcec4b640ad100c6) | `` asus/pro-ws-x570-ace: init ``                                         |
| [`1bcf7164`](https://github.com/NixOS/nixos-hardware/commit/1bcf716420ac6152edcd1277c743292da6b87529) | `` starfive visionfive2: use nixpkgs default u-boot version ``           |
| [`7e3a3f31`](https://github.com/NixOS/nixos-hardware/commit/7e3a3f3170676043024055615da19b58614c4a70) | `` apple/t2: add tiny-dfr service ``                                     |
| [`17ad09c3`](https://github.com/NixOS/nixos-hardware/commit/17ad09c30ce18c97c1d93bc500867ac0af6a930c) | `` apple/t2: update to kernel 6.7.7 ``                                   |
| [`74b75a95`](https://github.com/NixOS/nixos-hardware/commit/74b75a9598e800f94e7ba71f2d5e042c4979189e) | `` hp elitebook: fix eval ``                                             |
| [`8cde8633`](https://github.com/NixOS/nixos-hardware/commit/8cde8633d4f93659856695189fa3ead28b7a839b) | `` framework/12th-gen-intel: Refactor module ``                          |
| [`f8e89e4e`](https://github.com/NixOS/nixos-hardware/commit/f8e89e4e847d25f32c68adccf61e3ad42967847b) | `` framework: Add framework-laptop-kmod as default for NixOS >= 24.05 `` |
| [`0335d1a0`](https://github.com/NixOS/nixos-hardware/commit/0335d1a093dc3e2c577e2243a192775db23485ba) | `` common/gpu/intel: Make initrd - i915 an option ``                     |