### PR TITLE
chore(flake/emacs-overlay): `055941ef` -> `936895c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714901132,
-        "narHash": "sha256-uAlG5MB0nggYzexz+VFdWdn8u3cSKu6V5qZg5KYTHVI=",
+        "lastModified": 1714927983,
+        "narHash": "sha256-w7x4cKJp2ACkJGZwlzDePjx6wLx4Xo7xzsTsYegozc4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "055941efd5f9a4fc0477c3c9779ffca30c55f5f0",
+        "rev": "936895c776d3d965453dc972435b65e0f293b164",
         "type": "github"
       },
       "original": {
@@ -440,11 +440,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1714685007,
-        "narHash": "sha256-Q4ddhb5eC5pwci0QhAapFwnsc8X8H9ZMQiWpsofBsDc=",
+        "lastModified": 1714782413,
+        "narHash": "sha256-tbg0MEuKaPcUrnmGCu4xiY5F+7LW2+ECPKVAJd2HLwM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "383ffe076d9b633a2e97b6e4dd97fc15fcf30159",
+        "rev": "651b4702e27a388f0f18e1b970534162dec09aff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`936895c7`](https://github.com/nix-community/emacs-overlay/commit/936895c776d3d965453dc972435b65e0f293b164) | `` Updated melpa ``        |
| [`7d5a0b46`](https://github.com/nix-community/emacs-overlay/commit/7d5a0b46e8cf9d0079539c8873d65b4fc1c1a5af) | `` Updated elpa ``         |
| [`e8108cc8`](https://github.com/nix-community/emacs-overlay/commit/e8108cc8f392ef1719bc96e31c94d7cef819feec) | `` Updated flake inputs `` |