### PR TITLE
chore(flake/nur): `05392076` -> `e0f09d16`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715091972,
-        "narHash": "sha256-+ZCEXc6KTA91ZTXwYHxamZbBpgvNu0g7UjwMlZnU1lc=",
+        "lastModified": 1715095690,
+        "narHash": "sha256-U9qaMOxYbSEi9DyVF7ECJdZd/Oc2Ve6RX2MayGa1MVA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "05392076c1a0e8ab98b85821dcc1d1107e7e650a",
+        "rev": "e0f09d1671a6688472777f93e87a20d713491239",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e0f09d16`](https://github.com/nix-community/NUR/commit/e0f09d1671a6688472777f93e87a20d713491239) | `` automatic update `` |