### PR TITLE
chore(flake/emacs-overlay): `ac73346a` -> `d72860d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714727166,
-        "narHash": "sha256-+Te/3SrxrDkn4hbjd4mJhky+xJPVYE7hAPnF+vzW4hI=",
+        "lastModified": 1714755945,
+        "narHash": "sha256-N44WGoXubIaUwrlc7N2XIkS8pzxprWfyWHWBI1en1kM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ac73346af1405eb21d5c39071cc30f468a3789c3",
+        "rev": "d72860d651e27709884a8a2ef85f1e99e5eae21c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`d72860d6`](https://github.com/nix-community/emacs-overlay/commit/d72860d651e27709884a8a2ef85f1e99e5eae21c) | `` Updated emacs `` |
| [`a698edfd`](https://github.com/nix-community/emacs-overlay/commit/a698edfdf26c436e20856dc60606ae7321f70a9d) | `` Updated melpa `` |
| [`d58f4039`](https://github.com/nix-community/emacs-overlay/commit/d58f4039cf75aa882f1b87a164b695fcca64b625) | `` Updated elpa ``  |