### PR TITLE
chore(flake/nur): `6af23640` -> `9ab77d23`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -563,11 +563,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715262420,
-        "narHash": "sha256-TYH4mw6dZ/z68s3QTPBz2D4OHnZw9jCOOa4C4092E+k=",
+        "lastModified": 1715265912,
+        "narHash": "sha256-4uu7Elrs/fgISAohBV292NquBwgK1494L7xlMUH5QSY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6af23640d6b5f85e76ad617e40147e00df002c8b",
+        "rev": "9ab77d2356bee9096ccf091dd75a3522d682d92d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ab77d23`](https://github.com/nix-community/NUR/commit/9ab77d2356bee9096ccf091dd75a3522d682d92d) | `` automatic update `` |