### PR TITLE
chore(flake/nur): `e3d80dc3` -> `f4ede26a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714589090,
-        "narHash": "sha256-0ehJIqVHlLHcKbD9VGxv/HPYVwE3MJ8s/ux63Kw/bsQ=",
+        "lastModified": 1714592754,
+        "narHash": "sha256-Tc+4iDfTEyYBWOfH82OGIBvkCHzs0iODXUknzQO2UbQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e3d80dc3e783f6fa59da5b94466b0c7f5e6a8026",
+        "rev": "f4ede26a75d93a3f73744169368890a3aaa8db38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f4ede26a`](https://github.com/nix-community/NUR/commit/f4ede26a75d93a3f73744169368890a3aaa8db38) | `` automatic update `` |