### PR TITLE
chore(flake/home-manager): `e0825ea2` -> `fdaaf543`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -290,11 +290,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714865296,
-        "narHash": "sha256-02r2Qzh4fGYBPB/3Lj8vwPMtE6H/UchZnN7A/dQMHIA=",
+        "lastModified": 1714900398,
+        "narHash": "sha256-H7XYHpjk1G6dkA3AnbYrKtaTFjcCE7ul6nUVlVQxtsA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e0825ea2112d09d9f0680833cd716f6aee3b973f",
+        "rev": "fdaaf543bad047639ef0b356ea2e6caec2f1215c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`fdaaf543`](https://github.com/nix-community/home-manager/commit/fdaaf543bad047639ef0b356ea2e6caec2f1215c) | `` hypridle: add module ``              |
| [`f69bf670`](https://github.com/nix-community/home-manager/commit/f69bf670d29d3921e00cc626d174654769d743c6) | `` cliphist: add extraOptions option `` |
| [`2a44f4d0`](https://github.com/nix-community/home-manager/commit/2a44f4d09f891d8a9d72b9a7331fa8d94b066119) | `` flake.lock: Update ``                |