### PR TITLE
chore(flake/nur): `cd8a8ed7` -> `53a8759e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714337660,
-        "narHash": "sha256-HBcHX5eCYNirerVn2xDEk3q25wA/nX+0qOB++K4i84U=",
+        "lastModified": 1714340308,
+        "narHash": "sha256-2uX/VxxNTvxa0FZ5yY2BZDmMCtQVocqa6wdOC8YmzDE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cd8a8ed74a066dc2f01f9787671f9e9fde9bd2ab",
+        "rev": "53a8759e2675301db38ae5cc17aa9b954a936e9c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`53a8759e`](https://github.com/nix-community/NUR/commit/53a8759e2675301db38ae5cc17aa9b954a936e9c) | `` automatic update `` |
| [`bf991efd`](https://github.com/nix-community/NUR/commit/bf991efd4c07ad8d5f9ae54037e3de1a53de70bd) | `` automatic update `` |