### PR TITLE
chore(flake/nur): `a5239f39` -> `1def8834`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714242604,
-        "narHash": "sha256-1nRBcRsjCpgSg1ivM9Ivm6JE4DeWY8Z2FVxQRiTxAZY=",
+        "lastModified": 1714250691,
+        "narHash": "sha256-OIs8D5aNGgQlBbOXDSVw8hK+c1iyPrpAwIgs9/k+dN4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a5239f395888b90e6e0c8d522217298d864b3a08",
+        "rev": "1def883444a9bf8d2863558fda1f15910f43c7ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1def8834`](https://github.com/nix-community/NUR/commit/1def883444a9bf8d2863558fda1f15910f43c7ce) | `` automatic update `` |
| [`5f477515`](https://github.com/nix-community/NUR/commit/5f477515f14cedd2622b7b184fbeeeb1c264df6c) | `` automatic update `` |
| [`186d6557`](https://github.com/nix-community/NUR/commit/186d65571fdd7c6a1e0793e571bd9081dbef2633) | `` automatic update `` |