### PR TITLE
chore(flake/emacs-overlay): `136fe1fe` -> `03e77b28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714957272,
-        "narHash": "sha256-LRRAhe4Egi0oharLD8LFRivFfbHOJVfnvNBwOp0kw5w=",
+        "lastModified": 1714960145,
+        "narHash": "sha256-BlGVcAhjkPqTAbUlGjs0PVYYY54AGEq2kwiL97VwOZ8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "136fe1fe9c4f491810613ebfaea38394b76d5122",
+        "rev": "03e77b28d0e617a9961762986a9645e8fd21a8d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`03e77b28`](https://github.com/nix-community/emacs-overlay/commit/03e77b28d0e617a9961762986a9645e8fd21a8d2) | `` Updated emacs `` |
| [`ddc32ad5`](https://github.com/nix-community/emacs-overlay/commit/ddc32ad5afdcb4625e42683de878a07846e9616e) | `` Updated melpa `` |