### PR TITLE
chore(flake/nur): `a5c4ddb6` -> `16fa6a8b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714475336,
-        "narHash": "sha256-/yHw6xlHqpebjd8l058uJ6kJYVaOafpuAmzRlgQpH5Y=",
+        "lastModified": 1714481366,
+        "narHash": "sha256-i7vJpQtt9RxXSp5vESbPsJnJvF2A2g1oXYx5iyls13U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a5c4ddb6db335eab269fc532968f00bd3dca57e4",
+        "rev": "16fa6a8b0cba77a92145f86d540e6a82f663072f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`16fa6a8b`](https://github.com/nix-community/NUR/commit/16fa6a8b0cba77a92145f86d540e6a82f663072f) | `` automatic update `` |
| [`10f0a114`](https://github.com/nix-community/NUR/commit/10f0a114ece0bd2848360afc6e3e170656e4116d) | `` drop kampka ``      |