### PR TITLE
chore(flake/emacs-overlay): `fbbffc93` -> `ebf498ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714181635,
-        "narHash": "sha256-Mt1x1KEkNP7IvhFNjvCiYVbsesEiLIOoLyBpGHPYRSs=",
+        "lastModified": 1714208742,
+        "narHash": "sha256-p/DgJbd+zrMVzd73YxlD6kcI/XGvlB5vpUqllDFd59E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fbbffc93fc04ca59b01f23ffac35eef284d5770b",
+        "rev": "ebf498ef8ba1f45c25e50013ec715e6b0dedac62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`ebf498ef`](https://github.com/nix-community/emacs-overlay/commit/ebf498ef8ba1f45c25e50013ec715e6b0dedac62) | `` Updated emacs `` |
| [`c1c08e62`](https://github.com/nix-community/emacs-overlay/commit/c1c08e6209a53c037032f5314d136efa7993f73c) | `` Updated melpa `` |