### PR TITLE
chore(flake/nur): `cfad9875` -> `5213de02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714405537,
-        "narHash": "sha256-Lu3QD7dZq/ewFs3Dkau+02ddABNSt4d5M1N+hBU/kzQ=",
+        "lastModified": 1714408391,
+        "narHash": "sha256-eHB3/fQVtEhYbuwiZ3fzl1X4A4df75v1g3noml5TIeU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cfad987565e2da98baa3c899fafad88687aa0b19",
+        "rev": "5213de02085c57a78234b0d3b481c1090bad65d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5213de02`](https://github.com/nix-community/NUR/commit/5213de02085c57a78234b0d3b481c1090bad65d7) | `` automatic update `` |