### PR TITLE
chore(flake/nur): `459b808f` -> `cac68c1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715143204,
-        "narHash": "sha256-XxIeex0SBo5w/6yn5eIbyXVpmvIHpo1i+gsOPBLpHag=",
+        "lastModified": 1715147742,
+        "narHash": "sha256-JO3DNAQvaeKeBURvdUBCwwbDPUzCYq3fRVF5+RplNlI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "459b808fc79b7b5bf5228d246b036b11aadc0cd3",
+        "rev": "cac68c1d3a23d4fe705340fd11ad3526576c9590",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                             |
| -------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`cac68c1d`](https://github.com/nix-community/NUR/commit/cac68c1d3a23d4fe705340fd11ad3526576c9590) | `` automatic update ``              |
| [`6942af1d`](https://github.com/nix-community/NUR/commit/6942af1d6dae3de8cb5587962a40a836c9cb6753) | `` drop nltch repository for now `` |
| [`324a5f3b`](https://github.com/nix-community/NUR/commit/324a5f3b9fbfdb77336dc9fa1c0a02f33a6acf6d) | `` automatic update ``              |