### PR TITLE
chore(flake/nur): `82f5e3e6` -> `d5fb928d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714794940,
-        "narHash": "sha256-yniuLbIKnvXPU40k7Ye1YhVsMJsEkJTnQ4k1ETBKO08=",
+        "lastModified": 1714797858,
+        "narHash": "sha256-RvYVaBYPHyyDLZ7l9CH3ExXTL1hmJgt8xwjTUliAYC4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "82f5e3e60832cbf1e5a6b3bb1f1e6daffc860d08",
+        "rev": "d5fb928d65efa7e320d2052dc76b078b24e69e3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d5fb928d`](https://github.com/nix-community/NUR/commit/d5fb928d65efa7e320d2052dc76b078b24e69e3d) | `` automatic update `` |
| [`35442849`](https://github.com/nix-community/NUR/commit/354428490b46e0ae3c8015e20540f335bbd7ce60) | `` automatic update `` |
| [`5ad14cd0`](https://github.com/nix-community/NUR/commit/5ad14cd0f92839b242753d0e71edcf77c71850a8) | `` automatic update `` |