### PR TITLE
chore(flake/sops-nix): `893e3df0` -> `0dc50257`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -656,11 +656,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1715035358,
-        "narHash": "sha256-RY6kqhpCPa/q3vbqt3iYRyjO3hJz9KZnshMjbpPon8o=",
+        "lastModified": 1715244550,
+        "narHash": "sha256-ffOZL3eaZz5Y1nQ9muC36wBCWwS1hSRLhUzlA9hV2oI=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "893e3df091f6838f4f9d71c61ab079d5c5dedbd1",
+        "rev": "0dc50257c00ee3c65fef3a255f6564cfbfe6eb7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`0dc50257`](https://github.com/Mic92/sops-nix/commit/0dc50257c00ee3c65fef3a255f6564cfbfe6eb7f) | `` update vendorHash ``                                           |
| [`18653aed`](https://github.com/Mic92/sops-nix/commit/18653aed8b268f4b7f0271e91b102f0d41e07fc5) | `` build(deps): bump golang.org/x/crypto from 0.22.0 to 0.23.0 `` |