### PR TITLE
chore(flake/nur): `31d8b56e` -> `09f5a5a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714554822,
-        "narHash": "sha256-nmV4mw/Fu/+5/zlC8+p1/STc0SIDpOrolhX67MSZ4j0=",
+        "lastModified": 1714560279,
+        "narHash": "sha256-ULWq8u8EushwKSPFJucS7lrHYHIp7ecd/wnpc9WsprA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "31d8b56e5f9fa5fe1193af25eb2252ae6d2e2162",
+        "rev": "09f5a5a5276a717be553571b8bccea865f06c23d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`09f5a5a5`](https://github.com/nix-community/NUR/commit/09f5a5a5276a717be553571b8bccea865f06c23d) | `` automatic update `` |