### PR TITLE
chore(flake/emacs-overlay): `85a01953` -> `055941ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714899162,
-        "narHash": "sha256-9+LTGxyw4m025tzcJyI4aBB3VUa4F+FbX6iD+ZFzQcI=",
+        "lastModified": 1714901132,
+        "narHash": "sha256-uAlG5MB0nggYzexz+VFdWdn8u3cSKu6V5qZg5KYTHVI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "85a0195343cd4de9093117b953b06b657a988c1a",
+        "rev": "055941efd5f9a4fc0477c3c9779ffca30c55f5f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`055941ef`](https://github.com/nix-community/emacs-overlay/commit/055941efd5f9a4fc0477c3c9779ffca30c55f5f0) | `` Updated emacs `` |