### PR TITLE
chore(flake/nur): `5aa87b89` -> `e7225db8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714329868,
-        "narHash": "sha256-UqK2u/wjuUySqhS/eSBgf6qDB32fZSBaK54Y5LShjU4=",
+        "lastModified": 1714333962,
+        "narHash": "sha256-jO11ZRH+cDcVYdfbPQazTYqHf52k4+zJIRr9qrn+mqs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5aa87b899e1e1f19cf9d73b013e3d446dfb56e47",
+        "rev": "e7225db8c77300b3fb59b1e529afe1c69633900f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e7225db8`](https://github.com/nix-community/NUR/commit/e7225db8c77300b3fb59b1e529afe1c69633900f) | `` automatic update `` |