### PR TITLE
chore(flake/nixos-hardware): `53db5e10` -> `68d680c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -398,11 +398,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1714201532,
-        "narHash": "sha256-nk0W4rH7xYdDeS7k1SqqNtBaNrcgIBYNmOVc8P2puEY=",
+        "lastModified": 1714465198,
+        "narHash": "sha256-ySkEJvS0gPz2UhXm0H3P181T8fUxvDVcoUyGn0Kc5AI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "53db5e1070d07e750030bf65f1b9963df8f0c678",
+        "rev": "68d680c1b7c0e67a9b2144d6776583ee83664ef4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                 |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`68d680c1`](https://github.com/NixOS/nixos-hardware/commit/68d680c1b7c0e67a9b2144d6776583ee83664ef4) | `` Changed the kernel parameter ``      |
| [`fc738b1f`](https://github.com/NixOS/nixos-hardware/commit/fc738b1ff669bcb355165489453c685f853d9ae0) | `` kernel mkDefault added for kernel `` |
| [`627652ae`](https://github.com/NixOS/nixos-hardware/commit/627652ae642e24ed5119ddc08115c42845609929) | `` Updated read me ``                   |
| [`5c0b7f47`](https://github.com/NixOS/nixos-hardware/commit/5c0b7f47f4aabd0b6aedfbecec4ea9a31cb5a156) | `` common-gpu-nvidia-sync: fix typos `` |
| [`0cbc36e2`](https://github.com/NixOS/nixos-hardware/commit/0cbc36e2455c780b34f6329e4e71640b341eb658) | `` ASUS TUF FA507NV added. ``           |
| [`cdbb5bb0`](https://github.com/NixOS/nixos-hardware/commit/cdbb5bb040bacbd314e6cd79e4f0b163e0ae0300) | `` HP Elitebook 830 G6 (#904) ``        |