### PR TITLE
chore(flake/nur): `4d948474` -> `a2197d66`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714746830,
-        "narHash": "sha256-c+I/pO6ZQjBGwykKpwuzzxc6Fsrn29iTdyenljxHn2I=",
+        "lastModified": 1714751091,
+        "narHash": "sha256-yNxn5+EbvVKlWL1qHKFRZHVdd0jylQPvk6WDZpoqNyU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4d948474c1ba38a037fc52474fbbb3b79e8ac6e8",
+        "rev": "a2197d662c8c2c7b9c6245ba87fccf33adb4162f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a2197d66`](https://github.com/nix-community/NUR/commit/a2197d662c8c2c7b9c6245ba87fccf33adb4162f) | `` automatic update `` |