### PR TITLE
chore(flake/emacs-overlay): `cccda850` -> `b49e31f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714614481,
-        "narHash": "sha256-vykQwGwiu178RHmmRRTzId3qpc9YQtY29Jie7E2GFMg=",
+        "lastModified": 1714640845,
+        "narHash": "sha256-uAyf7QAFzgwJKUjS3Ik3PaCAVRj0IBV+IwbF2g8YxSI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cccda8508481ea8c8ff4e50a297900ed54b26dc3",
+        "rev": "b49e31f50e9772f18e582b8e75bbe9d5f08d2b1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`b49e31f5`](https://github.com/nix-community/emacs-overlay/commit/b49e31f50e9772f18e582b8e75bbe9d5f08d2b1f) | `` Updated emacs `` |
| [`16d97618`](https://github.com/nix-community/emacs-overlay/commit/16d976187c0e855c506b10d12e977eba24f6e9fc) | `` Updated melpa `` |