### PR TITLE
chore(flake/emacs-overlay): `f2804916` -> `3123b5c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715046400,
-        "narHash": "sha256-gryLgWTbv1C4/j/6YleqQ5UmJQwa+UdkXEaemwhkGlM=",
+        "lastModified": 1715100750,
+        "narHash": "sha256-vdn9v8y13pgPQjUAjlKGmEi+1Is5rkvxdQ9EHyCfHvI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f2804916dbc4655722f743b5299b6f706335b25b",
+        "rev": "3123b5c48655266adfba5979a88264f1d8d72ba9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`3123b5c4`](https://github.com/nix-community/emacs-overlay/commit/3123b5c48655266adfba5979a88264f1d8d72ba9) | `` Updated melpa `` |
| [`03e43bed`](https://github.com/nix-community/emacs-overlay/commit/03e43bed591d54c2a65370567d9e1ca2f0798d11) | `` Updated elpa ``  |