### PR TITLE
chore(flake/nur): `09f5a5a5` -> `67ff7c22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714560279,
-        "narHash": "sha256-ULWq8u8EushwKSPFJucS7lrHYHIp7ecd/wnpc9WsprA=",
+        "lastModified": 1714568100,
+        "narHash": "sha256-qdCdeo2ZBIPEi3jQRd9ed/hO4gZTx+2h2N6WqiYBl4s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "09f5a5a5276a717be553571b8bccea865f06c23d",
+        "rev": "67ff7c2201dba1268c376a7fab36b330a5e664ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`67ff7c22`](https://github.com/nix-community/NUR/commit/67ff7c2201dba1268c376a7fab36b330a5e664ab) | `` automatic update `` |