### PR TITLE
chore(flake/emacs-overlay): `1b287b19` -> `ab32c6d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714553817,
-        "narHash": "sha256-gwB5BYRhAQmNDSb44A6cWO5dP1K3J7few7K/mvIluUM=",
+        "lastModified": 1714583193,
+        "narHash": "sha256-RFiwISF+anGhMN3mVMBEOcxP+0zgizZposmBAyhIt94=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1b287b19f392c04b4e0314885339e89c2393a347",
+        "rev": "ab32c6d8e3f0a20d448540beb31208894066a6c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`ab32c6d8`](https://github.com/nix-community/emacs-overlay/commit/ab32c6d8e3f0a20d448540beb31208894066a6c7) | `` Updated emacs ``  |
| [`c06c47b0`](https://github.com/nix-community/emacs-overlay/commit/c06c47b024dd6d92f7b7062ce3b14897f7b43c99) | `` Updated melpa ``  |
| [`ce14ca66`](https://github.com/nix-community/emacs-overlay/commit/ce14ca664285a33988892c485f12d20fcb792d49) | `` Updated elpa ``   |
| [`0b739e0c`](https://github.com/nix-community/emacs-overlay/commit/0b739e0c6688d86c481285477495fde28316f011) | `` Updated nongnu `` |
| [`ed33acec`](https://github.com/nix-community/emacs-overlay/commit/ed33acecc69155dc98587331236e7d5bc2308205) | `` Updated emacs ``  |