### PR TITLE
chore(flake/nur): `d5fb928d` -> `c1173d6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714797858,
-        "narHash": "sha256-RvYVaBYPHyyDLZ7l9CH3ExXTL1hmJgt8xwjTUliAYC4=",
+        "lastModified": 1714802085,
+        "narHash": "sha256-wWuyit1ymT/jLHiP+7lv/YhG9YHbGFxhiBmKOcLFEIo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d5fb928d65efa7e320d2052dc76b078b24e69e3d",
+        "rev": "c1173d6d6371bce8b916d4694a5a3b8c9b1d8ce8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c1173d6d`](https://github.com/nix-community/NUR/commit/c1173d6d6371bce8b916d4694a5a3b8c9b1d8ce8) | `` automatic update `` |