### PR TITLE
chore(flake/nur): `112569c0` -> `2564ea5b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714657471,
-        "narHash": "sha256-VtMHUECpYMTZa9a0HFkEsnlm3tZwqE3htjWo+qoOygQ=",
+        "lastModified": 1714667472,
+        "narHash": "sha256-wHC60T9fJ1xNxUp8queHl0FI2ogmD94UGrqYfH/qdsk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "112569c052692431c9086beab1159c6c5d3941e6",
+        "rev": "2564ea5b1ae652e36d55da51f926b42aea82f256",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2564ea5b`](https://github.com/nix-community/NUR/commit/2564ea5b1ae652e36d55da51f926b42aea82f256) | `` automatic update `` |
| [`7182bb77`](https://github.com/nix-community/NUR/commit/7182bb77cdf51e1d559a9fe04a204fa96e43ff12) | `` automatic update `` |
| [`68136118`](https://github.com/nix-community/NUR/commit/68136118bfedc42bd4f277e35c24cb7a415c4c6a) | `` automatic update `` |