### PR TITLE
chore(flake/nur): `5ed8a748` -> `a2d99492`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714754675,
-        "narHash": "sha256-Yfjc2Edoknmct2Wfp8HUYDyPRL3Y688HU686LKDg6j8=",
+        "lastModified": 1714768544,
+        "narHash": "sha256-TSdLi3GBnms5zpP6TctA2Q5GcSuzCLOh2l2jXx8sOjI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5ed8a748a2d2b27f7409d9bd0140da2930d4f72b",
+        "rev": "a2d994920a0254547d4664a6ab291a9169d96225",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a2d99492`](https://github.com/nix-community/NUR/commit/a2d994920a0254547d4664a6ab291a9169d96225) | `` automatic update `` |
| [`2dd5015e`](https://github.com/nix-community/NUR/commit/2dd5015ec3e09717a0e381bcb5af6c82cdc73bd4) | `` automatic update `` |