### PR TITLE
chore(flake/emacs-overlay): `e01c8755` -> `136fe1fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714928633,
-        "narHash": "sha256-5aKIbs3+A7+JIbXKpXSs2BWYudkX/LmZGDGBRl1o0EE=",
+        "lastModified": 1714957272,
+        "narHash": "sha256-LRRAhe4Egi0oharLD8LFRivFfbHOJVfnvNBwOp0kw5w=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e01c875522b70bc2791e795980d61b2e80b9f30b",
+        "rev": "136fe1fe9c4f491810613ebfaea38394b76d5122",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`136fe1fe`](https://github.com/nix-community/emacs-overlay/commit/136fe1fe9c4f491810613ebfaea38394b76d5122) | `` Updated elpa ``         |
| [`a24fa568`](https://github.com/nix-community/emacs-overlay/commit/a24fa56819355b496c545797c0747504649613f8) | `` Updated flake inputs `` |