### PR TITLE
chore(flake/emacs-overlay): `ba78fc2c` -> `2a294b09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714525432,
-        "narHash": "sha256-IHmBoP/RAAXLoydFhq7tMF+LUwWj4pRxS0zZHU3oQKo=",
+        "lastModified": 1714528291,
+        "narHash": "sha256-eZe8RbeCwvBU4MO9tyIGBZ0TPUeBuqH0zvjyT0ANAo4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ba78fc2ce1946ddd7185d1fd15e5cc7fb655b236",
+        "rev": "2a294b099b479a62a5e37964dfe5ceb75e74fdd8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`2a294b09`](https://github.com/nix-community/emacs-overlay/commit/2a294b099b479a62a5e37964dfe5ceb75e74fdd8) | `` Updated emacs `` |
| [`bc8db8d6`](https://github.com/nix-community/emacs-overlay/commit/bc8db8d6d01141ab90b17590446a2699557bec9b) | `` Updated melpa `` |