### PR TITLE
chore(flake/catppuccin): `eaa6e281` -> `e5322f7b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1715128602,
-        "narHash": "sha256-KmIgXJ5fZmYsb+QeGZcauZIX7eN7PyTJI+t2LzuSLnU=",
+        "lastModified": 1715210854,
+        "narHash": "sha256-88jxvd+LIP/XwlvJ3+QPbGCFMChmBfIbUNp1mEP9DJY=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "eaa6e281f144a5ac90510d9a07d74bf5e9a4459f",
+        "rev": "e5322f7b4001aa8aab38ca5a0f42cafc590f42b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                              |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`e5322f7b`](https://github.com/catppuccin/nix/commit/e5322f7b4001aa8aab38ca5a0f42cafc590f42b6) | `` docs: update for 8d3e50a ``                       |
| [`8d3e50a6`](https://github.com/catppuccin/nix/commit/8d3e50a6774582d3d6c3f09e1421c01ead9b2d8e) | `` feat(nixos): add global `accent` option (#164) `` |
| [`068e0d40`](https://github.com/catppuccin/nix/commit/068e0d406b0893ac4fcd344751cf96d106e86ae6) | `` docs: update for 360c974 ``                       |
| [`360c9741`](https://github.com/catppuccin/nix/commit/360c974143bc66cfd7ecfef1a12c4e5e9bf95538) | `` fix(home-manager): capitalize gtkTheme (#159) ``  |