### PR TITLE
chore(flake/nur): `9f31bdbf` -> `bddb5edd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -563,11 +563,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715218418,
-        "narHash": "sha256-NWCchEgoyXCg3+Dxm3LbpzE7OaBrg/TbrKtzG97M1rk=",
+        "lastModified": 1715225965,
+        "narHash": "sha256-iMmchwgcPQ48z21d9tQMuCS4Z2K6sP0Zj2NC7fC/Jgg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9f31bdbf2559adca655c10d638c47992a80128d0",
+        "rev": "bddb5edd4fd599565b1a8e29c16ddb427fcff502",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bddb5edd`](https://github.com/nix-community/NUR/commit/bddb5edd4fd599565b1a8e29c16ddb427fcff502) | `` automatic update `` |
| [`1f414ab6`](https://github.com/nix-community/NUR/commit/1f414ab635577f1da9e5d7c3aca4930b68a7aaac) | `` automatic update `` |