### PR TITLE
chore(flake/catppuccin): `28d41bc7` -> `f46dffa3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1714415338,
-        "narHash": "sha256-EySL50daYkg4zHxsOVAW2B4cAywweORire9/ZIOOeDY=",
+        "lastModified": 1714422957,
+        "narHash": "sha256-fQ1NP//CLQSj/te/qUxO+YiHlz6KYPxzVFSW5ldQGMA=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "28d41bc7187a1e0e9a36440872c0b46bed124f34",
+        "rev": "f46dffa3345aba8b315ed7ddd1be4bc12f9e9e78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                          |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`f46dffa3`](https://github.com/catppuccin/nix/commit/f46dffa3345aba8b315ed7ddd1be4bc12f9e9e78) | `` fix(modules): pass version to mkOptionDoc correctly (#153) `` |
| [`0ebf33fe`](https://github.com/catppuccin/nix/commit/0ebf33fe97de58157f1e9f4f71e9543bb09c769a) | `` chore: update lockfiles (#142) ``                             |
| [`5b5648c1`](https://github.com/catppuccin/nix/commit/5b5648c10e2445e1c40e57d515009ca8f3e89030) | `` chore(modules): factor out option doc generation (#152) ``    |
| [`2983ec97`](https://github.com/catppuccin/nix/commit/2983ec979644e8ffb7e5ef342facfc8b8f22947a) | `` chore(modules): remove dangling source for gtk (#151) ``      |