### PR TITLE
chore(flake/nur): `f447185b` -> `85a902f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714859515,
-        "narHash": "sha256-oKnwBpuOYsG8v2ZR6MeZllIDgJ1GzKApfFIAtTEI+WY=",
+        "lastModified": 1714861609,
+        "narHash": "sha256-FgOd//nhYXAB0BOZxozUK54rpMslwm3jVTRFBOqh2Ss=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f447185b50a21c39510574ab8bc84ed88edd14be",
+        "rev": "85a902f0f7b2f39f498b5bb7e1d307997c9f151b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                             |
| -------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`85a902f0`](https://github.com/nix-community/NUR/commit/85a902f0f7b2f39f498b5bb7e1d307997c9f151b) | `` automatic update ``              |
| [`3b0dd579`](https://github.com/nix-community/NUR/commit/3b0dd57928a091006cdea51424bc68ac87a5223c) | `` automatic update ``              |
| [`d37828fa`](https://github.com/nix-community/NUR/commit/d37828faed8bf027cf8785e56fc0c0ea0fdee002) | `` add AndrewKvalheim repository `` |
| [`187e4508`](https://github.com/nix-community/NUR/commit/187e450838e3ab9ae00800f7cdccf2da9d21b510) | `` add wasabi375 repository ``      |