### PR TITLE
chore(flake/nur): `45130578` -> `82439dc5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714650265,
-        "narHash": "sha256-WPwv4YoeVS/zYmLCDXJWcuG2rSCuugA0KxqhwGxJdFU=",
+        "lastModified": 1714653697,
+        "narHash": "sha256-lekfSN4Qqc6OKRdSrDwJLSyeJo63nXiGKFJgWHzFqSQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4513057827a73cf844d7b99f58703c5ddbdda983",
+        "rev": "82439dc57b6e1df536af1e672fff5aedb3291d4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`82439dc5`](https://github.com/nix-community/NUR/commit/82439dc57b6e1df536af1e672fff5aedb3291d4c) | `` automatic update `` |
| [`d33e7943`](https://github.com/nix-community/NUR/commit/d33e7943e2c1a3bf6daa04bfbacdbdeb9ccb30d4) | `` automatic update `` |