### PR TITLE
chore(flake/nur): `b0e1d1e7` -> `1c9c3847`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715150720,
-        "narHash": "sha256-OLukB7IyD8L/MIwV5vbdE1doL1P+KXQ2BsNzwOdkphI=",
+        "lastModified": 1715159921,
+        "narHash": "sha256-CHOt5cEYjanjaBMGHZiogLGW2pthtXTEtJdkfOqJe1g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b0e1d1e7b9f6e9d0187750c01fc0e76a05cc2b7d",
+        "rev": "1c9c3847ba678c3ebb19b17d53ec8f918e09e5d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1c9c3847`](https://github.com/nix-community/NUR/commit/1c9c3847ba678c3ebb19b17d53ec8f918e09e5d8) | `` automatic update `` |
| [`f1c4fd9a`](https://github.com/nix-community/NUR/commit/f1c4fd9a84e30a4f669768e7e66700320809a2ee) | `` automatic update `` |
| [`5a6b1f64`](https://github.com/nix-community/NUR/commit/5a6b1f64e7d2a55a55ada8db1e16bb41ea79900c) | `` automatic update `` |
| [`a3ac707a`](https://github.com/nix-community/NUR/commit/a3ac707a54c94f913fd575da687675cea4de123e) | `` automatic update `` |