### PR TITLE
chore(flake/nur): `c1173d6d` -> `68012ea0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714802085,
-        "narHash": "sha256-wWuyit1ymT/jLHiP+7lv/YhG9YHbGFxhiBmKOcLFEIo=",
+        "lastModified": 1714805148,
+        "narHash": "sha256-oO84pR/2ca7TOsFMNOawD0fLjf3iHgv9dmVFmz2HWyk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c1173d6d6371bce8b916d4694a5a3b8c9b1d8ce8",
+        "rev": "68012ea0a4d3d49f94983e79948929441578b57a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`68012ea0`](https://github.com/nix-community/NUR/commit/68012ea0a4d3d49f94983e79948929441578b57a) | `` automatic update `` |