### PR TITLE
chore(flake/srvos): `885d705a` -> `65d83b87`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714956769,
-        "narHash": "sha256-49DQpGvr5N0l7rsFMP8zSwHeSa7f9N3NiY4mgdOwPn8=",
+        "lastModified": 1715216666,
+        "narHash": "sha256-0aTe4zSO5t6Wn+gaW5Bwr+84INd7htOdn3sdmE6/uC0=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "885d705a55f5a9bd5a85cb6869358a1e5c522009",
+        "rev": "65d83b87b55c9618cf02aa9b9c08ec8adaa08c9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`65d83b87`](https://github.com/nix-community/srvos/commit/65d83b87b55c9618cf02aa9b9c08ec8adaa08c9d) | `` dev/private/flake.lock: Update `` |
| [`f3efb325`](https://github.com/nix-community/srvos/commit/f3efb3258e2a9250f9c2fc5e0ea4df80acc2ae90) | `` flake.lock: Update ``             |