### PR TITLE
chore(flake/catppuccin): `f46dffa3` -> `b0dc7f31`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1714422957,
-        "narHash": "sha256-fQ1NP//CLQSj/te/qUxO+YiHlz6KYPxzVFSW5ldQGMA=",
+        "lastModified": 1714607657,
+        "narHash": "sha256-AnmN+JOzrpHv7Uw7JSPJ9JEjuqF7gjhx29UuuldNpas=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "f46dffa3345aba8b315ed7ddd1be4bc12f9e9e78",
+        "rev": "b0dc7f3181063daa6532dc5f757ded1a605dfbd5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                         |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`b0dc7f31`](https://github.com/catppuccin/nix/commit/b0dc7f3181063daa6532dc5f757ded1a605dfbd5) | `` docs: update for ef2f0d9 ``                                                  |
| [`ef2f0d91`](https://github.com/catppuccin/nix/commit/ef2f0d91ea4c8981276136f7f114f9dcb4858ba1) | `` feat(home-manager): add support for zsh-syntax-highlighting (#146) ``        |
| [`112cef79`](https://github.com/catppuccin/nix/commit/112cef79d9e2675ab1f77f273f9a599d58c72958) | `` docs: update for 1fbdfda ``                                                  |
| [`1fbdfdac`](https://github.com/catppuccin/nix/commit/1fbdfdacf96c14449aea52edba895e5ab419dd13) | `` fix(home-manager): make dark/light lowecase for style names in gtk (#147) `` |
| [`ccc188e2`](https://github.com/catppuccin/nix/commit/ccc188e244e8fb3248e3c8f19f70280076bf1408) | `` docs: update for 2788bec ``                                                  |
| [`2788becb`](https://github.com/catppuccin/nix/commit/2788becbb58bd2a60666fbbf2d4f6ae1721112d5) | `` feat(home-manager): add support for waybar (#133) ``                         |