### PR TITLE
chore(flake/srvos): `1fa90a0a` -> `885d705a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -599,11 +599,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714611022,
-        "narHash": "sha256-Cneh2G54TO1eVQBxLZp0JlW8LWbTE/N1WjcE2W+F3pI=",
+        "lastModified": 1714956769,
+        "narHash": "sha256-49DQpGvr5N0l7rsFMP8zSwHeSa7f9N3NiY4mgdOwPn8=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "1fa90a0a81fec38c117397fde79733cc78f12815",
+        "rev": "885d705a55f5a9bd5a85cb6869358a1e5c522009",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`885d705a`](https://github.com/nix-community/srvos/commit/885d705a55f5a9bd5a85cb6869358a1e5c522009) | `` dev/private/flake.lock: Update `` |
| [`e8c7836b`](https://github.com/nix-community/srvos/commit/e8c7836bb6500d93acc08662357ef623ac486d9b) | `` flake.lock: Update ``             |