### PR TITLE
chore(flake/nur): `36b55d72` -> `92f293e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714621571,
-        "narHash": "sha256-vlTPFdn/opcy2uPT2d05myYLqpLN3uXKcMQrz3fhHcA=",
+        "lastModified": 1714622712,
+        "narHash": "sha256-nAuCLngWRp6FxE5YbNIBmAec4KN917iimw1G7jz2sRc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "36b55d7275015d2517efe685eaab0a758024c6c8",
+        "rev": "92f293e1ccd904c88b3a9eceb0ef51cfad65e503",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`92f293e1`](https://github.com/nix-community/NUR/commit/92f293e1ccd904c88b3a9eceb0ef51cfad65e503) | `` automatic update `` |