### PR TITLE
chore(flake/emacs-overlay): `ab2169f5` -> `7c0c76c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714496056,
-        "narHash": "sha256-30CKfn4Cyj1Oq9v/1RAOjExSHYPb86n/+AcjZjLR+rA=",
+        "lastModified": 1714496845,
+        "narHash": "sha256-gXTcWDmnhS0xw21q9Ema6GzhOdwsOi7fb4SXXiSAlUg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ab2169f53db94a7628e54780179080920768e20b",
+        "rev": "7c0c76c9e970eb75efa0a8dc2a3b8aa5b1028613",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`7c0c76c9`](https://github.com/nix-community/emacs-overlay/commit/7c0c76c9e970eb75efa0a8dc2a3b8aa5b1028613) | `` Updated emacs `` |