### PR TITLE
chore(flake/nur): `0a8216b7` -> `09087b67`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714200784,
-        "narHash": "sha256-dUj2cco6qTaeuWaqWbahZiXOGmQSailzr0bzpgPJnaw=",
+        "lastModified": 1714205527,
+        "narHash": "sha256-56XsS0lhzwwBu+ZweifOpb/BpZFsnCtokRNB0EBoJ4A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0a8216b76cdf03dc03391053a44ab8c143e94e06",
+        "rev": "09087b678bb32aa248c3ba37f6c603bcdcea899d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`09087b67`](https://github.com/nix-community/NUR/commit/09087b678bb32aa248c3ba37f6c603bcdcea899d) | `` automatic update `` |