### PR TITLE
chore(flake/nur): `ce4da51a` -> `cfad9875`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714401933,
-        "narHash": "sha256-ZkkTLGc92s8iKnljMS5UyEXo6QOUK9zyH7EBVvoNRs0=",
+        "lastModified": 1714405537,
+        "narHash": "sha256-Lu3QD7dZq/ewFs3Dkau+02ddABNSt4d5M1N+hBU/kzQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ce4da51a8e7743766bb6e8eb0d49dbb25561b8ce",
+        "rev": "cfad987565e2da98baa3c899fafad88687aa0b19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cfad9875`](https://github.com/nix-community/NUR/commit/cfad987565e2da98baa3c899fafad88687aa0b19) | `` automatic update `` |
| [`7a1b3c61`](https://github.com/nix-community/NUR/commit/7a1b3c61ce60c7643d6953c1f0c8a08d9a74a76a) | `` automatic update `` |