### PR TITLE
chore(flake/nur): `810b592c` -> `e32b6a13`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714576435,
-        "narHash": "sha256-yccrh9EEjq1h2U7bvsLUXo+Eez2sQleMnKaKjDqLgHs=",
+        "lastModified": 1714581879,
+        "narHash": "sha256-96hknUuOtR8NeprIO+SJ/MKVCECAZU79wGx/uMEBxHQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "810b592c7374f872b1ebf7767d2ccd2bb8dc0f92",
+        "rev": "e32b6a1367ee1ce25490bd32255de7596f8abab8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e32b6a13`](https://github.com/nix-community/NUR/commit/e32b6a1367ee1ce25490bd32255de7596f8abab8) | `` automatic update `` |
| [`10d315f3`](https://github.com/nix-community/NUR/commit/10d315f304db96d733b0a2d489f921c6d7fb6114) | `` automatic update `` |
| [`a8feef9f`](https://github.com/nix-community/NUR/commit/a8feef9fcce773461ef0105a47b56126903463dc) | `` automatic update `` |