### PR TITLE
chore(flake/nur): `67ff7c22` -> `810b592c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714568100,
-        "narHash": "sha256-qdCdeo2ZBIPEi3jQRd9ed/hO4gZTx+2h2N6WqiYBl4s=",
+        "lastModified": 1714576435,
+        "narHash": "sha256-yccrh9EEjq1h2U7bvsLUXo+Eez2sQleMnKaKjDqLgHs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "67ff7c2201dba1268c376a7fab36b330a5e664ab",
+        "rev": "810b592c7374f872b1ebf7767d2ccd2bb8dc0f92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`810b592c`](https://github.com/nix-community/NUR/commit/810b592c7374f872b1ebf7767d2ccd2bb8dc0f92) | `` automatic update `` |