### PR TITLE
chore(flake/flake-parts): `4d34ce64` -> `e5d10a24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1714606777,
-        "narHash": "sha256-bMkNmAXLj8iyTvxaaD/StcLSadbj1chPcJOjtuVnLmA=",
+        "lastModified": 1714641030,
+        "narHash": "sha256-yzcRNDoyVP7+SCNX0wmuDju1NUCt8Dz9+lyUXEI0dbI=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4d34ce6412bc450b1d4208c953dc97c7fc764f1a",
+        "rev": "e5d10a24b66c3ea8f150e47dfdb0416ab7c3390e",
         "type": "github"
       },
       "original": {
@@ -428,20 +428,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "dir": "lib",
-        "lastModified": 1714253743,
-        "narHash": "sha256-mdTQw2XlariysyScCv2tTE45QSU9v/ezLcHJ22f0Nxc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "58a1abdbae3217ca6b702f03d3b35125d88a2994",
-        "type": "github"
+        "lastModified": 1714640452,
+        "narHash": "sha256-QBx10+k6JWz6u7VsohfSw8g8hjdBZEf8CFzXH1/1Z94=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
       },
       "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
       }
     },
     "nixpkgs-stable": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`99b383f9`](https://github.com/hercules-ci/flake-parts/commit/99b383f98859b688ea9c7d51fd1788deeaf5d422) | `` dev: Also update dev flake lock ``                |
| [`e807eea9`](https://github.com/hercules-ci/flake-parts/commit/e807eea9e845afc954ee189e8d3f57de67d7156f) | `` flake-update: Get the nixpkgs/lib subtree only `` |
| [`49771354`](https://github.com/hercules-ci/flake-parts/commit/497713541ecda51cee05f4376ba3f234b9ca8d1b) | `` dev/flake.lock: Update ``                         |
| [`59fc6f42`](https://github.com/hercules-ci/flake-parts/commit/59fc6f42218854aa35a8d76790649e8c737c8d69) | `` flake.lock: Update ``                             |
| [`288fa518`](https://github.com/hercules-ci/flake-parts/commit/288fa518e2d5ffa074a8deaa38398e96a211479f) | `` flake.nix: Update nixpkgs-lib tree ``             |