### PR TITLE
chore(flake/emacs-overlay): `d4426bf5` -> `fec26d98`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715158321,
-        "narHash": "sha256-/w93AM2j4v4m2D1s8ParP/TF+Fp4vke3K0evsiWolPY=",
+        "lastModified": 1715159081,
+        "narHash": "sha256-2LH+A3+IGj8260vorbmf9vv7n6hDwsanq70gT9aG2Qg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d4426bf5cc0e37247fb48b391c553e3957ceaafc",
+        "rev": "fec26d980c4598c52d6dd697660a60026fe96f3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`fec26d98`](https://github.com/nix-community/emacs-overlay/commit/fec26d980c4598c52d6dd697660a60026fe96f3a) | `` Updated emacs `` |