### PR TITLE
chore(flake/emacs-overlay): `b2b29771` -> `2a6f4ebb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715188006,
-        "narHash": "sha256-29BwNbk5R3CUPKY3NOY+uVYsuyViVsbvH8xdF812gh4=",
+        "lastModified": 1715219247,
+        "narHash": "sha256-op/p+fsOydQZDrW9glFsT11oiv7wFPnc8wizqK22TW0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b2b29771bfc8b8ce80839915c0d6828ed5ade2fa",
+        "rev": "2a6f4ebbe6ce61ad2cdcd826581d8c6fb3dfcce8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`2a6f4ebb`](https://github.com/nix-community/emacs-overlay/commit/2a6f4ebbe6ce61ad2cdcd826581d8c6fb3dfcce8) | `` Updated emacs ``        |
| [`7dc34ea1`](https://github.com/nix-community/emacs-overlay/commit/7dc34ea1703ab236983800ef9470759a2f3ed548) | `` Updated melpa ``        |
| [`3c3b4dbc`](https://github.com/nix-community/emacs-overlay/commit/3c3b4dbceb17a230909e8e17c6b539871e2fa4d3) | `` Updated elpa ``         |
| [`cb2d643b`](https://github.com/nix-community/emacs-overlay/commit/cb2d643b5aed7de08b762fd6e1db3f8adb619580) | `` Updated flake inputs `` |