### PR TITLE
chore(flake/nur): `a2197d66` -> `5ed8a748`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714751091,
-        "narHash": "sha256-yNxn5+EbvVKlWL1qHKFRZHVdd0jylQPvk6WDZpoqNyU=",
+        "lastModified": 1714754675,
+        "narHash": "sha256-Yfjc2Edoknmct2Wfp8HUYDyPRL3Y688HU686LKDg6j8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a2197d662c8c2c7b9c6245ba87fccf33adb4162f",
+        "rev": "5ed8a748a2d2b27f7409d9bd0140da2930d4f72b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5ed8a748`](https://github.com/nix-community/NUR/commit/5ed8a748a2d2b27f7409d9bd0140da2930d4f72b) | `` automatic update `` |