### PR TITLE
chore(flake/nur): `4476487f` -> `8f128e18`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714216145,
-        "narHash": "sha256-Ptj+dE9OrlB/08Ur6L40eI8V2cKmn+Q6R7UTOQRNKOQ=",
+        "lastModified": 1714225456,
+        "narHash": "sha256-mjC1hkvAMiDEQOugAkQ8k1W0JN3RJN8yVFKtpYP4OZ0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4476487ff03277727f7501f848ff1df5ec079246",
+        "rev": "8f128e18c07c1321851aeeee15b1061c7ca1a685",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8f128e18`](https://github.com/nix-community/NUR/commit/8f128e18c07c1321851aeeee15b1061c7ca1a685) | `` automatic update `` |