### PR TITLE
chore(flake/nur): `01afdd81` -> `5db0b852`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714534544,
-        "narHash": "sha256-L1g7Rcg86D9Le6sXQg6us3yHY/AF11j2G5nL1SsI5Nw=",
+        "lastModified": 1714537898,
+        "narHash": "sha256-vGT/GJoICbMGKwXGK22dvVhUbkfM0yxAdT28RvOSeyg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "01afdd81e289cb2f96966ce3e9cb6cee7c8c19f6",
+        "rev": "5db0b852fa8f493c78d8bd65293d4b1dad654eb6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5db0b852`](https://github.com/nix-community/NUR/commit/5db0b852fa8f493c78d8bd65293d4b1dad654eb6) | `` automatic update `` |
| [`02e97b1e`](https://github.com/nix-community/NUR/commit/02e97b1e65fa78b611d85ef089d0135d1a17f0a6) | `` automatic update `` |