### PR TITLE
chore(flake/nixos-hardware): `d1659c9e` -> `a4e2b790`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -398,11 +398,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1715010655,
-        "narHash": "sha256-FmdhvR/hgBkPDvIv/HOEIQsSMaVXh8wvTrnep8dF3Jc=",
+        "lastModified": 1715148395,
+        "narHash": "sha256-lRxjTxY3103LGMjWdVqntKZHhlmMX12QUjeFrQMmGaE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d1659c9eb8af718118fb4bbe2c86797c8b8623eb",
+        "rev": "a4e2b7909fc1bdf30c30ef21d388fde0b5cdde4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`a4e2b790`](https://github.com/NixOS/nixos-hardware/commit/a4e2b7909fc1bdf30c30ef21d388fde0b5cdde4a) | `` helios4: remove need for overlay ``                      |
| [`6cb18a66`](https://github.com/NixOS/nixos-hardware/commit/6cb18a664904afae03501ee613797f502030ee37) | `` purism/librem/5r4: make it usuable without an overlay `` |