### PR TITLE
chore(flake/emacs-overlay): `bcd6700a` -> `bd27cee9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714266226,
-        "narHash": "sha256-HF/Evj21AwuHrSzCNh8e3HIjEd1/NbvzUv1XNi9hHSg=",
+        "lastModified": 1714467229,
+        "narHash": "sha256-bOTS9flCHP8wvcLmrExlbMs4j1+D7CfZv6lmJJlF93E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bcd6700ad46dcf331c668fae0dd2584db7cebe0e",
+        "rev": "bd27cee9e668598f5d40518f780f84bd14f800db",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1713995372,
-        "narHash": "sha256-fFE3M0vCoiSwCX02z8VF58jXFRj9enYUSTqjyHAjrds=",
+        "lastModified": 1714272655,
+        "narHash": "sha256-3/ghIWCve93ngkx5eNPdHIKJP/pMzSr5Wc4rNKE1wOc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dd37924974b9202f8226ed5d74a252a9785aedf8",
+        "rev": "12430e43bd9b81a6b4e79e64f87c624ade701eaf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`bd27cee9`](https://github.com/nix-community/emacs-overlay/commit/bd27cee9e668598f5d40518f780f84bd14f800db) | `` Updated melpa ``        |
| [`2bdab12a`](https://github.com/nix-community/emacs-overlay/commit/2bdab12a3077f6f25be03d93569a06a177425c47) | `` Updated emacs ``        |
| [`d7e1758b`](https://github.com/nix-community/emacs-overlay/commit/d7e1758bf7cf62a5e46a8c56276123997a07f401) | `` Updated melpa ``        |
| [`1e218600`](https://github.com/nix-community/emacs-overlay/commit/1e2186001f600b56c393bc2ef4d3ea27200dc116) | `` Updated elpa ``         |
| [`482bc474`](https://github.com/nix-community/emacs-overlay/commit/482bc4749bcbfcaf19a668a3d0e5ba3423be730c) | `` Updated emacs ``        |
| [`1ac3c76d`](https://github.com/nix-community/emacs-overlay/commit/1ac3c76d7ec5d1eaaebe3ead670d40197eb7b6b7) | `` Updated melpa ``        |
| [`17580157`](https://github.com/nix-community/emacs-overlay/commit/175801574b4bafe2ce03d6d0ae0e69b47e3ac805) | `` Updated melpa ``        |
| [`509a62d6`](https://github.com/nix-community/emacs-overlay/commit/509a62d6cec302e020c5ad546c02815b0bb8acf8) | `` Updated emacs ``        |
| [`257f63e6`](https://github.com/nix-community/emacs-overlay/commit/257f63e680234ff7513e885b4f19a5725738538d) | `` Updated elpa ``         |
| [`bb943ccf`](https://github.com/nix-community/emacs-overlay/commit/bb943ccf9c2572550ddfdb7c92373c6671b870af) | `` Updated emacs ``        |
| [`17b457e7`](https://github.com/nix-community/emacs-overlay/commit/17b457e79d6b331fbdaa1958933750b4fd9ea172) | `` Updated melpa ``        |
| [`5b574344`](https://github.com/nix-community/emacs-overlay/commit/5b574344d31962522a23cfc6152e01fcb0f32a6a) | `` Updated elpa ``         |
| [`641b8f42`](https://github.com/nix-community/emacs-overlay/commit/641b8f42e2069a021279c4ef0bf2f9070f431ae6) | `` Updated nongnu ``       |
| [`bfa0e3d8`](https://github.com/nix-community/emacs-overlay/commit/bfa0e3d8b4a4987b433b915cc63f77fa491c7a89) | `` Updated flake inputs `` |
| [`12d9a5fe`](https://github.com/nix-community/emacs-overlay/commit/12d9a5fe7968aa89ed37fdb28f32fdff29d01c0f) | `` Updated emacs ``        |
| [`cfcc1669`](https://github.com/nix-community/emacs-overlay/commit/cfcc1669779b0abc206761895ff1515d02bd4e12) | `` Updated melpa ``        |
| [`ce6068e2`](https://github.com/nix-community/emacs-overlay/commit/ce6068e25235bfe396f0c954a9fefe9da7540183) | `` Updated emacs ``        |
| [`21cde010`](https://github.com/nix-community/emacs-overlay/commit/21cde01069588bc3827c80aaa19b70ba6aae3601) | `` Updated melpa ``        |