### PR TITLE
chore(flake/nur): `6351c17b` -> `5aa87b89`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714323481,
-        "narHash": "sha256-0rpsGYcOzWTqBk/p0LfQubmBAHhOYU3Ig2aGxQMzjlo=",
+        "lastModified": 1714329868,
+        "narHash": "sha256-UqK2u/wjuUySqhS/eSBgf6qDB32fZSBaK54Y5LShjU4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6351c17bf20576708aaa14d2e5b85ae88e67706d",
+        "rev": "5aa87b899e1e1f19cf9d73b013e3d446dfb56e47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5aa87b89`](https://github.com/nix-community/NUR/commit/5aa87b899e1e1f19cf9d73b013e3d446dfb56e47) | `` automatic update `` |
| [`b7abba15`](https://github.com/nix-community/NUR/commit/b7abba1583055e992ff02116a6d81f615805648b) | `` automatic update `` |