### PR TITLE
chore(flake/nur): `c8456769` -> `36b55d72`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714596740,
-        "narHash": "sha256-V3ZR38xu3JSUrg04wMTp0fzDSP+ogNJOOU5ckreCzLQ=",
+        "lastModified": 1714621571,
+        "narHash": "sha256-vlTPFdn/opcy2uPT2d05myYLqpLN3uXKcMQrz3fhHcA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c8456769a0904ac761020a76bf0bb72a92c27c7c",
+        "rev": "36b55d7275015d2517efe685eaab0a758024c6c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`36b55d72`](https://github.com/nix-community/NUR/commit/36b55d7275015d2517efe685eaab0a758024c6c8) | `` automatic update `` |
| [`e7551ba8`](https://github.com/nix-community/NUR/commit/e7551ba80a204da15714a7d10faac2c8d84de87a) | `` automatic update `` |
| [`5bfd08b7`](https://github.com/nix-community/NUR/commit/5bfd08b7ecb7d45c03cd379b212198297ce5cadf) | `` automatic update `` |