### PR TITLE
chore(flake/nur): `9c990bb1` -> `d3c11461`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714873496,
-        "narHash": "sha256-w8r/wecqioCoH4vILHsnZ1SB1D5VdUJn+cZJQy5OMpI=",
+        "lastModified": 1714881453,
+        "narHash": "sha256-ngSoO6iZnDahrgqcaE0Ej22kUj6ipF+Mwc3+2brDz6c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9c990bb1fbf969875018c136b8332fd773f527c1",
+        "rev": "d3c11461a44ae72d6a27bc78c9377df6b4ff41d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d3c11461`](https://github.com/nix-community/NUR/commit/d3c11461a44ae72d6a27bc78c9377df6b4ff41d0) | `` automatic update `` |
| [`49f72c69`](https://github.com/nix-community/NUR/commit/49f72c695fb2f46c8aeb1549704246b9558b2011) | `` automatic update `` |