### PR TITLE
chore(flake/nur): `4786dbf1` -> `19775c37`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1714892004,
-        "narHash": "sha256-MDJDEl+A7+uDdfP0J23Y75cReyhx/wRH6uKn4+5CrT0=",
+        "lastModified": 1715054320,
+        "narHash": "sha256-RpzJ9E17+TyDzGA/VFxO3cJjkFVL6Kmgolzqx7mshP4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4786dbf1c83729400b4ec37d88ddae089d75803c",
+        "rev": "19775c37649088292236e4433c98bbb78b53131f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                        |
| -------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`19775c37`](https://github.com/nix-community/NUR/commit/19775c37649088292236e4433c98bbb78b53131f) | `` automatic update ``         |
| [`98bbbfdc`](https://github.com/nix-community/NUR/commit/98bbbfdc54262c65e9ce06eecb58774dcd27c794) | `` automatic update ``         |
| [`0582342c`](https://github.com/nix-community/NUR/commit/0582342c125679310db9fd8132740ba9f65b51a0) | `` automatic update ``         |
| [`590b4fc8`](https://github.com/nix-community/NUR/commit/590b4fc898660027bfa5baf09cebb0dc87f49ed5) | `` automatic update ``         |
| [`abb8025a`](https://github.com/nix-community/NUR/commit/abb8025ae8b5b3e1e1dafce5872441e7aabe3fd7) | `` automatic update ``         |
| [`dddc6860`](https://github.com/nix-community/NUR/commit/dddc6860c3092394c69860b110554e0d65ded95f) | `` automatic update ``         |
| [`794fe595`](https://github.com/nix-community/NUR/commit/794fe595748e96f04210a8af077a2f768a3796ab) | `` automatic update ``         |
| [`4e77e26d`](https://github.com/nix-community/NUR/commit/4e77e26dd2faeb7841d53185032176720da75adf) | `` automatic update ``         |
| [`0aeb3690`](https://github.com/nix-community/NUR/commit/0aeb369061800fd0ab5833642e0fc67ed21af832) | `` automatic update ``         |
| [`4794c359`](https://github.com/nix-community/NUR/commit/4794c359bd98ac7ff46898dc9b8b30886678cf0d) | `` automatic update ``         |
| [`18c7dafe`](https://github.com/nix-community/NUR/commit/18c7dafe6d596235e0b462fd01576a737763e9e6) | `` automatic update ``         |
| [`4978745a`](https://github.com/nix-community/NUR/commit/4978745a9d9427580c4c3c9600b69db4fbfa3d37) | `` automatic update ``         |
| [`92319ea1`](https://github.com/nix-community/NUR/commit/92319ea1c3659134da57f4ab53c415f2994527a4) | `` automatic update ``         |
| [`2d4a93d3`](https://github.com/nix-community/NUR/commit/2d4a93d31d5990b06cd44340cff0db5ea4dffb95) | `` automatic update ``         |
| [`8da14a1b`](https://github.com/nix-community/NUR/commit/8da14a1b3f96e74dfda188f19f0bd61e4fa09a28) | `` automatic update ``         |
| [`de11824a`](https://github.com/nix-community/NUR/commit/de11824a6044aef4b883665491cd02880480f8f6) | `` automatic update ``         |
| [`532ff1c8`](https://github.com/nix-community/NUR/commit/532ff1c86747cae69dc6a8868e8a82d13cf662ab) | `` automatic update ``         |
| [`1976133d`](https://github.com/nix-community/NUR/commit/1976133d97017dff295bad0b1cb837316bb306ba) | `` automatic update ``         |
| [`ef30d006`](https://github.com/nix-community/NUR/commit/ef30d0069c3c60af06abad41ddc03c1f220bae1a) | `` automatic update ``         |
| [`5519e04c`](https://github.com/nix-community/NUR/commit/5519e04cd8be15565b5ca119c28c60535f5d11ca) | `` automatic update ``         |
| [`7b38409c`](https://github.com/nix-community/NUR/commit/7b38409c3333b8eaf4fde0ee07ca95c7330d6584) | `` automatic update ``         |
| [`2ae9f414`](https://github.com/nix-community/NUR/commit/2ae9f414a2dc3ab90453c0a611847aa0de0e93b0) | `` automatic update ``         |
| [`7e381457`](https://github.com/nix-community/NUR/commit/7e381457c87a47b1d1836941a772f007841ca960) | `` automatic update ``         |
| [`2a5c8beb`](https://github.com/nix-community/NUR/commit/2a5c8beba1ac4753f9de689a70b60b4b807a7d9d) | `` automatic update ``         |
| [`d23d3011`](https://github.com/nix-community/NUR/commit/d23d3011839d31c35f6ebfc3e5498d1a3cdbf2a3) | `` automatic update ``         |
| [`a9023ee0`](https://github.com/nix-community/NUR/commit/a9023ee05570e9f0f8fcef06cca643cccd415d62) | `` automatic update ``         |
| [`0c2de92c`](https://github.com/nix-community/NUR/commit/0c2de92cc60d7e8e50a890ea01cbcabe8fb22493) | `` add novel2430 repository `` |
| [`7a714baf`](https://github.com/nix-community/NUR/commit/7a714baf0e835441fd25494b4673f156ad1bd40a) | `` automatic update ``         |
| [`b67f5a5c`](https://github.com/nix-community/NUR/commit/b67f5a5c3989f2a875c0294f5b8620a5dbedf721) | `` automatic update ``         |
| [`9bd4c4c9`](https://github.com/nix-community/NUR/commit/9bd4c4c936dc9fb53ed0e41128065fd644bbc93a) | `` automatic update ``         |
| [`bb9a4e7b`](https://github.com/nix-community/NUR/commit/bb9a4e7b97f2b3ebd4a7b91d08f835ff7b5fb6ff) | `` automatic update ``         |
| [`c6b5b660`](https://github.com/nix-community/NUR/commit/c6b5b66043359c2ba532aa1172ee670e2d4e8c21) | `` automatic update ``         |
| [`5eed62d3`](https://github.com/nix-community/NUR/commit/5eed62d3c81ca027010df108d8e75b6773ce7f25) | `` automatic update ``         |
| [`c327b211`](https://github.com/nix-community/NUR/commit/c327b2116f6365718639fbece3545939d08e39d9) | `` automatic update ``         |
| [`4cdaf95b`](https://github.com/nix-community/NUR/commit/4cdaf95b76c4e58da55985e611947b9516b2c167) | `` automatic update ``         |
| [`0dec874d`](https://github.com/nix-community/NUR/commit/0dec874dc0a8b857e92e8fd583ce7511398a7595) | `` automatic update ``         |
| [`999db419`](https://github.com/nix-community/NUR/commit/999db419060948bbe9b45e7d0245805a0a36731d) | `` automatic update ``         |
| [`d80629a5`](https://github.com/nix-community/NUR/commit/d80629a51bc6afa6141928f6d00de69469d0e310) | `` automatic update ``         |
| [`1da664fd`](https://github.com/nix-community/NUR/commit/1da664fdb786f4536b209f252b68860777e5a6b6) | `` automatic update ``         |
| [`723151dd`](https://github.com/nix-community/NUR/commit/723151ddee642534b34429ce004771918c46c66b) | `` automatic update ``         |
| [`521cabd5`](https://github.com/nix-community/NUR/commit/521cabd5936a5b44c2b1b44eef39ef3337a9848e) | `` automatic update ``         |
| [`526b1780`](https://github.com/nix-community/NUR/commit/526b178083b4a66d48aa9bc317a670bffccc1b7e) | `` automatic update ``         |
| [`f866f795`](https://github.com/nix-community/NUR/commit/f866f79525a5ce790475107edc965110c1ddf62c) | `` automatic update ``         |
| [`b095ef4b`](https://github.com/nix-community/NUR/commit/b095ef4b597f1bde49621bbc4708ea4ca3c8682e) | `` automatic update ``         |
| [`57486a77`](https://github.com/nix-community/NUR/commit/57486a778b5614bbdfc96aad2b3585ef60f18c96) | `` automatic update ``         |
| [`c51b1cb0`](https://github.com/nix-community/NUR/commit/c51b1cb043f99cad00a72af976ddf0aded25dac8) | `` automatic update ``         |
| [`f2df7412`](https://github.com/nix-community/NUR/commit/f2df7412fa2d1da70459290e421d19918ec42d81) | `` automatic update ``         |
| [`3ec8f7a0`](https://github.com/nix-community/NUR/commit/3ec8f7a0d2585a151aafca380fd0cb4109116958) | `` automatic update ``         |
| [`8972cd85`](https://github.com/nix-community/NUR/commit/8972cd854b949370a47e0653d7822b3261745a2e) | `` automatic update ``         |
| [`f000f6b9`](https://github.com/nix-community/NUR/commit/f000f6b9571935c9368ecf17f223987125a4b28b) | `` automatic update ``         |