### PR TITLE
chore(flake/nur): `caee1d82` -> `c7113b3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714444972,
-        "narHash": "sha256-cMcN5mTH8fwRSsEG0BGAhY7D3gGPWjXTxdXnu/pb3vE=",
+        "lastModified": 1714451865,
+        "narHash": "sha256-+YesvqZDAFQlefEHGQQu48+2b9+lj2qOvwHt8OTLbhU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "caee1d8217a81a0c47e33b595541c545986c8061",
+        "rev": "c7113b3e9e08e4ae3e0f0cb7ffb1df4a754eace8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c7113b3e`](https://github.com/nix-community/NUR/commit/c7113b3e9e08e4ae3e0f0cb7ffb1df4a754eace8) | `` automatic update `` |
| [`b2c8c231`](https://github.com/nix-community/NUR/commit/b2c8c231965054e5cba7f9e6bb49b4b6301bd3e1) | `` automatic update `` |
| [`06c0ff20`](https://github.com/nix-community/NUR/commit/06c0ff2007c6edf8dbefe9f3872cffc9ac65c141) | `` automatic update `` |
| [`64d9ca2d`](https://github.com/nix-community/NUR/commit/64d9ca2d6165e0eae58675d3387921b9ed8c1728) | `` automatic update `` |
| [`c814e708`](https://github.com/nix-community/NUR/commit/c814e708f430f8b8e8d41915a91bb31b0e5af08f) | `` automatic update `` |
| [`eea5424d`](https://github.com/nix-community/NUR/commit/eea5424d3b9bfec15ad19fdbf120aa2b004da29a) | `` automatic update `` |