### PR TITLE
chore(flake/nur): `c38b915d` -> `6595c721`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714228349,
-        "narHash": "sha256-FmrQJ5uG8/A/eoiPdgEvPQdwMPy166paRHIFBm2klZs=",
+        "lastModified": 1714235024,
+        "narHash": "sha256-0enGrAOTwng09eFOxx5hHX/CLrERx6j6RfngdGSeDVg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c38b915d001d270ae31c24f70a2e7debd73b6e34",
+        "rev": "6595c721fda7656678209e71ecf45bda3f5d3c81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6595c721`](https://github.com/nix-community/NUR/commit/6595c721fda7656678209e71ecf45bda3f5d3c81) | `` automatic update `` |