### PR TITLE
chore(flake/nur): `68012ea0` -> `176bcb77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714805148,
-        "narHash": "sha256-oO84pR/2ca7TOsFMNOawD0fLjf3iHgv9dmVFmz2HWyk=",
+        "lastModified": 1714807751,
+        "narHash": "sha256-E7u6L842VacBvw0491YhHRjZFcdk+owvHugJXNANca4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "68012ea0a4d3d49f94983e79948929441578b57a",
+        "rev": "176bcb77f850dd7af52112ff5509ea6839e04800",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`176bcb77`](https://github.com/nix-community/NUR/commit/176bcb77f850dd7af52112ff5509ea6839e04800) | `` automatic update `` |