### PR TITLE
chore(flake/nur): `d2d85bfb` -> `4d948474`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714743872,
-        "narHash": "sha256-i0bNHXgHmFf3hpPLcOzLM79jbewYOEyDGbRcP9lfNMI=",
+        "lastModified": 1714746830,
+        "narHash": "sha256-c+I/pO6ZQjBGwykKpwuzzxc6Fsrn29iTdyenljxHn2I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d2d85bfb307a72c46d29c0cd674f46e2f19eacb2",
+        "rev": "4d948474c1ba38a037fc52474fbbb3b79e8ac6e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4d948474`](https://github.com/nix-community/NUR/commit/4d948474c1ba38a037fc52474fbbb3b79e8ac6e8) | `` automatic update `` |