### PR TITLE
chore(flake/nur): `76f28396` -> `33f7913a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714817343,
-        "narHash": "sha256-rRHZG1hJIORQI9SyUHIL97i6gwT7kYI2lnvO2N4q93E=",
+        "lastModified": 1714822436,
+        "narHash": "sha256-QnWfY6LlKBi5asOFaAe86A1rejF2LFzIRCzWZUUZvMc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "76f28396a56dae6b65e97cd9941cf9df825faebd",
+        "rev": "33f7913ac4b94015e465b9be78f90c5df6bfa498",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`33f7913a`](https://github.com/nix-community/NUR/commit/33f7913ac4b94015e465b9be78f90c5df6bfa498) | `` automatic update `` |