### PR TITLE
chore(flake/emacs-overlay): `ebf498ef` -> `aee4d3da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714208742,
-        "narHash": "sha256-p/DgJbd+zrMVzd73YxlD6kcI/XGvlB5vpUqllDFd59E=",
+        "lastModified": 1714237490,
+        "narHash": "sha256-5cdV7tlOHaQ8M808CRk5TJLBaqi2ANLcCq9Ar5JQG5s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ebf498ef8ba1f45c25e50013ec715e6b0dedac62",
+        "rev": "aee4d3daa7cb71f903492103d1ea522efcf6f740",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`aee4d3da`](https://github.com/nix-community/emacs-overlay/commit/aee4d3daa7cb71f903492103d1ea522efcf6f740) | `` Updated emacs ``  |
| [`020ebe57`](https://github.com/nix-community/emacs-overlay/commit/020ebe5726a5ad409870688dcb3195b40cccf621) | `` Updated melpa ``  |
| [`21684073`](https://github.com/nix-community/emacs-overlay/commit/2168407308427714e82ce8bb541dc841d55d7a23) | `` Updated elpa ``   |
| [`9d470ca5`](https://github.com/nix-community/emacs-overlay/commit/9d470ca5c1a24de8fe4830a33c2c3c178c1cd426) | `` Updated nongnu `` |