### PR TITLE
chore(flake/nur): `d669f475` -> `05392076`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715088887,
-        "narHash": "sha256-QTtXeu+Snm75o4vloKSG2xkEF7BayVO9OrgjRpuLKcY=",
+        "lastModified": 1715091972,
+        "narHash": "sha256-+ZCEXc6KTA91ZTXwYHxamZbBpgvNu0g7UjwMlZnU1lc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d669f475d3be3816bd7189977d93b9dd09d8e54d",
+        "rev": "05392076c1a0e8ab98b85821dcc1d1107e7e650a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`05392076`](https://github.com/nix-community/NUR/commit/05392076c1a0e8ab98b85821dcc1d1107e7e650a) | `` automatic update `` |