### PR TITLE
chore(flake/nur): `8bfc2ba6` -> `afc28f1f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714364748,
-        "narHash": "sha256-cPg8p6lPQJ8EZvt+1SUhTQkIThV0F+tAaAUx9hWD3Ao=",
+        "lastModified": 1714372302,
+        "narHash": "sha256-7U4ISqZo3fvLesLLqN+Tz44X8IZx3dp8FytpCqFqljA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8bfc2ba60b03c6f5591f633bd4bb481a97b511b9",
+        "rev": "afc28f1f53c4e2f4e4c6b7a9c6f9af94e4e314f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`afc28f1f`](https://github.com/nix-community/NUR/commit/afc28f1f53c4e2f4e4c6b7a9c6f9af94e4e314f0) | `` automatic update `` |