### PR TITLE
chore(flake/nur): `5db0b852` -> `d4f513b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714537898,
-        "narHash": "sha256-vGT/GJoICbMGKwXGK22dvVhUbkfM0yxAdT28RvOSeyg=",
+        "lastModified": 1714545326,
+        "narHash": "sha256-3I0C6w2gLOVyoHGmXLZNLS//24EhX4NKK0TQwho/GKQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5db0b852fa8f493c78d8bd65293d4b1dad654eb6",
+        "rev": "d4f513b98dac14dc9c87cfa698ef49d376793e1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d4f513b9`](https://github.com/nix-community/NUR/commit/d4f513b98dac14dc9c87cfa698ef49d376793e1f) | `` automatic update `` |
| [`62e6d5c0`](https://github.com/nix-community/NUR/commit/62e6d5c0708516434f2254bd03c18d23a7d9c3a7) | `` automatic update `` |