### PR TITLE
chore(flake/emacs-overlay): `e395276e` -> `efbc49e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715014805,
-        "narHash": "sha256-LkrkK7X6h64dRnSNJclieN6Y9cfITpWwRaUHBnaoEwM=",
+        "lastModified": 1715015577,
+        "narHash": "sha256-lVpyxToguhfFSIYLfUBFXKid7aRt/ghSS3A0wwQTca0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e395276e0db915ae9400c764a71672852771c9ed",
+        "rev": "efbc49e6be628b0a4ef55b731255a266bdaafd97",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`efbc49e6`](https://github.com/nix-community/emacs-overlay/commit/efbc49e6be628b0a4ef55b731255a266bdaafd97) | `` Updated emacs `` |