### PR TITLE
chore(flake/home-manager): `2af7c78b` -> `f8e6694e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -290,11 +290,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714377222,
-        "narHash": "sha256-UsDsjWCKlWn8vbXi8Zza9Hkq3xyk8fpvFNo2VM5S74E=",
+        "lastModified": 1714430505,
+        "narHash": "sha256-SSJQ/KOy8uISnoZgqDoRha7g7PFLSFP/BtMWm0wUz8Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2af7c78b7bb9cf18406a193eba13ef9f99388f49",
+        "rev": "f8e6694edabe4aaa7a85aac47b43ea5d978b116d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`f8e6694e`](https://github.com/nix-community/home-manager/commit/f8e6694edabe4aaa7a85aac47b43ea5d978b116d) | `` files: make collision error message more helpful `` |
| [`56326598`](https://github.com/nix-community/home-manager/commit/563265988637c27ba3abe39acb9be3ba2cb35a29) | `` swaync: add module ``                               |
| [`0125041f`](https://github.com/nix-community/home-manager/commit/0125041fc9ca3127fe95cf53f15c49c482ebaf70) | `` maintainers: add abayomi185 as maintainer ``        |
| [`4fe1f064`](https://github.com/nix-community/home-manager/commit/4fe1f064bd1a37754266eb4c190eac784ca4aaa9) | `` hyprland: use lib.generators.toHyprconf ``          |
| [`9fdd301a`](https://github.com/nix-community/home-manager/commit/9fdd301a5e4d8cf4d4cf3f990e799000a54a3737) | `` lib/generators: toHyprconf init ``                  |
| [`1a91cb7c`](https://github.com/nix-community/home-manager/commit/1a91cb7cdbcf6b18c27bbead57241baf279d4513) | `` neomutt: allow binds to override vimKeys ``         |
| [`7ec0ae18`](https://github.com/nix-community/home-manager/commit/7ec0ae18cda5e3aae80996d35f6d0ebd418f1ac8) | `` Translate using Weblate (Japanese) ``               |
| [`ba97ffcf`](https://github.com/nix-community/home-manager/commit/ba97ffcfb2bd3ef026bb0a14d8808e9926f57fd7) | `` Translate using Weblate (French) ``                 |
| [`08d3cbfe`](https://github.com/nix-community/home-manager/commit/08d3cbfe4d400dad74e54815127fd67c76608a55) | `` firefox: update extensions option description ``    |
| [`b8d81ef1`](https://github.com/nix-community/home-manager/commit/b8d81ef15ed8ec4c72ffc610279d39aa0c4ccbf0) | `` mpv: add extraInput option ``                       |