### PR TITLE
chore(flake/emacs-overlay): `410be154` -> `e395276e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1714986386,
-        "narHash": "sha256-+7Sn8Le9VjjegRKjhT5i7RRPLgB7gPU6AqbaUDyhujM=",
+        "lastModified": 1715014805,
+        "narHash": "sha256-LkrkK7X6h64dRnSNJclieN6Y9cfITpWwRaUHBnaoEwM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "410be154ee103e0477f00ea0edc28fe9050dd69f",
+        "rev": "e395276e0db915ae9400c764a71672852771c9ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`e395276e`](https://github.com/nix-community/emacs-overlay/commit/e395276e0db915ae9400c764a71672852771c9ed) | `` Updated melpa `` |
| [`33ef99d1`](https://github.com/nix-community/emacs-overlay/commit/33ef99d1547a6a3647b0a75be44d7766d1e1db2d) | `` Updated elpa ``  |