### PR TITLE
chore(flake/nur): `c2e5460d` -> `f2400f22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715111520,
-        "narHash": "sha256-OK1wKI1MKXBcERCCRLFz3PadBlpFQWA5OE4cs+1+LNg=",
+        "lastModified": 1715113425,
+        "narHash": "sha256-eUP1YApWNiTxwGvOwpwomiTMO3pYo0mKHj8jF+lSRyk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c2e5460d97a78b166664f9b49704d65614b86bb1",
+        "rev": "f2400f2299b96a4083dbf94c7d1ef8709790666a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f2400f22`](https://github.com/nix-community/NUR/commit/f2400f2299b96a4083dbf94c7d1ef8709790666a) | `` automatic update `` |