### PR TITLE
chore(flake/nur): `428b7f99` -> `104ed05d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714507581,
-        "narHash": "sha256-lTvZePeyupJPnbWjZk2ss+2FbLrnYVyEODcrpnW2jzM=",
+        "lastModified": 1714527920,
+        "narHash": "sha256-iAdj2ceFcZmk7hLEvcWl32vhiOG/lokdqcjyeAUecv4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "428b7f99a122d1a4744708615c2322ed59ea6db8",
+        "rev": "104ed05dc6e51992cef07df810b74f53c93c7e76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`104ed05d`](https://github.com/nix-community/NUR/commit/104ed05dc6e51992cef07df810b74f53c93c7e76) | `` automatic update `` |
| [`62b6fd5b`](https://github.com/nix-community/NUR/commit/62b6fd5ba1d3c2b193e338893a6645c83b337428) | `` automatic update `` |