### PR TITLE
chore(flake/nur): `a2d99492` -> `ff3e20bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714768544,
-        "narHash": "sha256-TSdLi3GBnms5zpP6TctA2Q5GcSuzCLOh2l2jXx8sOjI=",
+        "lastModified": 1714772762,
+        "narHash": "sha256-Lo3ehGzEhX1mBt+F1SI6Jb+d5Gn9/QXqeaz7jHzN04Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a2d994920a0254547d4664a6ab291a9169d96225",
+        "rev": "ff3e20bc90893e8278f1d64422ce1cd730c18d98",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ff3e20bc`](https://github.com/nix-community/NUR/commit/ff3e20bc90893e8278f1d64422ce1cd730c18d98) | `` automatic update `` |