### PR TITLE
chore(flake/nur): `25549d72` -> `a16bed92`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714383054,
-        "narHash": "sha256-zUDP3ykEnDpvqeDOwqZxjufjeMgzkbf0DLwHBeSNZbA=",
+        "lastModified": 1714387460,
+        "narHash": "sha256-p2WP/Mr7hh9QVXCbtlqf9bj62JOIqaP+C3/09DpCoaY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "25549d720af8d5ff6c7e76c09e8bdbcb8a383b03",
+        "rev": "a16bed921e49adac4f59bbaa4d2a28c69dafdf80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a16bed92`](https://github.com/nix-community/NUR/commit/a16bed921e49adac4f59bbaa4d2a28c69dafdf80) | `` automatic update `` |