### PR TITLE
chore(flake/nur): `e7225db8` -> `cd8a8ed7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714333962,
-        "narHash": "sha256-jO11ZRH+cDcVYdfbPQazTYqHf52k4+zJIRr9qrn+mqs=",
+        "lastModified": 1714337660,
+        "narHash": "sha256-HBcHX5eCYNirerVn2xDEk3q25wA/nX+0qOB++K4i84U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e7225db8c77300b3fb59b1e529afe1c69633900f",
+        "rev": "cd8a8ed74a066dc2f01f9787671f9e9fde9bd2ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cd8a8ed7`](https://github.com/nix-community/NUR/commit/cd8a8ed74a066dc2f01f9787671f9e9fde9bd2ab) | `` automatic update `` |
| [`8041ab72`](https://github.com/nix-community/NUR/commit/8041ab7215b57aa1958e426c261c195a09f8f2f0) | `` automatic update `` |