### PR TITLE
chore(flake/nur): `7642334d` -> `8bfc2ba6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714362861,
-        "narHash": "sha256-xWffe8xxVRInCAcSjOEKPaQbEMgnhzBgeYOIpnFlWbs=",
+        "lastModified": 1714364748,
+        "narHash": "sha256-cPg8p6lPQJ8EZvt+1SUhTQkIThV0F+tAaAUx9hWD3Ao=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7642334d7d00399be0eac385eb0e05e3e5f5ab28",
+        "rev": "8bfc2ba60b03c6f5591f633bd4bb481a97b511b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8bfc2ba6`](https://github.com/nix-community/NUR/commit/8bfc2ba60b03c6f5591f633bd4bb481a97b511b9) | `` automatic update `` |