### PR TITLE
chore(flake/nur): `cd410988` -> `247f1523`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714282280,
-        "narHash": "sha256-QlMZkr+GCcJQhvHXhf/1FSdw47jxdedjbR4WFnRrOig=",
+        "lastModified": 1714284561,
+        "narHash": "sha256-yCGQClPaEubKgyXT4Czr2W6YaXYXScWJ2TqEF5jQSh0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cd4109888e6c747dc4aed8987f7261111ee9366c",
+        "rev": "247f1523290796095d5182c67c4ed86c0e09021a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`247f1523`](https://github.com/nix-community/NUR/commit/247f1523290796095d5182c67c4ed86c0e09021a) | `` automatic update `` |