### PR TITLE
chore(flake/home-manager): `6d3b6dc9` -> `9036fe9e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -290,11 +290,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714515075,
-        "narHash": "sha256-azMK7aWH0eUc3IqU4Fg5rwZdB9WZBvimOGG3piqvtsY=",
+        "lastModified": 1714679908,
+        "narHash": "sha256-KzcXzDvDJjX34en8f3Zimm396x6idbt+cu4tWDVS2FI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6d3b6dc9222c12b951169becdf4b0592ee9576ef",
+        "rev": "9036fe9ef8e15a819fa76f47a8b1f287903fb848",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`9036fe9e`](https://github.com/nix-community/home-manager/commit/9036fe9ef8e15a819fa76f47a8b1f287903fb848) | `` flake.lock: Update ``                |
| [`67d0e7db`](https://github.com/nix-community/home-manager/commit/67d0e7db8827abc3634c02de62f3e651a0c92d8c) | `` Translate using Weblate (Persian) `` |