### PR TITLE
chore(flake/envrc): `1ebacbef` -> `5c1d1eb6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -154,11 +154,11 @@
     "envrc": {
       "flake": false,
       "locked": {
-        "lastModified": 1701204751,
-        "narHash": "sha256-RMxSjKv0Zg0EZg39uAicBtHyLSC09pdJFsB+20nM7Ok=",
+        "lastModified": 1715039043,
+        "narHash": "sha256-yz2B9c8ar9wc13LwAeycsvYkCpzyg8KqouYp4EBgM6A=",
         "owner": "siddharthverma314",
         "repo": "envrc",
-        "rev": "1ebacbefeb7f24ef484c6187132797a3af06522e",
+        "rev": "5c1d1eb64de927785e9fefa3c6fdbf023d7cfc4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                                        |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`5c1d1eb6`](https://github.com/siddharthverma314/envrc/commit/5c1d1eb64de927785e9fefa3c6fdbf023d7cfc4d) | `` Add sshx as a supported backend ``                                          |
| [`c6998ecf`](https://github.com/siddharthverma314/envrc/commit/c6998ecfa7952a3ca6f84eb40b3263efbfa3e3a3) | `` Add TRAMP support ``                                                        |
| [`8571bf94`](https://github.com/siddharthverma314/envrc/commit/8571bf94b6a63ffd9a84100106602f88ba186854) | `` Release 0.11 ``                                                             |
| [`88a38f08`](https://github.com/siddharthverma314/envrc/commit/88a38f081d56c61e56af8545d7904d821059c198) | `` Require Emacs 26.1 (for seq-sort-by) ``                                     |
| [`4ae0b23d`](https://github.com/siddharthverma314/envrc/commit/4ae0b23d2edcc55fe32e526ef1c96cf9e25f8bb7) | `` Release 0.10 ``                                                             |
| [`6568fcf0`](https://github.com/siddharthverma314/envrc/commit/6568fcf0fea865195c1e63067393fbd8f1773061) | `` envrc--summarise-changes: remove extra quotes in face names ``              |
| [`be24002c`](https://github.com/siddharthverma314/envrc/commit/be24002cb3c5bb425ab2cf233b5a7a448fcedb0a) | `` Use correct type for keymaps ``                                             |
| [`6595bdef`](https://github.com/siddharthverma314/envrc/commit/6595bdef2abaf704395e0c1bf560187e57f1dd42) | `` Release 0.9 ``                                                              |
| [`ec4988ea`](https://github.com/siddharthverma314/envrc/commit/ec4988ea4a3b6b2319b98afda6c0e6b303b4714f) | `` More details about enabling the global mode late in the startup sequence `` |
| [`e0e84964`](https://github.com/siddharthverma314/envrc/commit/e0e84964cf5d1096c95940d983e12cb7772b08fe) | `` Don't enable local mode when "direnv" is not found ``                       |
| [`b8180d3d`](https://github.com/siddharthverma314/envrc/commit/b8180d3d89d954aa12853a457545986e746b5eb3) | `` Release 0.8 ``                                                              |
| [`9d248a65`](https://github.com/siddharthverma314/envrc/commit/9d248a655a204ff227d9ccd7a2ab8db5f3b6fcbc) | `` Fix regression causing error when interrupting direnv (thanks @bcc32) ``    |
| [`2aaaa065`](https://github.com/siddharthverma314/envrc/commit/2aaaa06537e4df4686c0d49b40235fecef80ae8d) | `` Add emacs 29.3 to CI matrix ``                                              |
| [`9c983470`](https://github.com/siddharthverma314/envrc/commit/9c983470d38228f82de65bf23629aef67f807c57) | `` Release 0.7 ``                                                              |
| [`86b30ad0`](https://github.com/siddharthverma314/envrc/commit/86b30ad0c8a4126e436c9a5ec0af83880a95fec2) | `` Remove lingering reference to dash ``                                       |
| [`3368300e`](https://github.com/siddharthverma314/envrc/commit/3368300eae29f45268ac09e9f702f0e120ac5e7d) | `` Produce minibuffer summary without using dash, and change custom options `` |
| [`37f13594`](https://github.com/siddharthverma314/envrc/commit/37f13594f96716e08faa1e3241b477d28541ffc4) | `` feat: display pretty summary in the style of the `emacs-direnv' package ``  |
| [`4a13c920`](https://github.com/siddharthverma314/envrc/commit/4a13c920a44402e83613d7af82fb7beaa08fc0d3) | `` Fix up comment ``                                                           |
| [`efe68171`](https://github.com/siddharthverma314/envrc/commit/efe6817162f1c9b9eb2d8b4c1a50cda70c3e8f1d) | `` Let info.el parse INFOPATH ``                                               |
| [`d4b90c5d`](https://github.com/siddharthverma314/envrc/commit/d4b90c5d09fefe5664ae56b06ad735ebdd0e937e) | `` chore(deps): bump cachix/install-nix-action from 23 to 26 ``                |
| [`029db1aa`](https://github.com/siddharthverma314/envrc/commit/029db1aa49ab1bb9bffaf53134ed391487a51880) | `` Use "nix profile" instead of nix-env ``                                     |
| [`94785b4b`](https://github.com/siddharthverma314/envrc/commit/94785b4bd385432ccd1bbabc73842cadb3357ca6) | `` Prefer "zerop" to "eq 0" ``                                                 |
| [`d21db3cc`](https://github.com/siddharthverma314/envrc/commit/d21db3ccad16c6c9bc9e64a65cb9904b473209bf) | `` Fix byte-compilation warnings about apostrophes in docstrings ``            |
| [`b447638b`](https://github.com/siddharthverma314/envrc/commit/b447638bbaaf11ac6fecd997585030572de3a45c) | `` Fix CI triggers ``                                                          |
| [`5eabb994`](https://github.com/siddharthverma314/envrc/commit/5eabb99496060e9967d66660ad47049993d75b2f) | `` Clarify differences w.r.t. direnv.el ``                                     |