### PR TITLE
chore(flake/nur): `e993887d` -> `45130578`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714639442,
-        "narHash": "sha256-P3T6hV4IGhDI1j933nzNjtBun3X85thHJ59+9OsMuEQ=",
+        "lastModified": 1714650265,
+        "narHash": "sha256-WPwv4YoeVS/zYmLCDXJWcuG2rSCuugA0KxqhwGxJdFU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e993887d885d62f7104c1e93e243c8d32d948998",
+        "rev": "4513057827a73cf844d7b99f58703c5ddbdda983",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`45130578`](https://github.com/nix-community/NUR/commit/4513057827a73cf844d7b99f58703c5ddbdda983) | `` automatic update `` |
| [`2b457ac3`](https://github.com/nix-community/NUR/commit/2b457ac396f54d0e184f658d852080a6bb6ce80b) | `` automatic update `` |
| [`ed72c5e1`](https://github.com/nix-community/NUR/commit/ed72c5e1719663d05ff0df7fad4375fa52a7eee9) | `` automatic update `` |