### PR TITLE
chore(flake/home-manager): `c1609d58` -> `9fe79591`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -290,11 +290,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714203603,
-        "narHash": "sha256-eT7DENhYy7EPLOqHI9zkIMD9RvMCXcqh6gGqOK5BWYQ=",
+        "lastModified": 1714343445,
+        "narHash": "sha256-OzD1P0o46uD3Ix4ZI/g9z3YAeg+4g+W3qctB6bNOReo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c1609d584a6b5e9e6a02010f51bd368cb4782f8e",
+        "rev": "9fe79591c1005ce6f93084ae7f7dab0a2891440d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`9fe79591`](https://github.com/nix-community/home-manager/commit/9fe79591c1005ce6f93084ae7f7dab0a2891440d) | `` direnv: add nix-direnv to lib instead of sourcing `` |
| [`c002bc08`](https://github.com/nix-community/home-manager/commit/c002bc08c8ea6c87198f3024e8bfd6fdb1c90c9e) | `` cliphist: support images in clipboard history ``     |
| [`02002a08`](https://github.com/nix-community/home-manager/commit/02002a08b489b43e3ac1400609a9bf1b7c08e384) | `` flake.lock: Update ``                                |
| [`d1980931`](https://github.com/nix-community/home-manager/commit/d1980931de8252b6ac1104b7191fd68bbbe3a291) | `` psd: add module ``                                   |