### PR TITLE
chore(flake/emacs-overlay): `2a6f4ebb` -> `c6e73087`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715219247,
-        "narHash": "sha256-op/p+fsOydQZDrW9glFsT11oiv7wFPnc8wizqK22TW0=",
+        "lastModified": 1715274454,
+        "narHash": "sha256-QnQwZXWFE9fj1Y/0DZPRcVQIY/J8ejP6QtWd5QhMpQ8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2a6f4ebbe6ce61ad2cdcd826581d8c6fb3dfcce8",
+        "rev": "c6e7308733e76548d10615d74669919a243e93c8",
         "type": "github"
       },
       "original": {
@@ -515,11 +515,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1714971268,
-        "narHash": "sha256-IKwMSwHj9+ec660l+I4tki/1NRoeGpyA2GdtdYpAgEw=",
+        "lastModified": 1715106579,
+        "narHash": "sha256-gZMgKEGiK6YrwGBiccZ1gemiUwjsZ1Zv49KYOgmX2fY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "27c13997bf450a01219899f5a83bd6ffbfc70d3c",
+        "rev": "8be0d8a1ed4f96d99b09aa616e2afd47acc3da89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c6e73087`](https://github.com/nix-community/emacs-overlay/commit/c6e7308733e76548d10615d74669919a243e93c8) | `` Updated emacs ``        |
| [`7c9dbbcb`](https://github.com/nix-community/emacs-overlay/commit/7c9dbbcb358be717e1d602a85d9903441b5e8d3a) | `` Updated melpa ``        |
| [`89397da3`](https://github.com/nix-community/emacs-overlay/commit/89397da38d451c86d683bdfa19efe52eda7ad2f6) | `` Updated elpa ``         |
| [`92a51c0a`](https://github.com/nix-community/emacs-overlay/commit/92a51c0acabbf30f6d4c3b2e6ecd72d520903382) | `` Updated flake inputs `` |