### PR TITLE
chore(flake/nur): `5235f5f0` -> `f447185b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714841099,
-        "narHash": "sha256-G45aWsyMZSvIB2HhuecIVgs+zpqRMDWoHkUPZPItlbw=",
+        "lastModified": 1714859515,
+        "narHash": "sha256-oKnwBpuOYsG8v2ZR6MeZllIDgJ1GzKApfFIAtTEI+WY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5235f5f0626a9fd28c0949c0c1e6acfff59a5bb3",
+        "rev": "f447185b50a21c39510574ab8bc84ed88edd14be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f447185b`](https://github.com/nix-community/NUR/commit/f447185b50a21c39510574ab8bc84ed88edd14be) | `` automatic update `` |
| [`fa3542e0`](https://github.com/nix-community/NUR/commit/fa3542e0b83c506f7173b6b1a5e871d8490c1aa5) | `` automatic update `` |
| [`96d7a05f`](https://github.com/nix-community/NUR/commit/96d7a05f67988fc0e12345bb45f0b0cebab8068b) | `` automatic update `` |
| [`a999dc88`](https://github.com/nix-community/NUR/commit/a999dc88f41562ffe70d81d2de79cee6a74cefa4) | `` automatic update `` |