### PR TITLE
chore(flake/nur): `cac68c1d` -> `b0e1d1e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715147742,
-        "narHash": "sha256-JO3DNAQvaeKeBURvdUBCwwbDPUzCYq3fRVF5+RplNlI=",
+        "lastModified": 1715150720,
+        "narHash": "sha256-OLukB7IyD8L/MIwV5vbdE1doL1P+KXQ2BsNzwOdkphI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cac68c1d3a23d4fe705340fd11ad3526576c9590",
+        "rev": "b0e1d1e7b9f6e9d0187750c01fc0e76a05cc2b7d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b0e1d1e7`](https://github.com/nix-community/NUR/commit/b0e1d1e7b9f6e9d0187750c01fc0e76a05cc2b7d) | `` automatic update `` |
| [`ca0db453`](https://github.com/nix-community/NUR/commit/ca0db453fc83a1da66d792adb67d334661b92578) | `` automatic update `` |