### PR TITLE
chore(flake/nur): `1c9c3847` -> `6d84a289`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715159921,
-        "narHash": "sha256-CHOt5cEYjanjaBMGHZiogLGW2pthtXTEtJdkfOqJe1g=",
+        "lastModified": 1715169050,
+        "narHash": "sha256-ejOQOIb12hkdpg0XbGngtpiFNoEcvVOpu2skSjtW4bw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1c9c3847ba678c3ebb19b17d53ec8f918e09e5d8",
+        "rev": "6d84a289eb21f7f8b4dad11202d662e4af8b8e49",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6d84a289`](https://github.com/nix-community/NUR/commit/6d84a289eb21f7f8b4dad11202d662e4af8b8e49) | `` automatic update `` |
| [`4cb36136`](https://github.com/nix-community/NUR/commit/4cb3613629d44613191f6ea89b167f74344bcc0e) | `` automatic update `` |