### PR TITLE
chore(flake/nur): `4d6ea25b` -> `ce4da51a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714395381,
-        "narHash": "sha256-lOlCnbW7NZrMKptx+Oi6e97ejLRBZzO7jOzuEdyOtbg=",
+        "lastModified": 1714401933,
+        "narHash": "sha256-ZkkTLGc92s8iKnljMS5UyEXo6QOUK9zyH7EBVvoNRs0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4d6ea25b6eccac9c01e255b40d55a13cbda07ede",
+        "rev": "ce4da51a8e7743766bb6e8eb0d49dbb25561b8ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ce4da51a`](https://github.com/nix-community/NUR/commit/ce4da51a8e7743766bb6e8eb0d49dbb25561b8ce) | `` automatic update `` |
| [`478ada5c`](https://github.com/nix-community/NUR/commit/478ada5c05f38441199654d511d2429b6b55dffb) | `` automatic update `` |