### PR TITLE
chore(flake/emacs-overlay): `7c0c76c9` -> `ba78fc2c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714496845,
-        "narHash": "sha256-gXTcWDmnhS0xw21q9Ema6GzhOdwsOi7fb4SXXiSAlUg=",
+        "lastModified": 1714525432,
+        "narHash": "sha256-IHmBoP/RAAXLoydFhq7tMF+LUwWj4pRxS0zZHU3oQKo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7c0c76c9e970eb75efa0a8dc2a3b8aa5b1028613",
+        "rev": "ba78fc2ce1946ddd7185d1fd15e5cc7fb655b236",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1714272655,
-        "narHash": "sha256-3/ghIWCve93ngkx5eNPdHIKJP/pMzSr5Wc4rNKE1wOc=",
+        "lastModified": 1714409183,
+        "narHash": "sha256-Wacm/DrzLD7mjFGnSxxyGkJgg2unU/dNdNgdngBH+RU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "12430e43bd9b81a6b4e79e64f87c624ade701eaf",
+        "rev": "576ecd43d3b864966b4423a853412d6177775e8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ba78fc2c`](https://github.com/nix-community/emacs-overlay/commit/ba78fc2ce1946ddd7185d1fd15e5cc7fb655b236) | `` Updated elpa ``         |
| [`61ab87f5`](https://github.com/nix-community/emacs-overlay/commit/61ab87f5593d4b9478f0be00dab8a72ea667eea1) | `` Updated flake inputs `` |