### PR TITLE
chore(flake/nur): `86a94fc9` -> `5dea7f0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -563,11 +563,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715236348,
-        "narHash": "sha256-CbSHkYwXQLDYMtFt3xaFQ0Guj9z/9dslyaC0AaizyR0=",
+        "lastModified": 1715243633,
+        "narHash": "sha256-z4hWuUk6o/gPLQ873W6DF/tHcg2cAb8YMc+VT1ARdu8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "86a94fc9d8eb406457ebc71025c26f9784a59f23",
+        "rev": "5dea7f0b438b1d8f60590049dd83f680553b669c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5dea7f0b`](https://github.com/nix-community/NUR/commit/5dea7f0b438b1d8f60590049dd83f680553b669c) | `` automatic update `` |