### PR TITLE
chore(flake/nixos-hardware): `8a4adfe4` -> `e148ccbe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -398,11 +398,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1714979072,
-        "narHash": "sha256-OfShHRR4QmVwEof1EWuZUygw/SFnmxfHogtCKc4vNRM=",
+        "lastModified": 1714984131,
+        "narHash": "sha256-kjIvFbbKb6RGIJyOgcF+BBWHNzhNSNqRTxX/SkrkRno=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "8a4adfe48b68b50ef62e9a299898093436269b6d",
+        "rev": "e148ccbecbd2fe4dc4768fba67f6db828466ad06",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                              |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`e148ccbe`](https://github.com/NixOS/nixos-hardware/commit/e148ccbecbd2fe4dc4768fba67f6db828466ad06) | `` framework: install framework-tool ``              |
| [`88eb241b`](https://github.com/NixOS/nixos-hardware/commit/88eb241bbd87e21bbf6c8be7319fe997550b90f8) | `` framework/16-inch: moved out of the CPU folder `` |