### PR TITLE
chore(flake/nur): `ff3e20bc` -> `93696b49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714772762,
-        "narHash": "sha256-Lo3ehGzEhX1mBt+F1SI6Jb+d5Gn9/QXqeaz7jHzN04Y=",
+        "lastModified": 1714776283,
+        "narHash": "sha256-07rH+ZFXFtdMAB/UK5yVe7gsKM+pz4ONfKOlHq00Q6U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ff3e20bc90893e8278f1d64422ce1cd730c18d98",
+        "rev": "93696b49594470a4363c74ff29e29ece59ee5c4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`93696b49`](https://github.com/nix-community/NUR/commit/93696b49594470a4363c74ff29e29ece59ee5c4f) | `` automatic update `` |
| [`bdef1381`](https://github.com/nix-community/NUR/commit/bdef138130bd1d2370f43eff981ee8b5fe8b9dd8) | `` automatic update `` |