### PR TITLE
chore(flake/nur): `ff1b579a` -> `76f28396`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714809736,
-        "narHash": "sha256-DhqKYvpmLkIKCsA8wuW/FCKpVlvSBmTRAbPzSMxdRB4=",
+        "lastModified": 1714817343,
+        "narHash": "sha256-rRHZG1hJIORQI9SyUHIL97i6gwT7kYI2lnvO2N4q93E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ff1b579a6f25631904ee411d8f6175ecdd8bbb54",
+        "rev": "76f28396a56dae6b65e97cd9941cf9df825faebd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`76f28396`](https://github.com/nix-community/NUR/commit/76f28396a56dae6b65e97cd9941cf9df825faebd) | `` automatic update `` |