### PR TITLE
chore(flake/nur): `3acbb1cc` -> `60f67c69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715075140,
-        "narHash": "sha256-XCo6DgFdnVbS7bFKpC43tJz2SduJMyefbchRsfxGMA0=",
+        "lastModified": 1715078704,
+        "narHash": "sha256-7tdLdqmov1ISpjqJo5fs+XThb7+UY5eu+GRWMsEJ4Q8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3acbb1ccbfaae57554f3443dce02f71e986bd947",
+        "rev": "60f67c69a8af718ba07a88114c3d3b420eb9fdcd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`60f67c69`](https://github.com/nix-community/NUR/commit/60f67c69a8af718ba07a88114c3d3b420eb9fdcd) | `` automatic update `` |
| [`717226dc`](https://github.com/nix-community/NUR/commit/717226dc0546946b554b8eca07fbafc5fefd02ed) | `` automatic update `` |
| [`f810786f`](https://github.com/nix-community/NUR/commit/f810786f030ec8e1fb794b966f4e3a792df6f01d) | `` automatic update `` |