### PR TITLE
chore(flake/nur): `16fa6a8b` -> `fe76fa0f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714481366,
-        "narHash": "sha256-i7vJpQtt9RxXSp5vESbPsJnJvF2A2g1oXYx5iyls13U=",
+        "lastModified": 1714484243,
+        "narHash": "sha256-724nAabUL8ysxNtJwBvXuwjMYgaEGw5iiecYtg897ys=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "16fa6a8b0cba77a92145f86d540e6a82f663072f",
+        "rev": "fe76fa0f1a7e8c57bca76d0b4d523d0fd8022f3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fe76fa0f`](https://github.com/nix-community/NUR/commit/fe76fa0f1a7e8c57bca76d0b4d523d0fd8022f3e) | `` automatic update `` |