### PR TITLE
chore(flake/nur): `85a902f0` -> `ec864fb9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714861609,
-        "narHash": "sha256-FgOd//nhYXAB0BOZxozUK54rpMslwm3jVTRFBOqh2Ss=",
+        "lastModified": 1714869445,
+        "narHash": "sha256-Xt5A5HrdhhB4xKPPN7xJhLENqK6ThiSkGrzlhwT671A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "85a902f0f7b2f39f498b5bb7e1d307997c9f151b",
+        "rev": "ec864fb92873aa278e16dc75e3c1a2e72c3e2ea8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ec864fb9`](https://github.com/nix-community/NUR/commit/ec864fb92873aa278e16dc75e3c1a2e72c3e2ea8) | `` automatic update `` |
| [`059f6c2b`](https://github.com/nix-community/NUR/commit/059f6c2bf1f8b8ee1789f2692c2be200514d29b8) | `` automatic update `` |