### PR TITLE
chore(flake/nur): `afc28f1f` -> `7370a590`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714372302,
-        "narHash": "sha256-7U4ISqZo3fvLesLLqN+Tz44X8IZx3dp8FytpCqFqljA=",
+        "lastModified": 1714379102,
+        "narHash": "sha256-qPytAyr4yJF1qygaf2Q5+frIZ22NFqMH+uA5PU+ZDRo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "afc28f1f53c4e2f4e4c6b7a9c6f9af94e4e314f0",
+        "rev": "7370a5904601d453199dd6423ca492951adf7ed4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7370a590`](https://github.com/nix-community/NUR/commit/7370a5904601d453199dd6423ca492951adf7ed4) | `` automatic update `` |
| [`2639d3e5`](https://github.com/nix-community/NUR/commit/2639d3e57176d1b50ccb485366f8ce1b7009c18e) | `` automatic update `` |