### PR TITLE
chore(flake/nur): `797753c7` -> `cd410988`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714276584,
-        "narHash": "sha256-ZpdGdRZRkubTXgZtWSXZyyGUw7Ns6nfIgv3JHZwoZe8=",
+        "lastModified": 1714282280,
+        "narHash": "sha256-QlMZkr+GCcJQhvHXhf/1FSdw47jxdedjbR4WFnRrOig=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "797753c74be8ee21d97a9102f21e60c48071b9d9",
+        "rev": "cd4109888e6c747dc4aed8987f7261111ee9366c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cd410988`](https://github.com/nix-community/NUR/commit/cd4109888e6c747dc4aed8987f7261111ee9366c) | `` automatic update `` |
| [`4b419603`](https://github.com/nix-community/NUR/commit/4b41960394e76484528c481e46edfda41c1a26cd) | `` automatic update `` |