### PR TITLE
chore(flake/nur): `7370a590` -> `25549d72`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714379102,
-        "narHash": "sha256-qPytAyr4yJF1qygaf2Q5+frIZ22NFqMH+uA5PU+ZDRo=",
+        "lastModified": 1714383054,
+        "narHash": "sha256-zUDP3ykEnDpvqeDOwqZxjufjeMgzkbf0DLwHBeSNZbA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7370a5904601d453199dd6423ca492951adf7ed4",
+        "rev": "25549d720af8d5ff6c7e76c09e8bdbcb8a383b03",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`25549d72`](https://github.com/nix-community/NUR/commit/25549d720af8d5ff6c7e76c09e8bdbcb8a383b03) | `` automatic update `` |
| [`941417a9`](https://github.com/nix-community/NUR/commit/941417a976f87f793610431e883ca9b97d3fe283) | `` automatic update `` |