### PR TITLE
chore(flake/nur): `91d332bf` -> `b6cf1036`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715192202,
-        "narHash": "sha256-R7TaDlts0aww3LJoKcazVlmxC96kcK222aGEinmjtQU=",
+        "lastModified": 1715199012,
+        "narHash": "sha256-ULec750bFzQB24orDUDmPma5v80jPBYGR5PXuM8D2gc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "91d332bfe82905ef11c4a0ac85133860800230dc",
+        "rev": "b6cf1036905179e579c78bd0d82202ee907e250f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b6cf1036`](https://github.com/nix-community/NUR/commit/b6cf1036905179e579c78bd0d82202ee907e250f) | `` automatic update `` |
| [`223a5e35`](https://github.com/nix-community/NUR/commit/223a5e3596202212600c2c8d492f02a70600a85d) | `` automatic update `` |