### PR TITLE
chore(flake/nur): `52825969` -> `82f5e3e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714786251,
-        "narHash": "sha256-QzzbLIfAvfVcqxG1ELo5BAdwiM+sJaHKvv8LkbXWEb4=",
+        "lastModified": 1714794940,
+        "narHash": "sha256-yniuLbIKnvXPU40k7Ye1YhVsMJsEkJTnQ4k1ETBKO08=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "528259690171ef160057adc57903858d4b7fff73",
+        "rev": "82f5e3e60832cbf1e5a6b3bb1f1e6daffc860d08",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`82f5e3e6`](https://github.com/nix-community/NUR/commit/82f5e3e60832cbf1e5a6b3bb1f1e6daffc860d08) | `` automatic update `` |
| [`66afb883`](https://github.com/nix-community/NUR/commit/66afb8832acaa691e00c2a3397cc2583b662b538) | `` automatic update `` |