### PR TITLE
chore(flake/nur): `297a4c72` -> `d2d85bfb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714739858,
-        "narHash": "sha256-d4V7onR5g+WLlmGLdBKCuSBHlCI+1mOcjX0EsqCX43w=",
+        "lastModified": 1714743872,
+        "narHash": "sha256-i0bNHXgHmFf3hpPLcOzLM79jbewYOEyDGbRcP9lfNMI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "297a4c72610f0114ad6dd0152f0ebd7e8258db90",
+        "rev": "d2d85bfb307a72c46d29c0cd674f46e2f19eacb2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d2d85bfb`](https://github.com/nix-community/NUR/commit/d2d85bfb307a72c46d29c0cd674f46e2f19eacb2) | `` automatic update `` |
| [`e07c6238`](https://github.com/nix-community/NUR/commit/e07c6238f7b241545c2f58fc4c52d1aa6c2b6e51) | `` automatic update `` |