### PR TITLE
chore(flake/nur): `e3bb227d` -> `428b7f99`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714506262,
-        "narHash": "sha256-RLBkAwJkSuMVoW6EM9hXGay6WUwsqP6kkTNZyMRDQs8=",
+        "lastModified": 1714507581,
+        "narHash": "sha256-lTvZePeyupJPnbWjZk2ss+2FbLrnYVyEODcrpnW2jzM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e3bb227deb8c1410a8c00034750cd7a649a2cb74",
+        "rev": "428b7f99a122d1a4744708615c2322ed59ea6db8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`428b7f99`](https://github.com/nix-community/NUR/commit/428b7f99a122d1a4744708615c2322ed59ea6db8) | `` automatic update `` |