### PR TITLE
chore(flake/emacs-overlay): `fec26d98` -> `05b36231`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715159081,
-        "narHash": "sha256-2LH+A3+IGj8260vorbmf9vv7n6hDwsanq70gT9aG2Qg=",
+        "lastModified": 1715187231,
+        "narHash": "sha256-kCyORC3A5N+v85nhcMDUIMq4SoPRgTLksWX1EfZl8nU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fec26d980c4598c52d6dd697660a60026fe96f3a",
+        "rev": "05b362313783e1069406ed5279897bc63ec10d4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`05b36231`](https://github.com/nix-community/emacs-overlay/commit/05b362313783e1069406ed5279897bc63ec10d4d) | `` Updated melpa `` |
| [`c1cb824a`](https://github.com/nix-community/emacs-overlay/commit/c1cb824a430bc5cdee2ff6f53a65de91fd95951a) | `` Updated elpa ``  |