### PR TITLE
chore(flake/nur): `5bcd7880` -> `86a94fc9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -563,11 +563,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715233536,
-        "narHash": "sha256-d8UVTj2MtJfHGb4YMbK6Z5+YjuP48boULjIfC39tUnw=",
+        "lastModified": 1715236348,
+        "narHash": "sha256-CbSHkYwXQLDYMtFt3xaFQ0Guj9z/9dslyaC0AaizyR0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5bcd78809035d27064b6cc3a5a099f1435884bed",
+        "rev": "86a94fc9d8eb406457ebc71025c26f9784a59f23",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`86a94fc9`](https://github.com/nix-community/NUR/commit/86a94fc9d8eb406457ebc71025c26f9784a59f23) | `` automatic update `` |
| [`25c42936`](https://github.com/nix-community/NUR/commit/25c4293686cde4f529d5c99859710dcebceaec62) | `` automatic update `` |