### PR TITLE
chore(flake/nur): `c7113b3e` -> `4467f130`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714451865,
-        "narHash": "sha256-+YesvqZDAFQlefEHGQQu48+2b9+lj2qOvwHt8OTLbhU=",
+        "lastModified": 1714460311,
+        "narHash": "sha256-8iB+le4ubmCp0Bguu84cxEp/FKnQFJmiA/GYvozAXuo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c7113b3e9e08e4ae3e0f0cb7ffb1df4a754eace8",
+        "rev": "4467f1301c6b705bb18cf6ee307bd9cdb67ede0b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                       |
| -------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`4467f130`](https://github.com/nix-community/NUR/commit/4467f1301c6b705bb18cf6ee307bd9cdb67ede0b) | `` automatic update ``        |
| [`6683d993`](https://github.com/nix-community/NUR/commit/6683d993c2ab4c10f90b898aa2f97df1aca2e2cb) | `` automatic update ``        |
| [`83b403de`](https://github.com/nix-community/NUR/commit/83b403de989e4212ff4f60c0a0c23c189688f245) | `` add lcx12901 repository `` |
| [`8de6ff8a`](https://github.com/nix-community/NUR/commit/8de6ff8a60ff7508ba1eb4d1c2238f1ef61c1241) | `` add mur repository ``      |
| [`71e398c4`](https://github.com/nix-community/NUR/commit/71e398c4664789ebf01119bdb652cf099c5b191e) | `` automatic update ``        |