### PR TITLE
chore(flake/nur): `9e36117c` -> `6af23640`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -563,11 +563,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715258430,
-        "narHash": "sha256-WEFwvpyepEp2WL39r9ckDLVtvSV4kiTiS4JRcIoldms=",
+        "lastModified": 1715262420,
+        "narHash": "sha256-TYH4mw6dZ/z68s3QTPBz2D4OHnZw9jCOOa4C4092E+k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9e36117c5946cd3a8fa2f1f9b23ac2ccdddf6add",
+        "rev": "6af23640d6b5f85e76ad617e40147e00df002c8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6af23640`](https://github.com/nix-community/NUR/commit/6af23640d6b5f85e76ad617e40147e00df002c8b) | `` automatic update `` |
| [`b0ff9ac6`](https://github.com/nix-community/NUR/commit/b0ff9ac6df174deb5c74d93dedf6b39122495ec6) | `` automatic update `` |