### PR TITLE
chore(flake/nur): `ffac17ce` -> `6d73390b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714630137,
-        "narHash": "sha256-5en8e5kUHnksH1moQp7rrX4kTR5+b3R0WCvldymxZXE=",
+        "lastModified": 1714636883,
+        "narHash": "sha256-usIRLcBdRt+R4mdS0rY8ZMiTC8Dh5dH851oA8jtOt/I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ffac17ce614bb31258be576d55ef80d2f4ebcc29",
+        "rev": "6d73390b52f700231599a0dacff00979a050f46b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6d73390b`](https://github.com/nix-community/NUR/commit/6d73390b52f700231599a0dacff00979a050f46b) | `` automatic update `` |