### PR TITLE
chore(flake/nur): `e0f09d16` -> `c2e5460d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715095690,
-        "narHash": "sha256-U9qaMOxYbSEi9DyVF7ECJdZd/Oc2Ve6RX2MayGa1MVA=",
+        "lastModified": 1715111520,
+        "narHash": "sha256-OK1wKI1MKXBcERCCRLFz3PadBlpFQWA5OE4cs+1+LNg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e0f09d1671a6688472777f93e87a20d713491239",
+        "rev": "c2e5460d97a78b166664f9b49704d65614b86bb1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c2e5460d`](https://github.com/nix-community/NUR/commit/c2e5460d97a78b166664f9b49704d65614b86bb1) | `` automatic update `` |
| [`b952cd40`](https://github.com/nix-community/NUR/commit/b952cd407b3d1940280b44a8c29790ba6a1068dd) | `` automatic update `` |
| [`50030180`](https://github.com/nix-community/NUR/commit/500301808cba4b14aac5c6285537c355f277f8b0) | `` automatic update `` |
| [`484c4ba1`](https://github.com/nix-community/NUR/commit/484c4ba175163890420b23a90e0a1e963e52b138) | `` automatic update `` |
| [`4edb956c`](https://github.com/nix-community/NUR/commit/4edb956cecd5141f30782ed388a1e2876011f1e4) | `` automatic update `` |