### PR TITLE
chore(flake/emacs-overlay): `b49e31f5` -> `8f772539`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714640845,
-        "narHash": "sha256-uAyf7QAFzgwJKUjS3Ik3PaCAVRj0IBV+IwbF2g8YxSI=",
+        "lastModified": 1714669473,
+        "narHash": "sha256-LuwvRYxFw8bE3b75oun2HjdbnwGArYEDzRdhtxkx95o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b49e31f50e9772f18e582b8e75bbe9d5f08d2b1f",
+        "rev": "8f77253911c7dc3ac829781ac7f37d1d35447c5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`8f772539`](https://github.com/nix-community/emacs-overlay/commit/8f77253911c7dc3ac829781ac7f37d1d35447c5a) | `` Updated emacs ``  |
| [`3d3e4841`](https://github.com/nix-community/emacs-overlay/commit/3d3e48415335b09ceec614d4cdd0fdbb8fb0199e) | `` Updated melpa ``  |
| [`0696b2f1`](https://github.com/nix-community/emacs-overlay/commit/0696b2f1559daf7602cec05b2675ee0731cce4d8) | `` Updated elpa ``   |
| [`172b32e3`](https://github.com/nix-community/emacs-overlay/commit/172b32e362e021efb78fbfcbf7ced88698ef03e0) | `` Updated nongnu `` |