### PR TITLE
chore(flake/nur): `cf88e4cb` -> `e3d80dc3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714584024,
-        "narHash": "sha256-6bEi925FyAnIM6FtuDN5zaLUHpNhk4/xjtcTr4ZWbgU=",
+        "lastModified": 1714589090,
+        "narHash": "sha256-0ehJIqVHlLHcKbD9VGxv/HPYVwE3MJ8s/ux63Kw/bsQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cf88e4cb0265177b1cfba36be35dc3269d5d45df",
+        "rev": "e3d80dc3e783f6fa59da5b94466b0c7f5e6a8026",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e3d80dc3`](https://github.com/nix-community/NUR/commit/e3d80dc3e783f6fa59da5b94466b0c7f5e6a8026) | `` automatic update `` |
| [`fbe8bb6a`](https://github.com/nix-community/NUR/commit/fbe8bb6a00a9208bf2afd200be356f8288b86be9) | `` automatic update `` |