### PR TITLE
chore(flake/srvos): `71a8e8ab` -> `923491d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -605,11 +605,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714143163,
-        "narHash": "sha256-WMAziIBkwX//WUGxH49ZSm0yaPS6/PvNWUMMut8unm0=",
+        "lastModified": 1714434011,
+        "narHash": "sha256-i47mxeLAMCa9TBKM4yhYoDUOcdFTVLHQ/4VmTt2XOec=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "71a8e8ab6e4763714d20c22f42ba8860369a1508",
+        "rev": "923491d14bde002584c5cd3970b305a84f7c5e94",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`923491d1`](https://github.com/nix-community/srvos/commit/923491d14bde002584c5cd3970b305a84f7c5e94) | `` dev/private/flake.lock: Update `` |
| [`c33b0766`](https://github.com/nix-community/srvos/commit/c33b076664550a411b02a5652f06631237deb2e6) | `` flake.lock: Update ``             |