### PR TITLE
chore(flake/catppuccin): `a48e70a3` -> `28d41bc7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1713895615,
-        "narHash": "sha256-SVkxhcL0/IN5fNI2dqr702wXOnzktsm0LCEVGRAJQcY=",
+        "lastModified": 1714415338,
+        "narHash": "sha256-EySL50daYkg4zHxsOVAW2B4cAywweORire9/ZIOOeDY=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "a48e70a31616cb63e4794fd3465bff1835cc4246",
+        "rev": "28d41bc7187a1e0e9a36440872c0b46bed124f34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                               |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`28d41bc7`](https://github.com/catppuccin/nix/commit/28d41bc7187a1e0e9a36440872c0b46bed124f34) | `` docs: update for e0fa29f ``                                        |
| [`e0fa29f9`](https://github.com/catppuccin/nix/commit/e0fa29f9f79cdbb5083327705347030142333b56) | `` fix(home-manager): use local flavour option for delta (#150) ``    |
| [`a45c03fa`](https://github.com/catppuccin/nix/commit/a45c03fa32e9212f722688a4d11578aff56d2beb) | `` docs: update for 3d3db41 ``                                        |
| [`3d3db414`](https://github.com/catppuccin/nix/commit/3d3db414f3eae3dd10ab6bcbc71f632aa7ac1b5d) | `` chore(modules)!: use flavor and accent defaults from org (#145) `` |
| [`6e94e750`](https://github.com/catppuccin/nix/commit/6e94e7505a83c54fdc889837c81941bf796aaa1d) | `` docs: update for 78a000d ``                                        |
| [`78a000d0`](https://github.com/catppuccin/nix/commit/78a000d06c975d0c9214c65da1957113f71f33c1) | `` feat(home-manager): add support for gh-dash (#143) ``              |
| [`6cb150ad`](https://github.com/catppuccin/nix/commit/6cb150ad30fac652c2cd5d1d68fcbfdcc4473665) | `` docs: update for 0260166 ``                                        |
| [`02601660`](https://github.com/catppuccin/nix/commit/02601660436ef33a907178420cb35fffa27c66d8) | `` feat(home-manager): add support for tofi (#131) ``                 |