### PR TITLE
chore(flake/nixpkgs): `e9be4245` -> `25865a40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -412,11 +412,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714763106,
-        "narHash": "sha256-DrDHo74uTycfpAF+/qxZAMlP/Cpe04BVioJb6fdI0YY=",
+        "lastModified": 1714906307,
+        "narHash": "sha256-UlRZtrCnhPFSJlDQE7M0eyhgvuuHBTe1eJ9N9AQlJQ0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e9be42459999a253a9f92559b1f5b72e1b44c13d",
+        "rev": "25865a40d14b3f9cf19f19b924e2ab4069b09588",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`25865a40`](https://github.com/NixOS/nixpkgs/commit/25865a40d14b3f9cf19f19b924e2ab4069b09588) | `` veilid: 0.3.1 -> 0.3.2 ``                                                      |
| [`d74e8120`](https://github.com/NixOS/nixpkgs/commit/d74e81202e4afc012b4558ac5f51fc5eb400b9dc) | `` electron-source.electron_30: init at 30.0.2 ``                                 |
| [`acc51bc8`](https://github.com/NixOS/nixpkgs/commit/acc51bc86a59f254a713de239733045fb7feca05) | `` electron_30-bin: init at 30.0.2 ``                                             |
| [`655da9d3`](https://github.com/NixOS/nixpkgs/commit/655da9d3192cd1795d8ae2bad7e17c03d3a9f55b) | `` electron-source.electron_29: 29.3.0 -> 29.3.2 ``                               |
| [`eecceae0`](https://github.com/NixOS/nixpkgs/commit/eecceae03f7a2e334732931e43664e7fd022e51a) | `` electron_29-bin: 29.3.0 -> 29.3.2 ``                                           |
| [`b9dee98b`](https://github.com/NixOS/nixpkgs/commit/b9dee98bf4ef47c4457be1221c679b6c2734d7ee) | `` electron: Reformat info.json ``                                                |
| [`b35e5591`](https://github.com/NixOS/nixpkgs/commit/b35e5591af445883a5e4c1265b22d25dc93b0d65) | `` jrnl: override pytest version to fix tests ``                                  |
| [`474750b6`](https://github.com/NixOS/nixpkgs/commit/474750b668f2b44713943fedd0f8672e02188659) | `` fractal: 6 -> 7 ``                                                             |
| [`8040f2dc`](https://github.com/NixOS/nixpkgs/commit/8040f2dce103511fb0ff84da483ebdce0c9db8d3) | `` spicetify-cli: 2.36.5 -> 2.36.10 ``                                            |
| [`4676223c`](https://github.com/NixOS/nixpkgs/commit/4676223ca1dc1b639d25861556eca97ec0c418fb) | `` libmamba: 1.5.7 -> 1.5.8 ``                                                    |
| [`06643a08`](https://github.com/NixOS/nixpkgs/commit/06643a08b2c4b4cec877f625cc8cf4d416e3722c) | `` nixos/display-managers: fix assertion ``                                       |
| [`e315a815`](https://github.com/NixOS/nixpkgs/commit/e315a8156246a04afcd8df3d0d012760264dfe42) | `` mission-center: 0.4.4 -> 0.4.5 ``                                              |
| [`42a37761`](https://github.com/NixOS/nixpkgs/commit/42a3776187bafa4bdacd44486ce18ee0c741ae71) | `` python311Packages.yalexs: 3.0.1 -> 3.1.0 ``                                    |
| [`b823cc5d`](https://github.com/NixOS/nixpkgs/commit/b823cc5d0c99db3fbe11a614977d4ca6ed08d336) | `` godns: 3.1.5 -> 3.1.6 ``                                                       |
| [`66ffcefe`](https://github.com/NixOS/nixpkgs/commit/66ffcefea58990b35477ecf09f8e014c4d7c649d) | `` php.packages.composer: 2.7.3 -> 2.7.6 ``                                       |
| [`5b3df2be`](https://github.com/NixOS/nixpkgs/commit/5b3df2be2519b12a4e1f3841dfcac6927908f2f0) | `` terragrunt: 0.57.5 -> 0.58.2 ``                                                |
| [`01b5d7a0`](https://github.com/NixOS/nixpkgs/commit/01b5d7a05d55a9aa1dec076b4861a784aa0eb230) | `` gzdoom: 4.12.1 -> 4.12.2 ``                                                    |
| [`f619045a`](https://github.com/NixOS/nixpkgs/commit/f619045a24eeead19e351f9ac629c8990aab71b9) | `` python312Packages.zha: relax bellows constraint ``                             |
| [`bb53109f`](https://github.com/NixOS/nixpkgs/commit/bb53109fc9bdde96ef52ea8eeff7d18bfabf993c) | `` home-assistant: pin aiolyric at 1.1.1 ``                                       |
| [`f96f3c9e`](https://github.com/NixOS/nixpkgs/commit/f96f3c9e30d4ed127cab3637d2c74face4ecde08) | `` nixos/keycloak: pass --verbose to starting keycloak ``                         |
| [`ef0b1312`](https://github.com/NixOS/nixpkgs/commit/ef0b131256f1511a8c879b8ce491718b17c5c898) | `` python312Packages.homeassistant-stubs: 2024.4.4 -> 2024.5.0 ``                 |
| [`7cf9a942`](https://github.com/NixOS/nixpkgs/commit/7cf9a942d0e71e8b003e677a6f136dd02749d146) | `` home-assistant: 2024.4.4 -> 2024.5.0 ``                                        |
| [`0ee74915`](https://github.com/NixOS/nixpkgs/commit/0ee7491582a2068aec457f2e8e8cb07066f547d0) | `` python312Packages.aiohttp-session: init at 2.12.0 ``                           |
| [`1cc23f96`](https://github.com/NixOS/nixpkgs/commit/1cc23f964dc07733034c1646d440a2d9ebb41ae5) | `` Revert "tailscale: apply basic systemd hardening (#306241)" ``                 |
| [`75ae7621`](https://github.com/NixOS/nixpkgs/commit/75ae7621330ff8db944ce4dff4374e182d5d151f) | `` workflows/check-nix-format: enforce for build-support/php ``                   |
| [`c759efa5`](https://github.com/NixOS/nixpkgs/commit/c759efa5e7f825913f9a69ef20f025f50f56dc4d) | `` workflows/check-nix-format: enforce for php-packages ``                        |
| [`d62966d0`](https://github.com/NixOS/nixpkgs/commit/d62966d066317f0074cbe729273c3372ee7530bd) | `` typos-lsp: add comment ``                                                      |
| [`e94ecdea`](https://github.com/NixOS/nixpkgs/commit/e94ecdea5ac786fd0447c5b1c5fa8744d382db6d) | `` vscode-extensions.tekumara.typos-vscode: init at 0.1.18 ``                     |
| [`d856959b`](https://github.com/NixOS/nixpkgs/commit/d856959b52f592d089b68a4289b225af7214c39b) | `` yarn-berry: 4.1.1 -> 4.2.1 ``                                                  |
| [`c026e55e`](https://github.com/NixOS/nixpkgs/commit/c026e55e0f24e4bb224ef31877c08f3099b06ca9) | `` vimPlugins.sniprun: 1.3.12 -> 1.3.13 ``                                        |
| [`149c810d`](https://github.com/NixOS/nixpkgs/commit/149c810dcf8678a5c2f87ba44bd77793fb18adbb) | `` radicale: 3.1.9 -> 3.2.0 ``                                                    |
| [`791e0503`](https://github.com/NixOS/nixpkgs/commit/791e05037de5b497a23c3d8c821a4751a722547b) | `` ananicy-rules-cachyos: unstable-2024-04-22 -> unstable-2024-05-04 (#309083) `` |
| [`6a7a5613`](https://github.com/NixOS/nixpkgs/commit/6a7a561360b5593e70a8f8ab72393b13fb83dc8a) | `` chromium: remove `--ozone-platform-hint` patch ``                              |
| [`a5cc2cb8`](https://github.com/NixOS/nixpkgs/commit/a5cc2cb877203396ea3e2caa70ba3d33c2604b35) | `` ungoogled-chromium: 124.0.6367.91-1 -> 124.0.6367.118-1 ``                     |
| [`14c0d1b1`](https://github.com/NixOS/nixpkgs/commit/14c0d1b12cff92c76de3d163da9a9067ee48eb3c) | `` telegram-desktop: 5.0.0 -> 5.0.1 ``                                            |
| [`04a7f3c3`](https://github.com/NixOS/nixpkgs/commit/04a7f3c371575191f1b7dba95f3ece8dcdc10996) | `` nixos/xdg-terminal-exec: init module ``                                        |
| [`7848c2de`](https://github.com/NixOS/nixpkgs/commit/7848c2de0d6c3a2f114876115762e9171a8266db) | `` python312Packages.mypy-protobuf: migrate to `pyproject = true` ``              |
| [`71bb27da`](https://github.com/NixOS/nixpkgs/commit/71bb27da54522002b49cdc85fb80827b87801971) | `` python312Packages.mypy-protobuf: add passthru.tests.version ``                 |
| [`471a3b0c`](https://github.com/NixOS/nixpkgs/commit/471a3b0c6491fbadd06c4b4a2302cb9a68a20e11) | `` python312Packages.mypy-protobuf: fix build ``                                  |
| [`13c8d78d`](https://github.com/NixOS/nixpkgs/commit/13c8d78d7e1cbc372f747acf073d854155735a69) | `` pyprland: 2.2.15 -> 2.2.16 ``                                                  |
| [`19729bdd`](https://github.com/NixOS/nixpkgs/commit/19729bdd8caf60f7db48c0bc494c235f9fe4932d) | `` sarasa-gothic: 1.0.10 -> 1.0.11 ``                                             |
| [`2408658f`](https://github.com/NixOS/nixpkgs/commit/2408658fc1b76515f1bb3e2080c6c316e13c0748) | `` python312Packages.mypy-protobuf: format with nixfmt-rfc-style ``               |
| [`135d592d`](https://github.com/NixOS/nixpkgs/commit/135d592dcc5988221d4697eceff821b3ea434037) | `` wayland-proxy-virtwl: unstable-2024-04-08 -> 0-unstable-2024-04-08 ``          |
| [`f17ea11c`](https://github.com/NixOS/nixpkgs/commit/f17ea11c306feef5f030e56619c62b32889b343e) | `` untrunc-anthwlock: unstable-2021-11-21 -> 0-unstable-2021-11-21 ``             |
| [`6bdd9451`](https://github.com/NixOS/nixpkgs/commit/6bdd945196f30ec1c8ec2b33864fbfe97fd92819) | `` rofi-pass: unstable-2024-02-13 -> 2.0.2-unstable-2024-02-13 ``                 |
| [`24963b12`](https://github.com/NixOS/nixpkgs/commit/24963b128406941c1a5fc398b01eb2cc33f7f089) | `` bash-supergenpass: unstable-2024-03-24 -> 0-unstable-2024-03-24 ``             |
| [`66496969`](https://github.com/NixOS/nixpkgs/commit/6649696933e941eca9d777fc966172af176b1320) | `` urn-timer: unstable-2024-03-05 -> 0-unstable-2024-03-05 ``                     |
| [`34f7829f`](https://github.com/NixOS/nixpkgs/commit/34f7829f72c3d137d1655b81525a2e2a522f613b) | `` tewisay: unstable-2022-11-04 -> 0-unstable-2022-11-04 ``                       |
| [`a3193f95`](https://github.com/NixOS/nixpkgs/commit/a3193f95f3e0f9343be93082ba0e61813dd50e7a) | `` ipxe: unstable-2024-02-08 -> 1.21.1-unstable-2024-02-08 ``                     |
| [`8394f4f6`](https://github.com/NixOS/nixpkgs/commit/8394f4f63eacba526123cccfe83858876a280b08) | `` edid-decode: unstable-2024-04-02 -> 0-unstable-2024-04-02 ``                   |
| [`db589856`](https://github.com/NixOS/nixpkgs/commit/db58985637822370c2fdfd27f2eeb5221f386810) | `` cht-sh: unstable-2022-04-18 -> 0-unstable-2022-04-18 ``                        |
| [`467371b4`](https://github.com/NixOS/nixpkgs/commit/467371b4b3c010b61c4357ad8818837b681662ad) | `` vgmtools: unstable-2023-08-27 -> 0.1-unstable-2023-08-27 ``                    |
| [`e7d03c24`](https://github.com/NixOS/nixpkgs/commit/e7d03c2441ea76bc1c6359318b31bc69b1e76886) | `` kaldi: unstable-2024-01-31 -> 0-unstable-2024-01-31 ``                         |
| [`aacfa309`](https://github.com/NixOS/nixpkgs/commit/aacfa30990b2638a90eff136a91ee45523c9b890) | `` drawterm: unstable-2024-04-23 -> 0-unstable-2024-04-23 ``                      |
| [`31c56750`](https://github.com/NixOS/nixpkgs/commit/31c56750410152b72e2b736c43ed3256ff0150d9) | `` llvmPackages_18: 18.1.4 -> 18.1.5 ``                                           |
| [`faa2ea47`](https://github.com/NixOS/nixpkgs/commit/faa2ea4743a4eccc02692cb3a687cee68b61d6b5) | `` novops: 0.13.0 -> 0.14.0 ``                                                    |
| [`b413c925`](https://github.com/NixOS/nixpkgs/commit/b413c925a0fd00a7f157004cdecd29e8389eeae7) | `` fastfetch: set paths for pci.ids amdgpu.ids ``                                 |
| [`5a7cb0dc`](https://github.com/NixOS/nixpkgs/commit/5a7cb0dcbaa10a31a93bed0f16cea1377f2660a7) | `` tootik: 0.10.3 -> 0.10.4 ``                                                    |
| [`045ff5a2`](https://github.com/NixOS/nixpkgs/commit/045ff5a2f895d8f767ca1d3a4bb1ca71d69bb6c0) | `` xpipe: 9.0 -> 9.1 ``                                                           |
| [`f04348fc`](https://github.com/NixOS/nixpkgs/commit/f04348fc8589c0b7547b4ce7e1644e37b3dc5cd2) | `` quarkus: 3.9.5 -> 3.10.0 ``                                                    |
| [`3cad74b9`](https://github.com/NixOS/nixpkgs/commit/3cad74b919b1986f4ba5cf977c8e3779a61c0e6d) | `` python311Packages.glean-parser: fix runtime error ``                           |
| [`e807c7a5`](https://github.com/NixOS/nixpkgs/commit/e807c7a51d15a9b3be9fe71e82d0b79b72a10691) | `` python311Packages.glean-parser: 13.0.1 -> 14.1.0 ``                            |
| [`e4a2dfeb`](https://github.com/NixOS/nixpkgs/commit/e4a2dfeb84d4934f02975fb4ccfdf233b75f8d01) | `` python312Packages.bc-detect-secrets: 1.5.6 -> 1.5.9 ``                         |
| [`8701d5af`](https://github.com/NixOS/nixpkgs/commit/8701d5af386a8b07166c0b2c0e60e5ac280b490f) | `` kubectl-explore: 0.8.1 -> 0.8.3 ``                                             |
| [`78096808`](https://github.com/NixOS/nixpkgs/commit/78096808f6fb4f5e652a337840a56030fcb9bb7f) | `` kodiPackages.pvr-vdr-vnsi: 20.4.1 -> 21.1.1 ``                                 |
| [`8bb777ee`](https://github.com/NixOS/nixpkgs/commit/8bb777ee378082942231f63a035923a475538030) | `` plausible: Do not run createdb.sh unless configured to setup the database ``   |
| [`3567088d`](https://github.com/NixOS/nixpkgs/commit/3567088dfebd8747ee10f028d1fddba07c69bf28) | `` ironbar: 0.14.1 -> 0.15.0 ``                                                   |
| [`80b0072b`](https://github.com/NixOS/nixpkgs/commit/80b0072b8e8b89a0ad200d030e6e06d419d86310) | `` kodiPackages.pvr-hdhomerun: 20.4.0 -> 21.0.1 ``                                |
| [`2851beb2`](https://github.com/NixOS/nixpkgs/commit/2851beb279550e3e2b660125c47c017e740a7f81) | `` files-cli: 2.13.14 -> 2.13.27 ``                                               |
| [`a98dd90c`](https://github.com/NixOS/nixpkgs/commit/a98dd90cef69b7240440ddb52720dada0a2ba3e0) | `` pyradio: Disable update check ``                                               |
| [`30f81a77`](https://github.com/NixOS/nixpkgs/commit/30f81a77906091fd72656ae0c516c5b1acdd1540) | `` ludusavi: refactor, fix runtime error ``                                       |
| [`ca777257`](https://github.com/NixOS/nixpkgs/commit/ca777257768b73fa6e4d2db8009912ec4aed7586) | `` python312Packages.aiomcache: init at 0.8.1 ``                                  |
| [`9ca1d1f4`](https://github.com/NixOS/nixpkgs/commit/9ca1d1f4d6298b2e9d8bdbf1d13736358ff8f970) | `` kodiPackages.pvr-iptvsimple: 20.13.0 -> 21.8.4 ``                              |
| [`9b2ca9d6`](https://github.com/NixOS/nixpkgs/commit/9b2ca9d6269f2f98d250eea4e8862e75b7b27934) | `` python311Packages.pyphen: drop support for python 3.7 ``                       |
| [`04ba4c89`](https://github.com/NixOS/nixpkgs/commit/04ba4c899663ed00d10ccd7120d0966bac2b436e) | `` minecraft-server: 1.20.4 -> 1.20.5 ``                                          |
| [`5e455b5f`](https://github.com/NixOS/nixpkgs/commit/5e455b5f956cd2b92880e5e2877257092b539b2e) | `` python312Packages.aiohttp-isal: init at 0.3.1 ``                               |
| [`d49defc2`](https://github.com/NixOS/nixpkgs/commit/d49defc213ed2cc541e80a0b2ea067d97df600ad) | `` popcorntime: add libGL ``                                                      |
| [`5a5c2e0e`](https://github.com/NixOS/nixpkgs/commit/5a5c2e0e89e5f336bb3472d21c8fc11c666f387e) | `` python312Packages.isal: init at 1.6.1 ``                                       |
| [`3c8315ea`](https://github.com/NixOS/nixpkgs/commit/3c8315eac28138bb726cb45787c15c0334a8fcca) | `` popcorntime: update checksum ``                                                |
| [`53827c0c`](https://github.com/NixOS/nixpkgs/commit/53827c0c0ed5d32b4709b427b234a23ccfb4b62c) | `` popcorntime: 0.5.0 -> 0.5.1 ``                                                 |
| [`cf03cf35`](https://github.com/NixOS/nixpkgs/commit/cf03cf354810dced8568cd54c06f1484dc84487c) | `` minipro: 0.6 -> 0.7 ``                                                         |