### PR TITLE
chore(flake/nur): `ae91f59f` -> `297a4c72`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714733148,
-        "narHash": "sha256-xVqRFtuZjsWJcCZw61iAJGUvr+KSxpA381UKNkx+SB4=",
+        "lastModified": 1714739858,
+        "narHash": "sha256-d4V7onR5g+WLlmGLdBKCuSBHlCI+1mOcjX0EsqCX43w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ae91f59faef2c11201240768a5453c6cb745c1fb",
+        "rev": "297a4c72610f0114ad6dd0152f0ebd7e8258db90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`297a4c72`](https://github.com/nix-community/NUR/commit/297a4c72610f0114ad6dd0152f0ebd7e8258db90) | `` automatic update `` |
| [`5f91bfab`](https://github.com/nix-community/NUR/commit/5f91bfaba4e2a2a2fdcce3b711b76b9aed14cbde) | `` automatic update `` |