### PR TITLE
chore(flake/nur): `b196e8da` -> `6351c17b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714304964,
-        "narHash": "sha256-qVenqLZCvtLlJs/BnoCI8aFJTKnvTBZR+c4iPIHnrjs=",
+        "lastModified": 1714323481,
+        "narHash": "sha256-0rpsGYcOzWTqBk/p0LfQubmBAHhOYU3Ig2aGxQMzjlo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b196e8da8e8a49495973a09c66722feecf6105d2",
+        "rev": "6351c17bf20576708aaa14d2e5b85ae88e67706d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6351c17b`](https://github.com/nix-community/NUR/commit/6351c17bf20576708aaa14d2e5b85ae88e67706d) | `` automatic update `` |
| [`431a21ce`](https://github.com/nix-community/NUR/commit/431a21cee3f2f5d159a51b4babf4a6e2bcd7d343) | `` automatic update `` |