### PR TITLE
chore(flake/emacs-overlay): `ab32c6d8` -> `cccda850`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714583193,
-        "narHash": "sha256-RFiwISF+anGhMN3mVMBEOcxP+0zgizZposmBAyhIt94=",
+        "lastModified": 1714614481,
+        "narHash": "sha256-vykQwGwiu178RHmmRRTzId3qpc9YQtY29Jie7E2GFMg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ab32c6d8e3f0a20d448540beb31208894066a6c7",
+        "rev": "cccda8508481ea8c8ff4e50a297900ed54b26dc3",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1714409183,
-        "narHash": "sha256-Wacm/DrzLD7mjFGnSxxyGkJgg2unU/dNdNgdngBH+RU=",
+        "lastModified": 1714531828,
+        "narHash": "sha256-ILsf3bdY/hNNI/Hu5bSt2/KbmHaAVhBbNUOdGztTHEg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "576ecd43d3b864966b4423a853412d6177775e8b",
+        "rev": "0638fe2715d998fa81d173aad264eb671ce2ebc1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`cccda850`](https://github.com/nix-community/emacs-overlay/commit/cccda8508481ea8c8ff4e50a297900ed54b26dc3) | `` Updated emacs ``        |
| [`6f76c97c`](https://github.com/nix-community/emacs-overlay/commit/6f76c97c31de970e2654025725098b254c6ae032) | `` Updated melpa ``        |
| [`ff9afc2d`](https://github.com/nix-community/emacs-overlay/commit/ff9afc2dc6fff897e02c211a460d9574cf9d39a3) | `` Updated elpa ``         |
| [`7f1f3037`](https://github.com/nix-community/emacs-overlay/commit/7f1f3037c9c447b60ccd51f35e4565feef3d7849) | `` Updated nongnu ``       |
| [`69156805`](https://github.com/nix-community/emacs-overlay/commit/69156805053e7ca62dbf081b3910d5ee068d3ce6) | `` Updated flake inputs `` |