### PR TITLE
chore(flake/nur): `f4ede26a` -> `c8456769`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714592754,
-        "narHash": "sha256-Tc+4iDfTEyYBWOfH82OGIBvkCHzs0iODXUknzQO2UbQ=",
+        "lastModified": 1714596740,
+        "narHash": "sha256-V3ZR38xu3JSUrg04wMTp0fzDSP+ogNJOOU5ckreCzLQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f4ede26a75d93a3f73744169368890a3aaa8db38",
+        "rev": "c8456769a0904ac761020a76bf0bb72a92c27c7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c8456769`](https://github.com/nix-community/NUR/commit/c8456769a0904ac761020a76bf0bb72a92c27c7c) | `` automatic update `` |
| [`91cd5146`](https://github.com/nix-community/NUR/commit/91cd51467184515f2299cd4422beb8b7ce9da60f) | `` automatic update `` |
| [`e92f7032`](https://github.com/nix-community/NUR/commit/e92f70325004dfdc3f926256d192dd9f4aabc72c) | `` automatic update `` |