### PR TITLE
chore(flake/nur): `45ec4318` -> `a5239f39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714239940,
-        "narHash": "sha256-+62CRuBlXGALulvEJ0U35/ig1fG2ANLNftpkK/ssra0=",
+        "lastModified": 1714242604,
+        "narHash": "sha256-1nRBcRsjCpgSg1ivM9Ivm6JE4DeWY8Z2FVxQRiTxAZY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "45ec4318144a279f76f17d621c320953ddbf111d",
+        "rev": "a5239f395888b90e6e0c8d522217298d864b3a08",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a5239f39`](https://github.com/nix-community/NUR/commit/a5239f395888b90e6e0c8d522217298d864b3a08) | `` automatic update `` |
| [`c85f6195`](https://github.com/nix-community/NUR/commit/c85f61952f2f59f420bee00dd2f261cc777db012) | `` automatic update `` |