### PR TITLE
chore(flake/nur): `c10b6c14` -> `31726670`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714725122,
-        "narHash": "sha256-Y8RElOJgP4IXC6xpFoIRzf1o21wr6m+x3Oe09a0JD4Q=",
+        "lastModified": 1714729483,
+        "narHash": "sha256-sgwQmJlG1Vb7eAFy5ITikeAU3iPswiVHA58n+/21BxE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c10b6c148747de0c662073b200ce48bf2f08344b",
+        "rev": "3172667078b5918d32dba58dc7ba3e78095abbc6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`31726670`](https://github.com/nix-community/NUR/commit/3172667078b5918d32dba58dc7ba3e78095abbc6) | `` automatic update `` |