### PR TITLE
chore(flake/nur): `cc2d40da` -> `0e1d187e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714699163,
-        "narHash": "sha256-LIz0NHhj1qWDkIBW5VAuci6T5TV/NDCf00fOZcccu2s=",
+        "lastModified": 1714707959,
+        "narHash": "sha256-Oi5pTN2ZxFpLYjIzKNp42oAsbAmW4ofgjeB1nUgBkEA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cc2d40da8b03b84dc364efbe836ba536edc99303",
+        "rev": "0e1d187e6c5c3af05f0bac99d778348408b69d91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0e1d187e`](https://github.com/nix-community/NUR/commit/0e1d187e6c5c3af05f0bac99d778348408b69d91) | `` automatic update `` |
| [`0e12be63`](https://github.com/nix-community/NUR/commit/0e12be637c60f90b7fcc16af2f537ec10ccd5f5b) | `` automatic update `` |