### PR TITLE
chore(flake/emacs-overlay): `95efc569` -> `146fe1e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714813374,
-        "narHash": "sha256-x6I9usdTzVkxK09Jh576ieYDEfCeB4RTNclt11qKeh4=",
+        "lastModified": 1714842256,
+        "narHash": "sha256-q8oPSGCj1H1BLZg4a06lGrmNsgq1WkPMCIuMhAtCxu8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "95efc569e1dd1fd3f25aeb1baaf754415e4eafe2",
+        "rev": "146fe1e340847eeee5243f77af634d9d1b990c8e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`146fe1e3`](https://github.com/nix-community/emacs-overlay/commit/146fe1e340847eeee5243f77af634d9d1b990c8e) | `` Updated emacs `` |
| [`5c7d78da`](https://github.com/nix-community/emacs-overlay/commit/5c7d78da8c4506263b991239eda23d179c3ba183) | `` Updated melpa `` |
| [`b5fdda76`](https://github.com/nix-community/emacs-overlay/commit/b5fdda760466419fd065bf1a0bd5c7a72aeb39e3) | `` Updated elpa ``  |