### PR TITLE
chore(flake/emacs-overlay): `efbc49e6` -> `85142911`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715015577,
-        "narHash": "sha256-lVpyxToguhfFSIYLfUBFXKid7aRt/ghSS3A0wwQTca0=",
+        "lastModified": 1715043614,
+        "narHash": "sha256-3+sD60ZcPDrGS067JqVjPKrCvo+8H/Na26WHXbZANuM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "efbc49e6be628b0a4ef55b731255a266bdaafd97",
+        "rev": "851429115e5ba64520fc5f4e9b3b665ad59df996",
         "type": "github"
       },
       "original": {
@@ -440,11 +440,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1714782413,
-        "narHash": "sha256-tbg0MEuKaPcUrnmGCu4xiY5F+7LW2+ECPKVAJd2HLwM=",
+        "lastModified": 1714971268,
+        "narHash": "sha256-IKwMSwHj9+ec660l+I4tki/1NRoeGpyA2GdtdYpAgEw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "651b4702e27a388f0f18e1b970534162dec09aff",
+        "rev": "27c13997bf450a01219899f5a83bd6ffbfc70d3c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`85142911`](https://github.com/nix-community/emacs-overlay/commit/851429115e5ba64520fc5f4e9b3b665ad59df996) | `` Updated elpa ``         |
| [`4767b555`](https://github.com/nix-community/emacs-overlay/commit/4767b55535736a016ac4e900905ed35c69b4064e) | `` Updated flake inputs `` |