### PR TITLE
chore(flake/nur): `8f128e18` -> `c38b915d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714225456,
-        "narHash": "sha256-mjC1hkvAMiDEQOugAkQ8k1W0JN3RJN8yVFKtpYP4OZ0=",
+        "lastModified": 1714228349,
+        "narHash": "sha256-FmrQJ5uG8/A/eoiPdgEvPQdwMPy166paRHIFBm2klZs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8f128e18c07c1321851aeeee15b1061c7ca1a685",
+        "rev": "c38b915d001d270ae31c24f70a2e7debd73b6e34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c38b915d`](https://github.com/nix-community/NUR/commit/c38b915d001d270ae31c24f70a2e7debd73b6e34) | `` automatic update `` |