### PR TITLE
chore(flake/srvos): `923491d1` -> `b18e74f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -605,11 +605,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714434011,
-        "narHash": "sha256-i47mxeLAMCa9TBKM4yhYoDUOcdFTVLHQ/4VmTt2XOec=",
+        "lastModified": 1714444742,
+        "narHash": "sha256-FOWYXEEtwYKAGmXgKVYli/VsA8XpeR+4wNKt+3M/9b4=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "923491d14bde002584c5cd3970b305a84f7c5e94",
+        "rev": "b18e74f2245eaae150bc753821079c2512fe1516",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                              |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`b18e74f2`](https://github.com/nix-community/srvos/commit/b18e74f2245eaae150bc753821079c2512fe1516) | `` fix: Remove Nix experiemental-feature `repl-flake` after v2.22 `` |