### PR TITLE
chore(flake/nur): `19775c37` -> `d223869d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715054320,
-        "narHash": "sha256-RpzJ9E17+TyDzGA/VFxO3cJjkFVL6Kmgolzqx7mshP4=",
+        "lastModified": 1715056675,
+        "narHash": "sha256-d/Vc0mnRKPOm79QASiY11Ih4378a+xiTRkgW1wDCc2I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "19775c37649088292236e4433c98bbb78b53131f",
+        "rev": "d223869d5559ac8ff33f415554d0b090526b5f99",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d223869d`](https://github.com/nix-community/NUR/commit/d223869d5559ac8ff33f415554d0b090526b5f99) | `` automatic update `` |
| [`6bd678c5`](https://github.com/nix-community/NUR/commit/6bd678c5033e43c45e80d9540b4f2332500d51d9) | `` automatic update `` |
| [`99eaefc0`](https://github.com/nix-community/NUR/commit/99eaefc000dff54d5f8d54276635fedb890f5563) | `` automatic update `` |