### PR TITLE
chore(flake/nur): `24a4b276` -> `efade349`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714293134,
-        "narHash": "sha256-lJZaJMGZ3kLtu/rqME+cs9R60APx1f9F8i1IcqC/rr0=",
+        "lastModified": 1714297964,
+        "narHash": "sha256-Y3rBv8bOG4wA6ZzC+s1rupT9pvM80V5cr+s2w0jMErU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "24a4b276332db32f4fd810e1e46cd2f821c2184b",
+        "rev": "efade3499fe69ced7d8cddb420b98f7562c50c1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`efade349`](https://github.com/nix-community/NUR/commit/efade3499fe69ced7d8cddb420b98f7562c50c1f) | `` automatic update `` |
| [`55677227`](https://github.com/nix-community/NUR/commit/556772273fbf7340cabe4a821685d60f44e5a8a3) | `` automatic update `` |