### PR TITLE
chore(flake/nixos-hardware): `e148ccbe` -> `d1659c9e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -398,11 +398,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1714984131,
-        "narHash": "sha256-kjIvFbbKb6RGIJyOgcF+BBWHNzhNSNqRTxX/SkrkRno=",
+        "lastModified": 1715010655,
+        "narHash": "sha256-FmdhvR/hgBkPDvIv/HOEIQsSMaVXh8wvTrnep8dF3Jc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e148ccbecbd2fe4dc4768fba67f6db828466ad06",
+        "rev": "d1659c9eb8af718118fb4bbe2c86797c8b8623eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`d1659c9e`](https://github.com/NixOS/nixos-hardware/commit/d1659c9eb8af718118fb4bbe2c86797c8b8623eb) | `` Update flake.nix for ThinkPad A475 `` |
| [`00e73a45`](https://github.com/NixOS/nixos-hardware/commit/00e73a4509f9112f33188a24e56d9cc61523fd3b) | `` Update README.md for ThinkPad A475 `` |
| [`1a770577`](https://github.com/NixOS/nixos-hardware/commit/1a770577450681a835733a0f50a87a71ff5e4ee0) | `` added thinkpad a470 ``                |