### PR TITLE
chore(flake/nur): `5dea7f0b` -> `9e36117c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -563,11 +563,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715243633,
-        "narHash": "sha256-z4hWuUk6o/gPLQ873W6DF/tHcg2cAb8YMc+VT1ARdu8=",
+        "lastModified": 1715258430,
+        "narHash": "sha256-WEFwvpyepEp2WL39r9ckDLVtvSV4kiTiS4JRcIoldms=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5dea7f0b438b1d8f60590049dd83f680553b669c",
+        "rev": "9e36117c5946cd3a8fa2f1f9b23ac2ccdddf6add",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9e36117c`](https://github.com/nix-community/NUR/commit/9e36117c5946cd3a8fa2f1f9b23ac2ccdddf6add) | `` automatic update `` |