### PR TITLE
chore(flake/emacs-overlay): `2a294b09` -> `1b287b19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714528291,
-        "narHash": "sha256-eZe8RbeCwvBU4MO9tyIGBZ0TPUeBuqH0zvjyT0ANAo4=",
+        "lastModified": 1714553817,
+        "narHash": "sha256-gwB5BYRhAQmNDSb44A6cWO5dP1K3J7few7K/mvIluUM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2a294b099b479a62a5e37964dfe5ceb75e74fdd8",
+        "rev": "1b287b19f392c04b4e0314885339e89c2393a347",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`1b287b19`](https://github.com/nix-community/emacs-overlay/commit/1b287b19f392c04b4e0314885339e89c2393a347) | `` Updated melpa `` |