### PR TITLE
chore(flake/nur): `ae10c15b` -> `1d73c3f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714671884,
-        "narHash": "sha256-SGD4AD7IgXIvrVX2lUgB5UR6wv3NTf6Jdj5JBVNEUew=",
+        "lastModified": 1714674317,
+        "narHash": "sha256-XMmuZpqvLngz1HIbw6VqyeFEeyi1L2e9UgY+kUJ9PX4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ae10c15b223613ed98db4f2fc89953abbe490364",
+        "rev": "1d73c3f1d477f047fef15f8d07e865145790999f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1d73c3f1`](https://github.com/nix-community/NUR/commit/1d73c3f1d477f047fef15f8d07e865145790999f) | `` automatic update `` |