### PR TITLE
chore(flake/emacs-overlay): `85142911` -> `f2804916`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715043614,
-        "narHash": "sha256-3+sD60ZcPDrGS067JqVjPKrCvo+8H/Na26WHXbZANuM=",
+        "lastModified": 1715046400,
+        "narHash": "sha256-gryLgWTbv1C4/j/6YleqQ5UmJQwa+UdkXEaemwhkGlM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "851429115e5ba64520fc5f4e9b3b665ad59df996",
+        "rev": "f2804916dbc4655722f743b5299b6f706335b25b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`f2804916`](https://github.com/nix-community/emacs-overlay/commit/f2804916dbc4655722f743b5299b6f706335b25b) | `` Updated emacs `` |
| [`b4ea3fd0`](https://github.com/nix-community/emacs-overlay/commit/b4ea3fd0daf8c699e45026217c356bd0378464b7) | `` Updated melpa `` |