### PR TITLE
chore(flake/emacs-overlay): `03e77b28` -> `410be154`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714960145,
-        "narHash": "sha256-BlGVcAhjkPqTAbUlGjs0PVYYY54AGEq2kwiL97VwOZ8=",
+        "lastModified": 1714986386,
+        "narHash": "sha256-+7Sn8Le9VjjegRKjhT5i7RRPLgB7gPU6AqbaUDyhujM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "03e77b28d0e617a9961762986a9645e8fd21a8d2",
+        "rev": "410be154ee103e0477f00ea0edc28fe9050dd69f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`410be154`](https://github.com/nix-community/emacs-overlay/commit/410be154ee103e0477f00ea0edc28fe9050dd69f) | `` Updated emacs `` |
| [`f9c0d9af`](https://github.com/nix-community/emacs-overlay/commit/f9c0d9afdf959f34738e528af323291993492230) | `` Updated melpa `` |