### PR TITLE
chore(flake/nur): `efade349` -> `1a015f29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714297964,
-        "narHash": "sha256-Y3rBv8bOG4wA6ZzC+s1rupT9pvM80V5cr+s2w0jMErU=",
+        "lastModified": 1714301656,
+        "narHash": "sha256-ioil8wrhtXt5VAVhBISBRjNMlUGqqzjeIxnffc3AkAo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "efade3499fe69ced7d8cddb420b98f7562c50c1f",
+        "rev": "1a015f296483ea7a20262bcbd56d405ee1b8fcf5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1a015f29`](https://github.com/nix-community/NUR/commit/1a015f296483ea7a20262bcbd56d405ee1b8fcf5) | `` automatic update `` |
| [`9b2b8d27`](https://github.com/nix-community/NUR/commit/9b2b8d27a31b6d0380ff2435c06383dd764106e9) | `` automatic update `` |