### PR TITLE
chore(flake/nur): `6e5d7577` -> `a5c4ddb6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714470270,
-        "narHash": "sha256-HNwcICgvPZZ0IFjLfSuN7MwOWD4Vk/0HhppVs3eObXo=",
+        "lastModified": 1714475336,
+        "narHash": "sha256-/yHw6xlHqpebjd8l058uJ6kJYVaOafpuAmzRlgQpH5Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6e5d7577d4b9f8ffcba734cee6e98217396843ed",
+        "rev": "a5c4ddb6db335eab269fc532968f00bd3dca57e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a5c4ddb6`](https://github.com/nix-community/NUR/commit/a5c4ddb6db335eab269fc532968f00bd3dca57e4) | `` automatic update `` |