### PR TITLE
chore(flake/nixpkgs): `63c3a29c` -> `e9be4245`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -412,11 +412,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714635257,
-        "narHash": "sha256-4cPymbty65RvF1DWQfc+Bc8B233A1BWxJnNULJKQ1EY=",
+        "lastModified": 1714763106,
+        "narHash": "sha256-DrDHo74uTycfpAF+/qxZAMlP/Cpe04BVioJb6fdI0YY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "63c3a29ca82437c87573e4c6919b09a24ea61b0f",
+        "rev": "e9be42459999a253a9f92559b1f5b72e1b44c13d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                         |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
| [`e9be4245`](https://github.com/NixOS/nixpkgs/commit/e9be42459999a253a9f92559b1f5b72e1b44c13d) | `` calibre: 7.9.0 -> 7.10.0 (#308800) ``                                                                        |
| [`8528f327`](https://github.com/NixOS/nixpkgs/commit/8528f3272872a3f0d7e2e69595c67a95806286e6) | `` varnish75: init at 7.5.0 (#308604) ``                                                                        |
| [`67a4ef9d`](https://github.com/NixOS/nixpkgs/commit/67a4ef9d1e49f4ce4c5d2dfd15619bd411a52c23) | `` inotify-info: unstable-2024-01-05 -> 0.0.1 (#308759) ``                                                      |
| [`33ae86a9`](https://github.com/NixOS/nixpkgs/commit/33ae86a95140f3fdc877b4507955343debe32014) | `` texinfo: fix issue with libiconv not being passed in by removing top-level `with lib` statement (#308835) `` |
| [`7868b05e`](https://github.com/NixOS/nixpkgs/commit/7868b05e546858c27d8fa4c80d7fbbf76230c5c7) | `` rustscan: 2.2.2 -> 2.2.3 ``                                                                                  |
| [`dae84480`](https://github.com/NixOS/nixpkgs/commit/dae84480d124365629d27ca3d4d1d0c67baff536) | `` python311Packages.cvxpy: unbreak ``                                                                          |
| [`6b7692c8`](https://github.com/NixOS/nixpkgs/commit/6b7692c8f5e1f099eab6408f7ba11105544b3346) | `` nixos/networkmanager: fix incorrect documention about `extraConfig` ``                                       |
| [`2326c308`](https://github.com/NixOS/nixpkgs/commit/2326c308f6e2eb8ff13b179576021ab4da792f4a) | `` shopware-cli: 0.4.40 -> 0.4.42 ``                                                                            |
| [`67825897`](https://github.com/NixOS/nixpkgs/commit/67825897a497e62676118a2f8728bf3e598199e8) | `` jellyfin-ffmpeg: pick patch to fix build with new libjxl ``                                                  |
| [`12a45777`](https://github.com/NixOS/nixpkgs/commit/12a45777431227a53d7ceaf826634a2797a23fb2) | `` jellyfin-ffmpeg: 6.0.1-5 -> 6.0.1-6 ``                                                                       |
| [`446e914c`](https://github.com/NixOS/nixpkgs/commit/446e914cbe7732421c4913fd24bb133b236eaebf) | `` josm: 19039 -> 19067 ``                                                                                      |
| [`d5537cdf`](https://github.com/NixOS/nixpkgs/commit/d5537cdf0be205259eba5be6ad240e5d2190f162) | `` paperless-ngx: add missing runHooks ``                                                                       |
| [`2544167a`](https://github.com/NixOS/nixpkgs/commit/2544167a82ff99e00a8de68fa529701a30648128) | `` python3Packages.rpy2: drop already applied patch ``                                                          |
| [`b8a95810`](https://github.com/NixOS/nixpkgs/commit/b8a958101b0268408d2b34926b16e4583af53a4b) | `` sanjuuni: fix build (#308706) ``                                                                             |
| [`c693a5d4`](https://github.com/NixOS/nixpkgs/commit/c693a5d411445ec06fbf3b7b97632152f5fa43a0) | `` sdkmanager: 0.6.6 -> 0.6.7 (#308726) ``                                                                      |
| [`9c479cf0`](https://github.com/NixOS/nixpkgs/commit/9c479cf090a778328a00228b1b61588e4248584d) | `` compcert: 3.13.1 → 3.14 (#308752) ``                                                                         |
| [`8ee9e2c2`](https://github.com/NixOS/nixpkgs/commit/8ee9e2c2962f4fab0a862c875a807e86cfae9da8) | `` nf-test: init at 0.8.4 (#308756) ``                                                                          |
| [`39d27661`](https://github.com/NixOS/nixpkgs/commit/39d27661d51150ff5e79eeaf77669df79ca1d0c3) | `` bob: fix vulnerable dependencies ``                                                                          |
| [`c320522f`](https://github.com/NixOS/nixpkgs/commit/c320522f1d238c1d261aa5bf2463a03f1e046a89) | `` vscode: 1.88.1 -> 1.89.0 ``                                                                                  |
| [`b3741ce0`](https://github.com/NixOS/nixpkgs/commit/b3741ce0ae8f1703bce69a6622d96f1416c31b4e) | `` codeberg-pages: delete test in postPatch rather than with patch file ``                                      |
| [`5f7b03e1`](https://github.com/NixOS/nixpkgs/commit/5f7b03e13f05f858a9383577e7a6e2a17864dcae) | `` gitlab-container-registry: delete test in postPatch rather than with patch file ``                           |
| [`5def2206`](https://github.com/NixOS/nixpkgs/commit/5def220672cb264d33f876f10e7031daa5ad57b3) | `` protolint: 0.49.6 -> 0.49.7 ``                                                                               |
| [`f1e53bd5`](https://github.com/NixOS/nixpkgs/commit/f1e53bd5e86149f870a5a64e32568c37ca00727a) | `` pupdate: 3.10.1 -> 3.10.2 ``                                                                                 |
| [`013844af`](https://github.com/NixOS/nixpkgs/commit/013844af158b8f64b05fe338c25789e1c86a19d0) | `` kubescape: 3.0.8 -> 3.0.9 (#308791) ``                                                                       |
| [`77146829`](https://github.com/NixOS/nixpkgs/commit/77146829860a441f9dafd7e3a0ee257f2a5e2996) | `` media-downloader: 4.5.0 -> 4.6.0 ``                                                                          |
| [`e3c36fbf`](https://github.com/NixOS/nixpkgs/commit/e3c36fbf6906ab0085843cdae4d5c3b96ffb06f3) | `` hcl2json: 0.6.2 -> 0.6.3 ``                                                                                  |
| [`8fc20ac1`](https://github.com/NixOS/nixpkgs/commit/8fc20ac1c36e87d5d6c6001a4e77a91331d8eb07) | `` clockify: unbreak (#308765) ``                                                                               |
| [`a5dc01f1`](https://github.com/NixOS/nixpkgs/commit/a5dc01f1dd8f63760245a9245574862499f97f37) | `` python311Packages.oracledb: format with nixfmt ``                                                            |
| [`d9df9fb4`](https://github.com/NixOS/nixpkgs/commit/d9df9fb49e5bfd40b63b4ba3a261654f3220065d) | `` virtualboxKvm: 20240325 -> 20240502 ``                                                                       |
| [`ff381db4`](https://github.com/NixOS/nixpkgs/commit/ff381db4e75e7f57f5eece18aef1dd22469cff1f) | `` cargo-binstall: 1.6.4 -> 1.6.5 ``                                                                            |
| [`6b66d619`](https://github.com/NixOS/nixpkgs/commit/6b66d619637859e5d25ef453ab8669dc2deb4d51) | `` guile-lzlib: 0.0.2 -> 0.3.0 ``                                                                               |
| [`492f7b44`](https://github.com/NixOS/nixpkgs/commit/492f7b4484384b979358c29e571418ba49c2e838) | `` opustags: 1.9.0 -> 1.10.0 ``                                                                                 |
| [`0a6a5ca4`](https://github.com/NixOS/nixpkgs/commit/0a6a5ca4c120c7f8287fcb754365de2dc9fb889f) | `` valeStyles.google: 0.6.0 -> 0.6.1 ``                                                                         |
| [`123dbe97`](https://github.com/NixOS/nixpkgs/commit/123dbe970edd1d99df51618967808c9232389f76) | `` valeStyles.microsoft: 0.14.0 -> 0.14.1 ``                                                                    |
| [`6a3601a1`](https://github.com/NixOS/nixpkgs/commit/6a3601a1c654e27dc3a39e7732ed4b9972b8247f) | `` R: apply patch for CVE-2024-27322 ``                                                                         |
| [`315db4f0`](https://github.com/NixOS/nixpkgs/commit/315db4f0f26ecb703722e02a3ec300125d83d7ff) | `` heisenbridge: Drop piegames from maintainers ``                                                              |
| [`3813ff1a`](https://github.com/NixOS/nixpkgs/commit/3813ff1a48c169c943d5aed0dbeccaa852db9a56) | `` conduit: Drop piegames from maintainers ``                                                                   |
| [`e0c850e9`](https://github.com/NixOS/nixpkgs/commit/e0c850e97fb4f788b0ade33e751148c9ef3ec903) | `` CODEOWNERS: Drop piegames ``                                                                                 |
| [`fd7f2d32`](https://github.com/NixOS/nixpkgs/commit/fd7f2d32bc5986518ee2ef8bda6440d2d1002037) | `` bitcoin: reenable bdb legacy wallet support on non-Darwin platforms ``                                       |
| [`b8827d27`](https://github.com/NixOS/nixpkgs/commit/b8827d279cdf28c2522f25a1bb390a4588e0a3a1) | `` bazel-watcher: 0.24.0 -> 0.25.2 ``                                                                           |
| [`0b73f09d`](https://github.com/NixOS/nixpkgs/commit/0b73f09d086baf9559873dd21558f42322993a9e) | `` bazel-watcher: fix build after default-go version upgrade ``                                                 |
| [`448ac53f`](https://github.com/NixOS/nixpkgs/commit/448ac53f230789f77f0a7f588eb520cba6c15b69) | `` nh: 3.5.13 -> 3.5.14 ``                                                                                      |
| [`e768d95f`](https://github.com/NixOS/nixpkgs/commit/e768d95f414fa3ed2643b4b25fd15eafa3446254) | `` linux/generic.nix: Fix CONFIG_RUST ``                                                                        |
| [`54fd6284`](https://github.com/NixOS/nixpkgs/commit/54fd6284797d5111dc73dffe14bc297ea29fa791) | `` ceph: switch python from 3.10 to 3.11 ``                                                                     |
| [`3251e276`](https://github.com/NixOS/nixpkgs/commit/3251e2767863f58d2c6b5c2033c6e25fe449c7de) | `` python311Packages.oracledb: 2.1.2 -> 2.2.0 ``                                                                |
| [`ab83e3fd`](https://github.com/NixOS/nixpkgs/commit/ab83e3fd1e93b44660157369d58b1ba8e1e24f6b) | `` llama-cpp: 2746 -> 2781 ``                                                                                   |
| [`0fd18595`](https://github.com/NixOS/nixpkgs/commit/0fd185959674e5a330c4bba5eee917388d0ebdb3) | `` ceph: fix build of overridden pyopenssl ``                                                                   |
| [`ea51404f`](https://github.com/NixOS/nixpkgs/commit/ea51404f4e50c9a2692697f30dae6b2649f953f9) | `` coqPackages.ssprove: init at 0.2.0 (#306981) ``                                                              |
| [`baa67f8d`](https://github.com/NixOS/nixpkgs/commit/baa67f8d82bf5555d64eafc2a086901eaa29fda7) | `` gamescope: 3.14.6 -> 3.14.11 ``                                                                              |
| [`1c4f8146`](https://github.com/NixOS/nixpkgs/commit/1c4f8146a7919ab8a40564a33ae593ea898c7358) | `` graphite-gtk-theme: 2023-12-31 -> 2024-04-28 ``                                                              |
| [`171fa441`](https://github.com/NixOS/nixpkgs/commit/171fa441a985646b3ff3ff4d3342e27d90a19c28) | `` zigbee2mqtt: 1.36.1 -> 1.37.0 ``                                                                             |
| [`1d35c905`](https://github.com/NixOS/nixpkgs/commit/1d35c905a8846e249a9e4904f74dbb0b240be101) | `` typstyle: 0.11.13 -> 0.11.16 ``                                                                              |
| [`4d7c6503`](https://github.com/NixOS/nixpkgs/commit/4d7c65032c0752b8e9a0bc8564b194b291d6dc8d) | `` trezor-suite: 24.3.2 -> 24.4.3 ``                                                                            |
| [`05237d2d`](https://github.com/NixOS/nixpkgs/commit/05237d2d1b99f39c224f3a711b4ff04f2214f9e0) | `` python311Packages.ucsmsdk: 0.9.16 -> 0.9.17 ``                                                               |
| [`90097577`](https://github.com/NixOS/nixpkgs/commit/9009757709d43bc6e47cf044268a9bfb19e6d06d) | `` python312Packages.llama-index-core: 0.10.33 -> 0.10.34 ``                                                    |
| [`1c2c9516`](https://github.com/NixOS/nixpkgs/commit/1c2c9516fa706b75d531b0bcfeb6e254e08395b3) | `` python312Packages.mkdocs-rss-plugin: 1.12.1 -> 1.12.2 ``                                                     |
| [`cb5b2f9a`](https://github.com/NixOS/nixpkgs/commit/cb5b2f9aa36815f3614e2cc2c4a5e320f1bbb18b) | `` python312Packages.mkdocstrings-python: 1.9.2 -> 1.10.0 ``                                                    |
| [`dc4af9eb`](https://github.com/NixOS/nixpkgs/commit/dc4af9eb9e3ae8b5d113c04396194feda5d2070b) | `` python312Packages.playwrightcapture: 1.24.6 -> 1.24.7 ``                                                     |
| [`5f345fdf`](https://github.com/NixOS/nixpkgs/commit/5f345fdffc07ebd37564798dfdea0bdaff7290b4) | `` python312Packages.puremagic: format with nixfmt ``                                                           |
| [`407c357d`](https://github.com/NixOS/nixpkgs/commit/407c357d8ab91474bac8a2cf6c43d729d9bc06cd) | `` python312Packages.puremagic: 1.21 -> 1.22 ``                                                                 |
| [`4fc84a24`](https://github.com/NixOS/nixpkgs/commit/4fc84a24b86a6f02b54a37fc858436cc747b6e8b) | `` python312Packages.puremagic: refactor ``                                                                     |
| [`f9e7b448`](https://github.com/NixOS/nixpkgs/commit/f9e7b448127ad8ebe962190f8527d2324c49ede0) | `` python312Packages.roadtx: format with nixfmt ``                                                              |
| [`2313c67f`](https://github.com/NixOS/nixpkgs/commit/2313c67fcf0fa924652c73957240d2644abef9ab) | `` python312Packages.roadtx: 1.7.0 -> 1.8.1 ``                                                                  |
| [`ecd04ded`](https://github.com/NixOS/nixpkgs/commit/ecd04dede8a8db56b5c8ed0e15882d7bf27f3180) | `` python312Packages.roadtx: refactor ``                                                                        |
| [`74f9ef5b`](https://github.com/NixOS/nixpkgs/commit/74f9ef5b2e41d12f99b4d3657b107b1077ab3ea5) | `` roadrunner: refactor ``                                                                                      |
| [`aa10bacb`](https://github.com/NixOS/nixpkgs/commit/aa10bacb813a4abc9c3da66de11362244a57a502) | `` nixos/ebusd: clean up module ``                                                                              |
| [`e0d85632`](https://github.com/NixOS/nixpkgs/commit/e0d856327728d4d70946daabfddbfaa1a6d7525e) | `` python312Packages.lacuscore: 1.9.2 -> 1.9.3 ``                                                               |
| [`ad6582c9`](https://github.com/NixOS/nixpkgs/commit/ad6582c96dd065c49e38fd45c67903211202f3ca) | `` python312Packages.airthings-ble: format with nixfmt ``                                                       |
| [`2ac6998a`](https://github.com/NixOS/nixpkgs/commit/2ac6998abbd657cad987e416274215040e59865c) | `` python312Packages.airthings-ble: refactor ``                                                                 |
| [`8d984324`](https://github.com/NixOS/nixpkgs/commit/8d9843246c83c56246987fd9811bcc1704efb286) | `` python312Packages.airthings-ble: 0.7.1 -> 0.8.0 ``                                                           |
| [`71a0a41d`](https://github.com/NixOS/nixpkgs/commit/71a0a41d5d6d22b2c2f98f4f6a5e5e060dc84aec) | `` quark-engine: format with nixfmt ``                                                                          |
| [`fa92d21f`](https://github.com/NixOS/nixpkgs/commit/fa92d21f963c0525e9b6261632033ad49ab913f9) | `` quark-engine: refactor ``                                                                                    |
| [`dbb9bdf4`](https://github.com/NixOS/nixpkgs/commit/dbb9bdf420f0ecfeb3238f853676bd22cf580cdb) | `` python312Packages.roadlib: format with nixfmt ``                                                             |
| [`541d458d`](https://github.com/NixOS/nixpkgs/commit/541d458df41683faa25739d7fca4a0f54427b8f4) | `` python311Packages.roadlib: refactor ``                                                                       |
| [`a3ae0668`](https://github.com/NixOS/nixpkgs/commit/a3ae066838e765f666a5575010c1e97d679194fa) | `` python311Packages.yq: 3.4.1 -> 3.4.3 ``                                                                      |
| [`e428ac54`](https://github.com/NixOS/nixpkgs/commit/e428ac54ac0c2a056a661147dc2a264ca81c8d7d) | `` cosmic-tasks: use renamed wrapGAppsHook3 ``                                                                  |
| [`68627781`](https://github.com/NixOS/nixpkgs/commit/686277819bbba33974e735228b6abab04dc094c0) | `` python311Packages.recoll: 1.37.4 -> 1.37.5 ``                                                                |
| [`4265a82c`](https://github.com/NixOS/nixpkgs/commit/4265a82cba19b985cce23eff1a19d84de7712456) | `` genymotion: fix runtime error with qemu ``                                                                   |
| [`49eacfc4`](https://github.com/NixOS/nixpkgs/commit/49eacfc440b61b116faf28738159c4af9a0a768d) | `` redpanda-client: 23.3.13 -> 23.3.14 ``                                                                       |
| [`4e1a313c`](https://github.com/NixOS/nixpkgs/commit/4e1a313c73c2356a4ffd338b73022bd2d45ea229) | `` ast-grep: 0.21.1 -> 0.21.3 ``                                                                                |
| [`9d34a252`](https://github.com/NixOS/nixpkgs/commit/9d34a252774bcffec4b2340d32b880baf0d37814) | `` mtail: 3.0.0 -> 3.0.1 ``                                                                                     |
| [`00a140fa`](https://github.com/NixOS/nixpkgs/commit/00a140fa000ef985845f6bf3c650f4ce4a323d34) | `` emacsPackages.lsp-bridge: 20240424.1125 -> 20240502.2306 ``                                                  |
| [`b4f4199b`](https://github.com/NixOS/nixpkgs/commit/b4f4199b6ec3c88eca6ad1e9f2d8d0e2b90f5115) | `` openvscode-server: 1.88.0 > 1.88.1 ``                                                                        |
| [`81e6f5fe`](https://github.com/NixOS/nixpkgs/commit/81e6f5feed7ad4b22f6a25d693a5e9f9394487fa) | `` dnsproxy: 0.71.0 -> 0.71.1 ``                                                                                |
| [`be00ce08`](https://github.com/NixOS/nixpkgs/commit/be00ce08f2c7ff81910be68ea414c6cec34e828d) | `` python311Packages.aiounifi: 76 -> 77 ``                                                                      |
| [`86afd332`](https://github.com/NixOS/nixpkgs/commit/86afd332e9be3280436d09d170d56fdc6ebf1f19) | `` quark-engine: 24.4.1 -> 24.5.1 ``                                                                            |
| [`89822cc1`](https://github.com/NixOS/nixpkgs/commit/89822cc130c8928490caa37e3ab547f41841cd7e) | `` python311Packages.roadlib: 0.23.0 -> 0.24.0 ``                                                               |
| [`3b5af28d`](https://github.com/NixOS/nixpkgs/commit/3b5af28db31e4b324cc2f16d98f83ce811343044) | `` cemu: 2.0-79 -> 2.0-80 ``                                                                                    |
| [`0d87342e`](https://github.com/NixOS/nixpkgs/commit/0d87342ed19ff359832edd6d1b506942564153ea) | `` csvq: move to pkgs/by-name ``                                                                                |
| [`0878c3c3`](https://github.com/NixOS/nixpkgs/commit/0878c3c323ad0bc48ec2eec3baca72ddfd1ab34a) | `` phrase-cli: 2.25.0 -> 2.27.0 ``                                                                              |
| [`fc4123f5`](https://github.com/NixOS/nixpkgs/commit/fc4123f5fe20af5f7bbbb0affc86daac2b70f5c9) | `` kanji-stroke-order-font: 4.003 -> 4.004 ``                                                                   |
| [`d9556443`](https://github.com/NixOS/nixpkgs/commit/d95564433b543d0f99a6eee632274c43ab3992b7) | `` kics: 2.0.0 -> 2.0.1 ``                                                                                      |
| [`994c1f60`](https://github.com/NixOS/nixpkgs/commit/994c1f607ff70fb71a1e494bf1f47ea794553275) | `` trayscale: 0.11.2 -> 0.12.0 ``                                                                               |