### PR TITLE
chore(flake/nur): `d8853a14` -> `6e5d7577`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714466005,
-        "narHash": "sha256-H6WfRiO/rieAmdEKasp/0iP4xoLi7QdSDZJ2b+V5zx4=",
+        "lastModified": 1714470270,
+        "narHash": "sha256-HNwcICgvPZZ0IFjLfSuN7MwOWD4Vk/0HhppVs3eObXo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d8853a14e87ceeb66bd2f9dba90b11dcb5911b14",
+        "rev": "6e5d7577d4b9f8ffcba734cee6e98217396843ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6e5d7577`](https://github.com/nix-community/NUR/commit/6e5d7577d4b9f8ffcba734cee6e98217396843ed) | `` automatic update `` |