### PR TITLE
chore(flake/nur): `6580e348` -> `9f31bdbf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,11 +488,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715211950,
-        "narHash": "sha256-//YbMDEYB9O8ugYN1nsUQUhbBDFizhdnfHzkRIoc2MM=",
+        "lastModified": 1715218418,
+        "narHash": "sha256-NWCchEgoyXCg3+Dxm3LbpzE7OaBrg/TbrKtzG97M1rk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6580e34800c76147aa5d61cf598123f0de72971c",
+        "rev": "9f31bdbf2559adca655c10d638c47992a80128d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9f31bdbf`](https://github.com/nix-community/NUR/commit/9f31bdbf2559adca655c10d638c47992a80128d0) | `` automatic update `` |