### PR TITLE
chore(flake/sops-nix): `10dc3949` -> `893e3df0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -579,11 +579,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1714878026,
-        "narHash": "sha256-YJ1k/jyd6vKqmVgGkkAb4n+ZfPPAt8+L5a73eAThqFU=",
+        "lastModified": 1715035358,
+        "narHash": "sha256-RY6kqhpCPa/q3vbqt3iYRyjO3hJz9KZnshMjbpPon8o=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "10dc39496d5b027912038bde8d68c836576ad0bc",
+        "rev": "893e3df091f6838f4f9d71c61ab079d5c5dedbd1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                        |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`893e3df0`](https://github.com/Mic92/sops-nix/commit/893e3df091f6838f4f9d71c61ab079d5c5dedbd1) | `` update vendorHash ``                                        |
| [`2b264ce3`](https://github.com/Mic92/sops-nix/commit/2b264ce3714f99c8cde3cfa488688b332caed93e) | `` build(deps): bump golang.org/x/sys from 0.19.0 to 0.20.0 `` |