### PR TITLE
chore(flake/emacs-overlay): `2fd9e33a` -> `157ca12a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715101438,
-        "narHash": "sha256-xd5lymHwykYlqCPap6m7QG71Xuv0ShMjulQOLT8Hg6A=",
+        "lastModified": 1715132223,
+        "narHash": "sha256-3PKr65y061xFw3LqO8/JURilrruhTQjvC4CXW6KIwJI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2fd9e33a0e73cd390f35ecefe89ec9e271e4c2cb",
+        "rev": "157ca12a7b661b7c8cf4aec0ee77b5ec12bf115b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`157ca12a`](https://github.com/nix-community/emacs-overlay/commit/157ca12a7b661b7c8cf4aec0ee77b5ec12bf115b) | `` Updated emacs `` |
| [`6c7114f4`](https://github.com/nix-community/emacs-overlay/commit/6c7114f4bb26d1f7ad19502e63c06a201188b6e5) | `` Updated melpa `` |
| [`ba02b473`](https://github.com/nix-community/emacs-overlay/commit/ba02b47330f73f776047a15a09dac06e3c423795) | `` Updated elpa ``  |