### PR TITLE
chore(flake/srvos): `b18e74f2` -> `1fa90a0a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -605,11 +605,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714444742,
-        "narHash": "sha256-FOWYXEEtwYKAGmXgKVYli/VsA8XpeR+4wNKt+3M/9b4=",
+        "lastModified": 1714611022,
+        "narHash": "sha256-Cneh2G54TO1eVQBxLZp0JlW8LWbTE/N1WjcE2W+F3pI=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "b18e74f2245eaae150bc753821079c2512fe1516",
+        "rev": "1fa90a0a81fec38c117397fde79733cc78f12815",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`1fa90a0a`](https://github.com/nix-community/srvos/commit/1fa90a0a81fec38c117397fde79733cc78f12815) | `` dev/private/flake.lock: Update `` |
| [`350a3bd8`](https://github.com/nix-community/srvos/commit/350a3bd8358e1c94920f294552834d411e8951b1) | `` flake.lock: Update ``             |