### PR TITLE
chore(flake/home-manager): `fdaaf543` -> `3dfe05aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -290,11 +290,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714900398,
-        "narHash": "sha256-H7XYHpjk1G6dkA3AnbYrKtaTFjcCE7ul6nUVlVQxtsA=",
+        "lastModified": 1714931954,
+        "narHash": "sha256-QXpLmgmisNK2Zgpnu9DiO9ScrKJuJ4zmiMTNpObVIuk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fdaaf543bad047639ef0b356ea2e6caec2f1215c",
+        "rev": "3dfe05aa9b5646995ace887931fa60269a039777",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`3dfe05aa`](https://github.com/nix-community/home-manager/commit/3dfe05aa9b5646995ace887931fa60269a039777) | `` wlsunset: update options `` |