### PR TITLE
chore(flake/catppuccin): `b0dc7f31` -> `eaa6e281`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1714607657,
-        "narHash": "sha256-AnmN+JOzrpHv7Uw7JSPJ9JEjuqF7gjhx29UuuldNpas=",
+        "lastModified": 1715128602,
+        "narHash": "sha256-KmIgXJ5fZmYsb+QeGZcauZIX7eN7PyTJI+t2LzuSLnU=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "b0dc7f3181063daa6532dc5f757ded1a605dfbd5",
+        "rev": "eaa6e281f144a5ac90510d9a07d74bf5e9a4459f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                     |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`eaa6e281`](https://github.com/catppuccin/nix/commit/eaa6e281f144a5ac90510d9a07d74bf5e9a4459f) | `` docs: update for cab752b ``                                              |
| [`cab752b0`](https://github.com/catppuccin/nix/commit/cab752b0f04145f426181ee59f99c53a19e20139) | `` feat(home-manager): source hyprland theme and add accent colors (#80) `` |