### PR TITLE
chore(flake/nur): `60f67c69` -> `4cfdb909`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715078704,
-        "narHash": "sha256-7tdLdqmov1ISpjqJo5fs+XThb7+UY5eu+GRWMsEJ4Q8=",
+        "lastModified": 1715085636,
+        "narHash": "sha256-pIZ5IwKX/UFdrO6qIKc7siCgjFhBM+q2uPZIDEFu9Ys=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "60f67c69a8af718ba07a88114c3d3b420eb9fdcd",
+        "rev": "4cfdb90950c4d47f1c1d38ba1d1a0a945024bd00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4cfdb909`](https://github.com/nix-community/NUR/commit/4cfdb90950c4d47f1c1d38ba1d1a0a945024bd00) | `` automatic update `` |
| [`15b7d0fb`](https://github.com/nix-community/NUR/commit/15b7d0fb7de74554d9ccfa135fa97b320432dc3d) | `` automatic update `` |