### PR TITLE
chore(flake/nur): `4044fcb1` -> `db934809`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714349228,
-        "narHash": "sha256-ghWwfIueHfBeAgeYlQAsYQq08UUEwST+KX4KqXsW1ho=",
+        "lastModified": 1714356069,
+        "narHash": "sha256-gBohU4loXvroQBvy2OgcKEkFvLuFdizDIuCeMuy/BwQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4044fcb14edb075ec92d2e112afef07a439ca7a4",
+        "rev": "db9348095ede29bea8600f8e2dd7a470a90f872d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`db934809`](https://github.com/nix-community/NUR/commit/db9348095ede29bea8600f8e2dd7a470a90f872d) | `` automatic update `` |
| [`4486d7bd`](https://github.com/nix-community/NUR/commit/4486d7bd7f93c00895d5331a4f5d4d132b0ba214) | `` automatic update `` |