### PR TITLE
chore(flake/emacs-overlay): `8f772539` -> `1a2b6855`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714669473,
-        "narHash": "sha256-LuwvRYxFw8bE3b75oun2HjdbnwGArYEDzRdhtxkx95o=",
+        "lastModified": 1714700989,
+        "narHash": "sha256-HS+GVB4aLaeFLDZIatxSU4ORdG1jSMup0AXSbbdmP1U=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8f77253911c7dc3ac829781ac7f37d1d35447c5a",
+        "rev": "1a2b6855018b3351cfc434fac9dc89df395b93a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`1a2b6855`](https://github.com/nix-community/emacs-overlay/commit/1a2b6855018b3351cfc434fac9dc89df395b93a6) | `` Updated emacs ``        |
| [`8363d3fb`](https://github.com/nix-community/emacs-overlay/commit/8363d3fbffd191406fb6874fca78cfc6325c6ad0) | `` Updated melpa ``        |
| [`163af23c`](https://github.com/nix-community/emacs-overlay/commit/163af23c6cf7a425ca94f58981d82ab0c996d8a3) | `` Updated elpa ``         |
| [`08e21057`](https://github.com/nix-community/emacs-overlay/commit/08e210578b472597476754952196ce66b6fdffcc) | `` Updated flake inputs `` |