### PR TITLE
chore(flake/nix-index-database): `941c4973` -> `a362555e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -383,11 +383,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714273701,
-        "narHash": "sha256-bmoeZ5zMSSO/e8P51yjrzaxA9uzA3SZAEFvih6S3LFo=",
+        "lastModified": 1714878592,
+        "narHash": "sha256-E68C03sYRsYFsK7wiGHUIJm8IsyPRALOrFoTL0glXnI=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "941c4973c824509e0356be455d89613611f76c8a",
+        "rev": "a362555e9dbd4ecff3bb98969bbdb8f79fe87f10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`a362555e`](https://github.com/nix-community/nix-index-database/commit/a362555e9dbd4ecff3bb98969bbdb8f79fe87f10) | `` update packages.nix to release 2024-05-05-030852 `` |
| [`7a20d550`](https://github.com/nix-community/nix-index-database/commit/7a20d550bed76a862e355181d1eb5f23a6c86272) | `` flake.lock: Update ``                               |