### PR TITLE
chore(flake/nur): `1a015f29` -> `b196e8da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714301656,
-        "narHash": "sha256-ioil8wrhtXt5VAVhBISBRjNMlUGqqzjeIxnffc3AkAo=",
+        "lastModified": 1714304964,
+        "narHash": "sha256-qVenqLZCvtLlJs/BnoCI8aFJTKnvTBZR+c4iPIHnrjs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1a015f296483ea7a20262bcbd56d405ee1b8fcf5",
+        "rev": "b196e8da8e8a49495973a09c66722feecf6105d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b196e8da`](https://github.com/nix-community/NUR/commit/b196e8da8e8a49495973a09c66722feecf6105d2) | `` automatic update `` |
| [`539a8ca6`](https://github.com/nix-community/NUR/commit/539a8ca6813a75570103d60b0ba2046368595b44) | `` automatic update `` |
| [`cbf80eb0`](https://github.com/nix-community/NUR/commit/cbf80eb07150d17ddd7b883b7e26b7c4380e7bcf) | `` automatic update `` |