### PR TITLE
chore(flake/nur): `247f1523` -> `24a4b276`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714284561,
-        "narHash": "sha256-yCGQClPaEubKgyXT4Czr2W6YaXYXScWJ2TqEF5jQSh0=",
+        "lastModified": 1714293134,
+        "narHash": "sha256-lJZaJMGZ3kLtu/rqME+cs9R60APx1f9F8i1IcqC/rr0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "247f1523290796095d5182c67c4ed86c0e09021a",
+        "rev": "24a4b276332db32f4fd810e1e46cd2f821c2184b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`24a4b276`](https://github.com/nix-community/NUR/commit/24a4b276332db32f4fd810e1e46cd2f821c2184b) | `` automatic update `` |
| [`efc4f3c3`](https://github.com/nix-community/NUR/commit/efc4f3c31bb506958d8c3761fbc903039558ce46) | `` automatic update `` |