### PR TITLE
chore(flake/nur): `42425114` -> `797753c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714268652,
-        "narHash": "sha256-OOpCAIjcEkUyUJcWlM1rPq3z/QAeKAt+vXiDbyR1I6k=",
+        "lastModified": 1714276584,
+        "narHash": "sha256-ZpdGdRZRkubTXgZtWSXZyyGUw7Ns6nfIgv3JHZwoZe8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "424251142040e2aaea629e41e2ac01661bab65dd",
+        "rev": "797753c74be8ee21d97a9102f21e60c48071b9d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`797753c7`](https://github.com/nix-community/NUR/commit/797753c74be8ee21d97a9102f21e60c48071b9d9) | `` automatic update `` |
| [`150d6d62`](https://github.com/nix-community/NUR/commit/150d6d625f037a9633caf5682f623a7b2d656f8f) | `` automatic update `` |
| [`0fddc63e`](https://github.com/nix-community/NUR/commit/0fddc63eb9fb081bdb7e5063aed7d56c180c48ca) | `` automatic update `` |
| [`1348a217`](https://github.com/nix-community/NUR/commit/1348a217ce75f5171b65873c5146b47e0d26bc83) | `` automatic update `` |