### PR TITLE
chore(flake/nixpkgs): `7bb2ccd8` -> `58a1abdb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -412,11 +412,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714076141,
-        "narHash": "sha256-Drmja/f5MRHZCskS6mvzFqxEaZMeciScCTFxWVLqWEY=",
+        "lastModified": 1714253743,
+        "narHash": "sha256-mdTQw2XlariysyScCv2tTE45QSU9v/ezLcHJ22f0Nxc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7bb2ccd8cdc44c91edba16c48d2c8f331fb3d856",
+        "rev": "58a1abdbae3217ca6b702f03d3b35125d88a2994",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`804480fc`](https://github.com/NixOS/nixpkgs/commit/804480fc088b9f64ec6f906621bc7a83d014731a) | `` maintainers: remove msfjarvis ``                                            |
| [`f0d119ad`](https://github.com/NixOS/nixpkgs/commit/f0d119ad91d0d7d25816b10d9c1e7653ecd5c5d3) | `` gitu: 0.17.1 -> 0.19.2 ``                                                   |
| [`e8da6935`](https://github.com/NixOS/nixpkgs/commit/e8da693588000806c4a23d8c7d0cd4d233b4fca3) | `` uv: add GaetanLepage as maintainer ``                                       |
| [`3bcf9c10`](https://github.com/NixOS/nixpkgs/commit/3bcf9c10cef23a0ff2cf0649d3712b9bca4cbb2f) | `` uv: 0.1.36 -> 0.1.39 ``                                                     |
| [`82a0b76d`](https://github.com/NixOS/nixpkgs/commit/82a0b76d9cedf963534b394e010304ed34f8410e) | `` python311Packages.python-lsp-ruff: 2.2.0 -> 2.2.1 ``                        |
| [`ca9932ab`](https://github.com/NixOS/nixpkgs/commit/ca9932abe509e9f72f792d42de70b73329ba143a) | `` maintainers: remove andrew-d as a maintainer ``                             |
| [`b0920c5e`](https://github.com/NixOS/nixpkgs/commit/b0920c5e93e164bc3086be909c110a6feacf143e) | `` python312Packages.dirigera: 1.1.5 -> 1.1.6 ``                               |
| [`c21d362d`](https://github.com/NixOS/nixpkgs/commit/c21d362df9a2aeba17637f98e2fe43ea2c676683) | `` python312Packages.python-whois: format with nixfmt ``                       |
| [`bd895760`](https://github.com/NixOS/nixpkgs/commit/bd8957601332218546c762c4a06a30cb9b96b1cb) | `` python312Packages.python-whois: 0.9.3 -> 0.9.4 ``                           |
| [`7a772ebe`](https://github.com/NixOS/nixpkgs/commit/7a772ebe3d969e5f53829af8c6dffd722ba3294b) | `` python312Packages.pysigma: format with nixfmt ``                            |
| [`7dc4349d`](https://github.com/NixOS/nixpkgs/commit/7dc4349dce1195ed689feb605935541fc4f84b7c) | `` acorn: remove ``                                                            |
| [`02459a68`](https://github.com/NixOS/nixpkgs/commit/02459a68c93823744b8ce7ea0dc786831745cbb0) | `` python312Packages.pysigma: refactor ``                                      |
| [`1c6ab3cb`](https://github.com/NixOS/nixpkgs/commit/1c6ab3cbabc91dc691e9fddab5a375241245fc87) | `` python312Packages.pysigma: 0.11.4 -> 0.11.5 ``                              |
| [`c31ddf17`](https://github.com/NixOS/nixpkgs/commit/c31ddf170884befc5f46fcfac2af64595fb7da0a) | `` python312Packages.pyrisco: format with nixfmt ``                            |
| [`6c2fe69f`](https://github.com/NixOS/nixpkgs/commit/6c2fe69f64cc3dd2462dd28b45f240abd9fa1e14) | `` python312Packages.pyrisco: refactor ``                                      |
| [`aadf80f6`](https://github.com/NixOS/nixpkgs/commit/aadf80f69ce6e877e6b37e01924685383f69b594) | `` python312Packages.pyrisco: 0.6.0 -> 0.6.1 ``                                |
| [`9b268baa`](https://github.com/NixOS/nixpkgs/commit/9b268baa7ba135621ece46566d4df881ef469748) | `` python312Packages.potentials: format with nixfmt ``                         |
| [`0ef7f7e2`](https://github.com/NixOS/nixpkgs/commit/0ef7f7e258923e5980ca7ff5381de259103d106d) | `` python312Packages.yabadaba: refactor ``                                     |
| [`40dcc9be`](https://github.com/NixOS/nixpkgs/commit/40dcc9bea6d45603ffca4bc820cc94497e777a6b) | `` python312Packages.yabadaba: 0.2.1 -> 0.2.2 ``                               |
| [`dc78a65c`](https://github.com/NixOS/nixpkgs/commit/dc78a65c671741def8aed9c5feed26d18c849ab7) | `` python312Packages.potentials: refactor ``                                   |
| [`963b3eff`](https://github.com/NixOS/nixpkgs/commit/963b3eff92991c43218da02176647e7721f64f2a) | `` python312Packages.potentials: 0.3.7 -> 0.3.8 ``                             |
| [`ff3358b3`](https://github.com/NixOS/nixpkgs/commit/ff3358b3f5802d1b1ec61e79657f9220b0d75da5) | `` nixos/matrix-appservice-irc: fix chown of registration.yml in pre-script `` |
| [`6a20d4c1`](https://github.com/NixOS/nixpkgs/commit/6a20d4c13780c2aa718f90986b9bdf0bc0af58bb) | `` python312Packages.peaqevcore: 19.9.0 -> 19.9.2 ``                           |
| [`412eab19`](https://github.com/NixOS/nixpkgs/commit/412eab1966fcd17f3bed1aadaa8762ffb9914f0f) | `` tmuxp: remove peterhoeg from maintainer ``                                  |
| [`ddc51f13`](https://github.com/NixOS/nixpkgs/commit/ddc51f131f479348fbf92fea0af7e66cfc65451b) | `` tmuxp: cleanup, remove recursion ``                                         |
| [`9f7f6f57`](https://github.com/NixOS/nixpkgs/commit/9f7f6f57516c2109d2eb98dbc43c12c9f3e9af67) | `` ruff: 0.4.1 -> 0.4.2 ``                                                     |
| [`efff97cb`](https://github.com/NixOS/nixpkgs/commit/efff97cba609e620f1cfc36bef4eadff48df8924) | `` vitetris: fix build on macOS by adding -Wno-implicit-int flag (#306591) ``  |
| [`4565925a`](https://github.com/NixOS/nixpkgs/commit/4565925a480b6d59b5dcdbf07d14cb784f8f88ae) | `` python312Packages.ollama: refactor ``                                       |
| [`3d794501`](https://github.com/NixOS/nixpkgs/commit/3d7945013bf1f47cb69bc8cb9f1ff93548e7ae5b) | `` python312Packages.ollama: 0.1.8 -> 0.1.9 ``                                 |
| [`b2af07c7`](https://github.com/NixOS/nixpkgs/commit/b2af07c701c864723497860f202fa15b8e63ea56) | `` ananicy-rules-cachyos: unstable-2024-04-16 -> unstable-2024-04-22 ``        |
| [`018a2c20`](https://github.com/NixOS/nixpkgs/commit/018a2c201bb02efdae00cb7b97e20bf5e26fec4c) | `` genromfs: fix cross compilation ``                                          |
| [`195cf807`](https://github.com/NixOS/nixpkgs/commit/195cf807be15276babdf1c5481b9924e2cbcc7c1) | `` genromfs: add nickcao to maintainers ``                                     |
| [`a8476d88`](https://github.com/NixOS/nixpkgs/commit/a8476d88b79ebe8bdd44f9d1bb80038d02b7686b) | `` python312Packages.taskw-ng: refactor ``                                     |
| [`779d519e`](https://github.com/NixOS/nixpkgs/commit/779d519e7e853f3fb5f3af1b50fdd754399daf29) | `` maintainers: remove rapenne-s ``                                            |
| [`63aa2f8e`](https://github.com/NixOS/nixpkgs/commit/63aa2f8e425ff52cc3dbeda2bb0366c6ee803558) | `` python3Packages.eyeD3: fix cross compilation ``                             |
| [`5cd3c899`](https://github.com/NixOS/nixpkgs/commit/5cd3c899e36355d72bb8b25b6407071d0584bc3a) | `` vscode-extensions.myriad-dreamin.tinymist: 0.11.5 -> 0.11.6 ``              |
| [`36c588e1`](https://github.com/NixOS/nixpkgs/commit/36c588e1dc36c06ca7d0b8383105105ccb9554a1) | `` tootik: 0.10.2 -> 0.10.3 ``                                                 |
| [`54b3a6cf`](https://github.com/NixOS/nixpkgs/commit/54b3a6cf309af5c917aa292eabaa0369fae785cc) | `` tmuxp: add pyyaml as build dep, to fix build error ``                       |
| [`8f5c4cf5`](https://github.com/NixOS/nixpkgs/commit/8f5c4cf5eb969a7f048503a21ca6ffdd1b8c7c3d) | `` agebox: update vulnerable dependency ``                                     |
| [`793e3251`](https://github.com/NixOS/nixpkgs/commit/793e3251c97d68c05dcd3ddf16b2b884acd7bc1f) | `` nixd: 2.0.2 -> 2.1.0 ``                                                     |
| [`a77b665d`](https://github.com/NixOS/nixpkgs/commit/a77b665dc8059c1daf17a3ab37102a8560ec279f) | `` Rustdesk: fix desktop item not being created ``                             |
| [`aa25b28d`](https://github.com/NixOS/nixpkgs/commit/aa25b28db1ffa91231273c2151e3de8e568dab0a) | `` kubectl-explore: 0.7.2 -> 0.8.1 ``                                          |
| [`06cb5055`](https://github.com/NixOS/nixpkgs/commit/06cb5055c90a1b913769642f5b8cd618edde4212) | `` lxgw-neoxihei: 1.120.2 -> 1.121 ``                                          |
| [`2e0b0c27`](https://github.com/NixOS/nixpkgs/commit/2e0b0c270792db5b30bae72b9c7fa45176a1474a) | `` nixos/akkoma: Don't warn if no installWrapper ``                            |
| [`124fc242`](https://github.com/NixOS/nixpkgs/commit/124fc242c15349850743dde1255a5c53734c7132) | `` dvc: 3.50.0 -> 3.50.1 ``                                                    |
| [`ab6032f4`](https://github.com/NixOS/nixpkgs/commit/ab6032f43a4fa031b81e9d7c10d4128feb6a6da5) | `` python311Packages.dvclive: format with nixfmt ``                            |
| [`d7ab5cd0`](https://github.com/NixOS/nixpkgs/commit/d7ab5cd0c4366b78a347cd4ff6c04fe000c2a4fc) | `` python311Packages.dvclive: 3.45.0 -> 3.46.0 ``                              |
| [`596f3331`](https://github.com/NixOS/nixpkgs/commit/596f33317f5de2dd690853e5f8dcc70ca0626769) | `` python312Packages.scmrepo: format with nixfmt ``                            |
| [`202686c2`](https://github.com/NixOS/nixpkgs/commit/202686c284e7596bc9b8a153da599adc7e3a5b2a) | `` python312Packages.scmrepo: 3.3.1 -> 3.3.2 ``                                |
| [`c220a30c`](https://github.com/NixOS/nixpkgs/commit/c220a30c605861a6087f32bcaf1e75f9aed6dfb4) | `` python312Packages.dulwich: forma twith nixfmt ``                            |
| [`82d7a8b9`](https://github.com/NixOS/nixpkgs/commit/82d7a8b959a101dc9cc873b6aba3cfe45101f692) | `` python312Packages.dulwich: 0.21.7 -> 0.22.1 ``                              |
| [`5cef65b2`](https://github.com/NixOS/nixpkgs/commit/5cef65b22d9e6434997ca5bcccf55c06c40d3f9d) | `` python312Packages.dulwich: refactor ``                                      |
| [`c0ee181a`](https://github.com/NixOS/nixpkgs/commit/c0ee181ad574a92741cadc1d4741831ca5ed9f9c) | `` dumbpipe: init at 0.6.0 ``                                                  |
| [`12f16972`](https://github.com/NixOS/nixpkgs/commit/12f16972ac37251f46d0c0ffe97a45f6bf3a3e91) | `` nginx-sso: move to 'pkgs/by-name' ``                                        |
| [`240a9a5c`](https://github.com/NixOS/nixpkgs/commit/240a9a5c4f901f10215cab1a6103f743bca1841e) | `` nginx-sso: add ambroisie as maintainer ``                                   |
| [`6ed28334`](https://github.com/NixOS/nixpkgs/commit/6ed2833404297a1f3bee0d48f5d0df92c79b84f0) | `` python312Packages.pymatgen: format with nixfmt ``                           |
| [`0d9c130d`](https://github.com/NixOS/nixpkgs/commit/0d9c130d7546f39a85e279ec4a3eca824a61bfe2) | `` python312Packages.pymatgen: 2024.2.23 -> 2024.4.13 ``                       |
| [`2676356c`](https://github.com/NixOS/nixpkgs/commit/2676356c2accb7c2fc3f9bfa97c87bfefdd6c238) | `` hyprland-activewindow: 1.0.1 -> 1.0.2 ``                                    |
| [`eadd9c0a`](https://github.com/NixOS/nixpkgs/commit/eadd9c0a7fe45a0e6b9a005a70e062a1b5a8ef0c) | `` pulsar: patch additionals git binary ``                                     |
| [`66b8bcd1`](https://github.com/NixOS/nixpkgs/commit/66b8bcd1acc657d9ec915cca05c56ac2ca7176c4) | `` tpm2-tools: add tomfitzhenry as maintainer ``                               |
| [`23e494c3`](https://github.com/NixOS/nixpkgs/commit/23e494c3a59206832adf6018c93a7ff1c83d906b) | `` ibm-sw-tpm2: add tomfitzhenry as maintainer ``                              |
| [`025f6c02`](https://github.com/NixOS/nixpkgs/commit/025f6c0298c261fa5688ea9e4a9ce67664bfcc69) | `` git-absorb: add tomfitzhenry as maintainer ``                               |
| [`3d870b59`](https://github.com/NixOS/nixpkgs/commit/3d870b59dea0197af18c737b8872842dd4b3cdc4) | `` rclone: add tomfitzhenry as maintainer ``                                   |
| [`1a462800`](https://github.com/NixOS/nixpkgs/commit/1a462800bf6640bf5c02856ce20044020597eec3) | `` openssh_gssapi: 9.6p1 -> 9.7p1 ``                                           |
| [`db76929d`](https://github.com/NixOS/nixpkgs/commit/db76929d686f5879be658a84f3e137a7c32ed363) | `` feroxbuster: 2.10.2 -> 2.10.3 ``                                            |
| [`07606140`](https://github.com/NixOS/nixpkgs/commit/0760614080cedf70383eb82a2133f7d9b830eddf) | `` python312Packages.pymatgen: refactor ``                                     |
| [`a4550df4`](https://github.com/NixOS/nixpkgs/commit/a4550df403d601d33ebb9891b6894143754e48f1) | `` files-cli: 2.13.7 -> 2.13.14 ``                                             |
| [`783a35ca`](https://github.com/NixOS/nixpkgs/commit/783a35ca3d30ce4c91ee3710c5cc64c4547f6adf) | `` maintainers: remove fogti ``                                                |
| [`8e6bd4aa`](https://github.com/NixOS/nixpkgs/commit/8e6bd4aa5ef1c479ca5de42fdccd986ac7d1c507) | `` mixxc: init at 0.2.2 (#305497) ``                                           |
| [`9bc3e821`](https://github.com/NixOS/nixpkgs/commit/9bc3e8215408c533e4f357f4b263a766bfdc7b2b) | `` dovecot_fts_xapian: 1.7.10 -> 1.7.11 ``                                     |
| [`eba7be3d`](https://github.com/NixOS/nixpkgs/commit/eba7be3db97313dd974b6fe259e482a7fe4e5317) | `` python311Packages.cdcs: format with nixfmt ``                               |
| [`a177409a`](https://github.com/NixOS/nixpkgs/commit/a177409a58514552b7c700b41efc54591975c577) | `` python311Packages.cdcs: refactor ``                                         |
| [`f844ccd2`](https://github.com/NixOS/nixpkgs/commit/f844ccd28c5a31ad575b921045f1c55e9126d80f) | `` cargo-tally: 1.0.43 -> 1.0.44 ``                                            |
| [`c6040649`](https://github.com/NixOS/nixpkgs/commit/c6040649cec3347ee9e797d87f0b0ab5b2f3d916) | `` forgejo: 7.0.0 -> 7.0.1 ``                                                  |
| [`498d1399`](https://github.com/NixOS/nixpkgs/commit/498d139975eccd394f366383836e0045534895a2) | `` bpftop: 0.4.1 -> 0.4.2 ``                                                   |
| [`df708ff6`](https://github.com/NixOS/nixpkgs/commit/df708ff63f6b1feccd6539804614d802fd5ec133) | `` python311Packages.pysigma-backend-elasticsearch: format with nixfmt ``      |
| [`ef9c39ad`](https://github.com/NixOS/nixpkgs/commit/ef9c39adbbb2ffcf421e66736eca28addced89fd) | `` python311Packages.pysigma-backend-elasticsearch: refactor ``                |
| [`81a9ab2e`](https://github.com/NixOS/nixpkgs/commit/81a9ab2ea09cb52056bc0d93094094c40dee259c) | `` python311Packages.zwave-js-server-python: format with nixfmt ``             |
| [`44563596`](https://github.com/NixOS/nixpkgs/commit/44563596621a64a42f98f3675fd3c03e61fb5e0b) | `` python311Packages.zwave-js-server-python: refactor ``                       |
| [`d85147ea`](https://github.com/NixOS/nixpkgs/commit/d85147ead007b59064a1806f2a363178a29b22b9) | `` nixos/oauth2_proxy_nginx: fix URL escaping ``                               |
| [`ef401a37`](https://github.com/NixOS/nixpkgs/commit/ef401a37024bfc5c10029ad418dde4efb7470f9b) | `` gildas: 20230801_a -> 20240401_a; fix build on darwin (#304813) ``          |
| [`9da3476b`](https://github.com/NixOS/nixpkgs/commit/9da3476b42b853c116071dece25b01870fad89ca) | `` remove myself from a bunch of maintainer roles ``                           |
| [`4a12033a`](https://github.com/NixOS/nixpkgs/commit/4a12033a683770b587729f6e6f22b57befed23ea) | `` pt2-clone: 1.68 -> 1.69.2 ``                                                |
| [`5c372db9`](https://github.com/NixOS/nixpkgs/commit/5c372db9d3e1224ddfb36363c6b8d5882d4c0501) | `` maintainers: remove zumorica ``                                             |
| [`cbad4670`](https://github.com/NixOS/nixpkgs/commit/cbad467087036c4853f4350485be78cf6d589142) | `` python311Packages.neo4j: format with nixfmt ``                              |
| [`32c79ab3`](https://github.com/NixOS/nixpkgs/commit/32c79ab37d6cb5d08d8113ab49ce4d9ce5ef1665) | `` python311Packages.neo4j: 5.19.0 -> 5.20.0 ``                                |
| [`4a4e8a3e`](https://github.com/NixOS/nixpkgs/commit/4a4e8a3e88bffdb42327008e8992651bfffd01e4) | `` gqlgenc: 0.21.1 -> 0.22.0 ``                                                |
| [`ca140c88`](https://github.com/NixOS/nixpkgs/commit/ca140c88f1c7b96f5b223c38c62889c06777363d) | `` retool: 2.02.2-unstable-2024-03-17 -> 2.3.6 ``                              |
| [`619b26c4`](https://github.com/NixOS/nixpkgs/commit/619b26c4866527484cb445c654c56c3a939a41de) | `` bngblaster: 0.8.47 -> 0.8.49 ``                                             |
| [`37889a30`](https://github.com/NixOS/nixpkgs/commit/37889a30f95836c855d3ba12afb41abeea1dce3b) | `` maintainers: remove delroth ``                                              |
| [`40a7011c`](https://github.com/NixOS/nixpkgs/commit/40a7011c39bc6acb2ce89361f23f0ea3ccc5eb46) | `` maintainers: remove amaxine ``                                              |
| [`6de4b573`](https://github.com/NixOS/nixpkgs/commit/6de4b5739e54e85eb40c58c49bb5d21c2e464cf2) | `` haskellPackages.ghcjs-dom-hello: lift overly strict bounds ``               |
| [`e62270e3`](https://github.com/NixOS/nixpkgs/commit/e62270e35f308cdf18404aa080b71110070dc41d) | `` haskellPackages.jsaddle-hello: lift overly strict bounds ``                 |
| [`2b3f8cc2`](https://github.com/NixOS/nixpkgs/commit/2b3f8cc207fe9ebcb6219849a5f89a606646ccd8) | `` haskellPackages.lsql-csv: lift overly strict upper bounds ``                |
| [`8c3a95b3`](https://github.com/NixOS/nixpkgs/commit/8c3a95b3c51e69b13024f335aa74d464b5d03c88) | `` haskellPackages: mark builds failing on hydra as broken ``                  |
| [`a5b5d65b`](https://github.com/NixOS/nixpkgs/commit/a5b5d65b5b1c038eb121720772a70a250f46499d) | `` haskell.compiler.ghcjs: provide required ansi-wl-pprint < 0.7 ``            |
| [`a82be4ba`](https://github.com/NixOS/nixpkgs/commit/a82be4ba7c210d5ba04963cc7e6db2f393a16448) | `` wiki-js: 2.5.301 -> 2.5.302 ``                                              |
| [`6ed71c8d`](https://github.com/NixOS/nixpkgs/commit/6ed71c8d711c59d9f3f33c5e9b7b81e86dec96e0) | `` anki-bin: 24.04 -> 24.04.1 ``                                               |
| [`7992ec3a`](https://github.com/NixOS/nixpkgs/commit/7992ec3a816aa3f5cf2b62146c5412c8581943d1) | `` qq: 3.2.5-21453 -> 3.2.7 ``                                                 |
| [`1358106e`](https://github.com/NixOS/nixpkgs/commit/1358106e6e5ef18324b76578e921817c3707493f) | `` qq: fix download url ``                                                     |
| [`eacd0a96`](https://github.com/NixOS/nixpkgs/commit/eacd0a96dd79395aeb0bac130224e0ddbec40af1) | `` qq: fix update script ``                                                    |
| [`474f24e5`](https://github.com/NixOS/nixpkgs/commit/474f24e5d21b61286a5ea4c84b300120c2df189e) | `` maa-cli: 0.4.6 -> 0.4.7 ``                                                  |
| [`1d62f7ce`](https://github.com/NixOS/nixpkgs/commit/1d62f7ce9f667c42278947222a77e0e25dbb2731) | `` refind: 0.14.0.2 -> 0.14.2, fix build on aarch64 ``                         |