### PR TITLE
chore(flake/nur): `db934809` -> `7642334d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714356069,
-        "narHash": "sha256-gBohU4loXvroQBvy2OgcKEkFvLuFdizDIuCeMuy/BwQ=",
+        "lastModified": 1714362861,
+        "narHash": "sha256-xWffe8xxVRInCAcSjOEKPaQbEMgnhzBgeYOIpnFlWbs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "db9348095ede29bea8600f8e2dd7a470a90f872d",
+        "rev": "7642334d7d00399be0eac385eb0e05e3e5f5ab28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7642334d`](https://github.com/nix-community/NUR/commit/7642334d7d00399be0eac385eb0e05e3e5f5ab28) | `` automatic update `` |
| [`2ee02d49`](https://github.com/nix-community/NUR/commit/2ee02d4935e6d21aed54776568a1f6e912862250) | `` automatic update `` |
| [`a1a5a883`](https://github.com/nix-community/NUR/commit/a1a5a88317bc5ec6f5b1ed062331ec4ccd4e3706) | `` automatic update `` |