### PR TITLE
chore(flake/nur): `d4f513b9` -> `31d8b56e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714545326,
-        "narHash": "sha256-3I0C6w2gLOVyoHGmXLZNLS//24EhX4NKK0TQwho/GKQ=",
+        "lastModified": 1714554822,
+        "narHash": "sha256-nmV4mw/Fu/+5/zlC8+p1/STc0SIDpOrolhX67MSZ4j0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d4f513b98dac14dc9c87cfa698ef49d376793e1f",
+        "rev": "31d8b56e5f9fa5fe1193af25eb2252ae6d2e2162",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`31d8b56e`](https://github.com/nix-community/NUR/commit/31d8b56e5f9fa5fe1193af25eb2252ae6d2e2162) | `` automatic update `` |
| [`9e33d701`](https://github.com/nix-community/NUR/commit/9e33d701244a10585f31518e2fd1874134fbdca6) | `` automatic update `` |