### PR TITLE
chore(flake/nur): `af908267` -> `91d332bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715186949,
-        "narHash": "sha256-ugsb5RHUQr/Wa6aDDXjPMccrJDtIiMLEBnW6eD53nHk=",
+        "lastModified": 1715192202,
+        "narHash": "sha256-R7TaDlts0aww3LJoKcazVlmxC96kcK222aGEinmjtQU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "af908267887a420babf1acec8260a882b17ada98",
+        "rev": "91d332bfe82905ef11c4a0ac85133860800230dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`91d332bf`](https://github.com/nix-community/NUR/commit/91d332bfe82905ef11c4a0ac85133860800230dc) | `` automatic update `` |