### PR TITLE
chore(flake/emacs-overlay): `146fe1e3` -> `53d749b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714842256,
-        "narHash": "sha256-q8oPSGCj1H1BLZg4a06lGrmNsgq1WkPMCIuMhAtCxu8=",
+        "lastModified": 1714873811,
+        "narHash": "sha256-bTLuVi1Kt3P70mIPxquqyI+wB7+GjZ2Z1xhvaj6vqnw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "146fe1e340847eeee5243f77af634d9d1b990c8e",
+        "rev": "53d749b467ee0727d8417756137f4dcf657917dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`53d749b4`](https://github.com/nix-community/emacs-overlay/commit/53d749b467ee0727d8417756137f4dcf657917dc) | `` Updated emacs `` |
| [`5eda9c89`](https://github.com/nix-community/emacs-overlay/commit/5eda9c899cf20973476526f88680ba0309715be6) | `` Updated melpa `` |
| [`e73f687f`](https://github.com/nix-community/emacs-overlay/commit/e73f687f6a20850ae4aa8b3a613e183a87d9aba0) | `` Updated elpa ``  |