### PR TITLE
chore(flake/nur): `82439dc5` -> `112569c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714653697,
-        "narHash": "sha256-lekfSN4Qqc6OKRdSrDwJLSyeJo63nXiGKFJgWHzFqSQ=",
+        "lastModified": 1714657471,
+        "narHash": "sha256-VtMHUECpYMTZa9a0HFkEsnlm3tZwqE3htjWo+qoOygQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "82439dc57b6e1df536af1e672fff5aedb3291d4c",
+        "rev": "112569c052692431c9086beab1159c6c5d3941e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`112569c0`](https://github.com/nix-community/NUR/commit/112569c052692431c9086beab1159c6c5d3941e6) | `` automatic update `` |
| [`ebc0ec48`](https://github.com/nix-community/NUR/commit/ebc0ec48071a31a9624081d0e69cced8d4a0f1cf) | `` automatic update `` |